### PR TITLE
Change version log from info to debug

### DIFF
--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -112,4 +112,4 @@ def set_logging_level(level: str) -> None:
     )
 
 
-log.info(f"Using client version: {__version__}")
+log.debug(f"Using client version: {__version__}")


### PR DESCRIPTION
It would be great if we could only output the version number if the logging level is set to debug.