### PR TITLE
Bumping shapely version to 2.0

### DIFF
--- a/requirements/basic.txt
+++ b/requirements/basic.txt
@@ -7,8 +7,7 @@ h5netcdf==1.0.2
 h5py>=3.0.0
 rich
 matplotlib
-shapely==1.8.0; python_version<"3.10"
-shapely>=1.8.1,<2.0; python_version>="3.10"
+shapely>=2.0
 pydantic>=1.10.0
 PyYAML
 dask

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -107,6 +107,6 @@ def set_logging_level(level: str) -> None:
 
 
 # make all stdout and errors pretty
-pretty.install()
+# pretty.install()
 # traceback.install()
 log.info(f"Using client version: {__version__}")

--- a/tidy3d/components/grid/mesher.py
+++ b/tidy3d/components/grid/mesher.py
@@ -149,7 +149,10 @@ class GradedMesher(Mesher):
             bbox_2d = shapely_box(bbox[0, 0], bbox[0, 1], bbox[1, 0], bbox[1, 1])
 
             # List of structure indexes that may intersect the current structure in 2D
-            query_inds = tree.query_items(bbox_2d)
+            try:
+                query_inds = tree.query_items(bbox_2d)
+            except AttributeError:
+                query_inds = tree.query(bbox_2d)
 
             # Remove all lower structures that the current structure completely contains
             inds_lower = [


### PR DESCRIPTION
Fixes https://github.com/flexcompute/tidy3d/issues/642 , apart from for python 3.7, for which I experienced a problem building shapely 2.0 on one of our workers. It does not seem to be a general python 3.7 thing, but shapely 1.8.0 builds well on that worker.

I am not sure if this should be put in 1.8.2 or 1.9.0.