### PR TITLE
Splitting simulation file into json + extra data for submitting to server

### DIFF
--- a/tests/test_IO.py
+++ b/tests/test_IO.py
@@ -203,8 +203,10 @@ def test_yaml():
     assert sim1 == sim
 
 
+@clear_tmp
 def test_to_json_data():
     """Test that all simulations in ``SIM_DIR`` can be updated to current version and loaded."""
     data = make_flux_data()
     assert json.loads(data._json_string())["flux"] is not None
-    assert json.loads(data._json_string(include_data=False))["flux"] is None
+    data_file = "tests/tmp/data_file.hdf5"
+    assert json.loads(data._json_string(data_file=data_file))["flux"]["data_file"] == data_file

--- a/tests/test_data_sim.py
+++ b/tests/test_data_sim.py
@@ -161,12 +161,21 @@ def test_final_decay():
     assert dv == 0.11
 
 
-def test_to_json():
+def test_to_dict():
     sim_data = make_sim_data()
     j = sim_data.dict()
     sim_data2 = SimulationData(**j)
     assert sim_data == sim_data2
-    assert sim_data2["field"].Ex == sim_data["field"].Ex
+
+
+@clear_tmp
+def test_to_json():
+    sim_data = make_sim_data()
+    FNAME = "tests/tmp/sim_data_refactor.json"
+    DATA_FILE = "tests/tmp/sim_extra_data.hdf5"
+    sim_data.to_file(fname=FNAME, data_file=DATA_FILE)
+    sim_data2 = SimulationData.from_file(fname=FNAME)
+    assert sim_data == sim_data2
 
 
 def test_sel_kwarg_len1():

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -84,10 +84,16 @@ class DataArray(xr.DataArray):
         if isinstance(value, dict):
             if value.get("tag") == "DATA_ITEM":
                 # Read from external file
-                with h5py.File(value["data_file"], "r") as f:
-                    group = f[value["group_name"]]
-                    # pylint:disable=protected-access
-                    value = Tidy3dBaseModel._load_group_data(data_dict={}, hdf5_group=group)
+                data_file = value.get("data_file")
+                try:
+                    with h5py.File(data_file, "r") as f:
+                        group = f[value["group_name"]]
+                        # pylint:disable=protected-access
+                        value = Tidy3dBaseModel._load_group_data(data_dict={}, hdf5_group=group)
+                except FileNotFoundError as e:
+                    raise DataError(
+                        f"External data file {data_file} not found when loading data."
+                    ) from e
 
             data = value.get("data")
             coords = value.get("coords")

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -3,7 +3,9 @@ from typing import Dict
 
 import xarray as xr
 import numpy as np
+import h5py
 
+from ..base import Tidy3dBaseModel
 from ..types import DataObject
 from ...constants import HERTZ, SECOND, MICROMETER, RADIAN
 from ...log import DataError
@@ -80,6 +82,13 @@ class DataArray(xr.DataArray):
 
         # loading from raw dict (usually from file)
         if isinstance(value, dict):
+            if value.get("tag") == "DATA_ITEM":
+                # Read from external file
+                with h5py.File(value["data_file"], "r") as f:
+                    group = f[value["group_name"]]
+                    # pylint:disable=protected-access
+                    value = Tidy3dBaseModel._load_group_data(data_dict={}, hdf5_group=group)
+
             data = value.get("data")
             coords = value.get("coords")
 


### PR DESCRIPTION
This PR takes some elements from #466 but writes all extra data to a single user-supplied file, if provided. So e.g.

```
simulation.to_file("simulation.json", data_file="extra_data.hdf5")
```

would replace all `DataArray` fields in `simulation.json` with a dictionary of the form 

```
            {
                "group_name": "7c4c4b745fa80d7bc802f944fce2d14b",
                "data_file": "extra_data.hdf5",
                "tag": "DATA_ITEM"
            }
```

and the data will be written to the listed group name in the data file.

I also introduced the webapi change to upload the extra file, if needed.