### PR TITLE
Monitor downsampling

### DIFF
--- a/tests/sims/simulation_1_4_0.json
+++ b/tests/sims/simulation_1_4_0.json
@@ -364,7 +364,13 @@
                 "Hx",
                 "Hy",
                 "Hz"
-            ]
+            ],
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": false
         },
         {
             "center": [
@@ -389,7 +395,13 @@
                 "Hx",
                 "Hy",
                 "Hz"
-            ]
+            ],
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": false
         },
         {
             "center": [

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -205,6 +205,35 @@ def test_monitor_simulation_frequency_range(caplog, fwidth, log_level):
     assert_log_level(caplog, log_level)
 
 
+def test_monitor_downsampling():
+    # test that the downsampling parameters can be set and the colocation validator works
+
+    monitor = FieldMonitor(
+        size=(inf, inf, inf),
+        freqs=np.linspace(0, 200e12, 10001),
+        name="test",
+        interval_space=(1, 1, 1),
+    )
+    assert monitor.colocate is False
+
+    monitor = FieldMonitor(
+        size=(inf, inf, inf),
+        freqs=np.linspace(0, 200e12, 10001),
+        name="test",
+        interval_space=(1, 2, 3),
+    )
+    assert monitor.colocate is True
+
+    monitor = FieldMonitor(
+        size=(inf, inf, inf),
+        freqs=np.linspace(0, 200e12, 10001),
+        name="test",
+        interval_space=(1, 2, 3),
+        colocate=False,
+    )
+    assert monitor.colocate is False
+
+
 @pytest.mark.parametrize("grid_size,log_level", [(0.001, None), (3, 30)])
 def test_large_grid_size(caplog, grid_size, log_level):
     # small fwidth should be inside range, large one should throw warning

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -163,7 +163,7 @@ class AbstractFieldMonitor(Monitor, ABC):
     ] = pydantic.Field(
         (1, 1, 1),
         title="Spatial interval",
-        description="Number of grid step intervals between monitor recordings. If equal to `1`, "
+        description="Number of grid step intervals between monitor recordings. If equal to 1, "
         "there will be no downsampling. If greater than 1, fields will be downsampled "
         "and automatically colocated.",
     )
@@ -172,8 +172,8 @@ class AbstractFieldMonitor(Monitor, ABC):
         None,
         title="Colocate fields",
         description="Toggle whether fields should be colocated to grid cell centers. Default: "
-        "`False` if `interval_space` is 1 in each direction, `True` if `interval_space` is "
-        "greater than one in any direction.",
+        "``False`` if ``interval_space`` is 1 in each direction, ``True`` if ``interval_space`` "
+        "is greater than one in any direction.",
     )
 
     @pydantic.validator("colocate", always=True)

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -158,6 +158,32 @@ class AbstractFieldMonitor(Monitor, ABC):
         description="Collection of field components to store in the monitor.",
     )
 
+    interval_space: Tuple[
+        pydantic.PositiveInt, pydantic.PositiveInt, pydantic.PositiveInt
+    ] = pydantic.Field(
+        (1, 1, 1),
+        title="Spatial interval",
+        description="Number of grid step intervals between monitor recordings. If equal to `1`, "
+        "there will be no downsampling. If greater than 1, fields will be downsampled "
+        "and automatically colocated.",
+    )
+
+    colocate: bool = pydantic.Field(
+        None,
+        title="Colocate fields",
+        description="Toggle whether fields should be colocated to grid cell centers. Default: "
+        "`False` if `interval_space` is 1 in each direction, `True` if `interval_space` is "
+        "greater than one in any direction.",
+    )
+
+    @pydantic.validator("colocate", always=True)
+    def set_default_colocate(cls, val, values):
+        """Toggle default field colocation setting based on `interval_space`."""
+        interval_space = values.get("interval_space")
+        if val is None:
+            val = not sum(interval_space) == 3
+        return val
+
 
 class PlanarMonitor(Monitor, ABC):
     """:class:`Monitor` that has a planar geometry."""


### PR DESCRIPTION
Assuming for now that permittivity monitors are not downsampled.
Associated issue: https://github.com/flexcompute/tidy3d-core/issues/68
Associated backend PR: https://github.com/flexcompute/tidy3d-core/pull/63

Notebook (will eventually need to modify to run via web, not locally):
https://github.com/flexcompute-readthedocs/tidy3d-docs/blob/shash/monitor_downsampling/docs/source/notebooks/MonitorDownsampling.ipynb