### PR TITLE
performance improvements for saving / loading .hdf5

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,3 +11,4 @@ tox
 pytest
 pytest-timeout
 gdspy
+memory_profiler

--- a/tests/test_data_performance.py
+++ b/tests/test_data_performance.py
@@ -1,0 +1,122 @@
+import pytest
+import numpy as np
+import os
+import sys
+from memory_profiler import profile
+
+from tidy3d.components.data import SimulationData, FieldData, ScalarFieldDataArray
+from tidy3d.components.monitor import FieldMonitor
+from tidy3d.components.simulation import Simulation
+from tidy3d.components.source import PointDipole, GaussianPulse
+from tidy3d.components.grid import GridSpec
+
+import tidy3d as td
+
+sys.path.append("/users/twhughes/Documents/Flexcompute/tidy3d-core")
+from tidy3d_backend.utils import Profile
+
+PATH = "tests/tmp/memory.hdf5"
+
+""" Testing the memory usage of writing SimulationData to and from .hdf5 file.
+    
+    pip install memory_profiler
+    python -m memory_profiler tests/test_data_memory.py
+
+    note, units are in MiB, so need to convert to MB / GB.
+
+    https://www.thecalculatorsite.com/conversions/datastorage.php
+
+"""
+
+# will set size of sim_data1 to give a file size of this many GB
+FILE_SIZE_GB = 4.0
+
+
+def make_sim_data_1(file_size_gb=FILE_SIZE_GB):
+    # approximate # of points in the scalar field data
+
+    N = int(2.528e8 / 4 * file_size_gb)
+
+    n = int(N ** (0.25))
+
+    data = (1 + 1j) * np.random.random((n, n, n, n))
+    x = np.linspace(-1, 1, n)
+    y = np.linspace(-1, 1, n)
+    z = np.linspace(-1, 1, n)
+    f = np.linspace(2e14, 4e14, n)
+    src = PointDipole(
+        center=(0, 0, 0), source_time=GaussianPulse(freq0=3e14, fwidth=1e14), polarization="Ex"
+    )
+    coords = dict(x=x, y=y, z=z, f=f)
+    Ex = ScalarFieldDataArray(data, coords=coords)
+    monitor = FieldMonitor(size=(2, 2, 2), freqs=f, name="test", fields=["Ex"])
+    field_data = FieldData(monitor=monitor, Ex=Ex)
+    sim = Simulation(
+        size=(2, 2, 2),
+        grid_spec=GridSpec(wavelength=1),
+        monitors=(monitor,),
+        sources=(src,),
+        run_time=1e-12,
+    )
+    return SimulationData(
+        simulation=sim,
+        monitor_data=dict(test=field_data),
+    )
+
+
+SIM_DATA_1 = make_sim_data_1()
+
+
+@profile
+def test_memory_1_save():
+    print(f'sim_data_size = {SIM_DATA_1.monitor_data["test"].Ex.nbytes:.2e} Bytes')
+    SIM_DATA_1.to_file(PATH)
+    print(f"file_size = {os.path.getsize(PATH):.2e} Bytes")
+
+
+@profile
+def test_memory_2_load():
+    print(f"file_size = {os.path.getsize(PATH):.2e} Bytes")
+    return SimulationData.from_file(PATH)
+
+
+def test_core_profile_small_1_save():
+
+    Nx, Ny, Nz, Nt = 100, 100, 100, 10
+
+    x = np.arange(Nx)
+    y = np.arange(Ny)
+    z = np.arange(Nz)
+    t = np.arange(Nt)
+    coords = dict(x=x, y=y, z=z, t=t)
+    scalar_field = td.ScalarFieldTimeDataArray(np.random.random((Nx, Ny, Nz, Nt)), coords=coords)
+    monitor = td.FieldTimeMonitor(size=(2, 4, 6), interval=100, name="field", fields=["Ex", "Hz"])
+    data = td.FieldTimeData(monitor=monitor, Ex=scalar_field, Hz=scalar_field)
+    with Profile():
+        data.to_file(PATH)
+        print(f"file_size = {os.path.getsize(PATH):.2e} Bytes")
+
+
+def test_core_profile_small_2_load():
+
+    with Profile():
+        print(f"file_size = {os.path.getsize(PATH):.2e} Bytes")
+        data = td.FieldTimeData.from_file(PATH)
+
+
+def test_core_profile_large():
+
+    sim_data = make_sim_data_1()
+
+    with Profile():
+        sim_data.to_file(PATH)
+
+    print(f"file_size = {os.path.getsize(PATH):.2e} Bytes")
+
+    with Profile():
+        sim_data.from_file(PATH)
+
+
+if __name__ == "__main__":
+    test_memory_1_save()
+    sim_data1 = test_memory_2_load()

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -78,7 +78,7 @@ class DataArray(xr.DataArray):
         if isinstance(value, dict):
             data = value.get("data")
             coords = value.get("coords")
-            coords = {name: np.array(val.get("data")) for name, val in coords.items()}
+            coords = {name: np.array(val) for name, val in coords.items()}
             return cls(np.array(data), coords=coords)
 
         return cls(value)
@@ -90,8 +90,14 @@ class DataArray(xr.DataArray):
 
     def __eq__(self, other) -> bool:
         """Whether two data array objects are equal."""
+        if not np.all(self.data == other.data):
+            return False
+        for key, val in self.coords.items():
+            if not np.all(np.array(val) == np.array(other.coords[key])):
+                return False
+        return True
 
-        return self.to_dict() == other.to_dict()
+        # return self.to_dict() == other.to_dict()
 
 
 class ScalarFieldDataArray(DataArray):

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -78,8 +78,13 @@ class DataArray(xr.DataArray):
         if isinstance(value, dict):
             data = value.get("data")
             coords = value.get("coords")
-            coords = {name: np.array(val) for name, val in coords.items()}
-            return cls(np.array(data), coords=coords)
+
+            # convert to numpy if not already
+            coords = {k: v if isinstance(v, np.ndarray) else np.array(v) for k, v in coords.items()}
+            if not isinstance(data, np.ndarray):
+                data = np.array(data)
+
+            return cls(data, coords=coords)
 
         return cls(value)
 


### PR DESCRIPTION
For a `SimulationData.hdf5` file of size 4GB on disk:
* Requires 4.21 GB of memory to read and write(using `memory_profiler` python package).
* 11 sec of load time on my machine, few seconds to write.