### PR TITLE
splitting json into several hdf5 files

### DIFF
--- a/tests/test_data_sim.py
+++ b/tests/test_data_sim.py
@@ -191,6 +191,14 @@ def test_to_hdf5():
     assert sim_data == sim_data2
 
 
+def test_to_json():
+    sim_data = make_sim_data()
+    FNAME = "tests/tmp/sim_data_refactor.json"
+    sim_data.to_file(fname=FNAME)
+    sim_data2 = SimulationData.from_file(fname=FNAME)
+    assert sim_data == sim_data2
+
+
 @clear_tmp
 def test_empty_io():
     coords = {"x": np.arange(10), "y": np.arange(10), "z": np.arange(10), "t": []}

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -4,6 +4,7 @@ from typing import Dict
 import xarray as xr
 import numpy as np
 
+from ..base import Tidy3dBaseModel
 from ..types import DataObject
 from ...constants import HERTZ, SECOND, MICROMETER, RADIAN
 from ...log import DataError
@@ -77,6 +78,9 @@ class DataArray(xr.DataArray):
     @classmethod
     def validate(cls, value):
         """What gets called when you construct a DataArray."""
+
+        if isinstance(value, str):
+            value = Tidy3dBaseModel.hdf5_to_dict(value)
 
         # loading from raw dict (usually from file)
         if isinstance(value, dict):


### PR DESCRIPTION
A working example:

When  `.json()` is called (for writing to file, say):
* all `xr.DataArray` objects have their data hashed, which gives us a filename.
* the `DataArray` data is written to file.
* the filename is written to the json.
This ends up giving us a json file with the tidy3d component data + hdf5 file names and a bunch of extra files.


Then, when we load a`DataArray` object from file, if it's a string, we interpret as a filename and load the data from the file.

To see how this would work, run
```
pytest tests/test_data_sim.py -k to_json
```
and inspect `tests/tmp/sim_data_refactor.json`

One remaining ugliness is that all the files are just written to the current working directory, but we can find a workaround I'm sure.