### PR TITLE
Updating monitors to colocate to primal grid, and colocate=True by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `hlim` and `vlim` kwargs to `Simulation.plot()` and `Simulation.plot_eps()` for setting horizontal and veritcal plot limits.
 - Added support for chi3 nonlinearity via `NonlinearSusceptibility` class.
+- Spatial downsampling allowed in ``PermittivityMonitor`` through the ``interval_space`` argument.
 
 ### Changed
 - `nyquist_step` also taking the frequency range of frequency-domain monitors into account.
 - Added option to allow DC component in `GaussianPulse` spectrum, by setting `remove_dc_component=False` in `GaussianPulse`.
 - Jax installation from `pip install "tidy3d[jax]"` handled same way on windows as other OS if python >= 3.9.
+- `colocate` introduced as an argument to `ModeSolver` and a Field in `ModeSolverMonitor`, set to True by default.
+- `FieldTimeMonitor`-s and `FieldMonitor`-s that have `colocate=True` return fields colocated to the grid boundaries rather than centers. This matches better user expectations for example when the simulation has a symmetry (explicitly defined, or implicit) w.r.t. a given axis. When colocating to centers, fields would be ``dl / 2`` away from that symmetry plane, and components that are expected to go to zero do not (of course, they still do if interpolated to the symmetry plane). Another convenient use case is that it is easier to place a 2D monitor exactly on a grid boundary in the automatically generated grid, by simply passing an override structure with the monitor geometry.
+- In these monitors, `colocate` is now set to `True` by default. This is to avoid a lot of potential confusion coming from returning non-colocated fields by default, when colocated fields need to be used when computing quantities that depend on more than one field component, like flux or field intensity.
+- Field colocation for computations like flux, Poynting, and modal overlap also happen to cell boundaries rather than centers. The effect on final results
+should be close to imperceptible as verified by a large number of backend tests and our online examples. Any difference can be at most on the scale of
+the difference that can be observed when slightly modifying the grid resolution.
 
 ### Fixed
 - Bug in angled mode solver with negative `angle_theta`.
 - Properly include `JaxSimulation.input_structures` in `JaxSimulationData.plot_field()`.
 - Numerically stable sigmoid function in radius of curvature constraint.
 - Fixed 2d checking in `Geometry.intersections_2dbox()`.
+- Spatial monitor downsampling when the monitor is crossing a symmetry plane or Bloch boundary conditions.
 
 ## [2.4.0rc1] - 2023-7-27
 
@@ -87,6 +95,7 @@ that the fields match exactly except for a ``pi`` phase shift. This interpretati
 - `ArrayLike` validation properly fails with `None` or `nan` contents.
 - Apply finite grid correction to the fields when calculating the Poynting vector from 2D monitors.
 - `JaxCustomMedium` properly handles complex-valued permittivity.
+
 
 ## [2.3.0] - 2023-6-30
 

--- a/tests/test_components/test_field_projection.py
+++ b/tests/test_components/test_field_projection.py
@@ -282,7 +282,7 @@ def test_proj_clientside():
         Hz=scalar_field,
         symmetry=sim.symmetry,
         symmetry_center=sim.center,
-        grid_expanded=sim.discretize(monitor, extend=True),
+        grid_expanded=sim.discretize_monitor(monitor),
     )
 
     sim_data = td.SimulationData(simulation=sim, data=(data,))

--- a/tests/test_components/test_grid.py
+++ b/tests/test_components/test_grid.py
@@ -87,22 +87,14 @@ def test_extend_grid():
     box_left = td.Box(center=(0, center_y - 1e-5, 0), size=(2, 0, 6))
     # 2d box on the right of a grid center
     box_right = td.Box(center=(0, center_y + 1e-5, 0), size=(2, 0, 6))
