### PR TITLE
Out-of-bounds TFSF surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- A bug in a total-field scattered-field (TFSF) validator which was causing unnecessary errors when a TFSF surface intersected with 2D materials.
 
 ## [2.2.1] - 2023-5-23
 

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -975,6 +975,10 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
             sidewall_structs = []
             # get the structures that intersect each sidewall
             for surface in tfsf_surfaces:
+                # ignore the sidewall surface if it falls outside the simulation domain
+                if not self.intersects(surface):
+                    continue
+
                 if surface.name[-2] != "xyz"[source.injection_axis]:
                     sidewall_surfaces.append(surface)
                     intersecting_structs = self.intersecting_structures(


### PR DESCRIPTION
Ignore TFSF surfaces outside the simulation domain in the intersections validator.