### PR TITLE
Remove Medium2D as allowed for Simulation.medium in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Log messages provide the correct caller origin (file name and line number).
+- `Medium2D` is removed from the list of allowed options for `Simulation.medium` in the documentation.
 
 ## [2.1.1] - 2023-4-25
 

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -1472,7 +1472,7 @@ def test_sim_volumetric_structures():
     assert np.isclose(sim.volumetric_structures[1].medium.xx.permittivity, 2, rtol=RTOL)
 
     # test simulation.medium can't be Medium2D
-    with pytest.raises(Exception):
+    with pytest.raises(pydantic.ValidationError):
         sim = td.Simulation(
             size=(10, 10, 10),
             structures=[],
@@ -1488,16 +1488,16 @@ def test_sim_volumetric_structures():
         )
 
     # test 2d medium is added to 2d geometry
-    with pytest.raises(Exception):
+    with pytest.raises(pydantic.ValidationError):
         _ = td.Structure(geometry=td.Box(center=(0, 0, 0), size=(1, 1, 1)), medium=box.medium)
-    with pytest.raises(Exception):
+    with pytest.raises(pydantic.ValidationError):
         _ = td.Structure(geometry=td.Cylinder(radius=1, length=1), medium=box.medium)
-    with pytest.raises(Exception):
+    with pytest.raises(pydantic.ValidationError):
         _ = td.Structure(
             geometry=td.PolySlab(vertices=[(0, 0), (1, 0), (1, 1)], slab_bounds=(-1, 1)),
             medium=box.medium,
         )
-    with pytest.raises(Exception):
+    with pytest.raises(pydantic.ValidationError):
         _ = td.Structure(geometry=td.Sphere(radius=1), medium=box.medium)
 
 

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -125,7 +125,7 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
         units=SECOND,
     )
 
-    medium: MediumType = pydantic.Field(
+    medium: MediumType3D = pydantic.Field(
         Medium(),
         title="Background Medium",
         description="Background medium of simulation, defaults to vacuum if not specified.",
@@ -232,13 +232,6 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
         # otherwise, call the updator to update the values dictionary
         updater = Updater(sim_dict=values)
         return updater.update_to_current()
-
-    @pydantic.validator("medium", always=True)
-    def _validate_medium(cls, val):
-        """Check that the medium is not a :class:`.Medium2D`."""
-        if isinstance(val, Medium2D):
-            raise ValidationError("'Simulation.medium' cannot be a 'Medium2D'.")
-        return val
 
     @pydantic.validator("grid_spec", always=True)
     def _validate_auto_grid_wavelength(cls, val, values):


### PR DESCRIPTION
See https://github.com/flexcompute/tidy3d/issues/875
