### PR TITLE
custom medium generalized, eps_dataset->dataset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Internal refactor of spatially-varying mediums.
+- 'CustomMedium.eps_dataset' is replaced by 'CustomMedium.dataset' with deprecation warning.
 
 ### Fixed
 

--- a/tests/_test_local/_test_adjoint_performance.py
+++ b/tests/_test_local/_test_adjoint_performance.py
@@ -93,8 +93,8 @@ def make_sim(eps_values: np.ndarray) -> JaxSimulation:
 
     eps_ii = JaxDataArray(values=eps_values, coords=coords)
     field_components = {f"eps_{dim}{dim}": eps_ii for dim in "xyz"}
-    jax_eps_dataset = JaxPermittivityDataset(**field_components)
-    jax_med_custom = JaxCustomMedium(eps_dataset=jax_eps_dataset)
+    jax_dataset = JaxPermittivityDataset(**field_components)
+    jax_med_custom = JaxCustomMedium(dataset=jax_dataset)
     jax_struct_custom = JaxStructure(geometry=jax_box, medium=jax_med_custom)
 
     # TODO: Add new geometries as they are created.
@@ -240,8 +240,8 @@ def test_simple_jax_data_array(use_emulated_run):
 
     def make_custom_medium(values):
         components = {f"eps_{dim}{dim}": make_data_array(values) for dim in "xyz"}
-        eps_dataset = JaxPermittivityDataset(**components)
-        return JaxCustomMedium(eps_dataset=eps_dataset)
+        dataset = JaxPermittivityDataset(**components)
+        return JaxCustomMedium(dataset=dataset)
 
     def make_custom_structure(values):
         medium = make_custom_medium(values)
@@ -277,11 +277,11 @@ def test_simple_jax_data_array(use_emulated_run):
 
     def f(values):
         custom_medium = make_custom_medium(values)
-        return jnp.sum(custom_medium.eps_dataset.eps_xx.values)
+        return jnp.sum(custom_medium.dataset.eps_xx.values)
 
     def f(values):
         custom_structure = make_custom_structure(values)
-        return jnp.sum(custom_structure.medium.eps_dataset.eps_xx.values)
+        return jnp.sum(custom_structure.medium.dataset.eps_xx.values)
 
     def f(values):
         sim = make_sim(values)

