### PR TITLE
revamped ArrayLike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Simpler progressbars for `run_async`.
 - Medium property `n_cfl` added to adjust time step size according to CFL condition.
 - In the mode solver plugin, regular methods in `solver.py` transformed into classmethods.
+- `ArrayLike` types are stored internally as `np.ndarray` and written to json as lists. `constrained_array()` provides way to validate `ArrayLike` values based on `ndim` and `dtype`.
 
 ### Fixed
 - Bug in remote file transfer when client environment has no correct certificate authority pem file install locally. 

--- a/tests/test_components/test_types.py
+++ b/tests/test_components/test_types.py
@@ -1,7 +1,7 @@
 """Tests type definitions."""
 import pytest
 import tidy3d as td
-from tidy3d.components.types import ArrayLike, Complex
+from tidy3d.components.types import ArrayLike, Complex, constrained_array
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.exceptions import ValidationError
 import numpy as np
@@ -18,9 +18,45 @@ def _test_validate_array_like():
 
 def test_schemas():
     class S(Tidy3dBaseModel):
-        f: ArrayLike[float, 1]
+        f: ArrayLike
+        ca: constrained_array(ndim=1, dtype=complex)
         c: Complex
 
     # TODO: unexpected behavior, if list with more than one element, it fails.
-    s = S(f=[13], c=1 + 1j)
+    s = S(f=[13], c=1 + 1j, ca=1 + 1j)
     S.schema()
+
+
+def test_array_like():
+    class MyClass(Tidy3dBaseModel):
+
+        a: ArrayLike = None  # can be any array-like thing
+        b: constrained_array(ndim=2) = None  # must be 2D
+        c: constrained_array(dtype=float) = None  # must be float-like
+        d: constrained_array(ndim=1, dtype=complex) = None  # 1D complex
+        e: ArrayLike
+
+    my_obj = MyClass(
+        a=1.0 + 2j,
+        b=np.array([[1.0, 2.0]]),
+        c=[1, 3.0],
+        d=[1.0],
+        e=[[[[1.0]]]],
+    )
+
+    assert np.all(my_obj.a == [1.0 + 2j])  # scalars converted to list of len 1
+    assert np.all(my_obj.b == [1.0, 2.0])  # numpy arrays converted tolist()
+    assert np.all(my_obj.c == [1.0, 3.0])  # converted to float
+    assert np.all(my_obj.d == [1.0 + 0.0j])  # converted to complex
+
+    my_obj.json()
+
+
+def test_hash():
+    class MyClass(Tidy3dBaseModel):
+
+        a: ArrayLike
+        b: constrained_array(ndim=1)
+
+    c = MyClass(a=[1.0], b=[2.0, 1.0])
+    hash(c)

--- a/tidy3d/components/apodization.py
+++ b/tidy3d/components/apodization.py
@@ -6,7 +6,7 @@ import numpy as np
 from .base import Tidy3dBaseModel
 from ..constants import SECOND
 from ..exceptions import SetupError
-from .types import ArrayLike, Ax
+from .types import ArrayFloat1D, Ax
 from .viz import add_ax_if_none
 
 
@@ -57,7 +57,7 @@ class ApodizationSpec(Tidy3dBaseModel):
         return val
 
     @add_ax_if_none
