### PR TITLE
fix task name and expose solver version

### DIFF
--- a/tests/test_web/test_tidy3d_task.py
+++ b/tests/test_web/test_tidy3d_task.py
@@ -130,7 +130,7 @@ def test_create():
     responses.add(
         responses.POST,
         f"{Env.current.web_api_endpoint}/tidy3d/projects/1234/tasks",
-        match=[matchers.json_params_matcher({"task_name": "test task", "call_back_url": None})],
+        match=[matchers.json_params_matcher({"taskName": "test task", "call_back_url": None})],
         json={
             "data": {
                 "taskId": "1234",
@@ -156,7 +156,7 @@ def test_submit():
     responses.add(
         responses.POST,
         f"{Env.current.web_api_endpoint}/tidy3d/projects/1234/tasks",
-        match=[matchers.json_params_matcher({"task_name": "test task", "call_back_url": None})],
+        match=[matchers.json_params_matcher({"taskName": "test task", "call_back_url": None})],
         json={
             "data": {
                 "taskId": "1234",

--- a/tests/test_web/test_tidy3d_task.py
+++ b/tests/test_web/test_tidy3d_task.py
@@ -6,6 +6,7 @@ from responses import matchers
 
 from tidy3d.web.environment import Env, EnvironmentConfig
 from tidy3d.web.simulation_task import Folder, SimulationTask
+from tidy3d.version import __version__
 
 test_env = EnvironmentConfig(
     name="test",
@@ -171,7 +172,7 @@ def test_submit():
         f"{Env.current.web_api_endpoint}/tidy3d/tasks/1234/submit",
         match=[
             matchers.json_params_matcher(
-                {"solverVersion": None, "workerGroup": None, "protocolVersion": "1.6.3"}
+                {"solverVersion": None, "workerGroup": None, "protocolVersion": __version__}
             )
         ],
         json={
@@ -184,7 +185,7 @@ def test_submit():
         status=200,
     )
     task = SimulationTask.create(None, "test task", "test folder1")
-    task.submit(protocol_version="1.6.3")
+    task.submit()
 
 
 @responses.activate

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -56,7 +56,7 @@ def mock_upload(monkeypatch, set_api_key):
     responses.add(
         responses.POST,
         f"{Env.current.web_api_endpoint}/tidy3d/projects/{TASK_ID}/tasks",
-        match=[matchers.json_params_matcher({"task_name": TASK_NAME, "call_back_url": None})],
+        match=[matchers.json_params_matcher({"taskName": TASK_NAME, "call_back_url": None})],
         json={
             "data": {
                 "taskId": TASK_ID,

--- a/tidy3d/web/container.py
+++ b/tidy3d/web/container.py
@@ -48,6 +48,13 @@ class Job(WebContainer):
         "``{'id', 'status', 'name', 'workUnit', 'solverVersion'}``.",
     )
 
+    solver_version: str = pd.Field(
+        None,
+        title="Solver Version",
+        description_str="Custom solver version to use, "
+        "otherwise uses default for the current front end version.",
+    )
+
     verbose: bool = pd.Field(
         True, title="Verbose", description="Whether to print info messages and progressbars."
     )
@@ -114,7 +121,7 @@ class Job(WebContainer):
         ----
         To monitor progress of the :class:`Job`, call :meth:`Job.monitor` after started.
         """
-        web.start(self.task_id)
+        web.start(self.task_id, solver_version=self.solver_version)
 
     def get_run_info(self) -> RunInfo:
         """Return information about the running :class:`Job`.
@@ -252,6 +259,13 @@ class Batch(WebContainer):
         True, title="Verbose", description="Whether to print info messages and progressbars."
     )
 
+    solver_version: str = pd.Field(
+        None,
+        title="Solver Version",
+        description_str="Custom solver version to use, "
+        "otherwise uses default for the current front end version.",
+    )
+
     jobs: Dict[TaskName, Job] = pd.Field(
         None,
         title="Simulations",
@@ -316,6 +330,7 @@ class Batch(WebContainer):
                 simulation=simulation,
                 task_name=task_name,
                 folder_name=values.get("folder_name"),
+                solver_version=values.get("solver_version"),
                 verbose=verbose,
             )
             jobs[task_name] = job

--- a/tidy3d/web/simulation_task.py
+++ b/tidy3d/web/simulation_task.py
@@ -327,7 +327,6 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
         self,
         solver_version: str = None,
         worker_group: str = None,
-        protocol_version: str = None,
     ):
         """Kick off this task. If this task instance contain a :class:`.Simulation`,
          it will be uploaded to server first,
@@ -341,8 +340,6 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
             target solver version.
         worker_group: str = None
             worker group
-        protocol_version: str = None
-            protocol version
         """
         if self.simulation:
             upload_string(self.task_id, self.simulation.json(), SIMULATION_JSON, verbose=False)
@@ -361,7 +358,7 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
             },
         )
 
-    def estimate_cost(self, solver_version=None, protocol_version=None) -> float:
+    def estimate_cost(self, solver_version=None) -> float:
         """Compute the maximum flex unit charge for a given task, assuming the simulation runs for
         the full ``run_time``. If early shut-off is triggered, the cost is adjusted proportionately.
 
@@ -369,14 +366,18 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
         ----------
         solver_version: str
             target solver version.
-        protocol_version: str
-            protocol version
 
         Returns
         -------
         flex_unit_cost: float
             estimated cost in flex units
         """
+
+        if solver_version:
+            protocol_version = None
+        else:
+            protocol_version = __version__
+
         assert self.task_id
         resp = http.post(
             f"tidy3d/tasks/{self.task_id}/metadata",

--- a/tidy3d/web/simulation_task.py
+++ b/tidy3d/web/simulation_task.py
@@ -327,7 +327,7 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
         self,
         solver_version: str = None,
         worker_group: str = None,
-        protocol_version: str = __version__,
+        protocol_version: str = None,
     ):
         """Kick off this task. If this task instance contain a :class:`.Simulation`,
          it will be uploaded to server first,
@@ -346,6 +346,12 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
         """
         if self.simulation:
             upload_string(self.task_id, self.simulation.json(), SIMULATION_JSON, verbose=False)
+
+        if solver_version:
+            protocol_version = None
+        else:
+            protocol_version = __version__
+
         http.post(
             f"tidy3d/tasks/{self.task_id}/submit",
             {

--- a/tidy3d/web/simulation_task.py
+++ b/tidy3d/web/simulation_task.py
@@ -189,7 +189,7 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
 
         resp = http.post(
             f"tidy3d/projects/{folder.folder_id}/tasks",
-            {"task_name": task_name, "call_back_url": call_back_url},
+            {"taskName": task_name, "call_back_url": call_back_url},
         )
         return SimulationTask(**resp, simulation=simulation, folder=folder)
 
@@ -323,20 +323,25 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
             progress_callback=progress_callback,
         )
 
-    def submit(self, solver_version=None, worker_group=None, protocol_version=__version__):
-        """
-        Kick off this task. If this task instance contain a :class".simulation",
+    def submit(
+        self,
+        solver_version: str = None,
+        worker_group: str = None,
+        protocol_version: str = __version__,
+    ):
+        """Kick off this task. If this task instance contain a :class:`.Simulation`,
          it will be uploaded to server first,
-        then kick off the task. Otherwise, this method take assumption that
+        then kick off the task. Otherwise, this method makes assumption that
          the Simulation has been uploaded by the
         upload_file function, so the task will be kicked off directly.
+
         Parameters
         ----------
-        solver_version: str
+        solver_version: str = None
             target solver version.
-        worker_group: str
+        worker_group: str = None
             worker group
-        protocol_version: str
+        protocol_version: str = None
             protocol version
         """
         if self.simulation:

--- a/tidy3d/web/webapi.py
+++ b/tidy3d/web/webapi.py
@@ -40,7 +40,6 @@ def run(  # pylint:disable=too-many-arguments
     progress_callback_download: Callable[[float], None] = None,
     solver_version: str = None,
     worker_group: str = None,
-    protocol_version: str = None,
 ) -> SimulationData:
     """Submits a :class:`.Simulation` to server, starts running, monitors progress, downloads,
     and loads results as a :class:`.SimulationData` object.
@@ -68,8 +67,6 @@ def run(  # pylint:disable=too-many-arguments
         target solver version.
     worker_group: str = None
         worker group
-    protocol_version: str = None
-        protocol version
 
     Returns
     -------
@@ -88,7 +85,6 @@ def run(  # pylint:disable=too-many-arguments
         task_id,
         solver_version=solver_version,
         worker_group=worker_group,
-        protocol_version=protocol_version,
     )
     monitor(task_id, verbose=verbose)
     return load(
@@ -170,7 +166,6 @@ def start(
     task_id: TaskId,
     solver_version: str = None,
     worker_group: str = None,
-    protocol_version: str = None,
 ) -> None:
     """Start running the simulation associated with task.
 
@@ -183,8 +178,6 @@ def start(
         target solver version.
     worker_group: str = None
         worker group
-    protocol_version: str = None
-        protocol version
 
     Note
     ----
@@ -193,9 +186,7 @@ def start(
     task = SimulationTask.get(task_id)
     if not task:
         raise ValueError("Task not found.")
-    task.submit(
-        solver_version=solver_version, worker_group=worker_group, protocol_version=protocol_version
-    )
+    task.submit(solver_version=solver_version, worker_group=worker_group)
 
 
 def get_run_info(task_id: TaskId):

--- a/tidy3d/web/webapi.py
+++ b/tidy3d/web/webapi.py
@@ -9,7 +9,6 @@ import pytz
 from rich.console import Console
 from rich.progress import Progress
 
-from ..version import __version__
 from .environment import Env
 from .simulation_task import SimulationTask, SIM_FILE_HDF5, Folder
 from .task import TaskId, TaskInfo
@@ -41,7 +40,7 @@ def run(  # pylint:disable=too-many-arguments
     progress_callback_download: Callable[[float], None] = None,
     solver_version: str = None,
     worker_group: str = None,
-    protocol_version: str = __version__,
+    protocol_version: str = None,
 ) -> SimulationData:
     """Submits a :class:`.Simulation` to server, starts running, monitors progress, downloads,
     and loads results as a :class:`.SimulationData` object.
@@ -171,7 +170,7 @@ def start(
     task_id: TaskId,
     solver_version: str = None,
     worker_group: str = None,
-    protocol_version: str = __version__,
+    protocol_version: str = None,
 ) -> None:
     """Start running the simulation associated with task.
 


### PR DESCRIPTION
task name should be fixed now. 
Solver version can be passed to `web.run()` or directly to `web.start()`