### PR TITLE
Enable access to remote mode solver from python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `JaxGeometryGroup` in adjoint plugin.
 - Support for gradients w.r.t. `FieldMonitor` data from `output_monitors` in adjoint plugin.
 - `estimate_cost()` method for `Job` and `Batch`.
+- `s3utils.get_s3_sts_token` accepts extra query parameters.
+- `plugins.mode.web` to control the server-side mode solver.
 
 ### Changed
 - Add `Medium2D` to full simulation in tests.

--- a/tests/test_package/test_log.py
+++ b/tests/test_package/test_log.py
@@ -67,20 +67,19 @@ def test_logging_warning_capture():
     run_time = 10 / fwidth
     freqs = np.linspace(f0 - fwidth, f0 + fwidth, 11)
 
-    # 1 warning: "group_index_step" with single precision
     mode_mnt = td.ModeMonitor(
         center=(0, 0, 0),
         size=(domain_size, 0, domain_size),
         freqs=list(freqs),
-        mode_spec=td.ModeSpec(num_modes=3, group_index_step=1),
+        mode_spec=td.ModeSpec(num_modes=3),
         name="mode",
     )
 
-    # 2 warnings: "group_index_step" with single precision, too high num_freqs
+    # 1 warning: too high num_freqs
     mode_source = td.ModeSource(
         size=(domain_size, 0, domain_size),
         source_time=source_time,
-        mode_spec=td.ModeSpec(num_modes=2, group_index_step=1, precision="single"),
+        mode_spec=td.ModeSpec(num_modes=2, precision="single"),
         mode_index=1,
         num_freqs=50,
         direction="-",
@@ -130,5 +129,5 @@ def test_logging_warning_capture():
     td.log.set_capture(True)
     sim = td.Simulation.parse_raw(sim_json)
     warning_list = td.log.captured_warnings()
-    assert len(warning_list) == 17
+    assert len(warning_list) == 15
     td.log.set_capture(False)

--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -1,18 +1,17 @@
 import pytest
+import responses
 import numpy as np
 import matplotlib.pyplot as plt
-import pydantic
 
 import tidy3d as td
 
-from tidy3d.plugins.dispersion import DispersionFitter
+import tidy3d.plugins.mode.web as msweb
 from tidy3d.plugins.mode import ModeSolver
 from tidy3d.plugins.mode.derivatives import create_sfactor_b, create_sfactor_f
 from tidy3d.plugins.mode.solver import compute_modes
-from tidy3d import FieldData, ScalarFieldDataArray, FieldMonitor
-from tidy3d.plugins.smatrix.smatrix import Port, ComponentModeler
-from tidy3d.plugins.smatrix.smatrix import ComponentModeler
-from ..utils import clear_tmp, run_emulated
+from tidy3d import ScalarFieldDataArray
+from tidy3d.web.environment import Env
+
 
 WAVEGUIDE = td.Structure(geometry=td.Box(size=(100, 0.5, 0.5)), medium=td.Medium(permittivity=4.0))
 PLANE = td.Box(center=(0, 0, 0), size=(5, 0, 5))
@@ -21,8 +20,158 @@ SRC = td.PointDipole(
     center=(0, 0, 0), source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13), polarization="Ex"
 )
 
+PROJECT_NAME = "Mode Solver"
+TASK_NAME = "Untitled"
+MODESOLVER_NAME = "mode_solver"
+PROJECT_ID = "Project-ID"
+TASK_ID = "Task-ID"
+SOLVER_ID = "Solver-ID"
 
