### PR TITLE
Reorganize geometry.py

### DIFF
--- a/tests/sims/simulation_1_4_0.json
+++ b/tests/sims/simulation_1_4_0.json
@@ -150,7 +150,74 @@
             },
             "name": "t2",
             "type": "Structure"
-        }
+        },
+        {
+            "geometry": {
+                "type": "GeometryGroup",
+                "center": [
+                    2.0,
+                    2.0,
+                    0.0
+                ],                
+                "geometries": [
+                    {
+                        "type": "PolySlab",
+                        "axis": 2,
+                        "slab_bounds": [
+                            -1.0,
+                            1.0
+                        ],
+                        "length": 2.0,
+                        "center": [
+                            2.0,
+                            2.0,
+                            0.0
+                        ],
+                        "dilation": 0.0,
+                        "sidewall_angle": 0.0,
+                        "vertices": [
+                            [
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                2.0,
+                                3.0
+                            ],
+                            [
+                                4.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    {
+                        "type": "Cylinder",
+                        "axis": 2,
+                        "radius": 1.0,
+                        "center": [
+                            0.0,
+                            0.0,
+                            0.0
+                        ],
+                        "length": 1.0
+                    }
+                ]
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Drude",
+                "eps_inf": 1.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        1.0
+                    ]
+                ]
+            },
+            "name": null,
+            "type": "Structure"
+        }        
     ],
     "sources": [
         {

--- a/tests/sims/simulation_1_4_1.json
+++ b/tests/sims/simulation_1_4_1.json
@@ -150,7 +150,74 @@
             },
             "name": "t2",
             "type": "Structure"
-        }
+        },
+        {
+            "geometry": {
+                "type": "GeometryGroup",
+                "center": [
+                    2.0,
+                    2.0,
+                    0.0
+                ],                
+                "geometries": [
+                    {
+                        "type": "PolySlab",
+                        "axis": 2,
+                        "slab_bounds": [
+                            -1.0,
+                            1.0
+                        ],
+                        "length": 2.0,
+                        "center": [
+                            2.0,
+                            2.0,
+                            0.0
+                        ],
+                        "dilation": 0.0,
+                        "sidewall_angle": 0.0,
+                        "vertices": [
+                            [
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                2.0,
+                                3.0
+                            ],
+                            [
+                                4.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    {
+                        "type": "Cylinder",
+                        "axis": 2,
+                        "radius": 1.0,
+                        "center": [
+                            0.0,
+                            0.0,
+                            0.0
+                        ],
+                        "length": 1.0
+                    }
+                ]
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Drude",
+                "eps_inf": 1.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        1.0
+                    ]
+                ]
+            },
+            "name": null,
+            "type": "Structure"
+        }        
     ],
     "sources": [
         {
@@ -353,9 +420,9 @@
             ],
             "name": "field",
             "freqs": [
-                1.0,
-                2.0,
-                3.0
+                1,
+                2,
+                3
             ],
             "fields": [
                 "Ex",
@@ -417,9 +484,9 @@
             ],
             "name": "flux",
             "freqs": [
-                1.0,
-                2.0,
-                3.0
+                1,
+                2,
+                3
             ]
         },
         {
@@ -453,8 +520,8 @@
             ],
             "name": "mode",
             "freqs": [
-                1.0,
-                2.0
+                1,
+                2
             ],
             "mode_spec": {
                 "num_modes": 3,

--- a/tests/sims/simulation_1_5_0.json
+++ b/tests/sims/simulation_1_5_0.json
@@ -144,6 +144,62 @@
             },
             "name": "t2",
             "type": "Structure"
