### PR TITLE
fix throw KeyError exception when sources element is not correct

### DIFF
--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -401,7 +401,7 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
             return val
 
         # Get simulation frequency range
-        source_ranges = [source.source_time.frequency_range() for source in values["sources"]]
+        source_ranges = [source.source_time.frequency_range() for source in values.get("sources")]
         if not source_ranges:
             log.warning("No sources in simulation.")
             return val


### PR DESCRIPTION
If element in sources is incorrect, the `values` does not have key `sources`, so it will throw `KeyError` exception. It will block the correct pydantic ValidationError throw.