### PR TITLE
Fully anisotropic materials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adjoint processing is done server side by default, to avoid unnecessary downloading of data.
 - `run_local` and `run_async_local` options in `tidy3d.plugins.adjoint.web` to provide way to run adjoint processing locally.
 - `JaxPolySlab` in `adjoint` plugin, which can track derivatives through its `.vertices`.
+- Fully anisotropic medium class (`FullyAnisotropicMedium`) that allows to simulate materials with permittivity and conductivity tensors oriented arbitrary with respect to simulation grid.
 
 ### Changed
 - Perfect electric conductors (PECs) are now modeled as high-conductivity media in both the frontend and backend mode solvers, and their presence triggers the use of a preconditioner to improve numerical stability and robustness. Consequently, the mode solver provides more accurate eigenvectors and field distributions when PEC structures are present.

--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -290,3 +290,78 @@ def test_medium2d():
         sigma / 3,
         rtol=RTOL,
     )
+
+
+def test_rotation():
+    # check that transpose is inverse
+    axis = np.random.random(3)
+    rot = td.RotationAroundAxis(axis=tuple(axis), angle=1.23)
+
+    R = rot.matrix
+
+    assert np.all(np.abs(np.matmul(np.transpose(R), R) - np.eye(3)) < 1.0e-15)
+    assert np.all(np.abs(np.matmul(R, np.transpose(R)) - np.eye(3)) < 1.0e-15)
+
+    # check that rotation around x, y, z by 90 degrees works as expected
+    tan_dims = [[1, 2], [2, 0], [0, 1]]
+
+    for dim in range(3):
+        axis = [0, 0, 0]
+        axis[dim] = 1
+        rot = td.RotationAroundAxis(axis=axis, angle=np.pi / 2)
+
+        v0 = np.random.random(3)
+        vr = rot.rotate_vector(v0)
+        assert np.abs(v0[dim] - vr[dim]) < 1.0e-15
+        assert np.abs(v0[tan_dims[dim][0]] - vr[tan_dims[dim][1]]) < 1.0e-15
+        assert np.abs(v0[tan_dims[dim][1]] + vr[tan_dims[dim][0]]) < 1.0e-15
+
+
+def test_fully_anisotropic_media():
+    perm_diag = [[1, 0, 0], [0, 2, 0], [0, 0, 3]]
+    cond_diag = [[4, 0, 0], [0, 5, 0], [0, 0, 6]]
+
+    rot = td.RotationAroundAxis(axis=(1, 2, 3), angle=1.23)
+    rot2 = td.RotationAroundAxis(axis=(3, 2, 1), angle=1.23)
+
+    perm = rot.rotate_tensor(perm_diag)
+    cond = rot.rotate_tensor(cond_diag)
+    cond2 = rot2.rotate_tensor(cond_diag)
+
+    _ = td.FullyAnisotropicMedium(permittivity=perm, conductivity=cond)
+
+    # check that tensors are provided
+    with pytest.raises(pydantic.ValidationError):
+        td.FullyAnisotropicMedium(permittivity=2)
+    with pytest.raises(pydantic.ValidationError):
+        td.FullyAnisotropicMedium(permittivity=[3, 4, 2])
+
+    # check that permittivity >= 1 and conductivity >= 0
+    with pytest.raises(ValidationError):
+        td.FullyAnisotropicMedium(permittivity=[[3, 0, 0], [0, 0.5, 0], [0, 0, 1]])
+    with pytest.raises(ValidationError):
+        td.FullyAnisotropicMedium(conductivity=[[-3, 0, 0], [0, 0.5, 0], [0, 0, 1]])
+
+    # check that permittivity needs to be symmetric
+    with pytest.raises(ValidationError):
+        td.FullyAnisotropicMedium(permittivity=[[3, 0.1, 0], [0.2, 2, 0], [0, 0, 1]])
+
+    # check that differently oriented permittivity and conductivity are not accepted
+    with pytest.raises(ValidationError):
+        td.FullyAnisotropicMedium(permittivity=perm, conductivity=cond2)
+
+    # check creation from diagonal medium
+    m = td.FullyAnisotropicMedium.from_diagonal(
+        xx=td.Medium(permittivity=perm_diag[0][0], conductivity=cond_diag[0][0]),
+        yy=td.Medium(permittivity=perm_diag[1][1], conductivity=cond_diag[1][1]),
+        zz=td.Medium(permittivity=perm_diag[2][2], conductivity=cond_diag[2][2]),
+        rotation=rot,
+    )
+
+    assert np.allclose(m.permittivity, perm)
+    assert np.allclose(m.conductivity, cond)
+
+    perm_d, cond_d = m.eps_sigma_diag
+
+    assert all(np.isin(np.round(perm_d), np.round(np.diag(perm_diag))))
+    assert all(np.isin(np.round(cond_d), np.round(np.diag(cond_diag))))

