### PR TITLE
Updates to make user-side flux (and near2far) computation consistent

### DIFF
--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -13,6 +13,7 @@ from tidy3d.components.geometry import Geometry, Planar
 
 GEO = td.Box(size=(1, 1, 1))
 BOX = td.Box(size=(1, 1, 1))
+BOX_2D = td.Box(size=(1, 0, 1))
 POLYSLAB = td.PolySlab(vertices=((0, 0), (1, 0), (1, 1), (0, 1)), slab_bounds=(-0.5, 0.5), axis=2)
 SPHERE = td.Sphere(radius=1)
 CYLINDER = td.Cylinder(axis=2, length=1, radius=1)
@@ -101,6 +102,11 @@ def test_planar_bounds():
 @pytest.mark.parametrize("component", GEO_TYPES)
 def test_inside(component):
     b = component.inside(0, 0, 0)
+
+
+def test_zero_dims():
+    assert BOX.zero_dims == []
+    assert BOX_2D.zero_dims == [1]
 
 
 def test_inside_polyslab_sidewall():

--- a/tests/test_components/test_grid.py
+++ b/tests/test_components/test_grid.py
@@ -80,9 +80,29 @@ def test_getitem():
 
 
 def test_extend_grid():
+    """This test should clarify the expected behavior of various extensions."""
     g = make_grid()
