### PR TITLE
Refactor SimulationData normalization once again

### DIFF
--- a/simulation.json
+++ b/simulation.json
@@ -249,6 +249,7 @@
     },
     "shutoff": 1e-05,
     "subpixel": true,
+    "normalize_index": 0,
     "courant": 0.9,
-    "version": "1.5.0"
+    "version": "1.6.0"
 }

--- a/tests/_test_web.py
+++ b/tests/_test_web.py
@@ -137,14 +137,6 @@ def test_query_folder_by_name():
     _ = web.webapi._query_or_create_folder("default")
 
 
-@clear_tmp
-def test_source_norm():
-    """test complete run"""
-    sim_data_raw = web.run(
-        simulation=sim_original, task_name="test_webapi", path=PATH_SIM_DATA, normalize_index=None
-    )
-
-
 """ Jobs """
 
 jobs_global = []
@@ -210,14 +202,6 @@ def _test_job_7_delete():
     assert task_info.status in ("deleted", "deleting")
 
 
-def test_job_source_norm(caplog):
-    """test complete run"""
-    job = web.Job(simulation=sim_original, task_name="test_job", callback_url=CALLBACK_URL)
-    sim_data_norm = job.run(path=PATH_SIM_DATA, normalize_index=0)
-    with pytest.raises(DataError):
-        sim_data_norm = web.load(task_id=job.task_id, normalize_index=1)
-
-
 """ Batches """
 
 batches_global = []
@@ -270,7 +254,6 @@ def test_batch_5_download():
     batch.download(path_dir=PATH_DIR_SIM_DATA)
 
 
-@clear_tmp
 def test_batch_6_load():
     """load the results into sim_data"""
     batch = _get_gloabl_batch()
@@ -283,7 +266,9 @@ def test_batch_6_load():
 @clear_tmp
 def test_batchdata_7_load():
     """load the BatchData from file."""
-    sim_data_dict = BatchData.load(path_dir=PATH_DIR_SIM_DATA)
+    batch = _get_gloabl_batch()
+    batch.to_file(os.path.join(PATH_DIR_SIM_DATA, "batch.json"))
+    sim_data_dict = web.BatchData.load(path_dir=PATH_DIR_SIM_DATA)
 
 
 def _test_batch_8_delete():

