### PR TITLE
enable self type annotation

### DIFF
--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -1,4 +1,5 @@
 """global configuration / base class for pydantic models used to make simulation."""
+from __future__ import annotations
 
 import json
 from typing import Any
@@ -27,7 +28,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
     `Pydantic Models <https://pydantic-docs.helpmanual.io/usage/models/>`_
     """
 
-    def __init_subclass__(cls):
+    def __init_subclass__(cls) -> None:
         """Things that are done to each of the models."""
 
         cls.add_type_field()
@@ -66,7 +67,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
 
     _cached_properties = pydantic.PrivateAttr({})
 
-    def copy(self, validate: bool = True, **kwargs) -> "Self":
+    def copy(self, validate: bool = True, **kwargs) -> Tidy3dBaseModel:
         """Copy a Tidy3dBaseModel.  With ``deep=True`` as default."""
         if "deep" in kwargs and kwargs["deep"] is False:
             raise ValueError("Can't do shallow copy of component, set `deep=True` in copy().")
@@ -89,7 +90,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         rich.inspect(self, methods=methods)
 
     @classmethod
-    def from_file(cls, fname: str, **parse_kwargs):
+    def from_file(cls, fname: str, **parse_kwargs) -> Tidy3dBaseModel:
         """Loads a :class:`Tidy3dBaseModel` from .yaml or .json file.
 
         Parameters
@@ -139,7 +140,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         raise FileError(f"File must be .json, .yaml, or .hdf5 type, given {fname}")
 
     @classmethod
-    def from_json(cls, fname: str, **parse_file_kwargs):
+    def from_json(cls, fname: str, **parse_file_kwargs) -> Tidy3dBaseModel:
         """Load a :class:`Tidy3dBaseModel` from .json file.
 
         Parameters
@@ -177,7 +178,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
             file_handle.write(json_string)
 
     @classmethod
-    def from_yaml(cls, fname: str, **parse_raw_kwargs):
+    def from_yaml(cls, fname: str, **parse_raw_kwargs) -> Tidy3dBaseModel:
         """Loads :class:`Tidy3dBaseModel` from .yaml file.
 
         Parameters
@@ -219,7 +220,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
             yaml.dump(json_dict, file_handle, indent=INDENT)
 
     @classmethod
-    def from_hdf5(cls, fname: str, **parse_raw_kwargs):
+    def from_hdf5(cls, fname: str, **parse_raw_kwargs) -> Tidy3dBaseModel:
         """Loads :class:`Tidy3dBaseModel` from .yaml file.
 
         Parameters
@@ -318,7 +319,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         return value
 
     @classmethod
-    def load_from_handle(cls, hdf5_group: h5py.Group, **kwargs) -> "Self":
+    def load_from_handle(cls, hdf5_group: h5py.Group, **kwargs) -> Tidy3dBaseModel:
         """Loads an instance of the class from an hdf5 group,
 
         Parameters
@@ -482,7 +483,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         return json_string
 
     @classmethod
-    def add_type_field(cls):
+    def add_type_field(cls) -> None:
         """Automatically place "type" field with model name in the model field dictionary."""
 
         value = cls.__name__

--- a/tidy3d/components/boundary.py
+++ b/tidy3d/components/boundary.py
@@ -1,4 +1,6 @@
 """Defines electromagnetic boundary conditions"""
+from __future__ import annotations
+
 from abc import ABC
 from typing import Union, Tuple, List
 
@@ -65,7 +67,7 @@ class BlochBoundary(BoundaryEdge):
     @classmethod
     def from_source(
         cls, source: BlochSourceType, domain_size: float, axis: Axis, medium: Medium = None
-    ) -> "BlochBoundary":
+    ) -> BlochBoundary:
         """Set the Bloch vector component based on a given angled source and its center frequency.
            Note that if a broadband angled source is used, only the frequency components near the
            center frequency will exhibit angled incidence at the expect angle. In this case, a

--- a/tidy3d/components/data/README.md
+++ b/tidy3d/components/data/README.md
@@ -68,7 +68,7 @@ Final note: data for a `FluxMonitor` and `FluxTimeMonitor` are loaded in `FluxDa
 All `MonitorData` subclasses have a `.normalize()` method, which returns a copy of the instance normalized by a given source spectrum.
 
 ```python
-def normalize(self, source_spectrum_fn: Callable[[float], complex]) -> "MonitorData":
+def normalize(self, source_spectrum_fn: Callable[[float], complex]) -> MonitorData:
 ```
 
 Rather than raw data being passed to this, `source_spectrum_fn` is a function of frequency that returns the complex-valued source spectrum.  This was done to simplify things at the `SimulationData` level and provide more customizability.
@@ -82,7 +82,7 @@ All `MonitorData` subclasses also have an `.apply_symmetry()` method, whch retur
 def apply_symmetry(
     self,
     simulation: Simulation
-) -> "MonitorData":
+) -> MonitorData:
 ```
 
 #### Field-Like Data

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -1,4 +1,6 @@
 """ Monitor Level Data, store the DataArrays associated with a single monitor."""
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Union, Dict, Tuple, Callable
 import xarray as xr
@@ -32,13 +34,13 @@ class MonitorData(Tidy3dBaseModel, ABC):
 
     def apply_symmetry(
         self, simulation: Simulation  # pylint:disable=unused-argument
-    ) -> "MonitorData":
+    ) -> MonitorData:
         """Return copy of self with symmetry applied."""
         return self.copy()
 
     def normalize(
         self, source_spectrum_fn: Callable[[float], complex]  # pylint:disable=unused-argument
-    ) -> "MonitorData":
+    ) -> MonitorData:
         """Return copy of self after normalization is applied using source spectrum function."""
         return self.copy()
 
@@ -63,7 +65,7 @@ class AbstractFieldData(MonitorData, ABC):
     def symmetry_eigenvalues(self) -> Dict[str, Callable[[Axis], float]]:
         """Maps field components to their (positive) symmetry eigenvalues."""
 
-    def apply_symmetry(self, simulation: Simulation) -> "AbstractFieldData":
+    def apply_symmetry(self, simulation: Simulation) -> AbstractFieldData:
         """Return copy of self with symmetry applied."""
         return self._apply_field_symmetry(
             symmetry=simulation.symmetry,
@@ -76,7 +78,7 @@ class AbstractFieldData(MonitorData, ABC):
         symmetry: Tuple[Symmetry, Symmetry, Symmetry],
         symmetry_center: Coordinate,
         grid_expanded: Grid,
-    ) -> "AbstractFieldData":
+    ) -> AbstractFieldData:
         """Create a copy of the :class:`.AbstractFieldData` with symmetry applied
 
         Returns
