### PR TITLE
Unpinning importlib-metadata version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `PointDipole` sources now have a continuous dependence on the source position, as opposed to snapping to Yee grid locations.
 Behavior is controlled by the `interpolate` argument, set to `True` by default. 
 - Scattering matrix plugin accepts list of frequencies and returns data as an `xarray.DataArray` instead of a nested `dict`.
+- `importlib_metadata` version set to `>= 6.0.0`.
 
 ### Fixed
 

--- a/requirements/basic.txt
+++ b/requirements/basic.txt
@@ -2,7 +2,7 @@
 
 pyroots>=0.5.0
 xarray>=0.16.2
-importlib-metadata==4.13.0 # note: 5.0.0 breaks some xarray stuff, remove when xarray fixes this
+importlib-metadata>=6.0.0
 h5netcdf==1.0.2
 h5py>=3.0.0
 rich<12.6.0 # note: rich >= 12.6 adds double progressbars


### PR DESCRIPTION
Backend tests pass with this. Did you want to wait until after 2.0 though @tylerflex ?