--- a/tests/sims/simulation_1_6_0.json
+++ b/tests/sims/simulation_1_6_0.json
@@ -1,0 +1,561 @@
+{
+    "type": "Simulation",
+    "center": [
+        0.0,
+        0.0,
+        0.0
+    ],
+    "size": [
+        10.0,
+        10.0,
+        10.0
+    ],
+    "run_time": 1e-12,
+    "grid_size": null,
+    "medium": {
+        "name": null,
+        "frequency_range": null,
+        "type": "Medium",
+        "permittivity": 1.0,
+        "conductivity": 0.0
+    },
+    "symmetry": [
+        0,
+        -1,
+        1
+    ],
+    "structures": [
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Medium",
+                "permittivity": 1.0,
+                "conductivity": 0.0
+            },
+            "name": null,
+            "type": "Structure"
+        },
+        {
+            "geometry": {
+                "type": "Sphere",
+                "radius": 1.0,
+                "center": [
+                    0.0,
+                    0.0,
+                    0.0
+                ]
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "PoleResidue",
+                "eps_inf": 1.0,
+                "poles": []
+            },
+            "name": null,
+            "type": "Structure"
+        },
+        {
+            "geometry": {
+                "type": "Cylinder",
+                "axis": 2,
+                "radius": 1.0,
+                "center": [
+                    0.0,
+                    0.0,
+                    0.0
+                ],
+                "length": 1.0
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Lorentz",
+                "eps_inf": 1.0,
+                "coeffs": []
+            },
+            "name": null,
+            "type": "Structure"
+        },
+        {
+            "geometry": {
+                "type": "PolySlab",
+                "axis": 2,
+                "slab_bounds": [
+                    -1.0,
+                    1.0
+                ],
+                "dilation": 0.0,
+                "sidewall_angle": 0.0,
+                "vertices": [
+                    [
+                        0.0,
+                        0.0
+                    ],
+                    [
+                        2.0,
+                        3.0
+                    ],
+                    [
+                        4.0,
+                        3.0
+                    ]
+                ]
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Sellmeier",
+                "coeffs": []
+            },
+            "name": null,
+            "type": "Structure"
+        },
+        {
+            "geometry": {
+                "type": "Sphere",
+                "radius": 1.0,
+                "center": [
+                    0.0,
+                    0.0,
+                    0.0
+                ]
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Debye",
+                "eps_inf": 1.0,
+                "coeffs": []
+            },
+            "name": "t2",
+            "type": "Structure"
+        },
+        {
+            "geometry": {
+                "type": "GeometryGroup",
+                "geometries": [
+                    {
+                        "type": "PolySlab",
+                        "axis": 2,
+                        "slab_bounds": [
+                            -1.0,
+                            1.0
+                        ],
+                        "dilation": 0.0,
+                        "sidewall_angle": 0.0,
+                        "vertices": [
+                            [
+                                0.0,
+                                0.0
+                            ],
+                            [
+                                2.0,
+                                3.0
+                            ],
+                            [
+                                4.0,
+                                3.0
+                            ]
+                        ]
+                    },
+                    {
+                        "type": "Cylinder",
+                        "axis": 2,
+                        "radius": 1.0,
+                        "center": [
+                            0.0,
+                            0.0,
+                            0.0
+                        ],
+                        "length": 1.0
+                    }
+                ]
+            },
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Drude",
+                "eps_inf": 1.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        1.0
+                    ]
+                ]
+            },
+            "name": null,
+            "type": "Structure"
+        }
+    ],
+    "sources": [
+        {
+            "type": "UniformCurrentSource",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 1.0,
+                "fwidth": 1.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "polarization": "Ex"
+        },
+        {
+            "type": "PlaneWave",
+            "center": [
+                0.0,
+                0.0,
+                -4.0
+            ],
+            "size": [
+                "Infinity",
+                "Infinity",
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 1.0,
+                "fwidth": 1.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 2.0
+        },
+        {
+            "type": "GaussianBeam",
+            "center": [
+                0.0,
+                0.0,
+                -4.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 1.0,
+                "fwidth": 1.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 0.0,
+            "waist_radius": 1.0,
+            "waist_distance": 0.0
+        },
+        {
+            "type": "ModeSource",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                1.0,
+                1.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 1.0,
+                "fwidth": 1.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "direction": "-",
+            "mode_spec": {
+                "num_modes": 3,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "filter_pol": null,
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "precision": "single",
+                "bend_radius": null,
+                "bend_axis": null,
+                "type": "ModeSpec"
+            },
+            "mode_index": 2
+        }
+    ],
+    "boundary_spec": {
+        "x": {
+            "plus": {
+                "name": null,
+                "type": "Absorber",
+                "num_layers": 40,
+                "parameters": {
+                    "sigma_order": 3,
+                    "sigma_min": 0.0,
+                    "sigma_max": 6.4,
+                    "type": "AbsorberParams"
+                }
+            },
+            "minus": {
+                "name": null,
+                "type": "PML",
+                "num_layers": 12,
+                "parameters": {
+                    "sigma_order": 3,
+                    "sigma_min": 0.0,
+                    "sigma_max": 1.5,
+                    "type": "PMLParams",
+                    "kappa_order": 3,
+                    "kappa_min": 1.0,
+                    "kappa_max": 3.0,
+                    "alpha_order": 1,
+                    "alpha_min": 0.0,
+                    "alpha_max": 0.0
+                }
+            },
+            "type": "Boundary"
+        },
+        "y": {
+            "plus": {
+                "name": null,
+                "type": "PMCBoundary"
+            },
+            "minus": {
+                "name": null,
+                "type": "PMCBoundary"
+            },
+            "type": "Boundary"
+        },
+        "z": {
+            "plus": {
+                "name": null,
+                "type": "PECBoundary"
+            },
+            "minus": {
+                "name": null,
+                "type": "StablePML",
+                "num_layers": 40,
+                "parameters": {
+                    "sigma_order": 3,
+                    "sigma_min": 0.0,
+                    "sigma_max": 1.0,
+                    "type": "PMLParams",
+                    "kappa_order": 3,
+                    "kappa_min": 1.0,
+                    "kappa_max": 5.0,
+                    "alpha_order": 1,
+                    "alpha_min": 0.0,
+                    "alpha_max": 0.9
+                }
+            },
+            "type": "Boundary"
+        },
+        "type": "BoundarySpec"
+    },
+    "monitors": [
+        {
+            "type": "FieldMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                1.0
+            ],
+            "name": "field",
+            "freqs": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "fields": [
+                "Ex",
+                "Ey",
+                "Ez",
+                "Hx",
+                "Hy",
+                "Hz"
+            ],
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": false
+        },
+        {
+            "type": "FieldTimeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                1.0
+            ],
+            "name": "fieldtime",
+            "start": 1e-12,
+            "stop": null,
+            "interval": 3,
+            "fields": [
+                "Ex",
+                "Ey",
+                "Ez",
+                "Hx",
+                "Hy",
+                "Hz"
+            ],
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": false
+        },
+        {
+            "type": "FluxMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                0.0,
+                1.0
+            ],
+            "name": "flux",
+            "freqs": [
+                1.0,
+                2.0,
+                3.0
+            ]
+        },
+        {
+            "type": "FluxTimeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                0.0,
+                1.0
+            ],
+            "name": "fluxtime",
+            "start": 1e-12,
+            "stop": null,
+            "interval": 3
+        },
+        {
+            "type": "ModeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                0.0,
+                1.0
+            ],
+            "name": "mode",
+            "freqs": [
+                1.0,
+                2.0
+            ],
+            "mode_spec": {
+                "num_modes": 3,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "filter_pol": null,
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "precision": "single",
+                "bend_radius": null,
+                "bend_axis": null,
+                "type": "ModeSpec"
+            }
+        }
+    ],
+    "grid_spec": {
+        "grid_x": {
+            "type": "AutoGrid",
+            "min_steps_per_wvl": 10.0,
+            "max_scale": 1.4,
+            "mesher": {
+                "type": "GradedMesher"
+            }
+        },
+        "grid_y": {
+            "type": "AutoGrid",
+            "min_steps_per_wvl": 10.0,
+            "max_scale": 1.4,
+            "mesher": {
+                "type": "GradedMesher"
+            }
+        },
+        "grid_z": {
+            "type": "AutoGrid",
+            "min_steps_per_wvl": 10.0,
+            "max_scale": 1.4,
+            "mesher": {
+                "type": "GradedMesher"
+            }
+        },
+        "wavelength": null,
+        "override_structures": [],
+        "type": "GridSpec"
+    },
+    "shutoff": 1e-05,
+    "subpixel": true,
+    "normalize_index": 0,
+    "courant": 0.9,
+    "version": "1.6.0"
+}

