### PR TITLE
add custom medium

### DIFF
--- a/tests/test_components/test_custom.py
+++ b/tests/test_components/test_custom.py
@@ -239,12 +239,12 @@ def test_medium_smaller_than_one_positive_sigma():
         mat_custom = CustomMedium.from_nk(n_dataarray, k_dataarray)
 
 
-def test_medium_eps_diagonal_spatial():
-    """Test if ``eps_diagonal_spatial`` works."""
+def test_medium_eps_diagonal_on_grid():
+    """Test if ``eps_diagonal_on_grid`` works."""
     coord_interp = Coords(**{ax: np.linspace(-1, 1, 20 + ind) for ind, ax in enumerate("xyz")})
     freq_interp = 1e14
 
-    eps_output = CUSTOM_MEDIUM.eps_diagonal_spatial(freq_interp, coord_interp)
+    eps_output = CUSTOM_MEDIUM.eps_diagonal_on_grid(freq_interp, coord_interp)
 
     for i in range(3):
         assert np.allclose(eps_output[i].shape, [len(f) for f in coord_interp.to_list])

--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -13,6 +13,7 @@ from tidy3d.components.geometry import Geometry, Planar
 from ..utils import assert_log_level
 
 GEO = td.Box(size=(1, 1, 1))
+GEO_INF = td.Box(size=(1, 1, td.inf))
 BOX = td.Box(size=(1, 1, 1))
 BOX_2D = td.Box(size=(1, 0, 1))
 POLYSLAB = td.PolySlab(vertices=((0, 0), (1, 0), (1, 1), (0, 1)), slab_bounds=(-0.5, 0.5), axis=2)
@@ -35,6 +36,7 @@ def test_base_inside():
 
 def test_bounding_box():
     assert GEO.bounding_box == GEO
+    assert GEO_INF.bounding_box == GEO_INF
 
 
 def test_strip_coords_multi():

--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -68,6 +68,10 @@ def test_medium_conversions():
     eps_z_ = medium.eps_sigma_to_eps_complex(eps, sig, freq)
     assert np.isclose(eps_z, eps_z_)
 
+    eps_, sig_ = medium.eps_complex_to_eps_sigma(eps_z, freq)
+    assert np.isclose(eps_, eps)
+    assert np.isclose(sig_, sig)
+
     n_, k_ = medium.eps_complex_to_nk(eps_z)
     assert np.isclose(n, n_)
     assert np.isclose(k, k_)

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -13,6 +13,7 @@ from .components.geometry import Box, Sphere, Cylinder, PolySlab, GeometryGroup
 # medium
 from .components.medium import Medium, PoleResidue, AnisotropicMedium, PEC, PECMedium
 from .components.medium import Sellmeier, Debye, Drude, Lorentz
+from .components.medium import CustomMedium
 
 # structures
 from .components.structure import Structure, MeshOverrideStructure

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -4,6 +4,7 @@ from typing import Dict
 
 import xarray as xr
 import numpy as np
+import dask
 
 from ...constants import HERTZ, SECOND, MICROMETER, RADIAN
 from ...log import DataError, FileError
@@ -138,6 +139,11 @@ class DataArray(xr.DataArray):
                 f"Given filename of {fname}."
             )
         return cls.from_hdf5(fname=fname, group_path=group_path)
+
+    def __hash__(self) -> int:
+        """Generate hash value for a :class:.`DataArray` instance, needed for custom components."""
+        token_str = dask.base.tokenize(self)
+        return hash(token_str)
 
 
 class FreqDataArray(DataArray):

--- a/tidy3d/components/geometry.py
+++ b/tidy3d/components/geometry.py
@@ -143,14 +143,7 @@ class Geometry(Tidy3dBaseModel, ABC):
         :class:`Box`
             Geometric object representing bounding box.
         """
-        (xmin, ymin, zmin), (xmax, ymax, zmax) = self.bounds
-        Lx = xmax - xmin
-        Ly = ymax - ymin
-        Lz = zmax - zmin
-        x0 = (xmax + xmin) / 2.0
-        y0 = (ymax + ymin) / 2.0
-        z0 = (zmax + zmin) / 2.0
-        return Box(center=(x0, y0, z0), size=(Lx, Ly, Lz))
+        return Box.from_bounds(*self.bounds)
 
     def _pop_bounds(self, axis: Axis) -> Tuple[Coordinate2D, Tuple[Coordinate2D, Coordinate2D]]:
         """Returns min and max bounds in plane normal to and tangential to ``axis``.

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -359,7 +359,7 @@ class CustomMedium(AbstractMedium):
         title="Permittivity Dataset",
         description="User-supplied dataset containing complex-valued permittivity "
         "as a function of space. Permittivity distribution over the Yee-grid will be "
