### PR TITLE
retry connection in web functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `web.test()` to simply test if the authentication is configured correctly and raise exception otherwise.
 - Add `SimulationTask.get_running_tasks()` to get a list of running tasks from the server.
 - Argument `scale` to `ModeSolver.plot_field` to control plot scaling.
+- Retry for set number of seconds in web functions if internet connection error.
 
 ### Changed
 - Perfect electric conductors (PECs) are now modeled as high-conductivity media in both the frontend and backend mode solvers, and their presence triggers the use of a preconditioner to improve numerical stability and robustness. Consequently, the mode solver provides more accurate eigenvectors and field distributions when PEC structures are present.

--- a/tidy3d/web/webapi.py
+++ b/tidy3d/web/webapi.py
@@ -30,8 +30,6 @@ REFRESH_TIME = 0.3
 # time between checking run status
 RUN_REFRESH_TIME = 1.0
 
-TOTAL_DOTS = 3
-
 # file names when uploading to S3
 SIM_FILE_JSON = "simulation.json"
 

--- a/tidy3d/web/webapi.py
+++ b/tidy3d/web/webapi.py
@@ -39,7 +39,7 @@ SIM_FILE_JSON = "simulation.json"
 CONNECTION_RETRY_TIME = 30
 
 
-def wait_for_connection(wait_time_sec: float = CONNECTION_RETRY_TIME):
+def wait_for_connection(decorated_fn=None, wait_time_sec: float = CONNECTION_RETRY_TIME):
     """Causes function to ignore connection errors and retry for ``wait_time_sec`` secs."""
 
     def decorator(web_fn):
@@ -64,10 +64,13 @@ def wait_for_connection(wait_time_sec: float = CONNECTION_RETRY_TIME):
 
         return web_fn_wrapped
 
+    if decorated_fn:
+        return decorator(decorated_fn)
+
     return decorator
 
 