-    def plot(self, times: ArrayLike[float, 1], ax: Ax = None) -> Ax:
+    def plot(self, times: ArrayFloat1D, ax: Ax = None) -> Ax:
         """Plot the apodization function.
 
         Parameters

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -19,7 +19,7 @@ from .data_array import FreqDataArray, TimeDataArray, FreqModeDataArray
 from .dataset import Dataset, AbstractFieldDataset, ElectromagneticFieldDataset
 from .dataset import FieldDataset, FieldTimeDataset, ModeSolverDataset, PermittivityDataset
 from ..base import TYPE_TAG_STR, cached_property
-from ..types import Coordinate, Symmetry, ArrayLike, Size, Numpy, TrackFreq
+from ..types import Coordinate, Symmetry, ArrayFloat1D, Size, Numpy, TrackFreq
 from ..grid.grid import Grid, Coords
 from ..validators import enforce_monitor_fields_present, required_if_symmetry_present
 from ..monitor import MonitorType, FieldMonitor, FieldTimeMonitor, ModeSolverMonitor
@@ -32,6 +32,9 @@ from ..medium import Medium, MediumType
 from ...exceptions import SetupError, DataError, Tidy3dNotImplementedError
 from ...constants import ETA_0, C_0, MICROMETER
 from ...log import log
+
+
+Coords1D = ArrayFloat1D
 
 
 class MonitorData(Dataset, ABC):
@@ -221,7 +224,7 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
         return tan_fields
 
     @property
-    def _plane_grid_boundaries(self) -> Tuple[ArrayLike[float, 1], ArrayLike[float, 1]]:
+    def _plane_grid_boundaries(self) -> Tuple[Coords1D, Coords1D]:
         """For a 2D monitor data, return the boundaries of the in-plane grid to be used to compute
         differential area and to colocate fields to grid centers if needed."""
         if np.any(np.array(self.monitor.interval_space) > 1):

--- a/tidy3d/components/field_projection.py
+++ b/tidy3d/components/field_projection.py
@@ -8,11 +8,8 @@ import pydantic
 
 from rich.progress import track
 
-from .data.data_array import (
-    FieldProjectionAngleDataArray,
-    FieldProjectionCartesianDataArray,
-    FieldProjectionKSpaceDataArray,
-)
+from .data.data_array import FieldProjectionAngleDataArray, FieldProjectionCartesianDataArray
+from .data.data_array import FieldProjectionKSpaceDataArray
 from .data.monitor_data import FieldData
 from .data.monitor_data import AbstractFieldProjectionData, FieldProjectionAngleData
 from .data.monitor_data import FieldProjectionCartesianData, FieldProjectionKSpaceData
@@ -20,7 +17,7 @@ from .data.sim_data import SimulationData
 from .monitor import FieldProjectionSurface
 from .monitor import FieldMonitor, AbstractFieldProjectionMonitor, FieldProjectionAngleMonitor
 from .monitor import FieldProjectionCartesianMonitor, FieldProjectionKSpaceMonitor
-from .types import Direction, Coordinate, ArrayLike
+from .types import Direction, Coordinate, ArrayComplex4D
 from .medium import MediumType
 from .base import Tidy3dBaseModel, cached_property
 from ..exceptions import SetupError
@@ -31,7 +28,7 @@ PTS_PER_WVL = 10
 
 # Numpy float array and related array types
 # pylint: disable=invalid-name
-ArrayLikeN2F = Union[float, Tuple[float, ...], ArrayLike[float, 4]]
+ArrayLikeN2F = Union[float, Tuple[float, ...], ArrayComplex4D]
 
 
 class FieldProjector(Tidy3dBaseModel):

--- a/tidy3d/components/grid/grid.py
+++ b/tidy3d/components/grid/grid.py
@@ -6,13 +6,13 @@ import numpy as np
 import pydantic as pd
 
 from ..base import Tidy3dBaseModel, cached_property
-from ..types import ArrayLike, Axis, TYPE_TAG_STR
+from ..types import ArrayFloat1D, Axis, TYPE_TAG_STR
 from ..geometry import Box
 
 from ...exceptions import SetupError
 
 # data type of one dimensional coordinate array.
-Coords1D = ArrayLike[float, 1]
+Coords1D = ArrayFloat1D
 
 
 class Coords(Tidy3dBaseModel):
@@ -141,12 +141,12 @@ class Grid(Tidy3dBaseModel):
     )
 
     @staticmethod
-    def _avg(coords1d: ArrayLike[float, 1]):
+    def _avg(coords1d: Coords1D):
         """Return average positions of an array of 1D coordinates."""
         return (coords1d[1:] + coords1d[:-1]) / 2.0
 
     @staticmethod
-    def _min(coords1d: ArrayLike[float, 1]):
+    def _min(coords1d: Coords1D):
         """Return minus positions of 1D coordinates."""
         return coords1d[:-1]
 

--- a/tidy3d/components/grid/mesher.py
+++ b/tidy3d/components/grid/mesher.py
@@ -15,7 +15,7 @@ from shapely.geometry import box as shapely_box
 from shapely.errors import ShapelyDeprecationWarning
 
 from ..base import Tidy3dBaseModel
-from ..types import Axis, ArrayLike
+from ..types import Axis, ArrayFloat1D
 from ..structure import Structure, MeshOverrideStructure, StructureType
 from ..medium import PECMedium
 from ...exceptions import SetupError, ValidationError
@@ -35,17 +35,17 @@ class Mesher(Tidy3dBaseModel, ABC):
         wavelength: pd.PositiveFloat,
         min_steps_per_wvl: pd.NonNegativeInt,
         dl_min: pd.NonNegativeFloat,
-    ) -> Tuple[ArrayLike[float, 1], ArrayLike[float, 1]]:
+    ) -> Tuple[ArrayFloat1D, ArrayFloat1D]:
         """Calculate the positions of all bounding box interfaces along a given axis."""
 
     @abstractmethod
     def make_grid_multiple_intervals(
         self,
-        max_dl_list: ArrayLike[float, 1],
-        len_interval_list: ArrayLike[float, 1],
+        max_dl_list: ArrayFloat1D,
+        len_interval_list: ArrayFloat1D,
         max_scale: float,
         is_periodic: bool,
-    ) -> List[ArrayLike[float, 1]]:
+    ) -> List[ArrayFloat1D]:
         """Create grid steps in multiple connecting intervals."""
 
 
@@ -61,7 +61,7 @@ class GradedMesher(Mesher):
         wavelength: pd.PositiveFloat,
         min_steps_per_wvl: pd.NonNegativeInt,
         dl_min: pd.NonNegativeFloat,
-    ) -> Tuple[ArrayLike[float, 1], ArrayLike[float, 1]]:
+    ) -> Tuple[ArrayFloat1D, ArrayFloat1D]:
         """Calculate the positions of all bounding box interfaces along a given axis.
         In this implementation, in most cases the complexity should be O(len(structures)**2),
         although the worst-case complexity may approach O(len(structures)**3).
