### PR TITLE
Parallelizing polyslab vjp, and using matplotlib.path.contains_points in PolySlab.inside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Perfect electric conductors (PECs) are now modeled as high-conductivity media in both the frontend and backend mode solvers, and their presence triggers the use of a preconditioner to improve numerical stability and robustness. Consequently, the mode solver provides more accurate eigenvectors and field distributions when PEC structures are present.
+- `PolySlab.inside` now uses `matplotlib.path.contains_points`.
 
 ### Fixed
 - Log messages provide the correct caller origin (file name and line number).

--- a/tidy3d/plugins/adjoint/components/geometry.py
+++ b/tidy3d/plugins/adjoint/components/geometry.py
@@ -2,8 +2,10 @@
 """Defines jax-compatible geometries and their conversion to grad monitors."""
 from __future__ import annotations
 
+import os
 from abc import ABC
 from typing import Tuple, Union, Dict
+from multiprocessing import Pool
 
 import pydantic as pd
 import numpy as np
@@ -29,6 +31,9 @@ PTS_PER_WVL_INTEGRATION = 50
 
 # how much to expand the gradient monitors on each side beyond the self.bounds
 GRAD_MONITOR_EXPANSION = fp_eps
+
+# maximum number of vertices allowed in JaxPolySlab
+MAX_NUM_VERTICES = 1000
 
 
 class JaxGeometry(Geometry, ABC):
@@ -233,22 +238,26 @@ class JaxBox(JaxGeometry, Box, JaxObject):
                     if field_cmp_dim == dim_normal:
 
                         # construct normal D fields, dotted together at surface
-                        d_normal = d_mult_xyz[field_cmp_dim].interp(**normal_coord)
+                        d_normal = d_mult_xyz[field_cmp_dim]
+                        d_normal = d_normal.interp(**normal_coord, assume_sorted=True)
 
                         # compute adjoint contribution using perturbation theory for shifting bounds
                         delta_eps_inv = 1.0 / eps1 - 1.0 / eps2
-                        d_integrand = -(delta_eps_inv * d_normal).interp(**area_coords).real
+                        d_integrand = -(delta_eps_inv * d_normal).real
+                        d_integrand = d_integrand.interp(**area_coords, assume_sorted=True)
                         grad_contrib = d_area * jnp.sum(d_integrand.values)
 
                     # get gradient contribution for parallel components using parallel E fields
                     else:
 
                         # measure parallel E fields, dotted together at surface
-                        e_parallel = e_mult_xyz[field_cmp_dim].interp(**normal_coord)
+                        e_parallel = e_mult_xyz[field_cmp_dim]
+                        e_parallel = e_parallel.interp(**normal_coord, assume_sorted=True)
 
                         # compute adjoint contribution using perturbation theory for shifting bounds
                         delta_eps = eps1 - eps2
-                        e_integrand = +(delta_eps * e_parallel).interp(**area_coords).real
+                        e_integrand = +(delta_eps * e_parallel).real
+                        e_integrand = e_integrand.interp(**area_coords, assume_sorted=True)
                         grad_contrib = d_area * jnp.sum(e_integrand.values)
 
                     # add this field contribution to the dict storing the surface contributions
@@ -314,31 +323,40 @@ class JaxPolySlab(JaxGeometry, PolySlab, JaxObject):
 
     @pd.validator("sidewall_angle", always=True)
     def no_sidewall(cls, val):
-        """Overrides validator enforing that val is not inf."""
+        """Overrides validator enforcing that val is not inf."""
         if not np.isclose(val, 0.0):
             raise AdjointError("'JaxPolySlab' does not support slanted sidewall.")
         return val
 
     @pd.validator("dilation", always=True)
     def no_dilation(cls, val):
-        """Overrides validator enforing that val is not inf."""
+        """Overrides validator enforcing that val is not inf."""
         if not np.isclose(val, 0.0):
             raise AdjointError("'JaxPolySlab' does not support dilation.")
         return val
 
     @pd.validator("vertices", always=True)
     def correct_shape(cls, val):
