### PR TITLE
remove grid_size

### DIFF
--- a/tests/sims/simulation_1_6_1.json
+++ b/tests/sims/simulation_1_6_1.json
@@ -11,7 +11,6 @@
         10.0
     ],
     "run_time": 1e-12,
-    "grid_size": null,
     "medium": {
         "name": null,
         "frequency_range": null,

--- a/tests/sims/simulation_1_7_0.json
+++ b/tests/sims/simulation_1_7_0.json
@@ -560,5 +560,5 @@
     "subpixel": true,
     "normalize_index": 0,
     "courant": 0.9,
-    "version": "1.6.0"
+    "version": "1.7.0"
 }

--- a/tests/test_IO.py
+++ b/tests/test_IO.py
@@ -1,6 +1,7 @@
 import os
 import json
 
+import pytest
 import pydantic
 import numpy as np
 import os
@@ -185,15 +186,17 @@ def test_validation_speed():
         print(f"{n} structures \t {size:.1e} bytes \t {time_validate:.1f} seconds to validate")
 
 
-def test_simulation_updater():
-    """Test that all simulations in ``SIM_DIR`` can be updated to current version and loaded."""
-    sim_files = [os.path.join(SIM_DIR, file) for file in os.listdir(SIM_DIR)]
-    for sim_file in sim_files:
-        sim_updated = Simulation.from_file(sim_file)
-        assert sim_updated.version == __version__, "Simulation not converted properly"
+SIM_FILES = [os.path.join(SIM_DIR, file) for file in os.listdir(SIM_DIR)]
 
-        # just make sure the loaded sim does something properly using this version
-        sim_updated.grid
+
+@pytest.mark.parametrize("sim_file", SIM_FILES)
+def test_simulation_updater(sim_file):
+    """Test that all simulations in ``SIM_DIR`` can be updated to current version and loaded."""
+    sim_updated = Simulation.from_file(sim_file)
+    assert sim_updated.version == __version__, "Simulation not converted properly"
+
+    # just make sure the loaded sim does something properly using this version
+    sim_updated.grid
 
 
 @clear_tmp

--- a/tidy3d/components/README.md
+++ b/tidy3d/components/README.md
@@ -109,7 +109,7 @@ The `Simulation` is the core datastructure in `tidy3d` and contains all of the p
 `Simulation` inherits from `Box` and therefore accepts `center` and `size` arguments.
 
 It also accepts many arguments related to the global configuration of the simulation, including:
-- `grid_size` (defines the discretization).
+- `grid_spec` (defines the discretization).
 - `medium` (the background medium).
 - `run_time`
 - `pml_layers` (a list of three `PML(profile, num_layers)` objects specifying the PML, defined in `pml.py`).

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -14,7 +14,7 @@ from .base import cached_property
 from .validators import assert_unique_names, assert_objects_in_sim_bounds
 from .validators import validate_mode_objects_symmetry
 from .geometry import Box
-from .types import Ax, Shapely, FreqBound, GridSize, Axis, annotate_type
+from .types import Ax, Shapely, FreqBound, Axis, annotate_type
 from .grid import Coords1D, Grid, Coords, GridSpec, UniformGrid
 from .medium import Medium, MediumType, AbstractMedium, PECMedium
 from .boundary import BoundarySpec, Symmetry, BlochBoundary, PECBoundary, PMCBoundary
@@ -30,7 +30,7 @@ from .viz import plot_params_structure, plot_params_pml, plot_params_override_st
 from .viz import plot_params_pec, plot_params_pmc, plot_params_bloch
 
 from ..version import __version__
-from ..constants import C_0, MICROMETER, SECOND, inf
+from ..constants import C_0, SECOND, inf
 from ..log import log, Tidy3dKeyError, SetupError, ValidationError
 from ..updater import Updater
 
@@ -105,13 +105,6 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
         "Note: If simulation 'shutoff' is specified, "
         "simulation will terminate early when shutoff condition met. ",
         units=SECOND,
-    )
-
-    grid_size: Union[GridSpec, Tuple[GridSize, GridSize, GridSize]] = pydantic.Field(
-        None,
-        title="Grid Size",
-        description="NOTE: 'grid_size' has been replaced by 'grid_spec'.",
-        units=MICROMETER,
     )
 
     medium: MediumType = pydantic.Field(
@@ -206,18 +199,6 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
     )
 
     """ Validating setup """
-
-    @pydantic.validator("grid_size", always=True)
-    def _error_use_grid_size(cls, val):
-        """If ``grid_size`` is provided, raise an error."""
-
-        if val is not None:
-            raise ValidationError(
-                "'grid_size' has been replaced by 'grid_spec'. See the "
-                "'GridSpec' documentation for more information."
-            )
-
-        return val
 
     @pydantic.validator("grid_spec", always=True)
     def _validate_auto_grid_wavelength(cls, val, values):

--- a/tidy3d/updater.py
+++ b/tidy3d/updater.py
@@ -202,7 +202,7 @@ def iterate_update_dict(update_dict: Dict, update_types: Dict[str, Callable]):
 
 @updates_from_version("1.4")
 def update_1_4(sim_dict: dict) -> dict:
-    """Updates version 1.3 to 1.4."""
+    """Updates version 1.4."""
 
     def fix_polyslab(geo_dict):
         """Fix a PolySlab dictionary."""
@@ -229,13 +229,14 @@ def update_1_4(sim_dict: dict) -> dict:
     }
 
     iterate_update_dict(update_dict=sim_dict, update_types=update_types)
-
+    if "grid_size" in sim_dict:
+        sim_dict.pop("grid_size")
     return sim_dict
 
 
 @updates_from_version("1.3")
 def update_1_3(sim_dict: dict) -> dict:
-    """Updates version 1.3 to 1.4."""
+    """Updates version 1.3."""
 
     sim_dict["boundary_spec"] = {"x": {}, "y": {}, "z": {}}
     for dim, pml_layer in zip(["x", "y", "z"], sim_dict["pml_layers"]):

--- a/tidy3d/version.py
+++ b/tidy3d/version.py
@@ -1,3 +1,3 @@
 """Defines the front end version of tidy3d"""
 
-__version__ = "1.6.3"
+__version__ = "1.7.0"


### PR DESCRIPTION
This should be done only in the next major release, and we should add the `"grid_size"` removal in the updater for version 1.6 to latest update. This is because e.g. 1.6.2 files still have `"grid_size": None` so if I try to load such a json in 1.6.3 with `grid_size` removed as a Field, it errors.