### PR TITLE
Added four TMD monolayer materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ The source code for our documentation is [here](https://github.com/flexcompute-r
 Note that while this front end package is open source, to run simulations on Flexcompute servers requires an account with credits.
 You can sign up [here](https://client.simulation.cloud/register-waiting).  While it's currently a waitlist for new users, we will be rolling out to many more users in the coming weeks!  See [this page](https://flexcompute-tidy3ddocumentation.readthedocs-hosted.com/quickstart.html) in our documentation for more details.
 
-### Installing the package using pip
+### Installing the front end 
+
+#### Using pip (recommended)
 
 The easiest way to install tidy3d is through [pip](https://pip.pypa.io/en/stable/).
 
@@ -37,9 +39,9 @@ The easiest way to install tidy3d is through [pip](https://pip.pypa.io/en/stable
 pip install tidy3d
 ```
 
-### (Alternativelty) installing from source
+### Installing from source
 
-For development purposes, you can download and install the package from source as:
+For development purposes, and to get the latest development versions, you can download and install the package from source as:
 
 ```
 git clone https://github.com/flexcompute/tidy3d.git
@@ -47,9 +49,41 @@ cd tidy3d
 pip install -e .
 ```
 
-### Did it work?
+### Configuring and authentication
 
-You can verify the installation worked by running:
+Authentication (linking the front end to your account) will be done via an API key moving forward.
+
+You can find your API key in the web interface http://tidy3d.simulation.cloud
+
+After signing in, copy the API key for the next steps.
+
+To set up the API key to work with Tidy3D, we need to store it either in the `~/.tidy3d/config` file or an environment variable.
+
+You can set it up using one of three following options.
+
+#### Command line (recommended)
+
+``tidy3d configure`` and then enter your API key when prompted.
+
+#### Manually
+
+For an API key of `{your_api_key}`, you may run
+
+``echo 'apikey = "{your_api_key}"' > ~/.tidy3d/config``
+
+or manually insert the line `'apikey = "{your_api_key}"` in the `~/.tidy3d/config` file.
+
+#### Environment Variable
+
+Set the `SIMCLOUD_API_KEY` environment variable to your API key (in quotes).
+
+``export SIMCLOUD_API_KEY="{your_api_key}"``
+
+### Testing the installation and authentication
+
+#### Front end package
+
+You can verify the front end installation worked by running:
 
 ```
 python -c "import tidy3d as td; print(td.__version__)"
@@ -59,6 +93,14 @@ and it should print out the version number, for example:
 
 ```
 1.0.0
+```
+
+#### Authentication
+
+To test the web / authentication
+
+```
+python -c "import tidy3d.web"
 ```
 
 ## Issues / Feedback / Bug Reporting

--- a/requirements/basic.txt
+++ b/requirements/basic.txt
@@ -11,3 +11,4 @@ shapely>=2.0
 pydantic>=1.10.0
 PyYAML
 dask
+toml

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,6 @@
 -r core.txt
 
 # required for development
-click==8.0.3
 black==22.3.0
 pylint
 tox

--- a/requirements/web.txt
+++ b/requirements/web.txt
@@ -3,3 +3,4 @@
 boto3==1.23.1
 requests
 pyjwt
+click==8.0.3

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import setuptools
 from distutils.util import convert_path
 
-
 PACKAGE_NAME = "tidy3d"
 REPO_NAME = "tidy3d"
 
@@ -51,4 +50,9 @@ setuptools.setup(
     python_requires=">=3.7",
     install_requires=core_required,
     extras_require={"dev": dev_required},
+    entry_points={
+        "console_scripts": [
+            "tidy3d = tidy3d.web.cli:tidy3d_cli",
+        ],
+    },
 )

--- a/tests/README.md
+++ b/tests/README.md
@@ -88,29 +88,23 @@ def test_test_other():
     pass
 ```
 
-# Porting old tests
+## Test coverage
 
-Below is a list of all the test files in the `test/python` folder in the old repository. Most of them require running the C++ solver, but some do not. We may not end up porting everything if some things don't make sense, but we should make sure that everything that is covered in the old version is covered in the new version too.
+The test coverage tells you what percentage of lines in the source code were traversed over the course of the tests. The test coverage is at 92% as of Jan 20, 2023. We want to make sure any new code is very well tested, ideally as close to 100% as is reasonable. 
 
-| Test file                       | Requires C++ | Ported to file(s)                                         |
-| ------------------------------- | ------------ | --------------------------------------------------------- |
-| test_adjoint.py                 | Y            |                                                           | 
-| test_anisotropic.py             | Y            |                                                           | 
-| test_checks.py                  | N            |                                                           | 
-| test_divergence.py              | Y            |                                                           | 
-| test_grid.py                    | N            |                                                           | 
-| test_material_dispersion.py     | Y            |                                                           | 
-| test_material_library.py        | Y            |                                                           | 
-| test_medium.py                  | N            |                                                           | 
-| test_mode_nonuniform.py         | Y            |                                                           | 
-| test_mode_source.py             | Y            |                                                           | 
-| test_mode_symmetry.py           | Y            |                                                           | 
-| test_monitors.py                | Y            |                                                           | 
-| test_mpi.py                     | Y            |                                                           | 
-| test_near2far.py                | Y            |                                                           | 
-| test_pec.py                     | Y            |                                                           | 
-| test_pml.py                     | Y            |                                                           | 
-| test_sidewall.py                | Y            |                                                           | 
-| test_structure_bounded.py       | N            |                                                           | 
-| test_symmetries.py              | Y            |                                                           | 
-| test_volume_source.py           | Y            |                                                           | 
+To measure the test coverage:
+
+```
+pip install pytest-cov
+```
+if not already installed
+
+To run coverage tests with results printed to STDOUT:
+```
+pytest tests --cov-report term-missing --cov=tidy3d
+```
+To run coverage tests and get output as .html (more intuitive):
+```
+pytest tests --cov-report=html --cov=tidy3d
+open htmlcov/index.html
+```

--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -14,18 +14,24 @@ from tidy3d.plugins.smatrix.smatrix import ComponentModeler
 from ..utils import clear_tmp, run_emulated
 
 WAVEGUIDE = td.Structure(geometry=td.Box(size=(100, 0.5, 0.5)), medium=td.Medium(permittivity=4.0))
-PLANE = td.Box(center=(0, 0, 0), size=(1, 0, 1))
+PLANE = td.Box(center=(0, 0, 0), size=(5, 0, 5))
+SIM_SIZE = (5, 5, 5)
+SRC = td.PointDipole(
+    center=(0, 0, 0), source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13), polarization="Ex"
+)
 
 
 def test_mode_solver_simple():
     """Simple mode solver run (with symmetry)"""
 
     simulation = td.Simulation(
-        size=(2, 2, 2),
+        size=SIM_SIZE,
         grid_spec=td.GridSpec(wavelength=1.0),
         structures=[WAVEGUIDE],
         run_time=1e-12,
         symmetry=(1, 0, -1),
+        boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
+        sources=[SRC],
     )
     mode_spec = td.ModeSpec(
         num_modes=3,
@@ -46,11 +52,13 @@ def test_mode_solver_simple():
 def test_mode_solver_angle_bend():
     """Run mode solver with angle and bend and symmetry"""
     simulation = td.Simulation(
-        size=(2, 2, 2),
+        size=SIM_SIZE,
         grid_spec=td.GridSpec(wavelength=1.0),
         structures=[WAVEGUIDE],
         run_time=1e-12,
         symmetry=(-1, 0, 1),
+        boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
+        sources=[SRC],
     )
     mode_spec = td.ModeSpec(
         num_modes=3,
@@ -87,10 +95,12 @@ def test_mode_solver_2D():
         track_freq="central",
     )
     simulation = td.Simulation(
-        size=(0, 2, 2),
+        size=(0, SIM_SIZE[1], SIM_SIZE[2]),
         grid_spec=td.GridSpec(wavelength=1.0),
         structures=[WAVEGUIDE],
         run_time=1e-12,
+        boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
+        sources=[SRC],
     )
     ms = ModeSolver(
         simulation=simulation, plane=PLANE, mode_spec=mode_spec, freqs=[td.constants.C_0 / 1.0]
@@ -99,10 +109,11 @@ def test_mode_solver_2D():
 
     mode_spec = td.ModeSpec(num_modes=3, filter_pol="te", precision="double", num_pml=(10, 0))
     simulation = td.Simulation(
-        size=(2, 2, 0),
+        size=(SIM_SIZE[0], SIM_SIZE[1], 0),
         grid_spec=td.GridSpec(wavelength=1.0),
         structures=[WAVEGUIDE],
         run_time=1e-12,
+        sources=[SRC],
     )
     ms = ModeSolver(
         simulation=simulation, plane=PLANE, mode_spec=mode_spec, freqs=[td.constants.C_0 / 1.0]
@@ -114,6 +125,8 @@ def test_mode_solver_2D():
         size=PLANE.size,
         grid_spec=td.GridSpec(wavelength=1.0),
         run_time=1e-12,
+        boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
+        sources=[SRC],
     )
     ms = ModeSolver(
         simulation=simulation, plane=PLANE, mode_spec=mode_spec, freqs=[td.constants.C_0 / 1.0]

--- a/tests/test_web/test_cli.py
+++ b/tests/test_web/test_cli.py
@@ -1,0 +1,23 @@
+import os.path
+import shutil
+
+from click.testing import CliRunner
+
+from tidy3d.web.cli import tidy3d_cli
+from tidy3d.web.cli.app import CONFIG_FILE
+
+
+def test_tidy3d_cli():
+
+    if os.path.exists(CONFIG_FILE):
+        shutil.move(CONFIG_FILE, f"{CONFIG_FILE}.bak")
+
+    runner = CliRunner()
+    result = runner.invoke(tidy3d_cli, ["configure"], input="apikey")
+
+    assert result.exit_code == 0
+    if os.path.exists(CONFIG_FILE):
+        os.remove(CONFIG_FILE)
+
+    if os.path.exists(f"{CONFIG_FILE}.bak"):
+        shutil.move(f"{CONFIG_FILE}.bak", CONFIG_FILE)

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -28,6 +28,9 @@ class MockResponse:
     def json():
         return {}
 
+    def raise_for_status(self):
+        pass
+
 
 class MockResponseInfoOk(MockResponse):
     """response if web.getinfo(task_id) and task_id found"""

--- a/tidy3d/material_library/material_library.py
+++ b/tidy3d/material_library/material_library.py
@@ -154,6 +154,25 @@ Ag_JohnsonChristy1972 = VariantItem(
     data_url="https://refractiveindex.info/data_csv.php?datafile=data/main/Ag/Johnson.yml",
 )
 
+Ag_Yang2015Drude = VariantItem(
+    medium=PoleResidue(
+        eps_inf=5.0,
+        poles=(
+            (
+                (0.0j),
+                (1.5540587685959158e18 + 0j),
+            ),
+            (
+                (-58823530000000 + 0j),
+                (-1.5540587685959158e18 - 0j),
+            ),
+        ),
+        frequency_range=(154771532566312.25, 1595489401708072.2),
+    ),
+    reference=[material_refs["Yang2015"]],
+    data_url="https://refractiveindex.info/database/data/main/Ag/Yang.yml",
+)
+
 Al_Rakic1995 = VariantItem(
     medium=PoleResidue(
         eps_inf=1.0,
@@ -328,6 +347,25 @@ Au_Olmon2012crystal = VariantItem(
             ),
         ),
         frequency_range=(12025369359446.29, 999308193769986.8),
+    ),
+    reference=[material_refs["Olmon2012"]],
+    data_url="https://refractiveindex.info/data_csv.php?datafile=data/main/Au/Olmon-sc.yml",
+)
+
+Au_Olmon2012Drude = VariantItem(
+    medium=PoleResidue(
+        eps_inf=1.0,
+        poles=(
+            (
+                (0.0j),
+                ((1.153665672616558e18 + 0j)),
+            ),
+            (
+                (-71428570000000 + 0j),
+                (-1.153665672616558e18 - 0j),
+            ),
+        ),
+        frequency_range=(12025369359446.29, 241798930000000),
     ),
     reference=[material_refs["Olmon2012"]],
     data_url="https://refractiveindex.info/data_csv.php?datafile=data/main/Au/Olmon-sc.yml",
@@ -1267,6 +1305,7 @@ material_library = dict(
             Rakic1998BB=Ag_Rakic1998BB,
             JohnsonChristy1972=Ag_JohnsonChristy1972,
             RakicLorentzDrude1998=Ag_RakicLorentzDrude1998,
+            Yang2015Drude=Ag_Yang2015Drude,
         ),
         default="Rakic1998BB",
     ),
@@ -1327,6 +1366,7 @@ material_library = dict(
             Olmon2012crystal=Au_Olmon2012crystal,
             Olmon2012stripped=Au_Olmon2012stripped,
             Olmon2012evaporated=Au_Olmon2012evaporated,
+            Olmon2012Drude=Au_Olmon2012Drude,
             JohnsonChristy1972=Au_JohnsonChristy1972,
             RakicLorentzDrude1998=Au_RakicLorentzDrude1998,
         ),

--- a/tidy3d/material_library/material_library.py
+++ b/tidy3d/material_library/material_library.py
@@ -761,6 +761,36 @@ MgO_StephensMalitson1952 = VariantItem(
     data_url="https://refractiveindex.info/data_csv.php?datafile=data/main/MgO/Stephens.yml",
 )
 
+MoS2_Li2014 = VariantItem(
+    medium=PoleResidue(
+        eps_inf=7,
+        poles=(
+            ((-359315575683882.94-4351037853607888j), 1.3176033127808174e+16j),
+            ((-47550212723398.46-2830800196611070.5j), 423989981007996.2j),
+            ((-115583767884472.11-3044501424941655.5j), 1228598693488551.8j),
+            ((-71809429716556.45-4843776341355436j), 3676495982332201.5j),
+            ((-357036299948221.06-3522742014142554j), 1439441065103469.5j),
+        ),
+        frequency_range=(359760000000000, 719520000000000),
+    ),
+    reference=[material_refs["Li2014"]],
+)
+
+MoSe2_Li2014 = VariantItem(
+    medium=PoleResidue(
+        eps_inf=2.98,
+        poles=(
+            ((-36761326958106.516-2346800992876732.5j), 338220688925072j),
+            ((-529696146171994.1-3250011358803138j), 2592639640470081.5j),
+            ((-83845324190119.6-2655257170055444.5j), 600182265785651.4j),
+            ((-460941134311120.06-3946269084308785.5j), 1.1521315248761458e+16j),
+            ((-365616548688667.1-5272054887123941j), 1.176321407277452e+16j),
+        ),
+        frequency_range=(359760000000000, 719520000000000),
+    ),
+    reference=[material_refs["Li2014"]],
+)
+
 Ni_JohnsonChristy1972 = VariantItem(
     medium=PoleResidue(
         eps_inf=1.0,
@@ -1193,6 +1223,35 @@ W_RakicLorentzDrude1998 = VariantItem(
     data_url="https://refractiveindex.info/data_csv.php?datafile=data/main/W/Rakic-LD.yml",
 )
 
+WS2_Li2014 = VariantItem(
+    medium=PoleResidue(
+        eps_inf=6.18,
+        poles=(
+            ((-24007743182653.15-3052251370817458j), 716432281919880.8j),
+            ((-137029680488199.55-3645019841622440.5j), 1010556928646303.5j),
+            ((-209636856712237.66-4307630639419263j), 3158371314580892.5j),
+            ((-466855949030110.3-4891967555229964j), 1.1703841436358186e+16j),
+        ),
+        frequency_range=(359760000000000, 719520000000000),
+    ),
+    reference=[material_refs["Li2014"]],
+)
+
+WSe2_Li2014 = VariantItem(
+    medium=PoleResidue(
+        eps_inf=6.29,
+        poles=(
+            ((-32911988143375.11-2509059529797599.5j), 280960681034011.66j),
+            ((-138781520516435.52-3149502378897181.5j), 690812354204714j),
+            ((-28255484326386.598-5055392293836629j), 4415551968968067j),
+            ((-258471752123009.2-3675437972450793.5j), 2703088180177408.5j),
+            ((-354954812602843.94-4404690392224204.5j), 7012794593077168j),
+        ),
+        frequency_range=(359760000000000, 719520000000000),
+    ),
+    reference=[material_refs["Li2014"]],
+)
+
 Y2O3_Horiba = VariantItem(
     medium=PoleResidue(
         eps_inf=1.0,
@@ -1496,6 +1555,20 @@ material_library = dict(
         ),
         default="StephensMalitson1952",
     ),
+    MoS2=MaterialItem(
+        name="Molybdenum Disulfide",
+        variants=dict(
+            Li2014=MoS2_Li2014,
+        ),
+        default="Li2014",
+    ),
+    MoSe2=MaterialItem(
+        name="Molybdenum Diselenide",
+        variants=dict(
+            Li2014=MoSe2_Li2014,
+        ),
+        default="Li2014",
+    ),
     Ni=MaterialItem(
         name="Nickel",
         variants=dict(
@@ -1652,6 +1725,20 @@ material_library = dict(
             RakicLorentzDrude1998=W_RakicLorentzDrude1998,
         ),
         default="Werner2009",
+    ),
+    WS2=MaterialItem(
+        name="Tungsten Disulfide",
+        variants=dict(
+            Li2014=WS2_Li2014,
+        ),
+        default="Li2014",
+    ),
+    WSe2=MaterialItem(
+        name="Tungsten Diselenide",
+        variants=dict(
+            Li2014=WSe2_Li2014,
+        ),
+        default="Li2014",
     ),
     Y2O3=MaterialItem(
         name="Yttrium Oxide",

--- a/tidy3d/material_library/material_reference.py
+++ b/tidy3d/material_library/material_reference.py
@@ -21,6 +21,11 @@ class ReferenceData(Tidy3dBaseModel):
 
 
 material_refs = dict(
+    Yang2015=ReferenceData(
+        journal="H. U. Yang, J. D'Archangel, M. L. Sundheimer, E. Tucker, G. D. Boreman, "
+        "M. B. Raschke. Optical dielectric function of silver, Phys. Rev. B 91, 235137 (2015)",
+        doi="https://journals.aps.org/prb/abstract/10.1103/PhysRevB.91.235137",
+    ),
     Olmon2012=ReferenceData(
         journal="R. L. Olmon, B. Slovick, T. W. Johnson, D. Shelton, S.-H. Oh, "
         "G. D. Boreman, and M. B. Raschke. Optical dielectric function of "

--- a/tidy3d/material_library/material_reference.py
+++ b/tidy3d/material_library/material_reference.py
@@ -21,6 +21,13 @@ class ReferenceData(Tidy3dBaseModel):
 
 
 material_refs = dict(
+    Li2014=ReferenceData(
+        journal="Y. Li, A. Chernikov, X. Zhang, A. Rigosi, H. M. Hill, A. M. van der Zande, "
+        "D. A. Chenet, E. Shih, J. Hone, and T. F. Heinz. Measurement of the optical dielectric "
+        "function of monolayer transition-metal dichalcogenides: MoS2, MoSe2, WS2, and WSe2, "
+        "Phys. Rev. B 90, 205422 (2014)",
+        doi="https://doi.org/10.1103/PhysRevB.90.205422",
+    ),
     Yang2015=ReferenceData(
         journal="H. U. Yang, J. D'Archangel, M. L. Sundheimer, E. Tucker, G. D. Boreman, "
         "M. B. Raschke. Optical dielectric function of silver, Phys. Rev. B 91, 235137 (2015)",

--- a/tidy3d/version.py
+++ b/tidy3d/version.py
@@ -1,5 +1,5 @@
 """Defines the front end version of tidy3d"""
 
-__version__ = "1.8.2"
+__version__ = "1.9.0"
 
 PIP_NAME = "tidy3d-beta"

--- a/tidy3d/web/__init__.py
+++ b/tidy3d/web/__init__.py
@@ -5,3 +5,4 @@ from .webapi import run, upload, get_info, start, monitor, delete, download, loa
 from .webapi import get_tasks, delete_old, download_json, download_log, load_simulation
 from .container import Job, Batch, BatchData
 from .auth import get_credentials
+from .cli import tidy3d_cli

--- a/tidy3d/web/cli/__init__.py
+++ b/tidy3d/web/cli/__init__.py
@@ -1,0 +1,4 @@
+"""
+tidy3d command line tool.
+"""
+from .app import tidy3d_cli

--- a/tidy3d/web/cli/app.py
+++ b/tidy3d/web/cli/app.py
@@ -1,0 +1,69 @@
+"""
+Commandline interface for tidy3d.
+"""
+import os.path
+from os.path import expanduser
+
+import click
+import requests
+import toml
+
+from tidy3d.web.config import DEFAULT_CONFIG
+
+TIDY3D_DIR = f"{expanduser('~')}/.tidy3d"
+CONFIG_FILE = TIDY3D_DIR + "/config"
+
+if os.path.exists(CONFIG_FILE):
+    with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+        content = f.read()
+        config = toml.loads(content)
+        config_description = f"API Key:\nCurrent:[{config.get('apikey', '')}]\nNew"
+
+
+@click.group()
+def tidy3d_cli():
+    """
+    Tidy3d command line tool.
+    """
+
+
+@click.command()
+@click.option(
+    "--apikey", prompt=config_description if "config_description" in globals() else "API Key"
+)
+def configure(apikey):
+    """Click command to configure the api key.
+    Parameters
+    ----------
+    apikey : str
+        User input api key.
+    """
+
+    def auth(req):
+        """Enrich auth information to request.
+        Parameters
+        ----------
+        req : requests.Request
+            the request needs to add headers for auth.
+        Returns
+        -------
+        requests.Request
+            Enriched request.
+        """
+        req.headers["simcloud-api-key"] = apikey
+        return req
+
+    resp = requests.get(f"{DEFAULT_CONFIG.web_api_endpoint}/apikey", auth=auth)
+    if resp.status_code == 200:
+        click.echo("Configured successfully.")
+        if not os.path.exists(TIDY3D_DIR):
+            os.mkdir(TIDY3D_DIR)
+        with open(CONFIG_FILE, "w+", encoding="utf-8") as config_file:
+            toml_config = toml.loads(config_file.read())
+            toml_config.update({"apikey": apikey})
+            config_file.write(toml.dumps(toml_config))
+    else:
+        click.echo("API key is invalid.")
+
+
+tidy3d_cli.add_command(configure)

--- a/tidy3d/web/cli/readme.md
+++ b/tidy3d/web/cli/readme.md
@@ -1,0 +1,107 @@
+## API key
+
+### Generating an API key
+
+You can find your API key in the web http://tidy3d.simulation.cloud
+
+
+### Setup API key
+
+#### Environment Variable
+``export SIMCLOUD_API_KEY="your_api_key"``
+
+#### Command line
+``tidy3d configure``, then enter your API key when prompted
+
+#### Manually
+``echo 'apikey = "your_api_key"' > ~/.tidy3d/config``
+
+## Publishing Package
+
+First, configure poetry to work with test.PyPI. Give it a name of `test-pypi`.
+
+``poetry config repositories.test-pypi https://test.pypi.org/legacy/``
+
+``poetry config pypi-token.test-pypi <<test.pypi TOKEN>>``
+
+Then, build and upload, make sure to specify repository `-r` of `test-pypi`.
+
+``poetry publish --build -r test-pypi``
+
+The changes should be reflected on test PyPI https://test.pypi.org/project/tidy3d-beta/1.8.0/
+
+### Fixing pyproject.toml
+
+Note, this did not work originally because while the package directory name is `tidy3d/`, the repository name on PyPI is `tidy3d-beta`.
+
+So a couple changes were required in `pyproject.toml`.
+
+I needed to change the `name=tidy3d` to `name=tidy3d-beta`
+I needed to add what packages to include, namely
+```
+packages = [
+    { include = "tidy3d" },
+    { include = "tidy3d/web" },
+    { include = "tidy3d/plugins" },
+]
+```
+(note, not 100% sure I needed to include `web` and `plugins`, but I think they are needed because tey aren't imported in the top level `tidy3d/__init__.py` file.)
+
+Once I did this, the steps from the previous section worked properly.
+
+### Testing installation from test.PyPI
+
+To test, in a clean environment
+
+``python3.9 -m pip install --index-url https://test.pypi.org/simple/ tidy3d-beta``
+
+note: I was getting errors doing this, because it was trying to install all previously uploaded versions of `tidy3d-beta`. So when I did
+
+``python3.9 -m pip install --index-url https://test.pypi.org/simple/ tidy3d-beta==1.8.0``
+
+It started working, however I got another error
+
+```
+Collecting tidy3d-beta==1.8.0
+  Using cached https://test-files.pythonhosted.org/packages/5d/67/0cd75f00bb851289c79b584600b17daa7e5d077d2afa7ab8bfccc0331b3b/tidy3d_beta-1.8.0-py3-none-any.whl (257 kB)
+ERROR: Could not find a version that satisfies the requirement pyroots<0.6.0,>=0.5.0 (from tidy3d-beta) (from versions: none)
+ERROR: No matching distribution found for pyroots<0.6.0,>=0.5.0
+```
+
+It turns out this is expected using test pyPI as explained [here](https://packaging.python.org/en/latest/tutorials/packaging-projects/#installing-your-newly-uploaded-package).
+
+When I try to install `tidy3d-beta` from test.pyPI in an environment with the dependencies already installed from 
+``python3.9 -m pip install -e '.[dev]'``
+``python3.9 -m pip uninstall tidy3d-beta``
+
+It works as expected, besides needing `click`
+
+``python3.9 -c "import tidy3d as td; import tidy3d.web as web; from tidy3d.plugins import ModeSolver"``
+
+```
+[11:04:02] INFO     Using client version: 1.8.0                                                                                                                                              __init__.py:112
+Traceback (most recent call last):
+  File "<string>", line 1, in <module>
+  File "/usr/local/lib/python3.9/site-packages/tidy3d/web/__init__.py", line 8, in <module>
+    from .cli import tidy3d_cli
+  File "/usr/local/lib/python3.9/site-packages/tidy3d/web/cli/__init__.py", line 4, in <module>
+    from .app import tidy3d_cli
+  File "/usr/local/lib/python3.9/site-packages/tidy3d/web/cli/app.py", line 7, in <module>
+    import click
+ModuleNotFoundError: No module named 'click'
+```
+
+### Fixing the error
+
+So I added `click` with 
+
+``poetry add click``
+
+This changed the `poetry.lock` and `pyproject.toml`.
+
+I then bumped the version in `version.py` and `pyproject.toml` to `1.8.1` (otherwise, could not upload again to PyPI for same version) and repeated the publishing steps from above again.
+
+Testing the newly pip-installed version I was able to successfully import tidy3d and run a simulation!
+
+
+

--- a/tidy3d/web/httputils.py
+++ b/tidy3d/web/httputils.py
@@ -1,18 +1,64 @@
 """ handles communication with server """
-# import os
+import os
 import time
-from typing import Dict
 from enum import Enum
+from typing import Dict
 
 import jwt
+import toml
 from requests import Session
 
-from .auth import get_credentials, MAX_ATTEMPTS
+from .auth import get_credentials
+from .cli.app import CONFIG_FILE
 from .config import DEFAULT_CONFIG as Config
 from ..log import WebError
+from ..version import __version__
+
+SIMCLOUD_APIKEY = "SIMCLOUD_APIKEY"
+
+
+def api_key():
+    """
+    Get the api key for the current environment.
+    :return:
+    """
+    if os.environ.get(SIMCLOUD_APIKEY):
+        return os.environ.get(SIMCLOUD_APIKEY)
+    if os.path.exists(CONFIG_FILE):
+        with open(CONFIG_FILE, "r", encoding="utf-8") as config_file:
+            config = toml.loads(config_file.read())
+            return config.get("apikey", "")
+
+    return None
+
+
+def auth(request):
+    """
+    Set the authentication.
+    :param request:
+    :return:
+    """
+    key = api_key()
+    if key:
+        request.headers["simcloud-api-key"] = key
+        request.headers["tidy3d-python-version"] = __version__
+        return request
+
+    headers = get_headers()
+    if headers:
+        request.headers.update(headers)
+        return request
+
+    raise ValueError(
+        "API key not found, please set it by commandline or environment,"
+        " eg: tidy3d configure or export "
+        "SIMCLOUD_APIKEY=xxx"
+    )
+
 
 session = Session()
 session.verify = Config.env_settings.ssl_verify
+session.auth = auth
 
 
 class ResponseCodes(Enum):
@@ -31,23 +77,12 @@ def handle_response(func):
         # call originl request
         resp = func(*args, **kwargs)
 
-        # try to log in if unauthorized
-        attempts = 0
-        while resp.status_code == ResponseCodes.UNAUTHORIZED.value and attempts < MAX_ATTEMPTS:
-            # ask for credentials and call the http request again
-            get_credentials()
-            resp = func(*args, **kwargs)
-            attempts += 1
-
         # if still unauthorized, raise an error
         if resp.status_code == ResponseCodes.UNAUTHORIZED.value:
-            raise WebError("Failed to log in to server!")
+            raise WebError(resp.text)
 
-        # try returning the json of the response
-        try:
-            json_resp = resp.json()
-        except Exception:  # pylint:disable=broad-except
-            resp.raise_for_status()
+        resp.raise_for_status()
+        json_resp = resp.json()
 
         # if the response status is still not OK, try to raise error from the json
         if resp.status_code != ResponseCodes.OK.value:
@@ -89,29 +124,25 @@ def get_headers() -> Dict[str, str]:
 def post(method, data=None):
     """Uploads the file."""
     query_url = get_query_url(method)
-    headers = get_headers()
-    return session.post(query_url, headers=headers, json=data)
+    return session.post(query_url, json=data)
 
 
 @handle_response
 def put(method, data):
     """Runs the file."""
     query_url = get_query_url(method)
-    headers = get_headers()
-    return session.put(query_url, headers=headers, json=data)
+    return session.put(query_url, json=data)
 
 
 @handle_response
 def get(method):
     """Downloads the file."""
     query_url = get_query_url(method)
-    headers = get_headers()
-    return session.get(query_url, headers=headers)
+    return session.get(query_url)
 
 
 @handle_response
 def delete(method):
     """Deletes the file."""
     query_url = get_query_url(method)
-    headers = get_headers()
-    return session.delete(query_url, headers=headers)
+    return session.delete(query_url)

--- a/tidy3d/web/webapi.py
+++ b/tidy3d/web/webapi.py
@@ -215,6 +215,7 @@ def get_run_info(task_id: TaskId):
 
 # pylint: disable=too-many-statements
 def monitor(task_id: TaskId) -> None:
+    # pylint:disable=too-many-statements
     """Print the real time task progress until completion.
 
     Parameters

--- a/tox.ini
+++ b/tox.ini
@@ -57,3 +57,4 @@ commands =
     pytest -rA tests/test_web/test_auth.py
     pytest -rA tests/test_web/test_task.py
     pytest -rA tests/test_web/test_webapi.py
+    pytest -rA tests/test_web/test_cli.py


### PR DESCRIPTION
The most common four TMD monolayers, WSe2, WSe, MoSe2, MoS2, are added to the material library. The refractive indices are extracted from Tony Heinz's highly cited (<1000 citations) [paper](https://journals.aps.org/prb/abstract/10.1103/PhysRevB.90.205422). The raw data are then fitted with the Drude-Lorentz model using an external [fitter](https://reffit.ch/). Then Drude-Lorentz parameters are then converted to pole-residue pairs and added to the library. 

Overall the fitting is pretty good. Some small discrepancies can be seen on the lower bound of the frequency range. The fit has a slightly larger imaginary part of the permittivity. I tried different fitting strategies but didn't seem to be able to fit it exactly right unless a Drude term with negative linewidth is used. Personally I wouldn't be too worried about it since it's a small difference and for monolayers, it can barely lead to any observable results in the simulation. 

Here is a comparison of the published data (left) and the fitting (right).
<img width="306" alt="image" src="https://user-images.githubusercontent.com/116006359/214452036-5fe06e4f-0f35-4ffc-9e91-15af7958d971.png">

You can also test the materials using the attached notebook.
[MaterialLibraryTesting.zip](https://github.com/flexcompute/tidy3d/files/10495025/MaterialLibraryTesting.zip)