--- a/tests/test_data_monitor.py
+++ b/tests/test_data_monitor.py
@@ -31,23 +31,23 @@ FLUX_TIME = make_flux_time_data_array()
 """ Make the montor data """
 
 
-def make_field_data():
+def make_field_data(symmetry: bool = True):
     return FieldData(
         monitor=FIELD_MONITOR,
-        Ex=make_scalar_field_data_array("Ex"),
-        Ey=make_scalar_field_data_array("Ey"),
-        Ez=make_scalar_field_data_array("Ez"),
-        Hz=make_scalar_field_data_array("Hz"),
+        Ex=make_scalar_field_data_array("Ex", symmetry),
+        Ey=make_scalar_field_data_array("Ey", symmetry),
+        Ez=make_scalar_field_data_array("Ez", symmetry),
+        Hz=make_scalar_field_data_array("Hz", symmetry),
     )
 
 
-def make_field_time_data():
+def make_field_time_data(symmetry: bool = True):
     return FieldTimeData(
         monitor=FIELD_TIME_MONITOR,
-        Ex=make_scalar_field_time_data_array("Ex"),
-        Ey=make_scalar_field_time_data_array("Ey"),
-        Ez=make_scalar_field_time_data_array("Ez"),
-        Hz=make_scalar_field_time_data_array("Ez"),
+        Ex=make_scalar_field_time_data_array("Ex", symmetry),
+        Ey=make_scalar_field_time_data_array("Ey", symmetry),
+        Ez=make_scalar_field_time_data_array("Ez", symmetry),
+        Hz=make_scalar_field_time_data_array("Ez", symmetry),
     )
 
 