@@ -202,8 +202,8 @@ class GradedMesher(Mesher):
         self,
         intervals: Dict[str, List],
         str_ind: int,
-        str_bbox: ArrayLike[float, 1],
-        bbox_contained_2d: List[ArrayLike[float, 1]],
+        str_bbox: ArrayFloat1D,
+        bbox_contained_2d: List[ArrayFloat1D],
         min_step: float,
     ) -> Dict[str, List]:
         """Figure out where to place the bounding box coordinates of current structure.
@@ -223,9 +223,9 @@ class GradedMesher(Mesher):
             of lists of structures contained in each interval.
         str_ind : int
             Index of the current structure.
-        str_bbox : ArrayLike[float, 1]
+        str_bbox : ArrayFloat1D
             Bounding box of the current structure.
-        bbox_contained_2d : List[ArrayLike[float, 1]]
+        bbox_contained_2d : List[ArrayFloat1D]
             List of 3D bounding boxes that contain the current structure in 2D.
         min_step : float
             Absolute minimum interval size to impose.
@@ -352,7 +352,7 @@ class GradedMesher(Mesher):
         min_steps_per_wvl: float,
         dl_min: pd.NonNegativeFloat,
         axis: Axis,
-    ) -> ArrayLike[float, 1]:
+    ) -> ArrayFloat1D:
         """Get the minimum mesh required in each structure. Special media are set to index of 1,
         which would usually make the medium ignored in the meshing, while the structure geometry
         would still be used to place grid boundaries.
@@ -386,9 +386,7 @@ class GradedMesher(Mesher):
         return np.array(min_steps)
 
     @staticmethod
