### PR TITLE
arrow length based on simulation bounds

### DIFF
--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -5,7 +5,7 @@ from typing import List, Union, Tuple
 import pydantic
 import numpy as np
 
-from .types import Literal, Ax, EMField, ArrayLike, Array
+from .types import Literal, Ax, EMField, ArrayLike, Array, Bound
 from .geometry import Box
 from .validators import assert_plane
 from .mode import ModeSpec
@@ -178,14 +178,20 @@ class AbstractModeMonitor(PlanarMonitor, FreqMonitor):
         description="Parameters to feed to mode solver which determine modes measured by monitor.",
     )
 
-    def plot(
-        self, x: float = None, y: float = None, z: float = None, ax: Ax = None, **kwargs
+    def plot(  # pylint:disable=too-many-arguments
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        ax: Ax = None,
+        sim_bounds: Bound = None,
+        **patch_kwargs
     ) -> Ax:
 
         # call the monitor.plot() function first
-        ax = super().plot(x=x, y=y, z=z, ax=ax, **kwargs)
+        ax = super().plot(x=x, y=y, z=z, ax=ax, **patch_kwargs)
 
-        kwargs_alpha = kwargs.get("alpha")
+        kwargs_alpha = patch_kwargs.get("alpha")
         arrow_alpha = ARROW_ALPHA if kwargs_alpha is None else kwargs_alpha
 
         # and then add an arrow using the direction comuputed from `_dir_arrow`.
@@ -198,6 +204,7 @@ class AbstractModeMonitor(PlanarMonitor, FreqMonitor):
             color=ARROW_COLOR_MONITOR,
             alpha=arrow_alpha,
             both_dirs=True,
+            sim_bounds=sim_bounds,
         )
         return ax
 

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -961,8 +961,9 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
         matplotlib.axes._subplots.Axes
             The supplied or created matplotlib axes.
         """
+        bounds = self.bounds
         for source in self.sources:
-            ax = source.plot(x=x, y=y, z=z, alpha=alpha, ax=ax)
+            ax = source.plot(x=x, y=y, z=z, alpha=alpha, ax=ax, sim_bounds=bounds)
         ax = self._set_plot_bounds(ax=ax, x=x, y=y, z=z)
         return ax
 
@@ -991,8 +992,9 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
         matplotlib.axes._subplots.Axes
             The supplied or created matplotlib axes.
         """
+        bounds = self.bounds
         for monitor in self.monitors:
-            ax = monitor.plot(x=x, y=y, z=z, alpha=alpha, ax=ax)
+            ax = monitor.plot(x=x, y=y, z=z, alpha=alpha, ax=ax, sim_bounds=bounds)
         ax = self._set_plot_bounds(ax=ax, x=x, y=y, z=z)
         return ax
 

--- a/tidy3d/components/source.py
+++ b/tidy3d/components/source.py
@@ -9,7 +9,7 @@ import pydantic
 import numpy as np
 
 from .base import Tidy3dBaseModel
-from .types import Direction, Polarization, Ax, FreqBound, Array, Axis, ArrayLike
+from .types import Direction, Polarization, Ax, FreqBound, Array, Axis, ArrayLike, Bound
 from .validators import assert_plane, validate_name_str
 from .geometry import Box
 from .mode import ModeSpec
@@ -283,14 +283,20 @@ class Source(Box, ABC):
         """Returns a vector indicating the source polarization for arrow plotting, if not None."""
         return None
 
-    def plot(
-        self, x: float = None, y: float = None, z: float = None, ax: Ax = None, **kwargs
+    def plot(  #  pylint:disable=too-many-arguments
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        ax: Ax = None,
+        sim_bounds: Bound = None,
+        **patch_kwargs
     ) -> Ax:
 
         # call the `Source.plot()` function first.
-        ax = super().plot(x=x, y=y, z=z, ax=ax, **kwargs)
+        ax = super().plot(x=x, y=y, z=z, ax=ax, **patch_kwargs)
 
-        kwargs_alpha = kwargs.get("alpha")
+        kwargs_alpha = patch_kwargs.get("alpha")
         arrow_alpha = ARROW_ALPHA if kwargs_alpha is None else kwargs_alpha
 
         # then add the arrow based on the propagation direction
@@ -305,6 +311,7 @@ class Source(Box, ABC):
                 color=ARROW_COLOR_SOURCE,
                 alpha=arrow_alpha,
                 both_dirs=False,
+                sim_bounds=sim_bounds,
             )
 
         if self._pol_vector is not None:
@@ -318,6 +325,7 @@ class Source(Box, ABC):
                 color=ARROW_COLOR_POLARIZATION,
                 alpha=arrow_alpha,
                 both_dirs=False,
+                sim_bounds=sim_bounds,
             )
 
         return ax

--- a/tidy3d/components/viz.py
+++ b/tidy3d/components/viz.py
@@ -21,7 +21,7 @@ ARROW_ALPHA = 0.8
 
 
 # this times the min of axis height and width gives the arrow length
-ARROW_LENGTH_FACTOR = 0.4
+ARROW_LENGTH_FACTOR = 0.1
 
 # this times ARROW_LENGTH gives width
 ARROW_WIDTH_FACTOR = 0.4
@@ -88,7 +88,7 @@ class PlotParams(Tidy3dBaseModel):
         """Update the plot params with supplied kwargs."""
         new_plot_params = self.copy(deep=True)
         for key, value in kwargs.items():
-            if key not in ("type",) and value is not None:
+            if key not in ("type",) and value is not None and key in self.__fields__:
                 setattr(new_plot_params, key, value)
         return new_plot_params
 


### PR DESCRIPTION
source and monitor plotting accepts an optional `sim_bounds` argument.
If supplied, the arrow lengths are determined by the ARROW_LENGTH_FACTOR times the minimum length or width between the bounds on the plotting plane.

This avoids issues with using the axis limits, which might be temporarily resized for infinite monitor or source object, such as plane waves.