### PR TITLE
Dash App Refinements

### DIFF
--- a/tidy3d/plugins/__init__.py
+++ b/tidy3d/plugins/__init__.py
@@ -5,3 +5,5 @@ from .dispersion.fit_web import StableDispersionFitter, AdvancedFitterParam
 from .mode.mode_solver import ModeSolver
 from .near2far.near2far import Near2Far, Near2FarSurface
 from .smatrix.smatrix import ComponentModeler, Port
+from .plotly.app import SimulationDataApp
+from .plotly.simulation import SimulationPlotly

--- a/tidy3d/plugins/plotly/app.py
+++ b/tidy3d/plugins/plotly/app.py
@@ -21,6 +21,10 @@ PORT = 8090
 DEV_TOOLS_UI = False
 DEV_TOOLS_HOT_RELOAD = False
 
+# external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
+
+# app = Dash(__name__, external_stylesheets=external_stylesheets)
+
 
 class App(Tidy3dBaseModel, ABC):
     """Basic dash app template: initializes, makes layout, and fires up a server."""
@@ -34,9 +38,9 @@ class App(Tidy3dBaseModel, ABC):
     def _initialize_app(self) -> Dash:
         """Creates an app based on specs."""
         if "jupyter" in self.mode.lower():
-            return JupyterDash(__name__)
+            return JupyterDash(__name__)  # , external_stylesheets=external_stylesheets)
         if "python" in self.mode.lower():
-            return Dash(__name__)
+            return Dash(__name__)  # external_stylesheets=external_stylesheets)
         raise NotImplementedError(f"App doesn't support mode='{self.mode}'.")
 
     @abstractmethod

--- a/tidy3d/plugins/plotly/simulation.py
+++ b/tidy3d/plugins/plotly/simulation.py
@@ -584,19 +584,19 @@ class SimulationPlotly(UIComponent):
         self,
         fig: PlotlyFig,
         normal_axis: Axis,
-        width_pixels: float = 700,
+        # width_pixels: float = 700,
     ) -> PlotlyFig:
-        """Set the lmits and make equal aspect."""
+        """Set the limits."""
 
         (xmin, xmax), (ymin, ymax) = self._plotly_bounds(normal_axis=normal_axis)
 
-        width = xmax - xmin
-        height = ymax - ymin
+        # width = xmax - xmin
+        # height = ymax - ymin
 
         fig.update_xaxes(range=[xmin, xmax])
         fig.update_yaxes(range=[ymin, ymax])
 
-        fig.update_layout(width=float(width_pixels), height=float(width_pixels) * height / width)
+        # fig.update_layout(width=float(width_pixels), height=float(width_pixels) * height / width)
         return fig
 
     @staticmethod

--- a/tidy3d/plugins/plotly/utils.py
+++ b/tidy3d/plugins/plotly/utils.py
@@ -44,10 +44,10 @@ def equal_aspect_plotly(plotly):
     def _plotly(*args, **kwargs) -> PlotlyFig:
         """New plot function with equal aspect ratio axes returned."""
         fig = plotly(*args, **kwargs)
-        fig.update_yaxes(
-            scaleanchor="x",
-            scaleratio=1,
-        )
+        # fig.update_yaxes(
+        #     scaleanchor="x",
+        #     scaleratio=1,
+        # )
         fig.update_layout(plot_bgcolor="rgba(0,0,0,0)")
         return fig
 


### PR DESCRIPTION
## My own to do

- [ ] Eliminate slider bar for single values of things in coords list.
- [ ] Change fonts, colors, and cosmetic styling.

## Momchil comments

- [ ] `monitor.geometry.size` being 0 along a specific dimension should cause it to be ignored.
- [ ] Just a line plot for 1D monitor data
- [ ] Only give the planar data for 2D monitor, without the option to choose a different cross-section.
- [ ] Continuous slider bars vs discrete slider bars with positions only where data exists? (same treatment for x,y,z,t,and f)?
- [ ] If it performs fast enough, I don't see why not continuous.
- [ ] wondering if we can't have plotly and jupyter-dash as optional dependencies
- [x] it didn't pop up for me (chrome), and the hyperlink didn't work either, I had to copy the url in a new window. (Should be fixed)
- [ ] For small values of e.g. flux I'm getting some mu and n values on the tick labels. Is this supposed to mean 1e-6 and 1e-9, respectively? It may be confusing.
- [ ] Something's wrong with the simulation plotting in the y and z cross-sections. (has to do with aspect ratio and sizes).
- [ ] Equal aspect ratio in field plotting would be nice.

## Shash comments
- [x] didnt pop up (Should be fixed)
- [x] Figure size is off, lots of space on sides.
- [ ] Way too many decimal places in slider bar ticks
- [ ] edit axis labels, titles, etc for production ready plots.

## Xin comments
- [ ] Be able to visualize results (and structures) for 2D simulations.