### PR TITLE
Adjoint PolySlab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Retry for set number of seconds in web functions if internet connection error.
 - Adjoint processing is done server side by default, to avoid unnecessary downloading of data.
 - `run_local` and `run_async_local` options in `tidy3d.plugins.adjoint.web` to provide way to run adjoint processing locally.
+- `JaxPolySlab` in `adjoint` plugin, which can track derivatives through its `.vertices`.
 
 ### Changed
 - Perfect electric conductors (PECs) are now modeled as high-conductivity media in both the frontend and backend mode solvers, and their presence triggers the use of a preconditioner to improve numerical stability and robustness. Consequently, the mode solver provides more accurate eigenvectors and field distributions when PEC structures are present.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Perfect electric conductors (PECs) are now modeled as high-conductivity media in both the frontend and backend mode solvers, and their presence triggers the use of a preconditioner to improve numerical stability and robustness. Consequently, the mode solver provides more accurate eigenvectors and field distributions when PEC structures are present.
 - Include source amplitude in `amp_time`.
 - Increased the maximum allowed estimated simulation data storage to 50GB. Individual monitors with projected data larger than 10GB will trigger a warning.
+- `PolySlab.inside` now uses `matplotlib.path.contains_points`.
 
 ### Fixed
 - Log messages provide the correct caller origin (file name and line number).

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -189,7 +189,7 @@ def make_sim(
 ) -> JaxSimulation:
     """Construt a simulation out of some input parameters."""
 
-    box = td.Box(size=(1, 1, 1), center=(1, 2, 2))
+    box = td.Box(size=(0.2, 0.2, 0.2), center=(1, -2, 2))
     med = td.Medium(permittivity=2.0)
     extraneous_structure = td.Structure(geometry=box, medium=med)
 
