### PR TITLE
fix determinant warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Progressbars always set to 100% when webapi functions are finished.
 - Faster handling of `Geometry.intersects` and `Geometry.inside` by taking into account geometry bounds.
+- Numpy divide by zero warning in mode solver fixed by initializing jacobians as real instead of complex.
 
 
 ## [1.9.0rc2] - 2023-2-17

--- a/tidy3d/plugins/mode/solver.py
+++ b/tidy3d/plugins/mode/solver.py
@@ -81,8 +81,8 @@ def compute_modes(
         mu_tensor[dim, dim, :] = 1.0
 
     # Get Jacobian of all coordinate transformations. Initialize as identity (same as mu so far)
-    jac_e = np.copy(mu_tensor)
-    jac_h = np.copy(mu_tensor)
+    jac_e = np.real(np.copy(mu_tensor))
+    jac_h = np.real(np.copy(mu_tensor))
 
     if bend_radius is not None:
         new_coords, jac_e, jac_h = radial_transform(new_coords, bend_radius, bend_axis)


### PR DESCRIPTION
I was getting a lot of divide by zero warnings in the `np.linalg.det` calls from the mode solver.

Digging into the issue, I found it was because taking a determinant of a complex-valued identity matrix triggers this warning, which was the case for the jacobians in the mode solver that were being passed to `np.linalg.det`.

```py
import numpy as np
arr = np.eye(3) + 0j
np.linalg.det(arr)
```

```
/Users/twhughes/.pyenv/versions/3.10.9/lib/python3.10/site-packages/numpy/linalg/linalg.py:2139: RuntimeWarning: divide by zero encountered in det
  r = _umath_linalg.det(a, signature=signature)
/Users/twhughes/.pyenv/versions/3.10.9/lib/python3.10/site-packages/numpy/linalg/linalg.py:2139: RuntimeWarning: invalid value encountered in det
```

To fix this, I casted the jacobians to`np.real`.

@momchil-flex @weiliangjin2021 @dbochkov-flexcompute is this safe you think? or worth worrying about? I tried filtering the warning but don't know if we want to do that more generally in case we should be worrying about this.