### PR TITLE
adjoint differentiable `.interp` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `s3utils.get_s3_sts_token` accepts extra query parameters.
 - `plugins.mode.web` to control the server-side mode solver.
 - Support for `JaxDataArray.interp`, allowing differentiable linear interpolation.
+- Support for `JaxSimulationData.get_intensity()`, allowing intensity distribution to be differentiated in `adjoint` plugin.
 
 ### Changed
 - Add `Medium2D` to full simulation in tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `estimate_cost()` method for `Job` and `Batch`.
 - `s3utils.get_s3_sts_token` accepts extra query parameters.
 - `plugins.mode.web` to control the server-side mode solver.
+- Support for `JaxDataArray.interp`, allowing differentiable linear interpolation.
 
 ### Changed
 - Add `Medium2D` to full simulation in tests.

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -321,6 +321,10 @@ def extract_amp(sim_data: td.SimulationData) -> complex:
     mnt_name = MNT_NAME + "3"
     mnt_data = sim_data[mnt_name]
     ret_value += jnp.sum(jnp.array(mnt_data.Ex.values))
+    ret_value += jnp.sum(jnp.array(mnt_data.Ex.interp(z=0).values))
+
+    # this should work when we figure out a jax version of xr.DataArray
+    # sim_data.get_intensity(mnt_name)
 
     # FieldData (dipole)
     mnt_name = MNT_NAME + "4"
@@ -350,7 +354,7 @@ def use_emulated_run_async(monkeypatch):
     monkeypatch.setattr(adjoint_web, "webapi_run_async_adjoint_bwd", run_async_emulated_bwd)
 
 
-@pytest.mark.parametrize("local", (True, False))
+@pytest.mark.parametrize("local", (True,))  # False))
 def test_adjoint_pipeline(local, use_emulated_run):
     """Test computing gradient using jax."""
 
@@ -374,7 +378,7 @@ def test_adjoint_pipeline(local, use_emulated_run):
 
 
 @pytest.mark.parametrize("local", (True, False))
-def test_adjoint_pipeline_2d(local, use_emulated_run):
+def _test_adjoint_pipeline_2d(local, use_emulated_run):
 
     run_fn = run_local if local else run
 
@@ -630,6 +634,9 @@ def test_jax_data_array():
     _ = da.imag
     _ = da.as_list
 
+    # isel multi
+    z = da.isel(a=1, b=[0, 1], c=0)
+
     # isel
     z = da.isel(a=1, b=1, c=0)
     z = da.isel(c=0, b=1, a=1)
@@ -655,8 +662,19 @@ def test_jax_data_array():
         da.sel(c=5)
 
     # not implemented
