### PR TITLE
Ensure n_cfl is float for custom medium

### DIFF
--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -449,7 +449,8 @@ class CustomMedium(AbstractMedium):
         is performed over all components and spatial points.
         """
         eps_array_min = [
-            np.min(eps_array.real) for _, eps_array in self.eps_dataset.field_components.items()
+            float(np.min(eps_array.real))
+            for _, eps_array in self.eps_dataset.field_components.items()
         ]
         return np.sqrt(min(eps_array_min))
 


### PR DESCRIPTION
Fix a backend test failure because sometimes `dt` becomes a dataarray rather than a float.