### PR TITLE
Add ability to cache simulation hash in static context for speedup.

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,3 +10,4 @@ pylint
 tox
 pytest
 gdspy
+pytest-timeout

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -1,0 +1,150 @@
+"""Makes sure static context manager works as expected."""
+
+import pytest
+import time
+
+import numpy as np
+
+import tidy3d as td
+from tidy3d.static import MakeStatic, StaticException, make_static
+
+
+def make_sim(num_structures=100):
+    """Returns a fresh simulation."""
+    return td.Simulation(
+        size=(5, 5, 5),
+        grid_spec=td.GridSpec(wavelength=1.0),
+        run_time=1e-12,
+        structures=[
+            td.Structure(
+                geometry=td.Box(size=(1, 1, 1)),
+                medium=td.Medium(permittivity=1 + np.random.random()),
+            )
+            for i in range(num_structures)
+        ],
+        sources=[
+            td.PointDipole(
+                center=(0, 0.5, 0),
+                polarization="Ex",
+                source_time=td.GaussianPulse(
+                    freq0=2e14,
+                    fwidth=4e13,
+                ),
+            )
+        ],
+    )
+
+
+def test_context_manager_works_static():
+    """Makes sure the context manager works as expected when sim not mutated."""
+
+    sim_original = make_sim()
+
+    assert sim_original._hash is None, "sim hash is not None to start."
+
+    with MakeStatic(sim_original) as sim_static:
+
+        assert sim_static._hash is not None, "static sim._hash should not be None"
+
+        run_time_x2 = sim_original.run_time * 2
+
+    assert sim_original._hash is None
+
+
+def test_context_manager_fails_on_mutation():
+    """Makes sure the context manager raises StaticException when sim_static changed."""
+
+    sim_original = make_sim()
+
+    assert sim_original._hash is None, "sim hash is not None to start."
+
+    with pytest.raises(StaticException):
+        with MakeStatic(sim_original) as sim_static:
+            sim_static.run_time *= 2
+
+    assert sim_original._hash is None
+
+
+def test_context_manager_fails_on_list():
+    """Makes sure the context manager raises StaticException when sim_static's attr mutates."""
+
+    sim_original = make_sim()
+
+    assert sim_original._hash is None, "sim hash is not None to start."
+
+    with pytest.raises(StaticException):
+        with MakeStatic(sim_original) as sim_static:
+            sim_static.sources[0].source_time.freq0 *= 2
+
+    assert sim_original._hash is None
+
+
+def test_decorator_works_static():
+    """Make sure decorator works in static case, with many args."""
+
+    @make_static
+    def mult_and_shift_run_time(simulation, mult_factor, shift_factor=1e-12) -> float:
+        """Multiply run time by factor and shift by another factor."""
+        return simulation.run_time * mult_factor + shift_factor
+
+    sim_original = make_sim()
+
+    ret = mult_and_shift_run_time(sim_original, 2)
+
+
+def test_decorator_fails_mutate():
+    """Make sure decorator fails in mutated case, with many args."""
+
+    @make_static
+    def mult_and_shift_run_time_inplace(simulation, mult_factor, shift_factor=1e-12) -> None:
+        """Augment simulation run time by multiplicative factor and shift by another factor."""
+        simulation.run_time *= mult_factor
+        simulation.run_time += shift_factor
+
+    sim_original = make_sim()
+
+    with pytest.raises(StaticException):
+        ret = mult_and_shift_run_time_inplace(sim_original, 2)
+
+
+def test_one_arg_static():
+    """Make sure decorator works in static case when only one arg supplied."""
+
+    @make_static
+    def run_time_squared(simulation) -> float:
+        """Return 2x simulation run_time."""
+        return simulation.run_time * 2
+
+    sim_original = make_sim()
+
+    ret = run_time_squared(sim_original)
+
+
+def test_one_arg_static():
+    """Make sure decorator works in mutated case when only one arg supplied."""
+
+    @make_static
+    def run_time_squared_inplace(simulation) -> float:
+        """double simulation run time."""
+        simulation.run_time *= 2
+
+    sim_original = make_sim()
+
+    with pytest.raises(StaticException):
+        ret = run_time_squared_inplace(sim_original)
+
+
+def sum_of_N_timesteps(sim, N=50_000):
+    """sum of len(dt) computed N times."""
+    ret = 0
+    for _ in range(N):
+        ret += len(sim.tmesh)
+    return ret
+
+
+@pytest.mark.timeout(3.0)
+def test_grid_run_fast():
+    """Make sure repeated .grid computation is fast."""
+    sim = make_sim()
+    sum_of_N_timesteps_static = make_static(sum_of_N_timesteps)
+    sum = sum_of_N_timesteps_static(sim, N=10_000)

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -9,7 +9,7 @@ import numpy as np
 from pydantic.fields import ModelField
 
 from .types import ComplexNumber, NumpyArray, Literal
-from ..log import FileError, log
+from ..log import FileError
 
 # default indentation (# spaces) in files
 INDENT = 4
@@ -25,8 +25,6 @@ class Tidy3dBaseModel(pydantic.BaseModel):
     For more details on pydantic base models, see:
     `Pydantic Models <https://pydantic-docs.helpmanual.io/usage/models/>`_
     """
-
-    _hash : int = pydantic.PrivateAttr(None)
 
     def __init_subclass__(cls):
         """Things that are done to each of the models."""
@@ -217,11 +215,6 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         -------
         >>> hash_integer = hash(simulation)
         """
