### PR TITLE
if the bytes string is already a string, just return it

### DIFF
--- a/tidy3d/components/data.py
+++ b/tidy3d/components/data.py
@@ -95,6 +95,8 @@ class Tidy3dData(Tidy3dBaseModel):
         string_value_bytes = hdf5_grp.get(string_key)
         if not string_value_bytes:
             return None
+        if isinstance(string_value_bytes, str):
+            return string_value_bytes
         return Tidy3dData.decode_bytes(string_value_bytes)
 
     @staticmethod


### PR DESCRIPTION
I dont know if we need this as long as h5py version is 3.0.0 or later.
I already changed requirements.txt to include this version requirement.