### PR TITLE
fix custom dispersive medium IO with nested data arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Proper handling of nested list of custom data components in IO, needed for custom dispersive medium coefficients.
 
 ## [2.2.1] - 2023-5-23
 

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from functools import wraps
+from typing import Any
 
 import rich
 import pydantic
@@ -430,6 +431,10 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         >>> sim_dict = Simulation.dict_from_hdf5(fname='folder/sim.hdf5') # doctest: +SKIP
         """
 
+        def is_data_array(value: Any) -> bool:
+            """Whether a value is supposed to be a data array based on the contents."""
+            return isinstance(value, str) and value in DATA_ARRAY_MAP
+
         def load_data_from_file(model_dict: dict, group_path: str = "") -> None:
             """For every DataArray item in dictionary, load path of hdf5 group as value."""
 
@@ -438,15 +443,22 @@ class Tidy3dBaseModel(pydantic.BaseModel):
                 subpath = f"{group_path}/{key}"
 
                 # write the path to the element of the json dict where the data_array should be
-                if isinstance(value, str) and value in DATA_ARRAY_MAP:
+                if is_data_array(value):
                     data_array_type = DATA_ARRAY_MAP[value]
                     model_dict[key] = data_array_type.from_hdf5(fname=fname, group_path=subpath)
                     continue
 
                 # if a list, assign each element a unique key, recurse
                 if isinstance(value, (list, tuple)):
+
                     value_dict = cls.tuple_to_dict(tuple_values=value)
                     load_data_from_file(model_dict=value_dict, group_path=subpath)
+
+                    # handle case of nested list of DataArray elements
+                    val_tuple = list(value_dict.values())
+                    for ind, (model_item, value_item) in enumerate(zip(model_dict[key], val_tuple)):
+                        if is_data_array(model_item):
+                            model_dict[key][ind] = value_item
 
                 # if a dict, recurse
                 elif isinstance(value, dict):


### PR DESCRIPTION
Fixes the IO issue by adding a special handling for nested lists containing DataArray. Turns out the recursive algorithm wasn't handling this case properly and it wasn't really caught because we didn't have any instances like this to worry about until now.