### PR TITLE
Reorganize geometry.inside and intersection methods for some speed improvements

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,7 +1,7 @@
 [MASTER]
 load-plugins=pylint.extensions.no_self_use
 extension-pkg-allow-list=pydantic
-good-names=ax, im, Lx, Ly, Lz, x0, y0, z0, x, y, z, u, v, w, f, t, y1, y2, x1, x2, x3, x4, y3, y4, xs, ys, zs, Ax, Ay, Az, Nx, Ny, Nz, N, dl, rr, E, H, xx, yy, zz, dx, dy, Jx, Jy, Jz, Ex, Ey, Ez, Mx, My, Mz, Hx, Hy, Hz, dz, e, fp, dt, a, c, kx, ky, kz, k0, Jx_k, Jy_k, My_k, Mx_k, Ntheta, Nphi, Ltheta, Lphi, ux, uy, uz, nk, i, j, k, J, M, _N_th, _N_ph, _L_th, _L_ph, r, Et_array, Ep_array, Er_array, Ht_array, Hp_array, Hr_array, Et, Ep, Er, Ht, Hp, Hr, Ex_data, Ey_data, Ez_data, Hx_data, Hy_data, Hz_data, Ar, Atheta, Aphi, mu, n, k, J1, J2, M1, M2, E1, E2, H1, H2, new_values_J1, new_values_J2, new_values_M1, new_values_M2, E_normal, H_normal, Er, Etheta, Ephi, Hr, Htheta, Hphi
+good-names=ax, im, Lx, Ly, Lz, x0, y0, z0, x, y, z, u, v, w, f, t, y1, y2, x1, x2, x3, x4, y3, y4, xs, ys, zs, Ax, Ay, Az, Nx, Ny, Nz, N, dl, rr, E, H, xx, yy, zz, dx, dy, Jx, Jy, Jz, Ex, Ey, Ez, Mx, My, Mz, Hx, Hy, Hz, dz, e, fp, dt, a, c, kx, ky, kz, k0, Jx_k, Jy_k, My_k, Mx_k, Ntheta, Nphi, Ltheta, Lphi, ux, uy, uz, nk, i, j, k, J, M, _N_th, _N_ph, _L_th, _L_ph, r, Et_array, Ep_array, Er_array, Ht_array, Hp_array, Hr_array, Et, Ep, Er, Ht, Hp, Hr, Ex_data, Ey_data, Ez_data, Hx_data, Hy_data, Hz_data, Ar, Atheta, Aphi, mu, n, k, J1, J2, M1, M2, E1, E2, H1, H2, new_values_J1, new_values_J2, new_values_M1, new_values_M2, E_normal, H_normal, Er, Etheta, Ephi, Hr, Htheta, Hphi, xp, yp, zp
 
 [BASIC]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Progressbars always set to 100% when webapi functions are finished.
+- Faster handling of `Geometry.intersects` and `Geometry.inside` by taking into account geometry bounds.
 
 
 ## [1.9.0rc2] - 2023-2-17

--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -33,6 +33,18 @@ def test_plot(component):
 
 def test_base_inside():
     assert Geometry.inside(GEO, x=0, y=0, z=0)
+    assert np.all(Geometry.inside(GEO, np.array([0, 0]), np.array([0, 0]), np.array([0, 0])))
+    assert np.all(Geometry.inside(GEO, np.array([[0, 0]]), np.array([[0, 0]]), np.array([[0, 0]])))
+
+
+def test_base_inside_meshgrid():
+    assert np.all(Geometry.inside_meshgrid(GEO, x=[0], y=[0], z=[0]))
+    assert np.all(Geometry.inside_meshgrid(GEO, [0, 0], [0, 0], [0, 0]))
+    # Input dimensions different than 1 error for ``inside_meshgrid``.
+    with pytest.raises(ValueError):
+        b = Geometry.inside_meshgrid(GEO, x=0, y=0, z=0)
+    with pytest.raises(ValueError):
+        b = Geometry.inside_meshgrid(GEO, [[0, 0]], [[0, 0]], [[0, 0]])
 
 
 def test_bounding_box():
@@ -106,6 +118,8 @@ def test_planar_bounds():
 @pytest.mark.parametrize("component", GEO_TYPES)
 def test_inside(component):
     b = component.inside(0, 0, 0)
+    bs = component.inside(np.array([0, 0]), np.array([0, 0]), np.array([0, 0]))
+    bss = component.inside(np.array([[0, 0]]), np.array([[0, 0]]), np.array([[0, 0]]))
 
 
 def test_zero_dims():
@@ -237,6 +251,7 @@ def test_geo_group_methods():
     geo_group = make_geo_group()
     geo_group.inside(0, 1, 2)
     geo_group.inside(np.linspace(0, 1, 10), np.linspace(0, 1, 10), np.linspace(0, 1, 10))
+    geo_group.inside_meshgrid(np.linspace(0, 1, 10), np.linspace(0, 1, 10), np.linspace(0, 1, 10))
     geo_group.intersections(y=0)
     geo_group.intersects(td.Box(size=(1, 1, 1)))
     rmin, rmax = geo_group.bounds

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -1075,22 +1075,23 @@ def test_mode_object_syms():
     )
 
 
-@pytest.mark.parametrize("size, log_level", [(1.0, None), (65, "warning")])
-def test_warn_large_epsilon(caplog, size, log_level):
+@pytest.mark.parametrize(
+    "size, num_struct, log_level", [(1, 1, None), (50, 1, "warning"), (1, 11000, "warning")]
+)
+def test_warn_large_epsilon(caplog, size, num_struct, log_level):
     """Make sure we get a warning if the epsilon grid is too large."""
 
-    num_structures = 1000
     structures = [
         td.Structure(
             geometry=td.Box(center=(0, 0, 0), size=(0.1, 0.1, 0.1)),
             medium=td.Medium(permittivity=1.0),
         )
-        for _ in range(num_structures)
+        for _ in range(num_struct)
     ]
 
     sim = td.Simulation(
         size=(size, size, size),
-        grid_spec=td.GridSpec.uniform(dl=1.0),
+        grid_spec=td.GridSpec.uniform(dl=0.1),
         run_time=1e-12,
         boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
         sources=[


### PR DESCRIPTION
The two main updates are:
- `geometry.intersects_plane` is now much faster. Before, it would call `geometry.intersections`, which can be slow. Now, instead, `intersects_plane` is fast, and is used to speed up `geometry.intersections` in some cases by doing a quick check if the plane is out of bounds.
- `geometry.inside_meshgrid` method introduced to speed up `geometry.inside` computations that are defined on a regular grid in `x, y, z` (as in `sim.epsilon`). With these improvements, for example getting the epsilon in a region with 28k spheres takes just 5s (4s if they are defined as a GeometryGroup).

I would say this fixes #668 for now.