### PR TITLE
STL Import

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,4 +7,5 @@ include requirements/jax.txt
 include requirements/gdspy.txt
 include requirements/gdstk.txt
 include requirements/dev.txt
+include requirements/surfacemesh.txt
 include tidy3d/web/cacert.pem

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,7 @@
 -r gdstk.txt
 -r gdspy.txt
 -r jax.txt
+-r surfacemesh.txt
 
 # required for development
 pre-commit

--- a/requirements/surfacemesh.txt
+++ b/requirements/surfacemesh.txt
@@ -1,0 +1,6 @@
+# surfacemesh
+
+trimesh==3.20.0
+networkx >=2.6.3, <=3.0
+rtree==1.0.1
+

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ web_required = read_requirements("requirements/web.txt")
 jax_required = read_requirements("requirements/jax.txt")
 gdstk_required = read_requirements("requirements/gdstk.txt")
 gdspy_required = read_requirements("requirements/gdspy.txt")
+surfacemesh_required = read_requirements("requirements/surfacemesh.txt")
 core_required = read_requirements("requirements/core.txt")
 core_required += basic_required + web_required
 dev_required = read_requirements("requirements/dev.txt")
@@ -58,6 +59,7 @@ setuptools.setup(
         "jax": jax_required,
         "gdspy": gdspy_required,
         "gdstk": gdstk_required,
+        "surfacemesh": surfacemesh_required,
     },
     entry_points={
         "console_scripts": [

--- a/tests/data/tetrahedron.stl
+++ b/tests/data/tetrahedron.stl
@@ -1,0 +1,30 @@
+solid tetrahedron.stl
+facet normal 1.0 1.0 1.0
+  outer loop
+    vertex 1.0 0.0 0.0
+    vertex 0.0 1.0 0.0
+    vertex 0.0 0.0 1.0
+  endloop
+endfacet
+facet normal -1.0 0.0 0.0
+  outer loop
+    vertex 0.0 0.0 0.0
+    vertex 0.0 0.0 1.0
+    vertex 0.0 1.0 0.0
+  endloop
+endfacet
+facet normal 0.0 -1.0 0.0
+  outer loop
+    vertex 0.0 0.0 0.0
+    vertex 1.0 0.0 0.0
+    vertex 0.0 0.0 1.0
+  endloop
+endfacet
+facet normal 0.0 0.0 -1.0
+  outer loop
+    vertex 0.0 0.0 0.0
+    vertex 0.0 1.0 0.0
+    vertex 1.0 0.0 0.0
+  endloop
+endfacet
+endsolid tetrahedron.stl

--- a/tests/sims/simulation_1_9_0.json
+++ b/tests/sims/simulation_1_9_0.json
@@ -304,6 +304,24 @@
                     ]
                 ]
             }
+        },
+        {
+            "geometry": {
+                "type": "CustomSurfaceMeshGeometry",
+                "mesh_dataset": {
+                    "type": "SurfaceMeshDataset",
+                    "surface_mesh": "SurfaceMeshDataArray"
+                }
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Medium",
+                "permittivity": 5.0,
+                "conductivity": 0.0
+            }
         }
     ],
     "sources": [

--- a/tests/sims/simulation_1_9_0rc2.json
+++ b/tests/sims/simulation_1_9_0rc2.json
@@ -304,6 +304,24 @@
                     ]
                 ]
             }
