### PR TITLE
Momchil/mode solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Percent done monitoring of jobs running longer than 10 seconds.
 - Can use vectorized spherical coordinates in `tidy3d.plugins.Near2Far`.
+- `ModeSolverMonitor` and `ModeSolverData` allow the results of a mode solve run server-side to be stored.
+- Plotting of `ModeSolverData` fields in `SimulationData.plot_field`.
+- Ordering of modes by polarization fraction can be specified in `ModeSpec`.
 
 ### Changed
-
 - Significant speed improvement for `Near2Far` calculations.
+- `freq` no longer passed to `ModeSolver` upon init, instead a list of `freqs` passed to `ModeSolver.solve`.
+- Mode solver now returns `ModeSolverData` object containing information about the mode fields and propagation constants as data arrays over frequency and mode index.
 
 ## [1.1.1] - 2022-3-2
 

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -768,6 +768,8 @@ def test_monitor_plane():
         with pytest.raises(ValidationError) as e_info:
             ModeMonitor(size=size, freqs=freqs, modes=[])
         with pytest.raises(ValidationError) as e_info:
+            ModeSolverMonitor(size=size, freqs=freqs, modes=[])
+        with pytest.raises(ValidationError) as e_info:
             FluxMonitor(size=size, freqs=freqs, modes=[])
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -74,7 +74,7 @@ def test_mode_solver():
         size=(2, 2, 2), grid_size=(0.1, 0.1, 0.1), structures=[waveguide], run_time=1e-12
     )
     plane = td.Box(center=(0, 0, 0), size=(0, 1, 1))
-    ms = ModeSolver(simulation=simulation, plane=plane, freq=td.constants.C_0 / 1.5)
+    ms = ModeSolver(simulation=simulation, plane=plane)
     mode_spec = td.ModeSpec(
         num_modes=3,
         target_neff=2.0,
@@ -82,7 +82,7 @@ def test_mode_solver():
         bend_axis=0,
         num_pml=(10, 10),
     )
-    modes = ms.solve(mode_spec=mode_spec)
+    modes = ms.solve(mode_spec=mode_spec, freqs=[td.constants.C_0 / 1.])
 
 
 def _test_coeffs():

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -82,7 +82,7 @@ def test_mode_solver():
         bend_axis=0,
         num_pml=(10, 10),
     )
-    modes = ms.solve(mode_spec=mode_spec, freqs=[td.constants.C_0 / 1.])
+    modes = ms.solve(mode_spec=mode_spec, freqs=[td.constants.C_0 / 1.0])
 
 
 def _test_coeffs():

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -33,7 +33,7 @@ from .components import VolumeSource, PlaneWave, ModeSource, GaussianBeam
 
 # monitors
 from .components import FieldMonitor, FieldTimeMonitor, FluxMonitor, FluxTimeMonitor
-from .components import ModeMonitor
+from .components import ModeMonitor, ModeSolverMonitor
 
 # simulation
 from .components import Simulation

--- a/tidy3d/components/__init__.py
+++ b/tidy3d/components/__init__.py
@@ -27,8 +27,9 @@ from .source import GaussianPulse, ContinuousWave
 from .source import VolumeSource, PlaneWave, ModeSource, GaussianBeam
 
 # monitor
-from .monitor import AbstractFieldMonitor, FreqMonitor, TimeMonitor, FieldMonitor, FieldTimeMonitor
-from .monitor import Monitor, AbstractFluxMonitor, FluxMonitor, FluxTimeMonitor, ModeMonitor
+from .monitor import FreqMonitor, TimeMonitor, FieldMonitor, FieldTimeMonitor
+from .monitor import Monitor, FluxMonitor, FluxTimeMonitor, ModeMonitor
+from .monitor import ModeSolverMonitor
 
 # simulation
 from .simulation import Simulation

--- a/tidy3d/components/data.py
+++ b/tidy3d/components/data.py
@@ -723,6 +723,11 @@ class ModeIndexData(AbstractModeData):
         return
 
     @property
