### PR TITLE
fix 2d intersection plotting in Simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ the difference that can be observed when slightly modifying the grid resolution.
 - Bug in angled mode solver with negative `angle_theta`.
 - Properly include `JaxSimulation.input_structures` in `JaxSimulationData.plot_field()`.
 - Numerically stable sigmoid function in radius of curvature constraint.
-- Fixed 2d checking in `Geometry.intersections_2dbox()`.
 - Spatial monitor downsampling when the monitor is crossing a symmetry plane or Bloch boundary conditions.
 
 ## [2.4.0rc1] - 2023-7-27

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -2285,8 +2285,12 @@ class Simulation(Box):
             (xmin, xmax) = hlim
         if vlim is not None:
             (ymin, ymax) = vlim
-        ax.set_xlim(xmin, xmax)
-        ax.set_ylim(ymin, ymax)
+
+        if xmin != xmax:
+            ax.set_xlim(xmin, xmax)
+        if ymin != ymax:
+            ax.set_ylim(ymin, ymax)
+
         return ax
 
     @staticmethod
@@ -2364,8 +2368,8 @@ class Simulation(Box):
         # get center and size with h, v
         h_center = (hmin + hmax) / 2.0
         v_center = (vmin + vmax) / 2.0
-        h_size = hmax - hmin
-        v_size = vmax - vmin
+        h_size = (hmax - hmin) or inf
+        v_size = (vmax - vmin) or inf
 
         axis, center_normal = self.parse_xyz_kwargs(x=x, y=y, z=z)
         center = self.unpop_axis(center_normal, (h_center, v_center), axis=axis)


### PR DESCRIPTION
There were some things that got messed up with the simulation plotting that this fixes. It also fixes the deeper issue with #1061, which was that a 1D line was being created instead of a plane. In this commit, if the `plane` has any transverse dimensions of size 0, they are reset to `inf` so we always should have a 2D plane.