### PR TITLE
Fixing stuck estimate_cost test and reorganizing web api mock tests in general

### DIFF
--- a/tests/sims/simulation_2_3_0rc2.json
+++ b/tests/sims/simulation_2_3_0rc2.json
@@ -425,6 +425,7 @@
                 "allow_gain": false,
                 "type": "CustomMedium",
                 "interp_method": "nearest",
+                "subpixel": false,
                 "permittivity": "SpatialDataArray",
                 "conductivity": null,
                 "eps_dataset": null
@@ -458,7 +459,8 @@
                         "SpatialDataArray"
                     ]
                 ],
-                "interp_method": "nearest"
+                "interp_method": "nearest",
+                "subpixel": false
             }
         },
         {
@@ -490,7 +492,8 @@
                         "SpatialDataArray"
                     ]
                 ],
-                "interp_method": "nearest"
+                "interp_method": "nearest",
+                "subpixel": false
             }
         },
         {
@@ -521,7 +524,8 @@
                         "SpatialDataArray"
                     ]
                 ],
-                "interp_method": "nearest"
+                "interp_method": "nearest",
+                "subpixel": false
             }
         },
         {
@@ -552,7 +556,8 @@
                         "SpatialDataArray"
                     ]
                 ],
-                "interp_method": "nearest"
+                "interp_method": "nearest",
+                "subpixel": false
             }
         },
         {
@@ -582,7 +587,8 @@
                         "SpatialDataArray"
                     ]
                 ],
