### PR TITLE
makes run time a required parameter

### DIFF
--- a/tests/test_IO.py
+++ b/tests/test_IO.py
@@ -61,6 +61,7 @@ def test_simulation_preserve_types():
             FluxTimeMonitor(size=(1, 0, 1), start=1e-12, interval=3, name="fluxtime"),
             ModeMonitor(size=(1, 0, 1), freqs=[1, 2], mode_spec=ModeSpec(num_modes=3), name="mode"),
         ],
+        run_time=1e-12,
     )
 
     path = "tests/tmp/simulation.json"

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -90,6 +90,7 @@ def _test_version():
     sim = Simulation(
         size=(1, 1, 1),
         grid_size=(0.1, 0.1, 0.1),
+        run_time=1e-12,
     )
     path = "tests/tmp/simulation.json"
     sim.to_file("tests/tmp/simulation.json")
@@ -143,13 +144,13 @@ def test_sim_bounds():
 def test_sim_grid_size():
 
     size = (1, 1, 1)
-    _ = Simulation(size=size, grid_size=(1.0, 1.0, 1.0))
+    _ = Simulation(size=size, grid_size=(1.0, 1.0, 1.0), run_time=1e-12)
 
 
 def _test_sim_size():
 
     with pytest.raises(SetupError):
-        s = Simulation(size=(1, 1, 1), grid_size=(1e-5, 1e-5, 1e-5))
+        s = Simulation(size=(1, 1, 1), grid_size=(1e-5, 1e-5, 1e-5), run_time=1e-12)
         s._validate_size()
 
     with pytest.raises(SetupError):
@@ -168,6 +169,7 @@ def _test_monitor_size():
                     size=(inf, inf, inf), freqs=np.linspace(0, 200e12, 10000001), name="test"
                 )
             ],
+            run_time=1e-12,
         )
 
         s.validate_contents()
@@ -187,7 +189,12 @@ def test_monitor_medium_frequency_range(caplog, freq, log_level):
         polarization="Ex",
     )
     sim = Simulation(
-        size=(1, 1, 1), grid_size=(0.1, 0.1, 0.1), structures=[box], monitors=[mnt], sources=[src]
+        size=(1, 1, 1),
+        grid_size=(0.1, 0.1, 0.1),
+        structures=[box],
+        monitors=[mnt],
+        sources=[src],
+        run_time=1e-12,
     )
     assert_log_level(caplog, log_level)
 
@@ -203,7 +210,9 @@ def test_monitor_simulation_frequency_range(caplog, fwidth, log_level):
         polarization="Ex",
     )
     mnt = FieldMonitor(size=(0, 0, 0), name="freq", freqs=[1.5])
-    sim = Simulation(size=(1, 1, 1), grid_size=(0.1, 0.1, 0.1), monitors=[mnt], sources=[src])
+    sim = Simulation(
+        size=(1, 1, 1), grid_size=(0.1, 0.1, 0.1), monitors=[mnt], sources=[src], run_time=1e-12
+    )
     assert_log_level(caplog, log_level)
 
 
@@ -219,7 +228,11 @@ def test_sim_grid_size(caplog, grid_size, log_level):
         polarization="Ex",
     )
     _ = Simulation(
-        size=(1, 1, 1), grid_size=(0.01, 0.01, grid_size), structures=[box], sources=[src]
+        size=(1, 1, 1),
+        grid_size=(0.01, 0.01, grid_size),
+        structures=[box],
+        sources=[src],
+        run_time=1e-12,
     )
 
     assert_log_level(caplog, log_level)
@@ -241,6 +254,7 @@ def test_sim_structure_gap(caplog, box_size, log_level):
         structures=[box],
         sources=[src],
         pml_layers=[PML(num_layers=5), PML(num_layers=5), PML(num_layers=5)],
+        run_time=1e-12,
     )
     assert_log_level(caplog, log_level)
 
@@ -270,6 +284,7 @@ def test_sim_plane_wave_error():
         medium=medium_bg,
         structures=[box_transparent],
         sources=[src],
+        run_time=1e-12,
     )
 
     # with non-transparent box, raise
@@ -296,7 +311,9 @@ def test_sim_structure_extent(caplog, box_size, log_level):
         polarization="Ex",
     )
     box = Structure(geometry=Box(size=box_size), medium=Medium(permittivity=2))