-    inds_l_0_0 = g.discretize_inds(box=box_left, extend=False, extend_2d_normal=False)[1]
-    inds_r_0_0 = g.discretize_inds(box=box_right, extend=False, extend_2d_normal=False)[1]
-    inds_l_1_0 = g.discretize_inds(box=box_left, extend=True, extend_2d_normal=False)[1]
-    inds_r_1_0 = g.discretize_inds(box=box_right, extend=True, extend_2d_normal=False)[1]
-    inds_l_0_1 = g.discretize_inds(box=box_left, extend=False, extend_2d_normal=True)[1]
-    inds_r_0_1 = g.discretize_inds(box=box_right, extend=False, extend_2d_normal=True)[1]
-    inds_l_1_1 = g.discretize_inds(box=box_left, extend=True, extend_2d_normal=True)[1]
-    inds_r_1_1 = g.discretize_inds(box=box_right, extend=True, extend_2d_normal=True)[1]
+    inds_l_0_0 = g.discretize_inds(box=box_left, extend=False)[1]
+    inds_r_0_0 = g.discretize_inds(box=box_right, extend=False)[1]
+    inds_l_1_0 = g.discretize_inds(box=box_left, extend=True)[1]
+    inds_r_1_0 = g.discretize_inds(box=box_right, extend=True)[1]
 
     assert np.diff(inds_l_0_0) == np.diff(inds_r_0_0)
     assert np.diff(inds_l_0_0) == np.diff(inds_l_1_0) - 2
     assert np.diff(inds_r_0_0) == np.diff(inds_r_1_0) - 1
-    assert np.diff(inds_l_0_0) == np.diff(inds_l_0_1) - 1
-    assert np.diff(inds_r_0_0) == np.diff(inds_r_0_1) - 1
-    assert np.diff(inds_l_0_0) == np.diff(inds_l_1_1) - 2
-    assert np.diff(inds_r_0_0) == np.diff(inds_r_1_1) - 2
 
 
 def test_extended_subspace():

--- a/tests/test_components/test_monitor.py
+++ b/tests/test_components/test_monitor.py
@@ -4,6 +4,7 @@ import pydantic
 import numpy as np
 import tidy3d as td
 from tidy3d.exceptions import SetupError, ValidationError
+from ..utils import assert_log_level, log_capture
 
 
 def test_stop_start():
@@ -202,16 +203,8 @@ def test_monitor_freqs_empty():
         )
 
 
-def test_monitor_downsampling():
-    # test that the downsampling parameters can be set and the colocation validator works
-
-    monitor = td.FieldMonitor(
-        size=(td.inf, td.inf, td.inf),
-        freqs=np.linspace(0, 200e12, 10001),
-        name="test",
-        interval_space=(1, 1, 1),
-    )
-    assert monitor.colocate is False
+def test_monitor_colocate(log_capture):
+    """test default colocate value, and warning if not set"""
 
     monitor = td.FieldMonitor(
         size=(td.inf, td.inf, td.inf),
@@ -220,6 +213,7 @@ def test_monitor_downsampling():
         interval_space=(1, 2, 3),
     )
     assert monitor.colocate is True
+    assert_log_level(log_capture, "WARNING")
 
     monitor = td.FieldMonitor(
         size=(td.inf, td.inf, td.inf),

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -679,16 +679,6 @@ def test_nyquist():
     assert td.Simulation.nyquist_step.fget(m) == 1
 
 
-def test_min_sym_box():
-    S = SIM.copy(update=dict(symmetry=(1, 1, 1)))
-    b = td.Box(center=(-2, -2, -2), size=(1, 1, 1))
-    S.min_sym_box(b)
-    b = td.Box(center=(2, 2, 2), size=(1, 1, 1))
-    S.min_sym_box(b)
-    b = td.Box(size=(1, 1, 1))
-    S.min_sym_box(b)
-
-
 def test_discretize_non_intersect(log_capture):
     SIM.discretize(box=td.Box(center=(-20, -20, -20), size=(1, 1, 1)))
     assert_log_level(log_capture, "ERROR")

--- a/tests/test_data/test_data_arrays.py
+++ b/tests/test_data/test_data_arrays.py
@@ -121,13 +121,13 @@ def get_xyz(
     monitor: MonitorType, grid_key: str, symmetry: bool
 ) -> Tuple[List[float], List[float], List[float]]:
     if symmetry:
-        grid = SIM_SYM.discretize(monitor, extend=True)
+        grid = SIM_SYM.discretize_monitor(monitor)
         x, y, z = grid[grid_key].to_list
         x = [_x for _x in x if _x >= 0]
         y = [_y for _y in y if _y >= 0]
         z = [_z for _z in z if _z >= 0]
     else:
-        grid = SIM.discretize(monitor, extend=True)
+        grid = SIM.discretize_monitor(monitor)
         x, y, z = grid[grid_key].to_list
     return x, y, z
 

--- a/tests/test_data/test_monitor_data.py
+++ b/tests/test_data/test_monitor_data.py
@@ -48,7 +48,7 @@ def make_field_data(symmetry: bool = True):
         Hz=make_scalar_field_data_array("Hz", symmetry),
         symmetry=sim.symmetry,
         symmetry_center=sim.center,
-        grid_expanded=sim.discretize(FIELD_MONITOR, extend=True, snap_zero_dim=True),
+        grid_expanded=sim.discretize_monitor(FIELD_MONITOR),
     )
 
 
