### PR TITLE
Extra field plot options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `SimulationData.plot_field` accepts new field componets and values, including the Poynting vector.
+- `SimulationData.get_poynting_vector` for calculating the 3D Poynting vector at the Yee cell centers.
 
 ### Changed
 - `export_matlib_to_file` in `material_library` exports material's full name in additional to abbreviation.

--- a/tests/test_data/test_sim_data.py
+++ b/tests/test_data/test_sim_data.py
@@ -5,7 +5,7 @@ import matplotlib.pylab as plt
 import pydantic
 
 import tidy3d as td
-from tidy3d.log import DataError
+from tidy3d.log import DataError, Tidy3dKeyError
 
 from tidy3d.components.simulation import Simulation
 from tidy3d.components.grid.grid_spec import GridSpec
@@ -162,6 +162,12 @@ def test_intensity(monitor_name):
     _ = sim_data.get_intensity(monitor_name)
 
 
+@pytest.mark.parametrize("monitor_name", ["field", "field_time", "mode_solver"])
+def test_poynting(monitor_name):
+    sim_data = make_sim_data()
+    _ = sim_data.get_poynting_vector(monitor_name)
+
+
 def test_final_decay():
     sim_data = make_sim_data()
     dv = sim_data.final_decay_value
@@ -186,6 +192,37 @@ def test_to_json():
     with pytest.raises(pydantic.ValidationError):
         sim_data2 = SimulationData.from_file(fname=FNAME)
         # assert sim_data == sim_data2
+
+
+@pytest.mark.filterwarnings("ignore:log10")
+@pytest.mark.parametrize("field_name", ["Ex", "Ey", "Ez", "E", "Hx", "Hz", "Sy"])
+@pytest.mark.parametrize("val", ["real", "imag", "abs", "phase"])
+def test_derived_components(field_name, val):
+    sim_data = make_sim_data()
+    if len(field_name) == 1 and val == "phase":
+        with pytest.raises(Tidy3dKeyError):
+            sim_data.plot_field(
+                "field_time",
+                field_name=field_name,
+                val=val,
+                y=0.0,
+                time=1e-12,
+                ax=AX,
+            )
+    else:
+        sim_data.plot_field(
+            "field_time",
+            field_name=field_name,
+            val=val,
+            y=0.0,
+            time=1e-12,
+            ax=AX,
+        )
+
+
+def test_logscale():
+    sim_data = make_sim_data()
+    sim_data.plot_field("field_time", "Ex", val="real", scale="dB", y=0.0, time=1e-12, ax=AX)
 
 
 def test_sel_kwarg_freq():

--- a/tidy3d/components/data/README.md
+++ b/tidy3d/components/data/README.md
@@ -132,7 +132,8 @@ Selection with square brackets (`sim_data[monitor_name]`) returns a copy of that
 #### Getting Fields
 There are a few other convenience methods for dealing with ``AbstractFieldData`` objects stored in the `SimulationData.monitor_data` dict.
 `sim_data.at_centers(monitor_name)` gets the field-like data at the yee cell centers.
-`sim_data.get_intensity(monitor_name` gets the intensity data for a field-like data evaluated at the yee cell centers.
+`sim_data.get_intensity(monitor_name)` gets the intensity data for a field-like data evaluated at the yee cell centers.
+`sim_data.get_poynting_vector(monitor_name)` gets the Poynting vector data at the yee cell centers.
 
 #### Plotting
 

--- a/tidy3d/components/types.py
+++ b/tidy3d/components/types.py
@@ -180,6 +180,9 @@ ObsGridArray = Union[Tuple[float, ...], ArrayLike[float, 1]]
 
 Ax = Axes
 PlotVal = Literal["real", "imag", "abs"]
+FieldVal = Literal["real", "imag", "abs", "abs^2", "phase"]
+PlotScale = Literal["lin", "dB"]
+ColormapType = Literal["divergent", "sequential", "cyclic"]
 
 """ mode solver """
 

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -503,11 +503,11 @@ class ModeSolver(Tidy3dBaseModel):
         Parameters
         ----------
         field_name : str
-            Name of ``field`` component to plot (eg. ``'Ex'``).
-            Also accepts ``'int'`` to plot intensity.
-        val : Literal['real', 'imag', 'abs'] = 'real'
+            Name of `field` component to plot (eg. `'Ex'`).
+            Also accepts `'E'` and `'H'` to plot the vector magnitudes of the electric and
+            magnetic fields, and `'S'` for the Poynting vector.
+        val : Literal['real', 'imag', 'abs', 'abs^2', 'dB'] = 'real'
             Which part of the field to plot.
-            If ``field_name == 'int'``, this has no effect.
         eps_alpha : float = 0.2
             Opacity of the structure permittivity.
             Must be between 0 and 1 (inclusive).


### PR DESCRIPTION
- Allow plotting the Poynting vector from `SimulationData.field_plot` and full vectorial magnitudes for E and H.

- Include components `"abs^2"` and `"dB"` to `val`, applicable to all components.

- Improve the selection of divergent colormap whenever the data _could_ contain positive and negative values, and centralize map around zero.