+    def n_complex(self):
+        """Complex effective index."""
+        return self.data
+
+    @property
     def n_eff(self):
         """Get real part of effective index."""
         return self.data.real
@@ -803,14 +808,14 @@ class ModeFieldData(AbstractFieldData):
     data_dict: Dict[str, ScalarModeFieldData]
     type: Literal["ModeFieldData"] = "ModeFieldData"
 
-    def isel_mode_index(self, mode_index):
+    def sel_mode_index(self, mode_index):
         """Return a FieldData at the selected mode index."""
         data_dict = {}
         for field_name, scalar_data in self.data_dict.items():
             scalar_dict = scalar_data.dict()
             scalar_dict.pop("mode_index")
             scalar_dict.pop("type")
-            scalar_dict["values"] = scalar_data.data.isel(mode_index=mode_index).values
+            scalar_dict["values"] = scalar_data.data.sel(mode_index=mode_index).values
             data_dict[field_name] = ScalarFieldData(**scalar_dict)
 
         return FieldData(data_dict=data_dict)

--- a/tidy3d/components/data.py
+++ b/tidy3d/components/data.py
@@ -823,6 +823,48 @@ class ModeFieldData(AbstractFieldData):
         return FieldData(data_dict=data_dict)
 
 
+class ModeSolverData(CollectionData):
+    """Stores a collection of mode field profiles and mode effective indexes from the mode solver.
+
+    Parameters
+    ----------
+    data_dict : Dict[str, :class:`AbstractModeData`]
+        Mapping of "n_complex" to :class:`ModeIndexData`, and "fields" to :class:`ModeFieldData`.
+    """
+
+    data_dict: Dict[str, Union[AbstractModeData, AbstractFieldData]]
+    type: Literal["ModeSolverData"] = "ModeSolverData"
+
+    @property
+    def fields(self):
+        """Get field data."""
+        return self.data_dict.get("fields")
+
+    @property
+    def n_complex(self):
+        """Get complex effective indexes."""
+        scalar_data = self.data_dict.get("n_complex")
+        if scalar_data:
+            return scalar_data.data
+        return None
+
+    @property
+    def n_eff(self):
+        """Get real part of effective index."""
+        scalar_data = self.data_dict.get("n_complex")
+        if scalar_data:
+            return scalar_data.n_eff
+        return None
+
+    @property
+    def k_eff(self):
+        """Get imaginary part of effective index."""
+        scalar_data = self.data_dict.get("n_complex")
+        if scalar_data:
+            return scalar_data.k_eff
+        return None
+
+
 # maps MonitorData.type string to the actual type, for MonitorData.from_file()
 DATA_TYPE_MAP = {
     "ScalarFieldData": ScalarFieldData,
@@ -836,6 +878,7 @@ DATA_TYPE_MAP = {
     "ModeData": ModeData,
     "ModeFieldData": ModeFieldData,
     "ScalarModeFieldData": ScalarModeFieldData,
+    "ModeSolverData": ModeSolverData,
 }
 
 

--- a/tidy3d/components/geometry.py
+++ b/tidy3d/components/geometry.py
@@ -712,6 +712,7 @@ class Box(Geometry):
                     width=width_factor * arrow_length,
                     color=color,
                     alpha=alpha,
+                    zorder=np.inf,
                 )
 
             add_arrow(sign=1.0)

--- a/tidy3d/components/mode.py
+++ b/tidy3d/components/mode.py
@@ -6,7 +6,7 @@ import pydantic as pd
 
 from ..constants import MICROMETER
 from .base import Tidy3dBaseModel
-from .types import Axis2D
+from .types import Axis2D, Literal
 from ..log import SetupError
 
 
@@ -32,6 +32,16 @@ class ModeSpec(Tidy3dBaseModel):
         (0, 0),
         title="Number of PML layers",
         description="Number of standard pml layers to add in the two tangential axes.",
