### PR TITLE
Equalize vertex processing in Geometry and PolySlab

### DIFF
--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -561,7 +561,7 @@ def test_from_gds():
         cell, 2, (0, 1), gds_layer=0, dilation=-0.5, sidewall_angle=0.5, reference_plane="bottom"
     )
     assert len(geo.intersections_plane(z=0)) == 2
-    assert len(geo.intersections_plane(z=1)) == 5
+    assert len(geo.intersections_plane(z=1)) == 1
 
 
 def test_custom_surface_geometry(tmp_path):

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -24,9 +24,6 @@ _N_SAMPLE_POLYGON_INTERSECT = 5
 
 _IS_CLOSE_RTOL = np.finfo(float).eps
 
-# polygon merge
-_POLY_GRID_SIZE = 1e-12
-
 # Warn for too many divided polyslabs
 _COMPLEX_POLYSLAB_DIVISIONS_WARN = 100
 
@@ -335,7 +332,7 @@ class PolySlab(base.Planar):
 
         # convert vertices into polyslabs
         polygons = [shapely.Polygon(vertices).buffer(0) for vertices in all_vertices]
-        polys_union = shapely.unary_union(polygons, grid_size=_POLY_GRID_SIZE)
+        polys_union = shapely.unary_union(polygons, grid_size=base.POLY_GRID_SIZE)
 
         if polys_union.geom_type == "Polygon":
             all_vertices = [np.array(polys_union.exterior.coords)]
@@ -643,7 +640,7 @@ class PolySlab(base.Planar):
             h_base = h_top
 
         # merge touching polygons
-        polys_union = shapely.unary_union(polys, grid_size=_POLY_GRID_SIZE)
+        polys_union = shapely.unary_union(polys, grid_size=base.POLY_GRID_SIZE)
         if polys_union.geom_type == "Polygon":
             return [polys_union]
         if polys_union.geom_type == "MultiPolygon":


### PR DESCRIPTION
Use the same grid size for both when loading vertices from GDSII, and apply dilations in the same manner to avoid unexpected differences due to operation order.