-        """Overrides validator enforing that val is not inf."""
+        """Overrides validator enforcing that val is not inf."""
         return val
 
     @pd.validator("vertices", always=True)
     def no_self_intersecting_polygon_during_extrusion(cls, val, values):
-        """Overrides validator enforing that val is not inf."""
+        """Overrides validator enforcing that val is not inf."""
         return val
 
     @pd.validator("vertices", always=True)
     def no_complex_self_intersecting_polygon_at_reference_plane(cls, val, values):
-        """Overrides validator enforing that val is not inf."""
+        """Overrides validator enforcing that val is not inf."""
+        return val
+
+    @pd.validator("vertices", always=True)
+    def limit_number_of_vertices(cls, val):
+        """Limit the maximum number of vertices."""
+        if len(val) > MAX_NUM_VERTICES:
+            raise AdjointError(
+                f"For performance, a maximum of {MAX_NUM_VERTICES} are allowed in 'JaxPolySlab'."
+            )
         return val
 
     @cached_property
@@ -347,7 +365,183 @@ class JaxPolySlab(JaxGeometry, PolySlab, JaxObject):
         vertices = np.array(jax.lax.stop_gradient(self.vertices))
         return PolySlab._area(vertices) > 0
 
-    # pylint: disable=too-many-locals, too-many-arguments, too-many-statements, unused-argument
+    # pylint: disable=too-many-locals, too-many-arguments, too-many-statements
+    def edge_contrib(
+        self,
+        vertex_grad: Coordinate2D,
+        vertex_stat: Coordinate2D,
+        is_next: bool,
+        e_mult_xyz: Tuple[Dict[str, ScalarFieldDataArray]],
+        d_mult_xyz: Tuple[Dict[str, ScalarFieldDataArray]],
+        sim_bounds: Bound,
+        wvl_mat: float,
+        eps_out: complex,
+        eps_in: complex,
+    ) -> Coordinate2D:
+        """Gradient w.r.t change in `vertex_grad` connected to `vertex_stat`."""
+
+        # TODO: (later) compute these grabbing from grad_data_eps at some distance away
+        delta_eps_12 = eps_in - eps_out
+        delta_eps_inv_12 = 1.0 / eps_in - 1.0 / eps_out
+
+        # get edge pointing from moving vertex to static vertex
+        vertex_grad = np.array(jax.lax.stop_gradient(vertex_grad))
+        vertex_stat = np.array(jax.lax.stop_gradient(vertex_stat))
+        edge = vertex_stat - vertex_grad
+        length_edge = np.linalg.norm(edge)
+
+        # get normalized vectors tangent to and perpendicular to edge in global caresian basis
+        tx, ty = edge / length_edge
+        normal_vector = np.array((+ty, -tx))
+
+        # ensure normal vector is pointing "out" assuming clockwise vertices
+        if is_next:
+            normal_vector *= -1
+        nx, ny = normal_vector
+
+        # Check if vertices CCW or CW. Multiply by +1 if CCW to ensure normal out
+        if self.is_ccw:
+            normal_vector *= -1
+
+        def edge_position(s: np.array) -> np.array:
+            """Parameterization of position along edge from s=0 (static) to s=1 (gradient)."""
+            return (1 - s) * vertex_stat[:, None] + s * vertex_grad[:, None]
+
+        def edge_basis(
+            xyz_components: Tuple[FieldData, FieldData, FieldData]
+        ) -> Tuple[FieldData, FieldData, FieldData]:
+            """Puts a field component from the (x, y, z) basis to the (t, n, z) basis."""
+            cmp_z, (cmp_x_edge, cmp_y_edge) = self.pop_axis(xyz_components, axis=self.axis)
+
+            cmp_t = cmp_x_edge * tx + cmp_y_edge * ty
+            cmp_n = cmp_x_edge * nx + cmp_y_edge * ny
+
+            return cmp_t, cmp_n, cmp_z
+
+        def compute_integrand(s: np.array, z: np.array) -> np.array:
+            """Get integrand at positions `(s, z)` along the edge."""
+
+            # grab the position along edge and make dictionary of coords to interp with (s, z)
+            x, y = edge_position(s=s)
+            x = xr.DataArray(x, coords={"s": s})
+            y = xr.DataArray(y, coords={"s": s})
+            coords_interp = dict(x=x, y=y, z=z)
+
+            def evaluate(scalar_field: ScalarFieldDataArray) -> float:
+                """Evaluate a scalar field at a coordinate along the edge."""
+                scalar_field = scalar_field.isel(f=0)
+
+                # if only 1 z coordinate, just isel the data.
+                if len(z) == 1:
+                    scalar_field = scalar_field.isel(z=0)
+                    coords_xy = {key: coords_interp[key] for key in "xy"}
+                    return scalar_field.interp(**coords_xy, assume_sorted=True)
+
+                return scalar_field.interp(**coords_interp, assume_sorted=True)
+
+            e_xyz_eval = [evaluate(e_fld) for e_fld in e_mult_xyz.values()]
+            d_xyz_eval = [evaluate(d_fld) for d_fld in d_mult_xyz.values()]
+
+            e_t_edge, _, e_z_edge = edge_basis(xyz_components=e_xyz_eval)
+            _, d_n_edge, _ = edge_basis(xyz_components=d_xyz_eval)
+
+            # get the correct sign to apply to the new fields
+            sign_t, sign_n, sign_z = edge_basis(xyz_components=(1.0, 1.0, 1.0))
+            e_t_edge *= sign_t
+            d_n_edge *= sign_n
+            e_z_edge *= sign_z
+
+            # multiply by the change in epsilon (in, out) terms and sum contributions
+            contrib_e_t = delta_eps_12 * e_t_edge
+            contrib_e_z = delta_eps_12 * e_z_edge
+            contrib_d_n = -delta_eps_inv_12 * d_n_edge
+            contrib_total = contrib_e_t + contrib_d_n + contrib_e_z
+
+            # scale the gradient contribution by the normalized distange from the static edge
+            # make broadcasting work with both 2D and 3D simulation domains
+            return (s * contrib_total.T).T
+
+        # discretize along the edge
+        # TODO: handle edge case where a vertex lies far outside simulation domain
+        num_cells_edge = int(length_edge * PTS_PER_WVL_INTEGRATION / wvl_mat) + 1
+        ds = 1.0 / float(num_cells_edge)
+        s_vals = np.linspace(0 + ds / 2, 1 - ds / 2, num_cells_edge)
+
+        # find the min and max of the slab within the simulation bounds
+        slab_min, slab_max = self.slab_bounds
+        sim_rmin, sim_rmax = sim_bounds
+        sim_min = sim_rmin[self.axis]
+        sim_max = sim_rmax[self.axis]
+        z_max = min(slab_max, sim_max)
+        z_min = max(slab_min, sim_min)
+
+        # discretize along z
+        length_axis = abs(z_max - z_min)
+        num_cells_axis = int(length_axis * PTS_PER_WVL_INTEGRATION / wvl_mat) + 1
+        dz = float(length_axis) / float(num_cells_axis)
+
+        # handle a 2D simulation along axis (unitless)
+        z_vals = np.linspace(z_min + dz / 2, z_max - dz / 2, num_cells_axis)
+
+        if dz == 0.0:
+            dz = 1.0
+
+        # integrate by summing over axis edge (z) and parameterization point (s)
+        integrand = compute_integrand(s=s_vals, z=z_vals)
+        integral_result = np.sum(integrand.fillna(0).values)
+
+        # project to the normal direction
+        integral_result *= normal_vector
+
+        # take the real part (from adjoint math) and multiply by area element
+        return length_edge * ds * dz * np.real(integral_result)
+
+    # pylint: disable=too-many-arguments
+    def vertex_vjp(
+        self,
+        i_vertex,
+        e_mult_xyz: Tuple[Dict[str, ScalarFieldDataArray]],
+        d_mult_xyz: Tuple[Dict[str, ScalarFieldDataArray]],
+        sim_bounds: Bound,
+        wvl_mat: float,
+        eps_out: complex,
+        eps_in: complex,
+    ):
+        """Compute the vjp for every vertex."""
+
+        # get the location of the "previous" and "next" vertices in the polygon
+        vertex = self.vertices[i_vertex]
+        vertex_prev = self.vertices[(i_vertex - 1) % len(self.vertices)]
+        vertex_next = self.vertices[(i_vertex + 1) % len(self.vertices)]
+
+        # taking the current vertex "static", compute the edge contributions from prev and next
+        contrib_next = self.edge_contrib(
+            vertex_grad=vertex,
+            vertex_stat=vertex_next,
+            is_next=True,
+            e_mult_xyz=e_mult_xyz,
+            d_mult_xyz=d_mult_xyz,
+            sim_bounds=sim_bounds,
+            wvl_mat=wvl_mat,
+            eps_out=eps_out,
+            eps_in=eps_in,
+        )
+        contrib_prev = self.edge_contrib(
+            vertex_grad=vertex,
+            vertex_stat=vertex_prev,
+            is_next=False,
+            e_mult_xyz=e_mult_xyz,
+            d_mult_xyz=d_mult_xyz,
+            sim_bounds=sim_bounds,
+            wvl_mat=wvl_mat,
+            eps_out=eps_out,
+            eps_in=eps_in,
+        )
+
+        # add the "forward" contribution from the "previous" contribution to get the vertex VJP
+        return contrib_prev + contrib_next
+
+    # pylint: disable=too-many-arguments
     def store_vjp(
         self,
         grad_data_fwd: FieldData,
@@ -365,144 +559,22 @@ class JaxPolySlab(JaxGeometry, PolySlab, JaxObject):
             grad_data_fwd=grad_data_fwd, grad_data_adj=grad_data_adj, grad_data_eps=grad_data_eps
         )
 
