### PR TITLE
2D simulation boundary warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - asynchronous running of multiple simulations using `web.run_async`.
 - Warning in `Simulation.epsilon` if many grid cells and structures provided and slow run time expected as a result.
+- Warning if PML or absorbing boundaries are used along a simulation dimension with zero size.
 
 ### Changed
 

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -323,6 +323,42 @@ def test_validate_plane_wave_boundaries(caplog):
     assert_log_level(caplog, 30)
 
 
+def test_validate_zero_dim_boundaries(caplog):
+
+    # zero-dim simulation with an absorbing boundary in that direction should warn
+    src = td.PlaneWave(
+        source_time=td.GaussianPulse(freq0=2.5e14, fwidth=1e13),
+        center=(0, 0, 0),
+        size=(td.inf, 0, td.inf),
+        direction="+",
+        pol_angle=0.0,
+    )
+
+    td.Simulation(
+        size=(1, 1, 0),
+        run_time=1e-12,
+        sources=[src],
+        boundary_spec=td.BoundarySpec(
+            x=td.Boundary.periodic(),
+            y=td.Boundary.periodic(),
+            z=td.Boundary.pml(),
+        ),
+    )
+    assert_log_level(caplog, 30)
+
+    # zero-dim simulation with an absorbing boundary any other direction should not warn
+    td.Simulation(
+        size=(1, 1, 0),
+        run_time=1e-12,
+        sources=[src],
+        boundary_spec=td.BoundarySpec(
+            x=td.Boundary.pml(),
+            y=td.Boundary.stable_pml(),
+            z=td.Boundary.pec(),
+        ),
+    )
+
+
 def test_validate_components_none():
 
     assert SIM._structures_not_at_edges(val=None, values=SIM.dict()) is None

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -339,6 +339,21 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
                             )
         return val
 
+    @pydantic.validator("boundary_spec", always=True)
+    def boundaries_for_zero_dims(cls, val, values):
+        """Warn if an absorbing boundary is used along a zero dimension."""
+        boundaries = val.to_list
+        size = values.get("size")
+        for dim, (boundary, size_dim) in enumerate(zip(boundaries, size)):
+            num_absorbing_bdries = sum(isinstance(bnd, AbsorberSpec) for bnd in boundary)
+            if num_absorbing_bdries > 0 and size_dim == 0:
+                log.warning(
+                    f"If the simulation is intended to be 2D in the plane normal to the "
+                    f"{'xyz'[dim]} axis, using a PML or absorbing boundary along that axis "
+                    f"is incorrect. Consider using a 'Periodic' boundary along {'xyz'[dim]}."
+                )
+        return val
+
     @pydantic.validator("structures", always=True)
     def _validate_num_mediums(cls, val):
         """Error if too many mediums present."""


### PR DESCRIPTION
Warn if a 2D simulation uses an absorbing boundary in the zero dimension. Eventually we may want to automatically switch to a periodic boundary.

Not urgent; we can merge this later on after discussing further.