--- a/tests/sims/simulation_2_2_0.json
+++ b/tests/sims/simulation_2_2_0.json
@@ -1,0 +1,1386 @@
+{
+    "type": "Simulation",
+    "center": [
+        0.0,
+        0.0,
+        0.0
+    ],
+    "size": [
+        8.0,
+        8.0,
+        8.0
+    ],
+    "run_time": 1e-12,
+    "medium": {
+        "name": null,
+        "frequency_range": null,
+        "type": "Medium",
+        "permittivity": 1.0,
+        "conductivity": 0.0
+    },
+    "symmetry": [
+        0,
+        0,
+        0
+    ],
+    "structures": [
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Medium",
+                "permittivity": 2.0,
+                "conductivity": 0.0
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    "Infinity",
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Medium",
+                "permittivity": 1.0,
+                "conductivity": 3.0
+            }
+        },
+        {
+            "geometry": {
+                "type": "Sphere",
+                "radius": 1.0,
+                "center": [
+                    1.0,
+                    0.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Sellmeier",
+                "coeffs": [
+                    [
+                        1.03961212,
+                        0.00600069867
+                    ],
+                    [
+                        0.231792344,
+                        0.0200179144
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Lorentz",
+                "eps_inf": 2.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        2.0,
+                        3.0
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Debye",
+                "eps_inf": 2.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        3.0
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Drude",
+                "eps_inf": 2.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        3.0
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "GeometryGroup",
+                "geometries": [
+                    {
+                        "type": "Box",
+                        "center": [
+                            -1.0,
+                            0.0,
+                            0.0
+                        ],
+                        "size": [
+                            1.0,
+                            1.0,
+                            1.0
+                        ]
+                    }
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": "PEC",
+                "frequency_range": null,
+                "type": "PECMedium"
+            }
+        },
+        {
+            "geometry": {
+                "type": "Cylinder",
+                "axis": 1,
+                "sidewall_angle": 0.0,
+                "reference_plane": "middle",
+                "radius": 1.0,
+                "center": [
+                    1.0,
+                    0.0,
+                    -1.0
+                ],
+                "length": 2.0
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "AnisotropicMedium",
+                "xx": {
+                    "name": null,
+                    "frequency_range": null,
+                    "type": "Medium",
+                    "permittivity": 1.0,
+                    "conductivity": 0.0
+                },
+                "yy": {
+                    "name": null,
+                    "frequency_range": null,
+                    "type": "Medium",
+                    "permittivity": 2.0,
+                    "conductivity": 0.0
+                },
+                "zz": {
+                    "name": null,
+                    "frequency_range": null,
+                    "type": "Medium",
+                    "permittivity": 3.0,
+                    "conductivity": 0.0
+                }
+            }
+        },
+        {
+            "geometry": {
+                "type": "PolySlab",
+                "axis": 2,
+                "sidewall_angle": 0.0,
+                "reference_plane": "middle",
+                "slab_bounds": [
+                    -1.0,
+                    1.0
+                ],
+                "dilation": 0.0,
+                "vertices": [
+                    [
+                        -1.5,
+                        -1.5
+                    ],
+                    [
+                        -0.5,
+                        -1.5
+                    ],
+                    [
+                        -0.5,
+                        -0.5
+                    ]
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "PoleResidue",
+                "eps_inf": 1.0,
+                "poles": [
+                    [
+                        {
+                            "real": 0.0,
+                            "imag": 6206417594288582.0
+                        },
+                        {
+                            "real": -0.0,
+                            "imag": -3.311074436985222e+16
+                        }
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "TriangleMesh",
+                "mesh_dataset": {
+                    "type": "TriangleMeshDataset",
+                    "surface_mesh": "TriangleMeshDataArray"
+                }
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "type": "Medium",
+                "permittivity": 5.0,
+                "conductivity": 0.0
+            }
+        }
+    ],
+    "sources": [
+        {
+            "type": "UniformCurrentSource",
+            "center": [
+                0.0,
+                0.5,
+                0.0
+            ],
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "polarization": "Hx"
+        },
+        {
+            "type": "PointDipole",
+            "center": [
+                0.0,
+                0.5,
+                0.0
+            ],
+            "size": [
+                0,
+                0,
+                0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "polarization": "Ex",
+            "interpolate": true
+        },
+        {
+            "type": "ModeSource",
+            "center": [
+                0.0,
+                0.5,
+                0.0
+            ],
+            "size": [
+                2.0,
+                0.0,
+                2.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "num_freqs": 1,
+            "direction": "-",
+            "mode_spec": {
+                "num_modes": 1,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "filter_pol": null,
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "precision": "single",
+                "bend_radius": null,
+                "bend_axis": null,
+                "track_freq": "central",
+                "group_index_step": false,
+                "type": "ModeSpec"
+            },
+            "mode_index": 0
+        },
+        {
+            "type": "PlaneWave",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                "Infinity",
+                "Infinity"
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 0.1
+        },
+        {
+            "type": "GaussianBeam",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                3.0,
+                3.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "num_freqs": 1,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 1.5707963267948966,
+            "waist_radius": 1.0,
+            "waist_distance": 0.0
+        },
+        {
+            "type": "AstigmaticGaussianBeam",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                3.0,
+                3.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "num_freqs": 1,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 1.5707963267948966,
+            "waist_sizes": [
+                1.0,
+                2.0
+            ],
+            "waist_distances": [
+                3.0,
+                4.0
+            ]
+        },
+        {
+            "type": "CustomFieldSource",
+            "center": [
+                0.0,
+                1.0,
+                2.0
+            ],
+            "size": [
+                2.0,
+                2.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "field_dataset": {
+                "type": "FieldDataset",
+                "Ex": "ScalarFieldDataArray",
+                "Ey": null,
+                "Ez": null,
+                "Hx": null,
+                "Hy": null,
+                "Hz": null
+            }
+        },
+        {
+            "type": "TFSF",
+            "center": [
+                1.0,
+                2.0,
+                -3.0
+            ],
+            "size": [
+                2.5,
+                2.5,
+                0.5
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0
+            },
+            "name": null,
+            "direction": "+",
+            "angle_theta": 0.5235987755982988,
+            "angle_phi": 0.6283185307179586,
+            "pol_angle": 0.0,
+            "injection_axis": 2
+        }
+    ],
+    "boundary_spec": {
+        "x": {
+            "plus": {
+                "name": null,
+                "type": "PML",
+                "num_layers": 20,
+                "parameters": {
+                    "sigma_order": 3,
+                    "sigma_min": 0.0,
+                    "sigma_max": 1.5,
+                    "type": "PMLParams",
+                    "kappa_order": 3,
+                    "kappa_min": 1.0,
+                    "kappa_max": 3.0,
+                    "alpha_order": 1,
+                    "alpha_min": 0.0,
+                    "alpha_max": 0.0
+                }
+            },
+            "minus": {
+                "name": null,
+                "type": "Absorber",
+                "num_layers": 100,
+                "parameters": {
+                    "sigma_order": 3,
+                    "sigma_min": 0.0,
+                    "sigma_max": 6.4,
+                    "type": "AbsorberParams"
+                }
+            },
+            "type": "Boundary"
+        },
+        "y": {
+            "plus": {
+                "name": null,
+                "type": "BlochBoundary",
+                "bloch_vec": 1.0
+            },
+            "minus": {
+                "name": null,
+                "type": "BlochBoundary",
+                "bloch_vec": 1.0
+            },
+            "type": "Boundary"
+        },
+        "z": {
+            "plus": {
+                "name": null,
+                "type": "Periodic"
+            },
+            "minus": {
+                "name": null,
+                "type": "Periodic"
+            },
+            "type": "Boundary"
+        },
+        "type": "BoundarySpec"
+    },
+    "monitors": [
+        {
+            "type": "FieldMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "name": "field",
+            "freqs": [
+                150000000000000.0,
+                200000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "fields": [
+                "Ex"
+            ],
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": false
+        },
+        {
+            "type": "FieldTimeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "name": "field_time",
+            "start": 0.0,
+            "stop": null,
+            "interval": 100,
+            "fields": [
+                "Ex",
+                "Ey",
+                "Ez",
+                "Hx",
+                "Hy",
+                "Hz"
+            ],
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": false
+        },
+        {
+            "type": "FluxMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "flux",
+            "freqs": [
+                200000000000000.0,
+                250000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null
+        },
+        {
+            "type": "FluxTimeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "flux_time",
+            "start": 0.0,
+            "stop": null,
+            "interval": 1,
+            "normal_dir": "+",
+            "exclude_surfaces": null
+        },
+        {
+            "type": "PermittivityMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.1
+            ],
+            "name": "eps",
+            "freqs": [
+                100000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            }
+        },
+        {
+            "type": "ModeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "mode",
+            "freqs": [
+                200000000000000.0,
+                250000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "mode_spec": {
+                "num_modes": 1,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "filter_pol": null,
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "precision": "single",
+                "bend_radius": null,
+                "bend_axis": null,
+                "track_freq": "central",
+                "group_index_step": false,
+                "type": "ModeSpec"
+            }
+        },
+        {
+            "type": "ModeSolverMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "mode_solver",
+            "freqs": [
+                200000000000000.0,
+                250000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "mode_spec": {
+                "num_modes": 1,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "filter_pol": null,
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "precision": "single",
+                "bend_radius": null,
+                "bend_axis": null,
+                "track_freq": "central",
+                "group_index_step": false,
+                "type": "ModeSpec"
+            }
+        },
+        {
+            "type": "FieldProjectionAngleMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                2.0,
+                2.0
+            ],
+            "name": "proj_angle",
+            "freqs": [
+                250000000000000.0,
+                300000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null,
+            "custom_origin": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "far_field_approx": true,
+            "proj_distance": 1000000.0,
+            "theta": [
+                -1.5707963267948966,
+                -1.5390630676677268,
+                -1.5073298085405573,
+                -1.4755965494133876,
+                -1.443863290286218,
+                -1.4121300311590483,
+                -1.3803967720318788,
+                -1.348663512904709,
+                -1.3169302537775396,
+                -1.2851969946503699,
+                -1.2534637355232003,
+                -1.2217304763960306,
+                -1.189997217268861,
+                -1.1582639581416914,
+                -1.1265306990145216,
+                -1.0947974398873521,
+                -1.0630641807601826,
+                -1.0313309216330129,
+                -0.9995976625058433,
+                -0.9678644033786736,
+                -0.936131144251504,
+                -0.9043978851243344,
+                -0.8726646259971648,
+                -0.8409313668699951,
+                -0.8091981077428254,
+                -0.7774648486156558,
+                -0.7457315894884862,
+                -0.7139983303613165,
+                -0.6822650712341469,
+                -0.6505318121069773,
+                -0.6187985529798077,
+                -0.5870652938526381,
+                -0.5553320347254684,
+                -0.5235987755982987,
+                -0.4918655164711292,
+                -0.46013225734395946,
+                -0.42839899821678995,
+                -0.3966657390896202,
+                -0.3649324799624507,
+                -0.333199220835281,
+                -0.30146596170811146,
+                -0.26973270258094173,
+                -0.23799944345377222,
+                -0.2062661843266025,
+                -0.17453292519943298,
+                -0.14279966607226324,
+                -0.11106640694509373,
+                -0.079333147817924,
+                -0.047599888690754266,
+                -0.015866629563584755,
+                0.015866629563584977,
+                0.04759988869075449,
+                0.07933314781792422,
+                0.11106640694509373,
+                0.14279966607226346,
+                0.17453292519943298,
+                0.2062661843266027,
+                0.23799944345377222,
+                0.26973270258094195,
+                0.30146596170811146,
+                0.3331992208352812,
+                0.3649324799624507,
+                0.39666573908962044,
+                0.42839899821678995,
+                0.4601322573439597,
+                0.4918655164711292,
+                0.5235987755982991,
+                0.5553320347254687,
+                0.5870652938526382,
+                0.6187985529798077,
+                0.6505318121069776,
+                0.6822650712341471,
+                0.7139983303613167,
+                0.7457315894884862,
+                0.7774648486156561,
+                0.8091981077428256,
+                0.8409313668699951,
+                0.8726646259971647,
+                0.9043978851243346,
+                0.9361311442515041,
+                0.9678644033786736,
+                0.9995976625058436,
+                1.031330921633013,
+                1.0630641807601826,
+                1.0947974398873521,
+                1.126530699014522,
+                1.1582639581416916,
+                1.189997217268861,
+                1.2217304763960306,
+                1.2534637355232006,
+                1.28519699465037,
+                1.3169302537775396,
+                1.348663512904709,
+                1.380396772031879,
+                1.4121300311590486,
+                1.443863290286218,
+                1.475596549413388,
+                1.5073298085405575,
+                1.539063067667727,
+                1.5707963267948966
+            ],
+            "phi": [
+                0.0,
+                1.5707963267948966
+            ]
+        },
+        {
+            "type": "FieldProjectionCartesianMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                2.0,
+                2.0
+            ],
+            "name": "proj_cartesian",
+            "freqs": [
+                250000000000000.0,
+                300000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null,
+            "custom_origin": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "far_field_approx": true,
+            "proj_axis": 2,
+            "proj_distance": 5.0,
+            "x": [
+                -1.0,
+                0.0,
+                1.0
+            ],
+            "y": [
+                -2.0,
+                -1.0,
+                0.0,
+                1.0,
+                2.0
+            ]
+        },
+        {
+            "type": "FieldProjectionKSpaceMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                2.0,
+                2.0
+            ],
+            "name": "proj_kspace",
+            "freqs": [
+                250000000000000.0,
+                300000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null,
+            "custom_origin": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "far_field_approx": true,
+            "proj_axis": 2,
+            "proj_distance": 1000000.0,
+            "ux": [
+                0.1,
+                0.2
+            ],
+            "uy": [
+                0.3,
+                0.4,
+                0.5
+            ]
+        },
+        {
+            "type": "FieldProjectionAngleMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                2.0,
+                2.0
+            ],
+            "name": "proj_angle_exact",
+            "freqs": [
+                250000000000000.0,
+                300000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null,
+            "custom_origin": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "far_field_approx": true,
+            "proj_distance": 1000000.0,
+            "theta": [
+                -1.5707963267948966,
+                -1.5390630676677268,
+                -1.5073298085405573,
+                -1.4755965494133876,
+                -1.443863290286218,
+                -1.4121300311590483,
+                -1.3803967720318788,
+                -1.348663512904709,
+                -1.3169302537775396,
+                -1.2851969946503699,
+                -1.2534637355232003,
+                -1.2217304763960306,
+                -1.189997217268861,
+                -1.1582639581416914,
+                -1.1265306990145216,
+                -1.0947974398873521,
+                -1.0630641807601826,
+                -1.0313309216330129,
+                -0.9995976625058433,
+                -0.9678644033786736,
+                -0.936131144251504,
+                -0.9043978851243344,
+                -0.8726646259971648,
+                -0.8409313668699951,
+                -0.8091981077428254,
+                -0.7774648486156558,
+                -0.7457315894884862,
+                -0.7139983303613165,
+                -0.6822650712341469,
+                -0.6505318121069773,
+                -0.6187985529798077,
+                -0.5870652938526381,
+                -0.5553320347254684,
+                -0.5235987755982987,
+                -0.4918655164711292,
+                -0.46013225734395946,
+                -0.42839899821678995,
+                -0.3966657390896202,
+                -0.3649324799624507,
+                -0.333199220835281,
+                -0.30146596170811146,
+                -0.26973270258094173,
+                -0.23799944345377222,
+                -0.2062661843266025,
+                -0.17453292519943298,
+                -0.14279966607226324,
+                -0.11106640694509373,
+                -0.079333147817924,
+                -0.047599888690754266,
+                -0.015866629563584755,
+                0.015866629563584977,
+                0.04759988869075449,
+                0.07933314781792422,
+                0.11106640694509373,
+                0.14279966607226346,
+                0.17453292519943298,
+                0.2062661843266027,
+                0.23799944345377222,
+                0.26973270258094195,
+                0.30146596170811146,
+                0.3331992208352812,
+                0.3649324799624507,
+                0.39666573908962044,
+                0.42839899821678995,
+                0.4601322573439597,
+                0.4918655164711292,
+                0.5235987755982991,
+                0.5553320347254687,
+                0.5870652938526382,
+                0.6187985529798077,
+                0.6505318121069776,
+                0.6822650712341471,
+                0.7139983303613167,
+                0.7457315894884862,
+                0.7774648486156561,
+                0.8091981077428256,
+                0.8409313668699951,
+                0.8726646259971647,
+                0.9043978851243346,
+                0.9361311442515041,
+                0.9678644033786736,
+                0.9995976625058436,
+                1.031330921633013,
+                1.0630641807601826,
+                1.0947974398873521,
+                1.126530699014522,
+                1.1582639581416916,
+                1.189997217268861,
+                1.2217304763960306,
+                1.2534637355232006,
+                1.28519699465037,
+                1.3169302537775396,
+                1.348663512904709,
+                1.380396772031879,
+                1.4121300311590486,
+                1.443863290286218,
+                1.475596549413388,
+                1.5073298085405575,
+                1.539063067667727,
+                1.5707963267948966
+            ],
+            "phi": [
+                0.0,
+                1.5707963267948966
+            ]
+        },
+        {
+            "type": "DiffractionMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                "Infinity",
+                "Infinity"
+            ],
+            "name": "diffraction",
+            "freqs": [
+                100000000000000.0,
+                200000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+"
+        }
+    ],
+    "grid_spec": {
+        "grid_x": {
+            "type": "AutoGrid",
+            "min_steps_per_wvl": 10.0,
+            "max_scale": 1.4,
+            "dl_min": 0.0,
+            "mesher": {
+                "type": "GradedMesher"
+            }
+        },
+        "grid_y": {
+            "type": "CustomGrid",
+            "dl": [
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04
+            ],
+            "custom_offset": null
+        },
+        "grid_z": {
+            "type": "UniformGrid",
+            "dl": 0.05
+        },
+        "wavelength": null,
+        "override_structures": [
+            {
+                "geometry": {
+                    "type": "Box",
+                    "center": [
+                        -1.0,
+                        0.0,
+                        0.0
+                    ],
+                    "size": [
+                        1.0,
+                        1.0,
+                        1.0
+                    ]
+                },
+                "name": null,
+                "type": "Structure",
+                "medium": {
+                    "name": null,
+                    "frequency_range": null,
+                    "type": "Medium",
+                    "permittivity": 2.0,
+                    "conductivity": 0.0
+                }
+            }
+        ],
+        "type": "GridSpec"
+    },
+    "shutoff": 0.0001,
+    "subpixel": false,
+    "normalize_index": 0,
+    "courant": 0.8,
+    "version": "2.2.0"
+}

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -1290,8 +1290,8 @@ def test_tfsf_structures_grid(log_capture):
     data = np.ones((Nx, Ny, Nz, 1))
     eps_diagonal_data = td.ScalarFieldDataArray(data, coords=dict(x=X, y=Y, z=Z, f=[td.C_0]))
     eps_components = {f"eps_{d}{d}": eps_diagonal_data for d in "xyz"}
-    eps_dataset = td.PermittivityDataset(**eps_components)
-    custom_medium = td.CustomMedium(eps_dataset=eps_dataset, name="my_medium")
+    dataset = td.PermittivityDataset(**eps_components)
+    custom_medium = td.CustomMedium(dataset=dataset, name="my_medium")
     sim = td.Simulation(
         size=(2.0, 2.0, 2.0),
         grid_spec=td.GridSpec.auto(wavelength=1.0),

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -82,8 +82,8 @@ def make_sim(
     values = base_eps_val + np.random.random((Nx, Ny, Nz, 1))
     eps_ii = JaxDataArray(values=values, coords=coords)
     field_components = {f"eps_{dim}{dim}": eps_ii for dim in "xyz"}
-    jax_eps_dataset = JaxPermittivityDataset(**field_components)
-    jax_med_custom = JaxCustomMedium(eps_dataset=jax_eps_dataset)
+    jax_dataset = JaxPermittivityDataset(**field_components)
+    jax_med_custom = JaxCustomMedium(dataset=jax_dataset)
     jax_struct_custom = JaxStructure(geometry=jax_box1, medium=jax_med_custom)
 
     # TODO: Add new geometries as they are created.

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -240,6 +240,26 @@ class ScalarFieldDataArray(DataArray):
     _data_attrs = {"long_name": "field value"}
 
 
+class SpatialDataArray(DataArray):
+    """Spatial distribution of values.
+
+    Example
+    -------
+    >>> x = [1,2]
+    >>> y = [2,3,4]
+    >>> z = [3,4,5,6]
+    >>> coords = dict(x=x, y=y, z=z)
+    >>> fd = SpatialDataArray((1+1j) * np.random.random((2,3,4)), coords=coords)
+    """
+
+    __slots__ = ()
+    _dims = ("x", "y", "z")
+    _data_attrs = {"long_name": "value"}
+
+
+# TODO: add SpatialDataArray to data array tests
+
+
 class ScalarFieldTimeDataArray(DataArray):
     """Spatial distribution in the time-domain.
 
@@ -426,6 +446,7 @@ class TriangleMeshDataArray(DataArray):
 
 DATA_ARRAY_TYPES = [
     ScalarFieldDataArray,
+    SpatialDataArray,
     ScalarFieldTimeDataArray,
     ScalarModeFieldDataArray,
     FluxDataArray,

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Union, Dict, Callable
+from typing import Union, Dict, Callable, Tuple
 
 import xarray as xr
 import numpy as np
@@ -11,7 +11,7 @@ import pydantic as pd
 from .data_array import DataArray
 from .data_array import ScalarFieldDataArray, ScalarFieldTimeDataArray, ScalarModeFieldDataArray
 from .data_array import ModeIndexDataArray
-from .data_array import TriangleMeshDataArray
+from .data_array import TriangleMeshDataArray, SpatialDataArray
 
 from ..base import Tidy3dBaseModel
 from ..types import Axis
@@ -388,6 +388,37 @@ class PermittivityDataset(AbstractFieldDataset):
         title="Epsilon zz",
         description="Spatial distribution of the zz-component of the relative permittivity.",
     )
+
+
+class DispersiveDataset(Dataset):
+    """Dataset containing dispersive medium parameters."""
+
+    eps_inf: SpatialDataArray = pd.Field(...)
+
+    coeffs: Tuple[Tuple[SpatialDataArray, ...], ...] = pd.Field(...)
+
+    # TODO: validate that all supplied SpatialDataArrays have the same shape
+
+
+class PoleResidueDataset(Dataset):
+    """Dataset containing dispersive medium parameters."""
+
+    eps_inf: SpatialDataArray = pd.Field(...)
+
+    poles: Tuple[Tuple[SpatialDataArray, SpatialDataArray], ...] = pd.Field(...)
+
+
+class DrudeDataset(Dataset):
+    """Dataset containing dispersive medium parameters."""
+
+    eps_inf: SpatialDataArray = pd.Field(...)
+
+    coeffs: Tuple[Tuple[SpatialDataArray, SpatialDataArray], ...] = pd.Field(...)
+
+
+# TODO: if desired, subclasses of DispersiveDataset specific to Drude, etc.
+# TODO: should this all be moved to medium.py?
+# TODO: an AnisotropicDataset
 
 
 class TriangleMeshDataset(Dataset):

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -14,7 +14,7 @@ from .base import Tidy3dBaseModel, cached_property
 from .grid.grid import Coords, Grid
 from .types import PoleAndResidue, Ax, FreqBound, TYPE_TAG_STR, InterpMethod, Bound, ArrayComplex4D
 from .types import Axis
-from .data.dataset import PermittivityDataset
+from .data.dataset import PermittivityDataset, DispersiveDataset, PoleResidueDataset, DrudeDataset
 from .data.data_array import ScalarFieldDataArray
 from .viz import add_ax_if_none
 from .geometry import Geometry
@@ -396,349 +396,6 @@ class Medium(AbstractMedium):
         """
         eps, sigma = AbstractMedium.nk_to_eps_sigma(n, k, freq)
         return cls(permittivity=eps, conductivity=sigma, **kwargs)
-
-
-class CustomMedium(AbstractMedium):
-    """:class:`.Medium` with user-supplied permittivity distribution.
-
-    Example
-    -------
-    >>> Nx, Ny, Nz = 10, 9, 8
-    >>> X = np.linspace(-1, 1, Nx)
-    >>> Y = np.linspace(-1, 1, Ny)
-    >>> Z = np.linspace(-1, 1, Nz)
-    >>> freqs = [2e14]
-    >>> data = np.ones((Nx, Ny, Nz, 1))
-    >>> eps_diagonal_data = ScalarFieldDataArray(data, coords=dict(x=X, y=Y, z=Z, f=freqs))
-    >>> eps_components = {f"eps_{d}{d}": eps_diagonal_data for d in "xyz"}
-    >>> eps_dataset = PermittivityDataset(**eps_components)
-    >>> dielectric = CustomMedium(eps_dataset=eps_dataset, name='my_medium')
-    >>> eps = dielectric.eps_model(200e12)
-    """
-
-    eps_dataset: PermittivityDataset = pd.Field(
-        ...,
-        title="Permittivity Dataset",
-        description="User-supplied dataset containing complex-valued permittivity "
-        "as a function of space. Permittivity distribution over the Yee-grid will be "
-        "interpolated based on ``interp_method``.",
-    )
-
-    interp_method: InterpMethod = pd.Field(
-        "nearest",
-        title="Interpolation method",
-        description="Interpolation method to obtain permittivity values "
-        "that are not supplied at the Yee grids; For grids outside the range "
-        "of the supplied data, extrapolation will be applied. When the extrapolated "
-        "value is smaller (greater) than the minimal (maximal) of the supplied data, "
-        "the extrapolated value will take the minimal (maximal) of the supplied data.",
-    )
-
-    @pd.validator("eps_dataset", always=True)
-    def _single_frequency(cls, val):
-        """Assert only one frequency supplied."""
-        for name, eps_dataset_component in val.field_components.items():
-            freqs = eps_dataset_component.f
-            if len(freqs) != 1:
-                raise SetupError(
-                    f"'eps_dataset.{name}' must have a single frequency, "
-                    f"but it contains {len(freqs)} frequencies."
-                )
-        return val
-
-    @pd.validator("eps_dataset", always=True)
-    def _eps_inf_greater_no_less_than_one_sigma_positive(cls, val):
-        """Assert any eps_inf must be >=1"""
-
-        for comp in ["eps_xx", "eps_yy", "eps_zz"]:
-            eps_inf, sigma = CustomMedium.eps_complex_to_eps_sigma(
-                val.field_components[comp], val.field_components[comp].f
-            )
-            if np.any(eps_inf.values < 1):
-                raise SetupError(
-                    "Permittivity at infinite frequency at any spatial point "
-                    "must be no less than one."
-                )
-            if np.any(sigma.values < 0):
-                raise SetupError(
-                    "Negative imaginary part of refrative index leads to a gain medium, "
-                    "which is not supported."
-                )
-        return val
-
-    @cached_property
-    def n_cfl(self):
-        """This property computes the index of refraction related to CFL condition, so that
-        the FDTD with this medium is stable when the time step size that doesn't take
-        material factor into account is multiplied by ``n_cfl```.
-
-        For dispersiveless custom medium, it equals ``min[sqrt(eps_inf)]``, where ``min``
-        is performed over all components and spatial points.
-        """
-        eps_array_min = [
-            float(np.min(eps_array.real))
-            for _, eps_array in self.eps_dataset.field_components.items()
-        ]
-        return np.sqrt(min(eps_array_min))
-
-    @ensure_freq_in_range
-    def eps_dataset_freq(self, frequency: float) -> PermittivityDataset:
-        """Permittivity dataset at ``frequency``. The dispersion comes
-        from DC conductivity that results in nonzero Im[eps].
-
-        Parameters
-        ----------
-        frequency : float
-            Frequency to evaluate permittivity at (Hz).
-
-        Returns
-        -------
-        :class:`.PermittivityDataset`
-            The permittivity evaluated at ``frequency``.
-        """
-
-        new_field_components = {}
-        for name, eps_dataset_component in self.eps_dataset.field_components.items():
-            freq = eps_dataset_component.coords["f"][0]
-            eps_freq = (
-                eps_dataset_component.real + 1j * eps_dataset_component.imag * freq / frequency
-            )
-            eps_freq = eps_freq.assign_coords({"f": [frequency]})
-            new_field_components.update({name: eps_freq})
-        return PermittivityDataset(**new_field_components)
-
-    def eps_diagonal_on_grid(
-        self,
-        frequency: float,
-        coords: Coords,
-    ) -> Tuple[ArrayComplex4D, ArrayComplex4D, ArrayComplex4D]:
-        """Spatial profile of main diagonal of the complex-valued permittivity
-        at ``frequency`` interpolated at the supplied coordinates.
-
-        Parameters
-        ----------
-        frequency : float
-            Frequency to evaluate permittivity at (Hz).
-        coords : :class:`.Coords`
-            The grid point coordinates over which interpolation is performed.
-
-        Returns
-        -------
-        Tuple[np.ndarray, np.ndarray, np.ndarray]
-            The complex-valued permittivity tensor at ``frequency`` interpolated
-            at the supplied coordinate.
-        """
-
-        eps_freq = self.eps_dataset_freq(frequency)
-        interp_shape = [len(coord_comp) for coord_comp in coords.to_list]
-        eps_list = [
-            np.array(
-                self._interp(eps_freq.field_components[comp], coords, self.interp_method)
-            ).reshape(interp_shape)
-            for comp in ["eps_xx", "eps_yy", "eps_zz"]
-        ]
-        return tuple(eps_list)
-
-    @ensure_freq_in_range
-    def eps_diagonal(self, frequency: float) -> Tuple[complex, complex, complex]:
-        """Main diagonal of the complex-valued permittivity tensor
-        at ``frequency``. Spatially, we take max{||eps||}, so that autoMesh generation
-        works appropriately.
-        """
-        eps_freq = self.eps_dataset_freq(frequency)
-        eps_np_list = [
-            np.array(sclr_fld).ravel() for _, sclr_fld in eps_freq.field_components.items()
-        ]
-        eps_list = [eps_comp[np.argmax(np.abs(eps_comp))] for eps_comp in eps_np_list]
-        return tuple(eps_list)
-
-    @ensure_freq_in_range
-    def eps_model(self, frequency: float) -> complex:
-        """Spatial and poloarizaiton average of complex-valued permittivity
-        as a function of frequency.
-        """
-        eps_freq = self.eps_dataset_freq(frequency)
-        eps_array_avgs = [np.mean(eps_array) for _, eps_array in eps_freq.field_components.items()]
-        return np.mean(eps_array_avgs)
-
-    @classmethod
-    def from_eps_raw(
-        cls, eps: ScalarFieldDataArray, interp_method: InterpMethod = "nearest"
-    ) -> CustomMedium:
-        """Construct a :class:`.CustomMedium` from datasets containing raw permittivity values.
-
-        Parameters
-        ----------
-        eps : :class:`.ScalarFieldDataArray`
-            Dataset containing complex-valued permittivity as a function of space.
-        interp_method : :class:`.InterpMethod`, optional
-                Interpolation method to obtain permittivity values that are not supplied
-                at the Yee grids.
-
-        Returns
-        -------
-        :class:`.CustomMedium`
-            Medium containing the spatially varying permittivity data.
-        """
-        field_components = {field_name: eps.copy() for field_name in ("eps_xx", "eps_yy", "eps_zz")}
-        eps_dataset = PermittivityDataset(**field_components)
-        return cls(eps_dataset=eps_dataset, interp_method=interp_method)
-
-    @classmethod
-    def from_nk(
-        cls,
-        n: ScalarFieldDataArray,
-        k: Optional[ScalarFieldDataArray] = None,
-        interp_method: InterpMethod = "nearest",
-    ) -> CustomMedium:
-        """Construct a :class:`.CustomMedium` from datasets containing n and k values.
-
-        Parameters
-        ----------
-        n : :class:`.ScalarFieldDataArray`
-            Real part of refractive index.
-        k : :class:`.ScalarFieldDataArray` = None
-            Imaginary part of refrative index.
-        interp_method : :class:`.InterpMethod`, optional
-                Interpolation method to obtain permittivity values that are not supplied
-                at the Yee grids.
-
-        Returns
-        -------
-        :class:`.CustomMedium`
-            Medium containing the spatially varying permittivity data.
-        """
-        if k is None:
-            k = xr.zeros_like(n)
-
-        if n.coords != k.coords:
-            raise SetupError("`n` and `k` must have same coordinates.")
-
-        eps_values = Medium.nk_to_eps_complex(n=n.data, k=k.data)
-        coords = {k: np.array(v) for k, v in n.coords.items()}
-        eps_scalar_field_data = ScalarFieldDataArray(eps_values, coords=coords)
-        return cls.from_eps_raw(eps=eps_scalar_field_data, interp_method=interp_method)
-
-    @staticmethod
-    def _interp(
-        scalar_dataset: ScalarFieldDataArray,
-        coord_interp: Coords,
-        interp_method: InterpMethod,
-    ) -> ScalarFieldDataArray:
-        """
-        Enhance xarray's ``.interp`` in two ways:
-            1) Check if the coordinate of the supplied data are in monotically increasing order.
-            If they are, apply the faster ``assume_sorted=True``.
-
-            2) For axes of single entry, instead of error, apply ``isel()`` along the axis.
-
-            3) When linear interp is applied, in the extrapolated region, filter values smaller
-            or larger than the original data's min(max) will be replaced with the original min(max).
-
-        Parameters
-        ----------
-        scalar_dataset : :class:`.ScalarFieldDataArray`
-            Supplied scalar dataset.
-        coord_interp : :class:`.Coords`
-            The grid point coordinates over which interpolation is performed.
-        interp_method : :class:`.InterpMethod`
-            Interpolation method.
-
-        Returns
-        -------
-        :class:`.ScalarFieldDataArray`
-            The interpolated scalar dataset.
-        """
-
-        # check in x/y/z axes, which of them are supplied with a single entry.
-        all_coords = "xyz"
-        is_single_entry = [scalar_dataset.sizes[ax] == 1 for ax in all_coords]
-        interp_ax = [
-            ax for (ax, single_entry) in zip(all_coords, is_single_entry) if not single_entry
-        ]
-        isel_ax = [ax for ax in all_coords if ax not in interp_ax]
-
-        # apply isel for the axis containing single entry
-        if len(isel_ax) > 0:
-            scalar_dataset = scalar_dataset.isel(
-                {ax: [0] * len(coord_interp.to_dict[ax]) for ax in isel_ax}
-            )
-            scalar_dataset = scalar_dataset.assign_coords(
-                {ax: coord_interp.to_dict[ax] for ax in isel_ax}
-            )
-            if len(interp_ax) == 0:
-                return scalar_dataset
-
-        # Apply interp for the rest
-        #   first check if it's sorted
-        is_sorted = all((np.all(np.diff(scalar_dataset.coords[f]) > 0) for f in interp_ax))
-        interp_param = dict(
-            kwargs={"fill_value": FILL_VALUE},
-            assume_sorted=is_sorted,
-            method=interp_method,
-        )
-        #   interpolation
-        interp_dataset = scalar_dataset.interp(
-            {ax: coord_interp.to_dict[ax] for ax in interp_ax},
-            **interp_param,
-        )
-
-        # filter any values larger/smaller than the original data's max/min.
-        max_val = max(scalar_dataset.values.ravel())
-        min_val = min(scalar_dataset.values.ravel())
-        interp_dataset = interp_dataset.where(interp_dataset >= min_val, min_val)
-        interp_dataset = interp_dataset.where(interp_dataset <= max_val, max_val)
-        return interp_dataset
-
-    def grids(self, bounds: Bound) -> Dict[str, Grid]:
-        """Make a :class:`.Grid` corresponding to the data in each ``eps_ii`` component.
-        The min and max coordinates along each dimension are bounded by ``bounds``."""
-
-        rmin, rmax = bounds
-        pt_mins = dict(zip("xyz", rmin))
-        pt_maxs = dict(zip("xyz", rmax))
-
-        def make_grid(scalar_field: ScalarFieldDataArray) -> Grid:
-            """Make a grid for a single dataset."""
-
-            def make_bound_coords(coords: np.ndarray, pt_min: float, pt_max: float) -> List[float]:
-                """Convert user supplied coords into boundary coords to use in :class:`.Grid`."""
-
-                # get coordinates of the bondaries halfway between user-supplied data
-                coord_bounds = (coords[1:] + coords[:1]) / 2.0
-
-                # res-set coord boundaries that lie outside geometry bounds to the boundary (0 vol.)
-                coord_bounds[coord_bounds <= pt_min] = pt_min
-                coord_bounds[coord_bounds >= pt_max] = pt_max
-
-                # add the geometry bounds in explicitly
-                return [pt_min] + coord_bounds.tolist() + [pt_max]
-
-            # grab user supplied data long this dimension
-            coords = {key: np.array(val) for key, val in scalar_field.coords.items()}
-            spatial_coords = {key: coords[key] for key in "xyz"}
-
-            # convert each spatial coord to boundary coords
-            bound_coords = {}
-            for key, coords in spatial_coords.items():
-                pt_min = pt_mins[key]
-                pt_max = pt_maxs[key]
-                bound_coords[key] = make_bound_coords(coords=coords, pt_min=pt_min, pt_max=pt_max)
-
-            # construct grid
-            boundaries = Coords(**bound_coords)
-            return Grid(boundaries=boundaries)
-
-        grids = {}
-        for field_name in ("eps_xx", "eps_yy", "eps_zz"):
-
-            # grab user supplied data long this dimension
-            scalar_field = self.eps_dataset.field_components[field_name]
-
-            # feed it to make_grid
-            grids[field_name] = make_grid(scalar_field)
-
-        return grids
 
 
 """ Dispersive Media """
@@ -1267,11 +924,433 @@ class AnisotropicMedium(AbstractMedium):
         return dict(xx=self.xx, yy=self.yy, zz=self.zz)
 
 
+class AbstractCustomMedium(AbstractMedium):
+    """Base class defining a medium with spatially varying fields."""
+
+    dataset: Union[PermittivityDataset, PoleResidueDataset, DrudeDataset]
+
+    interp_method: InterpMethod = pd.Field(
+        "nearest",
+        title="Interpolation method",
+        description="Interpolation method to obtain permittivity values "
+        "that are not supplied at the Yee grids; For grids outside the range "
+        "of the supplied data, extrapolation will be applied. When the extrapolated "
+        "value is smaller (greater) than the minimal (maximal) of the supplied data, "
+        "the extrapolated value will take the minimal (maximal) of the supplied data.",
+    )
+
+
+class CustomMedium(AbstractCustomMedium):
+    """:class:`.Medium` with user-supplied permittivity distribution.
+
+    Example
+    -------
+    >>> Nx, Ny, Nz = 10, 9, 8
+    >>> X = np.linspace(-1, 1, Nx)
+    >>> Y = np.linspace(-1, 1, Ny)
+    >>> Z = np.linspace(-1, 1, Nz)
+    >>> freqs = [2e14]
+    >>> data = np.ones((Nx, Ny, Nz, 1))
+    >>> eps_diagonal_data = ScalarFieldDataArray(data, coords=dict(x=X, y=Y, z=Z, f=freqs))
+    >>> eps_components = {f"eps_{d}{d}": eps_diagonal_data for d in "xyz"}
+    >>> dataset = PermittivityDataset(**eps_components)
+    >>> dielectric = CustomMedium(dataset=dataset, name='my_medium')
+    >>> eps = dielectric.eps_model(200e12)
+    """
+
+    dataset: PermittivityDataset = pd.Field(
+        ...,
+        title="Permittivity Dataset",
+        description="User-supplied dataset containing complex-valued permittivity "
+        "as a function of space. Permittivity distribution over the Yee-grid will be "
+        "interpolated based on ``interp_method``. ",
+    )
+
+    eps_dataset: PermittivityDataset = pd.Field(
+        None,
+        title="Permittivity Dataset",
+        description="User-supplied dataset containing complex-valued permittivity "
+        "as a function of space. Permittivity distribution over the Yee-grid will be "
+        "interpolated based on ``interp_method``. "
+        "Note: this field is deprecated and .dataset should be used instead.",
+    )
+
+    @pd.root_validator(pre=True)
+    def _deprecation_dataset(cls, values):
+        """Raise deprecation warning if dataset supplied and convert to dataset."""
+
+        if values.get("eps_dataset") is None:
+            return values
+
+        log.warning(
+            "The 'eps_dataset' field is being replaced with 'dataset' in a future release. "
+            "We recommend you change your scripts to be compatible with the new API."
+        )
+
+        # replace 'dataset'` with supplied 'dataset'
+        dataset = values.pop("eps_dataset")
+        values["dataset"] = dataset
+        return values
+
+    @pd.validator("dataset", always=True)
+    def _single_frequency(cls, val):
+        """Assert only one frequency supplied."""
+        for name, dataset_component in val.field_components.items():
+            freqs = dataset_component.f
+            if len(freqs) != 1:
+                raise SetupError(
+                    f"'dataset.{name}' must have a single frequency, "
+                    f"but it contains {len(freqs)} frequencies."
+                )
+        return val
+
+    @pd.validator("dataset", always=True)
+    def _eps_inf_greater_no_less_than_one_sigma_positive(cls, val):
+        """Assert any eps_inf must be >=1"""
+
+        for comp in ["eps_xx", "eps_yy", "eps_zz"]:
+            eps_inf, sigma = CustomMedium.eps_complex_to_eps_sigma(
+                val.field_components[comp], val.field_components[comp].f
+            )
+            if np.any(eps_inf.values < 1):
+                raise SetupError(
+                    "Permittivity at infinite frequency at any spatial point "
+                    "must be no less than one."
+                )
+            if np.any(sigma.values < 0):
+                raise SetupError(
+                    "Negative imaginary part of refrative index leads to a gain medium, "
+                    "which is not supported."
+                )
+        return val
+
+    @cached_property
+    def n_cfl(self):
+        """This property computes the index of refraction related to CFL condition, so that
+        the FDTD with this medium is stable when the time step size that doesn't take
+        material factor into account is multiplied by ``n_cfl```.
+
+        For dispersiveless custom medium, it equals ``min[sqrt(eps_inf)]``, where ``min``
+        is performed over all components and spatial points.
+        """
+        eps_array_min = [
+            float(np.min(eps_array.real)) for _, eps_array in self.dataset.field_components.items()
+        ]
+        return np.sqrt(min(eps_array_min))
+
+    @ensure_freq_in_range
+    def dataset_freq(self, frequency: float) -> PermittivityDataset:
+        """Permittivity dataset at ``frequency``. The dispersion comes
+        from DC conductivity that results in nonzero Im[eps].
+
+        Parameters
+        ----------
+        frequency : float
+            Frequency to evaluate permittivity at (Hz).
+
+        Returns
+        -------
+        :class:`.PermittivityDataset`
+            The permittivity evaluated at ``frequency``.
+        """
+
+        new_field_components = {}
+        for name, dataset_component in self.dataset.field_components.items():
+            freq = dataset_component.coords["f"][0]
+            eps_freq = dataset_component.real + 1j * dataset_component.imag * freq / frequency
+            eps_freq = eps_freq.assign_coords({"f": [frequency]})
+            new_field_components.update({name: eps_freq})
+        return PermittivityDataset(**new_field_components)
+
+    def eps_diagonal_on_grid(
+        self,
+        frequency: float,
+        coords: Coords,
+    ) -> Tuple[ArrayComplex4D, ArrayComplex4D, ArrayComplex4D]:
+        """Spatial profile of main diagonal of the complex-valued permittivity
+        at ``frequency`` interpolated at the supplied coordinates.
+
+        Parameters
+        ----------
+        frequency : float
+            Frequency to evaluate permittivity at (Hz).
+        coords : :class:`.Coords`
+            The grid point coordinates over which interpolation is performed.
+
+        Returns
+        -------
+        Tuple[np.ndarray, np.ndarray, np.ndarray]
+            The complex-valued permittivity tensor at ``frequency`` interpolated
+            at the supplied coordinate.
+        """
+
+        eps_freq = self.dataset_freq(frequency)
+        interp_shape = [len(coord_comp) for coord_comp in coords.to_list]
+        eps_list = [
+            np.array(
+                self._interp(eps_freq.field_components[comp], coords, self.interp_method)
+            ).reshape(interp_shape)
+            for comp in ["eps_xx", "eps_yy", "eps_zz"]
+        ]
+        return tuple(eps_list)
+
+    @ensure_freq_in_range
+    def eps_diagonal(self, frequency: float) -> Tuple[complex, complex, complex]:
+        """Main diagonal of the complex-valued permittivity tensor
+        at ``frequency``. Spatially, we take max{||eps||}, so that autoMesh generation
+        works appropriately.
+        """
+        eps_freq = self.dataset_freq(frequency)
+        eps_np_list = [
+            np.array(sclr_fld).ravel() for _, sclr_fld in eps_freq.field_components.items()
+        ]
+        eps_list = [eps_comp[np.argmax(np.abs(eps_comp))] for eps_comp in eps_np_list]
+        return tuple(eps_list)
+
+    @ensure_freq_in_range
+    def eps_model(self, frequency: float) -> complex:
+        """Spatial and poloarizaiton average of complex-valued permittivity
+        as a function of frequency.
+        """
+        eps_freq = self.dataset_freq(frequency)
+        eps_array_avgs = [np.mean(eps_array) for _, eps_array in eps_freq.field_components.items()]
+        return np.mean(eps_array_avgs)
+
+    @classmethod
+    def from_eps_raw(
+        cls, eps: ScalarFieldDataArray, interp_method: InterpMethod = "nearest"
+    ) -> CustomMedium:
+        """Construct a :class:`.CustomMedium` from datasets containing raw permittivity values.
+
+        Parameters
+        ----------
+        eps : :class:`.ScalarFieldDataArray`
+            Dataset containing complex-valued permittivity as a function of space.
+        interp_method : :class:`.InterpMethod`, optional
+                Interpolation method to obtain permittivity values that are not supplied
+                at the Yee grids.
+
+        Returns
+        -------
+        :class:`.CustomMedium`
+            Medium containing the spatially varying permittivity data.
+        """
+        field_components = {field_name: eps.copy() for field_name in ("eps_xx", "eps_yy", "eps_zz")}
+        dataset = PermittivityDataset(**field_components)
+        return cls(dataset=dataset, interp_method=interp_method)
+
+    @classmethod
+    def from_nk(
+        cls,
+        n: ScalarFieldDataArray,
+        k: Optional[ScalarFieldDataArray] = None,
+        interp_method: InterpMethod = "nearest",
+    ) -> CustomMedium:
+        """Construct a :class:`.CustomMedium` from datasets containing n and k values.
+
+        Parameters
+        ----------
+        n : :class:`.ScalarFieldDataArray`
+            Real part of refractive index.
+        k : :class:`.ScalarFieldDataArray` = None
+            Imaginary part of refrative index.
+        interp_method : :class:`.InterpMethod`, optional
+                Interpolation method to obtain permittivity values that are not supplied
+                at the Yee grids.
+
+        Returns
+        -------
+        :class:`.CustomMedium`
+            Medium containing the spatially varying permittivity data.
+        """
+        if k is None:
+            k = xr.zeros_like(n)
+
+        if n.coords != k.coords:
+            raise SetupError("`n` and `k` must have same coordinates.")
+
+        eps_values = Medium.nk_to_eps_complex(n=n.data, k=k.data)
+        coords = {k: np.array(v) for k, v in n.coords.items()}
+        eps_scalar_field_data = ScalarFieldDataArray(eps_values, coords=coords)
+        return cls.from_eps_raw(eps=eps_scalar_field_data, interp_method=interp_method)
+
+    @staticmethod
+    def _interp(
+        scalar_dataset: ScalarFieldDataArray,
+        coord_interp: Coords,
+        interp_method: InterpMethod,
+    ) -> ScalarFieldDataArray:
+        """
+        Enhance xarray's ``.interp`` in two ways:
+            1) Check if the coordinate of the supplied data are in monotically increasing order.
+            If they are, apply the faster ``assume_sorted=True``.
+
+            2) For axes of single entry, instead of error, apply ``isel()`` along the axis.
+
+            3) When linear interp is applied, in the extrapolated region, filter values smaller
+            or larger than the original data's min(max) will be replaced with the original min(max).
+
+        Parameters
+        ----------
+        scalar_dataset : :class:`.ScalarFieldDataArray`
+            Supplied scalar dataset.
+        coord_interp : :class:`.Coords`
+            The grid point coordinates over which interpolation is performed.
+        interp_method : :class:`.InterpMethod`
+            Interpolation method.
+
+        Returns
+        -------
+        :class:`.ScalarFieldDataArray`
+            The interpolated scalar dataset.
+        """
+
+        # check in x/y/z axes, which of them are supplied with a single entry.
+        all_coords = "xyz"
+        is_single_entry = [scalar_dataset.sizes[ax] == 1 for ax in all_coords]
+        interp_ax = [
+            ax for (ax, single_entry) in zip(all_coords, is_single_entry) if not single_entry
+        ]
+        isel_ax = [ax for ax in all_coords if ax not in interp_ax]
+
+        # apply isel for the axis containing single entry
+        if len(isel_ax) > 0:
+            scalar_dataset = scalar_dataset.isel(
+                {ax: [0] * len(coord_interp.to_dict[ax]) for ax in isel_ax}
+            )
+            scalar_dataset = scalar_dataset.assign_coords(
+                {ax: coord_interp.to_dict[ax] for ax in isel_ax}
+            )
+            if len(interp_ax) == 0:
+                return scalar_dataset
+
+        # Apply interp for the rest
+        #   first check if it's sorted
+        is_sorted = all((np.all(np.diff(scalar_dataset.coords[f]) > 0) for f in interp_ax))
+        interp_param = dict(
+            kwargs={"fill_value": FILL_VALUE},
+            assume_sorted=is_sorted,
+            method=interp_method,
+        )
+        #   interpolation
+        interp_dataset = scalar_dataset.interp(
+            {ax: coord_interp.to_dict[ax] for ax in interp_ax},
+            **interp_param,
+        )
+
+        # filter any values larger/smaller than the original data's max/min.
+        max_val = max(scalar_dataset.values.ravel())
+        min_val = min(scalar_dataset.values.ravel())
+        interp_dataset = interp_dataset.where(interp_dataset >= min_val, min_val)
+        interp_dataset = interp_dataset.where(interp_dataset <= max_val, max_val)
+        return interp_dataset
+
+    def grids(self, bounds: Bound) -> Dict[str, Grid]:
+        """Make a :class:`.Grid` corresponding to the data in each ``eps_ii`` component.
+        The min and max coordinates along each dimension are bounded by ``bounds``."""
+
+        rmin, rmax = bounds
+        pt_mins = dict(zip("xyz", rmin))
+        pt_maxs = dict(zip("xyz", rmax))
+
+        def make_grid(scalar_field: ScalarFieldDataArray) -> Grid:
+            """Make a grid for a single dataset."""
+
+            def make_bound_coords(coords: np.ndarray, pt_min: float, pt_max: float) -> List[float]:
+                """Convert user supplied coords into boundary coords to use in :class:`.Grid`."""
+
+                # get coordinates of the bondaries halfway between user-supplied data
+                coord_bounds = (coords[1:] + coords[:1]) / 2.0
+
+                # res-set coord boundaries that lie outside geometry bounds to the boundary (0 vol.)
+                coord_bounds[coord_bounds <= pt_min] = pt_min
+                coord_bounds[coord_bounds >= pt_max] = pt_max
+
+                # add the geometry bounds in explicitly
+                return [pt_min] + coord_bounds.tolist() + [pt_max]
+
+            # grab user supplied data long this dimension
+            coords = {key: np.array(val) for key, val in scalar_field.coords.items()}
+            spatial_coords = {key: coords[key] for key in "xyz"}
+
+            # convert each spatial coord to boundary coords
+            bound_coords = {}
+            for key, coords in spatial_coords.items():
+                pt_min = pt_mins[key]
+                pt_max = pt_maxs[key]
+                bound_coords[key] = make_bound_coords(coords=coords, pt_min=pt_min, pt_max=pt_max)
+
+            # construct grid
+            boundaries = Coords(**bound_coords)
+            return Grid(boundaries=boundaries)
+
+        grids = {}
+        for field_name in ("eps_xx", "eps_yy", "eps_zz"):
+
+            # grab user supplied data long this dimension
+            scalar_field = self.dataset.field_components[field_name]
+
+            # feed it to make_grid
+            grids[field_name] = make_grid(scalar_field)
+
+        return grids
+
+
+class CustomDispersiveMedium(AbstractCustomMedium, ABC):
+    """:class:`.DispersiveMedium` with user-supplied permittivity distribution.
+
+    Example
+    -------
+    >>> Nx, Ny, Nz = 10, 9, 8
+    >>> X = np.linspace(-1, 1, Nx)
+    >>> Y = np.linspace(-1, 1, Ny)
+    >>> Z = np.linspace(-1, 1, Nz)
+    >>> freqs = [2e14]
+    >>> data = np.ones((Nx, Ny, Nz, 1))
+    >>> eps_diagonal_data = ScalarFieldDataArray(data, coords=dict(x=X, y=Y, z=Z, f=freqs))
+    >>> eps_components = {f"eps_{d}{d}": eps_diagonal_data for d in "xyz"}
+    >>> dataset = PermittivityDataset(**eps_components)
+    >>> dielectric = CustomMedium(dataset=dataset, name='my_medium')
+    >>> eps = dielectric.eps_model(200e12)
+    """
+
+    dataset: DispersiveDataset = pd.Field(
+        ...,
+        title="Dispersion Coefficients Dataset",
+        description="User-supplied dataset containing the spatially-varying coefficients for "
+        "Defining the medium properties. ",
+    )
+
+    # TODO: need to implement ABC methods to handle SpatialDataArray values?
+    # @cached_property
+    # def pole_residue(self):
+    #     """Representation of Medium as a pole-residue model."""
+    #     # TODO: generalize the pole_residue method of the DispersiveModel to
+    #     # # basic idea
+    #     # eps_inf = self.dataset.eps_inf
+    #     # coeffs = self.dataset.coeffs
+    #     # values = Drude.eps_model()
+    #     #     dataset = dataset.sel(points)
+    #     #     value = Drude.eps_model(dataset.values)
+    #     # return CustomPoleResidue(values)
+
+
+class CustomPoleResidue(CustomDispersiveMedium, PoleResidue):
+    """Pole Residue model with spatially-varying coefficients."""
+
+    dataset: PoleResidueDataset
+
+
+class CustomDrude(CustomDispersiveMedium, Drude):
+    """Drude model with spatially-varying coefficients."""
+
+    dataset: DrudeDataset
+
+
 # types of mediums that can be used in Simulation and Structures
 
 MediumType3D = Union[
     Medium,
-    CustomMedium,
     AnisotropicMedium,
     PECMedium,
     PoleResidue,
@@ -1279,6 +1358,9 @@ MediumType3D = Union[
     Lorentz,
     Debye,
     Drude,
+    CustomMedium,
+    # CustomDispersiveMedium,
+    # CustomAnisotropicMedium,
 ]
 
 

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -1477,8 +1477,8 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
         # custom medium, the min and max in the supplied dataset over all components and
         # spatial locations.
         for mat in [medium for medium in medium_list if isinstance(medium, CustomMedium)]:
-            eps_dataset_at_freq = mat.eps_dataset_freq(freq)
-            for eps_component in eps_dataset_at_freq.field_components.values():
+            dataset_at_freq = mat.dataset_freq(freq)
+            for eps_component in dataset_at_freq.field_components.values():
                 eps_min = min(eps_min, np.min(eps_component.real.values.ravel()))
                 eps_max = max(eps_max, np.max(eps_component.real.values.ravel()))
         return eps_min, eps_max
@@ -2590,7 +2590,7 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
         datasets_source = [
             src.field_dataset for src in self.sources if isinstance(src, CustomFieldSource)
         ]
-        datasets_medium = [mat.eps_dataset for mat in self.mediums if isinstance(mat, CustomMedium)]
+        datasets_medium = [mat.dataset for mat in self.mediums if isinstance(mat, CustomMedium)]
         datasets_geometry = [
             struct.geometry.mesh_dataset
             for struct in self.structures

--- a/tidy3d/schema.json
+++ b/tidy3d/schema.json
@@ -586,7 +586,7 @@
     },
     "CustomMedium": {
       "title": "CustomMedium",
-      "description": ":class:`.Medium` with user-supplied permittivity distribution.\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\neps_dataset : PermittivityDataset\n    User-supplied dataset containing complex-valued permittivity as a function of space. Permittivity distribution over the Yee-grid will be interpolated based on ``interp_method``.\ninterp_method : Literal['nearest', 'linear'] = nearest\n    Interpolation method to obtain permittivity values that are not supplied at the Yee grids; For grids outside the range of the supplied data, extrapolation will be applied. When the extrapolated value is smaller (greater) than the minimal (maximal) of the supplied data, the extrapolated value will take the minimal (maximal) of the supplied data.\n\nExample\n-------\n>>> Nx, Ny, Nz = 10, 9, 8\n>>> X = np.linspace(-1, 1, Nx)\n>>> Y = np.linspace(-1, 1, Ny)\n>>> Z = np.linspace(-1, 1, Nz)\n>>> freqs = [2e14]\n>>> data = np.ones((Nx, Ny, Nz, 1))\n>>> eps_diagonal_data = ScalarFieldDataArray(data, coords=dict(x=X, y=Y, z=Z, f=freqs))\n>>> eps_components = {f\"eps_{d}{d}\": eps_diagonal_data for d in \"xyz\"}\n>>> eps_dataset = PermittivityDataset(**eps_components)\n>>> dielectric = CustomMedium(eps_dataset=eps_dataset, name='my_medium')\n>>> eps = dielectric.eps_model(200e12)",
+      "description": ":class:`.Medium` with user-supplied permittivity distribution.\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\ndataset : PermittivityDataset\n    User-supplied dataset containing complex-valued permittivity as a function of space. Permittivity distribution over the Yee-grid will be interpolated based on ``interp_method``.\ninterp_method : Literal['nearest', 'linear'] = nearest\n    Interpolation method to obtain permittivity values that are not supplied at the Yee grids; For grids outside the range of the supplied data, extrapolation will be applied. When the extrapolated value is smaller (greater) than the minimal (maximal) of the supplied data, the extrapolated value will take the minimal (maximal) of the supplied data.\n\nExample\n-------\n>>> Nx, Ny, Nz = 10, 9, 8\n>>> X = np.linspace(-1, 1, Nx)\n>>> Y = np.linspace(-1, 1, Ny)\n>>> Z = np.linspace(-1, 1, Nz)\n>>> freqs = [2e14]\n>>> data = np.ones((Nx, Ny, Nz, 1))\n>>> eps_diagonal_data = ScalarFieldDataArray(data, coords=dict(x=X, y=Y, z=Z, f=freqs))\n>>> eps_components = {f\"eps_{d}{d}\": eps_diagonal_data for d in \"xyz\"}\n>>> dataset = PermittivityDataset(**eps_components)\n>>> dielectric = CustomMedium(dataset=dataset, name='my_medium')\n>>> eps = dielectric.eps_model(200e12)",
       "type": "object",
       "properties": {
         "name": {
@@ -621,7 +621,7 @@
           ],
           "type": "string"
         },
-        "eps_dataset": {
+        "dataset": {
           "title": "Permittivity Dataset",
           "description": "User-supplied dataset containing complex-valued permittivity as a function of space. Permittivity distribution over the Yee-grid will be interpolated based on ``interp_method``.",
           "allOf": [
@@ -642,7 +642,7 @@
         }
       },
       "required": [
-        "eps_dataset"
+        "dataset"
       ],
       "additionalProperties": false
     },


### PR DESCRIPTION
* Created `SpatialDataArray` with `xyz` coords only.
* Created `Dataset` subclasses for dispersive custom mediums.
* Abstracted `CustomMedium` to derive from `AbstractCustomMedium` with `dataset` and `interp_method` fields.
* Rename `CustomMedium.eps_dataset` to `.dataset` for generality, added deprecation warning and conversion + test.
* Fixed adjoint plugin and tests to handle new `dataset` syntax.
* Added templates for `CustomDispersiveMedium` and `CustomDrude`.
* Future work can include `CustomAnisotropicMedium` with little effort.