### PR TITLE
Medium perturbation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `FastDispersionFitter` for fast fitting of material dispersion data.
 - `Simulation.monitors_data_size` property mapping monitor name to its data size in bytes.
 - Source with arbitrary user-specified time dependence through `CustomSourceTime`.
+- Interface for specifying material heat and charge perturbation models. 
+Specifically, non-dispersive and dispersive mediums with heat and/or charge perturbation models can be defined through classes `PerturbationMedium` and `PerturbationPoleResidue`, 
+where perturbations to each parameter is specified using class `ParameterPerturbation`.
+A convenience function `Simulation.perturbed_mediums_copy` is added to class `Simulation` which applies heat and/or charge fields to mediums containing perturbation models.
+
 
 ### Changed
 - Add `width` and `height` options to `Simulation.plot_3d()`.
@@ -43,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Surface integration monitor validator changed to error only if *all* integration surfaces are outside of the simulation domain.
-- Inverse design convenience utilities in `plugins.adjoint.utils` for image filtering (`ConicFilter`), projection (`BinaryProjector`), and radius of curvature penalization (`RadiusPenalty)`.
+- Inverse design convenience utilities in `plugins.adjoint.utils` for image filtering (`ConicFilter`), projection (`BinaryProjector`), and radius of curvature penalization (`RadiusPenalty`).
 
 ### Fixed
 - Properly handle sign flip in `ModeMonitor` outputs with `direction="-"` in adjoint plugin.

--- a/test_local.sh
+++ b/test_local.sh
@@ -16,6 +16,7 @@ pytest -ra tests/test_components/test_medium.py
 pytest -ra tests/test_components/test_meshgenerate.py
 pytest -ra tests/test_components/test_mode.py
 pytest -ra tests/test_components/test_monitor.py
+pytest -ra tests/test_components/test_parameter_perturbation.py
 pytest -ra tests/test_components/test_field_projection.py
 pytest -ra tests/test_components/test_sidewall.py
 pytest -ra tests/test_components/test_simulation.py

--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -410,3 +410,98 @@ def test_fully_anisotropic_media():
 
     assert all(np.isin(np.round(perm_d), np.round(np.diag(perm_diag))))
     assert all(np.isin(np.round(cond_d), np.round(np.diag(cond_diag))))
+
+
+def test_perturbation_medium():
+
+    # Non-dispersive
+    pp_real = td.ParameterPerturbation(
+        heat=td.LinearHeatPerturbation(
+            coeff=-0.01,
+            temperature_ref=300,
+            temperature_range=(200, 500),
+        ),
+    )
+
+    pp_complex = td.ParameterPerturbation(
+        heat=td.LinearHeatPerturbation(
+            coeff=0.01j,
+            temperature_ref=300,
+            temperature_range=(200, 500),
+        ),
+        charge=td.LinearChargePerturbation(
+            electron_coeff=-1e-21,
+            electron_ref=0,
+            electron_range=(0, 1e20),
+            hole_coeff=-2e-21,
+            hole_ref=0,
+            hole_range=(0, 0.5e20),
+        ),
+    )
+
+    coords = dict(x=[1, 2], y=[3, 4], z=[5, 6])
+    temperature = td.SpatialDataArray(300 * np.ones((2, 2, 2)), coords=coords)
+    electron_density = td.SpatialDataArray(1e18 * np.ones((2, 2, 2)), coords=coords)
+    hole_density = td.SpatialDataArray(2e18 * np.ones((2, 2, 2)), coords=coords)
+
+    pmed = td.PerturbationMedium(permittivity=3, permittivity_perturbation=pp_real)
+
+    cmed = pmed.perturbed_copy()
+    # regular medium if no perturbations
+    assert isinstance(cmed, td.Medium)
+
+    cmed = pmed.perturbed_copy(temperature, electron_density)
+    cmed = pmed.perturbed_copy(temperature, electron_density, hole_density)
+
+    # correct propagation of parameters
+    assert cmed.name == pmed.name
+    assert cmed.frequency_range == pmed.frequency_range
+    assert cmed.subpixel == pmed.subpixel
+    assert cmed.allow_gain == pmed.allow_gain
+
+    # permittivity < 1
+    with pytest.raises(pydantic.ValidationError):
+        _ = pmed.perturbed_copy(2 * temperature)
+
+    # conductivity validators
+    pmed = td.PerturbationMedium(conductivity_perturbation=pp_real, subpixel=False)
+    cmed = pmed.perturbed_copy(0.9 * temperature)  # positive conductivity
+    assert cmed.subpixel == False
+    with pytest.raises(pydantic.ValidationError):
+        _ = pmed.perturbed_copy(1.1 * temperature)  # negative conductivity
+
+    # negative conductivity but allow gain
+    pmed = td.PerturbationMedium(conductivity_perturbation=pp_real, allow_gain=True)
+    _ = pmed.perturbed_copy(1.1 * temperature)
+
+    # complex perturbation
+    with pytest.raises(pydantic.ValidationError):
+        pmed = td.PerturbationMedium(permittivity=3, permittivity_perturbation=pp_complex)
+
+    # Dispersive
+    pmed = td.PerturbationPoleResidue(
+        poles=[(1j, 3), (2j, 4)],
+        poles_perturbation=[(None, pp_real), (pp_complex, None)],
+        subpixel=False,
+        allow_gain=True,
+    )
+
+    cmed = pmed.perturbed_copy()
+    # regular medium if no perturbations
+    assert isinstance(cmed, td.PoleResidue)
+
+    cmed = pmed.perturbed_copy(temperature, None, hole_density)
+    cmed = pmed.perturbed_copy(temperature, electron_density, hole_density)
+
+    # correct propagation of parameters
+    assert cmed.name == pmed.name
+    assert cmed.frequency_range == pmed.frequency_range
+    assert cmed.subpixel == pmed.subpixel
+    assert cmed.allow_gain == pmed.allow_gain
+
+    # mismatch between base parameter and perturbations
+    with pytest.raises(pydantic.ValidationError):
+        pmed = td.PerturbationPoleResidue(
+            poles=[(1j, 3), (2j, 4)],
+            poles_perturbation=[(None, pp_real)],
+        )

--- a/tests/test_components/test_parameter_perturbation.py
+++ b/tests/test_components/test_parameter_perturbation.py
@@ -1,0 +1,359 @@
+"""Tests parameter perturbations."""
+import numpy as np
+import pytest
+import pydantic
+import tidy3d as td
+
+
+def test_heat_perturbation():
+
+    perturb = td.LinearHeatPerturbation(
+        coeff=0.01,
+        temperature_ref=300,
+        temperature_range=(200, 400),
+    )
+
+    # test automatic calculation of ranges
+    assert perturb.perturbation_range == (-100 * 0.01, 100 * 0.01)
+
+    # test complex type detection
+    assert not perturb.is_complex
+
+    with pytest.raises(pydantic.ValidationError) as e_info:
+        perturb = td.LinearHeatPerturbation(
+            coeff=0.01,
+            temperature_ref=-300,
+            temperature_range=(200, 400),
+        )
+
+    with pytest.raises(pydantic.ValidationError) as e_info:
+        perturb = td.LinearHeatPerturbation(
+            coeff=0.01,
+            temperature_ref=300,
+            temperature_range=(-200, 400),
+        )
+
+    # test sample function on different arguments
+    sampled = perturb.sample(350)
+    assert isinstance(sampled, float)
+    sampled = perturb.sample([310, 320])
+    assert isinstance(sampled, np.ndarray)
+    sampled = perturb.sample(np.array([310, 320]))
+    assert isinstance(sampled, np.ndarray)
+    sampled = perturb.sample(
+        td.SpatialDataArray(300 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6]))
+    )
+    assert isinstance(sampled, td.SpatialDataArray)
+
+    # complex temperature
+    with pytest.raises(ValueError) as e_info:
+        _ = perturb.sample(350j)
+
+    # test plotting
+    ax = perturb.plot(temperature=np.linspace(200, 400, 10), val="abs")
+
+    # incorrect plotting value
+    with pytest.raises(ValueError) as e_info:
+        _ = perturb.plot(temperature=np.linspace(200, 400, 10), val="angle")
+
+    # test custom heat perturbation
+    perturb_data = td.HeatDataArray([1 + 1j, 3 + 1j, 1j], coords=dict(T=[200, 300, 400]))
+
+    for interp_method in ["linear", "nearest"]:
+
+        perturb = td.CustomHeatPerturbation(
+            perturbation_values=perturb_data, interp_method=interp_method
+        )
+
+        # test automatic calculation of ranges
+        assert perturb.temperature_range == (200, 400)
+        assert perturb.perturbation_range == (1j, 3 + 1j)
+
+        # test complex type detection
+        assert perturb.is_complex
+
+        # test sample function on different arguments
+        test_value_in = perturb.sample(380)
+        assert isinstance(test_value_in, complex)
+        test_value_out = perturb.sample(450)
+        assert isinstance(test_value_out, complex)
+        sampled = perturb.sample([310, 320])
+        assert isinstance(sampled, np.ndarray)
+        sampled = perturb.sample(np.array([310, 320]))
+        assert isinstance(sampled, np.ndarray)
+        sampled = perturb.sample(
+            td.SpatialDataArray(300 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6]))
+        )
+        assert isinstance(sampled, td.SpatialDataArray)
+
+        # test plotting
+        ax = perturb.plot(temperature=np.linspace(200, 400, 10), val="real", ax=ax)
+
+        # check interpolation works as expected
+        if interp_method == "linear":
+            assert test_value_in != perturb_data.data[2]
+        elif interp_method == "nearest":
+            assert test_value_in == perturb_data.data[2]
+
+        # test clipping works
+        assert test_value_out == perturb_data.data[2]
+
+    # test not allowed interpolation method
+    with pytest.raises(pydantic.ValidationError) as e_info:
+        perturb = td.CustomHeatPerturbation(
+            perturbation_values=perturb_data,
+            interp_method="quadratic",
+        )
+
+
+def test_charge_perturbation():
+
+    perturb = td.LinearChargePerturbation(
+        electron_coeff=1e-21,
+        electron_ref=0,
+        electron_range=(0, 1e20),
+        hole_coeff=2e-21,
+        hole_ref=0,
+        hole_range=(0, 0.5e20),
+    )
+
+    # test automatic calculation of ranges
+    assert perturb.perturbation_range == (0, 1e20 * 1e-21 + 2e20 * 0.5e-21)
+
+    # test complex type detection
+    assert not perturb.is_complex
+
+    with pytest.raises(pydantic.ValidationError) as e_info:
+        perturb = td.LinearChargePerturbation(
+            electron_coeff=1e-21,
+            electron_ref=0,
+            electron_range=(0, 1e20),
+            hole_coeff=2e-21,
+            hole_ref=-1e15,
+            hole_range=(0, 0.5e20),
+        )
+
+    with pytest.raises(pydantic.ValidationError) as e_info:
+        perturb = td.LinearChargePerturbation(
+            electron_coeff=1e-21,
+            electron_ref=0,
+            electron_range=(-1e15, 1e20),
+            hole_coeff=2e-21,
+            hole_ref=0,
+            hole_range=(0, 0.5e20),
+        )
+
+    # test sample function on different arguments
+    sampled = perturb.sample(electron_density=1e19, hole_density=2e19)
+    assert isinstance(sampled, float)
+    sampled = perturb.sample(electron_density=[1e17, 1e18, 1e19], hole_density=[2e17, 2e18])
+    assert isinstance(sampled, np.ndarray)
+    sampled = perturb.sample(electron_density=1e17, hole_density=[2e17, 2e18])
+    assert isinstance(sampled, np.ndarray)
+    sampled = perturb.sample(
+        electron_density=td.SpatialDataArray(
+            1e18 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6])
+        ),
+        hole_density=td.SpatialDataArray(
+            2e18 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6])
+        ),
+    )
+    assert isinstance(sampled, td.SpatialDataArray)
+    sampled = perturb.sample(
+        electron_density=0,
+        hole_density=td.SpatialDataArray(
+            2e18 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6])
+        ),
+    )
+    assert isinstance(sampled, td.SpatialDataArray)
+
+    # test mixing spatial data array and simple array
+    with pytest.raises(ValueError) as e_info:
+        _ = perturb.sample(
+            electron_density=td.SpatialDataArray(
+                1e18 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6])
+            ),
+            hole_density=[2e17, 2e18],
+        )
+
+    with pytest.raises(ValueError) as e_info:
+        _ = perturb.sample(electron_density=1e19j, hole_density=2e19)
+
+    # test plotting
+    ax_2d = perturb.plot(
+        electron_density=np.logspace(16, 19, 4),
+        hole_density=np.logspace(17, 18, 3),
+        val="abs",
+    )
+
+    ax_1d_e = perturb.plot(
+        electron_density=np.logspace(16, 19, 4),
+        hole_density=1,
+        val="abs",
+    )
+
+    ax_1d_h = perturb.plot(
+        electron_density=2,
+        hole_density=np.logspace(16, 19, 4),
+        val="abs",
+    )
+
+    # incorrect plotting value
+    with pytest.raises(ValueError) as e_info:
+        _ = perturb.plot(
+            electron_density=np.logspace(16, 19, 4),
+            hole_density=np.logspace(17, 18, 3),
+            val="angle",
+        )
+
+    # test custom charge perturbation
+    perturb_data = td.ChargeDataArray(
+        [[1 + 1j, 3 + 1j, 1j], [2 + 2j, 2j, 2 + 2j]],
+        coords=dict(n=[2e17, 2e18], p=[1e16, 1e17, 1e18]),
+    )
+
+    for interp_method in ["linear", "nearest"]:
+
+        perturb = td.CustomChargePerturbation(
+            perturbation_values=perturb_data, interp_method=interp_method
+        )
+
+        # test automatic calculation of ranges
+        assert perturb.electron_range == (2e17, 2e18)
+        assert perturb.hole_range == (1e16, 1e18)
+        assert perturb.perturbation_range == (1j, 3 + 1j)
+
+        # test complex type detection
+        assert perturb.is_complex
+
+        # test sample function on different arguments
+        test_value_in = perturb.sample(electron_density=1.5e18, hole_density=9e17)
+        assert isinstance(test_value_in, complex)
+        test_value_out = perturb.sample(electron_density=1e19, hole_density=2e19)
+        assert isinstance(test_value_out, complex)
+        sampled = perturb.sample(electron_density=[1e17, 1e18, 1e19], hole_density=[2e17, 2e18])
+        assert isinstance(sampled, np.ndarray)
+        sampled = perturb.sample(electron_density=1e17, hole_density=[2e17, 2e18])
+        assert isinstance(sampled, np.ndarray)
+        sampled = perturb.sample(
+            electron_density=td.SpatialDataArray(
+                1e18 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6])
+            ),
+            hole_density=td.SpatialDataArray(
+                2e18 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6])
+            ),
+        )
+        assert isinstance(sampled, td.SpatialDataArray)
+        sampled = perturb.sample(
+            electron_density=0,
+            hole_density=td.SpatialDataArray(
+                2e18 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6])
+            ),
+        )
+        assert isinstance(sampled, td.SpatialDataArray)
+
+        # test mixing spatial data array and simple array
+        with pytest.raises(ValueError) as e_info:
+            _ = perturb.sample(
+                electron_density=td.SpatialDataArray(
+                    1e18 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6])
+                ),
+                hole_density=[2e17, 2e18],
+            )
+
+        # test plotting
+        ax = perturb.plot(
+            electron_density=np.logspace(16, 19, 4),
+            hole_density=np.logspace(17, 18, 3),
+            val="abs",
+            ax=ax_2d,
+        )
+
+        ax = perturb.plot(
+            electron_density=np.logspace(16, 19, 4),
+            hole_density=1,
+            val="abs",
+            ax=ax_1d_e,
+        )
+
+        ax = perturb.plot(
+            electron_density=2,
+            hole_density=np.logspace(16, 19, 4),
+            val="abs",
+            ax=ax_1d_h,
+        )
+
+        # check interpolation works as expected
+        if interp_method == "linear":
+            assert test_value_in != perturb_data[-1, -1].item()
+        elif interp_method == "nearest":
+            assert test_value_in == perturb_data[-1, -1].item()
+
+        # check clipping works as expected
+        assert test_value_out == perturb_data[-1, -1].item()
+
+    # test not allowed interpolation method
+    with pytest.raises(pydantic.ValidationError) as e_info:
+        perturb = td.CustomChargePerturbation(
+            perturbation_values=perturb_data,
+            interp_method="quadratic",
+        )
+
+
+def test_parameter_perturbation():
+
+    heat = td.LinearHeatPerturbation(
+        coeff=0.01,
+        temperature_ref=300,
+        temperature_range=(200, 400),
+    )
+
+    heat_range = (-100 * 0.01, 100 * 0.01)
+    charge_range = (1j, 3 + 1j)
+
+    perturb_data = td.ChargeDataArray(
+        [[1 + 1j, 3 + 1j, 1j], [2 + 2j, 2j, 2 + 2j]],
+        coords=dict(n=[2e17, 2e18], p=[1e16, 1e17, 1e18]),
+    )
+
+    charge = td.CustomChargePerturbation(perturbation_values=perturb_data, interp_method="linear")
+
+    coords = dict(x=[1, 2], y=[3, 4], z=[5, 6])
+    coords2 = dict(x=[1, 2], y=[3, 4], z=[5])
+    temperature = td.SpatialDataArray(300 * np.ones((2, 2, 2)), coords=coords)
+    electron_density = td.SpatialDataArray(1e18 * np.ones((2, 2, 2)), coords=coords)
+    hole_density = td.SpatialDataArray(2e18 * np.ones((2, 2, 2)), coords=coords)
+
+    temperature2 = td.SpatialDataArray(300 * np.ones((2, 2, 1)), coords=coords2)
+
+    param_perturb = td.ParameterPerturbation(
+        heat=heat,
+    )
+    assert param_perturb.perturbation_list == [heat]
+    assert not param_perturb.is_complex
+    assert param_perturb.perturbation_range == heat_range
+
+    after_data = param_perturb.apply_data(temperature, electron_density, hole_density)
+
+    param_perturb = td.ParameterPerturbation(
+        charge=charge,
+    )
+    assert param_perturb.perturbation_list == [charge]
+    assert param_perturb.is_complex
+    assert param_perturb.perturbation_range == charge_range
+
+    after_data = param_perturb.apply_data(temperature, None, hole_density)
+
+    param_perturb = td.ParameterPerturbation(
+        heat=heat,
+        charge=charge,
+    )
+    assert param_perturb.perturbation_list == [heat, charge]
+    assert param_perturb.is_complex
+    assert param_perturb.perturbation_range == tuple(np.array(heat_range) + np.array(charge_range))
+
+    after_data = param_perturb.apply_data(None, electron_density, hole_density)
+
+    # array with mismatching coords
+    with pytest.raises(ValueError) as e_info:
+        after_data = param_perturb.apply_data(temperature2, electron_density, hole_density)

