### PR TITLE
remove python 3.7 from tested envs

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -17,6 +17,9 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         platform: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:
+          - platform: macos-latest
+            python-version: '3.7'       
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
To alleviate missing `bz2` package in github's Mac OS Python3.7 environments.