### PR TITLE
Retry connection in adjiont web functions

### DIFF
--- a/tidy3d/plugins/adjoint/web.py
+++ b/tidy3d/plugins/adjoint/web.py
@@ -10,6 +10,7 @@ from jax.tree_util import register_pytree_node_class
 from ...components.simulation import Simulation
 from ...components.data.sim_data import SimulationData
 from ...web.webapi import run as web_run
+from ...web.webapi import wait_for_connection
 from ...web.s3utils import download_file, upload_file
 from ...web.asynchronous import run_async as web_run_async
 from ...web.container import BatchData, DEFAULT_DATA_DIR, Job, Batch
@@ -190,6 +191,7 @@ def run_bwd(
 """TO DO: IMPLEMENT this section IN WEBAPI """
 
 
+@wait_for_connection
 def upload_jax_info(jax_info: JaxInfo, task_id: str, verbose: bool) -> None:
     """Upload jax_info for a task with a given task_id."""
 
@@ -204,6 +206,7 @@ def upload_jax_info(jax_info: JaxInfo, task_id: str, verbose: bool) -> None:
     )
 
 
+@wait_for_connection
 def download_sim_vjp(task_id: str, verbose: bool) -> JaxSimulation:
     """Download the vjp loaded simulation from the server to return to jax."""
 


### PR DESCRIPTION
The adjoint web functions can time out on e.g. upload of the jax info, or download of the sim_vjp. This is one way to fix it - another one would be to add the decorator to some of the base tidy3d.web.s3utils functions like upload_file and download_file.