### PR TITLE
deprecation warnings for API updates in 2.0

### DIFF
--- a/tests/test_components/test_boundaries.py
+++ b/tests/test_components/test_boundaries.py
@@ -176,3 +176,15 @@ def test_boundaryspec_classmethods():
     assert all(
         [isinstance(boundary, PML) for boundary_dim in boundaries for boundary in boundary_dim]
     )
+
+
+PLUS_MINUS_SPECIFIED = (("plus", "minus"), ("plus",), ("minus",), ())
+LOG_LEVELS_EXPECTED = (None, 30, 30, 30)
+
+# TODO: remove for 2.0
+@pytest.mark.parametrize("pm_keys, log_level", zip(PLUS_MINUS_SPECIFIED, LOG_LEVELS_EXPECTED))
+def test_deprecation_defaults(caplog, pm_keys, log_level):
+    """Make sure deprecation warnings thrown if defaults used."""
+    boundary_kwargs = {key: Periodic() for key in pm_keys}
+    bc = Boundary(**boundary_kwargs)
+    assert_log_level(caplog, log_level)

--- a/tidy3d/components/boundary.py
+++ b/tidy3d/components/boundary.py
@@ -355,6 +355,23 @@ class Boundary(Tidy3dBaseModel):
         discriminator=TYPE_TAG_STR,
     )
 
+    # TODO: remove for 2.0
+    @pd.root_validator(pre=True)
+    def _deprecation_2_0_missing_defaults(cls, values):
+        """Raise deprecation warning if a default `plus` or `minus` is used."""
+
+        fields_use_default = [field for field in ("plus", "minus") if values.get(field) is None]
+
+        for field in fields_use_default:
+            log.warning(
+                f"'Boundary.{field}' uses default value, which is 'Periodic()' "
+                "but will change to 'PML()' in Tidy3D version 2.0. "
+                "We recommend you change your 'BoundarySpec' to explicitly set "
+                "the boundary conditions ahead of this release to avoid unexpected results."
+            )
+
+        return values
+
     @pd.root_validator(skip_on_failure=True)
     def bloch_on_both_sides(cls, values):
         """Error if a Bloch boundary is applied on only one side."""


### PR DESCRIPTION
`log.warning()` if

* `Boundary.plus` or `Boundary.minus` not defined
* `reference_plane` not supplied but `sidewall_angle` is non-zero