-    def rotate_structure_bounds(
-        structures: List[StructureType], axis: Axis
-    ) -> List[ArrayLike[float, 1]]:
+    def rotate_structure_bounds(structures: List[StructureType], axis: Axis) -> List[ArrayFloat1D]:
         """Get sturcture bounding boxes with a given ``axis`` rotated to z.
 
         Parameters
@@ -400,7 +398,7 @@ class GradedMesher(Mesher):
 
         Returns
         -------
-        List[ArrayLike[float, 1]]
+        List[ArrayFloat1D]
             A list of the bounding boxes of shape ``(2, 3)`` for each structure, with the bounds
             along ``axis`` being ``(:, 2)``.
         """
@@ -415,7 +413,7 @@ class GradedMesher(Mesher):
         return struct_bbox
 
     @staticmethod
-    def bounds_2d_tree(struct_bbox: List[ArrayLike[float, 1]]):
+    def bounds_2d_tree(struct_bbox: List[ArrayFloat1D]):
         """Make a shapely Rtree for the 2D bounding boxes of all structures in the plane
         perpendicular to the meshing axis."""
 
@@ -430,9 +428,7 @@ class GradedMesher(Mesher):
         return stree
 
     @staticmethod
-    def contained_2d(
-        bbox0: ArrayLike[float, 1], query_bbox: List[ArrayLike[float, 1]]
-    ) -> List[ArrayLike[float, 1]]:
+    def contained_2d(bbox0: ArrayFloat1D, query_bbox: List[ArrayFloat1D]) -> List[ArrayFloat1D]:
         """Return a list of all bounding boxes among ``query_bbox`` that contain ``bbox0`` in 2D."""
         return [
             bbox
@@ -448,7 +444,7 @@ class GradedMesher(Mesher):
         ]
 
     @staticmethod
-    def contains_3d(bbox0: ArrayLike[float, 1], query_bbox: List[ArrayLike[float, 1]]) -> List[int]:
+    def contains_3d(bbox0: ArrayFloat1D, query_bbox: List[ArrayFloat1D]) -> List[int]:
         """Return a list of all indexes of bounding boxes in the ``query_bbox`` list that ``bbox0``
         fully contains."""
         return [
@@ -477,7 +473,7 @@ class GradedMesher(Mesher):
         )
 
     @staticmethod
-    def is_contained(normal_pos: float, contained_2d: List[ArrayLike[float, 1]]) -> bool:
+    def is_contained(normal_pos: float, contained_2d: List[ArrayFloat1D]) -> bool:
         """Check if a given ``normal_pos`` along the meshing direction is contained inside any
         of the bounding boxes that are in the ``contained_2d`` list.
         """
@@ -506,20 +502,20 @@ class GradedMesher(Mesher):
 
     def make_grid_multiple_intervals(  # pylint:disable=too-many-locals
         self,
-        max_dl_list: ArrayLike[float, 1],
-        len_interval_list: ArrayLike[float, 1],
+        max_dl_list: ArrayFloat1D,
+        len_interval_list: ArrayFloat1D,
         max_scale: float,
         is_periodic: bool,
-    ) -> List[ArrayLike[float, 1]]:
+    ) -> List[ArrayFloat1D]:
         """Create grid steps in multiple connecting intervals of length specified by
         ``len_interval_list``. The maximal allowed step size in each interval is given by
         ``max_dl_list``. The maximum ratio between neighboring steps is bounded by ``max_scale``.
 
         Parameters
         ----------
-        max_dl_list : ArrayLike[float, 1]
+        max_dl_list : ArrayFloat1D
             Maximal allowed step size of each interval.
-        len_interval_list : ArrayLike[float, 1]
+        len_interval_list : ArrayFloat1D
             A list of interval lengths
         max_scale : float
             Maximal ratio between consecutive steps.
@@ -528,7 +524,7 @@ class GradedMesher(Mesher):
 
         Returns
         -------
-        List[ArrayLike[float, 1]]
+        List[ArrayFloat1D]
             A list of of step sizes in each interval.
         """
 