@@ -63,7 +63,7 @@ def make_field_time_data(symmetry: bool = True):
         Hx=make_scalar_field_time_data_array("Hx", symmetry),
         symmetry=sim.symmetry,
         symmetry_center=sim.center,
-        grid_expanded=sim.discretize(FIELD_TIME_MONITOR, extend=True, snap_zero_dim=True),
+        grid_expanded=sim.discretize_monitor(FIELD_TIME_MONITOR),
     )
 
 
@@ -78,7 +78,7 @@ def make_field_data_2d(symmetry: bool = True):
         Hz=make_scalar_field_data_array("Hz", symmetry).interp(y=[0]),
         symmetry=sim.symmetry,
         symmetry_center=sim.center,
-        grid_expanded=sim.discretize(FIELD_MONITOR_2D, extend=True, snap_zero_dim=True),
+        grid_expanded=sim.discretize_monitor(FIELD_MONITOR_2D),
     )
 
 
@@ -93,7 +93,7 @@ def make_field_time_data_2d(symmetry: bool = True):
         Hz=make_scalar_field_time_data_array("Hz", symmetry).interp(y=[0]),
         symmetry=sim.symmetry,
         symmetry_center=sim.center,
-        grid_expanded=sim.discretize(FIELD_TIME_MONITOR_2D, extend=True, snap_zero_dim=True),
+        grid_expanded=sim.discretize_monitor(FIELD_TIME_MONITOR_2D),
     )
 
 
@@ -108,7 +108,7 @@ def make_mode_solver_data():
         Hz=make_scalar_mode_field_data_array("Hz"),
         symmetry=SIM_SYM.symmetry,
         symmetry_center=SIM_SYM.center,
-        grid_expanded=SIM_SYM.discretize(MODE_SOLVE_MONITOR, extend=True, snap_zero_dim=True),
+        grid_expanded=SIM_SYM.discretize_monitor(MODE_SOLVE_MONITOR),
         n_complex=N_COMPLEX.copy(),
         grid_primal_correction=GRID_CORRECTION,
         grid_dual_correction=GRID_CORRECTION,
@@ -131,7 +131,7 @@ def make_mode_solver_data_smooth():
         Hz=make_scalar_mode_field_data_array_smooth("Hz", rot=0.78 * np.pi),
         symmetry=SIM_SYM.symmetry,
         symmetry_center=SIM_SYM.center,
-        grid_expanded=SIM_SYM.discretize(MODE_SOLVE_MONITOR, extend=True, snap_zero_dim=True),
+        grid_expanded=SIM_SYM.discretize_monitor(MODE_SOLVE_MONITOR),
         n_complex=N_COMPLEX.copy(),
         grid_primal_correction=GRID_CORRECTION,
         grid_dual_correction=GRID_CORRECTION,
@@ -152,7 +152,7 @@ def make_permittivity_data(symmetry: bool = True):
         eps_zz=make_scalar_field_data_array("Ez", symmetry),
         symmetry=sim.symmetry,
         symmetry_center=sim.center,
