### PR TITLE
added kwargs to alternate constructor classmethods

### DIFF
--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -76,14 +76,16 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         rich.inspect(self, methods=methods)
 
     @classmethod
-    def from_file(cls, fname: str):
+    def from_file(cls, fname: str, **parse_kwargs):
         """Loads a :class:`Tidy3dBaseModel` from .yaml or .json file.
 
         Parameters
         ----------
         fname : str
             Full path to the .yaml or .json file to load the :class:`Tidy3dBaseModel` from.
-
+        **parse_kwargs
+            Keyword arguments passed to either pydantic's ``parse_file`` or ``parse_raw`` methods
+            for ``.json`` and ``.yaml`` file formats, respectively.
         Returns
         -------
         :class:`Tidy3dBaseModel`
@@ -94,9 +96,9 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         >>> simulation = Simulation.from_file(fname='folder/sim.json')
         """
         if ".json" in fname:
-            return cls.from_json(fname=fname)
+            return cls.from_json(fname=fname, **parse_kwargs)
         if ".yaml" in fname:
-            return cls.from_yaml(fname=fname)
+            return cls.from_yaml(fname=fname, **parse_kwargs)
         raise FileError(f"File must be .json or .yaml, given {fname}")
 
     def to_file(self, fname: str) -> None:
@@ -118,7 +120,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         raise FileError(f"File must be .json or .yaml, given {fname}")
 
     @classmethod
-    def from_json(cls, fname: str):
+    def from_json(cls, fname: str, **parse_file_kwargs):
         """Load a :class:`Tidy3dBaseModel` from .json file.
 
         Parameters
@@ -130,12 +132,14 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         -------
         :class:`Tidy3dBaseModel`
             An instance of the component class calling `load`.
+        **parse_file_kwargs
+            Keyword arguments passed to pydantic's ``parse_file`` method.
 
         Example
         -------
         >>> simulation = Simulation.from_json(fname='folder/sim.json')
         """
-        return cls.parse_file(fname)
+        return cls.parse_file(fname, **parse_file_kwargs)
 
     def to_json(self, fname: str) -> None:
         """Exports :class:`Tidy3dBaseModel` instance to .json file
@@ -154,13 +158,15 @@ class Tidy3dBaseModel(pydantic.BaseModel):
             file_handle.write(json_string)
 
     @classmethod
-    def from_yaml(cls, fname: str):
+    def from_yaml(cls, fname: str, **parse_raw_kwargs):
         """Loads :class:`Tidy3dBaseModel` from .yaml file.
 
         Parameters
         ----------
         fname : str
             Full path to the .yaml file to load the :class:`Tidy3dBaseModel` from.
+        **parse_raw_kwargs
+            Keyword arguments passed to pydantic's ``parse_raw`` method.
 
         Returns
         -------
@@ -174,7 +180,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         with open(fname, "r", encoding="utf-8") as yaml_in:
             json_dict = yaml.safe_load(yaml_in)
         json_raw = json.dumps(json_dict, indent=INDENT)
-        return cls.parse_raw(json_raw)
+        return cls.parse_raw(json_raw, **parse_raw_kwargs)
 
     def to_yaml(self, fname: str) -> None:
         """Exports :class:`Tidy3dBaseModel` instance to .yaml file.

--- a/tidy3d/components/data.py
+++ b/tidy3d/components/data.py
@@ -1452,7 +1452,7 @@ class SimulationData(AbstractSimulationData):
 
     @classmethod
     def from_file(
-        cls, fname: str, normalize_index: Optional[int] = 0
+        cls, fname: str, normalize_index: Optional[int] = 0, **kwargs
     ):  # pylint:disable=arguments-differ
         """Load :class:`SimulationData` from .hdf5 file.
 
@@ -1501,6 +1501,7 @@ class SimulationData(AbstractSimulationData):
             monitor_data=monitor_data_dict,
             log_string=log_string,
             diverged=diverged,
+            **kwargs,
         )
 
         # make sure to tag the SimulationData with the normalize_index stored from file

--- a/tidy3d/components/geometry.py
+++ b/tidy3d/components/geometry.py
@@ -715,7 +715,7 @@ class Box(Geometry):
     )
 
     @classmethod
