### PR TITLE
Momchil/sym data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - App / GUI for visualizing contents of `SimulationData` in `tidy3d.plugings.plotly`.
+- New `PermittivityMonitor` and `PermittivityData` to store the complex relative permittivity as used in the simulation.
 
 ### Changed
 - Faster plotting for matplotlib and plotly.
 - `SimulationData` normalization keeps track of source index and can be normalized when loading directly from .hdf5 file.
+- Monitor data with symmetries now store the minimum required data to file and expands the symmetries on the fly.
 
 ## [1.2.1] - 2022-3-30
 

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -33,7 +33,7 @@ from .components import VolumeSource, PlaneWave, ModeSource, GaussianBeam
 
 # monitors
 from .components import FieldMonitor, FieldTimeMonitor, FluxMonitor, FluxTimeMonitor
-from .components import ModeMonitor, ModeFieldMonitor
+from .components import ModeMonitor, ModeFieldMonitor, PermittivityMonitor
 
 # simulation
 from .components import Simulation

--- a/tidy3d/components/__init__.py
+++ b/tidy3d/components/__init__.py
@@ -29,7 +29,7 @@ from .source import VolumeSource, PlaneWave, ModeSource, GaussianBeam
 # monitor
 from .monitor import FreqMonitor, TimeMonitor, FieldMonitor, FieldTimeMonitor
 from .monitor import Monitor, FluxMonitor, FluxTimeMonitor, ModeMonitor
-from .monitor import ModeFieldMonitor
+from .monitor import ModeFieldMonitor, PermittivityMonitor
 
 # simulation
 from .simulation import Simulation

--- a/tidy3d/components/data.py
+++ b/tidy3d/components/data.py
@@ -401,8 +401,10 @@ class SpatialCollectionData(CollectionData, ABC):
                 new_data = new_data.interp({dim_name: coords_interp}, kwargs={"fill_value": 0.0})
                 new_data = new_data.assign_coords({dim_name: coords})
 
-                # Apply the correct +/-1 for the data_key component
-                new_data[{dim_name: flip_inds}] *= sym * self._sym_dict[data_key][dim]
+                sym_eval = self._sym_dict.get(data_key)
+                if sym_eval:
+                    # Apply the correct +/-1 for the data_key component
+                    new_data[{dim_name: flip_inds}] *= sym * sym_eval[dim]
 
             new_data_dict[data_key] = type(scalar_data)(values=new_data.values, **new_data.coords)
 
@@ -781,7 +783,6 @@ class PermittivityData(SpatialCollectionData):
 
     data_dict: Dict[str, ScalarPermittivityData]
     type: Literal["PermittivityData"] = "PermittivityData"
-    _sym_dict = {"eps_xx": (1, 1, 1), "eps_yy": (1, 1, 1), "eps_zz": (1, 1, 1)}
 
     """ Get the permittivity components from the dict using convenient "dot" syntax."""
 
@@ -882,7 +883,7 @@ class ModeData(CollectionData):
     >>> data = ModeData(data_dict={'n_complex': index_data, 'amps': amps_data})
     """
 
-    data_dict: Dict[str, AbstractModeData]
+    data_dict: Dict[str, Union[ModeAmpsData, ModeIndexData]]
     type: Literal["ModeData"] = "ModeData"
 
     @property
@@ -944,6 +945,8 @@ class ModeFieldData(AbstractFieldData):
 DATA_TYPE_MAP = {
     "ScalarFieldData": ScalarFieldData,
     "ScalarFieldTimeData": ScalarFieldTimeData,
+    "ScalarPermittivityData": ScalarPermittivityData,
+    "ScalarModeFieldData": ScalarModeFieldData,
     "FieldData": FieldData,
     "FieldTimeData": FieldTimeData,
     "PermittivityData": PermittivityData,
@@ -953,7 +956,6 @@ DATA_TYPE_MAP = {
     "ModeIndexData": ModeIndexData,
     "ModeData": ModeData,
     "ModeFieldData": ModeFieldData,
-    "ScalarModeFieldData": ScalarModeFieldData,
 }
 
 

--- a/tidy3d/components/grid.py
+++ b/tidy3d/components/grid.py
@@ -370,9 +370,24 @@ class Grid(Tidy3dBaseModel):
         return inds_list
 
     def periodic_subspace(self, axis: Axis, ind_beg: int = 0, ind_end: int = 0) -> Coords1D:
-        """Pick a subspace of 1D coords within ``range(ind_beg, ind_end)``. If any indexes lie
-        outside of the coords array, periodic padding is used, where the zeroth and last element
-        of coords are identified."""
+        """Pick a subspace of 1D boundaries within ``range(ind_beg, ind_end)``. If any indexes lie
+        outside of the grid boundaries array, periodic padding is used, where the zeroth and last
+        element of the boundaries are identified.
+
+        Parameters
+        ----------
+        axis : Axis
+            Axis along which to pick the subspace.
+        ind_beg : int, optional
+            Starting index for the subspace.
+        ind_end : int, optional
+            Ending index for the subspace.
+
+        Returns
+        -------
+        Coords1D
+            The subspace of the grid along ``axis``.
+        """
 
         coords = self.boundaries.to_list[axis]
         padded_coords = coords

--- a/tidy3d/components/grid.py
+++ b/tidy3d/components/grid.py
@@ -328,7 +328,7 @@ class Grid(Tidy3dBaseModel):
             Rectangular geometry within simulation to discretize.
         extend : bool = False
             If ``True``, ensure that the returned indexes extend sufficiently in very direction to
-            be able to interpolate any field component at any point within the Box.
+            be able to interpolate any field component at any point within the ``box``.
 
         Returns
         -------
@@ -377,10 +377,10 @@ class Grid(Tidy3dBaseModel):
         Parameters
         ----------
         axis : Axis
-            Axis along which to pick the subspace.
-        ind_beg : int, optional
+            Axis index along which to pick the subspace.
+        ind_beg : int = 0
             Starting index for the subspace.
-        ind_end : int, optional
+        ind_end : int = 0
             Ending index for the subspace.
 
         Returns

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -321,7 +321,9 @@ class FieldTimeMonitor(AbstractFieldMonitor, TimeMonitor):
 
 class PermittivityMonitor(FreqMonitor):
     """:class:`Monitor` that records the diagonal components of the complex-valued relative
