### PR TITLE
fixed deprecation warning with new copy_on_validation 

### DIFF
--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -69,7 +69,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         }
         frozen = True
         allow_mutation = False
-        copy_on_model_validation = False
+        copy_on_model_validation = "none"
 
     _cached_properties = pydantic.PrivateAttr({})
 


### PR DESCRIPTION
new way to set this config was introduced in pydantic 1.10. Without this change, will get a DeprecationWarning.

