### PR TITLE
factor out store_vjp sequential and parallel, fix num_procs passing

### DIFF
--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -39,6 +39,7 @@ from ..utils import SIM_DATA_PATH, SIM_FULL, TMP_DIR
 FWD_SIM_DATA_FILE = TMP_DIR + "adjoint_grad_data_fwd.hdf5"
 SIM_VJP_FILE = TMP_DIR + "adjoint_sim_vjp_file.hdf5"
 RUN_PATH = TMP_DIR + "simulation.hdf5"
+NUM_PROC_PARALLEL = 2
 
 EPS = 2.0
 SIZE = (1.0, 2.0, 3.0)
@@ -95,7 +96,7 @@ def run_emulated_bwd(
     folder_name: str,
     callback_url: str,
     verbose: bool,
-    num_proc: int = 2,
+    num_proc: int = NUM_PROC_PARALLEL,
 ) -> JaxSimulation:
     """Runs adjoint simulation on our servers, grabs the gradient data from fwd for processing."""
 
@@ -115,7 +116,7 @@ def run_emulated_bwd(
     grad_data_adj = jax_sim_data_adj.grad_data_symmetry
 
     # get gradient and insert into the resulting simulation structure medium
-    sim_vjp = jax_sim_data_adj.simulation.store_vjp_parallel(
+    sim_vjp = jax_sim_data_adj.simulation.store_vjp(
         grad_data_fwd, grad_data_adj, grad_eps_data_fwd, num_proc=num_proc
     )
 
@@ -178,7 +179,7 @@ def run_async_emulated_bwd(
             folder_name=folder_name,
             callback_url=callback_url,
             verbose=verbose,
-            num_proc=1,
+            num_proc=NUM_PROC_PARALLEL,
         )
         sim_vjps_orig.append(sim_vjp)
 

--- a/tidy3d/plugins/adjoint/components/simulation.py
+++ b/tidy3d/plugins/adjoint/components/simulation.py
@@ -25,6 +25,13 @@ from .structure import JaxStructure
 from .geometry import JaxPolySlab, JaxGeometryGroup
 
 
+# bandwidth of adjoint source in units of freq0 if no sources and no `fwidth_adjoint` specified
+FWIDTH_FACTOR = 1.0 / 10
+
+# how many processors to use for server and client side adjoint
+NUM_PROC_LOCAL = 1
+
+
 class JaxInfo(Tidy3dBaseModel):
     """Class to store information when converting between jax and tidy3d."""
 
@@ -58,10 +65,6 @@ class JaxInfo(Tidy3dBaseModel):
         description="Custom frequency width of the original JaxSimulation.",
         units=HERTZ,
     )
-
-
-# bandwidth of adjoint source in units of freq0 if no sources and no `fwidth_adjoint` specified
-FWIDTH_FACTOR = 1.0 / 10
 
 
 @register_pytree_node_class
@@ -447,7 +450,7 @@ class JaxSimulation(Simulation, JaxObject):
         fld_fwd: FieldData,
         fld_adj: FieldData,
         eps_data: PermittivityData,
-        num_proc: int = 1,
+        num_proc: int = NUM_PROC_LOCAL,
     ) -> JaxStructure:
         """Store the vjp for a single structure."""
 
@@ -467,9 +470,31 @@ class JaxSimulation(Simulation, JaxObject):
         grad_data_fwd: Tuple[FieldData],
         grad_data_adj: Tuple[FieldData],
         grad_eps_data: Tuple[PermittivityData],
+        num_proc: int = NUM_PROC_LOCAL,
     ) -> JaxSimulation:
         """Store the vjp w.r.t. each input_structure as a sim using fwd and adj grad_data."""
 
+        # if num_proc supplied and greater than 1, run parallel
+        if num_proc is not None and num_proc > 1:
+            return self.store_vjp_parallel(
+                grad_data_fwd=grad_data_fwd,
+                grad_data_adj=grad_data_adj,
+                grad_eps_data=grad_eps_data,
+                num_proc=num_proc,
+            )
+
+        # otherwise, call regular sequential one
+        return self.store_vjp_sequential(
+            grad_data_fwd=grad_data_fwd, grad_data_adj=grad_data_adj, grad_eps_data=grad_eps_data
+        )
+
+    def store_vjp_sequential(
+        self,
+        grad_data_fwd: Tuple[FieldData],
+        grad_data_adj: Tuple[FieldData],
+        grad_eps_data: Tuple[PermittivityData],
+    ) -> JaxSimulation:
+        """Store the vjp w.r.t. each input_structure without multiprocessing."""
         map_args = [self.input_structures, grad_data_fwd, grad_data_adj, grad_eps_data]
         input_structures_vjp = list(map(self._store_vjp_structure, *map_args))
 
@@ -513,7 +538,7 @@ class JaxSimulation(Simulation, JaxObject):
         vjps_par_internal = list(map(self._store_vjp_structure, *args_par_internal))
 
         # Get vjps for structures where we parallelize directly here
-        args_par_external = make_args(inds_par_external, num_proc_internal=1)
+        args_par_external = make_args(inds_par_external, num_proc_internal=NUM_PROC_LOCAL)
         with Pool(num_proc) as pool:
             vjps_par_external = list(
                 pool.starmap(self._store_vjp_structure, zip(*args_par_external))

--- a/tidy3d/plugins/adjoint/web.py
+++ b/tidy3d/plugins/adjoint/web.py
@@ -21,9 +21,7 @@ from .components.simulation import JaxSimulation, JaxInfo
 from .components.data.sim_data import JaxSimulationData
 
 
-# TODO: confused about these paths, they aren't local but rather wherre the jax info and sim_vjp get
-# stored on the server? maybe add a comment for each?
-# when i changed them, adjoint runs errored on the solver.
+# file names and paths for server side adjoint
 SIM_VJP_FILE = "output/jax_sim_vjp.hdf5"
 JAX_INFO_FILE = "jax_info.json"
 


### PR DESCRIPTION
A few changes:

1. made NUM_PROCS_LOCAL and NUM_PROCS_SERVER for toggling these. Added into tests and default kwargs where appropriate. I think before the tests might have not been triggering the parallel vjp, at least for JaxPolySlab (not sure now) so I did some work to ensure that all pathways were tested depending on whether run_local or run were used in the tests.
2. refactored so that `store_vjp` generally toggles between a `store_local_parallel` and a `store_local_sequential` based on `num_procs`, seemed slightly cleaner (but more verbose) to handle it this way.
3. A bit more refactoring (eg separate function for making args in the jax polyslab VJP).

Let me know what you think and feel free to take any of these changes as you feel necessary.