### PR TITLE
multi-objective adjoint through `adjoint.async_run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Asynchronous running of multiple simulations using `web.run_async`.
+- Asynchronous running of multiple simulations concurrently using `web.run_async`.
+- Jax-compatible `run_async` in the `adjoint` plugin for efficiently running multi-simulation objectives concurrently and differentiating result.
 - Warning in `Simulation.epsilon` if many grid cells and structures provided and slow run time expected as a result.
 - Warning if PML or absorbing boundaries are used along a simulation dimension with zero size.
 

--- a/requirements/basic.txt
+++ b/requirements/basic.txt
@@ -12,3 +12,4 @@ pydantic>=1.10.0
 PyYAML
 dask
 toml
+nest_asyncio

--- a/tests/_test_local/_test_web.py
+++ b/tests/_test_local/_test_web.py
@@ -273,7 +273,7 @@ def _test_batch_8_delete():
 
 
 @clear_tmp
-def atest_web_run_async():
+def test_web_run_async():
     """test complete run"""
     sims = 2 * [sim_original]
     batch_data = web.run_async(sims)

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -210,6 +210,7 @@ def test_adjoint_setup_fwd(use_emulated_run):
         folder_name="default",
         path="simulation_data.hdf5",
         callback_url=None,
+        verbose=False,
     )
     sim_orig = sim_data_orig.simulation
     sim_fwd = sim_data_fwd.simulation

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -16,15 +16,12 @@ from typing import Tuple, Any
 from tidy3d.log import DataError, Tidy3dKeyError
 from tidy3d.plugins.adjoint.components.base import JaxObject
 from tidy3d.plugins.adjoint.components.geometry import JaxBox, JaxPolySlab
-from tidy3d.plugins.adjoint.components.medium import (
-    JaxMedium,
-    JaxAnisotropicMedium,
-    JaxCustomMedium,
-)
+from tidy3d.plugins.adjoint.components.medium import JaxMedium, JaxAnisotropicMedium
+from tidy3d.plugins.adjoint.components.medium import JaxCustomMedium
 from tidy3d.plugins.adjoint.components.structure import JaxStructure
 from tidy3d.plugins.adjoint.components.simulation import JaxSimulation
 from tidy3d.plugins.adjoint.components.data.sim_data import JaxSimulationData
-from tidy3d.plugins.adjoint.components.data.monitor_data import JaxModeData
+from tidy3d.plugins.adjoint.components.data.monitor_data import JaxModeData, JaxDiffractionData
 from tidy3d.plugins.adjoint.components.data.data_array import JaxDataArray
 from tidy3d.plugins.adjoint.components.data.dataset import JaxPermittivityDataset
 from tidy3d.plugins.adjoint.web import run, run_async
@@ -724,3 +721,44 @@ def test_adjoint_run_async(use_emulated_run_async):
     f0 = f(x0)
     g = jax.grad(f)
     g0 = g(x0)
+
+
+@pytest.mark.parametrize("axis", (0, 1, 2))
+def test_diff_data_angles(axis):
+
+    center = td.DiffractionMonitor.unpop_axis(2, (0, 0), axis)
+    size = td.DiffractionMonitor.unpop_axis(0, (td.inf, td.inf), axis)
+
+    SIZE_2D = 1.0
+    ORDERS_X = [-1, 0, 1]
+    ORDERS_Y = [-1, 0, 1]
+    FS = [2e14]
+
+    DIFFRACTION_MONITOR = td.DiffractionMonitor(
+        center=center,
+        size=size,
+        freqs=FS,
+        name="diffraction",
+    )
+
+    values = (1 + 1j) * np.random.random((len(ORDERS_X), len(ORDERS_Y), len(FS)))
+    sim_size = [SIZE_2D, SIZE_2D]
+    bloch_vecs = [0, 0]
+    data = JaxDataArray(values=values, coords=dict(orders_x=ORDERS_X, orders_y=ORDERS_Y, f=FS))
+
+    diff_data = JaxDiffractionData(
+        monitor=DIFFRACTION_MONITOR,
+        Etheta=data,
+        Ephi=data,
+        Er=data,
+        Htheta=data,
+        Hphi=data,
+        Hr=data,
+        sim_size=sim_size,
+        bloch_vecs=bloch_vecs,
+    )
+
+    thetas, phis = diff_data.angles
+    zeroth_order_theta = thetas.sel(orders_x=0, orders_y=0).isel(f=0)
+
+    assert np.isclose(zeroth_order_theta, 0.0)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,10 +1,12 @@
 import os
 from pathlib import Path
+from typing import Dict
 
 import numpy as np
 from tidy3d import *
 import tidy3d as td
 from tidy3d.log import _get_level_int
+from tidy3d.web import BatchData
 
 
 """ utilities shared between all tests """
@@ -361,6 +363,11 @@ def run_emulated(simulation: Simulation, **kwargs) -> SimulationData:
     data = [MONITOR_MAKER_MAP[type(mnt)](mnt) for mnt in simulation.monitors]
 
     return SimulationData(simulation=simulation, data=data)
+
+
+def run_async_emulated(simulations: Dict[str, Simulation], **kwargs) -> BatchData:
+    """Emulate an async run function."""
+    return {task_name: run_emulated(sim) for task_name, sim in simulations.items()}
 
 
 def assert_log_level(caplog, log_level_expected: str):

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -1661,6 +1661,10 @@ class DiffractionData(AbstractFieldProjectionData):
         the power carried by the wave of that order and polarization equals ``abs(amps)^2``.
         """
         cos_theta = np.cos(np.nan_to_num(self.angles[0]))
+
+        # will set amplitudes to 0 for glancing or negative angles
+        cos_theta[cos_theta <= 0] = np.inf
+
         norm = 1.0 / np.sqrt(2.0 * self.eta) / np.sqrt(cos_theta)
         amp_theta = self.Etheta.values * norm
         amp_phi = self.Ephi.values * norm

--- a/tidy3d/plugins/adjoint/__init__.py
+++ b/tidy3d/plugins/adjoint/__init__.py
@@ -2,7 +2,7 @@
 
 # import the jax version of tidy3d components
 try:
-    from .web import run
+    from .web import run, run_async
     from .components.geometry import JaxBox, JaxPolySlab
     from .components.medium import JaxMedium, JaxAnisotropicMedium, JaxCustomMedium
     from .components.structure import JaxStructure

--- a/tidy3d/plugins/adjoint/components/data/monitor_data.py
+++ b/tidy3d/plugins/adjoint/components/data/monitor_data.py
@@ -22,6 +22,10 @@ from ..base import JaxObject
 from ...log import AdjointError
 
 
+# small amount to add to cos_theta in JaxDiffractionData angles to avoid warnings
+EPSILON_ANGLE = 1e-6
+
+
 class JaxMonitorData(MonitorData, JaxObject, ABC):
     """A :class:`.MonitorData` that we regsiter with jax."""
 
@@ -229,7 +233,7 @@ class JaxDiffractionData(JaxMonitorData, DiffractionData):
 
         # compute angles and normalization factors
         theta_angles = jnp.array(self.angles[0].values)
-        cos_theta = np.cos(np.nan_to_num(theta_angles))
+        cos_theta = np.cos(np.nan_to_num(theta_angles)) + EPSILON_ANGLE
         norm = 1.0 / np.sqrt(2.0 * self.eta) / np.sqrt(cos_theta)
 
         # stack the amplitudes in s- and p-components along a new polarization axis

--- a/tidy3d/plugins/adjoint/components/data/monitor_data.py
+++ b/tidy3d/plugins/adjoint/components/data/monitor_data.py
@@ -22,10 +22,6 @@ from ..base import JaxObject
 from ...log import AdjointError
 
 
-# small amount to add to cos_theta in JaxDiffractionData angles to avoid warnings
-EPSILON_ANGLE = 1e-6
-
-
 class JaxMonitorData(MonitorData, JaxObject, ABC):
     """A :class:`.MonitorData` that we regsiter with jax."""
 
@@ -233,7 +229,8 @@ class JaxDiffractionData(JaxMonitorData, DiffractionData):
 
         # compute angles and normalization factors
         theta_angles = jnp.array(self.angles[0].values)
-        cos_theta = np.cos(np.nan_to_num(theta_angles)) + EPSILON_ANGLE
+        cos_theta = np.cos(np.nan_to_num(theta_angles))
+        cos_theta[cos_theta <= 0] = np.inf
         norm = 1.0 / np.sqrt(2.0 * self.eta) / np.sqrt(cos_theta)
 
         # stack the amplitudes in s- and p-components along a new polarization axis

--- a/tidy3d/plugins/adjoint/web.py
+++ b/tidy3d/plugins/adjoint/web.py
@@ -1,5 +1,5 @@
 """Adjoint-specific webapi."""
-from typing import Tuple
+from typing import Tuple, Dict
 from functools import partial
 
 from jax import custom_vjp
@@ -7,6 +7,8 @@ from jax import custom_vjp
 from ...components.simulation import Simulation
 from ...components.data.sim_data import SimulationData
 from ...web.webapi import run as web_run
+from ...web.queue import run_async as web_run_async
+from ...web.container import BatchData, DEFAULT_DATA_DIR
 
 from .components.simulation import JaxSimulation
 from .components.data.sim_data import JaxSimulationData
@@ -14,17 +16,25 @@ from .components.data.sim_data import JaxSimulationData
 
 def _task_name_fwd(task_name: str) -> str:
     """task name for forward run as a function of the original task name."""
-    return task_name + "_fwd"
+    return str(task_name) + "_fwd"
 
 
 def _task_name_adj(task_name: str) -> str:
     """task name for adjoint run as a function of the original task name."""
-    return task_name + "_adj"
+    return str(task_name) + "_adj"
 
 
 def tidy3d_run_fn(simulation: Simulation, task_name: str, **kwargs) -> SimulationData:
     """Run a regular :class:`.Simulation` after conversion from jax type."""
     return web_run(simulation=simulation, task_name=task_name, **kwargs)
+
+
+def tidy3d_run_async_fn(simulations: Dict[str, Simulation], **kwargs) -> BatchData:
+    """Run a set of regular :class:`.Simulation` objects after conversion from jax type."""
+    return web_run_async(simulations=simulations, **kwargs)
+
+
+""" Running a single simulation using web.run. """
 
 
 @partial(custom_vjp, nondiff_argnums=tuple(range(1, 5)))
@@ -35,7 +45,29 @@ def run(
     path: str = "simulation_data.hdf5",
     callback_url: str = None,
 ) -> JaxSimulationData:
-    """Mocking original web.run function, using regular tidy3d components."""
+    """Submits a :class:`.JaxSimulation` to server, starts running, monitors progress, downloads,
+    and loads results as a :class:`.JaxSimulationData` object.
+    Can be included within a function that will have ``jax.grad`` applied.
+
+    Parameters
+    ----------
+    simulation : :class:`.JaxSimulation`
+        Simulation to upload to server.
+    task_name : str
+        Name of task.
+    path : str = "simulation_data.hdf5"
+        Path to download results file (.hdf5), including filename.
+    folder_name : str = "default"
+        Name of folder to store task on web UI.
+    callback_url : str = None
+        Http PUT url to receive simulation finish event. The body content is a json file with
+        fields ``{'id', 'status', 'name', 'workUnit', 'solverVersion'}``.
+
+    Returns
+    -------
+    :class:`.JaxSimulationData`
+        Object containing solver results for the supplied :class:`.JaxSimulation`.
+    """
 
     # convert to regular tidy3d (and accounting info)
     sim_tidy3d, jax_info = simulation.to_simulation()
@@ -43,7 +75,7 @@ def run(
     # run using regular tidy3d simulation running fn
     sim_data_tidy3d = tidy3d_run_fn(
         simulation=sim_tidy3d,
-        task_name=task_name,
+        task_name=str(task_name),
         folder_name=folder_name,
         path=path,
         callback_url=callback_url,
@@ -114,3 +146,180 @@ def run_bwd(
 
 # register the custom forward and backward functions
 run.defvjp(run_fwd, run_bwd)
+
+
+""" Running a batch of simulations using web.run_async. """
+
+
+def _task_name_orig(index: int, task_name_suffix: str = None):
+    """Task name as function of index into simulations. Note: for original must be int."""
+    if task_name_suffix is not None:
+        return f"{index}{task_name_suffix}"
+    return int(index)
+
+
+# pylint:disable=too-many-locals
+@partial(custom_vjp, nondiff_argnums=tuple(range(1, 6)))
+def run_async(
+    simulations: Tuple[JaxSimulation, ...],
+    folder_name: str = "default",
+    path_dir: str = DEFAULT_DATA_DIR,
+    callback_url: str = None,
+    num_workers: int = None,
+    task_name_suffix: str = None,
+) -> Tuple[JaxSimulationData, ...]:
+    """Submits a set of :class:`.JaxSimulation` objects to server, starts running,
+    monitors progress, downloads, and loads results
+    as a tuple of :class:`.JaxSimulationData` objects.
+    Uses ``asyncio`` to perform these steps asynchronously.
+
+    Parameters
+    ----------
+    simulations : Tuple[:class:`.JaxSimulation`, ...]
+        Mapping of task name to simulation.
+    folder_name : str = "default"
+        Name of folder to store each task on web UI.
+    path_dir : str
+        Base directory where data will be downloaded, by default current working directory.
+    callback_url : str = None
+        Http PUT url to receive simulation finish event. The body content is a json file with
+        fields ``{'id', 'status', 'name', 'workUnit', 'solverVersion'}``.
+    num_workers: int = None
+        Number of tasks to submit at once in a batch, if None, will run all at the same time.
+
+    Note
+    ----
+    This is an experimental feature and may not work on all systems or configurations.
+    For more details, see ``https://realpython.com/async-io-python/``.
+
+    Returns
+    ------
+    Tuple[:class:`JaxSimulationData, ...]
+        Contains the :class:`.JaxSimulationData` of each :class:`.JaxSimulation`.
+    """
+
+    simulations = {_task_name_orig(i, task_name_suffix): sim for i, sim in enumerate(simulations)}
+
+    task_info = {task_name: jax_sim.to_simulation() for task_name, jax_sim in simulations.items()}
+
+    # TODO: anyone know a better syntax for this?
+    sims_tidy3d = {str(task_name): sim for task_name, (sim, _) in task_info.items()}
+    jax_infos = {str(task_name): jax_info for task_name, (_, jax_info) in task_info.items()}
+
+    # run using regular tidy3d simulation running fn
+    batch_data_tidy3d = tidy3d_run_async_fn(
+        simulations=sims_tidy3d,
+        folder_name=folder_name,
+        path_dir=path_dir,
+        callback_url=callback_url,
+        num_workers=num_workers,
+    )
+
+    # convert back to jax type and return
+    task_name_suffix = "" if task_name_suffix is None else task_name_suffix
+    jax_batch_data = []
+    for i in range(len(simulations)):
+        task_name = _task_name_orig(i, task_name_suffix)
+        sim_data_tidy3d = batch_data_tidy3d[task_name]
+        jax_info = jax_infos[str(task_name)]
+        jax_sim_data = JaxSimulationData.from_sim_data(sim_data_tidy3d, jax_info=jax_info)
+        jax_batch_data.append(jax_sim_data)
+
+    return jax_batch_data
+
+
+# pylint:disable=too-many-locals, unused-argument
+def run_async_fwd(
+    simulations: Tuple[JaxSimulation, ...],
+    folder_name: str,
+    path_dir: str,
+    callback_url: str,
+    num_workers: int,
+    task_name_suffix: str,
+) -> Tuple[Dict[str, JaxSimulationData], tuple]:
+    """Run forward pass and stash extra objects for the backwards pass."""
+
+    task_name_suffix_fwd = _task_name_fwd("")
+
+    sims_fwd = []
+    for simulation in simulations:
+        grad_mnts = simulation.get_grad_monitors()
+        sim_fwd = simulation.updated_copy(**grad_mnts)
+        sims_fwd.append(sim_fwd)
+
+    batch_data_fwd = run_async(
+        simulations=sims_fwd,
+        folder_name=folder_name,
+        path_dir=path_dir,
+        callback_url=callback_url,
+        num_workers=num_workers,
+        task_name_suffix=task_name_suffix_fwd,
+    )
+
+    # remove the gradient data from the returned version (not needed)
+    batch_data_orig = []
+    for i, sim_data_fwd in enumerate(batch_data_fwd):
+        sim_orig = simulations[i]
+        sim_data_orig = sim_data_fwd.copy(update=dict(grad_data=(), simulation=sim_orig))
+        batch_data_orig.append(sim_data_orig)
+
+    return batch_data_orig, (batch_data_fwd,)
+
+
+# pylint:disable=too-many-arguments, too-many-locals, unused-argument
+def run_async_bwd(
+    folder_name: str,
+    path_dir: str,
+    callback_url: str,
+    num_workers: int,
+    task_name_suffix: str,
+    res: tuple,
+    batch_data_vjp: Tuple[JaxSimulationData, ...],
+) -> Tuple[Dict[str, JaxSimulation]]:
+    """Run backward pass and return simulation storing vjp of the objective w.r.t. the sim."""
+
+    # grab the forward simulation and its gradient monitor data
+    (batch_data_fwd,) = res
+
+    task_name_suffix_adj = _task_name_adj("")
+
+    grad_data_fwd = {}
+    grad_eps_data_fwd = {}
+
+    for i, sim_data_fwd in enumerate(batch_data_fwd):
+        grad_data_fwd[i] = sim_data_fwd.grad_data
+        grad_eps_data_fwd[i] = sim_data_fwd.grad_eps_data
+
+    # make and run adjoint simulation
+    sims_adj = []
+    for i, sim_data_fwd in enumerate(batch_data_fwd):
+        fwidth_adj = sim_data_fwd.simulation._fwidth_adjoint  # pylint:disable=protected-access
+        sim_data_vjp = batch_data_vjp[i]
+        sim_adj = sim_data_vjp.make_adjoint_simulation(fwidth=fwidth_adj)
+        sims_adj.append(sim_adj)
+
+    batch_data_adj = run_async(
+        simulations=sims_adj,
+        folder_name=folder_name,
+        path_dir=path_dir,
+        callback_url=callback_url,
+        num_workers=num_workers,
+        task_name_suffix=task_name_suffix_adj,
+    )
+
+    sims_vjp = []
+    for i, (sim_data_fwd, sim_data_adj) in enumerate(zip(batch_data_fwd, batch_data_adj)):
+
+        grad_data_fwd = sim_data_fwd.grad_data
+        grad_data_adj = sim_data_adj.grad_data
+        grad_data_eps_fwd = sim_data_fwd.grad_eps_data
+
+        sim_data_vjp = batch_data_vjp[i]
+        sim_vjp = sim_data_vjp.simulation.store_vjp(grad_data_fwd, grad_data_adj, grad_data_eps_fwd)
+        sims_vjp.append(sim_vjp)
+
+    return (sims_vjp,)
+
+
+# register the custom forward and backward functions
+run_async.defvjp(run_async_fwd, run_async_bwd)

--- a/tidy3d/web/queue.py
+++ b/tidy3d/web/queue.py
@@ -11,13 +11,14 @@ from ..components.simulation import Simulation
 nest_asyncio.apply()
 
 
+# pylint:disable=too-many-arguments, too-many-locals
 async def _run_async(
     simulations: Dict[str, Simulation],
     folder_name: str = "default",
     path_dir: str = DEFAULT_DATA_DIR,
     callback_url: str = None,
     num_workers: int = None,
-    # verbose: bool = True,
+    verbose: bool = True,
 ) -> BatchData:
     """Submits a set of :class:`.Simulation` objects to server, starts running,
     monitors progress, downloads, and loads results as a :class:`.BatchData` object.
