### PR TITLE
Phase 1: self-intersecting polyslab

### DIFF
--- a/tests/test_plugins/test_polyslab.py
+++ b/tests/test_plugins/test_polyslab.py
@@ -1,0 +1,198 @@
+import pytest
+import numpy as np
+import matplotlib.pyplot as plt
+import gdstk
+
+import tidy3d as td
+
+from tidy3d.plugins import ComplexPolySlab
+from ..utils import clear_tmp, assert_log_level
+
+
+def test_divide_simple_events():
+    """PolySlab division for simple neighbor vertex-vertex type edge events."""
+
+    # simple edge events occurs during erosion
+    vertices_ero = ((0, 0), (1, 0), (1, 1), (0, 1), (0, 0.9), (0, 0.11))
+    # simple edge events occurs during dilation
+    vertices_dil = ((0, 0), (3, 0), (3, 1), (0, 1), (0, 0.9), (0.5, 0.55), (0.5, 0.45), (0, 0.1))
+
+    vertices_list = [vertices_ero, vertices_dil]
+    for vertices in vertices_list:
+        for angle in [0, np.pi / 4, -np.pi / 4]:
+            for reference_plane in ["top", "middle", "bottom"]:
+                s = ComplexPolySlab(
+                    vertices=vertices,
+                    slab_bounds=(0, 1),
+                    axis=2,
+                    sidewall_angle=angle,
+                    reference_plane=reference_plane,
+                )
+                subpolyslabs = s.sub_polyslabs
+                geometry_group = s.geometry_group
+
+                # for i, poly in enumerate(subpolyslabs):
+                #     print(f"------------{i}-th polyglab----------")
+                #     print(f"bounds = ({poly.slab_bounds[0]},  {poly.slab_bounds[1]})")
+                #     print(np.array(poly.vertices))
+
+
+def test_many_sub_polyslabs(caplog):
+    """warn when too many subpolyslabs are generated."""
+
+    # generate vertices that can generate at least this number
+    # of sub-polyslabs
+    num_subpoly = 200
+    dl_list = np.linspace(0, 0.1, num_subpoly)
+    vertices = [(sum(dl_list[: i + 1]), 0) for i in range(num_subpoly)]
+    vertices = vertices + [(5, 20)]
+
+    s = ComplexPolySlab(
+        vertices=vertices,
+        slab_bounds=(0, 10),
+        axis=2,
+        sidewall_angle=np.pi / 4,
+        reference_plane="bottom",
+    )
+    struct = td.Structure(
+        geometry=s.geometry_group,
+        medium=td.Medium(permittivity=2),
+    )
+    assert_log_level(caplog, 30)
+
+
+def test_divide_simulation():
+    """Test adding to a simulation."""
+
+    vertices = ((0, 0), (1, 0), (1, 1), (0, 1), (0, 0.9), (0, 0.11))
+
+    s = ComplexPolySlab(
+        vertices=vertices,
+        slab_bounds=(0, 1),
+        axis=2,
+        sidewall_angle=np.pi / 4,
+        reference_plane="bottom",
+    )
+    struct = td.Structure(
+        geometry=s.geometry_group,
+        medium=td.Medium(permittivity=2),
+    )
+    sim = td.Simulation(
+        run_time=1e-12,
+        size=(1, 1, 1),
+        grid_spec=td.GridSpec.auto(wavelength=1.0),
+        structures=(struct,),
+    )
+    sim2 = td.Simulation(
+        run_time=1e-12,
+        size=(1, 1, 1),
+        grid_spec=td.GridSpec.auto(wavelength=1.0),
+        structures=(s.to_structure(td.Medium(permittivity=2)),),
+    )
+
+
+@clear_tmp
+def test_gds_import():
+    """construct complex polyslabs from gds (mostly from GDSII notebook)"""
+
+    # Waveguide width
+    wg_width = 0.45
+    # Waveguide separation in the beginning/end
+    wg_spacing_in = 8
+    # Length of the coupling region
+    coup_length = 10
+    # Angle of the sidewall deviating from the vertical ones, positive values for the base larger than the top
+    sidewall_angle = np.pi / 4
+    # Reference plane where the cross section of the device is defined
+    reference_plane = "bottom"
+    # Length of the bend region
+    bend_length = 16
+    # Waveguide separation in the coupling region
+    wg_spacing_coup = 0.10
+    # Total device length along propagation direction
+    device_length = 100
+
+    def tanh_interp(max_arg):
+        """Interpolator for tanh with adjustable extension"""
+        scale = 1 / np.tanh(max_arg)
+        return lambda u: 0.5 * (1 + scale * np.tanh(max_arg * (u * 2 - 1)))
+
+    def make_coupler(
+        length, wg_spacing_in, wg_width, wg_spacing_coup, coup_length, bend_length, npts_bend=30
+    ):
+        """Make an integrated coupler using the gdstk RobustPath object."""
+        # bend interpolator
+        interp = tanh_interp(3)
+        delta = wg_width + wg_spacing_coup - wg_spacing_in
+        offset = lambda u: wg_spacing_in + interp(u) * delta
+
+        coup = gdstk.RobustPath(
+            (-0.5 * length, 0),
+            (wg_width, wg_width),
+            wg_spacing_in,
+            simple_path=True,
+            layer=1,
+            datatype=[0, 1],
+        )
+        coup.segment((-0.5 * coup_length - bend_length, 0))
+        coup.segment(
+            (-0.5 * coup_length, 0), offset=[lambda u: -0.5 * offset(u), lambda u: 0.5 * offset(u)]
+        )
+        coup.segment((0.5 * coup_length, 0))
+        coup.segment(
+            (0.5 * coup_length + bend_length, 0),
+            offset=[lambda u: -0.5 * offset(1 - u), lambda u: 0.5 * offset(1 - u)],
+        )
+        coup.segment((0.5 * length, 0))
+        return coup
+
+    # Create a gds cell to add our structures to
+    coup_cell = gdstk.Cell("Coupler")
+
+    # make substrate and add to cell
+    substrate = gdstk.rectangle(
+        (-device_length / 2, -wg_spacing_in / 2 - 10),
+        (device_length / 2, wg_spacing_in / 2 + 10),
+        layer=0,
+    )
+
+    coup_cell.add(substrate)
+
+    # make coupler and add to the cell
+    coup = make_coupler(
+        device_length, wg_spacing_in, wg_width, wg_spacing_coup, coup_length, bend_length
+    )
+
+    coup_cell.add(coup)
+
+    # Create a library for the cell and save it, just so that we can demosntrate loading
+    # geometry from a gds file
+    gds_path = "tests/tmp/coupler.gds"
+
+    lib = gdstk.Library()
+    lib.add(coup_cell)
+    lib.write_gds(gds_path)
+
+    lib_loaded = gdstk.read_gds(gds_path)
+    coup_cell_loaded = lib_loaded.top_level()[0]
+
+    # Define waveguide height
+    wg_height = 0.3
+    dilation = 0.02
+
+    [substrate_geo] = ComplexPolySlab.from_gds(
+        coup_cell_loaded,
+        gds_layer=0,
+        gds_dtype=0,
+        axis=2,
+        slab_bounds=(-430, 0),
+        reference_plane=reference_plane,
+    )
+    arm_geo = ComplexPolySlab.from_gds(
+        coup_cell_loaded,
+        gds_layer=1,
+        axis=2,
+        slab_bounds=(0, wg_height),
+        sidewall_angle=sidewall_angle,
+        dilation=dilation,
+    )

