### PR TITLE
add finite extent to PML for dims where simulation.size == 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Web functions create the leading directories for the supplied filename if they don't exist.
 - Some docstring examples that were giving warnings.
 - `web.monitor()` only prints message when condition met.
+- PML boxes have non-zero extent along any dimensions where the simulation has 0 size, to fix plotting issues for 2D simulations.
 
 ## [2.0.2] - 2023-4-3
 

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -61,6 +61,9 @@ NUM_STRUCTURES_WARN_EPSILON = 10_000
 # equal to this times the grid size
 DIST_NEIGHBOR_REL_2D_MED = 1e-5
 
+# height of the PML plotting boxes along any dimensions where sim.size[dim] == 0
+PML_HEIGHT_FOR_0_DIMS = 0.02
+
 
 class Simulation(Box):  # pylint:disable=too-many-public-methods
     """Contains all information about Tidy3d simulation.
@@ -1772,7 +1775,16 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
             rmax[pml_axis] = rmin[pml_axis] + pml_height
         else:
             rmin[pml_axis] = rmax[pml_axis] - pml_height
-        return Box.from_bounds(rmin=rmin, rmax=rmax)
+        pml_box = Box.from_bounds(rmin=rmin, rmax=rmax)
+
+        # if any dimension of the sim has size 0, set the PML to a very small size along that dim
+        new_size = list(pml_box.size)
+        for dim_index, sim_size in enumerate(self.size):
+            if sim_size == 0.0:
+                new_size[dim_index] = PML_HEIGHT_FOR_0_DIMS
+        pml_box = pml_box.updated_copy(size=new_size)
+
+        return pml_box
 
     @equal_aspect
     @add_ax_if_none


### PR DESCRIPTION
Makes the PML boxes (for plotting) have a size of `0.02` along any dimensions where sim.size == 0.
Otherwise, there are times where the PML will not show, eg plotting a simulation with size (1, 1, 0) along the z axis, because the PML has a size of 0 along z and the box does not get picked up by the plotter.

note, used a small number instead of td.inf to avoid potential weirdness in the 3D or cross section plots.
Also, the plotting wasn't picking up any number smaller than 0.02..

Before:
<img width="595" alt="image" src="https://user-images.githubusercontent.com/92756888/230410715-1ace192b-91e6-4d8d-9847-9240d1836f61.png">

After:
<img width="446" alt="image" src="https://user-images.githubusercontent.com/92756888/230410747-ead3f59b-586d-4974-99c5-d629819a4291.png">