-        # TODO: (later) compute these grabbing from grad_data_eps at some distance away
-        delta_eps_12 = eps_in - eps_out
-        delta_eps_inv_12 = 1.0 / eps_in - 1.0 / eps_out
+        # Construct arguments to pass to the parallel vertices_vjp computation
+        num_verts = len(self.vertices)
+        args = [range(num_verts)]
+        # append all of the arguments that are the same for each call
+        constant_args = [e_mult_xyz, d_mult_xyz, sim_bounds, wvl_mat, eps_out, eps_in]
+        args += [[arg] * num_verts for arg in constant_args]
 
-        def edge_contrib(
-            vertex_grad: Coordinate2D, vertex_stat: Coordinate2D, is_next: bool
-        ) -> Coordinate2D:
-            """Gradient w.r.t change in `vertex_grad` connected to `vertex_stat`."""
-
-            # get edge pointing from moving vertex to static vertex
-            vertex_grad = np.array(jax.lax.stop_gradient(vertex_grad))
-            vertex_stat = np.array(jax.lax.stop_gradient(vertex_stat))
-            edge = vertex_stat - vertex_grad
-            length_edge = np.linalg.norm(edge)
-
-            # get normalized vectors tangent to and perpendicular to edge in global caresian basis
-            tx, ty = edge / length_edge
-            normal_vector = np.array((+ty, -tx))
-
-            # ensure normal vector is pointing "out" assuming clockwise vertices
-            if is_next:
-                normal_vector *= -1
-            nx, ny = normal_vector
-
-            # Check if vertices CCW or CW. Multiply by +1 if CCW to ensure normal out
-            if self.is_ccw:
-                normal_vector *= -1
-
-            def edge_position(s: np.array) -> np.array:
-                """Parameterization of position along edge from s=0 (static) to s=1 (gradient)."""
-                return (1 - s) * vertex_stat[:, None] + s * vertex_grad[:, None]
-
-            def edge_basis(
-                xyz_components: Tuple[FieldData, FieldData, FieldData]
-            ) -> Tuple[FieldData, FieldData, FieldData]:
-                """Puts a field component from the (x, y, z) basis to the (t, n, z) basis."""
-                cmp_z, (cmp_x_edge, cmp_y_edge) = self.pop_axis(xyz_components, axis=self.axis)
-
-                cmp_t = cmp_x_edge * tx + cmp_y_edge * ty
-                cmp_n = cmp_x_edge * nx + cmp_y_edge * ny
-
-                return cmp_t, cmp_n, cmp_z
-
-            def compute_integrand(s: np.array, z: np.array) -> np.array:
-                """Get integrand at positions `(s, z)` along the edge."""
-
-                # grab the position along edge and make dictionary of coords to interp with (s, z)
-                x, y = edge_position(s=s)
-                x = xr.DataArray(x, coords={"s": s})
-                y = xr.DataArray(y, coords={"s": s})
-                coords_interp = dict(x=x, y=y, z=z)
-
-                def evaluate(scalar_field: ScalarFieldDataArray) -> float:
-                    """Evaluate a scalar field at a coordinate along the edge."""
-                    scalar_field = scalar_field.isel(f=0)
-
-                    # if only 1 z coordinate, just isel the data.
-                    if len(z) == 1:
-                        scalar_field = scalar_field.isel(z=0)
-                        return scalar_field.interp(x=coords_interp["x"], y=coords_interp["y"])
-
-                    return scalar_field.interp(**coords_interp)
-
-                e_xyz_eval = [evaluate(e_fld) for e_fld in e_mult_xyz.values()]
-                d_xyz_eval = [evaluate(d_fld) for d_fld in d_mult_xyz.values()]
-
-                e_t_edge, _, e_z_edge = edge_basis(xyz_components=e_xyz_eval)
-                _, d_n_edge, _ = edge_basis(xyz_components=d_xyz_eval)
-
-                # get the correct sign to apply to the new fields
-                sign_t, sign_n, sign_z = edge_basis(xyz_components=(1.0, 1.0, 1.0))
-                e_t_edge *= sign_t
-                d_n_edge *= sign_n
-                e_z_edge *= sign_z
-
-                # multiply by the change in epsilon (in, out) terms and sum contributions
-                contrib_e_t = delta_eps_12 * e_t_edge
-                contrib_e_z = delta_eps_12 * e_z_edge
-                contrib_d_n = -delta_eps_inv_12 * d_n_edge
-                contrib_total = contrib_e_t + contrib_d_n + contrib_e_z
-
-                # scale the gradient contribution by the normalized distange from the static edge
-                # make broadcasting work with both 2D and 3D simulation domains
-                return (s * contrib_total.T).T
-
-            # discretize along the edge
-            # TODO: handle edge case where a vertex lies far outside simulation domain
-            num_cells_edge = int(length_edge * PTS_PER_WVL_INTEGRATION / wvl_mat) + 1
-            ds = 1.0 / float(num_cells_edge)
-            s_vals = np.linspace(0 + ds / 2, 1 - ds / 2, num_cells_edge)
-
-            # find the min and max of the slab within the simulation bounds
-            slab_min, slab_max = self.slab_bounds
-            sim_rmin, sim_rmax = sim_bounds
-            sim_min = sim_rmin[self.axis]
-            sim_max = sim_rmax[self.axis]
-            z_max = min(slab_max, sim_max)
-            z_min = max(slab_min, sim_min)
-
-            # discretize along z
-            length_axis = abs(z_max - z_min)
-            num_cells_axis = int(length_axis * PTS_PER_WVL_INTEGRATION / wvl_mat) + 1
-            dz = float(length_axis) / float(num_cells_axis)
-
-            # handle a 2D simulation along axis (unitless)
-            z_vals = np.linspace(z_min + dz / 2, z_max - dz / 2, num_cells_axis)
-
-            if dz == 0.0:
-                dz = 1.0
-
-            # integrate by summing over axis edge (z) and parameterization point (s)
-            integrand = compute_integrand(s=s_vals, z=z_vals)
-            integral_result = np.sum(integrand.fillna(0).values)
-
-            # project to the normal direction
-            integral_result *= normal_vector
-
-            # take the real part (from adjoint math) and multiply by area element
-            return length_edge * ds * dz * np.real(integral_result)
-
-        def mod(num: int) -> int:
-            """Get index modulo number of vertices."""
-            return num % len(self.vertices)
-
-        # loop through vertices, compute gradient contributions from each edge, store
-        vertices_vjp = []
-        for i_vertex, vertex in enumerate(self.vertices):
-
-            # get the location of the "previous" and "next" vertices in the polygon
-            vertex_prev = self.vertices[mod(i_vertex - 1)]
-            vertex_next = self.vertices[mod(i_vertex + 1)]
-
-            # taking the current vertex "static", compute the edge contributions from prev and next
-            contrib_next = edge_contrib(vertex_grad=vertex, vertex_stat=vertex_next, is_next=True)
-            contrib_prev = edge_contrib(vertex_grad=vertex, vertex_stat=vertex_prev, is_next=False)
-
-            # add the "forward" contribution from the "previous" contibution to get the vertex VJP
-            vertices_vjp.append(contrib_prev + contrib_next)
+        try:
+            # Try to use multiprocessing over polygon vertices.
+            # Use only half of the available cpus in case there is something else running.
+            num_proc = max(1, os.cpu_count() // 2)
+            with Pool(num_proc) as p:
+                vertices_vjp = p.starmap(self.vertex_vjp, zip(*args))
+        except Exception:  # pylint:disable=broad-except
+            # Compute without parallel pool
+            vertices_vjp = list(map(self.vertex_vjp, *args))
 
         # return copy of the polyslab with the vertices storing the
         return self.copy(update=dict(vertices=vertices_vjp))

--- a/tidy3d/plugins/adjoint/components/medium.py
+++ b/tidy3d/plugins/adjoint/components/medium.py
@@ -110,7 +110,7 @@ class JaxMedium(Medium, JaxObject):
             if isinstance(value, float) or len(value) <= 1
         }
         interp_kwargs = {key: value for key, value in vol_coords.items() if key not in isel_kwargs}