-        "based on nearest-neighbor interpolation.",
+        "interpolated based on ``interp_method``.",
     )
 
     interp_method: InterpMethod = pd.Field(
@@ -367,7 +367,9 @@ class CustomMedium(AbstractMedium):
         title="Interpolation method",
         description="Interpolation method to obtain permittivity values "
         "that are not supplied at the Yee grids; For grids outside the range "
-        "of the supplied data, extrapolation will be applied.",
+        "of the supplied data, extrapolation will be applied. When the extrapolated "
+        "value is smaller (greater) than the minimal (maximal) of the supplied data, "
+        "the extrapolated value will take the minimal (maximal) of the supplied data.",
     )
 
     @pd.validator("eps_dataset", always=True)
@@ -397,14 +399,15 @@ class CustomMedium(AbstractMedium):
                 )
             if np.any(sigma.values < 0):
                 raise SetupError(
-                    "Negative imaginary part of refrative index results in a gain medium."
+                    "Negative imaginary part of refrative index leads to a gain medium, "
+                    "which is not supported."
                 )
         return val
 
     @ensure_freq_in_range
     def eps_dataset_freq(self, frequency: float) -> PermittivityDataset:
         """Permittivity dataset at ``frequency``. The dispersion comes
-        from DC conductivity that results in nonzero Im[permittivity].
+        from DC conductivity that results in nonzero Im[eps].
 
         Parameters
         ----------
@@ -413,7 +416,7 @@ class CustomMedium(AbstractMedium):
 
         Returns
         -------
-        PermittivityDataset
+        :class:`.PermittivityDataset`
             The permittivity evaluated at ``frequency``.
         """
 
@@ -467,8 +470,7 @@ class CustomMedium(AbstractMedium):
         """
         eps_freq = self.eps_dataset_freq(frequency)
         eps_np_list = [
-            np.array(eps_freq.field_components[comp]).ravel()
-            for comp in ["eps_xx", "eps_yy", "eps_zz"]
+            np.array(sclr_fld).ravel() for _, sclr_fld in eps_freq.field_components.items()
         ]
         eps_list = [eps_comp[np.argmax(np.abs(eps_comp))] for eps_comp in eps_np_list]
         return tuple(eps_list)
@@ -479,27 +481,26 @@ class CustomMedium(AbstractMedium):
         as a function of frequency.
         """
         eps_freq = self.eps_dataset_freq(frequency)
-        eps_arrays = [eps_freq.field_components[comp] for comp in ["eps_xx", "eps_yy", "eps_zz"]]
-        eps_array_avgs = [np.mean(eps_array) for eps_array in eps_arrays]
+        eps_array_avgs = [np.mean(eps_array) for _, eps_array in eps_freq.field_components.items()]
         return np.mean(eps_array_avgs)
 
     @classmethod
     def from_eps_raw(
         cls, eps: ScalarFieldDataArray, interp_method: InterpMethod = "nearest"
     ) -> CustomMedium:
-        """Construct a :class:`CustomMedium` from datasets containing raw permittivity values.
+        """Construct a :class:`.CustomMedium` from datasets containing raw permittivity values.
 
         Parameters
         ----------
         eps : :class:`.ScalarFieldDataArray`
             Dataset containing complex-valued permittivity as a function of space.
-        interp_method : InterpMethod, optional
+        interp_method : :class:`.InterpMethod`, optional
                 Interpolation method to obtain permittivity values that are not supplied
                 at the Yee grids.
 
         Returns
         -------
-        :class:`CustomMedium`
+        :class:`.CustomMedium`
             Medium containing the spatially varying permittivity data.
         """
         field_components = {field_name: eps.copy() for field_name in ("eps_xx", "eps_yy", "eps_zz")}
@@ -513,7 +514,7 @@ class CustomMedium(AbstractMedium):
         k: Optional[ScalarFieldDataArray] = None,
         interp_method: InterpMethod = "nearest",
     ) -> CustomMedium:
-        """Construct a :class:`CustomMedium` from datasets containing n and k values.
+        """Construct a :class:`.CustomMedium` from datasets containing n and k values.
 
         Parameters
         ----------
@@ -521,13 +522,13 @@ class CustomMedium(AbstractMedium):
             Real part of refractive index.
         k : :class:`.ScalarFieldDataArray` = None
             Imaginary part of refrative index.
-        interp_method : InterpMethod, optional
+        interp_method : :class:`.InterpMethod`, optional
                 Interpolation method to obtain permittivity values that are not supplied
                 at the Yee grids.
 
         Returns
         -------
-        :class:`CustomMedium`
+        :class:`.CustomMedium`
             Medium containing the spatially varying permittivity data.
         """
         if k is None:
@@ -563,7 +564,7 @@ class CustomMedium(AbstractMedium):
             Supplied scalar dataset.
         coord_interp : :class:`.Coords`
             The grid point coordinates over which interpolation is performed.
-        interp_method : InterpMethod
+        interp_method : :class:`.InterpMethod`
             Interpolation method.
 
         Returns

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -18,7 +18,7 @@ from .geometry import Box
 from .types import Ax, Shapely, FreqBound, Axis, annotate_type, Symmetry
 from .grid.grid import Coords1D, Grid, Coords
 from .grid.grid_spec import GridSpec, UniformGrid
-from .medium import Medium, MediumType, AbstractMedium, PECMedium
+from .medium import Medium, MediumType, AbstractMedium, PECMedium, CustomMedium
 from .boundary import BoundarySpec, BlochBoundary, PECBoundary, PMCBoundary, Periodic
 from .boundary import PML, StablePML, Absorber, AbsorberSpec
 from .structure import Structure
@@ -2050,5 +2050,8 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
         """List of custom datasets for verification purposes. If the list is not empty, then
         the simulation needs to be exported to hdf5 to store the data.
         """
-        datasets = [src.field_dataset for src in self.sources if isinstance(src, CustomFieldSource)]
-        return datasets
+        datasets_source = [
+            src.field_dataset for src in self.sources if isinstance(src, CustomFieldSource)
+        ]
+        datasets_medium = [mat.eps_dataset for mat in self.mediums if isinstance(mat, CustomMedium)]
+        return datasets_source + datasets_medium

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -92,7 +92,7 @@ class Structure(AbstractStructure):
             The diagonal elements of the relative permittivity tensor evaluated at ``frequency``.
         """
         if isinstance(self.medium, CustomMedium):
-            return self.medium.eps_diagonal_spatial(frequency=frequency, coords=coords)
+            return self.medium.eps_diagonal_on_grid(frequency=frequency, coords=coords)
         return self.medium.eps_diagonal(frequency=frequency)
 
 

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -5,9 +5,10 @@ import pydantic
 from .base import Tidy3dBaseModel
 from .validators import validate_name_str
 from .geometry import GeometryType
-from .medium import MediumType
+from .medium import MediumType, CustomMedium
 from .types import Ax, TYPE_TAG_STR
 from .viz import add_ax_if_none, equal_aspect
+from .grid.grid import Coords
 from ..constants import MICROMETER
 
 
@@ -77,7 +78,7 @@ class Structure(AbstractStructure):
         discriminator=TYPE_TAG_STR,
     )
 
-    def eps_diagonal(self, frequency: float) -> Tuple[complex, complex, complex]:
+    def eps_diagonal(self, frequency: float, coords: Coords) -> Tuple[complex, complex, complex]:
         """Main diagonal of the complex-valued permittivity tensor as a function of frequency.
 
         Parameters
@@ -90,6 +91,8 @@ class Structure(AbstractStructure):
         complex
             The diagonal elements of the relative permittivity tensor evaluated at ``frequency``.
         """
+        if isinstance(self.medium, CustomMedium):
+            return self.medium.eps_diagonal_spatial(frequency=frequency, coords=coords)
         return self.medium.eps_diagonal(frequency=frequency)
 
 

--- a/tidy3d/components/types.py
+++ b/tidy3d/components/types.py
@@ -152,6 +152,9 @@ PlanePosition = Literal["bottom", "middle", "top"]
 
 """ medium """
 
+# custom medium
+InterpMethod = Literal["nearest", "linear"]
+
 # Complex = Union[complex, ComplexNumber]
 Complex = Union[tidycomplex, ComplexNumber]
 PoleAndResidue = Tuple[Complex, Complex]

--- a/tidy3d/components/viz.py
+++ b/tidy3d/components/viz.py
@@ -130,6 +130,8 @@ MEDIUM_CMAP = [
     "#877EBC",
 ]
 
+# colormap for structure's permittivity in plot_eps
+STRUCTURE_EPS_CMAP = "gist_yarg"
 
 """=================================================================================================
 Descartes modified from https://pypi.org/project/descartes/ for Shapely >= 1.8.0


### PR DESCRIPTION
Incorporate changes from #498 with the new data refactor in mind.

A few things of note:
* `CustomMedium.from_eps_raw()`allows user to construct each of the `eps_ii` data arrays from a single data array. How do we handle this on the backend? Do we want to change this behavior or add a new class method constructor, for example, for supplying eps at the center only?
* All of the medium `.eps_model()` take `frequency` argument, maybe we can change to `f` instead to be consistent with the data coordinates?

Needs backend implementation.