-    box = td.Box(size=(2, 4, 6))
-    g.discretize_inds(box=box, extend=True)
+    center_y = g.centers.to_list[1][g.num_cells[1] // 2]
+    # 2d box on the left of a grid center
+    box_left = td.Box(center=(0, center_y - 1e-5, 0), size=(2, 0, 6))
+    # 2d box on the right of a grid center
+    box_right = td.Box(center=(0, center_y + 1e-5, 0), size=(2, 0, 6))
+    inds_l_0_0 = g.discretize_inds(box=box_left, extend=False, extend_2d_normal=False)[1]
+    inds_r_0_0 = g.discretize_inds(box=box_right, extend=False, extend_2d_normal=False)[1]
+    inds_l_1_0 = g.discretize_inds(box=box_left, extend=True, extend_2d_normal=False)[1]
+    inds_r_1_0 = g.discretize_inds(box=box_right, extend=True, extend_2d_normal=False)[1]
+    inds_l_0_1 = g.discretize_inds(box=box_left, extend=False, extend_2d_normal=True)[1]
+    inds_r_0_1 = g.discretize_inds(box=box_right, extend=False, extend_2d_normal=True)[1]
+    inds_l_1_1 = g.discretize_inds(box=box_left, extend=True, extend_2d_normal=True)[1]
+    inds_r_1_1 = g.discretize_inds(box=box_right, extend=True, extend_2d_normal=True)[1]
+
+    assert np.diff(inds_l_0_0) == np.diff(inds_r_0_0)
+    assert np.diff(inds_l_0_0) == np.diff(inds_l_1_0) - 2
+    assert np.diff(inds_r_0_0) == np.diff(inds_r_1_0) - 1
+    assert np.diff(inds_l_0_0) == np.diff(inds_l_0_1) - 1
+    assert np.diff(inds_r_0_0) == np.diff(inds_r_0_1) - 1
+    assert np.diff(inds_l_0_0) == np.diff(inds_l_1_1) - 2
+    assert np.diff(inds_r_0_0) == np.diff(inds_r_1_1) - 2
 
 
 def test_periodic_subspace():

--- a/tests/test_data/test_data_arrays.py
+++ b/tests/test_data/test_data_arrays.py
@@ -23,6 +23,8 @@ from tidy3d.constants import inf
 
 from ..utils import clear_tmp
 
+np.random.seed(4)
+
 STRUCTURES = [
     Structure(geometry=Box(size=(1, inf, 1)), medium=material_library["cSi"]["SalzbergVilla1957"])
 ]
@@ -158,7 +160,7 @@ def make_mode_amps_data_array():
 
 
 def make_mode_index_data_array():
-    values = (1 + 1j) * np.random.random((len(FS), len(MODE_INDICES)))
+    values = (1 + 0.1j) * np.random.random((len(FS), len(MODE_INDICES)))
     return ModeIndexDataArray(values, coords=dict(f=FS, mode_index=MODE_INDICES))
 
 

--- a/tests/test_data/test_data_arrays.py
+++ b/tests/test_data/test_data_arrays.py
@@ -145,7 +145,7 @@ def make_scalar_field_time_data_array(grid_key: str, symmetry=True):
 
 def make_scalar_mode_field_data_array(grid_key: str, symmetry=True):
     XS, YS, ZS = get_xyz(MODE_SOLVE_MONITOR, grid_key, symmetry)
-    values = np.random.random((len(XS), 1, len(ZS), len(FS), len(MODE_INDICES)))
+    values = (1 + 0.1j) * np.random.random((len(XS), 1, len(ZS), len(FS), len(MODE_INDICES)))
 
     return ScalarModeFieldDataArray(
         values, coords=dict(x=XS, y=[0.0], z=ZS, f=FS, mode_index=MODE_INDICES)

--- a/tests/test_data/test_sim_data.py
+++ b/tests/test_data/test_sim_data.py
@@ -101,6 +101,22 @@ def test_no_symmetry():
     assert np.allclose(Ex_raw, Ex_ret)
 
 
+def test_mode_solver_numerical_grid_data():
+    sim_data = make_sim_data(symmetry=False)
+    mode_data = sim_data["mode_solver"]
+    # Renomralize to numerical grid and compute flux
+    mode_data_num = mode_data.finite_grid_copy(sim_data.simulation.grid)
+    flux = np.abs(mode_data.flux)
+    # Check that flux is still normalized
+    assert np.linalg.norm(flux - 1) < 1e-10
+    # Check that data is only slightly different
+    for comp, field in mode_data.field_components.items():
+        comp_diff_norm = np.linalg.norm(field - mode_data_num.field_components[comp])
+        comp_diff_norm /= np.prod(field.shape)
+        max_diff = np.amax(np.abs(field - mode_data_num.field_components[comp]))
+        assert 0.1 > max_diff > 0
+
+
 def test_normalize():
     sim_data_norm0 = make_sim_data()
     sim_data_norm_none = sim_data_norm0.renormalize(normalize_index=None)
@@ -208,7 +224,7 @@ def test_sel_kwarg_len1():
     sim_data.plot_field("mode_solver", "Ex", y=0.0, val="real", f=1e14, mode_index=1, ax=AX)
 
     # passing y=1 sel kwarg should error
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         sim_data.plot_field("mode_solver", "Ex", y=-1.0, val="real", f=1e14, mode_index=1, ax=AX)
 
 

--- a/tests/test_data/test_sim_data.py
+++ b/tests/test_data/test_sim_data.py
@@ -101,22 +101,6 @@ def test_no_symmetry():
     assert np.allclose(Ex_raw, Ex_ret)
 
 
-def test_mode_solver_numerical_grid_data():
-    sim_data = make_sim_data(symmetry=False)
-    mode_data = sim_data["mode_solver"]
-    # Renomralize to numerical grid and compute flux
-    mode_data_num = mode_data.finite_grid_copy(sim_data.simulation.grid)
-    flux = np.abs(mode_data.flux)
-    # Check that flux is still normalized
-    assert np.linalg.norm(flux - 1) < 1e-10
-    # Check that data is only slightly different
-    for comp, field in mode_data.field_components.items():
-        comp_diff_norm = np.linalg.norm(field - mode_data_num.field_components[comp])
-        comp_diff_norm /= np.prod(field.shape)
-        max_diff = np.amax(np.abs(field - mode_data_num.field_components[comp]))
-        assert 0.1 > max_diff > 0
-
-
 def test_normalize():
     sim_data_norm0 = make_sim_data()
     sim_data_norm_none = sim_data_norm0.renormalize(normalize_index=None)

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -140,6 +140,47 @@ class DataArray(xr.DataArray):
         return cls.from_hdf5(fname=fname, group_path=group_path)
 
 
+class FreqDataArray(DataArray):
+    """Frequency-domain array.
+
+    Example
+    -------
+    >>> f = [2e14, 3e14]
+    >>> fd = FreqDataArray((1+1j) * np.random.random((2,)), coords=dict(f=f))
+    """
+
+    __slots__ = ()
+    _dims = "f"
+
+
+class FreqModeDataArray(DataArray):
+    """Array over frequency and mode index.
+
+    Example
+    -------
+    >>> f = [2e14, 3e14]
+    >>> mode_index = np.arange(5)
+    >>> coords = dict(f=f, mode_index=mode_index)
+    >>> fd = FreqModeDataArray((1+1j) * np.random.random((2, 5)), coords=coords)
+    """
+
+    __slots__ = ()
+    _dims = ("f", "mode_index")
+
+
+class TimeDataArray(DataArray):
+    """Time-domain array.
+
+    Example
+    -------
+    >>> t = [0, 1e-12, 2e-12]
+    >>> td = TimeDataArray((1+1j) * np.random.random((3,)), coords=dict(t=t))
+    """
+
+    __slots__ = ()
+    _dims = "t"
+
+
 class ScalarFieldDataArray(DataArray):
     """Spatial distribution in the frequency-domain.
 

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -328,15 +328,6 @@ class ModeSolverDataset(ElectromagneticFieldDataset):
         """Imaginary part of the propagation index."""
         return self.n_complex.imag
 
-    def sel_mode_index(self, mode_index: pd.NonNegativeInt) -> FieldDataset:
-        """Return :class:`.FieldData` for the specificed mode index."""
-
-        fields = {}
-        for field_name, data in self.field_components.items():
-            fields[field_name] = data.sel(mode_index=[mode_index])
-
-        return self.copy(update=fields)
-
     def plot_field(self, *args, **kwargs):
         """Warn user to use the :class:`.ModeSolver` ``plot_field`` function now."""
         raise DeprecationWarning(

--- a/tidy3d/components/geometry.py
+++ b/tidy3d/components/geometry.py
@@ -1167,6 +1167,11 @@ class Box(Centered):
         """
         return Box(center=self.center, size=self.size)
 
+    @cached_property
+    def zero_dims(self) -> List[Axis]:
+        """A list of axes along which the :class:`Box` is zero-sized."""
+        return [dim for dim, size in enumerate(self.size) if size == 0]
+
     def _plot_arrow(  # pylint:disable=too-many-arguments, too-many-locals
         self,
         direction: Tuple[float, float, float],

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -407,14 +407,6 @@ class FluxMonitor(AbstractFluxMonitor, FreqMonitor):
     ...     size=(2,2,0),
     ...     freqs=[200e12, 210e12],
     ...     name='flux_monitor')
-
-    Note
-    ----
-    For a 2D plane, the flux is summed up over all Yee grid pixels that are touched by the plane,
-    rather than integrated over the exact span of the plane. For a 3D monitor, this is also the
-    case, but care is taken to not over- or under-count the power at the edges. Because of this,
-    there can be small discrepancies between using a 3D FluxMonitor and manually placing six
-    2D monitors at the surface locations.
     """
 
     def storage_size(self, num_cells: int, tmesh: ArrayLike[float, 1]) -> int:
@@ -439,14 +431,6 @@ class FluxTimeMonitor(AbstractFluxMonitor, TimeMonitor):
     ...     stop=5e-13,
     ...     interval=2,
     ...     name='flux_vs_time')
-
-    Note
-    ----
-    For a 2D plane, the flux is summed up over all Yee grid pixels that are touched by the plane,
-    rather than integrated over the exact span of the plane. For a 3D monitor, this is also the
-    case, but care is taken to not over- or under-count the power at the edges. Because of this,
-    there can be small discrepancies between using a 3D FluxMonitor and manually placing six
-    2D monitors at the surface locations.
     """
 
     def storage_size(self, num_cells: int, tmesh: ArrayLike[float, 1]) -> int:

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -479,6 +479,16 @@ class ModeSolverMonitor(AbstractModeMonitor):
         """Size of monitor storage given the number of points after discretization."""
         return 6 * BYTES_COMPLEX * num_cells * len(self.freqs) * self.mode_spec.num_modes
 
+    @property
+    def interval_space(self):
+        """No downsampling is applied to the stored fields."""
+        return (1, 1, 1)
+
+    @property
+    def colocate(self):
+        """Fields are stored on the Yee grid."""
+        return False
+
 
 class FieldProjectionSurface(Tidy3dBaseModel):
     """Data structure to store surface monitors where near fields are recorded for

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -1874,20 +1874,19 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
 
         return Box.from_bounds(bmin_new, bmax_new)
 
-    def discretize(self, box: Box, extend: bool = False, snap_zero_dim: bool = False) -> Grid:
+    def discretize(self, box: Box, snap_zero_dim: bool = False, **kwargs) -> Grid:
         """Grid containing only cells that intersect with a :class:`Box`.
 
         Parameters
         ----------
         box : :class:`Box`
             Rectangular geometry within simulation to discretize.
-        extend : bool
-            If ``True``, extra pixels are added to the discretized grid if needed, such that Yee
-            grid fields can be interpolated to any point inside the ``box``.
         snap_zero_dim : bool
             If ``True``, and the ``box`` has size zero along a given direction, the ``grid`` is
             defined to also have a zero-sized cell exactly centered at the ``box`` center. If
             false, the ``simulation`` grid cell containing the ``box`` center is instead used.
+        kwargs :
+            Extra keyword arguments passed to ``discretize_inds`` method of :class:`.Grid`.
 
         Returns
         -------
@@ -1898,7 +1897,7 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
         if not self.intersects(box):
             log.error(f"Box {box} is outside simulation, cannot discretize")
 
-        span_inds = self.grid.discretize_inds(box, extend=extend)
+        span_inds = self.grid.discretize_inds(box, **kwargs)
         boundary_dict = {}
         for idim, dim in enumerate("xyz"):
             if snap_zero_dim and box.size[idim] == 0:

--- a/tidy3d/log.py
+++ b/tidy3d/log.py
@@ -70,6 +70,10 @@ class Tidy3dImportError(Tidy3dError):
     """Error importing a package needed for tidy3d."""
 
 
+class Tidy3dNotImplementedError(Tidy3dError):
+    """Error when a functionality is not (yet) supported."""
+
+
 """ Logging functions """
 
 

--- a/tidy3d/web/webapi.py
+++ b/tidy3d/web/webapi.py
@@ -204,7 +204,7 @@ def get_run_info(task_id: TaskId):
         client = token.get_client()
         progress = client.get_object(Bucket=token.get_bucket(), Key=token.get_s3_key())["Body"]
         progress_string = progress.read().split(b"\n")
-        perc_done, field_decay = progress_string[-2].split(b",")
+        perc_done, field_decay = progress_string[-2].split(b",")[:2]
         return float(perc_done), float(field_decay)
     except Exception:  # pylint:disable=broad-except
         return None, None


### PR DESCRIPTION
The fundamental issue that this PR addresses is the following. Say you have a primal grid along `z` defined on `n dz` and a dual grid defined on `(n + 0.5) dz`. Say also that you have a perfectly injected mode propagating along z, such that the frequency-domain tangential fields on the primal grid are exactly given by some `E0 exp(1j * k * n * dz)`, `H0 exp(1j * k * (n + 0.5) * dz)`, where k is the effective wave vector of the mode at a particular frequency. Now, if you pick an arbitrary position `z` along the propagation direction, and use linear interpolation to compute `E(z)` and `H(z)`, and then use those to compute the flux at that location, you will get values that *oscillate* with `z` weakly but non-negligibly.

So far, to hide this from the user, we have been normalizing the sources to inject `flux = 1` when computed *on the dual grid*, i.e. at the cell centers. Note that the difference between this flux and the analytic one coming from E0 and H0 is a factor of `cos(k * dz / 2)`. This factor is specific to interpolating to a grid center, and comes entirely from the E-field interpolation, as the H fields are not interpolated as they are defined exactly at the center. This factor is what would vary if you were to vary the interpolation position. To avoid this, and to match the source normalization, the backend `FluxMonitor`-s have also been always returning the flux at the grid centers, and similarly that's how mode amps are computed, such that in the end `flux` and `np.abs(amps) ** 2` are always very close to 1.

However, we have introduced `FieldData.flux` and `FieldData.dot` methods available to the user, which can be applied to any 2D field data where the fields have been interpolated to an arbitrary `z`. This results in the unphysical oscillations of the flux as discusses above, and also makes user-side and server-side results differ if a `FieldMonitor` is not placed exactly at a cell center.

There are two main stipulations of this PR:
- The first is that the correct way to compute flux along the *normal* direction is *not* to directly interpolate E(z) and H(z) and then compute the flux, but rather to compute the flux at the grid centers surrounding z (by interpolating the fields to those centers), and then interpolate *the flux* to z. This ensures that in the example above, the flux will vary very weakly with `z`, and, due to the source normalization to inject unit power as recorded at the *centers*, the flux will be very close to 1 regardless of `z`. This is now what backend `FluxMonitor`-s do, and they now create an illusion of continuity along all 3 directions. Along the tangential directions, the computation is much more straightforward: we interpolate fields to centers, compute the Poynting vector, and integrate over the monitor area, adjusting the differential area of the cells at the edges to match the exact monitor dimensions.
- The second is that when snapping 2D `FieldMonitor` results to the exact location along `z`, the first consideration needs to be taken into account. So now, instead of directly interpolating E(z) and H(z) and be done with it, we do something more complicated. On the backend, we expand the `FieldMonitor` sufficiently along `z` to be able to compute the flux at the two cell centers surrounding the exact monitor `z`. Then, we compute the flux at `z` in two different ways:
  -  By interpolating E and H to z (call this `flux_interp1`). This is what `FieldData.flux` would return for that monitor if we don't do anything else.
  -  By interpolating E and H to `(n + 0.5) dz` and `(n + 1.5) dz` (center positions around `z`), computing the flux, and then interpolating *that* to `z` (call this `flux_interp2`).

   Finally, we scale all the fields of the `FieldMonitor` by `np.sqrt(flux_interp2 / flux_interp1)`. Now, `FieldData.flux` for this monitor will return the desired `flux_interp2`, and match the server-side results from a `FluxMonitor`.

Similar considerations need to be applied to make user-side and server-side mode amps computed as `ModeSolverData.dot(FieldData)` consistent. However, since the mode solver does not take the grid along the normal direction into account, we cannot really automatically apply the correction in that case (consider for example the fact that the `ModeSolverData` could be coming from a local mode solver run). Well, we *could*, but it would mean that the mode solver results would depend on the grid along the normal direction, and even more unexpectedly, on the exact placement of the `ModeSolverMonitor` along that direction with respect to the Yee grid. To avoid this, I have instead introduced a `ModeSolverData.finite_grid_copy(grid)` method. Thus the user can replicate server-side mode amplitudes by doing e.g. `ModeSolverData.finite_grid_copy(sim.grid).dot(FieldData)`.

These changes, together with the corresponding backend ones, have the following nice features:
- User-side and server-side flux and amps computations should now be always equivalent.
- Flux monitors (and the `flux` method of field monitors) take the analytic geometry of the monitor into account as well as possible, under the constraints of doing a linear interpolation on the Yee grid.

And here are some caveats *introduced* by the new handling:
- Pretty much all monitors should be placed at least *two* cells away from a source or structure interface to avoid numerical artifacts. Should we put this somewhere in the docs, and how? Should we have it as a note under every monitor?
- If someone puts a 3D `FieldMonitor` and interpolates the fields to a given z, they will not get the same results as a 2D `FieldMonitor` at that z (unless it's a grid cell center). We could again explain this in a note in the monitors docstrings?

Some other updates:
- The `flux` and `dot` methods now also handle monitors with `colocate=True` correctly. For down-sampling monitors, they raise a not implemented error. I also added trivial `colocate` and `interval_space` properties to `ModeSolverData` to unify this treatment.
- I've removed `ModeSolverDataset.sel_mode_index` since it's a bit inconsistent and our strategy tends to be to *not* implement methods like this.
- I've introduced an extra kwarg "expansion" kwarg in the `discretize` methods that's related to the flux interpolation along the normal direction discussed above.
- Added a `ElectromagneticFieldData.time_reversed_copy` property that can be used to compute mode amplitudes in the backward direction. Note: for time-domain data, this just flips the sign of `H`. Does this make sense? If the data was a regular numpy array, I could be reversing the indexing along the time dimension. However, in the xarray data the coords are labeled, so it doesn't seem necessary?
  