### PR TITLE
fix web fitter by using API key auth

### DIFF
--- a/tidy3d/plugins/dispersion/fit_web.py
+++ b/tidy3d/plugins/dispersion/fit_web.py
@@ -16,7 +16,6 @@ from ...web.httputils import get_headers
 from ...web.config import DEFAULT_CONFIG as Config
 from .fit import DispersionFitter
 
-
 BOUND_MAX_FACTOR = 10
 
 
@@ -182,9 +181,6 @@ class StableDispersionFitter(DispersionFitter):
             URL for the server
         """
 
-        access_token = get_headers()
-        headers = {"Authorization": access_token["Authorization"]}
-
         try:
             # test connection
             resp = requests.get(f"{url_server}/health", verify=Config.ssl_verify)
@@ -196,16 +192,7 @@ class StableDispersionFitter(DispersionFitter):
         except Exception as e:
             raise WebError("Connection to the server failed. Please try again.") from e
 
-        # test authorization
-        resp = requests.get(
-            f"{url_server}/health/access", headers=headers, verify=Config.ssl_verify
-        )
-        try:
-            resp.raise_for_status()
-        except Exception as e:
-            raise WebError("Authorization to the server failed. Please try again.") from e
-
-        return headers
+        return get_headers()
 
     def _setup_webdata(
         self,

--- a/tidy3d/web/httputils.py
+++ b/tidy3d/web/httputils.py
@@ -10,7 +10,6 @@ import toml
 from requests import Session
 import requests
 
-from .auth import get_credentials
 from .cli.constants import CONFIG_FILE
 from .config import DEFAULT_CONFIG as Config
 from ..exceptions import WebError
@@ -159,13 +158,8 @@ def get_headers() -> Dict[str, str]:
     Dict[str, str]
         dictionary with "Authorization" and "Application" keys.
     """
-    if Config.auth is None or Config.auth["accessToken"] is None:
-        get_credentials()
-    elif need_token_refresh(Config.auth["accessToken"]):
-        get_credentials()
-    access_token = Config.auth["accessToken"]
     return {
-        "Authorization": f"Bearer {access_token}",
+        "simcloud-api-key": api_key(),
         "Application": "TIDY3D",
     }
 


### PR DESCRIPTION
Replaces auth.json approach with setting the API key in the request header in the fitter.