### PR TITLE
Warning info attempt

### DIFF
--- a/tests/_test_warning_info.py
+++ b/tests/_test_warning_info.py
@@ -1,0 +1,96 @@
+# standard python imports
+import numpy as np
+import matplotlib.pyplot as plt
+
+# tidy3d imports
+import tidy3d as td
+import tidy3d.web as web
+
+# Define material properties
+medium = td.Medium(permittivity=3)
+
+wavelength = 1
+f0 = td.C_0 / wavelength / np.sqrt(medium.permittivity)
+
+# Set the domain size in x, y, and z
+domain_size = 12 * wavelength
+
+# create the geometry
+geometry = []
+
+# construct simulation size array
+sim_size = (domain_size, domain_size, domain_size)
+
+# Bandwidth in Hz
+fwidth = f0 / 10.0
+
+source_time = td.GaussianPulse(freq0=f0, fwidth=fwidth)
+
+run_time = 10 / fwidth
+
+freqs = np.linspace(f0 - fwidth, f0 + fwidth, 11)
+
+dipole = td.PointDipole(
+    center=(0, 0, 0),
+    source_time=source_time,
+    polarization="Ex",
+)
+
+monitor_xz_time = td.FieldTimeMonitor(
+    center=(0, 0, 0), size=(domain_size, 0, domain_size), interval=50, name="xz_time"
+)
+
+monitor_flux = td.FluxMonitor(
+    center=(0, 0, 0),
+    size=(8, 8, 8),
+    freqs=freqs,
+    name="flux",
+    normal_dir="+",  # warning
+)
+
+box1 = td.Structure(
+    geometry=td.Box(center=(0, 0, 0), size=(11.5, 11.5, 11.5)),  # warning
+    medium=td.Medium(permittivity=4),
+)
+
+box2 = td.Structure(
+    geometry=td.Box(center=(0, 0, 0), size=(5, 5, 5)),
+    medium=td.Medium(permittivity=5),
+)
+
+box3 = td.Structure(
+    geometry=td.Box(center=(0, 0, 0), size=(1, 1, 1)),
+    medium=td.Medium(permittivity=6),
+)
+
+
+# define a basic boundary spec setting PML in all directions
+bspec_pml = td.BoundarySpec.all_sides(boundary=td.PML())
+
+source = td.GaussianBeam(
+   center=(4, 0, 0),
+   size=(0, 8, 9),
+   waist_radius=2.0,
+   waist_distance=1,
+   source_time=td.GaussianPulse(freq0=f0, fwidth=fwidth, amplitude=1),
+   direction="+",
+   angle_theta=0,
+   angle_phi=0,
+   pol_angle=0,
+   num_freqs=30,  # warning
+)
+
+sim = td.Simulation(
+   size=sim_size,
+   sources=[source],
+   structures=[box1, box2, box3],
+   monitors=[monitor_xz_time, monitor_flux],
+   run_time=run_time,
+   boundary_spec=bspec_pml,
+   grid_spec=td.GridSpec.uniform(dl=0.04),
+   shutoff=1e-10,
+)
+
+# write and load to trigger whole hierarchy parsing
+sim.to_file("test_sim.json")
+sim = td.Simulation.from_file("test_sim.json")

--- a/tidy3d/log.py
+++ b/tidy3d/log.py
@@ -63,6 +63,9 @@ class Logger:
     def __init__(self):
         self.handlers = {}
 
+        # for tracing
+        self.trace = None
+
     def _log(self, level: int, level_name: str, message: str, *args) -> None:
         """Distribute log messages to all handlers"""
         if len(args) > 0:
@@ -75,6 +78,11 @@ class Logger:
             composed_message = str(message)
         for handler in self.handlers.values():
             handler.handle(level, level_name, composed_message)
+
+        # if tracing is on, record for tracing purposes
+        # for now just record everything
+        if self.trace:
+            self.trace["logs"].append((level_name, message))
 
     def log(self, level: LogValue, message: str, *args) -> None:
         """Log (message) % (args) with given level"""


### PR DESCRIPTION
Wanted to get some opinions on this attempt to trace warning info during object initialization @tylerflex, @momchil-flex 

Basically, the idea is to have a dict `trace` in logger in which:
1. objects (any derivative of `Tidy3dBaseModel`) write hierarchically their info when they get initialized
2. logger write warnings (and anything else if needed)

so that it allows to trace where each of the warnings occurred exactly. It's only initialized and used during `Tidy3dBaseModel.__init__()` and cleared out after it is finished. In some more detail, for each initialized object we store hierarchically three lists/dicts: 
- "children": hashes of initialized children objects 
- "logs": warnings occured during initialization
- "fields": names of parent's fields pointing at the current object (could be multiple if fields point at the same object)

This is what I get in `tests/_test_warning_info.py`:
```
{
    "3935611705871406881": {
        "children": {
            "4411795910099000673": {
                "children": {},
                "logs": [
                    [
                        "WARNING",
                        "A large number (30) of frequency points is used in a broadband source. This can slow down simulation time and is only needed if the mode fields are expected to have a very sharp frequency dependence. 'num_freqs' < 20 is sufficient in most cases."
                    ]
                ],
                "fields": [
                    [
                        "sources",
                        0
                    ]
                ],
                "type": "GaussianBeam"
            },
            "-4149933756106994820": {
                "children": {},
                "logs": [
                    [
                        "WARNING",
                        "The ``normal_dir`` field is relevant only for surface monitors and will be ignored for monitor flux, which is a box."
                    ]
                ],
                "fields": [
                    [
                        "monitors",
                        1
                    ]
                ],
                "type": "FluxMonitor"
            }
        },
        "logs": [
            [
                "WARNING",
                "Structure at structures[0] was detected as being less than half of a central wavelength from a PML on side x-min. To avoid inaccurate results, please increase gap between any structures and PML or fully extend structure through the pml. Skipping check for structure indexes > 0."
            ]
        ],
        "fields": [],
        "type": "Simulation"
    }
}
```
With some processing we can easily reconstruct
```
sim -> sources -> 0 -> (GaussianBeam) "A large number (30) of frequency points is used in a broadband source. This can slow down simulation time and is only needed if the mode fields are expected to have a very sharp frequency dependence. 'num_freqs' < 20 is sufficient in most cases."
```
```
sim -> monitors -> 1 -> (FluxMonitor) "The ``normal_dir`` field is relevant only for surface monitors and will be ignored for monitor flux, which is a box."
```
```
sim -> (Simulation) "Structure at structures[0] was detected as being less than half of a central wavelength from a PML on side x-min. To avoid inaccurate results, please increase gap between any structures and PML or fully extend structure through the pml. Skipping check for structure indexes > 0."
```
which kind of mimics pydantic info.

Not sure exactly if this would impact performance, maybe the best to access this experimentally. If you don't see any major downsides, red flags, we could probably work on this further.

By the way, currently we don't have many warnings in initialization of Simulation components, maybe just one or two more to the two already shown above. Most of warnings are at Simulation level, i.e., based on interplay between different components.