### PR TITLE
fix schema for ArrayLike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix to the setting of the mode solver PML parameters that produces better results for modes which do not decay in the PML, and fewer spurious modes.
 - Fix to single-precision mode solver to do the type conversion on the final matrix only rather than at intermediate steps, which improves accuracy in some cases.
 - Improvements to graphene medium fit.
+- Schema titles in `ArrayLike` fields.
 
 ## [2.2.3] - 2023-6-15
 

--- a/tidy3d/components/types.py
+++ b/tidy3d/components/types.py
@@ -90,7 +90,6 @@ class ArrayLike:
         """Sets the schema of DataArray object."""
 
         schema = dict(
-            title="ArrayLike",
             type="ArrayLike",
         )
         field_schema.update(schema)

--- a/tidy3d/schema.json
+++ b/tidy3d/schema.json
@@ -1,6 +1,6 @@
 {
   "title": "Simulation",
-  "description": "Contains all information about Tidy3d simulation.\n\nParameters\n----------\ncenter : Tuple[float, float, float] = (0.0, 0.0, 0.0)\n    [units = um].  Center of object in x, y, and z.\nsize : Tuple[NonNegativeFloat, NonNegativeFloat, NonNegativeFloat]\n    [units = um].  Size in x, y, and z directions.\nrun_time : PositiveFloat\n    [units = sec].  Total electromagnetic evolution time in seconds. Note: If simulation 'shutoff' is specified, simulation will terminate early when shutoff condition met. \nmedium : Union[Medium, AnisotropicMedium, PECMedium, PoleResidue, Sellmeier, Lorentz, Debye, Drude, FullyAnisotropicMedium, CustomMedium, CustomPoleResidue, CustomSellmeier, CustomLorentz, CustomDebye, CustomDrude, CustomAnisotropicMedium] = Medium(name=None, frequency_range=None, type='Medium', permittivity=1.0, conductivity=0.0)\n    Background medium of simulation, defaults to vacuum if not specified.\nsymmetry : Tuple[Literal[0, -1, 1], Literal[0, -1, 1], Literal[0, -1, 1]] = (0, 0, 0)\n    Tuple of integers defining reflection symmetry across a plane bisecting the simulation domain normal to the x-, y-, and z-axis at the simulation center of each axis, respectively. Each element can be ``0`` (no symmetry), ``1`` (even, i.e. 'PMC' symmetry) or ``-1`` (odd, i.e. 'PEC' symmetry). Note that the vectorial nature of the fields must be taken into account to correctly determine the symmetry value.\nstructures : Tuple[Structure, ...] = ()\n    Tuple of structures present in simulation. Note: Structures defined later in this list override the simulation material properties in regions of spatial overlap.\nsources : Tuple[Annotated[Union[tidy3d.components.source.UniformCurrentSource, tidy3d.components.source.PointDipole, tidy3d.components.source.GaussianBeam, tidy3d.components.source.AstigmaticGaussianBeam, tidy3d.components.source.ModeSource, tidy3d.components.source.PlaneWave, tidy3d.components.source.CustomFieldSource, tidy3d.components.source.CustomCurrentSource, tidy3d.components.source.TFSF], FieldInfo(default=PydanticUndefined, discriminator='type', extra={})], ...] = ()\n    Tuple of electric current sources injecting fields into the simulation.\nboundary_spec : BoundarySpec = BoundarySpec(x=Boundary(plus=PML(name=None,, type='PML',, num_layers=12,, parameters=PMLParams(sigma_order=3,, sigma_min=0.0,, sigma_max=1.5,, type='PMLParams',, kappa_order=3,, kappa_min=1.0,, kappa_max=3.0,, alpha_order=1,, alpha_min=0.0,, alpha_max=0.0)),, minus=PML(name=None,, type='PML',, num_layers=12,, parameters=PMLParams(sigma_order=3,, sigma_min=0.0,, sigma_max=1.5,, type='PMLParams',, kappa_order=3,, kappa_min=1.0,, kappa_max=3.0,, alpha_order=1,, alpha_min=0.0,, alpha_max=0.0)),, type='Boundary'), y=Boundary(plus=PML(name=None,, type='PML',, num_layers=12,, parameters=PMLParams(sigma_order=3,, sigma_min=0.0,, sigma_max=1.5,, type='PMLParams',, kappa_order=3,, kappa_min=1.0,, kappa_max=3.0,, alpha_order=1,, alpha_min=0.0,, alpha_max=0.0)),, minus=PML(name=None,, type='PML',, num_layers=12,, parameters=PMLParams(sigma_order=3,, sigma_min=0.0,, sigma_max=1.5,, type='PMLParams',, kappa_order=3,, kappa_min=1.0,, kappa_max=3.0,, alpha_order=1,, alpha_min=0.0,, alpha_max=0.0)),, type='Boundary'), z=Boundary(plus=PML(name=None,, type='PML',, num_layers=12,, parameters=PMLParams(sigma_order=3,, sigma_min=0.0,, sigma_max=1.5,, type='PMLParams',, kappa_order=3,, kappa_min=1.0,, kappa_max=3.0,, alpha_order=1,, alpha_min=0.0,, alpha_max=0.0)),, minus=PML(name=None,, type='PML',, num_layers=12,, parameters=PMLParams(sigma_order=3,, sigma_min=0.0,, sigma_max=1.5,, type='PMLParams',, kappa_order=3,, kappa_min=1.0,, kappa_max=3.0,, alpha_order=1,, alpha_min=0.0,, alpha_max=0.0)),, type='Boundary'), type='BoundarySpec')\n    Specification of boundary conditions along each dimension. If ``None``, periodic boundary conditions are applied on all sides. Default will change to PML in 2.0 so explicitly setting the boundaries is recommended.\nmonitors : Tuple[Annotated[Union[tidy3d.components.monitor.FieldMonitor, tidy3d.components.monitor.FieldTimeMonitor, tidy3d.components.monitor.PermittivityMonitor, tidy3d.components.monitor.FluxMonitor, tidy3d.components.monitor.FluxTimeMonitor, tidy3d.components.monitor.ModeMonitor, tidy3d.components.monitor.ModeSolverMonitor, tidy3d.components.monitor.FieldProjectionAngleMonitor, tidy3d.components.monitor.FieldProjectionCartesianMonitor, tidy3d.components.monitor.FieldProjectionKSpaceMonitor, tidy3d.components.monitor.DiffractionMonitor], FieldInfo(default=PydanticUndefined, discriminator='type', extra={})], ...] = ()\n    Tuple of monitors in the simulation. Note: monitor names are used to access data after simulation is run.\ngrid_spec : GridSpec = GridSpec(grid_x=AutoGrid(type='AutoGrid',, min_steps_per_wvl=10.0,, max_scale=1.4,, dl_min=0.0,, mesher=GradedMesher(type='GradedMesher')), grid_y=AutoGrid(type='AutoGrid',, min_steps_per_wvl=10.0,, max_scale=1.4,, dl_min=0.0,, mesher=GradedMesher(type='GradedMesher')), grid_z=AutoGrid(type='AutoGrid',, min_steps_per_wvl=10.0,, max_scale=1.4,, dl_min=0.0,, mesher=GradedMesher(type='GradedMesher')), wavelength=None, override_structures=(), type='GridSpec')\n    Specifications for the simulation grid along each of the three directions.\nshutoff : NonNegativeFloat = 1e-05\n    Ratio of the instantaneous integrated E-field intensity to the maximum value at which the simulation will automatically terminate time stepping. Used to prevent extraneous run time of simulations with fully decayed fields. Set to ``0`` to disable this feature.\nsubpixel : bool = True\n    If ``True``, uses subpixel averaging of the permittivity based on structure definition, resulting in much higher accuracy for a given grid size.\nnormalize_index : Optional[NonNegativeInt] = 0\n    Index of the source in the tuple of sources whose spectrum will be used to normalize the frequency-dependent data. If ``None``, the raw field data is returned unnormalized.\ncourant : ConstrainedFloatValue = 0.99\n    Courant stability factor, controls time step to spatial step ratio. Lower values lead to more stable simulations for dispersive materials, but result in longer simulation times. This factor is normalized to no larger than 1 when CFL stability condition is met in 3D.\nversion : str = 2.3.0rc1\n    String specifying the front end version number.\n\nExample\n-------\n>>> from tidy3d import Sphere, Cylinder, PolySlab\n>>> from tidy3d import UniformCurrentSource, GaussianPulse\n>>> from tidy3d import FieldMonitor, FluxMonitor\n>>> from tidy3d import GridSpec, AutoGrid\n>>> from tidy3d import BoundarySpec, Boundary\n>>> sim = Simulation(\n...     size=(3.0, 3.0, 3.0),\n...     grid_spec=GridSpec(\n...         grid_x = AutoGrid(min_steps_per_wvl = 20),\n...         grid_y = AutoGrid(min_steps_per_wvl = 20),\n...         grid_z = AutoGrid(min_steps_per_wvl = 20)\n...     ),\n...     run_time=40e-11,\n...     structures=[\n...         Structure(\n...             geometry=Box(size=(1, 1, 1), center=(0, 0, 0)),\n...             medium=Medium(permittivity=2.0),\n...         ),\n...     ],\n...     sources=[\n...         UniformCurrentSource(\n...             size=(0, 0, 0),\n...             center=(0, 0.5, 0),\n...             polarization=\"Hx\",\n...             source_time=GaussianPulse(\n...                 freq0=2e14,\n...                 fwidth=4e13,\n...             ),\n...         )\n...     ],\n...     monitors=[\n...         FieldMonitor(size=(0, 0, 0), center=(0, 0, 0), freqs=[1.5e14, 2e14], name='point'),\n...         FluxMonitor(size=(1, 1, 0), center=(0, 0, 0), freqs=[2e14, 2.5e14], name='flux'),\n...     ],\n...     symmetry=(0, 0, 0),\n...     boundary_spec=BoundarySpec(\n...         x = Boundary.pml(num_layers=20),\n...         y = Boundary.pml(num_layers=30),\n...         z = Boundary.periodic(),\n...     ),\n...     shutoff=1e-6,\n...     courant=0.8,\n...     subpixel=False,\n... )",
+  "description": "Contains all information about Tidy3d simulation.\n\nParameters\n----------\ncenter : Tuple[float, float, float] = (0.0, 0.0, 0.0)\n    [units = um].  Center of object in x, y, and z.\nsize : Tuple[NonNegativeFloat, NonNegativeFloat, NonNegativeFloat]\n    [units = um].  Size in x, y, and z directions.\nrun_time : PositiveFloat\n    [units = sec].  Total electromagnetic evolution time in seconds. Note: If simulation 'shutoff' is specified, simulation will terminate early when shutoff condition met. \nmedium : Union[Medium, AnisotropicMedium, PECMedium, PoleResidue, Sellmeier, Lorentz, Debye, Drude, FullyAnisotropicMedium, CustomMedium, CustomPoleResidue, CustomSellmeier, CustomLorentz, CustomDebye, CustomDrude, CustomAnisotropicMedium] = Medium(name=None, frequency_range=None, allow_gain=False, type='Medium', permittivity=1.0, conductivity=0.0)\n    Background medium of simulation, defaults to vacuum if not specified.\nsymmetry : Tuple[Literal[0, -1, 1], Literal[0, -1, 1], Literal[0, -1, 1]] = (0, 0, 0)\n    Tuple of integers defining reflection symmetry across a plane bisecting the simulation domain normal to the x-, y-, and z-axis at the simulation center of each axis, respectively. Each element can be ``0`` (no symmetry), ``1`` (even, i.e. 'PMC' symmetry) or ``-1`` (odd, i.e. 'PEC' symmetry). Note that the vectorial nature of the fields must be taken into account to correctly determine the symmetry value.\nstructures : Tuple[Structure, ...] = ()\n    Tuple of structures present in simulation. Note: Structures defined later in this list override the simulation material properties in regions of spatial overlap.\nsources : Tuple[Annotated[Union[tidy3d.components.source.UniformCurrentSource, tidy3d.components.source.PointDipole, tidy3d.components.source.GaussianBeam, tidy3d.components.source.AstigmaticGaussianBeam, tidy3d.components.source.ModeSource, tidy3d.components.source.PlaneWave, tidy3d.components.source.CustomFieldSource, tidy3d.components.source.CustomCurrentSource, tidy3d.components.source.TFSF], FieldInfo(default=PydanticUndefined, discriminator='type', extra={})], ...] = ()\n    Tuple of electric current sources injecting fields into the simulation.\nboundary_spec : BoundarySpec = BoundarySpec(x=Boundary(plus=PML(name=None,, type='PML',, num_layers=12,, parameters=PMLParams(sigma_order=3,, sigma_min=0.0,, sigma_max=1.5,, type='PMLParams',, kappa_order=3,, kappa_min=1.0,, kappa_max=3.0,, alpha_order=1,, alpha_min=0.0,, alpha_max=0.0)),, minus=PML(name=None,, type='PML',, num_layers=12,, parameters=PMLParams(sigma_order=3,, sigma_min=0.0,, sigma_max=1.5,, type='PMLParams',, kappa_order=3,, kappa_min=1.0,, kappa_max=3.0,, alpha_order=1,, alpha_min=0.0,, alpha_max=0.0)),, type='Boundary'), y=Boundary(plus=PML(name=None,, type='PML',, num_layers=12,, parameters=PMLParams(sigma_order=3,, sigma_min=0.0,, sigma_max=1.5,, type='PMLParams',, kappa_order=3,, kappa_min=1.0,, kappa_max=3.0,, alpha_order=1,, alpha_min=0.0,, alpha_max=0.0)),, minus=PML(name=None,, type='PML',, num_layers=12,, parameters=PMLParams(sigma_order=3,, sigma_min=0.0,, sigma_max=1.5,, type='PMLParams',, kappa_order=3,, kappa_min=1.0,, kappa_max=3.0,, alpha_order=1,, alpha_min=0.0,, alpha_max=0.0)),, type='Boundary'), z=Boundary(plus=PML(name=None,, type='PML',, num_layers=12,, parameters=PMLParams(sigma_order=3,, sigma_min=0.0,, sigma_max=1.5,, type='PMLParams',, kappa_order=3,, kappa_min=1.0,, kappa_max=3.0,, alpha_order=1,, alpha_min=0.0,, alpha_max=0.0)),, minus=PML(name=None,, type='PML',, num_layers=12,, parameters=PMLParams(sigma_order=3,, sigma_min=0.0,, sigma_max=1.5,, type='PMLParams',, kappa_order=3,, kappa_min=1.0,, kappa_max=3.0,, alpha_order=1,, alpha_min=0.0,, alpha_max=0.0)),, type='Boundary'), type='BoundarySpec')\n    Specification of boundary conditions along each dimension. If ``None``, periodic boundary conditions are applied on all sides. Default will change to PML in 2.0 so explicitly setting the boundaries is recommended.\nmonitors : Tuple[Annotated[Union[tidy3d.components.monitor.FieldMonitor, tidy3d.components.monitor.FieldTimeMonitor, tidy3d.components.monitor.PermittivityMonitor, tidy3d.components.monitor.FluxMonitor, tidy3d.components.monitor.FluxTimeMonitor, tidy3d.components.monitor.ModeMonitor, tidy3d.components.monitor.ModeSolverMonitor, tidy3d.components.monitor.FieldProjectionAngleMonitor, tidy3d.components.monitor.FieldProjectionCartesianMonitor, tidy3d.components.monitor.FieldProjectionKSpaceMonitor, tidy3d.components.monitor.DiffractionMonitor], FieldInfo(default=PydanticUndefined, discriminator='type', extra={})], ...] = ()\n    Tuple of monitors in the simulation. Note: monitor names are used to access data after simulation is run.\ngrid_spec : GridSpec = GridSpec(grid_x=AutoGrid(type='AutoGrid',, min_steps_per_wvl=10.0,, max_scale=1.4,, dl_min=0.0,, mesher=GradedMesher(type='GradedMesher')), grid_y=AutoGrid(type='AutoGrid',, min_steps_per_wvl=10.0,, max_scale=1.4,, dl_min=0.0,, mesher=GradedMesher(type='GradedMesher')), grid_z=AutoGrid(type='AutoGrid',, min_steps_per_wvl=10.0,, max_scale=1.4,, dl_min=0.0,, mesher=GradedMesher(type='GradedMesher')), wavelength=None, override_structures=(), type='GridSpec')\n    Specifications for the simulation grid along each of the three directions.\nshutoff : NonNegativeFloat = 1e-05\n    Ratio of the instantaneous integrated E-field intensity to the maximum value at which the simulation will automatically terminate time stepping. Used to prevent extraneous run time of simulations with fully decayed fields. Set to ``0`` to disable this feature.\nsubpixel : bool = True\n    If ``True``, uses subpixel averaging of the permittivity based on structure definition, resulting in much higher accuracy for a given grid size.\nnormalize_index : Optional[NonNegativeInt] = 0\n    Index of the source in the tuple of sources whose spectrum will be used to normalize the frequency-dependent data. If ``None``, the raw field data is returned unnormalized.\ncourant : ConstrainedFloatValue = 0.99\n    Courant stability factor, controls time step to spatial step ratio. Lower values lead to more stable simulations for dispersive materials, but result in longer simulation times. This factor is normalized to no larger than 1 when CFL stability condition is met in 3D.\nversion : str = 2.3.0rc2\n    String specifying the front end version number.\n\nExample\n-------\n>>> from tidy3d import Sphere, Cylinder, PolySlab\n>>> from tidy3d import UniformCurrentSource, GaussianPulse\n>>> from tidy3d import FieldMonitor, FluxMonitor\n>>> from tidy3d import GridSpec, AutoGrid\n>>> from tidy3d import BoundarySpec, Boundary\n>>> sim = Simulation(\n...     size=(3.0, 3.0, 3.0),\n...     grid_spec=GridSpec(\n...         grid_x = AutoGrid(min_steps_per_wvl = 20),\n...         grid_y = AutoGrid(min_steps_per_wvl = 20),\n...         grid_z = AutoGrid(min_steps_per_wvl = 20)\n...     ),\n...     run_time=40e-11,\n...     structures=[\n...         Structure(\n...             geometry=Box(size=(1, 1, 1), center=(0, 0, 0)),\n...             medium=Medium(permittivity=2.0),\n...         ),\n...     ],\n...     sources=[\n...         UniformCurrentSource(\n...             size=(0, 0, 0),\n...             center=(0, 0.5, 0),\n...             polarization=\"Hx\",\n...             source_time=GaussianPulse(\n...                 freq0=2e14,\n...                 fwidth=4e13,\n...             ),\n...         )\n...     ],\n...     monitors=[\n...         FieldMonitor(size=(0, 0, 0), center=(0, 0, 0), freqs=[1.5e14, 2e14], name='point'),\n...         FluxMonitor(size=(1, 1, 0), center=(0, 0, 0), freqs=[2e14, 2.5e14], name='flux'),\n...     ],\n...     symmetry=(0, 0, 0),\n...     boundary_spec=BoundarySpec(\n...         x = Boundary.pml(num_layers=20),\n...         y = Boundary.pml(num_layers=30),\n...         z = Boundary.periodic(),\n...     ),\n...     shutoff=1e-6,\n...     courant=0.8,\n...     subpixel=False,\n... )",
   "type": "object",
   "properties": {
     "type": {
@@ -70,6 +70,7 @@
       "default": {
         "name": null,
         "frequency_range": null,
+        "allow_gain": false,
         "type": "Medium",
         "permittivity": 1.0,
         "conductivity": 0.0
@@ -477,7 +478,7 @@
     "version": {
       "title": "Version",
       "description": "String specifying the front end version number.",
-      "default": "2.3.0rc1",
+      "default": "2.3.0rc2",
       "type": "string"
     }
   },
@@ -489,7 +490,7 @@
   "definitions": {
     "Medium": {
       "title": "Medium",
-      "description": "Dispersionless medium.\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\npermittivity : ConstrainedFloatValue = 1.0\n    [units = None (relative permittivity)].  Relative permittivity.\nconductivity : ConstrainedFloatValue = 0.0\n    [units = S/um].  Electric conductivity. Defined such that the imaginary part of the complex permittivity at angular frequency omega is given by conductivity/omega.\n\nExample\n-------\n>>> dielectric = Medium(permittivity=4.0, name='my_medium')\n>>> eps = dielectric.eps_model(200e12)",
+      "description": "Dispersionless medium.\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\nallow_gain : bool = False\n    Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.\npermittivity : ConstrainedFloatValue = 1.0\n    [units = None (relative permittivity)].  Relative permittivity.\nconductivity : float = 0.0\n    [units = S/um].  Electric conductivity. Defined such that the imaginary part of the complex permittivity at angular frequency omega is given by conductivity/omega.\n\nExample\n-------\n>>> dielectric = Medium(permittivity=4.0, name='my_medium')\n>>> eps = dielectric.eps_model(200e12)",
       "type": "object",
       "properties": {
         "name": {
@@ -516,6 +517,12 @@
             }
           ]
         },
+        "allow_gain": {
+          "title": "Allow gain medium",
+          "description": "Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.",
+          "default": false,
+          "type": "boolean"
+        },
         "type": {
           "title": "Type",
           "default": "Medium",
@@ -536,7 +543,6 @@
           "title": "Conductivity",
           "description": "Electric conductivity. Defined such that the imaginary part of the complex permittivity at angular frequency omega is given by conductivity/omega.",
           "default": 0.0,
-          "minimum": 0.0,
           "units": "S/um",
           "type": "number"
         }
@@ -564,7 +570,7 @@
     },
     "PoleResidue": {
       "title": "PoleResidue",
-      "description": "A dispersive medium described by the pole-residue pair model.\nThe frequency-dependence of the complex-valued permittivity is described by:\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\neps_inf : PositiveFloat = 1.0\n    [units = None (relative permittivity)].  Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).\npoles : Tuple[Tuple[Union[tidy3d.components.types.tidycomplex, tidy3d.components.types.ComplexNumber], Union[tidy3d.components.types.tidycomplex, tidy3d.components.types.ComplexNumber]], ...] = ()\n    [units = (rad/sec, rad/sec)].  Tuple of complex-valued (:math:`a_i, c_i`) poles for the model.\n\nNote\n----\n.. math::\n\n    \\epsilon(\\omega) = \\epsilon_\\infty - \\sum_i\n    \\left[\\frac{c_i}{j \\omega + a_i} +\n    \\frac{c_i^*}{j \\omega + a_i^*}\\right]\n\nExample\n-------\n>>> pole_res = PoleResidue(eps_inf=2.0, poles=[((1+2j), (3+4j)), ((5+6j), (7+8j))])\n>>> eps = pole_res.eps_model(200e12)",
+      "description": "A dispersive medium described by the pole-residue pair model.\nThe frequency-dependence of the complex-valued permittivity is described by:\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\nallow_gain : bool = False\n    Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.\neps_inf : PositiveFloat = 1.0\n    [units = None (relative permittivity)].  Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).\npoles : Tuple[Tuple[Union[tidy3d.components.types.tidycomplex, tidy3d.components.types.ComplexNumber], Union[tidy3d.components.types.tidycomplex, tidy3d.components.types.ComplexNumber]], ...] = ()\n    [units = (rad/sec, rad/sec)].  Tuple of complex-valued (:math:`a_i, c_i`) poles for the model.\n\nNote\n----\n.. math::\n\n    \\epsilon(\\omega) = \\epsilon_\\infty - \\sum_i\n    \\left[\\frac{c_i}{j \\omega + a_i} +\n    \\frac{c_i^*}{j \\omega + a_i^*}\\right]\n\nExample\n-------\n>>> pole_res = PoleResidue(eps_inf=2.0, poles=[((-1+2j), (3+4j)), ((-5+6j), (7+8j))])\n>>> eps = pole_res.eps_model(200e12)",
       "type": "object",
       "properties": {
         "name": {
@@ -590,6 +596,12 @@
               "type": "number"
             }
           ]
+        },
+        "allow_gain": {
+          "title": "Allow gain medium",
+          "description": "Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.",
+          "default": false,
+          "type": "boolean"
         },
         "type": {
           "title": "Type",
@@ -681,7 +693,7 @@
     },
     "Sellmeier": {
       "title": "Sellmeier",
-      "description": "A dispersive medium described by the Sellmeier model.\nThe frequency-dependence of the refractive index is described by:\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\ncoeffs : Tuple[Tuple[float, pydantic.types.PositiveFloat], ...]\n    [units = (None, um^2)].  List of Sellmeier (:math:`B_i, C_i`) coefficients.\n\nNote\n----\n.. math::\n\n    n(\\lambda)^2 = 1 + \\sum_i \\frac{B_i \\lambda^2}{\\lambda^2 - C_i}\n\nExample\n-------\n>>> sellmeier_medium = Sellmeier(coeffs=[(1,2), (3,4)])\n>>> eps = sellmeier_medium.eps_model(200e12)",
+      "description": "A dispersive medium described by the Sellmeier model.\nThe frequency-dependence of the refractive index is described by:\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\nallow_gain : bool = False\n    Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.\ncoeffs : Tuple[Tuple[float, pydantic.types.PositiveFloat], ...]\n    [units = (None, um^2)].  List of Sellmeier (:math:`B_i, C_i`) coefficients.\n\nNote\n----\n.. math::\n\n    n(\\lambda)^2 = 1 + \\sum_i \\frac{B_i \\lambda^2}{\\lambda^2 - C_i}\n\nExample\n-------\n>>> sellmeier_medium = Sellmeier(coeffs=[(1,2), (3,4)])\n>>> eps = sellmeier_medium.eps_model(200e12)",
       "type": "object",
       "properties": {
         "name": {
@@ -707,6 +719,12 @@
               "type": "number"
             }
           ]
+        },
+        "allow_gain": {
+          "title": "Allow gain medium",
+          "description": "Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.",
+          "default": false,
+          "type": "boolean"
         },
         "type": {
           "title": "Type",
@@ -747,7 +765,7 @@
     },
     "Lorentz": {
       "title": "Lorentz",
-      "description": "A dispersive medium described by the Lorentz model.\nThe frequency-dependence of the complex-valued permittivity is described by:\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\neps_inf : PositiveFloat = 1.0\n    [units = None (relative permittivity)].  Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).\ncoeffs : Tuple[Tuple[float, float, float], ...]\n    [units = (None (relative permittivity), Hz, Hz)].  List of (:math:`\\Delta\\epsilon_i, f_i, \\delta_i`) values for model.\n\nNote\n----\n.. math::\n\n    \\epsilon(f) = \\epsilon_\\infty + \\sum_i\n    \\frac{\\Delta\\epsilon_i f_i^2}{f_i^2 - 2jf\\delta_i - f^2}\n\nExample\n-------\n>>> lorentz_medium = Lorentz(eps_inf=2.0, coeffs=[(1,2,3), (4,5,6)])\n>>> eps = lorentz_medium.eps_model(200e12)",
+      "description": "A dispersive medium described by the Lorentz model.\nThe frequency-dependence of the complex-valued permittivity is described by:\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\nallow_gain : bool = False\n    Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.\neps_inf : PositiveFloat = 1.0\n    [units = None (relative permittivity)].  Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).\ncoeffs : Tuple[Tuple[float, float, pydantic.types.NonNegativeFloat], ...]\n    [units = (None (relative permittivity), Hz, Hz)].  List of (:math:`\\Delta\\epsilon_i, f_i, \\delta_i`) values for model.\n\nNote\n----\n.. math::\n\n    \\epsilon(f) = \\epsilon_\\infty + \\sum_i\n    \\frac{\\Delta\\epsilon_i f_i^2}{f_i^2 - 2jf\\delta_i - f^2}\n\nExample\n-------\n>>> lorentz_medium = Lorentz(eps_inf=2.0, coeffs=[(1,2,3), (4,5,6)])\n>>> eps = lorentz_medium.eps_model(200e12)",
       "type": "object",
       "properties": {
         "name": {
@@ -773,6 +791,12 @@
               "type": "number"
             }
           ]
+        },
+        "allow_gain": {
+          "title": "Allow gain medium",
+          "description": "Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.",
+          "default": false,
+          "type": "boolean"
         },
         "type": {
           "title": "Type",
@@ -811,7 +835,8 @@
                 "type": "number"
               },
               {
-                "type": "number"
+                "type": "number",
+                "minimum": 0
               }
             ]
           }
@@ -824,7 +849,7 @@
     },
     "Debye": {
       "title": "Debye",
-      "description": "A dispersive medium described by the Debye model.\nThe frequency-dependence of the complex-valued permittivity is described by:\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\neps_inf : PositiveFloat = 1.0\n    [units = None (relative permittivity)].  Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).\ncoeffs : Tuple[Tuple[float, pydantic.types.PositiveFloat], ...]\n    [units = (None (relative permittivity), sec)].  List of (:math:`\\Delta\\epsilon_i, \\tau_i`) values for model.\n\nNote\n----\n.. math::\n\n    \\epsilon(f) = \\epsilon_\\infty + \\sum_i\n    \\frac{\\Delta\\epsilon_i}{1 - jf\\tau_i}\n\nExample\n-------\n>>> debye_medium = Debye(eps_inf=2.0, coeffs=[(1,2),(3,4)])\n>>> eps = debye_medium.eps_model(200e12)",
+      "description": "A dispersive medium described by the Debye model.\nThe frequency-dependence of the complex-valued permittivity is described by:\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\nallow_gain : bool = False\n    Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.\neps_inf : PositiveFloat = 1.0\n    [units = None (relative permittivity)].  Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).\ncoeffs : Tuple[Tuple[float, pydantic.types.PositiveFloat], ...]\n    [units = (None (relative permittivity), sec)].  List of (:math:`\\Delta\\epsilon_i, \\tau_i`) values for model.\n\nNote\n----\n.. math::\n\n    \\epsilon(f) = \\epsilon_\\infty + \\sum_i\n    \\frac{\\Delta\\epsilon_i}{1 - jf\\tau_i}\n\nExample\n-------\n>>> debye_medium = Debye(eps_inf=2.0, coeffs=[(1,2),(3,4)])\n>>> eps = debye_medium.eps_model(200e12)",
       "type": "object",
       "properties": {
         "name": {
@@ -850,6 +875,12 @@
               "type": "number"
             }
           ]
+        },
+        "allow_gain": {
+          "title": "Allow gain medium",
+          "description": "Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.",
+          "default": false,
+          "type": "boolean"
         },
         "type": {
           "title": "Type",
@@ -898,7 +929,7 @@
     },
     "Drude": {
       "title": "Drude",
-      "description": "A dispersive medium described by the Drude model.\nThe frequency-dependence of the complex-valued permittivity is described by:\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\neps_inf : PositiveFloat = 1.0\n    [units = None (relative permittivity)].  Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).\ncoeffs : Tuple[Tuple[float, pydantic.types.PositiveFloat], ...]\n    [units = (Hz, Hz)].  List of (:math:`f_i, \\delta_i`) values for model.\n\nNote\n----\n.. math::\n\n    \\epsilon(f) = \\epsilon_\\infty - \\sum_i\n    \\frac{ f_i^2}{f^2 + jf\\delta_i}\n\nExample\n-------\n>>> drude_medium = Drude(eps_inf=2.0, coeffs=[(1,2), (3,4)])\n>>> eps = drude_medium.eps_model(200e12)",
+      "description": "A dispersive medium described by the Drude model.\nThe frequency-dependence of the complex-valued permittivity is described by:\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\nallow_gain : bool = False\n    Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.\neps_inf : PositiveFloat = 1.0\n    [units = None (relative permittivity)].  Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).\ncoeffs : Tuple[Tuple[float, pydantic.types.PositiveFloat], ...]\n    [units = (Hz, Hz)].  List of (:math:`f_i, \\delta_i`) values for model.\n\nNote\n----\n.. math::\n\n    \\epsilon(f) = \\epsilon_\\infty - \\sum_i\n    \\frac{ f_i^2}{f^2 + jf\\delta_i}\n\nExample\n-------\n>>> drude_medium = Drude(eps_inf=2.0, coeffs=[(1,2), (3,4)])\n>>> eps = drude_medium.eps_model(200e12)",
       "type": "object",
       "properties": {
         "name": {
@@ -924,6 +955,12 @@
               "type": "number"
             }
           ]
+        },
+        "allow_gain": {
+          "title": "Allow gain medium",
+          "description": "Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.",
+          "default": false,
+          "type": "boolean"
         },
         "type": {
           "title": "Type",
@@ -972,7 +1009,7 @@
     },
     "AnisotropicMedium": {
       "title": "AnisotropicMedium",
-      "description": "Diagonally anisotropic medium.\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\nxx : Union[Medium, PoleResidue, Sellmeier, Lorentz, Debye, Drude]\n    Medium describing the xx-component of the diagonal permittivity tensor.\nyy : Union[Medium, PoleResidue, Sellmeier, Lorentz, Debye, Drude]\n    Medium describing the yy-component of the diagonal permittivity tensor.\nzz : Union[Medium, PoleResidue, Sellmeier, Lorentz, Debye, Drude]\n    Medium describing the zz-component of the diagonal permittivity tensor.\n\nNote\n----\nOnly diagonal anisotropy is currently supported.\n\nExample\n-------\n>>> medium_xx = Medium(permittivity=4.0)\n>>> medium_yy = Medium(permittivity=4.1)\n>>> medium_zz = Medium(permittivity=3.9)\n>>> anisotropic_dielectric = AnisotropicMedium(xx=medium_xx, yy=medium_yy, zz=medium_zz)",
+      "description": "Diagonally anisotropic medium.\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\nallow_gain : Optional[bool] = None\n    This field is ignored. Please set ``allow_gain`` in each component\nxx : Union[Medium, PoleResidue, Sellmeier, Lorentz, Debye, Drude]\n    Medium describing the xx-component of the diagonal permittivity tensor.\nyy : Union[Medium, PoleResidue, Sellmeier, Lorentz, Debye, Drude]\n    Medium describing the yy-component of the diagonal permittivity tensor.\nzz : Union[Medium, PoleResidue, Sellmeier, Lorentz, Debye, Drude]\n    Medium describing the zz-component of the diagonal permittivity tensor.\n\nNote\n----\nOnly diagonal anisotropy is currently supported.\n\nExample\n-------\n>>> medium_xx = Medium(permittivity=4.0)\n>>> medium_yy = Medium(permittivity=4.1)\n>>> medium_zz = Medium(permittivity=3.9)\n>>> anisotropic_dielectric = AnisotropicMedium(xx=medium_xx, yy=medium_yy, zz=medium_zz)",
       "type": "object",
       "properties": {
         "name": {
@@ -998,6 +1035,11 @@
               "type": "number"
             }
           ]
+        },
+        "allow_gain": {
+          "title": "Allow gain medium",
+          "description": "This field is ignored. Please set ``allow_gain`` in each component",
+          "type": "boolean"
         },
         "type": {
           "title": "Type",
@@ -1122,7 +1164,7 @@
     },
     "PECMedium": {
       "title": "PECMedium",
-      "description": "Perfect electrical conductor class.\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\n\nNote\n----\nTo avoid confusion from duplicate PECs, must import ``tidy3d.PEC`` instance directly.",
+      "description": "Perfect electrical conductor class.\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\nallow_gain : bool = False\n    Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.\n\nNote\n----\nTo avoid confusion from duplicate PECs, must import ``tidy3d.PEC`` instance directly.",
       "type": "object",
       "properties": {
         "name": {
@@ -1148,6 +1190,12 @@
               "type": "number"
             }
           ]
+        },
+        "allow_gain": {
+          "title": "Allow gain medium",
+          "description": "Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.",
+          "default": false,
+          "type": "boolean"
         },
         "type": {
           "title": "Type",
@@ -1162,7 +1210,7 @@
     },
     "FullyAnisotropicMedium": {
       "title": "FullyAnisotropicMedium",
-      "description": "Fully anisotropic medium including all 9 components of the permittivity and conductivity\ntensors. Provided permittivity tensor and the symmetric part of the conductivity tensor must\nhave coinciding main directions. A non-symmetric conductivity tensor can be used to model\nmagneto-optic effects. Note that dispersive properties and subpixel averaging are currently not\nsupported for fully anisotropic materials.\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\npermittivity : ArrayLike_dtype=<class 'float'>_ndim=2_shape=(3, 3) = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]\n    [units = None (relative permittivity)].  Relative permittivity tensor.\nconductivity : ArrayLike_dtype=<class 'float'>_ndim=2_shape=(3, 3) = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]\n    [units = S/um].  Electric conductivity tensor. Defined such that the imaginary part of the complex permittivity at angular frequency omega is given by conductivity/omega.\n\nNote\n----\nSimulations involving fully anisotropic materials are computationally more intensive, thus,\nthey take longer time to complete. This increase strongly depends on the filling fraction of\nthe simulation domain by fully anisotropic materials, varying approximately in the range from\n1.5 to 5. Cost of running a simulation is adjusted correspondingly.\n\nExample\n-------\n>>> perm = [[2, 0, 0], [0, 1, 0], [0, 0, 3]]\n>>> cond = [[0.1, 0, 0], [0, 0, 0], [0, 0, 0]]\n>>> anisotropic_dielectric = FullyAnisotropicMedium(permittivity=perm, conductivity=cond)",
+      "description": "Fully anisotropic medium including all 9 components of the permittivity and conductivity\ntensors. Provided permittivity tensor and the symmetric part of the conductivity tensor must\nhave coinciding main directions. A non-symmetric conductivity tensor can be used to model\nmagneto-optic effects. Note that dispersive properties and subpixel averaging are currently not\nsupported for fully anisotropic materials.\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\nallow_gain : bool = False\n    Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.\npermittivity : ArrayLike_dtype=<class 'float'>_ndim=2_shape=(3, 3) = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]\n    [units = None (relative permittivity)].  Relative permittivity tensor.\nconductivity : ArrayLike_dtype=<class 'float'>_ndim=2_shape=(3, 3) = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]\n    [units = S/um].  Electric conductivity tensor. Defined such that the imaginary part of the complex permittivity at angular frequency omega is given by conductivity/omega.\n\nNote\n----\nSimulations involving fully anisotropic materials are computationally more intensive, thus,\nthey take longer time to complete. This increase strongly depends on the filling fraction of\nthe simulation domain by fully anisotropic materials, varying approximately in the range from\n1.5 to 5. Cost of running a simulation is adjusted correspondingly.\n\nExample\n-------\n>>> perm = [[2, 0, 0], [0, 1, 0], [0, 0, 3]]\n>>> cond = [[0.1, 0, 0], [0, 0, 0], [0, 0, 0]]\n>>> anisotropic_dielectric = FullyAnisotropicMedium(permittivity=perm, conductivity=cond)",
       "type": "object",
       "properties": {
         "name": {
@@ -1189,6 +1237,12 @@
             }
           ]
         },
