### PR TITLE
more robust handling of `web.Batch.monitor()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- `web.Batch` monitoring is more robust, will not raise exception if a job errors or diverges. In this case, the progressbar text will render in red.
 
 ## [2.0.3] - 2023-4-11
 


### PR DESCRIPTION
changes
* the batch monitor makes sure the status is in the run_statuses list before indexing. If not in the list (error, diverge), it will set to 100%, no exception will be raised.
* if error or diverge, the final description in the progress bar text will be red to indicate an issue.