### PR TITLE
Try gdspy vertices loading if gdstk loading fails

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,7 @@ include requirements/web.txt
 include requirements/plugins.txt
 include requirements/core.txt
 include requirements/jax.txt
+include requirements/gdspy.txt
+include requirements/gdstk.txt
 include requirements/dev.txt
 include tidy3d/web/cacert.pem

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,8 @@
 # core and tests
 
 -r core.txt
+-r gdstk.txt
+-r gdspy.txt
 
 # required for development
 black==22.3.0
@@ -8,6 +10,5 @@ pylint
 tox
 pytest
 pytest-timeout
-gdstk
 memory_profiler
 dill

--- a/requirements/gdspy.txt
+++ b/requirements/gdspy.txt
@@ -1,0 +1,3 @@
+# gdspy
+
+gdspy

--- a/requirements/gdstk.txt
+++ b/requirements/gdstk.txt
@@ -1,0 +1,3 @@
+# gdstk
+
+gdstk

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ def read_requirements(req_file: str):
 basic_required = read_requirements("requirements/basic.txt")
 web_required = read_requirements("requirements/web.txt")
 jax_required = read_requirements("requirements/jax.txt")
+gdstk_required = read_requirements("requirements/gdstk.txt")
+gdspy_required = read_requirements("requirements/gdspy.txt")
 core_required = read_requirements("requirements/core.txt")
 core_required += basic_required + web_required
 dev_required = read_requirements("requirements/dev.txt")
@@ -53,6 +55,8 @@ setuptools.setup(
     extras_require={
         "dev": dev_required,
         "jax": jax_required,
+        "gdspy": gdspy_required,
+        "gdstk": gdstk_required,
     },
     entry_points={
         "console_scripts": [

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,8 @@ setenv =
     MPLBACKEND=agg
 deps =
     -rrequirements/jax.txt
+    -rrequirements/gdspy.txt
+    -rrequirements/gdstk.txt
     -rrequirements/dev.txt
 commands = 
     pip install requests


### PR DESCRIPTION
And add gdspy and gdstk as optional requirements.

@lucas-flexcompute 
Just took a stab at this using (perhaps an abuse of) `try: except:`, but let me know if you think there's a better way to handle it.

I also notice that neither `gdstk` nor `gdspy` are actually required for these to work as they aren't imported in the main package. The user just supplies a `Cell` from either package. In that case, do we need them as optional requirements at all?