-        grid_expanded=sim.discretize(PERMITTIVITY_MONITOR, extend=True),
+        grid_expanded=sim.discretize_monitor(PERMITTIVITY_MONITOR),
     )
 
 
@@ -357,7 +357,7 @@ def test_empty_array():
         monitor=monitor,
         symmetry=SIM.symmetry,
         symmetry_center=SIM.center,
-        grid_expanded=SIM.discretize(monitor, extend=True),
+        grid_expanded=SIM.discretize_monitor(monitor),
         **fields
     )
 
@@ -371,7 +371,7 @@ def _test_empty_list():
         monitor=monitor,
         symmetry=SIM.symmetry,
         symmetry_center=SIM.center,
-        grid_expanded=SIM.discretize(monitor, extend=True),
+        grid_expanded=SIM.discretize_monitor(monitor),
         **fields
     )
 
@@ -385,7 +385,7 @@ def _test_empty_tuple():
         monitor=monitor,
         symmetry=SIM.symmetry,
         symmetry_center=SIM.center,
-        grid_expanded=SIM.discretize(monitor, extend=True),
+        grid_expanded=SIM.discretize_monitor(monitor),
         **fields
     )
 
@@ -398,7 +398,7 @@ def test_empty_io(tmp_path):
         monitor=monitor,
         symmetry=SIM.symmetry,
         symmetry_center=SIM.center,
-        grid_expanded=SIM.discretize(monitor, extend=True),
+        grid_expanded=SIM.discretize_monitor(monitor),
         **fields
     )
     field_data.to_file(str(tmp_path / "field_data.hdf5"))
@@ -428,7 +428,7 @@ def test_field_data_symmetry_present():
         _ = td.FieldTimeData(
             monitor=monitor,
             symmetry=(1, -1, 0),
-            grid_expanded=SIM.discretize(monitor, extend=True),
+            grid_expanded=SIM.discretize_monitor(monitor),
             **fields
         )
 

--- a/tests/test_data/test_sim_data.py
+++ b/tests/test_data/test_sim_data.py
@@ -290,7 +290,7 @@ def test_empty_io(tmp_path):
         monitor=monitor,
         symmetry=sim.symmetry,
         symmetry_center=sim.center,
