### PR TITLE
Fix backwards compatibility break

### DIFF
--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -10,7 +10,7 @@ import gdspy
 import trimesh
 
 import tidy3d as td
-from tidy3d.exceptions import SetupError, Tidy3dKeyError
+from tidy3d.exceptions import SetupError, Tidy3dKeyError, ValidationError
 from tidy3d.components.geometry.base import Geometry, Planar
 
 
@@ -454,6 +454,26 @@ def test_pop_axis():
         assert Lz == _Lz
         assert Lx == _Lx
         assert Ly == _Ly
+
+
+def test_2b_box_intersections():
+    plane = td.Box(size=(1, 4, 0))
+    box1 = td.Box(size=(1, 1, 1))
+    box2 = td.Box(size=(1, 1, 1), center=(3, 0, 0))
+
+    result = plane.intersections_with(box1)
+    assert len(result) == 1
+    assert result[0].geom_type == "Polygon"
+    assert len(plane.intersections_with(box2)) == 0
+
+    with pytest.raises(ValidationError):
+        _ = box1.intersections_with(box2)
+
+    assert len(box1.intersections_2dbox(plane)) == 1
+    assert len(box2.intersections_2dbox(plane)) == 0
+
+    with pytest.raises(ValidationError):
+        _ = box2.intersections_2dbox(box1)
 
 
 def test_polyslab_merge():

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -161,6 +161,22 @@ class Geometry(Tidy3dBaseModel, ABC):
             `Shapely's Documentaton <https://shapely.readthedocs.io/en/stable/project.html>`_.
         """
 
+    def intersections_2dbox(self, plane: Box) -> List[Shapely]:
+        """Returns list of shapely geomtries representing the intersections of the geometry with
+        a 2D box.
+
+        Returns
+        -------
+        List[shapely.geometry.base.BaseGeometry]
+            List of 2D shapes that intersect plane. For more details refer to
+            `Shapely's Documentaton <https://shapely.readthedocs.io/en/stable/project.html>`_.
+        """
+        log.warning(
+            "'intersections_2dbox()' is deprecated and will be removed in the future. "
+            "Use 'plane.intersections_with(...)' for the same functionality."
+        )
+        return plane.intersections_with(self)
+
     def intersects(self, other) -> bool:
         """Returns ``True`` if two :class:`Geometry` have intersecting `.bounds`.
 
@@ -1509,7 +1525,9 @@ class Box(Centered):
 
         # Verify 2D
         if self.size.count(0.0) != 1:
-            raise ValueError("Intersections with other geometry are only calculated from a 2D box.")
+            raise ValidationError(
+                "Intersections with other geometry are only calculated from a 2D box."
+            )
 
         # dont bother if the geometry doesn't intersect the self at all
         if not other.intersects(self):


### PR DESCRIPTION
Reinstate `Geometry.intersections_2dbox` to avoid breaking backwards compatibility.