--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -361,7 +361,7 @@ def test_fully_anisotropic_media():
     assert np.allclose(m.permittivity, perm)
     assert np.allclose(m.conductivity, cond)
 
-    perm_d, cond_d = m.eps_sigma_diag
+    perm_d, cond_d, _ = m.eps_sigma_diag
 
     assert all(np.isin(np.round(perm_d), np.round(np.diag(perm_diag))))
     assert all(np.isin(np.round(cond_d), np.round(np.diag(cond_diag))))

--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -337,17 +337,17 @@ def test_fully_anisotropic_media():
         td.FullyAnisotropicMedium(permittivity=[3, 4, 2])
 
     # check that permittivity >= 1 and conductivity >= 0
-    with pytest.raises(ValidationError):
+    with pytest.raises(pydantic.ValidationError):
         td.FullyAnisotropicMedium(permittivity=[[3, 0, 0], [0, 0.5, 0], [0, 0, 1]])
-    with pytest.raises(ValidationError):
+    with pytest.raises(pydantic.ValidationError):
         td.FullyAnisotropicMedium(conductivity=[[-3, 0, 0], [0, 0.5, 0], [0, 0, 1]])
 
     # check that permittivity needs to be symmetric
-    with pytest.raises(ValidationError):
+    with pytest.raises(pydantic.ValidationError):
         td.FullyAnisotropicMedium(permittivity=[[3, 0.1, 0], [0.2, 2, 0], [0, 0, 1]])
 
     # check that differently oriented permittivity and conductivity are not accepted
-    with pytest.raises(ValidationError):
+    with pytest.raises(pydantic.ValidationError):
         td.FullyAnisotropicMedium(permittivity=perm, conductivity=cond2)
 
     # check creation from diagonal medium

--- a/tests/test_components/test_meshgenerate.py
+++ b/tests/test_components/test_meshgenerate.py
@@ -665,8 +665,8 @@ def test_shapely_strtree_warnings():
 
 def test_anisotropic_material_meshing():
     """Make sure the largest propagation index defines refinement in all directions."""
