### PR TITLE
Add subpixel field in custom medium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `JaxDataArray.interp`, allowing differentiable linear interpolation.
 - Support for `JaxSimulationData.get_intensity()`, allowing intensity distribution to be differentiated in `adjoint` plugin.
 - Support for `JaxFieldData.flux` to compute differentiable flux value from `FieldData`.
+- All custom medium types accept `subpixel` which is `False` by default, but applies subpixel averaging of the permittivity on the interfaces of the structure (including exterior boundary and intersection interfaces with other structures) if `True` and simulation's `subpixel` is also `True`.
 
 ### Changed
 - Add `Medium2D` to full simulation in tests.

--- a/tests/test_components/test_custom.py
+++ b/tests/test_components/test_custom.py
@@ -580,6 +580,7 @@ def test_custom_sellmeier():
     with pytest.raises(pydantic.ValidationError):
         mat = CustomSellmeier(coeffs=((b1, c1), (btmp, c2)))
     mat = CustomSellmeier(coeffs=((b1, c1), (btmp, c2)), allow_gain=True)
+    assert mat.pole_residue.allow_gain
 
     # inconsistent coord
     with pytest.raises(pydantic.ValidationError):
@@ -642,9 +643,12 @@ def test_custom_lorentz():
     verify_custom_dispersive_medium_methods(mat)
     assert mat.n_cfl > 1
 
-    mat = CustomLorentz(eps_inf=eps_inf, coeffs=((de1, f1, delta1), (de2, f2, delta2)))
+    mat = CustomLorentz(
+        eps_inf=eps_inf, coeffs=((de1, f1, delta1), (de2, f2, delta2)), subpixel=True
+    )
     verify_custom_dispersive_medium_methods(mat)
     assert mat.n_cfl > 1
+    assert mat.pole_residue.subpixel
 
 
 def test_custom_drude():
@@ -724,7 +728,7 @@ def test_custom_debye():
     assert mat.n_cfl > 1
 
 
-def test_custom_anisotropic_medium():
+def test_custom_anisotropic_medium(log_capture):
     """Custom anisotropic medium."""
 
     # xx
@@ -751,6 +755,9 @@ def test_custom_anisotropic_medium():
     # anisotropic
     mat = CustomAnisotropicMedium(xx=mat_xx, yy=mat_yy, zz=mat_zz)
     verify_custom_medium_methods(mat)
+
+    mat = CustomAnisotropicMedium(xx=mat_xx, yy=mat_yy, zz=mat_zz, subpixel=True)
+    assert_log_level(log_capture, "WARNING")
 
     ## interpolation method verification for "xx" component
     # 1) xx-component is using `interp_method = nearest`, and mat using `None`;


### PR DESCRIPTION
- Applies subpixel to a structure made of custom medium if 1) simulation's subpixel=True; 2) custom medium's subpixel=True
- For CustomAnisotropicMedium, each component has its own subpixel field. E.g. if xx-component has subpixel=True, and yy-component has subpixel=False, subpixel will be applied to xx component but not yy component.