### PR TITLE
Broader broadcasting in FieldData.dot

### DIFF
--- a/tests/test_data/test_monitor_data.py
+++ b/tests/test_data/test_monitor_data.py
@@ -185,7 +185,17 @@ def test_mode_solver_data():
     field_data = make_field_data_2d()
     dot = data.dot(field_data)
     # Check that broadcasting worked
-    assert data.Ex.shape[-2:] == dot.shape
+    assert data.Ex.f == dot.f
+    assert data.Ex.mode_index == dot.mode_index
+    # Also try with a feild data at a single frequency that is not in the data frequencies
+    freq = 0.9 * field_data.Ex.f[0]
+    fields = field_data.field_components.items()
+    fields_single_f = {key: val.isel(f=[0]).assign_coords(f=[freq]) for key, val in fields}
+    field_data = field_data.copy(update=fields_single_f)
+    dot = data.dot(field_data)
+    # Check that broadcasting worked
+    assert data.Ex.f == dot.f
+    assert data.Ex.mode_index == dot.mode_index
 
 
 def test_permittivity_data():

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -255,7 +255,10 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
         to be frequency-domain data associated with a 2D monitor. Along the tangential directions,
         the datasets have to have the same discretization. Along the normal direction, the monitor
         position may differ and is ignored. Other coordinates (``frequency``, ``mode_index``) have
-        to be either identical or broadcastable.
+        to be either identical or broadcastable. Broadcasting is also supported in the case in
+        which the other ``field_data`` has a dimension of size ``1`` whose coordinate is not in the
+        list of coordinates in the ``self`` dataset along the corresponding dimension. In that case,
+        the coordinates of the ``self`` dataset are used in the output.
 
         Parameters
         ----------
@@ -283,6 +286,9 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
         fields_other = field_data._centered_tangential_fields
         if conjugate:
             fields_self = {key: field.conj() for key, field in fields_self.items()}
+
+        # Drop size-1 dimensions in the other data
+        fields_other = {key: field.squeeze(drop=True) for key, field in fields_other.items()}
 
         # Cross products of fields
         dim1, dim2 = self._tangential_dims


### PR DESCRIPTION
With this change, we can do e.g. `mode_data.dot(other_mode_data)` for frequency / mode index coords that do not match, if the supplied `other_mode_data` has a single element along these dimensions. The coords of the original data are preserved. This is because you don't necessarily always want to do the dot product for modes at exactly the same frequency or with exactly the same mode ordering.