+        },
+        {
+            "geometry": {
+                "type": "GeometryGroup",
+                "geometries": [
+                    {
+                        "type": "PolySlab",
+                        "axis": 2,
+                        "slab_bounds": [
+                            -1.0,
+                            1.0
+                        ],
+                        "dilation": 0.0,
+                        "sidewall_angle": 0.0,
+                        "vertices": [
+                            [
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                2.0,
+                                3.0
+                            ],
+                            [
+                                4.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    {
+                        "type": "Cylinder",
+                        "axis": 2,
+                        "radius": 1.0,
+                        "center": [
+                            0.0,
+                            0.0,
+                            0.0
+                        ],
+                        "length": 1.0
+                    }
+                ]
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Drude",
+                "eps_inf": 1.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        1.0
+                    ]
+                ]
+            },
+            "name": null,
+            "type": "Structure"
         }
     ],
     "sources": [

--- a/tests/sims/simulation_1_5_0.json
+++ b/tests/sims/simulation_1_5_0.json
@@ -1,0 +1,502 @@
+{
+    "type": "Simulation",
+    "center": [
+        0.0,
+        0.0,
+        0.0
+    ],
+    "size": [
+        10.0,
+        10.0,
+        10.0
+    ],
+    "run_time": 1e-12,
+    "grid_size": null,
+    "medium": {
+        "name": null,
+        "frequency_range": null,
+        "type": "Medium",
+        "permittivity": 1.0,
+        "conductivity": 0.0
+    },
+    "symmetry": [
+        0,
+        -1,
+        1
+    ],
+    "structures": [
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Medium",
+                "permittivity": 1.0,
+                "conductivity": 0.0
+            },
+            "name": null,
+            "type": "Structure"
+        },
+        {
+            "geometry": {
+                "type": "Sphere",
+                "radius": 1.0,
+                "center": [
+                    0.0,
+                    0.0,
+                    0.0
+                ]
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "PoleResidue",
+                "eps_inf": 1.0,
+                "poles": []
+            },
+            "name": null,
+            "type": "Structure"
+        },
+        {
+            "geometry": {
+                "type": "Cylinder",
+                "axis": 2,
+                "radius": 1.0,
+                "center": [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                "length": 1.0
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Lorentz",
+                "eps_inf": 1.0,
+                "coeffs": []
+            },
+            "name": null,
+            "type": "Structure"
+        },
+        {
+            "geometry": {
+                "type": "PolySlab",
+                "axis": 2,
+                "slab_bounds": [
+                    -1.0,
+                    1.0
+                ],
+                "dilation": 0.0,
+                "sidewall_angle": 0.0,
+                "vertices": [
+                    [
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        2.0,
+                        3.0
+                    ],
+                    [
+                        4.0,
+                        3.0
+                    ]
+                ]
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Sellmeier",
+                "coeffs": []
+            },
+            "name": null,
+            "type": "Structure"
+        },
+        {
+            "geometry": {
+                "type": "Sphere",
+                "radius": 1.0,
+                "center": [
+                    0.0,
+                    0.0,
+                    0.0
+                ]
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Debye",
+                "eps_inf": 1.0,
+                "coeffs": []
+            },
+            "name": "t2",
+            "type": "Structure"
+        }
+    ],
+    "sources": [
+        {
+            "type": "UniformCurrentSource",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 1.0,
+                "fwidth": 1.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "polarization": "Ex"
+        },
+        {
+            "type": "PlaneWave",
+            "center": [
+                0.0,
+                0.0,
+                -4.0
+            ],
+            "size": [
+                "Infinity",
+                "Infinity",
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 1.0,
+                "fwidth": 1.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 2.0
+        },
+        {
+            "type": "GaussianBeam",
+            "center": [
+                0.0,
+                0.0,
+                -4.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 1.0,
+                "fwidth": 1.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 0.0,
+            "waist_radius": 1.0,
+            "waist_distance": 0.0
+        },
+        {
+            "type": "ModeSource",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                1.0,
+                1.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 1.0,
+                "fwidth": 1.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "direction": "-",
+            "mode_spec": {
+                "num_modes": 3,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "sort_by": "largest_neff",
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "bend_radius": null,
+                "bend_axis": null,
+                "type": "ModeSpec"
+            },
+            "mode_index": 2
+        }
+    ],
+    "boundary_spec": {
+        "x": {
+            "plus": {
+                "name": null,
+                "type": "Absorber",
+                "num_layers": 40,
+                "parameters": {
+                    "sigma_order": 3,
+                    "sigma_min": 0.0,
+                    "sigma_max": 6.4,
+                    "type": "AbsorberParams"
+                }
+            },
+            "minus": {
+                "name": null,
+                "type": "PML",
+                "num_layers": 12,
+                "parameters": {
+                    "sigma_order": 3,
+                    "sigma_min": 0.0,
+                    "sigma_max": 1.5,
+                    "type": "PMLParams",
+                    "kappa_order": 3,
+                    "kappa_min": 1.0,
+                    "kappa_max": 3.0,
+                    "alpha_order": 1,
+                    "alpha_min": 0.0,
+                    "alpha_max": 0.0
+                }
+            },
+            "type": "Boundary"
+        },
+        "y": {
+            "plus": {
+                "name": null,
+                "type": "PMCBoundary"
+            },
+            "minus": {
+                "name": null,
+                "type": "PMCBoundary"
+            },
+            "type": "Boundary"
+        },
+        "z": {
+            "plus": {
+                "name": null,
+                "type": "PECBoundary"
+            },
+            "minus": {
+                "name": null,
+                "type": "StablePML",
+                "num_layers": 40,
+                "parameters": {
+                    "sigma_order": 3,
+                    "sigma_min": 0.0,
+                    "sigma_max": 1.0,
+                    "type": "PMLParams",
+                    "kappa_order": 3,
+                    "kappa_min": 1.0,
+                    "kappa_max": 5.0,
+                    "alpha_order": 1,
+                    "alpha_min": 0.0,
+                    "alpha_max": 0.9
+                }
+            },
+            "type": "Boundary"
+        },
+        "type": "BoundarySpec"
+    },
+    "monitors": [
+        {
+            "type": "FieldMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                1.0
+            ],
+            "name": "field",
+            "freqs": [
+                1,
+                2,
+                3
+            ],
+            "fields": [
+                "Ex",
+                "Ey",
+                "Ez",
+                "Hx",
+                "Hy",
+                "Hz"
+            ],
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": false
+        },
+        {
+            "type": "FieldTimeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                1.0
+            ],
+            "name": "fieldtime",
+            "start": 1e-12,
+            "stop": null,
+            "interval": 3,
+            "fields": [
+                "Ex",
+                "Ey",
+                "Ez",
+                "Hx",
+                "Hy",
+                "Hz"
+            ],
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": false
+        },
+        {
+            "type": "FluxMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                0.0,
+                1.0
+            ],
+            "name": "flux",
+            "freqs": [
+                1,
+                2,
+                3
+            ]
+        },
+        {
+            "type": "FluxTimeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                0.0,
+                1.0
+            ],
+            "name": "fluxtime",
+            "start": 1e-12,
+            "stop": null,
+            "interval": 3
+        },
+        {
+            "type": "ModeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                0.0,
+                1.0
+            ],
+            "name": "mode",
+            "freqs": [
+                1,
+                2
+            ],
+            "mode_spec": {
+                "num_modes": 3,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "sort_by": "largest_neff",
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "bend_radius": null,
+                "bend_axis": null,
+                "type": "ModeSpec"
+            }
+        }
+    ],
+    "grid_spec": {
+        "grid_x": {
+            "type": "AutoGrid",
+            "min_steps_per_wvl": 10.0,
+            "max_scale": 1.4,
+            "mesher": {
+                "type": "GradedMesher"
+            }
+        },
+        "grid_y": {
+            "type": "AutoGrid",
+            "min_steps_per_wvl": 10.0,
+            "max_scale": 1.4,
+            "mesher": {
+                "type": "GradedMesher"
+            }
+        },
+        "grid_z": {
+            "type": "AutoGrid",
+            "min_steps_per_wvl": 10.0,
+            "max_scale": 1.4,
+            "mesher": {
+                "type": "GradedMesher"
+            }
+        },
+        "wavelength": null,
+        "override_structures": [],
+        "type": "GridSpec"
+    },
+    "shutoff": 1e-05,
+    "subpixel": true,
+    "courant": 0.9,
+    "version": "1.5.0"
+}