+        },
+        {
+            "geometry": {
+                "type": "CustomSurfaceMeshGeometry",
+                "mesh_dataset": {
+                    "type": "SurfaceMeshDataset",
+                    "triangles": "SurfaceMeshDataArray"
+                }
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Medium",
+                "permittivity": 5.0,
+                "conductivity": 0.0
+            }
         }
     ],
     "sources": [

--- a/tests/test_components/test_IO.py
+++ b/tests/test_components/test_IO.py
@@ -24,6 +24,7 @@ from ..test_data.test_sim_data import make_sim_data
 from tidy3d.components.data.data_array import FluxDataArray
 from tidy3d.components.data.sim_data import DATA_TYPE_MAP
 from tidy3d.components.data.monitor_data import FluxData
+from tidy3d.components.geometry import CustomSurfaceMeshGeometry
 
 # Store an example of every minor release simulation to test updater in the future
 SIM_DIR = "tests/sims"
@@ -34,6 +35,9 @@ def set_datasets_to_none(sim):
     for src in sim_dict["sources"]:
         if src["type"] == "CustomFieldSource":
             src["field_dataset"] = None
+    for structure in sim_dict["structures"]:
+        if structure["geometry"]["type"] == "CustomSurfaceMeshGeometry":
+            structure["geometry"]["mesh_dataset"] = None
     return td.Simulation.parse_obj(sim_dict)
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -106,6 +106,27 @@ SIM_FULL = Simulation(
             ),
             medium=PoleResidue(eps_inf=1.0, poles=((6206417594288582j, (-3.311074436985222e16j)),)),
         ),
