### PR TITLE
Refactoring functions to communicate through files

### DIFF
--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -27,7 +27,7 @@ from tidy3d.plugins.adjoint.components.data.dataset import JaxPermittivityDatase
 from tidy3d.plugins.adjoint.web import run, run_async
 from tidy3d.plugins.adjoint.components.data.data_array import VALUE_FILTER_THRESHOLD
 
-from ..utils import run_emulated, assert_log_level, log_capture, run_async_emulated
+from ..utils import run_emulated, assert_log_level, log_capture, run_async_emulated, SIM_DATA_PATH
 
 
 EPS = 2.0
@@ -186,13 +186,13 @@ def test_adjoint_pipeline(use_emulated_run):
     """Test computing gradient using jax."""
 
     sim = make_sim(permittivity=EPS, size=SIZE, vertices=VERTICES, base_eps_val=BASE_EPS_VAL)
-    sim_data = run(sim, task_name="test")
+    sim_data = run(sim, task_name="test", path=SIM_DATA_PATH)
 
     def f(permittivity, size, vertices, base_eps_val):
         sim = make_sim(
             permittivity=permittivity, size=size, vertices=vertices, base_eps_val=base_eps_val
         )
-        sim_data = run(sim, task_name="test")
+        sim_data = run(sim, task_name="test", path=SIM_DATA_PATH)
         amp = extract_amp(sim_data)
         return objective(amp)
 
@@ -209,7 +209,7 @@ def test_adjoint_setup_fwd(use_emulated_run):
         simulation=sim,
         task_name="test",
         folder_name="default",
-        path="simulation_data.hdf5",
+        path=SIM_DATA_PATH,
         callback_url=None,
         verbose=False,
     )
@@ -233,7 +233,7 @@ def _test_adjoint_setup_adj(use_emulated_run):
         simulation=sim_orig,
         task_name="test",
         folder_name="default",
-        path="simulation_data.hdf5",
+        path=SIM_DATA_PATH,
         callback_url=None,
     )
 
@@ -250,7 +250,7 @@ def _test_adjoint_setup_adj(use_emulated_run):
     (sim_vjp,) = run.bwd(
         task_name="test",
         folder_name="default",
-        path="simulation_data.hdf5",
+        path=SIM_DATA_PATH,
         callback_url=None,
         res=(sim_data_fwd,),
         sim_data_vjp=sim_data_vjp,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,6 +22,7 @@ def clear_dir(path: str):
 
 
 TMP_DIR = "tests/tmp/"
+SIM_DATA_PATH = TMP_DIR + "simulation_data.hdf5"
 
 
 # decorator that clears the tmp/ directory before test
@@ -311,7 +312,7 @@ SIM_FULL = Simulation(
 )
 
 
-def run_emulated(simulation: Simulation, **kwargs) -> SimulationData:
+def run_emulated(simulation: Simulation, path: str = SIM_DATA_PATH, **kwargs) -> SimulationData:
     """Emulates a simulation run."""
 
     from scipy.ndimage.filters import gaussian_filter
@@ -395,8 +396,10 @@ def run_emulated(simulation: Simulation, **kwargs) -> SimulationData:
     }
 
     data = [MONITOR_MAKER_MAP[type(mnt)](mnt) for mnt in simulation.monitors]
+    sim_data = SimulationData(simulation=simulation, data=data)
+    sim_data.to_file(path)
 
-    return SimulationData(simulation=simulation, data=data)
+    return sim_data
 
 
 def run_async_emulated(simulations: Dict[str, Simulation], **kwargs) -> BatchData:


### PR DESCRIPTION
I managed to get a first iteration working on the backend. We need a few modifications on the frontend, I started working on those here. I think they all revolve around making everything communicate through files instead of keeping things in memory as it was set up. @tylerflex could you help with the refactor?

Some things to think about:
- Writing and reading JaxInfo to file.
- Ideally no simulation-related data should be read from the web response. This should only be used for metadata, status, etc. I have refactored things to write SimulationData to file in the tests, and then read it in, to emulate how it will actually work. For this I had to work with SimulationData and not JaxSimulationData, as writing this to hdf5 and then reading it back in caused jax to error.
- There seems to be no simple way right now to get a SimulationData without the grad monitors from a SimulationData (or JaxSimulationData) that includes the grad monitors. So I had to do two `tidy3d_run_fn` calls in the forward pass, but hopefully we can fix this.
- The full forward simulation data should also ideally be written to file and then read back out in the backward pass to emulate and test what will actually happen on the server. The two passes will be independent processes and need to communicate through file. I think we also cannot use pickle, because the file will sit in the user's S3 bucket and can be tampered with in between the two processes.
- `sim_vjp` should also be downloaded to file. It seems like we need to define more than one `path`-s, or have the `path` be a folder as opposed to a file path as it is currently.
- Not sure how to pass `fwidth_adj`. It *could* be through the response, but it would be better if it's packaged in a file, especially if in the future there could be other things that also will need to be returned by the forward pass. Maybe after the forward pass, an updated JaxInfo can be downloaded? Not sure.