### PR TITLE
fix typo in `from_hdf5` docstring example

### DIFF
--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -470,7 +470,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
 
         Example
         -------
-        >>> simulation.to_hdf5(fname='folder/sim.hdf5') # doctest: +SKIP
+        >>> simulation = Simulation.from_file(fname='folder/sim.hdf5') # doctest: +SKIP
         """
 
         group_path = cls._construct_group_path(group_path)


### PR DESCRIPTION
fixes https://github.com/flexcompute-readthedocs/tidy3d-docs/issues/183