### PR TITLE
fix trianglemesh custom_dataset bug

### DIFF
--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -579,3 +579,23 @@ def test_custom_surface_geometry():
     )
     _, ax = plt.subplots()
     _ = sim.plot(y=0, ax=ax)
+
+
+def test_geo_group_sim():
+
+    geo_grp = td.TriangleMesh.from_stl("tests/data/two_boxes_separate.stl")
+    geos_orig = list(geo_grp.geometries)
+    geo_grp_full = geo_grp.updated_copy(geometries=geos_orig + [td.Box(size=(1, 1, 1))])
+
+    sim = td.Simulation(
+        size=(10, 10, 10),
+        grid_spec=td.GridSpec.uniform(dl=0.1),
+        sources=[],
+        structures=[td.Structure(geometry=geo_grp_full, medium=td.Medium(permittivity=2))],
+        monitors=[],
+        run_time=1e-12,
+        boundary_spec=td.BoundarySpec.all_sides(td.PML()),
+    )
+
+    # why is this failing?  assert 4==2
+    assert len(sim.custom_datasets) == len(geos_orig)

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -2759,11 +2759,11 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
         datasets_geometry = []
 
         for struct in self.structures:
-            if isinstance(struct.geometry, TriangleMesh):
-                datasets_geometry += struct.geometry.mesh_dataset
-            elif isinstance(struct.geometry, GeometryGroup):
-                for geometry in struct.geometry.geometries:
-                    datasets_geometry += geometry.mesh_dataset
+            geo = struct.geometry
+            geometries = geo.geometries if isinstance(geo, GeometryGroup) else [geo]
+            for geometry in geometries:
+                if isinstance(geometry, TriangleMesh):
+                    datasets_geometry += [geometry.mesh_dataset]
 
         return (
             datasets_source_time


### PR DESCRIPTION
The `custom_datasets` had the wrong logic. It was looping through geometry group items but not checking if they were TriangleMesh before grabbing the datasets. Was breaking Anderson localization (and probably metalens) notebooks.

For now, omitting changelog item since this bug was introduced in [this commit ](https://github.com/flexcompute/tidy3d/commit/264a745ccfc10b5ae7ed90b62b43a018b096fdc1) and doesn't affect develop.
