### PR TITLE
Fix to zero-dim monitor when applying symmetry

### DIFF
--- a/tests/test_data_sim.py
+++ b/tests/test_data_sim.py
@@ -199,7 +199,7 @@ def test_sel_kwarg_len1():
     sim_data.plot_field("mode_solver", "Ex", y=0.0, val="real", f=1e14, mode_index=1)
 
     # passing y=1 sel kwarg should error
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         sim_data.plot_field("mode_solver", "Ex", y=1.0, val="real", f=1e14, mode_index=1)
 
 

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -94,10 +94,11 @@ class SimulationData(Tidy3dBaseModel):
 
     def apply_symmetry(self, monitor_data: MonitorDataType) -> MonitorDataType:
         """Return copy of :class:`.MonitorData` object with symmetry values applied."""
+        grid = self.simulation.discretize(monitor_data.monitor, extend=True, snap_zero_dim=True)
         return monitor_data.apply_symmetry(
             symmetry=self.simulation.symmetry,
             symmetry_center=self.simulation.center,
-            grid_expanded=self.simulation.discretize(monitor_data.monitor, extend=True),
+            grid_expanded=grid,
         )
 
     def source_spectrum(self, source_index: int) -> Callable:

--- a/tidy3d/components/grid/grid.py
+++ b/tidy3d/components/grid/grid.py
@@ -350,7 +350,7 @@ class Grid(Tidy3dBaseModel):
             inds_leq_pt_min = np.where(bound_coords <= pt_min)[0]
             ind_min = 0 if len(inds_leq_pt_min) == 0 else inds_leq_pt_min[-1]
 
-            if extend:
+            if extend and ind_max > ind_min:
                 # If the box bounds on the left side are to the left of the closest grid center,
                 # we need an extra pixel to be able to interpolate the center components.
                 if box.bounds[0][axis] < self.centers.to_list[axis][ind_min]:


### PR DESCRIPTION
also fix to grid.discretize_inds to not error if the box is out of the simulation bounds