### PR TITLE
robust handling for 2D medium structure validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `adjoint` plugin now filters out adjoint sources that are below a threshold in amplitude relative to the maximum amplitude of the monitor data, reducing unnecessary processing by eliminating sources that won't contribute to the gradient.
 
 ### Fixed
+- More robust handling for 2D structure validator.
 
 ## [2.0.0] - 2023-3-31
 

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -10,6 +10,7 @@ from .types import Ax, TYPE_TAG_STR
 from .viz import add_ax_if_none, equal_aspect
 from .grid.grid import Coords
 from ..constants import MICROMETER
+from ..exceptions import SetupError
 
 
 class AbstractStructure(Tidy3dBaseModel):
@@ -98,9 +99,13 @@ class Structure(AbstractStructure):
     @pydantic.validator("medium", always=True)
     def _check_2d_geometry(cls, val, values):
         """Medium2D is only consistent with certain geometry types"""
-        geom = values["geometry"]
         if isinstance(val, Medium2D):
             # validate that the geometry is actually 2d
+            geom = values.get("geometry")
+            if not geom:
+                raise SetupError(
+                    "Can't validate 2D structure because its geometry did not pass validation."
+                )
             _ = geom._normal_2dmaterial  # pylint: disable=protected-access
         return val
 


### PR DESCRIPTION
Previous 2D medium validator for `td.Structure` grabbed `values["geometry"]` before checking if it was needed. 

The problem with this is that it `Structure.geometry` fails validation for some reason, the `values` dictionary will not contain a `geometry` key and we'll get an obscure KeyError.

This PR changes it so that:
* `values["geometry"]` is only accessed when it's needed (if the `Structure.medium` is determined to be a 2D medium).
* we use `values.get("geometry")` and raise a more helpful error if this is None, directing the user to fix the `.geometry` field.