+        Structure(
+            geometry=CustomSurfaceMeshGeometry.from_triangles(
+                np.array(
+                    [
+                        [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                        [[0, 0, 0], [0, 0, 1], [0, 1, 0]],
+                        [[0, 0, 0], [1, 0, 0], [0, 0, 1]],
+                        [[0, 0, 0], [0, 1, 0], [1, 0, 0]],
+                    ]
+                )
+                + np.array(
+                    [
+                        [[1, 1, 1], [1, 1, 1], [1, 1, 1]],
+                        [[1, 1, 1], [1, 1, 1], [1, 1, 1]],
+                        [[1, 1, 1], [1, 1, 1], [1, 1, 1]],
+                        [[1, 1, 1], [1, 1, 1], [1, 1, 1]],
+                    ]
+                )
+            ),
+            medium=td.Medium(permittivity=5),
+        ),
     ],
     sources=[
         UniformCurrentSource(

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -6,6 +6,7 @@ from .components.grid.grid_spec import GridSpec, UniformGrid, CustomGrid, AutoGr
 
 # geometry
 from .components.geometry import Box, Sphere, Cylinder, PolySlab, GeometryGroup
+from .components.geometry import CustomSurfaceMeshGeometry
 
 # medium
 from .components.medium import Medium, PoleResidue, AnisotropicMedium, PEC, PECMedium

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -25,6 +25,9 @@ DIM_ATTRS = {
     "uy": {"long_name": "normalized ky"},
     "orders_x": {"long_name": "diffraction order"},
     "orders_y": {"long_name": "diffraction order"},
+    "face_index": {"long_name": "face index"},
+    "vertex_index": {"long_name": "vertex index"},
+    "axis": {"long_name": "axis"},
 }
 
 
@@ -397,6 +400,14 @@ class DiffractionDataArray(DataArray):
     _data_attrs = {"long_name": "diffraction amplitude"}
 
 
+class SurfaceMeshDataArray(DataArray):
+    """Data of the triangles of a surface mesh as in the STL file format."""
+
+    __slots__ = ()
+    _dims = ("face_index", "vertex_index", "axis")
+    _data_attrs = {"long_name": "surface mesh triangles"}
+
+
 DATA_ARRAY_TYPES = [
     ScalarFieldDataArray,
     ScalarFieldTimeDataArray,
@@ -413,5 +424,6 @@ DATA_ARRAY_TYPES = [
     FreqDataArray,
     TimeDataArray,
     FreqModeDataArray,
+    SurfaceMeshDataArray,
 ]
 DATA_ARRAY_MAP = {data_array.__name__: data_array for data_array in DATA_ARRAY_TYPES}

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -11,6 +11,7 @@ import pydantic as pd
 from .data_array import DataArray
 from .data_array import ScalarFieldDataArray, ScalarFieldTimeDataArray, ScalarModeFieldDataArray
 from .data_array import ModeIndexDataArray
+from .data_array import SurfaceMeshDataArray
 
 from ..base import Tidy3dBaseModel
 from ..types import Axis
@@ -380,4 +381,15 @@ class PermittivityDataset(AbstractFieldDataset):
         ...,
         title="Epsilon zz",
         description="Spatial distribution of the zz-component of the relative permittivity.",
+    )
+
+
+class SurfaceMeshDataset(Dataset):
+    """Dataset for storing triangular surface data."""
+
+    surface_mesh: SurfaceMeshDataArray = pd.Field(
+        ...,
+        title="Surface mesh data",
+        description="Dataset containing the surface triangles and corresponding face indices "
+        "for a surface mesh.",
     )

--- a/tidy3d/components/geometry.py
+++ b/tidy3d/components/geometry.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List, Tuple, Union, Any, Callable
+from typing import List, Tuple, Union, Any, Callable, Optional
 from math import isclose
 import functools
 
@@ -19,8 +19,26 @@ from .types import Vertices, Ax, Shapely, annotate_type
 from .viz import add_ax_if_none, equal_aspect
 from .viz import PLOT_BUFFER, ARROW_LENGTH, arrow_style
 from .viz import PlotParams, plot_params_geometry, polygon_patch
-from ..log import Tidy3dKeyError, SetupError, ValidationError, log
+from ..log import Tidy3dKeyError, SetupError, ValidationError, log, DataError
 from ..constants import MICROMETER, LARGE_NUMBER, RADIAN, fp_eps, inf
+from .data.dataset import SurfaceMeshDataset
+from .data.data_array import SurfaceMeshDataArray, DATA_ARRAY_MAP
+
+try:
+    import trimesh
+
+    TRIMESH_AVAILABLE = True
+except ImportError:
+    TRIMESH_AVAILABLE = False
+
+try:
+    import networkx  # pylint:disable=unused-import
+    import rtree  # pylint:disable=unused-import
+
+    NETWORKX_RTREE_AVAILABLE = True
+except ImportError:
+    NETWORKX_RTREE_AVAILABLE = False
+
 
 # sampling polygon along dilation for validating polygon to be
 # non self-intersecting during the entire dilation process
@@ -707,7 +725,7 @@ class Geometry(Tidy3dBaseModel, ABC):
         Returns
         -------
         float
-            Volume.
+            Volume in um^3.
         """
 
         if not bounds:
@@ -730,7 +748,7 @@ class Geometry(Tidy3dBaseModel, ABC):
         Returns
         -------
         float
-            Surface area.
+            Surface area in um^2.
         """
 
         if not bounds:
@@ -3280,8 +3298,387 @@ class PolySlab(Planar):
         return area
 
 
+class CustomSurfaceMeshGeometry(Geometry, ABC):
+    """Custom surface geometry given by a triangle mesh, as in the STL file format.
+
+    Example
+    -------
+    >>> vertices = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    >>> faces = np.array([[1, 2, 3], [0, 3, 2], [0, 1, 3], [0, 2, 1]])
+    >>> stl_geom = CustomSurfaceMeshGeometry.from_vertices_faces(vertices, faces)
+    """
+
+    mesh_dataset: Optional[SurfaceMeshDataset] = pydantic.Field(
+        ...,
+        title="Surface mesh data",
+        description="Surface mesh data.",
+    )
+
+    @pydantic.root_validator(pre=True)
+    def _check_trimesh_library(cls, values):
+        """Check if the trimesh package is imported."""
+        if not TRIMESH_AVAILABLE:
+            raise ImportError(
+                "The package 'trimesh' was not found. Please install the 'surfacemesh' "
+                "dependencies to use 'CustomSurfaceMeshGeometry'. For example: "
+                "pip install 'tidy3d[surfacemesh]==1.10.0rc1'."
+            )
+        return values
+
+    @pydantic.validator("mesh_dataset", pre=True, always=True)
+    def _warn_if_none(cls, val: SurfaceMeshDataset) -> SurfaceMeshDataset:
+        """Warn if the Dataset fails to load."""
+        if isinstance(val, dict):
+            if any((v in DATA_ARRAY_MAP for _, v in val.items() if isinstance(v, str))):
+                log.warning("Loading 'mesh_dataset' without data.")
+                return None
+        return val
+
+    @pydantic.validator("mesh_dataset", always=True)
+    def _check_mesh(cls, val: SurfaceMeshDataset) -> SurfaceMeshDataset:
+        """Check that the mesh is valid."""
+        if val is None:
+            return None
+        mesh = cls._triangles_to_trimesh(val.surface_mesh)
+        if not all(np.array(mesh.area_faces) > fp_eps):
+            raise ValidationError(
+                "The provided mesh has triangles with zero area. "
+                "Consider using 'trimesh.Trimesh.remove_degenerate_faces' to fix this."
+            )
+        if not mesh.is_winding_consistent:
+            log.warning(
+                "The provided mesh does not have consistent winding (face orientations). "
+                "This can lead to incorrect permittivity distributions. You can use a "
+                "'PermittivityMonitor' to check if the permittivity distribution is correct. "
+                "You could repair the mesh manually, or try 'trimesh.repair.fix_winding'."
+            )
+        if not mesh.is_watertight:
+            log.warning(
+                "The provided mesh is not watertight and may require manual repair. "
+                "Non-watertight meshes can generate incorrect permittivity distributions. "
+                "They also cause problems with plotting. You can use a "
+                "'PermittivityMonitor' to check if the permittivity distribution is correct. "
+                "You can see which faces are broken using 'trimesh.repair.broken_faces'."
+            )
+
+        return val
+
+    @classmethod
+    def from_stl(
+        cls,
+        filename: str,
+        scale: float = 1.0,
+        origin: Tuple[float, float, float] = (0, 0, 0),
+        solid_index: int = None,
+        **kwargs,
+    ) -> Union[CustomSurfaceMeshGeometry, GeometryGroup]:
+        """Load a :class:`.CustomSurfaceMeshGeometry` directly from an STL file.
+        The ``solid_index`` parameter can be used to select a single solid from the file.
+        Otherwise, if the file contains a single solid, it will be loaded as a
+        :class:`.CustomSurfaceMeshGeometry`; if the file contains multiple solids,
+        they will all be loaded as a :class:`.GeometryGroup`.
+
+        Parameters
+        ----------
+        filename : str
+            The name of the STL file containing the surface geometry mesh data.
+        scale : float = 1.0
+            The length scale for the loaded geometry (um).
+            For example, a scale of 10.0 means that a vertex (1, 0, 0) will be placed at
+            x = 10 um.
+        origin : Tuple[float, float, float] = (0, 0, 0)
+            The origin of the loaded geometry, in units of ``scale``.
+            Translates from (0, 0, 0) to this point after applying the scaling.
+        solid_index : int = None
+            If set, read a single solid with this index from the file.
+
+        Returns
+        -------
+        Union[:class:`.CustomSurfaceMeshGeometry`, :class:`.GeometryGroup`]
+            The geometry or geometry group from the file.
+        """
+
+        def process_single(mesh: trimesh.Trimesh) -> CustomSurfaceMeshGeometry:
+            """Process a single 'trimesh.Trimesh' using scale and origin."""
+            mesh.apply_scale(scale)
+            mesh.apply_translation(origin)
+            return cls.from_trimesh(mesh)
+
+        scene = trimesh.load(filename, **kwargs)
+        meshes = []
+        if isinstance(scene, trimesh.Trimesh):
+            meshes = [scene]
+        elif isinstance(scene.trimesh.Scene):
+            meshes = scene.dump()
+        else:
+            raise ValidationError(
+                "Invalid trimesh type in file. Supported types are 'trimesh.Trimesh' "
+                "and 'trimesh.Scene'."
+            )
+
+        if solid_index is None:
+            if isinstance(scene, trimesh.Trimesh):
+                return process_single(scene)
+            if isinstance(scene, trimesh.Scene):
+                geoms = [process_single(mesh) for mesh in meshes]
+                return GeometryGroup(geometries=geoms)
+
+        if solid_index < len(meshes):
+            return process_single(meshes[solid_index])
+        raise ValidationError("No solid found at 'solid_index' in the stl file.")
+
+    @classmethod
+    def from_trimesh(cls, mesh: trimesh.Trimesh) -> CustomSurfaceMeshGeometry:
+        """Create a :class:`.CustomSurfaceMeshGeometry` from a ``trimesh.Trimesh`` object.
+
+        Parameters
+        ----------
+        trimesh : ``trimesh.Trimesh``
+            The Trimesh object containing the surface geometry mesh data.
+
+        Returns
+        -------
+        :class:`.CustomSurfaceMeshGeometry`
+            The custom surface mesh geometry given by the ``trimesh.Trimesh`` provided.
+        """
+        return cls.from_vertices_faces(mesh.vertices, mesh.faces)
+
+    @classmethod
+    def from_triangles(cls, triangles: np.ndarray) -> CustomSurfaceMeshGeometry:
+        """Create a :class:`.CustomSurfaceMeshGeometry` from a numpy array
+        containing the triangles of a surface mesh.
+
+        Parameters
+        ----------
+        triangles : ``np.ndarray``
+            A numpy array of shape (N, 3, 3) storing the triangles of the surface mesh.
+            The first index labels the triangle, the second index labels the vertex
+            within a given triangle, and the third index is the coordinate (x, y, or z).
+
+        Returns
+        -------
+        :class:`.CustomSurfaceMeshGeometry`
+            The custom surface mesh geometry given by the triangles provided.
+
+        """
+        triangles = np.array(triangles)
+        if len(triangles.shape) != 3 or triangles.shape[1] != 3 or triangles.shape[2] != 3:
+            raise ValidationError(
+                f"Provided 'triangles' must be an N x 3 x 3 array, given {triangles.shape}."
+            )
+        num_faces = len(triangles)
+        coords = dict(
+            face_index=np.arange(num_faces),
+            vertex_index=np.arange(3),
+            axis=np.arange(3),
+        )
+        vertices = SurfaceMeshDataArray(triangles, coords=coords)
+        mesh_dataset = SurfaceMeshDataset(surface_mesh=vertices)
+        return CustomSurfaceMeshGeometry(mesh_dataset=mesh_dataset)
+
+    @classmethod
+    def from_vertices_faces(
+        cls, vertices: np.ndarray, faces: np.ndarray
+    ) -> CustomSurfaceMeshGeometry:
+        """Create a :class:`.CustomSurfaceMeshGeometry` from numpy arrays containing the data
+        of a surface mesh. The first array contains the vertices, and the second array contains
+        faces formed from triples of the vertices.
+
+        Parameters
+        ----------
+        vertices: ``np.ndarray``
+            A numpy array of shape (N, 3) storing the vertices of the surface mesh.
+            The first index labels the vertex, and the second index is the coordinate
+            (x, y, or z).
+        faces : ``np.ndarray``
+            A numpy array of shape (M, 3) storing the indices of the vertices of each face
+            in the surface mesh. The first index labels the face, and the second index
+            labels the vertex index within the ``vertices`` array.
+
+        Returns
+        -------
+        :class:`.CustomSurfaceMeshGeometry`
+            The custom surface mesh geometry given by the vertices and faces provided.
+
+        """
+        vertices = np.array(vertices)
+        faces = np.array(faces)
+        if len(vertices.shape) != 2 or vertices.shape[1] != 3:
+            raise ValidationError(
+                f"Provided 'vertices' must be an N x 3 array, given {vertices.shape}."
+            )
+        if len(faces.shape) != 2 or faces.shape[1] != 3:
+            raise ValidationError(f"Provided 'faces' must be an M x 3 array, given {faces.shape}.")
+        return cls.from_triangles(trimesh.Trimesh(vertices, faces).triangles)
+
+    @classmethod
+    def _triangles_to_trimesh(cls, triangles: np.ndarray) -> trimesh.Trimesh:
+        """Convert an (N, 3, 3) numpy array of triangles to a ``trimesh.Trimesh``."""
+        return trimesh.Trimesh(**trimesh.triangles.to_kwargs(triangles))
+
+    @cached_property
+    def trimesh(self) -> trimesh.Trimesh:
+        """A ``trimesh.Trimesh`` object representing the custom surface mesh geometry."""
+        return self._triangles_to_trimesh(self.triangles)
+
+    @cached_property
+    def triangles(self) -> np.ndarray:
+        """The triangles of the surface mesh as an ``np.ndarray``."""
+        if self.mesh_dataset is None:
+            raise DataError("Can't get triangles as 'mesh_dataset' is None.")
+        return self.mesh_dataset.surface_mesh.to_numpy()
+
+    def _surface_area(self, bounds: Bound) -> float:
+        """Returns object's surface area given bounds."""
+        # currently ignores bounds
+        return self.trimesh.area
+
+    def _volume(self, bounds: Bound) -> float:
+        """Returns object's volume given bounds."""
+        # currently ignores bounds
+        return self.trimesh.volume
+
+    @cached_property
+    def bounds(self) -> Bound:
+        """Returns bounding box min and max coordinates.
+
+        Returns
+        -------
+        Tuple[float, float, float], Tuple[float, float float]
+            Min and max bounds packaged as ``(minx, miny, minz), (maxx, maxy, maxz)``.
+        """
+        if self.mesh_dataset is None:
+            return ((-inf, -inf, -inf), (inf, inf, inf))
+        return self.trimesh.bounds
+
+    def intersections_plane(
+        self, x: float = None, y: float = None, z: float = None
+    ) -> List[Shapely]:
+        """Returns list of shapely geoemtries at plane specified by one non-None value of x,y,z.
+
+        Parameters
+        ----------
+        x : float = None
+            Position of plane in x direction, only one of x,y,z can be specified to define plane.
+        y : float = None
+            Position of plane in y direction, only one of x,y,z can be specified to define plane.
+        z : float = None
+            Position of plane in z direction, only one of x,y,z can be specified to define plane.
+
+        Returns
+        -------
+        List[shapely.geometry.base.BaseGeometry]
+            List of 2D shapes that intersect plane.
+            For more details refer to
+            `Shapely's Documentaton <https://shapely.readthedocs.io/en/stable/project.html>`_.
+        """
+
+        if self.mesh_dataset is None:
+            return []
+
+        axis, position = self.parse_xyz_kwargs(x=x, y=y, z=z)
+
+        origin = self.unpop_axis(position, (0, 0), axis=axis)
+        normal = self.unpop_axis(1, (0, 0), axis=axis)
+
+        mesh = self.trimesh
+
+        if not NETWORKX_RTREE_AVAILABLE:
+            raise ImportError(
+                "'CustomSurfaceMeshGeometry.intersections_plane' requires 'networkx' and 'rtree'. "
+                "Please install the 'surfacemesh' dependencies. For example: "
+                "pip install 'tidy3d[surfacemesh]==1.10.0rc1'."
+            )
+
+        section = mesh.section(plane_origin=origin, plane_normal=normal)
+
+        if section is None:
+            return []
+
+        # homogeneous transformation matrix to map to xy plane
+        mapping = np.eye(4)
+
+        # translate to origin
+        mapping[3, :3] = -np.array(origin)
+
+        # permute so normal is aligned with z axis
+        # and (y, z), (x, z), resp. (x, y) are aligned with (x, y)
+        identity = np.eye(3)
+        permutation = self.unpop_axis(identity[2], identity[0:2], axis=axis)
+        mapping[:3, :3] = np.array(permutation).T
+
+        section2d, _ = section.to_planar(to_2D=mapping)
+        return section2d.polygons_full
+
+    def inside(
+        self, x: np.ndarray[float], y: np.ndarray[float], z: np.ndarray[float]
+    ) -> np.ndarray[bool]:
+        """For input arrays ``x``, ``y``, ``z`` of arbitrary but identical shape, return an array
+        with the same shape which is ``True`` for every point in zip(x, y, z) that is inside the
+        volume of the :class:`Geometry`, and ``False`` otherwise.
+
+        Parameters
+        ----------
+        x : np.ndarray[float]
+            Array of point positions in x direction.
+        y : np.ndarray[float]
+            Array of point positions in y direction.
+        z : np.ndarray[float]
+            Array of point positions in z direction.
+
+        Returns
+        -------
+        np.ndarray[bool]
+            ``True`` for every point that is inside the geometry.
+        """
+
+        arrays = tuple(map(np.array, (x, y, z)))
+        self._ensure_equal_shape(*arrays)
+        inside = np.zeros((arrays[0].size,), dtype=bool)
+        arrays_flat = map(np.ravel, arrays)
+        arrays_stacked = np.stack(tuple(arrays_flat), axis=-1)
+        inside = self.trimesh.contains(arrays_stacked)
+        return inside.reshape(arrays[0].shape)
+
+    @equal_aspect
+    @add_ax_if_none
+    def plot(
+        self, x: float = None, y: float = None, z: float = None, ax: Ax = None, **patch_kwargs
+    ) -> Ax:
+        """Plot geometry cross section at single (x,y,z) coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            Position of plane in x direction, only one of x,y,z can be specified to define plane.
+        y : float = None
+            Position of plane in y direction, only one of x,y,z can be specified to define plane.
+        z : float = None
+            Position of plane in z direction, only one of x,y,z can be specified to define plane.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        **patch_kwargs
+            Optional keyword arguments passed to the matplotlib patch plotting of structure.
+            For details on accepted values, refer to
+            `Matplotlib's documentation <https://tinyurl.com/2nf5c2fk>`_.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+
+        log.warning(
+            "Plotting a 'CustomSurfaceMeshGeometry' may give inconsistent results "
+            "if the mesh is not unionized. We recommend unionizing all meshes before import. "
+            "A 'PermittivityMonitor' can be used to check that the mesh is loaded correctly."
+        )
+
+        return Geometry.plot(self, x=x, y=y, z=z, ax=ax, **patch_kwargs)
+
+
 # types of geometry including just one Geometry object (exluding group)
-SingleGeometryType = Union[Box, Sphere, Cylinder, PolySlab]
+SingleGeometryType = Union[Box, Sphere, Cylinder, PolySlab, CustomSurfaceMeshGeometry]
 
 
 class GeometryGroup(Geometry):

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ deps =
     -rrequirements/gdspy.txt
     -rrequirements/gdstk.txt
     -rrequirements/dev.txt
+    -rrequirements/surfacemesh.txt
 commands = 
     pip install requests
     black --check --diff . --line-length 100


### PR DESCRIPTION
Features:
- `CustomSurfaceMeshGeometry` class
- Import from and export to STL (uses trimesh library)
- `SurfaceMeshDataArray` class handling HDF5 packaging of STL data
- Plotting simulations containing custom surface mesh geometry
- Validate STL mesh as watertight, consistent winding, and nonzero face area

Limitations:
- The plotting and epsilon on frontend is only self-consistent if the mesh is unionized. The backend should handle non-unionized meshes correctly. We can't check whether a mesh is unionized, so we just give a warning when plot or epsilon are called.
- Volume and surface area calculation ignores bounds
- Volume and surface area can overcount for non-unionized meshes.