### PR TITLE
Treat infinite slanted cylinder and add validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SourceTime` plotting methods `.plot()` and `.plot_spectrum()` accept a `val` kwarg, which selects which part of the data (`'real'`, `'imag'`, or `'abs'`) to plot, rather than plotting all at once.
 - Tidy3D exceptions inherit from `ValueError` so they are handled properly by pydantic.
 - Two unstable materials in `material_library`: `Cu_JohnsonChristy1972` and `Ni_JohnsonChristy1972`. `TiOx_HoribStable` added for improved stability.
+- Bug in infinite long cylinder when the `reference_plane` is not at the bottom or the cylinder is slanted.
 
 ## [1.10.0rc1] - 2023-3-07
 

--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -170,6 +170,41 @@ def test_center_not_inf_validate():
 def test_radius_not_inf_validate():
     with pytest.raises(pydantic.ValidationError):
         g = td.Sphere(radius=td.inf)
+    with pytest.raises(pydantic.ValidationError):
+        g = td.Cylinder(radius=td.inf, center=(0, 0, 0), axis=1, length=1)
+
+
+def test_slanted_cylinder_infinite_length_validate():
+    g = td.Cylinder(radius=1, center=(0, 0, 0), axis=1, length=td.inf)
+    g = td.Cylinder(radius=1, center=(0, 0, 0), axis=1, length=td.inf, reference_plane="top")
+    g = td.Cylinder(radius=1, center=(0, 0, 0), axis=1, length=td.inf, reference_plane="bottom")
+    g = td.Cylinder(radius=1, center=(0, 0, 0), axis=1, length=td.inf, reference_plane="middle")
+    g = td.Cylinder(
+        radius=1,
+        center=(0, 0, 0),
+        axis=1,
+        length=td.inf,
+        sidewall_angle=0.1,
+        reference_plane="middle",
+    )
+    with pytest.raises(pydantic.ValidationError):
+        g = td.Cylinder(
+            radius=1,
+            center=(0, 0, 0),
+            axis=1,
+            length=td.inf,
+            sidewall_angle=0.1,
+            reference_plane="top",
+        )
+    with pytest.raises(pydantic.ValidationError):
+        g = td.Cylinder(
+            radius=1,
+            center=(0, 0, 0),
+            axis=1,
+            length=td.inf,
+            sidewall_angle=0.1,
+            reference_plane="bottom",
+        )
 
 
 def test_box_from_bounds():


### PR DESCRIPTION
For a slanted cylinder of infinite length, the reference plane can only lie in the middle. Otherwise, the behavior of cylinder at the `center` is confusing. A validator has been added.

Additionally, when `self.length_axis` is td.inf, internally in cylinder, we use `LARGE_NUMBER` instead. This is to make sure for a slanted cylinder, `radius_max` etc. are well defined. 

Finally, override the `radius` attribute in cylinder to clarify where the radius is defined.