### PR TITLE
Use pytest's tmp path instead of hard-codded ones

### DIFF
--- a/tests/_test_local/_test_adjoint_performance.py
+++ b/tests/_test_local/_test_adjoint_performance.py
@@ -1,52 +1,25 @@
 import pytest
 import numpy as np
-import os
 import sys
 from memory_profiler import profile
-import matplotlib.pylab as plt
+import matplotlib.pyplot as plt
 import time
 
-from tidy3d.components.data.sim_data import SimulationData
-from tidy3d.components.data.monitor_data import FieldData
-from tidy3d.components.data.data_array import ScalarFieldDataArray
-from tidy3d.components.monitor import FieldMonitor
-from tidy3d.components.simulation import Simulation
-from tidy3d.components.source import PointDipole, GaussianPulse
-from tidy3d.components.grid.grid_spec import GridSpec
-
-
-from typing import Callable, Tuple
-
-import pytest
-import pydantic
 import jax.numpy as jnp
-import numpy as np
-from jax import grad, custom_vjp
-import jax
-from numpy.random import random
+from jax import grad
 
 import tidy3d as td
-from typing import Tuple, Any
 
-from tidy3d.exceptions import DataError, Tidy3dKeyError, AdjointError
-from tidy3d.plugins.adjoint.components.base import JaxObject
-from tidy3d.plugins.adjoint.components.geometry import JaxBox, JaxPolySlab
-from tidy3d.plugins.adjoint.components.medium import (
-    JaxMedium,
-    JaxAnisotropicMedium,
-    JaxCustomMedium,
-)
+from tidy3d.plugins.adjoint.components.geometry import JaxBox
+from tidy3d.plugins.adjoint.components.medium import JaxCustomMedium
 from tidy3d.plugins.adjoint.components.structure import JaxStructure
 from tidy3d.plugins.adjoint.components.simulation import JaxSimulation
-from tidy3d.plugins.adjoint.components.data.sim_data import JaxSimulationData
-from tidy3d.plugins.adjoint.components.data.monitor_data import JaxModeData
 from tidy3d.plugins.adjoint.components.data.data_array import JaxDataArray
 from tidy3d.plugins.adjoint.components.data.dataset import JaxPermittivityDataset
 from tidy3d.plugins.adjoint.web import run
 
 from ..utils import run_emulated
 
-import tidy3d as td
 
 sys.path.append("/users/twhughes/Documents/Flexcompute/tidy3d-core")
 from tidy3d_backend.utils import Profile
@@ -190,7 +163,7 @@ def test_large_custom_medium(use_emulated_run):
 
     with Profile():
         grad_f = grad(f)
-        df_eps_values = grad_f(EPS_VALUES)
+        _ = grad_f(EPS_VALUES)
 
 
 def test_time_custom_medium(use_emulated_run):
@@ -217,7 +190,7 @@ def test_time_custom_medium(use_emulated_run):
         eps_array = 1 + np.random.random((nx, ny, 1, 1))
 
         tstart = time.time()
-        deps = g(eps_array)
+        _ = g(eps_array)
         tend = time.time()
         times_sec[i] = tend - tstart
         num_pixels[i] = eps_array.size
@@ -228,7 +201,8 @@ def test_time_custom_medium(use_emulated_run):
     plt.ylabel("grad(eps) time (sec)")
     plt.yscale("log")
     plt.xscale("log")
-    plt.show()
+    # plt.show()
+    plt.close()
 
 
 def test_simple_jax_data_array(use_emulated_run):

--- a/tests/_test_local/_test_data_performance.py
+++ b/tests/_test_local/_test_data_performance.py
@@ -1,4 +1,3 @@
-import pytest
 import numpy as np
 import os
 import sys

--- a/tests/_test_local/_test_plugins_web.py
+++ b/tests/_test_local/_test_plugins_web.py
@@ -8,12 +8,12 @@ def test_dispersion_load_list():
     num_data = 10
     n_data = np.random.random(num_data)
     wvls = np.linspace(1, 2, num_data)
-    fitter = StableDispersionFitter(wvl_um=wvls, n_data=n_data)
+    _ = StableDispersionFitter(wvl_um=wvls, n_data=n_data)
 
 
 def test_dispersion_load_file():
     """loads dispersion model from nk data file"""
-    fitter = StableDispersionFitter.from_file("tests/data/nk_data.csv", skiprows=1, delimiter=",")
+    _ = StableDispersionFitter.from_file("tests/data/nk_data.csv", skiprows=1, delimiter=",")
 
 
 def test_dispersion_load_url():

--- a/tests/test_components/test_apodization.py
+++ b/tests/test_components/test_apodization.py
@@ -2,16 +2,14 @@
 import pytest
 import pydantic
 import tidy3d as td
-from tidy3d.exceptions import SetupError
-import matplotlib.pylab as plt
+import matplotlib.pyplot as plt
 
 
 def test_apodization():
-
-    a = td.ApodizationSpec(width=0.2)
-    a = td.ApodizationSpec(start=1, width=0.2)
-    a = td.ApodizationSpec(end=2, width=0.2)
-    a = td.ApodizationSpec(start=1, end=2, width=0.2)
+    _ = td.ApodizationSpec(width=0.2)
+    _ = td.ApodizationSpec(start=1, width=0.2)
+    _ = td.ApodizationSpec(end=2, width=0.2)
+    _ = td.ApodizationSpec(start=1, end=2, width=0.2)
 
 
 def test_end_lt_start():
@@ -46,6 +44,8 @@ def test_plot():
 
     a = td.ApodizationSpec(start=0.2 * run_time, end=0.8 * run_time, width=0.02 * run_time)
     a.plot(times)
+    plt.close()
 
     fig, ax = plt.subplots(1, 1)
     a.plot(times, ax=ax)
+    plt.close()

--- a/tests/test_components/test_base.py
+++ b/tests/test_components/test_base.py
@@ -1,12 +1,9 @@
 """Tests the base model."""
-from typing import Dict, Union, List
 import pytest
 import numpy as np
-import pydantic
 
 import tidy3d as td
 from tidy3d.components.base import Tidy3dBaseModel
-from tidy3d.exceptions import ValidationError, SetupError, Tidy3dKeyError
 
 
 M = td.Medium()
@@ -38,15 +35,15 @@ def test_comparisons():
     M == M2
 
 
-def _test_version():
+def _test_version(tmp_path):
     """ensure there's a version in simulation"""
 
     sim = td.Simulation(
         size=(1, 1, 1),
         run_time=1e-12,
     )
-    path = "tests/tmp/simulation.json"
-    sim.to_file("tests/tmp/simulation.json")
+    path = str(tmp_path / "simulation.json")
+    sim.to_file(path)
     with open(path, "r") as f:
         s = f.read()
         assert '"version": ' in s

--- a/tests/test_components/test_boundaries.py
+++ b/tests/test_components/test_boundaries.py
@@ -1,44 +1,42 @@
 """Tests boundary conditions."""
 
-import numpy as np
 import pytest
 import pydantic
 
 import tidy3d as td
-from tidy3d.components.boundary import BoundarySpec, Boundary, BoundaryEdgeType
+from tidy3d.components.boundary import BoundarySpec, Boundary
 from tidy3d.components.boundary import Periodic, PECBoundary, PMCBoundary, BlochBoundary
 from tidy3d.components.boundary import PML, StablePML, Absorber
 from tidy3d.components.source import GaussianPulse, PlaneWave, PointDipole
-from tidy3d.components.types import TYPE_TAG_STR
-from tidy3d.exceptions import SetupError, ValidationError, DataError
+from tidy3d.exceptions import SetupError, DataError
 from ..utils import assert_log_level, log_capture
 
 
 def test_bloch_phase():
     bb = BlochBoundary(bloch_vec=1.0)
-    ph = bb.bloch_phase
+    _ = bb.bloch_phase
 
 
 @pytest.mark.parametrize("dimension", ["x", "y", "z"])
 def test_getitem(dimension):
     spec = BoundarySpec.pml(y=True, z=True)
-    edge_spec = spec[dimension]
+    _ = spec[dimension]
 
 
 def test_getitem_not_a_dim():
     spec = BoundarySpec.pml(y=True, z=True)
     with pytest.raises(DataError):
-        edge_spec = spec["NOT_A_DIMENSION"]
+        _ = spec["NOT_A_DIMENSION"]
 
 
 @pytest.mark.parametrize("plane_wave_dir", ["+", "-"])
 def test_boundaryedge_types(plane_wave_dir):
     """Test that each type of boundary condition can be defined."""
-    periodic = Periodic()
-    pec = PECBoundary()
-    pmc = PMCBoundary()
+    _ = Periodic()
+    _ = PECBoundary()
+    _ = PMCBoundary()
 
-    bloch = BlochBoundary(bloch_vec=1)
+    _ = BlochBoundary(bloch_vec=1)
     pulse = GaussianPulse(freq0=200e12, fwidth=20e12)
     source = PlaneWave(
         size=(td.inf, td.inf, 0),
@@ -47,18 +45,18 @@ def test_boundaryedge_types(plane_wave_dir):
         angle_theta=1.5,
         angle_phi=0.3,
     )
-    bloch_from_source = BlochBoundary.from_source(source=source, domain_size=5, axis=0)
+    _ = BlochBoundary.from_source(source=source, domain_size=5, axis=0)
 
     # Bloch boundaries should raise errors if incorrectly defined
-    with pytest.raises(SetupError) as e_info:
-        bloch_from_source = BlochBoundary.from_source(source=source, domain_size=5, axis=2)
-    with pytest.raises(SetupError) as e_info:
+    with pytest.raises(SetupError):
+        _ = BlochBoundary.from_source(source=source, domain_size=5, axis=2)
+    with pytest.raises(SetupError):
         pt_dipole = PointDipole(center=(1, 2, 3), source_time=pulse, polarization="Ex")
-        bloch_from_source = BlochBoundary.from_source(source=pt_dipole, domain_size=5, axis=0)
+        _ = BlochBoundary.from_source(source=pt_dipole, domain_size=5, axis=0)
 
-    pml = PML(num_layers=10)
-    stable_pml = StablePML(num_layers=40)
-    absorber = Absorber(num_layers=40)
+    _ = PML(num_layers=10)
+    _ = StablePML(num_layers=40)
+    _ = Absorber(num_layers=40)
 
 
 def test_boundary_validators():
@@ -70,12 +68,12 @@ def test_boundary_validators():
     periodic = Periodic()
 
     # test `bloch_on_both_sides`
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        boundary = Boundary(plus=bloch, minus=pec)
+    with pytest.raises(pydantic.ValidationError):
+        _ = Boundary(plus=bloch, minus=pec)
 
     # test `periodic_with_pml`
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        boundary = Boundary(plus=periodic, minus=pml)
+    with pytest.raises(pydantic.ValidationError):
+        _ = Boundary(plus=periodic, minus=pml)
 
 
 @pytest.mark.parametrize("boundary, log_level", [(PMCBoundary(), None), (Periodic(), "WARNING")])

--- a/tests/test_components/test_field_projection.py
+++ b/tests/test_components/test_field_projection.py
@@ -3,8 +3,7 @@ import numpy as np
 import tidy3d as td
 import pytest
 
-from tidy3d.exceptions import SetupError, DataError
-from ..utils import clear_tmp
+from tidy3d.exceptions import DataError
 
 
 MEDIUM = td.Medium(permittivity=3)
@@ -125,7 +124,7 @@ def test_proj_monitors():
 
     all_monitors = near_monitors + list(proj_monitors)
 