-    def from_bounds(cls, rmin: Coordinate, rmax: Coordinate):
+    def from_bounds(cls, rmin: Coordinate, rmax: Coordinate, **kwargs):
         """Constructs a :class:`Box` from minimum and maximum coordinate bounds
 
         Parameters
@@ -738,7 +738,7 @@ class Box(Geometry):
 
         center = tuple(get_center(pt_min, pt_max) for pt_min, pt_max in zip(rmin, rmax))
         size = tuple((pt_max - pt_min) for pt_min, pt_max in zip(rmin, rmax))
-        return cls(center=center, size=size)
+        return cls(center=center, size=size, **kwargs)
 
     def intersections(self, x: float = None, y: float = None, z: float = None):
         """Returns shapely geometry at plane specified by one non None value of x,y,z.
@@ -1290,7 +1290,7 @@ class PolySlab(Planar):
         return val
 
     @classmethod
-    def from_gds(  # pylint:disable=too-many-arguments
+    def from_gds(  # pylint:disable=too-many-arguments, too-many-locals
         cls,
         gds_cell,
         axis: Axis,
@@ -1300,6 +1300,7 @@ class PolySlab(Planar):
         gds_scale: pydantic.PositiveFloat = 1.0,
         dilation: float = 0.0,
         sidewall_angle: float = 0,
+        **kwargs,
     ) -> List["PolySlab"]:
         """Import :class:`PolySlab` from a ``gdspy.Cell``.
 
@@ -1361,6 +1362,7 @@ class PolySlab(Planar):
                 slab_bounds=slab_bounds,
                 dilation=dilation,
                 sidewall_angle=sidewall_angle,
+                **kwargs,
             )
             for verts in all_vertices
         ]

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -259,7 +259,7 @@ class Medium(AbstractMedium):
         )
 
     @classmethod
-    def from_nk(cls, n: float, k: float, freq: float):
+    def from_nk(cls, n: float, k: float, freq: float, **kwargs):
         """Convert ``n`` and ``k`` values at frequency ``freq`` to :class:`Medium`.
 
         Parameters
@@ -277,7 +277,7 @@ class Medium(AbstractMedium):
             medium containing the corresponding ``permittivity`` and ``conductivity``.
         """
         eps, sigma = AbstractMedium.nk_to_eps_sigma(n, k, freq)
-        return cls(permittivity=eps, conductivity=sigma)
+        return cls(permittivity=eps, conductivity=sigma, **kwargs)
 
 
 class AnisotropicMedium(AbstractMedium):
@@ -499,7 +499,7 @@ class Sellmeier(DispersiveMedium):
         )
 
     @classmethod
-    def from_dispersion(cls, n: float, freq: float, dn_dwvl: float = 0):
+    def from_dispersion(cls, n: float, freq: float, dn_dwvl: float = 0, **kwargs):
         """Convert ``n`` and wavelength dispersion ``dn_dwvl`` values at frequency ``freq`` to
         a single-pole :class:`Sellmeier` medium.
 
@@ -529,7 +529,7 @@ class Sellmeier(DispersiveMedium):
         b_coeff = (wvl**2 - c_coeff) / wvl**2 * nsqm1
         coeffs = [(b_coeff, c_coeff)]
 
-        return cls(coeffs=coeffs)
+        return cls(coeffs=coeffs, **kwargs)
 
 
 class Lorentz(DispersiveMedium):

--- a/tidy3d/plugins/dispersion/fit.py
+++ b/tidy3d/plugins/dispersion/fit.py
@@ -604,7 +604,7 @@ class DispersionFitter(BaseModel):
             raise ValidationError("Invalid URL. Too many k labels.")
 
     @classmethod
-    def from_url(cls, url_file: str, delimiter: str = ","):
+    def from_url(cls, url_file: str, delimiter: str = ",", **kwargs):
         """loads :class:`DispersionFitter` from url linked to a csv/txt file that
         contains wavelength (micron), n, and optionally k data. Preferred from
         refractiveindex.info.
@@ -690,8 +690,8 @@ class DispersionFitter(BaseModel):
                     "Invalid URL. Both n and k should be provided at each wavelength."
                 )
 
-            return cls(wvl_um=n_lam[:, 0], n_data=n_lam[:, 1], k_data=k_lam[:, 1])
-        return cls(wvl_um=n_lam[:, 0], n_data=n_lam[:, 1])
+            return cls(wvl_um=n_lam[:, 0], n_data=n_lam[:, 1], k_data=k_lam[:, 1], **kwargs)
+        return cls(wvl_um=n_lam[:, 0], n_data=n_lam[:, 1], **kwargs)
 
     @classmethod
     def from_file(cls, fname: str, **loadtxt_kwargs):

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -138,7 +138,7 @@ class ModeSolverData(AbstractSimulationData):
             self.add_to_handle(f_handle)
 
     @classmethod
-    def from_file(cls, fname: str):
+    def from_file(cls, fname: str, **kwargs):  # pylint:disable=unused-argument
         """Load :class:`.ModeSolverData` from .hdf5 file.
 
         Parameters

--- a/tidy3d/plugins/webplots/app.py
+++ b/tidy3d/plugins/webplots/app.py
@@ -100,13 +100,13 @@ class SimulationDataApp(App):
 
     @classmethod
     def from_file(
-        cls, fname: str, mode: AppMode = DEFAULT_MODE, normalize_index: Optional[int] = 0
+        cls, fname: str, mode: AppMode = DEFAULT_MODE, normalize_index: Optional[int] = 0, **kwargs
     ):  # pylint:disable=arguments-differ
         """Load the :class:`.SimulationDataApp` from a tidy3d data file in .hdf5 format."""
         sim_data = SimulationData.from_file(fname, normalize_index=normalize_index)
 
         set_store(LocalStore(fname))
-        return cls(sim_data=sim_data, mode=mode)
+        return cls(sim_data=sim_data, mode=mode, **kwargs)
 
 
 class SimulationApp(App):
@@ -117,7 +117,9 @@ class SimulationApp(App):
     )
 
     @classmethod