-    perm_d = [[3, 0, 0], [0, 2, 0], [0, 0, 1]]
-    cond_d = [[0.2, 0, 0], [0, 0.15, 0], [0, 0, 0.1]]
+    perm_diag = [3, 2, 1]
+    cond_diag = [0.2, 0.15, 0.1]
 
     box = td.Box(
         center=(0, 0, 0),
@@ -675,25 +675,23 @@ def test_anisotropic_material_meshing():
 
     box_iso = td.Structure(
         geometry=box,
-        medium=td.Medium(permittivity=perm_d[0][0], conductivity=cond_d[0][0]),
+        medium=td.Medium(permittivity=perm_diag[0], conductivity=cond_diag[0]),
     )
 
     box_diag = td.Structure(
         geometry=box,
         medium=td.AnisotropicMedium(
-            xx=td.Medium(permittivity=perm_d[0][0], conductivity=cond_d[0][0]),
-            yy=td.Medium(permittivity=perm_d[1][1], conductivity=cond_d[1][1]),
-            zz=td.Medium(permittivity=perm_d[2][2], conductivity=cond_d[2][2]),
+            xx=td.Medium(permittivity=perm_diag[0], conductivity=cond_diag[0]),
+            yy=td.Medium(permittivity=perm_diag[1], conductivity=cond_diag[1]),
+            zz=td.Medium(permittivity=perm_diag[2], conductivity=cond_diag[2]),
         ),
     )
 
     box_full = td.Structure(
         geometry=box,
-        medium=td.FullyAnisotropicMedium.from_diagonal(
-            xx=td.Medium(permittivity=perm_d[0][0], conductivity=cond_d[0][0]),
-            yy=td.Medium(permittivity=perm_d[1][1], conductivity=cond_d[1][1]),
-            zz=td.Medium(permittivity=perm_d[2][2], conductivity=cond_d[2][2]),
-            rotation=td.RotationAroundAxis(axis=(1, 2, 3), angle=1.23),
+        medium=td.FullyAnisotropicMedium(
+            permittivity=np.diag(perm_diag),
+            conductivity=np.diag(cond_diag),
         ),
     )
 

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -1382,6 +1382,25 @@ def test_tfsf_structures_grid(log_capture):
     with pytest.raises(SetupError) as e:
         sim.validate_pre_upload()
 
+    # TFSF box must not intersect a fully anisotropic medium
+    anisotropic_medium = td.FullyAnisotropicMedium(
+        permittivity=np.eye(3).tolist(), conductivity=np.eye(3).tolist()
+    )
+    sim = td.Simulation(
+        size=(2.0, 2.0, 2.0),
+        grid_spec=td.GridSpec.auto(wavelength=1.0),
+        run_time=1e-12,
+        sources=[source],
+        structures=[
+            td.Structure(
+                geometry=td.Box(center=(0.5, 0, 0), size=(td.inf, td.inf, 0.25)),
+                medium=anisotropic_medium,
+            )
+        ],
+    )
+    with pytest.raises(SetupError) as e:
+        sim.validate_pre_upload()
+
 
 @pytest.mark.parametrize(
     "size, num_struct, log_level", [(1, 1, None), (50, 1, "WARNING"), (1, 11000, "WARNING")]

--- a/tests/test_components/test_types.py
+++ b/tests/test_components/test_types.py
@@ -1,7 +1,7 @@
 """Tests type definitions."""
 import pytest
 import tidy3d as td
-from tidy3d.components.types import ArrayLike, Complex, constrained_array
+from tidy3d.components.types import ArrayLike, Complex, constrained_array, Tuple
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.exceptions import ValidationError
 import numpy as np
@@ -14,6 +14,15 @@ def _test_validate_array_like():
     s = S(f=np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
     with pytest.raises(pydantic.ValidationError):
         s = S(f=np.array([1.0, 2.0, 3.0]))
+
+    class MyClass(Tidy3dBaseModel):
+        f: constrained_array(ndim=3, shape=(1, 2, 3))
+
+    with pytest.raises(pydantic.ValidationError):
+        _ = MyClass(f=np.ones((2, 2, 3)))
+
+    with pytest.raises(pydantic.ValidationError):
+        _ = MyClass(f=np.ones((1, 2, 3, 4)))
 
 
 def test_schemas():
@@ -35,6 +44,7 @@ def test_array_like():
         c: constrained_array(dtype=float) = None  # must be float-like
         d: constrained_array(ndim=1, dtype=complex) = None  # 1D complex
         e: ArrayLike
+        f: constrained_array(ndim=3, shape=(1, 2, 3)) = None  # must have certain shape
 
     my_obj = MyClass(
         a=1.0 + 2j,
@@ -42,6 +52,7 @@ def test_array_like():
         c=[1, 3.0],
         d=[1.0],
         e=[[[[1.0]]]],
+        f=np.ones((1, 2, 3)),
     )
 
     assert np.all(my_obj.a == [1.0 + 2j])  # scalars converted to list of len 1
@@ -57,6 +68,7 @@ def test_hash():
 
         a: ArrayLike
         b: constrained_array(ndim=1)
+        c: Tuple[ArrayLike, ...]
 
-    c = MyClass(a=[1.0], b=[2.0, 1.0])
+    c = MyClass(a=[1.0], b=[2.0, 1.0], c=([2.0, 1.0]))
     hash(c.json())

--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -179,7 +179,7 @@ def test_compute_modes():
     coords = np.arange(11)
     mode_spec = td.ModeSpec(num_modes=3, target_neff=2.0)
     modes = compute_modes(
-        eps_cross=[eps_cross] * 3,
+        eps_cross=[eps_cross] * 9,
         coords=[coords, coords],
         freq=td.C_0 / 1.0,
         mode_spec=mode_spec,

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -11,7 +11,8 @@ from .components.geometry import TriangleMesh
 # medium
 from .components.medium import Medium, PoleResidue, AnisotropicMedium, PEC, PECMedium, Medium2D
 from .components.medium import Sellmeier, Debye, Drude, Lorentz
-from .components.medium import CustomMedium
+from .components.medium import CustomMedium, FullyAnisotropicMedium
+from .components.medium import RotationAroundAxis
 
 # structures
 from .components.structure import Structure, MeshOverrideStructure

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -12,7 +12,7 @@ from .components.geometry import TriangleMesh
 from .components.medium import Medium, PoleResidue, AnisotropicMedium, PEC, PECMedium, Medium2D
 from .components.medium import Sellmeier, Debye, Drude, Lorentz
 from .components.medium import CustomMedium, FullyAnisotropicMedium
-from .components.medium import RotationAroundAxis
+from .components.transformation import RotationAroundAxis
 
 # structures
 from .components.structure import Structure, MeshOverrideStructure

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -66,6 +66,13 @@ class Tidy3dBaseModel(pydantic.BaseModel):
     `Pydantic Models <https://pydantic-docs.helpmanual.io/usage/models/>`_
     """
 
+    def __hash__(self) -> int:
+        """Hash method."""
+        try:
+            return super().__hash__(self)
+        except TypeError:
+            return hash(self.json())
+
     def __init__(self, **kwargs):
         """Init method, includes post-init validators."""
         super().__init__(**kwargs)

--- a/tidy3d/components/grid/mesher.py
+++ b/tidy3d/components/grid/mesher.py
@@ -380,9 +380,10 @@ class GradedMesher(Mesher):
                     index = 1.0
                 else:
                     n, k = structure.medium.eps_complex_to_nk(
-                        structure.medium.eps_diagonal(C_0 / wavelength)[axis]
+                        structure.medium.eps_diagonal(C_0 / wavelength)
                     )
-                    index = max(abs(n), abs(k))
+                    # take max among all directions because perpendicular eps defines wavelength
+                    index = max(max(abs(n)), max(abs(k)))
                 min_steps.append(max(dl_min, wavelength / index / min_steps_per_wvl))
             elif isinstance(structure, MeshOverrideStructure):
                 min_steps.append(max(dl_min, structure.dl[axis]))

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -1359,6 +1359,13 @@ class FullyAnisotropicMedium(AbstractMedium):
     magneto-optic effects. Note that dispersive properties and subpixel averaging are currently not
     supported for fully anisotropic materials.
 
+    Note
+    ----
+    Simulations involving fully anisotropic materials are computationally more intensive, thus,
+    they take longer time to complete. This increase strongly depends on the filling fraction of
+    the simulation domain by fully anisotropic materials, varying approximately in the range from
+    1.5 to 5. Cost of running a simulation is adjusted correspondingly.
+
     Example
     -------
     >>> perm = [[2, 0, 0], [0, 1, 0], [0, 0, 3]]

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -1477,6 +1477,7 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
         medium_list = [self.medium] + list(self.mediums)
         medium_list = [medium for medium in medium_list if not isinstance(medium, PECMedium)]
         # regular medium
+        # wouldn't using eps_diagonal be more accurate?
         eps_list = [
             medium.eps_model(freq).real
             for medium in medium_list
@@ -2547,8 +2548,12 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
             """Select the correct epsilon component if field locations are requested."""
             if coord_key[0] != "E":
                 return np.mean(structure.eps_diagonal(frequency, coords), axis=0)
-            component = ["x", "y", "z"].index(coord_key[1])
-            return structure.eps_diagonal(frequency, coords)[component]
+            row = ["x", "y", "z"].index(coord_key[1])
+            if len(coord_key) == 2:
+                col = row
+            else:
+                col = ["x", "y", "z"].index(coord_key[2])
+            return structure.eps_comp(row, col, frequency, coords)
 
         def make_eps_data(coords: Coords):
             """returns epsilon data on grid of points defined by coords"""
@@ -2589,7 +2594,10 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
             return xr.DataArray(eps_array, coords=coords, dims=("x", "y", "z"))
 
         # combine all data into dictionary
-        coords = grid[coord_key]
+        if coord_key[0] != "E":
+            coords = grid[coord_key]
+        else:
+            coords = grid[coord_key[0:2]]
         return make_eps_data(coords)
 
     @property

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -6,7 +6,7 @@ from .base import Tidy3dBaseModel
 from .validators import validate_name_str
 from .geometry import GeometryType
 from .medium import MediumType, CustomMedium, Medium2D
-from .types import Ax, TYPE_TAG_STR
+from .types import Ax, TYPE_TAG_STR, Axis
 from .viz import add_ax_if_none, equal_aspect
 from .grid.grid import Coords
 from ..constants import MICROMETER
@@ -108,6 +108,29 @@ class Structure(AbstractStructure):
                 )
             _ = geom._normal_2dmaterial  # pylint: disable=protected-access
         return val
+
+    def eps_comp(self, row: Axis, col: Axis, frequency: float, coords: Coords) -> complex:
+        """Single component of the complex-valued permittivity tensor as a function of frequency.
+
+        Parameters
+        ----------
+        row : Axis
+            Component's row in the permittivity tensor.
+        col : Axis
+            Component's column in the permittivity tensor.
+        frequency : float
+            Frequency to evaluate permittivity at (Hz).
+
+        Returns
+        -------
+        complex
+           Element of the relative permittivity tensor evaluated at ``frequency``.
+        """
+        if isinstance(self.medium, CustomMedium):
+            return self.medium.eps_comp_on_grid(
+                row=row, col=col, frequency=frequency, coords=coords
+            )
+        return self.medium.eps_comp(row=row, col=col, frequency=frequency)
 
 
 class MeshOverrideStructure(AbstractStructure):

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -114,10 +114,10 @@ class Structure(AbstractStructure):
 
         Parameters
         ----------
-        row : Axis
-            Component's row in the permittivity tensor.
-        col : Axis
-            Component's column in the permittivity tensor.
+        row : int
+            Component's row in the permittivity tensor (0, 1, or 2 for x, y, or z respectively).
+        col : int
+            Component's column in the permittivity tensor (0, 1, or 2 for x, y, or z respectively).
         frequency : float
             Frequency to evaluate permittivity at (Hz).
 

--- a/tidy3d/components/transformation.py
+++ b/tidy3d/components/transformation.py
@@ -1,0 +1,114 @@
+"""Defines geometric transformation classes"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Union
+
+import pydantic as pd
+import numpy as np
+
+from .base import Tidy3dBaseModel, cached_property
+from .types import Coordinate, TensorReal, ArrayFloat2D
+from ..constants import RADIAN
+
+
+class AbstractRotation(ABC, Tidy3dBaseModel):
+    """Abstract rotation of vectors and tensors."""
+
+    @cached_property
+    @abstractmethod
+    def matrix(self) -> TensorReal:
+        """Rotation matrix."""
+
+    @cached_property
+    @abstractmethod
+    def isidentity(self) -> bool:
+        """Check whether rotation is identity."""
+
+    def rotate_vector(self, vector: ArrayFloat2D) -> ArrayFloat2D:
+        """Rotate a vector/point or a list of vectors/points.
+
+        Parameters
+        ----------
+        points : ArrayLike[float]
+            Array of shape ``(3, ...)``.
+
+        Returns
+        -------
+        Coordinate
+            Rotated vector.
+        """
+
+        if self.isidentity:
+            return vector
+
+        if len(vector.shape) == 1:
+            return self.matrix @ vector
+
+        return np.tensordot(self.matrix, vector, axes=1)
+
+    def rotate_tensor(self, tensor: TensorReal) -> TensorReal:
+        """Rotate a tensor.
+
+        Parameters
+        ----------
+        tensor : ArrayLike[float]
+            Array of shape ``(3, 3)``.
+
+        Returns
+        -------
+        TensorReal
+            Rotated tensor.
+        """
+
+        if self.isidentity:
+            return tensor
+
+        return np.matmul(self.matrix, np.matmul(tensor, self.matrix.T))
+
+
+class RotationAroundAxis(AbstractRotation):
+    """Rotation of vectors and tensors around a given vector."""
+
+    axis: Coordinate = pd.Field(
+        [1, 0, 0],
+        title="Axis of Rotation",
+        description="A vector that specifies the axis of rotation.",
+    )
+
+    angle: float = pd.Field(
+        0.0,
+        title="Angle of Rotation",
+        description="Angle of rotation in radians.",
+        units=RADIAN,
+    )
+
+    @cached_property
+    def isidentity(self) -> bool:
+        """Check whether rotation is identity."""
+
+        return np.isclose(self.angle % (2 * np.pi), 0)
+
+    @cached_property
+    # pylint: disable=invalid-name
+    def matrix(self) -> TensorReal:
+        """Rotation matrix."""
+
+        if self.isidentity:
+            return np.eye(3)
+
+        n = self.axis / np.linalg.norm(self.axis)
+        c = np.cos(self.angle)
+        s = np.sin(self.angle)
+        R = np.zeros((3, 3))
+        tan_dim = [[1, 2], [2, 0], [0, 1]]
+
+        for dim in range(3):
+            R[dim, dim] = c + n[dim] ** 2 * (1 - c)
+            R[dim, tan_dim[dim][0]] = n[dim] * n[tan_dim[dim][0]] * (1 - c) - n[tan_dim[dim][1]] * s
+            R[dim, tan_dim[dim][1]] = n[dim] * n[tan_dim[dim][1]] * (1 - c) + n[tan_dim[dim][0]] * s
+
+        return R
+
+
+RotationType = Union[RotationAroundAxis]

--- a/tidy3d/components/types.py
+++ b/tidy3d/components/types.py
@@ -182,6 +182,18 @@ FreqBoundMax = float
 FreqBoundMin = float
 FreqBound = Tuple[FreqBoundMin, FreqBoundMax]
 
+ComplexTensor = Tuple[
+    Tuple[Complex, Complex, Complex],
+    Tuple[Complex, Complex, Complex],
+    Tuple[Complex, Complex, Complex],
+]
+
+RealTensor = Tuple[
+    Tuple[float, float, float],
+    Tuple[float, float, float],
+    Tuple[float, float, float],
+]
+
 """ sources """
 
 Polarization = Literal["Ex", "Ey", "Ez", "Hx", "Hy", "Hz"]

--- a/tidy3d/plugins/mode/solver.py
+++ b/tidy3d/plugins/mode/solver.py
@@ -69,9 +69,11 @@ class EigSolver(Tidy3dBaseModel):
         k0 = omega / C_0
 
         if isinstance(eps_cross, Numpy):
-            eps_xx, eps_yy, eps_zz = eps_cross
-        elif len(eps_cross) == 3:
-            eps_xx, eps_yy, eps_zz = [np.copy(e) for e in eps_cross]
+            eps_xx, eps_xy, eps_xz, eps_yx, eps_yy, eps_yz, eps_zx, eps_zy, eps_zz = eps_cross
+        elif len(eps_cross) == 9:
+            eps_xx, eps_xy, eps_xz, eps_yx, eps_yy, eps_yz, eps_zx, eps_zy, eps_zz = [
+                np.copy(e) for e in eps_cross
+            ]
         else:
             raise ValueError("Wrong input to mode solver pemittivity!")
 
@@ -88,9 +90,12 @@ class EigSolver(Tidy3dBaseModel):
         (2N, 2N), and the full tensorial case, in which case it has shape (4N, 4N)."""
         eps_tensor = np.zeros((3, 3, N), dtype=np.complex128)
         mu_tensor = np.zeros((3, 3, N), dtype=np.complex128)
-        for dim, eps in enumerate([eps_xx, eps_yy, eps_zz]):
-            eps_tensor[dim, dim, :] = eps.ravel()
-            mu_tensor[dim, dim, :] = 1.0
+        for row, eps_row in enumerate(
+            [[eps_xx, eps_xy, eps_xz], [eps_yx, eps_yy, eps_yz], [eps_zx, eps_zy, eps_zz]]
+        ):
+            mu_tensor[row, row, :] = 1.0
+            for col, eps in enumerate(eps_row):
+                eps_tensor[row, col, :] = eps.ravel()
 
         # Get Jacobian of all coordinate transformations. Initialize as identity (same as mu so far)
         jac_e = np.real(np.copy(mu_tensor))

--- a/tidy3d/plugins/mode/solver.py
+++ b/tidy3d/plugins/mode/solver.py
@@ -41,8 +41,8 @@ class EigSolver(Tidy3dBaseModel):
         ----------
         eps_cross : array_like or tuple of array_like
             Either a single 2D array defining the relative permittivity in the cross-section,
-            or three 2D arrays defining the permittivity at the Ex, Ey, and Ez locations
-            of the Yee grid.
+            or nine 2D arrays defining the permittivity at the Ex, Ey, and Ez locations
+            of the Yee grid in the order xx, xy, xz, yx, yy, yz, zx, zy, zz.
         coords : List[Numpy]
             Two 1D arrays with each with size one larger than the corresponding axis of
             ``eps_cross``.
@@ -114,7 +114,7 @@ class EigSolver(Tidy3dBaseModel):
         different from just the transformation of the derivative operator. For example, in a bent
         waveguide, there is strictly speaking no k-vector in the original coordinates as the system
         is not translationally invariant there. However, if we define kz = R k_phi, then the
-        effective index approaches that for a straight-waveguide in the limit of infinite radius. 
+        effective index approaches that for a straight-waveguide in the limit of infinite radius.
         Since we use w = R phi in the radial_transform, there is nothing else neede in the k transform.
         For the angled_transform, the transformation between k-vectors follows from writing the field as
         E' exp(i k_p w) in transformed coordinates, and identifying this with


### PR DESCRIPTION
Frontend interface for fully anisotropic materials:
- Since `AnisotropicMedium` was already taken, fully anisotropic materials are called `FullyAnisotropicMedium`
- Currently only materials for which main directions of permittivity and conductivity (symmetric part) tensors coincide (to have well-defined main complex permittivities)
- A helper class `RotationAroundAxis(AbstractRotation)` is implemented for convenient rotation of tensors in space. In future we can add more methods like `RotationEulerAngles(AbstractRotation)`, etc.
- Automatic mesher now takes into account only the max eps among all directions (previous treatment based on normal direction resulted in underresolving because tangential direction define wavelength)
- For now injection of plane waves and gaussian beams into anisotropic materials is prohibited
- When plotted, `FullyAnisotropicMedium` returns main components
- Slight modification of `ModeSolver` so that it is feeded with the full permittivity tensor
- To help that new method `eps_comp` is introduced in material classes to retrieve a specified component of a permittivity tensor

Review todo's:
- [x] Unify rotation functionality
- [x] Generalize `ArrayLike`
- [x] Standardize order of components in mode solver
- [x] changelog
- [x] unify plotting for `AnisotropicMedium` and `FullyAnisotropicMedium`
- [ ] converge on naming/unification of `AnisotropicMedium` and `FullyAnisotropicMedium`