### PR TITLE
Near2Far vectorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed issue where smatrix was not uploaded to pyPI.
+- Allowed users to provide observation coordinates as vectors in `tidy3d.plugins.Near2Far` and optimized the routines therein for faster computation of far fields.
 
 ## [1.1.0] - 2022-3-1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Allowed users to provide observation coordinates as vectors in `tidy3d.plugins.Near2Far` and optimized the routines therein for faster computation of far fields.
+
 ## [1.1.1] - 2022-3-2
 
 ### Added
@@ -16,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed issue where smatrix was not uploaded to pyPI.
-- Allowed users to provide observation coordinates as vectors in `tidy3d.plugins.Near2Far` and optimized the routines therein for faster computation of far fields.
 
 ## [1.1.0] - 2022-3-1
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -46,11 +46,23 @@ def test_near2far():
         normal_dirs=["-", "+", "-", "+", "-", "+"],
         frequency=f0,
     )
+
+    # single inputs
     n2f.radar_cross_section(1, 1)
     n2f.power_spherical(1, 1, 1)
     n2f.power_cartesian(1, 1, 1)
     n2f.fields_spherical(1, 1, 1)
     n2f.fields_cartesian(1, 1, 1)
+
+    # vectorized inputs
+    pts1 = [0,1]
+    pts2 = [0,1,2]
+    pts3 = [3,4,5]
+    n2f.radar_cross_section(pts1, pts2)
+    n2f.power_spherical(1, pts2, pts3)
+    n2f.power_cartesian(pts1, pts2, pts3)
+    n2f.fields_spherical(1, pts2, pts3)
+    n2f.fields_cartesian(pts1, pts2, pts3)
 
 
 def test_mode_solver():

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -55,9 +55,9 @@ def test_near2far():
     n2f.fields_cartesian(1, 1, 1)
 
     # vectorized inputs
-    pts1 = [0,1]
-    pts2 = [0,1,2]
-    pts3 = [3,4,5]
+    pts1 = [0, 1]
+    pts2 = [0, 1, 2]
+    pts3 = [3, 4, 5]
     n2f.radar_cross_section(pts1, pts2)
     n2f.power_spherical(1, pts2, pts3)
     n2f.power_cartesian(pts1, pts2, pts3)

--- a/tidy3d/plugins/near2far/near2far.py
+++ b/tidy3d/plugins/near2far/near2far.py
@@ -517,8 +517,7 @@ the number of directions ({len(normal_dirs)})."
 
         return N_theta, N_phi, L_theta, L_phi
 
-    def fields_spherical(
-        self, r: float, theta: ArrayLikeN2F, phi: ArrayLikeN2F) -> xr.Dataset:
+    def fields_spherical(self, r: float, theta: ArrayLikeN2F, phi: ArrayLikeN2F) -> xr.Dataset:
         """Get fields at a point relative to monitor center in spherical coordinates.
 
         Parameters
@@ -546,8 +545,13 @@ the number of directions ({len(normal_dirs)})."
         k = self.k
         eta = self.eta
 
-        scalar_proj_r = (-self.phasor_positive_sign * 1j * k * np.exp(
-            self.phasor_positive_sign * 1j * k * r) / (4 * np.pi * r))
+        scalar_proj_r = (
+            -self.phasor_positive_sign
+            * 1j
+            * k
+            * np.exp(self.phasor_positive_sign * 1j * k * r)
+            / (4 * np.pi * r)
+        )
 
         # assemble E felds
         Et_array = -scalar_proj_r * (L_phi + eta * N_theta)
@@ -571,12 +575,12 @@ the number of directions ({len(normal_dirs)})."
         Hp = xr.DataArray(data=Hp_array[None, ...], coords=coords, dims=dims)
 
         field_data = xr.Dataset(
-            {"E_r": Er, "E_theta": Et, "E_phi": Ep, "H_r": Hr, "H_theta": Ht, "H_phi": Hp})
+            {"E_r": Er, "E_theta": Et, "E_phi": Ep, "H_r": Hr, "H_theta": Ht, "H_phi": Hp}
+        )
 
         return field_data
 
-    def fields_cartesian(
-        self, x: ArrayLikeN2F, y: ArrayLikeN2F, z: ArrayLikeN2F) -> xr.Dataset:
+    def fields_cartesian(self, x: ArrayLikeN2F, y: ArrayLikeN2F, z: ArrayLikeN2F) -> xr.Dataset:
         """Get fields at a point relative to monitor center in cartesian coordinates.
 
         Parameters
