### PR TITLE
Small conceptual change to constants definitions

### DIFF
--- a/tidy3d/constants.py
+++ b/tidy3d/constants.py
@@ -13,10 +13,10 @@ Attributes:
 
 import numpy as np
 
-# fundamental constants
-EPSILON_0 = 8.85418782e-18
-MU_0 = 1.25663706e-12
-C_0 = 1 / np.sqrt(EPSILON_0 * MU_0)
+# fundamental constants (https://physics.nist.gov)
+C_0 = 2.99792458e14
+MU_0 = 1.25663706212e-12
+EPSILON_0 = 1 / (MU_0 * C_0**2)
 
 #: Free space impedance
 ETA_0 = np.sqrt(MU_0 / EPSILON_0)


### PR DESCRIPTION
The speed of light in vacuum has an exactly defined value, whereas the vacuum permittivity and permeability are measured to a certain precision.  It is usual to use the exact value of the speed of light and the permeability to calculate the permittivity.

(This is very minor, but I felt like changing to be more accurate, since I was looking into the inner works of the mode solver.)