### PR TITLE
merge develop into pre/1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `TriangleMesh` class for modeling geometries specified by triangle surface meshes, with support for STL file import.
 
+## [1.9.3] - 2023-3-08
+
+### Fixed
+- Allow new `tidy3d.config.logging_level` to accept lower case for backwards compatibility.
+
+## [1.9.2] - 2023-3-08
+
+### Added
+- `set_logging_console` allows redirection of console messages to stderr.
+
+### Changed
+- Use custom logger to avoid changing global logging state when importing tidy3d.
+- Separate logging configuration from custom exception definitions.
+
 ## [1.9.1] - 2023-3-06
 
 ### Fixed
@@ -260,7 +274,7 @@ which fields are to be projected is now determined automatically based on the me
 - Bug in auto-mesh generation.
 
 ### Added
-- Ability to compute far fields server-side on GPUs.
+- Ability to compute field projections server-side.
 
 ### Changed
 - All Tidy3D components apart from data structures are now fully immutable.
@@ -606,6 +620,9 @@ which fields are to be projected is now determined automatically based on the me
 
 [Unreleased]: https://github.com/flexcompute/tidy3d/compare/v1.10.0rc1...develop
 [1.10.0rc1]: https://github.com/flexcompute/tidy3d/compare/v1.9.1...v1.10.0rc1
+[Unreleased]: https://github.com/flexcompute/tidy3d/compare/v1.9.3...develop
+[1.9.3]: https://github.com/flexcompute/tidy3d/compare/v1.9.2...v1.9.3
+[1.9.2]: https://github.com/flexcompute/tidy3d/compare/v1.9.1...v1.9.2
 [1.9.1]: https://github.com/flexcompute/tidy3d/compare/v1.9.0...v1.9.1
 [1.9.0]: https://github.com/flexcompute/tidy3d/compare/v1.8.4...v1.9.0
 [1.8.4]: https://github.com/flexcompute/tidy3d/compare/v1.8.3...v1.8.4

--- a/tests/_test_local/_test_adjoint_performance.py
+++ b/tests/_test_local/_test_adjoint_performance.py
@@ -28,7 +28,7 @@ from numpy.random import random
 import tidy3d as td
 from typing import Tuple, Any
 
