### PR TITLE
Sort_by -> filter_pol in ModeSpec, updated updater

### DIFF
--- a/tests/sims/simulation_1_5_0.json
+++ b/tests/sims/simulation_1_5_0.json
@@ -309,7 +309,7 @@
                     0,
                     0
                 ],
-                "sort_by": "largest_neff",
+                "filter_pol": null,
                 "angle_theta": 0.0,
                 "angle_phi": 0.0,
                 "bend_radius": null,
@@ -403,9 +403,9 @@
             ],
             "name": "field",
             "freqs": [
-                1,
-                2,
-                3
+                1.0,
+                2.0,
+                3.0
             ],
             "fields": [
                 "Ex",
@@ -467,9 +467,9 @@
             ],
             "name": "flux",
             "freqs": [
-                1,
-                2,
-                3
+                1.0,
+                2.0,
+                3.0
             ]
         },
         {
@@ -503,8 +503,8 @@
             ],
             "name": "mode",
             "freqs": [
-                1,
-                2
+                1.0,
+                2.0
             ],
             "mode_spec": {
                 "num_modes": 3,
@@ -513,7 +513,7 @@
                     0,
                     0
                 ],
-                "sort_by": "largest_neff",
+                "filter_pol": null,
                 "angle_theta": 0.0,
                 "angle_phi": 0.0,
                 "bend_radius": null,

--- a/tidy3d/components/mode.py
+++ b/tidy3d/components/mode.py
@@ -35,14 +35,20 @@ class ModeSpec(Tidy3dBaseModel):
         description="Number of standard pml layers to add in the two tangential axes.",
     )
 
