### PR TITLE
Replaced nlopt with scipy in dispersion fitter

### DIFF
--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,4 +1,3 @@
 # build and run simulations, use plugins (no plotly, no tests)
 -r basic.txt
 -r web.txt
--r plugins.txt

--- a/requirements/plugins.txt
+++ b/requirements/plugins.txt
@@ -1,3 +1,0 @@
-# plugins-specific, excluding plotly
-
-nlopt

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 core_required = []
-for core_file in ["requirements/basic.txt", "requirements/web.txt", "requirements/plugins.txt"]:
+for core_file in ["requirements/basic.txt", "requirements/web.txt"]:
     with open(core_file) as f:
         core_required.append(f.read().splitlines())
 

--- a/tidy3d/plugins/dispersion/fit.py
+++ b/tidy3d/plugins/dispersion/fit.py
@@ -485,7 +485,7 @@ class DispersionFitter(Tidy3dBaseModel):
             obj,
             coeffs0,
             args=(),
-            method="Nelder-Mead",
+            method="SLSQP",
             bounds=bounds,
             constraints=(scipy_constraint,),
             tol=1e-7,

--- a/tidy3d/plugins/dispersion/fit_web.py
+++ b/tidy3d/plugins/dispersion/fit_web.py
@@ -51,7 +51,7 @@ class AdvancedFitterParam(Tidy3dBaseModel):
         "so restrictive that all good solutions are missed, then please try the 'soft' constraints "
         "for larger search space. However, both constraints improve stability equally well.",
     )
-    nlopt_maxeval: PositiveInt = Field(
+    maxeval: PositiveInt = Field(
         5000,
         title="Number of inner iterations",
         description="Number of iterations in each inner optimization.",
@@ -224,7 +224,7 @@ class StableDispersionFitter(DispersionFitter):
             bound_f=self._Hz_to_eV(advanced_param.bound_f),
             bound_eps_inf=advanced_param.bound_eps_inf,
             constraint=advanced_param.constraint,
-            nlopt_maxeval=advanced_param.nlopt_maxeval,
+            maxeval=advanced_param.maxeval,
         )
 
         return web_data

--- a/tidy3d/plugins/dispersion/fit_web.py
+++ b/tidy3d/plugins/dispersion/fit_web.py
@@ -51,7 +51,7 @@ class AdvancedFitterParam(Tidy3dBaseModel):
         "so restrictive that all good solutions are missed, then please try the 'soft' constraints "
         "for larger search space. However, both constraints improve stability equally well.",
     )
-    maxeval: PositiveInt = Field(
+    nlopt_maxeval: PositiveInt = Field(
         5000,
         title="Number of inner iterations",
         description="Number of iterations in each inner optimization.",
@@ -224,7 +224,7 @@ class StableDispersionFitter(DispersionFitter):
             bound_f=self._Hz_to_eV(advanced_param.bound_f),
             bound_eps_inf=advanced_param.bound_eps_inf,
             constraint=advanced_param.constraint,
-            maxeval=advanced_param.maxeval,
+            nlopt_maxeval=advanced_param.nlopt_maxeval,
         )
 
         return web_data


### PR DESCRIPTION
In an attempt to remove `nlopt` from requirements, this PR replaces `nlopt` with the `scipy.optimize.minimize` from scipy. 

It needs a 2nd pair of eyes on it to make sure I set up the constriaints and various parameters correctly, could you take a look Weiliang?

When running the dispersion fitter tests in `test/plugins`, I get similar (but slightly worse) final results:

with nlopt
```
_________________________________ test_dispersion _________________________________
------------------------------ Captured stdout call -------------------------------
best RMS error so far: 3.20e-01 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
-------------------------------- Captured log call --------------------------------
WARNING  rich:fit.py:364 	warning: did not find fit with RMS error under tolerance_rms of 1.00e-02
INFO     rich:fit.py:368 	returning best fit with RMS error 3.20e-01
______________________________ test_dispersion_load _______________________________
------------------------------ Captured stdout call -------------------------------
best RMS error so far: 9.95e-02 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
-------------------------------- Captured log call --------------------------------
WARNING  rich:fit.py:364 	warning: did not find fit with RMS error under tolerance_rms of 1.00e-02
INFO     rich:fit.py:368 	returning best fit with RMS error 9.95e-02
______________________________ test_dispersion_plot _______________________________
------------------------------ Captured stdout call -------------------------------
best RMS error so far: 9.95e-02 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
-------------------------------- Captured log call --------------------------------
WARNING  rich:fit.py:364 	warning: did not find fit with RMS error under tolerance_rms of 1.00e-02
INFO     rich:fit.py:368 	returning best fit with RMS error 9.95e-02
__________________________ test_dispersion_set_wvg_range __________________________
------------------------------ Captured stdout call -------------------------------
best RMS error so far: 2.99e-01 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
-------------------------------- Captured log call --------------------------------
WARNING  rich:fit.py:364 	warning: did not find fit with RMS error under tolerance_rms of 1.00e-02
INFO     rich:fit.py:368 	returning best fit with RMS error 2.99e-01
```

with scipy:
```
_________________________________ test_dispersion _________________________________
------------------------------ Captured stdout call -------------------------------
best RMS error so far: 4.05e-01 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
-------------------------------- Captured log call --------------------------------
WARNING  rich:fit.py:364 	warning: did not find fit with RMS error under tolerance_rms of 1.00e-02
INFO     rich:fit.py:368 	returning best fit with RMS error 4.05e-01
______________________________ test_dispersion_load _______________________________
------------------------------ Captured stdout call -------------------------------
best RMS error so far: 9.95e-02 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
-------------------------------- Captured log call --------------------------------
WARNING  rich:fit.py:364 	warning: did not find fit with RMS error under tolerance_rms of 1.00e-02
INFO     rich:fit.py:368 	returning best fit with RMS error 9.95e-02
______________________________ test_dispersion_plot _______________________________
------------------------------ Captured stdout call -------------------------------
best RMS error so far: 9.95e-02 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
-------------------------------- Captured log call --------------------------------
WARNING  rich:fit.py:364 	warning: did not find fit with RMS error under tolerance_rms of 1.00e-02
INFO     rich:fit.py:368 	returning best fit with RMS error 9.95e-02
__________________________ test_dispersion_set_wvg_range __________________________
------------------------------ Captured stdout call -------------------------------
best RMS error so far: 3.31e-01 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
-------------------------------- Captured log call --------------------------------
WARNING  rich:fit.py:364 	warning: did not find fit with RMS error under tolerance_rms of 1.00e-02
INFO     rich:fit.py:368 	returning best fit with RMS error 3.31e-01
```


