### PR TITLE
Grid correction to Poynting  in 2D monitor (#839)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Source validation happens before simulation upload and raises an error if no source is present.
 - Warning instead of error if structure out of simulation bounds.
+- Cleaner display of `ArrayLike` in docs.
 
 ### Fixed
 - Point-like objects correctly appear as single points using `plt.scatter`.
-### Changed
-- Source validation happens before simulation upload and raises an error if no source is present.
-- Cleaner display of `ArrayLike` in docs.
+- Apply finite grid correction to the fields when calculating the Poynting vector from 2D monitors.
 
 ## [2.3.0] - 2023-6-30
 


### PR DESCRIPTION
To add up to the thoughts in #839: considering the grid points where the calculation is performed comes from `SimulationData`, creating a `poyting` method directly in `MonitorData` would end up more convoluted than just exposing a method to apply the correction from the 2D monitor. That's the reson for the current implementation.

Just to make sure: @momchil-flex, the correction should be applied in the case of a 2D monitor no matter the grid points, right? Or am I misunderstanding the correction factor?