### PR TITLE
Updating surface integration validator to only error if all integrati…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+- Surface integration monitor validator changed to error only if *all* integration surfaces are outside of the simulation domain.
+
 ## [2.3.1] - 2023-7-14
 
 ### Added

--- a/tests/test_components/test_monitor.py
+++ b/tests/test_components/test_monitor.py
@@ -119,8 +119,8 @@ def test_fieldproj_surfaces():
 
 
 def test_fieldproj_surfaces_in_simulaiton():
-    # test error if a projection surfaces is outside the simulation domain
-    M = td.FieldProjectionAngleMonitor(size=(1, 3, 3), theta=[1], phi=[0], name="f", freqs=[2e12])
+    # test error if all projection surfaces are outside the simulation domain
+    M = td.FieldProjectionAngleMonitor(size=(3, 3, 3), theta=[1], phi=[0], name="f", freqs=[2e12])
     with pytest.raises(pydantic.ValidationError):
         sim = td.Simulation(
             size=(2, 2, 2),
@@ -128,14 +128,24 @@ def test_fieldproj_surfaces_in_simulaiton():
             monitors=[M],
             grid_spec=td.GridSpec.uniform(0.1),
         )
-    # no error when outside surfaces are excluded
-    M = M.updated_copy(exclude_surfaces=["y-", "y+", "z-", "z+"])
+    # no error when some surfaces are in
+    M = M.updated_copy(size=(1, 3, 3))
     sim = td.Simulation(
         size=(2, 2, 2),
         run_time=1e-12,
         monitors=[M],
         grid_spec=td.GridSpec.uniform(0.1),
     )
+
+    # error when the surfaces that are in are excluded
+    M = M.updated_copy(exclude_surfaces=["x-", "x+"])
+    with pytest.raises(pydantic.ValidationError):
+        sim = td.Simulation(
+            size=(2, 2, 2),
+            run_time=1e-12,
+            monitors=[M],
+            grid_spec=td.GridSpec.uniform(0.1),
+        )
 
 
 def test_fieldproj_kspace_range():

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -667,13 +667,11 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
         sim_box = Box(size=sim_size, center=sim_center)
 
         for mnt in (mnt for mnt in val if isinstance(mnt, SurfaceIntegrationMonitor)):
-            for surface in mnt.integration_surfaces:
-                if not sim_box.intersects(surface):
-                    raise SetupError(
-                        f"Integration surface '{surface.name}' of monitor "
-                        f"'{mnt.name}' is outside of the simulation bounds. Modify monitor "
-                        "geometry or use 'exclude_surfaces' to exclude that surface."
-                    )
+            if not any(sim_box.intersects(surf) for surf in mnt.integration_surfaces):
+                raise SetupError(
+                    f"All integration surfaces of monitor '{mnt.name}' are outside of the "
+                    "simulation bounds."
+                )
 
         return val
 


### PR DESCRIPTION
…on surfaces are outside of the domain

It is actually convenient in some cases for the user to place a box that's partly outside of the domain without having to explicitly exclude the surfaces. The solver works as long as there's any part that's inside the domain. We could also fix the solver to work if everything is outside, but in that case probably the monitor was incorrectly set up.