--- a/tidy3d/plugins/__init__.py
+++ b/tidy3d/plugins/__init__.py
@@ -23,3 +23,4 @@ from .adjoint.components.data.sim_data import JaxSimulationData
 from .adjoint.components.data.monitor_data import JaxModeData
 from .adjoint.components.data.dataset import JaxPermittivityDataset
 from .adjoint.components.data.data_array import JaxDataArray
+from .polyslab.polyslab import ComplexPolySlab

--- a/tidy3d/plugins/adjoint/components/geometry.py
+++ b/tidy3d/plugins/adjoint/components/geometry.py
@@ -300,7 +300,7 @@ class JaxPolySlab(JaxGeometry, PolySlab, JaxObject):
         return val
 
     @pd.validator("vertices", always=True)
-    def no_self_intersecting_polygon_at_reference_plane(cls, val, values):
+    def no_complex_self_intersecting_polygon_at_reference_plane(cls, val, values):
         """Overrides validator enforing that val is not inf."""
         return val
 

--- a/tidy3d/plugins/polyslab/__init__.py
+++ b/tidy3d/plugins/polyslab/__init__.py
@@ -1,0 +1,3 @@
+"""polyslab plugins."""
+
+from .polyslab import ComplexPolySlab

--- a/tidy3d/plugins/polyslab/polyslab.py
+++ b/tidy3d/plugins/polyslab/polyslab.py
@@ -1,0 +1,274 @@
+""" Divide a complex polyslab where self-intersecting polygon can occur during extrusion."""
+
+from typing import List, Tuple
+from math import isclose
+
+import pydantic
+from shapely.geometry import Polygon
+
+from ...components.geometry import PolySlab, GeometryGroup
+from ...components.medium import MediumType
+from ...components.structure import Structure
+from ...components.types import Axis
+from ...log import log
+from ...constants import fp_eps
+
+# Warn for too many divided polyslabs
+_WARN_MAX_NUM_DIVISION = 100
+
+
+class ComplexPolySlab(PolySlab):
+    """Interface for dividing a complex polyslab where self-intersecting polygon can
+    occur during extrusion.
+
+    Example
+    -------
+    >>> vertices = ((0, 0), (1, 0), (1, 1), (0, 1), (0, 0.9), (0, 0.11))
+    >>> p = ComplexPolySlab(vertices=vertices, axis=2, slab_bounds=(0, 1), sidewall_angle=0.785)
+    >>> # To obtain the divided polyslabs, there are two approaches:
+    >>> # 1) a list of divided polyslabs
+    >>> geo_list = p.sub_polyslabs
+    >>> # 2) geometry group containing the divided polyslabs
+    >>> geo_group = p.geometry_group
+    >>> # Or directly obtain the structure with a user-specified medium
+    >>> mat = td.Medium(permittivity=2)
+    >>> structure = p.to_structure(mat)
+
+    Note
+    ----
+    This version is limited to neighboring vertex-vertex crossing type of
+    self-intersecting events. Extension to cover all types of self-intersecting
+    events is expected in the future.
+
+    The algorithm is as follows (for the convenience of illustration,
+    let's consider the reference plane to lie at the bottom of the polyslab),
+
+    1. Starting from the reference plane, find out the critical
+    extrusion distance for the first vertices degeneracy
+    event when marching towards the top of the polyslab;
+
+    2. Construct a sub-polyslab whose base is the polygon at
+    the reference plane and height to be the critical
+    extrusion distance;
+
+    3. At the critical extrusion distance, constructing a new polygon
+    that keeps only one of the degenerate vertices;
+
+    4. Set the reference plane to the position of the new polygon,
+    and  repeating 1-3 to construct sub-polyslabs until reaching
+    the top of the polyslab, or all vertices collapsed into a 1D curve
+    or a 0D point.
+    """
+
+    @pydantic.validator("vertices", always=True)
+    def no_self_intersecting_polygon_during_extrusion(cls, val, values):
+        """Turn off the validation for this class."""
+        return val
+
+    @classmethod
+    def from_gds(  # pylint:disable=too-many-arguments
+        cls,
+        gds_cell,
+        axis: Axis,
+        slab_bounds: Tuple[float, float],
+        gds_layer: int,
+        gds_dtype: int = None,
+        gds_scale: pydantic.PositiveFloat = 1.0,
+        dilation: float = 0.0,
+        sidewall_angle: float = 0,
+        **kwargs,
+    ) -> List[PolySlab]:
+        """Import :class:`.PolySlab` from a ``gdstk.Cell``.
+
+        Parameters
+        ----------
+        gds_cell : gdstk.Cell
+            ``gdstk.Cell`` containing 2D geometric data.
+        axis : int
+            Integer index into the polygon's slab axis. (0,1,2) -> (x,y,z).
+        slab_bounds: Tuple[float, float]
+            Minimum and maximum positions of the slab along ``axis``.
+        gds_layer : int
+            Layer index in the ``gds_cell``.
+        gds_dtype : int = None
+            Data-type index in the ``gds_cell``.
+            If ``None``, imports all data for this layer into the returned list.
+        gds_scale : float = 1.0
+            Length scale used in GDS file in units of MICROMETER.
+            For example, if gds file uses nanometers, set ``gds_scale=1e-3``.
+            Must be positive.
+        dilation : float = 0.0
+            Dilation of the polygon in the base by shifting each edge along its
+            normal outwards direction by a distance;
+            a negative value corresponds to erosion.
+        sidewall_angle : float = 0
+            Angle of the sidewall.
+            ``sidewall_angle=0`` (default) specifies vertical wall,
+            while ``0<sidewall_angle<np.pi/2`` for the base to be larger than the top.
+        reference_plane : PlanePosition = "bottom"
+            The position of the GDS layer. It can be at the ``bottom``, ``middle``,
+            or ``top`` of the PolySlab. E.g. if ``axis=1``, ``bottom`` refers to the
+            negative side of y-axis, and ``top`` refers to the positive side of y-axis.
+
+        Returns
+        -------
+        List[:class:`.PolySlab`]
+            List of :class:`.PolySlab` objects sharing ``axis`` and  slab bound properties.
+        """
+
+        # TODO: change for 2.0
+        # handle reference plane kwarg
+        reference_plane = cls._set_reference_plane_kwarg(sidewall_angle, **kwargs)
+        all_vertices = cls._load_gds_vertices(gds_cell, gds_layer, gds_dtype, gds_scale)
+        polyslabs = [
+            cls(
+                vertices=verts,
+                axis=axis,
+                slab_bounds=slab_bounds,
+                dilation=dilation,
+                sidewall_angle=sidewall_angle,
+                reference_plane=reference_plane,
+            )
+            for verts in all_vertices
+        ]
+        return [sub_poly for sub_polys in polyslabs for sub_poly in sub_polys.sub_polyslabs]
+
+    def to_structure(self, medium: MediumType) -> Structure:
+        """Construct a structure containing a user-specified medium
+        and a GeometryGroup made of all the divided PolySlabs from this object.
+
+        Parameters
+        ----------
+        medium : :class:`.MediumType`
+            Medium for the complex polyslab.
+
+        Returns
+        -------
+        :class:`.Structure`
+            The structure containing all divided polyslabs made of a user-specified
+            medium.
+        """
+        return Structure(geometry=self.geometry_group, medium=medium)
+
+    @property
+    def geometry_group(self) -> GeometryGroup:
+        """Divide a complex polyslab into a list of simple polyslabs, which
+        are assembled into a :class:`.GeometryGroup`.
+
+        Returns
+        -------
+        :class:`.GeometryGroup`
+            GeometryGroup for a list of simple polyslabs divided from the complex
+            polyslab.
+        """
+        return GeometryGroup(geometries=self.sub_polyslabs)
+
+    @property
+    def sub_polyslabs(self) -> List[PolySlab]:
+        """Divide a complex polyslab into a list of simple polyslabs.
+        Only neighboring vertex-vertex crossing events are treated in this
+        version.
+
+        Returns
+        -------
+        List[PolySlab]
+            A list of simple polyslabs.
+        """
+        sub_polyslab_list = []
+        num_division_count = 0
+        # initialize sub-polyslab parameters
+        sub_polyslab_dict = self.dict(exclude={"type"}).copy()
+        if isclose(self.sidewall_angle, 0):
+            return [PolySlab.parse_obj(sub_polyslab_dict)]
+
+        sub_polyslab_dict.update({"dilation": 0})  # dilation accounted in setup
+        # initalize offset distance
+        offset_distance = 0
+
+        for dist_val in self._dilation_length:
+            dist_now = 0.0
+            vertices_now = self.reference_polygon
+
+            # constructing sub-polyslabs until reaching the base/top
+            while not isclose(dist_now, dist_val):
+                # bounds for sub-polyslabs assuming no self-intersection
+                slab_bounds = [
+                    self._dilation_value_at_reference_to_coord(dist_now),
+                    self._dilation_value_at_reference_to_coord(dist_val),
+                ]
+                # 1) find out any vertices touching events between the current
+                # position to the base/top
+                max_dist = PolySlab._neighbor_vertices_crossing_detection(
+                    vertices_now, dist_val - dist_now
+                )
+
+                # vertices touching events captured, update bounds for sub-polyslab
+                if max_dist is not None:
+                    # max_dist doesn't have sign, so construct signed offset distance
+                    offset_distance = max_dist * dist_val / abs(dist_val)
+                    slab_bounds[1] = self._dilation_value_at_reference_to_coord(
+                        dist_now + offset_distance
+                    )
+
+                # 2) construct sub-polyslab
+                slab_bounds.sort()  # for reference_plane=top/bottom, bounds need to be ordered
+                # direction of marching
+                reference_plane = "bottom" if dist_val / self._tanq < 0 else "top"
+                sub_polyslab_dict.update(
+                    dict(
+                        slab_bounds=tuple(slab_bounds),
+                        vertices=vertices_now,
+                        reference_plane=reference_plane,
+                    )
+                )
+                sub_polyslab_list.append(PolySlab.parse_obj(sub_polyslab_dict))
+
+                # Now Step 3
+                if max_dist is None:
+                    break
+                dist_now += offset_distance
+                # new polygon vertices where collapsing vertices are removed but keep one
+                vertices_now = PolySlab._shift_vertices(vertices_now, offset_distance)[0]
+                vertices_now = PolySlab._remove_duplicate_vertices(vertices_now)
+                # all vertices collapse
+                if len(vertices_now) < 3:
+                    break
+                # polygon collapse into 1D
+                if Polygon(vertices_now).buffer(0).area < fp_eps**2:
+                    break
+                vertices_now = PolySlab._orient(vertices_now)
+                num_division_count += 1
+
+        if num_division_count > _WARN_MAX_NUM_DIVISION:
+            log.warning(
+                "Two many self-intersecting events: "
+                f"The polyslab has been divided into {num_division_count} polyslabs; "
+                f"any more than around {_WARN_MAX_NUM_DIVISION} may slow down the simulation."
+            )
+
+        return sub_polyslab_list
+
+    @property
+    def _dilation_length(self) -> List[float]:
+        """dilation length from reference plane to the top/bottom of the polyslab."""
+
+        # for "bottom", only needs to compute the offset length to the top
+        dist = [self._extrusion_length_to_offset_distance(self.length_axis)]
+        # reverse the dilation value if the reference plane is on the top
+        if self.reference_plane == "top":
+            dist = [-dist[0]]
+        # for middle, both directions
+        elif self.reference_plane == "middle":
+            dist = [dist[0] / 2, -dist[0] / 2]
+        return dist
+
+    def _dilation_value_at_reference_to_coord(self, dilation: float) -> float:
+        """Compute the coordinate based on the dilation value to the reference plane."""
+
+        z_coord = -dilation / self._tanq + self.slab_bounds[0]
+        if self.reference_plane == "middle":
+            return z_coord + self.length_axis / 2
+        if self.reference_plane == "top":
+            return z_coord + self.length_axis
+        # bottom case
+        return z_coord


