### PR TITLE
add ssl verify

### DIFF
--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -3,6 +3,8 @@ import pytest
 import requests
 import datetime
 
+from requests import Session
+
 import tidy3d as td
 import tidy3d.web as web
 from tidy3d.web import httputils, s3utils, webapi
@@ -113,18 +115,18 @@ def mock_response(monkeypatch):
         method = url.split(preamble)[-1]
         return RESPONSE_MAP[method]
 
-    def mock_get(url, **kwargs):
-        return get_response(url)
+    class MockRequests:
+        def get(self, url, **kwargs):
+            return get_response(url)
 
-    def mock_post(url, **kwargs):
-        return get_response(url)
+        def post(self, url, **kwargs):
+            return get_response(url)
 
     monkeypatch.setattr(
         httputils, "get_headers", lambda: {"Authorization": None, "Application": "TIDY3D"}
     )
     monkeypatch.setattr(webapi, "upload_string", lambda a, b, c: None)
-    monkeypatch.setattr(requests, "get", mock_get)
-    monkeypatch.setattr(requests, "post", mock_post)
+    monkeypatch.setattr(httputils, "session", MockRequests())
 
 
 def make_sim():

--- a/tidy3d/web/config.py
+++ b/tidy3d/web/config.py
@@ -3,6 +3,15 @@ import os
 from typing import Any, Dict
 
 import pydantic as pd
+from pydantic import Field
+
+
+class EnvSettings(pd.BaseSettings):
+    """
+    Settings for reading environment variables
+    """
+
+    ssl_verify: bool = Field(True, env="TIDY3D_SSL_VERIFY")
 
 
 class WebConfig(pd.BaseModel):  # pylint:disable=too-many-instance-attributes
@@ -18,6 +27,7 @@ class WebConfig(pd.BaseModel):  # pylint:disable=too-many-instance-attributes
     auth: str = None
     user: Dict[str, str] = None
     auth_retry: int = 1
+    env_settings: EnvSettings = EnvSettings()
 
 
 # development config

--- a/tidy3d/web/httputils.py
+++ b/tidy3d/web/httputils.py
@@ -5,11 +5,14 @@ from typing import Dict
 from enum import Enum
 
 import jwt
-import requests
+from requests import Session
 
 from .auth import get_credentials, MAX_ATTEMPTS
 from .config import DEFAULT_CONFIG as Config
 from ..log import WebError
+
+session = Session()
+session.verify = Config.env_settings.ssl_verify
 
 
 class ResponseCodes(Enum):
@@ -87,7 +90,7 @@ def post(method, data=None):
     """Uploads the file."""
     query_url = get_query_url(method)
     headers = get_headers()
-    return requests.post(query_url, headers=headers, json=data)
+    return session.post(query_url, headers=headers, json=data)
 
 
 @handle_response
@@ -95,7 +98,7 @@ def put(method, data):
     """Runs the file."""
     query_url = get_query_url(method)
     headers = get_headers()
-    return requests.put(query_url, headers=headers, json=data)
+    return session.put(query_url, headers=headers, json=data)
 
 
 @handle_response
@@ -103,7 +106,7 @@ def get(method):
     """Downloads the file."""
     query_url = get_query_url(method)
     headers = get_headers()
-    return requests.get(query_url, headers=headers)
+    return session.get(query_url, headers=headers)
 
 
 @handle_response
@@ -111,4 +114,4 @@ def delete(method):
     """Deletes the file."""
     query_url = get_query_url(method)
     headers = get_headers()
-    return requests.delete(query_url, headers=headers)
+    return session.delete(query_url, headers=headers)


### PR DESCRIPTION
Added environment name TIDY3D_SSL_VERIFY checking.
Default value is True.
When user ``export TIDY3D_SSL_VERIFY=false``, it will skip certification verify.

 Please note that the name is TIDY3D_SSL_VERIFY, instead of TIDY3d_DISABLE_SSL which is used in hotfix branch.