@@ -614,10 +618,12 @@ the number of directions ({len(normal_dirs)})."
                     r, theta, phi = self._car_2_sph(_x, _y, _z)
                     _field_data = self.fields_spherical(r, theta, phi)
 
-                    Er, Etheta, Ephi = [_field_data[comp].values \
-                        for comp in ["E_r", "E_theta", "E_phi"]]
-                    Hr, Htheta, Hphi = [_field_data[comp].values \
-                        for comp in ["H_r", "H_theta", "H_phi"]]
+                    Er, Etheta, Ephi = [
+                        _field_data[comp].values for comp in ["E_r", "E_theta", "E_phi"]
+                    ]
+                    Hr, Htheta, Hphi = [
+                        _field_data[comp].values for comp in ["H_r", "H_theta", "H_phi"]
+                    ]
 
                     Ex_data[i, j, k], Ey_data[i, j, k], Ez_data[i, j, k] = self._sph_2_car_field(
                         Er, Etheta, Ephi, theta, phi
@@ -637,8 +643,7 @@ the number of directions ({len(normal_dirs)})."
         Hy = xr.DataArray(data=Hy_data, coords=coords, dims=dims)
         Hz = xr.DataArray(data=Hz_data, coords=coords, dims=dims)
 
-        field_data = xr.Dataset(
-            {"Ex": Ex, "Ey": Ey, "Ez": Ez, "Hx": Hx, "Hy": Hy, "Hz": Hz})
+        field_data = xr.Dataset({"Ex": Ex, "Ey": Ey, "Ez": Ez, "Hx": Hx, "Hy": Hy, "Hz": Hz})
 
         return field_data
 

--- a/tidy3d/plugins/near2far/near2far.py
+++ b/tidy3d/plugins/near2far/near2far.py
@@ -3,12 +3,13 @@
 from typing import List, Dict
 import numpy as np
 import xarray as xr
+import dask.array as da
 import pydantic
 
 from ...constants import C_0, ETA_0, HERTZ, MICROMETER
 from ...components.data import SimulationData, FieldData
 from ...components.monitor import FieldMonitor
-from ...components.types import Direction, Axis, Coordinate
+from ...components.types import Direction, Axis, Coordinate, Numpy
 from ...components.medium import Medium
 from ...log import SetupError, ValidationError
 
@@ -388,7 +389,7 @@ the number of directions ({len(normal_dirs)})."
         return currents
 
     # pylint:disable=too-many-locals
-    def _radiation_vectors_for_surface(
+    def _radiation_vectors_for_surface_old(
         self, theta: float, phi: float, surface: Near2FarSurface, currents: xr.Dataset
     ):
         """Compute radiation vectors at an angle in spherical coordinates
@@ -417,21 +418,21 @@ the number of directions ({len(normal_dirs)})."
         sin_phi = np.sin(phi)
         cos_phi = np.cos(phi)
 
-        # make sure that observation points are interpreted w.r.t. the local origin
-        pts = [currents[name] - origin for name, origin in zip(["x", "y", "z"], self.origin)]
-
         k = self.k
 
-        phase_x = np.exp(-self.phasor_sign * 1j * k * pts[0] * sin_theta * cos_phi)
-        phase_y = np.exp(-self.phasor_sign * 1j * k * pts[1] * sin_theta * sin_phi)
-        phase_z = np.exp(-self.phasor_sign * 1j * k * pts[2] * cos_theta)
-        phase = phase_x * phase_y * phase_z
+        # make sure that observation points are interpreted w.r.t. the local origin
+        pts = [currents[name] - origin for name, origin in zip(["x", "y", "z"], self.origin)]
 
         _, idx_uv = surface.monitor.pop_axis((0, 1, 2), axis=surface.axis)
         _, source_names = surface.monitor.pop_axis(("x", "y", "z"), axis=surface.axis)
 
         idx_u, idx_v = idx_uv
         cmp_1, cmp_2 = source_names
+
+        phase_x = np.exp(-self.phasor_sign * 1j * k * pts[0] * sin_theta * cos_phi)
+        phase_y = np.exp(-self.phasor_sign * 1j * k * pts[1] * sin_theta * sin_phi)
+        phase_z = np.exp(-self.phasor_sign * 1j * k * pts[2] * cos_theta)
+        phase = phase_x * phase_y * phase_z
 
         J = [0, 0, 0]
         M = [0, 0, 0]
@@ -460,7 +461,103 @@ the number of directions ({len(normal_dirs)})."
 
         return N_theta, N_phi, L_theta, L_phi
 
-    def _radiation_vectors(self, theta: float, phi: float):
+    # pylint:disable=too-many-locals
+    def _radiation_vectors_for_surface(
+        self, theta: Numpy, phi: Numpy, surface: Near2FarSurface, currents: xr.Dataset
+    ):
+        """Compute radiation vectors at an angle in spherical coordinates
+        for a given set of surface currents and observation angles.
+
+        Parameters
+        ----------
+        theta : float
+            Polar angle (rad) downward from x=y=0 line relative to the local origin.
+        phi : float
+            Azimuthal (rad) angle from y=z=0 line relative to the local origin.
+        surface: :class:`Near2FarSurface`
+            :class:`Near2FarSurface` object to use as source of near field.
+        currents : xarray.Dataset
+            xarray Dataset containing surface currents associated with the surface monitor.
+
+        Returns
+        -------
+        tuple[float, float, float, float]
+            ``N_theta``, ``N_phi``, ``L_theta``, ``L_phi`` radiation vectors for the given surface.
+        """
+
+        da = np
+
+        k = self.k
+
+        # make sure that observation points are interpreted w.r.t. the local origin
+        pts = [currents[name] - origin for name, origin in zip(["x", "y", "z"], self.origin)]
+
+        _, idx_uv = surface.monitor.pop_axis((0, 1, 2), axis=surface.axis)
+        _, source_names = surface.monitor.pop_axis(("x", "y", "z"), axis=surface.axis)
+
+        idx_u, idx_v = idx_uv
+        cmp_1, cmp_2 = source_names
+
+        # currents = currents.chunk(chunks='auto')
+
+        sin_theta = da.sin(np.atleast_1d(theta))
+        cos_theta = da.cos(np.atleast_1d(theta))
+        sin_phi = da.sin(np.atleast_1d(phi))
+        cos_phi = da.cos(np.atleast_1d(phi))
+
+        term1 = np.atleast_1d(pts[0])[:, np.newaxis, np.newaxis] * da.outer(sin_theta, cos_phi)
+        term2 = np.atleast_1d(pts[1])[:, np.newaxis, np.newaxis] * da.outer(sin_theta, sin_phi)
+        term3 = (np.atleast_1d(pts[2])[:, np.newaxis] * cos_theta)[:, :, np.newaxis]
+
+        phase_x = (da.exp(-self.phasor_sign * 1j * k * term1))
+        phase_y = (da.exp(-self.phasor_sign * 1j * k * term2))
+        phase_z = (da.exp(-self.phasor_sign * 1j * k * term3))
+
+        phase = da.squeeze(phase_x[:, np.newaxis, np.newaxis] * phase_y[np.newaxis, :, np.newaxis] * phase_z[np.newaxis, np.newaxis, :])
+        dims = len(phase.shape) - 2
+
+        J = [0, 0, 0]
+        M = [0, 0, 0]
+
+        # def integrate_2D(function, dim_u: str, dim_v: str):
+        #     """Trapezoidal integration in two dimensions for an xarray dataset."""
+        #     outer_integrand = function.integrate(dim_u)
+        #     return outer_integrand.integrate(dim_v)
+
+        # J[idx_u] = integrate_2D(currents["J" + cmp_1].values[(..., *([np.newaxis] * dims))] * phase, cmp_1, cmp_2)
+        # J[idx_v] = integrate_2D(currents["J" + cmp_2].values[(..., *([np.newaxis] * dims))] * phase, cmp_1, cmp_2)
+
+        # M[idx_u] = integrate_2D(currents["M" + cmp_1].values[(..., *([np.newaxis] * dims))] * phase, cmp_1, cmp_2)
+        # M[idx_v] = integrate_2D(currents["M" + cmp_2].values[(..., *([np.newaxis] * dims))] * phase, cmp_1, cmp_2)
+
+        def integrate_2D(function, pts_u, pts_v):
+            """Trapezoidal integration in two dimensions."""
+            return np.trapz(np.trapz(function, pts_u, axis=0), pts_v, axis=0)
+
+        J[idx_u] = integrate_2D(currents["J" + cmp_1].values[(..., *([np.newaxis] * dims))] * phase, pts[idx_u], pts[idx_v])
+        J[idx_v] = integrate_2D(currents["J" + cmp_2].values[(..., *([np.newaxis] * dims))] * phase, pts[idx_u], pts[idx_v])
+
+        M[idx_u] = integrate_2D(currents["M" + cmp_1].values[(..., *([np.newaxis] * dims))] * phase, pts[idx_u], pts[idx_v])
+        M[idx_v] = integrate_2D(currents["M" + cmp_2].values[(..., *([np.newaxis] * dims))] * phase, pts[idx_u], pts[idx_v])
+
+        cos_theta_cos_phi = da.outer(cos_theta, cos_phi)
+        cos_theta_sin_phi = da.outer(cos_theta, sin_phi)
+
+        # N_theta (8.33a)
+        N_theta = J[0] * cos_theta_cos_phi + J[1] * cos_theta_sin_phi - J[2] * sin_theta[:, np.newaxis]
+
+        # N_phi (8.33b)
+        N_phi = -J[0] * sin_phi[np.newaxis, :] + J[1] * cos_phi[np.newaxis, :]
+
+        # L_theta  (8.34a)
+        L_theta = M[0] * cos_theta_cos_phi + M[1] * cos_theta_sin_phi - M[2] * sin_theta[:, np.newaxis]
+
+        # L_phi  (8.34b)
+        L_phi = -M[0] * sin_phi[np.newaxis, :] + M[1] * cos_phi[np.newaxis, :]
+
+        return N_theta, N_phi, L_theta, L_phi
+
+    def _radiation_vectors(self, theta: Numpy, phi: Numpy):
         """Compute radiation vectors at an angle in spherical coordinates.
 
         Parameters
@@ -477,7 +574,11 @@ the number of directions ({len(normal_dirs)})."
         """
 
         # compute radiation vectors for the dataset associated with each monitor
-        N_theta, N_phi, L_theta, L_phi = 0.0, 0.0, 0.0, 0.0
+        N_theta = np.zeros((len(np.atleast_1d(theta)), len(np.atleast_1d(phi))), dtype=complex)
+        N_phi = np.zeros_like(N_theta)
+        L_theta = np.zeros_like(N_theta)
+        L_phi = np.zeros_like(N_theta)
+
         for surface in self.surfaces:
             _N_th, _N_ph, _L_th, _L_ph = self._radiation_vectors_for_surface(
                 theta, phi, surface, self.currents[surface.monitor.name]
@@ -489,7 +590,7 @@ the number of directions ({len(normal_dirs)})."
 
         return N_theta, N_phi, L_theta, L_phi
 
-    def fields_spherical(self, r, theta, phi):
+    def fields_spherical(self, r: float, theta: Numpy, phi: Numpy):
         """Get fields at a point relative to monitor center in spherical coordinates.
 
         Parameters


### PR DESCRIPTION
`Near2Far` supports vectorized inputs in the observation coordinates; uses vectorized calculations where advantageous. Output far fields are now `xarray` datasets.

Note that the use of the progress bar in the function `_radiation_vectors_for_surface` is a bit ugly. This was to avoid a limitation of the progress bar: even when it is disabled (e.g. when only a single observation point is given) it still prints a bunch of blank lines. This is an issue for the functions which compute far fields in Cartesian coordinates. The "ugly" way only invokes the progress bar when more than one `theta` is given.