-        integrand = e_dotted.isel(f=0, **isel_kwargs).interp(**interp_kwargs)
+        integrand = e_dotted.isel(f=0, **isel_kwargs).interp(**interp_kwargs, assume_sorted=True)
 
         # mask out any contributions not inside the structure volume
         inside_mask = self.make_inside_mask(vol_coords=vol_coords, inside_fn=inside_fn)
@@ -314,7 +314,8 @@ class JaxCustomMedium(CustomMedium, JaxObject):
             # interpolate into the forward and adjoint fields along this dimension and dot them
             e_fwd = grad_data_fwd.field_components[field_name]
             e_adj = grad_data_adj.field_components[field_name]
-            e_dotted = (e_fwd * e_adj).isel(f=0, **isel_coords).interp(**interp_coords)
+            e_dotted = (e_fwd * e_adj).isel(f=0, **isel_coords)
+            e_dotted = e_dotted.interp(**interp_coords, assume_sorted=True)
 
             # compute the size of the user-supplied medium along each dimension.
             grid = grids[eps_field_name]


### PR DESCRIPTION
In the adjoint vjp timing test, this reduces the run time for 1000 vertices from 120s to 14s on my machine.

To-dos:

- [x] See if matplotlib will be what we go with for `PolySlab.inside`. Move import to top level and remove commented out old handling.
- [x] I would suggest still restricting the adjoint polyslabs to 1000 vertices for now - figure out where exactly to add this validation @tylerflex ?
- [x] I had to rearrange functions a bit in order to use multiprocessing, such that the namespace of the `store_vjp` methods couldn't be reused. Any thoughts on handling better the large list of arguments being passed around?