### PR TITLE
extra condition before printing early shutoff log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Port name duplication in smatrix plugin for multimode ports.
 - Web functions create the leading directories for the supplied filename if they don't exist.
 - Some docstring examples that were giving warnings.
+- `web.monitor()` only prints message when condition met.
 
 ## [2.0.2] - 2023-4-3
 

--- a/tidy3d/web/webapi.py
+++ b/tidy3d/web/webapi.py
@@ -309,7 +309,8 @@ def monitor(task_id: TaskId, verbose: bool = True) -> None:
                 progress.update(pbar_pd, completed=perc_done, description=new_description)
                 time.sleep(RUN_REFRESH_TIME)
 
-            if perc_done is not None and perc_done < 100:
+            perc_done, field_decay = get_run_info(task_id)
+            if perc_done is not None and perc_done < 100 and field_decay > 0:
                 console.log("early shutoff detected, exiting.")
 
             progress.update(pbar_pd, completed=100, refresh=True)


### PR DESCRIPTION
For some reason, the run info webapi seems to have started returning: 
perc_done = 0
field_decay = 0
early in the task. (maybe before the solver progress csv is ready).

As a result, the condition for printing the early shutoff warning:
```py
if perc_done is not None and perc_done < 100:
```
was being triggered even if the task was finishing without early shutoff.

This PR changes to only trigger if 
```py
if perc_done is not None and perc_done < 100 and field_decay > 0:
```
basically if the solver progress is not present and the task has stopped running, it doesn't print this log message anymore. We should follow up with MC though.