### PR TITLE
restrict number of adjoint input structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Batch` prints total estimated cost if `verbose=True`.
 - Unified config and authentication.
 - Remove restriction that `JaxCustomMedium` must not be a 3D pixelated array.
+- Limit total number of input structures in adjoint plugin for performance reasons.
 
 ### Fixed
 - Plotting 2D materials in `SimulationData.plot_field` and other circumstances.

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -24,6 +24,7 @@ from tidy3d.plugins.adjoint.components.medium import JaxMedium, JaxAnisotropicMe
 from tidy3d.plugins.adjoint.components.medium import JaxCustomMedium, MAX_NUM_CELLS_CUSTOM_MEDIUM
 from tidy3d.plugins.adjoint.components.structure import JaxStructure
 from tidy3d.plugins.adjoint.components.simulation import JaxSimulation, JaxInfo
+from tidy3d.plugins.adjoint.components.simulation import MAX_NUM_INPUT_STRUCTURES
 from tidy3d.plugins.adjoint.components.data.sim_data import JaxSimulationData
 from tidy3d.plugins.adjoint.components.data.monitor_data import JaxModeData, JaxDiffractionData
 from tidy3d.plugins.adjoint.components.data.data_array import JaxDataArray, JAX_DATA_ARRAY_TAG
@@ -1384,3 +1385,18 @@ def test_jax_sim_io():
     sim2 = JaxSimulation.from_file(fname)
 
     assert sim == sim2
+
+
+def test_num_input_structures():
+    """Assert proper error is raised if number of input structures is too large."""
+
+    def make_sim_(num_input_structures: int) -> JaxSimulation:
+
+        sim = make_sim(permittivity=EPS, size=SIZE, vertices=VERTICES, base_eps_val=BASE_EPS_VAL)
+        struct = sim.input_structures[0]
+        return sim.updated_copy(input_structures=num_input_structures * [struct])
+
+    sim = make_sim_(num_input_structures=MAX_NUM_INPUT_STRUCTURES)
+
+    with pytest.raises(pydantic.ValidationError):
+        sim = make_sim_(num_input_structures=MAX_NUM_INPUT_STRUCTURES + 1)

--- a/tidy3d/plugins/adjoint/components/simulation.py
+++ b/tidy3d/plugins/adjoint/components/simulation.py
@@ -62,6 +62,9 @@ class JaxInfo(Tidy3dBaseModel):
 # bandwidth of adjoint source in units of freq0 if no sources and no `fwidth_adjoint` specified
 FWIDTH_FACTOR = 1.0 / 10
 
+# number of input structures before it errors
+MAX_NUM_INPUT_STRUCTURES = 400
+
 
 @register_pytree_node_class
 class JaxSimulation(Simulation, JaxObject):
@@ -131,6 +134,18 @@ class JaxSimulation(Simulation, JaxObject):
         """Assert subpixel is on."""
         if not val:
             raise AdjointError("'JaxSimulation.subpixel' must be 'True' to use adjoint plugin.")
+        return val
+
+    @pd.validator("input_structures", always=True)
+    def _restrict_input_structures(cls, val):
+        """Restrict number of input structures."""
+        num_input_structures = len(val)
+        if num_input_structures > MAX_NUM_INPUT_STRUCTURES:
+            raise AdjointError(
+                "For performance, adjoint plugin restricts the number of input structures to "
+                f"{MAX_NUM_INPUT_STRUCTURES}. Found {num_input_structures}."
+            )
+
         return val
 
     @pd.validator("input_structures", always=True)


### PR DESCRIPTION
feel free to change the number, as long as the Metalens Demo supports it.  I think it's currently 18x18 = 324 for the symmetry expanded one and under 100 without symmetry. However, we construct the symmetry expanded one for plotting at the end.. (even though we dont run it). Not really sure how to approach this. maybe a pre-upload validator?  Note, if we go this route, we'll need to somehow ensure that the Simulation.validate_pre_upload() is still called.