### PR TITLE
Added Drude model options for gold and silver

### DIFF
--- a/tidy3d/material_library/material_library.py
+++ b/tidy3d/material_library/material_library.py
@@ -154,6 +154,25 @@ Ag_JohnsonChristy1972 = VariantItem(
     data_url="https://refractiveindex.info/data_csv.php?datafile=data/main/Ag/Johnson.yml",
 )
 
+Ag_Yang2015Drude = VariantItem(
+    medium=PoleResidue(
+        eps_inf=5.0,
+        poles=(
+            (
+                (0.0j),
+                (1.5540587685959158e18 + 0j),
+            ),
+            (
+                (-58823530000000 + 0j),
+                (-1.5540587685959158e18 - 0j),
+            ),
+        ),
+        frequency_range=(154771532566312.25, 1595489401708072.2),
+    ),
+    reference=[material_refs["Yang2015"]],
+    data_url="https://refractiveindex.info/database/data/main/Ag/Yang.yml",
+)
+
 Al_Rakic1995 = VariantItem(
     medium=PoleResidue(
         eps_inf=1.0,
@@ -328,6 +347,25 @@ Au_Olmon2012crystal = VariantItem(
             ),
         ),
         frequency_range=(12025369359446.29, 999308193769986.8),
+    ),
+    reference=[material_refs["Olmon2012"]],
+    data_url="https://refractiveindex.info/data_csv.php?datafile=data/main/Au/Olmon-sc.yml",
+)
+
+Au_Olmon2012Drude = VariantItem(
+    medium=PoleResidue(
+        eps_inf=1.0,
+        poles=(
+            (
+                (0.0j),
+                ((1.153665672616558e18 + 0j)),
+            ),
+            (
+                (-71428570000000 + 0j),
+                (-1.153665672616558e18 - 0j),
+            ),
+        ),
+        frequency_range=(12025369359446.29, 241798930000000),
     ),
     reference=[material_refs["Olmon2012"]],
     data_url="https://refractiveindex.info/data_csv.php?datafile=data/main/Au/Olmon-sc.yml",
@@ -1267,6 +1305,7 @@ material_library = dict(
             Rakic1998BB=Ag_Rakic1998BB,
             JohnsonChristy1972=Ag_JohnsonChristy1972,
             RakicLorentzDrude1998=Ag_RakicLorentzDrude1998,
+            Yang2015Drude=Ag_Yang2015Drude,
         ),
         default="Rakic1998BB",
     ),
@@ -1327,6 +1366,7 @@ material_library = dict(
             Olmon2012crystal=Au_Olmon2012crystal,
             Olmon2012stripped=Au_Olmon2012stripped,
             Olmon2012evaporated=Au_Olmon2012evaporated,
+            Olmon2012Drude=Au_Olmon2012Drude,
             JohnsonChristy1972=Au_JohnsonChristy1972,
             RakicLorentzDrude1998=Au_RakicLorentzDrude1998,
         ),

--- a/tidy3d/material_library/material_reference.py
+++ b/tidy3d/material_library/material_reference.py
@@ -21,6 +21,11 @@ class ReferenceData(Tidy3dBaseModel):
 
 
 material_refs = dict(
+    Yang2015=ReferenceData(
+        journal="H. U. Yang, J. D'Archangel, M. L. Sundheimer, E. Tucker, G. D. Boreman, "
+        "M. B. Raschke. Optical dielectric function of silver, Phys. Rev. B 91, 235137 (2015)",
+        doi="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.91.235137",
+    ),
     Olmon2012=ReferenceData(
         journal="R. L. Olmon, B. Slovick, T. W. Johnson, D. Shelton, S.-H. Oh, "
         "G. D. Boreman, and M. B. Raschke. Optical dielectric function of "


### PR DESCRIPTION
Added a `Olmon2012Drude` option for gold and a `Yang2015Drude` option for silver to the material library. The poles are obtained by converting the Drude model so the number of poles is much smaller compared to other options of gold and silver in the library.

These options are mainly targeted towards lower frequency in mid to far IR. The data frequency range is 0.05eV (12 THz) to 1 eV (240 THz) although I think it can be safely used all the way to even below 1 THz. According to the data from the referenced papers, Drude model works well up to 1 eV and starts to show discrepancy above 1 eV. 

The attached notebook tested the added options. The plotted permittivity is in agreement with the data from the referenced papers.
[MaterialLibraryTesting.zip](https://github.com/flexcompute/tidy3d/files/10469716/MaterialLibraryTesting.zip)