### PR TITLE
Fixing pml profiles in mode solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More segments in plotting of large cylinder and sphere cross-sections.
 - Proper handling of nested list of custom data components in IO, needed for custom dispersive medium coefficients.
 - `ElectromagneticFieldData.outer_dot` now works correctly for `FieldData`, not only `ModeSolverData`.
+- Fix to the setting of the mode solver PML parameters that produces better results for modes which do not decay in the PML, and fewer spurious modes.
 
 ## [2.2.2] - 2023-5-25
 

--- a/tests/sims/simulation_2_3_0rc1.json
+++ b/tests/sims/simulation_2_3_0rc1.json
@@ -14,6 +14,7 @@
     "medium": {
         "name": null,
         "frequency_range": null,
+        "allow_gain": false,
         "type": "Medium",
         "permittivity": 1.0,
         "conductivity": 0.0
@@ -43,6 +44,7 @@
             "medium": {
                 "name": null,
                 "frequency_range": null,
+                "allow_gain": false,
                 "type": "Medium",
                 "permittivity": 2.0,
                 "conductivity": 0.0
@@ -67,6 +69,7 @@
             "medium": {
                 "name": null,
                 "frequency_range": null,
+                "allow_gain": false,
                 "type": "Medium",
                 "permittivity": 1.0,
                 "conductivity": 3.0
@@ -87,6 +90,7 @@
             "medium": {
                 "name": null,
                 "frequency_range": null,
+                "allow_gain": false,
                 "type": "Sellmeier",
                 "coeffs": [
                     [
@@ -119,6 +123,7 @@
             "medium": {
                 "name": null,
                 "frequency_range": null,
+                "allow_gain": false,
                 "type": "Lorentz",
                 "eps_inf": 2.0,
                 "coeffs": [
@@ -149,6 +154,7 @@
             "medium": {
                 "name": null,
                 "frequency_range": null,
+                "allow_gain": false,
                 "type": "Debye",
                 "eps_inf": 2.0,
                 "coeffs": [
@@ -178,6 +184,7 @@
             "medium": {
                 "name": null,
                 "frequency_range": null,
+                "allow_gain": false,
                 "type": "Drude",
                 "eps_inf": 2.0,
                 "coeffs": [
@@ -207,10 +214,12 @@
             "medium": {
                 "name": null,
                 "frequency_range": null,
+                "allow_gain": false,
                 "type": "Medium2D",
                 "ss": {
                     "name": null,
                     "frequency_range": null,
+                    "allow_gain": false,
                     "type": "PoleResidue",
                     "eps_inf": 1.0,
                     "poles": [
@@ -229,6 +238,7 @@
                 "tt": {
                     "name": null,
                     "frequency_range": null,
+                    "allow_gain": false,
                     "type": "PoleResidue",
                     "eps_inf": 1.0,
                     "poles": [
@@ -270,6 +280,7 @@
             "medium": {
                 "name": "PEC",
                 "frequency_range": null,
+                "allow_gain": false,
                 "type": "PECMedium"
             }
         },
@@ -292,10 +303,12 @@
             "medium": {
                 "name": null,
                 "frequency_range": null,
+                "allow_gain": null,
                 "type": "AnisotropicMedium",
                 "xx": {
                     "name": null,
                     "frequency_range": null,
+                    "allow_gain": false,
                     "type": "Medium",
                     "permittivity": 1.0,
                     "conductivity": 0.0
@@ -303,6 +316,7 @@
                 "yy": {
                     "name": null,
                     "frequency_range": null,
+                    "allow_gain": false,
                     "type": "Medium",
                     "permittivity": 2.0,
                     "conductivity": 0.0
@@ -310,6 +324,7 @@
                 "zz": {
                     "name": null,
                     "frequency_range": null,
+                    "allow_gain": false,
                     "type": "Medium",
                     "permittivity": 3.0,
                     "conductivity": 0.0
@@ -347,6 +362,7 @@
             "medium": {
                 "name": null,
                 "frequency_range": null,
+                "allow_gain": false,
                 "type": "PoleResidue",
                 "eps_inf": 1.0,
                 "poles": [
@@ -376,6 +392,7 @@
             "medium": {
                 "name": null,
                 "frequency_range": null,
+                "allow_gain": false,
                 "type": "Medium",
                 "permittivity": 5.0,
                 "conductivity": 0.0
@@ -1459,6 +1476,7 @@
                 "medium": {
                     "name": null,
                     "frequency_range": null,
+                    "allow_gain": false,
                     "type": "Medium",
                     "permittivity": 2.0,
                     "conductivity": 0.0

--- a/tidy3d/plugins/mode/derivatives.py
+++ b/tidy3d/plugins/mode/derivatives.py
@@ -139,24 +139,26 @@ def create_sfactor(direction, omega, dls, N, n_pml, dmin_pml):
 
 
 def create_sfactor_f(omega, dls, N, n_pml, dmin_pml):
-    """S-factor profile for forward derivative matrix"""
+    """S-factor profile applied after forward derivative matrix, i.e. applied to H-field
+    locations."""
     sfactor_array = np.ones(N, dtype=np.complex128)
     for i in range(N):
-        if i <= n_pml and dmin_pml:
-            sfactor_array[i] = s_value(dls[0], (n_pml - i + 0.5) / n_pml, omega)
-        elif i > N - n_pml:
-            sfactor_array[i] = s_value(dls[-1], (i - (N - n_pml) - 0.5) / n_pml, omega)
+        if i <= n_pml - 1 and dmin_pml:
+            sfactor_array[i] = s_value(dls[0], (n_pml - i - 0.5) / n_pml, omega)
+        elif i >= N - n_pml:
+            sfactor_array[i] = s_value(dls[-1], (i - (N - n_pml) + 0.5) / n_pml, omega)
     return sfactor_array
 
 
 def create_sfactor_b(omega, dls, N, n_pml, dmin_pml):
-    """S-factor profile for backward derivative matrix"""
+    """S-factor profile applied after backward derivative matrix, i.e. applied to E-field
+    locations."""
     sfactor_array = np.ones(N, dtype=np.complex128)
     for i in range(N):
-        if i <= n_pml and dmin_pml:
-            sfactor_array[i] = s_value(dls[0], (n_pml - i + 1) / n_pml, omega)
+        if i < n_pml and dmin_pml:
+            sfactor_array[i] = s_value(dls[0], (n_pml - i) / n_pml, omega)
         elif i > N - n_pml:
-            sfactor_array[i] = s_value(dls[-1], (i - (N - n_pml) - 1) / n_pml, omega)
+            sfactor_array[i] = s_value(dls[-1], (i - (N - n_pml)) / n_pml, omega)
     return sfactor_array
 
 


### PR DESCRIPTION
Something was slightly off in the pml profiles set in the mode solver. I have updated them to what seems correct to me and added a test. This improved a lot the non-orthogonality for modes that have strong component in the PML as discussed [here](https://github.com/flexcompute/tidy3d/issues/423#issuecomment-1586016544). Also it improved the modes when the underlying structure is effectively symmetric, without a symmetry being explicitly defined.