### PR TITLE
Avoid setting axis limits if lower and upper limits are equal

### DIFF
--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -1509,8 +1509,10 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
         _, (xmin, ymin) = self.pop_axis(self.bounds_pml[0], axis=axis)
         _, (xmax, ymax) = self.pop_axis(self.bounds_pml[1], axis=axis)
 
-        ax.set_xlim(xmin, xmax)
-        ax.set_ylim(ymin, ymax)
+        if xmin != xmax:
+            ax.set_xlim(xmin, xmax)
+        if ymin != ymax:
+            ax.set_ylim(ymin, ymax)
         return ax
 
     @staticmethod


### PR DESCRIPTION
Hi @tylerflex this small fix gets rid of the warning when one of the plot dimension's size is zero. I tested on a bunch of 1D, 2D, and 3D examples and it doesn't seem to affect any plotting functions so far. Do you see any potential adversarial effect it could have?