@@ -209,7 +209,7 @@ def make_sim(
     jax_struct2 = JaxStructure(geometry=jax_box2, medium=jax_med2)
 
     jax_polyslab1 = JaxPolySlab(axis=POLYSLAB_AXIS, vertices=vertices, slab_bounds=(-1, 1))
-    # jax_struct3 = JaxStructure(geometry=jax_polyslab1, medium=jax_med1)
+    jax_struct3 = JaxStructure(geometry=jax_polyslab1, medium=jax_med1)
 
     # custom medium
     Nx, Ny, Nz = 10, 10, 1
@@ -221,12 +221,13 @@ def make_sim(
         f=[FREQ0],
     )
 
+    jax_box_custom = JaxBox(size=size, center=(1, 0, 2))
     values = base_eps_val + np.random.random((Nx, Ny, Nz, 1))
     eps_ii = JaxDataArray(values=values, coords=coords)
     field_components = {f"eps_{dim}{dim}": eps_ii for dim in "xyz"}
     jax_eps_dataset = JaxPermittivityDataset(**field_components)
     jax_med_custom = JaxCustomMedium(eps_dataset=jax_eps_dataset)
-    jax_struct_custom = JaxStructure(geometry=jax_box1, medium=jax_med_custom)
+    jax_struct_custom = JaxStructure(geometry=jax_box_custom, medium=jax_med_custom)
 
     # TODO: Add new geometries as they are created.
 
@@ -268,7 +269,7 @@ def make_sim(
         monitors=(extraneous_field_monitor,),
         structures=(extraneous_structure,),
         output_monitors=(output_mnt1, output_mnt2),  # , output_mnt3),
-        input_structures=(jax_struct1, jax_struct2, jax_struct_custom),
+        input_structures=(jax_struct1, jax_struct2, jax_struct_custom, jax_struct3),
         boundary_spec=td.BoundarySpec.pml(x=False, y=False, z=False),
     )
 
@@ -725,7 +726,7 @@ def test_strict_types():
         b = JaxBox(size=(1, 1, [1, 2]), center=(0, 0, 0))
 
 
-def _test_polyslab_box(use_emulated_run):
+def test_polyslab_box(use_emulated_run):
     """Make sure box made with polyslab gives equivalent gradients (note, doesn't pass now)."""
 
     np.random.seed(0)
@@ -751,8 +752,8 @@ def _test_polyslab_box(use_emulated_run):
             size_axis, (size_1, size_2) = JaxPolySlab.pop_axis(size, axis=POLYSLAB_AXIS)
             cent_axis, (cent_1, cent_2) = JaxPolySlab.pop_axis(center, axis=POLYSLAB_AXIS)
 
-            pos_x1 = cent_1 - size_1 / 2.0
             pos_x2 = cent_1 + size_1 / 2.0
+            pos_x1 = cent_1 - size_1 / 2.0
             pos_y1 = cent_2 - size_2 / 2.0
             pos_y2 = cent_2 + size_2 / 2.0
 
@@ -766,7 +767,7 @@ def _test_polyslab_box(use_emulated_run):
 
         # ModeMonitors
         output_mnt1 = td.ModeMonitor(
-            size=(10, 10, 0),
+            size=(td.inf, td.inf, 0),
             mode_spec=td.ModeSpec(num_modes=3),
             freqs=[2e14],
             name=MNT_NAME + "1",
@@ -779,12 +780,6 @@ def _test_polyslab_box(use_emulated_run):
             normal_dir="+",
             freqs=[2e14],
             name=MNT_NAME + "2",
-        )
-
-        extraneous_field_monitor = td.FieldMonitor(
-            size=(10, 10, 0),
-            freqs=[1e14, 2e14],
-            name="field",
         )
 
         sim = JaxSimulation(
@@ -822,6 +817,9 @@ def _test_polyslab_box(use_emulated_run):
     print("grad_size_poly = ", gs_p)
     print("grad_cent_box  = ", gc_b)
     print("grad_cent_poly = ", gc_p)
+
+    print(gs_b / (gs_p + 1e-12))
+    print(gc_b / (gc_p + 1e-12))
 
     assert np.allclose(gs_b, gs_p), f"size gradients dont match, got {gs_b} and {gs_p}"
     assert np.allclose(gc_b, gc_p), f"center gradients dont match, got {gc_b} and {gc_p}"

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -825,6 +825,75 @@ def test_polyslab_box(use_emulated_run):
     assert np.allclose(gc_b, gc_p), f"center gradients dont match, got {gc_b} and {gc_p}"
 
 
+@pytest.mark.parametrize("sim_size_axis", [0, 10])
+def test_polyslab_2d(sim_size_axis, use_emulated_run):
+    """Make sure box made with polyslab gives equivalent gradients (note, doesn't pass now)."""
+
+    np.random.seed(0)
+
+    def f(size, center):
+
+        jax_med = JaxMedium(permittivity=2.0)
+        POLYSLAB_AXIS = 2
+
+        size_axis, (size_1, size_2) = JaxPolySlab.pop_axis(size, axis=POLYSLAB_AXIS)
+        cent_axis, (cent_1, cent_2) = JaxPolySlab.pop_axis(center, axis=POLYSLAB_AXIS)
+
+        pos_x2 = cent_1 + size_1 / 2.0
+        pos_x1 = cent_1 - size_1 / 2.0
+        pos_y1 = cent_2 - size_2 / 2.0
+        pos_y2 = cent_2 + size_2 / 2.0
+
+        vertices = ((pos_x1, pos_y1), (pos_x2, pos_y1), (pos_x2, pos_y2), (pos_x1, pos_y2))
+        slab_bounds = (cent_axis - size_axis / 2, cent_axis + size_axis / 2)
+        slab_bounds = tuple(jax.lax.stop_gradient(x) for x in slab_bounds)
+        jax_polyslab = JaxPolySlab(vertices=vertices, axis=POLYSLAB_AXIS, slab_bounds=slab_bounds)
+        jax_struct = JaxStructure(geometry=jax_polyslab, medium=jax_med)
+
+        # ModeMonitors
+        output_mnt1 = td.ModeMonitor(
+            size=(td.inf, td.inf, 0),
+            mode_spec=td.ModeSpec(num_modes=3),
+            freqs=[2e14],
+            name=MNT_NAME + "1",
+        )
+
+        # DiffractionMonitor
+        output_mnt2 = td.DiffractionMonitor(
+            center=(0, 4, 0),
+            size=(td.inf, 0, td.inf),
+            normal_dir="+",
+            freqs=[2e14],
+            name=MNT_NAME + "2",
+        )
+
+        sim = JaxSimulation(
+            size=(10, 10, sim_size_axis),
+            run_time=1e-12,
+            grid_spec=td.GridSpec(wavelength=1.0),
+            boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
+            output_monitors=(output_mnt1, output_mnt2),
+            input_structures=(jax_struct,),
+            sources=[
+                td.PointDipole(
+                    source_time=td.GaussianPulse(freq0=1e14, fwidth=1e14),
+                    center=(0, 0, 0),
+                    polarization="Ex",
+                )
+            ],
+        )
+
+        sim_data = run(sim, task_name="test")
+        amp = extract_amp(sim_data)
+        return objective(amp)
+
+    f_b = lambda size, center: f(size, center)
+
+    g_b = grad(f_b, argnums=(0, 1))
+
+    gs_b, gc_b = g_b((1.0, 2.0, 100.0), CENTER)
+
+
 @pytest.mark.parametrize("local", (True, False))
 def test_adjoint_run_async(local, use_emulated_run_async):
     """Test differnetiating thorugh async adjoint runs"""

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -17,7 +17,7 @@ from typing import Tuple, Any, List
 
 from tidy3d.exceptions import DataError, Tidy3dKeyError, AdjointError
 from tidy3d.plugins.adjoint.components.base import JaxObject
-from tidy3d.plugins.adjoint.components.geometry import JaxBox, JaxPolySlab
+from tidy3d.plugins.adjoint.components.geometry import JaxBox, JaxPolySlab, MAX_NUM_VERTICES
 from tidy3d.plugins.adjoint.components.medium import JaxMedium, JaxAnisotropicMedium
 from tidy3d.plugins.adjoint.components.medium import JaxCustomMedium
 from tidy3d.plugins.adjoint.components.structure import JaxStructure
@@ -1027,7 +1027,7 @@ def test_save_load_simdata(use_emulated_run):
     assert sim_data == sim_data2
 
 
-def _test_polyslab_scale(use_emulated_run):
+def test_polyslab_scale(use_emulated_run):
     """Make sure box made with polyslab gives equivalent gradients (note, doesn't pass now)."""
 
     nums = np.logspace(np.log10(3), 3, 13)
@@ -1050,8 +1050,8 @@ def _test_polyslab_scale(use_emulated_run):
             size_axis, (size_1, size_2) = JaxPolySlab.pop_axis(SIZE, axis=POLYSLAB_AXIS)
             cent_axis, (cent_1, cent_2) = JaxPolySlab.pop_axis(CENTER, axis=POLYSLAB_AXIS)
 
-            # vertices_jax = [(scale * x, scale * y) for x, y in vertices]
-            vertices_jax = [(x, y) for x, y in vertices]
+            vertices_jax = [(scale * x, scale * y) for x, y in vertices]
+            # vertices_jax = [(x, y) for x, y in vertices]
 
             slab_bounds = (cent_axis - size_axis / 2, cent_axis + size_axis / 2)
             slab_bounds = tuple(jax.lax.stop_gradient(x) for x in slab_bounds)
@@ -1111,3 +1111,12 @@ def _test_polyslab_scale(use_emulated_run):
     plt.xscale("log")
     plt.yscale("log")
     plt.show()
+
+
+def test_validate_vertices():
+    """Test the maximum number of vertices."""
+    vertices = np.random.rand(MAX_NUM_VERTICES, 2)
+    poly = JaxPolySlab(vertices=vertices, slab_bounds=(-1, 1))
+    vertices = np.random.rand(MAX_NUM_VERTICES + 1, 2)
+    with pytest.raises(pydantic.ValidationError):
+        poly = JaxPolySlab(vertices=vertices, slab_bounds=(-1, 1))

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -728,8 +728,11 @@ def test_strict_types():
         b = JaxBox(size=(1, 1, [1, 2]), center=(0, 0, 0))
 
 
-def test_polyslab_box(use_emulated_run):
-    """Make sure box made with polyslab gives equivalent gradients (note, doesn't pass now)."""
+def _test_polyslab_box(use_emulated_run):
+    """Make sure box made with polyslab gives equivalent gradients.
+    Note: doesn't pass now since JaxBox samples the permittivity inside and outside the box,
+    and a random permittivity data is created by the emulated run function. JaxPolySlab just
+    uses the slab permittivity and the background simulation permittivity."""
 
     np.random.seed(0)
 
@@ -1027,7 +1030,7 @@ def test_save_load_simdata(use_emulated_run):
     assert sim_data == sim_data2
 
 
-def test_polyslab_scale(use_emulated_run):
+def _test_polyslab_scale(use_emulated_run):
     """Make sure box made with polyslab gives equivalent gradients (note, doesn't pass now)."""
 
     nums = np.logspace(np.log10(3), 3, 13)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -321,9 +321,12 @@ def run_emulated(simulation: Simulation, path: str = SIM_DATA_PATH, **kwargs) ->
     def make_data(coords: dict, data_array_type: type, is_complex: bool = False) -> "data_type":
         """make a random DataArray out of supplied coordinates and data_type."""
         data_shape = [len(coords[k]) for k in data_array_type._dims]
+        np.random.seed(1)
         data = np.random.random(data_shape)
+
+        # data = np.ones(data_shape)
         data = (1 + 1j) * data if is_complex else data
-        data = gaussian_filter(data, sigma=0.5)  # smooth out the data a little so it isnt random
+        data = gaussian_filter(data, sigma=1.0)  # smooth out the data a little so it isnt random
         data_array = data_array_type(data, coords=coords)
         return data_array
 

--- a/tidy3d/plugins/adjoint/__init__.py
+++ b/tidy3d/plugins/adjoint/__init__.py
@@ -16,3 +16,8 @@ except ImportError as e:
         "To get the appropriate packages, install tidy3d using '[jax]' option, for example: "
         "$pip install 'tidy3d[jax]'."
     ) from e
+
+try:
+    from .web import run, run_async
+except ImportError:
+    pass

--- a/tidy3d/plugins/adjoint/components/geometry.py
+++ b/tidy3d/plugins/adjoint/components/geometry.py
@@ -470,10 +470,10 @@ class JaxPolySlab(JaxGeometry, PolySlab, JaxObject):
             dz = float(length_axis) / float(num_cells_axis)
 
             # handle a 2D simulation along axis (unitless)
+            z_vals = np.linspace(z_min + dz / 2, z_max - dz / 2, num_cells_axis)
+
             if dz == 0.0:
                 dz = 1.0
-
-            z_vals = np.linspace(slab_min + dz / 2, slab_max - dz / 2, num_cells_axis)
 
             # integrate by summing over axis edge (z) and parameterization point (s)
             integrand = compute_integrand(s=s_vals, z=z_vals)

--- a/tidy3d/plugins/adjoint/components/geometry.py
+++ b/tidy3d/plugins/adjoint/components/geometry.py
@@ -226,9 +226,6 @@ class JaxBox(JaxGeometry, Box, JaxObject):
                     eps2 = eps_data.isel(**{dim_normal: isel_out})
                     eps1 = eps_data.isel(**{dim_normal: isel_ins})
 
-                    eps2 = 1.0
-                    eps1 = 2.0
-
                     # get gradient contribution for normal component using normal D field
                     if field_cmp_dim == dim_normal:
 

--- a/tidy3d/plugins/adjoint/components/medium.py
+++ b/tidy3d/plugins/adjoint/components/medium.py
@@ -110,7 +110,7 @@ class JaxMedium(Medium, JaxObject):
             if isinstance(value, float) or len(value) <= 1
         }
         interp_kwargs = {key: value for key, value in vol_coords.items() if key not in isel_kwargs}
