### PR TITLE
remove redundant phase from shifted source in smatrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix the `Environment has no attribute _current` issue when set `TIDY3D_ENV=prod`
+- Redundant phase compensation for shifted source in smatrix plugin.
 
 ## [2.3.2] - 2023-7-21
 

--- a/tidy3d/plugins/smatrix/smatrix.py
+++ b/tidy3d/plugins/smatrix/smatrix.py
@@ -7,7 +7,7 @@ import os
 import pydantic as pd
 import numpy as np
 
-from ...constants import HERTZ, C_0
+from ...constants import HERTZ
 from ...components.simulation import Simulation
 from ...components.geometry import Box
 from ...components.mode import ModeSpec
@@ -368,14 +368,9 @@ class ComponentModeler(Tidy3dBaseModel):
             f=self.freqs,
             direction=port_source.direction,
             mode_index=mode_index,
-        ).values
+        )
 
-        normalize_n_eff = port_monitor_data.n_eff.sel(f=self.freqs, mode_index=mode_index).values
-
-        k0s = 2 * np.pi * C_0 / np.array(self.freqs)
-        k_effs = k0s * normalize_n_eff
-        shift_value = self._shift_value_signed(port=port_source)
-        return normalize_amps * np.exp(1j * k_effs * shift_value)
+        return normalize_amps.values
 
     @cached_property
     def max_mode_index(self) -> Tuple[int, int]:


### PR DESCRIPTION
In case this is found to be the source of discrepancy in tests.

Not sure if it warrants a patch or we should merge into pre/2.4