@@ -36,6 +37,8 @@ async def _run_async(
         fields ``{'id', 'status', 'name', 'workUnit', 'solverVersion'}``.
     num_workers: int = None
         Number of tasks to submit at once in a batch, if None, will run all at the same time.
+    verbose : bool = True
+        If `True`, will print progressbars and status, otherwise, will run silently.
 
     Note
     ----
@@ -88,7 +91,7 @@ async def _run_async(
             task_name=task_name,
             callback_url=callback_url,
             folder_name=folder_name,
-            # verbose=verbose,
+            verbose=verbose,
         )
         job.start()
 
@@ -116,16 +119,17 @@ async def _run_async(
     await asyncio.gather(*tasks, return_exceptions=True)
 
     # return the batch data containing all of the job run details for loading later
-    return BatchData(task_ids=task_ids, task_paths=task_paths)
+    return BatchData(task_ids=task_ids, task_paths=task_paths, verbose=verbose)
 
 
+# pylint:disable=too-many-arguments
 def run_async(
     simulations: Dict[str, Simulation],
     folder_name: str = "default",
     path_dir: str = DEFAULT_DATA_DIR,
     callback_url: str = None,
     num_workers: int = None,
-    # verbose: bool = True,
+    verbose: bool = True,
 ) -> BatchData:
     """Submits a set of :class:`.Simulation` objects to server, starts running,
     monitors progress, downloads, and loads results as a :class:`.BatchData` object.
@@ -144,6 +148,8 @@ def run_async(
         fields ``{'id', 'status', 'name', 'workUnit', 'solverVersion'}``.
     num_workers: int = None
         Number of tasks to submit at once in a batch, if None, will run all at the same time.
+    verbose : bool = True
+        If `True`, will print progressbars and status, otherwise, will run silently.
 
     Note
     ----
@@ -163,5 +169,6 @@ def run_async(
             path_dir=path_dir,
             callback_url=callback_url,
             num_workers=num_workers,
+            verbose=verbose,
         )
     )


### PR DESCRIPTION
Introduces a new function into the adjoint webapi called `async_run`, which accepts a tuple of `JaxSimulation` objects and runs them asynchronously using the `tidy3d.web.async_run` function.

This enables functions like:

```py
def objective(x) -> float
    """A multi-frequency objective."""
    sims = [make_sim(x, freq) for freq in freqs]
    sim_datas = async_run(sims)
    return jnp.sum([post_process(sim_data) for sim_data in sim_datas])
```

to be differentiated.

Note, this PR changes the behavior of the `web.run_async` function introduced in #702 as it makes this function no longer asynchronous to the user, meaning they can use as normal without needing to `await` the result.