@@ -262,7 +264,7 @@ class FieldData(ElectromagneticFieldData):
 
     _contains_monitor_fields = enforce_monitor_fields_present()
 
-    def normalize(self, source_spectrum_fn: Callable[[float], complex]) -> "FieldData":
+    def normalize(self, source_spectrum_fn: Callable[[float], complex]) -> FieldData:
         """Return copy of self after normalization is applied using source spectrum function."""
         fields_norm = {}
         for field_name, field_data in self.field_components.items():
@@ -520,7 +522,7 @@ class ModeData(MonitorData):
         """Imaginary part of the propagation index."""
         return self.n_complex.imag
 
-    def normalize(self, source_spectrum_fn) -> "ModeData":
+    def normalize(self, source_spectrum_fn) -> ModeData:
         """Return copy of self after normalization is applied using source spectrum function."""
         if self.amps is None:
             raise DataError("ModeData contains no amp data, can't normalize.")
@@ -543,7 +545,7 @@ class FluxData(MonitorData):
     monitor: FluxMonitor
     flux: FluxDataArray
 
-    def normalize(self, source_spectrum_fn) -> "Self":
+    def normalize(self, source_spectrum_fn) -> FluxData:
         """Return copy of self after normalization is applied using source spectrum function."""
         source_freq_amps = source_spectrum_fn(self.flux.f)
         source_power = abs(source_freq_amps) ** 2

--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -1,4 +1,5 @@
 """ Defines classes specifying meshing in 1D and a collective class for 3D """
+from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import Tuple, List, Union
@@ -504,7 +505,7 @@ class GridSpec(Tidy3dBaseModel):
         max_scale: pd.PositiveFloat = 1.4,
         override_structures: List[Structure] = (),
         mesher: MesherType = GradedMesher(),
-    ) -> "GridSpec":
+    ) -> GridSpec:
         """Use the same :class:`AutoGrid` along each of the three directions.
 
         Parameters
@@ -540,7 +541,7 @@ class GridSpec(Tidy3dBaseModel):
         )
 
     @classmethod
-    def uniform(cls, dl: float) -> "GridSpec":
+    def uniform(cls, dl: float) -> GridSpec:
         """Use the same :class:`UniformGrid` along each of the three directions.
 
         Parameters

--- a/tidy3d/components/viz.py
+++ b/tidy3d/components/viz.py
@@ -1,5 +1,7 @@
 # pylint: disable=invalid-name
 """ utilities for plotting """
+from __future__ import annotations
+
 from typing import Any
 from functools import wraps
 
@@ -87,7 +89,7 @@ class PlotParams(Tidy3dBaseModel):
     hatch: str = pd.Field(None, title="Hatch Style")
     linewidth: pd.NonNegativeFloat = pd.Field(1, title="Line Width", alias="lw")
 
-    def include_kwargs(self, **kwargs) -> "PlotParams":
+    def include_kwargs(self, **kwargs) -> PlotParams:
         """Update the plot params with supplied kwargs."""
         update_dict = {
             key: value

--- a/tidy3d/plugins/webplots/data.py
+++ b/tidy3d/plugins/webplots/data.py
@@ -48,7 +48,7 @@ class DataPlotly(UIComponent, ABC):
     #     return f"monitor_{self.monitor_name}"
 
     @staticmethod
-    def sel_by_val(data, val: str) -> "data":
+    def sel_by_val(data, val: str) -> Tidy3dBaseModelType:
         """Select the correct data type based on the `val` selection."""
         if val.lower() == "real":
             return data.real
@@ -67,7 +67,7 @@ class DataPlotly(UIComponent, ABC):
     @classmethod
     def from_monitor_data(
         cls, monitor_name: str, monitor_data: Tidy3dBaseModelType, **kwargs
-    ) -> "cls":
+    ) -> Tidy3dBaseModelType:
         """Load a PlotlyData UI component from the monitor name and its data."""
 
         # maps the supplied ``monitor_data`` argument to the corresponding plotly wrapper.


### PR DESCRIPTION
Before, when type annotating a class method, could not reference the class name. Instead, we put it in quotes:
```py
class MyClass:
    def copy(self) -> 'MyClass':
        pass
```
In python 3.7 +, we can use the class name in the annotations by importing

```py
from __future__ import annotations

class MyClass:
    def copy(self) -> MyClass:
        pass
```

note, breaks python 3.6. Are we even supporting it though?