+        "allow_gain": {
+          "title": "Allow gain medium",
+          "description": "Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.",
+          "default": false,
+          "type": "boolean"
+        },
         "type": {
           "title": "Type",
           "default": "FullyAnisotropicMedium",
@@ -1198,7 +1252,7 @@
           "type": "string"
         },
         "permittivity": {
-          "title": "ArrayLike",
+          "title": "Permittivity",
           "description": "Relative permittivity tensor.",
           "default": [
             [
@@ -1221,7 +1275,7 @@
           "type": "ArrayLike"
         },
         "conductivity": {
-          "title": "ArrayLike",
+          "title": "Conductivity",
           "description": "Electric conductivity tensor. Defined such that the imaginary part of the complex permittivity at angular frequency omega is given by conductivity/omega.",
           "default": [
             [
@@ -1311,7 +1365,7 @@
     },
     "CustomMedium": {
       "title": "CustomMedium",
-      "description": ":class:`.Medium` with user-supplied permittivity distribution.\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\ninterp_method : Literal['nearest', 'linear'] = nearest\n    Interpolation method to obtain permittivity values that are not supplied at the Yee grids; For grids outside the range of the supplied data, extrapolation will be applied. When the extrapolated value is smaller (greater) than the minimal (maximal) of the supplied data, the extrapolated value will take the minimal (maximal) of the supplied data.\npermittivity : Optional[SpatialDataArray] = None\n    [units = None (relative permittivity)].  Spatial profile of relative permittivity.\nconductivity : Optional[SpatialDataArray] = None\n    [units = S/um].  Spatial profile Electric conductivity. Defined such that the imaginary part of the complex permittivity at angular frequency omega is given by conductivity/omega.\neps_dataset : Optional[PermittivityDataset] = None\n    [To be deprecated] User-supplied dataset containing complex-valued permittivity as a function of space. Permittivity distribution over the Yee-grid will be interpolated based on ``interp_method``.\n\nExample\n-------\n>>> Nx, Ny, Nz = 10, 9, 8\n>>> X = np.linspace(-1, 1, Nx)\n>>> Y = np.linspace(-1, 1, Ny)\n>>> Z = np.linspace(-1, 1, Nz)\n>>> coords = dict(x=X, y=Y, z=Z)\n>>> permittivity= SpatialDataArray(np.ones((Nx, Ny, Nz)), coords=coords)\n>>> conductivity= SpatialDataArray(np.ones((Nx, Ny, Nz)), coords=coords)\n>>> dielectric = CustomMedium(permittivity=permittivity, conductivity=conductivity)\n>>> eps = dielectric.eps_model(200e12)",
+      "description": ":class:`.Medium` with user-supplied permittivity distribution.\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\nallow_gain : bool = False\n    Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.\ninterp_method : Literal['nearest', 'linear'] = nearest\n    Interpolation method to obtain permittivity values that are not supplied at the Yee grids; For grids outside the range of the supplied data, extrapolation will be applied. When the extrapolated value is smaller (greater) than the minimal (maximal) of the supplied data, the extrapolated value will take the minimal (maximal) of the supplied data.\npermittivity : Optional[SpatialDataArray] = None\n    [units = None (relative permittivity)].  Spatial profile of relative permittivity.\nconductivity : Optional[SpatialDataArray] = None\n    [units = S/um].  Spatial profile Electric conductivity. Defined such that the imaginary part of the complex permittivity at angular frequency omega is given by conductivity/omega.\neps_dataset : Optional[PermittivityDataset] = None\n    [To be deprecated] User-supplied dataset containing complex-valued permittivity as a function of space. Permittivity distribution over the Yee-grid will be interpolated based on ``interp_method``.\n\nExample\n-------\n>>> Nx, Ny, Nz = 10, 9, 8\n>>> X = np.linspace(-1, 1, Nx)\n>>> Y = np.linspace(-1, 1, Ny)\n>>> Z = np.linspace(-1, 1, Nz)\n>>> coords = dict(x=X, y=Y, z=Z)\n>>> permittivity= SpatialDataArray(np.ones((Nx, Ny, Nz)), coords=coords)\n>>> conductivity= SpatialDataArray(np.ones((Nx, Ny, Nz)), coords=coords)\n>>> dielectric = CustomMedium(permittivity=permittivity, conductivity=conductivity)\n>>> eps = dielectric.eps_model(200e12)",
       "type": "object",
       "properties": {
         "name": {
@@ -1337,6 +1391,12 @@
               "type": "number"
             }
           ]
+        },
+        "allow_gain": {
+          "title": "Allow gain medium",
+          "description": "Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.",
+          "default": false,
+          "type": "boolean"
         },
         "type": {
           "title": "Type",
@@ -1400,7 +1460,7 @@
     },
     "CustomPoleResidue": {
       "title": "CustomPoleResidue",
-      "description": "A spatially varying dispersive medium described by the pole-residue pair model.\nThe frequency-dependence of the complex-valued permittivity is described by:\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\neps_inf : SpatialDataArray\n    [units = None (relative permittivity)].  Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).\npoles : Tuple[Tuple[tidy3d.components.data.data_array.SpatialDataArray, tidy3d.components.data.data_array.SpatialDataArray], ...] = ()\n    [units = (rad/sec, rad/sec)].  Tuple of complex-valued (:math:`a_i, c_i`) poles for the model.\ninterp_method : Literal['nearest', 'linear'] = nearest\n    Interpolation method to obtain permittivity values that are not supplied at the Yee grids; For grids outside the range of the supplied data, extrapolation will be applied. When the extrapolated value is smaller (greater) than the minimal (maximal) of the supplied data, the extrapolated value will take the minimal (maximal) of the supplied data.\n\nNote\n----\n.. math::\n\n    \\epsilon(\\omega) = \\epsilon_\\infty - \\sum_i\n    \\left[\\frac{c_i}{j \\omega + a_i} +\n    \\frac{c_i^*}{j \\omega + a_i^*}\\right]\n\nExample\n-------\n>>> x = np.linspace(-1, 1, 5)\n>>> y = np.linspace(-1, 1, 6)\n>>> z = np.linspace(-1, 1, 7)\n>>> coords = dict(x=x, y=y, z=z)\n>>> eps_inf = SpatialDataArray(np.ones((5, 6, 7)), coords=coords)\n>>> a1 = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> c1 = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> a2 = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> c2 = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> pole_res = CustomPoleResidue(eps_inf=eps_inf, poles=[(a1, c1), (a2, c2)])\n>>> eps = pole_res.eps_model(200e12)",
+      "description": "A spatially varying dispersive medium described by the pole-residue pair model.\nThe frequency-dependence of the complex-valued permittivity is described by:\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\nallow_gain : bool = False\n    Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.\neps_inf : SpatialDataArray\n    [units = None (relative permittivity)].  Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).\npoles : Tuple[Tuple[tidy3d.components.data.data_array.SpatialDataArray, tidy3d.components.data.data_array.SpatialDataArray], ...] = ()\n    [units = (rad/sec, rad/sec)].  Tuple of complex-valued (:math:`a_i, c_i`) poles for the model.\ninterp_method : Literal['nearest', 'linear'] = nearest\n    Interpolation method to obtain permittivity values that are not supplied at the Yee grids; For grids outside the range of the supplied data, extrapolation will be applied. When the extrapolated value is smaller (greater) than the minimal (maximal) of the supplied data, the extrapolated value will take the minimal (maximal) of the supplied data.\n\nNote\n----\n.. math::\n\n    \\epsilon(\\omega) = \\epsilon_\\infty - \\sum_i\n    \\left[\\frac{c_i}{j \\omega + a_i} +\n    \\frac{c_i^*}{j \\omega + a_i^*}\\right]\n\nExample\n-------\n>>> x = np.linspace(-1, 1, 5)\n>>> y = np.linspace(-1, 1, 6)\n>>> z = np.linspace(-1, 1, 7)\n>>> coords = dict(x=x, y=y, z=z)\n>>> eps_inf = SpatialDataArray(np.ones((5, 6, 7)), coords=coords)\n>>> a1 = SpatialDataArray(-np.random.random((5, 6, 7)), coords=coords)\n>>> c1 = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> a2 = SpatialDataArray(-np.random.random((5, 6, 7)), coords=coords)\n>>> c2 = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> pole_res = CustomPoleResidue(eps_inf=eps_inf, poles=[(a1, c1), (a2, c2)])\n>>> eps = pole_res.eps_model(200e12)",
       "type": "object",
       "properties": {
         "name": {
@@ -1426,6 +1486,12 @@
               "type": "number"
             }
           ]
+        },
+        "allow_gain": {
+          "title": "Allow gain medium",
+          "description": "Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.",
+          "default": false,
+          "type": "boolean"
         },
         "type": {
           "title": "Type",
@@ -1511,7 +1577,7 @@
     },
     "CustomSellmeier": {
       "title": "CustomSellmeier",
-      "description": "A spatially varying dispersive medium described by the Sellmeier model.\nThe frequency-dependence of the refractive index is described by:\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\ncoeffs : Tuple[Tuple[tidy3d.components.data.data_array.SpatialDataArray, tidy3d.components.data.data_array.SpatialDataArray], ...]\n    [units = (None, um^2)].  List of Sellmeier (:math:`B_i, C_i`) coefficients.\ninterp_method : Literal['nearest', 'linear'] = nearest\n    Interpolation method to obtain permittivity values that are not supplied at the Yee grids; For grids outside the range of the supplied data, extrapolation will be applied. When the extrapolated value is smaller (greater) than the minimal (maximal) of the supplied data, the extrapolated value will take the minimal (maximal) of the supplied data.\n\nNote\n----\n.. math::\n\n    n(\\lambda)^2 = 1 + \\sum_i \\frac{B_i \\lambda^2}{\\lambda^2 - C_i}\n\nExample\n-------\n>>> x = np.linspace(-1, 1, 5)\n>>> y = np.linspace(-1, 1, 6)\n>>> z = np.linspace(-1, 1, 7)\n>>> coords = dict(x=x, y=y, z=z)\n>>> b1 = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> c1 = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> sellmeier_medium = CustomSellmeier(coeffs=[(b1,c1),])\n>>> eps = sellmeier_medium.eps_model(200e12)",
+      "description": "A spatially varying dispersive medium described by the Sellmeier model.\nThe frequency-dependence of the refractive index is described by:\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\nallow_gain : bool = False\n    Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.\ncoeffs : Tuple[Tuple[tidy3d.components.data.data_array.SpatialDataArray, tidy3d.components.data.data_array.SpatialDataArray], ...]\n    [units = (None, um^2)].  List of Sellmeier (:math:`B_i, C_i`) coefficients.\ninterp_method : Literal['nearest', 'linear'] = nearest\n    Interpolation method to obtain permittivity values that are not supplied at the Yee grids; For grids outside the range of the supplied data, extrapolation will be applied. When the extrapolated value is smaller (greater) than the minimal (maximal) of the supplied data, the extrapolated value will take the minimal (maximal) of the supplied data.\n\nNote\n----\n.. math::\n\n    n(\\lambda)^2 = 1 + \\sum_i \\frac{B_i \\lambda^2}{\\lambda^2 - C_i}\n\nExample\n-------\n>>> x = np.linspace(-1, 1, 5)\n>>> y = np.linspace(-1, 1, 6)\n>>> z = np.linspace(-1, 1, 7)\n>>> coords = dict(x=x, y=y, z=z)\n>>> b1 = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> c1 = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> sellmeier_medium = CustomSellmeier(coeffs=[(b1,c1),])\n>>> eps = sellmeier_medium.eps_model(200e12)",
       "type": "object",
       "properties": {
         "name": {
@@ -1537,6 +1603,12 @@
               "type": "number"
             }
           ]
+        },
+        "allow_gain": {
+          "title": "Allow gain medium",
+          "description": "Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.",
+          "default": false,
+          "type": "boolean"
         },
         "type": {
           "title": "Type",
@@ -1606,7 +1678,7 @@
     },
     "CustomLorentz": {
       "title": "CustomLorentz",
-      "description": "A spatially varying dispersive medium described by the Lorentz model.\nThe frequency-dependence of the complex-valued permittivity is described by:\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\neps_inf : SpatialDataArray\n    [units = None (relative permittivity)].  Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).\ncoeffs : Tuple[Tuple[tidy3d.components.data.data_array.SpatialDataArray, tidy3d.components.data.data_array.SpatialDataArray, tidy3d.components.data.data_array.SpatialDataArray], ...]\n    [units = (None (relative permittivity), Hz, Hz)].  List of (:math:`\\Delta\\epsilon_i, f_i, \\delta_i`) values for model.\ninterp_method : Literal['nearest', 'linear'] = nearest\n    Interpolation method to obtain permittivity values that are not supplied at the Yee grids; For grids outside the range of the supplied data, extrapolation will be applied. When the extrapolated value is smaller (greater) than the minimal (maximal) of the supplied data, the extrapolated value will take the minimal (maximal) of the supplied data.\n\nNote\n----\n.. math::\n\n    \\epsilon(f) = \\epsilon_\\infty + \\sum_i\n    \\frac{\\Delta\\epsilon_i f_i^2}{f_i^2 - 2jf\\delta_i - f^2}\n\nExample\n-------\n>>> x = np.linspace(-1, 1, 5)\n>>> y = np.linspace(-1, 1, 6)\n>>> z = np.linspace(-1, 1, 7)\n>>> coords = dict(x=x, y=y, z=z)\n>>> eps_inf = SpatialDataArray(np.ones((5, 6, 7)), coords=coords)\n>>> d_epsilon = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> f = SpatialDataArray(1+np.random.random((5, 6, 7)), coords=coords)\n>>> delta = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> lorentz_medium = CustomLorentz(eps_inf=eps_inf, coeffs=[(d_epsilon,f,delta),])\n>>> eps = lorentz_medium.eps_model(200e12)",
+      "description": "A spatially varying dispersive medium described by the Lorentz model.\nThe frequency-dependence of the complex-valued permittivity is described by:\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\nallow_gain : bool = False\n    Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.\neps_inf : SpatialDataArray\n    [units = None (relative permittivity)].  Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).\ncoeffs : Tuple[Tuple[tidy3d.components.data.data_array.SpatialDataArray, tidy3d.components.data.data_array.SpatialDataArray, tidy3d.components.data.data_array.SpatialDataArray], ...]\n    [units = (None (relative permittivity), Hz, Hz)].  List of (:math:`\\Delta\\epsilon_i, f_i, \\delta_i`) values for model.\ninterp_method : Literal['nearest', 'linear'] = nearest\n    Interpolation method to obtain permittivity values that are not supplied at the Yee grids; For grids outside the range of the supplied data, extrapolation will be applied. When the extrapolated value is smaller (greater) than the minimal (maximal) of the supplied data, the extrapolated value will take the minimal (maximal) of the supplied data.\n\nNote\n----\n.. math::\n\n    \\epsilon(f) = \\epsilon_\\infty + \\sum_i\n    \\frac{\\Delta\\epsilon_i f_i^2}{f_i^2 - 2jf\\delta_i - f^2}\n\nExample\n-------\n>>> x = np.linspace(-1, 1, 5)\n>>> y = np.linspace(-1, 1, 6)\n>>> z = np.linspace(-1, 1, 7)\n>>> coords = dict(x=x, y=y, z=z)\n>>> eps_inf = SpatialDataArray(np.ones((5, 6, 7)), coords=coords)\n>>> d_epsilon = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> f = SpatialDataArray(1+np.random.random((5, 6, 7)), coords=coords)\n>>> delta = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> lorentz_medium = CustomLorentz(eps_inf=eps_inf, coeffs=[(d_epsilon,f,delta),])\n>>> eps = lorentz_medium.eps_model(200e12)",
       "type": "object",
       "properties": {
         "name": {
@@ -1632,6 +1704,12 @@
               "type": "number"
             }
           ]
+        },
+        "allow_gain": {
+          "title": "Allow gain medium",
+          "description": "Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.",
+          "default": false,
+          "type": "boolean"
         },
         "type": {
           "title": "Type",
@@ -1731,7 +1809,7 @@
     },
     "CustomDebye": {
       "title": "CustomDebye",
-      "description": "A spatially varying dispersive medium described by the Debye model.\nThe frequency-dependence of the complex-valued permittivity is described by:\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\neps_inf : SpatialDataArray\n    [units = None (relative permittivity)].  Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).\ncoeffs : Tuple[Tuple[tidy3d.components.data.data_array.SpatialDataArray, tidy3d.components.data.data_array.SpatialDataArray], ...]\n    [units = (None (relative permittivity), sec)].  List of (:math:`\\Delta\\epsilon_i, \\tau_i`) values for model.\ninterp_method : Literal['nearest', 'linear'] = nearest\n    Interpolation method to obtain permittivity values that are not supplied at the Yee grids; For grids outside the range of the supplied data, extrapolation will be applied. When the extrapolated value is smaller (greater) than the minimal (maximal) of the supplied data, the extrapolated value will take the minimal (maximal) of the supplied data.\n\nNote\n----\n.. math::\n\n    \\epsilon(f) = \\epsilon_\\infty + \\sum_i\n    \\frac{\\Delta\\epsilon_i}{1 - jf\\tau_i}\n\nExample\n-------\n>>> x = np.linspace(-1, 1, 5)\n>>> y = np.linspace(-1, 1, 6)\n>>> z = np.linspace(-1, 1, 7)\n>>> coords = dict(x=x, y=y, z=z)\n>>> eps_inf = SpatialDataArray(1+np.random.random((5, 6, 7)), coords=coords)\n>>> eps1 = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> tau1 = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> debye_medium = CustomDebye(eps_inf=eps_inf, coeffs=[(eps1,tau1),])\n>>> eps = debye_medium.eps_model(200e12)",
+      "description": "A spatially varying dispersive medium described by the Debye model.\nThe frequency-dependence of the complex-valued permittivity is described by:\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\nallow_gain : bool = False\n    Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.\neps_inf : SpatialDataArray\n    [units = None (relative permittivity)].  Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).\ncoeffs : Tuple[Tuple[tidy3d.components.data.data_array.SpatialDataArray, tidy3d.components.data.data_array.SpatialDataArray], ...]\n    [units = (None (relative permittivity), sec)].  List of (:math:`\\Delta\\epsilon_i, \\tau_i`) values for model.\ninterp_method : Literal['nearest', 'linear'] = nearest\n    Interpolation method to obtain permittivity values that are not supplied at the Yee grids; For grids outside the range of the supplied data, extrapolation will be applied. When the extrapolated value is smaller (greater) than the minimal (maximal) of the supplied data, the extrapolated value will take the minimal (maximal) of the supplied data.\n\nNote\n----\n.. math::\n\n    \\epsilon(f) = \\epsilon_\\infty + \\sum_i\n    \\frac{\\Delta\\epsilon_i}{1 - jf\\tau_i}\n\nExample\n-------\n>>> x = np.linspace(-1, 1, 5)\n>>> y = np.linspace(-1, 1, 6)\n>>> z = np.linspace(-1, 1, 7)\n>>> coords = dict(x=x, y=y, z=z)\n>>> eps_inf = SpatialDataArray(1+np.random.random((5, 6, 7)), coords=coords)\n>>> eps1 = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> tau1 = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> debye_medium = CustomDebye(eps_inf=eps_inf, coeffs=[(eps1,tau1),])\n>>> eps = debye_medium.eps_model(200e12)",
       "type": "object",
       "properties": {
         "name": {
@@ -1757,6 +1835,12 @@
               "type": "number"
             }
           ]
+        },
+        "allow_gain": {
+          "title": "Allow gain medium",
+          "description": "Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.",
+          "default": false,
+          "type": "boolean"
         },
         "type": {
           "title": "Type",
@@ -1842,7 +1926,7 @@
     },
     "CustomDrude": {
       "title": "CustomDrude",
-      "description": "A spatially varying dispersive medium described by the Drude model.\nThe frequency-dependence of the complex-valued permittivity is described by:\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\neps_inf : SpatialDataArray\n    [units = None (relative permittivity)].  Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).\ncoeffs : Tuple[Tuple[tidy3d.components.data.data_array.SpatialDataArray, tidy3d.components.data.data_array.SpatialDataArray], ...]\n    [units = (Hz, Hz)].  List of (:math:`f_i, \\delta_i`) values for model.\ninterp_method : Literal['nearest', 'linear'] = nearest\n    Interpolation method to obtain permittivity values that are not supplied at the Yee grids; For grids outside the range of the supplied data, extrapolation will be applied. When the extrapolated value is smaller (greater) than the minimal (maximal) of the supplied data, the extrapolated value will take the minimal (maximal) of the supplied data.\n\nNote\n----\n.. math::\n\n    \\epsilon(f) = \\epsilon_\\infty - \\sum_i\n    \\frac{ f_i^2}{f^2 + jf\\delta_i}\n\nExample\n-------\n>>> x = np.linspace(-1, 1, 5)\n>>> y = np.linspace(-1, 1, 6)\n>>> z = np.linspace(-1, 1, 7)\n>>> coords = dict(x=x, y=y, z=z)\n>>> eps_inf = SpatialDataArray(np.ones((5, 6, 7)), coords=coords)\n>>> f1 = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> delta1 = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> drude_medium = CustomDrude(eps_inf=eps_inf, coeffs=[(f1,delta1),])\n>>> eps = drude_medium.eps_model(200e12)",
+      "description": "A spatially varying dispersive medium described by the Drude model.\nThe frequency-dependence of the complex-valued permittivity is described by:\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\nallow_gain : bool = False\n    Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.\neps_inf : SpatialDataArray\n    [units = None (relative permittivity)].  Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).\ncoeffs : Tuple[Tuple[tidy3d.components.data.data_array.SpatialDataArray, tidy3d.components.data.data_array.SpatialDataArray], ...]\n    [units = (Hz, Hz)].  List of (:math:`f_i, \\delta_i`) values for model.\ninterp_method : Literal['nearest', 'linear'] = nearest\n    Interpolation method to obtain permittivity values that are not supplied at the Yee grids; For grids outside the range of the supplied data, extrapolation will be applied. When the extrapolated value is smaller (greater) than the minimal (maximal) of the supplied data, the extrapolated value will take the minimal (maximal) of the supplied data.\n\nNote\n----\n.. math::\n\n    \\epsilon(f) = \\epsilon_\\infty - \\sum_i\n    \\frac{ f_i^2}{f^2 + jf\\delta_i}\n\nExample\n-------\n>>> x = np.linspace(-1, 1, 5)\n>>> y = np.linspace(-1, 1, 6)\n>>> z = np.linspace(-1, 1, 7)\n>>> coords = dict(x=x, y=y, z=z)\n>>> eps_inf = SpatialDataArray(np.ones((5, 6, 7)), coords=coords)\n>>> f1 = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> delta1 = SpatialDataArray(np.random.random((5, 6, 7)), coords=coords)\n>>> drude_medium = CustomDrude(eps_inf=eps_inf, coeffs=[(f1,delta1),])\n>>> eps = drude_medium.eps_model(200e12)",
       "type": "object",
       "properties": {
         "name": {
@@ -1868,6 +1952,12 @@
               "type": "number"
             }
           ]
+        },
+        "allow_gain": {
+          "title": "Allow gain medium",
+          "description": "Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.",
+          "default": false,
+          "type": "boolean"
         },
         "type": {
           "title": "Type",
@@ -1953,7 +2043,7 @@
     },
     "CustomAnisotropicMedium": {
       "title": "CustomAnisotropicMedium",
-      "description": "Diagonally anisotropic medium with spatially varying permittivity in each component.\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\nxx : Union[CustomPoleResidue, CustomSellmeier, CustomLorentz, CustomDebye, CustomDrude, CustomMedium]\n    Medium describing the xx-component of the diagonal permittivity tensor.\nyy : Union[CustomPoleResidue, CustomSellmeier, CustomLorentz, CustomDebye, CustomDrude, CustomMedium]\n    Medium describing the yy-component of the diagonal permittivity tensor.\nzz : Union[CustomPoleResidue, CustomSellmeier, CustomLorentz, CustomDebye, CustomDrude, CustomMedium]\n    Medium describing the zz-component of the diagonal permittivity tensor.\ninterp_method : Optional[Literal['nearest', 'linear']] = None\n    When the value is 'None', each component will follow its own interpolation method. When the value is other than 'None', the interpolation method specified by this field will override the one in each component.\n\nNote\n----\nOnly diagonal anisotropy is currently supported.\n\nExample\n-------\n>>> Nx, Ny, Nz = 10, 9, 8\n>>> x = np.linspace(-1, 1, Nx)\n>>> y = np.linspace(-1, 1, Ny)\n>>> z = np.linspace(-1, 1, Nz)\n>>> coords = dict(x=x, y=y, z=z)\n>>> permittivity= SpatialDataArray(np.ones((Nx, Ny, Nz)), coords=coords)\n>>> conductivity= SpatialDataArray(np.ones((Nx, Ny, Nz)), coords=coords)\n>>> medium_xx = CustomMedium(permittivity=permittivity, conductivity=conductivity)\n>>> medium_yy = CustomMedium(permittivity=permittivity, conductivity=conductivity)\n>>> d_epsilon = SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=coords)\n>>> f = SpatialDataArray(1+np.random.random((Nx, Ny, Nz)), coords=coords)\n>>> delta = SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=coords)\n>>> medium_zz = CustomLorentz(eps_inf=permittivity, coeffs=[(d_epsilon,f,delta),])\n>>> anisotropic_dielectric = CustomAnisotropicMedium(xx=medium_xx, yy=medium_yy, zz=medium_zz)",
+      "description": "Diagonally anisotropic medium with spatially varying permittivity in each component.\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\nallow_gain : Optional[bool] = None\n    This field is ignored. Please set ``allow_gain`` in each component\nxx : Union[CustomPoleResidue, CustomSellmeier, CustomLorentz, CustomDebye, CustomDrude, CustomMedium]\n    Medium describing the xx-component of the diagonal permittivity tensor.\nyy : Union[CustomPoleResidue, CustomSellmeier, CustomLorentz, CustomDebye, CustomDrude, CustomMedium]\n    Medium describing the yy-component of the diagonal permittivity tensor.\nzz : Union[CustomPoleResidue, CustomSellmeier, CustomLorentz, CustomDebye, CustomDrude, CustomMedium]\n    Medium describing the zz-component of the diagonal permittivity tensor.\ninterp_method : Optional[Literal['nearest', 'linear']] = None\n    When the value is 'None', each component will follow its own interpolation method. When the value is other than 'None', the interpolation method specified by this field will override the one in each component.\n\nNote\n----\nOnly diagonal anisotropy is currently supported.\n\nExample\n-------\n>>> Nx, Ny, Nz = 10, 9, 8\n>>> x = np.linspace(-1, 1, Nx)\n>>> y = np.linspace(-1, 1, Ny)\n>>> z = np.linspace(-1, 1, Nz)\n>>> coords = dict(x=x, y=y, z=z)\n>>> permittivity= SpatialDataArray(np.ones((Nx, Ny, Nz)), coords=coords)\n>>> conductivity= SpatialDataArray(np.ones((Nx, Ny, Nz)), coords=coords)\n>>> medium_xx = CustomMedium(permittivity=permittivity, conductivity=conductivity)\n>>> medium_yy = CustomMedium(permittivity=permittivity, conductivity=conductivity)\n>>> d_epsilon = SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=coords)\n>>> f = SpatialDataArray(1+np.random.random((Nx, Ny, Nz)), coords=coords)\n>>> delta = SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=coords)\n>>> medium_zz = CustomLorentz(eps_inf=permittivity, coeffs=[(d_epsilon,f,delta),])\n>>> anisotropic_dielectric = CustomAnisotropicMedium(xx=medium_xx, yy=medium_yy, zz=medium_zz)",
       "type": "object",
       "properties": {
         "name": {
@@ -1979,6 +2069,11 @@
               "type": "number"
             }
           ]
+        },
+        "allow_gain": {
+          "title": "Allow gain medium",
+          "description": "This field is ignored. Please set ``allow_gain`` in each component",
+          "type": "boolean"
         },
         "type": {
           "title": "Type",
@@ -2382,7 +2477,7 @@
           "type": "number"
         },
         "vertices": {
-          "title": "ArrayLike",
+          "title": "Vertices",
           "description": "List of (d1, d2) defining the 2 dimensional positions of the polygon face vertices at the ``reference_plane``. The index of dimension should be in the ascending order: e.g. if the slab normal axis is ``axis=y``, the coordinate of the vertices will be in (x, z)",
           "units": "um",
           "type": "ArrayLike"
@@ -2510,7 +2605,7 @@
     },
     "Medium2D": {
       "title": "Medium2D",
-      "description": "2D diagonally anisotropic medium.\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\nss : Union[Medium, PoleResidue, Sellmeier, Lorentz, Debye, Drude]\n    Medium describing the ss-component of the diagonal permittivity tensor. The ss-component refers to the in-plane dimension of the medium that is the first component in order of 'x', 'y', 'z'. If the 2D material is normal to the y-axis, for example, then this determines the xx-component of the corresponding 3D medium.\ntt : Union[Medium, PoleResidue, Sellmeier, Lorentz, Debye, Drude]\n    Medium describing the tt-component of the diagonal permittivity tensor. The tt-component refers to the in-plane dimension of the medium that is the second component in order of 'x', 'y', 'z'. If the 2D material is normal to the y-axis, for example, then this determines the zz-component of the corresponding 3D medium.\n\nNote\n----\nOnly diagonal anisotropy is currently supported.\n\nExample\n-------\n>>> drude_medium = Drude(eps_inf=2.0, coeffs=[(1,2), (3,4)])\n>>> medium2d = Medium2D(ss=drude_medium, tt=drude_medium)",
+      "description": "2D diagonally anisotropic medium.\n\nParameters\n----------\nname : Optional[str] = None\n    Optional unique name for medium.\nfrequency_range : Optional[Tuple[float, float]] = None\n    [units = (Hz, Hz)].  Optional range of validity for the medium.\nallow_gain : bool = False\n    Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.\nss : Union[Medium, PoleResidue, Sellmeier, Lorentz, Debye, Drude]\n    Medium describing the ss-component of the diagonal permittivity tensor. The ss-component refers to the in-plane dimension of the medium that is the first component in order of 'x', 'y', 'z'. If the 2D material is normal to the y-axis, for example, then this determines the xx-component of the corresponding 3D medium.\ntt : Union[Medium, PoleResidue, Sellmeier, Lorentz, Debye, Drude]\n    Medium describing the tt-component of the diagonal permittivity tensor. The tt-component refers to the in-plane dimension of the medium that is the second component in order of 'x', 'y', 'z'. If the 2D material is normal to the y-axis, for example, then this determines the zz-component of the corresponding 3D medium.\n\nNote\n----\nOnly diagonal anisotropy is currently supported.\n\nExample\n-------\n>>> drude_medium = Drude(eps_inf=2.0, coeffs=[(1,2), (3,4)])\n>>> medium2d = Medium2D(ss=drude_medium, tt=drude_medium)",
       "type": "object",
       "properties": {
         "name": {
@@ -2536,6 +2631,12 @@
               "type": "number"
             }
           ]
+        },
+        "allow_gain": {
+          "title": "Allow gain medium",
+          "description": "Allow the medium to be active. Caution: simulations with gain medium are unstable, and are likely to diverge.Simulations where 'allow_gain' is set to 'True' will still be charged even if diverged. Monitor data up to the divergence point will still be returned and can be useful in some cases.",
+          "default": false,
+          "type": "boolean"
         },
         "type": {
           "title": "Type",
@@ -4913,7 +5014,6 @@
               }
             },
             {
-              "title": "ArrayLike",
               "type": "ArrayLike"
             }
           ]
@@ -5222,7 +5322,6 @@
               }
             },
             {
-              "title": "ArrayLike",
               "type": "ArrayLike"
             }
           ]