@@ -602,19 +598,19 @@ class GradedMesher(Mesher):
 
     def grid_multiple_interval_analy_refinement(
         self,
-        max_dl_list: ArrayLike[float, 1],
-        len_interval_list: ArrayLike[float, 1],
+        max_dl_list: ArrayFloat1D,
+        len_interval_list: ArrayFloat1D,
         max_scale: float,
         is_periodic: bool,
-    ) -> Tuple[ArrayLike[float, 1], ArrayLike[float, 1]]:
+    ) -> Tuple[ArrayFloat1D, ArrayFloat1D]:
         """Analytical refinement for multiple intervals. "analytical" meaning we allow
         non-integar step sizes, so that we don't consider snapping here.
 
         Parameters
         ----------
-        max_dl_list : ArrayLike[float, 1]
+        max_dl_list : ArrayFloat1D
             Maximal allowed step size of each interval.
-        len_interval_list : ArrayLike[float, 1]
+        len_interval_list : ArrayFloat1D
             A list of interval lengths
         max_scale : float
             Maximal ratio between consecutive steps.
@@ -623,7 +619,7 @@ class GradedMesher(Mesher):
 
         Returns
         -------
-        Tuple[ArrayLike[float, 1], ArrayLike[float, 1]]
+        Tuple[ArrayFloat1D, ArrayFloat1D]
             left and right step sizes of each interval.
         """
 
@@ -691,7 +687,7 @@ class GradedMesher(Mesher):
         max_dl: float,
         max_scale: float,
         len_interval: float,
-    ) -> ArrayLike[float, 1]:
+    ) -> ArrayFloat1D:
         """Create a set of grid steps in an interval of length ``len_interval``,
         with first step no larger than ``max_scale * left_neighbor_dl`` and last step no larger than
         ``max_scale * right_neighbor_dl``, with maximum ratio ``max_scale`` between
@@ -712,7 +708,7 @@ class GradedMesher(Mesher):
 
         Returns
         -------
-        ArrayLike[float, 1]
+        ArrayFloat1D
             A list of step sizes in the interval.
         """
 
@@ -797,7 +793,7 @@ class GradedMesher(Mesher):
         max_dl: float,
         max_scale: float,
         len_interval: float,
-    ) -> ArrayLike[float, 1]:
+    ) -> ArrayFloat1D:
         """In an interval, grid grows, plateau, and decrease, resembling Lambda letter but
         with plateau in the connection part..
 
@@ -866,7 +862,7 @@ class GradedMesher(Mesher):
         right_dl: float,
         max_scale: float,
         len_interval: float,
-    ) -> ArrayLike[float, 1]:
+    ) -> ArrayFloat1D:
         """In an interval, grid grows, and decrease, resembling Lambda letter.
 
         Parameters
@@ -954,7 +950,7 @@ class GradedMesher(Mesher):
         large_dl: float,
         max_scale: float,
         len_interval: float,
-    ) -> ArrayLike[float, 1]:
+    ) -> ArrayFloat1D:
         """In an interval, grid grows, then plateau.
 
         Parameters
@@ -970,7 +966,7 @@ class GradedMesher(Mesher):
 
         Returns
         -------
-        ArrayLike[float, 1]
+        ArrayFloat1D
             A list of step sizes in the interval, in ascending order.
         """
         # steps for scaling
@@ -1008,7 +1004,7 @@ class GradedMesher(Mesher):
         small_dl: float,
         max_scale: float,
         len_interval: float,
-    ) -> ArrayLike[float, 1]:
+    ) -> ArrayFloat1D:
         """Mesh simply grows in an interval.
 
         Parameters
@@ -1022,7 +1018,7 @@ class GradedMesher(Mesher):
 
         Returns
         -------
-        ArrayLike[float, 1]
+        ArrayFloat1D
             A list of step sizes in the interval, in ascending order.
         """
 

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -12,7 +12,7 @@ import xarray as xr
 
 from .base import Tidy3dBaseModel, cached_property
 from .grid.grid import Coords, Grid
