### PR TITLE
added explicit download file functions

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -10,7 +10,7 @@ shapely<=1.8.0,>=1.7.0
 descartes
 pydantic>=1.9.0
 PyYAML
-boto3
+boto3==1.23.1
 requests
 dask
 gdspy

--- a/tidy3d/web/__init__.py
+++ b/tidy3d/web/__init__.py
@@ -2,6 +2,6 @@
 import sys
 
 from .webapi import run, upload, get_info, start, monitor, delete, download, load, estimate_cost
-from .webapi import get_tasks, delete_old
+from .webapi import get_tasks, delete_old, download_json, download_log, load_simulation
 from .container import Job, Batch
 from .auth import get_credentials

--- a/tidy3d/web/webapi.py
+++ b/tidy3d/web/webapi.py
@@ -318,21 +318,59 @@ def download(task_id: TaskId, path: str = "simulation_data.hdf5") -> None:
     path : str = "simulation_data.hdf5"
         Download path to .hdf5 data file (including filename).
 
+    """
+
+    # TODO: it should be possible to load "diverged" simulations
+    _download_file(task_id, fname="monitor_data.hdf5", path=path)
+
+
+def download_json(task_id: TaskId, path: str = "simulation.json") -> None:
+    """Download the `.json` file associated with the :class:`.Simulation` of a given task.
+
+    Parameters
+    ----------
+    task_id : str
+        Unique identifier of task on server.  Returned by :meth:`upload`.
+    path : str = "simulation.json"
+        Download path to .json file of simulation (including filename).
+    """
+    _download_file(task_id, fname="simulation.json", path=path)
+
+
+def load_simulation(task_id: TaskId, path: str = "simulation.json") -> Simulation:
+    """Download the `.json` file of a task and load the associated :class:`.Simulation`.
+
+    Parameters
+    ----------
+    task_id : str
+        Unique identifier of task on server.  Returned by :meth:`upload`.
+    path : str = "simulation.json"
+        Download path to .json file of simulation (including filename).
+
+    Returns
+    -------
+    :class:`.Simulation`
+        Simulation loaded from downloaded json file.
+    """
+    download_json(task_id, path=path)
+    return Simulation.from_file(path)
+
+
+def download_log(task_id: TaskId, path: str = "tidy3d.log") -> None:
+    """Download the tidy3d log file associated with a task.
+
+    Parameters
+    ----------
+    task_id : str
+        Unique identifier of task on server.  Returned by :meth:`upload`.
+    path : str = "tidy3d.log"
+        Download path to log file (including filename).
+
     Note
     ----
     To load downloaded results into data, call :meth:`load` with option `replace_existing=False`.
     """
-
-    # TODO: it should be possible to load "diverged" simulations
-    task_info = get_info(task_id)
-    if task_info.status in ("error", "deleted"):
-        raise WebError(f"can't download task '{task_id}', status = '{task_info.status}'")
-
-    directory, _ = os.path.split(path)
-    if directory != "":
-        os.makedirs(directory, exist_ok=True)
-
-    _download_file(task_id, fname="monitor_data.hdf5", path=path)
+    _download_file(task_id, fname="tidy3d.log", path=path)
 
 
 def load(
@@ -534,6 +572,15 @@ def _download_file(task_id: TaskId, fname: str, path: str) -> None:
     path : str
         Path where the file will be downloaded to (including filename).
     """
+
+    task_info = get_info(task_id)
+    if task_info.status in ("error", "deleted"):
+        raise WebError(f"can't download task '{task_id}', status = '{task_info.status}'")
+
+    directory, _ = os.path.split(path)
+    if directory != "":
+        os.makedirs(directory, exist_ok=True)
+
     log.info(f'downloading file "{fname}" to "{path}"')
 
     try:


### PR DESCRIPTION
Before, there was a single `web.download()` function that grabbed the entire `.hdf5`.

The private `web._download_file()` could grab individual files from the server if the user knew the path.

This file also didn't try to authenticate, and would fail without a useful warning if trying to do so without calling another webapi function first.

This PR adds `web.download_log()`, `web.download_json()`, `web.download_simulation() -> Simulation` functions for explicitly grabbing the files a user would want. The last function is for convenience to avoid needing to then load the file into `Simulation` (could remove it).

Also, the authentication bits (and checking of task status) were moved into `_download_file()` so they are always called.
