### PR TITLE
Simulation updater for loading old json versions

### DIFF
--- a/tests/sims/simulation_1_3_3.json
+++ b/tests/sims/simulation_1_3_3.json
@@ -1,0 +1,337 @@
+{
+    "center": [
+        0.0,
+        0.0,
+        0.0
+    ],
+    "type": "Simulation",
+    "size": [
+        10.0,
+        10.0,
+        10.0
+    ],
+    "run_time": 4e-10,
+    "grid_size": null,
+    "medium": {
+        "name": null,
+        "frequency_range": null,
+        "type": "Medium",
+        "permittivity": 1.0,
+        "conductivity": 0.0
+    },
+    "symmetry": [
+        0,
+        0,
+        0
+    ],
+    "structures": [
+        {
+            "geometry": {
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "type": "Box",
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Medium",
+                "permittivity": 2.0,
+                "conductivity": 0.0
+            },
+            "name": null,
+            "type": "Structure"
+        },
+        {
+            "geometry": {
+                "center": [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                "type": "Box",
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Medium",
+                "permittivity": 1.0,
+                "conductivity": 3.0
+            },
+            "name": null,
+            "type": "Structure"
+        },
+        {
+            "geometry": {
+                "center": [
+                    1.0,
+                    0.0,
+                    1.0
+                ],
+                "type": "Sphere",
+                "radius": 1.4
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Medium",
+                "permittivity": 6.0,
+                "conductivity": 0.0
+            },
+            "name": null,
+            "type": "Structure"
+        },
+        {
+            "geometry": {
+                "center": [
+                    1.0,
+                    0.0,
+                    -1.0
+                ],
+                "type": "Cylinder",
+                "axis": 1,
+                "length": 2.0,
+                "radius": 1.4
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Medium",
+                "permittivity": 5.0,
+                "conductivity": 0.0
+            },
+            "name": null,
+            "type": "Structure"
+        },
+        {
+            "geometry": {
+                "center": [
+                    -0.8333333333333334,
+                    -1.1666666666666667,
+                    0.0
+                ],
+                "type": "PolySlab",
+                "axis": 2,
+                "length": 2.0,
+                "slab_bounds": [
+                    -1.0,
+                    1.0
+                ],
+                "dilation": 0.0,
+                "sidewall_angle": 0.0,
+                "vertices": [
+                    [
+                        -1.5,
+                        -1.5
+                    ],
+                    [
+                        -0.5,
+                        -1.5
+                    ],
+                    [
+                        -0.5,
+                        -0.5
+                    ]
+                ]
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Medium",
+                "permittivity": 3.0,
+                "conductivity": 0.0
+            },
+            "name": null,
+            "type": "Structure"
+        }
+    ],
+    "sources": [
+        {
+            "center": [
+                0.0,
+                0.5,
+                0.0
+            ],
+            "type": "UniformCurrentSource",
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "polarization": "Hx"
+        },
+        {
+            "center": [
+                0.0,
+                0.5,
+                0.0
+            ],
+            "type": "PointDipole",
+            "size": [
+                0,
+                0,
+                0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "polarization": "Ex"
+        }
+    ],
+    "monitors": [
+        {
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "type": "FluxMonitor",
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "plane",
+            "freqs": [
+                200000000000000.0,
+                250000000000000.0
+            ]
+        },
+        {
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "type": "FieldMonitor",
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "name": "point",
+            "freqs": [
+                150000000000000.0,
+                200000000000000.0
+            ],
+            "fields": [
+                "Ex",
+                "Ey",
+                "Ez",
+                "Hx",
+                "Hy",
+                "Hz"
+            ]
+        }
+    ],
+    "grid_spec": {
+        "grid_x": {
+            "type": "AutoGrid",
+            "min_steps_per_wvl": 10.0,
+            "max_scale": 1.4,
+            "mesher": {
+                "type": "GradedMesher"
+            }
+        },
+        "grid_y": {
+            "type": "AutoGrid",
+            "min_steps_per_wvl": 10.0,
+            "max_scale": 1.4,
+            "mesher": {
+                "type": "GradedMesher"
+            }
+        },
+        "grid_z": {
+            "type": "AutoGrid",
+            "min_steps_per_wvl": 10.0,
+            "max_scale": 1.4,
+            "mesher": {
+                "type": "GradedMesher"
+            }
+        },
+        "wavelength": null,
+        "override_structures": [],
+        "type": "GridSpec"
+    },
+    "pml_layers": [
+        {
+            "num_layers": 20,
+            "parameters": {
+                "sigma_order": 3,
+                "sigma_min": 0.0,
+                "sigma_max": 1.5,
+                "type": "PMLParams",
+                "kappa_order": 3,
+                "kappa_min": 1.0,
+                "kappa_max": 3.0,
+                "alpha_order": 1,
+                "alpha_min": 0.0,
+                "alpha_max": 0.0
+            },
+            "type": "PML"
+        },
+        {
+            "num_layers": 30,
+            "parameters": {
+                "sigma_order": 3,
+                "sigma_min": 0.0,
+                "sigma_max": 1.5,
+                "type": "PMLParams",
+                "kappa_order": 3,
+                "kappa_min": 1.0,
+                "kappa_max": 3.0,
+                "alpha_order": 1,
+                "alpha_min": 0.0,
+                "alpha_max": 0.0
+            },
+            "type": "PML"
+        },
+        {
+            "num_layers": 0,
+            "parameters": {
+                "sigma_order": 3,
+                "sigma_min": 0.0,
+                "sigma_max": 1.5,
+                "type": "PMLParams",
+                "kappa_order": 3,
+                "kappa_min": 1.0,
+                "kappa_max": 3.0,
+                "alpha_order": 1,
+                "alpha_min": 0.0,
+                "alpha_max": 0.0
+            },
+            "type": "PML"
+        }
+    ],
+    "shutoff": 1e-06,
+    "subpixel": false,
+    "courant": 0.8,
+    "version": "1.3.3"
+}

--- a/tests/sims/simulation_1_4_0.json
+++ b/tests/sims/simulation_1_4_0.json
@@ -1,0 +1,496 @@
+{
+    "center": [
+        0.0,
+        0.0,
+        0.0
+    ],
+    "type": "Simulation",
+    "size": [
+        10.0,
+        10.0,
+        10.0
+    ],
+    "run_time": 1e-12,
+    "grid_size": null,
+    "medium": {
+        "name": null,
+        "frequency_range": null,
+        "type": "Medium",
+        "permittivity": 1.0,
+        "conductivity": 0.0
+    },
+    "symmetry": [
+        0,
+        -1,
+        1
+    ],
+    "structures": [
+        {
+            "geometry": {
+                "center": [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                "type": "Box",
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Medium",
+                "permittivity": 1.0,
+                "conductivity": 0.0
+            },
+            "name": null,
+            "type": "Structure"
+        },
+        {
+            "geometry": {
+                "center": [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                "type": "Sphere",
+                "radius": 1.0
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "PoleResidue",
+                "eps_inf": 1.0,
+                "poles": []
+            },
+            "name": null,
+            "type": "Structure"
+        },
+        {
+            "geometry": {
+                "center": [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                "type": "Cylinder",
+                "axis": 2,
+                "length": 1.0,
+                "radius": 1.0
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Lorentz",
+                "eps_inf": 1.0,
+                "coeffs": []
+            },
+            "name": null,
+            "type": "Structure"
+        },
+        {
+            "geometry": {
+                "center": [
+                    2.0,
+                    2.0,
+                    0.0
+                ],
+                "type": "PolySlab",
+                "axis": 2,
+                "length": 2.0,
+                "slab_bounds": [
+                    -1.0,
+                    1.0
+                ],
+                "dilation": 0.0,
+                "sidewall_angle": 0.0,
+                "vertices": [
+                    [
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        2.0,
+                        3.0
+                    ],
+                    [
+                        4.0,
+                        3.0
+                    ]
+                ]
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Sellmeier",
+                "coeffs": []
+            },
+            "name": null,
+            "type": "Structure"
+        },
+        {
+            "geometry": {
+                "center": [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                "type": "Sphere",
+                "radius": 1.0
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Debye",
+                "eps_inf": 1.0,
+                "coeffs": []
+            },
+            "name": "t2",
+            "type": "Structure"
+        }
+    ],
+    "sources": [
+        {
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "type": "UniformCurrentSource",
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 1.0,
+                "fwidth": 1.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "polarization": "Ex"
+        },
+        {
+            "center": [
+                0.0,
+                0.0,
+                -4.0
+            ],
+            "type": "PlaneWave",
+            "size": [
+                "Infinity",
+                "Infinity",
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 1.0,
+                "fwidth": 1.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 2.0
+        },
+        {
+            "center": [
+                0.0,
+                0.0,
+                -4.0
+            ],
+            "type": "GaussianBeam",
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 1.0,
+                "fwidth": 1.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 0.0,
+            "waist_radius": 1.0,
+            "waist_distance": 0.0
+        },
+        {
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "type": "ModeSource",
+            "size": [
+                0.0,
+                1.0,
+                1.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 1.0,
+                "fwidth": 1.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "direction": "-",
+            "mode_spec": {
+                "num_modes": 3,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "sort_by": "largest_neff",
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "bend_radius": null,
+                "bend_axis": null,
+                "type": "ModeSpec"
+            },
+            "mode_index": 2
+        }
+    ],
+    "boundary_spec": {
+        "x": {
+            "plus": {
+                "name": null,
+                "type": "Absorber",
+                "num_layers": 40,
+                "parameters": {
+                    "sigma_order": 3,
+                    "sigma_min": 0.0,
+                    "sigma_max": 6.4,
+                    "type": "AbsorberParams"
+                }
+            },
+            "minus": {
+                "name": null,
+                "type": "PML",
+                "num_layers": 12,
+                "parameters": {
+                    "sigma_order": 3,
+                    "sigma_min": 0.0,
+                    "sigma_max": 1.5,
+                    "type": "PMLParams",
+                    "kappa_order": 3,
+                    "kappa_min": 1.0,
+                    "kappa_max": 3.0,
+                    "alpha_order": 1,
+                    "alpha_min": 0.0,
+                    "alpha_max": 0.0
+                }
+            },
+            "type": "Boundary"
+        },
+        "y": {
+            "plus": {
+                "name": null,
+                "type": "PMCBoundary"
+            },
+            "minus": {
+                "name": null,
+                "type": "PMCBoundary"
+            },
+            "type": "Boundary"
+        },
+        "z": {
+            "plus": {
+                "name": null,
+                "type": "PECBoundary"
+            },
+            "minus": {
+                "name": null,
+                "type": "StablePML",
+                "num_layers": 40,
+                "parameters": {
+                    "sigma_order": 3,
+                    "sigma_min": 0.0,
+                    "sigma_max": 1.0,
+                    "type": "PMLParams",
+                    "kappa_order": 3,
+                    "kappa_min": 1.0,
+                    "kappa_max": 5.0,
+                    "alpha_order": 1,
+                    "alpha_min": 0.0,
+                    "alpha_max": 0.9
+                }
+            },
+            "type": "Boundary"
+        },
+        "type": "BoundarySpec"
+    },
+    "monitors": [
+        {
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "type": "FieldMonitor",
+            "size": [
+                1.0,
+                1.0,
+                1.0
+            ],
+            "name": "field",
+            "freqs": [
+                1,
+                2,
+                3
+            ],
+            "fields": [
+                "Ex",
+                "Ey",
+                "Ez",
+                "Hx",
+                "Hy",
+                "Hz"
+            ]
+        },
+        {
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "type": "FieldTimeMonitor",
+            "size": [
+                1.0,
+                1.0,
+                1.0
+            ],
+            "name": "fieldtime",
+            "start": 1e-12,
+            "stop": null,
+            "interval": 3,
+            "fields": [
+                "Ex",
+                "Ey",
+                "Ez",
+                "Hx",
+                "Hy",
+                "Hz"
+            ]
+        },
+        {
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "type": "FluxMonitor",
+            "size": [
+                1.0,
+                0.0,
+                1.0
+            ],
+            "name": "flux",
+            "freqs": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "type": "FluxTimeMonitor",
+            "size": [
+                1.0,
+                0.0,
+                1.0
+            ],
+            "name": "fluxtime",
+            "start": 1e-12,
+            "stop": null,
+            "interval": 3
+        },
+        {
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "type": "ModeMonitor",
+            "size": [
+                1.0,
+                0.0,
+                1.0
+            ],
+            "name": "mode",
+            "freqs": [
+                1,
+                2
+            ],
+            "mode_spec": {
+                "num_modes": 3,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "sort_by": "largest_neff",
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "bend_radius": null,
+                "bend_axis": null,
+                "type": "ModeSpec"
+            }
+        }
+    ],
+    "grid_spec": {
+        "grid_x": {
+            "type": "AutoGrid",
+            "min_steps_per_wvl": 10.0,
+            "max_scale": 1.4,
+            "mesher": {
+                "type": "GradedMesher"
+            }
+        },
+        "grid_y": {
+            "type": "AutoGrid",
+            "min_steps_per_wvl": 10.0,
+            "max_scale": 1.4,
+            "mesher": {
+                "type": "GradedMesher"
+            }
+        },
+        "grid_z": {
+            "type": "AutoGrid",
+            "min_steps_per_wvl": 10.0,
+            "max_scale": 1.4,
+            "mesher": {
+                "type": "GradedMesher"
+            }
+        },
+        "wavelength": null,
+        "override_structures": [],
+        "type": "GridSpec"
+    },
+    "shutoff": 1e-05,
+    "subpixel": true,
+    "courant": 0.9,
+    "version": "1.4.0"
+}

--- a/tests/test_IO.py
+++ b/tests/test_IO.py
@@ -1,12 +1,19 @@
+import os
+import json
+
 import pydantic
 import numpy as np
 import os
 from time import time
 
 from tidy3d import *
+from tidy3d import __version__
 from .utils import SIM_FULL as SIM
 from .utils import SIM_MONITORS as SIM2
 from .utils import clear_tmp
+
+# Store an example of every minor release simulation to test updater in the future
+SIM_DIR = "tests/sims"
 
 
 @clear_tmp
@@ -29,6 +36,15 @@ def test_simulation_load_export_yaml():
 
 @clear_tmp
 def test_simulation_preserve_types():
+
+    st = GaussianPulse(freq0=1.0, fwidth=1.0)
+
+
+@clear_tmp
+def test_simulation_preserve_types():
+    """This test also writes a simulation file to ``tests/sims/simulation_x_y_z.json`` to store
+    an example of the current version. Updating all of these files is then checked in
+    ``test_simulation_updater``."""
 
     st = GaussianPulse(freq0=1.0, fwidth=1.0)
 
@@ -63,6 +79,14 @@ def test_simulation_preserve_types():
                 direction="+",
                 waist_radius=1,
             ),
+            ModeSource(
+                center=(0, 0, 0),
+                size=(0, 1, 1),
+                mode_spec=ModeSpec(num_modes=3),
+                mode_index=2,
+                direction="-",
+                source_time=st,
+            ),
         ],
         monitors=[
             FieldMonitor(size=(1, 1, 1), freqs=[1, 2, 3], name="field"),
@@ -72,9 +96,16 @@ def test_simulation_preserve_types():
             ModeMonitor(size=(1, 0, 1), freqs=[1, 2], mode_spec=ModeSpec(num_modes=3), name="mode"),
         ],
         run_time=1e-12,
+        symmetry=(0, -1, 1),
+        boundary_spec=BoundarySpec(
+            x=Boundary(minus=PML(), plus=Absorber()),
+            y=Boundary(minus=PMCBoundary(), plus=Periodic()),
+            z=Boundary(minus=StablePML(), plus=PECBoundary()),
+        ),
     )
 
-    path = "tests/tmp/simulation.json"
+    major, minor, patch = __version__.split(".")
+    path = os.path.join(SIM_DIR, f"simulation_{major}_{minor}_{patch}.json")
     sim_all.to_file(path)
     sim_2 = Simulation.from_file(path)
     assert sim_all == sim_2
@@ -135,6 +166,21 @@ def test_validation_speed():
         sizes_bytes.append(size)
 
         print(f"{n} structures \t {size:.1e} bytes \t {time_validate:.1f} seconds to validate")
+
+
+def test_simulation_updater():
+    """Test that all simulations in ``SIM_DIR`` can be updated to current version and loaded."""
+    sim_files = [os.path.join(SIM_DIR, file) for file in os.listdir(SIM_DIR)]
+    for sim_file in sim_files:
+        with open(sim_file, "r") as f:
+            sim_dict_loaded = json.load(f)
+        updater = Updater(sim_dict=sim_dict_loaded)
+        sim_dict_updated = updater.update_to_current()
+        sim_updated = Simulation.parse_obj(sim_dict_updated)
+        assert sim_updated.version == __version__, "Simulation not converted properly"
+
+        # just make sure the loaded sim does something properly using this version
+        sim_updated.grid
 
 
 @clear_tmp

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -8,6 +8,9 @@ from .config import config
 # version
 from .version import __version__
 
+# updater
+from .updater import Updater
+
 # grid
 from .components import Grid, Coords, GridSpec, UniformGrid, CustomGrid, AutoGrid
 

--- a/tidy3d/updater.py
+++ b/tidy3d/updater.py
@@ -1,0 +1,120 @@
+"""Utilities for converting between tidy3d versions."""
+import json
+import functools
+
+import pydantic as pd
+
+from .version import __version__
+from .log import FileError, SetupError
+
+
+"""Storing version numbers."""
+
+
+class Version(pd.BaseModel):
+    """Stores a version number (excluding patch)."""
+
+    major: int
+    minor: int
+
+    @classmethod
+    def from_string(cls, string) -> "Version":
+        """Return Version from a version string."""
+        try:
+            major, minor, _ = string.split(".")
+            version = cls(major=major, minor=minor)
+        except Exception as e:
+            raise SetupError(f"version string {version_string} can't be parsed.") from e
+        return version
+
+    @property
+    def as_tuple(self):
+        """version as a tuple, leave out patch for now."""
+        return (self.major, self.minor, None)
+
+    def __hash__(self):
+        """define a hash."""
+        return hash(self.as_tuple)
+
+
+CurrentVersion = Version.from_string(__version__)
+
+"""Class for updating simulation objects."""
+
+
+class Updater(pd.BaseModel):
+    """Converts a tidy3d simulation.json file to an up-to-date Simulation instance."""
+
+    sim_dict: dict
+
+    @classmethod
+    def from_file(cls, fname: str) -> "Updater":
+        """Dictionary representing the simulation loaded from file."""
+
+        try:
+            with open(fname, "r") as f:
+                sim_dict = json.load(f)
+        except Exception as e:
+            raise FileError(f"Could not load file {fname}") from e
+        return cls(sim_dict=sim_dict)
+
+    @property
+    def version(self) -> Version:
+        """Version of the supplied file."""
+        version_string = self.sim_dict.get("version")
+        if version_string is None:
+            raise SetupError("Could not find a version in the supplied json.")
+        return Version.from_string(version_string)
+
+    def update_to_current(self) -> dict:
+        """Update supplied simulation dictionary to current version."""
+        while self.version != CurrentVersion:
+            update_fn = UPDATE_MAP.get(self.version)
+            if update_fn is None:
+                raise SetupError(f"version {self.version} not found in update map.")
+            self.sim_dict = update_fn(self.sim_dict)
+        self.sim_dict['version'] == __version__
+        return self.sim_dict
+
+
+"""Update conversion functions."""
+
+# versions will be dynamically mapped in this table when the update functions are initialized.
+UPDATE_MAP = {}
+
+
+def updates_to_version(version_from_string, version_to_string):
+    """Decorates a sim_dict update function to change the version."""
+
+    # make sure the version strings are legit
+    from_version = Version.from_string(version_from_string)
+    _ = Version.from_string(version_to_string)
+
+    def decorator(update_fn):
+        """The actual decorator that gets returned by `updates_to_version('x.y.z')`"""
+
+        @functools.wraps(update_fn)
+        def new_update_function(sim_dict: dict) -> dict:
+            """Update function that automatically adds version string."""
+
+            sim_dict_updated = update_fn(sim_dict)
+            sim_dict_updated["version"] = version_to_string
+            return sim_dict_updated
+
+        UPDATE_MAP[from_version] = new_update_function
+
+        return new_update_function
+
+    return decorator
+
+
+@updates_to_version(version_from_string="1.3.x", version_to_string="1.4.0")
+def update_1_3(sim_dict: dict) -> dict:
+    """Updates version 1.3 to 1.4."""
+
+    sim_dict["boundary_spec"] = {"x": {}, "y": {}, "z": {}}
+    for dim, pml_layer in zip(["x", "y", "z"], sim_dict["pml_layers"]):
+        sim_dict["boundary_spec"][dim]["plus"] = pml_layer
+        sim_dict["boundary_spec"][dim]["minus"] = pml_layer
+    sim_dict.pop("pml_layers")
+    return sim_dict

--- a/tidy3d/version.py
+++ b/tidy3d/version.py
@@ -1,3 +1,3 @@
 """Defines the front end version of tidy3d"""
 
-__version__ = "1.3.3"
+__version__ = "1.4.0"


### PR DESCRIPTION
Running `test_IO.py` will now also export a simulation file with the current version name to `tests/sims`. Then, `test_simulation_updater` will try to update all of these files to the current version. This should alert us if there's any issue with the conversion (although it's contingent on `sim_all` having as many example components as possible).

Infinity seems to work fine.