-    with pytest.raises(NotImplementedError):
-        da.interp(b=2.5)
+    # with pytest.raises(NotImplementedError):
+    da.interp(b=2.5)
+
+    assert np.isclose(da.interp(a=2, b=3, c=4), values[1, 1, 0])
+    assert np.isclose(da.interp(a=1, b=2, c=4), values[0, 0, 0])
+
+    with pytest.raises(Tidy3dKeyError):
+        da.interp(d=3)
+
+    # assert np.isclose(da.interp(a=1.5, b=2, c=4), (values[1, 0, 0] + values[0, 0, 0]) / 2)
+
+    da1d = JaxDataArray(values=[0.0, 1.0, 2.0, 3.0], coords=dict(x=[0, 1, 2, 3]))
+    assert np.isclose(da1d.interp(x=0.5), 0.5)
 
 
 def test_jax_sim_data(use_emulated_run):

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -270,7 +270,7 @@ def make_sim(
     sim = JaxSimulation(
         size=(10, 10, 10),
         run_time=1e-12,
-        grid_spec=td.GridSpec(wavelength=1.0),
+        grid_spec=td.GridSpec(wavelength=4.0),
         monitors=(extraneous_field_monitor,),
         structures=(extraneous_structure,),
         input_structures=(
@@ -324,7 +324,7 @@ def extract_amp(sim_data: td.SimulationData) -> complex:
     ret_value += jnp.sum(jnp.array(mnt_data.Ex.interp(z=0).values))
 
     # this should work when we figure out a jax version of xr.DataArray
-    # sim_data.get_intensity(mnt_name)
+    sim_data.get_intensity(mnt_name)
 
     # FieldData (dipole)
     mnt_name = MNT_NAME + "4"
@@ -354,7 +354,7 @@ def use_emulated_run_async(monkeypatch):
     monkeypatch.setattr(adjoint_web, "webapi_run_async_adjoint_bwd", run_async_emulated_bwd)
 
 
-@pytest.mark.parametrize("local", (True,))  # False))
+@pytest.mark.parametrize("local", (True, False))
 def test_adjoint_pipeline(local, use_emulated_run):
     """Test computing gradient using jax."""
 
@@ -378,7 +378,7 @@ def test_adjoint_pipeline(local, use_emulated_run):
 
 
 @pytest.mark.parametrize("local", (True, False))
-def _test_adjoint_pipeline_2d(local, use_emulated_run):
+def test_adjoint_pipeline_2d(local, use_emulated_run):
 
     run_fn = run_local if local else run
 
@@ -661,8 +661,6 @@ def test_jax_data_array():
     with pytest.raises(DataError):
         da.sel(c=5)
 
-    # not implemented
-    # with pytest.raises(NotImplementedError):
     da.interp(b=2.5)
 
     assert np.isclose(da.interp(a=2, b=3, c=4), values[1, 1, 0])
@@ -670,8 +668,6 @@ def test_jax_data_array():
 
     with pytest.raises(Tidy3dKeyError):
         da.interp(d=3)
-
-    # assert np.isclose(da.interp(a=1.5, b=2, c=4), (values[1, 0, 0] + values[0, 0, 0]) / 2)
 
     da1d = JaxDataArray(values=[0.0, 1.0, 2.0, 3.0], coords=dict(x=[0, 1, 2, 3]))
     assert np.isclose(da1d.interp(x=0.5), 0.5)

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Union, Dict, Callable
+from typing import Union, Dict, Callable, Any
 
 import xarray as xr
 import numpy as np
@@ -39,6 +39,10 @@ class AbstractFieldDataset(Dataset, ABC):
     @abstractmethod
     def symmetry_eigenvalues(self) -> Dict[str, Callable[[Axis], float]]:
         """Maps field components to their (positive) symmetry eigenvalues."""
+
+    def package_colocate_results(self, centered_fields: Dict[str, ScalarFieldDataArray]) -> Any:
+        """How to package the dictionary of fields computed via self.colocate()."""
+        return xr.Dataset(centered_fields)
 
     def colocate(self, x=None, y=None, z=None) -> xr.Dataset:
         """colocate all of the data at a set of x, y, z coordinates.
@@ -93,7 +97,7 @@ class AbstractFieldDataset(Dataset, ABC):
             )
 
         # combine all centered fields in a dataset
-        return xr.Dataset(centered_fields)
+        return self.package_colocate_results(centered_fields)
 
 
 EMScalarFieldType = Union[ScalarFieldDataArray, ScalarFieldTimeDataArray, ScalarModeFieldDataArray]

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -79,11 +79,11 @@ class AbstractFieldDataset(Dataset, ABC):
 
             # loop through x, y, z dimensions and raise an error if only one element along dim
             for coord_name, coords_supplied in supplied_coord_map.items():
-                coord_data = field_data.coords[coord_name]
+                coord_data = np.array(field_data.coords[coord_name])
                 if coord_data.size == 1:
                     raise DataError(
                         f"colocate given {coord_name}={coords_supplied}, but "
-                        f"data only has one coordinate at {coord_name}={coord_data.values[0]}. "
+                        f"data only has one coordinate at {coord_name}={coord_data[0]}. "
                         "Therefore, can't colocate along this dimension. "
                         f"supply {coord_name}=None to skip it."
                     )

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -104,7 +104,6 @@ class AbstractFieldData(MonitorData, AbstractFieldDataset, ABC):
             return self.copy()
 
         update_dict = {}
-
         for field_name, scalar_data in self.field_components.items():
 
             eigenval_fn = self.symmetry_eigenvalues[field_name]

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -104,6 +104,7 @@ class AbstractFieldData(MonitorData, AbstractFieldDataset, ABC):
             return self.copy()
 
         update_dict = {}
+
         for field_name, scalar_data in self.field_components.items():
 
             eigenval_fn = self.symmetry_eigenvalues[field_name]

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -369,12 +369,13 @@ class SimulationData(Tidy3dBaseModel):
                 derived_data.name = f"|Im{{{field_name}}}|"
 
             elif val == "abs":
-                derived_data = sum(np.abs(f) ** 2 for f in field_components) ** 0.5
+                derived_data = sum(abs(f) ** 2 for f in field_components) ** 0.5
                 derived_data.name = f"|{field_name}|"
 
             elif val == "abs^2":
-                derived_data = sum(np.abs(f) ** 2 for f in field_components)
-                derived_data.name = f"|{field_name}|²"
+                derived_data = sum(abs(f) ** 2 for f in field_components)
+                if hasattr(derived_data, "name"):
+                    derived_data.name = f"|{field_name}|²"
 
             elif val == "phase":
                 raise Tidy3dKeyError(f"Phase is not defined for complex vector {field_name}")

--- a/tidy3d/plugins/adjoint/components/data/monitor_data.py
+++ b/tidy3d/plugins/adjoint/components/data/monitor_data.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Union, List
+from typing import Union, List, Dict, Any
 import pydantic as pd
 import numpy as np
 import jax.numpy as jnp
@@ -148,6 +148,19 @@ class JaxFieldData(JaxMonitorData, FieldData):
         description="Spatial distribution of the z-component of the magnetic field.",
         jax_field=True,
     )
+
+    def __contains__(self, item: str) -> bool:
+        """Whether this data array contains a field name."""
+        if item not in self.field_components:
+            return False
+        return self.field_components[item] is not None
+
+    def __getitem__(self, item: str) -> bool:
+        return self.field_components[item]
+
+    def package_colocate_results(self, centered_fields: Dict[str, ScalarFieldDataArray]) -> Any:
+        """How to package the dictionary of fields computed via self.colocate()."""
+        return self.updated_copy(**centered_fields)
 
     @property
     def intensity(self) -> ScalarFieldDataArray:

--- a/tidy3d/plugins/adjoint/components/medium.py
+++ b/tidy3d/plugins/adjoint/components/medium.py
@@ -497,9 +497,6 @@ class JaxCustomMedium(CustomMedium, AbstractJaxMedium):
                 inside_fn=inside_fn,
             ).sum(sum_axes)
 
-            # if np.any(np.isnan(e_dotted)) or np.isclose(np.sum(e_dotted), 0):
-            #     import pdb; pdb.set_trace()
-
             # reshape values to the expected vjp shape to be more safe
             vjp_shape = tuple(len(coord) for _, coord in coords.items())
             vjp_values = e_dotted.real.values.reshape(vjp_shape)


### PR DESCRIPTION
@momchil-flex this is ready for review. I separated the `flux` bits into #968 . This PR allows `interp` and `get_intensity()`. 