-    def from_file(cls, fname: str, mode: AppMode = DEFAULT_MODE):  # pylint:disable=arguments-differ
+    def from_file(
+        cls, fname: str, mode: AppMode = DEFAULT_MODE, **kwargs
+    ):  # pylint:disable=arguments-differ
         """Load the SimulationApp from a tidy3d Simulation file in .json or .yaml format."""
         simulation = Simulation.from_file(fname)
-        return cls(simulation=simulation, mode=mode)
+        return cls(simulation=simulation, mode=mode, **kwargs)

--- a/tidy3d/plugins/webplots/data.py
+++ b/tidy3d/plugins/webplots/data.py
@@ -63,7 +63,7 @@ class DataPlotly(UIComponent, ABC):
         return {"type": f"{type(self.data).__name__}_{value}", "name": self.monitor_name}
 
     @classmethod
-    def from_monitor_data(cls, monitor_name: str, monitor_data: Tidy3dDataType) -> "cls":
+    def from_monitor_data(cls, monitor_name: str, monitor_data: Tidy3dDataType, **kwargs) -> "cls":
         """Load a PlotlyData UI component from the monitor name and its data."""
 
         # maps the supplied ``monitor_data`` argument to the corresponding plotly wrapper.
@@ -89,7 +89,7 @@ class DataPlotly(UIComponent, ABC):
             return None
 
         # return the right component
-        return plotly_data_type(data=monitor_data, monitor_name=monitor_name)
+        return plotly_data_type(data=monitor_data, monitor_name=monitor_name, **kwargs)
 
 
 class AbstractFluxDataPlotly(DataPlotly, ABC):


### PR DESCRIPTION
These get passed to the `init` functions.

Example

```python

class Box(Geometry):

    @classmethod
    def from_bounds(cls, rmin: Coordinate, rmax: Coordinate, **kwargs):

        def get_center(pt_min: float, pt_max: float) -> float:
            """Returns center point based on bounds along dimension."""
            if np.isneginf(pt_min) and np.isposinf(pt_max):
                return 0.0
            return (pt_min + pt_max) / 2.0

        center = tuple(get_center(pt_min, pt_max) for pt_min, pt_max in zip(rmin, rmax))
        size = tuple((pt_max - pt_min) for pt_min, pt_max in zip(rmin, rmax))
        return cls(center=center, size=size, **kwargs)
```

Doing it this way means you can call 

```python
sim = Simulation.from_bounds(rmin=(0,0,0), rmax=(1,1,1), grid_size=(.1, .1, .1), run_time=1e-12)

mon = FluxMonitor.from_bounds(rmin=(0,0,0), rmax=(0,1,1), freqs=[1e14])

```
automatically.