-from tidy3d.log import DataError, Tidy3dKeyError
+from tidy3d.exceptions import DataError, Tidy3dKeyError, AdjointError
 from tidy3d.plugins.adjoint.components.base import JaxObject
 from tidy3d.plugins.adjoint.components.geometry import JaxBox, JaxPolySlab
 from tidy3d.plugins.adjoint.components.medium import (
@@ -43,9 +43,8 @@ from tidy3d.plugins.adjoint.components.data.monitor_data import JaxModeData
 from tidy3d.plugins.adjoint.components.data.data_array import JaxDataArray
 from tidy3d.plugins.adjoint.components.data.dataset import JaxPermittivityDataset
 from tidy3d.plugins.adjoint.web import run
-from tidy3d.plugins.adjoint.log import AdjointError
 
-from ..utils import run_emulated, assert_log_level
+from ..utils import run_emulated
 
 import tidy3d as td
 

--- a/tests/sims/simulation_1_9_2.json
+++ b/tests/sims/simulation_1_9_2.json
@@ -1,0 +1,1336 @@
+{
+    "type": "Simulation",
+    "center": [
+        0.0,
+        0.0,
+        0.0
+    ],
+    "size": [
+        8.0,
+        8.0,
+        8.0
+    ],
+    "run_time": 1e-12,
+    "medium": {
+        "name": null,
+        "frequency_range": null,
+        "type": "Medium",
+        "permittivity": 1.0,
+        "conductivity": 0.0
+    },
+    "symmetry": [
+        0,
+        0,
+        0
+    ],
+    "structures": [
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Medium",
+                "permittivity": 2.0,
+                "conductivity": 0.0
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    "Infinity",
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Medium",
+                "permittivity": 1.0,
+                "conductivity": 3.0
+            }
+        },
+        {
+            "geometry": {
+                "type": "Sphere",
+                "radius": 1.0,
+                "center": [
+                    1.0,
+                    0.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Sellmeier",
+                "coeffs": [
+                    [
+                        1.03961212,
+                        0.00600069867
+                    ],
+                    [
+                        0.231792344,
+                        0.0200179144
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Lorentz",
+                "eps_inf": 2.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        2.0,
+                        3.0
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Debye",
+                "eps_inf": 2.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        3.0
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Drude",
+                "eps_inf": 2.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        3.0
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "GeometryGroup",
+                "geometries": [
+                    {
+                        "type": "Box",
+                        "center": [
+                            -1.0,
+                            0.0,
+                            0.0
+                        ],
+                        "size": [
+                            1.0,
+                            1.0,
+                            1.0
+                        ]
+                    }
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": "PEC",
+                "frequency_range": null,
+                "type": "PECMedium"
+            }
+        },
+        {
+            "geometry": {
+                "type": "Cylinder",
+                "axis": 1,
+                "sidewall_angle": 0.0,
+                "reference_plane": "bottom",
+                "radius": 1.0,
+                "center": [
+                    1.0,
+                    0.0,
+                    -1.0
+                ],
+                "length": 2.0
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "AnisotropicMedium",
+                "xx": {
+                    "name": null,
+                    "frequency_range": null,
+                    "type": "Medium",
+                    "permittivity": 1.0,
+                    "conductivity": 0.0
+                },
+                "yy": {
+                    "name": null,
+                    "frequency_range": null,
+                    "type": "Medium",
+                    "permittivity": 2.0,
+                    "conductivity": 0.0
+                },
+                "zz": {
+                    "name": null,
+                    "frequency_range": null,
+                    "type": "Medium",
+                    "permittivity": 3.0,
+                    "conductivity": 0.0
+                }
+            }
+        },
+        {
+            "geometry": {
+                "type": "PolySlab",
+                "axis": 2,
+                "sidewall_angle": 0.0,
+                "reference_plane": "bottom",
+                "slab_bounds": [
+                    -1.0,
+                    1.0
+                ],
+                "dilation": 0.0,
+                "vertices": [
+                    [
+                        -1.5,
+                        -1.5
+                    ],
+                    [
+                        -0.5,
+                        -1.5
+                    ],
+                    [
+                        -0.5,
+                        -0.5
+                    ]
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "PoleResidue",
+                "eps_inf": 1.0,
+                "poles": [
+                    [
+                        {
+                            "real": 0.0,
+                            "imag": 6206417594288582.0
+                        },
+                        {
+                            "real": -0.0,
+                            "imag": -3.311074436985222e+16
+                        }
+                    ]
+                ]
+            }
+        }
+    ],
+    "sources": [
+        {
+            "type": "UniformCurrentSource",
+            "center": [
+                0.0,
+                0.5,
+                0.0
+            ],
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "polarization": "Hx"
+        },
+        {
+            "type": "PointDipole",
+            "center": [
+                0.0,
+                0.5,
+                0.0
+            ],
+            "size": [
+                0,
+                0,
+                0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "polarization": "Ex"
+        },
+        {
+            "type": "ModeSource",
+            "center": [
+                0.0,
+                0.5,
+                0.0
+            ],
+            "size": [
+                2.0,
+                0.0,
+                2.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "num_freqs": 1,
+            "direction": "-",
+            "mode_spec": {
+                "num_modes": 1,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "filter_pol": null,
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "precision": "single",
+                "bend_radius": null,
+                "bend_axis": null,
+                "track_freq": "central",
+                "type": "ModeSpec"
+            },
+            "mode_index": 0
+        },
+        {
+            "type": "PlaneWave",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                "Infinity",
+                "Infinity"
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 0.1
+        },
+        {
+            "type": "GaussianBeam",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                3.0,
+                3.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "num_freqs": 1,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 1.5707963267948966,
+            "waist_radius": 1.0,
+            "waist_distance": 0.0
+        },
+        {
+            "type": "AstigmaticGaussianBeam",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                3.0,
+                3.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "num_freqs": 1,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 1.5707963267948966,
+            "waist_sizes": [
+                1.0,
+                2.0
+            ],
+            "waist_distances": [
+                3.0,
+                4.0
+            ]
+        },
+        {
+            "type": "CustomFieldSource",
+            "center": [
+                0.0,
+                1.0,
+                2.0
+            ],
+            "size": [
+                2.0,
+                2.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "field_dataset": {
+                "type": "FieldDataset",
+                "Ex": "ScalarFieldDataArray",
+                "Ey": null,
+                "Ez": null,
+                "Hx": null,
+                "Hy": null,
+                "Hz": null
+            }
+        }
+    ],
+    "boundary_spec": {
+        "x": {
+            "plus": {
+                "name": null,
+                "type": "PML",
+                "num_layers": 20,
+                "parameters": {
+                    "sigma_order": 3,
+                    "sigma_min": 0.0,
+                    "sigma_max": 1.5,
+                    "type": "PMLParams",
+                    "kappa_order": 3,
+                    "kappa_min": 1.0,
+                    "kappa_max": 3.0,
+                    "alpha_order": 1,
+                    "alpha_min": 0.0,
+                    "alpha_max": 0.0
+                }
+            },
+            "minus": {
+                "name": null,
+                "type": "Absorber",
+                "num_layers": 100,
+                "parameters": {
+                    "sigma_order": 3,
+                    "sigma_min": 0.0,
+                    "sigma_max": 6.4,
+                    "type": "AbsorberParams"
+                }
+            },
+            "type": "Boundary"
+        },
+        "y": {
+            "plus": {
+                "name": null,
+                "type": "BlochBoundary",
+                "bloch_vec": 1.0
+            },
+            "minus": {
+                "name": null,
+                "type": "BlochBoundary",
+                "bloch_vec": 1.0
+            },
+            "type": "Boundary"
+        },
+        "z": {
+            "plus": {
+                "name": null,
+                "type": "Periodic"
+            },
+            "minus": {
+                "name": null,
+                "type": "Periodic"
+            },
+            "type": "Boundary"
+        },
+        "type": "BoundarySpec"
+    },
+    "monitors": [
+        {
+            "type": "FieldMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "name": "field",
+            "freqs": [
+                150000000000000.0,
+                200000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "fields": [
+                "Ex"
+            ],
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": false
+        },
+        {
+            "type": "FieldTimeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "name": "field_time",
+            "start": 0.0,
+            "stop": null,
+            "interval": 100,
+            "fields": [
+                "Ex",
+                "Ey",
+                "Ez",
+                "Hx",
+                "Hy",
+                "Hz"
+            ],
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": false
+        },
+        {
+            "type": "FluxMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "flux",
+            "freqs": [
+                200000000000000.0,
+                250000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null
+        },
+        {
+            "type": "FluxTimeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "flux_time",
+            "start": 0.0,
+            "stop": null,
+            "interval": 1,
+            "normal_dir": "+",
+            "exclude_surfaces": null
+        },
+        {
+            "type": "PermittivityMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.1
+            ],
+            "name": "eps",
+            "freqs": [
+                100000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            }
+        },
+        {
+            "type": "ModeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "mode",
+            "freqs": [
+                200000000000000.0,
+                250000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "mode_spec": {
+                "num_modes": 1,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "filter_pol": null,
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "precision": "single",
+                "bend_radius": null,
+                "bend_axis": null,
+                "track_freq": "central",
+                "type": "ModeSpec"
+            }
+        },
+        {
+            "type": "ModeSolverMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "mode_solver",
+            "freqs": [
+                200000000000000.0,
+                250000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "mode_spec": {
+                "num_modes": 1,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "filter_pol": null,
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "precision": "single",
+                "bend_radius": null,
+                "bend_axis": null,
+                "track_freq": "central",
+                "type": "ModeSpec"
+            }
+        },
+        {
+            "type": "FieldProjectionAngleMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                2.0,
+                2.0
+            ],
+            "name": "proj_angle",
+            "freqs": [
+                250000000000000.0,
+                300000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null,
+            "custom_origin": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "far_field_approx": true,
+            "proj_distance": 1000000.0,
+            "theta": [
+                -1.5707963267948966,
+                -1.5390630676677268,
+                -1.5073298085405573,
+                -1.4755965494133876,
+                -1.443863290286218,
+                -1.4121300311590483,
+                -1.3803967720318788,
+                -1.348663512904709,
+                -1.3169302537775396,
+                -1.2851969946503699,
+                -1.2534637355232003,
+                -1.2217304763960306,
+                -1.189997217268861,
+                -1.1582639581416914,
+                -1.1265306990145216,
+                -1.0947974398873521,
+                -1.0630641807601826,
+                -1.0313309216330129,
+                -0.9995976625058433,
+                -0.9678644033786736,
+                -0.936131144251504,
+                -0.9043978851243344,
+                -0.8726646259971648,
+                -0.8409313668699951,
+                -0.8091981077428254,
+                -0.7774648486156558,
+                -0.7457315894884862,
+                -0.7139983303613165,
+                -0.6822650712341469,
+                -0.6505318121069773,
+                -0.6187985529798077,
+                -0.5870652938526381,
+                -0.5553320347254684,
+                -0.5235987755982987,
+                -0.4918655164711292,
+                -0.46013225734395946,
+                -0.42839899821678995,
+                -0.3966657390896202,
+                -0.3649324799624507,
+                -0.333199220835281,
+                -0.30146596170811146,
+                -0.26973270258094173,
+                -0.23799944345377222,
+                -0.2062661843266025,
+                -0.17453292519943298,
+                -0.14279966607226324,
+                -0.11106640694509373,
+                -0.079333147817924,
+                -0.047599888690754266,
+                -0.015866629563584755,
+                0.015866629563584977,
+                0.04759988869075449,
+                0.07933314781792422,
+                0.11106640694509373,
+                0.14279966607226346,
+                0.17453292519943298,
+                0.2062661843266027,
+                0.23799944345377222,
+                0.26973270258094195,
+                0.30146596170811146,
+                0.3331992208352812,
+                0.3649324799624507,
+                0.39666573908962044,
+                0.42839899821678995,
+                0.4601322573439597,
+                0.4918655164711292,
+                0.5235987755982991,
+                0.5553320347254687,
+                0.5870652938526382,
+                0.6187985529798077,
+                0.6505318121069776,
+                0.6822650712341471,
+                0.7139983303613167,
+                0.7457315894884862,
+                0.7774648486156561,
+                0.8091981077428256,
+                0.8409313668699951,
+                0.8726646259971647,
+                0.9043978851243346,
+                0.9361311442515041,
+                0.9678644033786736,
+                0.9995976625058436,
+                1.031330921633013,
+                1.0630641807601826,
+                1.0947974398873521,
+                1.126530699014522,
+                1.1582639581416916,
+                1.189997217268861,
+                1.2217304763960306,
+                1.2534637355232006,
+                1.28519699465037,
+                1.3169302537775396,
+                1.348663512904709,
+                1.380396772031879,
+                1.4121300311590486,
+                1.443863290286218,
+                1.475596549413388,
+                1.5073298085405575,
+                1.539063067667727,
+                1.5707963267948966
+            ],
+            "phi": [
+                0.0,
+                1.5707963267948966
+            ]
+        },
+        {
+            "type": "FieldProjectionCartesianMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                2.0,
+                2.0
+            ],
+            "name": "proj_cartesian",
+            "freqs": [
+                250000000000000.0,
+                300000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null,
+            "custom_origin": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "far_field_approx": true,
+            "proj_axis": 2,
+            "proj_distance": 5.0,
+            "x": [
+                -1.0,
+                0.0,
+                1.0
+            ],
+            "y": [
+                -2.0,
+                -1.0,
+                0.0,
+                1.0,
+                2.0
+            ]
+        },
+        {
+            "type": "FieldProjectionKSpaceMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                2.0,
+                2.0
+            ],
+            "name": "proj_kspace",
+            "freqs": [
+                250000000000000.0,
+                300000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null,
+            "custom_origin": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "far_field_approx": true,
+            "proj_axis": 2,
+            "proj_distance": 1000000.0,
+            "ux": [
+                0.1,
+                0.2
+            ],
+            "uy": [
+                0.3,
+                0.4,
+                0.5
+            ]
+        },
+        {
+            "type": "FieldProjectionAngleMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                2.0,
+                2.0
+            ],
+            "name": "proj_angle_exact",
+            "freqs": [
+                250000000000000.0,
+                300000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null,
+            "custom_origin": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "far_field_approx": true,
+            "proj_distance": 1000000.0,
+            "theta": [
+                -1.5707963267948966,
+                -1.5390630676677268,
+                -1.5073298085405573,
+                -1.4755965494133876,
+                -1.443863290286218,
+                -1.4121300311590483,
+                -1.3803967720318788,
+                -1.348663512904709,
+                -1.3169302537775396,
+                -1.2851969946503699,
+                -1.2534637355232003,
+                -1.2217304763960306,
+                -1.189997217268861,
+                -1.1582639581416914,
+                -1.1265306990145216,
+                -1.0947974398873521,
+                -1.0630641807601826,
+                -1.0313309216330129,
+                -0.9995976625058433,
+                -0.9678644033786736,
+                -0.936131144251504,
+                -0.9043978851243344,
+                -0.8726646259971648,
+                -0.8409313668699951,
+                -0.8091981077428254,
+                -0.7774648486156558,
+                -0.7457315894884862,
+                -0.7139983303613165,
+                -0.6822650712341469,
+                -0.6505318121069773,
+                -0.6187985529798077,
+                -0.5870652938526381,
+                -0.5553320347254684,
+                -0.5235987755982987,
+                -0.4918655164711292,
+                -0.46013225734395946,
+                -0.42839899821678995,
+                -0.3966657390896202,
+                -0.3649324799624507,
+                -0.333199220835281,
+                -0.30146596170811146,
+                -0.26973270258094173,
+                -0.23799944345377222,
+                -0.2062661843266025,
+                -0.17453292519943298,
+                -0.14279966607226324,
+                -0.11106640694509373,
+                -0.079333147817924,
+                -0.047599888690754266,
+                -0.015866629563584755,
+                0.015866629563584977,
+                0.04759988869075449,
+                0.07933314781792422,
+                0.11106640694509373,
+                0.14279966607226346,
+                0.17453292519943298,
+                0.2062661843266027,
+                0.23799944345377222,
+                0.26973270258094195,
+                0.30146596170811146,
+                0.3331992208352812,
+                0.3649324799624507,
+                0.39666573908962044,
+                0.42839899821678995,
+                0.4601322573439597,
+                0.4918655164711292,
+                0.5235987755982991,
+                0.5553320347254687,
+                0.5870652938526382,
+                0.6187985529798077,
+                0.6505318121069776,
+                0.6822650712341471,
+                0.7139983303613167,
+                0.7457315894884862,
+                0.7774648486156561,
+                0.8091981077428256,
+                0.8409313668699951,
+                0.8726646259971647,
+                0.9043978851243346,
+                0.9361311442515041,
+                0.9678644033786736,
+                0.9995976625058436,
+                1.031330921633013,
+                1.0630641807601826,
+                1.0947974398873521,
+                1.126530699014522,
+                1.1582639581416916,
+                1.189997217268861,
+                1.2217304763960306,
+                1.2534637355232006,
+                1.28519699465037,
+                1.3169302537775396,
+                1.348663512904709,
+                1.380396772031879,
+                1.4121300311590486,
+                1.443863290286218,
+                1.475596549413388,
+                1.5073298085405575,
+                1.539063067667727,
+                1.5707963267948966
+            ],
+            "phi": [
+                0.0,
+                1.5707963267948966
+            ]
+        },
+        {
+            "type": "DiffractionMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                "Infinity",
+                "Infinity"
+            ],
+            "name": "diffraction",
+            "freqs": [
+                100000000000000.0,
+                200000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+"
+        }
+    ],
+    "grid_spec": {
+        "grid_x": {
+            "type": "AutoGrid",
+            "min_steps_per_wvl": 10.0,
+            "max_scale": 1.4,
+            "dl_min": 0.0,
+            "mesher": {
+                "type": "GradedMesher"
+            }
+        },
+        "grid_y": {
+            "type": "CustomGrid",
+            "dl": [
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04
+            ]
+        },
+        "grid_z": {
+            "type": "UniformGrid",
+            "dl": 0.05
+        },
+        "wavelength": null,
+        "override_structures": [
+            {
+                "geometry": {
+                    "type": "Box",
+                    "center": [
+                        -1.0,
+                        0.0,
+                        0.0
+                    ],
+                    "size": [
+                        1.0,
+                        1.0,
+                        1.0
+                    ]
+                },
+                "name": null,
+                "type": "Structure",
+                "medium": {
+                    "name": null,
+                    "frequency_range": null,
+                    "type": "Medium",
+                    "permittivity": 2.0,
+                    "conductivity": 0.0
+                }
+            }
+        ],
+        "type": "GridSpec"
+    },
+    "shutoff": 0.0001,
+    "subpixel": false,
+    "normalize_index": 0,
+    "courant": 0.8,
+    "version": "1.9.2"
+}

--- a/tests/test_components/test_apodization.py
+++ b/tests/test_components/test_apodization.py
@@ -2,7 +2,7 @@
 import pytest
 import pydantic
 import tidy3d as td
-from tidy3d.log import SetupError
+from tidy3d.exceptions import SetupError
 import matplotlib.pylab as plt
 
 

--- a/tests/test_components/test_base.py
+++ b/tests/test_components/test_base.py
@@ -6,8 +6,7 @@ import pydantic
 
 import tidy3d as td
 from tidy3d.components.base import Tidy3dBaseModel
-from tidy3d.log import ValidationError, SetupError, Tidy3dKeyError
-from ..utils import assert_log_level
+from tidy3d.exceptions import ValidationError, SetupError, Tidy3dKeyError
 
 
 M = td.Medium()

--- a/tests/test_components/test_boundaries.py
+++ b/tests/test_components/test_boundaries.py
@@ -10,8 +10,8 @@ from tidy3d.components.boundary import Periodic, PECBoundary, PMCBoundary, Bloch
 from tidy3d.components.boundary import PML, StablePML, Absorber
 from tidy3d.components.source import GaussianPulse, PlaneWave, PointDipole
 from tidy3d.components.types import TYPE_TAG_STR
-from tidy3d.log import SetupError, ValidationError, DataError
-from ..utils import assert_log_level
+from tidy3d.exceptions import SetupError, ValidationError, DataError
+from ..utils import assert_log_level, log_capture
 
 
 def test_bloch_phase():
@@ -79,17 +79,17 @@ def test_boundary_validators():
 
 
 @pytest.mark.parametrize("boundary, log_level", [(PMCBoundary(), None), (Periodic(), "warning")])
-def test_boundary_validator_warnings(caplog, boundary, log_level):
+def test_boundary_validator_warnings(log_capture, boundary, log_level):
     """Test the validators in class `Boundary` which should show a warning but not an error"""
     boundary = Boundary(plus=PECBoundary(), minus=boundary)
-    assert_log_level(caplog, log_level)
+    assert_log_level(log_capture, log_level)
 
 
 @pytest.mark.parametrize("boundary, log_level", [(PMCBoundary(), None), (Periodic(), "warning")])
-def test_boundary_validator_warnings_switched(caplog, boundary, log_level):
+def test_boundary_validator_warnings_switched(log_capture, boundary, log_level):
     """Test the validators in class `Boundary` which should show a warning but not an error"""
     boundary = Boundary(minus=PECBoundary(), plus=boundary)
-    assert_log_level(caplog, log_level)
+    assert_log_level(log_capture, log_level)
 
 
 def test_boundary():
@@ -184,8 +184,8 @@ LOG_LEVELS_EXPECTED = (None, "warning", "warning", "warning")
 
 # TODO: remove for 2.0
 @pytest.mark.parametrize("pm_keys, log_level", zip(PLUS_MINUS_SPECIFIED, LOG_LEVELS_EXPECTED))
-def test_deprecation_defaults(caplog, pm_keys, log_level):
+def test_deprecation_defaults(log_capture, pm_keys, log_level):
     """Make sure deprecation warnings thrown if defaults used."""
     boundary_kwargs = {key: Periodic() for key in pm_keys}
     bc = Boundary(**boundary_kwargs)
-    assert_log_level(caplog, log_level)
+    assert_log_level(log_capture, log_level)

--- a/tests/test_components/test_custom.py
+++ b/tests/test_components/test_custom.py
@@ -12,10 +12,10 @@ from tidy3d import Coords
 from tidy3d.components.source import CustomFieldSource, GaussianPulse
 from tidy3d.components.data.data_array import ScalarFieldDataArray
 from tidy3d.components.data.dataset import FieldDataset
-from tidy3d.log import SetupError, DataError, ValidationError
+from tidy3d.exceptions import SetupError, DataError, ValidationError
 
 from ..test_data.test_monitor_data import make_field_data
-from ..utils import clear_tmp, assert_log_level
+from ..utils import clear_tmp, assert_log_level, log_capture
 from tidy3d.components.data.dataset import PermittivityDataset
 from tidy3d.components.medium import CustomMedium
 
@@ -124,13 +124,13 @@ def test_io_hdf5():
     assert FIELD_SRC == FIELD_SRC2
 
 
-def test_io_json(caplog):
+def test_io_json(log_capture):
     """to json warns and then from json errors."""
     path = "tests/tmp/custom_source.json"
     FIELD_SRC.to_file(path)
-    assert_log_level(caplog, "warning")
+    assert_log_level(log_capture, "warning")
     FIELD_SRC2 = FIELD_SRC.from_file(path)
-    assert_log_level(caplog, "warning")
+    assert_log_level(log_capture, "warning")
     assert FIELD_SRC2.field_dataset is None
 
 

--- a/tests/test_components/test_field_projection.py
+++ b/tests/test_components/test_field_projection.py
@@ -3,7 +3,7 @@ import numpy as np
 import tidy3d as td
 import pytest
 
-from tidy3d.log import SetupError, DataError
+from tidy3d.exceptions import SetupError, DataError
 from ..utils import clear_tmp
 
 

--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -10,9 +10,10 @@ import gdspy
 import trimesh
 
 import tidy3d as td
-from tidy3d.log import ValidationError, SetupError, Tidy3dKeyError
+from tidy3d.exceptions import ValidationError, SetupError, Tidy3dKeyError
 from tidy3d.components.geometry import Geometry, Planar
-from ..utils import assert_log_level, prepend_tmp
+from ..utils import assert_log_level, prepend_tmp, log_capture
+
 
 GEO = td.Box(size=(1, 1, 1))
 GEO_INF = td.Box(size=(1, 1, td.inf))
@@ -415,7 +416,7 @@ def make_ref_plane_kwargs(reference_plane: str):
     "sidewall_angle, reference_plane, log_level",
     zip(SIDEWALL_ANGLES, REFERENCE_PLANES, LOG_LEVELS_EXPECTED),
 )
-def test_polyslab_deprecation_field(caplog, sidewall_angle, reference_plane, log_level):
+def test_polyslab_deprecation_field(log_capture, sidewall_angle, reference_plane, log_level):
     """Test that deprectaion warnings thrown if polyslab reference plane not specified."""
 
     reference_plane_kwargs = make_ref_plane_kwargs(reference_plane)
@@ -427,7 +428,7 @@ def test_polyslab_deprecation_field(caplog, sidewall_angle, reference_plane, log
         sidewall_angle=sidewall_angle,
         **reference_plane_kwargs,
     )
-    assert_log_level(caplog, log_level)
+    assert_log_level(log_capture, log_level)
 
 
 # TODO: remove for 2.0
@@ -435,7 +436,7 @@ def test_polyslab_deprecation_field(caplog, sidewall_angle, reference_plane, log
     "sidewall_angle, reference_plane, log_level",
     zip(SIDEWALL_ANGLES, REFERENCE_PLANES, LOG_LEVELS_EXPECTED),
 )
-def test_cylinder_deprecation_field(caplog, sidewall_angle, reference_plane, log_level):
+def test_cylinder_deprecation_field(log_capture, sidewall_angle, reference_plane, log_level):
     """Test that deprectaion warnings thrown if cylinder reference plane not specified."""
 
     reference_plane_kwargs = make_ref_plane_kwargs(reference_plane)
@@ -447,7 +448,7 @@ def test_cylinder_deprecation_field(caplog, sidewall_angle, reference_plane, log
         sidewall_angle=sidewall_angle,
         **reference_plane_kwargs,
     )
-    assert_log_level(caplog, log_level)
+    assert_log_level(log_capture, log_level)
 
 
 # TODO: remove for 2.0
@@ -455,7 +456,7 @@ def test_cylinder_deprecation_field(caplog, sidewall_angle, reference_plane, log
     "sidewall_angle, reference_plane, log_level",
     zip(SIDEWALL_ANGLES, REFERENCE_PLANES, LOG_LEVELS_EXPECTED),
 )
-def test_polyslab_deprecation_classmethod(caplog, sidewall_angle, reference_plane, log_level):
+def test_polyslab_deprecation_classmethod(log_capture, sidewall_angle, reference_plane, log_level):
     """Test that deprectaion warnings thrown if polyslab reference plane not specified."""
 
     reference_plane_kwargs = make_ref_plane_kwargs(reference_plane)
@@ -472,7 +473,7 @@ def test_polyslab_deprecation_classmethod(caplog, sidewall_angle, reference_plan
         **reference_plane_kwargs,
     )
 
-    assert_log_level(caplog, log_level)
+    assert_log_level(log_capture, log_level)
 
 
 def test_polyslab_merge():

--- a/tests/test_components/test_grid.py
+++ b/tests/test_components/test_grid.py
@@ -5,7 +5,7 @@ import numpy as np
 import tidy3d as td
 from tidy3d.components.grid.grid import Coords, FieldGrid, YeeGrid, Grid
 from tidy3d.components.types import TYPE_TAG_STR
-from tidy3d.log import SetupError
+from tidy3d.exceptions import SetupError
 
 
 def make_grid():

--- a/tests/test_components/test_grid_spec.py
+++ b/tests/test_components/test_grid_spec.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 
 import tidy3d as td
-from tidy3d.log import SetupError
+from tidy3d.exceptions import SetupError
 
 
 def make_grid_spec():

--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -4,7 +4,7 @@ import pytest
 import pydantic
 import matplotlib.pylab as plt
 import tidy3d as td
-from tidy3d.log import ValidationError
+from tidy3d.exceptions import ValidationError
 from typing import Dict
 
 MEDIUM = td.Medium()

--- a/tests/test_components/test_meshgenerate.py
+++ b/tests/test_components/test_meshgenerate.py
@@ -7,7 +7,6 @@ import tidy3d as td
 from tidy3d.constants import fp_eps
 
 from tidy3d.components.grid.mesher import GradedMesher
-from ..utils import assert_log_level
 
 np.random.seed(4)
 
@@ -651,7 +650,7 @@ def test_mesher_timeout():
     grid = sim.grid
 
 
-def test_shapely_strtree_warnings(caplog):
+def test_shapely_strtree_warnings():
 
     with warnings.catch_warnings():
         warnings.simplefilter("error")

--- a/tests/test_components/test_mode.py
+++ b/tests/test_components/test_mode.py
@@ -3,7 +3,7 @@ import pytest
 import pydantic
 import numpy as np
 import tidy3d as td
-from tidy3d.log import SetupError
+from tidy3d.exceptions import SetupError
 
 
 def test_modes():

--- a/tests/test_components/test_monitor.py
+++ b/tests/test_components/test_monitor.py
@@ -3,7 +3,7 @@ import pytest
 import pydantic
 import numpy as np
 import tidy3d as td
-from tidy3d.log import SetupError, ValidationError
+from tidy3d.exceptions import SetupError, ValidationError
 
 
 def test_stop_start():

--- a/tests/test_components/test_sidewall.py
+++ b/tests/test_components/test_sidewall.py
@@ -7,7 +7,7 @@ from shapely.geometry import Polygon, Point
 
 import tidy3d as td
 from tidy3d.constants import fp_eps
-from tidy3d.log import ValidationError, SetupError
+from tidy3d.exceptions import ValidationError, SetupError
 
 np.random.seed(4)
 _BUFFER_PARAM = {"join_style": 2, "mitre_limit": 1e10}

--- a/tests/test_components/test_source.py
+++ b/tests/test_components/test_source.py
@@ -4,7 +4,7 @@ import pydantic
 import matplotlib.pylab as plt
 import numpy as np
 import tidy3d as td
-from tidy3d.log import SetupError, DataError, ValidationError
+from tidy3d.exceptions import SetupError, DataError, ValidationError
 from tidy3d.components.source import DirectionalSource, CHEB_GRID_WIDTH
 
 _, AX = plt.subplots()

--- a/tests/test_components/test_types.py
+++ b/tests/test_components/test_types.py
@@ -3,7 +3,7 @@ import pytest
 import tidy3d as td
 from tidy3d.components.types import ArrayLike, Complex
 from tidy3d.components.base import Tidy3dBaseModel
-from tidy3d.log import ValidationError
+from tidy3d.exceptions import ValidationError
 import numpy as np
 
 

--- a/tests/test_data/test_monitor_data.py
+++ b/tests/test_data/test_monitor_data.py
@@ -8,7 +8,7 @@ from tidy3d.components.monitor import FieldMonitor, FieldTimeMonitor, Permittivi
 from tidy3d.components.monitor import ModeSolverMonitor, ModeMonitor
 from tidy3d.components.monitor import FluxMonitor, FluxTimeMonitor
 from tidy3d.components.mode import ModeSpec
-from tidy3d.log import DataError, SetupError
+from tidy3d.exceptions import DataError, SetupError
 
 from tidy3d.components.data.dataset import FieldDataset
 from tidy3d.components.data.data_array import FreqModeDataArray
@@ -27,7 +27,7 @@ from .test_data_arrays import FIELD_MONITOR, FIELD_TIME_MONITOR, MODE_SOLVE_MONI
 from .test_data_arrays import MODE_MONITOR, PERMITTIVITY_MONITOR, FLUX_MONITOR, FLUX_TIME_MONITOR
 from .test_data_arrays import FIELD_MONITOR_2D, FIELD_TIME_MONITOR_2D
 from .test_data_arrays import DIFFRACTION_MONITOR, SIM_SYM, SIM
-from ..utils import clear_tmp, assert_log_level
+from ..utils import clear_tmp, assert_log_level, log_capture
 
 # data array instances
 AMPS = make_mode_amps_data_array()
@@ -436,16 +436,16 @@ def test_data_array_attrs():
     assert data.flux.f.attrs, "data coordinates have no attrs"
 
 
-def test_data_array_json_warns(caplog):
+def test_data_array_json_warns(log_capture):
     data = make_flux_data()
     data.to_file("tests/tmp/flux.json")
-    assert_log_level(caplog, "warning")
+    assert_log_level(log_capture, "warning")
 
 
-def test_data_array_hdf5_no_warnings(caplog):
+def test_data_array_hdf5_no_warnings(log_capture):
     data = make_flux_data()
     data.to_file("tests/tmp/flux.hdf5")
-    assert_log_level(caplog, None)
+    assert_log_level(log_capture, None)
 
 
 def test_diffraction_data_use_medium():

--- a/tests/test_data/test_sim_data.py
+++ b/tests/test_data/test_sim_data.py
@@ -5,7 +5,7 @@ import matplotlib.pylab as plt
 import pydantic
 
 import tidy3d as td
-from tidy3d.log import DataError, Tidy3dKeyError
+from tidy3d.exceptions import DataError, Tidy3dKeyError
 
 from tidy3d.components.simulation import Simulation
 from tidy3d.components.grid.grid_spec import GridSpec

--- a/tests/test_package/test_config.py
+++ b/tests/test_package/test_config.py
@@ -4,21 +4,19 @@ import pytest
 import pydantic
 
 import tidy3d as td
-from tidy3d.log import log, DEFAULT_LEVEL, LEVEL_MAP
-
-from ..utils import assert_log_level
+from tidy3d.log import DEFAULT_LEVEL, _level_value
 
 
 def test_logging_level():
     """Make sure setting the logging level in config affects the log.level"""
 
     # default level
-    assert log.level == LEVEL_MAP[DEFAULT_LEVEL.lower()]
+    assert td.log.handlers["console"].level == _level_value[DEFAULT_LEVEL]
 
     # check etting all levels
-    for key, val in LEVEL_MAP.items():
+    for key, val in _level_value.items():
         td.config.logging_level = key
-        assert log.level == val
+        assert td.log.handlers["console"].level == val
 
 
 def test_log_level_not_found():

--- a/tests/test_package/test_log.py
+++ b/tests/test_package/test_log.py
@@ -1,34 +1,39 @@
 """Test the logging."""
 
 import pytest
+
 import pydantic as pd
 import tidy3d as td
-from tidy3d.log import Tidy3dError, ConfigError, set_logging_level
-from tidy3d.log import DEFAULT_LEVEL, _get_level_int
-
-log = td.log
+from tidy3d.exceptions import Tidy3dError
+from tidy3d.log import DEFAULT_LEVEL, _get_level_int, set_logging_level
+from ..utils import log_capture, assert_log_level
 
 
 def test_log():
-    log.debug("test")
-    log.info("test")
-    log.warning("test")
-    log.error("test")
+    td.log.debug("debug test")
+    td.log.info("info test")
+    td.log.warning("warning test")
+    td.log.error("error test")
+    td.log.critical("critical test")
+    td.log.log(0, "zero test")
 
 
 def test_log_config():
-    td.config.logging_level = "debug"
+    td.config.logging_level = "DEBUG"
     td.set_logging_file("test.log")
+    assert len(td.log.handlers) == 2
+    assert td.log.handlers["console"].level == _get_level_int("DEBUG")
+    assert td.log.handlers["file"].level == _get_level_int(DEFAULT_LEVEL)
 
 
 def test_log_level_not_found():
-    with pytest.raises(ConfigError):
+    with pytest.raises(ValueError):
         set_logging_level("NOT_A_LEVEL")
 
 
 def test_set_logging_level_deprecated():
     with pytest.raises(DeprecationWarning):
-        td.set_logging_level("warning")
+        td.set_logging_level("WARNING")
 
 
 def test_exception_message():
@@ -37,25 +42,20 @@ def test_exception_message():
     assert str(e) == MESSAGE
 
 
-def test_reset_logging_level():
+@pytest.mark.parametrize(
+    "level_supplied, desired_level",
+    [
+        ("warning", "WARNING"),
+        ("WARNING", None),
+    ],
+)
+def test_logging_upper(log_capture, level_supplied, desired_level):
+    """Make sure we get a deprecation warning if lowrcase."""
+    td.config.logging_level = level_supplied
+    assert_log_level(log_capture, desired_level)
 
-    import logging
-    from rich.logging import RichHandler
 
-    td.config.logging_level = DEFAULT_LEVEL.lower()
-    LEVEL = logging.ERROR
-    assert DEFAULT_LEVEL != LEVEL, "set LEVEL something different from the DEFAULT_LEVEL for tidy3d"
-
-    logging.basicConfig(
-        level=LEVEL,
-        format="%(message)s",
-        datefmt="[%X]",
-        handlers=[RichHandler(rich_tracebacks=True)],
-    )
-
-    log_test = logging.getLogger("rich")
-    log_test.setLevel(LEVEL)
-    assert log_test.level == LEVEL, "test logger level wasnt set correctly."
-    assert log.level == _get_level_int(
-        DEFAULT_LEVEL.lower()
-    ), "tidy3d log level was reset by making a new logger"
+def test_logging_unrecognized():
+    """If unrecognized option, raise validation errorr."""
+    with pytest.raises(pd.ValidationError):
+        td.config.logging_level = "blah"

--- a/tests/test_package/test_material_library.py
+++ b/tests/test_package/test_material_library.py
@@ -10,7 +10,7 @@ from tidy3d.material_library.material_library import (
     export_matlib_to_file,
 )
 import tidy3d as td
-from tidy3d.log import SetupError
+from tidy3d.exceptions import SetupError
 from ..utils import clear_tmp
 
 

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -13,7 +13,7 @@ from numpy.random import random
 import tidy3d as td
 from typing import Tuple, Any
 
-from tidy3d.log import DataError, Tidy3dKeyError
+from tidy3d.exceptions import DataError, Tidy3dKeyError, AdjointError
 from tidy3d.plugins.adjoint.components.base import JaxObject
 from tidy3d.plugins.adjoint.components.geometry import JaxBox, JaxPolySlab
 from tidy3d.plugins.adjoint.components.medium import JaxMedium, JaxAnisotropicMedium
@@ -25,9 +25,8 @@ from tidy3d.plugins.adjoint.components.data.monitor_data import JaxModeData, Jax
 from tidy3d.plugins.adjoint.components.data.data_array import JaxDataArray
 from tidy3d.plugins.adjoint.components.data.dataset import JaxPermittivityDataset
 from tidy3d.plugins.adjoint.web import run, run_async
-from tidy3d.plugins.adjoint.log import AdjointError
 
-from ..utils import run_emulated, assert_log_level, run_async_emulated
+from ..utils import run_emulated, assert_log_level, log_capture, run_async_emulated
 
 
 EPS = 2.0
@@ -479,7 +478,7 @@ def test_jax_sim_data(use_emulated_run):
         mnt_data_c = sim_data[mnt_name]
 
 
-def test_intersect_structures(caplog):
+def test_intersect_structures(log_capture):
     """Test validators for structures touching and intersecting."""
 
     SIZE_X = 1.0
@@ -510,7 +509,7 @@ def test_intersect_structures(caplog):
 
     # shouldnt error, just warn because of touching but not intersecting
     sim = make_sim_intersect(spacing=0.0)
-    assert_log_level(caplog, "warning")
+    assert_log_level(log_capture, "warning")
 
 
 def test_structure_overlaps():

--- a/tests/test_plugins/test_component_modeler.py
+++ b/tests/test_plugins/test_component_modeler.py
@@ -7,7 +7,7 @@ import gdstk
 import tidy3d as td
 from tidy3d.web.container import Batch
 from tidy3d.plugins.smatrix.smatrix import Port, ComponentModeler
-from tidy3d.log import SetupError, Tidy3dKeyError
+from tidy3d.exceptions import SetupError, Tidy3dKeyError
 from ..utils import clear_tmp, run_emulated
 
 # Waveguide height

--- a/tests/test_plugins/test_polyslab.py
+++ b/tests/test_plugins/test_polyslab.py
@@ -6,7 +6,7 @@ import gdstk
 import tidy3d as td
 
 from tidy3d.plugins import ComplexPolySlab
-from ..utils import clear_tmp, assert_log_level
+from ..utils import clear_tmp, assert_log_level, log_capture
 
 
 def test_divide_simple_events():
@@ -37,7 +37,7 @@ def test_divide_simple_events():
                 #     print(np.array(poly.vertices))
 
 
-def test_many_sub_polyslabs(caplog):
+def test_many_sub_polyslabs(log_capture):
     """warn when too many subpolyslabs are generated."""
 
     # generate vertices that can generate at least this number
@@ -58,7 +58,7 @@ def test_many_sub_polyslabs(caplog):
         geometry=s.geometry_group,
         medium=td.Medium(permittivity=2),
     )
-    assert_log_level(caplog, "warning")
+    assert_log_level(log_capture, "warning")
 
 
 def test_divide_simulation():

--- a/tests/test_web/test_auth.py
+++ b/tests/test_web/test_auth.py
@@ -23,7 +23,7 @@ def test__save_credential_to_stored_file(mock_credential_path):
     tidy3d_auth._save_credential_to_stored_file("user", "pwd")
     with open(tidy3d_auth.CREDENTIAL_PATH, "r", encoding="utf-8") as fp:
         auth_json = json.load(fp)
-        log.info(auth_json)
+        log.info(str(auth_json))
 
     assert sorted(auth_json.items()) == sorted({"email": "user", "password": "pwd"}.items())
 

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -3,8 +3,7 @@ import tempfile
 import pytest
 import responses
 import tidy3d as td
-import os
-import time
+import tidy3d.web as web
 
 from responses import matchers
 

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -84,8 +84,7 @@ from .components.source import Source, SourceTime
 from .components.monitor import Monitor
 from .components.grid.grid import YeeGrid, FieldGrid, Coords1D
 
-# logging
-from .log import log, set_logging_file, WebError
+from .log import log, set_logging_file, set_logging_console
 
 # config
 from .config import config
@@ -95,6 +94,7 @@ from .version import __version__, PIP_NAME
 
 # updater
 from .updater import Updater
+
 
 # warn if this was uploaded to the beta PyPI, also sets the pyPI repository that we upload to
 if "beta" in PIP_NAME:

--- a/tidy3d/components/apodization.py
+++ b/tidy3d/components/apodization.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from .base import Tidy3dBaseModel
 from ..constants import SECOND
-from ..log import SetupError
+from ..exceptions import SetupError
 from .types import ArrayLike, Ax
 from .viz import add_ax_if_none
 

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -14,8 +14,9 @@ import h5py
 import xarray as xr
 
 from .types import ComplexNumber, Literal, TYPE_TAG_STR
-from ..log import FileError, log
 from .data.data_array import DataArray, DATA_ARRAY_MAP
+from ..exceptions import FileError
+from ..log import log
 
 # default indentation (# spaces) in files
 INDENT = 4

--- a/tidy3d/components/boundary.py
+++ b/tidy3d/components/boundary.py
@@ -12,8 +12,9 @@ from .types import Complex, Axis, TYPE_TAG_STR
 from .source import GaussianBeam, ModeSource, PlaneWave, TFSF
 from .medium import Medium
 
-from ..log import log, SetupError, DataError
 from ..constants import EPSILON_0, MU_0, PML_SIGMA
+from ..exceptions import SetupError, DataError
+from ..log import log
 
 
 class BoundaryEdge(ABC, Tidy3dBaseModel):

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -8,7 +8,7 @@ import dask
 import h5py
 
 from ...constants import HERTZ, SECOND, MICROMETER, RADIAN
-from ...log import DataError, FileError
+from ...exceptions import DataError, FileError
 
 # maps the dimension names to their attributes
 DIM_ATTRS = {

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -15,7 +15,7 @@ from .data_array import TriangleMeshDataArray
 
 from ..base import Tidy3dBaseModel
 from ..types import Axis
-from ...log import DataError
+from ...exceptions import DataError
 
 
 class Dataset(Tidy3dBaseModel, ABC):

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from abc import ABC
 from typing import Union, Tuple, Callable, Dict, List
 import warnings
+
 import xarray as xr
 import numpy as np
 import pydantic as pd
@@ -28,8 +29,9 @@ from ..monitor import FieldProjectionKSpaceMonitor, FieldProjectionSurface
 from ..monitor import DiffractionMonitor
 from ..source import SourceTimeType, CustomFieldSource
 from ..medium import Medium, MediumType
-from ...log import SetupError, DataError, Tidy3dNotImplementedError, log
+from ...exceptions import SetupError, DataError, Tidy3dNotImplementedError
 from ...constants import ETA_0, C_0, MICROMETER
+from ...log import log
 
 
 class MonitorData(Dataset, ABC):

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -13,7 +13,9 @@ from ..boundary import BlochBoundary
 from ..source import TFSF
 from ..types import Ax, Axis, annotate_type, FieldVal, PlotScale, ColormapType
 from ..viz import equal_aspect, add_ax_if_none
-from ...log import DataError, log, Tidy3dKeyError, ValidationError
+from ...exceptions import DataError, Tidy3dKeyError, ValidationError
+from ...log import log
+
 
 DATA_TYPE_MAP = {data.__fields__["monitor"].type_: data for data in MonitorDataTypes}
 

--- a/tidy3d/components/field_projection.py
+++ b/tidy3d/components/field_projection.py
@@ -23,7 +23,7 @@ from .monitor import FieldProjectionCartesianMonitor, FieldProjectionKSpaceMonit
 from .types import Direction, Coordinate, ArrayLike
 from .medium import MediumType
 from .base import Tidy3dBaseModel, cached_property
-from ..log import SetupError
+from ..exceptions import SetupError
 from ..constants import C_0, MICROMETER, ETA_0, EPSILON_0, MU_0
 
 # Default number of points per wavelength in the background medium to use for resampling fields.

--- a/tidy3d/components/geometry.py
+++ b/tidy3d/components/geometry.py
@@ -19,7 +19,8 @@ from .types import Vertices, Ax, Shapely, annotate_type
 from .viz import add_ax_if_none, equal_aspect
 from .viz import PLOT_BUFFER, ARROW_LENGTH, arrow_style
 from .viz import PlotParams, plot_params_geometry, polygon_patch
-from ..log import Tidy3dKeyError, SetupError, ValidationError, log, DataError
+from ..log import log
+from ..exceptions import Tidy3dKeyError, SetupError, ValidationError, DataError
 from ..constants import MICROMETER, LARGE_NUMBER, RADIAN, fp_eps, inf
 from .data.dataset import TriangleMeshDataset
 from .data.data_array import TriangleMeshDataArray, DATA_ARRAY_MAP

--- a/tidy3d/components/grid/grid.py
+++ b/tidy3d/components/grid/grid.py
@@ -9,7 +9,7 @@ from ..base import Tidy3dBaseModel, cached_property
 from ..types import ArrayLike, Axis, TYPE_TAG_STR
 from ..geometry import Box
 
-from ...log import SetupError
+from ...exceptions import SetupError
 
 # data type of one dimensional coordinate array.
 Coords1D = ArrayLike[float, 1]

--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -14,8 +14,9 @@ from ..types import Axis, Symmetry, annotate_type
 from ..source import SourceType
 from ..structure import Structure, StructureType
 from ..geometry import Box
-from ...log import SetupError, log
-from ...constants import C_0, MICROMETER, fp_eps
+from ...log import log
+from ...exceptions import SetupError
+from ...constants import MICROMETER, C_0, fp_eps
 
 
 class GridSpec1d(Tidy3dBaseModel, ABC):

--- a/tidy3d/components/grid/mesher.py
+++ b/tidy3d/components/grid/mesher.py
@@ -18,7 +18,7 @@ from ..base import Tidy3dBaseModel
 from ..types import Axis, ArrayLike
 from ..structure import Structure, MeshOverrideStructure, StructureType
 from ..medium import PECMedium
-from ...log import SetupError, ValidationError
+from ...exceptions import SetupError, ValidationError
 from ...constants import C_0, fp_eps
 
 _ROOTS_TOL = 1e-10

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -19,7 +19,9 @@ from .viz import add_ax_if_none
 from .validators import validate_name_str
 from ..constants import C_0, pec_val, EPSILON_0
 from ..constants import HERTZ, CONDUCTIVITY, PERMITTIVITY, RADPERSEC, MICROMETER, SECOND
-from ..log import log, ValidationError, SetupError
+from ..exceptions import ValidationError, SetupError
+from ..log import log
+
 
 # evaluate frequency as this number (Hz) if inf
 FREQ_EVAL_INF = 1e50
@@ -885,13 +887,14 @@ class Sellmeier(DispersiveMedium):
             Real part of refractive index. Must be larger than or equal to one.
         dn_dwvl : float = 0
             Derivative of the refractive index with wavelength (1/um). Must be negative.
-        frequency : float
-            Frequency to evaluate permittivity at (Hz).
+        freq : float
+            Frequency at which ``n`` and ``dn_dwvl`` are sampled.
 
         Returns
         -------
-        :class:`Medium`
-            medium containing the corresponding ``permittivity`` and ``conductivity``.
+        :class:`Sellmeier`
+            Single-pole Sellmeier medium with the prvoided refractive index and index dispersion
+            valuesat at the prvoided frequency.
         """
 
         if dn_dwvl >= 0:

--- a/tidy3d/components/mode.py
+++ b/tidy3d/components/mode.py
@@ -8,7 +8,7 @@ import numpy as np
 from ..constants import MICROMETER, RADIAN, GLANCING_CUTOFF
 from .base import Tidy3dBaseModel
 from .types import Axis2D, Literal, TrackFreq
-from ..log import SetupError
+from ..exceptions import SetupError
 
 
 class ModeSpec(Tidy3dBaseModel):

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -14,7 +14,8 @@ from .mode import ModeSpec
 from .apodization import ApodizationSpec
 from .viz import PlotParams, plot_params_monitor, ARROW_COLOR_MONITOR, ARROW_ALPHA
 from ..constants import HERTZ, SECOND, MICROMETER, RADIAN, inf
-from ..log import SetupError, log, ValidationError
+from ..exceptions import SetupError, ValidationError
+from ..log import log
 
 
 BYTES_REAL = 4

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -35,8 +35,10 @@ from .viz import plot_params_pec, plot_params_pmc, plot_params_bloch
 
 from ..version import __version__
 from ..constants import C_0, SECOND, inf
-from ..log import log, Tidy3dKeyError, SetupError, ValidationError
+from ..exceptions import Tidy3dKeyError, SetupError, ValidationError
+from ..log import log
 from ..updater import Updater
+
 
 # minimum number of grid points allowed per central wavelength in a medium
 MIN_GRIDS_PER_WVL = 6.0

--- a/tidy3d/components/source.py
+++ b/tidy3d/components/source.py
@@ -17,7 +17,9 @@ from .viz import add_ax_if_none, PlotParams, plot_params_source
 from .viz import ARROW_COLOR_SOURCE, ARROW_ALPHA, ARROW_COLOR_POLARIZATION
 from ..constants import RADIAN, HERTZ, MICROMETER, GLANCING_CUTOFF
 from ..constants import inf  # pylint:disable=unused-import
-from ..log import SetupError, log
+from ..exceptions import SetupError
+from ..log import log
+
 
 # in spectrum computation, discard amplitudes with relative magnitude smaller than cutoff
 DFT_CUTOFF = 1e-8

--- a/tidy3d/components/types.py
+++ b/tidy3d/components/types.py
@@ -13,7 +13,7 @@ import pydantic
 import numpy as np
 from matplotlib.axes import Axes
 from shapely.geometry.base import BaseGeometry
-from ..log import ValidationError
+from ..exceptions import ValidationError
 
 """ Numpy Arrays """
 

--- a/tidy3d/components/validators.py
+++ b/tidy3d/components/validators.py
@@ -5,7 +5,7 @@ from typing import Any
 import pydantic
 
 from .geometry import Box
-from ..log import ValidationError, SetupError
+from ..exceptions import ValidationError, SetupError
 
 """ Explanation of pydantic validators:
 

--- a/tidy3d/config.py
+++ b/tidy3d/config.py
@@ -1,9 +1,8 @@
 """Sets the configuration of the script, can be changed with `td.config.config_name = new_val`."""
 
 import pydantic as pd
-from typing_extensions import Literal
 
-from .log import set_logging_level, DEFAULT_LEVEL
+from .log import DEFAULT_LEVEL, LogLevel, set_logging_level, log
 
 
 class Tidy3dConfig(pd.BaseModel):
@@ -19,18 +18,25 @@ class Tidy3dConfig(pd.BaseModel):
         allow_population_by_field_name = True
         frozen = False
 
-    logging_level: Literal["debug", "info", "warning", "error"] = pd.Field(
-        DEFAULT_LEVEL.lower(),
+    logging_level: LogLevel = pd.Field(
+        DEFAULT_LEVEL,
         title="Logging Level",
         description="The lowest level of logging output that will be displayed. "
-        'Can be "debug", "info", "warning", "error".',
+        'Can be "DEBUG", "INFO", "WARNING", "ERROR", or "CRITICAL".',
     )
 
-    @pd.validator("logging_level", always=True)
+    @pd.validator("logging_level", pre=True, always=True)
     def _set_logging_level(cls, val):
         """Set the logging level if logging_level is changed."""
-        set_logging_level(val)
-        return val
+        val_upper = val.upper()
+        if val_upper != val:
+            log.warning(
+                f"'{val}' provided to 'td.config.logging_level'. "
+                "In the future, only upper-case logging levels may be specified. "
+                f"This value will be converted to upper case '{val_upper}'."
+            )
+        set_logging_level(val_upper)
+        return val_upper
 
 
 # instance of the config that can be modified.

--- a/tidy3d/exceptions.py
+++ b/tidy3d/exceptions.py
@@ -1,0 +1,56 @@
+"""Custom Tidy3D exceptions"""
+
+from .log import log
+
+
+class Tidy3dError(ValueError):
+    """Any error in tidy3d"""
+
+    def __init__(self, message: str = None):
+        """Log just the error message and then raise the Exception."""
+        super().__init__(message)
+        log.error(message)
+
+
+class ConfigError(Tidy3dError):
+    """Error when configuring Tidy3d."""
+
+
+class Tidy3dKeyError(Tidy3dError):
+    """Could not find a key in a Tidy3d dictionary."""
+
+
+class ValidationError(Tidy3dError):
+    """Error when constructing Tidy3d components."""
+
+
+class SetupError(Tidy3dError):
+    """Error regarding the setup of the components (outside of domains, etc)."""
+
+
+class FileError(Tidy3dError):
+    """Error reading or writing to file."""
+
+
+class WebError(Tidy3dError):
+    """Error with the webAPI."""
+
+
+class AuthenticationError(Tidy3dError):
+    """Error authenticating a user through webapi webAPI."""
+
+
+class DataError(Tidy3dError):
+    """Error accessing data."""
+
+
+class Tidy3dImportError(Tidy3dError):
+    """Error importing a package needed for tidy3d."""
+
+
+class Tidy3dNotImplementedError(Tidy3dError):
+    """Error when a functionality is not (yet) supported."""
+
+
+class AdjointError(Tidy3dError):
+    """An error in setting up the adjoint solver."""

--- a/tidy3d/material_library/material_library.py
+++ b/tidy3d/material_library/material_library.py
@@ -4,7 +4,7 @@ from typing import Dict, List
 import pydantic as pd
 from ..components.medium import PoleResidue
 from ..components.base import Tidy3dBaseModel
-from ..log import SetupError
+from ..exceptions import SetupError
 from .material_reference import material_refs, ReferenceData
 
 

--- a/tidy3d/plugins/adjoint/components/data/data_array.py
+++ b/tidy3d/plugins/adjoint/components/data/data_array.py
@@ -8,8 +8,7 @@ import numpy as np
 import jax.numpy as jnp
 from jax.tree_util import register_pytree_node_class
 from .....components.base import Tidy3dBaseModel, cached_property
-from .....log import DataError, Tidy3dKeyError
-from ...log import AdjointError
+from .....exceptions import DataError, Tidy3dKeyError, AdjointError
 
 
 @register_pytree_node_class

--- a/tidy3d/plugins/adjoint/components/data/monitor_data.py
+++ b/tidy3d/plugins/adjoint/components/data/monitor_data.py
@@ -16,10 +16,10 @@ from .....components.data.monitor_data import ModeData, DiffractionData, FieldDa
 from .....components.data.dataset import FieldDataset
 from .....components.data.data_array import ScalarFieldDataArray
 from .....constants import C_0, ETA_0
+from .....exceptions import AdjointError
 
 from .data_array import JaxDataArray
 from ..base import JaxObject
-from ...log import AdjointError
 
 
 class JaxMonitorData(MonitorData, JaxObject, ABC):

--- a/tidy3d/plugins/adjoint/components/geometry.py
+++ b/tidy3d/plugins/adjoint/components/geometry.py
@@ -17,10 +17,10 @@ from ....components.geometry import Geometry, Box, PolySlab
 from ....components.data.monitor_data import FieldData, PermittivityData
 from ....components.monitor import FieldMonitor, PermittivityMonitor
 from ....constants import fp_eps, MICROMETER
+from ....exceptions import AdjointError
 
 from .base import JaxObject
 from .types import JaxFloat, validate_jax_tuple, validate_jax_tuple_tuple
-from ..log import AdjointError
 
 # number of integration points per unit wavelength in material
 PTS_PER_WVL_INTEGRATION = 50

--- a/tidy3d/plugins/adjoint/components/medium.py
+++ b/tidy3d/plugins/adjoint/components/medium.py
@@ -20,7 +20,6 @@ from .types import JaxFloat, validate_jax_float
 from .data.data_array import JaxDataArray
 from .data.dataset import JaxPermittivityDataset
 
-# from ..log import AdjointError
 
 # number of integration points per unit wavelength in material
 PTS_PER_WVL_INTEGRATION = 20

--- a/tidy3d/plugins/adjoint/components/simulation.py
+++ b/tidy3d/plugins/adjoint/components/simulation.py
@@ -9,19 +9,20 @@ import numpy as np
 
 from jax.tree_util import register_pytree_node_class
 
+from ....log import log
 from ....components.base import cached_property
 from ....components.monitor import FieldMonitor, PermittivityMonitor
 from ....components.monitor import ModeMonitor, DiffractionMonitor
 from ....components.simulation import Simulation
 from ....components.data.monitor_data import FieldData, PermittivityData
 from ....components.types import Ax, annotate_type
-from ....log import log
 from ....constants import HERTZ
+from ....exceptions import AdjointError
 
-from ..log import AdjointError
 from .base import JaxObject
 from .structure import JaxStructure
 from .geometry import JaxBox
+
 
 # used to store information when converting between jax and tidy3d
 JaxInfo = namedtuple(

--- a/tidy3d/plugins/adjoint/log.py
+++ b/tidy3d/plugins/adjoint/log.py
@@ -1,7 +1,0 @@
-"""Defines custom error messages."""
-
-from ...log import Tidy3dError
-
-
-class AdjointError(Tidy3dError):
-    """An error in setting up the adjoint solver."""

--- a/tidy3d/plugins/dispersion/fit.py
+++ b/tidy3d/plugins/dispersion/fit.py
@@ -11,12 +11,13 @@ import numpy as np
 from rich.progress import Progress
 from pydantic import Field, validator
 
+from ...log import log
 from ...components.base import Tidy3dBaseModel
 from ...components.medium import PoleResidue, AbstractMedium
 from ...components.viz import add_ax_if_none
 from ...components.types import Ax, ArrayLike
 from ...constants import C_0, HBAR, MICROMETER
-from ...log import log, ValidationError, WebError, SetupError
+from ...exceptions import ValidationError, WebError, SetupError
 from ...web.config import DEFAULT_CONFIG as Config
 
 

--- a/tidy3d/plugins/dispersion/fit_web.py
+++ b/tidy3d/plugins/dispersion/fit_web.py
@@ -6,14 +6,16 @@ from enum import Enum
 import requests
 from pydantic import PositiveInt, NonNegativeFloat, PositiveFloat, Field, validator
 
+from ...log import log
 from ...components.base import Tidy3dBaseModel
 from ...components.types import Literal
 from ...components.medium import PoleResidue
 from ...constants import MICROMETER, HERTZ
-from ...log import log, WebError, Tidy3dError, SetupError
+from ...exceptions import WebError, Tidy3dError, SetupError
 from ...web.httputils import get_headers
 from ...web.config import DEFAULT_CONFIG as Config
 from .fit import DispersionFitter
+
 
 BOUND_MAX_FACTOR = 10
 

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -8,6 +8,7 @@ import numpy as np
 import pydantic
 import xarray as xr
 
+from ...log import log
 from ...components.base import Tidy3dBaseModel, cached_property
 from ...components.geometry import Box
 from ...components.simulation import Simulation
@@ -20,9 +21,10 @@ from ...components.data.data_array import ModeIndexDataArray, ScalarModeFieldDat
 from ...components.data.data_array import FreqModeDataArray
 from ...components.data.sim_data import SimulationData
 from ...components.data.monitor_data import ModeSolverData
-from ...log import ValidationError, log
+from ...exceptions import ValidationError
 from ...constants import C_0
 from .solver import compute_modes
+
 
 FIELD = Tuple[ArrayLike[complex, 3], ArrayLike[complex, 3], ArrayLike[complex, 3]]
 MODE_MONITOR_NAME = "<<<MODE_SOLVER_MONITOR>>>"

--- a/tidy3d/plugins/polyslab/polyslab.py
+++ b/tidy3d/plugins/polyslab/polyslab.py
@@ -6,12 +6,13 @@ from math import isclose
 import pydantic
 from shapely.geometry import Polygon
 
+from ...log import log
 from ...components.geometry import PolySlab, GeometryGroup
 from ...components.medium import MediumType
 from ...components.structure import Structure
 from ...components.types import Axis
-from ...log import log
 from ...constants import fp_eps
+
 
 # Warn for too many divided polyslabs
 _WARN_MAX_NUM_DIVISION = 100

--- a/tidy3d/plugins/resonance/resonance.py
+++ b/tidy3d/plugins/resonance/resonance.py
@@ -10,12 +10,14 @@ import xarray as xr
 
 from pydantic import Field, NonNegativeFloat, PositiveInt, validator
 
+from ...log import log
 from ...components.base import Tidy3dBaseModel
 from ...components.types import ArrayLike
 from ...components.data.data_array import ScalarFieldTimeDataArray
 from ...components.data.monitor_data import FieldTimeData
 from ...constants import HERTZ
-from ...log import log, SetupError, ValidationError
+from ...exceptions import SetupError, ValidationError
+
 
 INIT_NUM_FREQS = 200
 

--- a/tidy3d/plugins/smatrix/smatrix.py
+++ b/tidy3d/plugins/smatrix/smatrix.py
@@ -5,6 +5,7 @@ from typing import List, Tuple, Optional, Callable, Dict
 import pydantic as pd
 import numpy as np
 
+from ...log import log
 from ...constants import HERTZ, C_0
 from ...components.simulation import Simulation
 from ...components.geometry import Box
@@ -15,8 +16,9 @@ from ...components.data.sim_data import SimulationData
 from ...components.types import Direction, Ax, Complex
 from ...components.viz import add_ax_if_none, equal_aspect
 from ...components.base import Tidy3dBaseModel
-from ...log import SetupError, Tidy3dKeyError, log
+from ...exceptions import SetupError, Tidy3dKeyError
 from ...web.container import Batch, BatchData
+
 
 # fwidth of gaussian pulse in units of central frequency
 FWIDTH_FRAC = 1.0 / 10

--- a/tidy3d/schema.json
+++ b/tidy3d/schema.json
@@ -334,7 +334,7 @@
     "version": {
       "title": "Version",
       "description": "String specifying the front end version number.",
-      "default": "1.10.0rc1",
+      "default": "1.10.0rc2",
       "type": "string"
     }
   },

--- a/tidy3d/updater.py
+++ b/tidy3d/updater.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 from typing import Dict, Callable
 import json
 import functools
-import yaml
 
+import yaml
 import pydantic as pd
 
+from .log import log
 from .version import __version__
-from .log import FileError, SetupError, log
+from .exceptions import FileError, SetupError
 from .components.base import Tidy3dBaseModel
+
 
 """Storing version numbers."""
 

--- a/tidy3d/version.py
+++ b/tidy3d/version.py
@@ -1,5 +1,4 @@
 """Defines the front end version of tidy3d"""
 
 __version__ = "1.10.0rc2"
-
 PIP_NAME = "tidy3d-beta"

--- a/tidy3d/web/auth.py
+++ b/tidy3d/web/auth.py
@@ -10,7 +10,9 @@ from typing import Tuple
 import requests
 
 from .config import DEFAULT_CONFIG as Config
-from ..log import log, WebError
+from ..exceptions import WebError
+from ..log import log
+
 
 # maximum attempts for credentials input
 MAX_ATTEMPTS = 3

--- a/tidy3d/web/config.py
+++ b/tidy3d/web/config.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 import pydantic as pd
 from pydantic import Field
 
-from tidy3d import log
+from ..log import log
 
 
 class EnvSettings(pd.BaseSettings):

--- a/tidy3d/web/container.py
+++ b/tidy3d/web/container.py
@@ -16,7 +16,7 @@ from ..components.simulation import Simulation
 from ..components.base import Tidy3dBaseModel
 from ..components.data.sim_data import SimulationData
 
-from ..log import DataError
+from ..exceptions import DataError
 
 
 DEFAULT_DATA_PATH = "simulation_data.hdf5"

--- a/tidy3d/web/httputils.py
+++ b/tidy3d/web/httputils.py
@@ -13,7 +13,7 @@ import requests
 from .auth import get_credentials
 from .cli.app import CONFIG_FILE
 from .config import DEFAULT_CONFIG as Config
-from ..log import WebError
+from ..exceptions import WebError
 from ..version import __version__
 
 SIMCLOUD_APIKEY = "SIMCLOUD_APIKEY"

--- a/tidy3d/web/webapi.py
+++ b/tidy3d/web/webapi.py
@@ -15,7 +15,9 @@ from .task import TaskId, TaskInfo
 from ..components.data.sim_data import SimulationData
 from ..components.simulation import Simulation
 from ..components.types import Literal
-from ..log import log, WebError
+from ..log import log
+from ..exceptions import WebError
+
 
 # time between checking task status
 REFRESH_TIME = 0.3


### PR DESCRIPTION
this is the result of merging `develop` into `pre/1.10.0` and fixing all of the merge commits. There is one remaining issue, which I need @weiliangjin2021 's help with. 

In `tests/test_plugins/test_polyslab.py`, the `test_gds_import` fails due to a ValidationError after this merge.

I was hoping you could look into this and see what's causing it to fail, maybe some validator that was added in `pre/1.10.0` that wasn't caught before. Note that the test passes in `develop`.

Feel free to push a commit to this branch fixing the test if you can figure it out.

Everything else looks good.  Thanks!

```
tests/test_plugins/test_polyslab.py:191: in test_gds_import
    arm_geo = ComplexPolySlab.from_gds(
tidy3d/plugins/polyslab/polyslab.py:135: in from_gds
    return [sub_poly for sub_polys in polyslabs for sub_poly in sub_polys.sub_polyslabs]
tidy3d/plugins/polyslab/polyslab.py:135: in <listcomp>
    return [sub_poly for sub_polys in polyslabs for sub_poly in sub_polys.sub_polyslabs]
tidy3d/plugins/polyslab/polyslab.py:225: in sub_polyslabs
    sub_polyslab_list.append(PolySlab.parse_obj(sub_polyslab_dict))
pydantic/main.py:527: in pydantic.main.BaseModel.parse_obj
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   pydantic.error_wrappers.ValidationError: 1 validation error for PolySlab
E   vertices
E     Polygon is self-intersecting, resulting in polygon splitting or generation of holes/islands. A general treatment to self-intersecting polygon will be available in future releases. (type=value_error.setup)

pydantic/main.py:342: ValidationError
```