--- a/tests/test_data/test_data_arrays.py
+++ b/tests/test_data/test_data_arrays.py
@@ -8,6 +8,7 @@ from tidy3d.components.data.data_array import ScalarModeFieldDataArray
 from tidy3d.components.data.data_array import ModeAmpsDataArray, ModeIndexDataArray
 from tidy3d.components.data.data_array import FluxDataArray, FluxTimeDataArray
 from tidy3d.components.data.data_array import DiffractionDataArray
+from tidy3d.components.data.data_array import HeatDataArray, ChargeDataArray
 from tidy3d.components.source import PointDipole, GaussianPulse, ModeSource
 from tidy3d.components.simulation import Simulation
 from tidy3d.components.grid.grid_spec import GridSpec
@@ -284,3 +285,14 @@ def test_empty_field_time():
 def test_abs():
     data = make_mode_amps_data_array()
     dabs = data.abs
+
+
+def test_heat_data_array():
+    T = [0, 1e-12, 2e-12]
+    test = HeatDataArray((1 + 1j) * np.random.random((3,)), coords=dict(T=T))
+
+
+def test_heat_data_array():
+    n = [0, 1e-12, 2e-12]
+    p = [0, 3e-12, 4e-12]
+    test = ChargeDataArray((1 + 1j) * np.random.random((3, 3)), coords=dict(n=n, p=p))

