### PR TITLE
add pre-commit hook for black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,3 @@ repos:
     rev: 22.12.0
     hooks:
     - id: black
-      language_version: python3.10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 22.12.0
+    hooks:
+    - id: black
+      language_version: python3.10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,4 @@ repos:
     rev: 22.12.0
     hooks:
     - id: black
+      name: black <<< NOTE:, if you get a message stating that "All done! n file(s) reformatted", you must git add and commit the changes again to complete the commit. >>>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,17 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''

--- a/requirements/basic.txt
+++ b/requirements/basic.txt
@@ -1,5 +1,6 @@
 # build and load models and data, no web running or plugins
 
+pre-commit
 pyroots>=0.5.0
 xarray>=0.16.2
 importlib-metadata==4.13.0 # note: 5.0.0 breaks some xarray stuff, remove when xarray fixes this


### PR DESCRIPTION
If you make a commit and black can make formatting changes, the changes are made and the commit isn't registered. Should avoid any commits where black is not applied.

```
pip install pre-commit
pre-commit install
```
I also needed
```
pre-commit run --all-files
```
before it started working.

[see this guide](https://ljvmiranda921.github.io/notebook/2018/06/21/precommits-using-black-and-flake8/) for more info.