-@wait_for_connection(wait_time_sec=CONNECTION_RETRY_TIME)
+@wait_for_connection
 def run(  # pylint:disable=too-many-arguments
     simulation: Simulation,
     task_name: str,
@@ -131,7 +134,7 @@ def run(  # pylint:disable=too-many-arguments
     )
 
 
-@wait_for_connection(wait_time_sec=CONNECTION_RETRY_TIME)
+@wait_for_connection
 def upload(  # pylint:disable=too-many-locals,too-many-arguments
     simulation: Simulation,
     task_name: str,
@@ -194,7 +197,7 @@ def upload(  # pylint:disable=too-many-locals,too-many-arguments
     return task.task_id
 
 
-@wait_for_connection(wait_time_sec=CONNECTION_RETRY_TIME)
+@wait_for_connection
 def get_info(task_id: TaskId) -> TaskInfo:
     """Return information about a task.
 
@@ -214,7 +217,7 @@ def get_info(task_id: TaskId) -> TaskInfo:
     return TaskInfo(**{"taskId": task.task_id, **task.dict()})
 
 
-@wait_for_connection(wait_time_sec=CONNECTION_RETRY_TIME)
+@wait_for_connection
 def start(
     task_id: TaskId,
     solver_version: str = None,
@@ -242,7 +245,7 @@ def start(
     task.submit(solver_version=solver_version, worker_group=worker_group)
 
 
-@wait_for_connection(wait_time_sec=CONNECTION_RETRY_TIME)
+@wait_for_connection
 def get_run_info(task_id: TaskId):
     """Gets the % done and field_decay for a running task.
 
@@ -393,7 +396,7 @@ def monitor(task_id: TaskId, verbose: bool = True) -> None:
             time.sleep(REFRESH_TIME)
 
 
-@wait_for_connection(wait_time_sec=CONNECTION_RETRY_TIME)
+@wait_for_connection
 def download(
     task_id: TaskId,
     path: str = "simulation_data.hdf5",
@@ -418,7 +421,7 @@ def download(
     task.get_simulation_hdf5(path, verbose=verbose, progress_callback=progress_callback)
 
 
-@wait_for_connection(wait_time_sec=CONNECTION_RETRY_TIME)
+@wait_for_connection
 def download_json(
     task_id: TaskId,
     path: str = SIM_FILE_JSON,
@@ -444,7 +447,7 @@ def download_json(
     task.get_simulation_json(path, verbose=verbose, progress_callback=progress_callback)
 
 
-@wait_for_connection(wait_time_sec=CONNECTION_RETRY_TIME)
+@wait_for_connection
 def download_hdf5(
     task_id: TaskId,
     path: str = SIM_FILE_HDF5,
@@ -470,7 +473,7 @@ def download_hdf5(
     task.get_simulation_hdf5(path, verbose=verbose, progress_callback=progress_callback)
 
 
-@wait_for_connection(wait_time_sec=CONNECTION_RETRY_TIME)
+@wait_for_connection
 def load_simulation(
     task_id: TaskId,
     path: str = SIM_FILE_JSON,
@@ -502,7 +505,7 @@ def load_simulation(
     return Simulation.from_file(path)
 
 
-@wait_for_connection(wait_time_sec=CONNECTION_RETRY_TIME)
+@wait_for_connection
 def download_log(
     task_id: TaskId,
     path: str = "tidy3d.log",
@@ -530,7 +533,7 @@ def download_log(
     task.get_log(path, verbose=verbose, progress_callback=progress_callback)
 
 
-@wait_for_connection(wait_time_sec=CONNECTION_RETRY_TIME)
+@wait_for_connection
 def load(
     task_id: TaskId,
     path: str = "simulation_data.hdf5",
@@ -580,7 +583,7 @@ def load(
     return sim_data
 
 
-@wait_for_connection(wait_time_sec=CONNECTION_RETRY_TIME)
+@wait_for_connection
 def delete(task_id: TaskId) -> TaskInfo:
     """Delete server-side data associated with task.
 
@@ -601,7 +604,7 @@ def delete(task_id: TaskId) -> TaskInfo:
     return TaskInfo(**{"taskId": task.task_id, **task.dict()})
 
 
-@wait_for_connection(wait_time_sec=CONNECTION_RETRY_TIME)
+@wait_for_connection
 def delete_old(
     days_old: int = 100,
     folder: str = "default",
@@ -636,7 +639,7 @@ def delete_old(
 
 
 # TODO: make this return a list of TaskInfo instead?
-@wait_for_connection(wait_time_sec=CONNECTION_RETRY_TIME)
+@wait_for_connection
 def get_tasks(
     num_tasks: int = None, order: Literal["new", "old"] = "new", folder: str = "default"
 ) -> List[Dict]:
@@ -667,7 +670,7 @@ def get_tasks(
     return [task.dict() for task in tasks]
 
 
-@wait_for_connection(wait_time_sec=CONNECTION_RETRY_TIME)
+@wait_for_connection
 def estimate_cost(task_id: str) -> float:
     """Compute the maximum FlexCredit charge for a given task.
 
@@ -710,7 +713,7 @@ def estimate_cost(task_id: str) -> float:
     return flex_unit
 
 
-@wait_for_connection(wait_time_sec=CONNECTION_RETRY_TIME)
+@wait_for_connection
 def real_cost(task_id: str) -> float:
     """Get the billed cost for given task after it has been run.
 
@@ -729,7 +732,7 @@ def real_cost(task_id: str) -> float:
     return flex_unit
 
 
-@wait_for_connection(wait_time_sec=CONNECTION_RETRY_TIME)
+@wait_for_connection
 def test() -> None:
     """Confirm whether Tidy3D authentication is configured. Raises exception if not."""
     try:


### PR DESCRIPTION
Short term attempt at making the webapi more stable in connection outages.

For all major webapi functions, if connection errors, logs a warning once and retries connection for CONNECTION_RETRY_TIME=30 seconds (with REFRESH_TIME period in between tries). 

Note, not applied to `web.monitor` as this function wraps other webapi functions so it is already covered and adding it at top level would cause the warning to trigger twice.