### PR TITLE
Parallelizing store_vjp over structures

### DIFF
--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -97,6 +97,7 @@ def run_emulated_bwd(
     folder_name: str,
     callback_url: str,
     verbose: bool,
+    num_proc: int = 2,
 ) -> JaxSimulation:
     """Runs adjoint simulation on our servers, grabs the gradient data from fwd for processing."""
 
@@ -116,7 +117,9 @@ def run_emulated_bwd(
     grad_data_adj = jax_sim_data_adj.grad_data_symmetry
 
     # get gradient and insert into the resulting simulation structure medium
-    sim_vjp = jax_sim_data_adj.simulation.store_vjp(grad_data_fwd, grad_data_adj, grad_eps_data_fwd)
+    sim_vjp = jax_sim_data_adj.simulation.store_vjp_parallel(
+        grad_data_fwd, grad_data_adj, grad_eps_data_fwd, num_proc=num_proc
+    )
 
     # write VJP sim to and from file to emulate webapi download and loading
     sim_vjp.to_file(SIM_VJP_FILE)
@@ -177,6 +180,7 @@ def run_async_emulated_bwd(
             folder_name=folder_name,
             callback_url=callback_url,
             verbose=verbose,
+            num_proc=1,
         )
         sim_vjps_orig.append(sim_vjp)
 

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -41,6 +41,7 @@ from ..utils import SIM_DATA_PATH, SIM_FULL, TMP_DIR
 FWD_SIM_DATA_FILE = TMP_DIR + "adjoint_grad_data_fwd.hdf5"
 SIM_VJP_FILE = TMP_DIR + "adjoint_sim_vjp_file.hdf5"
 RUN_PATH = TMP_DIR + "simulation.hdf5"
+NUM_PROC_PARALLEL = 2
 
 EPS = 2.0
 SIZE = (1.0, 2.0, 3.0)
@@ -97,7 +98,7 @@ def run_emulated_bwd(
     folder_name: str,
     callback_url: str,
     verbose: bool,
-    num_proc: int = 2,
+    num_proc: int = NUM_PROC_PARALLEL,
 ) -> JaxSimulation:
     """Runs adjoint simulation on our servers, grabs the gradient data from fwd for processing."""
 
@@ -117,7 +118,7 @@ def run_emulated_bwd(
     grad_data_adj = jax_sim_data_adj.grad_data_symmetry
 
     # get gradient and insert into the resulting simulation structure medium
-    sim_vjp = jax_sim_data_adj.simulation.store_vjp_parallel(
+    sim_vjp = jax_sim_data_adj.simulation.store_vjp(
         grad_data_fwd, grad_data_adj, grad_eps_data_fwd, num_proc=num_proc
     )
 
@@ -180,7 +181,7 @@ def run_async_emulated_bwd(
             folder_name=folder_name,
             callback_url=callback_url,
             verbose=verbose,
-            num_proc=1,
+            num_proc=NUM_PROC_PARALLEL,
         )
         sim_vjps_orig.append(sim_vjp)
 

--- a/tidy3d/plugins/adjoint/components/simulation.py
+++ b/tidy3d/plugins/adjoint/components/simulation.py
@@ -531,9 +531,16 @@ class JaxSimulation(Simulation, JaxObject):
 
         # Indexing into structures which use internal parallelization, and those which don't.
         # For the latter, simple parallelization over the list will be used.
+        internal_par_structs = [JaxGeometryGroup]
+
+        # Parallelize polyslabs internally or externally depending on total number
+        polyslabs = [struct for struct in self.input_structures if isinstance(struct, JaxPolySlab)]
+        if len(polyslabs) < num_proc:
+            internal_par_structs += [JaxPolySlab]
+
         inds_par_internal, inds_par_external = [], []
         for index, structure in enumerate(self.input_structures):
-            if isinstance(structure.geometry, (JaxPolySlab, JaxGeometryGroup)):
+            if isinstance(structure.geometry, tuple(internal_par_structs)):
                 inds_par_internal.append(index)
             else:
                 inds_par_external.append(index)

--- a/tidy3d/plugins/adjoint/components/structure.py
+++ b/tidy3d/plugins/adjoint/components/structure.py
@@ -64,14 +64,15 @@ class JaxStructure(Structure, JaxObject):
         grad_data_eps: PermittivityData,
         sim_bounds: Bound,
         eps_out: complex,
-        eps_in: complex,
+        num_proc: int = 1,
     ) -> JaxStructure:
         """Returns the gradient of the structure parameters given forward and adjoint field data."""
 
         # compute wavelength in material (to use for determining integration points)
         freq = float(grad_data_eps.eps_xx.f)
         wvl_free_space = C_0 / freq
-        ref_ind = np.sqrt(np.max(np.real(self.medium.eps_model(freq))))
+        eps_in = self.medium.eps_model(frequency=freq)
+        ref_ind = np.sqrt(np.max(np.real(eps_in)))
         wvl_mat = wvl_free_space / ref_ind
 
         geo_vjp = self.geometry.store_vjp(
@@ -82,6 +83,7 @@ class JaxStructure(Structure, JaxObject):
             wvl_mat=wvl_mat,
             eps_out=eps_out,
             eps_in=eps_in,
+            num_proc=num_proc,
         )
 
         medium_vjp = self.medium.store_vjp(

--- a/tidy3d/plugins/adjoint/web.py
+++ b/tidy3d/plugins/adjoint/web.py
@@ -21,9 +21,7 @@ from .components.simulation import JaxSimulation, JaxInfo
 from .components.data.sim_data import JaxSimulationData
 
 
-# TODO: confused about these paths, they aren't local but rather wherre the jax info and sim_vjp get
-# stored on the server? maybe add a comment for each?
-# when i changed them, adjoint runs errored on the solver.
+# file names and paths for server side adjoint
 SIM_VJP_FILE = "output/jax_sim_vjp.hdf5"
 JAX_INFO_FILE = "jax_info.json"
 

--- a/tidy3d/plugins/adjoint/web.py
+++ b/tidy3d/plugins/adjoint/web.py
@@ -311,6 +311,7 @@ def webapi_run_adjoint_fwd(
         verbose=verbose,
         simulation_type="adjoint_fwd",
         jax_info=jax_info,
+        solver_version="parallel-0.0.0",
     )
 
     sim_data = job.run()
@@ -337,6 +338,7 @@ def webapi_run_adjoint_bwd(
         simulation_type="adjoint_bwd",
         parent_tasks=[fwd_task_id],
         jax_info=jax_info_adj,
+        solver_version="parallel-0.0.0",
     )
 
     job.start()


### PR DESCRIPTION
This is not exactly pretty currently, but I'm not sure how to improve. Have to pass these big args lists around that can be confusing. However, when you work with a parallel pool, you can't directly use values and functions that are in the local namespace.

The other complication is that some structures need to *internally* use multi-processing (PolySlab, GeometryGroup), while others don't do that. So we split the list in two parts, structures where store_vjp is called in serial with num_proc internally, and structures for which the store_vjp calls are parallelized over num_proc, with no multi-processing inside store_vjp.

Ideally, some day we can refactor that, e.g. if PolySlab is fully vectorized, and GeometryGroup could be unraveled, maybe.