### PR TITLE
Rearranging requirements and removing plugins from tidy3d init

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,7 @@
 include requirements.txt
+include requirements/basic.txt
+include requirements/web.txt
+include requirements/plugins.txt
 include requirements/core.txt
 include requirements/plotly.txt
 include requirements/dev.txt

--- a/requirements/basic.txt
+++ b/requirements/basic.txt
@@ -1,0 +1,11 @@
+# build and load models and data, no web running or plugins
+
+xarray>=0.16.2
+h5py>=3.0.0
+rich
+matplotlib
+shapely==1.8.0; python_version<"3.10"
+shapely>=1.8.1; python_version>="3.10"
+pydantic>=1.9.0
+PyYAML
+dask

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,16 +1,4 @@
-# just core (no plotly, no tests)
-
-xarray>=0.16.2
-scipy
-h5py>=3.0.0
-rich
-nlopt
-matplotlib
-shapely==1.8.0; python_version<"3.10"
-shapely>=1.8.1; python_version>="3.10"
-pydantic>=1.9.0
-PyYAML
-boto3==1.23.1
-requests
-dask
-pyjwt
+# build and run simulations, use plugins (no plotly, no tests)
+-r basic.txt
+-r web.txt
+-r plugins.txt

--- a/requirements/plugins.txt
+++ b/requirements/plugins.txt
@@ -1,0 +1,3 @@
+# plugins-specific, excluding plotly
+scipy
+nlopt

--- a/requirements/web.txt
+++ b/requirements/web.txt
@@ -1,0 +1,5 @@
+# to use the web interface (needed to run tasks)
+
+boto3==1.23.1
+requests
+pyjwt

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,10 @@ print(version["__version__"])
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
-with open("requirements/core.txt") as f:
-    core_required = f.read().splitlines()
+core_required = []
+for core_file in ["requirements/basic.txt", "requirements/web.txt", "requirements/plugins.txt"]:
+    with open(core_file) as f:
+        core_required.append(f.read().splitlines())
 
 with open("requirements/plotly.txt") as f:
     plotly_required = f.read().splitlines()
@@ -26,6 +28,7 @@ with open("requirements/plotly.txt") as f:
 with open("requirements/dev.txt") as f:
     dev_required = f.read().splitlines()
     dev_required = [req for req in dev_required if "-r" not in req]
+dev_required.append(plotly_required)
 
 setuptools.setup(
     name=PIP_NAME,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,17 +21,6 @@ def test_logging_level():
         assert log.level == val
 
 
-def test_config():
-    """Make sure setting the web_config in config affects the DEFAULT_CONFIG"""
-
-    for config_key, target_config in WEB_CONFIGS.items():
-
-        td.config.web_config = config_key
-
-        for key in DEFAULT_CONFIG.dict():
-            assert DEFAULT_CONFIG.dict()[key] == target_config.dict()[key]
-
-
 def _test_frozen():
     """Make sure you can dynamically freeze tidy3d components."""
 

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -3,14 +3,6 @@ from concurrent.futures import ProcessPoolExecutor, process
 
 from rich import pretty, traceback
 
-from .config import config
-
-# version
-from .version import __version__
-
-# updater
-from .updater import Updater
-
 # grid
 from .components import Grid, Coords, GridSpec, UniformGrid, CustomGrid, AutoGrid
 
@@ -58,9 +50,6 @@ from .components import DefaultPMLParameters, DefaultStablePMLParameters, Defaul
 # constants imported as `C_0 = td.C_0` or `td.constants.C_0`
 from .constants import C_0, ETA_0, HBAR, EPSILON_0, MU_0, Q_e, inf
 
-# plugins typically imported as `from tidy3d.plugins import DispersionFitter`
-from . import plugins
-
 # material library dict imported as `from tidy3d import material_library`
 # get material `mat` and variant `var` as `material_library[mat][var]`
 from .material_library import material_library
@@ -74,6 +63,15 @@ from .components.grid import YeeGrid, FieldGrid, Coords1D
 
 # logging
 from .log import log, set_logging_file
+
+# config
+from .config import config
+
+# version
+from .version import __version__
+
+# updater
+from .updater import Updater
 
 
 def set_logging_level(level: str) -> None:

--- a/tidy3d/config.py
+++ b/tidy3d/config.py
@@ -1,16 +1,9 @@
 """Sets the configuration of the script, can be changed with `td.config.config_name = new_val`."""
 
-import os
-
 import pydantic as pd
 from typing_extensions import Literal
 
-from .log import set_logging_level, DEFAULT_LEVEL, Tidy3dKeyError
-from .web.config import DEFAULT_CONFIG, WEB_CONFIGS
-
-# set the default web config based on environment variable, if present
-env_config = os.environ.get("TIDY3D_ENV")
-DEFAULT_WEB_CONFIG = "prod" if env_config is None else env_config
+from .log import set_logging_level, DEFAULT_LEVEL
 
 
 class Tidy3dConfig(pd.BaseModel):
@@ -33,29 +26,10 @@ class Tidy3dConfig(pd.BaseModel):
         'Can be "debug", "info", "warning", "error".',
     )
 
-    web_config: Literal["prod", "preprod", "dev", "uat"] = pd.Field(
-        DEFAULT_WEB_CONFIG,
-        title="Web Configuration",
-        description="Default configuration that webapi uses.",
-    )
-
     @pd.validator("logging_level", always=True)
     def _set_logging_level(cls, val):
         """Set the logging level if logging_level is changed."""
         set_logging_level(val)
-        return val
-
-    @pd.validator("web_config", always=True)
-    def _set_web_config(cls, val):
-        """Set the default web config."""
-        if val not in WEB_CONFIGS:
-            raise Tidy3dKeyError(
-                f"web config '{val}' not found. " f"Must be one of {list(WEB_CONFIGS.keys())}"
-            )
-        new_config = WEB_CONFIGS[val]
-        for key, value in new_config.dict().items():
-            setattr(DEFAULT_CONFIG, key, value)
-
         return val
 
 


### PR DESCRIPTION
- Removed plugins from tidy3d init so importing tidy3d now does not require dependencies for web or plugins
- Instead of removing `config` from tidy3d init, I decided to just remove the web stuff from `tidy3d.config`. The whole web config is a bit hacky anyway, but if we want to keep the code I removed, we should just move it in `tidy3d.web.config`. 
- Added a `basic` requirements file. This together with the fixed init means that you can construct models and load and save data without the need for the web or plugins dependencies. The `tidy3d[basic]` install can probably be used in all of our services that need tidy3d frontend, and make for a smaller build and smaller overhead in tidy3d import.
- The `core` requirements are currently unchanged.

This fixes #441 in that if a user gets the install error, they can instead do `pip install "tidy3d[web]"` to get the installation without the plugins requirements (currently this just means the user-side material fitter won't work). Is there a better way to reorganize things?