-    permittivity tensor in the frequency domain.
+    permittivity tensor in the frequency domain. The recorded data has the same shape as a
+    :class:`.FieldMonitor` of the same geometry: the permittivity values are saved at the
+    Yee grid locations, and can be interpolated to any point inside the monitor.
 
     Example
     -------

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -319,6 +319,26 @@ class FieldTimeMonitor(AbstractFieldMonitor, TimeMonitor):
         return BYTES_REAL * num_steps * num_cells * len(self.fields)
 
 
+class PermittivityMonitor(FreqMonitor):
+    """:class:`Monitor` that records the diagonal components of the complex-valued relative
+    permittivity tensor in the frequency domain.
+
+    Example
+    -------
+    >>> monitor = PermittivityMonitor(
+    ...     center=(1,2,3),
+    ...     size=(2,2,2),
+    ...     freqs=[250e12, 300e12],
+    ...     name='eps_monitor')
+    """
+
+    _data_type: Literal["PermittivityData"] = pydantic.Field("PermittivityData")
+
+    def storage_size(self, num_cells: int, tmesh: Array) -> int:
+        # stores 3 complex number per grid cell, per frequency
+        return BYTES_COMPLEX * num_cells * len(self.freqs) * 3
+
+
 class FluxMonitor(AbstractFluxMonitor, FreqMonitor):
     """:class:`Monitor` that records power flux through a plane in the frequency domain.
 
@@ -406,5 +426,11 @@ class ModeFieldMonitor(AbstractModeMonitor):
 
 # types of monitors that are accepted by simulation
 MonitorType = Union[
-    FieldMonitor, FieldTimeMonitor, FluxMonitor, FluxTimeMonitor, ModeMonitor, ModeFieldMonitor
+    FieldMonitor,
+    FieldTimeMonitor,
+    PermittivityMonitor,
+    FluxMonitor,
+    FluxTimeMonitor,
+    ModeMonitor,
+    ModeFieldMonitor,
 ]

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -349,7 +349,7 @@ class ModeSolver(Tidy3dBaseModel):
             )
 
         field_data = ModeFieldData(data_dict=data_dict).apply_syms(
-            plane_grid, self.simulation.center, self.simulation.symmetry
+            plane_grid.yee.grid_dict, self.simulation.center, self.simulation.symmetry
         )
         index_data = ModeIndexData(
             f=self.freqs,

--- a/tidy3d/plugins/plotly/data.py
+++ b/tidy3d/plugins/plotly/data.py
@@ -12,7 +12,7 @@ from .component import UIComponent
 from .utils import PlotlyFig
 
 from ...components.data import FluxData, FluxTimeData, FieldData, FieldTimeData
-from ...components.data import ModeFieldData, ModeData, AbstractScalarFieldData
+from ...components.data import ModeFieldData, ModeData, ScalarSpatialData
 from ...components.geometry import Geometry
 from ...components.types import Axis, Direction
 from ...log import Tidy3dKeyError, log
@@ -491,7 +491,7 @@ class AbstractFieldDataPlotly(DataPlotly, ABC):
         return field_vals[0]
 
     @property
-    def scalar_field_data(self) -> AbstractScalarFieldData:
+    def scalar_field_data(self) -> ScalarSpatialData:
         """The current scalar field monitor data."""
         if self.field_val is None:
             self.field_val = self.inital_field_val

--- a/tidy3d/version.py
+++ b/tidy3d/version.py
@@ -1,3 +1,3 @@
 """Defines the front end version of tidy3d"""
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"


### PR DESCRIPTION
- Field data with symmetries is now loaded and saved in the smallest required region only. It is automatically expanded upon `field_data = sim_data[monitor_name]`
- New PermittivityData and PermittivityMonitor
- Reorganizing data.py a little bit