### PR TITLE
Fix overlap calculation for FieldData (#423)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Plotting 2D materials in `SimulationData.plot_field` and other circumstances.
 - More segments in plotting of large cylinder and sphere cross-sections.
 - Proper handling of nested list of custom data components in IO, needed for custom dispersive medium coefficients.
+- `ElectromagneticFieldData.outer_dot` now works correctly for `FieldData`, not only `ModeSolverData`.
 
 ## [2.2.2] - 2023-5-25
 

--- a/tests/test_data/test_monitor_data.py
+++ b/tests/test_data/test_monitor_data.py
@@ -510,3 +510,12 @@ def test_mode_solver_numerical_grid_data():
             max_diff = np.amax(np.abs(np.abs(field) - np.abs(tan_fields[comp])))
             max_diff /= np.amax(np.abs(field))
             assert 0.1 > max_diff > 0
+
+
+def test_outer_dot():
+    mode_data = make_mode_solver_data()
+    field_data = make_field_data_2d()
+    _ = mode_data.outer_dot(mode_data)
+    _ = field_data.outer_dot(mode_data)
+    _ = mode_data.outer_dot(field_data)
+    _ = field_data.outer_dot(field_data)

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -490,8 +490,8 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
 
         Returns
         -------
-        :class:`.MixedModeDataArray`
-            Dataset with the complex-valued modal overlaps between the two mode data.
+        :class:`xarray.DataArray`
+            Data array with the complex-valued modal overlaps between the two mode data.
 
         See also
         --------
@@ -566,7 +566,7 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
                     dot[i, mi0, mi1] = 0.25 * integrand.sum(dim=d_area.dims)
 
         coords = {"f": f, "mode_index_0": mode_index_0, "mode_index_1": mode_index_1}
-        result = MixedModeDataArray(dot, coords=coords)
+        result = xr.DataArray(dot, coords=coords)
 
         # Remove mode index coordinate if the input did not have it
         if not modes_in_self:


### PR DESCRIPTION
Skip selection by mode_index when it doesn't exist in the input and remove it from the output.