-        if self._hash is not None:
-            log.info('using stored hash value')
-            return self._hash
-
-        log.info('computing hash value')
         return hash(self.json())
 
     def __lt__(self, other):

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -9,7 +9,7 @@ import numpy as np
 from pydantic.fields import ModelField
 
 from .types import ComplexNumber, NumpyArray, Literal
-from ..log import FileError
+from ..log import FileError, log
 
 # default indentation (# spaces) in files
 INDENT = 4
@@ -25,6 +25,8 @@ class Tidy3dBaseModel(pydantic.BaseModel):
     For more details on pydantic base models, see:
     `Pydantic Models <https://pydantic-docs.helpmanual.io/usage/models/>`_
     """
+
+    _hash : int = pydantic.PrivateAttr(None)
 
     def __init_subclass__(cls):
         """Things that are done to each of the models."""
@@ -215,6 +217,11 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         -------
         >>> hash_integer = hash(simulation)
         """
+        if self._hash is not None:
+            log.info('using stored hash value')
+            return self._hash
+
+        log.info('computing hash value')
         return hash(self.json())
 
     def __lt__(self, other):

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -192,6 +192,41 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
         description="String specifying the front end version number.",
     )
 
+    """ Static simulation tools."""
+
+    _hash: int = pydantic.PrivateAttr(None)
+
+    def __hash__(self) -> int:
+        """Hash a :class:`Tidy3dBaseModel` objects using its json string.
+
+        Returns
+        -------
+        int
+            Integer representation of the hash of the :class:`Tidy3dBaseModel`.
+
+        Example
+        -------
+        >>> hash_integer = hash(simulation)
+        """
+        if self._hash is not None:
+            # log.warning('using computed hash')
+            return self._hash
+
+        # log.warning('computing hash')
+        return super().__hash__()
+
+    def _freeze(self) -> int:
+        """Computes the hash, sets ``self._hash``, and returns it."""
+        frozen_hash = hash(self)
+        self._hash = frozen_hash
+        return frozen_hash
+
+    def _unfreeze(self) -> int:
+        """Sets ``self._hash`` to ``None``, returns final hash"""
+        self._hash = None
+        final_hash = hash(self)
+        return final_hash
+
     """ Validating setup """
 
     @pydantic.validator("grid_size", always=True)

--- a/tidy3d/static.py
+++ b/tidy3d/static.py
@@ -1,0 +1,77 @@
+from .log import Tidy3dError, log
+from .components.base import Tidy3dBaseModel
+
+class StaticException(Tidy3dError):
+    """An exception when the tidy3d object has changed."""
+
+def freeze_component(tidy3d_component) -> int:
+    """Hashes an object if it's a tidy3dBaseModel.  Returns object and the hash value."""
+
+    if not isinstance(tidy3d_component, Tidy3dBaseModel):
+        return None
+
+    object_hash = hash(tidy3d_component)
+    tidy3d_component._hash = object_hash
+
+    return object_hash
+
+def unfreeze_component(tidy3d_component, object_hash) -> None:
+
+    if not isinstance(tidy3d_component, Tidy3dBaseModel):
+        return
+    
+    final_hash = hash(tidy3d_component)
+    tidy3d_component._hash = None
+
+    log.info(f'checking whether object has been modified')
+    if final_hash != object_hash:
+        raise StaticException(f"object has changed in static context.")
+
+
+class MakeStatic:
+    """Context manager that stores a hash and checks if the object has changed upon teardown."""
+
+    def __init__(self, tidy3d_component):
+        self.tidy3d_component = tidy3d_component
+
+    def __enter__(self):
+        self.original_hash = freeze_component(self.tidy3d_component)
+        log.info(f'-> entering static context')
+        return self.tidy3d_component
+
+    def __exit__(self, *args):
+        log.info(f'<- done with static context')
+        unfreeze_component(self.tidy3d_component, self.original_hash)
+
+def make_static(method):
+    """Decorates a method to make any tidy3d objects static during the method call."""
+
+    # stores the hashes of each of the args / kwargs
+    hashes = {}
+
+    def store_hash(obj):
+        hash_value = freeze_component(obj)
+        if hash_value is not None:
+            hashes[obj] = hash_value        
+
+    def method_static(*args, **kwargs):
+        """The method in the static context."""
+
+        # store the args and kwargs if they are tidy3d base model objects
+        for arg in args:
+            store_hash(arg)
+
+        for value in kwargs.values():
+            store_hash(value)
+
+        # call original method
+        return_value = method(*args, **kwargs)
+
+        # unfreeze anything previously frozen
+        for obj, hash_value in hashes.items():
+            unfreeze_component(obj, hash_value)
+
+        return return_value
+
+    return method_static
+


### PR DESCRIPTION
* Adds `Simulation._hash` private attribute.  If this is not `None`, the `__hash__` function will return it rather than hashing `self.json()`.  This can provide significant speedup for `.grid()` and other `@lru_cache`ed properties.
* `tidy3d/static.py` defines a context manager `MakeStatic` and a decorator `make_static`, which can be used as follows.

```python
with MakeStatic(sim) as sim_static:
    # any operations with sim_static will use `._hash` when needed.
```

```python
@make_static
def formerly_slow(sim, arg2, kwarg1=1.0):
    # any operation with `sim` in here will use `._hash` when needed
```

the context manager checks that the hash of `sim` is the same before and after the context, catching instances where anything contained in the `Simulation` may have been mutated.

Speed tests confirm that this provides significant speedup.