### PR TITLE
add python function `web.configure(apikey)` to configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ElectromagneticFieldData.intensity` returns the sum of the squared components of the electric field.
 - Group index calculation added to ModeSolver.
 - Web interface prints clickable link to task on Tidy3D web interface.
+- Allow configuration through API key in python via `tidy3d.web.configure(apikey: str)` function.
 
 ### Changed
 - `adjoint` plugin now filters out adjoint sources that are below a threshold in amplitude relative to the maximum amplitude of the monitor data, reducing unnecessary processing by eliminating sources that won't contribute to the gradient.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ tidy3d configure --apikey=XXX
 
 Where `XXX` is your API key, which can be copied from your [account page](https://tidy3d.simulation.cloud/account) in the web interface.
 
+In a hosted jupyter notebook environment (eg google colab), it may be more convenient to install and configure via the following lines at the top of the notebook.
+
+```
+!pip install tidy3d
+import tidy3d.web as web
+web.configure("XXX")
+```
+
 If those commands did not work, advanced installation instructions are below, which should help solve the issue.
 
 ### Advanced Installation Instructions

--- a/tidy3d/web/__init__.py
+++ b/tidy3d/web/__init__.py
@@ -7,6 +7,7 @@ from .webapi import get_tasks, delete_old, download_json, download_log, load_sim
 from .container import Job, Batch, BatchData
 from .auth import get_credentials
 from .cli import tidy3d_cli
+from .cli.app import configure_fn as configure
 from .asynchronous import run_async
 
 migrate()

--- a/tidy3d/web/cli/app.py
+++ b/tidy3d/web/cli/app.py
@@ -43,6 +43,18 @@ def tidy3d_cli():
 @click.option("--apikey", prompt=False)
 def configure(apikey):
     """Click command to configure the api key.
+
+    Parameters
+    ----------
+    apikey : str
+        User input api key.
+    """
+    configure_fn(apikey)
+
+
+def configure_fn(apikey: str) -> None:
+    """Python function that tries to set configuration based on a provided API key.
+
     Parameters
     ----------
     apikey : str


### PR DESCRIPTION
In a hosted jupyter notebook environment (eg google colab), it may be more convenient to install and configure via the following lines at the top of the notebook.

```
!pip install tidy3d
import tidy3d.web as web
web.configure("XXX")
```

note, README is updated to include these instructions as well as the Quickstart in the docs.