### PR TITLE
coordinate properties in DiffractionData use `coords["coord_name"]`

### DIFF
--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -881,7 +881,7 @@ class AbstractFieldProjectionData(MonitorData):
     @property
     def f(self) -> np.ndarray:
         """Frequencies."""
-        return self.Etheta.f.values
+        return np.array(self.Etheta.coords["f"])
 
     @property
     def coords(self) -> Dict[str, np.ndarray]:
@@ -1541,12 +1541,12 @@ class DiffractionData(AbstractFieldProjectionData):
     @property
     def orders_x(self) -> np.ndarray:
         """Allowed orders along x."""
-        return np.atleast_1d(self.Etheta.orders_x.values)
+        return np.atleast_1d(np.array(self.Etheta.coords["orders_x"]))
 
     @property
     def orders_y(self) -> np.ndarray:
         """Allowed orders along y."""
-        return np.atleast_1d(self.Etheta.orders_y.values)
+        return np.atleast_1d(np.array(self.Etheta.coords["orders_y"]))
 
     @property
     def reciprocal_vectors(self) -> Tuple[np.ndarray, np.ndarray]:


### PR DESCRIPTION
instead of `self.coord_name` eg. `self.Etheta.f`

This makes it a tiny bit more general for subclasses of `DiffractionData` and therefore easier for the adjoint plugin to work properly.

No rush to merge this, can be done after 1.8. Just simplifies a bit in the adjoint plugin and shouldn't affect anything else.