--- a/tests/test_plugins/test_dispersion_fitter.py
+++ b/tests/test_plugins/test_dispersion_fitter.py
@@ -149,3 +149,13 @@ def test_dispersion_set_wvg_range(random_data):
     fastfitter = fastfitter.copy(update={"wvl_range": wvl_range})
     assert len(fastfitter.freqs) == 11
     medium, rms = fastfitter.fit(advanced_param=advanced_param)
+
+
+def test_dispersion_guess(random_data):
+    """plots a medium fit from file"""
+    wvl_um, n_data, k_data = random_data
+
+    fitter = DispersionFitter(wvl_um=wvl_um, n_data=n_data)
+    medium, rms = fitter.fit(num_tries=2)
+
+    medium_new, rms_new = fitter.fit(num_tries=1, guess=medium)

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -15,6 +15,10 @@ from .components.medium import CustomMedium, CustomPoleResidue
 from .components.medium import CustomSellmeier, FullyAnisotropicMedium
 from .components.medium import CustomLorentz, CustomDrude, CustomDebye, CustomAnisotropicMedium
 from .components.transformation import RotationAroundAxis
+from .components.medium import PerturbationMedium, PerturbationPoleResidue
+from .components.parameter_perturbation import ParameterPerturbation
+from .components.parameter_perturbation import LinearHeatPerturbation, CustomHeatPerturbation
+from .components.parameter_perturbation import LinearChargePerturbation, CustomChargePerturbation
 
 # structures
 from .components.structure import Structure, MeshOverrideStructure