-        integrand = e_dotted.isel(f=0, **isel_kwargs).interp(**interp_kwargs)
+        integrand = e_dotted.isel(f=0, **isel_kwargs).interp(**interp_kwargs, assume_sorted=True)
 
         # mask out any contributions not inside the structure volume
         inside_mask = self.make_inside_mask(vol_coords=vol_coords, inside_fn=inside_fn)
@@ -314,7 +314,8 @@ class JaxCustomMedium(CustomMedium, JaxObject):
             # interpolate into the forward and adjoint fields along this dimension and dot them
             e_fwd = grad_data_fwd.field_components[field_name]
             e_adj = grad_data_adj.field_components[field_name]
-            e_dotted = (e_fwd * e_adj).isel(f=0, **isel_coords).interp(**interp_coords)
+            e_dotted = (e_fwd * e_adj).isel(f=0, **isel_coords)
+            e_dotted = e_dotted.interp(**interp_coords, assume_sorted=True)
 
             # compute the size of the user-supplied medium along each dimension.
             grid = grids[eps_field_name]

--- a/tidy3d/plugins/adjoint/components/simulation.py
+++ b/tidy3d/plugins/adjoint/components/simulation.py
@@ -174,7 +174,7 @@ class JaxSimulation(Simulation, JaxObject):
                         f"'JaxPolySlab'-containing 'JaxSimulation.input_structures[{i}]' "
                         f"intersects with 'JaxSimulation.structures[{j}]'. "
                         "Note that in this version of the adjoint plugin, there may be errors "
