### PR TITLE
Fix syntax bug in mode solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Bug in `ModeSolver` which was causing a preconditioner to be applied even when it is not needed.
 
 ## [2.2.1] - 2023-5-23
 

--- a/tidy3d/plugins/mode/solver.py
+++ b/tidy3d/plugins/mode/solver.py
@@ -336,7 +336,7 @@ class EigSolver(Tidy3dBaseModel):
             """Check if there are any PEC values in the given permittivity array."""
             return np.any(np.abs(eps_vec) >= threshold)
 
-        if np.any(any_pec(i) for i in [eps_xx, eps_yy, eps_zz]):
+        if any(any_pec(i) for i in [eps_xx, eps_yy, eps_zz]):
             enable_preconditioner = True
 
         # Compute the matrix for diagonalization


### PR DESCRIPTION
Fixed a very silly bug in the recent mode solver improvements which was causing the preconditioner to always be applied.