### PR TITLE
Include material name in material_library's export_matlib_to_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `export_matlib_to_file` in `material_library` exports material's full name in additional to abbreviation.
+
 ## [1.10.0rc1] - 2023-3-07
 
 ### Added

--- a/tidy3d/material_library/material_library.py
+++ b/tidy3d/material_library/material_library.py
@@ -12,7 +12,7 @@ def export_matlib_to_file(fname: str = "matlib.json") -> None:
     """Write the material library to a .json file."""
 
     mat_lib_dict = {
-        mat_name: {
+        f'{mat.name} ("{mat_name}")': {
             var_name: json.loads(var.medium._json_string)  # pylint: disable=protected-access
             for var_name, var in mat.variants.items()
         }


### PR DESCRIPTION
Requested by @jwang-magicloud to include material name info with a specific format in the generated json file. 