### PR TITLE
Speeding up PolySlab.bounds 

### DIFF
--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -2,6 +2,7 @@
 """ Container holding all information about simulation and its components"""
 from typing import Dict, Tuple, List, Set, Union
 from functools import lru_cache
+from math import isclose
 
 import pydantic
 import numpy as np
@@ -274,7 +275,7 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
 
             for sim_val, struct_val in zip(sim_bounds, struct_bounds):
 
-                if np.isclose(sim_val, struct_val):
+                if isclose(sim_val, struct_val):
                     log.warning(
                         f"Structure at structures[{istruct}] has bounds that extend exactly to "
                         "simulation edges. This can cause unexpected behavior. "


### PR DESCRIPTION
I made the bounds property less strict in the case of dilution or slant. The bounds should always fully contain the PolySlab, even though they may not be as tight as possible. They are much faster to compute though as no calls to the base and top polygons are needed.