-def test_mode_solver_simple():
+
+@pytest.fixture
+def mock_remote_api(monkeypatch):
+    def void(*args, **kwargs):
+        return None
+
+    def mock_download(task_id, remote_path, to_file, *args, **kwargs):
+        simulation = td.Simulation(
+            size=SIM_SIZE,
+            grid_spec=td.GridSpec(wavelength=1.0),
+            structures=[WAVEGUIDE],
+            run_time=1e-12,
+            symmetry=(1, 0, -1),
+            boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
+            sources=[SRC],
+        )
+        mode_spec = td.ModeSpec(
+            num_modes=1,
+            target_neff=2.0,
+            filter_pol="tm",
+            precision="double",
+            track_freq="lowest",
+        )
+        ms = ModeSolver(
+            simulation=simulation,
+            plane=PLANE,
+            mode_spec=mode_spec,
+            freqs=[td.C_0 / 1.0],
+        )
+        ms.data_raw.to_file(to_file)
+
+    monkeypatch.setattr(td.web.http_management, "api_key", lambda: "api_key")
+    monkeypatch.setattr("tidy3d.plugins.mode.web.upload_file", void)
+    monkeypatch.setattr("tidy3d.plugins.mode.web.upload_string", void)
+    monkeypatch.setattr("tidy3d.plugins.mode.web.download_file", mock_download)
+
+    responses.add(
+        responses.GET,
+        f"{Env.current.web_api_endpoint}/tidy3d/project",
+        match=[responses.matchers.query_param_matcher({"projectName": PROJECT_NAME})],
+        json={"data": {"projectId": PROJECT_ID, "projectName": PROJECT_NAME}},
+        status=200,
+    )
+
+    responses.add(
+        responses.POST,
+        f"{Env.current.web_api_endpoint}/tidy3d/modesolver/py",
+        match=[
+            responses.matchers.json_params_matcher(
+                {
+                    "projectId": PROJECT_ID,
+                    "taskName": TASK_NAME,
+                    "modeSolverName": MODESOLVER_NAME,
+                    "fileType": "Json",
+                }
+            )
+        ],
+        json={
+            "data": {
+                "refId": TASK_ID,
+                "id": SOLVER_ID,
+                "status": "draft",
+                "createdAt": "2023-05-19T16:47:57.190Z",
+                "charge": 0,
+                "fileType": "Json",
+            }
+        },
+        status=200,
+    )
+
+    responses.add(
+        responses.POST,
+        f"{Env.current.web_api_endpoint}/tidy3d/modesolver/py",
+        match=[
+            responses.matchers.json_params_matcher(
+                {
+                    "projectId": PROJECT_ID,
+                    "taskName": TASK_NAME,
+                    "modeSolverName": MODESOLVER_NAME,
+                    "fileType": "Hdf5",
+                }
+            )
+        ],
+        json={
+            "data": {
+                "refId": TASK_ID,
+                "id": SOLVER_ID,
+                "status": "draft",
+                "createdAt": "2023-05-19T16:47:57.190Z",
+                "charge": 0,
+                "fileType": "Hdf5",
+            }
+        },
+        status=200,
+    )
+
+    responses.add(
+        responses.GET,
+        f"{Env.current.web_api_endpoint}/tidy3d/modesolver/py/{TASK_ID}/{SOLVER_ID}",
+        json={
+            "data": {
+                "refId": TASK_ID,
+                "id": SOLVER_ID,
+                "status": "success",
+                "createdAt": "2023-05-19T16:47:57.190Z",
+                "charge": 0,
+                "fileType": "Json",
+            }
+        },
+        status=200,
+    )
+
+    responses.add(
+        responses.POST,
+        f"{Env.current.web_api_endpoint}/tidy3d/modesolver/py/{TASK_ID}/{SOLVER_ID}/run",
+        json={
+            "data": {
+                "refId": TASK_ID,
+                "id": SOLVER_ID,
+                "status": "queued",
+                "createdAt": "2023-05-19T16:47:57.190Z",
+                "charge": 0,
+                "fileType": "Json",
+            }
+        },
+        status=200,
+    )
+
+
+def test_compute_modes():
+    """Test direct call to `compute_modes`."""
+    eps_cross = np.random.rand(10, 10)
+    coords = np.arange(11)
+    mode_spec = td.ModeSpec(num_modes=3, target_neff=2.0)
+    _ = compute_modes(
+        eps_cross=[eps_cross] * 9,
+        coords=[coords, coords],
+        freq=td.C_0 / 1.0,
+        mode_spec=mode_spec,
+    )
+
+
+@pytest.mark.parametrize("local", [True, False])
+@responses.activate
+def test_mode_solver_simple(mock_remote_api, local):
     """Simple mode solver run (with symmetry)"""
 
     simulation = td.Simulation(
@@ -38,7 +187,7 @@ def test_mode_solver_simple():
         num_modes=3,
         target_neff=2.0,
         filter_pol="tm",
-        precision="double",
+        precision="double" if local else "single",
         track_freq="lowest",
     )
     ms = ModeSolver(
@@ -47,10 +196,12 @@ def test_mode_solver_simple():
         mode_spec=mode_spec,
         freqs=[td.C_0 / 0.9, td.C_0 / 1.0, td.C_0 / 1.1],
     )