@@ -5327,7 +5426,6 @@
               }
             },
             {
-              "title": "ArrayLike",
               "type": "ArrayLike"
             }
           ]
@@ -5576,7 +5674,6 @@
               }
             },
             {
-              "title": "ArrayLike",
               "type": "ArrayLike"
             }
           ]
@@ -5691,7 +5788,6 @@
               }
             },
             {
-              "title": "ArrayLike",
               "type": "ArrayLike"
             }
           ]
@@ -5731,7 +5827,7 @@
     },
     "FieldProjectionAngleMonitor": {
       "title": "FieldProjectionAngleMonitor",
-      "description": ":class:`Monitor` that samples electromagnetic near fields in the frequency domain\nand projects them at given observation angles.\n\nParameters\n----------\ncenter : Tuple[float, float, float] = (0.0, 0.0, 0.0)\n    [units = um].  Center of object in x, y, and z.\nsize : Tuple[NonNegativeFloat, NonNegativeFloat, NonNegativeFloat]\n    [units = um].  Size in x, y, and z directions.\nname : ConstrainedStrValue\n    Unique name for monitor.\nfreqs : Union[Tuple[float, ...], ArrayLike_dtype=<class 'float'>_ndim=1]\n    [units = Hz].  Array or list of frequencies stored by the field monitor.\napodization : ApodizationSpec = ApodizationSpec(start=None, end=None, width=None, type='ApodizationSpec')\n    Sets parameters of (optional) apodization. Apodization applies a windowing function to the Fourier transform of the time-domain fields into frequency-domain ones, and can be used to truncate the beginning and/or end of the time signal, for example to eliminate the source pulse when studying the eigenmodes of a system. Note: apodization affects the normalization of the frequency-domain fields.\nnormal_dir : Optional[Literal['+', '-']] = None\n    Direction of the surface monitor's normal vector w.r.t. the positive x, y or z unit vectors. Must be one of ``'+'`` or ``'-'``. Applies to surface monitors only, and defaults to ``'+'`` if not provided.\nexclude_surfaces : Optional[Tuple[Literal['x-', 'x+', 'y-', 'y+', 'z-', 'z+'], ...]] = None\n    Surfaces to exclude in the integration, if a volume monitor.\ncustom_origin : Optional[Tuple[float, float, float]] = None\n    [units = um].  Local origin used for defining observation points. If ``None``, uses the monitor's center.\nfar_field_approx : bool = True\n    Whether to enable the far field approximation when projecting fields.\nproj_distance : float = 1000000.0\n    [units = um].  Radial distance of the projection points from ``local_origin``.\ntheta : Union[Tuple[float, ...], ArrayLike_dtype=<class 'float'>_ndim=1]\n    [units = rad].  Polar angles with respect to the global z axis, relative to the location of ``local_origin``, at which to project fields.\nphi : Union[Tuple[float, ...], ArrayLike_dtype=<class 'float'>_ndim=1]\n    [units = rad].  Azimuth angles with respect to the global z axis, relative to the location of ``local_origin``, at which to project fields.\n\nExample\n-------\n>>> monitor = FieldProjectionAngleMonitor(\n...     center=(1,2,3),\n...     size=(2,2,2),\n...     freqs=[250e12, 300e12],\n...     name='n2f_monitor',\n...     custom_origin=(1,2,3),\n...     phi=[0, np.pi/2],\n...     theta=np.linspace(-np.pi/2, np.pi/2, 100)\n...     )",
+      "description": ":class:`Monitor` that samples electromagnetic near fields in the frequency domain\nand projects them at given observation angles. The ``center`` and ``size`` fields define\nwhere the monitor will be placed in order to record near fields, typically very close\nto the structure of interest. The near fields are then projected\nto far-field locations defined by ``phi``, ``theta``, and ``proj_distance``, relative\nto the ``custom_origin``. If the distance between the near and far field locations is\nmuch larger than the size of the device, one can typically set ``far_field_approx`` to\n``True``, which will make use of the far-field approximation to speed up calculations.\nIf the projection distance is comparable to the size of the device, we recommend setting\n``far_field_approx`` to ``False``, so that the approximations are not used, and the\nprojection is accurate even just a few wavelengths away from the near field locations.\nFor applications where the monitor is an open surface rather than a box that\nencloses the device, it is advisable to pick the size of the monitor such that the\nrecorded near fields decay to negligible values near the edges of the monitor.\n\nParameters\n----------\ncenter : Tuple[float, float, float] = (0.0, 0.0, 0.0)\n    [units = um].  Center of object in x, y, and z.\nsize : Tuple[NonNegativeFloat, NonNegativeFloat, NonNegativeFloat]\n    [units = um].  Size in x, y, and z directions.\nname : ConstrainedStrValue\n    Unique name for monitor.\nfreqs : Union[Tuple[float, ...], ArrayLike_dtype=<class 'float'>_ndim=1]\n    [units = Hz].  Array or list of frequencies stored by the field monitor.\napodization : ApodizationSpec = ApodizationSpec(start=None, end=None, width=None, type='ApodizationSpec')\n    Sets parameters of (optional) apodization. Apodization applies a windowing function to the Fourier transform of the time-domain fields into frequency-domain ones, and can be used to truncate the beginning and/or end of the time signal, for example to eliminate the source pulse when studying the eigenmodes of a system. Note: apodization affects the normalization of the frequency-domain fields.\nnormal_dir : Optional[Literal['+', '-']] = None\n    Direction of the surface monitor's normal vector w.r.t. the positive x, y or z unit vectors. Must be one of ``'+'`` or ``'-'``. Applies to surface monitors only, and defaults to ``'+'`` if not provided.\nexclude_surfaces : Optional[Tuple[Literal['x-', 'x+', 'y-', 'y+', 'z-', 'z+'], ...]] = None\n    Surfaces to exclude in the integration, if a volume monitor.\ncustom_origin : Optional[Tuple[float, float, float]] = None\n    [units = um].  Local origin used for defining observation points. If ``None``, uses the monitor's center.\nfar_field_approx : bool = True\n    Whether to enable the far field approximation when projecting fields. If ``True``, terms that decay as O(1/r^2) are ignored, as are the radial components of fields. Typically, this should be set to ``True`` only when the projection distance is much larger than the size of the device being modeled, and the projected points are in the far field of the device.\nproj_distance : float = 1000000.0\n    [units = um].  Radial distance of the projection points from ``local_origin``.\ntheta : Union[Tuple[float, ...], ArrayLike_dtype=<class 'float'>_ndim=1]\n    [units = rad].  Polar angles with respect to the global z axis, relative to the location of ``local_origin``, at which to project fields.\nphi : Union[Tuple[float, ...], ArrayLike_dtype=<class 'float'>_ndim=1]\n    [units = rad].  Azimuth angles with respect to the global z axis, relative to the location of ``local_origin``, at which to project fields.\n\nExample\n-------\n>>> monitor = FieldProjectionAngleMonitor(\n...     center=(1,2,3),\n...     size=(2,2,2),\n...     freqs=[250e12, 300e12],\n...     name='n2f_monitor',\n...     custom_origin=(1,2,3),\n...     phi=[0, np.pi/2],\n...     theta=np.linspace(-np.pi/2, np.pi/2, 100)\n...     )",
       "type": "object",
       "properties": {
         "type": {
@@ -5806,7 +5902,6 @@
               }
             },
             {
-              "title": "ArrayLike",
               "type": "ArrayLike"
             }
           ]