@@ -64,12 +64,12 @@ def make_mode_solver_data():
     )
 
 
-def make_permittivity_data():
+def make_permittivity_data(symmetry: bool = True):
     return PermittivityData(
         monitor=PERMITTIVITY_MONITOR,
-        eps_xx=make_scalar_field_data_array("Ex"),
-        eps_yy=make_scalar_field_data_array("Ey"),
-        eps_zz=make_scalar_field_data_array("Ez"),
+        eps_xx=make_scalar_field_data_array("Ex", symmetry),
+        eps_yy=make_scalar_field_data_array("Ey", symmetry),
+        eps_zz=make_scalar_field_data_array("Ez", symmetry),
     )
 
 

--- a/tests/test_data_sim.py
+++ b/tests/test_data_sim.py
@@ -74,8 +74,11 @@ def test_apply_symmetry3():
 
 def test_normalize():
     sim_data = make_sim_data()
-    for monitor_data in sim_data.monitor_data.values():
-        _ = sim_data.normalize_monitor_data(monitor_data)
+    sim_data_without_norm = sim_data.renormalize(normalize_index=None)
+    sim_data_with_norm = sim_data_without_norm.renormalize(normalize_index=0)
+    name = FIELD_MONITOR.name
+    assert np.allclose(sim_data[name].Ex, sim_data_with_norm[name].Ex)
+    assert not np.allclose(sim_data[name].Ex, sim_data_without_norm[name].Ex)
 
 
 def test_getitem():
@@ -222,10 +225,10 @@ def test_run_time_lt_start():
     sim_data = SimulationData(
         simulation=sim,
         monitor_data={tmnt.name: field_data},
-        normalize_index=0,
+        normalize_index=None,
     )
 
-    sim_data.to_file("tests/tmp/sim_data_empty.hdf5")
+    sim_data.renormalize(0).to_file("tests/tmp/sim_data_empty.hdf5")
     sim_data = SimulationData.from_file("tests/tmp/sim_data_empty.hdf5")
     tmnt_data = sim_data.monitor_data[tmnt.name]
     tmnt_data = sim_data[tmnt.name]

--- a/tests/test_data_sim.py
+++ b/tests/test_data_sim.py
@@ -84,9 +84,9 @@ def test_apply_symmetry3():
 
 def test_no_symmetry():
     sim_data = make_sim_data(symmetry=False)
-    Ex_raw = sim_data.monitor_data["field"]
-    Ex_ret = sim_data["field"]
-    assert id(Ex_raw) == id(Ex_ret)
+    Ex_raw = sim_data.monitor_data["field"].Ex
+    Ex_ret = sim_data["field"].Ex
+    assert np.allclose(Ex_raw, Ex_ret)
 
 
 def test_normalize():

--- a/tidy3d/components/data/README.md
+++ b/tidy3d/components/data/README.md
@@ -109,11 +109,11 @@ Like before, the `SimulationData` object contains all of the data for a given `S
 
 #### Normalizing
 
-The `SimulationData` objects are initialzed with a `normalize_index` integer. The `SimulationData` has no notion of normalization "state", but rather uses this `normalize_index` to decide how to normalize the `monitor_data` components when returning them.
+The frequency-dependent data in `SimulationData` objects is normalized to the source given by `SimulationData.Simulation.normalize_index`, such that it matches exactly what is written to file (as opposed to the old workflow of the file containing un-normalized data). A copy of the `SimulationData` with a different normalization can be obtained using the
 
 Normalization is achieved through the 
 ```python
