### PR TITLE
Bumping default courant factor to 0.99

### DIFF
--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -185,7 +185,7 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
     )
 
     courant: float = pydantic.Field(
-        0.9,
+        0.99,
         title="Courant Factor",
         description="Courant stability factor, controls time step to spatial step ratio. "
         "Lower values lead to more stable simulations for dispersive materials, "


### PR DESCRIPTION
All backend tests pass, just a few of them needed a small increase in the tolerances, but everything looks good and this should make the time stepping 10% faster.