@@ -5872,7 +5967,7 @@
         },
         "far_field_approx": {
           "title": "Far field approximation",
-          "description": "Whether to enable the far field approximation when projecting fields.",
+          "description": "Whether to enable the far field approximation when projecting fields. If ``True``, terms that decay as O(1/r^2) are ignored, as are the radial components of fields. Typically, this should be set to ``True`` only when the projection distance is much larger than the size of the device being modeled, and the projected points are in the far field of the device.",
           "default": true,
           "type": "boolean"
         },
@@ -5895,7 +5990,6 @@
               }
             },
             {
-              "title": "ArrayLike",
               "type": "ArrayLike"
             }
           ]
@@ -5912,7 +6006,6 @@
               }
             },
             {
-              "title": "ArrayLike",
               "type": "ArrayLike"
             }
           ]
@@ -5929,7 +6022,7 @@
     },
     "FieldProjectionCartesianMonitor": {
       "title": "FieldProjectionCartesianMonitor",
-      "description": ":class:`Monitor` that samples electromagnetic near fields in the frequency domain\nand projects them on a Cartesian observation plane.\n\nParameters\n----------\ncenter : Tuple[float, float, float] = (0.0, 0.0, 0.0)\n    [units = um].  Center of object in x, y, and z.\nsize : Tuple[NonNegativeFloat, NonNegativeFloat, NonNegativeFloat]\n    [units = um].  Size in x, y, and z directions.\nname : ConstrainedStrValue\n    Unique name for monitor.\nfreqs : Union[Tuple[float, ...], ArrayLike_dtype=<class 'float'>_ndim=1]\n    [units = Hz].  Array or list of frequencies stored by the field monitor.\napodization : ApodizationSpec = ApodizationSpec(start=None, end=None, width=None, type='ApodizationSpec')\n    Sets parameters of (optional) apodization. Apodization applies a windowing function to the Fourier transform of the time-domain fields into frequency-domain ones, and can be used to truncate the beginning and/or end of the time signal, for example to eliminate the source pulse when studying the eigenmodes of a system. Note: apodization affects the normalization of the frequency-domain fields.\nnormal_dir : Optional[Literal['+', '-']] = None\n    Direction of the surface monitor's normal vector w.r.t. the positive x, y or z unit vectors. Must be one of ``'+'`` or ``'-'``. Applies to surface monitors only, and defaults to ``'+'`` if not provided.\nexclude_surfaces : Optional[Tuple[Literal['x-', 'x+', 'y-', 'y+', 'z-', 'z+'], ...]] = None\n    Surfaces to exclude in the integration, if a volume monitor.\ncustom_origin : Optional[Tuple[float, float, float]] = None\n    [units = um].  Local origin used for defining observation points. If ``None``, uses the monitor's center.\nfar_field_approx : bool = True\n    Whether to enable the far field approximation when projecting fields.\nproj_axis : Literal[0, 1, 2]\n    Axis along which the observation plane is oriented.\nproj_distance : float = 1000000.0\n    [units = um].  Signed distance of the projection plane along ``proj_axis``. from the plane containing ``local_origin``.\nx : Union[Tuple[float, ...], ArrayLike_dtype=<class 'float'>_ndim=1]\n    [units = um].  Local x observation coordinates w.r.t. ``local_origin`` and ``proj_axis``. When ``proj_axis`` is 0, this corresponds to the global y axis. When ``proj_axis`` is 1, this corresponds to the global x axis. When ``proj_axis`` is 2, this corresponds to the global x axis. \ny : Union[Tuple[float, ...], ArrayLike_dtype=<class 'float'>_ndim=1]\n    [units = um].  Local y observation coordinates w.r.t. ``local_origin`` and ``proj_axis``. When ``proj_axis`` is 0, this corresponds to the global z axis. When ``proj_axis`` is 1, this corresponds to the global z axis. When ``proj_axis`` is 2, this corresponds to the global y axis. \n\nExample\n-------\n>>> monitor = FieldProjectionCartesianMonitor(\n...     center=(1,2,3),\n...     size=(2,2,2),\n...     freqs=[250e12, 300e12],\n...     name='n2f_monitor',\n...     custom_origin=(1,2,3),\n...     x=[-1, 0, 1],\n...     y=[-2, -1, 0, 1, 2],\n...     proj_axis=2,\n...     proj_distance=5\n...     )",
+      "description": ":class:`Monitor` that samples electromagnetic near fields in the frequency domain\nand projects them on a Cartesian observation plane. The ``center`` and ``size`` fields define\nwhere the monitor will be placed in order to record near fields, typically very close\nto the structure of interest. The near fields are then projected\nto far-field locations defined by ``x``, ``y``, and ``proj_distance``, relative\nto the ``custom_origin``. Here, ``x`` and ``y`` correspond to a local coordinate system\nwhere the local z axis is defined by ``proj_axis``: which is the axis normal to this monitor.\nIf the distance between the near and far field locations is much larger than the size of the\ndevice, one can typically set ``far_field_approx`` to ``True``, which will make use of the\nfar-field approximation to speed up calculations. If the projection distance is comparable\nto the size of the device, we recommend setting ``far_field_approx`` to ``False``,\nso that the approximations are not used, and the projection is accurate even just a few\nwavelengths away from the near field locations.\nFor applications where the monitor is an open surface rather than a box that\nencloses the device, it is advisable to pick the size of the monitor such that the\nrecorded near fields decay to negligible values near the edges of the monitor.\n\nParameters\n----------\ncenter : Tuple[float, float, float] = (0.0, 0.0, 0.0)\n    [units = um].  Center of object in x, y, and z.\nsize : Tuple[NonNegativeFloat, NonNegativeFloat, NonNegativeFloat]\n    [units = um].  Size in x, y, and z directions.\nname : ConstrainedStrValue\n    Unique name for monitor.\nfreqs : Union[Tuple[float, ...], ArrayLike_dtype=<class 'float'>_ndim=1]\n    [units = Hz].  Array or list of frequencies stored by the field monitor.\napodization : ApodizationSpec = ApodizationSpec(start=None, end=None, width=None, type='ApodizationSpec')\n    Sets parameters of (optional) apodization. Apodization applies a windowing function to the Fourier transform of the time-domain fields into frequency-domain ones, and can be used to truncate the beginning and/or end of the time signal, for example to eliminate the source pulse when studying the eigenmodes of a system. Note: apodization affects the normalization of the frequency-domain fields.\nnormal_dir : Optional[Literal['+', '-']] = None\n    Direction of the surface monitor's normal vector w.r.t. the positive x, y or z unit vectors. Must be one of ``'+'`` or ``'-'``. Applies to surface monitors only, and defaults to ``'+'`` if not provided.\nexclude_surfaces : Optional[Tuple[Literal['x-', 'x+', 'y-', 'y+', 'z-', 'z+'], ...]] = None\n    Surfaces to exclude in the integration, if a volume monitor.\ncustom_origin : Optional[Tuple[float, float, float]] = None\n    [units = um].  Local origin used for defining observation points. If ``None``, uses the monitor's center.\nfar_field_approx : bool = True\n    Whether to enable the far field approximation when projecting fields. If ``True``, terms that decay as O(1/r^2) are ignored, as are the radial components of fields. Typically, this should be set to ``True`` only when the projection distance is much larger than the size of the device being modeled, and the projected points are in the far field of the device.\nproj_axis : Literal[0, 1, 2]\n    Axis along which the observation plane is oriented.\nproj_distance : float = 1000000.0\n    [units = um].  Signed distance of the projection plane along ``proj_axis``. from the plane containing ``local_origin``.\nx : Union[Tuple[float, ...], ArrayLike_dtype=<class 'float'>_ndim=1]\n    [units = um].  Local x observation coordinates w.r.t. ``local_origin`` and ``proj_axis``. When ``proj_axis`` is 0, this corresponds to the global y axis. When ``proj_axis`` is 1, this corresponds to the global x axis. When ``proj_axis`` is 2, this corresponds to the global x axis. \ny : Union[Tuple[float, ...], ArrayLike_dtype=<class 'float'>_ndim=1]\n    [units = um].  Local y observation coordinates w.r.t. ``local_origin`` and ``proj_axis``. When ``proj_axis`` is 0, this corresponds to the global z axis. When ``proj_axis`` is 1, this corresponds to the global z axis. When ``proj_axis`` is 2, this corresponds to the global y axis. \n\nExample\n-------\n>>> monitor = FieldProjectionCartesianMonitor(\n...     center=(1,2,3),\n...     size=(2,2,2),\n...     freqs=[250e12, 300e12],\n...     name='n2f_monitor',\n...     custom_origin=(1,2,3),\n...     x=[-1, 0, 1],\n...     y=[-2, -1, 0, 1, 2],\n...     proj_axis=2,\n...     proj_distance=5\n...     )",
       "type": "object",
       "properties": {
         "type": {
@@ -6004,7 +6097,6 @@
               }
             },
             {
-              "title": "ArrayLike",
               "type": "ArrayLike"
             }
           ]