--- a/tests/test_IO.py
+++ b/tests/test_IO.py
@@ -56,6 +56,15 @@ def test_simulation_preserve_types():
                 medium=Sellmeier(coeffs=[]),
             ),
             Structure(geometry=Sphere(radius=1), medium=Debye(eps_inf=1.0, coeffs=[]), name="t2"),
+            Structure(
+                geometry=GeometryGroup(
+                    geometries=[
+                        PolySlab(vertices=[(0, 0), (2, 3), (4, 3)], slab_bounds=(-1, 1), axis=2),
+                        Cylinder(radius=1, length=1, axis=2),
+                    ]
+                ),
+                medium=Drude(coeffs=[[1.0, 1.0]]),
+            ),
         ],
         sources=[
             UniformCurrentSource(size=(0, 0, 0), source_time=st, polarization="Ex"),

--- a/tidy3d/updater.py
+++ b/tidy3d/updater.py
@@ -188,6 +188,7 @@ def update_1_4(sim_dict: dict) -> dict:
         if geo_dict["type"] == "PolySlab":
             fix_polyslab_dict(geo_dict)
         elif geo_dict["type"] == "GeometryGroup":
+            geo_dict.pop("center", None)
             for sub_geo in geo_dict["geometries"]:
                 if sub_geo["type"] == "PolySlab":
                     fix_polyslab_dict(sub_geo)

--- a/tidy3d/updater.py
+++ b/tidy3d/updater.py
@@ -174,6 +174,27 @@ def updates_from_version(version_from_string: str):
     return decorator
 
 
+@updates_from_version("1.4")
+def update_1_4(sim_dict: dict) -> dict:
+    """Updates version 1.3 to 1.4."""
+
+    def fix_polyslab_dict(geo_dict):
+        """Fix a single PolySlab dictionary."""
+        geo_dict.pop("length", None)
+        geo_dict.pop("center", None)
+
+    for structure in sim_dict["structures"]:
+        geo_dict = structure["geometry"]
+        if geo_dict["type"] == "PolySlab":
+            fix_polyslab_dict(geo_dict)
+        elif geo_dict["type"] == "GeometryGroup":
+            for sub_geo in geo_dict["geometries"]:
+                if sub_geo["type"] == "PolySlab":
+                    fix_polyslab_dict(sub_geo)
+
+    return sim_dict
+
+
 @updates_from_version("1.3")
 def update_1_3(sim_dict: dict) -> dict:
     """Updates version 1.3 to 1.4."""

--- a/tidy3d/version.py
+++ b/tidy3d/version.py
@@ -1,3 +1,3 @@
 """Defines the front end version of tidy3d"""
 
-__version__ = "1.4.1"
+__version__ = "1.5.0"


### PR DESCRIPTION
A bit of reorganization so we dont abuse pydantic validators.

* Removed `Geometry.center` and added it as another abstract class that `Box`, `Sphere`, and `Cylinder` inherit from.
* Removed `Planar.length` and added it explicitly to `Cylinder`.
* Introduced abstract `center_axis` and `length_axis` properties to `Planar`, which must be implemented in subclasses for the planar logic to function appropriately.

Result is that validators are no longer used to set fields.

Note that version was changed to 1.5.0 because it introduces a minor schema change (no longer a "center" and "length" in PolySlab schema).