### PR TITLE
poetry publish works with test.PyPI

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -107,7 +107,7 @@ unicode-backport = ["unicodedata2"]
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -127,7 +127,7 @@ python-versions = ">=3.6"
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 
@@ -1042,7 +1042,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.2"
-content-hash = "fa7cf5d382d0bc145b7847717f522775361c4ba4c2481ec55085abd11e960973"
+content-hash = "b95837619317ebd04f0ebba2e7797457f8be1fce4f4fec05e0d30aeee15a5202"
 
 [metadata.files]
 astroid = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tidy3d-beta"
-version = "1.8.0"
+version = "1.8.1"
 description = ""
 authors = ["Tyler Hughes <tyler@flexcompute.com>"]
 readme = "README.md"
@@ -37,6 +37,7 @@ boto3 = "^1.26.31"
 requests = "^2.28.1"
 pyjwt = "^2.6.0"
 toml = "^0.10.2"
+click = "^8.1.3"
 
 [tool.poetry.group.dev.dependencies]
 click = "^8.1.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,15 @@
 [tool.poetry]
-name = "tidy3d"
+name = "tidy3d-beta"
 version = "1.8.0"
 description = ""
 authors = ["Tyler Hughes <tyler@flexcompute.com>"]
 readme = "README.md"
+packages = [
+    { include = "tidy3d" },
+    { include = "tidy3d/web" },
+    { include = "tidy3d/plugins" },
+]
+
 
 [tool.poetry.dependencies]
 python = "^3.7.2"

--- a/tidy3d/version.py
+++ b/tidy3d/version.py
@@ -1,3 +1,3 @@
 """Defines the front end version of tidy3d"""
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"

--- a/tidy3d/web/cli/readme.md
+++ b/tidy3d/web/cli/readme.md
@@ -30,6 +30,25 @@ Then, build and upload, make sure to specify repository `-r` of `test-pypi`.
 
 The changes should be reflected on test PyPI https://test.pypi.org/project/tidy3d-beta/1.8.0/
 
+### Fixing pyproject.toml
+
+Note, this did not work originally because while the package directory name is `tidy3d/`, the repository name on PyPI is `tidy3d-beta`.
+
+So a couple changes were required in `pyproject.toml`.
+
+I needed to change the `name=tidy3d` to `name=tidy3d-beta`
+I needed to add what packages to include, namely
+```
+packages = [
+    { include = "tidy3d" },
+    { include = "tidy3d/web" },
+    { include = "tidy3d/plugins" },
+]
+```
+(note, not 100% sure I needed to include `web` and `plugins`, but I think they are needed because tey aren't imported in the top level `tidy3d/__init__.py` file.)
+
+Once I did this, the steps from the previous section worked properly.
+
 ### Testing installation from test.PyPI
 
 To test, in a clean environment

--- a/tidy3d/web/cli/readme.md
+++ b/tidy3d/web/cli/readme.md
@@ -30,6 +30,8 @@ Then, build and upload, make sure to specify repository `-r` of `test-pypi`.
 
 The changes should be reflected on test PyPI https://test.pypi.org/project/tidy3d-beta/1.8.0/
 
+### Testing installation from test.PyPI
+
 To test, in a clean environment
 
 ``python3.9 -m pip install --index-url https://test.pypi.org/simple/ tidy3d-beta``
@@ -47,5 +49,40 @@ ERROR: Could not find a version that satisfies the requirement pyroots<0.6.0,>=0
 ERROR: No matching distribution found for pyroots<0.6.0,>=0.5.0
 ```
 
-Work in progress.
+It turns out this is expected using test pyPI as explained [here](https://packaging.python.org/en/latest/tutorials/packaging-projects/#installing-your-newly-uploaded-package).
+
+When I try to install `tidy3d-beta` from test.pyPI in an environment with the dependencies already installed from 
+``python3.9 -m pip install -e '.[dev]'``
+``python3.9 -m pip uninstall tidy3d-beta``
+
+It works as expected, besides needing `click`
+
+``python3.9 -c "import tidy3d as td; import tidy3d.web as web; from tidy3d.plugins import ModeSolver"``
+
+```
+[11:04:02] INFO     Using client version: 1.8.0                                                                                                                                              __init__.py:112
+Traceback (most recent call last):
+  File "<string>", line 1, in <module>
+  File "/usr/local/lib/python3.9/site-packages/tidy3d/web/__init__.py", line 8, in <module>
+    from .cli import tidy3d_cli
+  File "/usr/local/lib/python3.9/site-packages/tidy3d/web/cli/__init__.py", line 4, in <module>
+    from .app import tidy3d_cli
+  File "/usr/local/lib/python3.9/site-packages/tidy3d/web/cli/app.py", line 7, in <module>
+    import click
+ModuleNotFoundError: No module named 'click'
+```
+
+### Fixing the error
+
+So I added `click` with 
+
+``poetry add click``
+
+This changed the `poetry.lock` and `pyproject.toml`.
+
+I then bumped the version in `version.py` and `pyproject.toml` to `1.8.1` (otherwise, could not upload again to PyPI for same version) and repeated the publishing steps from above again.
+
+Testing the newly pip-installed version I was able to successfully import tidy3d and run a simulation!
+
+
 

--- a/tidy3d/web/cli/readme.md
+++ b/tidy3d/web/cli/readme.md
@@ -15,3 +15,37 @@ You can find your API key in the web http://tidy3d.simulation.cloud
 
 #### Manually
 ``echo 'apikey = "your_api_key"' > ~/.tidy3d/config``
+
+## Publishing Package
+
+First, configure poetry to work with test.PyPI. Give it a name of `test-pypi`.
+
+``poetry config repositories.test-pypi https://test.pypi.org/legacy/``
+
+``poetry config pypi-token.test-pypi <<test.pypi TOKEN>>``
+
+Then, build and upload, make sure to specify repository `-r` of `test-pypi`.
+
+``poetry publish --build -r test-pypi``
+
+The changes should be reflected on test PyPI https://test.pypi.org/project/tidy3d-beta/1.8.0/
+
+To test, in a clean environment
+
+``python3.9 -m pip install --index-url https://test.pypi.org/simple/ tidy3d-beta``
+
+note: I was getting errors doing this, because it was trying to install all previously uploaded versions of `tidy3d-beta`. So when I did
+
+``python3.9 -m pip install --index-url https://test.pypi.org/simple/ tidy3d-beta==1.8.0``
+
+It started working, however I got another error
+
+```
+Collecting tidy3d-beta==1.8.0
+  Using cached https://test-files.pythonhosted.org/packages/5d/67/0cd75f00bb851289c79b584600b17daa7e5d077d2afa7ab8bfccc0331b3b/tidy3d_beta-1.8.0-py3-none-any.whl (257 kB)
+ERROR: Could not find a version that satisfies the requirement pyroots<0.6.0,>=0.5.0 (from tidy3d-beta) (from versions: none)
+ERROR: No matching distribution found for pyroots<0.6.0,>=0.5.0
+```
+
+Work in progress.
+


### PR DESCRIPTION
Hi @An-Li-magicloud 

I did a bit of work on trying to get this working with test PyPI. 

I had to modify the `pyproject.toml` a bit.

Now it seems like the dependencies are conflicting when I try to pip install from test.pyPI.

I put my process in the `tidy3d/web/cli/README.md` and sent you my token separately.