-from .types import PoleAndResidue, Ax, FreqBound, TYPE_TAG_STR, InterpMethod, Numpy, Bound
+from .types import PoleAndResidue, Ax, FreqBound, TYPE_TAG_STR, InterpMethod, Bound, ArrayComplex4D
 from .data.dataset import PermittivityDataset
 from .data.data_array import ScalarFieldDataArray
 from .viz import add_ax_if_none
@@ -486,7 +486,7 @@ class CustomMedium(AbstractMedium):
         self,
         frequency: float,
         coords: Coords,
-    ) -> Tuple[Numpy, Numpy, Numpy]:
+    ) -> Tuple[ArrayComplex4D, ArrayComplex4D, ArrayComplex4D]:
         """Spatial profile of main diagonal of the complex-valued permittivity
         at ``frequency`` interpolated at the supplied coordinates.
 
@@ -499,7 +499,7 @@ class CustomMedium(AbstractMedium):
 
         Returns
         -------
-        Tuple[Numpy, Numpy, Numpy]
+        Tuple[np.ndarray, np.ndarray, np.ndarray]
             The complex-valued permittivity tensor at ``frequency`` interpolated
             at the supplied coordinate.
         """

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -5,7 +5,7 @@ from typing import Union, Tuple
 import pydantic
 import numpy as np
 
-from .types import Ax, EMField, ArrayLike, FreqArray
+from .types import Ax, EMField, ArrayFloat1D, FreqArray
 from .types import Literal, Direction, Coordinate, Axis, ObsGridArray
 from .geometry import Box
 from .validators import assert_plane
@@ -49,7 +49,7 @@ class Monitor(Box, ABC):
         return Box(center=self.center, size=self.size)
 
     @abstractmethod
-    def storage_size(self, num_cells: int, tmesh: ArrayLike[float, 1]) -> int:
+    def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
         """Size of monitor storage given the number of points after discretization.
 
         Parameters
@@ -126,7 +126,7 @@ class TimeMonitor(Monitor, ABC):
             raise SetupError("Monitor start time is greater than stop time.")
         return val
 
-    def time_inds(self, tmesh: ArrayLike[float, 1]) -> Tuple[int, int]:
+    def time_inds(self, tmesh: ArrayFloat1D) -> Tuple[int, int]:
         """Compute the starting and stopping index of the monitor in a given discrete time mesh."""
 
         tmesh = np.array(tmesh)
@@ -155,7 +155,7 @@ class TimeMonitor(Monitor, ABC):
             tind_beg = tbeg[0] if tbeg.size > 0 else tind_end
         return (tind_beg, tind_end)
 
-    def num_steps(self, tmesh: ArrayLike[float, 1]) -> int:
+    def num_steps(self, tmesh: ArrayFloat1D) -> int:
         """Compute number of time steps for a time monitor."""
 
         tind_beg, tind_end = self.time_inds(tmesh)
@@ -290,7 +290,7 @@ class FieldMonitor(AbstractFieldMonitor, FreqMonitor):
     ...     name='steady_state_monitor')
     """
 
-    def storage_size(self, num_cells: int, tmesh: ArrayLike[float, 1]) -> int:
+    def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
         """Size of monitor storage given the number of points after discretization."""
         # stores 1 complex number per grid cell, per frequency, per field
         return BYTES_COMPLEX * num_cells * len(self.freqs) * len(self.fields)
@@ -311,7 +311,7 @@ class FieldTimeMonitor(AbstractFieldMonitor, TimeMonitor):
     ...     name='movie_monitor')
     """
 
-    def storage_size(self, num_cells: int, tmesh: ArrayLike[float, 1]) -> int:
+    def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
         """Size of monitor storage given the number of points after discretization."""
         # stores 1 real number per grid cell, per time step, per field
         num_steps = self.num_steps(tmesh)
@@ -333,7 +333,7 @@ class PermittivityMonitor(FreqMonitor):
     ...     name='eps_monitor')
     """
 
