### PR TITLE
Find stack offset to log correct calling site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Perfect electric conductors (PECs) are now modeled as high-conductivity media in both the frontend and backend mode solvers, and their presence triggers the use of a preconditioner to improve numerical stability and robustness. Consequently, the mode solver provides more accurate eigenvectors and field distributions when PEC structures are present.
 
 ### Fixed
+- Log messages provide the correct caller origin (file name and line number).
 
 ## [2.1.0] - 2023-4-18
 

--- a/tidy3d/log.py
+++ b/tidy3d/log.py
@@ -1,5 +1,7 @@
 """Logging for Tidy3d."""
 
+import inspect
+
 from typing import Union
 from typing_extensions import Literal
 
@@ -47,7 +49,12 @@ class LogHandler:
     def handle(self, level, level_name, message):
         """Output log messages depending on log level"""
         if level >= self.level:
-            self.console.log(level_name, message, sep=": ")
+            stack = inspect.stack()
+            offset = 4
+            if stack[offset - 1].filename.endswith("exceptions.py"):
+                # We want the calling site for exceptions.py
+                offset += 1
+            self.console.log(level_name, message, sep=": ", _stack_offset=offset)
 
 
 class Logger:


### PR DESCRIPTION
Fix for logging the correct calling site.
For example, before this patch:
```sh
$ python -c 'import tidy3d; tidy3d.log.warning("Warning test"); raise tidy3d.exceptions.Tidy3dError("Error test")'
[15:53:47] WARNING: Warning test                                                                                                                                                                           log.py:50
           ERROR: Error test                                                                                                                                                                               log.py:50
Traceback (most recent call last):
  File "<string>", line 1, in <module>
tidy3d.exceptions.Tidy3dError: Error test
```

After the patch:
```sh
$ python -c 'import tidy3d; tidy3d.log.warning("Warning test"); raise tidy3d.exceptions.Tidy3dError("Error test")'
[15:54:36] WARNING: Warning test                                                                                                                                                                          <string>:1
           ERROR: Error test                                                                                                                                                                              <string>:1
Traceback (most recent call last):
  File "<string>", line 1, in <module>
tidy3d.exceptions.Tidy3dError: Error test
```