### PR TITLE
Adding Simulation._volumetric_structures for speed

### DIFF
--- a/tests/sims/simulation_1_9_0rc2.json
+++ b/tests/sims/simulation_1_9_0rc2.json
@@ -1,1 +1,1336 @@
-{"type": "Simulation", "center": [0.0, 0.0, 0.0], "size": [8.0, 8.0, 8.0], "run_time": 1e-12, "medium": {"name": null, "frequency_range": null, "type": "Medium", "permittivity": 1.0, "conductivity": 0.0}, "symmetry": [0, 0, 0], "structures": [{"geometry": {"type": "Box", "center": [-1.0, 0.0, 0.0], "size": [1.0, 1.0, 1.0]}, "name": null, "type": "Structure", "medium": {"name": null, "frequency_range": null, "type": "Medium", "permittivity": 2.0, "conductivity": 0.0}}, {"geometry": {"type": "Box", "center": [-1.0, 0.0, 0.0], "size": [1.0, "Infinity", 1.0]}, "name": null, "type": "Structure", "medium": {"name": null, "frequency_range": null, "type": "Medium", "permittivity": 1.0, "conductivity": 3.0}}, {"geometry": {"type": "Sphere", "radius": 1.0, "center": [1.0, 0.0, 1.0]}, "name": null, "type": "Structure", "medium": {"name": null, "frequency_range": null, "type": "Sellmeier", "coeffs": [[1.03961212, 0.00600069867], [0.231792344, 0.0200179144]]}}, {"geometry": {"type": "Box", "center": [-1.0, 0.0, 0.0], "size": [1.0, 1.0, 1.0]}, "name": null, "type": "Structure", "medium": {"name": null, "frequency_range": null, "type": "Lorentz", "eps_inf": 2.0, "coeffs": [[1.0, 2.0, 3.0]]}}, {"geometry": {"type": "Box", "center": [-1.0, 0.0, 0.0], "size": [1.0, 1.0, 1.0]}, "name": null, "type": "Structure", "medium": {"name": null, "frequency_range": null, "type": "Debye", "eps_inf": 2.0, "coeffs": [[1.0, 3.0]]}}, {"geometry": {"type": "Box", "center": [-1.0, 0.0, 0.0], "size": [1.0, 1.0, 1.0]}, "name": null, "type": "Structure", "medium": {"name": null, "frequency_range": null, "type": "Drude", "eps_inf": 2.0, "coeffs": [[1.0, 3.0]]}}, {"geometry": {"type": "GeometryGroup", "geometries": [{"type": "Box", "center": [-1.0, 0.0, 0.0], "size": [1.0, 1.0, 1.0]}]}, "name": null, "type": "Structure", "medium": {"name": "PEC", "frequency_range": null, "type": "PECMedium"}}, {"geometry": {"type": "Cylinder", "axis": 1, "sidewall_angle": 0.0, "reference_plane": "bottom", "radius": 1.0, "center": [1.0, 0.0, -1.0], "length": 2.0}, "name": null, "type": "Structure", "medium": {"name": null, "frequency_range": null, "type": "AnisotropicMedium", "xx": {"name": null, "frequency_range": null, "type": "Medium", "permittivity": 1.0, "conductivity": 0.0}, "yy": {"name": null, "frequency_range": null, "type": "Medium", "permittivity": 2.0, "conductivity": 0.0}, "zz": {"name": null, "frequency_range": null, "type": "Medium", "permittivity": 3.0, "conductivity": 0.0}}}, {"geometry": {"type": "PolySlab", "axis": 2, "sidewall_angle": 0.0, "reference_plane": "bottom", "slab_bounds": [-1.0, 1.0], "dilation": 0.0, "vertices": [[-1.5, -1.5], [-0.5, -1.5], [-0.5, -0.5]]}, "name": null, "type": "Structure", "medium": {"name": null, "frequency_range": null, "type": "PoleResidue", "eps_inf": 1.0, "poles": [[{"real": 0.0, "imag": 6206417594288582.0}, {"real": -0.0, "imag": -3.311074436985222e+16}]]}}], "sources": [{"type": "UniformCurrentSource", "center": [0.0, 0.5, 0.0], "size": [0.0, 0.0, 0.0], "source_time": {"amplitude": 1.0, "phase": 0.0, "type": "GaussianPulse", "freq0": 200000000000000.0, "fwidth": 40000000000000.0, "offset": 5.0}, "name": null, "polarization": "Hx"}, {"type": "PointDipole", "center": [0.0, 0.5, 0.0], "size": [0, 0, 0], "source_time": {"amplitude": 1.0, "phase": 0.0, "type": "GaussianPulse", "freq0": 200000000000000.0, "fwidth": 40000000000000.0, "offset": 5.0}, "name": null, "polarization": "Ex"}, {"type": "ModeSource", "center": [0.0, 0.5, 0.0], "size": [2.0, 0.0, 2.0], "source_time": {"amplitude": 1.0, "phase": 0.0, "type": "GaussianPulse", "freq0": 200000000000000.0, "fwidth": 40000000000000.0, "offset": 5.0}, "name": null, "num_freqs": 1, "direction": "-", "mode_spec": {"num_modes": 1, "target_neff": null, "num_pml": [0, 0], "filter_pol": null, "angle_theta": 0.0, "angle_phi": 0.0, "precision": "single", "bend_radius": null, "bend_axis": null, "track_freq": "central", "type": "ModeSpec"}, "mode_index": 0}, {"type": "PlaneWave", "center": [0.0, 0.0, 0.0], "size": [0.0, "Infinity", "Infinity"], "source_time": {"amplitude": 1.0, "phase": 0.0, "type": "GaussianPulse", "freq0": 200000000000000.0, "fwidth": 40000000000000.0, "offset": 5.0}, "name": null, "direction": "+", "angle_theta": 0.0, "angle_phi": 0.0, "pol_angle": 0.1}, {"type": "GaussianBeam", "center": [0.0, 0.0, 0.0], "size": [0.0, 3.0, 3.0], "source_time": {"amplitude": 1.0, "phase": 0.0, "type": "GaussianPulse", "freq0": 200000000000000.0, "fwidth": 40000000000000.0, "offset": 5.0}, "name": null, "num_freqs": 1, "direction": "+", "angle_theta": 0.0, "angle_phi": 0.0, "pol_angle": 1.5707963267948966, "waist_radius": 1.0, "waist_distance": 0.0}, {"type": "AstigmaticGaussianBeam", "center": [0.0, 0.0, 0.0], "size": [0.0, 3.0, 3.0], "source_time": {"amplitude": 1.0, "phase": 0.0, "type": "GaussianPulse", "freq0": 200000000000000.0, "fwidth": 40000000000000.0, "offset": 5.0}, "name": null, "num_freqs": 1, "direction": "+", "angle_theta": 0.0, "angle_phi": 0.0, "pol_angle": 1.5707963267948966, "waist_sizes": [1.0, 2.0], "waist_distances": [3.0, 4.0]}, {"type": "CustomFieldSource", "center": [0.0, 1.0, 2.0], "size": [2.0, 2.0, 0.0], "source_time": {"amplitude": 1.0, "phase": 0.0, "type": "GaussianPulse", "freq0": 200000000000000.0, "fwidth": 40000000000000.0, "offset": 5.0}, "name": null, "field_dataset": {"type": "FieldDataset", "Ex": "ScalarFieldDataArray", "Ey": null, "Ez": null, "Hx": null, "Hy": null, "Hz": null}}], "boundary_spec": {"x": {"plus": {"name": null, "type": "PML", "num_layers": 20, "parameters": {"sigma_order": 3, "sigma_min": 0.0, "sigma_max": 1.5, "type": "PMLParams", "kappa_order": 3, "kappa_min": 1.0, "kappa_max": 3.0, "alpha_order": 1, "alpha_min": 0.0, "alpha_max": 0.0}}, "minus": {"name": null, "type": "Absorber", "num_layers": 100, "parameters": {"sigma_order": 3, "sigma_min": 0.0, "sigma_max": 6.4, "type": "AbsorberParams"}}, "type": "Boundary"}, "y": {"plus": {"name": null, "type": "BlochBoundary", "bloch_vec": 1.0}, "minus": {"name": null, "type": "BlochBoundary", "bloch_vec": 1.0}, "type": "Boundary"}, "z": {"plus": {"name": null, "type": "Periodic"}, "minus": {"name": null, "type": "Periodic"}, "type": "Boundary"}, "type": "BoundarySpec"}, "monitors": [{"type": "FieldMonitor", "center": [0.0, 0.0, 0.0], "size": [0.0, 0.0, 0.0], "name": "field", "freqs": [150000000000000.0, 200000000000000.0], "apodization": {"start": null, "end": null, "width": null, "type": "ApodizationSpec"}, "fields": ["Ex"], "interval_space": [1, 1, 1], "colocate": false}, {"type": "FieldTimeMonitor", "center": [0.0, 0.0, 0.0], "size": [0.0, 0.0, 0.0], "name": "field_time", "start": 0.0, "stop": null, "interval": 100, "fields": ["Ex", "Ey", "Ez", "Hx", "Hy", "Hz"], "interval_space": [1, 1, 1], "colocate": false}, {"type": "FluxMonitor", "center": [0.0, 0.0, 0.0], "size": [1.0, 1.0, 0.0], "name": "flux", "freqs": [200000000000000.0, 250000000000000.0], "apodization": {"start": null, "end": null, "width": null, "type": "ApodizationSpec"}, "normal_dir": "+", "exclude_surfaces": null}, {"type": "FluxTimeMonitor", "center": [0.0, 0.0, 0.0], "size": [1.0, 1.0, 0.0], "name": "flux_time", "start": 0.0, "stop": null, "interval": 1, "normal_dir": "+", "exclude_surfaces": null}, {"type": "PermittivityMonitor", "center": [0.0, 0.0, 0.0], "size": [1.0, 1.0, 0.1], "name": "eps", "freqs": [100000000000000.0], "apodization": {"start": null, "end": null, "width": null, "type": "ApodizationSpec"}}, {"type": "ModeMonitor", "center": [0.0, 0.0, 0.0], "size": [1.0, 1.0, 0.0], "name": "mode", "freqs": [200000000000000.0, 250000000000000.0], "apodization": {"start": null, "end": null, "width": null, "type": "ApodizationSpec"}, "mode_spec": {"num_modes": 1, "target_neff": null, "num_pml": [0, 0], "filter_pol": null, "angle_theta": 0.0, "angle_phi": 0.0, "precision": "single", "bend_radius": null, "bend_axis": null, "track_freq": "central", "type": "ModeSpec"}}, {"type": "ModeSolverMonitor", "center": [0.0, 0.0, 0.0], "size": [1.0, 1.0, 0.0], "name": "mode_solver", "freqs": [200000000000000.0, 250000000000000.0], "apodization": {"start": null, "end": null, "width": null, "type": "ApodizationSpec"}, "mode_spec": {"num_modes": 1, "target_neff": null, "num_pml": [0, 0], "filter_pol": null, "angle_theta": 0.0, "angle_phi": 0.0, "precision": "single", "bend_radius": null, "bend_axis": null, "track_freq": "central", "type": "ModeSpec"}}, {"type": "FieldProjectionAngleMonitor", "center": [0.0, 0.0, 0.0], "size": [0.0, 2.0, 2.0], "name": "proj_angle", "freqs": [250000000000000.0, 300000000000000.0], "apodization": {"start": null, "end": null, "width": null, "type": "ApodizationSpec"}, "normal_dir": "+", "exclude_surfaces": null, "custom_origin": [1.0, 2.0, 3.0], "far_field_approx": true, "proj_distance": 1000000.0, "theta": [-1.5707963267948966, -1.5390630676677268, -1.5073298085405573, -1.4755965494133876, -1.443863290286218, -1.4121300311590483, -1.3803967720318788, -1.348663512904709, -1.3169302537775396, -1.2851969946503699, -1.2534637355232003, -1.2217304763960306, -1.189997217268861, -1.1582639581416914, -1.1265306990145216, -1.0947974398873521, -1.0630641807601826, -1.0313309216330129, -0.9995976625058433, -0.9678644033786736, -0.936131144251504, -0.9043978851243344, -0.8726646259971648, -0.8409313668699951, -0.8091981077428254, -0.7774648486156558, -0.7457315894884862, -0.7139983303613165, -0.6822650712341469, -0.6505318121069773, -0.6187985529798077, -0.5870652938526381, -0.5553320347254684, -0.5235987755982987, -0.4918655164711292, -0.46013225734395946, -0.42839899821678995, -0.3966657390896202, -0.3649324799624507, -0.333199220835281, -0.30146596170811146, -0.26973270258094173, -0.23799944345377222, -0.2062661843266025, -0.17453292519943298, -0.14279966607226324, -0.11106640694509373, -0.079333147817924, -0.047599888690754266, -0.015866629563584755, 0.015866629563584977, 0.04759988869075449, 0.07933314781792422, 0.11106640694509373, 0.14279966607226346, 0.17453292519943298, 0.2062661843266027, 0.23799944345377222, 0.26973270258094195, 0.30146596170811146, 0.3331992208352812, 0.3649324799624507, 0.39666573908962044, 0.42839899821678995, 0.4601322573439597, 0.4918655164711292, 0.5235987755982991, 0.5553320347254687, 0.5870652938526382, 0.6187985529798077, 0.6505318121069776, 0.6822650712341471, 0.7139983303613167, 0.7457315894884862, 0.7774648486156561, 0.8091981077428256, 0.8409313668699951, 0.8726646259971647, 0.9043978851243346, 0.9361311442515041, 0.9678644033786736, 0.9995976625058436, 1.031330921633013, 1.0630641807601826, 1.0947974398873521, 1.126530699014522, 1.1582639581416916, 1.189997217268861, 1.2217304763960306, 1.2534637355232006, 1.28519699465037, 1.3169302537775396, 1.348663512904709, 1.380396772031879, 1.4121300311590486, 1.443863290286218, 1.475596549413388, 1.5073298085405575, 1.539063067667727, 1.5707963267948966], "phi": [0.0, 1.5707963267948966]}, {"type": "FieldProjectionCartesianMonitor", "center": [0.0, 0.0, 0.0], "size": [0.0, 2.0, 2.0], "name": "proj_cartesian", "freqs": [250000000000000.0, 300000000000000.0], "apodization": {"start": null, "end": null, "width": null, "type": "ApodizationSpec"}, "normal_dir": "+", "exclude_surfaces": null, "custom_origin": [1.0, 2.0, 3.0], "far_field_approx": true, "proj_axis": 2, "proj_distance": 5.0, "x": [-1.0, 0.0, 1.0], "y": [-2.0, -1.0, 0.0, 1.0, 2.0]}, {"type": "FieldProjectionKSpaceMonitor", "center": [0.0, 0.0, 0.0], "size": [0.0, 2.0, 2.0], "name": "proj_kspace", "freqs": [250000000000000.0, 300000000000000.0], "apodization": {"start": null, "end": null, "width": null, "type": "ApodizationSpec"}, "normal_dir": "+", "exclude_surfaces": null, "custom_origin": [1.0, 2.0, 3.0], "far_field_approx": true, "proj_axis": 2, "proj_distance": 1000000.0, "ux": [0.1, 0.2], "uy": [0.3, 0.4, 0.5]}, {"type": "FieldProjectionAngleMonitor", "center": [0.0, 0.0, 0.0], "size": [0.0, 2.0, 2.0], "name": "proj_angle_exact", "freqs": [250000000000000.0, 300000000000000.0], "apodization": {"start": null, "end": null, "width": null, "type": "ApodizationSpec"}, "normal_dir": "+", "exclude_surfaces": null, "custom_origin": [1.0, 2.0, 3.0], "far_field_approx": true, "proj_distance": 1000000.0, "theta": [-1.5707963267948966, -1.5390630676677268, -1.5073298085405573, -1.4755965494133876, -1.443863290286218, -1.4121300311590483, -1.3803967720318788, -1.348663512904709, -1.3169302537775396, -1.2851969946503699, -1.2534637355232003, -1.2217304763960306, -1.189997217268861, -1.1582639581416914, -1.1265306990145216, -1.0947974398873521, -1.0630641807601826, -1.0313309216330129, -0.9995976625058433, -0.9678644033786736, -0.936131144251504, -0.9043978851243344, -0.8726646259971648, -0.8409313668699951, -0.8091981077428254, -0.7774648486156558, -0.7457315894884862, -0.7139983303613165, -0.6822650712341469, -0.6505318121069773, -0.6187985529798077, -0.5870652938526381, -0.5553320347254684, -0.5235987755982987, -0.4918655164711292, -0.46013225734395946, -0.42839899821678995, -0.3966657390896202, -0.3649324799624507, -0.333199220835281, -0.30146596170811146, -0.26973270258094173, -0.23799944345377222, -0.2062661843266025, -0.17453292519943298, -0.14279966607226324, -0.11106640694509373, -0.079333147817924, -0.047599888690754266, -0.015866629563584755, 0.015866629563584977, 0.04759988869075449, 0.07933314781792422, 0.11106640694509373, 0.14279966607226346, 0.17453292519943298, 0.2062661843266027, 0.23799944345377222, 0.26973270258094195, 0.30146596170811146, 0.3331992208352812, 0.3649324799624507, 0.39666573908962044, 0.42839899821678995, 0.4601322573439597, 0.4918655164711292, 0.5235987755982991, 0.5553320347254687, 0.5870652938526382, 0.6187985529798077, 0.6505318121069776, 0.6822650712341471, 0.7139983303613167, 0.7457315894884862, 0.7774648486156561, 0.8091981077428256, 0.8409313668699951, 0.8726646259971647, 0.9043978851243346, 0.9361311442515041, 0.9678644033786736, 0.9995976625058436, 1.031330921633013, 1.0630641807601826, 1.0947974398873521, 1.126530699014522, 1.1582639581416916, 1.189997217268861, 1.2217304763960306, 1.2534637355232006, 1.28519699465037, 1.3169302537775396, 1.348663512904709, 1.380396772031879, 1.4121300311590486, 1.443863290286218, 1.475596549413388, 1.5073298085405575, 1.539063067667727, 1.5707963267948966], "phi": [0.0, 1.5707963267948966]}, {"type": "DiffractionMonitor", "center": [0.0, 0.0, 0.0], "size": [0.0, "Infinity", "Infinity"], "name": "diffraction", "freqs": [100000000000000.0, 200000000000000.0], "apodization": {"start": null, "end": null, "width": null, "type": "ApodizationSpec"}, "normal_dir": "+"}], "grid_spec": {"grid_x": {"type": "AutoGrid", "min_steps_per_wvl": 10.0, "max_scale": 1.4, "dl_min": 0.0, "mesher": {"type": "GradedMesher"}}, "grid_y": {"type": "CustomGrid", "dl": [0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04]}, "grid_z": {"type": "UniformGrid", "dl": 0.05}, "wavelength": null, "override_structures": [{"geometry": {"type": "Box", "center": [-1.0, 0.0, 0.0], "size": [1.0, 1.0, 1.0]}, "name": null, "type": "Structure", "medium": {"name": null, "frequency_range": null, "type": "Medium", "permittivity": 2.0, "conductivity": 0.0}}], "type": "GridSpec"}, "shutoff": 0.0001, "subpixel": false, "normalize_index": 0, "courant": 0.8, "version": "1.9.0rc2"}
+{
+    "type": "Simulation",
+    "center": [
+        0.0,
+        0.0,
+        0.0
+    ],
+    "size": [
+        8.0,
+        8.0,
+        8.0
+    ],
+    "run_time": 1e-12,
+    "medium": {
+        "name": null,
+        "frequency_range": null,
+        "type": "Medium",
+        "permittivity": 1.0,
+        "conductivity": 0.0
+    },
+    "symmetry": [
+        0,
+        0,
+        0
+    ],
+    "structures": [
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Medium",
+                "permittivity": 2.0,
+                "conductivity": 0.0
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    "Infinity",
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Medium",
+                "permittivity": 1.0,
+                "conductivity": 3.0
+            }
+        },
+        {
+            "geometry": {
+                "type": "Sphere",
+                "radius": 1.0,
+                "center": [
+                    1.0,
+                    0.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Sellmeier",
+                "coeffs": [
+                    [
+                        1.03961212,
+                        0.00600069867
+                    ],
+                    [
+                        0.231792344,
+                        0.0200179144
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Lorentz",
+                "eps_inf": 2.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        2.0,
+                        3.0
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Debye",
+                "eps_inf": 2.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        3.0
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Drude",
+                "eps_inf": 2.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        3.0
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "GeometryGroup",
+                "geometries": [
+                    {
+                        "type": "Box",
+                        "center": [
+                            -1.0,
+                            0.0,
+                            0.0
+                        ],
+                        "size": [
+                            1.0,
+                            1.0,
+                            1.0
+                        ]
+                    }
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": "PEC",
+                "frequency_range": null,
+                "type": "PECMedium"
+            }
+        },
+        {
+            "geometry": {
+                "type": "Cylinder",
+                "axis": 1,
+                "sidewall_angle": 0.0,
+                "reference_plane": "bottom",
+                "radius": 1.0,
+                "center": [
+                    1.0,
+                    0.0,
+                    -1.0
+                ],
+                "length": 2.0
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "AnisotropicMedium",
+                "xx": {
+                    "name": null,
+                    "frequency_range": null,
+                    "type": "Medium",
+                    "permittivity": 1.0,
+                    "conductivity": 0.0
+                },
+                "yy": {
+                    "name": null,
+                    "frequency_range": null,
+                    "type": "Medium",
+                    "permittivity": 2.0,
+                    "conductivity": 0.0
+                },
+                "zz": {
+                    "name": null,
+                    "frequency_range": null,
+                    "type": "Medium",
+                    "permittivity": 3.0,
+                    "conductivity": 0.0
+                }
+            }
+        },
+        {
+            "geometry": {
+                "type": "PolySlab",
+                "axis": 2,
+                "sidewall_angle": 0.0,
+                "reference_plane": "bottom",
+                "slab_bounds": [
+                    -1.0,
+                    1.0
+                ],
+                "dilation": 0.0,
+                "vertices": [
+                    [
+                        -1.5,
+                        -1.5
+                    ],
+                    [
+                        -0.5,
+                        -1.5
+                    ],
+                    [
+                        -0.5,
+                        -0.5
+                    ]
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "PoleResidue",
+                "eps_inf": 1.0,
+                "poles": [
+                    [
+                        {
+                            "real": 0.0,
+                            "imag": 6206417594288582.0
+                        },
+                        {
+                            "real": -0.0,
+                            "imag": -3.311074436985222e+16
+                        }
+                    ]
+                ]
+            }
+        }
+    ],
+    "sources": [
+        {
+            "type": "UniformCurrentSource",
+            "center": [
+                0.0,
+                0.5,
+                0.0
+            ],
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "polarization": "Hx"
+        },
+        {
+            "type": "PointDipole",
+            "center": [
+                0.0,
+                0.5,
+                0.0
+            ],
+            "size": [
+                0,
+                0,
+                0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "polarization": "Ex"
+        },
+        {
+            "type": "ModeSource",
+            "center": [
+                0.0,
+                0.5,
+                0.0
+            ],
+            "size": [
+                2.0,
+                0.0,
+                2.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "num_freqs": 1,
+            "direction": "-",
+            "mode_spec": {
+                "num_modes": 1,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "filter_pol": null,
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "precision": "single",
+                "bend_radius": null,
+                "bend_axis": null,
+                "track_freq": "central",
+                "type": "ModeSpec"
+            },
+            "mode_index": 0
+        },
+        {
+            "type": "PlaneWave",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                "Infinity",
+                "Infinity"
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 0.1
+        },
+        {
+            "type": "GaussianBeam",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                3.0,
+                3.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "num_freqs": 1,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 1.5707963267948966,
+            "waist_radius": 1.0,
+            "waist_distance": 0.0
+        },
+        {
+            "type": "AstigmaticGaussianBeam",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                3.0,
+                3.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "num_freqs": 1,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 1.5707963267948966,
+            "waist_sizes": [
+                1.0,
+                2.0
+            ],
+            "waist_distances": [
+                3.0,
+                4.0
+            ]
+        },
+        {
+            "type": "CustomFieldSource",
+            "center": [
+                0.0,
+                1.0,
+                2.0
+            ],
+            "size": [
+                2.0,
+                2.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "field_dataset": {
+                "type": "FieldDataset",
+                "Ex": "ScalarFieldDataArray",
+                "Ey": null,
+                "Ez": null,
+                "Hx": null,
+                "Hy": null,
+                "Hz": null
+            }
+        }
+    ],
+    "boundary_spec": {
+        "x": {
+            "plus": {
+                "name": null,
+                "type": "PML",
+                "num_layers": 20,
+                "parameters": {
+                    "sigma_order": 3,
+                    "sigma_min": 0.0,
+                    "sigma_max": 1.5,
+                    "type": "PMLParams",
+                    "kappa_order": 3,
+                    "kappa_min": 1.0,
+                    "kappa_max": 3.0,
+                    "alpha_order": 1,
+                    "alpha_min": 0.0,
+                    "alpha_max": 0.0
+                }
+            },
+            "minus": {
+                "name": null,
+                "type": "Absorber",
+                "num_layers": 100,
+                "parameters": {
+                    "sigma_order": 3,
+                    "sigma_min": 0.0,
+                    "sigma_max": 6.4,
+                    "type": "AbsorberParams"
+                }
+            },
+            "type": "Boundary"
+        },
+        "y": {
+            "plus": {
+                "name": null,
+                "type": "BlochBoundary",
+                "bloch_vec": 1.0
+            },
+            "minus": {
+                "name": null,
+                "type": "BlochBoundary",
+                "bloch_vec": 1.0
+            },
+            "type": "Boundary"
+        },
+        "z": {
+            "plus": {
+                "name": null,
+                "type": "Periodic"
+            },
+            "minus": {
+                "name": null,
+                "type": "Periodic"
+            },
+            "type": "Boundary"
+        },
+        "type": "BoundarySpec"
+    },
+    "monitors": [
+        {
+            "type": "FieldMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "name": "field",
+            "freqs": [
+                150000000000000.0,
+                200000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "fields": [
+                "Ex"
+            ],
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": false
+        },
+        {
+            "type": "FieldTimeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "name": "field_time",
+            "start": 0.0,
+            "stop": null,
+            "interval": 100,
+            "fields": [
+                "Ex",
+                "Ey",
+                "Ez",
+                "Hx",
+                "Hy",
+                "Hz"
+            ],
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": false
+        },
+        {
+            "type": "FluxMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "flux",
+            "freqs": [
+                200000000000000.0,
+                250000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null
+        },
+        {
+            "type": "FluxTimeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "flux_time",
+            "start": 0.0,
+            "stop": null,
+            "interval": 1,
+            "normal_dir": "+",
+            "exclude_surfaces": null
+        },
+        {
+            "type": "PermittivityMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.1
+            ],
+            "name": "eps",
+            "freqs": [
+                100000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            }
+        },
+        {
+            "type": "ModeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "mode",
+            "freqs": [
+                200000000000000.0,
+                250000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "mode_spec": {
+                "num_modes": 1,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "filter_pol": null,
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "precision": "single",
+                "bend_radius": null,
+                "bend_axis": null,
+                "track_freq": "central",
+                "type": "ModeSpec"
+            }
+        },
+        {
+            "type": "ModeSolverMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "mode_solver",
+            "freqs": [
+                200000000000000.0,
+                250000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "mode_spec": {
+                "num_modes": 1,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "filter_pol": null,
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "precision": "single",
+                "bend_radius": null,
+                "bend_axis": null,
+                "track_freq": "central",
+                "type": "ModeSpec"
+            }
+        },
+        {
+            "type": "FieldProjectionAngleMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                2.0,
+                2.0
+            ],
+            "name": "proj_angle",
+            "freqs": [
+                250000000000000.0,
+                300000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null,
+            "custom_origin": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "far_field_approx": true,
+            "proj_distance": 1000000.0,
+            "theta": [
+                -1.5707963267948966,
+                -1.5390630676677268,
+                -1.5073298085405573,
+                -1.4755965494133876,
+                -1.443863290286218,
+                -1.4121300311590483,
+                -1.3803967720318788,
+                -1.348663512904709,
+                -1.3169302537775396,
+                -1.2851969946503699,
+                -1.2534637355232003,
+                -1.2217304763960306,
+                -1.189997217268861,
+                -1.1582639581416914,
+                -1.1265306990145216,
+                -1.0947974398873521,
+                -1.0630641807601826,
+                -1.0313309216330129,
+                -0.9995976625058433,
+                -0.9678644033786736,
+                -0.936131144251504,
+                -0.9043978851243344,
+                -0.8726646259971648,
+                -0.8409313668699951,
+                -0.8091981077428254,
+                -0.7774648486156558,
+                -0.7457315894884862,
+                -0.7139983303613165,
+                -0.6822650712341469,
+                -0.6505318121069773,
+                -0.6187985529798077,
+                -0.5870652938526381,
+                -0.5553320347254684,
+                -0.5235987755982987,
+                -0.4918655164711292,
+                -0.46013225734395946,
+                -0.42839899821678995,
+                -0.3966657390896202,
+                -0.3649324799624507,
+                -0.333199220835281,
+                -0.30146596170811146,
+                -0.26973270258094173,
+                -0.23799944345377222,
+                -0.2062661843266025,
+                -0.17453292519943298,
+                -0.14279966607226324,
+                -0.11106640694509373,
+                -0.079333147817924,
+                -0.047599888690754266,
+                -0.015866629563584755,
+                0.015866629563584977,
+                0.04759988869075449,
+                0.07933314781792422,
+                0.11106640694509373,
+                0.14279966607226346,
+                0.17453292519943298,
+                0.2062661843266027,
+                0.23799944345377222,
+                0.26973270258094195,
+                0.30146596170811146,
+                0.3331992208352812,
+                0.3649324799624507,
+                0.39666573908962044,
+                0.42839899821678995,
+                0.4601322573439597,
+                0.4918655164711292,
+                0.5235987755982991,
+                0.5553320347254687,
+                0.5870652938526382,
+                0.6187985529798077,
+                0.6505318121069776,
+                0.6822650712341471,
+                0.7139983303613167,
+                0.7457315894884862,
+                0.7774648486156561,
+                0.8091981077428256,
+                0.8409313668699951,
+                0.8726646259971647,
+                0.9043978851243346,
+                0.9361311442515041,
+                0.9678644033786736,
+                0.9995976625058436,
+                1.031330921633013,
+                1.0630641807601826,
+                1.0947974398873521,
+                1.126530699014522,
+                1.1582639581416916,
+                1.189997217268861,
+                1.2217304763960306,
+                1.2534637355232006,
+                1.28519699465037,
+                1.3169302537775396,
+                1.348663512904709,
+                1.380396772031879,
+                1.4121300311590486,
+                1.443863290286218,
+                1.475596549413388,
+                1.5073298085405575,
+                1.539063067667727,
+                1.5707963267948966
+            ],
+            "phi": [
+                0.0,
+                1.5707963267948966
+            ]
+        },
+        {
+            "type": "FieldProjectionCartesianMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                2.0,
+                2.0
+            ],
+            "name": "proj_cartesian",
+            "freqs": [
+                250000000000000.0,
+                300000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null,
+            "custom_origin": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "far_field_approx": true,
+            "proj_axis": 2,
+            "proj_distance": 5.0,
+            "x": [
+                -1.0,
+                0.0,
+                1.0
+            ],
+            "y": [
+                -2.0,
+                -1.0,
+                0.0,
+                1.0,
+                2.0
+            ]
+        },
+        {
+            "type": "FieldProjectionKSpaceMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                2.0,
+                2.0
+            ],
+            "name": "proj_kspace",
+            "freqs": [
+                250000000000000.0,
+                300000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null,
+            "custom_origin": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "far_field_approx": true,
+            "proj_axis": 2,
+            "proj_distance": 1000000.0,
+            "ux": [
+                0.1,
+                0.2
+            ],
+            "uy": [
+                0.3,
+                0.4,
+                0.5
+            ]
+        },
+        {
+            "type": "FieldProjectionAngleMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                2.0,
+                2.0
+            ],
+            "name": "proj_angle_exact",
+            "freqs": [
+                250000000000000.0,
+                300000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null,
+            "custom_origin": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "far_field_approx": true,
+            "proj_distance": 1000000.0,
+            "theta": [
+                -1.5707963267948966,
+                -1.5390630676677268,
+                -1.5073298085405573,
+                -1.4755965494133876,
+                -1.443863290286218,
+                -1.4121300311590483,
+                -1.3803967720318788,
+                -1.348663512904709,
+                -1.3169302537775396,
+                -1.2851969946503699,
+                -1.2534637355232003,
+                -1.2217304763960306,
+                -1.189997217268861,
+                -1.1582639581416914,
+                -1.1265306990145216,
+                -1.0947974398873521,
+                -1.0630641807601826,
+                -1.0313309216330129,
+                -0.9995976625058433,
+                -0.9678644033786736,
+                -0.936131144251504,
+                -0.9043978851243344,
+                -0.8726646259971648,
+                -0.8409313668699951,
+                -0.8091981077428254,
+                -0.7774648486156558,
+                -0.7457315894884862,
+                -0.7139983303613165,
+                -0.6822650712341469,
+                -0.6505318121069773,
+                -0.6187985529798077,
+                -0.5870652938526381,
+                -0.5553320347254684,
+                -0.5235987755982987,
+                -0.4918655164711292,
+                -0.46013225734395946,
+                -0.42839899821678995,
+                -0.3966657390896202,
+                -0.3649324799624507,
+                -0.333199220835281,
+                -0.30146596170811146,
+                -0.26973270258094173,
+                -0.23799944345377222,
+                -0.2062661843266025,
+                -0.17453292519943298,
+                -0.14279966607226324,
+                -0.11106640694509373,
+                -0.079333147817924,
+                -0.047599888690754266,
+                -0.015866629563584755,
+                0.015866629563584977,
+                0.04759988869075449,
+                0.07933314781792422,
+                0.11106640694509373,
+                0.14279966607226346,
+                0.17453292519943298,
+                0.2062661843266027,
+                0.23799944345377222,
+                0.26973270258094195,
+                0.30146596170811146,
+                0.3331992208352812,
+                0.3649324799624507,
+                0.39666573908962044,
+                0.42839899821678995,
+                0.4601322573439597,
+                0.4918655164711292,
+                0.5235987755982991,
+                0.5553320347254687,
+                0.5870652938526382,
+                0.6187985529798077,
+                0.6505318121069776,
+                0.6822650712341471,
+                0.7139983303613167,
+                0.7457315894884862,
+                0.7774648486156561,
+                0.8091981077428256,
+                0.8409313668699951,
+                0.8726646259971647,
+                0.9043978851243346,
+                0.9361311442515041,
+                0.9678644033786736,
+                0.9995976625058436,
+                1.031330921633013,
+                1.0630641807601826,
+                1.0947974398873521,
+                1.126530699014522,
+                1.1582639581416916,
+                1.189997217268861,
+                1.2217304763960306,
+                1.2534637355232006,
+                1.28519699465037,
+                1.3169302537775396,
+                1.348663512904709,
+                1.380396772031879,
+                1.4121300311590486,
+                1.443863290286218,
+                1.475596549413388,
+                1.5073298085405575,
+                1.539063067667727,
+                1.5707963267948966
+            ],
+            "phi": [
+                0.0,
+                1.5707963267948966
+            ]
+        },
+        {
+            "type": "DiffractionMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                "Infinity",
+                "Infinity"
+            ],
+            "name": "diffraction",
+            "freqs": [
+                100000000000000.0,
+                200000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+"
+        }
+    ],
+    "grid_spec": {
+        "grid_x": {
+            "type": "AutoGrid",
+            "min_steps_per_wvl": 10.0,
+            "max_scale": 1.4,
+            "dl_min": 0.0,
+            "mesher": {
+                "type": "GradedMesher"
+            }
+        },
+        "grid_y": {
+            "type": "CustomGrid",
+            "dl": [
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04
+            ]
+        },
+        "grid_z": {
+            "type": "UniformGrid",
+            "dl": 0.05
+        },
+        "wavelength": null,
+        "override_structures": [
+            {
+                "geometry": {
+                    "type": "Box",
+                    "center": [
+                        -1.0,
+                        0.0,
+                        0.0
+                    ],
+                    "size": [
+                        1.0,
+                        1.0,
+                        1.0
+                    ]
+                },
+                "name": null,
+                "type": "Structure",
+                "medium": {
+                    "name": null,
+                    "frequency_range": null,
+                    "type": "Medium",
+                    "permittivity": 2.0,
+                    "conductivity": 0.0
+                }
+            }
+        ],
+        "type": "GridSpec"
+    },
+    "shutoff": 0.0001,
+    "subpixel": false,
+    "normalize_index": 0,
+    "courant": 0.8,
+    "version": "1.9.0rc2"
+}

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -1106,13 +1106,30 @@ def test_sim_volumetric_equivalent():
         rtol=RTOL,
     )
     # nonuniform sub/super-strate should error
-    below = td.Structure(
+    below_half = td.Structure(
         geometry=td.Box.from_bounds([-100, -td.inf, -1000], [0, td.inf, 0]),
         medium=aniso_medium,
     )
     sim = td.Simulation(
         size=(10, 10, 10),
-        structures=[below, box],
+        structures=[below_half, box],
+        sources=[src],
+        boundary_spec=td.BoundarySpec(
+            x=td.Boundary.pml(num_layers=5),
+            y=td.Boundary.pml(num_layers=5),
+            z=td.Boundary.pml(num_layers=5),
+        ),
+        grid_spec=td.GridSpec.uniform(dl=grid_dl),
+        run_time=1e-12,
+    )
+
+    with pytest.raises(SetupError):
+        _ = sim.volumetric_equivalent()
+
+    # structure overlaying the 2D material should error
+    sim = td.Simulation(
+        size=(10, 10, 10),
+        structures=[box, below],
         sources=[src],
         boundary_spec=td.BoundarySpec(
             x=td.Boundary.pml(num_layers=5),


### PR DESCRIPTION
The new method returns quickly if no 2D media are found, and even if they are found, does not make a copy of the full simulation, just returns a tuple with the volumetric structures. This is faster in the case of many many structures (with or without 2d media).

I also noticed that in the current implementation, if a structure overlays a 2D medium, the structures are then rearranged such that the 2D medium will come out on top. This is probably not expected behavior, so I added an error if this happens, and a test for the error.