### PR TITLE
Rearranging make_coords_initial and fixing symmetry bug in auto mesh

### DIFF
--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -66,17 +66,13 @@ class GridSpec1d(Tidy3dBaseModel, ABC):
         )
 
         # incooperate symmetries
-        # print(bound_coords)
         if symmetry[axis] != 0:
             # Offset to center if symmetry present
-            # print(structures[0])
             center = structures[0].geometry.center[axis]
             center_ind = np.argmin(np.abs(center - bound_coords))
-            # print(center_ind, bound_coords[center_ind])
             bound_coords += center - bound_coords[center_ind]
             bound_coords = bound_coords[bound_coords >= center]
             bound_coords = np.append(2 * center - bound_coords[:0:-1], bound_coords)
-        # print(bound_coords)
 
         # Add PML layers in using dl on edges
         bound_coords = self._add_pml_to_bounds(num_pml_layers, bound_coords)
@@ -330,6 +326,7 @@ class AutoGrid(GridSpec1d):
         struct_list = [
             Structure(geometry=Box(center=sim_cent, size=sim_size), medium=structures[0].medium)
         ]
+        # Remove structures that are outside the simulation domain (with symmetry applied)
         for structure in structures[1:]:
             if struct_list[0].geometry.intersects(structure.geometry):
                 struct_list.append(structure)

--- a/tidy3d/components/grid/mesher.py
+++ b/tidy3d/components/grid/mesher.py
@@ -108,7 +108,7 @@ class GradedMesher(Mesher):
             struct_contains.append(self.contains_2d(bbox, struct_bbox[:struct_ind]))
 
             # Figure out where to place the bounding box coordinates of current structure
-            indsmin = np.argwhere(bbox[0, 2] < interval_coords)
+            indsmin = np.argwhere(bbox[0, 2] <= interval_coords)
             indmin = int(indsmin[0])
             bbox0 = np.copy(bbox)
             bbox0[1, 2] = bbox0[0, 2]
@@ -119,7 +119,7 @@ class GradedMesher(Mesher):
                 struct_list = interval_structs[max(0, indmin - 1)]
                 interval_structs.insert(indmin, struct_list.copy())
 
-            indsmax = np.argwhere(bbox[1, 2] > interval_coords)
+            indsmax = np.argwhere(bbox[1, 2] >= interval_coords)
             indmax = int(indsmax[-1])
             bbox0 = np.copy(bbox)
             bbox0[0, 2] = bbox0[1, 2]

--- a/tidy3d/components/grid/mesher.py
+++ b/tidy3d/components/grid/mesher.py
@@ -173,6 +173,8 @@ class GradedMesher(Mesher):
                 structs_filter.append(interval_structs[coord_ind])
         interval_coords = np.array(coords_filter)
         interval_structs = structs_filter
+        # print(interval_structs)
+        # print(struct_contains)
 
         # Compute the maximum allowed step size in each interval
         max_steps = []
@@ -190,6 +192,8 @@ class GradedMesher(Mesher):
                 # Remove all structures that current structure overrides
                 contains = struct_contains[struct_ind]
                 struct_list = [ind for ind in struct_list if ind not in contains]
+
+            # print(struct_list_filter)
 
             # Define the max step as the minimum over all medium steps of media in this interval
             max_step = np.amin(medium_steps[struct_list_filter])

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -48,7 +48,7 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
     Example
     -------
     >>> from tidy3d import Sphere, Cylinder, PolySlab
-    >>> from tidy3d import CurrentSource, GaussianPulse
+    >>> from tidy3d import UniformCurrentSource, GaussianPulse
     >>> from tidy3d import FieldMonitor, FluxMonitor
     >>> from tidy3d import GridSpec, AutoGrid
     >>> sim = Simulation(
@@ -66,7 +66,7 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
     ...         ),
     ...     ],
     ...     sources=[
-    ...         CurrentSource(
+    ...         UniformCurrentSource(
     ...             size=(0, 0, 0),
     ...             center=(0, 0.5, 0),
     ...             polarization="Hx",

--- a/tidy3d/version.py
+++ b/tidy3d/version.py
@@ -1,3 +1,3 @@
 """Defines the front end version of tidy3d"""
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"


### PR DESCRIPTION
- The first structure in the structures list is the simulation, so the center and size can be taken from there - don't need to be passed
- The symmetry on the other hand needs to be passed, because we need to truncate the domain to the symmetry quadrant when we do the auto meshing