### PR TITLE
uses numpy inf instead of LARGE_NUMBER

### DIFF
--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -44,10 +44,7 @@ from .components import DATA_TYPE_MAP, ScalarFieldData, ScalarFieldTimeData
 from .components import ModeData, ModeAmpsData, ModeIndexData
 
 # constants imported as `C_0 = td.C_0` or `td.constants.C_0`
-from .constants import C_0, ETA_0, HBAR, EPSILON_0, MU_0, Q_e
-
-# types
-from .components import inf
+from .constants import C_0, ETA_0, HBAR, EPSILON_0, MU_0, Q_e, inf
 
 # plugins typically imported as `from tidy3d.plugins import DispersionFitter`
 from . import plugins

--- a/tidy3d/components/__init__.py
+++ b/tidy3d/components/__init__.py
@@ -36,6 +36,3 @@ from .simulation import Simulation
 # data
 from .data import SimulationData, FieldData, FluxData, ModeData, FluxTimeData
 from .data import ScalarFieldData, ScalarFieldTimeData, ModeAmpsData, ModeIndexData, DATA_TYPE_MAP
-
-# types
-from .types import inf

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -12,7 +12,7 @@ from descartes import PolygonPatch
 
 from .validators import assert_unique_names, assert_objects_in_sim_bounds
 from .geometry import Box
-from .types import Symmetry, Ax, Shapely, FreqBound, GridSize, inf
+from .types import Symmetry, Ax, Shapely, FreqBound, GridSize
 from .grid import Coords1D, Grid, Coords
 from .medium import Medium, MediumType, AbstractMedium
 from .structure import Structure
@@ -23,7 +23,7 @@ from .viz import StructMediumParams, StructEpsParams, PMLParams, SymParams
 from .viz import add_ax_if_none, equal_aspect
 
 from ..version import __version__
-from ..constants import C_0, MICROMETER, SECOND, pec_val
+from ..constants import C_0, MICROMETER, SECOND, pec_val, inf
 from ..log import log, Tidy3dKeyError, SetupError
 
 # for docstring examples

--- a/tidy3d/components/source.py
+++ b/tidy3d/components/source.py
@@ -8,12 +8,12 @@ import numpy as np
 
 from .base import Tidy3dBaseModel
 from .types import Direction, Polarization, Ax, FreqBound, Array
-from .types import inf  # pylint:disable=unused-import
 from .validators import assert_plane, validate_name_str
 from .geometry import Box
 from .mode import ModeSpec
 from .viz import add_ax_if_none, SourceParams, equal_aspect
 from ..constants import RADIAN, HERTZ, MICROMETER
+from ..constants import inf  # pylint:disable=unused-import
 from ..log import SetupError
 
 # in spectrum computation, discard amplitudes with relative magnitude smaller than cutoff

--- a/tidy3d/components/types.py
+++ b/tidy3d/components/types.py
@@ -44,6 +44,7 @@ class NegInf(pydantic.BaseModel):
 
 # built in instance of Inf ()
 inf = LARGE_NUMBER  # pylint:disable=invalid-name
+inf = np.inf
 # TODO: use inf as a reserved quantity for plotting, etc.
 # inf = Inf()
 

--- a/tidy3d/components/types.py
+++ b/tidy3d/components/types.py
@@ -13,11 +13,6 @@ import numpy as np
 from matplotlib.axes._subplots import Axes
 from shapely.geometry.base import BaseGeometry
 
-""" infinity """
-
-inf = np.inf
-# from ..constants import LARGE_NUMBER
-# inf = LARGE_NUMBER  # pylint:disable=invalid-name
 
 """ Complex Values """
 

--- a/tidy3d/components/types.py
+++ b/tidy3d/components/types.py
@@ -13,41 +13,11 @@ import numpy as np
 from matplotlib.axes._subplots import Axes
 from shapely.geometry.base import BaseGeometry
 
-from ..constants import LARGE_NUMBER
-
 """ infinity """
 
 inf = np.inf