+    )
+
+    sort_by: Literal["largest_neff", "te_fraction", "tm_fraction"] = pd.Field(
+        "largest_neff",
+        title="Ordering of the returned modes",
+        description="The solver will always compute the ``num_modes`` modes closest to the "
+        "``target_neff``, but they can be reordered by the largest ``te_fraction``, defined "
+        "as the integral of the intensity of the E-field component parallel to the first plane "
+        "axis normalized to the total in-plane E-field intensity. Similarly, ``tm_fraction`` "
+        "uses the E field component parallel to the second plane axis.",
     )
 
     bend_radius: float = pd.Field(

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -408,7 +408,7 @@ class ModeSolverMonitor(AbstractModeMonitor):
         field_size = 6 * BYTES_COMPLEX * num_cells * len(self.freqs) * self.mode_spec.num_modes
         # effective index stores 1 complex number per frequency per mode
         neff_size = BYTES_COMPLEX * len(self.freqs) * self.mode_spec.num_modes
-        return field_size * neff_size
+        return field_size + neff_size
 
 
 # types of monitors that are accepted by simulation

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -657,6 +657,12 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
             patch = PolygonPatch(shape, **kwargs_struct)
             ax.add_artist(patch)
         ax = self._set_plot_bounds(ax=ax, x=x, y=y, z=z)
+
+        # clean up the axis display
+        axis, position = self.parse_xyz_kwargs(x=x, y=y, z=z)
+        ax = self.add_ax_labels_lims(axis=axis, ax=ax)
+        ax.set_title(f"cross section at {'xyz'[axis]}={position:.2f}")
+
         return ax
 
     @staticmethod
@@ -728,6 +734,12 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
         if cbar:
             self._add_cbar(eps_min=eps_min, eps_max=eps_max, ax=ax)
         ax = self._set_plot_bounds(ax=ax, x=x, y=y, z=z)
+
+        # clean up the axis display
+        axis, position = self.parse_xyz_kwargs(x=x, y=y, z=z)
+        ax = self.add_ax_labels_lims(axis=axis, ax=ax)
+        ax.set_title(f"cross section at {'xyz'[axis]}={position:.2f}")
+
         return ax
 
     @equal_aspect

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -183,8 +183,11 @@ class ModeSolver(Tidy3dBaseModel):
         E, H = mode_fields[..., mode_index]
 
         # Warn if not decayed at edges
-        e_edge = np.sum(np.abs(E[:, 0, :]) ** 2 + np.abs(E[:, -1, :]) ** 2)
-        e_edge += np.sum(np.abs(E[:, :, 0]) ** 2 + np.abs(E[:, :, -1]) ** 2)
+        e_edge = 0
+        if E.shape[1] > 1:
+            e_edge = np.sum(np.abs(E[:, 0, :]) ** 2 + np.abs(E[:, -1, :]) ** 2)
+        if E.shape[2] > 1:
+            e_edge += np.sum(np.abs(E[:, :, 0]) ** 2 + np.abs(E[:, :, -1]) ** 2)
         e_norm = np.sum(np.abs(E) ** 2)
 
         if e_edge / e_norm > FIELD_DECAY_CUTOFF:

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -72,7 +72,22 @@ class ModeInfo(Tidy3dBaseModel):
 
     mode_spec: ModeSpec
     field_data: ModeFieldData
-    n_complex: ModeIndexData
+    index_data: ModeIndexData
+
+    @property
+    def n_complex(self):
+        """Complex effective index."""
+        return self.index_data.n_complex
+
+    @property
+    def n_eff(self):
+        """Get real part of effective index."""
+        return self.index_data.n_eff
+
+    @property
+    def k_eff(self):
+        """Get imaginary part of effective index."""
+        return self.index_data.k_eff
 
 
 class ModeSolver(Tidy3dBaseModel):
@@ -199,7 +214,7 @@ class ModeSolver(Tidy3dBaseModel):
         field_data = ModeFieldData(data_dict=data_dict).apply_syms(
             plane_grid, self.simulation.center, self.simulation.symmetry
         )
-        n_data = ModeIndexData(
+        index_data = ModeIndexData(
             f=freqs,
             mode_index=np.arange(mode_spec.num_modes),
             values=n_complex[None, ...],
@@ -207,7 +222,7 @@ class ModeSolver(Tidy3dBaseModel):
         mode_info = ModeInfo(
             field_data=field_data,
             mode_spec=mode_spec,
-            n_complex=n_data,
+            index_data=index_data,
         )
 
         return mode_info

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -20,23 +20,23 @@ from ...log import ValidationError
 from .solver import compute_modes
 
 FIELD = Tuple[Array[complex], Array[complex], Array[complex]]
-FIELD_DECAY_CUTOFF = 1e-3
+
+# Warning for field intensity at edges over total field intensity larger than this value
+FIELD_DECAY_CUTOFF = 1e-2
 
 
 class ModeSolver(Tidy3dBaseModel):
     """Interface for solving electromagnetic eigenmodes in a 2D plane with translational
     invariance in the third dimension.
-
-    Parameters
-    ----------
-    simulation : Simulation
-        ``Simulation`` the ``Mode`` will be inserted into.
-    plane : Box
-        Plane where the mode will be computed in ``Simulation``.
     """
 
-    simulation: Simulation
-    plane: Box
+    simulation: Simulation = pydantic.Field(
+        ..., title="Simulation", description="Simulation defining all structures and mediums."
+    )
+
+    plane: Box = pydantic.Field(
+        ..., title="Plane", description="Cross-sectional plane in which the mode will be computed."
+    )
 
     @pydantic.validator("plane", allow_reuse=True, always=True)
     def is_plane(cls, val):

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -38,7 +38,7 @@ class ModeSolver(Tidy3dBaseModel):
         ..., title="Plane", description="Cross-sectional plane in which the mode will be computed."
     )
 
-    @pydantic.validator("plane", allow_reuse=True, always=True)
+    @pydantic.validator("plane", always=True)
     def is_plane(cls, val):
         """Raise validation error if not planar."""
         if val.size.count(0.0) != 1:
@@ -60,7 +60,7 @@ class ModeSolver(Tidy3dBaseModel):
 
         Parameters
         ----------
-        mode_spec : ModeSpec
+        mode_spec : :class:`ModeSpec`
             ``ModeSpec`` object containing specifications of the mode solver.
         freqs : List[float]
             List of frequencies to solve at (Hz).
@@ -150,7 +150,7 @@ class ModeSolver(Tidy3dBaseModel):
         return np.stack((eps_xx, eps_yy, eps_zz), axis=0)
 
     def solver_eps(self, freq: float) -> Array[complex]:
-        """Get the diagonal permittivity as supplied to the sovler, with the nomral axis rotated to
+        """Get the diagonal permittivity as supplied to the sovler, with the normal axis rotated to
         z."""
 
         # Get diagonal epsilon components in the plane
@@ -169,7 +169,7 @@ class ModeSolver(Tidy3dBaseModel):
         return np.stack((eps_xx, eps_yy, eps_zz), axis=0)
 
     def rotate_field_coords(self, field):
-        """move the propagation axis=z to the proper order in the array"""
+        """Move the propagation axis=z to the proper order in the array."""
         f_x, f_y, f_z = np.moveaxis(field, source=3, destination=1 + self.normal_axis)
         f_rot = np.stack(self.plane.unpop_axis(f_z, (f_x, f_y), axis=self.normal_axis), axis=0)
         return f_rot
@@ -177,7 +177,7 @@ class ModeSolver(Tidy3dBaseModel):
     def process_fields(
         self, mode_fields: Array[complex], freq_index: int, mode_index: int
     ) -> Tuple[FIELD, FIELD]:
-        """transform solver fields to simulation axes, set gauge, and check decay at boundaries."""
+        """Transform solver fields to simulation axes, set gauge, and check decay at boundaries."""
 
         # Separate E and H fields (in solver coordinates)
         E, H = mode_fields[..., mode_index]
@@ -221,13 +221,13 @@ class ModeSolver(Tidy3dBaseModel):
         direction: Direction,
         mode_index: int = 0,
     ) -> ModeSource:
-        """Creates ``ModeSource`` from a Mode + additional specifications.
+        """Creates :class:`ModeSource` from a ModeSolver instance + additional specifications.
 
         Parameters
         ----------
-        mode_spec : ModeSpec
+        mode_spec : :class:`ModeSpec`
             :class:`ModeSpec` object containing specifications of mode.
-        source_time: SourceTime
+        source_time: :class:`SourceTime`
             Specification of the source time-dependence.
         direction : Direction
             Whether source will inject in ``"+"`` or ``"-"`` direction relative to plane normal.
@@ -252,11 +252,11 @@ class ModeSolver(Tidy3dBaseModel):
         )
 
     def to_monitor(self, mode_spec: ModeSpec, freqs: List[float], name: str) -> ModeMonitor:
-        """Creates ``ModeMonitor`` from a Mode + additional specifications.
+        """Creates :class:`ModeMonitor` from a ModeSolver instance + additional specifications.
 
         Parameters
         ----------
-        mode_spec : ModeSpec
+        mode_spec : :class:`ModeSpec`
             :class:`ModeSpec` object containing specifications of mode.
         freqs : List[float]
             Frequencies to include in Monitor (Hz).

--- a/tidy3d/plugins/mode/solver.py
+++ b/tidy3d/plugins/mode/solver.py
@@ -175,7 +175,7 @@ def compute_modes(
         E = E[..., sort_inds]
         H = H[..., sort_inds]
         neff = neff[..., sort_inds]
-        neff = neff[..., sort_inds]
+        keff = keff[..., sort_inds]
 
     # Transform back to original axes, E = J^T E'
     E = np.sum(jac_e[..., None] * E[:, None, ...], axis=0)

--- a/tidy3d/plugins/mode/solver.py
+++ b/tidy3d/plugins/mode/solver.py
@@ -46,6 +46,7 @@ def compute_modes(
     num_modes = mode_spec.num_modes
     bend_radius = mode_spec.bend_radius
     bend_axis = mode_spec.bend_axis
+    sort_by = mode_spec.sort_by
     omega = 2 * np.pi * freq
     k0 = omega / C_0
 
@@ -163,6 +164,18 @@ def compute_modes(
 
     # Solve for the modes
     E, H, neff, keff = solver_em(eps_tensor, mu_tensor, SDmats, num_modes, target_neff_p)
+
+    # Reorder if needed
+    if sort_by != "largest_neff":
+        if sort_by == "te_fraction":
+            sort_int = np.sum(np.abs(E[0]) ** 2, axis=0) / np.sum(np.abs(E[:2]) ** 2, axis=(0, 1))
+        elif sort_by == "tm_fraction":
+            sort_int = np.sum(np.abs(E[1]) ** 2, axis=0) / np.sum(np.abs(E[:2]) ** 2, axis=(0, 1))
+        sort_inds = np.argsort(sort_int)[::-1]
+        E = E[..., sort_inds]
+        H = H[..., sort_inds]
+        neff = neff[..., sort_inds]
+        neff = neff[..., sort_inds]
 
     # Transform back to original axes, E = J^T E'
     E = np.sum(jac_e[..., None] * E[:, None, ...], axis=0)


### PR DESCRIPTION
Some highlights:

- New `ModeFieldData` and `ScalarModeFieldData` are like `FieldData` but defined with an additional coordinate, `mode_index`.
- Revmoed `freq` from `ModeSolver` and instead `ModeSolver.solve` now takes a list of frequencies. `ModeSolver.to_source` takes a `source_time` instead of an `fwidth`.
- Frontend and backend tests pass, docs notebooks still need to be fixed.

And some thoughts:
- I have a `sel_mode_index` method on `ModeFieldData` right now, used in the backend. Should we instead consider introducing a `sel` method for all `CollectionData` objects, which iterates over all data and calls xarray `sel` if coordinate exists?
- I think we can combine `Tidy3dData` and `MonitorData` into just Tidy3dData? Right now `ModeFieldData` is technically a subclass of `MonitorData`, even though it's not really associated to a montior.
- `CollectionData`-s like `FieldData` have some nice properties, so I don't think we can convert them to Dataset, but maybe everything that's not a `CollectionData` can be converted to an xarray `DataArray` as per #228 .