@@ -54,6 +58,7 @@ from .components.data.data_array import FieldProjectionAngleDataArray
 from .components.data.data_array import FieldProjectionCartesianDataArray
 from .components.data.data_array import FieldProjectionKSpaceDataArray
 from .components.data.data_array import DiffractionDataArray
+from .components.data.data_array import HeatDataArray, ChargeDataArray
 from .components.data.dataset import FieldDataset, FieldTimeDataset
 from .components.data.dataset import PermittivityDataset, ModeSolverDataset
 from .components.data.monitor_data import FieldData, FieldTimeData, PermittivityData

--- a/tidy3d/components/parameter_perturbation.py
+++ b/tidy3d/components/parameter_perturbation.py
@@ -1,0 +1,930 @@
+# pylint: disable=invalid-name, too-many-lines
+"""Defines perturbations to properties of the medium / materials"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Callable, Union, Tuple, List
+import functools
+
+import pydantic as pd
+import numpy as np
+import xarray as xr
+import matplotlib.pyplot as plt
+
+from .data.data_array import SpatialDataArray, HeatDataArray, ChargeDataArray
+from .base import Tidy3dBaseModel, cached_property
+from ..constants import KELVIN, CMCUBE, PERCMCUBE, inf
+from ..log import log
+from ..components.types import Ax, ArrayLike, Complex, FieldVal, InterpMethod
+from ..components.viz import add_ax_if_none
+
+""" Generic perturbation classes """
+
+
+class AbstractPerturbation(ABC, Tidy3dBaseModel):
+    """Abstract class for a generic perturbation."""
+
+    @cached_property
+    @abstractmethod
+    def perturbation_range(self) -> Union[Tuple[float, float], Tuple[Complex, Complex]]:
+        """Perturbation range."""
+
+    @cached_property
+    @abstractmethod
+    def is_complex(self) -> bool:
+        """Whether perturbation is complex valued."""
+
+    @staticmethod
+    def _linear_range(interval: Tuple[float, float], ref: float, coeff: Union[float, Complex]):
+        """Find value range for a linear perturbation."""
+        if coeff in (0, 0j):  # to avoid 0*inf
+            return np.array([0, 0])
+        return tuple(np.sort(coeff * (np.array(interval) - ref)))
+
+    @staticmethod
+    def _get_val(
+        field: Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray], val: FieldVal
+    ) -> Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]:
+        """Get specified value from a field."""
+
+        if val == "real":
+            return np.real(field)
+
+        if val == "imag":
+            return np.imag(field)
+
+        if val == "abs":
+            return np.abs(field)
+
+        if val == "abs^2":
+            return np.abs(field) ** 2
+
+        if val == "phase":
+            return np.arctan2(np.real(field), np.imag(field))
+
+        raise ValueError(
+            "Unknown 'val' key. Argument 'val' can take values 'real', 'imag', 'abs', "
+            "'abs^2', or 'phase'."
+        )
+
+    @staticmethod
+    def _array_type(value: Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]) -> str:
+        """Check whether variable is scalar, array, or spatial array."""
+        if isinstance(value, SpatialDataArray):
+            return "spatial"
+        if np.ndim(value) == 0:
+            return "scalar"
+        return "array"
+
+
+""" Elementary heat perturbation classes """
+
+
+def ensure_temp_in_range(
+    sample: Callable[
+        Union[ArrayLike[float], SpatialDataArray],
+        Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray],
+    ]
+) -> Callable[
+    Union[ArrayLike[float], SpatialDataArray],
+    Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray],
+]:
+    """Decorate ``sample`` to log warning if temperature supplied is out of bounds."""
+
+    @functools.wraps(sample)
+    def _sample(
+        self, temperature: Union[ArrayLike[float], SpatialDataArray]
+    ) -> Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]:
+        """New sample function."""
+
+        if np.iscomplexobj(temperature):
+            raise ValueError("Cannot pass complex 'temperature' to 'sample()'")
+
+        temp_min, temp_max = self.temperature_range
+        temperature_numpy = np.array(temperature)
+        if np.any(temperature_numpy < temp_min) or np.any(temperature_numpy > temp_max):
+            log.warning(
+                "Temperature passed to 'HeatPerturbation.sample()'"
+                f"is outside of 'HeatPerturbation.temperature_range' = {self.temperature_range}"
+            )
+        return sample(self, temperature)
+
+    return _sample
+
+
+class HeatPerturbation(AbstractPerturbation):
+    """Abstract class for heat perturbation."""
+
+    temperature_range: Tuple[pd.NonNegativeFloat, pd.NonNegativeFloat] = pd.Field(
+        (0, inf),
+        title="Temperature range",
+        description="Temparature range in which perturbation model is valid.",
+        units=KELVIN,
+    )
+
+    @abstractmethod
+    def sample(
+        self, temperature: Union[ArrayLike[float], SpatialDataArray]
+    ) -> Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]:
+        """Sample perturbation.
+
+        Parameters
+        ----------
+        temperature : Union[ArrayLike[float], SpatialDataArray]
+            Temperature sample point(s).
+
+        Returns
+        -------
+        Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]
+            Sampled perturbation value(s).
+        """
+
+    @add_ax_if_none
+    def plot(
+        self,
+        temperature: ArrayLike[float],
+        val: FieldVal = "real",
+        ax: Ax = None,
+    ) -> Ax:
+        """Plot perturbation using provided temperature sample points.
+
+        Parameters
+        ----------
+        temperature : ArrayLike[float]
+            Array of temperature sample points.
+        val : Literal['real', 'imag', 'abs', 'abs^2', 'phase'] = 'real'
+            Which part of the field to plot.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+
+        temperature_numpy = np.array(temperature)
+
+        values = self.sample(temperature_numpy)
+        values = self._get_val(values, val)
+
+        ax.plot(temperature_numpy, values)
+        ax.set_xlabel("temperature (K)")
+        ax.set_ylabel(f"{val}(perturbation value)")
+        ax.set_title("temperature dependence")
+        ax.set_aspect("auto")
+
+        return ax
+
+
+class LinearHeatPerturbation(HeatPerturbation):
+    """Specifies parameter's perturbation due to thermal effects as a linear function of
+    temperature:
+
+    Note
+    ----
+    .. math::
+
+        \\Delta X (T) = \\text{coeff} \\times (T - \\text{temperature\\_ref}),
+
+    where ``coeff`` is the parameter's sensitivity (thermo-optic coefficient) to temperature and
+    ``temperature_ref`` is the reference temperature point. A temperature range in which such
+    a model is deemed accurate may be provided as a field ``temperature_range``
+    (default: ``[0, inf]``). Wherever is applied, Tidy3D will check that the parameter's value
+    does not go out of its physical bounds within ``temperature_range`` due to perturbations and
+    raise a warning if this check fails. A warning is also issued if the perturbation model is
+    evaluated outside of ``temperature_range``.
+
+    Example
+    -------
+    >>> heat_perturb = LinearHeatPerturbation(
+    ...     temperature_ref=300,
+    ...     coeff=0.0001,
+    ...     temperature_range=[200, 500],
+    ... )
+    """
+
+    temperature_ref: pd.NonNegativeFloat = pd.Field(
+        ...,
+        title="Reference temperature",
+        description="Temperature at which perturbation is zero.",
+        units=KELVIN,
+    )
+
+    coeff: Union[float, Complex] = pd.Field(
+        ...,
+        title="Thermo-optic Coefficient",
+        description="Sensitivity (derivative) of perturbation with respect to temperature.",
+        units=f"1/{KELVIN}",
+    )
+
+    @cached_property
+    def perturbation_range(self) -> Union[Tuple[float, float], Tuple[Complex, Complex]]:
+        """Range of possible perturbation values in the provided ``temperature_range``."""
+        return self._linear_range(self.temperature_range, self.temperature_ref, self.coeff)
+
+    @ensure_temp_in_range
+    def sample(
+        self, temperature: Union[ArrayLike[float], SpatialDataArray]
+    ) -> Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]:
+        """Sample perturbation at temperature points.
+
+        Parameters
+        ----------
+        temperature : Union[ArrayLike[float], SpatialDataArray]
+            Temperature sample point(s).
+
+        Returns
+        -------
+        Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]
+            Sampled perturbation value(s).
+        """
+
+        # convert to numpy if not spatial data array
+        t_vals = np.array(temperature) if self._array_type(temperature) == "array" else temperature
+
+        return self.coeff * (t_vals - self.temperature_ref)
+
+    @cached_property
+    def is_complex(self) -> bool:
+        """Whether perturbation is complex valued."""
+        return np.iscomplex(self.coeff)
+
+
+class CustomHeatPerturbation(HeatPerturbation):
+    """Specifies parameter's perturbation due to thermal effects as a custom function of
+    temperature defined as an array of perturbation values at sample temperature points. The linear
+    interpolation is used to calculate perturbation values between sample temperature points. For
+    temperature values outside of the provided sample region the perturbation value is extrapolated
+    as a constant.
+    The temperature range, ``temperature_range``, in which the perturbation model is assumed to be
+    accurate is calculated automatically as the minimal and maximal sample temperature points.
+    Wherever is applied, Tidy3D will check that the parameter's value
+    does not go out of its physical bounds within ``temperature_range`` due to perturbations and
+    raise a warning if this check fails. A warning is also issued if the perturbation model is
+    evaluated outside of ``temperature_range``.
+
+    Example
+    -------
+    >>> from tidy3d import HeatDataArray
+    >>> perturbation_data = HeatDataArray([0.001, 0.002, 0.004], coords=dict(T=[250, 300, 350]))
+    >>> heat_perturb = CustomHeatPerturbation(
+    ...     perturbation_values=perturbation_data
+    ... )
+    """
+
+    perturbation_values: HeatDataArray = pd.Field(
+        ...,
+        title="Perturbation Values",
+        description="Sampled perturbation values.",
+    )
+
+    temperature_range: Tuple[pd.NonNegativeFloat, pd.NonNegativeFloat] = pd.Field(
+        None,
+        title="Temperature range",
+        description="Temparature range in which perturbation model is valid. For "
+        ":class:`.CustomHeatPerturbation` this field is computed automatically based on "
+        "temperature sample points provided in ``perturbation_values``.",
+        units=KELVIN,
+    )
+
+    interp_method: InterpMethod = pd.Field(
+        "linear",
+        title="Interpolation method",
+        description="Interpolation method to obtain perturbation values between sample points.",
+    )
+
+    @cached_property
+    def perturbation_range(self) -> Union[Tuple[float, float], Tuple[Complex, Complex]]:
+        """Range of possible parameter perturbation values."""
+        return np.min(self.perturbation_values).item(), np.max(self.perturbation_values).item()
+
+    @pd.root_validator(skip_on_failure=True)
+    def compute_temperature_range(cls, values):
+        """Compute and set temperature range based on provided ``perturbation_values``."""
+        if values["temperature_range"] is not None:
+            log.warning(
+                "Temperature range for 'CustomHeatPerturbation' is calculated automatically "
+                "based on provided 'perturbation_values'. Provided 'temperature_range' will be "
+                "overwritten."
+            )
+
+        perturbation_values = values["perturbation_values"]
+
+        # .item() to convert to a scalar
+        temperature_range = (
+            np.min(perturbation_values.coords["T"]).item(),
+            np.max(perturbation_values.coords["T"]).item(),
+        )
+
+        values.update({"temperature_range": temperature_range})
+
+        return values
+
+    @ensure_temp_in_range
+    def sample(
+        self, temperature: Union[ArrayLike[float], SpatialDataArray]
+    ) -> Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]:
+        """Sample perturbation at provided temperature points.
+
+        Parameters
+        ----------
+        temperature : Union[ArrayLike[float], SpatialDataArray]
+            Temperature sample point(s).
+
+        Returns
+        -------
+        Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]
+            Sampled perturbation value(s).
+        """
+
+        t_range = self.temperature_range
+        temperature_clip = np.clip(temperature, t_range[0], t_range[1])
+        data = self.perturbation_values.interp(T=temperature_clip, method=self.interp_method)
+        # preserve input type
+        if isinstance(temperature, SpatialDataArray):
+            return SpatialDataArray(data.drop_vars("T"))
+        if np.ndim(temperature) == 0:
+            return data.item()
+        return data.data
+
+    @cached_property
+    def is_complex(self) -> bool:
+        """Whether perturbation is complex valued."""
+        return np.iscomplexobj(self.perturbation_values)
+
+
+HeatPerturbationType = Union[LinearHeatPerturbation, CustomHeatPerturbation]
+
+
+""" Elementary charge perturbation classes """
+
+
+def ensure_charge_in_range(
+    sample: Callable[
+        [Union[ArrayLike[float], SpatialDataArray], Union[ArrayLike[float], SpatialDataArray]],
+        Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray],
+    ]
+) -> Callable[
+    [Union[ArrayLike[float], SpatialDataArray], Union[ArrayLike[float], SpatialDataArray]],
+    Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray],
+]:
+    """Decorate ``sample`` to log warning if charge supplied is out of bounds."""
+
+    @functools.wraps(sample)
+    def _sample(
+        self,
+        electron_density: Union[ArrayLike[float], SpatialDataArray],
+        hole_density: Union[ArrayLike[float], SpatialDataArray],
+    ) -> Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]:
+        """New sample function."""
+
+        # disable complex input
+        if np.iscomplexobj(electron_density):
+            raise ValueError("Cannot pass complex 'electron_density' to 'sample()'")
+
+        if np.iscomplexobj(hole_density):
+            raise ValueError("Cannot pass complex 'hole_density' to 'sample()'")
+
+        # check ranges
+        e_min, e_max = self.electron_range
+
+        electron_numpy = np.array(electron_density)
+        if np.any(electron_numpy < e_min) or np.any(electron_numpy > e_max):
+            log.warning(
+                "Electron density values passed to 'ChargePerturbation.sample()'"
+                f"is outside of 'ChargePerturbation.electron_range' = {self.electron_range}"
+            )
+
+        h_min, h_max = self.hole_range
+
+        hole_numpy = np.array(hole_density)
+        if np.any(hole_numpy < h_min) or np.any(hole_numpy > h_max):
+            log.warning(
+                "Hole density values passed to 'ChargePerturbation.sample()'"
+                f"is outside of 'ChargePerturbation.hole_range' = {self.hole_range}"
+            )
+
+        return sample(self, electron_density, hole_density)
+
+    return _sample
+
+
+class ChargePerturbation(AbstractPerturbation):
+    """Abstract class for charge perturbation."""
+
+    electron_range: Tuple[pd.NonNegativeFloat, pd.NonNegativeFloat] = pd.Field(
+        (0, inf),
+        title="Electron Density Range",
+        description="Range of electrons densities in which perturbation model is valid.",
+    )
+
+    hole_range: Tuple[pd.NonNegativeFloat, pd.NonNegativeFloat] = pd.Field(
+        (0, inf),
+        title="Hole Density Range",
+        description="Range of holes densities in which perturbation model is valid.",
+    )
+
+    @abstractmethod
+    def sample(
+        self,
+        electron_density: Union[ArrayLike[float], SpatialDataArray],
+        hole_density: Union[ArrayLike[float], SpatialDataArray],
+    ) -> Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]:
+        """Sample perturbation.
+
+        Parameters
+        ----------
+        electron_density : Union[ArrayLike[float], SpatialDataArray]
+            Electron density sample point(s).
+        hole_density : Union[ArrayLike[float], SpatialDataArray]
+            Hole density sample point(s).
+
+        Note
+        ----
+        Cannot provide a :class:`.SpatialDataArray` for one argument and a regular array
+        (``list``, ``tuple``, ``numpy.nd_array``) for the other. Additionally, if both arguments are
+        regular arrays they must be one-dimensional arrays.
+
+        Returns
+        -------
+        Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]
+            Sampled perturbation value(s).
+        """
+
+    @add_ax_if_none
+    def plot(
+        self,
+        electron_density: ArrayLike[float],
+        hole_density: ArrayLike[float],
+        val: FieldVal = "real",
+        ax: Ax = None,
+    ) -> Ax:
+        """Plot perturbation using provided electron and hole density sample points.
+
+        Parameters
+        ----------
+        electron_density : Union[ArrayLike[float], SpatialDataArray]
+            Array of electron density sample points.
+        hole_density : Union[ArrayLike[float], SpatialDataArray]
+            Array of hole density sample points.
+        val : Literal['real', 'imag', 'abs', 'abs^2', 'phase'] = 'real'
+            Which part of the field to plot.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+
+        values = self.sample(electron_density, hole_density)
+        values = self._get_val(values, val)
+
+        if np.ndim(electron_density) == 0:
+            ax.plot(hole_density, values, label=f"electron density = {electron_density} 1/cm^3")
+            ax.set_ylabel(f"{val}(perturbation value)")
+            ax.set_xlabel("hole density (1/cm^3)")
+            ax.set_title(f"charge dependence of {val}(perturbation value)")
+            ax.set_aspect("auto")
+            ax.legend()
+
+        elif np.ndim(hole_density) == 0:
+            ax.plot(electron_density, values, label=f"hole density = {hole_density} 1/cm^3")
+            ax.set_ylabel(f"{val}(perturbation value)")
+            ax.set_xlabel("electron density (1/cm^3)")
+            ax.set_title(f"charge dependence of {val}(perturbation value)")
+            ax.set_aspect("auto")
+            ax.legend()
+
+        else:
+            e_mesh, h_mesh = np.meshgrid(electron_density, hole_density, indexing="ij")
+            pc = ax.pcolormesh(e_mesh, h_mesh, values, shading="gouraud")
+            plt.colorbar(pc, ax=ax)
+            ax.set_xlabel("electron density (1/cm^3)")
+            ax.set_ylabel("hole density (1/cm^3)")
+
+        ax.set_title(f"charge dependence of {val}(perturbation value)")
+        ax.set_aspect("auto")
+
+        return ax
+
+    @staticmethod
+    def _get_eh_types(electron_density, hole_density):
+        """Get types of provided arguments and check that no mixing between spatial and regular
+        arrays.
+        """
+        e_type = AbstractPerturbation._array_type(electron_density)
+        h_type = AbstractPerturbation._array_type(hole_density)
+
+        one_array = e_type == "array" or h_type == "array"
+        one_spatial = e_type == "spatial" or h_type == "spatial"
+
+        if one_array and one_spatial:
+            raise ValueError(
+                "Cannot mix 'SpatialDataArray' and regular python arrays for 'electron_density'"
+                "'hole_density'."
+            )
+
+        if e_type == "array" and h_type == "array" and (np.ndim(e_type) > 1 or np.ndim(h_type) > 1):
+            raise ValueError(
+                "Cannot mix multidimensional arrays for 'electron_density' and 'hole_density'."
+            )
+
+        return e_type, h_type
+
+
+class LinearChargePerturbation(ChargePerturbation):
+    """Specifies parameter's perturbation due to free carrier effects as a linear function of
+    electron and hole densities:
+
+    Note
+    ----
+    .. math::
+
+        \\Delta X (T) = \\text{electron\\_coeff} \\times (N_e - \\text{electron\\_ref})
+        + \\text{hole\\_coeff} \\times (N_h - \\text{hole\\_ref}),
+
+    where ``electron_coeff`` and ``hole_coeff`` are the parameter's sensitivities to electron and
+    hole densities, while ``electron_ref`` and ``hole_ref`` are reference electron and hole density
+    values. Ranges of electron and hole densities in which such
+    a model is deemed accurate may be provided as fields ``electron_range`` and ``hole_range``
+    (default: ``[0, inf]`` each). Wherever is applied, Tidy3D will check that the parameter's value
+    does not go out of its physical bounds within ``electron_range`` x ``hole_range`` due to
+    perturbations and raise a warning if this check fails. A warning is also issued if
+    the perturbation model is evaluated outside of ``electron_range`` x ``hole_range``.
+
+    Example
+    -------
+    >>> charge_perturb = LinearChargePerturbation(
+    ...     electron_ref=0,
+    ...     electron_coeff=0.0001,
+    ...     electron_range=[0, 1e19],
+    ...     hole_ref=0,
+    ...     hole_coeff=0.0002,
+    ...     hole_range=[0, 2e19],
+    ... )
+    """
+
+    electron_ref: pd.NonNegativeFloat = pd.Field(
+        ...,
+        title="Reference Electron Density",
+        description="Electron density value at which there is no perturbation due to electrons's "
+        "presence.",
+        units=PERCMCUBE,
+    )
+
+    hole_ref: pd.NonNegativeFloat = pd.Field(
+        ...,
+        title="Reference Hole Density",
+        description="Hole density value at which there is no perturbation due to holes' presence.",
+        units=PERCMCUBE,
+    )
+
+    electron_coeff: float = pd.Field(
+        ...,
+        title="Sensitivity to Electron Density",
+        description="Sensitivity (derivative) of perturbation with respect to electron density.",
+        units=CMCUBE,
+    )
+
+    hole_coeff: float = pd.Field(
+        ...,
+        title="Sensitivity to Hole Density",
+        description="Sensitivity (derivative) of perturbation with respect to hole density.",
+        units=CMCUBE,
+    )
+
+    @cached_property
+    def perturbation_range(self) -> Union[Tuple[float, float], Tuple[Complex, Complex]]:
+        """Range of possible perturbation values within provided ``electron_range`` and
+        ``hole_range``.
+        """
+
+        range_from_e = self._linear_range(
+            self.electron_range, self.electron_ref, self.electron_coeff
+        )
+        range_from_h = self._linear_range(self.hole_range, self.hole_ref, self.hole_coeff)
+
+        return tuple(np.array(range_from_e) + np.array(range_from_h))
+
+    @ensure_charge_in_range
+    def sample(
+        self,
+        electron_density: Union[ArrayLike[float], SpatialDataArray],
+        hole_density: Union[ArrayLike[float], SpatialDataArray],
+    ) -> Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]:
+        """Sample perturbation at electron and hole density points.
+
+        Parameters
+        ----------
+        electron_density : Union[ArrayLike[float], SpatialDataArray]
+            Electron density sample point(s).
+        hole_density : Union[ArrayLike[float], SpatialDataArray]
+            Hole density sample point(s).
+
+        Note
+        ----
+        Cannot provide a :class:`.SpatialDataArray` for one argument and a regular array
+        (``list``, ``tuple``, ``numpy.nd_array``) for the other. Additionally, if both arguments are
+        regular arrays they must be one-dimensional arrays.
+
+        Returns
+        -------
+        Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]
+            Sampled perturbation value(s).
+        """
+        e_type, h_type = self._get_eh_types(electron_density, hole_density)
+
+        if e_type == "array" and h_type == "array":
+
+            e_mesh, h_mesh = np.meshgrid(electron_density, hole_density, indexing="ij")
+
+            return self.electron_coeff * (e_mesh - self.electron_ref) + self.hole_coeff * (
+                h_mesh - self.hole_ref
+            )
+
+        e_vals = np.array(electron_density) if e_type == "array" else electron_density
+        h_vals = np.array(hole_density) if h_type == "array" else hole_density
+
+        return self.electron_coeff * (e_vals - self.electron_ref) + self.hole_coeff * (
+            h_vals - self.hole_ref
+        )
+
+    @cached_property
+    def is_complex(self) -> bool:
+        """Whether perturbation is complex valued."""
+        return np.iscomplex(self.electron_coeff) or np.iscomplex(self.hole_coeff)
+
+
+class CustomChargePerturbation(ChargePerturbation):
+    """Specifies parameter's perturbation due to free carrier effects as a custom function of
+    electron and hole densities defined as a two-dimensional array of perturbation values at sample
+    electron and hole density points. The linear interpolation is used to calculate perturbation
+    values between sample points. For electron and hole density values outside of the provided
+    sample region the perturbation value is extrapolated as a constant.
+    The electron and hole density ranges, ``electron_range`` and ``hole_range``, in which
+    the perturbation model is assumed to be accurate is calculated automatically as the minimal and
+    maximal density values provided in ``perturbation_values``. Wherever is applied, Tidy3D will
+    check that the parameter's value does not go out of its physical bounds within
+    ``electron_range`` x ``hole_range`` due to perturbations and raise a warning if this check
+    fails. A warning is also issued if the perturbation model is evaluated outside of
+    ``electron_range`` x ``hole_range``.
+
+    Example
+    -------
+    >>> from tidy3d import ChargeDataArray
+    >>> perturbation_data = ChargeDataArray(
+    ...     [[0.001, 0.002, 0.004], [0.003, 0.002, 0.001]],
+    ...     coords=dict(n=[2e15, 2e19], p=[1e16, 1e17, 1e18]),
+    ... )
+    >>> charge_perturb = CustomChargePerturbation(
+    ...     perturbation_values=perturbation_data,
+    ... )
+    """
+
+    perturbation_values: ChargeDataArray = pd.Field(
+        ...,
+        title="Petrubation Values",
+        description="2D array (vs electron and hole densities) of sampled perturbation values.",
+    )
+
+    electron_range: Tuple[pd.NonNegativeFloat, pd.NonNegativeFloat] = pd.Field(
+        None,
+        title="Electron Density Range",
+        description="Range of electrons densities in which perturbation model is valid. For "
+        ":class:`.CustomChargePerturbation` this field is computed automatically based on "
+        "provided ``perturbation_values``",
+    )
+
+    hole_range: Tuple[pd.NonNegativeFloat, pd.NonNegativeFloat] = pd.Field(
+        None,
+        title="Hole Density Range",
+        description="Range of holes densities in which perturbation model is valid. For "
+        ":class:`.CustomChargePerturbation` this field is computed automatically based on "
+        "provided ``perturbation_values``",
+    )
+
+    interp_method: InterpMethod = pd.Field(
+        "linear",
+        title="Interpolation method",
+        description="Interpolation method to obtain perturbation values between sample points.",
+    )
+
+    @cached_property
+    def perturbation_range(self) -> Union[Tuple[float, float], Tuple[complex, complex]]:
+        """Range of possible parameter perturbation values."""
+        return np.min(self.perturbation_values).item(), np.max(self.perturbation_values).item()
+
+    @pd.root_validator(skip_on_failure=True)
+    def compute_eh_ranges(cls, values):
+        """Compute and set electron and hole density ranges based on provided
+        ``perturbation_values``.
+        """
+        if values["electron_range"] is not None:
+            log.warning(
+                "Electron density range for 'CustomChargePerturbation' is calculated automatically "
+                "based on provided 'perturbation_values'. Provided 'electron_range' will be "
+                "overwritten."
+            )
+
+        if values["hole_range"] is not None:
+            log.warning(
+                "Hole density range for 'CustomChargePerturbation' is calculated automatically "
+                "based on provided 'perturbation_values'. Provided 'hole_range' will be "
+                "overwritten."
+            )
+
+        perturbation_values = values["perturbation_values"]
+
+        electron_range = (
+            np.min(perturbation_values.coords["n"]).item(),
+            np.max(perturbation_values.coords["n"]).item(),
+        )
+
+        hole_range = (
+            np.min(perturbation_values.coords["p"]).item(),
+            np.max(perturbation_values.coords["p"]).item(),
+        )
+
+        values.update({"electron_range": electron_range, "hole_range": hole_range})
+
+        return values
+
+    @ensure_charge_in_range
+    def sample(
+        self,
+        electron_density: Union[ArrayLike[float], SpatialDataArray],
+        hole_density: Union[ArrayLike[float], SpatialDataArray],
+    ) -> Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]:
+        """Sample perturbation at electron and hole density points.
+
+        Parameters
+        ----------
+        electron_density : Union[ArrayLike[float], SpatialDataArray]
+            Electron density sample point(s).
+        hole_density : Union[ArrayLike[float], SpatialDataArray]
+            Hole density sample point(s).
+
+        Note
+        ----
+        Cannot provide a :class:`.SpatialDataArray` for one argument and a regular array
+        (``list``, ``tuple``, ``numpy.nd_array``) for the other. Additionally, if both arguments are
+        regular arrays they must be one-dimensional arrays.
+
+        Returns
+        -------
+        Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]
+            Sampled perturbation value(s).
+        """
+        e_type, h_type = self._get_eh_types(electron_density, hole_density)
+
+        e_clip = np.clip(electron_density, self.electron_range[0], self.electron_range[1])
+        h_clip = np.clip(hole_density, self.hole_range[0], self.hole_range[1])
+
+        data = self.perturbation_values.interp(n=e_clip, p=h_clip, method=self.interp_method)
+
+        if e_type == "scalar" and h_type == "scalar":
+            return data.item()
+        if e_type == "spatial" or h_type == "spatial":
+            return SpatialDataArray(data.drop_vars(["n", "p"]))
+        return data.data
+
+    @cached_property
+    def is_complex(self) -> bool:
+        """Whether perturbation is complex valued."""
+        return np.iscomplexobj(self.perturbation_values)
+
+
+ChargePerturbationType = Union[LinearChargePerturbation, CustomChargePerturbation]
+
+PerturbationType = Union[HeatPerturbationType, ChargePerturbationType]
+
+
+class ParameterPerturbation(Tidy3dBaseModel):
+    """Stores information about parameter perturbations due to different physical effect. If both
+    heat and charge perturbation models are included their effects are superimposed.
+
+    Example
+    -------
+    >>> from tidy3d import LinearChargePerturbation, CustomHeatPerturbation, HeatDataArray
+    >>>
+    >>> perturbation_data = HeatDataArray([0.001, 0.002, 0.004], coords=dict(T=[250, 300, 350]))
+    >>> heat_perturb = CustomHeatPerturbation(
+    ...     perturbation_values=perturbation_data
+    ... )
+    >>> charge_perturb = LinearChargePerturbation(
+    ...     electron_ref=0,
+    ...     electron_coeff=0.0001,
+    ...     electron_range=[0, 1e19],
+    ...     hole_ref=0,
+    ...     hole_coeff=0.0002,
+    ...     hole_range=[0, 2e19],
+    ... )
+    >>> param_perturb = ParameterPerturbation(heat=heat_perturb, charge=charge_perturb)
+    """
+
+    heat: HeatPerturbationType = pd.Field(
+        None,
+        title="Heat Perturbation",
+        description="Heat perturbation to apply.",
+    )
+
+    charge: ChargePerturbationType = pd.Field(
+        None,
+        title="Charge Perturbation",
+        description="Charge perturbation to apply.",
+    )
+
+    @cached_property
+    def perturbation_list(self) -> List[PerturbationType]:
+        """Provided perturbations as a list."""
+        perturb_list = []
+        for p in [self.heat, self.charge]:
+            if p is not None:
+                perturb_list.append(p)
+        return perturb_list
+
+    @cached_property
+    def perturbation_range(self) -> Union[Tuple[float, float], Tuple[Complex, Complex]]:
+        """Range of possible parameter perturbation values due to both heat and charge effects."""
+        prange = np.zeros(2)
+
+        for p in self.perturbation_list:
+            prange = prange + p.perturbation_range
+
+        return tuple(prange)
+
+    @staticmethod
+    def _zeros_like(
+        T: SpatialDataArray = None,
+        n: SpatialDataArray = None,
+        p: SpatialDataArray = None,
+    ):
+        """Check that fields have the same coordinates and return an array field with zeros."""
+        template = None
+        for field in [T, n, p]:
+            if field is not None:
+                if template is not None and field.coords != template.coords:
+                    raise ValueError(
+                        "'temperature', 'electron_density', and 'hole_density' must have the same "
+                        "coordinates if provided."
+                    )
+                template = field
+
+        if template is None:
+            raise ValueError(
+                "At least one of 'temperature', 'electron_density', or 'hole_density' must be "
+                "provided."
+            )
+
+        return xr.zeros_like(template)
+
+    def apply_data(
+        self,
+        temperature: SpatialDataArray = None,
+        electron_density: SpatialDataArray = None,
+        hole_density: SpatialDataArray = None,
+    ) -> SpatialDataArray:
+        """Sample perturbations on provided heat and/or charge data. At least one of
+        ``temperature``, ``electron_density``, and ``hole_density`` must be not ``None``.
+        All provided fields must have identical coords.
+
+        Parameters
+        ----------
+        temperature : SpatialDataArray = None
+            Temperature field data.
+        electron_density : SpatialDataArray = None
+            Electron density field data.
+        hole_density : SpatialDataArray = None
+            Hole density field data.
+
+        Returns
+        -------
+        SpatialDataArray
+            Sampled perturbation field.
+        """
+
+        result = self._zeros_like(temperature, electron_density, hole_density)
+
+        if temperature is not None and self.heat is not None:
+            result = result + self.heat.sample(temperature)
+
+        if (electron_density is not None or hole_density is not None) and self.charge is not None:
+
+            if electron_density is None:
+                electron_density = 0
+
+            if hole_density is None:
+                hole_density = 0
+
+            result = result + self.charge.sample(electron_density, hole_density)
+
+        return result
+
+    @cached_property
+    def is_complex(self) -> bool:
+        """Whether perturbation is complex valued."""
+
+        return np.any([p.is_complex for p in self.perturbation_list])

--- a/tidy3d/constants.py
+++ b/tidy3d/constants.py
@@ -46,6 +46,8 @@ PML_SIGMA = "2*EPSILON_0/dt"
 RADPERSEC = "rad/sec"
 ELECTRON_VOLT = "eV"
 KELVIN = "K"
+CMCUBE = "cm^3"
+PERCMCUBE = "1/cm^3"
 
 # large number used for comparing infinity
 LARGE_NUMBER = 1e10

--- a/tidy3d/plugins/dispersion/web.py
+++ b/tidy3d/plugins/dispersion/web.py
@@ -353,11 +353,12 @@ class StableDispersionFitter(DispersionFitter):
         )
         return values
 
-    def fit(  # pylint:disable=arguments-differ, too-many-locals
+    def fit(  # pylint:disable=arguments-differ, too-many-locals, too-many-arguments
         self,
         num_poles: PositiveInt = 1,
         num_tries: PositiveInt = 50,
         tolerance_rms: NonNegativeFloat = 1e-2,
+        guess: PoleResidue = None,
         advanced_param: AdvancedFitterParam = AdvancedFitterParam(),
     ) -> Tuple[PoleResidue, float]:
         """Deprecated."""

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ commands =
     pytest -rA tests/test_components/test_meshgenerate.py
     pytest -rA tests/test_components/test_mode.py
     pytest -rA tests/test_components/test_monitor.py
+    pytest -rA tests/test_components/test_parameter_perturbation.py
     pytest -rA tests/test_components/test_field_projection.py
     pytest -rA tests/test_components/test_sidewall.py
     pytest -rA tests/test_components/test_simulation.py


### PR DESCRIPTION
Heat and charge perturbation functionality. Currently, implemented for `Medium` and `PoleResidue`, but this is ready for an initial "big picture" review, to check if anything seems bad/needs a rework. Here's a notebook with demonstrations and explanations to help the review https://github.com/flexcompute-readthedocs/tidy3d-docs/blob/daniil/perturbation-medium/docs/source/notebooks/PerturbationMedium.ipynb. If everything looks more or less alright, I will go ahead and finish some remaining to-do's:
- [ ] do the rest of dispersive models, that is, add `PerturbationDebye`, `PerturbationLorentz`, etc
- [x] add front-end tests
- [x] check all code documentation is in place

tagging @momchil-flex just in case