-
-# class Inf(pydantic.BaseModel):
-#     """Infinity.  Can use built-in instance: ``tidy3d.inf``."""
-
-#     def __neg__(self):
-#         """Negative Infinity"""
-#         return NegInf()
-
-#     def __truediv__(self, other):
-#         """dividing by something equals a large number"""
-#         return LARGE_NUMBER
-
-
-# class NegInf(pydantic.BaseModel):
-#     """Negative infinity.  Can use built-in instance as: ``-tidy3d.inf``."""
-
-#     def __neg__(self):
-#         """Positive Infinity"""
-#         return Inf()
-
-#     def __truediv__(self, other):
-#         """dividing by something equals a very large negative number"""
-#         return -LARGE_NUMBER
-
-
-# built in instance of Inf ()
+# from ..constants import LARGE_NUMBER
 # inf = LARGE_NUMBER  # pylint:disable=invalid-name
-# TODO: use inf as a reserved quantity for plotting, etc.
-# inf = Inf()
-
 
 """ Complex Values """
 
@@ -91,7 +61,7 @@ class tidycomplex(complex):  # pylint: disable=invalid-name
 
 """ geometric """
 
-Size1D = Union[pydantic.NonNegativeFloat, Inf]
+Size1D = pydantic.NonNegativeFloat
 Size = Tuple[Size1D, Size1D, Size1D]
 Coordinate = Tuple[float, float, float]
 Coordinate2D = Tuple[float, float]
@@ -109,8 +79,8 @@ Complex = Union[tidycomplex, ComplexNumber]
 PoleAndResidue = Tuple[Complex, Complex]
 
 # PoleAndResidue = Tuple[Tuple[float, float], Tuple[float, float]]
-FreqBoundMax = Union[float, Inf]
-FreqBoundMin = Union[float, NegInf]
+FreqBoundMax = float
+FreqBoundMin = float
 FreqBound = Tuple[FreqBoundMin, FreqBoundMax]
 
 """ symmetries """

--- a/tidy3d/components/types.py
+++ b/tidy3d/components/types.py
@@ -17,34 +17,34 @@ from ..constants import LARGE_NUMBER
 
 """ infinity """
 
+inf = np.inf
 
-class Inf(pydantic.BaseModel):
-    """Infinity.  Can use built-in instance: ``tidy3d.inf``."""
+# class Inf(pydantic.BaseModel):
+#     """Infinity.  Can use built-in instance: ``tidy3d.inf``."""
 
-    def __neg__(self):
-        """Negative Infinity"""
-        return NegInf()
+#     def __neg__(self):
+#         """Negative Infinity"""
+#         return NegInf()
 
-    def __truediv__(self, other):
-        """dividing by something equals a large number"""
-        return LARGE_NUMBER
+#     def __truediv__(self, other):
+#         """dividing by something equals a large number"""
+#         return LARGE_NUMBER
 
 
-class NegInf(pydantic.BaseModel):
-    """Negative infinity.  Can use built-in instance as: ``-tidy3d.inf``."""
+# class NegInf(pydantic.BaseModel):
+#     """Negative infinity.  Can use built-in instance as: ``-tidy3d.inf``."""
 
-    def __neg__(self):
-        """Positive Infinity"""
-        return Inf()
+#     def __neg__(self):
+#         """Positive Infinity"""
+#         return Inf()
 
-    def __truediv__(self, other):
-        """dividing by something equals a very large negative number"""
-        return -LARGE_NUMBER
+#     def __truediv__(self, other):
+#         """dividing by something equals a very large negative number"""
+#         return -LARGE_NUMBER
 
 
 # built in instance of Inf ()
-inf = LARGE_NUMBER  # pylint:disable=invalid-name
-inf = np.inf
+# inf = LARGE_NUMBER  # pylint:disable=invalid-name
 # TODO: use inf as a reserved quantity for plotting, etc.
 # inf = Inf()
 

--- a/tidy3d/constants.py
+++ b/tidy3d/constants.py
@@ -46,3 +46,5 @@ RADPERSEC = "rad/sec"
 
 # large number used for comparing infinity
 LARGE_NUMBER = np.float32(1e20)
+
+inf = np.inf


### PR DESCRIPTION
Previously, we defined `td.inf` to point to a `LARGE_NUMBER` defined in `components/constants.py`.  This got the job done but had a few downsides:
* Was not explicit  in the data files whether a number was just large or was supposed to be infinite.
* Needed to still be careful we got expected behavior if comparing this with another number that happened to be large (like frequencies in Hz).

This PR sets `td.inf = np.inf`, which seems to write to json fine.
The visualizations also render correctly.

I had to add a `@staticmenthod` in `Geometry` to evaluate the infinity values as `LARGE_NUMBER` in before setting axes limits as matplotlib could not handle this.

Everything else should be good to go.