### PR TITLE
numerically stable radius penalty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Bug in angled mode solver with negative `angle_theta`.
 - Properly include `JaxSimulation.input_structures` in `JaxSimulationData.plot_field()`.
+- Numerically stable sigmoid function in radius of curvature constraint.
 
 ## [2.4.0rc1] - 2023-7-27
 

--- a/tidy3d/plugins/adjoint/utils/penalty.py
+++ b/tidy3d/plugins/adjoint/utils/penalty.py
@@ -83,13 +83,14 @@ class RadiusPenalty(Penalty):
             xp, yp = dps
             xp2, yp2 = d2ps
             num = (xp**2 + yp**2) ** (3.0 / 2.0)
-            den = abs(xp * yp2 - yp * xp2) + 1e-2
+            den = abs(xp * yp2 - yp * xp2)
             return num / den
 
         def penalty_fn(radius):
             """Get the penalty for a given radius."""
-            arg = -self.kappa * (self.min_radius - radius)
-            return self.alpha * ((1 + jnp.exp(arg)) ** (-1))
+            arg = self.kappa * (radius - self.min_radius)
+            exp_arg = jnp.exp(-arg)
+            return self.alpha * (exp_arg / (1 + exp_arg))
 
         xs, ys = jnp.array(points).T
         rs = get_radii_curvature(xs, ys)


### PR DESCRIPTION
previously, I smoothed the radius of curvature calculation by adding 1e-2 to the denominator. This avoided it going to infinity for infinitely straight edges. However, when the actual radius of curvature was close to 1e-2 it gave inaccurate results. Instead, I made the penalty function a numerically stable version for x > 0, which solves the issue more generally.

# old
penalty(x) = 1/(1 + exp(x))
# new
penalty(x)= exp(-x)/(1 + exp(-x))

