### PR TITLE
Change missing source from warning to info (#813)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+# Changed
+- Source validation happens before simulation upload and raises an error if no source is present.
+
 ## [2.3.0] - 2023-6-30
 
 ### Added

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -579,7 +579,7 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
 
         source_ranges = [source.source_time.frequency_range() for source in values["sources"]]
         if not source_ranges:
-            log.warning("No sources in simulation.")
+            log.info("No sources in simulation.")
             return val
 
         freq_min = min((freq_range[0] for freq_range in source_ranges), default=0.0)
@@ -890,14 +890,22 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
 
     """ Pre submit validation (before web.upload()) """
 
-    def validate_pre_upload(self) -> None:
-        """Validate the fully initialized simulation is ok for upload to our servers."""
+    def validate_pre_upload(self, source_required: bool = True) -> None:
+        """Validate the fully initialized simulation is ok for upload to our servers.
+
+        Parameters
+        ----------
+        source_required: bool = True
+            If ``True``, validation will fail in case no sources are found in the simulation.
+        """
         self._validate_size()
         self._validate_monitor_size()
         self._validate_datasets_not_none()
         self._validate_tfsf_structure_intersections()
         # self._validate_run_time()
         _ = self.volumetric_structures
+        if source_required and len(self.sources) == 0:
+            raise SetupError("No sources in simulation.")
 
     def _validate_size(self) -> None:
         """Ensures the simulation is within size limits before simulation is uploaded."""

--- a/tidy3d/plugins/mode/web.py
+++ b/tidy3d/plugins/mode/web.py
@@ -189,7 +189,7 @@ class ModeSolverTask(ResourceLifecycle, Submittable, extra=pydantic.Extra.allow)
             mode_spec = mode_solver.mode_spec.copy(update={"precision": "single"})
             mode_solver = mode_solver.copy(update={"mode_spec": mode_spec})
 
-        mode_solver.simulation.validate_pre_upload()
+        mode_solver.simulation.validate_pre_upload(source_required=False)
         resp = http.post(
             MODESOLVER_API,
             {

--- a/tidy3d/web/container.py
+++ b/tidy3d/web/container.py
@@ -76,6 +76,12 @@ class Job(WebContainer):
         description="Task ID number, set when the task is uploaded, leave as None.",
     )
 
+    source_required: bool = pd.Field(
+        True,
+        title="Source Required",
+        deacription="If ``True``, simulations without sources will raise an error before upload.",
+    )
+
     _upload_fields = (
         "simulation",
         "task_name",
@@ -84,6 +90,7 @@ class Job(WebContainer):
         "verbose",
         "simulation_type",
         "parent_tasks",
+        "source_required",
     )
 
     def run(self, path: str = DEFAULT_DATA_PATH) -> SimulationData:
@@ -327,6 +334,12 @@ class Batch(WebContainer):
         None,
         title="Parent Tasks",
         description="Collection of parent task ids for each job in batch, used internally only.",
+    )
+
+    source_required: bool = pd.Field(
+        True,
+        title="Source Required",
+        deacription="If ``True``, simulations without sources will raise an error before upload.",
     )
 
     jobs: Dict[TaskName, Job] = pd.Field(

--- a/tidy3d/web/container.py
+++ b/tidy3d/web/container.py
@@ -76,12 +76,6 @@ class Job(WebContainer):
         description="Task ID number, set when the task is uploaded, leave as None.",
     )
 
-    source_required: bool = pd.Field(
-        True,
-        title="Source Required",
-        deacription="If ``True``, simulations without sources will raise an error before upload.",
-    )
-
     _upload_fields = (
         "simulation",
         "task_name",
@@ -90,7 +84,6 @@ class Job(WebContainer):
         "verbose",
         "simulation_type",
         "parent_tasks",
-        "source_required",
     )
 
     def run(self, path: str = DEFAULT_DATA_PATH) -> SimulationData:
@@ -334,12 +327,6 @@ class Batch(WebContainer):
         None,
         title="Parent Tasks",
         description="Collection of parent task ids for each job in batch, used internally only.",
-    )
-
-    source_required: bool = pd.Field(
-        True,
-        title="Source Required",
-        deacription="If ``True``, simulations without sources will raise an error before upload.",
     )
 
     jobs: Dict[TaskName, Job] = pd.Field(

--- a/tidy3d/web/webapi.py
+++ b/tidy3d/web/webapi.py
@@ -142,6 +142,7 @@ def upload(  # pylint:disable=too-many-locals,too-many-arguments
     progress_callback: Callable[[float], None] = None,
     simulation_type: str = "tidy3d",
     parent_tasks: List[str] = None,
+    source_required: bool = True,
 ) -> TaskId:
     """Upload simulation to server, but do not start running :class:`.Simulation`.
 
@@ -164,6 +165,8 @@ def upload(  # pylint:disable=too-many-locals,too-many-arguments
         Type of simulation being uploaded.
     parent_tasks : List[str]
         List of related task ids.
+    source_required: bool = True
+        If ``True``, simulations without sources will raise an error before being uploaded.
 
     Returns
     -------
@@ -175,7 +178,7 @@ def upload(  # pylint:disable=too-many-locals,too-many-arguments
     To start the simulation running, must call :meth:`start` after uploaded.
     """
 
-    simulation.validate_pre_upload()
+    simulation.validate_pre_upload(source_required=source_required)
     log.debug("Creating task.")
 
     task = SimulationTask.create(


### PR DESCRIPTION
Also included a flag in the pre upload validator to optionally raise an error if no sources are present in the simulation. This flag is true by default on `run` and manual job creation, but false for the mode solver. It cannot be changed from `run` (only in `Job` or `Batch`), because simulations with no sources should be very rare and we already have a lot of arguments in `run`.