### PR TITLE
frozen properties

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,37 @@
+"""Test the grid caching."""
+import tidy3d as td
+
+
+def make_sim():
+    """Generate a starting simulation."""
+    return td.Simulation(
+        size=(10, 10, 10),
+        run_time=1e-12,
+        structures=[
+            td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=td.Medium(permittivity=4))
+        ],
+        grid_spec=td.GridSpec(wavelength=1),
+    )
+
+
+def test_no_cache():
+    """test without anything"""
+
+    sim = make_sim()
+    sim.grid
+
+
+def test_cached():
+
+    sim = make_sim()
+    for i in range(5):
+        sim.grid
+
+
+def test_frozen():
+
+    sim = make_sim()
+    sim.freeze_properties()
+    sim.grid
+    sim.unfreeze_properties()
+    sim.grid


### PR DESCRIPTION
* introduces `Tidy3dBaseModel.freeze_properties()`  and `Tidy3dBaseModel.unfreeze_properties()`
* each `Tidy3dBaseModel`  instance has a `PrivateAttr` dictionary storing the property name -> frozen value.
* when the models are initialized, there is a register of all of the `@cache` properties in each model of `Tidy3d` that is stored and when` freeze_properties()` is called
* for all properties in that register, the value is computed and stored in the local storage of that instance and then can be grabbed in `@cache`