@@ -6070,7 +6162,7 @@
         },
         "far_field_approx": {
           "title": "Far field approximation",
-          "description": "Whether to enable the far field approximation when projecting fields.",
+          "description": "Whether to enable the far field approximation when projecting fields. If ``True``, terms that decay as O(1/r^2) are ignored, as are the radial components of fields. Typically, this should be set to ``True`` only when the projection distance is much larger than the size of the device being modeled, and the projected points are in the far field of the device.",
           "default": true,
           "type": "boolean"
         },
@@ -6103,7 +6195,6 @@
               }
             },
             {
-              "title": "ArrayLike",
               "type": "ArrayLike"
             }
           ]
@@ -6120,7 +6211,6 @@
               }
             },
             {
-              "title": "ArrayLike",
               "type": "ArrayLike"
             }
           ]
@@ -6138,7 +6228,7 @@
     },
     "FieldProjectionKSpaceMonitor": {
       "title": "FieldProjectionKSpaceMonitor",
-      "description": ":class:`Monitor` that samples electromagnetic near fields in the frequency domain\nand projects them on an observation plane defined in k-space.\n\nParameters\n----------\ncenter : Tuple[float, float, float] = (0.0, 0.0, 0.0)\n    [units = um].  Center of object in x, y, and z.\nsize : Tuple[NonNegativeFloat, NonNegativeFloat, NonNegativeFloat]\n    [units = um].  Size in x, y, and z directions.\nname : ConstrainedStrValue\n    Unique name for monitor.\nfreqs : Union[Tuple[float, ...], ArrayLike_dtype=<class 'float'>_ndim=1]\n    [units = Hz].  Array or list of frequencies stored by the field monitor.\napodization : ApodizationSpec = ApodizationSpec(start=None, end=None, width=None, type='ApodizationSpec')\n    Sets parameters of (optional) apodization. Apodization applies a windowing function to the Fourier transform of the time-domain fields into frequency-domain ones, and can be used to truncate the beginning and/or end of the time signal, for example to eliminate the source pulse when studying the eigenmodes of a system. Note: apodization affects the normalization of the frequency-domain fields.\nnormal_dir : Optional[Literal['+', '-']] = None\n    Direction of the surface monitor's normal vector w.r.t. the positive x, y or z unit vectors. Must be one of ``'+'`` or ``'-'``. Applies to surface monitors only, and defaults to ``'+'`` if not provided.\nexclude_surfaces : Optional[Tuple[Literal['x-', 'x+', 'y-', 'y+', 'z-', 'z+'], ...]] = None\n    Surfaces to exclude in the integration, if a volume monitor.\ncustom_origin : Optional[Tuple[float, float, float]] = None\n    [units = um].  Local origin used for defining observation points. If ``None``, uses the monitor's center.\nfar_field_approx : bool = True\n    Whether to enable the far field approximation when projecting fields.\nproj_axis : Literal[0, 1, 2]\n    Axis along which the observation plane is oriented.\nproj_distance : float = 1000000.0\n    [units = um].  Radial distance of the projection points from ``local_origin``.\nux : Union[Tuple[float, ...], ArrayLike_dtype=<class 'float'>_ndim=1]\n    Local x component of wave vectors on the observation plane, relative to ``local_origin`` and oriented with respect to ``proj_axis``, normalized by (2*pi/lambda) where lambda is the wavelength associated with the background medium. Must be in the range [-1, 1].\nuy : Union[Tuple[float, ...], ArrayLike_dtype=<class 'float'>_ndim=1]\n    Local y component of wave vectors on the observation plane, relative to ``local_origin`` and oriented with respect to ``proj_axis``, normalized by (2*pi/lambda) where lambda is the wavelength associated with the background medium. Must be in the range [-1, 1].\n\nExample\n-------\n>>> monitor = FieldProjectionKSpaceMonitor(\n...     center=(1,2,3),\n...     size=(2,2,2),\n...     freqs=[250e12, 300e12],\n...     name='n2f_monitor',\n...     custom_origin=(1,2,3),\n...     proj_axis=2,\n...     ux=[0.1,0.2],\n...     uy=[0.3,0.4,0.5]\n...     )",
+      "description": ":class:`Monitor` that samples electromagnetic near fields in the frequency domain\nand projects them on an observation plane defined in k-space. The ``center`` and ``size``\nfields define where the monitor will be placed in order to record near fields, typically\nvery close to the structure of interest. The near fields are then\nprojected to far-field locations defined in k-space by ``ux``, ``uy``, and ``proj_distance``,\nrelative to the ``custom_origin``. Here, ``ux`` and ``uy`` are associated with a local\ncoordinate system where the local 'z' axis is defined by ``proj_axis``: which is the axis\nnormal to this monitor. If the distance between the near and far field locations is much\nlarger than the size of the device, one can typically set ``far_field_approx`` to ``True``,\nwhich will make use of the far-field approximation to speed up calculations. If the\nprojection distance is comparable to the size of the device, we recommend setting\n``far_field_approx`` to ``False``, so that the approximations are not used, and the\nprojection is accurate even just a few wavelengths away from the near field locations.\nFor applications where the monitor is an open surface rather than a box that\nencloses the device, it is advisable to pick the size of the monitor such that the\nrecorded near fields decay to negligible values near the edges of the monitor.\n\nParameters\n----------\ncenter : Tuple[float, float, float] = (0.0, 0.0, 0.0)\n    [units = um].  Center of object in x, y, and z.\nsize : Tuple[NonNegativeFloat, NonNegativeFloat, NonNegativeFloat]\n    [units = um].  Size in x, y, and z directions.\nname : ConstrainedStrValue\n    Unique name for monitor.\nfreqs : Union[Tuple[float, ...], ArrayLike_dtype=<class 'float'>_ndim=1]\n    [units = Hz].  Array or list of frequencies stored by the field monitor.\napodization : ApodizationSpec = ApodizationSpec(start=None, end=None, width=None, type='ApodizationSpec')\n    Sets parameters of (optional) apodization. Apodization applies a windowing function to the Fourier transform of the time-domain fields into frequency-domain ones, and can be used to truncate the beginning and/or end of the time signal, for example to eliminate the source pulse when studying the eigenmodes of a system. Note: apodization affects the normalization of the frequency-domain fields.\nnormal_dir : Optional[Literal['+', '-']] = None\n    Direction of the surface monitor's normal vector w.r.t. the positive x, y or z unit vectors. Must be one of ``'+'`` or ``'-'``. Applies to surface monitors only, and defaults to ``'+'`` if not provided.\nexclude_surfaces : Optional[Tuple[Literal['x-', 'x+', 'y-', 'y+', 'z-', 'z+'], ...]] = None\n    Surfaces to exclude in the integration, if a volume monitor.\ncustom_origin : Optional[Tuple[float, float, float]] = None\n    [units = um].  Local origin used for defining observation points. If ``None``, uses the monitor's center.\nfar_field_approx : bool = True\n    Whether to enable the far field approximation when projecting fields. If ``True``, terms that decay as O(1/r^2) are ignored, as are the radial components of fields. Typically, this should be set to ``True`` only when the projection distance is much larger than the size of the device being modeled, and the projected points are in the far field of the device.\nproj_axis : Literal[0, 1, 2]\n    Axis along which the observation plane is oriented.\nproj_distance : float = 1000000.0\n    [units = um].  Radial distance of the projection points from ``local_origin``.\nux : Union[Tuple[float, ...], ArrayLike_dtype=<class 'float'>_ndim=1]\n    Local x component of wave vectors on the observation plane, relative to ``local_origin`` and oriented with respect to ``proj_axis``, normalized by (2*pi/lambda) where lambda is the wavelength associated with the background medium. Must be in the range [-1, 1].\nuy : Union[Tuple[float, ...], ArrayLike_dtype=<class 'float'>_ndim=1]\n    Local y component of wave vectors on the observation plane, relative to ``local_origin`` and oriented with respect to ``proj_axis``, normalized by (2*pi/lambda) where lambda is the wavelength associated with the background medium. Must be in the range [-1, 1].\n\nExample\n-------\n>>> monitor = FieldProjectionKSpaceMonitor(\n...     center=(1,2,3),\n...     size=(2,2,2),\n...     freqs=[250e12, 300e12],\n...     name='n2f_monitor',\n...     custom_origin=(1,2,3),\n...     proj_axis=2,\n...     ux=[0.1,0.2],\n...     uy=[0.3,0.4,0.5]\n...     )",
       "type": "object",
       "properties": {
         "type": {
@@ -6213,7 +6303,6 @@
               }
             },
             {
-              "title": "ArrayLike",
               "type": "ArrayLike"
             }
           ]
@@ -6279,7 +6368,7 @@
         },
         "far_field_approx": {
           "title": "Far field approximation",
-          "description": "Whether to enable the far field approximation when projecting fields.",
+          "description": "Whether to enable the far field approximation when projecting fields. If ``True``, terms that decay as O(1/r^2) are ignored, as are the radial components of fields. Typically, this should be set to ``True`` only when the projection distance is much larger than the size of the device being modeled, and the projected points are in the far field of the device.",
           "default": true,
           "type": "boolean"
         },
@@ -6311,7 +6400,6 @@
               }
             },
             {
-              "title": "ArrayLike",
               "type": "ArrayLike"
             }
           ]
@@ -6327,7 +6415,6 @@
               }
             },
             {
-              "title": "ArrayLike",
               "type": "ArrayLike"
             }
           ]
@@ -6420,7 +6507,6 @@
               }
             },
             {
-              "title": "ArrayLike",
               "type": "ArrayLike"
             }
           ]


### PR DESCRIPTION
It was pointed out that fields with `ArrayLike` types had the wrong `title` in the schema. The titles were just saying `ArrayLike`. this PR fixes it, which is verified in the updated schema.json.