### PR TITLE
assert_log_level takes level string instead of int

### DIFF
--- a/tests/test_components/test_boundaries.py
+++ b/tests/test_components/test_boundaries.py
@@ -77,14 +77,14 @@ def test_boundary_validators():
         boundary = Boundary(plus=periodic, minus=pml)
 
 
-@pytest.mark.parametrize("boundary, log_level", [(PMCBoundary(), None), (Periodic(), 30)])
+@pytest.mark.parametrize("boundary, log_level", [(PMCBoundary(), None), (Periodic(), "warning")])
 def test_boundary_validator_warnings(caplog, boundary, log_level):
     """Test the validators in class `Boundary` which should show a warning but not an error"""
     boundary = Boundary(plus=PECBoundary(), minus=boundary)
     assert_log_level(caplog, log_level)
 
 
-@pytest.mark.parametrize("boundary, log_level", [(PMCBoundary(), None), (Periodic(), 30)])
+@pytest.mark.parametrize("boundary, log_level", [(PMCBoundary(), None), (Periodic(), "warning")])
 def test_boundary_validator_warnings_switched(caplog, boundary, log_level):
     """Test the validators in class `Boundary` which should show a warning but not an error"""
     boundary = Boundary(minus=PECBoundary(), plus=boundary)
@@ -179,7 +179,7 @@ def test_boundaryspec_classmethods():
 
 
 PLUS_MINUS_SPECIFIED = (("plus", "minus"), ("plus",), ("minus",), ())
-LOG_LEVELS_EXPECTED = (None, 30, 30, 30)
+LOG_LEVELS_EXPECTED = (None, "warning", "warning", "warning")
 
 # TODO: remove for 2.0
 @pytest.mark.parametrize("pm_keys, log_level", zip(PLUS_MINUS_SPECIFIED, LOG_LEVELS_EXPECTED))

--- a/tests/test_components/test_custom.py
+++ b/tests/test_components/test_custom.py
@@ -127,9 +127,9 @@ def test_io_json(caplog):
     """to json warns and then from json errors."""
     path = "tests/tmp/custom_source.json"
     FIELD_SRC.to_file(path)
-    assert_log_level(caplog, 30)
+    assert_log_level(caplog, "warning")
     FIELD_SRC2 = FIELD_SRC.from_file(path)
-    assert_log_level(caplog, 30)
+    assert_log_level(caplog, "warning")
     assert FIELD_SRC2.field_dataset is None
 
 

--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -385,7 +385,7 @@ def test_polyslab_axis(axis):
 ANGLE = 0.01
 SIDEWALL_ANGLES = (0.0, ANGLE, 0.0, ANGLE, 0.0, ANGLE)
 REFERENCE_PLANES = ("bottom", "bottom", "middle", "middle", None, None)
-LOG_LEVELS_EXPECTED = (None, None, None, None, None, 30)
+LOG_LEVELS_EXPECTED = (None, None, None, None, None, "warning")
 
 
 def make_ref_plane_kwargs(reference_plane: str):

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -97,7 +97,7 @@ def test_deprecation_defaults(caplog):
     s = td.Simulation(
         size=(1, 1, 1), run_time=1e-12, grid_spec=td.GridSpec.uniform(dl=0.1), boundary_spec=None
     )
-    assert_log_level(caplog, 30)
+    assert_log_level(caplog, "warning")
 
 
 def test_sim_bounds():
@@ -185,7 +185,7 @@ def _test_monitor_size():
         s.validate_pre_upload()
 
 
-@pytest.mark.parametrize("freq, log_level", [(1.5, 30), (2.5, None), (3.5, 30)])
+@pytest.mark.parametrize("freq, log_level", [(1.5, "warning"), (2.5, None), (3.5, "warning")])
 def test_monitor_medium_frequency_range(caplog, freq, log_level):
     # monitor frequency above or below a given medium's range should throw a warning
 
@@ -209,7 +209,7 @@ def test_monitor_medium_frequency_range(caplog, freq, log_level):
     assert_log_level(caplog, log_level)
 
 
-@pytest.mark.parametrize("fwidth, log_level", [(0.1, 30), (2, None)])
+@pytest.mark.parametrize("fwidth, log_level", [(0.1, "warning"), (2, None)])
 def test_monitor_simulation_frequency_range(caplog, fwidth, log_level):
     # monitor frequency outside of the simulation's frequency range should throw a warning
 
@@ -311,7 +311,7 @@ def test_validate_plane_wave_boundaries(caplog):
         sources=[src2],
         boundary_spec=bspec3,
     )
-    assert_log_level(caplog, 30)
+    assert_log_level(caplog, "warning")
 
     # angled incidence plane wave with wrong Bloch vector should warn
     td.Simulation(
@@ -320,7 +320,7 @@ def test_validate_plane_wave_boundaries(caplog):
         sources=[src2],
         boundary_spec=bspec4,
     )
-    assert_log_level(caplog, 30)
+    assert_log_level(caplog, "warning")
 
 
 def test_validate_components_none():
@@ -463,7 +463,7 @@ def test_min_sym_box():
 
 def test_discretize_non_intersect(caplog):
     SIM.discretize(box=td.Box(center=(-20, -20, -20), size=(1, 1, 1)))
-    assert_log_level(caplog, 40)
+    assert_log_level(caplog, "error")
 
 
 def test_filter_structures():
