### PR TITLE
normalize sim data upon .from_file()

### DIFF
--- a/tidy3d/components/data.py
+++ b/tidy3d/components/data.py
@@ -1250,7 +1250,9 @@ class SimulationData(AbstractSimulationData):
                 mon_data.add_to_group(mon_grp)
 
     @classmethod
-    def from_file(cls, fname: str, normalize_index: Optional[int] = 0): #pylint:disable=arguments-differ
+    def from_file(
+        cls, fname: str, normalize_index: Optional[int] = 0
+    ):  # pylint:disable=arguments-differ
         """Load :class:`SimulationData` from .hdf5 file.
 
         Parameters


### PR DESCRIPTION
```python
from tidy3d import SimulationData

# load data and normalize it by default with normalilze_index=0
sim_data = SimulationData.from_file("something.hdf5")

print(sim_data.normalized)
# True

# saves the normalized version
sim_data.to_file("something2.hdf5")

# try to load again fails
sim_data2 = SimulationData.from_file("something2.hdf5")

[10:39:57] ERROR    Data from this file is already normalized.  log.py:33
                    Instead, load `.from_file()` with
                    `normalize_index=None.

# passes
sim_data2 = SimulationData.from_file("something2.hdf5", normalize_index=None)
```

Let me know if we want to change behavior here.