### PR TITLE
reverts way symmetry is applied to mode solver

### DIFF
--- a/tests/test_data_arrays.py
+++ b/tests/test_data_arrays.py
@@ -78,7 +78,7 @@ DIRECTIONS = ["+", "-"]
 
 
 def get_xyz(monitor: MonitorType, grid_key: str) -> Tuple[List[float], List[float], List[float]]:
-    grid = SIM.discretize(monitor, extend=False)
+    grid = SIM.discretize(monitor, extend=True)
     x, y, z = grid[grid_key].to_list
     x = [_x for _x in x if _x >= 0]
     y = [_y for _y in y if _y >= 0]

--- a/tests/test_data_monitor.py
+++ b/tests/test_data_monitor.py
@@ -2,6 +2,8 @@
 import numpy as np
 import pytest
 
+import tidy3d as td
+
 from tidy3d.components.monitor import FieldMonitor, FieldTimeMonitor, PermittivityMonitor
 from tidy3d.components.monitor import ModeSolverMonitor, ModeMonitor
 from tidy3d.components.monitor import FluxMonitor, FluxTimeMonitor
@@ -18,6 +20,7 @@ from .test_data_arrays import make_flux_data_array, make_flux_time_data_array
 from .test_data_arrays import make_mode_amps_data_array, make_mode_index_data_array
 from .test_data_arrays import FIELD_MONITOR, FIELD_TIME_MONITOR, MODE_SOLVE_MONITOR
 from .test_data_arrays import MODE_MONITOR, PERMITTIVITY_MONITOR, FLUX_MONITOR, FLUX_TIME_MONITOR
+from .utils import clear_tmp
 
 # data array instances
 AMPS = make_mode_amps_data_array()
@@ -168,10 +171,33 @@ def _test_eq():
     assert data1 != data3, "different data are equal"
 
 
-def test_empty():
-    import tidy3d as td
-
-    coords = {"x": np.arange(10), "y": np.arange(10), "z": np.arange(10), "t": np.arange(0)}
+def test_empty_array():
+    coords = {"x": np.arange(10), "y": np.arange(10), "z": np.arange(10), "t": []}
     fields = {"Ex": td.ScalarFieldTimeDataArray(np.random.rand(10, 10, 10, 0), coords=coords)}
     monitor = td.FieldTimeMonitor(size=(1, 1, 1), fields=["Ex"], name="test")
     field_data = td.FieldTimeData(monitor=monitor, **fields)
+
+
+def test_empty_list():
+    coords = {"x": np.arange(10), "y": np.arange(10), "z": np.arange(10), "t": []}
+    fields = {"Ex": td.ScalarFieldTimeDataArray([], coords=coords)}
+    monitor = td.FieldTimeMonitor(size=(1, 1, 1), fields=["Ex"], name="test")
+    field_data = td.FieldTimeData(monitor=monitor, **fields)
+
+
+def test_empty_tuple():
+    coords = {"x": np.arange(10), "y": np.arange(10), "z": np.arange(10), "t": []}
+    fields = {"Ex": td.ScalarFieldTimeDataArray((), coords=coords)}
+    monitor = td.FieldTimeMonitor(size=(1, 1, 1), fields=["Ex"], name="test")
+    field_data = td.FieldTimeData(monitor=monitor, **fields)
+
+
+@clear_tmp
+def test_empty_io():
+    coords = {"x": np.arange(10), "y": np.arange(10), "z": np.arange(10), "t": []}
+    fields = {"Ex": td.ScalarFieldTimeDataArray(np.random.rand(10, 10, 10, 0), coords=coords)}
+    monitor = td.FieldTimeMonitor(size=(1, 1, 1), name="test", fields=["Ex"])
+    field_data = td.FieldTimeData(monitor=monitor, **fields)
+    field_data.to_file("tests/tmp/field_data.hdf5")
+    field_data = td.FieldTimeData.from_file("tests/tmp/field_data.hdf5")
+    assert field_data.Ex.size == 0

--- a/tests/test_data_sim.py
+++ b/tests/test_data_sim.py
@@ -1,8 +1,11 @@
 import numpy as np
 
+import tidy3d as td
+
 from tidy3d.components.simulation import Simulation
 from tidy3d.components.grid.grid_spec import GridSpec
 from tidy3d.components.data.sim_data import SimulationData
+from tidy3d.components.data import ScalarFieldTimeDataArray, FieldTimeData
 from tidy3d.components.monitor import FieldMonitor, FieldTimeMonitor, ModeSolverMonitor
 from tidy3d.components.source import GaussianPulse, PointDipole
 
@@ -147,3 +150,82 @@ def test_to_hdf5():
     sim_data.to_file(fname=FNAME)
     sim_data2 = SimulationData.from_file(fname=FNAME)
     assert sim_data == sim_data2