-                        "in the the gradient when "
+                        "in the gradient when "
                         "'JaxPolySlab' intersects with background structures. "
                         "Skipping the rest of the structures."
                     )
@@ -437,14 +437,13 @@ class JaxSimulation(Simulation, JaxObject):
     ) -> JaxSimulation:
         """Store the vjp w.r.t. each input_structure as a sim using fwd and adj grad_data."""
 
-        freq = self.freq_adjoint
-        eps_out = self.medium.eps_model(frequency=freq)
-
         input_structures_vjp = []
         adjoint_info = zip(self.input_structures, grad_data_fwd, grad_data_adj, grad_eps_data)
 
         for in_struct, fld_fwd, fld_adj, eps_data in adjoint_info:
 
+            freq = float(eps_data.eps_xx.coords["f"])
+            eps_out = self.medium.eps_model(frequency=freq)
             eps_in = in_struct.medium.eps_model(frequency=freq)
 
             input_structure_vjp = in_struct.store_vjp(

--- a/tidy3d/plugins/adjoint/components/structure.py
+++ b/tidy3d/plugins/adjoint/components/structure.py
@@ -63,6 +63,8 @@ class JaxStructure(Structure, JaxObject):
         grad_data_adj: FieldData,
         grad_data_eps: PermittivityData,
         sim_bounds: Bound,
+        eps_out: complex,
+        eps_in: complex,
     ) -> JaxStructure:
         """Returns the gradient of the structure parameters given forward and adjoint field data."""
 
@@ -78,6 +80,8 @@ class JaxStructure(Structure, JaxObject):
             grad_data_eps=grad_data_eps,
             sim_bounds=sim_bounds,
             wvl_mat=wvl_mat,
+            eps_out=eps_out,
+            eps_in=eps_in,
         )
 
         medium_vjp = self.medium.store_vjp(
@@ -85,6 +89,7 @@ class JaxStructure(Structure, JaxObject):
             grad_data_adj=grad_data_adj,
             sim_bounds=sim_bounds,
             wvl_mat=wvl_mat,
+            inside_fn=self.geometry.inside,
         )
 
         return self.copy(update=dict(geometry=geo_vjp, medium=medium_vjp))


### PR DESCRIPTION
Introduces 
* `JaxPolySlab` geometry that can track gradients through its `.vertices`.
* `JaxStructure` with `JaxPolySlab` geometries can accurately track gradients through its medium using `inside()` to mask the volume integration.

Limitations:
* Gradients will be inaccurate if the `JaxPolySlab` immediate background is inhomogeneous (validator to warn)
* `.slab_bounds` not supported but coming soon.