-    def storage_size(self, num_cells: int, tmesh: ArrayLike[float, 1]) -> int:
+    def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
         """Size of monitor storage given the number of points after discretization."""
         # stores 3 complex number per grid cell, per frequency
         return BYTES_COMPLEX * num_cells * len(self.freqs) * 3
@@ -418,7 +418,7 @@ class FluxMonitor(AbstractFluxMonitor, FreqMonitor):
     ...     name='flux_monitor')
     """
 
-    def storage_size(self, num_cells: int, tmesh: ArrayLike[float, 1]) -> int:
+    def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
         """Size of monitor storage given the number of points after discretization."""
         # stores 1 real number per frequency
         return BYTES_REAL * len(self.freqs)
@@ -442,7 +442,7 @@ class FluxTimeMonitor(AbstractFluxMonitor, TimeMonitor):
     ...     name='flux_vs_time')
     """
 
-    def storage_size(self, num_cells: int, tmesh: ArrayLike[float, 1]) -> int:
+    def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
         """Size of monitor storage given the number of points after discretization."""
         # stores 1 real number per time step
         num_steps = self.num_steps(tmesh)
@@ -612,7 +612,7 @@ class FieldProjectionAngleMonitor(AbstractFieldProjectionMonitor):
         units=RADIAN,
     )
 
-    def storage_size(self, num_cells: int, tmesh: ArrayLike[float, 1]) -> int:
+    def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
         """Size of monitor storage given the number of points after discretization."""
         # stores 1 complex number per pair of angles, per frequency,
         # for Er, Etheta, Ephi, Hr, Htheta, and Hphi (6 components)
@@ -672,7 +672,7 @@ class FieldProjectionCartesianMonitor(AbstractFieldProjectionMonitor):
         units=MICROMETER,
     )
 
-    def storage_size(self, num_cells: int, tmesh: ArrayLike[float, 1]) -> int:
+    def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
         """Size of monitor storage given the number of points after discretization."""
         # stores 1 complex number per pair of grid points, per frequency,
         # for Er, Etheta, Ephi, Hr, Htheta, and Hphi (6 components)
@@ -740,7 +740,7 @@ class FieldProjectionKSpaceMonitor(AbstractFieldProjectionMonitor):
             raise SetupError(f"Entries of 'uy' must lie in the range [-1, 1] for monitor {name}.")
         return values
 
-    def storage_size(self, num_cells: int, tmesh: ArrayLike[float, 1]) -> int:
+    def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
         """Size of monitor storage given the number of points after discretization."""
         # stores 1 complex number per pair of grid points, per frequency,
         # for Er, Etheta, Ephi, Hr, Htheta, and Hphi (6 components)
@@ -780,7 +780,7 @@ class DiffractionMonitor(PlanarMonitor, FreqMonitor):
             )
         return val
 
-    def storage_size(self, num_cells: int, tmesh: ArrayLike[float, 1]) -> int:
+    def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
         """Size of monitor storage given the number of points after discretization."""
         # assumes 1 diffraction order per frequency; actual size will be larger
         return BYTES_COMPLEX * len(self.freqs)

--- a/tidy3d/components/source.py
+++ b/tidy3d/components/source.py
@@ -8,7 +8,8 @@ import pydantic
 import numpy as np
 
 from .base import Tidy3dBaseModel, cached_property, DATA_ARRAY_MAP
-from .types import Direction, Polarization, Ax, FreqBound, ArrayLike, Axis, PlotVal
+
+from .types import Direction, Polarization, Ax, FreqBound, ArrayFloat1D, Axis, PlotVal
 from .validators import assert_plane, assert_volumetric, validate_name_str, get_value
 from .data.dataset import FieldDataset
 from .geometry import Box, Coordinate