-                "interp_method": "nearest"
+                "interp_method": "nearest",
+                "subpixel": false
             }
         },
         {

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -25,6 +25,7 @@ TASK_ID = "1234"
 CREATED_AT = "2022-01-01T00:00:00.000Z"
 PROJECT_NAME = "default"
 FLEX_UNIT = 1.0
+EST_FLEX_UNIT = 11.11
 
 
 def make_sim():
@@ -91,8 +92,13 @@ def mock_get_info(monkeypatch, set_api_key):
         json={
             "data": {
                 "taskId": TASK_ID,
+                "taskName": TASK_NAME,
                 "createdAt": CREATED_AT,
                 "realFlexUnit": FLEX_UNIT,
+                "estFlexUnit": EST_FLEX_UNIT,
+                "metadataStatus": "processed",
+                "status": "success",
+                "s3Storage": 1.0,
             }
         },
         status=200,
@@ -100,20 +106,9 @@ def mock_get_info(monkeypatch, set_api_key):
 
 
 @pytest.fixture
-def mock_start(monkeypatch, set_api_key):
+def mock_start(monkeypatch, set_api_key, mock_get_info):
     """Mocks webapi.start."""
 
-    responses.add(
-        responses.GET,
-        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/detail",
-        json={
-            "data": {
-                "taskId": TASK_ID,
-                "createdAt": CREATED_AT,
-            }
-        },
-        status=200,
-    )
     responses.add(
         responses.POST,
         f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/submit",
@@ -143,12 +138,13 @@ def mock_monitor(monkeypatch):
     status_count = [0]
     statuses = ("upload", "running", "running", "running", "running", "running", "success")
 
-    def mock_get_info(task_id):
+    def mock_get_status(task_id):
 
         current_count = min(status_count[0], len(statuses) - 1)
         current_status = statuses[current_count]
         status_count[0] += 1
-        return TaskInfo(status=current_status, taskName=TASK_NAME, taskId=task_id, realFlexUnit=1.0)
+        return current_status
+        # return TaskInfo(status=current_status, taskName=TASK_NAME, taskId=task_id, realFlexUnit=1.0)
 
     run_count = [0]
     perc_dones = (1, 10, 20, 30, 100)
@@ -161,24 +157,13 @@ def mock_monitor(monkeypatch):
 
     monkeypatch.setattr("tidy3d.web.webapi.REFRESH_TIME", 0.00001)
     monkeypatch.setattr("tidy3d.web.webapi.RUN_REFRESH_TIME", 0.00001)
-    monkeypatch.setattr("tidy3d.web.webapi.get_info", mock_get_info)
+    monkeypatch.setattr("tidy3d.web.webapi.get_status", mock_get_status)
     monkeypatch.setattr("tidy3d.web.webapi.get_run_info", mock_get_run_info)
 
 
 @pytest.fixture
-def mock_download(monkeypatch, set_api_key):
+def mock_download(monkeypatch, set_api_key, mock_get_info):
     """Mocks webapi.download."""
-    responses.add(
-        responses.GET,
-        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/detail",
-        json={
-            "data": {
-                "taskId": TASK_ID,
-                "createdAt": CREATED_AT,
-            }
-        },
-        status=200,
-    )
 
     def _mock_download(*args, **kwargs):
         file_path = kwargs["to_file"]
@@ -192,51 +177,28 @@ def mock_download(monkeypatch, set_api_key):
 
 
 @pytest.fixture
-def mock_load(monkeypatch, set_api_key):
+def mock_load(monkeypatch, set_api_key, mock_get_info):
     """Mocks webapi.load"""
-
-    responses.add(
-        responses.GET,
-        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/detail",
-        json={
-            "data": {
-                "taskId": TASK_ID,
-                "createdAt": CREATED_AT,
-            }
-        },
-        status=200,
-    )
 
     def _mock_download(*args, **kwargs):
         pass
 
     monkeypatch.setattr("tidy3d.web.simulation_task.download_file", _mock_download)
 
-    # estimate cost
+
+@pytest.fixture
+def mock_metadata(monkeypatch, set_api_key):
+    """Mocks call to metadata api"""
     responses.add(
-        responses.GET,
-        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/detail",
+        responses.POST,
+        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/metadata",
         json={
             "data": {
-                "taskId": TASK_ID,
                 "createdAt": CREATED_AT,
             }
         },
         status=200,
     )
-
-
-responses.add(
-    responses.POST,
-    f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/metadata",
-    json={
-        "data": {
-            "flex_unit": 11.11,
-            "createdAt": CREATED_AT,
-        }
-    },
-    status=200,
-)
 
 
 @pytest.fixture
@@ -256,7 +218,9 @@ def mock_get_run_info(monkeypatch, set_api_key):
 
 
 @pytest.fixture
-def mock_webapi(mock_upload, mock_get_info, mock_start, mock_monitor, mock_download, mock_load):
+def mock_webapi(
+    mock_upload, mock_metadata, mock_get_info, mock_start, mock_monitor, mock_download, mock_load
+):
     """Mocks all webapi operation."""
 
 
@@ -289,19 +253,7 @@ def test_download(mock_download):
 
 
 @responses.activate
-def _test_load(mock_load):
-    responses.add(
-        responses.GET,
-        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/detail",
-        json={
-            "data": {
-                "taskId": TASK_ID,
-                "createdAt": CREATED_AT,
-            }
-        },
-        status=200,
-    )
-
+def _test_load(mock_load, mock_get_info):
     def mock_download(*args, **kwargs):
         pass
 
@@ -310,18 +262,7 @@ def _test_load(mock_load):
 
 
 @responses.activate
-def test_delete(set_api_key):
-    responses.add(
-        responses.GET,
-        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/detail",
-        json={
-            "data": {
-                "taskId": TASK_ID,
-                "createdAt": CREATED_AT,
-            }
-        },
-        status=200,
-    )
+def test_delete(set_api_key, mock_get_info):
 
     responses.add(
         responses.DELETE,
@@ -339,46 +280,12 @@ def test_delete(set_api_key):
 
 
 @responses.activate
-def test_estimate_cost(set_api_key):
-    responses.add(
-        responses.GET,
-        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/detail",
-        json={
-            "data": {
-                "taskId": TASK_ID,
-                "createdAt": CREATED_AT,
-            }
-        },
-        status=200,
-    )
-    responses.add(
-        responses.POST,
-        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/metadata",
-        json={
-            "data": {
-                "flex_unit": 11.11,
-                "createdAt": CREATED_AT,
-            }
-        },
-        status=200,
-    )
-    assert estimate_cost(TASK_ID) == 11.11
+def test_estimate_cost(set_api_key, mock_get_info, mock_metadata):
+    assert estimate_cost(TASK_ID) == EST_FLEX_UNIT
 
 
 @responses.activate
-def test_download_json(monkeypatch):
-    responses.add(
-        responses.GET,
-        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/detail",
-        json={
-            "data": {
-                "taskId": TASK_ID,
-                "createdAt": CREATED_AT,
-            }
-        },
-        status=200,
-    )
-
+def test_download_json(monkeypatch, mock_get_info):
     def mock_download(*args, **kwargs):
         file_path = kwargs["to_file"]
         with open(file_path, "w") as f:
@@ -392,19 +299,7 @@ def test_download_json(monkeypatch):
 
 
 @responses.activate
-def test_load_simulation(monkeypatch):
-    responses.add(
-        responses.GET,
-        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/detail",
-        json={
-            "data": {
-                "taskId": TASK_ID,
-                "createdAt": CREATED_AT,
-            }
-        },
-        status=200,
-    )
-
+def test_load_simulation(monkeypatch, mock_get_info):
     def mock_download(*args, **kwargs):
         make_sim().to_file(args[1])
 
@@ -416,19 +311,7 @@ def test_load_simulation(monkeypatch):
 
 
 @responses.activate
-def test_download_log(monkeypatch):
-    responses.add(
-        responses.GET,
-        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/detail",
-        json={
-            "data": {
-                "taskId": TASK_ID,
-                "createdAt": CREATED_AT,
-            }
-        },
-        status=200,
-    )
-
+def test_download_log(monkeypatch, mock_get_info):
     def mock(*args, **kwargs):
         file_path = kwargs["to_file"]
         with open(file_path, "w") as f:
@@ -500,7 +383,7 @@ def test_run(mock_webapi, monkeypatch):
 
 
 @responses.activate
-def test_monitor(mock_monitor):
+def test_monitor(mock_get_info, mock_monitor):
     monitor(TASK_ID, verbose=True)
     monitor(TASK_ID, verbose=False)
 
@@ -516,36 +399,12 @@ def test_real_cost(mock_get_info):
 @responses.activate
 def test_job(mock_webapi, monkeypatch):
 
-    responses.add(
-        responses.GET,
-        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/detail",
-        json={
-            "data": {
-                "taskId": TASK_ID,
-                "createdAt": CREATED_AT,
-            }
-        },
-        status=200,
-    )
-    responses.add(
-        responses.POST,
-        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/metadata",
-        json={
-            "data": {
-                "flex_unit": 11.11,
-                "createdAt": CREATED_AT,
-            }
-        },
-        status=200,
-    )
-
     monkeypatch.setattr("tidy3d.web.container.Job.load", lambda *args, **kwargs: True)
     sim = make_sim()
     j = Job(simulation=sim, task_name=TASK_NAME, folder_name=PROJECT_NAME)
 
     sim_data = j.run(path=FNAME_TMP)
     j.status
-    j.get_info()
     j.estimate_cost()
     # j.download
     j.delete
@@ -564,29 +423,6 @@ def test_batch(mock_webapi, mock_job_status):
     # monkeypatch.setattr("tidy3d.web.container.Batch.monitor", lambda self: time.sleep(0.1))
     # monkeypatch.setattr("tidy3d.web.container.Job.status", property(lambda self: "success"))
 
-    responses.add(
-        responses.GET,
-        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/detail",
-        json={
-            "data": {
-                "taskId": TASK_ID,
-                "createdAt": CREATED_AT,
-            }
-        },
-        status=200,
-    )
-    responses.add(
-        responses.POST,
-        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/metadata",
-        json={
-            "data": {
-                "flex_unit": 11.11,
-                "createdAt": CREATED_AT,
-            }
-        },
-        status=200,
-    )
-
     sims = {TASK_NAME: make_sim()}
     b = Batch(simulations=sims, folder_name=PROJECT_NAME)
     b.estimate_cost()
@@ -599,17 +435,6 @@ def test_batch(mock_webapi, mock_job_status):
 
 @responses.activate
 def test_async(mock_webapi, mock_job_status):
-
-    responses.add(
-        responses.POST,
-        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/metadata",
-        json={
-            "data": {
-                "flex_unit": 11.11,
-                "createdAt": CREATED_AT,
-            }
-        },
-    )
 
     # monkeypatch.setattr("tidy3d.web.container.Job.status", property(lambda self: "success"))
     sims = {TASK_NAME: make_sim()}
@@ -629,17 +454,6 @@ def test_main(mock_webapi, monkeypatch, mock_job_status):
         sim = Simulation(size=(1, 1, 1), grid_spec=td.GridSpec.auto(wavelength=1.0), run_time=1e-12)
         sim.to_file(path)
 
-    def mock_get_info(task_id):
-        return TaskInfo(
-            status="success",
-            taskName=TASK_NAME,
-            taskId=TASK_ID,
-            realFlexUnit=1.0,
-            s3Storage=1.0,
-            estFlexUnit=1.0,
-        )
-
-    monkeypatch.setattr("tidy3d.web.webapi.get_info", mock_get_info)
     monkeypatch.setattr("builtins.input", lambda _: "Y")
 
     path = f"tests/tmp/sim.json"


### PR DESCRIPTION
The `estimate_cost` test was hanging because it now relies on `get_info` having a `metadataStatus` field, and waits for it. The `detail` request that is called by the `get_info` function, and the function itself, were overwritten/monkeypatched in various ways all over the test file, which was causing some unwanted effects. I refactored things such that it is just defined once. Similarly for the `metadata` api call.