-    sim = Simulation(size=(1, 1, 1), grid_size=(0.1, 0.1, 0.1), structures=[box], sources=[src])
+    sim = Simulation(
+        size=(1, 1, 1), grid_size=(0.1, 0.1, 0.1), structures=[box], sources=[src], run_time=1e-12
+    )
 
     assert_log_level(caplog, log_level)
 
@@ -309,13 +326,17 @@ def test_num_mediums():
         structures.append(
             Structure(geometry=Box(size=(1, 1, 1)), medium=Medium(permittivity=i + 1))
         )
-    sim = Simulation(size=(1, 1, 1), grid_size=(0.1, 0.1, 0.1), structures=structures)
+    sim = Simulation(
+        size=(1, 1, 1), grid_size=(0.1, 0.1, 0.1), structures=structures, run_time=1e-12
+    )
 
     with pytest.raises(SetupError):
         structures.append(
             Structure(geometry=Box(size=(1, 1, 1)), medium=Medium(permittivity=i + 2))
         )
-        sim = Simulation(size=(1, 1, 1), grid_size=(0.1, 0.1, 0.1), structures=structures)
+        sim = Simulation(
+            size=(1, 1, 1), grid_size=(0.1, 0.1, 0.1), structures=structures, run_time=1e-12
+        )
 
 
 """ geometry """
@@ -356,13 +377,13 @@ def test_geometry_sizes():
         with pytest.raises(pydantic.ValidationError) as e_info:
             a = Box(size=size, center=(0, 0, 0))
         with pytest.raises(pydantic.ValidationError) as e_info:
-            s = Simulation(size=size, grid_size=(1.0, 1.0, 1.0))
+            s = Simulation(size=size, grid_size=(1.0, 1.0, 1.0), run_time=1e-12)
         with pytest.raises(pydantic.ValidationError) as e_info:
-            s = Simulation(size=(1, 1, 1), grid_size=size)
+            s = Simulation(size=(1, 1, 1), grid_size=size, run_time=1e-12)
 
     # negative grid sizes error?
     with pytest.raises(pydantic.ValidationError) as e_info:
-        s = Simulation(size=(1, 1, 1), grid_size=-1.0)
+        s = Simulation(size=(1, 1, 1), grid_size=-1.0, run_time=1e-12)
 
 
 def test_pop_axis():
@@ -623,11 +644,6 @@ def _test_names_default():
 
     for i, source in enumerate(sim.sources):
         assert source.name == f"sources[{i}]"
-
-    # distinct_mediums = [f"mediums[{i}]" for i in range(len(sim.mediums))]
-    # for i, medium in enumerate(sim.mediums):
-    #     assert medium.name in distinct_mediums
-    #     distinct_mediums.pop(distinct_mediums.index(medium.name))
 
 
 def test_names_unique():

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -53,6 +53,7 @@ def test_sim_nonuniform_small():
         size=(size_x, 4, 4),
         grid_size=(grid_size_x, 1, 1),
         pml_layers=[td.PML(num_layers=num_layers_pml_x), None, None],
+        run_time=1e-12,
     )
 
     bound_coords = sim.grid.boundaries.x
@@ -97,6 +98,7 @@ def test_sim_nonuniform_large():
         size=(size_x, 4, 4),
         grid_size=(grid_size_x, 1, 1),
         pml_layers=[td.PML(num_layers=num_layers_pml_x), None, None],
+        run_time=1e-12,
     )
 
     bound_coords = sim.grid.boundaries.x
@@ -125,10 +127,7 @@ def test_sim_nonuniform_large():
 
 def test_sim_grid():
 
-    sim = td.Simulation(
-        size=(4, 4, 4),
-        grid_size=(1, 1, 1),
-    )
+    sim = td.Simulation(size=(4, 4, 4), grid_size=(1, 1, 1), run_time=1e-12)
 
     for c in sim.grid.centers.dict(exclude={TYPE_TAG_STR}).values():
         assert np.all(c == np.array([-1.5, -0.5, 0.5, 1.5]))
@@ -150,6 +149,7 @@ def test_sim_symmetry_grid():
         ]
         * 3,
         symmetry=(0, 1, -1),
+        run_time=1e-12,
     )
 
     coords_x, coords_y, coords_z = sim.grid.boundaries.to_list