-        grid_expanded=sim.discretize(monitor, extend=True),
+        grid_expanded=sim.discretize_monitor(monitor),
         **fields,
     )
     sim_data = SimulationData(simulation=sim, data=(field_data,))

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -263,12 +263,14 @@ def make_sim(
         size=(2, 0, 2),
         freqs=[FREQ0],
         name=MNT_NAME + "3",
+        colocate=False,
     )
 
     output_mnt4 = td.FieldMonitor(
         size=(0, 0, 0),
         freqs=[FREQ0],
         name=MNT_NAME + "4",
+        colocate=False,
     )
 
     extraneous_field_monitor = td.FieldMonitor(
@@ -1027,12 +1029,14 @@ def test_polyslab_2d(sim_size_axis, use_emulated_run):
             size=(2, 0, 2),
             freqs=[FREQ0],
             name=MNT_NAME + "3",
+            colocate=False,
         )
 
         output_mnt4 = td.FieldMonitor(
             size=(0, 0, 0),
             freqs=[FREQ0],
             name=MNT_NAME + "4",
+            colocate=False,
         )
 
         sim = JaxSimulation(
@@ -1445,5 +1449,5 @@ def test_sim_data_plot_field(use_emulated_run):
     jax_sim = make_sim(permittivity=EPS, size=SIZE, vertices=VERTICES, base_eps_val=BASE_EPS_VAL)
     jax_sim_data = run(jax_sim, task_name="test")
     ax = jax_sim_data.plot_field("field", "Ez", "real", f=1e14)
-    plt.show()
+    # plt.show()
     assert len(ax.collections) == 1

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -470,7 +470,7 @@ def run_emulated(simulation: td.Simulation, path=None, **kwargs) -> td.Simulatio
         """make a random FieldData from a FieldMonitor."""
         field_cmps = {}
         coords = {}
-        grid = simulation.discretize(monitor, extend=True)
+        grid = simulation.discretize_monitor(monitor)
 
         for field_name in monitor.fields:
             spatial_coords_dict = grid[field_name].dict()
@@ -499,11 +499,15 @@ def run_emulated(simulation: td.Simulation, path=None, **kwargs) -> td.Simulatio
         field_mnt = td.FieldMonitor(**monitor.dict(exclude={"type", "fields"}))
         field_data = make_field_data(monitor=field_mnt)
         return td.PermittivityData(
-            monitor=monitor, eps_xx=field_data.Ex, eps_yy=field_data.Ey, eps_zz=field_data.Ez
+            monitor=monitor,
+            eps_xx=field_data.Ex,
+            eps_yy=field_data.Ey,
+            eps_zz=field_data.Ez,
+            grid_expanded=simulation.discretize_monitor(monitor),
         )
 
     def make_diff_data(monitor: td.DiffractionMonitor) -> td.DiffractionData:
-        """make a random PermittivityData from a PermittivityMonitor."""
+        """make a random DiffractionData from a DiffractionMonitor."""
         f = list(monitor.freqs)
         orders_x = np.linspace(-1, 1, 3)
         orders_y = np.linspace(-2, 2, 5)

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -17,6 +17,7 @@ from .data_array import TimeDataArray
 from ..base import Tidy3dBaseModel
 from ..types import Axis
 from ...exceptions import DataError
+from ...log import log
 
 
 class Dataset(Tidy3dBaseModel, ABC):
@@ -46,7 +47,7 @@ class AbstractFieldDataset(Dataset, ABC):
         return xr.Dataset(centered_fields)
 
     def colocate(self, x=None, y=None, z=None) -> xr.Dataset:
-        """colocate all of the data at a set of x, y, z coordinates.
+        """Colocate all of the data at a set of x, y, z coordinates.
 
         Parameters
         ----------
@@ -72,6 +73,16 @@ class AbstractFieldDataset(Dataset, ABC):
         it is important that the fields are colocated at the same spatial locations.
         Be sure to apply this method to your field data in those cases.
         """
+
+        if hasattr(self, "monitor") and getattr(self, "monitor").colocate:
+            with log as consolidated_logger:
+                consolidated_logger.warning(
+                    "Colocating data that has already been colocated during the solver "
+                    "run. For most accurate results when colocating to custom coordinates set "
+                    "'Monitor.colocate' to 'False' to use the raw data on the Yee grid "
+                    "and avoid double interpolation. Note: the default value was changed to 'True' "
+                    "in Tidy3D version 2.4.0."
+                )
 
         # convert supplied coordinates to array and assign string mapping to them
         supplied_coord_map = {k: np.array(v) for k, v in zip("xyz", (x, y, z)) if v is not None}

--- a/tidy3d/components/field_projection.py
+++ b/tidy3d/components/field_projection.py
@@ -309,7 +309,7 @@ class FieldProjector(Tidy3dBaseModel):
             )
 
             if pts_per_wavelength is None:
-                points = sim_data.simulation.grid.centers.to_list[idx]
+                points = sim_data.simulation.grid.boundaries.to_list[idx]
                 points[np.argwhere(points < start)] = start
                 points[np.argwhere(points > stop)] = stop
                 colocation_points[idx] = np.unique(points)
@@ -320,7 +320,7 @@ class FieldProjector(Tidy3dBaseModel):
                 colocation_points[idx] = points
 
         for idx, points in enumerate(colocation_points):
-            if (hasattr(points, "__len__") and len(points) == 1) or not hasattr(points, "__len__"):
+            if np.array(points).size == 1:
                 colocation_points[idx] = None
 
         currents = currents.colocate(*colocation_points)

--- a/tidy3d/plugins/adjoint/components/geometry.py
+++ b/tidy3d/plugins/adjoint/components/geometry.py
@@ -68,6 +68,7 @@ class JaxGeometry(Geometry, ABC):
             fields=["Ex", "Ey", "Ez"],
             freqs=[freq],
             name=name + "_field",
+            colocate=False,
         )
 
         eps_mnt = PermittivityMonitor(
@@ -225,7 +226,7 @@ class JaxBox(JaxGeometry, Box, JaxObject):
                     eps_data = grad_data_eps.field_components[eps_field_name].isel(f=0)
 
                     # get the permittivity values just inside and outside the edge
-                    n_cells_in = 2
+                    n_cells_in = 3
                     isel_out = 0 if min_max_index == 0 else -1
                     isel_ins = n_cells_in if min_max_index == 0 else -n_cells_in - 1
                     eps2 = eps_data.isel(**{dim_normal: isel_out})

--- a/tidy3d/plugins/adjoint/components/simulation.py
+++ b/tidy3d/plugins/adjoint/components/simulation.py
@@ -133,6 +133,19 @@ class JaxSimulation(Simulation, JaxObject):
             )
         return val
 
+    @pd.validator("output_monitors", always=True)
+    def _output_monitors_colocate_false(cls, val):
+        """Make sure server-side colocation is off."""
+        for mnt in val:
+            if mnt.dict().get("colocate", False):
+                raise AdjointError(
+                    "Server-side colocation ('Monitor.colocate') must be set to 'False' in the "
+                    "adjoint plugin. Instead, use 'SimulationData.at_boundaries' after the solver "
+                    "run to automatically colocate the fields to the grid boundaries, "
+                    "or 'MonitorData.colocate' if colocating to custom coordinates."
+                )
+        return val
+
     @pd.validator("subpixel", always=True)
     def _subpixel_is_on(cls, val):
         """Assert subpixel is on."""


### PR DESCRIPTION
[backend PR](https://github.com/flexcompute/tidy3d-core/pull/323)

From a user point of view, the most notable changes of this PR are as described in the title:

- FieldTimeMonitor-s and FieldMonitor-s that have `colocate=True` return fields colocated to the grid *boundaries* rather than centers.
- `colocate` = True is now set by default.
- The `colocate` argument was also introduced in the `ModeSolver` and `ModeSolverMonitor`, also set to True by default.

The goal of this is to avoid some common confusions that users have about the field data, and also to make it easier to use the data outside of our python frontend.

Internally, various quantities like `flux`, `dot` and `poynting` also use colocation to boundaries, which however should not produce any noticeable difference as confirmed by the passing of all the old backend tests. There is a lot more internal refactoring in the associated [backend PR](https://github.com/flexcompute/tidy3d-core/pull/323), which however should not produce any noticeable differences, apart from bugfixes in some edge cases when things like Bloch boundary conditions, symmetries, down-sampling, and / or colocation were not interacting too well with each other.

Probably the most notable refactoring on the frontend is the introduction of a `Simulation.discretize_monitor` method which should always give the exact grid on which field data lives and is also used on the backend. There, the grid is stored as `grid_expanded` when the monitor data is created, since the monitor data doesn't have access to the `simulation` that created it, after it is created. The stored `grid_expanded` is then used not just for expanding symmetries anymore, but also for things like computing dA when integrating flux, as well as computing the coordinates to colocate to if things like `at_boundaries` are called. I was considering making `grid_expanded` a required field, but decided against it for now - but in practice it should always be set whenever the data is created. This design choice was because the previous handling was quite a mess of getting coordinates in three different ways:

a) when expanding symmetries, the coordinates are taken from grid_expanded 
b) when calling sim_data["monitor_name"].at_centers , as also used in e.g. get_poynting and get_intensity, the center coordinates are computed using simulation.discretize(monitor, extend=True) 
c) when calling e.g. MonitorData.poynting or flux for a 2D monitor, coordinates are taken directly from the field data coords. The problem is that there is no guarantee that e.g. all E-field components are present. We could have a MonitorData with just Ex, which is not enough to define the grid boundaries. The reason this had not been a problem yet is I believe largely because we store all field components by default so no one had stumbled on this issue (that we know of)

The present handling unifies all of this into a), and also makes sure that on the backend there is no inconsistency between data coordinates and `grid_expanded` (there used to be some in some edge cases).