### PR TITLE
2D Materials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SimulationData.plot_field` accepts new field componets and values, including the Poynting vector.
 - `SimulationData.get_poynting_vector` for calculating the 3D Poynting vector at the Yee cell centers.
 - Post init validation of Tidy3D components.
+- `Medium2D` class for surface conductivity model of a 2D material.
+- Entries in `material_library` for graphene and some common TMDs.
+- Ability to create a 2D representation of a thin 3D metal.
+- `AutoGrid` for 2D materials.
 
 ### Changed
 - `export_matlib_to_file` in `material_library` exports material's full name in additional to abbreviation.

--- a/tests/test_components/test_grid_spec.py
+++ b/tests/test_components/test_grid_spec.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 
 import tidy3d as td
-from tidy3d.exceptions import SetupError
+from tidy3d.exceptions import SetupError, ValidationError
 
 
 def make_grid_spec():
@@ -84,3 +84,73 @@ def test_auto_grid_from_sources():
         sources=[src],
         num_pml_layers=((10, 10), (0, 5), (0, 0)),
     )
+
+
+RTOL = 0.01
+
+
+def test_autogrid_2dmaterials():
+    sigma = 0.45
+    thickness = 0.01
+    medium = td.Medium2D.from_medium(td.Medium(conductivity=sigma), thickness=thickness)
+    grid_dl = 0.03
+    box = td.Structure(geometry=td.Box(size=(td.inf, td.inf, 0), center=(0, 0, 1)), medium=medium)
+    src = td.UniformCurrentSource(
+        source_time=td.GaussianPulse(freq0=1.5e14, fwidth=0.5e14),
+        size=(0, 0, 0),
+        polarization="Ex",
+    )
+    sim = td.Simulation(
+        size=(10, 10, 10),
+        structures=[box],
+        sources=[src],
+        boundary_spec=td.BoundarySpec(
+            x=td.Boundary.pml(num_layers=5),
+            y=td.Boundary.pml(num_layers=5),
+            z=td.Boundary.pml(num_layers=5),
+        ),
+        grid_spec=td.GridSpec.auto(),
+        run_time=1e-12,
+    )
+    assert np.isclose(sim.volumetric_structures[0].geometry.center[2], 1, rtol=RTOL)
+    grid_dl = sim.discretize(box.geometry).sizes.z[0]
+    assert np.isclose(sim.volumetric_structures[0].geometry.size[2], grid_dl, rtol=RTOL)
+
+    # now if we increase conductivity, the in-plane grid size should decrease
+    sigma2 = 4.5
+    medium2 = td.Medium2D.from_medium(td.Medium(conductivity=sigma2), thickness=thickness)
+    box2 = td.Structure(geometry=td.Box(size=(td.inf, td.inf, 0), center=(0, 0, 1)), medium=medium2)
+
+    sim2 = td.Simulation(
+        size=(10, 10, 10),
+        structures=[box2],
+        sources=[src],
+        boundary_spec=td.BoundarySpec(
+            x=td.Boundary.pml(num_layers=5),
+            y=td.Boundary.pml(num_layers=5),
+            z=td.Boundary.pml(num_layers=5),
+        ),
+        grid_spec=td.GridSpec.auto(),
+        run_time=1e-12,
+    )
+    grid_dl1_inplane = sim.discretize(box.geometry).sizes.x[0]
+    grid_dl2_inplane = sim2.discretize(box2.geometry).sizes.x[0]
+    assert grid_dl1_inplane > grid_dl2_inplane
+
+    # should error if two 2d materials have different normals and both autogrid
+    box2 = td.Structure(geometry=td.Box(size=(td.inf, 0, td.inf), center=(0, 0, 1)), medium=medium)
+    sim = td.Simulation(
+        size=(10, 10, 10),
+        structures=[box, box2],
+        sources=[src],
+        boundary_spec=td.BoundarySpec(
+            x=td.Boundary.pml(num_layers=5),
+            y=td.Boundary.pml(num_layers=5),
+            z=td.Boundary.pml(num_layers=5),
+        ),
+        grid_spec=td.GridSpec.auto(),
+        run_time=1e-12,
+    )
+
+    with pytest.raises(ValidationError):
+        _ = sim.grid

--- a/tests/test_components/test_grid_spec.py
+++ b/tests/test_components/test_grid_spec.py
@@ -135,7 +135,8 @@ def test_autogrid_2dmaterials():
     )
     grid_dl1_inplane = sim.discretize(box.geometry).sizes.x[0]
     grid_dl2_inplane = sim2.discretize(box2.geometry).sizes.x[0]
-    assert grid_dl1_inplane > grid_dl2_inplane
+    # This is commented out until inplane AutoGrid for 2D materials is enabled
+    # assert grid_dl1_inplane > grid_dl2_inplane
 
     # should error if two 2d materials have different normals and both autogrid
     box2 = td.Structure(geometry=td.Box(size=(td.inf, 0, td.inf), center=(0, 0, 1)), medium=medium)
@@ -152,5 +153,6 @@ def test_autogrid_2dmaterials():
         run_time=1e-12,
     )
 
-    with pytest.raises(ValidationError):
-        _ = sim.grid
+    # Commented until inplane AutoGrid for 2D materials is enabled
+    # with pytest.raises(ValidationError):
+    #    _ = sim.grid

--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -19,6 +19,8 @@ MEDIUMS = [MEDIUM, ANIS_MEDIUM, PEC, PR, SM, LZ, DR, DB]
 
 f, AX = plt.subplots()
 
+RTOL = 0.001
+
 
 @pytest.mark.parametrize("component", MEDIUMS)
 def test_plot(component):
@@ -263,3 +265,28 @@ def test_n_cfl():
     assert material.n_cfl == 2
     material = td.Debye(eps_inf=4, coeffs=[(1, 2)])
     assert material.n_cfl == 2
+
+
+def test_medium2d():
+    sigma = 0.45
+    thickness = 0.01
+    cond_med = td.Medium(conductivity=sigma)
+    medium = td.Medium2D.from_medium(cond_med, thickness=thickness)
+
+    _ = medium.plot(freqs=[2e14, 3e14], ax=AX)
+    _ = medium.plot_sigma(freqs=[2e14, 3e14], ax=AX)
+    assert np.isclose(medium.ss.to_medium().conductivity, sigma * thickness, rtol=RTOL)
+    aniso_medium = td.AnisotropicMedium(xx=td.Medium(permittivity=2), yy=cond_med, zz=td.Medium())
+    medium = td.Medium2D.from_anisotropic_medium(aniso_medium, axis=2, thickness=thickness)
+    medium3d = medium.to_anisotropic_medium(axis=2, thickness=1.5 * thickness)
+    assert np.isclose(medium3d.xx.to_medium().permittivity, 1 + (2 - 1) / 1.5, rtol=RTOL)
+    assert np.isclose(medium3d.yy.to_medium().conductivity, sigma / 1.5, rtol=RTOL)
+    assert np.isclose(medium3d.zz.permittivity, 1, rtol=RTOL)
+    assert np.isclose(
+        medium.to_medium(thickness=1.5 * thickness).conductivity, sigma / 3, rtol=RTOL
+    )
+    assert np.isclose(
+        medium.to_pole_residue(thickness=1.5 * thickness).to_medium().conductivity,
+        sigma / 3,
+        rtol=RTOL,
+    )

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -1459,7 +1459,7 @@ def test_sim_volumetric_structures():
     assert np.isclose(sim.volumetric_structures[1].medium.xx.permittivity, 2, rtol=RTOL)
 
     # test simulation.medium can't be Medium2D
-    with pytest.raises(ValidationError):
+    with pytest.raises(Exception):
         sim = td.Simulation(
             size=(10, 10, 10),
             structures=[],
@@ -1475,14 +1475,14 @@ def test_sim_volumetric_structures():
         )
 
     # test 2d medium is added to 2d geometry
-    with pytest.raises(ValidationError):
+    with pytest.raises(Exception):
         _ = td.Structure(geometry=td.Box(center=(0, 0, 0), size=(1, 1, 1)), medium=box.medium)
-    with pytest.raises(ValidationError):
+    with pytest.raises(Exception):
         _ = td.Structure(geometry=td.Cylinder(radius=1, length=1), medium=box.medium)
-    with pytest.raises(ValidationError):
+    with pytest.raises(Exception):
         _ = td.Structure(
             geometry=td.PolySlab(vertices=[(0, 0), (1, 0), (1, 1)], slab_bounds=(-1, 1)),
             medium=box.medium,
         )
-    with pytest.raises(ValidationError):
+    with pytest.raises(Exception):
         _ = td.Structure(geometry=td.Sphere(radius=1), medium=box.medium)

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -1342,7 +1342,6 @@ def test_dt():
     )
     sim_new = sim.copy(update=dict(structures=[structure]))
     assert sim_new.dt == 0.4 * dt
-    assert_log_level(caplog, log_level)
 
 
 def test_sim_volumetric_structures():

--- a/tests/test_package/test_material_library.py
+++ b/tests/test_package/test_material_library.py
@@ -45,6 +45,8 @@ def test_MaterialItem():
 def test_library():
     """for each member of material library, ensure that it evaluates eps_model correctly"""
     for material_name, material in material_library.items():
+        if isinstance(material, type):
+            continue
         for variant_name, variant in material.variants.items():
             if variant.medium.frequency_range:
                 fmin, fmax = variant.medium.frequency_range

--- a/tests/test_package/test_parametric_variants.py
+++ b/tests/test_package/test_parametric_variants.py
@@ -1,0 +1,41 @@
+import pytest
+import numpy as np
+
+from tidy3d.material_library.material_library import material_library
+from tidy3d.material_library.parametric_materials import Graphene
+import tidy3d as td
+
+from numpy.random import default_rng
+
+
+# tolerance
+ATOL = 1e-5
+
+
+@pytest.mark.parametrize("rng_seed", np.arange(0, 4))
+def test_graphene(rng_seed):
+    """test graphene for range of physical parameters"""
+    rng = default_rng(rng_seed)
+    gamma_min = 1e-5
+    gamma_max = 1e-2
+    mu_min = 0
+    mu_max = 0.5
+    temp_min = 200
+    temp_max = 1000
+
+    freqs = np.linspace(1e12, 1e15, 1000)
+
+    gamma = gamma_min + (gamma_max - gamma_min) * rng.random()
+    mu_c = mu_min + (mu_max - mu_min) * rng.random()
+    temp = temp_min + (temp_max - temp_min) * rng.random()
+
+    graphene = Graphene(gamma=gamma, mu_c=mu_c, temp=temp)
+    sigma1 = graphene.medium.sigma_model(freqs)
+    sigma2 = graphene.numerical_conductivity(freqs)
+
+    assert np.allclose(sigma1, sigma2, rtol=0, atol=ATOL)
+
+    graphene = Graphene(gamma=gamma, mu_c=mu_c, temp=temp, include_interband=False)
+    sigma1 = graphene.medium.sigma_model(freqs)
+    sigma2 = graphene.intraband_drude.sigma_model(freqs)
+    assert np.allclose(sigma1, sigma2, rtol=0, atol=ATOL)

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -9,7 +9,7 @@ from .components.geometry import Box, Sphere, Cylinder, PolySlab, GeometryGroup
 from .components.geometry import TriangleMesh
 
 # medium
-from .components.medium import Medium, PoleResidue, AnisotropicMedium, PEC, PECMedium
+from .components.medium import Medium, PoleResidue, AnisotropicMedium, PEC, PECMedium, Medium2D
 from .components.medium import Sellmeier, Debye, Drude, Lorentz
 from .components.medium import CustomMedium
 
@@ -71,11 +71,12 @@ from .components.boundary import DefaultPMLParameters, DefaultStablePMLParameter
 from .components.boundary import DefaultAbsorberParameters
 
 # constants imported as `C_0 = td.C_0` or `td.constants.C_0`
-from .constants import C_0, ETA_0, HBAR, EPSILON_0, MU_0, Q_e, inf
+from .constants import C_0, ETA_0, HBAR, EPSILON_0, MU_0, Q_e, K_B, inf
 
 # material library dict imported as `from tidy3d import material_library`
 # get material `mat` and variant `var` as `material_library[mat][var]`
 from .material_library.material_library import material_library
+from .material_library.parametric_materials import Graphene
 
 # for docs
 from .components.medium import AbstractMedium

--- a/tidy3d/components/geometry.py
+++ b/tidy3d/components/geometry.py
@@ -377,6 +377,27 @@ class Geometry(Tidy3dBaseModel, ABC):
             )
         return (pt_min + pt_max) / 2.0
 
+    @cached_property
+    def _normal_2dmaterial(self) -> Axis:
+        """Get the normal to the given geometry, checking that it is a 2D geometry."""
+        if isinstance(self, Box):
+            if np.count_nonzero(self.size) != 2:
+                raise ValidationError(
+                    "'Medium2D' requires exactly one of the 'Box' dimensions to have size zero."
+                )
+            return self.size.index(0)
+        if isinstance(self, PolySlab):
+            if self.slab_bounds[0] != self.slab_bounds[1]:
+                raise ValidationError("'Medium2D' requires the 'PolySlab' bounds to be equal.")
+            return self.axis
+        if isinstance(self, Cylinder):
+            if self.length != 0:
+                raise ValidationError("'Medium2D' requires the 'Cylinder' length to be zero.")
+            return self.axis
+        raise ValidationError(
+            "'Medium2D' is only compatible with 'Box', 'PolySlab', and 'Cylinder' geometries."
+        )
+
     @equal_aspect
     @add_ax_if_none
     def plot(

--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -556,30 +556,16 @@ class GridSpec(Tidy3dBaseModel):
                     "use 'AutoGrid'."
                 )
 
-        coords_x = self.grid_x.make_coords(
-            axis=0,
-            structures=list(structures) + list(self.override_structures),
-            symmetry=symmetry,
-            wavelength=wavelength,
-            num_pml_layers=num_pml_layers[0],
-        )
-        coords_y = self.grid_y.make_coords(
-            axis=1,
-            structures=list(structures) + list(self.override_structures),
-            symmetry=symmetry,
-            wavelength=wavelength,
-            num_pml_layers=num_pml_layers[1],
-        )
-        coords_z = self.grid_z.make_coords(
-            axis=2,
-            structures=list(structures) + list(self.override_structures),
-            symmetry=symmetry,
-            wavelength=wavelength,
-            num_pml_layers=num_pml_layers[2],
-        )
-
-        coords = Coords(x=coords_x, y=coords_y, z=coords_z)
-        return Grid(boundaries=coords)
+        coords_all = [None, None, None]
+        for axis in range(3):
+            coords_all[axis] = [self.grid_x, self.grid_y, self.grid_z][axis].make_coords(
+                axis=axis,
+                structures=list(structures) + list(self.override_structures),
+                symmetry=symmetry,
+                wavelength=wavelength,
+                num_pml_layers=num_pml_layers[axis],
+            )
+        return Grid(boundaries=Coords(**dict(zip("xyz", coords_all))))
 
     @classmethod
     def auto(  # pylint:disable=too-many-arguments

--- a/tidy3d/components/grid/mesher.py
+++ b/tidy3d/components/grid/mesher.py
@@ -17,7 +17,7 @@ from shapely.errors import ShapelyDeprecationWarning
 from ..base import Tidy3dBaseModel
 from ..types import Axis, ArrayFloat1D
 from ..structure import Structure, MeshOverrideStructure, StructureType
-from ..medium import PECMedium
+from ..medium import PECMedium, Medium2D
 from ...exceptions import SetupError, ValidationError
 from ...constants import C_0, fp_eps
 
@@ -325,6 +325,7 @@ class GradedMesher(Mesher):
         """For :class:`.MeshOverrideStructure`, we allow ``dl`` along some axis
         to be ``None`` so that no override occurs along this axis.Here those
         structures with ``dl[axis]=None`` is filtered.
+        Also removes any :class:`.Medium2D` from the list.
 
         Parameters
         ----------
@@ -339,11 +340,17 @@ class GradedMesher(Mesher):
             A list of filtered structures whose ``dl`` along this axis is not ``None``.
         """
 
-        return [
-            structure
-            for structure in structures
-            if not (isinstance(structure, MeshOverrideStructure) and structure.dl[axis] is None)
-        ]
+        structures_filtered = []
+        for structure in structures:
+            if isinstance(structure, MeshOverrideStructure):
+                # skip override structure if dl not defined along axis
+                if structure.dl[axis] is None:
+                    continue
+            elif isinstance(structure.medium, Medium2D):
+                # skip 2D medium
+                continue
+            structures_filtered.append(structure)
+        return structures_filtered
 
     @staticmethod
     def structure_steps(

--- a/tidy3d/components/grid/mesher.py
+++ b/tidy3d/components/grid/mesher.py
@@ -325,7 +325,6 @@ class GradedMesher(Mesher):
         """For :class:`.MeshOverrideStructure`, we allow ``dl`` along some axis
         to be ``None`` so that no override occurs along this axis.Here those
         structures with ``dl[axis]=None`` is filtered.
-        Also removes any :class:`.Medium2D` from the list.
 
         Parameters
         ----------
@@ -346,9 +345,6 @@ class GradedMesher(Mesher):
                 # skip override structure if dl not defined along axis
                 if structure.dl[axis] is None:
                     continue
-            elif isinstance(structure.medium, Medium2D):
-                # skip 2D medium
-                continue
             structures_filtered.append(structure)
         return structures_filtered
 
@@ -380,7 +376,7 @@ class GradedMesher(Mesher):
         min_steps = []
         for structure in structures:
             if isinstance(structure, Structure):
-                if isinstance(structure.medium, PECMedium):
+                if isinstance(structure.medium, (PECMedium, Medium2D)):
                     index = 1.0
                 else:
                     n, k = structure.medium.eps_complex_to_nk(

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -13,7 +13,7 @@ import xarray as xr
 from .base import Tidy3dBaseModel, cached_property
 from .grid.grid import Coords, Grid
 from .types import PoleAndResidue, Ax, FreqBound, TYPE_TAG_STR, InterpMethod, Bound, ArrayComplex4D
-from .types import Numpy, Axis
+from .types import Axis
 from .data.dataset import PermittivityDataset
 from .data.data_array import ScalarFieldDataArray
 from .viz import add_ax_if_none
@@ -1607,6 +1607,14 @@ class Medium2D(AbstractMedium):
     def elements(self) -> Dict[str, IsotropicMediumType]:
         """The diagonal elements of the 2D medium as a dictionary."""
         return dict(ss=self.ss, tt=self.tt)
+
+    @cached_property
+    def n_cfl(self):
+        """This property computes the index of refraction related to CFL condition, so that
+        the FDTD with this medium is stable when the time step size that doesn't take
+        material factor into account is multiplied by ``n_cfl``.
+        """
+        return 1.0
 
 
 # types of mediums that can be used in Simulation and Structures

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -13,11 +13,13 @@ import xarray as xr
 from .base import Tidy3dBaseModel, cached_property
 from .grid.grid import Coords, Grid
 from .types import PoleAndResidue, Ax, FreqBound, TYPE_TAG_STR, InterpMethod, Bound, ArrayComplex4D
+from .types import Numpy, Axis
 from .data.dataset import PermittivityDataset
 from .data.data_array import ScalarFieldDataArray
 from .viz import add_ax_if_none
+from .geometry import Geometry
 from .validators import validate_name_str
-from ..constants import C_0, pec_val, EPSILON_0
+from ..constants import C_0, pec_val, EPSILON_0, LARGE_NUMBER, fp_eps
 from ..constants import HERTZ, CONDUCTIVITY, PERMITTIVITY, RADPERSEC, MICROMETER, SECOND
 from ..exceptions import ValidationError, SetupError
 from ..log import log
@@ -50,6 +52,9 @@ def ensure_freq_in_range(eps_model: Callable[[float], complex]) -> Callable[[flo
             return eps_model(self, frequency)
 
         fmin, fmax = self.frequency_range
+        # don't warn for evaluating infinite frequency
+        if is_inf_scalar:
+            return eps_model(self, frequency)
         if np.any(frequency < fmin) or np.any(frequency > fmax):
             log.warning(
                 "frequency passed to `Medium.eps_model()`"
@@ -280,6 +285,26 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
         omega = 2 * np.pi * freq
         sigma = omega * eps_imag * EPSILON_0
         return eps_real, sigma
+
+    @ensure_freq_in_range
+    def sigma_model(self, freq: float) -> complex:
+        """Complex-valued conductivity as a function of frequency.
+
+        Parameters
+        ----------
+        freq: float
+            Frequency to evaluate conductivity at (Hz).
+
+        Returns
+        -------
+        complex
+            Complex conductivity at this frequency.
+        """
+        omega = freq * 2 * np.pi
+        eps_complex = self.eps_model(freq)
+        eps_inf = self.eps_model(np.inf)
+        sigma = (eps_inf - eps_complex) * 1j * omega * EPSILON_0
+        return sigma
 
 
 """ Dispersionless Medium """
@@ -817,6 +842,41 @@ class PoleResidue(DispersiveMedium):
             f"\n\tfrequency_range={self.frequency_range})"
         )
 
+    @classmethod
+    def from_medium(cls, medium: Medium) -> "PoleResidue":
+        """Convert a :class:`.Medium` to a pole residue model.
+
+        Parameters
+        ----------
+        medium: :class:`.Medium`
+            The medium with permittivity and conductivity to convert.
+
+        Returns
+        -------
+        :class:`.PoleResidue`
+            The pole residue equivalent.
+        """
+        poles = [(0, medium.conductivity / (2 * EPSILON_0))]
+        return PoleResidue(eps_inf=medium.permittivity, poles=poles)
+
+    def to_medium(self) -> Medium:
+        """Convert to a :class:`.Medium`.
+        Requires the pole residue model to only have a pole at 0 frequency,
+        corresponding to a constant conductivity term.
+
+        Returns
+        -------
+        :class:`.Medium`
+            The non-dispersive equivalent with constant permittivity and conductivity.
+        """
+        res = 0
+        for (a, c) in self.poles:
+            if abs(a) > fp_eps:
+                raise ValidationError("Cannot convert dispersive 'PoleResidue' to 'Medium'.")
+            res += (c + np.conj(c)) / 2
+        sigma = res * 2 * EPSILON_0
+        return Medium(permittivity=self.eps_inf, conductivity=np.real(sigma))
+
 
 class Sellmeier(DispersiveMedium):
     """A dispersive medium described by the Sellmeier model.
@@ -1164,10 +1224,7 @@ class AnisotropicMedium(AbstractMedium):
     def eps_model(self, frequency: float) -> complex:
         """Complex-valued permittivity as a function of frequency."""
 
-        eps_xx = self.xx.eps_model(frequency)
-        eps_yy = self.yy.eps_model(frequency)
-        eps_zz = self.zz.eps_model(frequency)
-        return np.mean((eps_xx, eps_yy, eps_zz))
+        return np.mean(self.eps_diagonal(frequency), axis=0)
 
     @ensure_freq_in_range
     def eps_diagonal(self, frequency: float) -> Tuple[complex, complex, complex]:
@@ -1180,12 +1237,12 @@ class AnisotropicMedium(AbstractMedium):
 
     @add_ax_if_none
     def plot(self, freqs: float, ax: Ax = None) -> Ax:
-        """Plot n, k of a :class:`Medium` as a function of frequency."""
+        """Plot n, k of a :class:`.Medium` as a function of frequency."""
 
         freqs = np.array(freqs)
         freqs_thz = freqs / 1e12
 
-        for label, medium_component in zip(("xx", "yy", "zz"), (self.xx, self.yy, self.zz)):
+        for label, medium_component in self.elements.items():
 
             eps_complex = medium_component.eps_model(freqs)
             n, k = AbstractMedium.eps_complex_to_nk(eps_complex)
@@ -1198,10 +1255,15 @@ class AnisotropicMedium(AbstractMedium):
         ax.set_aspect("auto")
         return ax
 
+    @property
+    def elements(self) -> Dict[str, IsotropicMediumType]:
+        """The diagonal elements of the medium as a dictionary."""
+        return dict(xx=self.xx, yy=self.yy, zz=self.zz)
+
 
 # types of mediums that can be used in Simulation and Structures
 
-MediumType = Union[
+MediumType3D = Union[
     Medium,
     CustomMedium,
     AnisotropicMedium,
@@ -1212,3 +1274,341 @@ MediumType = Union[
     Debye,
     Drude,
 ]
+
+
+class Medium2D(AbstractMedium):
+    """2D diagonally anisotropic medium.
+
+    Note
+    ----
+    Only diagonal anisotropy is currently supported.
+
+    Example
+    -------
+    >>> drude_medium = Drude(eps_inf=2.0, coeffs=[(1,2), (3,4)])
+    >>> medium2d = Medium2D(ss=drude_medium, tt=drude_medium)
+
+    """
+
+    ss: IsotropicMediumType = pd.Field(
+        ...,
+        title="SS Component",
+        description="Medium describing the ss-component of the diagonal permittivity tensor. "
+        "The ss-component refers to the in-plane dimension of the medium that is the first "
+        "component in order of 'x', 'y', 'z'. "
+        "If the 2D material is normal to the y-axis, for example, then this determines the "
+        "xx-component of the corresponding 3D medium.",
+        discriminator=TYPE_TAG_STR,
+    )
+
+    tt: IsotropicMediumType = pd.Field(
+        ...,
+        title="TT Component",
+        description="Medium describing the tt-component of the diagonal permittivity tensor. "
+        "The tt-component refers to the in-plane dimension of the medium that is the second "
+        "component in order of 'x', 'y', 'z'. "
+        "If the 2D material is normal to the y-axis, for example, then this determines the "
+        "zz-component of the corresponding 3D medium.",
+        discriminator=TYPE_TAG_STR,
+    )
+
+    @classmethod
+    def _weighted_avg(cls, meds: List[IsotropicMediumType], weights: List[float]) -> PoleResidue:
+        """Average ``meds`` with weights ``weights``."""
+        eps_inf = 1
+        poles = []
+        for (med, weight) in zip(meds, weights):
+            if isinstance(med, DispersiveMedium):
+                pole_res = med.pole_residue
+                eps_inf += weight * (med.pole_residue.eps_inf - 1)
+            elif isinstance(med, Medium):
+                pole_res = PoleResidue.from_medium(med)
+                eps_inf += weight * (med.eps_model(np.inf) - 1)
+            elif isinstance(med, PECMedium):
+                pole_res = PoleResidue.from_medium(Medium(conductivity=LARGE_NUMBER))
+            else:
+                raise ValidationError("Invalid medium type for the components of 'Medium2D'.")
+            poles += [(a, weight * c) for (a, c) in pole_res.poles]
+        return PoleResidue(eps_inf=np.real(eps_inf), poles=poles)
+
+    def volumetric_equivalent(
+        self,
+        axis: Axis,
+        adjacent_media: Tuple[MediumType3D, MediumType3D],
+        adjacent_dls: Tuple[float, float],
+    ) -> AnisotropicMedium:
+        """Produces a 3D volumetric equivalent medium. The new medium has thickness equal to
+        the average of the ``dls`` in the ``axis`` direction.
+        The ss and tt components of the 2D material are mapped in order onto the xx, yy, and
+        zz components of the 3D material, excluding the ``axis`` component. The conductivity
+        and residues (in the case of a dispersive 2D material) are rescaled by ``1/dl``.
+        The neighboring media ``neighbors`` enter in as a background for the resulting
+        volumetric equivalent.
+
+
+        Parameters
+        ----------
+        axis : Axis
+            Index (0, 1, or 2 for x, y, or z respectively) of the normal direction to the
+            2D material.
+        adjacent_media : Tuple[MediumType3D, MediumType3D]
+            The neighboring media on either side of the 2D material.
+            The first element is directly on the - side of the 2D material in the supplied axis,
+            and the second element is directly on the + side.
+        adjacent_dls : Tuple[float, float]
+            Each dl represents twice the thickness of the desired volumetric model on the
+            respective side of the 2D material.
+
+        Returns
+        -------
+        :class:`.AnisotropicMedium`
+            The 3D material corresponding to this 2D material.
+        """
+
+        def get_component(med: MediumType3D, comp: Axis) -> IsotropicMediumType:
+            """Extract the ``comp`` component of ``med``."""
+            if isinstance(med, AnisotropicMedium):
+                dim = "xyz"[comp]
+                element_name = dim + dim
+                return med.elements[element_name]
+            return med
+
+        def get_background(comp: Axis) -> PoleResidue:
+            """Get the background medium appropriate for the ``comp`` component."""
+            meds = [get_component(med=med, comp=comp) for med in adjacent_media]
+            # the Yee site for the E field in the normal direction is fully contained
+            # in the medium on the + side
+            if comp == axis:
+                return meds[1]
+            weights = np.array(adjacent_dls) / np.sum(adjacent_dls)
+            return self._weighted_avg(meds, weights)
+
+        dl = (adjacent_dls[0] + adjacent_dls[1]) / 2
+        media_bg = [get_background(comp=i) for i in range(3)]
+
+        # perform weighted average of planar media transverse dimensions with the
+        # respective background media
+        media_fg_plane = list(self.elements.values())
+        _, media_bg_plane = Geometry.pop_axis(media_bg, axis=axis)
+        media_fg_weighted = [
+            self._weighted_avg([media_bg, media_fg], [1, 1 / dl])
+            for media_bg, media_fg in zip(media_bg_plane, media_fg_plane)
+        ]
+
+        # combine the two weighted, planar media with the background medium and put in the xyz basis
+        media_3d = Geometry.unpop_axis(
+            ax_coord=media_bg[axis], plane_coords=media_fg_weighted, axis=axis
+        )
+        media_3d_kwargs = {dim + dim: medium for dim, medium in zip("xyz", media_3d)}
+        return AnisotropicMedium(**media_3d_kwargs)
+
+    def to_anisotropic_medium(self, axis: Axis, thickness: float) -> AnisotropicMedium:
+        """Generate a 3D :class:`.AnisotropicMedium` equivalent of a given thickness.
+
+        Parameters
+        ----------
+        axis: Axis
+            The normal axis to the 2D medium.
+        thickness: float
+            The thickness of the desired 3D medium.
+
+        Returns
+        -------
+        :class:`.AnisotropicMedium`
+            The 3D equivalent of this 2D medium.
+        """
+        media = list(self.elements.values())
+        print(media)
+        media_weighted = [self._weighted_avg([medium], [1 / thickness]) for medium in media]
+        media_3d = Geometry.unpop_axis(ax_coord=Medium(), plane_coords=media_weighted, axis=axis)
+        media_3d_kwargs = {dim + dim: medium for dim, medium in zip("xyz", media_3d)}
+        return AnisotropicMedium(**media_3d_kwargs)
+
+    def to_pole_residue(self, thickness: float) -> PoleResidue:
+        """Generate a :class:`.PoleResidue` equivalent of a given thickness.
+        The 2D medium to be isotropic in-plane (otherwise the components are averaged).
+
+        Parameters
+        ----------
+        thickness: float
+            The thickness of the desired 3D medium.
+
+        Returns
+        -------
+        :class:`.PoleResidue`
+            The 3D equivalent pole residue model of this 2D medium.
+        """
+        return self._weighted_avg([self.ss, self.tt], [1 / (2 * thickness), 1 / (2 * thickness)])
+
+    def to_medium(self, thickness: float) -> Medium:
+        """Generate a :class:`.Medium` equivalent of a given thickness.
+        The 2D medium should be isotropic in-plane (otherwise the components are averaged)
+        and non-dispersive besides a constant conductivity.
+
+        Parameters
+        ----------
+        thickness: float
+            The thickness of the desired 3D medium.
+
+        Returns
+        -------
+        :class:`.Medium`
+            The 3D equivalent of this 2D medium.
+        """
+        return self._weighted_avg(
+            [self.ss, self.tt], [1 / (2 * thickness), 1 / (2 * thickness)]
+        ).to_medium()
+
+    @classmethod
+    def from_medium(cls, medium: Medium, thickness: float) -> Medium2D:
+        """Generate a :class:`.Medium2D` equivalent of a :class:`.Medium`
+        with a given thickness.
+
+        Parameters
+        ----------
+        medium: :class:`.Medium`
+            The 3D medium to convert.
+        thickness : float
+            The thickness of the 3D material.
+
+        Returns
+        -------
+        :class:`.Medium2D`
+            The 2D equivalent of the given 3D medium.
+        """
+        med = cls._weighted_avg([medium], [thickness])
+        return Medium2D(ss=med, tt=med)
+
+    @classmethod
+    def from_dispersive_medium(cls, medium: DispersiveMedium, thickness: float) -> Medium2D:
+        """Generate a :class:`.Medium2D` equivalent of a :class:`.DispersiveMedium`
+        with a given thickness.
+
+        Parameters
+        ----------
+        medium: :class:`.DispersiveMedium`
+            The 3D dispersive medium to convert.
+        thickness : float
+            The thickness of the 3D material.
+
+        Returns
+        -------
+        :class:`.Medium2D`
+            The 2D equivalent of the given 3D medium.
+        """
+        med = cls._weighted_avg([medium], [thickness])
+        return Medium2D(ss=med, tt=med)
+
+    @classmethod
+    def from_anisotropic_medium(
+        cls, medium: AnisotropicMedium, axis: Axis, thickness: float
+    ) -> Medium2D:
+        """Generate a :class:`.Medium2D` equivalent of a :class:`.AnisotropicMedium`
+        with given normal axis and thickness. The ``ss`` and ``tt`` components of the resulting
+        2D medium correspond to the first of the ``xx``, ``yy``, and ``zz`` components of
+        the 3D medium, with the ``axis`` component removed.
+
+        Parameters
+        ----------
+        medium: :class:`.AnisotropicMedium`
+            The 3D anisotropic medium to convert.
+        axis: :class:`.Axis`
+            The normal axis to the 2D material.
+        thickness : float
+            The thickness of the 3D material.
+
+        Returns
+        -------
+        :class:`.Medium2D`
+            The 2D equivalent of the given 3D medium.
+        """
+        media = list(medium.elements.values())
+        _, media_plane = Geometry.pop_axis(media, axis=axis)
+        media_plane_scaled = []
+        for _, med in enumerate(media_plane):
+            media_plane_scaled.append(cls._weighted_avg([med], [thickness]))
+        media_kwargs = {dim + dim: medium for dim, medium in zip("st", media_plane_scaled)}
+        return Medium2D(**media_kwargs)
+
+    @ensure_freq_in_range
+    def eps_model(self, frequency: float) -> complex:
+        """Complex-valued permittivity as a function of frequency."""
+        return np.mean(self.eps_diagonal(frequency=frequency), axis=0)
+
+    @ensure_freq_in_range
+    def eps_diagonal(self, frequency: float) -> Tuple[complex, complex]:
+        """Main diagonal of the complex-valued permittivity tensor as a function of frequency."""
+        log.warning("Evaluating permittivity of a 'Medium2D' is unphysical.")
+
+        eps_ss = self.ss.eps_model(frequency)
+        eps_tt = self.tt.eps_model(frequency)
+        return (eps_ss, eps_tt)
+
+    @add_ax_if_none
+    def plot(self, freqs: float, ax: Ax = None) -> Ax:
+        """Plot n, k of a :class:`.Medium` as a function of frequency."""
+        log.warning(
+            "The refractive index of a 'Medium2D' is unphysical. "
+            "Use 'Medium2D.plot_sigma' instead to plot surface conductivty, or call "
+            "'Medium2D.to_anisotropic_medium' or 'Medium2D.to_pole_residue' first "
+            "to obtain the physical refractive index."
+        )
+
+        freqs = np.array(freqs)
+        freqs_thz = freqs / 1e12
+
+        for label, medium_component in self.elements.items():
+
+            eps_complex = medium_component.eps_model(freqs)
+            n, k = AbstractMedium.eps_complex_to_nk(eps_complex)
+            ax.plot(freqs_thz, n, label=f"n, eps_{label}")
+            ax.plot(freqs_thz, k, label=f"k, eps_{label}")
+
+        ax.set_xlabel("frequency (THz)")
+        ax.set_title("medium dispersion")
+        ax.legend()
+        ax.set_aspect("auto")
+        return ax
+
+    @add_ax_if_none
+    def plot_sigma(self, freqs: float, ax: Ax = None) -> Ax:
+        """Plot the surface conductivity of the 2D material."""
+        freqs = np.array(freqs)
+        freqs_thz = freqs / 1e12
+
+        for label, medium_component in self.elements.items():
+            sigma = medium_component.sigma_model(freqs)
+            ax.plot(freqs_thz, np.real(sigma) * 1e6, label=f"Re($\\sigma$) ($\\mu$S), eps_{label}")
+            ax.plot(freqs_thz, np.imag(sigma) * 1e6, label=f"Im($\\sigma$) ($\\mu$S), eps_{label}")
+
+        ax.set_xlabel("frequency (THz)")
+        ax.set_title("surface conductivity")
+        ax.legend()
+        ax.set_aspect("auto")
+        return ax
+
+    @ensure_freq_in_range
+    def sigma_model(self, freq: float) -> complex:
+        """Complex-valued conductivity as a function of frequency.
+
+        Parameters
+        ----------
+        freq: float
+            Frequency to evaluate conductivity at (Hz).
+
+        Returns
+        -------
+        complex
+            Complex conductivity at this frequency.
+        """
+        return np.mean([self.ss.sigma_model(freq), self.tt.sigma_model(freq)], axis=0)
+
+    @property
+    def elements(self) -> Dict[str, IsotropicMediumType]:
+        """The diagonal elements of the 2D medium as a dictionary."""
+        return dict(ss=self.ss, tt=self.tt)
+
+
+# types of mediums that can be used in Simulation and Structures
+
+MediumType = Union[MediumType3D, Medium2D]

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -324,6 +324,11 @@ class PermittivityMonitor(FreqMonitor):
     :class:`.FieldMonitor` of the same geometry: the permittivity values are saved at the
     Yee grid locations, and can be interpolated to any point inside the monitor.
 
+    Note
+    ----
+    If 2D materials are present, then the permittivity values correspond to the
+    volumetric equivalent of the 2D materials.
+
     Example
     -------
     >>> monitor = PermittivityMonitor(

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -2298,7 +2298,9 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
             num_pml_layers=self.num_pml_layers,
         )
 
-        return self._grid_corrections_2dmaterials(grid)
+        # This would AutoGrid the in-plane directions of the 2D materials
+        # return self._grid_corrections_2dmaterials(grid)
+        return grid
 
     @cached_property
     def num_cells(self) -> int:

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-lines, too-many-arguments
+# pylint: disable=too-many-lines, too-many-arguments, too-many-statements
 """ Container holding all information about simulation and its components"""
 from __future__ import annotations
 from typing import Dict, Tuple, List, Set, Union
@@ -14,11 +14,12 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 from .base import cached_property
 from .validators import assert_unique_names, assert_objects_in_sim_bounds
 from .validators import validate_mode_objects_symmetry
-from .geometry import Box, TriangleMesh
+from .geometry import Box, TriangleMesh, Geometry, PolySlab, Cylinder
 from .types import Ax, Shapely, FreqBound, Axis, annotate_type, Symmetry
 from .grid.grid import Coords1D, Grid, Coords
 from .grid.grid_spec import GridSpec, UniformGrid
-from .medium import Medium, MediumType, AbstractMedium, PECMedium, CustomMedium
+from .medium import Medium, MediumType, AbstractMedium, PECMedium
+from .medium import CustomMedium, Medium2D, MediumType3D
 from .boundary import BoundarySpec, BlochBoundary, PECBoundary, PMCBoundary, Periodic
 from .boundary import PML, StablePML, Absorber, AbsorberSpec
 from .structure import Structure
@@ -35,7 +36,7 @@ from .viz import plot_params_pec, plot_params_pmc, plot_params_bloch
 
 from ..version import __version__
 from ..constants import C_0, SECOND, inf
-from ..exceptions import Tidy3dKeyError, SetupError, ValidationError
+from ..exceptions import Tidy3dKeyError, SetupError, ValidationError, Tidy3dError
 from ..log import log
 from ..updater import Updater
 
@@ -56,6 +57,9 @@ MAX_MONITOR_DATA_SIZE_BYTES = 10e9
 NUM_CELLS_WARN_EPSILON = 100_000_000
 # number of structures at which we warn about slow Simulation.epsilon()
 NUM_STRUCTURES_WARN_EPSILON = 10_000
+# for 2d materials. to find neighboring media, search a distance on either side
+# equal to this times the grid size
+DIST_NEIGHBOR_REL_2D_MED = 1e-5
 
 
 class Simulation(Box):  # pylint:disable=too-many-public-methods
@@ -241,6 +245,13 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
             values["boundary_spec"] = BoundarySpec.all_sides(boundary=Periodic())
 
         return values
+
+    @pydantic.validator("medium", always=True)
+    def _validate_medium(cls, val):
+        """Check that the medium is not a :class:`.Medium2D`."""
+        if isinstance(val, Medium2D):
+            raise ValidationError("'Simulation.medium' cannot be a 'Medium2D'.")
+        return val
 
     @pydantic.validator("grid_spec", always=True)
     def _validate_auto_grid_wavelength(cls, val, values):
@@ -722,6 +733,9 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
                 # min wavelength in PEC is meaningless and we'll get divide by inf errors
                 if isinstance(medium, PECMedium):
                     continue
+                # min wavelength in Medium2D is meaningless
+                if isinstance(medium, Medium2D):
+                    continue
 
                 eps_material = medium.eps_model(freq0)
                 n_material, _ = medium.eps_complex_to_nk(eps_material)
@@ -877,6 +891,7 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
         self._validate_datasets_not_none()
         self._validate_tfsf_structure_intersections()
         # self._validate_run_time()
+        _ = self.volumetric_structures
 
     def _validate_size(self) -> None:
         """Ensures the simulation is within size limits before simulation is uploaded."""
@@ -1342,6 +1357,9 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
             plot_params = plot_params.copy(
                 update={"facecolor": "gold", "edgecolor": "k", "linewidth": 1}
             )
+        elif isinstance(medium, Medium2D):
+            # 2d material
+            plot_params = plot_params.copy(update={"edgecolor": "k", "linewidth": 1})
         else:
             # regular medium
             facecolor = MEDIUM_CMAP[(mat_index - 1) % len(MEDIUM_CMAP)]
@@ -1566,6 +1584,9 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
             plot_params = plot_params.copy(
                 update={"facecolor": "gold", "edgecolor": "k", "linewidth": 1}
             )
+        elif isinstance(medium, Medium2D):
+            # 2d material
+            plot_params = plot_params.copy(update={"edgecolor": "k", "linewidth": 1})
         else:
             # regular medium
             eps_medium = medium.eps_model(frequency=freq).real
@@ -2454,7 +2475,8 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
             )
             shape = tuple(len(array) for array in arrays)
             eps_array = eps_background * np.ones(shape, dtype=complex)
-            for structure in self.structures:
+            # replace 2d materials with volumetric equivalents
+            for structure in self.volumetric_structures:
                 # Indexing subset within the bounds of the structure
                 # pylint:disable=protected-access
                 inds = structure.geometry._inds_inside_bounds(*arrays)
@@ -2502,3 +2524,108 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
             if isinstance(struct.geometry, TriangleMesh)
         ]
         return datasets_source + datasets_medium + datasets_geometry
+
+    @cached_property
+    def volumetric_structures(self) -> Tuple[Structure]:
+        """Generate a tuple of structures wherein any 2D materials are converted to 3D
+        volumetric equivalents."""
+
+        if not any(isinstance(medium, Medium2D) for medium in self.mediums):
+            return self.structures
+
+        def get_bounds(geom: Geometry, axis: Axis) -> Tuple[float, float]:
+            """Get the bounds of a geometry in the axis direction."""
+            return (geom.bounds[0][axis], geom.bounds[1][axis])
+
+        def set_bounds(geom: Geometry, bounds: Tuple[float, float], axis: Axis) -> Geometry:
+            """Set the bounds of a geometry in the axis direction."""
+            if isinstance(geom, Box):
+                new_center = list(geom.center)
+                new_center[axis] = (bounds[0] + bounds[1]) / 2
+                new_size = list(geom.size)
+                new_size[axis] = bounds[1] - bounds[0]
+                return geom.updated_copy(center=new_center, size=new_size)
+            if isinstance(geom, PolySlab):
+                return geom.updated_copy(slab_bounds=bounds)
+            if isinstance(geom, Cylinder):
+                new_center = list(geom.center)
+                new_center[axis] = (bounds[0] + bounds[1]) / 2
+                new_length = bounds[1] - bounds[0]
+                return geom.updated_copy(center=new_center, length=new_length)
+            raise ValidationError(
+                "'Medium2D' is only compatible with 'Box', 'PolySlab', or 'Cylinder' geometry."
+            )
+
+        def get_dls(geom: Geometry, axis: Axis, num_dls: int) -> float:
+            """Get grid size around the 2D material."""
+            dls = self.discretize(Box.from_bounds(*geom.bounds)).sizes.to_list[axis]
+            if len(dls) != num_dls:
+                raise Tidy3dError(
+                    "Failed to detect grid size around the 2D material. "
+                    "Can't generate volumetric equivalent for this simulation. "
+                    "If you received this error, please create an issue in the Tidy3D "
+                    "github repository."
+                )
+            return dls
+
+        def snap_to_grid(geom: Geometry, axis: Axis) -> Geometry:
+            """Snap a 2D material to the Yee grid."""
+            new_center = self.discretize(Box.from_bounds(*geom.bounds)).boundaries.to_list[axis][0]
+            return set_bounds(geom, (new_center, new_center), axis)
+
+        def get_neighboring_media(
+            geom: Geometry, axis: Axis, structures: List[Structure]
+        ) -> Tuple[List[MediumType3D], List[float]]:
+            """Find the neighboring material properties and grid sizes."""
+            dl = get_dls(geom, axis, 1)[0]
+            center = get_bounds(geom, axis)[0]
+            thickness = dl * DIST_NEIGHBOR_REL_2D_MED
+            thickened_geom = set_bounds(
+                geom, bounds=(center - thickness / 2, center + thickness / 2), axis=axis
+            )
+            grid_sizes = get_dls(thickened_geom, axis, 2)
+            dls_signed = [-grid_sizes[0], grid_sizes[1]]
+            neighbors = []
+            for _, dl_signed in enumerate(dls_signed):
+                geom_shifted = set_bounds(
+                    geom, bounds=(center + dl_signed, center + dl_signed), axis=axis
+                )
+                media = self.intersecting_media(Box.from_bounds(*geom_shifted.bounds), structures)
+                if len(media) > 1:
+                    raise SetupError(
+                        "2D materials do not support multiple neighboring media on a side. "
+                        "Please split the 2D material into multiple smaller 2D materials, one "
+                        "for each background medium."
+                    )
+                medium_side = Medium() if len(media) == 0 else list(media)[0]
+                neighbors.append(medium_side)
+            return (neighbors, grid_sizes)
+
+        simulation_background = Structure(geometry=self.geometry, medium=self.medium)
+        background_structures = [simulation_background]
+        new_structures = []
+        for structure in self.structures:
+            if not isinstance(structure.medium, Medium2D):
+                # found a 3D material; keep it
+                background_structures.append(structure)
+                new_structures.append(structure)
+                continue
+            # otherwise, found a 2D material; replace it with volumetric equivalent
+            axis = structure.geometry._normal_2dmaterial  # pylint: disable=protected-access
+
+            # snap monolayer to grid
+            geometry = snap_to_grid(structure.geometry, axis)
+            center = get_bounds(geometry, axis)[0]
+
+            # get neighboring media and grid sizes
+            (neighbors, dls) = get_neighboring_media(geometry, axis, background_structures)
+
+            new_bounds = (center - dls[0] / 2, center + dls[1] / 2)
+            new_geometry = set_bounds(structure.geometry, bounds=new_bounds, axis=axis)
+
+            new_medium = structure.medium.volumetric_equivalent(
+                axis=axis, adjacent_media=neighbors, adjacent_dls=dls
+            )
+            new_structures.append(structure.updated_copy(geometry=new_geometry, medium=new_medium))
+
+        return tuple(new_structures)

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -5,7 +5,7 @@ import pydantic
 from .base import Tidy3dBaseModel
 from .validators import validate_name_str
 from .geometry import GeometryType
-from .medium import MediumType, CustomMedium
+from .medium import MediumType, CustomMedium, Medium2D
 from .types import Ax, TYPE_TAG_STR
 from .viz import add_ax_if_none, equal_aspect
 from .grid.grid import Coords
@@ -94,6 +94,15 @@ class Structure(AbstractStructure):
         if isinstance(self.medium, CustomMedium):
             return self.medium.eps_diagonal_on_grid(frequency=frequency, coords=coords)
         return self.medium.eps_diagonal(frequency=frequency)
+
+    @pydantic.validator("medium", always=True)
+    def _check_2d_geometry(cls, val, values):
+        """Medium2D is only consistent with certain geometry types"""
+        geom = values["geometry"]
+        if isinstance(val, Medium2D):
+            # validate that the geometry is actually 2d
+            _ = geom._normal_2dmaterial  # pylint: disable=protected-access
+        return val
 
 
 class MeshOverrideStructure(AbstractStructure):

--- a/tidy3d/constants.py
+++ b/tidy3d/constants.py
@@ -22,6 +22,7 @@ EPSILON_0 = 1 / (MU_0 * C_0**2)
 ETA_0 = np.sqrt(MU_0 / EPSILON_0)
 Q_e = 1.602176634e-19
 HBAR = 6.582119569e-16
+K_B = 8.617333262e-5
 
 # floating point precisions
 dp_eps = np.finfo(np.float64).eps
@@ -43,6 +44,8 @@ CONDUCTIVITY = "S/um"
 PERMITTIVITY = "None (relative permittivity)"
 PML_SIGMA = "2*EPSILON_0/dt"
 RADPERSEC = "rad/sec"
+ELECTRON_VOLT = "eV"
+KELVIN = "K"
 
 # large number used for comparing infinity
 LARGE_NUMBER = 1e10

--- a/tidy3d/material_library/material_library.py
+++ b/tidy3d/material_library/material_library.py
@@ -2,10 +2,12 @@
 import json
 from typing import Dict, List
 import pydantic as pd
-from ..components.medium import PoleResidue
+
+from ..components.medium import PoleResidue, Medium2D
 from ..components.base import Tidy3dBaseModel
 from ..exceptions import SetupError
 from .material_reference import material_refs, ReferenceData
+from .parametric_materials import Graphene
 
 
 def export_matlib_to_file(fname: str = "matlib.json") -> None:
@@ -17,6 +19,7 @@ def export_matlib_to_file(fname: str = "matlib.json") -> None:
             for var_name, var in mat.variants.items()
         }
         for mat_name, mat in material_library.items()
+        if not isinstance(mat, type)
     }
 
     with open(fname, "w") as f:
@@ -35,7 +38,7 @@ class VariantItem(Tidy3dBaseModel):
     reference: List[ReferenceData] = pd.Field(
         None,
         title="Reference information",
-        description="A list of reference related to this variant model.",
+        description="A list of references related to this variant model.",
     )
 
     data_url: str = pd.Field(
@@ -78,6 +81,29 @@ class MaterialItem(Tidy3dBaseModel):
     def medium(self):
         """The default medium."""
         return self.variants[self.default].medium
+
+
+class VariantItem2D(VariantItem):
+    """Reference, data_source, and material model for a variant of a 2D material."""
+
+    medium: Medium2D = pd.Field(
+        ...,
+        title="Material dispersion model",
+        description="A dispersive 2D medium described by a surface conductivity model, "
+        "which is handled as an anisotropic medium with pole-residue pair models "
+        "defined for the in-plane directions of the 2D geometry.",
+    )
+
+
+class MaterialItem2D(MaterialItem):
+    """A 2D material that includes several variants."""
+
+    variants: Dict[str, VariantItem2D] = pd.Field(
+        ...,
+        title="Dictionary of available variants for this material",
+        description="A dictionary of available variants for this material "
+        "that maps from a key to the variant model.",
+    )
 
 
 Ag_Rakic1998BB = VariantItem(
@@ -758,6 +784,43 @@ MgO_StephensMalitson1952 = VariantItem(
     data_url="https://refractiveindex.info/data_csv.php?datafile=data/main/MgO/Stephens.yml",
 )
 
+MoS2_Li2014 = VariantItem2D(
+    medium=Medium2D.from_dispersive_medium(
+        PoleResidue(
+            eps_inf=7,
+            poles=(
+                ((-359315575683882.94 - 4351037853607888j), 1.3176033127808174e16j),
+                ((-47550212723398.46 - 2830800196611070.5j), 423989981007996.2j),
+                ((-115583767884472.11 - 3044501424941655.5j), 1228598693488551.8j),
+                ((-71809429716556.45 - 4843776341355436j), 3676495982332201.5j),
+                ((-357036299948221.06 - 3522742014142554j), 1439441065103469.5j),
+            ),
+            frequency_range=(359760000000000, 719520000000000),
+        ),
+        thickness=6.15e-4,
+    ),
+    reference=[material_refs["Li2014"]],
+)
+
+MoSe2_Li2014 = VariantItem2D(
+    medium=Medium2D.from_dispersive_medium(
+        PoleResidue(
+            eps_inf=2.98,
+            poles=(
+                ((-36761326958106.516 - 2346800992876732.5j), 338220688925072j),
+                ((-529696146171994.1 - 3250011358803138j), 2592639640470081.5j),
+                ((-83845324190119.6 - 2655257170055444.5j), 600182265785651.4j),
+                ((-460941134311120.06 - 3946269084308785.5j), 1.1521315248761458e16j),
+                ((-365616548688667.1 - 5272054887123941j), 1.176321407277452e16j),
+            ),
+            frequency_range=(359760000000000, 719520000000000),
+        ),
+        thickness=6.46e-4,
+    ),
+    reference=[material_refs["Li2014"]],
+)
+
+
 Ni_JohnsonChristy1972 = VariantItem(
     medium=PoleResidue(
         eps_inf=1.0,
@@ -1196,6 +1259,41 @@ W_RakicLorentzDrude1998 = VariantItem(
     data_url="https://refractiveindex.info/data_csv.php?datafile=data/main/W/Rakic-LD.yml",
 )
 
+WS2_Li2014 = VariantItem2D(
+    medium=Medium2D.from_dispersive_medium(
+        PoleResidue(
+            eps_inf=6.18,
+            poles=(
+                ((-24007743182653.15 - 3052251370817458j), 716432281919880.8j),
+                ((-137029680488199.55 - 3645019841622440.5j), 1010556928646303.5j),
+                ((-209636856712237.66 - 4307630639419263j), 3158371314580892.5j),
+                ((-466855949030110.3 - 4891967555229964j), 1.1703841436358186e16j),
+            ),
+            frequency_range=(359760000000000, 719520000000000),
+        ),
+        thickness=6.18e-4,
+    ),
+    reference=[material_refs["Li2014"]],
+)
+
+WSe2_Li2014 = VariantItem2D(
+    medium=Medium2D.from_dispersive_medium(
+        PoleResidue(
+            eps_inf=6.29,
+            poles=(
+                ((-32911988143375.11 - 2509059529797599.5j), 280960681034011.66j),
+                ((-138781520516435.52 - 3149502378897181.5j), 690812354204714j),
+                ((-28255484326386.598 - 5055392293836629j), 4415551968968067j),
+                ((-258471752123009.2 - 3675437972450793.5j), 2703088180177408.5j),
+                ((-354954812602843.94 - 4404690392224204.5j), 7012794593077168j),
+            ),
+            frequency_range=(359760000000000, 719520000000000),
+        ),
+        thickness=6.49e-4,
+    ),
+    reference=[material_refs["Li2014"]],
+)
+
 Y2O3_Horiba = VariantItem(
     medium=PoleResidue(
         eps_inf=1.0,
@@ -1499,6 +1597,20 @@ material_library = dict(
         ),
         default="StephensMalitson1952",
     ),
+    MoS2=MaterialItem2D(
+        name="Molybdenum Disulfide",
+        variants=dict(
+            Li2014=MoS2_Li2014,
+        ),
+        default="Li2014",
+    ),
+    MoSe2=MaterialItem2D(
+        name="Molybdenum Diselenide",
+        variants=dict(
+            Li2014=MoSe2_Li2014,
+        ),
+        default="Li2014",
+    ),
     Ni=MaterialItem(
         name="Nickel",
         variants=dict(
@@ -1657,6 +1769,20 @@ material_library = dict(
         ),
         default="Werner2009",
     ),
+    WS2=MaterialItem2D(
+        name="Tungsten Disulfide",
+        variants=dict(
+            Li2014=WS2_Li2014,
+        ),
+        default="Li2014",
+    ),
+    WSe2=MaterialItem2D(
+        name="Tungsten Diselenide",
+        variants=dict(
+            Li2014=WSe2_Li2014,
+        ),
+        default="Li2014",
+    ),
     Y2O3=MaterialItem(
         name="Yttrium Oxide",
         variants=dict(
@@ -1695,4 +1821,5 @@ material_library = dict(
         ),
         default="SalzbergVilla1957",
     ),
+    graphene=Graphene,
 )

--- a/tidy3d/material_library/material_reference.py
+++ b/tidy3d/material_library/material_reference.py
@@ -21,6 +21,13 @@ class ReferenceData(Tidy3dBaseModel):
 
 
 material_refs = dict(
+    Li2014=ReferenceData(
+        journal="Y. Li, A. Chernikov, X. Zhang, A. Rigosi, H. M. Hill, A. M. van der Zande, "
+        "D. A. Chenet, E. Shih, J. Hone, and T. F. Heinz. Measurement of the optical dielectric "
+        "function of monolayer transition-metal dichalcogenides: MoS2, MoSe2, WS2, and WSe2, "
+        "Phys. Rev. B 90, 205422 (2014)",
+        doi="https://doi.org/10.1103/PhysRevB.90.205422",
+    ),
     Yang2015=ReferenceData(
         journal="H. U. Yang, J. D'Archangel, M. L. Sundheimer, E. Tucker, G. D. Boreman, "
         "M. B. Raschke. Optical dielectric function of silver, Phys. Rev. B 91, 235137 (2015)",
@@ -166,5 +173,10 @@ material_refs = dict(
     Zemax=ReferenceData(
         journal="SCHOTT Zemax catalog 2017-01-20b",
         url="https://refractiveindex.info/download/data/2017/schott_2017-01-20.pdf",
+    ),
+    Hanson2008=ReferenceData(
+        journal="George W. Hanson. Dyadic Green's Functions for an Anisotropic, "
+        "Non-Local Model of Biased Graphene, IEEE Trans. Antennas Propag. 56, 3, 747-757 (2008)",
+        doi="https://doi.org/10.1109/TAP.2008.917005",
     ),
 )

--- a/tidy3d/material_library/parametric_materials.py
+++ b/tidy3d/material_library/parametric_materials.py
@@ -1,0 +1,365 @@
+"""Parametric material models."""
+from abc import ABC, abstractmethod
+from typing import List, Tuple
+import pydantic as pd
+import numpy as np
+from scipy import integrate
+
+from ..components.medium import PoleResidue, Medium2D, Drude
+from ..components.base import Tidy3dBaseModel
+from ..constants import EPSILON_0, Q_e, HBAR, K_B, ELECTRON_VOLT, KELVIN
+
+# default values of the physical parameters for graphene
+# scattering rate in eV
+GRAPHENE_DEF_GAMMA = 0.00041
+# chemical potential in eV
+GRAPHENE_DEF_MU_C = 0
+# temperature in K
+GRAPHENE_DEF_TEMP = 300
+
+# constants controlling the numerical integration of the interband term in graphene
+# frequency limits of integration
+GRAPHENE_INT_MIN = 0
+GRAPHENE_INT_MAX = 1e16
+# integration absolute tolerance
+GRAPHENE_INT_TOL = 1e-20
+
+# constants controlling the Pade approximation of the interband term in graphene
+# frequency range for fitting
+GRAPHENE_FIT_FREQ_MIN = 1e12
+GRAPHENE_FIT_FREQ_MAX = 1e15
+# the fitting for the interband feature has this width relative to the absorption threshold
+GRAPHENE_FIT_REL_WIDTH = 1.1
+# number of optimization iterations for fitting
+GRAPHENE_FIT_NUM_ITERS = 100
+
+
+class ParametricVariantItem2D(ABC, Tidy3dBaseModel):
+    """A variant of a 2D material depending on parameters, that must be initialized in order to
+    generate the material model."""
+
+    @property
+    @abstractmethod
+    def medium(self) -> Medium2D:
+        """Calculate the material model at the current parameter values."""
+
+
+class Graphene(ParametricVariantItem2D):
+    """Surface conductivity model for graphene, including intraband and interband terms,
+    as described in
+
+    George W. Hanson, "Dyadic Green's Functions for an Anisotropic,
+    Non-Local Model of Biased Graphene," IEEE Trans. Antennas Propag.
+    56, 3, 747-757 (2008).
+
+    Example
+    -------
+    >>> graphene_medium = Graphene(mu_c = 0.2).medium
+
+    """
+
+    mu_c: float = pd.Field(
+        GRAPHENE_DEF_MU_C,
+        title="Chemical potential in eV",
+        description="Chemical potential in eV.",
+        units=ELECTRON_VOLT,
+    )
+    temp: float = pd.Field(
+        GRAPHENE_DEF_TEMP, title="Temperature in K", description="Temperature in K.", units=KELVIN
+    )
+    gamma: float = pd.Field(
+        GRAPHENE_DEF_GAMMA,
+        title="Scattering rate in eV",
+        description="Scattering rate in eV. Must be small compared to the optical frequency.",
+        units=ELECTRON_VOLT,
+    )
+    scaling: float = pd.Field(
+        1,
+        title="Scaling factor",
+        description="Scaling factor used to model multiple layers of graphene.",
+    )
+
+    include_interband: bool = pd.Field(
+        True,
+        title="Include interband terms",
+        description="Include interband terms, relevant at high frequency (IR). "
+        "Otherwise, the intraband terms only give a simpler Drude-type model relevant "
+        "only at low frequency (THz).",
+    )
+    interband_fit_freq_nodes: List[Tuple[float, float]] = pd.Field(
+        None,
+        title="Interband fitting frequency nodes",
+        description="Frequency nodes for fitting interband term. "
+        "Each pair of nodes in the list corresponds to a single Pade approximant of order "
+        "(1, 2), which is optimized to minimize the error at these two frequencies. "
+        "The default behavior is to fit a first approximant at one very low frequency and "
+        "one very high frequency, and to fit a second approximant in the vicinity of the "
+        "interband feature. This default behavior works for a wide range "
+        "of frequencies; consider changing the nodes to obtain a better fit for a "
+        "narrow-band simulation.",
+    )
+    interband_fit_num_iters: pd.NonNegativeInt = pd.Field(
+        GRAPHENE_FIT_NUM_ITERS,
+        title="Interband fitting number of iterations",
+        description="Number of iterations for optimizing each Pade approximant when "
+        "fitting the interband term. Making this larger might give a better fit "
+        "at the cost of decreased stability in the fitting algorithm.",
+    )
+
+    @pd.validator("interband_fit_freq_nodes", always=True)
+    def _calculate_freq_nodes(cls, val, values):
+        """Calculate the default frequency nodes if none are provided."""
+        if val is None:
+            mu_c = values["mu_c"] / (2 * np.pi * HBAR)
+            temp = values["temp"] * K_B / (2 * np.pi * HBAR)
+            center = max(np.sqrt(abs(mu_c**2 - temp**2)), GRAPHENE_FIT_FREQ_MIN * 1e-5)
+            return [
+                (GRAPHENE_FIT_FREQ_MIN, GRAPHENE_FIT_FREQ_MAX),
+                (2 * center, 2 * (center + temp) * GRAPHENE_FIT_REL_WIDTH),
+            ]
+        return val
+
+    @property
+    def medium(self) -> Medium2D:
+        """Surface conductivity model for graphene."""
+        intraband = self.intraband_drude
+        if self.include_interband:
+            interband = self.interband_pole_residue
+            intraband_poles = intraband.pole_residue.poles
+            interband_poles = interband.pole_residue.poles
+            poles = intraband_poles + interband_poles
+            pole_residue = self._filter_poles(PoleResidue(poles=poles))
+            return Medium2D(ss=pole_residue, tt=pole_residue)
+        return Medium2D(ss=intraband, tt=intraband)
+
+    @property
+    def intraband_drude(self) -> Drude:
+        """A Drude-type model for the intraband term of graphene.
+
+        Returns
+        -------
+        :class:`.Drude`
+            A Drude-type model for the intraband term of graphene.
+
+        """
+        factor1 = Q_e * K_B * self.temp / (HBAR**2 * 4 * np.pi**3 * EPSILON_0)
+        factor2 = self.mu_c / (K_B * self.temp) + 2 * np.log(
+            np.exp(-self.mu_c / (K_B * self.temp)) + 1
+        )
+        intra_f1 = np.sqrt(self.scaling * factor1 * factor2)
+        intra_delta1 = (1 / HBAR) * self.gamma / np.pi
+        return Drude(coeffs=[(intra_f1, intra_delta1)])
+
+    @property
+    def interband_pole_residue(self) -> PoleResidue:
+        """A pole-residue model for the interband term of graphene. Note that this does not
+        include the intraband term, which is added in separately.
+
+        Returns
+        -------
+        :class:`.PoleResidue`
+            A pole-residue model for the interband term of graphene.
+        """
+
+        nodes = self.interband_fit_freq_nodes
+        flattened_freqs = [freq for pair in nodes for freq in pair]
+        sigma = self.interband_conductivity(flattened_freqs)
+        inds = [(2 * i, 2 * i + 1) for i in range(len(nodes))]
+
+        pole_residue = self._fit_interband_conductivity(flattened_freqs, sigma, inds)
+        return self._filter_poles(pole_residue)
+
+    def numerical_conductivity(self, freqs: List[float]) -> List[complex]:
+        """Numerically calculate the conductivity. If this differs from the
+        conductivity of the :class:`.Medium2D`, it is due to error while
+        fitting the interband term, and you may try values of ``interband_fit_freq_nodes``
+        different from its default (calculated) value.
+
+        Parameters
+        ----------
+        freqs : List[float]
+            The list of frequencies.
+
+        Returns
+        -------
+        List[complex]
+            The list of corresponding conductivities, in S.
+        """
+        intra_sigma = self.intraband_drude.sigma_model(freqs)
+        inter_sigma = self.interband_conductivity(freqs)
+        return intra_sigma + inter_sigma
+
+    def interband_conductivity(self, freqs: List[float]) -> List[complex]:
+        """Numerically integrate interband term.
+
+        Parameters
+        ----------
+        freqs : List[float]
+            The list of frequencies.
+
+        Returns
+        -------
+        List[complex]
+            The list of corresponding interband conductivities, in S.
+        """
+
+        def fermi(E: float) -> float:
+            """Fermi distribution."""
+            return 1 / (np.exp((E - self.mu_c) / (K_B * self.temp)) + 1)
+
+        def fermi_g(E: float) -> float:
+            """Difference of fermi distributions."""
+            return fermi(-E) - fermi(E)
+
+        def integrand(E: float, omega: float) -> float:
+            """Integrand for interband term."""
+            return (fermi_g(E * HBAR) - fermi_g(HBAR * omega / 2)) / (omega**2 - 4 * E**2)
+
+        omegas = 2 * np.pi * np.array(freqs)
+        sigma = np.zeros(len(omegas), dtype=complex)
+        integration_min = GRAPHENE_INT_MIN
+        integration_max = GRAPHENE_INT_MAX
+        for i, omega in enumerate(omegas):
+
+            integral, _ = integrate.quad(
+                integrand, integration_min, integration_max, args=(omega,), epsabs=GRAPHENE_INT_TOL
+            )
+            sigma[i] = (Q_e / (4 * HBAR)) * (
+                fermi_g(HBAR * omega / 2) - (4 * omega / (1j * np.pi)) * integral
+            )
+
+        return self.scaling * sigma
+
+    def _fit_interband_conductivity(  # pylint: disable=too-many-locals
+        self,
+        freqs: List[float],
+        sigma: List[complex],
+        indslist: List[Tuple[int, int]],
+    ):
+        """Fit the interband conductivity with a Pade approximation, as described in
+
+        Stamatios Amanatiadis, Theodoros Zygiridis, Tadao Ohtani, Yasushi Kanai,
+        and Nikolaos Kantartzis, "A Consistent Scheme for the Precise FDTD Modeling
+        of the Graphene Interband Contribution," IEEE Trans. Magn. 57, 6 (2021).
+
+        Parameters
+        ----------
+        freqs : List[float]
+            The input frequencies.
+        sigma : List[complex]
+            The interband conductivity to fit.
+        indslist : List[Tuple[int, int]]
+            The indices at which to sample the data for fitting.
+            The length of this list determines the number of Pade terms used.
+        Returns
+        -------
+        :class:`.PoleResidue`
+            A pole-residue model approximating the interband conductivity.
+        """
+
+        def evaluate_coeffslist(omega: List[float], coeffslist: List[List[float]]) -> List[float]:
+            """Evaluate the Pade approximants given by ``coeffslist` to ``omega``.
+            Each item in ``coeffslist`` is a list of four coefficients corresponding to
+            a single Pade term."""
+            res = np.zeros(len(omega), dtype=complex)
+            for (alpha0, alpha1, beta1, beta2) in coeffslist:
+                res += (alpha0 + alpha1 * 1j * omega) / (
+                    1 + beta1 * 1j * omega + beta2 * (1j * omega) ** 2
+                )
+            return res
+
+        def fit_single(
+            omega: List[float], sigma: List[complex], inds: Tuple[int, int]
+        ) -> List[float]:
+            """Fit a single Pade approximant of degree (1, 2) to ``sigma``
+            as a real function of i ``omega``. The method is described in
+
+            Adam Mock, "Pade approximant spectral fit for FDTD
+            simulation of graphene in the near infrared,"
+            Opt. Mater. Express 2, 6, pp. 771-781 (2012).
+            """
+            gamma = [np.real(sigma[i]) for i in inds]
+            eta = [np.imag(sigma[i]) for i in inds]
+            omegas = [omega[i] for i in inds]
+            matrix = np.array(
+                [
+                    [1, 0, omegas[0] * eta[0], omegas[0] ** 2 * gamma[0]],
+                    [0, omegas[0], -omegas[0] * gamma[0], omegas[0] ** 2 * eta[0]],
+                    [1, 0, omegas[1] * eta[1], omegas[1] ** 2 * gamma[1]],
+                    [0, omegas[1], -omegas[1] * gamma[1], omegas[1] ** 2 * eta[1]],
+                ]
+            )
+            return np.linalg.pinv(matrix) @ np.array([gamma[0], eta[0], gamma[1], eta[1]])
+
+        def optimize(
+            omega: List[float],
+            sigma: List[complex],
+            indslist: List[Tuple[int, int]],
+            coeffslist: List[List[float]],
+        ) -> List[float]:
+            """Optimize the coefficients in ``coeffslist`` by sampling ``omega`` and ``sigma``
+            at the indices in ``indslist``."""
+            for _ in range(self.interband_fit_num_iters):
+                old_coeffslist = coeffslist
+                res = sigma - evaluate_coeffslist(omega, old_coeffslist)
+                for j, coeffs in enumerate(old_coeffslist):
+                    curr_res = res + evaluate_coeffslist(omega, [coeffs])
+                    coeffslist[j] = fit_single(omega, curr_res, indslist[j])
+            return coeffslist
+
+        def get_pole_residue(coeffslist: List[List[float]]) -> PoleResidue:
+            """Convert a list of Pade coefficients into a :class:`.PoleResidue` model."""
+            poles = []
+            for (alpha0, alpha1, beta1, beta2) in coeffslist:
+                disc = beta1**2 - 4 * beta2
+                root1 = (beta1 + np.sqrt(complex(disc))) / (2 * beta2)
+                root2 = (beta1 - np.sqrt(complex(disc))) / (2 * beta2)
+                res1 = (alpha0 - alpha1 * root1) / (beta2 * (root2 - root1))
+                res2 = alpha1 / beta2 - res1
+
+                if disc > 0:
+                    for (root, res) in zip([root1, root2], [res1, res2]):
+                        poles.append((root, res / 2))
+                else:
+                    poles.append((root1, res1))
+
+            return PoleResidue(poles=poles)
+
+        # fitting works better with normalized quantities (THz and uS)
+        omega_thz = 2 * np.pi * np.array(freqs) * 1e-12
+        sigma_us = np.array(sigma) * 1e6
+        coeffslist = []
+        for inds in indslist:
+            res = np.array(sigma_us) - evaluate_coeffslist(omega_thz, coeffslist)
+            coeffslist.append(fit_single(omega_thz, res, inds))
+
+        coeffslist = optimize(omega_thz, sigma_us, indslist, coeffslist)
+
+        pole_res = get_pole_residue(coeffslist)
+        # unnormalize, and convert from conductivity to permittivity
+        poles = [(a * 1e12, -c / (a * EPSILON_0 * 1e6)) for (a, c) in pole_res.poles]
+
+        flipped_poles = []
+        for (a, c) in poles:
+            if np.real(a) > 0:
+                flipped_poles += [(-1j * np.conj(1j * a), c)]
+            else:
+                flipped_poles += [(a, c)]
+
+        # residue at omega = 0
+        zero_res = -np.sum([c for (_, c) in flipped_poles])
+
+        return PoleResidue(poles=flipped_poles + [(0, zero_res)])
+
+    def _filter_poles(self, medium: PoleResidue) -> PoleResidue:
+        """Clean up poles, merging poles at zero frequency."""
+        zero_res = 0
+        poles = []
+        for (a, c) in medium.poles:
+            if a == 0:
+                zero_res += c
+            elif abs(a) > 1e17:
+                continue
+            else:
+                poles += [(a, c)]
+        return PoleResidue(poles=poles + [(0, zero_res)])


### PR DESCRIPTION
Features:
- `Medium2D` class for surface conductivity model of 2D material
- Material library entries for graphene and some common TMDs
- Ability to create a 2D representation of a thin 3D metal
- AutoGrid for 2D materials.

Todo:
- [x] Add backend tests to validate simulation results (I just need to move these from my notebook)
- [x] prohibit Simulation.medium from being a 2D medium
- [x] validate that a 2d medium is added to a 2d geometry immediately when the structure is constructed
- [x] autogrid for 2d materials (after the one for PEC is merged) and test for autogrid

Plan for autogrid:
- Place a grid boundary at the 2d material
- Mesh the normal direction ignoring the 2d material
- Then mesh the in-plane directions using the volumetric equivalent

Limitations:
- Autogrid will not support non-parallel 2d materials
- Won't allow multiple 2d materials with separation smaller than the minimum grid size
- Does not support non-homogeneous neighboring materials above and below the 2d material. So, for example, you might need to manually divide a 2D material into multiple pieces, one for each substrate medium.