-    sim = td.Simulation(
+    _ = td.Simulation(
         size=sim_size,
         grid_spec=grid_spec,
         structures=[],
@@ -137,8 +136,7 @@ def test_proj_monitors():
     )
 
 
-@clear_tmp
-def test_proj_data():
+def test_proj_data(tmp_path):
     """Make sure all the near-to-far data structures can be created."""
 
     f = np.linspace(1e14, 2e14, 10)
@@ -218,8 +216,8 @@ def test_proj_data():
 
     sim_data = td.SimulationData(simulation=sim, data=(data_xy, data_u, data_tp))
     sim_data[monitor_xy.name]
-    sim_data.to_file("tests/tmp/sim_data_n2f.hdf5")
-    sim_data = td.SimulationData.from_file("tests/tmp/sim_data_n2f.hdf5")
+    sim_data.to_file(str(tmp_path / "sim_data_n2f.hdf5"))
+    sim_data = td.SimulationData.from_file(str(tmp_path / "sim_data_n2f.hdf5"))
 
     x = np.linspace(0, 5, 10)
     y = np.linspace(0, 10, 20)
@@ -227,7 +225,7 @@ def test_proj_data():
     coords_xy = dict(x=x, y=y, z=z, f=f)
     values_xy = (1 + 1j) * np.random.random((len(x), len(y), len(z), len(f)))
     scalar_field_xy = td.FieldProjectionCartesianDataArray(values_xy, coords=coords_xy)
-    monitor_xy_exact = td.FieldProjectionCartesianMonitor(
+    _ = td.FieldProjectionCartesianMonitor(
         center=(1, 2, 3),
         size=(2, 2, 2),
         freqs=f,
@@ -238,7 +236,7 @@ def test_proj_data():
         proj_distance=50,
         far_field_approx=False,
     )
-    data_xy_exact = td.FieldProjectionCartesianData(
+    _ = td.FieldProjectionCartesianData(
         monitor=monitor_xy,
         projection_surfaces=monitor_xy.projection_surfaces,
         Er=scalar_field_xy,

--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -4,15 +4,14 @@ import pytest
 import pydantic
 import numpy as np
 import shapely
-import matplotlib.pylab as plt
+import matplotlib.pyplot as plt
 import gdstk
 import gdspy
 import trimesh
 
 import tidy3d as td
-from tidy3d.exceptions import ValidationError, SetupError, Tidy3dKeyError
+from tidy3d.exceptions import SetupError, Tidy3dKeyError
 from tidy3d.components.geometry import Geometry, Planar
-from ..utils import assert_log_level, prepend_tmp, log_capture
 
 
 GEO = td.Box(size=(1, 1, 1))
@@ -31,6 +30,7 @@ _, AX = plt.subplots()
 @pytest.mark.parametrize("component", GEO_TYPES)
 def test_plot(component):
     _ = component.plot(z=0, ax=AX)
+    plt.close()
 
 
 def test_base_inside():
@@ -44,9 +44,9 @@ def test_base_inside_meshgrid():
     assert np.all(Geometry.inside_meshgrid(GEO, [0, 0], [0, 0], [0, 0]))
     # Input dimensions different than 1 error for ``inside_meshgrid``.
     with pytest.raises(ValueError):
-        b = Geometry.inside_meshgrid(GEO, x=0, y=0, z=0)
+        _ = Geometry.inside_meshgrid(GEO, x=0, y=0, z=0)
     with pytest.raises(ValueError):
-        b = Geometry.inside_meshgrid(GEO, [[0, 0]], [[0, 0]], [[0, 0]])
+        _ = Geometry.inside_meshgrid(GEO, [[0, 0]], [[0, 0]], [[0, 0]])
 
 
 def test_bounding_box():
@@ -90,27 +90,27 @@ def test_reflect_points(axis):
 
 @pytest.mark.parametrize("component", GEO_TYPES)
 def test_volume(component):
-    v = component.volume()
-    v = component.volume(bounds=GEO.bounds)
-    v = component.volume(bounds=((-100, -100, -100), (100, 100, 100)))
-    v = component.volume(bounds=((-0.1, -0.1, -0.1), (0.1, 0.1, 0.1)))
-    v = component.volume(bounds=((-100, -100, -100), (-10, -10, -10)))
-    v = component.volume(bounds=((10, 10, 10), (100, 100, 100)))
+    _ = component.volume()
+    _ = component.volume(bounds=GEO.bounds)
+    _ = component.volume(bounds=((-100, -100, -100), (100, 100, 100)))
+    _ = component.volume(bounds=((-0.1, -0.1, -0.1), (0.1, 0.1, 0.1)))
+    _ = component.volume(bounds=((-100, -100, -100), (-10, -10, -10)))
+    _ = component.volume(bounds=((10, 10, 10), (100, 100, 100)))
 
 
 @pytest.mark.parametrize("component", GEO_TYPES)
 def test_surface_area(component):
-    sa = component.surface_area()
-    sa = component.surface_area(bounds=GEO.bounds)
-    sa = component.surface_area(bounds=((-100, -100, -100), (100, 100, 100)))
-    sa = component.surface_area(bounds=((-0.1, -0.1, -0.1), (0.1, 0.1, 0.1)))
-    sa = component.surface_area(bounds=((-100, -100, -100), (-10, -10, -10)))
-    sa = component.surface_area(bounds=((10, 10, 10), (100, 100, 100)))
+    _ = component.surface_area()
+    _ = component.surface_area(bounds=GEO.bounds)
+    _ = component.surface_area(bounds=((-100, -100, -100), (100, 100, 100)))
+    _ = component.surface_area(bounds=((-0.1, -0.1, -0.1), (0.1, 0.1, 0.1)))
+    _ = component.surface_area(bounds=((-100, -100, -100), (-10, -10, -10)))
+    _ = component.surface_area(bounds=((10, 10, 10), (100, 100, 100)))
 
 
 @pytest.mark.parametrize("component", GEO_TYPES)
 def test_bounds(component):
-    b = component.bounds
+    _ = component.bounds
 
 
 def test_planar_bounds():
@@ -119,9 +119,9 @@ def test_planar_bounds():
 
 @pytest.mark.parametrize("component", GEO_TYPES)
 def test_inside(component):
-    b = component.inside(0, 0, 0)
-    bs = component.inside(np.array([0, 0]), np.array([0, 0]), np.array([0, 0]))
-    bss = component.inside(np.array([[0, 0]]), np.array([[0, 0]]), np.array([[0, 0]]))
+    _ = component.inside(0, 0, 0)
+    _ = component.inside(np.array([0, 0]), np.array([0, 0]), np.array([0, 0]))
+    _ = component.inside(np.array([[0, 0]]), np.array([[0, 0]]), np.array([[0, 0]]))
 
 
 def test_zero_dims():
@@ -162,24 +162,24 @@ def test_bounds_base():
 
 def test_center_not_inf_validate():
     with pytest.raises(pydantic.ValidationError):
-        g = td.Box(center=(td.inf, 0, 0))
+        _ = td.Box(center=(td.inf, 0, 0))
     with pytest.raises(pydantic.ValidationError):
-        g = td.Box(center=(-td.inf, 0, 0))
+        _ = td.Box(center=(-td.inf, 0, 0))
 
 
 def test_radius_not_inf_validate():
     with pytest.raises(pydantic.ValidationError):
-        g = td.Sphere(radius=td.inf)
+        _ = td.Sphere(radius=td.inf)
     with pytest.raises(pydantic.ValidationError):
-        g = td.Cylinder(radius=td.inf, center=(0, 0, 0), axis=1, length=1)
+        _ = td.Cylinder(radius=td.inf, center=(0, 0, 0), axis=1, length=1)
 
 
 def test_slanted_cylinder_infinite_length_validate():
-    g = td.Cylinder(radius=1, center=(0, 0, 0), axis=1, length=td.inf)
-    g = td.Cylinder(radius=1, center=(0, 0, 0), axis=1, length=td.inf, reference_plane="top")
-    g = td.Cylinder(radius=1, center=(0, 0, 0), axis=1, length=td.inf, reference_plane="bottom")
-    g = td.Cylinder(radius=1, center=(0, 0, 0), axis=1, length=td.inf, reference_plane="middle")
-    g = td.Cylinder(
+    _ = td.Cylinder(radius=1, center=(0, 0, 0), axis=1, length=td.inf)
+    _ = td.Cylinder(radius=1, center=(0, 0, 0), axis=1, length=td.inf, reference_plane="top")
+    _ = td.Cylinder(radius=1, center=(0, 0, 0), axis=1, length=td.inf, reference_plane="bottom")
+    _ = td.Cylinder(radius=1, center=(0, 0, 0), axis=1, length=td.inf, reference_plane="middle")
+    _ = td.Cylinder(
         radius=1,
         center=(0, 0, 0),
         axis=1,
@@ -188,7 +188,7 @@ def test_slanted_cylinder_infinite_length_validate():
         reference_plane="middle",
     )
     with pytest.raises(pydantic.ValidationError):
-        g = td.Cylinder(
+        _ = td.Cylinder(
             radius=1,
             center=(0, 0, 0),
             axis=1,
@@ -197,7 +197,7 @@ def test_slanted_cylinder_infinite_length_validate():
             reference_plane="top",
         )
     with pytest.raises(pydantic.ValidationError):
-        g = td.Cylinder(
+        _ = td.Cylinder(
             radius=1,
             center=(0, 0, 0),
             axis=1,
@@ -262,29 +262,37 @@ def test_arrow_both_dirs():
     GEO._plot_arrow(direction=(1, 2, 3), x=0, both_dirs=True, ax=ax)
 
 
-def test_gds_cell():
+def test_gdstk_cell():
     gds_cell = gdstk.Cell("name")
     gds_cell.add(gdstk.rectangle((0, 0), (1, 1)))
     td.PolySlab.from_gds(gds_cell=gds_cell, axis=2, slab_bounds=(-1, 1), gds_layer=0)
     td.PolySlab.from_gds(gds_cell=gds_cell, axis=2, slab_bounds=(-1, 1), gds_layer=0, gds_dtype=0)
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(Tidy3dKeyError):
         td.PolySlab.from_gds(gds_cell=gds_cell, axis=2, slab_bounds=(-1, 1), gds_layer=1)
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(Tidy3dKeyError):
         td.PolySlab.from_gds(
             gds_cell=gds_cell, axis=2, slab_bounds=(-1, 1), gds_layer=1, gds_dtype=0
         )
 
 
+def test_gdspy_cell():
+    gds_cell = gdspy.Cell("name")
+    gds_cell.add(gdspy.Rectangle((0, 0), (1, 1)))
+    td.PolySlab.from_gds(gds_cell=gds_cell, axis=2, slab_bounds=(-1, 1), gds_layer=0)
+    with pytest.raises(Tidy3dKeyError):
+        td.PolySlab.from_gds(gds_cell=gds_cell, axis=2, slab_bounds=(-1, 1), gds_layer=1)
+
+
 def test_geo_group_initialize():
     """make sure you can construct one."""
-    geo_group = make_geo_group()
+    _ = make_geo_group()
 
 
 def test_geo_group_structure():
     """make sure you can construct a structure using GeometryGroup."""
 
     geo_group = make_geo_group()
-    structure = td.Structure(geometry=geo_group, medium=td.Medium())
+    _ = td.Structure(geometry=geo_group, medium=td.Medium())
 
 
 def test_geo_group_methods():
@@ -303,7 +311,7 @@ def test_geo_group_empty():
     """dont allow empty geometry list."""
 
     with pytest.raises(pydantic.ValidationError):
-        geo_group = td.GeometryGroup(geometries=[])
+        _ = td.GeometryGroup(geometries=[])
 
 
 def test_geo_group_volume():
@@ -321,44 +329,44 @@ def test_geo_group_surface_area():
 
 def test_geometry():
 
-    b = td.Box(size=(1, 1, 1), center=(0, 0, 0))
-    s = td.Sphere(radius=1, center=(0, 0, 0))
-    s = td.Cylinder(radius=1, center=(0, 0, 0), axis=1, length=1)
-    s = td.PolySlab(vertices=((1, 2), (3, 4), (5, 4)), slab_bounds=(-1, 1), axis=2)
+    _ = td.Box(size=(1, 1, 1), center=(0, 0, 0))
+    _ = td.Sphere(radius=1, center=(0, 0, 0))
+    _ = td.Cylinder(radius=1, center=(0, 0, 0), axis=1, length=1)
+    _ = td.PolySlab(vertices=((1, 2), (3, 4), (5, 4)), slab_bounds=(-1, 1), axis=2)
     # vertices_np = np.array(s.vertices)
     # s_np = PolySlab(vertices=vertices_np, slab_bounds=(-1, 1), axis=1)
 
     # make sure wrong axis arguments error
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = td.Cylinder(radius=1, center=(0, 0, 0), axis=-1, length=1)
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = td.PolySlab(radius=1, center=(0, 0, 0), axis=-1, slab_bounds=(-0.5, 0.5))
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = td.Cylinder(radius=1, center=(0, 0, 0), axis=3, length=1)
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = td.PolySlab(radius=1, center=(0, 0, 0), axis=3, slab_bounds=(-0.5, 0.5))
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Cylinder(radius=1, center=(0, 0, 0), axis=-1, length=1)
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.PolySlab(radius=1, center=(0, 0, 0), axis=-1, slab_bounds=(-0.5, 0.5))
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Cylinder(radius=1, center=(0, 0, 0), axis=3, length=1)
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.PolySlab(radius=1, center=(0, 0, 0), axis=3, slab_bounds=(-0.5, 0.5))
 
     # make sure negative values error
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = td.Sphere(radius=-1, center=(0, 0, 0))
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = td.Cylinder(radius=-1, center=(0, 0, 0), axis=3, length=1)
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = td.Cylinder(radius=1, center=(0, 0, 0), axis=3, length=-1)
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Sphere(radius=-1, center=(0, 0, 0))
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Cylinder(radius=-1, center=(0, 0, 0), axis=3, length=1)
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Cylinder(radius=1, center=(0, 0, 0), axis=3, length=-1)
 
 
 def test_geometry_sizes():
 
     # negative in size kwargs errors
     for size in (-1, 1, 1), (1, -1, 1), (1, 1, -1):
-        with pytest.raises(pydantic.ValidationError) as e_info:
-            a = td.Box(size=size, center=(0, 0, 0))
-        with pytest.raises(pydantic.ValidationError) as e_info:
-            s = td.Simulation(size=size, run_time=1e-12, grid_spec=td.GridSpec(wavelength=1.0))
+        with pytest.raises(pydantic.ValidationError):
+            _ = td.Box(size=size, center=(0, 0, 0))
+        with pytest.raises(pydantic.ValidationError):
+            _ = td.Simulation(size=size, run_time=1e-12, grid_spec=td.GridSpec(wavelength=1.0))
 
     # negative grid sizes error?
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = td.Simulation(size=(1, 1, 1), grid_spec=td.GridSpec.uniform(dl=-1.0), run_time=1e-12)
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Simulation(size=(1, 1, 1), grid_spec=td.GridSpec.uniform(dl=-1.0), run_time=1e-12)
 
 
 @pytest.mark.parametrize("x0", [5])
@@ -457,47 +465,17 @@ def test_polyslab_axis(axis):
     # inside
     point = [0, 0]
     point.insert(axis, 3)
-    assert ps.inside(point[0], point[1], point[2]) == False
+    assert not ps.inside(point[0], point[1], point[2])
 
     # intersections
     plane_coord = [None] * 3
     plane_coord[axis] = 3
-    assert ps.intersects_plane(x=plane_coord[0], y=plane_coord[1], z=plane_coord[2]) == False
+    assert not ps.intersects_plane(x=plane_coord[0], y=plane_coord[1], z=plane_coord[2])
     plane_coord[axis] = -3
-    assert ps.intersects_plane(x=plane_coord[0], y=plane_coord[1], z=plane_coord[2]) == False
+    assert not ps.intersects_plane(x=plane_coord[0], y=plane_coord[1], z=plane_coord[2])
 
 
-def test_polyslab_merge():
-    """make sure polyslabs from gds get merged when they should."""
-
-    import gdspy
-
-    def make_polyslabs(gap_size):
-        """Construct two rectangular polyslabs separated by a gap."""
-        lib = gdspy.GdsLibrary()
-        cell = lib.new_cell(f"polygons_{gap_size:.2f}")
-        rect1 = gdspy.Rectangle((gap_size / 2, 0), (1, 1))
-        rect2 = gdspy.Rectangle((-1, 0), (-gap_size / 2, 1))
-        cell.add(rect1)
-        cell.add(rect2)
-        return td.PolySlab.from_gds(gds_cell=cell, gds_layer=0, axis=2, slab_bounds=(-1, 1))
-
-    polyslabs_gap = make_polyslabs(gap_size=0.3)
-    assert len(polyslabs_gap) == 2, "untouching polylsabs were merged incorrectly."
-
-    polyslabs_touching = make_polyslabs(gap_size=0)
-    assert len(polyslabs_touching) == 1, "polyslabs didnt merge correctly."
-
-
-def test_gds_cell():
-    gds_cell = gdspy.Cell("name")
-    gds_cell.add(gdspy.Rectangle((0, 0), (1, 1)))
-    td.PolySlab.from_gds(gds_cell=gds_cell, axis=2, slab_bounds=(-1, 1), gds_layer=0)
-    with pytest.raises(Tidy3dKeyError):
-        td.PolySlab.from_gds(gds_cell=gds_cell, axis=2, slab_bounds=(-1, 1), gds_layer=1)
-
-
-def test_custom_surface_geometry():
+def test_custom_surface_geometry(tmp_path):
     # create tetrahedron STL
     vertices = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
     faces = np.array([[1, 2, 3], [0, 3, 2], [0, 1, 3], [0, 2, 1]])
@@ -509,8 +487,8 @@ def test_custom_surface_geometry():
     assert np.allclose(import_geom.triangles, geom.triangles)
 
     # test export and then import
-    geom.trimesh.export(prepend_tmp("export.stl"))
-    import_geom = td.TriangleMesh.from_stl(prepend_tmp("export.stl"))
+    geom.trimesh.export(str(tmp_path / "export.stl"))
+    import_geom = td.TriangleMesh.from_stl(str(tmp_path / "export.stl"))
     assert np.allclose(import_geom.triangles, geom.triangles)
 
     # assert np.array_equal(tetrahedron.vectors, export_vectors)
@@ -518,7 +496,7 @@ def test_custom_surface_geometry():
     areas = [0.5 * np.sqrt(2) * np.sqrt(1 + 2 * 0.5**2), 0.5, 0.5, 0.5]
     unit_normals_unnormalized = [[1, 1, 1], [-1, 0, 0], [0, -1, 0], [0, 0, -1]]
     unit_normals = [n / np.linalg.norm(n) for n in unit_normals_unnormalized]
-    normals = [n * a for (n, a) in zip(unit_normals, areas)]
+    _ = [n * a for (n, a) in zip(unit_normals, areas)]
 
     # test bounds
     assert np.allclose(np.array(geom.bounds), [[0, 0, 0], [1, 1, 1]])
@@ -542,6 +520,7 @@ def test_custom_surface_geometry():
     # test plot
     _, ax = plt.subplots()
     _ = geom.plot(z=0.1, ax=ax)
+    plt.close()
 
     # test inconsistent winding
     vertices = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
@@ -579,6 +558,7 @@ def test_custom_surface_geometry():
     )
     _, ax = plt.subplots()
     _ = sim.plot(y=0, ax=ax)
+    plt.close()
 
 
 def test_geo_group_sim():

--- a/tests/test_components/test_grid.py
+++ b/tests/test_components/test_grid.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 
 import tidy3d as td
-from tidy3d.components.grid.grid import Coords, FieldGrid, YeeGrid, Grid
+from tidy3d.components.grid.grid import Coords, FieldGrid, Grid
 from tidy3d.components.types import TYPE_TAG_STR
 from tidy3d.exceptions import SetupError
 
@@ -20,7 +20,7 @@ def test_coords():
     x = np.linspace(-1, 1, 100)
     y = np.linspace(-1, 1, 100)
     z = np.linspace(-1, 1, 100)
-    c = Coords(x=x, y=y, z=z)
+    _ = Coords(x=x, y=y, z=z)
 
 
 def test_field_grid():
@@ -28,7 +28,7 @@ def test_field_grid():
     y = np.linspace(-1, 1, 100)
     z = np.linspace(-1, 1, 100)
     c = Coords(x=x, y=y, z=z)
-    f = FieldGrid(x=c, y=c, z=c)
+    _ = FieldGrid(x=c, y=c, z=c)
 
 
 def test_grid():
@@ -36,7 +36,7 @@ def test_grid():
     boundaries_x = np.arange(-1, 2, 1)
     boundaries_y = np.arange(-2, 3, 1)
     boundaries_z = np.arange(-3, 4, 1)
-    boundaries = Coords(x=boundaries_x, y=boundaries_y, z=boundaries_z)
+    _ = Coords(x=boundaries_x, y=boundaries_y, z=boundaries_z)
     g = make_grid()
 
     assert np.all(g.centers.x == np.array([-0.5, 0.5]))
@@ -54,22 +54,22 @@ def test_grid():
 def test_grid_dict():
     g = make_grid()
     yee = g.yee
-    gd = yee.grid_dict
+    _ = yee.grid_dict
 
 
 def test_primal_steps():
     g = make_grid()
-    ps = g._primal_steps
+    _ = g._primal_steps
 
 
 def test_dual_steps():
     g = make_grid()
-    ps = g._dual_steps
+    _ = g._dual_steps
 
 
 def test_num_cells():
     g = make_grid()
-    nc = g.num_cells
+    _ = g.num_cells
 
 
 def test_getitem():
@@ -297,7 +297,7 @@ def test_sim_discretize_vol():
     for c in subgrid.centers.dict(exclude={TYPE_TAG_STR}).values():
         assert np.all(c == np.array([-0.5, 0.5]))
 
-    plane = td.Box(size=(6, 6, 0))
+    _ = td.Box(size=(6, 6, 0))
 
 
 def test_sim_discretize_plane():

--- a/tests/test_components/test_grid_spec.py
+++ b/tests/test_components/test_grid_spec.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 
 import tidy3d as td
-from tidy3d.exceptions import SetupError, ValidationError
+from tidy3d.exceptions import SetupError
 
 
 def make_grid_spec():
@@ -19,7 +19,7 @@ def test_add_pml_to_bounds():
 
 def test_make_coords():
     gs = make_grid_spec()
-    cs = gs.grid_x.make_coords(
+    _ = gs.grid_x.make_coords(
         axis=0,
         structures=[
             td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=td.Medium()),
@@ -34,7 +34,7 @@ def test_make_coords():
 
 def test_make_coords_2d():
     gs = make_grid_spec()
-    cs = gs.grid_x.make_coords(
+    _ = gs.grid_x.make_coords(
         axis=1,
         structures=[
             td.Structure(geometry=td.Box(size=(1, 0, 1)), medium=td.Medium()),

--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -2,7 +2,7 @@
 import numpy as np
 import pytest
 import pydantic
-import matplotlib.pylab as plt
+import matplotlib.pyplot as plt
 import tidy3d as td
 from tidy3d.exceptions import ValidationError
 from ..utils import assert_log_level, log_capture
@@ -26,6 +26,7 @@ RTOL = 0.001
 @pytest.mark.parametrize("component", MEDIUMS)
 def test_plot(component):
     _ = component.plot(freqs=[2e14, 3e14], ax=AX)
+    plt.close()
 
 
 def test_eps_sigma_freq_none():
@@ -40,7 +41,7 @@ def test_tuple_complex_convert():
 
 
 def test_str():
-    s = str(PR)
+    _ = str(PR)
 
 
 def test_from_n_less_than_1():
@@ -51,10 +52,10 @@ def test_from_n_less_than_1():
 def test_medium():
 
     # mediums error with unacceptable values
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        m = td.Medium(permittivity=0.0)
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        m = td.Medium(conductivity=-1.0)
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Medium(permittivity=0.0)
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Medium(conductivity=-1.0)
 
 
 def test_medium_conversions():
@@ -82,7 +83,7 @@ def test_medium_conversions():
 
 def test_PEC():
 
-    struct = td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=td.PEC)
+    _ = td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=td.PEC)
 
 
 def test_medium_dispersion():
@@ -95,14 +96,14 @@ def test_medium_dispersion():
     m_DR = td.Drude(eps_inf=1.0, coeffs=[(1, 3), (2, 4)])
     m_DB = td.Debye(eps_inf=1.0, coeffs=[(1, 3), (2, 4)])
 
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        mf_SM = td.Sellmeier(coeffs=[(2, 0), (2, 4)])
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Sellmeier(coeffs=[(2, 0), (2, 4)])
 
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        mf_DR = td.Drude(eps_inf=1.0, coeffs=[(1, 0), (2, 4)])
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Drude(eps_inf=1.0, coeffs=[(1, 0), (2, 4)])
 
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        mf_DB = td.Debye(eps_inf=1.0, coeffs=[(1, 0), (2, 4)])
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Debye(eps_inf=1.0, coeffs=[(1, 0), (2, 4)])
 
     freqs = np.linspace(0.01, 1, 1001)
     for medium in [m_PR, m_SM, m_LZ, m_LZ2, m_DR, m_DB]:
@@ -139,7 +140,7 @@ def test_medium_dispersion_create():
     m_DB = td.Debye(eps_inf=1.0, coeffs=[(1, 3), (2, 4)])
 
     for medium in [m_PR, m_SM, m_DB, m_LZ, m_DR, m_LZ2]:
-        struct = td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=medium)
+        _ = td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=medium)
 
 
 def test_sellmeier_from_dispersion():
@@ -147,7 +148,7 @@ def test_sellmeier_from_dispersion():
     wvl = 0.5
     freq = td.C_0 / wvl
     dn_dwvl = -0.1
-    with pytest.raises(ValidationError) as e:
+    with pytest.raises(ValidationError):
         # Check that postivie dispersion raises an error
         medium = td.Sellmeier.from_dispersion(n=n, freq=freq, dn_dwvl=-dn_dwvl)
 
@@ -271,43 +272,43 @@ def test_n_cfl():
 def test_gain_medium(log_capture):
     """Test passive and gain medium validations."""
     # non-dispersive
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        m = td.Medium(conductivity=-0.1)
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        m = td.Medium(conductivity=-1.0, allow_gain=False)
-    mM = td.Medium(conductivity=-1.0, allow_gain=True)
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Medium(conductivity=-0.1)
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Medium(conductivity=-1.0, allow_gain=False)
+    _ = td.Medium(conductivity=-1.0, allow_gain=True)
 
     # pole residue, causality
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        m = td.PoleResidue(eps_inf=0.16, poles=[(1 + 1j, 2 + 2j)])
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.PoleResidue(eps_inf=0.16, poles=[(1 + 1j, 2 + 2j)])
 
     # Sellmeier
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        m = td.Sellmeier(coeffs=((-1, 1),))
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Sellmeier(coeffs=((-1, 1),))
     mS = td.Sellmeier(coeffs=((-1, 1),), allow_gain=True)
 
     # Lorentz
     # causality, negative gamma
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        m = td.Lorentz(eps_inf=0.04, coeffs=[(1, 2, -3)])
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Lorentz(eps_inf=0.04, coeffs=[(1, 2, -3)])
     # gain, negative Delta epsilon
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        m = td.Lorentz(eps_inf=0.04, coeffs=[(-1, 2, 3)])
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Lorentz(eps_inf=0.04, coeffs=[(-1, 2, 3)])
     mL = td.Lorentz(eps_inf=0.04, coeffs=[(-1, 2, 3)], allow_gain=True)
     assert mL.pole_residue.allow_gain
 
     # f_i can take whatever sign
-    m = td.Lorentz(eps_inf=0.04, coeffs=[(1, -2, 3)])
+    _ = td.Lorentz(eps_inf=0.04, coeffs=[(1, -2, 3)])
 
     # Drude, only causality constraint
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        m = td.Drude(eps_inf=0.04, coeffs=[(1, -2)])
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Drude(eps_inf=0.04, coeffs=[(1, -2)])
 
     # anisotropic medium, warn allow_gain is ignored
-    m = td.AnisotropicMedium(xx=td.Medium(), yy=mL, zz=mS, allow_gain=True)
+    _ = td.AnisotropicMedium(xx=td.Medium(), yy=mL, zz=mS, allow_gain=True)
     assert_log_level(log_capture, "WARNING")
 
-    m = td.AnisotropicMedium(xx=td.Medium(), yy=mL, zz=mS, allow_gain=False)
+    _ = td.AnisotropicMedium(xx=td.Medium(), yy=mL, zz=mS, allow_gain=False)
     assert_log_level(log_capture, "WARNING")
 
 
@@ -318,7 +319,9 @@ def test_medium2d():
     medium = td.Medium2D.from_medium(cond_med, thickness=thickness)
 
     _ = medium.plot(freqs=[2e14, 3e14], ax=AX)
+    plt.close()
     _ = medium.plot_sigma(freqs=[2e14, 3e14], ax=AX)
+    plt.close()
     assert np.isclose(medium.ss.to_medium().conductivity, sigma * thickness, rtol=RTOL)
     aniso_medium = td.AnisotropicMedium(xx=td.Medium(permittivity=2), yy=cond_med, zz=td.Medium())
     medium = td.Medium2D.from_anisotropic_medium(aniso_medium, axis=2, thickness=thickness)
@@ -466,7 +469,7 @@ def test_perturbation_medium():
     # conductivity validators
     pmed = td.PerturbationMedium(conductivity_perturbation=pp_real, subpixel=False)
     cmed = pmed.perturbed_copy(0.9 * temperature)  # positive conductivity
-    assert cmed.subpixel == False
+    assert not cmed.subpixel
     with pytest.raises(pydantic.ValidationError):
         _ = pmed.perturbed_copy(1.1 * temperature)  # negative conductivity
 

--- a/tests/test_components/test_meshgenerate.py
+++ b/tests/test_components/test_meshgenerate.py
@@ -42,7 +42,7 @@ def validate_dl_multiple_interval(
     dl_list = np.concatenate(dl_list)
     ratio_f = np.all(dl_list[1:] / dl_list[:-1] <= max_scale + fp_eps)
     ratio_b = np.all(dl_list[1:] / dl_list[:-1] >= 1 / (max_scale + fp_eps))
-    assert (ratio_f and ratio_b) == True
+    assert ratio_f and ratio_b
     assert np.min(dl_list) >= 0.5 * np.min(max_dl_list)
 
 
@@ -57,7 +57,7 @@ def validate_dl_in_interval(
     """Validate dl_list"""
     ratio_f = np.all(dl_list[1:] / dl_list[:-1] <= max_scale + fp_eps)
     ratio_b = np.all(dl_list[1:] / dl_list[:-1] >= 1 / (max_scale + fp_eps))
-    assert (ratio_f and ratio_b) == True
+    assert ratio_f and ratio_b
 
     left_dl = min(max_dl, left_neighbor_dl)
     right_dl = min(max_dl, right_neighbor_dl)
@@ -79,7 +79,7 @@ def test_uniform_grid_in_interval():
         max_dl = np.random.random(1)[0]
         max_scale = 1
         dl = MESHER.make_grid_in_interval(left_dl, right_dl, max_dl, max_scale, len_interval)
-        assert np.any(dl - dl[0]) == False
+        assert not np.any(dl - dl[0])
         validate_dl_in_interval(dl, max_scale, left_dl, right_dl, max_dl, len_interval)
 
         # max_scale > 1, but left_dl = right_dl
@@ -88,7 +88,7 @@ def test_uniform_grid_in_interval():
         max_scale = 1 + np.random.random(1)[0]
         max_dl = left_dl
         dl = MESHER.make_grid_in_interval(left_dl, right_dl, max_dl, max_scale, len_interval)
-        assert np.any(dl - dl[0]) == False
+        assert not np.any(dl - dl[0])
         validate_dl_in_interval(dl, max_scale, left_dl, right_dl, max_dl, len_interval)
 
         # single pixel
@@ -286,7 +286,7 @@ def test_grid_analytic_refinement():
     left_dl, right_dl = MESHER.grid_multiple_interval_analy_refinement(
         max_dl_list, len_interval_list, max_scale, periodic
     )
-    assert np.all(np.isclose(left_dl[1:], right_dl[:-1])) == True
+    assert np.all(np.isclose(left_dl[1:], right_dl[:-1]))
 
 
 def test_grid_refinement():
@@ -626,7 +626,7 @@ def test_mesher_timeout():
         center = sim_size * (np.random.rand(3) - 0.5)
         center[0] = 0
         size = np.abs(box_scale * np.random.randn(3))
-        n = 1 + (n_max - 1) * np.random.rand(1)
+        _ = 1 + (n_max - 1) * np.random.rand(1)
         box = td.Structure(
             geometry=td.Box(center=center.tolist(), size=size.tolist()),
             medium=mediums[np.random.randint(0, 100)],
@@ -647,14 +647,14 @@ def test_mesher_timeout():
         ],
     )
 
-    grid = sim.grid
+    _ = sim.grid
 
 
 def test_shapely_strtree_warnings():
 
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        m = GradedMesher().parse_structures(
+        _ = GradedMesher().parse_structures(
             axis=2,
             structures=[BOX1, BOX2],
             wavelength=1.0,

--- a/tests/test_components/test_mode.py
+++ b/tests/test_components/test_mode.py
@@ -3,22 +3,21 @@ import pytest
 import pydantic
 import numpy as np
 import tidy3d as td
-from tidy3d.exceptions import SetupError
 
 
 def test_modes():
 
-    m = td.ModeSpec(num_modes=2)
-    m = td.ModeSpec(num_modes=1, target_neff=1.0)
+    _ = td.ModeSpec(num_modes=2)
+    _ = td.ModeSpec(num_modes=1, target_neff=1.0)
 
     options = [None, "lowest", "highest", "central"]
     for opt in options:
-        m = td.ModeSpec(num_modes=3, track_freq=opt)
+        _ = td.ModeSpec(num_modes=3, track_freq=opt)
 
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        m = td.ModeSpec(num_modes=3, track_freq="middle")
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        m = td.ModeSpec(num_modes=3, track_freq=4)
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.ModeSpec(num_modes=3, track_freq="middle")
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.ModeSpec(num_modes=3, track_freq=4)
 
 
 def test_bend_axis_not_given():

--- a/tests/test_components/test_monitor.py
+++ b/tests/test_components/test_monitor.py
@@ -32,7 +32,7 @@ def test_downsampled():
 def test_excluded_surfaces_flat():
 
     with pytest.raises(pydantic.ValidationError):
-        M = td.FluxMonitor(size=(1, 1, 0), name="f", freqs=[1e12], exclude_surfaces=("x-",))
+        _ = td.FluxMonitor(size=(1, 1, 0), name="f", freqs=[1e12], exclude_surfaces=("x-",))
 
 
 def test_fld_mnt_freqs_none():
@@ -122,7 +122,7 @@ def test_fieldproj_surfaces_in_simulaiton():
     # test error if all projection surfaces are outside the simulation domain
     M = td.FieldProjectionAngleMonitor(size=(3, 3, 3), theta=[1], phi=[0], name="f", freqs=[2e12])
     with pytest.raises(pydantic.ValidationError):
-        sim = td.Simulation(
+        _ = td.Simulation(
             size=(2, 2, 2),
             run_time=1e-12,
             monitors=[M],
@@ -130,7 +130,7 @@ def test_fieldproj_surfaces_in_simulaiton():
         )
     # no error when some surfaces are in
     M = M.updated_copy(size=(1, 3, 3))
-    sim = td.Simulation(
+    _ = td.Simulation(
         size=(2, 2, 2),
         run_time=1e-12,
         monitors=[M],
@@ -140,7 +140,7 @@ def test_fieldproj_surfaces_in_simulaiton():
     # error when the surfaces that are in are excluded
     M = M.updated_copy(exclude_surfaces=["x-", "x+"])
     with pytest.raises(pydantic.ValidationError):
-        sim = td.Simulation(
+        _ = td.Simulation(
             size=(2, 2, 2),
             run_time=1e-12,
             monitors=[M],
@@ -151,14 +151,14 @@ def test_fieldproj_surfaces_in_simulaiton():
 def test_fieldproj_kspace_range():
     # make sure ux, uy are in [-1, 1] for k-space projection monitors
     with pytest.raises(pydantic.ValidationError):
-        M = td.FieldProjectionKSpaceMonitor(
+        _ = td.FieldProjectionKSpaceMonitor(
             size=(2, 0, 2), ux=[0.1, 2], uy=[0], name="f", freqs=[2e12], proj_axis=1
         )
     with pytest.raises(pydantic.ValidationError):
-        M = td.FieldProjectionKSpaceMonitor(
+        _ = td.FieldProjectionKSpaceMonitor(
             size=(2, 0, 2), ux=[0.1, 0.2], uy=[1.1], name="f", freqs=[2e12], proj_axis=1
         )
-    M = td.FieldProjectionKSpaceMonitor(
+    _ = td.FieldProjectionKSpaceMonitor(
         size=(2, 0, 2), ux=[1, 0.2], uy=[1.0], name="f", freqs=[2e12], proj_axis=1
     )
 
@@ -194,7 +194,7 @@ def test_monitor_freqs_empty():
     # errors when no frequencies supplied
 
     with pytest.raises(pydantic.ValidationError):
-        monitor = td.FieldMonitor(
+        _ = td.FieldMonitor(
             size=(td.inf, td.inf, td.inf),
             freqs=[],
             name="test",
@@ -239,8 +239,8 @@ def test_diffraction_validators():
         y=td.Boundary.periodic(),
         z=td.Boundary.pml(),
     )
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        sim = td.Simulation(
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Simulation(
             size=(2, 2, 2),
             run_time=1e-12,
             structures=[td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=td.Medium())],
@@ -250,8 +250,8 @@ def test_diffraction_validators():
         )
 
     # ensure error if monitor isn't infinite in two directions
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        monitor = td.DiffractionMonitor(size=[td.inf, 4, 0], freqs=[1e12], name="de")
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.DiffractionMonitor(size=[td.inf, 4, 0], freqs=[1e12], name="de")
 
 
 def test_monitor():
@@ -260,7 +260,7 @@ def test_monitor():
     center = (1, 2, 3)
 
     m1 = td.FieldMonitor(size=size, center=center, freqs=[1, 2, 3], name="test_monitor")
-    m1s = td.FieldMonitor.surfaces(size=size, center=center, freqs=[1, 2, 3], name="test_monitor")
+    _ = td.FieldMonitor.surfaces(size=size, center=center, freqs=[1, 2, 3], name="test_monitor")
     m2 = td.FieldTimeMonitor(size=size, center=center, name="test_mon")
     m3 = td.FluxMonitor(size=(1, 1, 0), center=center, freqs=[1, 2, 3], name="test_mon")
     m4 = td.FluxTimeMonitor(size=(1, 1, 0), center=center, name="test_mon")
@@ -281,6 +281,7 @@ def test_monitor():
 
     for m in [m1, m2, m3, m4, m5, m6, m7]:
         # m.plot(y=2)
+        # plt.close()
         m.storage_size(num_cells=100, tmesh=tmesh)
 
     for m in [m2, m4]:
@@ -294,16 +295,16 @@ def test_monitor_plane():
 
     # make sure flux, mode and diffraction monitors fail with non planar geometries
     for size in ((0, 0, 0), (1, 0, 0), (1, 1, 1)):
-        with pytest.raises(pydantic.ValidationError) as e_info:
+        with pytest.raises(pydantic.ValidationError):
             td.ModeMonitor(size=size, freqs=freqs, modes=[])
-        with pytest.raises(pydantic.ValidationError) as e_info:
+        with pytest.raises(pydantic.ValidationError):
             td.ModeSolverMonitor(size=size, freqs=freqs, modes=[])
-        with pytest.raises(pydantic.ValidationError) as e_info:
+        with pytest.raises(pydantic.ValidationError):
             td.DiffractionMonitor(size=size, freqs=freqs, name="de")
 
 
 def _test_freqs_nonempty():
-    with pytest.raises(ValidationError) as e_info:
+    with pytest.raises(ValidationError):
         td.FieldMonitor(size=(1, 1, 1), freqs=[])
 
 
@@ -313,8 +314,8 @@ def test_monitor_surfaces_from_volume():
 
     # make sure that monitors with zero volume raise an error (adapted from test_monitor_plane())
     for size in ((0, 0, 0), (1, 0, 0), (1, 1, 0)):
-        with pytest.raises(SetupError) as e_info:
-            mon_surfaces = td.FieldMonitor.surfaces(
+        with pytest.raises(SetupError):
+            _ = td.FieldMonitor.surfaces(
                 size=size, center=center, freqs=[1, 2, 3], name="test_monitor"
             )
 

--- a/tests/test_components/test_sidewall.py
+++ b/tests/test_components/test_sidewall.py
@@ -472,9 +472,7 @@ def test_bound_poly(execution_number):
         angle = 0.0
         # avoid vertex-edge crossing case
         try:
-            s = setup_polyslab(
-                vertices, dilation, angle, bounds, reference_plane=reference_plane
-            )
+            s = setup_polyslab(vertices, dilation, angle, bounds, reference_plane=reference_plane)
         except:
             continue
         validate_poly_bound(s)

--- a/tests/test_components/test_sidewall.py
+++ b/tests/test_components/test_sidewall.py
@@ -1,5 +1,4 @@
 """test slanted polyslab can be correctly setup and visualized. """
-from typing import Dict
 import pytest
 import numpy as np
 import pydantic
@@ -7,7 +6,6 @@ from shapely.geometry import Polygon, Point
 
 import tidy3d as td
 from tidy3d.constants import fp_eps
-from tidy3d.exceptions import ValidationError, SetupError
 
 np.random.seed(4)
 _BUFFER_PARAM = {"join_style": 2, "mitre_limit": 1e10}
@@ -79,6 +77,12 @@ def convert_valid_polygon(vertices):
     if type(poly) is not Polygon:
         poly = poly.geoms[0]
 
+    # ensure minimal area
+    while poly.area < 1e-3:
+        poly = poly.buffer(0.1, **_BUFFER_PARAM)
+        if type(poly) is not Polygon:
+            poly = poly.geoms[0]
+
     vertices_n = np.array(poly.exterior.coords[:])
     return vertices_n
 
@@ -125,18 +129,18 @@ def test_valid_polygon():
 
     # area = 0
     vertices = ((0, 0), (1, 0), (2, 0))
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = setup_polyslab(vertices, dilation, angle, bounds)
+    with pytest.raises(pydantic.ValidationError):
+        _ = setup_polyslab(vertices, dilation, angle, bounds)
 
     # only two points
     vertices = ((0, 0), (1, 0), (1, 0))
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = setup_polyslab(vertices, dilation, angle, bounds)
+    with pytest.raises(pydantic.ValidationError):
+        _ = setup_polyslab(vertices, dilation, angle, bounds)
 
     # intersecting edges
     vertices = ((0, 0), (1, 0), (1, 1), (0, 1), (0.5, -1))
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = setup_polyslab(vertices, dilation, angle, bounds)
+    with pytest.raises(pydantic.ValidationError):
+        _ = setup_polyslab(vertices, dilation, angle, bounds)
 
 
 def test_crossing_square_poly():
@@ -148,35 +152,35 @@ def test_crossing_square_poly():
     vertices = ((0, 0), (1, 0), (1, -1), (0, -1))
     dilation = 0.0
     angle = np.pi / 4
-    s = setup_polyslab(vertices, dilation, angle, bounds)
+    _ = setup_polyslab(vertices, dilation, angle, bounds)
 
     # fully eroded
     dilation = -1.1
     angle = 0
     for ref_plane in ["bottom", "middle", "top"]:
-        with pytest.raises(pydantic.ValidationError) as e_info:
-            s = setup_polyslab(vertices, dilation, angle, bounds, reference_plane=ref_plane)
+        with pytest.raises(pydantic.ValidationError):
+            _ = setup_polyslab(vertices, dilation, angle, bounds, reference_plane=ref_plane)
 
     # angle too large, self-intersecting
     dilation = 0
     angle = np.pi / 3
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = setup_polyslab(vertices, dilation, angle, bounds)
-        s = setup_polyslab(vertices, dilation, angle, bounds, reference_plane="top")
+    with pytest.raises(pydantic.ValidationError):
+        _ = setup_polyslab(vertices, dilation, angle, bounds)
+        _ = setup_polyslab(vertices, dilation, angle, bounds, reference_plane="top")
     # middle plane
     angle = np.arctan(1.999)
-    s = setup_polyslab(vertices, dilation, angle, bounds, reference_plane="middle")
+    _ = setup_polyslab(vertices, dilation, angle, bounds, reference_plane="middle")
 
     # angle too large for middle reference plane
     angle = np.arctan(2.001)
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = setup_polyslab(vertices, dilation, angle, bounds, reference_plane="middle")
+    with pytest.raises(pydantic.ValidationError):
+        _ = setup_polyslab(vertices, dilation, angle, bounds, reference_plane="middle")
 
     # combines both
     dilation = -0.1
     angle = np.pi / 4
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = setup_polyslab(vertices, dilation, angle, bounds)
+    with pytest.raises(pydantic.ValidationError):
+        _ = setup_polyslab(vertices, dilation, angle, bounds)
 
 
 def test_crossing_concave_poly():
@@ -189,47 +193,47 @@ def test_crossing_concave_poly():
     vertices = ((-0.5, 1), (-0.5, -1), (1, -1), (0, -0.1), (0, 0.1), (1, 1))
     dilation = 0.5
     angle = 0
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = setup_polyslab(vertices, dilation, angle, bounds)
+    with pytest.raises(pydantic.ValidationError):
+        _ = setup_polyslab(vertices, dilation, angle, bounds)
 
     # polygon splitting
     dilation = -0.3
     angle = 0
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = setup_polyslab(vertices, dilation, angle, bounds)
+    with pytest.raises(pydantic.ValidationError):
+        _ = setup_polyslab(vertices, dilation, angle, bounds)
 
     # polygon fully eroded
     dilation = -0.5
     angle = 0
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = setup_polyslab(vertices, dilation, angle, bounds)
+    with pytest.raises(pydantic.ValidationError):
+        _ = setup_polyslab(vertices, dilation, angle, bounds)
 
     # # or, effectively
     dilation = 0
     angle = -np.pi / 4
     for bounds in [(0, 0.3), (0, 0.5)]:
-        with pytest.raises(pydantic.ValidationError) as e_info:
-            s = setup_polyslab(vertices, dilation, angle, bounds)
-            s = setup_polyslab(vertices, dilation, -angle, bounds, reference_plane="top")
+        with pytest.raises(pydantic.ValidationError):
+            _ = setup_polyslab(vertices, dilation, angle, bounds)
+            _ = setup_polyslab(vertices, dilation, -angle, bounds, reference_plane="top")
 
     # middle plane
     angle = np.pi / 4
     bounds = (0, 0.44)
-    s = setup_polyslab(vertices, dilation, angle, bounds, reference_plane="middle")
-    s = setup_polyslab(vertices, dilation, -angle, bounds, reference_plane="middle")
-    with pytest.raises(pydantic.ValidationError) as e_info:
+    _ = setup_polyslab(vertices, dilation, angle, bounds, reference_plane="middle")
+    _ = setup_polyslab(vertices, dilation, -angle, bounds, reference_plane="middle")
+    with pytest.raises(pydantic.ValidationError):
         # vertices degenerate
         bounds = (0, 0.45)
-        s = setup_polyslab(vertices, dilation, angle, bounds, reference_plane="middle")
-        s = setup_polyslab(vertices, dilation, -angle, bounds, reference_plane="middle")
+        _ = setup_polyslab(vertices, dilation, angle, bounds, reference_plane="middle")
+        _ = setup_polyslab(vertices, dilation, -angle, bounds, reference_plane="middle")
         # polygon splitting
         bounds = (0, 0.6)
-        s = setup_polyslab(vertices, dilation, angle, bounds, reference_plane="middle")
-        s = setup_polyslab(vertices, dilation, -angle, bounds, reference_plane="middle")
+        _ = setup_polyslab(vertices, dilation, angle, bounds, reference_plane="middle")
+        _ = setup_polyslab(vertices, dilation, -angle, bounds, reference_plane="middle")
         # fully eroded
         bounds = (0, 1)
-        s = setup_polyslab(vertices, dilation, angle, bounds, reference_plane="middle")
-        s = setup_polyslab(vertices, dilation, -angle, bounds, reference_plane="middle")
+        _ = setup_polyslab(vertices, dilation, angle, bounds, reference_plane="middle")
+        _ = setup_polyslab(vertices, dilation, -angle, bounds, reference_plane="middle")
 
 
 def test_edge_events():
@@ -246,7 +250,7 @@ def test_edge_events():
     vertices = vertice1 + vertice2 + vertice3 + vertice4
 
     angle = -np.pi / 20
-    s = td.PolySlab(
+    _ = td.PolySlab(
         vertices=vertices,
         axis=0,
         slab_bounds=(-1, 1),
@@ -255,26 +259,25 @@ def test_edge_events():
     )
 
 
-def test_max_erosion_polygon():
+@pytest.mark.parametrize("execution_number", range(50))
+def test_max_erosion_polygon(execution_number):
     """
     Maximal erosion distance validation
     """
     N = 10  # number of vertices
-    for i in range(50):
-        vertices = convert_valid_polygon(np.random.random((N, 2)) * 10)
+    vertices = convert_valid_polygon(np.random.random((N, 2)) * 10)
 
-        dilation = 0
-        angle = 0
-        bounds = (0, 0.5)
-        s = setup_polyslab(vertices, dilation, angle, bounds)
+    dilation = 0
+    angle = 0
+    bounds = (0, 0.5)
+    s = setup_polyslab(vertices, dilation, angle, bounds)
 
-        # compute maximal allowed erosion distance
-        max_dist = s._neighbor_vertices_crossing_detection(s.reference_polygon, -100)
-        # verify it is indeed maximal allowed
-        dilation = -max_dist + 1e-10
-        # avoid polygon splitting etc. case
-        if s._edge_events_detection(s.reference_polygon, dilation, ignore_at_dist=False):
-            continue
+    # compute maximal allowed erosion distance
+    max_dist = s._neighbor_vertices_crossing_detection(s.reference_polygon, -100)
+    # verify it is indeed maximal allowed
+    dilation = -max_dist + 1e-10
+    # avoid polygon splitting etc. case
+    if not s._edge_events_detection(s.reference_polygon, dilation, ignore_at_dist=False):
         s = setup_polyslab(vertices, dilation, angle, bounds)
         assert np.isclose(minimal_edge_length(s.reference_polygon), 0, atol=1e-4)
 
@@ -286,29 +289,29 @@ def test_max_erosion_polygon():
         assert np.isclose(minimal_edge_length(s.top_polygon), 0, atol=1e-4)
 
 
-def test_shift_height_poly():
+@pytest.mark.parametrize("execution_number", range(50))
+def test_shift_height_poly(execution_number):
     """Make sure a list of height where the plane will intersect with the vertices
     works properly
     """
     N = 10  # number of vertices
     Lx = 10.0
-    for i in range(50):
-        vertices = convert_valid_polygon(np.random.random((N, 2)) * Lx)
-        dilation = 0
-        angle = 0
-        bounds = (0, 1)
+    vertices = convert_valid_polygon(np.random.random((N, 2)) * Lx)
+    dilation = 0
+    angle = 0
+    bounds = (0, 1)
+    s = setup_polyslab(vertices, dilation, angle, bounds)
+    # set up proper thickness
+    max_dist = s._neighbor_vertices_crossing_detection(s.base_polygon, -100)
+    dilation = 0.0
+    bounds = (0, max_dist * 0.99)
+    angle = np.pi / 4
+    # avoid vertex-edge crossing case
+    try:
         s = setup_polyslab(vertices, dilation, angle, bounds)
-        # set up proper thickness
-        max_dist = s._neighbor_vertices_crossing_detection(s.base_polygon, -100)
-        dilation = 0.0
-        bounds = (0, max_dist * 0.99)
-        angle = np.pi / 4
-        # avoid vertex-edge crossing case
-        try:
-            s = setup_polyslab(vertices, dilation, angle, bounds)
-        except:
-            continue
-
+    except:
+        s = None
+    if s is not None:
         for axis in (0, 1):
             position = np.random.random(1)[0] * Lx - Lx / 2
             height = s._find_intersecting_height(position, axis)
@@ -316,7 +319,7 @@ def test_shift_height_poly():
                 bounds = (0, h)
                 s = setup_polyslab(vertices, dilation, angle, bounds)
                 diff = s.top_polygon[:, axis] - position
-                assert np.any(np.isclose(diff, 0)) == True
+                assert np.any(np.isclose(diff, 0))
 
 
 def test_intersection_with_inside_poly():
@@ -350,7 +353,9 @@ def test_intersection_with_inside_poly():
                     bounds = (0, 1)
                     s_bottom = setup_polyslab(vertices, dilation, angle_tmp, bounds, axis=axis)
                     # set up proper thickness
-                    max_dist = s_bottom._neighbor_vertices_crossing_detection(s.base_polygon, -100)
+                    max_dist = s_bottom._neighbor_vertices_crossing_detection(
+                        s_bottom.base_polygon, -100
+                    )
 
                 bounds = (-(max_dist * 0.95) / 2, (max_dist * 0.95) / 2)
 
@@ -444,55 +449,53 @@ def test_intersection_with_inside_poly():
                         )
 
 
-def test_bound_poly():
-    """
-    Make sure bound works, even though it might not be tight.
-    """
+@pytest.mark.parametrize("execution_number", range(50))
+def test_bound_poly(execution_number):
+    """Make sure bound works, even though it might not be tight."""
     N = 10  # number of vertices
     Lx = 10  # maximal length in x,y direction
-    for i in range(50):
-        for reference_plane in ["bottom", "middle", "top"]:
-            vertices = convert_valid_polygon(np.random.random((N, 2)) * Lx)
-            vertices = np.array(vertices)  # .astype("float32")
+    for reference_plane in ["bottom", "middle", "top"]:
+        vertices = convert_valid_polygon(np.random.random((N, 2)) * Lx)
+        vertices = np.array(vertices)  # .astype("float32")
 
-            ### positive dilation
-            dilation = 0
-            angle = 0
-            bounds = (0, 1)
-            s = setup_polyslab(vertices, dilation, angle, bounds, reference_plane=reference_plane)
-            max_dist = s._neighbor_vertices_crossing_detection(s.base_polygon, 100)
-            # verify it is indeed maximal allowed
-            dilation = 1
-            if max_dist is not None:
-                dilation = max_dist - 1e-10
-            bounds = (0, 1)
-            angle = 0.0
-            # avoid vertex-edge crossing case
-            try:
-                s = setup_polyslab(
-                    vertices, dilation, angle, bounds, reference_plane=reference_plane
-                )
-            except:
-                continue
-            validate_poly_bound(s)
+        ### positive dilation
+        dilation = 0
+        angle = 0
+        bounds = (0, 1)
+        s = setup_polyslab(vertices, dilation, angle, bounds, reference_plane=reference_plane)
+        max_dist = s._neighbor_vertices_crossing_detection(s.base_polygon, 100)
+        # verify it is indeed maximal allowed
+        dilation = 1
+        if max_dist is not None:
+            dilation = max_dist - 1e-10
+        bounds = (0, 1)
+        angle = 0.0
+        # avoid vertex-edge crossing case
+        try:
+            s = setup_polyslab(
+                vertices, dilation, angle, bounds, reference_plane=reference_plane
+            )
+        except:
+            continue
+        validate_poly_bound(s)
 
-            ## sidewall
-            dilation = 0
-            angle = 0
-            bounds = (0, 1)
+        ## sidewall
+        dilation = 0
+        angle = 0
+        bounds = (0, 1)
+        s = setup_polyslab(vertices, dilation, angle, bounds)
+        # set up proper thickness
+        max_dist = s._neighbor_vertices_crossing_detection(s.base_polygon, -100)
+        dilation = 0.0
+        bounds = (0, (max_dist * 0.95))
+        angle = np.pi / 4
+        # avoid vertex-edge crossing case
+        try:
             s = setup_polyslab(vertices, dilation, angle, bounds)
-            # set up proper thickness
-            max_dist = s._neighbor_vertices_crossing_detection(s.base_polygon, -100)
-            dilation = 0.0
-            bounds = (0, (max_dist * 0.95))
-            angle = np.pi / 4
-            # avoid vertex-edge crossing case
-            try:
-                s = setup_polyslab(vertices, dilation, angle, bounds)
-            except:
-                continue
-            s = convert_polyslab_other_reference_plane(s, reference_plane)
-            validate_poly_bound(s)
+        except:
+            continue
+        s = convert_polyslab_other_reference_plane(s, reference_plane)
+        validate_poly_bound(s)
 
 
 def test_normal_intersection_with_inside_cylinder():
@@ -557,12 +560,12 @@ def test_side_intersection_cylinder():
     )
 
     shape_intersect = cyl.intersections_plane(x=0)
-    assert shape_intersect[0].covers(Point(1.25, 0.4)) == False
-    assert shape_intersect[0].covers(Point(1.25, -0.4)) == True
+    assert not shape_intersect[0].covers(Point(1.25, 0.4))
+    assert shape_intersect[0].covers(Point(1.25, -0.4))
 
     shape_intersect = cyl.intersections_plane(x=np.sqrt(3) / 2)
-    assert shape_intersect[0].covers(Point(1.25, -0.4)) == False
-    assert shape_intersect[0].covers(Point(0.7, -0.4)) == True
+    assert not shape_intersect[0].covers(Point(1.25, -0.4))
+    assert shape_intersect[0].covers(Point(0.7, -0.4))
 
 
 def test_slanted_infinite_cylinder():
@@ -582,8 +585,8 @@ def test_slanted_infinite_cylinder():
     )
 
     shape_intersect = cyl.intersections_plane(x=0)
-    assert shape_intersect[0].covers(Point(1.25, 0.4)) == False
-    assert shape_intersect[0].covers(Point(1.25, -0.4)) == True
+    assert not shape_intersect[0].covers(Point(1.25, 0.4))
+    assert shape_intersect[0].covers(Point(1.25, -0.4))
 
     shape_intersect = cyl.intersections_plane(x=np.sqrt(3) / 2)
-    assert shape_intersect[0].covers(Point(1.25, -0.4)) == False
+    assert not shape_intersect[0].covers(Point(1.25, -0.4))

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -1,19 +1,17 @@
 """Tests the simulation and its validators."""
 import pytest
 import pydantic
-import matplotlib.pylab as plt
+import matplotlib.pyplot as plt
 
 import numpy as np
 import tidy3d as td
 from tidy3d.exceptions import SetupError, ValidationError, Tidy3dKeyError
 from tidy3d.components import simulation
 from tidy3d.components.simulation import MAX_NUM_MEDIUMS
-from ..utils import assert_log_level, SIM_FULL, log_capture, run_emulated, clear_tmp
+from ..utils import assert_log_level, SIM_FULL, log_capture, run_emulated
 from tidy3d.constants import LARGE_NUMBER
 
 SIM = td.Simulation(size=(1, 1, 1), run_time=1e-12, grid_spec=td.GridSpec(wavelength=1.0))
-
-_, AX = plt.subplots()
 
 RTOL = 0.01
 
@@ -76,17 +74,20 @@ def test_sim_init():
         subpixel=False,
     )
 
-    dt = sim.dt
-    tm = sim.tmesh
+    _ = sim.dt
+    _ = sim.tmesh
     sim.validate_pre_upload()
-    ms = sim.mediums
-    mm = sim.medium_map
+    _ = sim.mediums
+    _ = sim.medium_map
     m = sim.get_monitor_by_name("point")
-    s = sim.background_structure
+    _ = sim.background_structure
     # sim.plot(x=0)
+    # plt.close()
     # sim.plot_eps(x=0)
+    # plt.close()
     sim.num_pml_layers
     # sim.plot_grid(x=0)
+    # plt.close()
     sim.frequency_range
     sim.grid
     sim.num_cells
@@ -158,7 +159,7 @@ def test_monitors_data_size():
 
 def test_deprecation_defaults(log_capture):
     """Make sure deprecation warnings NOT thrown if defaults used."""
-    s = td.Simulation(
+    _ = td.Simulation(
         size=(1, 1, 1),
         run_time=1e-12,
         grid_spec=td.GridSpec.uniform(dl=0.1),
@@ -184,7 +185,7 @@ def test_sim_bounds(shift_amount, log_level, log_capture):
 
         shifted_center = tuple(c + s for (c, s) in zip(center_offset, CENTER_SHIFT))
 
-        sim = td.Simulation(
+        _ = td.Simulation(
             size=(1.5, 1.5, 1.5),
             center=CENTER_SHIFT,
             grid_spec=td.GridSpec(wavelength=1.0),
@@ -274,7 +275,6 @@ def _test_monitor_size():
 def test_monitor_medium_frequency_range(log_capture, freq, log_level):
     # monitor frequency above or below a given medium's range should throw a warning
 
-    size = (1, 1, 1)
     medium = td.Medium(frequency_range=(2, 3))
     box = td.Structure(geometry=td.Box(size=(0.1, 0.1, 0.1)), medium=medium)
     mnt = td.FieldMonitor(size=(0, 0, 0), name="freq", freqs=[freq])
@@ -283,7 +283,7 @@ def test_monitor_medium_frequency_range(log_capture, freq, log_level):
         size=(0, 0, 0),
         polarization="Ex",
     )
-    sim = td.Simulation(
+    _ = td.Simulation(
         size=(1, 1, 1),
         structures=[box],
         monitors=[mnt],
@@ -298,14 +298,13 @@ def test_monitor_medium_frequency_range(log_capture, freq, log_level):
 def test_monitor_simulation_frequency_range(log_capture, fwidth, log_level):
     # monitor frequency outside of the simulation's frequency range should throw a warning
 
-    size = (1, 1, 1)
     src = td.UniformCurrentSource(
         source_time=td.GaussianPulse(freq0=2.0, fwidth=fwidth),
         size=(0, 0, 0),
         polarization="Ex",
     )
     mnt = td.FieldMonitor(size=(0, 0, 0), name="freq", freqs=[1.5])
-    sim = td.Simulation(
+    _ = td.Simulation(
         size=(1, 1, 1),
         monitors=[mnt],
         sources=[src],
@@ -541,46 +540,62 @@ def test_no_monitor():
 
 
 def test_plot_eps():
-    ax = SIM_FULL.plot_eps(ax=AX, x=0)
+    ax = SIM_FULL.plot_eps(x=0)
     SIM_FULL._add_cbar(eps_min=1, eps_max=2, ax=ax)
+    plt.close()
 
 
 def test_plot_eps_bounds():
-    _ = SIM_FULL.plot_eps(ax=AX, x=0, hlim=[-0.45, 0.45])
-    _ = SIM_FULL.plot_eps(ax=AX, x=0, vlim=[-0.45, 0.45])
-    _ = SIM_FULL.plot_eps(ax=AX, x=0, hlim=[-0.45, 0.45], vlim=[-0.45, 0.45])
+    _ = SIM_FULL.plot_eps(x=0, hlim=[-0.45, 0.45])
+    plt.close()
+    _ = SIM_FULL.plot_eps(x=0, vlim=[-0.45, 0.45])
+    plt.close()
+    _ = SIM_FULL.plot_eps(x=0, hlim=[-0.45, 0.45], vlim=[-0.45, 0.45])
+    plt.close()
 
 
 def test_plot():
-    SIM_FULL.plot(x=0, ax=AX)
+    SIM_FULL.plot(x=0)
+    plt.close()
 
 
 def test_plot_bounds():
-    _ = SIM_FULL.plot(ax=AX, x=0, hlim=[-0.45, 0.45])
-    _ = SIM_FULL.plot(ax=AX, x=0, vlim=[-0.45, 0.45])
-    _ = SIM_FULL.plot(ax=AX, x=0, hlim=[-0.45, 0.45], vlim=[-0.45, 0.45])
+    _ = SIM_FULL.plot(x=0, hlim=[-0.45, 0.45])
+    plt.close()
+    _ = SIM_FULL.plot(x=0, vlim=[-0.45, 0.45])
+    plt.close()
+    _ = SIM_FULL.plot(x=0, hlim=[-0.45, 0.45], vlim=[-0.45, 0.45])
+    plt.close()
 
 
 def test_plot_3d():
     SIM_FULL.plot_3d()
+    plt.close()
 
 
 def test_structure_alpha():
-    _ = SIM_FULL.plot_structures_eps(x=0, ax=AX, alpha=None)
-    _ = SIM_FULL.plot_structures_eps(x=0, ax=AX, alpha=-1)
-    _ = SIM_FULL.plot_structures_eps(x=0, ax=AX, alpha=1)
-    _ = SIM_FULL.plot_structures_eps(x=0, ax=AX, alpha=0.5)
-    _ = SIM_FULL.plot_structures_eps(x=0, ax=AX, alpha=0.5, cbar=True)
+    _ = SIM_FULL.plot_structures_eps(x=0, alpha=None)
+    plt.close()
+    _ = SIM_FULL.plot_structures_eps(x=0, alpha=-1)
+    plt.close()
+    _ = SIM_FULL.plot_structures_eps(x=0, alpha=1)
+    plt.close()
+    _ = SIM_FULL.plot_structures_eps(x=0, alpha=0.5)
+    plt.close()
+    _ = SIM_FULL.plot_structures_eps(x=0, alpha=0.5, cbar=True)
+    plt.close()
     new_structs = [
         td.Structure(geometry=s.geometry, medium=SIM_FULL.medium) for s in SIM_FULL.structures
     ]
     S2 = SIM_FULL.copy(update=dict(structures=new_structs))
-    ax5 = S2.plot_structures_eps(x=0, ax=AX, alpha=0.5)
+    _ = S2.plot_structures_eps(x=0, alpha=0.5)
+    plt.close()
 
 
 def test_plot_symmetries():
     S2 = SIM.copy(update=dict(symmetry=(1, 0, -1)))
-    S2.plot_symmetries(x=0, ax=AX)
+    S2.plot_symmetries(x=0)
+    plt.close()
 
 
 def test_plot_grid():
@@ -589,6 +604,7 @@ def test_plot_grid():
         update=dict(grid_spec=td.GridSpec(wavelength=1.0, override_structures=[override]))
     )
     S2.plot_grid(x=0)
+    plt.close()
 
 
 def test_plot_boundaries():
@@ -602,6 +618,7 @@ def test_plot_boundaries():
     )
     S2 = SIM_FULL.copy(update=dict(boundary_spec=bound_spec))
     S2.plot_boundaries(z=0)
+    plt.close()
 
 
 def test_wvl_mat_grid():
@@ -686,7 +703,7 @@ def test_get_structure_plot_params():
 
 
 def test_warn_sim_background_medium_freq_range(log_capture):
-    S = SIM.copy(
+    _ = SIM.copy(
         update=dict(
             sources=(
                 td.PointDipole(
@@ -732,7 +749,7 @@ def test_sim_structure_gap(log_capture, box_size, log_level):
         size=(0, 0, 0),
         polarization="Ex",
     )
-    sim = td.Simulation(
+    _ = td.Simulation(
         size=(10, 10, 10),
         structures=[box],
         sources=[src],
@@ -820,7 +837,7 @@ def test_sim_monitor_homogeneous():
 
     box_transparent = td.Structure(geometry=td.Box(size=(0.2, 0.1, 0.1)), medium=medium_bg)
 
-    monitor_n2f = td.FieldProjectionAngleMonitor(
+    _ = td.FieldProjectionAngleMonitor(
         center=(0, 0, 0),
         size=(td.inf, td.inf, 0),
         freqs=[250e12, 300e12],
@@ -838,7 +855,7 @@ def test_sim_monitor_homogeneous():
         phi=[0],
     )
 
-    monitor_diffraction = td.DiffractionMonitor(
+    _ = td.DiffractionMonitor(
         center=(0, 0, 0),
         size=(td.inf, td.inf, 0),
         freqs=[250e12, 300e12],
@@ -854,7 +871,7 @@ def test_sim_monitor_homogeneous():
 
     for monitor in [monitor_n2f_vol]:
         # with transparent box continue
-        sim1 = td.Simulation(
+        _ = td.Simulation(
             size=(1, 1, 1),
             medium=medium_bg,
             structures=[box_transparent],
@@ -1045,7 +1062,7 @@ def test_sim_structure_extent(log_capture, box_size, log_level):
         polarization="Ex",
     )
     box = td.Structure(geometry=td.Box(size=box_size), medium=td.Medium(permittivity=2))
-    sim = td.Simulation(
+    _ = td.Simulation(
         size=(1, 1, 1),
         structures=[box],
         sources=[src],
@@ -1079,13 +1096,17 @@ def test_sim_validate_structure_bounds_pml(log_capture, box_length, absorb_type,
         geometry=td.Box(size=(box_length, 0.5, 0.5), center=(0, 0, 0)),
         medium=td.Medium(permittivity=2),
     )
-    sim = td.Simulation(
+    _ = td.Simulation(
         size=(1, 1, 1),
         structures=[box],
         grid_spec=td.GridSpec.auto(wavelength=0.001),
         sources=[src],
         run_time=1e-12,
-        boundary_spec=td.BoundarySpec.pml(x=True, y=False, z=False),
+        boundary_spec=td.BoundarySpec(
+            x=td.Boundary(plus=boundary, minus=boundary),
+            y=td.Boundary.pec(),
+            z=td.Boundary.pec(),
+        ),
     )
 
     assert_log_level(log_capture, log_level)
@@ -1100,7 +1121,7 @@ def test_num_mediums():
         structures.append(
             td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=td.Medium(permittivity=i + 1))
         )
-    sim = td.Simulation(
+    _ = td.Simulation(
         size=(5, 5, 5),
         grid_spec=grid_spec,
         structures=structures,
@@ -1112,7 +1133,7 @@ def test_num_mediums():
         structures.append(
             td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=td.Medium(permittivity=i + 2))
         )
-        sim = td.Simulation(
+        _ = td.Simulation(
             size=(5, 5, 5), grid_spec=grid_spec, structures=structures, run_time=1e-12
         )
 
@@ -1177,8 +1198,8 @@ def _test_names_default():
 
 def test_names_unique():
 
-    with pytest.raises(pydantic.ValidationError) as e:
-        sim = td.Simulation(
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Simulation(
             size=(2.0, 2.0, 2.0),
             run_time=1e-12,
             structures=[
@@ -1196,8 +1217,8 @@ def test_names_unique():
             boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
         )
 
-    with pytest.raises(pydantic.ValidationError) as e:
-        sim = td.Simulation(
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Simulation(
             size=(2.0, 2.0, 2.0),
             run_time=1e-12,
             sources=[
@@ -1219,8 +1240,8 @@ def test_names_unique():
             boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
         )
 
-    with pytest.raises(pydantic.ValidationError) as e:
-        sim = td.Simulation(
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Simulation(
             size=(2.0, 2.0, 2.0),
             run_time=1e-12,
             monitors=[
@@ -1236,8 +1257,8 @@ def test_mode_object_syms():
     g = td.GaussianPulse(freq0=1, fwidth=0.1)
 
     # wrong mode source
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        sim = td.Simulation(
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Simulation(
             center=(1.0, -1.0, 0.5),
             size=(2.0, 2.0, 2.0),
             grid_spec=td.GridSpec.auto(wavelength=td.C_0 / 1.0),
@@ -1248,8 +1269,8 @@ def test_mode_object_syms():
         )
 
     # wrong mode monitor
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        sim = td.Simulation(
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Simulation(
             center=(1.0, -1.0, 0.5),
             size=(2.0, 2.0, 2.0),
             grid_spec=td.GridSpec.auto(wavelength=td.C_0 / 1.0),
@@ -1262,7 +1283,7 @@ def test_mode_object_syms():
         )
 
     # right mode source (centered on the symmetry)
-    sim = td.Simulation(
+    _ = td.Simulation(
         center=(1.0, -1.0, 0.5),
         size=(2.0, 2.0, 2.0),
         grid_spec=td.GridSpec.auto(wavelength=td.C_0 / 1.0),
@@ -1273,7 +1294,7 @@ def test_mode_object_syms():
     )
 
     # right mode monitor (entirely in the main quadrant)
-    sim = td.Simulation(
+    _ = td.Simulation(
         center=(1.0, -1.0, 0.5),
         size=(2.0, 2.0, 2.0),
         grid_spec=td.GridSpec.auto(wavelength=td.C_0 / 1.0),
@@ -1302,7 +1323,7 @@ def test_tfsf_symmetry():
         injection_axis=2,
     )
 
-    with pytest.raises(pydantic.ValidationError) as e:
+    with pytest.raises(pydantic.ValidationError):
         _ = td.Simulation(
             size=(2.0, 2.0, 2.0),
             grid_spec=td.GridSpec.auto(wavelength=td.C_0 / 1.0),
@@ -1372,7 +1393,7 @@ def test_tfsf_boundaries(log_capture):
     assert_log_level(log_capture, "WARNING")
 
     # cannot cross any boundary in the direction of injection
-    with pytest.raises(pydantic.ValidationError) as e:
+    with pytest.raises(pydantic.ValidationError):
         _ = td.Simulation(
             size=(2.0, 2.0, 0.5),
             grid_spec=td.GridSpec.auto(wavelength=1.0),
@@ -1381,7 +1402,7 @@ def test_tfsf_boundaries(log_capture):
         )
 
     # cannot cross any non-periodic boundary in the transverse direction
-    with pytest.raises(pydantic.ValidationError) as e:
+    with pytest.raises(pydantic.ValidationError):
         _ = td.Simulation(
             center=(0.5, 0, 0),  # also check the case when the boundary is crossed only on one side
             size=(0.5, 0.5, 2.0),
@@ -1426,7 +1447,7 @@ def test_tfsf_structures_grid(log_capture):
     assert_log_level(log_capture, "WARNING")
 
     # must not have different material profiles on different faces along the injection axis
-    with pytest.raises(SetupError) as e:
+    with pytest.raises(SetupError):
         sim = td.Simulation(
             size=(2.0, 2.0, 2.0),
             grid_spec=td.GridSpec.auto(wavelength=1.0),
@@ -1476,7 +1497,7 @@ def test_tfsf_structures_grid(log_capture):
             )
         ],
     )
-    with pytest.raises(SetupError) as e:
+    with pytest.raises(SetupError):
         sim.validate_pre_upload()
 
     # TFSF box must not intersect a fully anisotropic medium
@@ -1495,7 +1516,7 @@ def test_tfsf_structures_grid(log_capture):
             )
         ],
     )
-    with pytest.raises(SetupError) as e:
+    with pytest.raises(SetupError):
         sim.validate_pre_upload()
 
 
@@ -1550,8 +1571,7 @@ def test_dt():
     assert sim_new.dt == 0.4 * dt
 
 
-@clear_tmp
-def test_sim_volumetric_structures():
+def test_sim_volumetric_structures(tmp_path):
     """Test volumetric equivalent of 2D materials."""
     sigma = 0.45
     thickness = 0.01
@@ -1634,9 +1654,12 @@ def test_sim_volumetric_structures():
     )
     # check that plotting 2d material doesn't raise an error
     sim_data = run_emulated(sim)
-    sim_data.plot_field(ax=AX, field_monitor_name="field_xz", field_name="Ex", val="real")
-    _ = sim.plot_eps(ax=AX, x=0, alpha=0.2)
-    _ = sim.plot(ax=AX, x=0)
+    sim_data.plot_field(field_monitor_name="field_xz", field_name="Ex", val="real")
+    plt.close()
+    _ = sim.plot_eps(x=0, alpha=0.2)
+    plt.close()
+    _ = sim.plot(x=0)
+    plt.close()
 
     # nonuniform sub/super-strate should error
     below_half = td.Structure(

--- a/tests/test_components/test_source.py
+++ b/tests/test_components/test_source.py
@@ -1,13 +1,11 @@
 """Tests sources."""
 import pytest
 import pydantic
-import matplotlib.pylab as plt
+import matplotlib.pyplot as plt
 import numpy as np
 import tidy3d as td
-from tidy3d.exceptions import SetupError, DataError, ValidationError
+from tidy3d.exceptions import SetupError
 from tidy3d.components.source import DirectionalSource, CHEB_GRID_WIDTH
-
-_, AX = plt.subplots()
 
 ST = td.GaussianPulse(freq0=2e14, fwidth=1e14)
 S = td.PointDipole(source_time=ST, polarization="Ex")
@@ -19,18 +17,20 @@ ATOL = 1e-8
 def test_plot_source_time():
 
     for val in ("real", "imag", "abs"):
-        ST.plot(times=[1e-15, 2e-15, 3e-15], val=val, ax=AX)
-        ST.plot_spectrum(times=[1e-15, 2e-15, 3e-15], num_freqs=4, val=val, ax=AX)
+        ST.plot(times=[1e-15, 2e-15, 3e-15], val=val)
+        ST.plot_spectrum(times=[1e-15, 2e-15, 3e-15], num_freqs=4, val=val)
 
     with pytest.raises(ValueError):
-        ST.plot(times=[1e-15, 2e-15, 3e-15], val="blah", ax=AX)
+        ST.plot(times=[1e-15, 2e-15, 3e-15], val="blah")
 
     with pytest.raises(ValueError):
-        ST.plot_spectrum(times=[1e-15, 2e-15, 3e-15], num_freqs=4, val="blah", ax=AX)
+        ST.plot_spectrum(times=[1e-15, 2e-15, 3e-15], num_freqs=4, val="blah")
 
     # uneven spacing in times
     with pytest.raises(SetupError):
-        ST.plot_spectrum(times=[1e-15, 3e-15, 4e-15], num_freqs=4, ax=AX)
+        ST.plot_spectrum(times=[1e-15, 3e-15, 4e-15], num_freqs=4)
+
+    plt.close("all")
 
 
 def test_dir_vector():
@@ -44,10 +44,8 @@ def test_UniformCurrentSource():
     g = td.GaussianPulse(freq0=1, fwidth=0.1)
 
     # test we can make generic UniformCurrentSource
-    s1 = td.UniformCurrentSource(
-        size=(1, 1, 1), source_time=g, polarization="Ez", interpolate=False
-    )
-    s2 = td.UniformCurrentSource(size=(1, 1, 1), source_time=g, polarization="Ez", interpolate=True)
+    _ = td.UniformCurrentSource(size=(1, 1, 1), source_time=g, polarization="Ez", interpolate=False)
+    _ = td.UniformCurrentSource(size=(1, 1, 1), source_time=g, polarization="Ez", interpolate=True)
 
 
 def test_source_times():
@@ -57,6 +55,7 @@ def test_source_times():
     ts = np.linspace(0, 30, 1001)
     g.amp_time(ts)
     # g.plot(ts)
+    # plt.close()
 
     # test we can make cw pulse
     from tidy3d.components.source import ContinuousWave
@@ -69,12 +68,13 @@ def test_source_times():
 def test_dipole():
 
     g = td.GaussianPulse(freq0=1, fwidth=0.1)
-    p1 = td.PointDipole(center=(1, 2, 3), source_time=g, polarization="Ex", interpolate=True)
-    p2 = td.PointDipole(center=(1, 2, 3), source_time=g, polarization="Ex", interpolate=False)
+    _ = td.PointDipole(center=(1, 2, 3), source_time=g, polarization="Ex", interpolate=True)
+    _ = td.PointDipole(center=(1, 2, 3), source_time=g, polarization="Ex", interpolate=False)
     # p.plot(y=2)
+    # plt.close()
 
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        p = td.PointDipole(size=(1, 1, 1), source_time=g, center=(1, 2, 3), polarization="Ex")
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.PointDipole(size=(1, 1, 1), source_time=g, center=(1, 2, 3), polarization="Ex")
 
 
 def test_FieldSource():
@@ -82,15 +82,17 @@ def test_FieldSource():
     mode_spec = td.ModeSpec(num_modes=2)
 
     # test we can make planewave
-    s = td.PlaneWave(size=(0, td.inf, td.inf), source_time=g, pol_angle=np.pi / 2, direction="+")
+    _ = td.PlaneWave(size=(0, td.inf, td.inf), source_time=g, pol_angle=np.pi / 2, direction="+")
     # s.plot(y=0)
+    # plt.close()
 
     # test we can make gaussian beam
-    s = td.GaussianBeam(size=(0, 1, 1), source_time=g, pol_angle=np.pi / 2, direction="+")
+    _ = td.GaussianBeam(size=(0, 1, 1), source_time=g, pol_angle=np.pi / 2, direction="+")
     # s.plot(y=0)
+    # plt.close()
 
     # test we can make an astigmatic gaussian beam
-    s = td.AstigmaticGaussianBeam(
+    _ = td.AstigmaticGaussianBeam(
         size=(0, 1, 1),
         source_time=g,
         pol_angle=np.pi / 2,
@@ -100,18 +102,19 @@ def test_FieldSource():
     )
 
     # test we can make mode source
-    s = td.ModeSource(
+    _ = td.ModeSource(
         size=(0, 1, 1), direction="+", source_time=g, mode_spec=mode_spec, mode_index=0
     )
     # s.plot(y=0)
+    # plt.close()
 
     # test that non-planar geometry crashes plane wave and gaussian beams
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = td.PlaneWave(size=(1, 1, 1), source_time=g, pol_angle=np.pi / 2, direction="+")
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = td.GaussianBeam(size=(1, 1, 1), source_time=g, pol_angle=np.pi / 2, direction="+")
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = td.AstigmaticGaussianBeam(
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.PlaneWave(size=(1, 1, 1), source_time=g, pol_angle=np.pi / 2, direction="+")
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.GaussianBeam(size=(1, 1, 1), source_time=g, pol_angle=np.pi / 2, direction="+")
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.AstigmaticGaussianBeam(
             size=(1, 1, 1),
             source_time=g,
             pol_angle=np.pi / 2,
@@ -119,19 +122,18 @@ def test_FieldSource():
             waist_sizes=(0.2, 0.4),
             waist_distances=(0.1, 0.3),
         )
-    with pytest.raises(pydantic.ValidationError) as e_info:
-        s = td.ModeSource(size=(1, 1, 1), source_time=g, mode_spec=mode_spec)
-
-    from tidy3d.components.source import TFSF
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.ModeSource(size=(1, 1, 1), source_time=g, mode_spec=mode_spec)
 
     tfsf = td.TFSF(size=(1, 1, 1), direction="+", source_time=g, injection_axis=2)
     _ = tfsf.injection_plane_center
 
     # assert that TFSF must be volumetric
-    with pytest.raises(pydantic.ValidationError) as e_info:
+    with pytest.raises(pydantic.ValidationError):
         _ = td.TFSF(size=(1, 1, 0), direction="+", source_time=g, injection_axis=2)
 
     # s.plot(z=0)
+    # plt.close()
 
 
 def test_pol_arrow():
@@ -227,11 +229,11 @@ def test_broadband_source():
     check_freq_grid(freq_grid, num_freqs)
 
     # check validators for num_freqs
-    with pytest.raises(pydantic.ValidationError) as e_info:
+    with pytest.raises(pydantic.ValidationError):
         s = td.GaussianBeam(
             size=(0, 1, 1), source_time=g, pol_angle=np.pi / 2, direction="+", num_freqs=200
         )
-    with pytest.raises(pydantic.ValidationError) as e_info:
+    with pytest.raises(pydantic.ValidationError):
         s = td.AstigmaticGaussianBeam(
             size=(0, 1, 1),
             source_time=g,
@@ -241,7 +243,7 @@ def test_broadband_source():
             waist_distances=(0.1, 0.3),
             num_freqs=100,
         )
-    with pytest.raises(pydantic.ValidationError) as e_info:
+    with pytest.raises(pydantic.ValidationError):
         s = td.ModeSource(
             size=(0, 1, 1),
             direction="+",

--- a/tests/test_components/test_types.py
+++ b/tests/test_components/test_types.py
@@ -1,9 +1,8 @@
 """Tests type definitions."""
 import pytest
-import tidy3d as td
+import pydantic
 from tidy3d.components.types import ArrayLike, Complex, constrained_array, Tuple
 from tidy3d.components.base import Tidy3dBaseModel
-from tidy3d.exceptions import ValidationError
 import numpy as np
 
 
@@ -11,9 +10,9 @@ def _test_validate_array_like():
     class S(Tidy3dBaseModel):
         f: ArrayLike[float, 2]
 
-    s = S(f=np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+    _ = S(f=np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
     with pytest.raises(pydantic.ValidationError):
-        s = S(f=np.array([1.0, 2.0, 3.0]))
+        _ = S(f=np.array([1.0, 2.0, 3.0]))
 
     class MyClass(Tidy3dBaseModel):
         f: constrained_array(ndim=3, shape=(1, 2, 3))
@@ -32,7 +31,7 @@ def test_schemas():
         c: Complex
 
     # TODO: unexpected behavior, if list with more than one element, it fails.
-    s = S(f=[13], c=1 + 1j, ca=1 + 1j)
+    _ = S(f=[13], c=1 + 1j, ca=1 + 1j)
     S.schema()
 
 

--- a/tests/test_components/test_viz.py
+++ b/tests/test_components/test_viz.py
@@ -1,6 +1,6 @@
 """Tests visualization operations."""
 import pytest
-import matplotlib.pylab as plt
+import matplotlib.pyplot as plt
 import tidy3d as td
 from tidy3d.components.viz import Polygon
 
@@ -33,3 +33,5 @@ def test_0d_plot(center_z, len_collections):
 
     # if a point is plotted, a single collection will be present, otherwise nothing
     assert len(ax.collections) == len_collections
+
+    plt.close()

--- a/tests/test_data/test_data_arrays.py
+++ b/tests/test_data/test_data_arrays.py
@@ -1,5 +1,4 @@
 """Tests tidy3d/components/data/data_array.py"""
-import pytest
 import numpy as np
 from typing import Tuple, List
 
@@ -22,8 +21,6 @@ from tidy3d.components.geometry import Box
 from tidy3d.components.boundary import BoundarySpec, Periodic
 from tidy3d import material_library
 from tidy3d.constants import inf
-
-from ..utils import clear_tmp
 
 np.random.seed(4)
 
@@ -272,11 +269,11 @@ def test_ops():
 
 
 def test_empty_field_time():
-    data = ScalarFieldTimeDataArray(
+    _ = ScalarFieldTimeDataArray(
         np.random.rand(5, 5, 5, 0),
         coords=dict(x=np.arange(5), y=np.arange(5), z=np.arange(5), t=[]),
     )
-    data = ScalarFieldTimeDataArray(
+    _ = ScalarFieldTimeDataArray(
         np.random.rand(5, 5, 5, 0),
         coords=dict(x=np.arange(5), y=np.arange(5), z=np.arange(5), t=[]),
     )
@@ -284,15 +281,15 @@ def test_empty_field_time():
 
 def test_abs():
     data = make_mode_amps_data_array()
-    dabs = data.abs
+    _ = data.abs
 
 
 def test_heat_data_array():
     T = [0, 1e-12, 2e-12]
-    test = HeatDataArray((1 + 1j) * np.random.random((3,)), coords=dict(T=T))
+    _ = HeatDataArray((1 + 1j) * np.random.random((3,)), coords=dict(T=T))
 
 
-def test_heat_data_array():
+def test_charge_data_array():
     n = [0, 1e-12, 2e-12]
     p = [0, 3e-12, 4e-12]
-    test = ChargeDataArray((1 + 1j) * np.random.random((3, 3)), coords=dict(n=n, p=p))
+    _ = ChargeDataArray((1 + 1j) * np.random.random((3, 3)), coords=dict(n=n, p=p))

--- a/tests/test_package/test_log.py
+++ b/tests/test_package/test_log.py
@@ -7,7 +7,6 @@ import numpy as np
 import tidy3d as td
 from tidy3d.exceptions import Tidy3dError
 from tidy3d.log import DEFAULT_LEVEL, _get_level_int, set_logging_level
-from ..utils import log_capture, assert_log_level
 
 
 def test_log():
@@ -19,12 +18,13 @@ def test_log():
     td.log.log(0, "zero test")
 
 
-def test_log_config():
+def test_log_config(tmp_path):
     td.config.logging_level = "DEBUG"
-    td.set_logging_file("tests/tmp/test.log")
+    td.set_logging_file(str(tmp_path / "test.log"))
     assert len(td.log.handlers) == 2
     assert td.log.handlers["console"].level == _get_level_int("DEBUG")
     assert td.log.handlers["file"].level == _get_level_int(DEFAULT_LEVEL)
+    del td.log.handlers["file"]
 
 
 def test_log_level_not_found():

--- a/tests/test_package/test_main.py
+++ b/tests/test_package/test_main.py
@@ -4,8 +4,6 @@ import tidy3d as td
 import pytest
 from tidy3d.__main__ import main
 
-DEFAULT_PATH = "tests/tmp/sim.json"
-
 
 def save_sim_to_path(path: str) -> None:
     sim = td.Simulation(size=(1, 1, 1), grid_spec=td.GridSpec.auto(wavelength=1.0), run_time=1e-12)
@@ -13,7 +11,7 @@ def save_sim_to_path(path: str) -> None:
 
 
 @pytest.mark.parametrize("extension", (".json", ".yaml"))
-def test_main(extension):
-    path = f"tests/tmp/sim{extension}"
+def test_main(extension, tmp_path):
+    path = str((tmp_path / "sim").with_suffix(extension))
     save_sim_to_path(path)
     main([path, "--test_only"])

--- a/tests/test_package/test_make_script.py
+++ b/tests/test_package/test_make_script.py
@@ -1,13 +1,9 @@
 """Tests generation of pythons script from simulation file."""
-import os
-
 import tidy3d as td
 from make_script import main
-from ..utils import clear_tmp
 
 
-@clear_tmp
-def test_make_script():
+def test_make_script(tmp_path):
 
     # make a sim
     simulation = td.Simulation(
@@ -21,16 +17,16 @@ def test_make_script():
         run_time=1e-12,
     )
 
-    sim_path = "tests/tmp/sim.json"
-    out_path = "tests/tmp/sim.py"
+    sim_path = tmp_path / "sim.json"
+    out_path = tmp_path / "sim.py"
 
     # save it to file, assuring it does not exist already
-    simulation.to_file(sim_path)
-    assert not os.path.exists(out_path), f"out file {out_path} already exists."
+    simulation.to_file(str(sim_path))
+    assert not out_path.exists(), f"out file {out_path} already exists."
 
     # generate out script from the simulation file
-    main([sim_path, out_path])
+    main([str(sim_path), str(out_path)])
 
     # make sure that file was created and is not empty
-    assert os.path.exists(out_path), f"out file {out_path} wasn't created."
-    assert os.stat(out_path).st_size > 0, f"out file {out_path} is empty."
+    assert out_path.is_file(), f"out file {out_path} wasn't created."
+    assert len(out_path.read_text()) > 0, f"out file {out_path} is empty."

--- a/tests/test_package/test_material_library.py
+++ b/tests/test_package/test_material_library.py
@@ -10,13 +10,11 @@ from tidy3d.material_library.material_library import (
     export_matlib_to_file,
 )
 import tidy3d as td
-from tidy3d.exceptions import SetupError
-from ..utils import clear_tmp
 
 
 def test_VariantItem():
     """Test if the variant class is working as expected."""
-    variant = VariantItem(
+    _ = VariantItem(
         medium=td.PoleResidue(),
         reference=[ReferenceData(doi="etc.com", journal="paper", url="www")],
     )
@@ -59,6 +57,5 @@ def test_library():
             assert np.allclose(eps_complex1, eps_complex2)
 
 
-@clear_tmp
-def test_test_export():
-    export_matlib_to_file("tests/tmp/matlib.json")
+def test_test_export(tmp_path):
+    export_matlib_to_file(str(tmp_path / "matlib.json"))

--- a/tests/test_package/test_parametric_variants.py
+++ b/tests/test_package/test_parametric_variants.py
@@ -1,8 +1,6 @@
 import pytest
-import pydantic
 import numpy as np
 
-from tidy3d.material_library.material_library import material_library
 from tidy3d.material_library.parametric_materials import (
     GRAPHENE_FIT_FREQ_MIN,
     GRAPHENE_FIT_FREQ_MAX,
@@ -10,7 +8,6 @@ from tidy3d.material_library.parametric_materials import (
     GRAPHENE_FIT_ATOL,
 )
 from tidy3d.material_library.parametric_materials import Graphene
-import tidy3d as td
 
 from numpy.random import default_rng
 
@@ -28,8 +25,8 @@ GRAPHENE_GAMMA_MAX = 0.03
 def test_graphene_defaults():
     freqs = np.linspace(GRAPHENE_FIT_FREQ_MIN, GRAPHENE_FIT_FREQ_MAX, GRAPHENE_FIT_NUM_FREQS)
     graphene = Graphene()
-    sigma1 = graphene.medium.sigma_model(freqs)
-    sigma2 = graphene.numerical_conductivity(freqs)
+    _ = graphene.medium.sigma_model(freqs)
+    _ = graphene.numerical_conductivity(freqs)
 
 
 @pytest.mark.parametrize("rng_seed", np.arange(0, 15))

--- a/tests/test_plugins/test_dispersion_fitter.py
+++ b/tests/test_plugins/test_dispersion_fitter.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 import responses
 
-import matplotlib.pylab as plt
+import matplotlib.pyplot as plt
 
 import tidy3d as td
 from tidy3d.plugins.dispersion import DispersionFitter, FastDispersionFitter
@@ -103,13 +103,17 @@ def test_dispersion_plot(random_data):
 
     fitter = DispersionFitter(wvl_um=wvl_um, n_data=n_data)
     fitter.plot(ax=AX)
+    plt.close()
     medium, rms = fitter.fit(num_tries=2)
     fitter.plot(medium, ax=AX)
+    plt.close()
 
     fitter = DispersionFitter(wvl_um=wvl_um, n_data=n_data, k_data=k_data)
     fitter.plot()
+    plt.close()
     medium, rms = fitter.fit(num_tries=2)
     fitter.plot(medium, ax=AX)
+    plt.close()
 
 
 def test_dispersion_set_wvg_range(random_data):

--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -217,7 +217,7 @@ def test_mode_solver_simple(mock_remote_api, local):
 
 @pytest.mark.parametrize("local", [True, False])
 @responses.activate
-def test_mode_solver_custom_medium(mock_remote_api, local):
+def test_mode_solver_custom_medium(mock_remote_api, local, tmp_path):
     """Test mode solver can work with custom medium. Consider a waveguide with varying
     permittivity along x-direction. The value of n_eff at different x position should be
     different.
@@ -260,7 +260,7 @@ def test_mode_solver_custom_medium(mock_remote_api, local):
         modes = ms.solve() if local else msweb.run(ms)
         n_eff.append(modes.n_eff.values)
 
-        fname = "tests/tmp/ms_custom_medium.hdf5"
+        fname = str(tmp_path / "ms_custom_medium.hdf5")
         ms.to_file(fname)
         m2 = ModeSolver.from_file(fname)
         assert m2 == ms

--- a/tests/test_plugins/test_polyslab.py
+++ b/tests/test_plugins/test_polyslab.py
@@ -1,12 +1,10 @@
-import pytest
 import numpy as np
-import matplotlib.pyplot as plt
 import gdstk
 
 import tidy3d as td
 
 from tidy3d.plugins.polyslab import ComplexPolySlab
-from ..utils import clear_tmp, assert_log_level, log_capture
+from ..utils import assert_log_level, log_capture
 
 
 def test_divide_simple_events():
@@ -28,13 +26,8 @@ def test_divide_simple_events():
                     sidewall_angle=angle,
                     reference_plane=reference_plane,
                 )
-                subpolyslabs = s.sub_polyslabs
-                geometry_group = s.geometry_group
-
-                # for i, poly in enumerate(subpolyslabs):
-                #     print(f"------------{i}-th polyglab----------")
-                #     print(f"bounds = ({poly.slab_bounds[0]},  {poly.slab_bounds[1]})")
-                #     print(np.array(poly.vertices))
+                _ = s.sub_polyslabs
+                _ = s.geometry_group
 
 
 def test_many_sub_polyslabs(log_capture):
@@ -54,7 +47,7 @@ def test_many_sub_polyslabs(log_capture):
         sidewall_angle=np.pi / 4,
         reference_plane="bottom",
     )
-    struct = td.Structure(
+    _ = td.Structure(
         geometry=s.geometry_group,
         medium=td.Medium(permittivity=2),
     )
@@ -77,13 +70,13 @@ def test_divide_simulation():
         geometry=s.geometry_group,
         medium=td.Medium(permittivity=2),
     )
-    sim = td.Simulation(
+    _ = td.Simulation(
         run_time=1e-12,
         size=(1, 1, 1),
         grid_spec=td.GridSpec.auto(wavelength=1.0),
         structures=(struct,),
     )
-    sim2 = td.Simulation(
+    _ = td.Simulation(
         run_time=1e-12,
         size=(1, 1, 1),
         grid_spec=td.GridSpec.auto(wavelength=1.0),
@@ -91,8 +84,7 @@ def test_divide_simulation():
     )
 
 
-@clear_tmp
-def test_gds_import():
+def test_gds_import(tmp_path):
     """construct complex polyslabs from gds (mostly from GDSII notebook)"""
 
     # Waveguide width
@@ -101,7 +93,7 @@ def test_gds_import():
     wg_spacing_in = 8
     # Length of the coupling region
     coup_length = 10
-    # Angle of the sidewall deviating from the vertical ones, positive values for the base larger than the top
+    # Angle of the sidewall: positive values for the base larger than the top
     sidewall_angle = np.pi / 4
     # Reference plane where the cross section of the device is defined
     reference_plane = "bottom"
@@ -167,7 +159,7 @@ def test_gds_import():
 
     # Create a library for the cell and save it, just so that we can demosntrate loading
     # geometry from a gds file
-    gds_path = "tests/tmp/coupler.gds"
+    gds_path = tmp_path / "coupler.gds"
 
     lib = gdstk.Library()
     lib.add(coup_cell)
@@ -188,7 +180,7 @@ def test_gds_import():
         slab_bounds=(-430, 0),
         reference_plane=reference_plane,
     )
-    arm_geo = ComplexPolySlab.from_gds(
+    _ = ComplexPolySlab.from_gds(
         coup_cell_loaded,
         gds_layer=1,
         axis=2,

--- a/tests/test_plugins/test_resonance_finder.py
+++ b/tests/test_plugins/test_resonance_finder.py
@@ -1,8 +1,5 @@
 import pytest
 import numpy as np
-import pydantic
-
-import tidy3d as td
 
 from numpy.random import default_rng
 

--- a/tests/test_web/test_material_fitter.py
+++ b/tests/test_web/test_material_fitter.py
@@ -1,5 +1,4 @@
 import pytest
-import re
 
 import responses
 from tidy3d.plugins.dispersion import DispersionFitter

--- a/tests/test_web/test_tidy3d_task.py
+++ b/tests/test_web/test_tidy3d_task.py
@@ -5,7 +5,6 @@ import tempfile
 import responses
 from responses import matchers
 
-from tidy3d.web import monitor
 from tidy3d.web.environment import Env, EnvironmentConfig
 from tidy3d.web.simulation_task import Folder, SimulationTask
 from tidy3d.version import __version__
@@ -82,7 +81,7 @@ def test_query_task(set_api_key):
 
 
 @responses.activate
-def test_get_simulation_json(monkeypatch, set_api_key):
+def test_get_simulation_json(monkeypatch, set_api_key, tmp_path):
     def mock_download(*args, **kwargs):
         file_path = kwargs["to_file"]
         with open(file_path, "w") as f:
@@ -102,10 +101,9 @@ def test_get_simulation_json(monkeypatch, set_api_key):
         status=200,
     )
     task = SimulationTask.get("3eb06d16-208b-487b-864b-e9b1d3e010a7")
-    JSON_NAME = "tests/tmp/task.json"
-    with open(JSON_NAME, "w") as f:
-        task.get_simulation_json(JSON_NAME)
-        assert os.path.getsize(JSON_NAME) > 0
+    JSON_NAME = str(tmp_path / "task.json")
+    task.get_simulation_json(JSON_NAME)
+    assert os.path.getsize(JSON_NAME) > 0
 
 
 @responses.activate
@@ -277,7 +275,7 @@ def test_estimate_cost(set_api_key):
 
 
 @responses.activate
-def test_get_log(monkeypatch, set_api_key):
+def test_get_log(monkeypatch, set_api_key, tmp_path):
     def mock(*args, **kwargs):
         file_path = kwargs["to_file"]
         with open(file_path, "w") as f:
@@ -296,10 +294,9 @@ def test_get_log(monkeypatch, set_api_key):
         status=200,
     )
     task = SimulationTask.get("3eb06d16-208b-487b-864b-e9b1d3e010a7")
-    LOG_FNAME = "tests/tmp/test.log"
-    with open(LOG_FNAME, "w") as f:
-        task.get_log(LOG_FNAME)
-        assert os.path.getsize(LOG_FNAME) > 0
+    LOG_FNAME = str(tmp_path / "test.log")
+    task.get_log(LOG_FNAME)
+    assert os.path.getsize(LOG_FNAME) > 0
 
 
 @responses.activate

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from typing import Dict, Tuple
 import pydantic as pd
@@ -6,7 +5,6 @@ import trimesh
 
 import pytest
 import numpy as np
-from tidy3d import *
 import tidy3d as td
 from tidy3d.log import _get_level_int
 from tidy3d.web import BatchData
@@ -16,69 +14,40 @@ from tidy3d.components.base import Tidy3dBaseModel
 np.random.seed(4)
 
 
-def clear_dir(path: str):
-    """clears a dir"""
-    for f in os.listdir(path):
-        full_path = os.path.join(path, f)
-        if not os.path.isdir(full_path):
-            os.remove(full_path)
-
-
-TMP_DIR = "tests/tmp/"
-SIM_DATA_PATH = TMP_DIR + "simulation_data.hdf5"
-
-
-# decorator that clears the tmp/ directory before test
-def clear_tmp(fn):
-    if not os.path.exists(TMP_DIR):
-        os.mkdir(TMP_DIR)
-
-    def new_fn(*args, **kwargs):
-        clear_dir(TMP_DIR)
-        return fn(*args, **kwargs)
-
-    return new_fn
-
-
-def prepend_tmp(path):
-    """prepents "TMP_DIR" to the path"""
-    return os.path.join(TMP_DIR, path)
-
-
-SIM_MONITORS = Simulation(
+SIM_MONITORS = td.Simulation(
     size=(10.0, 10.0, 10.0),
-    grid_spec=GridSpec(wavelength=1.0),
+    grid_spec=td.GridSpec(wavelength=1.0),
     run_time=1e-13,
     monitors=[
-        FieldMonitor(size=(1, 1, 1), center=(0, 1, 0), freqs=[1, 2, 5, 7, 8], name="field_freq"),
-        FieldTimeMonitor(size=(1, 1, 0), center=(1, 0, 0), interval=10, name="field_time"),
-        FluxMonitor(size=(1, 1, 0), center=(0, 0, 0), freqs=[1, 2, 5, 9], name="flux_freq"),
-        FluxTimeMonitor(size=(1, 1, 0), center=(0, 0, 0), start=1e-12, name="flux_time"),
-        ModeMonitor(
+        td.FieldMonitor(size=(1, 1, 1), center=(0, 1, 0), freqs=[1, 2, 5, 7, 8], name="field_freq"),
+        td.FieldTimeMonitor(size=(1, 1, 0), center=(1, 0, 0), interval=10, name="field_time"),
+        td.FluxMonitor(size=(1, 1, 0), center=(0, 0, 0), freqs=[1, 2, 5, 9], name="flux_freq"),
+        td.FluxTimeMonitor(size=(1, 1, 0), center=(0, 0, 0), start=1e-12, name="flux_time"),
+        td.ModeMonitor(
             size=(1, 1, 0),
             center=(0, 0, 0),
             freqs=[1.90, 2.01, 2.2],
-            mode_spec=ModeSpec(num_modes=3),
+            mode_spec=td.ModeSpec(num_modes=3),
             name="mode",
         ),
     ],
-    boundary_spec=BoundarySpec.all_sides(boundary=Periodic()),
+    boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
 )
 
 # STL geometry
 VERTICES = np.array([[-1.5, -0.5, -0.5], [-0.5, -0.5, -0.5], [-1.5, 0.5, -0.5], [-1.5, -0.5, 0.5]])
 FACES = np.array([[1, 2, 3], [0, 3, 2], [0, 1, 3], [0, 2, 1]])
-STL_GEO = TriangleMesh.from_trimesh(trimesh.Trimesh(VERTICES, FACES))
+STL_GEO = td.TriangleMesh.from_trimesh(trimesh.Trimesh(VERTICES, FACES))
 
 # custom medium
 COORDS = dict(x=[-1.5, -0.5], y=[0, 1], z=[0, 1])
-custom_medium = CustomMedium(
+custom_medium = td.CustomMedium(
     permittivity=td.SpatialDataArray(
         1 + np.random.random((2, 2, 2)),
         coords=COORDS,
     ),
 )
-custom_poleresidue = CustomPoleResidue(
+custom_poleresidue = td.CustomPoleResidue(
     eps_inf=td.SpatialDataArray(1 + np.random.random((2, 2, 2)), coords=COORDS),
     poles=(
         (
@@ -87,7 +56,7 @@ custom_poleresidue = CustomPoleResidue(
         ),
     ),
 )
-custom_debye = CustomDebye(
+custom_debye = td.CustomDebye(
     eps_inf=td.SpatialDataArray(1 + np.random.random((2, 2, 2)), coords=COORDS),
     coeffs=(
         (
@@ -97,7 +66,7 @@ custom_debye = CustomDebye(
     ),
 )
 
-custom_drude = CustomDrude(
+custom_drude = td.CustomDrude(
     eps_inf=td.SpatialDataArray(1 + np.random.random((2, 2, 2)), coords=COORDS),
     coeffs=(
         (
@@ -107,7 +76,7 @@ custom_drude = CustomDrude(
     ),
 )
 
-custom_lorentz = CustomLorentz(
+custom_lorentz = td.CustomLorentz(
     eps_inf=td.SpatialDataArray(1 + np.random.random((2, 2, 2)), coords=COORDS),
     coeffs=(
         (
@@ -118,7 +87,7 @@ custom_lorentz = CustomLorentz(
     ),
 )
 
-custom_sellmeier = CustomSellmeier(
+custom_sellmeier = td.CustomSellmeier(
     coeffs=(
         (
             td.SpatialDataArray(0.1 + np.random.random((2, 2, 2)), coords=COORDS),
@@ -127,110 +96,114 @@ custom_sellmeier = CustomSellmeier(
     ),
 )
 
-SIM_FULL = Simulation(
+SIM_FULL = td.Simulation(
     size=(8.0, 8.0, 8.0),
     run_time=1e-12,
     structures=[
-        Structure(
-            geometry=Box(size=(1, 1, 1), center=(-1, 0, 0)),
-            medium=Medium(permittivity=2.0),
+        td.Structure(
+            geometry=td.Box(size=(1, 1, 1), center=(-1, 0, 0)),
+            medium=td.Medium(permittivity=2.0),
         ),
-        Structure(
-            geometry=Box(size=(1, inf, 1), center=(-1, 0, 0)),
-            medium=Medium(permittivity=1.0, conductivity=3.0),
+        td.Structure(
+            geometry=td.Box(size=(1, td.inf, 1), center=(-1, 0, 0)),
+            medium=td.Medium(permittivity=1.0, conductivity=3.0),
         ),
-        Structure(
-            geometry=Sphere(radius=1.0, center=(1.0, 0.0, 1.0)),
-            medium=Sellmeier(coeffs=[(1.03961212, 0.00600069867), (0.231792344, 0.0200179144)]),
+        td.Structure(
+            geometry=td.Sphere(radius=1.0, center=(1.0, 0.0, 1.0)),
+            medium=td.Sellmeier(coeffs=[(1.03961212, 0.00600069867), (0.231792344, 0.0200179144)]),
         ),
-        Structure(
-            geometry=Box(size=(1, 1, 1), center=(-1, 0, 0)),
-            medium=Lorentz(eps_inf=2.0, coeffs=[(1, 2, 3)]),
+        td.Structure(
+            geometry=td.Box(size=(1, 1, 1), center=(-1, 0, 0)),
+            medium=td.Lorentz(eps_inf=2.0, coeffs=[(1, 2, 3)]),
         ),
-        Structure(
-            geometry=Box(size=(1, 1, 1), center=(-1, 0, 0)),
-            medium=Debye(eps_inf=2.0, coeffs=[(1, 3)]),
+        td.Structure(
+            geometry=td.Box(size=(1, 1, 1), center=(-1, 0, 0)),
+            medium=td.Debye(eps_inf=2.0, coeffs=[(1, 3)]),
         ),
-        Structure(
+        td.Structure(
             geometry=STL_GEO,
-            medium=Debye(eps_inf=2.0, coeffs=[(1, 3)]),
+            medium=td.Debye(eps_inf=2.0, coeffs=[(1, 3)]),
         ),
-        Structure(
-            geometry=Box(size=(1, 1, 1), center=(-1, 0, 0)),
-            medium=Drude(eps_inf=2.0, coeffs=[(1, 3)]),
+        td.Structure(
+            geometry=td.Box(size=(1, 1, 1), center=(-1, 0, 0)),
+            medium=td.Drude(eps_inf=2.0, coeffs=[(1, 3)]),
         ),
-        Structure(
-            geometry=Box(size=(1, 0, 1), center=(-1, 0, 0)),
-            medium=Medium2D.from_medium(Medium(conductivity=0.45), thickness=0.01),
+        td.Structure(
+            geometry=td.Box(size=(1, 0, 1), center=(-1, 0, 0)),
+            medium=td.Medium2D.from_medium(td.Medium(conductivity=0.45), thickness=0.01),
         ),
-        Structure(
-            geometry=GeometryGroup(geometries=[Box(size=(1, 1, 1), center=(-1, 0, 0))]),
-            medium=PEC,
+        td.Structure(
+            geometry=td.GeometryGroup(geometries=[td.Box(size=(1, 1, 1), center=(-1, 0, 0))]),
+            medium=td.PEC,
         ),
-        Structure(
-            geometry=Cylinder(radius=1.0, length=2.0, center=(1.0, 0.0, -1.0), axis=1),
-            medium=AnisotropicMedium(
+        td.Structure(
+            geometry=td.Cylinder(radius=1.0, length=2.0, center=(1.0, 0.0, -1.0), axis=1),
+            medium=td.AnisotropicMedium(
                 xx=td.Medium(permittivity=1),
                 yy=td.Medium(permittivity=2),
                 zz=td.Medium(permittivity=3),
             ),
         ),
-        Structure(
-            geometry=PolySlab(
+        td.Structure(
+            geometry=td.PolySlab(
                 vertices=[(-1.5, -1.5), (-0.5, -1.5), (-0.5, -0.5)], slab_bounds=[-1, 1]
             ),
-            medium=PoleResidue(eps_inf=1.0, poles=((6206417594288582j, (-3.311074436985222e16j)),)),
+            medium=td.PoleResidue(
+                eps_inf=1.0, poles=((6206417594288582j, (-3.311074436985222e16j)),)
+            ),
         ),
-        Structure(
-            geometry=Box(
+        td.Structure(
+            geometry=td.Box(
                 size=(1, 1, 1),
                 center=(-1.0, 0.5, 0.5),
             ),
             medium=custom_medium,
         ),
-        Structure(
-            geometry=Box(
+        td.Structure(
+            geometry=td.Box(
                 size=(1, 1, 1),
                 center=(-1.0, 0.5, 0.5),
             ),
             medium=custom_drude,
         ),
-        Structure(
-            geometry=Box(
+        td.Structure(
+            geometry=td.Box(
                 size=(1, 1, 1),
                 center=(-1.0, 0.5, 0.5),
             ),
             medium=custom_lorentz,
         ),
-        Structure(
-            geometry=Box(
+        td.Structure(
+            geometry=td.Box(
                 size=(1, 1, 1),
                 center=(-1.0, 0.5, 0.5),
             ),
             medium=custom_debye,
         ),
-        Structure(
-            geometry=Box(
+        td.Structure(
+            geometry=td.Box(
                 size=(1, 1, 1),
                 center=(-1.0, 0.5, 0.5),
             ),
             medium=custom_poleresidue,
         ),
-        Structure(
-            geometry=Box(
+        td.Structure(
+            geometry=td.Box(
                 size=(1, 1, 1),
                 center=(-1.0, 0.5, 0.5),
             ),
             medium=custom_sellmeier,
         ),
-        Structure(
-            geometry=PolySlab(
+        td.Structure(
+            geometry=td.PolySlab(
                 vertices=[(-1.5, -1.5), (-0.5, -1.5), (-0.5, -0.5)], slab_bounds=[-1, 1]
             ),
-            medium=PoleResidue(eps_inf=1.0, poles=((6206417594288582j, (-3.311074436985222e16j)),)),
+            medium=td.PoleResidue(
+                eps_inf=1.0, poles=((6206417594288582j, (-3.311074436985222e16j)),)
+            ),
         ),
-        Structure(
-            geometry=TriangleMesh.from_triangles(
+        td.Structure(
+            geometry=td.TriangleMesh.from_triangles(
                 np.array(
                     [
                         [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
@@ -250,53 +223,53 @@ SIM_FULL = Simulation(
             ),
             medium=td.Medium(permittivity=5),
         ),
-        Structure(
-            geometry=TriangleMesh.from_stl(
+        td.Structure(
+            geometry=td.TriangleMesh.from_stl(
                 "tests/data/two_boxes_separate.stl", scale=0.1, origin=(0.5, 0.5, 0.5)
             ),
             medium=td.Medium(permittivity=5),
         ),
     ],
     sources=[
-        UniformCurrentSource(
+        td.UniformCurrentSource(
             size=(0, 0, 0),
             center=(0, 0.5, 0),
             polarization="Hx",
-            source_time=GaussianPulse(
+            source_time=td.GaussianPulse(
                 freq0=2e14,
                 fwidth=4e13,
             ),
         ),
-        PointDipole(
+        td.PointDipole(
             center=(0, 0.5, 0),
             polarization="Ex",
-            source_time=GaussianPulse(
+            source_time=td.GaussianPulse(
                 freq0=2e14,
                 fwidth=4e13,
             ),
         ),
-        ModeSource(
+        td.ModeSource(
             center=(0, 0.5, 0),
             size=(2, 0, 2),
             mode_spec=td.ModeSpec(),
-            source_time=GaussianPulse(
+            source_time=td.GaussianPulse(
                 freq0=2e14,
                 fwidth=4e13,
             ),
             direction="-",
         ),
-        PlaneWave(
-            size=(0, inf, inf),
-            source_time=GaussianPulse(
+        td.PlaneWave(
+            size=(0, td.inf, td.inf),
+            source_time=td.GaussianPulse(
                 freq0=2e14,
                 fwidth=4e13,
             ),
             pol_angle=0.1,
             direction="+",
         ),
-        GaussianBeam(
+        td.GaussianBeam(
             size=(0, 3, 3),
-            source_time=GaussianPulse(
+            source_time=td.GaussianPulse(
                 freq0=2e14,
                 fwidth=4e13,
             ),
@@ -304,9 +277,9 @@ SIM_FULL = Simulation(
             direction="+",
             waist_radius=1.0,
         ),
-        AstigmaticGaussianBeam(
+        td.AstigmaticGaussianBeam(
             size=(0, 3, 3),
-            source_time=GaussianPulse(
+            source_time=td.GaussianPulse(
                 freq0=2e14,
                 fwidth=4e13,
             ),
@@ -315,15 +288,15 @@ SIM_FULL = Simulation(
             waist_sizes=(1.0, 2.0),
             waist_distances=(3.0, 4.0),
         ),
-        CustomFieldSource(
+        td.CustomFieldSource(
             center=(0, 1, 2),
             size=(2, 2, 0),
-            source_time=GaussianPulse(
+            source_time=td.GaussianPulse(
                 freq0=2e14,
                 fwidth=4e13,
             ),
-            field_dataset=FieldDataset(
-                Ex=ScalarFieldDataArray(
+            field_dataset=td.FieldDataset(
+                Ex=td.ScalarFieldDataArray(
                     np.ones((101, 101, 1, 1)),
                     coords=dict(
                         x=np.linspace(-1, 1, 101),
@@ -334,15 +307,15 @@ SIM_FULL = Simulation(
                 )
             ),
         ),
-        CustomCurrentSource(
+        td.CustomCurrentSource(
             center=(0, 1, 2),
             size=(2, 2, 0),
-            source_time=GaussianPulse(
+            source_time=td.GaussianPulse(
                 freq0=2e14,
                 fwidth=4e13,
             ),
-            current_dataset=FieldDataset(
-                Ex=ScalarFieldDataArray(
+            current_dataset=td.FieldDataset(
+                Ex=td.ScalarFieldDataArray(
                     np.ones((101, 101, 1, 1)),
                     coords=dict(
                         x=np.linspace(-1, 1, 101),
@@ -353,10 +326,10 @@ SIM_FULL = Simulation(
                 )
             ),
         ),
-        TFSF(
+        td.TFSF(
             center=(1, 2, -3),
             size=(2.5, 2.5, 0.5),
-            source_time=GaussianPulse(
+            source_time=td.GaussianPulse(
                 freq0=2e14,
                 fwidth=4e13,
             ),
@@ -365,38 +338,38 @@ SIM_FULL = Simulation(
             angle_phi=np.pi / 5,
             injection_axis=2,
         ),
-        UniformCurrentSource(
+        td.UniformCurrentSource(
             size=(0, 0, 0),
             center=(0, 0.5, 0),
             polarization="Hx",
-            source_time=CustomSourceTime.from_values(
+            source_time=td.CustomSourceTime.from_values(
                 freq0=2e14, fwidth=4e13, values=np.linspace(0, 10, 1000), dt=1e-12 / 100
             ),
         ),
     ],
     monitors=(
-        FieldMonitor(
+        td.FieldMonitor(
             size=(0, 0, 0), center=(0, 0, 0), fields=["Ex"], freqs=[1.5e14, 2e14], name="field"
         ),
-        FieldTimeMonitor(size=(0, 0, 0), center=(0, 0, 0), name="field_time", interval=100),
-        FluxMonitor(size=(1, 1, 0), center=(0, 0, 0), freqs=[2e14, 2.5e14], name="flux"),
-        FluxTimeMonitor(size=(1, 1, 0), center=(0, 0, 0), name="flux_time"),
-        PermittivityMonitor(size=(1, 1, 0.1), name="eps", freqs=[1e14]),
-        ModeMonitor(
+        td.FieldTimeMonitor(size=(0, 0, 0), center=(0, 0, 0), name="field_time", interval=100),
+        td.FluxMonitor(size=(1, 1, 0), center=(0, 0, 0), freqs=[2e14, 2.5e14], name="flux"),
+        td.FluxTimeMonitor(size=(1, 1, 0), center=(0, 0, 0), name="flux_time"),
+        td.PermittivityMonitor(size=(1, 1, 0.1), name="eps", freqs=[1e14]),
+        td.ModeMonitor(
             size=(1, 1, 0),
             center=(0, 0, 0),
             name="mode",
             freqs=[2e14, 2.5e14],
-            mode_spec=ModeSpec(),
+            mode_spec=td.ModeSpec(),
         ),
-        ModeSolverMonitor(
+        td.ModeSolverMonitor(
             size=(1, 1, 0),
             center=(0, 0, 0),
             name="mode_solver",
             freqs=[2e14, 2.5e14],
-            mode_spec=ModeSpec(),
+            mode_spec=td.ModeSpec(),
         ),
-        FieldProjectionAngleMonitor(
+        td.FieldProjectionAngleMonitor(
             center=(0, 0, 0),
             size=(0, 2, 2),
             freqs=[250e12, 300e12],
@@ -405,7 +378,7 @@ SIM_FULL = Simulation(
             phi=[0, np.pi / 2],
             theta=np.linspace(-np.pi / 2, np.pi / 2, 100),
         ),
-        FieldProjectionCartesianMonitor(
+        td.FieldProjectionCartesianMonitor(
             center=(0, 0, 0),
             size=(0, 2, 2),
             freqs=[250e12, 300e12],
@@ -416,7 +389,7 @@ SIM_FULL = Simulation(
             proj_axis=2,
             proj_distance=5,
         ),
-        FieldProjectionKSpaceMonitor(
+        td.FieldProjectionKSpaceMonitor(
             center=(0, 0, 0),
             size=(0, 2, 2),
             freqs=[250e12, 300e12],
@@ -426,7 +399,7 @@ SIM_FULL = Simulation(
             ux=[0.1, 0.2],
             uy=[0.3, 0.4, 0.5],
         ),
-        FieldProjectionAngleMonitor(
+        td.FieldProjectionAngleMonitor(
             center=(0, 0, 0),
             size=(0, 2, 2),
             freqs=[250e12, 300e12],
@@ -436,42 +409,43 @@ SIM_FULL = Simulation(
             theta=np.linspace(-np.pi / 2, np.pi / 2, 100),
             far_field_approx=False,
         ),
-        DiffractionMonitor(
-            size=(0, inf, inf),
+        td.DiffractionMonitor(
+            size=(0, td.inf, td.inf),
             center=(0, 0, 0),
             name="diffraction",
             freqs=[1e14, 2e14],
         ),
     ),
     symmetry=(0, 0, 0),
-    boundary_spec=BoundarySpec(
-        x=Boundary(plus=PML(num_layers=20), minus=Absorber(num_layers=100)),
-        y=Boundary.bloch(bloch_vec=1),
-        z=Boundary.periodic(),
+    boundary_spec=td.BoundarySpec(
+        x=td.Boundary(plus=td.PML(num_layers=20), minus=td.Absorber(num_layers=100)),
+        y=td.Boundary.bloch(bloch_vec=1),
+        z=td.Boundary.periodic(),
     ),
     shutoff=1e-4,
     courant=0.8,
     subpixel=False,
-    grid_spec=GridSpec(
-        grid_x=AutoGrid(),
-        grid_y=CustomGrid(dl=100 * [0.04]),
-        grid_z=UniformGrid(dl=0.05),
+    grid_spec=td.GridSpec(
+        grid_x=td.AutoGrid(),
+        grid_y=td.CustomGrid(dl=100 * [0.04]),
+        grid_z=td.UniformGrid(dl=0.05),
         override_structures=[
             td.Structure(
-                geometry=Box(size=(1, 1, 1), center=(-1, 0, 0)),
-                medium=Medium(permittivity=2.0),
+                geometry=td.Box(size=(1, 1, 1), center=(-1, 0, 0)),
+                medium=td.Medium(permittivity=2.0),
             )
         ],
     ),
 )
 
 
-def run_emulated(simulation: Simulation, path: str = SIM_DATA_PATH, **kwargs) -> SimulationData:
+def run_emulated(simulation: td.Simulation, path=None, **kwargs) -> td.SimulationData:
     """Emulates a simulation run."""
-
     from scipy.ndimage.filters import gaussian_filter
 
-    def make_data(coords: dict, data_array_type: type, is_complex: bool = False) -> "data_type":
+    def make_data(
+        coords: dict, data_array_type: type, is_complex: bool = False
+    ) -> td.components.data.data_array.DataArray:
         """make a random DataArray out of supplied coordinates and data_type."""
         data_shape = [len(coords[k]) for k in data_array_type._dims]
         np.random.seed(1)
@@ -483,7 +457,7 @@ def run_emulated(simulation: Simulation, path: str = SIM_DATA_PATH, **kwargs) ->
         data_array = data_array_type(data, coords=coords)
         return data_array
 
-    def make_field_data(monitor: FieldMonitor) -> FieldData:
+    def make_field_data(monitor: td.FieldMonitor) -> td.FieldData:
         """make a random FieldData from a FieldMonitor."""
         field_cmps = {}
         coords = {}
@@ -500,10 +474,10 @@ def run_emulated(simulation: Simulation, path: str = SIM_DATA_PATH, **kwargs) ->
 
             coords["f"] = list(monitor.freqs)
             field_cmps[field_name] = make_data(
-                coords=coords, data_array_type=ScalarFieldDataArray, is_complex=True
+                coords=coords, data_array_type=td.ScalarFieldDataArray, is_complex=True
             )
 
-        return FieldData(
+        return td.FieldData(
             monitor=monitor,
             symmetry=simulation.symmetry,
             symmetry_center=simulation.center,
@@ -511,50 +485,52 @@ def run_emulated(simulation: Simulation, path: str = SIM_DATA_PATH, **kwargs) ->
             **field_cmps,
         )
 
-    def make_eps_data(monitor: PermittivityMonitor) -> PermittivityData:
+    def make_eps_data(monitor: td.PermittivityMonitor) -> td.PermittivityData:
         """make a random PermittivityData from a PermittivityMonitor."""
-        field_mnt = FieldMonitor(**monitor.dict(exclude={"type", "fields"}))
+        field_mnt = td.FieldMonitor(**monitor.dict(exclude={"type", "fields"}))
         field_data = make_field_data(monitor=field_mnt)
-        return PermittivityData(
+        return td.PermittivityData(
             monitor=monitor, eps_xx=field_data.Ex, eps_yy=field_data.Ey, eps_zz=field_data.Ez
         )
 
-    def make_diff_data(monitor: DiffractionMonitor) -> DiffractionData:
+    def make_diff_data(monitor: td.DiffractionMonitor) -> td.DiffractionData:
         """make a random PermittivityData from a PermittivityMonitor."""
         f = list(monitor.freqs)
         orders_x = np.linspace(-1, 1, 3)
         orders_y = np.linspace(-2, 2, 5)
         coords = dict(orders_x=orders_x, orders_y=orders_y, f=f)
         values = np.random.random((len(orders_x), len(orders_y), len(f)))
-        data = DiffractionDataArray(values, coords=coords)
+        data = td.DiffractionDataArray(values, coords=coords)
         field_data = {field: data for field in ("Er", "Etheta", "Ephi", "Hr", "Htheta", "Hphi")}
-        return DiffractionData(monitor=monitor, sim_size=(1, 1), bloch_vecs=(0, 0), **field_data)
+        return td.DiffractionData(monitor=monitor, sim_size=(1, 1), bloch_vecs=(0, 0), **field_data)
 
-    def make_mode_data(monitor: ModeMonitor) -> ModeData:
+    def make_mode_data(monitor: td.ModeMonitor) -> td.ModeData:
         """make a random ModeData from a ModeMonitor."""
-        mode_indices = np.arange(monitor.mode_spec.num_modes)
+        _ = np.arange(monitor.mode_spec.num_modes)
         coords_ind = {
             "f": list(monitor.freqs),
             "mode_index": np.arange(monitor.mode_spec.num_modes),
         }
         n_complex = make_data(
-            coords=coords_ind, data_array_type=ModeIndexDataArray, is_complex=True
+            coords=coords_ind, data_array_type=td.ModeIndexDataArray, is_complex=True
         )
         coords_amps = dict(direction=["+", "-"])
         coords_amps.update(coords_ind)
-        amps = make_data(coords=coords_amps, data_array_type=ModeAmpsDataArray, is_complex=True)
-        return ModeData(monitor=monitor, n_complex=n_complex, amps=amps)
+        amps = make_data(coords=coords_amps, data_array_type=td.ModeAmpsDataArray, is_complex=True)
+        return td.ModeData(monitor=monitor, n_complex=n_complex, amps=amps)
 
     MONITOR_MAKER_MAP = {
-        FieldMonitor: make_field_data,
-        ModeMonitor: make_mode_data,
-        PermittivityMonitor: make_eps_data,
-        DiffractionMonitor: make_diff_data,
+        td.FieldMonitor: make_field_data,
+        td.ModeMonitor: make_mode_data,
+        td.PermittivityMonitor: make_eps_data,
+        td.DiffractionMonitor: make_diff_data,
     }
 
     data = [MONITOR_MAKER_MAP[type(mnt)](mnt) for mnt in simulation.monitors]
-    sim_data = SimulationData(simulation=simulation, data=data)
-    sim_data.to_file(path)
+    sim_data = td.SimulationData(simulation=simulation, data=data)
+
+    if path is not None:
+        sim_data.to_file(str(path))
 
     return sim_data
 
@@ -572,25 +548,25 @@ class BatchDataTest(Tidy3dBaseModel):
         ..., title="Task IDs", description="Mapping of task_name to task_id for each task in batch."
     )
 
-    sim_data: Dict[str, SimulationData]
+    sim_data: Dict[str, td.SimulationData]
 
-    def load_sim_data(self, task_name: str) -> SimulationData:
+    def load_sim_data(self, task_name: str) -> td.SimulationData:
         """Load a :class:`.SimulationData` from file by task name."""
-        task_data_path = self.task_paths[task_name]
-        task_id = self.task_ids[task_name]
+        _ = self.task_paths[task_name]
+        _ = self.task_ids[task_name]
         return self.sim_data[task_name]
 
-    def items(self) -> Tuple[str, SimulationData]:
+    def items(self) -> Tuple[str, td.SimulationData]:
         """Iterate through the :class:`.SimulationData` for each task_name."""
         for task_name in self.task_paths.keys():
             yield task_name, self.load_sim_data(task_name)
 
-    def __getitem__(self, task_name: str) -> SimulationData:
+    def __getitem__(self, task_name: str) -> td.SimulationData:
         """Get the :class:`.SimulationData` for a given ``task_name``."""
         return self.load_sim_data(task_name)
 
 
-def run_async_emulated(simulations: Dict[str, Simulation], **kwargs) -> BatchData:
+def run_async_emulated(simulations: Dict[str, td.Simulation], **kwargs) -> BatchData:
     """Emulate an async run function."""
     task_ids = {task_name: f"task_id={i}" for i, task_name in enumerate(simulations.keys())}
     task_paths = {task_name: "NONE" for task_name in simulations.keys()}

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -8,7 +8,7 @@ from math import isclose
 import pydantic
 import numpy as np
 import xarray as xr
-import matplotlib.pylab as plt
+import matplotlib.pyplot as plt
 import matplotlib as mpl
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 

--- a/tidy3d/components/viz.py
+++ b/tidy3d/components/viz.py
@@ -7,7 +7,7 @@ from functools import wraps
 import random
 import time
 
-import matplotlib.pylab as plt
+import matplotlib.pyplot as plt
 from matplotlib.patches import PathPatch, ArrowStyle
 from matplotlib.path import Path
 from numpy import array, concatenate, ones


### PR DESCRIPTION
Hard-codded paths can be an issue when tests are run in parallel or unordered, particularly in Windows. This commit removes all hard-codded paths from the test suite, replacing them with pytest's tmp_path fixture, which is also automatically cleaned after run.

A few ruff warnings were also cleaned up in the process: mostly unused imports and variables, and warnings caused by a large number of matplotlib figures being created.