### PR TITLE
Reorganizing of ModeSolver and ModeSolverData

### DIFF
--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -768,7 +768,7 @@ def test_monitor_plane():
         with pytest.raises(ValidationError) as e_info:
             ModeMonitor(size=size, freqs=freqs, modes=[])
         with pytest.raises(ValidationError) as e_info:
-            ModeSolverMonitor(size=size, freqs=freqs, modes=[])
+            ModeFieldMonitor(size=size, freqs=freqs, modes=[])
         with pytest.raises(ValidationError) as e_info:
             FluxMonitor(size=size, freqs=freqs, modes=[])
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -74,7 +74,6 @@ def test_mode_solver():
         size=(2, 2, 2), grid_size=(0.1, 0.1, 0.1), structures=[waveguide], run_time=1e-12
     )
     plane = td.Box(center=(0, 0, 0), size=(0, 1, 1))
-    ms = ModeSolver(simulation=simulation, plane=plane)
     mode_spec = td.ModeSpec(
         num_modes=3,
         target_neff=2.0,
@@ -82,7 +81,10 @@ def test_mode_solver():
         bend_axis=0,
         num_pml=(10, 10),
     )
-    modes = ms.solve(mode_spec=mode_spec, freqs=[td.constants.C_0 / 1.0])
+    ms = ModeSolver(
+        simulation=simulation, plane=plane, mode_spec=mode_spec, freqs=[td.constants.C_0 / 1.0]
+    )
+    modes = ms.solve()
 
 
 def _test_coeffs():

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -33,7 +33,7 @@ from .components import VolumeSource, PlaneWave, ModeSource, GaussianBeam
 
 # monitors
 from .components import FieldMonitor, FieldTimeMonitor, FluxMonitor, FluxTimeMonitor
-from .components import ModeMonitor, ModeSolverMonitor
+from .components import ModeMonitor, ModeFieldMonitor
 
 # simulation
 from .components import Simulation

--- a/tidy3d/components/__init__.py
+++ b/tidy3d/components/__init__.py
@@ -29,7 +29,7 @@ from .source import VolumeSource, PlaneWave, ModeSource, GaussianBeam
 # monitor
 from .monitor import FreqMonitor, TimeMonitor, FieldMonitor, FieldTimeMonitor
 from .monitor import Monitor, FluxMonitor, FluxTimeMonitor, ModeMonitor
-from .monitor import ModeSolverMonitor
+from .monitor import ModeFieldMonitor
 
 # simulation
 from .simulation import Simulation

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -225,7 +225,7 @@ class FieldMonitor(AbstractFieldMonitor, FreqMonitor):
     ...     name='steady_state_monitor')
     """
 
-    _data_type: Literal["ScalarFieldData"] = pydantic.Field("ScalarFieldData")
+    _data_type: Literal["FieldData"] = pydantic.Field("FieldData")
 
     def storage_size(self, num_cells: int, tmesh: Array) -> int:
         # stores 1 complex number per grid cell, per frequency, per field
@@ -316,7 +316,7 @@ class FieldTimeMonitor(AbstractFieldMonitor, TimeMonitor):
     ...     name='movie_monitor')
     """
 
-    _data_type: Literal["ScalarFieldTimeData"] = pydantic.Field("ScalarFieldTimeData")
+    _data_type: Literal["FieldTimeData"] = pydantic.Field("FieldTimeData")
 
     def storage_size(self, num_cells: int, tmesh: Array) -> int:
         # stores 1 real number per grid cell, per time step, per field
@@ -386,14 +386,14 @@ class ModeMonitor(AbstractModeMonitor):
         return 3 * BYTES_COMPLEX * len(self.freqs) * self.mode_spec.num_modes
 
 
-class ModeSolverMonitor(AbstractModeMonitor):
-    """:class:`Monitor` that stores the mode data (field profiles and effective index)
-    returned by the mode solver in the monitor plane.
+class ModeFieldMonitor(AbstractModeMonitor):
+    """:class:`Monitor` that stores the mode field profiles returned by the mode solver in the
+    monitor plane.
 
     Example
     -------
     >>> mode_spec = ModeSpec(num_modes=3)
-    >>> monitor = ModeSolverMonitor(
+    >>> monitor = ModeFieldMonitor(
     ...     center=(1,2,3),
     ...     size=(2,2,0),
     ...     freqs=[200e12, 210e12],
@@ -401,17 +401,15 @@ class ModeSolverMonitor(AbstractModeMonitor):
     ...     name='mode_monitor')
     """
 
-    _data_type: Literal["ModeSolverData"] = pydantic.Field("ModeSolverData")
+    _data_type: Literal["ModeFieldData"] = pydantic.Field("ModeFieldData")
 
     def storage_size(self, num_cells: int, tmesh: int) -> int:
         # fields store 6 complex numbers per grid cell, per frequency, per mode.
         field_size = 6 * BYTES_COMPLEX * num_cells * len(self.freqs) * self.mode_spec.num_modes
-        # effective index stores 1 complex number per frequency per mode
-        neff_size = BYTES_COMPLEX * len(self.freqs) * self.mode_spec.num_modes
-        return field_size + neff_size
+        return field_size
 
 
 # types of monitors that are accepted by simulation
 MonitorType = Union[
-    FieldMonitor, FieldTimeMonitor, FluxMonitor, FluxTimeMonitor, ModeMonitor, ModeSolverMonitor
+    FieldMonitor, FieldTimeMonitor, FluxMonitor, FluxTimeMonitor, ModeMonitor, ModeFieldMonitor
 ]

--- a/tidy3d/web/config.py
+++ b/tidy3d/web/config.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from dataclasses import dataclass
 
-SOLVER_VERSION = "multinode-22.1.6"
+SOLVER_VERSION = "release-22.1.6"
 
 
 @dataclass


### PR DESCRIPTION
- Remove current ModeSolverMonitor and ModeSolverData
- Introduce instead ModeFieldMonitor and ModeFieldData
- Put mode_spec and freqs as fields in ModeSolver
- ModeSolverData is the return of .solve and stores the ModeSolver simulation, plane, and mode_spec as well as well as the ModeFieldData and ModeIndexData

Notes:
- ModeSolverData is not storing the entire ModeSolver instance because of circular dependence in ModeSolver.solve which returns ModeSolverData...
- Yet to add a field plotting method which will use a lot of the same code from SimulationData