### PR TITLE
include `input_structures` in jax_sim_data.plot_field()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Bug in angled mode solver with negative `angle_theta`.
+- Properly include `JaxSimulation.input_structures` in `JaxSimulationData.plot_field()`.
 
 ## [2.4.0rc1] - 2023-7-27
 

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -1437,3 +1437,13 @@ def test_adjoint_utils(strict_binarize):
 
     radius_penalty = RadiusPenalty(min_radius=0.2, wrap=True)
     _ = radius_penalty.evaluate(polyslab.vertices)
+
+
+def test_sim_data_plot_field(use_emulated_run):
+    """Test splitting of regular simulation data into user and server data."""
+
+    jax_sim = make_sim(permittivity=EPS, size=SIZE, vertices=VERTICES, base_eps_val=BASE_EPS_VAL)
+    jax_sim_data = run(jax_sim, task_name="test")
+    ax = jax_sim_data.plot_field("field", "Ez", "real", f=1e14)
+    plt.show()
+    assert len(ax.collections) == 1

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -481,7 +481,7 @@ def run_emulated(simulation: td.Simulation, path=None, **kwargs) -> td.Simulatio
             monitor=monitor,
             symmetry=simulation.symmetry,
             symmetry_center=simulation.center,
-            grid_expanded=simulation.discretize(monitor, extend=True),
+            grid_expanded=grid,
             **field_cmps,
         )
 

--- a/tidy3d/plugins/adjoint/components/simulation.py
+++ b/tidy3d/plugins/adjoint/components/simulation.py
@@ -338,6 +338,109 @@ class JaxSimulation(Simulation, JaxObject):
             vlim=vlim,
         )
 
+    def plot_structures(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        ax: Ax = None,
+        hlim: Tuple[float, float] = None,
+        vlim: Tuple[float, float] = None,
+    ) -> Ax:
+        """Plot each of simulation's structures on a plane defined by one nonzero x,y,z coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            position of plane in z direction, only one of x, y, z must be specified to define plane.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        hlim : Tuple[float, float] = None
+            The x range if plotting on xy or xz planes, y range if plotting on yz plane.
+        vlim : Tuple[float, float] = None
+            The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+        sim, _ = self.to_simulation()
+        return sim.plot_structures(
+            x=x,
+            y=y,
+            z=z,
+            ax=ax,
+            hlim=hlim,
+            vlim=vlim,
+        )
+
+    # pylint: disable=too-many-arguments,too-many-locals
+    def plot_structures_eps(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        freq: float = None,
+        alpha: float = None,
+        cbar: bool = True,
+        reverse: bool = False,
+        ax: Ax = None,
+        hlim: Tuple[float, float] = None,
+        vlim: Tuple[float, float] = None,
+    ) -> Ax:
+        """Plot each of simulation's structures on a plane defined by one nonzero x,y,z coordinate.
+        The permittivity is plotted in grayscale based on its value at the specified frequency.
+
+        Parameters
+        ----------
+        x : float = None
+            position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            position of plane in z direction, only one of x, y, z must be specified to define plane.
+        freq : float = None
+            Frequency to evaluate the relative permittivity of all mediums.
+            If not specified, evaluates at infinite frequency.
+        reverse : bool = False
+            If ``False``, the highest permittivity is plotted in black.
+            If ``True``, it is plotteed in white (suitable for black backgrounds).
+        cbar : bool = True
+            Whether to plot a colorbar for the relative permittivity.
+        alpha : float = None
+            Opacity of the structures being plotted.
+            Defaults to the structure default alpha.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        hlim : Tuple[float, float] = None
+            The x range if plotting on xy or xz planes, y range if plotting on yz plane.
+        vlim : Tuple[float, float] = None
+            The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+        sim, _ = self.to_simulation()
+        return sim.plot_structures_eps(
+            x=x,
+            y=y,
+            z=z,
+            freq=freq,
+            alpha=alpha,
+            cbar=cbar,
+            reverse=reverse,
+            ax=ax,
+            hlim=hlim,
+            vlim=vlim,
+        )
+
     def __eq__(self, other: JaxSimulation) -> bool:
         """Are two JaxSimulation objects equal?"""
         return self.to_simulation()[0] == other.to_simulation()[0]


### PR DESCRIPTION
Fixes #1062.

This PR basically includes all of the structures when `JaxSimulation.plot_structures` or `JaxSimulation.plot_eps_structures` is called. The latter is used in `SimulationData.plot_field()`. Previously, this was being ignored in some `plot_field()` plots but after this change, it works

<img width="414" alt="image" src="https://github.com/flexcompute/tidy3d/assets/92756888/332cac00-72ac-442e-a3ab-e04fb05f5345">