@@ -172,6 +172,7 @@ def test_sim_pml_grid():
         size=(4, 4, 4),
         grid_size=(1, 1, 1),
         pml_layers=(td.PML(num_layers=2), td.Absorber(num_layers=2), td.StablePML(num_layers=2)),
+        run_time=1e-12,
     )
 
     for c in sim.grid.centers.dict(exclude={TYPE_TAG_STR}).values():
@@ -182,10 +183,7 @@ def test_sim_pml_grid():
 
 def test_sim_discretize_vol():
 
-    sim = td.Simulation(
-        size=(4, 4, 4),
-        grid_size=(1, 1, 1),
-    )
+    sim = td.Simulation(size=(4, 4, 4), grid_size=(1, 1, 1), run_time=1e-12)
 
     vol = td.Box(size=(1.9, 1.9, 1.9))
 
@@ -202,10 +200,7 @@ def test_sim_discretize_vol():
 
 def test_sim_discretize_plane():
 
-    sim = td.Simulation(
-        size=(4, 4, 4),
-        grid_size=(1, 1, 1),
-    )
+    sim = td.Simulation(size=(4, 4, 4), grid_size=(1, 1, 1), run_time=1e-12)
 
     plane = td.Box(size=(6, 6, 0))
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -22,7 +22,7 @@ def test_near2far():
 
     sim_size = (5, 5, 5)
     dl = 0.1
-    sim = td.Simulation(size=sim_size, grid_size=[dl, dl, dl], monitors=monitors, run_time=10)
+    sim = td.Simulation(size=sim_size, grid_size=[dl, dl, dl], monitors=monitors, run_time=1e-12)
 
     def rand_data():
         return ScalarFieldData(
@@ -58,7 +58,9 @@ def test_mode_solver():
     waveguide = td.Structure(
         geometry=td.Box(size=(100, 0.5, 0.5)), medium=td.Medium(permittivity=4.0)
     )
-    simulation = td.Simulation(size=(2, 2, 2), grid_size=(0.1, 0.1, 0.1), structures=[waveguide])
+    simulation = td.Simulation(
+        size=(2, 2, 2), grid_size=(0.1, 0.1, 0.1), structures=[waveguide], run_time=1e-12
+    )
     plane = td.Box(center=(0, 0, 0), size=(0, 1, 1))
     ms = ModeSolver(simulation=simulation, plane=plane, freq=td.constants.C_0 / 1.5)
     mode_spec = td.ModeSpec(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -36,6 +36,7 @@ def prepend_tmp(path):
 SIM_MONITORS = Simulation(
     size=(10.0, 10.0, 10.0),
     grid_size=(0.1, 0.1, 0.1),
+    run_time=1e-13,
     monitors=[
         FieldMonitor(size=(1, 1, 1), center=(0, 1, 0), freqs=[1, 2, 5, 7, 8], name="field_freq"),
         FieldTimeMonitor(size=(1, 1, 0), center=(1, 0, 0), interval=10, name="field_time"),
@@ -132,6 +133,6 @@ SIM_CONVERT = td.Simulation(
             name="field_monitor",
         )
     ],
-    run_time=1 / 1e12,
+    run_time=1e-12,
     pml_layers=3 * [PML()],
 )

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -100,19 +100,19 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
         units=MICROMETER,
     )
 
-    medium: MediumType = pydantic.Field(
-        Medium(),
-        title="Background Medium",
-        description="Background medium of simulation, defaults to vacuum if not specified.",
-    )
-
-    run_time: pydantic.NonNegativeFloat = pydantic.Field(
-        0.0,
+    run_time: pydantic.PositiveFloat = pydantic.Field(
+        ...,
         title="Run Time",
         description="Total electromagnetic evolution time in seconds. "
         "Note: If simulation 'shutoff' is specified, "
         "simulation will terminate early when shutoff condition met.",
         units=SECOND,
+    )
+
+    medium: MediumType = pydantic.Field(
+        Medium(),
+        title="Background Medium",
+        description="Background medium of simulation, defaults to vacuum if not specified.",
     )
 
     symmetry: Tuple[Symmetry, Symmetry, Symmetry] = pydantic.Field(


### PR DESCRIPTION
Not much to see here.
`run_time > 0` is required now.
Changed all of the tests to include `run_time` if not supplied so they pass.