### PR DESCRIPTION
The support of self-intersecting polyslabs is scheduled to roll out in two phases. In phase 1, we consider the case where the length of some edges can approach 0 (or neighboring vertices become degenerate) at some point during extrusion. In phase 2, more general types of edge events will be treated. The main idea in this PR is to divide a complex polyslab into many simple polyslabs.

-  A class `ComplexPolySlab` is defined in plugin. It takes the same fields as `PolySlab`. We can consider move this class to `geometry.py`. The current design is to leave space for phase 2.
- An example on how to use this class can be found [here](https://github.com/flexcompute-readthedocs/tidy3d-docs/blob/weiliang/self-intersecting/docs/source/notebooks/SI_example.ipynb). In short, one can use the property method `.sub_polyslabs` to obtain a list of simple polyslabs, or `.geometry_group` that wraps up the simple polyslabs in a geometry group.
- Constructing from GDS file is also supported. The usage is the same as `PolySlab`. Here is an [example](https://github.com/flexcompute-readthedocs/tidy3d-docs/blob/weiliang/self-intersecting/docs/source/notebooks/SI_GDS.ipynb).
- There some updates to the visualization part in `PolySlab`: previously we cache the polygon on the base, and always use base polygon to construct polygons at other extrusion distance. However, now as we construct simple polyslabs from a complex polyslab, the degenerate vertices of the simple polyslab are removed on the top or the base. So the polygon on the base or the top can be different from the polygon in the between. An appropriate way is to use the polygon in the middle to construct polygons at other extrusion distance.