+
+
+@clear_tmp
+def test_empty_io():
+    coords = {"x": np.arange(10), "y": np.arange(10), "z": np.arange(10), "t": []}
+    fields = {"Ex": td.ScalarFieldTimeDataArray(np.random.rand(10, 10, 10, 0), coords=coords)}
+    monitor = td.FieldTimeMonitor(size=(1, 1, 1), name="test", fields=["Ex"])
+    field_data = td.FieldTimeData(monitor=monitor, **fields)
+    sim = td.Simulation(
+        size=(1, 1, 1), monitors=(monitor,), run_time=1e-12, grid_spec=td.GridSpec(wavelength=1.0)
+    )
+    sim_data = SimulationData(
+        simulation=sim, monitor_data={"tmnt": field_data}, normalize_index=None
+    )
+    sim_data.to_file("tests/tmp/sim_data_empty.hdf5")
+    sim_data = SimulationData.from_file("tests/tmp/sim_data_empty.hdf5")
+    field_data = sim_data["tmnt"]
+    Ex = field_data.Ex
+    assert Ex.size == 0
+
+
+@clear_tmp
+def test_run_time_lt_start():
+
+    # Point source inside a box
+    box = td.Structure(
+        geometry=td.Box(center=(0, 0, 0), size=(1, 1, 1)),
+        medium=td.Medium(permittivity=10, conductivity=0.0),
+    )
+
+    tmnt = td.FieldTimeMonitor(
+        center=(0.0, 0.0, 0.1),
+        size=(1.2, 1.2, 0.0),
+        name="tmnt",
+        start=1e-13,
+        stop=None,
+        interval=1,
+        fields=("Ex", "Ey", "Ez", "Hx", "Hy", "Hz"),
+        interval_space=(1, 1, 1),
+        colocate=False,
+    )
+
+    sim = td.Simulation(
+        size=(2, 2, 2),
+        run_time=1e-50,
+        grid_spec=td.GridSpec(
+            grid_x=td.UniformGrid(dl=1 / 20),
+            grid_y=td.UniformGrid(dl=1 / 22),
+            grid_z=td.UniformGrid(dl=1 / 24),
+        ),
+        structures=(box,),
+        monitors=(tmnt,),
+        boundary_spec=td.BoundarySpec.all_sides(boundary=td.PML()),
+    )
+
+    coords = dict(
+        x=np.linspace(-0.6, 0.6, 10),
+        y=np.linspace(-0.6, 0.6, 10),
+        z=[0.1],
+        t=[],
+    )
+
+    field_components = {
+        field_name: ScalarFieldTimeDataArray(np.zeros((10, 10, 1, 0)), coords=coords)
+        for field_name in tmnt.fields
+    }
+
+    field_data = FieldTimeData(monitor=tmnt, **field_components)
+
+    sim_data = SimulationData(
+        simulation=sim,
+        monitor_data={tmnt.name: field_data},
+        normalize_index=0,
+    )
+
+    sim_data.to_file("tests/tmp/sim_data_empty.hdf5")
+    sim_data = SimulationData.from_file("tests/tmp/sim_data_empty.hdf5")
+    tmnt_data = sim_data.monitor_data[tmnt.name]
+    tmnt_data = sim_data[tmnt.name]

--- a/tidy3d/components/data/README.md
+++ b/tidy3d/components/data/README.md
@@ -81,9 +81,7 @@ All `MonitorData` subclasses also have an `.apply_symmetry()` method, whch retur
 ```python
 def apply_symmetry(
     self,
-    symmetry: Tuple[Symmetry, Symmetry, Symmetry],
-    symmetry_center: Coordinate,
-    grid_expanded: Grid,
+    simulation: Simulation
 ) -> "MonitorData":
 ```
 

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -52,6 +52,17 @@ class DataArray(xr.DataArray):
         if (not kwargs.get("fastpath")) and ("attrs" not in kwargs) and (self._data_attrs):
             kwargs["attrs"] = self._data_attrs
 
+        # fix case if data of empty list or tuple is supplied as first arg
+        data_arg = args[0]
+        is_empty_array = isinstance(data_arg, np.ndarray) and (data_arg.size == 0)
+        is_empty_list = (isinstance(data_arg, list)) and (data_arg == [])
+        is_empty_tuple = (isinstance(data_arg, tuple)) and (data_arg == ())
+        if is_empty_array or is_empty_list or is_empty_tuple:
+            shape = tuple(len(values) for _, values, _ in coords)
+            new_args = list(args)
+            new_args[0] = np.zeros(shape=shape)
+            args = tuple(new_args)
+
         super().__init__(*args, **kwargs)
 
     @classmethod

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -94,13 +94,11 @@ class ModeSolver(Tidy3dBaseModel):
         ModeSolverData
             :class:`.ModeSolverData` object containing the effective index and mode fields.
         """
-        # note: calling sim_data like this expands the symmetries under the hood
-        # ModeSolver.data will instead return the data without symmetry expansion
-        return self.sim_data[MODE_MONITOR_NAME]
+        return self.data
 
     @cached_property
-    def data(self) -> ModeSolverData:
-        """:class:`.ModeSolverData` containing the field and effective index data.
+    def data_raw(self) -> ModeSolverData:
+        """:class:`.ModeSolverData` containing the field and effective index on unexpanded grid.
 
         Returns
         -------
@@ -150,6 +148,18 @@ class ModeSolver(Tidy3dBaseModel):
         mode_solver_data = ModeSolverData(monitor=mode_solver_monitor, **data_dict)
         self._field_decay_warning(mode_solver_data)
         return mode_solver_data
+
+    @cached_property
+    def data(self) -> ModeSolverData:
+        """:class:`.ModeSolverData` containing the field and effective index data.
+
+        Returns
+        -------
+        ModeSolverData
+            :class:`.ModeSolverData` object containing the effective index and mode fields.
+        """
+        mode_solver_data = self.data_raw
+        return mode_solver_data.apply_symmetry(simulation=self.simulation)
 
     @cached_property
     def sim_data(self) -> SimulationData:


### PR DESCRIPTION
Note, the way this would work is:
1. `ModeSolver.data` (or `.solve()`) returns a `ModeSolverData` object with symmetry applied (`extend=False`)
2. `SimulationData[mode_solver_monitor_name]` returns a `ModeSolverData` object with symmetry applied (`extend=True`)

The backend then just uses 1. instead of doing things with `SimulationData`, which ends up complicating things a bit because of some monitor naming conflict (`MODE_MONITOR_NAME` conflicted with an existing monitor named 'mode' in the sim_data).
