### PR TITLE
Changed CustomSourceTime to automatically modulate at freq0

### DIFF
--- a/tests/sims/simulation_2_4_0rc2.json
+++ b/tests/sims/simulation_2_4_0rc2.json
@@ -1811,5 +1811,5 @@
     "subpixel": false,
     "normalize_index": 0,
     "courant": 0.8,
-    "version": "2.4.0rc1"
+    "version": "2.4.0rc2"
 }

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -926,16 +926,6 @@ class Simulation(Box):  # pylint:disable=too-many-public-methods
                 if dataset is None:
                     continue
                 times = dataset.values.coords["t"].values
-                if (
-                    min(times) > self.tmesh[0]
-                    or max(times) < self.tmesh[-1] - CUSTOMSOURCETIME_TOL * self.dt
-                ):
-                    raise ValidationError(
-                        "'CustomSourceTime' found with time coordinates "
-                        "'times' that do not cover the entire 'Simulation.tmesh'. Currently, "
-                        f"'(min(times), max(times)) = ({min(times)}, {max(times)})', while "
-                        f"'(min(tmesh), max(tmesh)) = ({self.tmesh[0]}, {self.tmesh[-1]}).' "
-                    )
                 max_dt = np.amax(np.diff(times))
                 if max_dt > self.dt * CUSTOMSOURCETIME_TOL:
                     log.warning(


### PR DESCRIPTION
Changed `CustomSourceTime` to accept a (real or complex) envelope, and automatically multiply it by `e^{i \omega_0 t}`. This particular complex modulation is needed for it to accept the phase shift from the different source types (e.g. `e^{i k_0 \cdot r}` for `PlaneWave`). Currently, one could put in `cos(\omega_0 t)` time dependence (or even something stranger), which leads to inaccuracies when attempting the phase shift. Having automatic complex modulation removes these inaccuracies.