@@ -497,10 +497,10 @@ def test_warn_sim_background_medium_freq_range(caplog):
             medium=td.Medium(frequency_range=(0, 1)),
         )
     )
-    assert_log_level(caplog, 30)
+    assert_log_level(caplog, "warning")
 
 
-@pytest.mark.parametrize("grid_size,log_level", [(0.001, None), (3, 30)])
+@pytest.mark.parametrize("grid_size,log_level", [(0.001, None), (3, "warning")])
 def test_large_grid_size(caplog, grid_size, log_level):
     # small fwidth should be inside range, large one should throw warning
 
@@ -522,7 +522,7 @@ def test_large_grid_size(caplog, grid_size, log_level):
     assert_log_level(caplog, log_level)
 
 
-@pytest.mark.parametrize("box_size,log_level", [(0.001, None), (9.9, 30), (20, None)])
+@pytest.mark.parametrize("box_size,log_level", [(0.001, None), (9.9, "warning"), (20, None)])
 def test_sim_structure_gap(caplog, box_size, log_level):
     """Make sure the gap between a structure and PML is not too small compared to lambda0."""
     medium = td.Medium(permittivity=2)
@@ -744,7 +744,7 @@ def test_proj_monitor_distance(caplog):
         monitors=[monitor_n2f_far],
         boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
     )
-    assert_log_level(caplog, 30)
+    assert_log_level(caplog, "warning")
 
     # proj_distance not too large - don't warn
     _ = td.Simulation(
@@ -815,7 +815,12 @@ def test_diffraction_medium():
 
 @pytest.mark.parametrize(
     "box_size,log_level",
-    [((0.1, 0.1, 0.1), None), ((1, 0.1, 0.1), 30), ((0.1, 1, 0.1), 30), ((0.1, 0.1, 1), 30)],
+    [
+        ((0.1, 0.1, 0.1), None),
+        ((1, 0.1, 0.1), "warning"),
+        ((0.1, 1, 0.1), "warning"),
+        ((0.1, 0.1, 1), "warning"),
+    ],
 )
 def test_sim_structure_extent(caplog, box_size, log_level):
     """Make sure we warn if structure extends exactly to simulation edges."""
@@ -1034,7 +1039,7 @@ def test_mode_object_syms():
     )
 
 
-@pytest.mark.parametrize("size, log_level", [(1.0, None), (65, 30)])
+@pytest.mark.parametrize("size, log_level", [(1.0, None), (65, "warning")])
 def test_warn_large_epsilon(caplog, size, log_level):
     """Make sure we get a warning if the epsilon grid is too large."""
 

--- a/tests/test_data/test_monitor_data.py
+++ b/tests/test_data/test_monitor_data.py
@@ -439,7 +439,7 @@ def test_data_array_attrs():
 def test_data_array_json_warns(caplog):
     data = make_flux_data()
     data.to_file("tests/tmp/flux.json")
-    assert_log_level(caplog, 30)
+    assert_log_level(caplog, "warning")
 
 
 def test_data_array_hdf5_no_warnings(caplog):

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -504,7 +504,7 @@ def test_intersect_structures(caplog):
 
     # shouldnt error, just warn because of touching but not intersecting
     sim = make_sim_intersect(spacing=0.0)
-    assert_log_level(caplog, 30)
+    assert_log_level(caplog, "warning")
 
 
 def test_structure_overlaps():

--- a/tests/test_plugins/test_polyslab.py
+++ b/tests/test_plugins/test_polyslab.py
@@ -58,7 +58,7 @@ def test_many_sub_polyslabs(caplog):
         geometry=s.geometry_group,
         medium=td.Medium(permittivity=2),
     )
-    assert_log_level(caplog, 30)
+    assert_log_level(caplog, "warning")
 
 
 def test_divide_simulation():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import numpy as np
 from tidy3d import *
 import tidy3d as td
+from tidy3d.log import _get_level_int
+
 
 """ utilities shared between all tests """
 
@@ -361,28 +363,33 @@ def run_emulated(simulation: Simulation, **kwargs) -> SimulationData:
     return SimulationData(simulation=simulation, data=data)
 
 
-def assert_log_level(caplog, log_level_expected):
+def assert_log_level(caplog, log_level_expected: str):
     """ensure something got logged if log_level is not None.
     note: I put this here rather than utils.py because if we import from utils.py,
     it will validate the sims there and those get included in log.
     """
 
+    if log_level_expected is None:
+        log_level_expected_int = None
+    else:
+        log_level_expected_int = _get_level_int(log_level_expected)
+
     # get log output
     logs = caplog.record_tuples
 
     # there's a log but the log level is not None (problem)
-    if logs and not log_level_expected:
+    if logs and not log_level_expected_int:
         raise Exception
 
     # we expect a log but none is given (problem)
-    if log_level_expected and not logs:
+    if log_level_expected_int and not logs:
         raise Exception
 
     # both expected and got log, check the log levels match
     if logs and log_level_expected:
         for log in logs:
             log_level = log[1]
-            if log_level == log_level_expected:
+            if log_level == log_level_expected_int:
                 # log level was triggered, exit
                 return
         raise Exception


### PR DESCRIPTION
Makes it more intuitive and easier to write tests that we want to warn, log, etc.