### PR TITLE
Add arrow curvature to sources and monitors with bend radius (#272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Saving and loading of `.hdf5` files is made orders of magnitude faster due to an internal refactor.
+### Changed
+- Sources and monitors with bend radii are displayed with curved arrows.
+
 ## [1.8.4] - 2023-2-13
 
 ### Fixed

--- a/tidy3d/components/viz.py
+++ b/tidy3d/components/viz.py
@@ -6,7 +6,7 @@ from typing import Any
 from functools import wraps
 
 import matplotlib.pylab as plt
-from matplotlib.patches import PathPatch
+from matplotlib.patches import PathPatch, ArrowStyle
 from matplotlib.path import Path
 from numpy import array, concatenate, ones
 import pydantic as pd
@@ -25,14 +25,8 @@ ARROW_COLOR_POLARIZATION = "brown"
 ARROW_ALPHA = 0.8
 
 
-# this times the min of axis height and width gives the arrow length
-ARROW_LENGTH_FACTOR = 0.1
-
-# this times ARROW_LENGTH gives width
-ARROW_WIDTH_FACTOR = 0.4
-
-# arrow width cannot be larger than this factor times the max of axis height and width
-MAX_ARROW_WIDTH_FACTOR = 0.02
+# Arrow length in inches
+ARROW_LENGTH = 0.3
 
 
 """ Decorators """
@@ -132,6 +126,10 @@ MEDIUM_CMAP = [
 
 # colormap for structure's permittivity in plot_eps
 STRUCTURE_EPS_CMAP = "gist_yarg"
+
+# default arrow style
+arrow_style = ArrowStyle.Simple(head_length=12, head_width=9, tail_width=4)
+
 
 """=================================================================================================
 Descartes modified from https://pypi.org/project/descartes/ for Shapely >= 1.8.0


### PR DESCRIPTION
Curved arrows are only possible through FancyArrowPatch, but those define the arrow head size in display coordinates and end points in data coordinates.  Furthermore, the arrow head is included in the total length, as opposed to what happens with Axes.arrow, that was used before.  The result is that the arrow length calculated based on the axes limits or simulation boundaries can end up too small for the arrow head (and for visualization as well).

The solution here, which might actually be preferable even without the bending, is to define the arrow size in real units (inches, following matplotlib's DPI setting) so that the arrows are always the same size. That can only be accomplished by waiting for the transformations to be set, at drawing time, so we use a `draw_event` callback to calculate the arrow shape.

If the drawing window is resized, the arrow length will change, though, because the callback is only called once (to avoid the danger of inifite loops).