-    sort_by: Literal["largest_neff", "te_fraction", "tm_fraction"] = pd.Field(
-        "largest_neff",
-        title="Ordering of the returned modes",
-        description="The solver will always compute the ``num_modes`` modes closest to the "
-        "``target_neff``, but they can be reordered by the largest ``te_fraction``, defined "
-        "as the integral of the intensity of the E-field component parallel to the first plane "
-        "axis normalized to the total in-plane E-field intensity. Similarly, ``tm_fraction`` "
-        "uses the E field component parallel to the second plane axis.",
+    filter_pol: Literal["te", "tm"] = pd.Field(
+        None,
+        title="Polarization filtering",
+        description="The solver always computes the ``num_modes`` modes closest to the given "
+        "``target_neff``. If ``filter_pol==None``, they are simply sorted in order of decresing "
+        "effective index. If a polarization filter is selected, the modes are rearranged such that "
+        "the first ``n_pol`` modes in the list are the ones with the selected polarization "
+        "fraction larger than or equal to 0.5, while the next ``num_modes - n_pol`` modes are the "
+        "ones where it is smaller than 0.5 (i.e. the opposite polarization fraction is larger than "
+        "0.5). Within each polarization subset, the modes are still ordered by decreasing "
+        "effective index. "
+        "``te``-fraction is defined as the integrated intensity of the E-field component parallel "
+        "to the first plane axis, normalized to the total in-plane E-field intensity. Conversely, "
+        "``tm``-fraction uses the E field component parallel to the second plane axis.",
     )
 
     angle_theta: float = pd.Field(

--- a/tidy3d/plugins/mode/solver.py
+++ b/tidy3d/plugins/mode/solver.py
@@ -165,13 +165,13 @@ def compute_modes(
     # Solve for the modes
     E, H, neff, keff = solver_em(eps_tensor, mu_tensor, der_mats, num_modes, target_neff_p)
 
-    # Reorder if needed
-    if mode_spec.sort_by != "largest_neff":
-        if mode_spec.sort_by == "te_fraction":
-            sort_int = np.sum(np.abs(E[0]) ** 2, axis=0) / np.sum(np.abs(E[:2]) ** 2, axis=(0, 1))
-        elif mode_spec.sort_by == "tm_fraction":
-            sort_int = np.sum(np.abs(E[1]) ** 2, axis=0) / np.sum(np.abs(E[:2]) ** 2, axis=(0, 1))
-        sort_inds = np.argsort(sort_int)[::-1]
+    # Filter polarization if needed
+    if mode_spec.filter_pol is not None:
+        te_int = np.sum(np.abs(E[0]) ** 2, axis=0) / np.sum(np.abs(E[:2]) ** 2, axis=(0, 1))
+        if mode_spec.filter_pol == "te":
+            sort_inds = np.concatenate((np.nonzero(te_int >= 0.5)[0], np.nonzero(te_int < 0.5)[0]))
+        elif mode_spec.filter_pol == "tm":
+            sort_inds = np.concatenate((np.nonzero(te_int <= 0.5)[0], np.nonzero(te_int > 0.5)[0]))
         E = E[..., sort_inds]
         H = H[..., sort_inds]
         neff = neff[..., sort_inds]

--- a/tidy3d/updater.py
+++ b/tidy3d/updater.py
@@ -1,4 +1,5 @@
 """Utilities for converting between tidy3d versions."""
+from typing import Dict, Callable
 import json
 import functools
 import yaml
@@ -174,24 +175,53 @@ def updates_from_version(version_from_string: str):
     return decorator
 
 
+def iterate_update_dict(update_dict: Dict, update_types: Dict[str, Callable]):
+    """Recursively iterate nested ``update_dict``. For any nested ``nested_dict`` found,
+    apply an update function if its ``nested_dict["type"]`` is in the keys of the ``update_types``
+    dictionary. Also iterates lists and tuples.
+    """
+
+    if isinstance(update_dict, dict):
+        # Update if we need to, and iterate recursively all items
+        if update_dict.get("type") in update_types.keys():
+            update_types[update_dict["type"]](update_dict)
+        for item in update_dict.values():
+            iterate_update_dict(item, update_types)
+    elif isinstance(update_dict, (list, tuple)):
+        # Try other iterables
+        for item in update_dict:
+            iterate_update_dict(item, update_types)
+
+
 @updates_from_version("1.4")
 def update_1_4(sim_dict: dict) -> dict:
     """Updates version 1.3 to 1.4."""
 
-    def fix_polyslab_dict(geo_dict):
-        """Fix a single PolySlab dictionary."""
+    def fix_polyslab(geo_dict):
+        """Fix a PolySlab dictionary."""
         geo_dict.pop("length", None)
         geo_dict.pop("center", None)
 
-    for structure in sim_dict["structures"]:
-        geo_dict = structure["geometry"]
-        if geo_dict["type"] == "PolySlab":
-            fix_polyslab_dict(geo_dict)
-        elif geo_dict["type"] == "GeometryGroup":
-            geo_dict.pop("center", None)
-            for sub_geo in geo_dict["geometries"]:
-                if sub_geo["type"] == "PolySlab":
-                    fix_polyslab_dict(sub_geo)
+    def fix_modespec(ms_dict):
+        """Fix a ModeSpec dictionary."""
+        sort_by = ms_dict.pop("sort_by", None)
+        if sort_by != "largest_neff":
+            log.warning(
+                "ModeSpec.sort_by was removed in Tidy3D 1.5.0, reverting to sorting by "
+                "largest effective index. Use ModeSpec.filter_pol to select polarization instead."
+            )
+
+    def fix_geometry_group(geo_dict):
+        """Fix a GeometryGroup dictionary."""
+        geo_dict.pop("center", None)
+
+    update_types = {
+        "PolySlab": fix_polyslab,
+        "ModeSpec": fix_modespec,
+        "GeometryGroup": fix_geometry_group,
+    }
+
+    iterate_update_dict(update_dict=sim_dict, update_types=update_types)
 
     return sim_dict
 


### PR DESCRIPTION
Previous use: `sort_by: Literal["largest_neff", "te_fraction", "tm_fraction"]`. Not very convenient because what you typically want to do is not e.g. inject the te mode with the largest te fraction, but rather inject e.g. the fundamental (largest neff) mode that is predominantly te polarized.

New use: `filter_pol: Literal["te", "tm"]`. If None, just sort by largest neff. If e.g. `"te"`, then the modes with te-fraction larger than 0.5 are placed first (ordered by largest neff), then the other modes are grouped second (again ordered by largest neff).

I also added a convenience function for the updater for recursively updating the dict.

Fixes #298 