### PR TITLE
Set grid size for union of GDSII shapes

### DIFF
--- a/tidy3d/components/geometry.py
+++ b/tidy3d/components/geometry.py
@@ -2336,7 +2336,9 @@ class PolySlab(Planar):
 
         # convert vertices into polyslabs
         polygons = (Polygon(vertices) for vertices in all_vertices)
-        polys_union = functools.reduce(lambda poly1, poly2: poly1.union(poly2), polygons)
+        polys_union = functools.reduce(
+            lambda poly1, poly2: poly1.union(poly2, grid_size=1e-12), polygons
+        )
 
         if isinstance(polys_union, Polygon):
             all_vertices = [PolySlab.strip_coords(polys_union)[0]]


### PR DESCRIPTION
Without a grid size, the default from shapely is `double` precision, which leads to artifacts in the final geometry.  Because the GDSII cordinates are already snapped to a grid, this should have no adverse effect unless the GDSII grid is finer than 1e-12.  The usual default in GDSII files is for precision to be 1e-9 with unit 1e-6, that is a grid size of 1e-3, so the chosen value of 1e-12 should be quite safe.