### PR TITLE
Changing custom dls centering

### DIFF
--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -154,8 +154,8 @@ def test_sim_symmetry_grid():
 
     coords_x, coords_y, coords_z = sim.grid.boundaries.to_list
 
-    # Assert coords size is even for the non-symmetry axis but odd otherwise
-    assert coords_x.size % 2 == 0
+    # Assert coords size is odd
+    assert coords_x.size % 2 != 0
     assert coords_y.size % 2 != 0
     assert coords_z.size % 2 != 0
 

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -1280,8 +1280,8 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
         dl = np.array(dl)
         bound_coords = np.array([np.sum(dl[:i]) for i in range(len(dl) + 1)])
 
-        # place the middle boundary at the center of the simulation along dimension
-        bound_coords += center - bound_coords[bound_coords.size // 2]
+        # place the middle of the bounds at the center of the simulation along dimension
+        bound_coords += center - bound_coords[-1] / 2
 
         # chop off any coords outside of simulation bounds
         bound_min = center - size / 2


### PR DESCRIPTION
Previously we always put the N/2 - th grid boundary at the simulation center. Now we just put the simulation center at `sum(dls) / 2`, which makes more sense (even with respect to the description of the `dls` in the `grid_size` Field), and is also less constrictive.