### PR TITLE
Bumping maximum allowed projected data size to 50GB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Perfect electric conductors (PECs) are now modeled as high-conductivity media in both the frontend and backend mode solvers, and their presence triggers the use of a preconditioner to improve numerical stability and robustness. Consequently, the mode solver provides more accurate eigenvectors and field distributions when PEC structures are present.
 - Include source amplitude in `amp_time`.
+- Increased the maximum allowed estimated simulation data storage to 50GB. Individual monitors with projected data larger than 10GB will trigger a warning.
 
 ### Fixed
 - Log messages provide the correct caller origin (file name and line number).

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -446,8 +446,16 @@ def test_validate_size_spatial_and_time(monkeypatch):
         s._validate_size()
 
 
-def test_validate_mnt_size(monkeypatch):
-    monkeypatch.setattr(simulation, "MAX_MONITOR_DATA_SIZE_BYTES", 1)
+def test_validate_mnt_size(monkeypatch, log_capture):
+
+    # warning for monitor size
+    monkeypatch.setattr(simulation, "WARN_MONITOR_DATA_SIZE_GB", 1 / 2**30)
+    s = SIM.copy(update=dict(monitors=(td.FieldMonitor(name="f", freqs=[1], size=(1, 1, 1)),)))
+    s._validate_monitor_size()
+    assert_log_level(log_capture, "WARNING")
+
+    # error for simulation size
+    monkeypatch.setattr(simulation, "MAX_SIMULATION_DATA_SIZE_GB", 1 / 2**30)
     with pytest.raises(SetupError):
         s = SIM.copy(update=dict(monitors=(td.FieldMonitor(name="f", freqs=[1], size=(1, 1, 1)),)))
         s._validate_monitor_size()


### PR DESCRIPTION
Fixes #873 .

@tomflexcompute actually you were right, I thought that the current limit was per monitor but it was actually for the full simulation. I made the modifications as we discussed and made user messages show things in GB which I think makes more sense.