### PR TITLE
install jax normally on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `nyquist_step` also taking the frequency range of frequency-domain monitors into account.
 - Added option to allow DC component in `GaussianPulse` spectrum, by setting `remove_dc_component=False` in `GaussianPulse`.
+- Jax installation from `pip install "tidy3d[jax]"` handled same way on windows as other OS if python >= 3.9.
 
 ### Fixed
 

--- a/requirements/jax.txt
+++ b/requirements/jax.txt
@@ -2,9 +2,15 @@
 
 -r core.txt
 
+# regular case (linux, macos)
 jaxlib>=0.3.14,<=0.4.14; platform_system != "Windows"
 jax[cpu]>=0.3.14,<=0.4.14; platform_system != "Windows"
 
+
 # we downgrade to 0.3 for windows users because the only binaries for windows are 0.3 currently.
-jaxlib==0.3.14; platform_system == "Windows"
-jax[cpu]==0.3.14; platform_system == "Windows"
+jaxlib==0.3.14; platform_system == "Windows" and python_version < "3.9"
+jax[cpu]==0.3.14; platform_system == "Windows" and python_version < "3.9"
+
+# windows users running python > 3.9 can install same jax version as unix
+jaxlib>=0.3.14,<=0.4.14; platform_system == "Windows" and python_version >= "3.9"
+jax[cpu]>=0.3.14,<=0.4.14; platform_system == "Windows" and python_version >= "3.9"

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,6 @@ commands =
     pytest -rA tests/test_components/test_meshgenerate.py
     pytest -rA tests/test_components/test_mode.py
     pytest -rA tests/test_components/test_monitor.py
-    pytest -rA tests/test_components/test_parameter_perturbation.py
     pytest -rA tests/test_components/test_field_projection.py
     pytest -rA tests/test_components/test_sidewall.py
     pytest -rA tests/test_components/test_simulation.py


### PR DESCRIPTION
previously we needed to install jax 3.* on windows and add a specific pip find link, apparently now jax is supported normally on windows so we dont have to handle this special case.