@@ -58,8 +59,8 @@ class SourceTime(ABC, Tidy3dBaseModel):
 
     def spectrum(
         self,
-        times: ArrayLike[float, 1],
-        freqs: ArrayLike[float, 1],
+        times: ArrayFloat1D,
+        freqs: ArrayFloat1D,
         dt: float,
         complex_fields: bool = False,
     ) -> complex:
@@ -101,7 +102,7 @@ class SourceTime(ABC, Tidy3dBaseModel):
         return dt * dft_matrix @ time_amps
 
     @add_ax_if_none
-    def plot(self, times: ArrayLike[float, 1], val: PlotVal = "real", ax: Ax = None) -> Ax:
+    def plot(self, times: ArrayFloat1D, val: PlotVal = "real", ax: Ax = None) -> Ax:
         """Plot the complex-valued amplitude of the source time-dependence.
 
         Parameters
@@ -141,7 +142,7 @@ class SourceTime(ABC, Tidy3dBaseModel):
     @add_ax_if_none
     def plot_spectrum(
         self,
-        times: ArrayLike[float, 1],
+        times: ArrayFloat1D,
         num_freqs: int = 101,
         val: PlotVal = "real",
         ax: Ax = None,

--- a/tidy3d/plugins/adjoint/components/geometry.py
+++ b/tidy3d/plugins/adjoint/components/geometry.py
@@ -240,6 +240,18 @@ class JaxPolySlab(JaxGeometry, PolySlab, JaxObject):
         jax_field=True,
     )
 
+    @pd.validator("vertices", pre=True, always=True)
+    def convert_to_numpy(cls, val):
+        """Overwrite to not convert vertices to numpy."""
+        return val
+
+    @pd.validator("vertices", pre=True, always=True)
+    def to_list(cls, val):
+        """Convert any numpy to list."""
+        if isinstance(val, np.ndarray):
+            return val.tolist()
+        return val
+
     # @pd.validator("slab_bounds", always=True)
     # def _is_3d(cls, val):
     #     """Make sure the box is 3D."""

--- a/tidy3d/plugins/dispersion/fit.py
+++ b/tidy3d/plugins/dispersion/fit.py
@@ -15,7 +15,7 @@ from ...log import log
 from ...components.base import Tidy3dBaseModel
 from ...components.medium import PoleResidue, AbstractMedium
 from ...components.viz import add_ax_if_none
-from ...components.types import Ax, ArrayLike
+from ...components.types import Ax, ArrayFloat1D
 from ...constants import C_0, HBAR, MICROMETER
 from ...exceptions import ValidationError, WebError, SetupError
 from ...web.config import DEFAULT_CONFIG as Config
@@ -25,20 +25,20 @@ class DispersionFitter(Tidy3dBaseModel):
     """Tool for fitting refractive index data to get a
     dispersive medium described by :class:`.PoleResidue` model."""
 
-    wvl_um: Union[Tuple[float, ...], ArrayLike[float, 1]] = Field(
+    wvl_um: Union[Tuple[float, ...], ArrayFloat1D] = Field(
         ...,
         title="Wavelength data",
         description="Wavelength data in micrometers.",
         units=MICROMETER,
     )
 
-    n_data: Union[Tuple[float, ...], ArrayLike[float, 1]] = Field(
+    n_data: Union[Tuple[float, ...], ArrayFloat1D] = Field(
         ...,
         title="Index of refraction data",
         description="Real part of the complex index of refraction.",
     )
 
-    k_data: Union[Tuple[float, ...], ArrayLike[float, 1]] = Field(
+    k_data: Union[Tuple[float, ...], ArrayFloat1D] = Field(
         None,
         title="Extinction coefficient data",
         description="Imaginary part of the complex index of refraction.",


### PR DESCRIPTION
`ArrayLike` converts provided value into `np.array` and is encoded to json using `tolist()` for real and imaginary parts separately.
`constrained_array(dtype, ndim)` returns an `ArrayLike` with the dtype and number of dimensions either cast or validated.