### PR TITLE
fix tidy3d exception subclasses

### DIFF
--- a/tests/test_package/test_log.py
+++ b/tests/test_package/test_log.py
@@ -28,3 +28,9 @@ def test_log_level_not_found():
 def test_set_logging_level_deprecated():
     with pytest.raises(DeprecationWarning):
         td.set_logging_level("warning")
+
+
+def test_exception_message():
+    MESSAGE = "message"
+    e = Tidy3dError(MESSAGE)
+    assert str(e) == MESSAGE

--- a/tidy3d/log.py
+++ b/tidy3d/log.py
@@ -30,8 +30,8 @@ class Tidy3dError(Exception):
 
     def __init__(self, message: str = None):
         """Log just the error message and then raise the Exception."""
+        super().__init__(message)
         log.error(message)
-        super().__init__(self, message)
 
 
 class ConfigError(Tidy3dError):


### PR DESCRIPTION
Previously `self` was being passed to `Exception.__init__` instead of the exception message in the Tidy3dException and other subclasses. This was causing the resulting exception to store `str(self)` as the "message" and causing issues in formatting.