-def normalize_monitor_data(self, monitor_data: MonitorDataType) -> MonitorDataType:`
+def renormalize(self, normalize_index: int) -> SimulationData:`
 ```
 method.
 

--- a/tidy3d/components/data/README.md
+++ b/tidy3d/components/data/README.md
@@ -76,7 +76,7 @@ Rather than raw data being passed to this, `source_spectrum_fn` is a function of
 
 #### Symmetry
 
-All `MonitorData` subclasses also have an `.apply_symmetry()` method, whch returns a copy of the instance with symmetry applied. If no symmetry is applied (all symmetry values are 0), then the original data is returned. There is therefore no notion of "state" with regard to the symmetry of a monitor data.
+All `MonitorData` subclasses also have an `.apply_symmetry()` method, whch returns a copy of the instance with symmetry applied. There is therefore no notion of "state" with regard to the symmetry of a monitor data.
 
 ```python
 def apply_symmetry(

--- a/tidy3d/components/data/README.md
+++ b/tidy3d/components/data/README.md
@@ -76,12 +76,14 @@ Rather than raw data being passed to this, `source_spectrum_fn` is a function of
 
 #### Symmetry
 
-All `MonitorData` subclasses also have an `.apply_symmetry()` method, whch returns a copy of the instance with symmetry applied. By default, it just returns a straight copy of the object (if not affected by symmetry). There is therefore no notion of "state" with regard to the symmetry of a monitor data.
+All `MonitorData` subclasses also have an `.apply_symmetry()` method, whch returns a copy of the instance with symmetry applied. If no symmetry is applied (all symmetry values are 0), then the original data is returned. There is therefore no notion of "state" with regard to the symmetry of a monitor data.
 
 ```python
 def apply_symmetry(
     self,
-    simulation: Simulation
+    symmetry: Tuple[Symmetry, Symmetry, Symmetry],
+    symmetry_center: Coordinate,
+    grid_expanded: Grid,
 ) -> MonitorData:
 ```
 

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -74,8 +74,8 @@ class AbstractFieldData(MonitorData, ABC):
         symmetry_center: Coordinate,
         grid_expanded: Grid,
     ) -> AbstractFieldData:
-        """If symmetry is present, create a copy of the :class:`.AbstractFieldData` with the fields
-        expanded. If symmetry not present, returns the same data object.
+        """Create a copy of the :class:`.AbstractFieldData` with the fields expanded based on
+        symmetry, if any.
 
         Returns
         -------
@@ -84,7 +84,7 @@ class AbstractFieldData(MonitorData, ABC):
         """
 
         if all(sym == 0 for sym in symmetry):
-            return self
+            return self.copy()
 
         new_fields = {}
 

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -1,6 +1,6 @@
 # pylint: disable=too-many-lines, too-many-arguments
 """ Container holding all information about simulation and its components"""
-from typing import Dict, Tuple, List, Set, Union, Optional
+from typing import Dict, Tuple, List, Set, Union
 from math import isclose
 
 import pydantic
@@ -180,11 +180,12 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
         "based on structure definition, resulting in much higher accuracy for a given grid size.",
     )
 
-    normalize_index: Optional[pydantic.NonNegativeInt] = pydantic.Field(
+    normalize_index: Union[pydantic.NonNegativeInt, None] = pydantic.Field(
         0,
         title="Normalization index",
         description="Index of the source in the tuple of sources whose spectrum will be used to "
-        "normalize the frequency-dependent data. If ``None``, the raw field data is returned.",
+        "normalize the frequency-dependent data. If ``None``, the raw field data is returned "
+        "unnormalized.",
     )
 
     courant: float = pydantic.Field(

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -169,7 +169,11 @@ class ModeSolver(Tidy3dBaseModel):
             :class:`.ModeSolverData` object containing the effective index and mode fields.
         """
         mode_solver_data = self.data_raw
-        return mode_solver_data.apply_symmetry(simulation=self.simulation)
+        return mode_solver_data.apply_symmetry(
+            symmetry=self.simulation.symmetry,
+            symmetry_center=self.simulation.center,
+            grid_expanded=self.simulation.discretize(self.plane, extend=True),
+        )
 
     @cached_property
     def sim_data(self) -> SimulationData:

--- a/tidy3d/version.py
+++ b/tidy3d/version.py
@@ -1,3 +1,3 @@
 """Defines the front end version of tidy3d"""
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"

--- a/tidy3d/web/webapi.py
+++ b/tidy3d/web/webapi.py
@@ -5,7 +5,7 @@ import logging
 import os
 import time
 from datetime import datetime, timedelta
-from typing import List, Dict, Optional
+from typing import List, Dict
 
 import requests
 from dateutil import parser
@@ -32,7 +32,6 @@ def run(  # pylint:disable=too-many-arguments
     folder_name: str = "default",
     path: str = "simulation_data.hdf5",
     callback_url: str = None,
-    normalize_index: Optional[int] = 0,
 ) -> SimulationData:
     """Submits a :class:`.Simulation` to server, starts running, monitors progress, downloads,
     and loads results as a :class:`.SimulationData` object.
@@ -50,11 +49,6 @@ def run(  # pylint:disable=too-many-arguments
     callback_url : str = None
         Http PUT url to receive simulation finish event. The body content is a json file with
         fields ``{'id', 'status', 'name', 'workUnit', 'solverVersion'}``.
-    normalize_index : int = 0
-        If specified, normalizes the frequency-domain data by the amplitude spectrum of the source
-        corresponding to ``simulation.sources[normalize_index]``.
-        This occurs when the data is loaded into a :class:`.SimulationData` object.
-        To turn off normalization, set ``normalize_index`` to ``None``.
 
     Returns
     -------
@@ -69,7 +63,7 @@ def run(  # pylint:disable=too-many-arguments
     )
     start(task_id)
     monitor(task_id)
-    return load(task_id=task_id, path=path, normalize_index=normalize_index)
+    return load(task_id=task_id, path=path)
 
 
 def upload(  # pylint:disable=too-many-locals,too-many-arguments
@@ -368,7 +362,6 @@ def load(
     task_id: TaskId,
     path: str = "simulation_data.hdf5",
     replace_existing: bool = True,
-    normalize_index: Optional[int] = 0,
 ) -> SimulationData:
     """Download and Load simultion results into :class:`.SimulationData` object.
 
@@ -380,11 +373,6 @@ def load(
         Download path to .hdf5 data file (including filename).
     replace_existing: bool = True
         Downloads the data even if path exists (overwriting the existing).
-    normalize_index : int = 0
-        If specified, normalizes the frequency-domain data by the amplitude spectrum of the source
-        corresponding to ``simulation.sources[normalize_index]``.
-        This occurs when the data is loaded into a :class:`.SimulationData` object.
-        To turn off normalization, set ``normalize_index`` to ``None``.
 
     Returns
     -------
@@ -396,7 +384,7 @@ def load(
         download(task_id=task_id, path=path)
 
     log.info(f"loading SimulationData from {path}")
-    sim_data = SimulationData.from_file(path, normalize_index=normalize_index)
+    sim_data = SimulationData.from_file(path)
 
     final_decay_value = sim_data.final_decay_value
     shutoff_value = sim_data.simulation.shutoff


### PR DESCRIPTION
`SimulationData` is now such that the normalization (still corresponding to the recorded `normalize_index`) is incorporated in the stored data. A new `renormalize` method is introduced to create a copy of the `SimulationData` with a different normalization. 

This has the following benefits:

- Avoids the confusion users may have of why the data in the hdf5 file is different from the data in python. There will always be a one-to-one match. 
- On the backend, we will use normalize_index = 0 by default. This is what the user downloads, and also can directly be used for post-run viz. Then the user can use the `renormalize` method if they want to remove the normalization (`renormalize(normalize_index=None)`) or pick a different source.
- Together with a change I made for `MonitorData.apply_symmetry` to only make a copy if any symmetries are actually present, now `sim_data["monitor_name"]` will no longer make a copy of the data (more memory efficient) (unless symmetries are present).

I also reverted the `apply_symmetry` method to not use `simulation` but only the necessary quantities.