### PR TITLE
Remove warning from CustomSourceTime

### DIFF
--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -72,10 +72,6 @@ DIST_NEIGHBOR_REL_2D_MED = 1e-5
 # height of the PML plotting boxes along any dimensions where sim.size[dim] == 0
 PML_HEIGHT_FOR_0_DIMS = 0.02
 
-# allow some numerical flexibility before warning about CustomSourceTime
-# in units of dt
-CUSTOMSOURCETIME_TOL = 1.1
-
 
 class Simulation(Box):
     """Contains all information about Tidy3d simulation.
@@ -844,7 +840,6 @@ class Simulation(Box):
         """Call validators taking z`self` that get run after init."""
         self._validate_no_structures_pml()
         self._validate_tfsf_nonuniform_grid()
-        self._validate_customsourcetime()
 
     def _validate_no_structures_pml(self) -> None:
         """Ensure no structures terminate / have bounds inside of PML."""
@@ -913,24 +908,6 @@ class Simulation(Box):
                             "uniform grid in both directions tangential to the TFSF injection "
                             f"axis, '{'xyz'[source.injection_axis]}'."
                         )
-
-    def _validate_customsourcetime(self) -> None:
-        """Make sure custom source time is not undersampled.
-        Also, make sure that all simulation.tmesh values are covered."""
-        for source in self.sources:
-            if isinstance(source.source_time, CustomSourceTime):
-                dataset = source.source_time.source_time_dataset
-                if dataset is None:
-                    continue
-                times = dataset.values.coords["t"].values
-                max_dt = np.amax(np.diff(times))
-                if max_dt > self.dt * CUSTOMSOURCETIME_TOL:
-                    log.warning(
-                        f"'CustomSourceTime' found with time step 'max(dt) = {max_dt:.3g}', "
-                        f"while the simulation time step is 'dt={self.dt}'. "
-                        "We recommend that the largest time step of the custom source "
-                        f"be smaller than the time step of the simulation."
-                    )
 
     """ Pre submit validation (before web.upload()) """
 

--- a/tidy3d/components/source.py
+++ b/tidy3d/components/source.py
@@ -328,9 +328,8 @@ class CustomSourceTime(Pulse):
     Note
     ----
     The source time dependence is linearly interpolated to the simulation time steps.
-    To ensure that this interpolation does not introduce artifacts, it is necessary
-    to use a sampling rate that is sufficiently fast relative to the simulation time step.
-    The source should also ideally start at zero and ramp up smoothly.
+    The sampling rate should be sufficiently fast that this interpolation does not
+    introduce artifacts. The source time dependence should also start at zero and ramp up smoothly.
     The first and last values of the envelope will be used for times that are out of range
     of the provided data.
 
@@ -382,7 +381,7 @@ class CustomSourceTime(Pulse):
             Complex values of the source envelope.
         dt: float
             Time step for the `values` array. This value should be sufficiently small
-            relative to the simulation `dt` in order to avoid interpolation artifacts.
+            that the interpolation to simulation time steps does not introduce artifacts.
 
         Returns
         -------


### PR DESCRIPTION
This warning was previously necessary because undersampling CustomSourceTime could result in unanticipated sharp jumps in amp_time, which could lead to simulation artifacts. Now, CustomSourceTime is by default modulated at freq0. This means the typical use case can use a sampling time step much larger than the simulation dt without causing any problems.