### PR TITLE
@stored_property

### DIFF
--- a/tidy3d/components/geometry.py
+++ b/tidy3d/components/geometry.py
@@ -10,7 +10,7 @@ import numpy as np
 from shapely.geometry import Point, Polygon, box, MultiPolygon
 from descartes import PolygonPatch
 
-from .base import Tidy3dBaseModel
+from .base import Tidy3dBaseModel, stored_property
 from .types import Bound, Size, Coordinate, Axis, Coordinate2D, tidynumpy, Array
 from .types import Vertices, Ax, Shapely
 from .viz import add_ax_if_none, equal_aspect
@@ -27,7 +27,7 @@ _N_SAMPLE_POLYGON_INTERSECT = 100
 class Geometry(Tidy3dBaseModel, ABC):
     """Abstract base class, defines where something exists in space."""
 
-    @property
+    @stored_property
     def plot_params(self):
         """Default parameters for plotting a Geometry object."""
         return plot_params_geometry

--- a/tidy3d/components/grid/grid.py
+++ b/tidy3d/components/grid/grid.py
@@ -41,7 +41,7 @@ class Coords(Tidy3dBaseModel):
     @property
     def to_list(self):
         """Return a list of the three Coord1D objects."""
-        return list(self.dict(exclude={TYPE_TAG_STR}).values())
+        return list(self.dict(exclude={TYPE_TAG_STR, '_cached_properties'}).values())
 
 
 class FieldGrid(Tidy3dBaseModel):
@@ -167,7 +167,7 @@ class Grid(Tidy3dBaseModel):
         return Coords(
             **{
                 key: self._avg(val)
-                for key, val in self.boundaries.dict(exclude={TYPE_TAG_STR}).items()
+                for key, val in self.boundaries.dict(exclude={TYPE_TAG_STR, '_cached_properties'}).items()
             }
         )
 
@@ -192,7 +192,7 @@ class Grid(Tidy3dBaseModel):
         return Coords(
             **{
                 key: np.diff(val)
-                for key, val in self.boundaries.dict(exclude={TYPE_TAG_STR}).items()
+                for key, val in self.boundaries.dict(exclude={TYPE_TAG_STR, '_cached_properties'}).items()
             }
         )
 
@@ -215,7 +215,7 @@ class Grid(Tidy3dBaseModel):
         >>> Nx, Ny, Nz = grid.num_cells
         """
         return [
-            coords1d.size - 1 for coords1d in self.boundaries.dict(exclude={TYPE_TAG_STR}).values()
+            coords1d.size - 1 for coords1d in self.boundaries.dict(exclude={TYPE_TAG_STR, '_cached_properties'}).values()
         ]
 
     @property
@@ -240,7 +240,7 @@ class Grid(Tidy3dBaseModel):
             applied.
         """
 
-        primal_steps = self._primal_steps.dict(exclude={TYPE_TAG_STR})
+        primal_steps = self._primal_steps.dict(exclude={TYPE_TAG_STR, '_cached_properties'})
         dsteps = {}
         for (key, psteps) in primal_steps.items():
             dsteps[key] = (psteps + np.roll(psteps, 1)) / 2
@@ -296,7 +296,7 @@ class Grid(Tidy3dBaseModel):
     def _yee_e(self, axis: Axis):
         """E field yee lattice sites for axis."""
 
-        boundary_coords = self.boundaries.dict(exclude={TYPE_TAG_STR})
+        boundary_coords = self.boundaries.dict(exclude={TYPE_TAG_STR, '_cached_properties'})
 
         # initially set all to the minus bounds
         yee_coords = {key: self._min(val) for key, val in boundary_coords.items()}
@@ -310,7 +310,7 @@ class Grid(Tidy3dBaseModel):
     def _yee_h(self, axis: Axis):
         """H field yee lattice sites for axis."""
 
-        boundary_coords = self.boundaries.dict(exclude={TYPE_TAG_STR})
+        boundary_coords = self.boundaries.dict(exclude={TYPE_TAG_STR, '_cached_properties'})
 
         # initially set all to centers
         yee_coords = {key: self._avg(val) for key, val in boundary_coords.items()}

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -10,6 +10,7 @@ import matplotlib.pylab as plt
 import matplotlib as mpl
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
+from .base import stored_property
 from .validators import assert_unique_names, assert_objects_in_sim_bounds
 from .validators import validate_mode_objects_symmetry
 from .geometry import Box
@@ -1381,8 +1382,7 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
 
         return len(self.tmesh)
 
-    @property
-    @lru_cache()
+    @stored_property
     def grid(self) -> Grid:
         """FDTD grid spatial locations and information.
 


### PR DESCRIPTION
Note: WIP

Adds a decorator `@stored_property`
```python
from .components.base import stored_property
```
that you can swap out for `@property` in your `Tidy3dBaseModel` properties

```python
@stored_property
def grid(self):
    # stuff
```

Every `Tidy3dBaseModel` has a `._cached_properties` `Field()`, storing a dictionary of `property` name to stored value.
Whenever a `@stored_property` is called, it looks in this dictionary for the result.  If it finds it, it returns. Otherwise, it computes the return value and stores it in the dictionary.
A `pydantic.root_validator` ensures that whenever the model is changed, the `._cached_properties` is cleared.

Adding this decorator to `Simulation.grid` results in significant speedup when called many times

```python
for i in range(100_000):
    g = s.grid
```
takes ~30 seconds with regular `@property` on `def grid(self):` and less than a second with `@stored_property`.

## To Do
* make `._cached_properties` a `PrivateAttr` while keeping the validator working..
* test that if one does something like `sim.sources.pop()`, this triggers the clearing of the `._cached_properties` dict.