-    modes = ms.solve()
+    _ = ms.solve() if local else msweb.run(ms)
 
 
-def test_mode_solver_custom_medium():
+@pytest.mark.parametrize("local", [True, False])
+@responses.activate
+def test_mode_solver_custom_medium(mock_remote_api, local):
     """Test mode solver can work with custom medium. Consider a waveguide with varying
     permittivity along x-direction. The value of n_eff at different x position should be
     different.
@@ -75,7 +226,7 @@ def test_mode_solver_custom_medium():
     )
     mode_spec = td.ModeSpec(
         num_modes=1,
-        precision="double",
+        precision="double" if local else "single",
     )
 
     plane_left = td.Box(center=(-0.5, 0, 0), size=(1, 0, 1))
@@ -89,12 +240,13 @@ def test_mode_solver_custom_medium():
             mode_spec=mode_spec,
             freqs=[freq0],
         )
-        modes = ms.solve()
+        modes = ms.solve() if local else msweb.run(ms)
         n_eff.append(modes.n_eff.values)
 
-    assert n_eff[0] < 1.5
-    assert n_eff[1] > 4
-    assert n_eff[1] < 5
+    if local:
+        assert n_eff[0] < 1.5
+        assert n_eff[1] > 4
+        assert n_eff[1] < 5
 
 
 def test_mode_solver_angle_bend():
@@ -120,15 +272,16 @@ def test_mode_solver_angle_bend():
     # put plane entirely in the symmetry quadrant rather than sitting on its center
     plane = td.Box(center=(0, 0.5, 0), size=(1, 0, 1))
     ms = ModeSolver(simulation=simulation, plane=plane, mode_spec=mode_spec, freqs=[td.C_0 / 1.0])
-    modes = ms.solve()
+    _ = ms.solve()
     # Plot field
     _, ax = plt.subplots(1)
     ms.plot_field("Ex", ax=ax, mode_index=1)
+    plt.close()
 
     # Create source and monitor
     st = td.GaussianPulse(freq0=1.0, fwidth=1.0)
-    msource = ms.to_source(source_time=st, direction="-")
-    mmonitor = ms.to_monitor(freqs=[1.0, 2.0], name="mode_mnt")
+    _ = ms.to_source(source_time=st, direction="-")
+    _ = ms.to_monitor(freqs=[1.0, 2.0], name="mode_mnt")
 
 
 def test_mode_solver_2D():
@@ -149,9 +302,14 @@ def test_mode_solver_2D():
         sources=[SRC],
     )
     ms = ModeSolver(simulation=simulation, plane=PLANE, mode_spec=mode_spec, freqs=[td.C_0 / 1.0])
-    modes = ms.solve()
+    _ = ms.solve()
 
-    mode_spec = td.ModeSpec(num_modes=3, filter_pol="te", precision="double", num_pml=(10, 0))
+    mode_spec = td.ModeSpec(
+        num_modes=3,
+        filter_pol="te",
+        precision="double",
+        num_pml=(10, 0),
+    )
     simulation = td.Simulation(
         size=(SIM_SIZE[0], SIM_SIZE[1], 0),
         grid_spec=td.GridSpec(wavelength=1.0),
@@ -160,7 +318,7 @@ def test_mode_solver_2D():
         sources=[SRC],
     )
     ms = ModeSolver(simulation=simulation, plane=PLANE, mode_spec=mode_spec, freqs=[td.C_0 / 1.0])
-    modes = ms.solve()
+    _ = ms.solve()
 
     # The simulation and the mode plane are both 0D along the same dimension
     simulation = td.Simulation(
@@ -171,23 +329,12 @@ def test_mode_solver_2D():
         sources=[SRC],
     )
     ms = ModeSolver(simulation=simulation, plane=PLANE, mode_spec=mode_spec, freqs=[td.C_0 / 1.0])
-    modes = ms.solve()
+    _ = ms.solve()
 
 
-def test_compute_modes():
-    """Test direct call to ``compute_modes`` (used in e.g. gdsfactory)."""
-    eps_cross = np.random.rand(10, 10)
-    coords = np.arange(11)
-    mode_spec = td.ModeSpec(num_modes=3, target_neff=2.0)
-    modes = compute_modes(
-        eps_cross=[eps_cross] * 9,
-        coords=[coords, coords],
-        freq=td.C_0 / 1.0,
-        mode_spec=mode_spec,
-    )
-
-
-def test_group_index():
+@pytest.mark.parametrize("local", [True, False])
+@responses.activate
+def test_group_index(mock_remote_api, local):
     """Test group index calculation"""
 
     simulation = td.Simulation(
@@ -206,7 +353,7 @@ def test_group_index():
     mode_spec = td.ModeSpec(
         num_modes=2,
         target_neff=3.0,
-        precision="double",
+        precision="double" if local else "single",
         track_freq="central",
     )
 
@@ -217,7 +364,9 @@ def test_group_index():
         mode_spec=mode_spec,
         freqs=[td.C_0 / 1.54, td.C_0 / 1.55, td.C_0 / 1.56],
     )
-    assert ms.data.n_group is None
+    modes = ms.solve() if local else msweb.run(ms)
+    if local:
+        assert modes.n_group is None
 
     # Group index calculated
     ms = ModeSolver(
@@ -226,11 +375,12 @@ def test_group_index():
         mode_spec=mode_spec.copy(update={"group_index_step": True}),
         freqs=[td.C_0 / 1.54, td.C_0 / 1.55, td.C_0 / 1.56],
     )
-    modes = ms.solve()
-    assert (modes.n_group.sel(mode_index=0).values > 3.9).all()
-    assert (modes.n_group.sel(mode_index=0).values < 4.2).all()
-    assert (modes.n_group.sel(mode_index=1).values > 3.7).all()
-    assert (modes.n_group.sel(mode_index=1).values < 4.0).all()
+    modes = ms.solve() if local else msweb.run(ms)
+    if local:
+        assert (modes.n_group.sel(mode_index=0).values > 3.9).all()
+        assert (modes.n_group.sel(mode_index=0).values < 4.2).all()
+        assert (modes.n_group.sel(mode_index=1).values > 3.7).all()
+        assert (modes.n_group.sel(mode_index=1).values < 4.0).all()
 
 
 def test_pml_params():

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -42,7 +42,7 @@ def set_api_key(monkeypatch):
 
 @pytest.fixture
 def mock_upload(monkeypatch, set_api_key):
-    """Mocks webapi.uupload."""
+    """Mocks webapi.upload."""
 
     responses.add(
         responses.GET,

--- a/tidy3d/components/mode.py
+++ b/tidy3d/components/mode.py
@@ -148,9 +148,4 @@ class ModeSpec(Tidy3dBaseModel):
                     "Group index calculation without mode tracking can lead to incorrect results "
                     "around mode crossings. Consider setting 'track_freq' to 'central'."
                 )
-            if values["precision"] != "double":
-                log.warning(
-                    "Group index calculation should be performed with double precision for better "
-                    "accuracy. Consider setting 'precision' to 'double'."
-                )
         return values

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -168,11 +168,6 @@ class ModeSolver(Tidy3dBaseModel):
         """
 
         if self.mode_spec.group_index_step > 0:
-            if self.mode_spec.precision != "double":
-                log.warning(
-                    "In the local solver, group index calculation should be performed with double "
-                    "precision for better accuracy. Consider setting 'precision' to 'double'."
-                )
             return self._get_data_with_group_index()
 
         _, _solver_coords = self.plane.pop_axis(

--- a/tidy3d/plugins/mode/web.py
+++ b/tidy3d/plugins/mode/web.py
@@ -1,0 +1,467 @@
+"""Web API for mode solver"""
+
+from __future__ import annotations
+from typing import Optional, Callable
+
+from datetime import datetime
+import os
+import pathlib
+import tempfile
+import time
+
+import pydantic
+import rich
+
+from ...components.simulation import Simulation
+from ...components.data.monitor_data import ModeSolverData
+from ...exceptions import WebError
+from ...log import log
+from ...web.http_management import http
+from ...web.s3utils import download_file, upload_file, upload_string
+from ...web.simulation_task import Folder, SIMULATION_JSON
+from ...web.types import ResourceLifecycle, Submittable
+
+from .mode_solver import ModeSolver, MODE_MONITOR_NAME
+
+MODESOLVER_API = "tidy3d/modesolver/py"
+MODESOLVER_JSON = "mode_solver.json"
+MODESOLVER_HDF5 = "mode_solver.hdf5"
+MODESOLVER_LOG = "output/result.log"
+MODESOLVER_RESULT = "output/result.hdf5"
+
+
+# pylint:disable=too-many-arguments
+def run(
+    mode_solver: ModeSolver,
+    task_name: str = "Untitled",
+    mode_solver_name: str = "mode_solver",
+    folder_name: str = "Mode Solver",
+    results_file: str = "mode_solver.hdf5",
+    verbose: bool = True,
+    progress_callback_upload: Callable[[float], None] = None,
+    progress_callback_download: Callable[[float], None] = None,
+) -> ModeSolverData:
+    """Submits a :class:`.ModeSolver` to server, starts running, monitors progress, downloads,
+    and loads results as a :class:`.ModeSolverData` object.
+
+    Parameters
+    ----------
+    mode_solver : :class:`.ModeSolver`
+        Mode solver to upload to server.
+    task_name : str = "Untitled"
+        Name of task.
+    mode_solver_name: str = "mode_solver"
+        The name of the mode solver to create the in task.
+    folder_name : str = "Mode Solver"
+        Name of folder to store task on web UI.
+    results_file : str = "mode_solver.hdf5"
+        Path to download results file (.hdf5).
+    verbose : bool = True
+        If `True`, will print status, otherwise, will run silently.
+    progress_callback_upload : Callable[[float], None] = None
+        Optional callback function called when uploading file with ``bytes_in_chunk`` as argument.
+    progress_callback_download : Callable[[float], None] = None
+        Optional callback function called when downloading file with ``bytes_in_chunk`` as argument.
+
+    Returns
+    -------
+    :class:`.ModeSolverData`
+        Mode solver data with the calculated results.
+    """
+
+    log_level = "DEBUG" if verbose else "INFO"
+    if verbose:
+        console = rich.console.Console()
+
+    task = ModeSolverTask.create(mode_solver, task_name, mode_solver_name, folder_name)
+    task.upload(verbose=verbose, progress_callback=progress_callback_upload)
+    task.submit()
+
+    # Wait for task to finish
+    prev_status = "draft"
+    status = task.status
+    while status not in ("success", "error", "diverged", "deleted"):
+        if status != prev_status:
+            log.log(log_level, f"Mode solver status: {status}")
+            if verbose:
+                console.log(f"Mode solver status: {status}")
+            prev_status = status
+        time.sleep(0.5)
+        status = task.get_info().status
+
+    if status == "error":
+        raise WebError("Error runnig mode solver.")
+
+    log.log(log_level, f"Mode solver status: {status}")
+    if verbose:
+        console.log(f"Mode solver status: {status}")
+
+    if status != "success":
+        # Our cache discards None, so the user is able to re-run
+        return None
+
+    return task.get_result(
+        to_file=results_file, verbose=verbose, progress_callback=progress_callback_download
+    )
+
+
+class ModeSolverTask(ResourceLifecycle, Submittable, extra=pydantic.Extra.allow):
+    """Interface for managing the running of a :class:`.ModeSolver` task on server."""
+
+    task_id: str = pydantic.Field(
+        None,
+        title="task_id",
+        description="Task ID number, set when the task is created, leave as None.",
+        alias="refId",
+    )
+
+    solver_id: str = pydantic.Field(
+        None,
+        title="solver",
+        description="Solver ID number, set when the task is created, leave as None.",
+        alias="id",
+    )
+
+    real_flex_unit: float = pydantic.Field(
+        None, title="real FlexCredits", description="Billed FlexCredits.", alias="charge"
+    )
+
+    created_at: Optional[datetime] = pydantic.Field(
+        title="created_at", description="Time at which this task was created.", alias="createdAt"
+    )
+
+    status: str = pydantic.Field(
+        None,
+        title="status",
+        description="Mode solver task status.",
+    )
+
+    file_type: str = pydantic.Field(
+        None,
+        title="file_type",
+        description="File type used to upload the mode solver.",
+        alias="fileType",
+    )
+
+    mode_solver: ModeSolver = pydantic.Field(
+        None,
+        title="mode_solver",
+        description="Mode solver being run by this task.",
+    )
+
+    # pylint: disable=arguments-differ
+    @classmethod
+    def create(
+        cls,
+        mode_solver: ModeSolver,
+        task_name: str = "Untitled",
+        mode_solver_name: str = "mode_solver",
+        folder_name: str = "Mode Solver",
+    ) -> ModeSolverTask:
+        """Create a new mode solver task on the server.
+
+        Parameters
+        ----------
+        mode_solver: :class".ModeSolver"
+            The object that will be uploaded to server in the submitting phase.
+        task_name: str = "Untitled"
+            The name of the task.
+        mode_solver_name: str = "mode_solver"
+            The name of the mode solver to create the in task.
+        folder_name: str = "Mode Solver"
+            The name of the folder to store the task.
+
+        Returns
+        -------
+        :class:`ModeSolverTask`
+            :class:`ModeSolverTask` object containing information about the created task.
+        """
+        folder = Folder.get(folder_name, create=True)
+
+        if mode_solver.mode_spec.precision != "single":
+            log.warning(
+                "Mode solver server does not support 'double' precision: setting to 'single'."
+            )
+            mode_spec = mode_solver.mode_spec.copy(update={"precision": "single"})
+            mode_solver = mode_solver.copy(update={"mode_spec": mode_spec})
+
+        mode_solver.simulation.validate_pre_upload()
+        resp = http.post(
+            MODESOLVER_API,
+            {
+                "projectId": folder.folder_id,
+                "taskName": task_name,
+                "modeSolverName": mode_solver_name,
+                "fileType": "Hdf5" if len(mode_solver.simulation.custom_datasets) > 0 else "Json",
+            },
+        )
+        log.info(
+            "Mode solver created with task_id='%s', solver_id='%s'.", resp["refId"], resp["id"]
+        )
+        return ModeSolverTask(**resp, mode_solver=mode_solver)
+
+    # pylint: disable=arguments-differ, too-many-arguments
+    @classmethod
+    def get(
+        cls,
+        task_id: str,
+        solver_id: str,
+        to_file: str = "mode_solver.json",
+        sim_file: str = "simulation.json",
+        verbose: bool = True,
+        progress_callback: Callable[[float], None] = None,
+    ) -> ModeSolverTask:
+        """Get mode solver task from the server by id.
+
+        Parameters
+        ----------
+        task_id: str
+            Unique identifier of the task on server.
+        solver_id: str
+            Unique identifier of the mode solver in the task.
+        to_file: str = "mode_solver.json"
+            File to store the mode solver downloaded from the task.
+        sim_file: str = "simulation.json"
+            File to store the simulation downloaded from the task.
+        verbose: bool = True
+            Whether to display progress bars.
+        progress_callback : Callable[[float], None] = None
+            Optional callback function called while downloading the data.
+
+        Returns
+        -------
+        :class:`ModeSolverTask`
+            :class:`ModeSolverTask` object containing information about the task.
+        """
+        resp = http.get(f"{MODESOLVER_API}/{task_id}/{solver_id}")
+        task = ModeSolverTask(**resp)
+        mode_solver = task.get_modesolver(to_file, sim_file, verbose, progress_callback)
+        return task.copy(update={"mode_solver": mode_solver})
+
+    @property
+    def mode_solver_path(self):
+        """Return the mode solver path on the server for this task."""
+        return f"mode_solver/{self.solver_id}/"
+
+    def get_info(self) -> ModeSolverTask:
+        """Get the current state of this task on the server.
+
+        Returns
+        -------
+        :class:`ModeSolverTask`
+            :class:`ModeSolverTask` object containing information about the task, without the mode
+            solver.
+        """
+        resp = http.get(f"{MODESOLVER_API}/{self.task_id}/{self.solver_id}")
+        return ModeSolverTask(**resp, mode_solver=self.mode_solver)
+
+    def upload(
+        self, verbose: bool = True, progress_callback: Callable[[float], None] = None
+    ) -> None:
+        """Upload this task's 'mode_solver' to the server.
+
+        Parameters
+        ----------
+        verbose: bool = True
+            Whether to display progress bars.
+        progress_callback : Callable[[float], None] = None
+            Optional callback function called while uploading the data.
+        """
+        mode_solver = self.mode_solver.copy()
+
+        # Upload simulation as json for GUI display
+        upload_string(
+            self.task_id,
+            mode_solver.simulation._json_string,  # pylint: disable=protected-access
+            SIMULATION_JSON,
+            verbose=verbose,
+            progress_callback=progress_callback,
+        )
+
+        if self.file_type == "Hdf5":
+            # Upload a single HDF5 file with the full data
+            file, file_name = tempfile.mkstemp()
+            os.close(file)
+            mode_solver.to_hdf5(file_name)
+
+            try:
+                upload_file(
+                    self.solver_id,
+                    file_name,
+                    MODESOLVER_HDF5,
+                    verbose=verbose,
+                    progress_callback=progress_callback,
+                )
+            finally:
+                os.unlink(file_name)
+        else:
+            # Send only mode solver, without simulation
+            mode_solver_spec = mode_solver.dict()
+
+            # Upload mode solver without simulation: 'construct' skips all validation
+            mode_solver_spec["simulation"] = None
+            mode_solver = ModeSolver.construct(**mode_solver_spec)
+            upload_string(
+                self.solver_id,
+                mode_solver._json_string,  # pylint: disable=protected-access
+                MODESOLVER_JSON,
+                verbose=verbose,
+                progress_callback=progress_callback,
+                extra_arguments={"type": "ms"},
+            )
+
+    # pylint: disable=arguments-differ
+    def submit(self):
+        """Start the execution of this task.
+
+        The mode solver must be uploaded to the server with the :meth:`ModeSolverTask.upload` method
+        before this step.
+        """
+        http.post(f"{MODESOLVER_API}/{self.task_id}/{self.solver_id}/run")
+
+    # pylint: disable=arguments-differ
+    def delete(self):
+        """Delete the mode solver and its corresponding task from the server."""
+        # Delete mode solver
+        http.delete(f"{MODESOLVER_API}/{self.task_id}/{self.solver_id}")
+        # Delete parent task
+        http.delete(f"tidy3d/tasks/{self.task_id}")
+
+    def get_modesolver(
+        self,
+        to_file: str = "mode_solver.json",
+        sim_file: str = "simulation.json",
+        verbose: bool = True,
+        progress_callback: Callable[[float], None] = None,
+    ) -> ModeSolver:
+        """Get mode solver associated with this task from the server.
+
+        Parameters
+        ----------
+        to_file: str = "mode_solver.json"
+            File to store the mode solver downloaded from the task.
+        sim_file: str = "simulation.json"
+            File to store the simulation downloaded from the task.
+        verbose: bool = True
+            Whether to display progress bars.
+        progress_callback : Callable[[float], None] = None
+            Optional callback function called while downloading the data.
+
+        Returns
+        -------
+        :class:`ModeSolver`
+            :class:`ModeSolver` object associated with this task.
+
+        Note
+        ----
+        If the simulation contains custom datasets (such as custom media), an HDF5 file will be
+        stored in the same path as 'to_file', but with '.hdf5' extension, and neither 'to_file' or
+        'sim_file' will be created.
+        """
+        if self.file_type == "Hdf5":
+            to_hdf5 = pathlib.Path(to_file).with_suffix(".hdf5")
+            download_file(
+                self.task_id,
+                self.mode_solver_path + MODESOLVER_HDF5,
+                to_file=to_hdf5,
+                verbose=verbose,
+                progress_callback=progress_callback,
+            )
+
+            to_file = str(to_hdf5)
+            mode_solver = ModeSolver.from_hdf5(to_hdf5)
+
+        else:
+            download_file(
+                self.task_id,
+                self.mode_solver_path + MODESOLVER_JSON,
+                to_file=to_file,
+                verbose=verbose,
+                progress_callback=progress_callback,
+            )
+            download_file(
+                self.task_id,
+                SIMULATION_JSON,
+                to_file=sim_file,
+                verbose=verbose,
+                progress_callback=progress_callback,
+            )
+
+            mode_solver_dict = ModeSolver.dict_from_json(to_file)
+            mode_solver_dict["simulation"] = Simulation.from_json(sim_file)
+
+            mode_solver = ModeSolver.parse_obj(mode_solver_dict)
+
+        # Overwrite downloaded file with valid contents
+        mode_solver.to_file(to_file)
+        return mode_solver
+
+    def get_result(
+        self,
+        to_file: str = "mode_solver.hdf5",
+        verbose: bool = True,
+        progress_callback: Callable[[float], None] = None,
+    ) -> ModeSolverData:
+        """Get mode solver results for this task from the server.
+
+        Parameters
+        ----------
+        to_file: str = "mode_solver.hdf5"
+            File to store the mode solver downloaded from the task.
+        verbose: bool = True
+            Whether to display progress bars.
+        progress_callback : Callable[[float], None] = None
+            Optional callback function called while downloading the data.
+
+        Returns
+        -------
+        :class:`.ModeSolverData`
+            Mode solver data with the calculated results.
+        """
+        download_file(
+            self.task_id,
+            self.mode_solver_path + MODESOLVER_RESULT,
+            to_file=to_file,
+            verbose=verbose,
+            progress_callback=progress_callback,
+        )
+        data = ModeSolverData.from_hdf5(to_file)
+        data = data.copy(
+            update={"monitor": self.mode_solver.to_mode_solver_monitor(name=MODE_MONITOR_NAME)}
+        )
+
+        # pylint:disable=protected-access
+        self.mode_solver._cached_properties["data_raw"] = data
+
+        # Perform symmetry expansion
+        return self.mode_solver.data
+
+    def get_log(
+        self,
+        to_file: str = "mode_solver.log",
+        verbose: bool = True,
+        progress_callback: Callable[[float], None] = None,
+    ) -> pathlib.Path:
+        """Get execution log for this task from the server.
+
+        Parameters
+        ----------
+        to_file: str = "mode_solver.log"
+            File to store the mode solver downloaded from the task.
+        verbose: bool = True
+            Whether to display progress bars.
+        progress_callback : Callable[[float], None] = None
+            Optional callback function called while downloading the data.
+
+        Returns
+        -------
+        path: pathlib.Path
+            Path to saved file.
+        """
+        return download_file(
+            self.task_id,
+            self.mode_solver_path + MODESOLVER_LOG,
+            to_file=to_file,
+            verbose=verbose,
+            progress_callback=progress_callback,
+        )

--- a/tidy3d/plugins/waveguide/rectangular_dielectric.py
+++ b/tidy3d/plugins/waveguide/rectangular_dielectric.py
@@ -13,6 +13,7 @@ from ...components.grid.grid_spec import GridSpec
 from ...components.medium import Medium, MediumType
 from ...components.mode import ModeSpec
 from ...components.simulation import Simulation
+
 from ...components.source import ModeSource, GaussianPulse
 from ...components.structure import Structure
 from ...components.types import ArrayFloat1D, Ax, Axis, Coordinate, Literal, Size1D, Union
@@ -630,6 +631,10 @@ class RectangularDielectric(Tidy3dBaseModel):
 
         """
         freqs = C_0 / self.wavelength
+        f_max = freqs.max()
+        f_min = freqs.min()
+        freq0 = 0.5 * (f_max + f_min)
+        fwidth = max(0.1 * freq0, f_max - f_min)
 
         plane = Box(
             center=self._translate(0, 0.5 * self.height - self.box_thickness, 0),
@@ -640,7 +645,7 @@ class RectangularDielectric(Tidy3dBaseModel):
         mode_source = ModeSource(
             center=plane.center,
             size=plane.size,
-            source_time=GaussianPulse(freq0=freqs[0], fwidth=freqs[0] / 10),
+            source_time=GaussianPulse(freq0=freq0, fwidth=fwidth),
             direction="+",
             mode_spec=self.mode_spec,
         )

--- a/tidy3d/plugins/waveguide/rectangular_dielectric.py
+++ b/tidy3d/plugins/waveguide/rectangular_dielectric.py
@@ -176,7 +176,7 @@ class RectangularDielectric(Tidy3dBaseModel):
     )
 
     mode_spec: ModeSpec = pydantic.Field(
-        ModeSpec(num_modes=2, precision="double"),
+        ModeSpec(num_modes=2),
         title="Mode Specification",
         description=":class:`ModeSpec` defining waveguide mode properties.",
     )

--- a/tidy3d/web/webapi.py
+++ b/tidy3d/web/webapi.py
@@ -91,10 +91,10 @@ def run(  # pylint:disable=too-many-arguments
         Simulation to upload to server.
     task_name : str
         Name of task.
-    path : str = "simulation_data.hdf5"
-        Path to download results file (.hdf5), including filename.
     folder_name : str = "default"
         Name of folder to store task on web UI.
+    path : str = "simulation_data.hdf5"
+        Path to download results file (.hdf5), including filename.
     callback_url : str = None
         Http PUT url to receive simulation finish event. The body content is a json file with
         fields ``{'id', 'status', 'name', 'workUnit', 'solverVersion'}``.


### PR DESCRIPTION
The local mode solver can be used through `ModeSolver.solve_local`.

This is a WIP because the changes to the current mode solver can be "messy", so everyone's input is welcome.

The cache system had to be extended to allow for caching aliases, because the solve function returns the value of the `data_raw` property, which is cached. Thus `solve_local` must share a cache entry with `data_raw`, which is now possible by passing a name to the cache decorator.