### PR TITLE
Complex-valued field fixes

### DIFF
--- a/test_local.sh
+++ b/test_local.sh
@@ -4,12 +4,17 @@ set -e
 black .
 python lint.py
 pytest -ra tests/test_components.py
-pytest -ra tests/test_grid.py
 pytest -ra tests/test_boundaries.py
+pytest -ra tests/test_config.py
+pytest -ra tests/test_data.py
+pytest -ra tests/test_geo_group.py
+pytest -ra tests/test_grid.py
 pytest -ra tests/test_IO.py
+pytest -ra tests/test_log.py
+pytest -ra tests/test_main.py
 pytest -ra tests/test_material_library.py
+pytest -ra tests/test_meshgenerate.py
 pytest -ra tests/test_plugins.py
 pytest -ra tests/test_sidewall.py
-pytest -ra tests/test_meshgenerate.py
 
 pytest --doctest-modules tidy3d/components

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -30,6 +30,16 @@ def test_scalar_field_time_data():
     _ = data.data
 
 
+def test_complex_scalar_field_time_data():
+    t = np.linspace(0, 1e-12, 1001)
+    x = np.linspace(-1, 1, 10)
+    y = np.linspace(-2, 2, 20)
+    z = np.linspace(0, 0, 1)
+    values = (1 + 1j) * np.random.random((len(x), len(y), len(z), len(t)))
+    data = ScalarFieldTimeData(values=values, x=x, y=y, z=z, t=t)
+    _ = data.data
+
+
 def test_scalar_permittivity_data():
     f = np.linspace(1e14, 2e14, 1001)
     x = np.linspace(-1, 1, 10)

--- a/tidy3d/components/boundary.py
+++ b/tidy3d/components/boundary.py
@@ -67,6 +67,9 @@ class BlochBoundary(BoundaryEdge):
         cls, source: BlochSourceType, domain_size: float, axis: Axis, medium: Medium = None
     ) -> "BlochBoundary":
         """Set the Bloch vector component based on a given angled source and its center frequency.
+           Note that if a broadband angled source is used, only the frequency components near the
+           center frequency will exhibit angled incidence at the expect angle. In this case, a
+           narrowband source is recommended.
 
         Parameters
         ----------

--- a/tidy3d/components/data.py
+++ b/tidy3d/components/data.py
@@ -671,7 +671,7 @@ class ScalarFieldTimeData(ScalarSpatialData, TimeData):
     >>> data = ScalarFieldTimeData(values=values, x=x, y=y, z=z, t=t)
     """
 
-    values: Array[float] = pd.Field(
+    values: Array[complex] = pd.Field(
         ...,
         title="Scalar Field Values",
         description="Multi-dimensional array storing the raw scalar field values in time domain.",


### PR DESCRIPTION
- Complex-valued fields allowed in `ScalarFieldTimeData`
- Added missing frontend tests in test_local
- Added clarification in docstring for Bloch boundaries

Related issue: https://github.com/flexcompute/tidy3d-core/issues/89