### PR TITLE
Heat solver interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Time zone in webAPI logging output.
+- Class `Scene` consisting of a background medium and structures for easier drafting and visualization of simulation setups as well as transferring such information between different simulations.
+- Solver for thermal simulation (see `HeatSimulation` and related classes).
+- Specification of material thermal properties in medium classes through an optional field `.heat_spec`.
 
 ### Changed
 - Internal refactor of Web API functionality.
 - `Geometry.from_gds` doesn't create unecessary groups of single elements.
-
-### Fixed
-
-## [Unreleased]
-
-### Added
-
-### Changed
-
-### Fixed
 - Properly handle `.freqs` in `output_monitors` of adjoint plugin.
+
+### Fixed
 
 ## [2.4.2] - 2023-9-28
 

--- a/tests/sims/simulation_2_5_0rc1.json
+++ b/tests/sims/simulation_2_5_0rc1.json
@@ -1,0 +1,1969 @@
+{
+    "type": "Simulation",
+    "center": [
+        0.0,
+        0.0,
+        0.0
+    ],
+    "size": [
+        8.0,
+        8.0,
+        8.0
+    ],
+    "run_time": 1e-12,
+    "medium": {
+        "name": null,
+        "frequency_range": null,
+        "allow_gain": false,
+        "nonlinear_spec": null,
+        "heat_spec": null,
+        "type": "Medium",
+        "permittivity": 1.0,
+        "conductivity": 0.0
+    },
+    "symmetry": [
+        0,
+        0,
+        0
+    ],
+    "structures": [
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": "dieletric_box",
+            "type": "Structure",
+            "medium": {
+                "name": "dieletric",
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "heat_spec": null,
+                "type": "Medium",
+                "permittivity": 2.0,
+                "conductivity": 0.0
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    "Infinity",
+                    1.0
+                ]
+            },
+            "name": "lossy_box",
+            "type": "Structure",
+            "medium": {
+                "name": "lossy_dieletric",
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "heat_spec": null,
+                "type": "Medium",
+                "permittivity": 1.0,
+                "conductivity": 3.0
+            }
+        },
+        {
+            "geometry": {
+                "type": "Sphere",
+                "radius": 1.0,
+                "center": [
+                    1.0,
+                    0.0,
+                    1.0
+                ]
+            },
+            "name": "sellmeier_sphere",
+            "type": "Structure",
+            "medium": {
+                "name": "sellmeier",
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "heat_spec": null,
+                "type": "Sellmeier",
+                "coeffs": [
+                    [
+                        1.03961212,
+                        0.00600069867
+                    ],
+                    [
+                        0.231792344,
+                        0.0200179144
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": "lorentz_box",
+            "type": "Structure",
+            "medium": {
+                "name": "lorentz",
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "heat_spec": null,
+                "type": "Lorentz",
+                "eps_inf": 2.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        2.0,
+                        3.0
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "heat_spec": null,
+                "type": "Debye",
+                "eps_inf": 2.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        3.0
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "TriangleMesh",
+                "mesh_dataset": {
+                    "type": "TriangleMeshDataset",
+                    "surface_mesh": "TriangleMeshDataArray"
+                }
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "heat_spec": null,
+                "type": "Debye",
+                "eps_inf": 2.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        3.0
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": "drude_box",
+            "type": "Structure",
+            "medium": {
+                "name": "drude",
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "heat_spec": null,
+                "type": "Drude",
+                "eps_inf": 2.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        3.0
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    0.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "heat_spec": null,
+                "type": "Medium2D",
+                "ss": {
+                    "name": null,
+                    "frequency_range": null,
+                    "allow_gain": false,
+                    "nonlinear_spec": null,
+                    "heat_spec": null,
+                    "type": "PoleResidue",
+                    "eps_inf": 1.0,
+                    "poles": [
+                        [
+                            {
+                                "real": 0.0,
+                                "imag": 0.0
+                            },
+                            {
+                                "real": 254117040158918.28,
+                                "imag": 0.0
+                            }
+                        ]
+                    ]
+                },
+                "tt": {
+                    "name": null,
+                    "frequency_range": null,
+                    "allow_gain": false,
+                    "nonlinear_spec": null,
+                    "heat_spec": null,
+                    "type": "PoleResidue",
+                    "eps_inf": 1.0,
+                    "poles": [
+                        [
+                            {
+                                "real": 0.0,
+                                "imag": 0.0
+                            },
+                            {
+                                "real": 254117040158918.28,
+                                "imag": 0.0
+                            }
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "geometry": {
+                "type": "GeometryGroup",
+                "geometries": [
+                    {
+                        "type": "Box",
+                        "center": [
+                            -1.0,
+                            0.0,
+                            0.0
+                        ],
+                        "size": [
+                            1.0,
+                            1.0,
+                            1.0
+                        ]
+                    }
+                ]
+            },
+            "name": "pec_group",
+            "type": "Structure",
+            "medium": {
+                "name": "PEC",
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "heat_spec": null,
+                "type": "PECMedium"
+            }
+        },
+        {
+            "geometry": {
+                "type": "Cylinder",
+                "axis": 1,
+                "sidewall_angle": 0.0,
+                "reference_plane": "middle",
+                "radius": 1.0,
+                "center": [
+                    1.0,
+                    0.0,
+                    -1.0
+                ],
+                "length": 2.0
+            },
+            "name": "anisotopic_cylinder",
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": null,
+                "nonlinear_spec": null,
+                "heat_spec": null,
+                "type": "AnisotropicMedium",
+                "xx": {
+                    "name": null,
+                    "frequency_range": null,
+                    "allow_gain": false,
+                    "nonlinear_spec": null,
+                    "heat_spec": null,
+                    "type": "Medium",
+                    "permittivity": 1.0,
+                    "conductivity": 0.0
+                },
+                "yy": {
+                    "name": null,
+                    "frequency_range": null,
+                    "allow_gain": false,
+                    "nonlinear_spec": null,
+                    "heat_spec": null,
+                    "type": "Medium",
+                    "permittivity": 2.0,
+                    "conductivity": 0.0
+                },
+                "zz": {
+                    "name": null,
+                    "frequency_range": null,
+                    "allow_gain": false,
+                    "nonlinear_spec": null,
+                    "heat_spec": null,
+                    "type": "Medium",
+                    "permittivity": 3.0,
+                    "conductivity": 0.0
+                }
+            }
+        },
+        {
+            "geometry": {
+                "type": "PolySlab",
+                "axis": 2,
+                "sidewall_angle": 0.0,
+                "reference_plane": "middle",
+                "slab_bounds": [
+                    -1.0,
+                    1.0
+                ],
+                "dilation": 0.0,
+                "vertices": [
+                    [
+                        -1.5,
+                        -1.5
+                    ],
+                    [
+                        -0.5,
+                        -1.5
+                    ],
+                    [
+                        -0.5,
+                        -0.5
+                    ]
+                ]
+            },
+            "name": "pole_slab",
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "heat_spec": null,
+                "type": "PoleResidue",
+                "eps_inf": 1.0,
+                "poles": [
+                    [
+                        {
+                            "real": 0.0,
+                            "imag": 6206417594288582.0
+                        },
+                        {
+                            "real": -0.0,
+                            "imag": -3.311074436985222e+16
+                        }
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.5,
+                    0.5
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "heat_spec": null,
+                "type": "CustomMedium",
+                "interp_method": "nearest",
+                "subpixel": false,
+                "permittivity": "SpatialDataArray",
+                "conductivity": null,
+                "eps_dataset": null
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.5,
+                    0.5
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "heat_spec": null,
+                "type": "CustomDrude",
+                "eps_inf": "SpatialDataArray",
+                "coeffs": [
+                    [
+                        "SpatialDataArray",
+                        "SpatialDataArray"
+                    ]
+                ],
+                "interp_method": "nearest",
+                "subpixel": false
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.5,
+                    0.5
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "heat_spec": null,
+                "type": "CustomLorentz",
+                "eps_inf": "SpatialDataArray",
+                "coeffs": [
+                    [
+                        "SpatialDataArray",
+                        "SpatialDataArray",
+                        "SpatialDataArray"
+                    ]
+                ],
+                "interp_method": "nearest",
+                "subpixel": false
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.5,
+                    0.5
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "heat_spec": null,
+                "type": "CustomDebye",
+                "eps_inf": "SpatialDataArray",
+                "coeffs": [
+                    [
+                        "SpatialDataArray",
+                        "SpatialDataArray"
+                    ]
+                ],
+                "interp_method": "nearest",
+                "subpixel": false
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.5,
+                    0.5
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "heat_spec": null,
+                "type": "CustomPoleResidue",
+                "eps_inf": "SpatialDataArray",
+                "poles": [
+                    [
+                        "SpatialDataArray",
+                        "SpatialDataArray"
+                    ]
+                ],
+                "interp_method": "nearest",
+                "subpixel": false
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.5,
+                    0.5
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "heat_spec": null,
+                "type": "CustomSellmeier",
+                "coeffs": [
+                    [
+                        "SpatialDataArray",
+                        "SpatialDataArray"
+                    ]
+                ],
+                "interp_method": "nearest",
+                "subpixel": false
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.5,
+                    0.5
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": {
+                    "numiters": 20,
+                    "type": "NonlinearSusceptibility",
+                    "chi3": 0.1
+                },
+                "heat_spec": null,
+                "type": "Medium",
+                "permittivity": 1.0,
+                "conductivity": 0.0
+            }
+        },
+        {
+            "geometry": {
+                "type": "PolySlab",
+                "axis": 2,
+                "sidewall_angle": 0.0,
+                "reference_plane": "middle",
+                "slab_bounds": [
+                    -1.0,
+                    1.0
+                ],
+                "dilation": 0.0,
+                "vertices": [
+                    [
+                        -1.5,
+                        -1.5
+                    ],
+                    [
+                        -0.5,
+                        -1.5
+                    ],
+                    [
+                        -0.5,
+                        -0.5
+                    ]
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "heat_spec": null,
+                "type": "PoleResidue",
+                "eps_inf": 1.0,
+                "poles": [
+                    [
+                        {
+                            "real": 0.0,
+                            "imag": 6206417594288582.0
+                        },
+                        {
+                            "real": -0.0,
+                            "imag": -3.311074436985222e+16
+                        }
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "TriangleMesh",
+                "mesh_dataset": {
+                    "type": "TriangleMeshDataset",
+                    "surface_mesh": "TriangleMeshDataArray"
+                }
+            },
+            "name": "dieletric_mesh",
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "heat_spec": null,
+                "type": "Medium",
+                "permittivity": 5.0,
+                "conductivity": 0.0
+            }
+        },
+        {
+            "geometry": {
+                "type": "GeometryGroup",
+                "geometries": [
+                    {
+                        "type": "TriangleMesh",
+                        "mesh_dataset": {
+                            "type": "TriangleMeshDataset",
+                            "surface_mesh": "TriangleMeshDataArray"
+                        }
+                    },
+                    {
+                        "type": "TriangleMesh",
+                        "mesh_dataset": {
+                            "type": "TriangleMeshDataset",
+                            "surface_mesh": "TriangleMeshDataArray"
+                        }
+                    }
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "heat_spec": null,
+                "type": "Medium",
+                "permittivity": 5.0,
+                "conductivity": 0.0
+            }
+        }
+    ],
+    "sources": [
+        {
+            "type": "UniformCurrentSource",
+            "center": [
+                0.0,
+                0.5,
+                0.0
+            ],
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0,
+                "remove_dc_component": true
+            },
+            "name": null,
+            "interpolate": true,
+            "polarization": "Hx"
+        },
+        {
+            "type": "PointDipole",
+            "center": [
+                0.0,
+                0.5,
+                0.0
+            ],
+            "size": [
+                0,
+                0,
+                0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0,
+                "remove_dc_component": true
+            },
+            "name": null,
+            "interpolate": true,
+            "polarization": "Ex"
+        },
+        {
+            "type": "ModeSource",
+            "center": [
+                0.0,
+                0.5,
+                0.0
+            ],
+            "size": [
+                2.0,
+                0.0,
+                2.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0,
+                "remove_dc_component": true
+            },
+            "name": null,
+            "num_freqs": 1,
+            "direction": "-",
+            "mode_spec": {
+                "num_modes": 1,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "filter_pol": null,
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "precision": "single",
+                "bend_radius": null,
+                "bend_axis": null,
+                "track_freq": "central",
+                "group_index_step": false,
+                "type": "ModeSpec"
+            },
+            "mode_index": 0
+        },
+        {
+            "type": "PlaneWave",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                "Infinity",
+                "Infinity"
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0,
+                "remove_dc_component": true
+            },
+            "name": null,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 0.1
+        },
+        {
+            "type": "GaussianBeam",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                3.0,
+                3.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0,
+                "remove_dc_component": true
+            },
+            "name": null,
+            "num_freqs": 1,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 1.5707963267948966,
+            "waist_radius": 1.0,
+            "waist_distance": 0.0
+        },
+        {
+            "type": "AstigmaticGaussianBeam",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                3.0,
+                3.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0,
+                "remove_dc_component": true
+            },
+            "name": null,
+            "num_freqs": 1,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 1.5707963267948966,
+            "waist_sizes": [
+                1.0,
+                2.0
+            ],
+            "waist_distances": [
+                3.0,
+                4.0
+            ]
+        },
+        {
+            "type": "CustomFieldSource",
+            "center": [
+                0.0,
+                1.0,
+                2.0
+            ],
+            "size": [
+                2.0,
+                2.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0,
+                "remove_dc_component": true
+            },
+            "name": null,
+            "field_dataset": {
+                "type": "FieldDataset",
+                "Ex": "ScalarFieldDataArray",
+                "Ey": null,
+                "Ez": null,
+                "Hx": null,
+                "Hy": null,
+                "Hz": null
+            }
+        },
+        {
+            "type": "CustomCurrentSource",
+            "center": [
+                0.0,
+                1.0,
+                2.0
+            ],
+            "size": [
+                2.0,
+                2.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0,
+                "remove_dc_component": true
+            },
+            "name": null,
+            "interpolate": true,
+            "current_dataset": {
+                "type": "FieldDataset",
+                "Ex": "ScalarFieldDataArray",
+                "Ey": null,
+                "Ez": null,
+                "Hx": null,
+                "Hy": null,
+                "Hz": null
+            }
+        },
+        {
+            "type": "TFSF",
+            "center": [
+                1.0,
+                2.0,
+                -3.0
+            ],
+            "size": [
+                2.5,
+                2.5,
+                0.5
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0,
+                "remove_dc_component": true
+            },
+            "name": null,
+            "direction": "+",
+            "angle_theta": 0.5235987755982988,
+            "angle_phi": 0.6283185307179586,
+            "pol_angle": 0.0,
+            "injection_axis": 2
+        },
+        {
+            "type": "UniformCurrentSource",
+            "center": [
+                0.0,
+                0.5,
+                0.0
+            ],
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "CustomSourceTime",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 0.0,
+                "source_time_dataset": {
+                    "type": "TimeDataset",
+                    "values": "TimeDataArray"
+                }
+            },
+            "name": null,
+            "interpolate": true,
+            "polarization": "Hx"
+        }
+    ],
+    "boundary_spec": {
+        "x": {
+            "plus": {
+                "name": null,
+                "type": "PML",
+                "num_layers": 20,
+                "parameters": {
+                    "sigma_order": 3,
+                    "sigma_min": 0.0,
+                    "sigma_max": 1.5,
+                    "type": "PMLParams",
+                    "kappa_order": 3,
+                    "kappa_min": 1.0,
+                    "kappa_max": 3.0,
+                    "alpha_order": 1,
+                    "alpha_min": 0.0,
+                    "alpha_max": 0.0
+                }
+            },
+            "minus": {
+                "name": null,
+                "type": "Absorber",
+                "num_layers": 100,
+                "parameters": {
+                    "sigma_order": 3,
+                    "sigma_min": 0.0,
+                    "sigma_max": 6.4,
+                    "type": "AbsorberParams"
+                }
+            },
+            "type": "Boundary"
+        },
+        "y": {
+            "plus": {
+                "name": null,
+                "type": "BlochBoundary",
+                "bloch_vec": 1.0
+            },
+            "minus": {
+                "name": null,
+                "type": "BlochBoundary",
+                "bloch_vec": 1.0
+            },
+            "type": "Boundary"
+        },
+        "z": {
+            "plus": {
+                "name": null,
+                "type": "Periodic"
+            },
+            "minus": {
+                "name": null,
+                "type": "Periodic"
+            },
+            "type": "Boundary"
+        },
+        "type": "BoundarySpec"
+    },
+    "monitors": [
+        {
+            "type": "FieldMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "name": "field",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": true,
+            "freqs": [
+                150000000000000.0,
+                200000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "fields": [
+                "Ex"
+            ]
+        },
+        {
+            "type": "FieldTimeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "name": "field_time",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": true,
+            "start": 0.0,
+            "stop": null,
+            "interval": 100,
+            "fields": [
+                "Ex",
+                "Ey",
+                "Ez",
+                "Hx",
+                "Hy",
+                "Hz"
+            ]
+        },
+        {
+            "type": "FluxMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "flux",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": true,
+            "freqs": [
+                200000000000000.0,
+                250000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null
+        },
+        {
+            "type": "FluxTimeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "flux_time",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": true,
+            "start": 0.0,
+            "stop": null,
+            "interval": 1,
+            "normal_dir": "+",
+            "exclude_surfaces": null
+        },
+        {
+            "type": "PermittivityMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.1
+            ],
+            "name": "eps",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": false,
+            "freqs": [
+                100000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            }
+        },
+        {
+            "type": "ModeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "mode",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": false,
+            "freqs": [
+                200000000000000.0,
+                250000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "mode_spec": {
+                "num_modes": 1,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "filter_pol": null,
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "precision": "single",
+                "bend_radius": null,
+                "bend_axis": null,
+                "track_freq": "central",
+                "group_index_step": false,
+                "type": "ModeSpec"
+            }
+        },
+        {
+            "type": "ModeSolverMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "mode_solver",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": true,
+            "freqs": [
+                200000000000000.0,
+                250000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "mode_spec": {
+                "num_modes": 1,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "filter_pol": null,
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "precision": "single",
+                "bend_radius": null,
+                "bend_axis": null,
+                "track_freq": "central",
+                "group_index_step": false,
+                "type": "ModeSpec"
+            },
+            "direction": "+"
+        },
+        {
+            "type": "FieldProjectionAngleMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                2.0,
+                2.0
+            ],
+            "name": "proj_angle",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": true,
+            "freqs": [
+                250000000000000.0,
+                300000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null,
+            "custom_origin": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "far_field_approx": true,
+            "proj_distance": 1000000.0,
+            "theta": [
+                -1.5707963267948966,
+                -1.5390630676677268,
+                -1.5073298085405573,
+                -1.4755965494133876,
+                -1.443863290286218,
+                -1.4121300311590483,
+                -1.3803967720318788,
+                -1.348663512904709,
+                -1.3169302537775396,
+                -1.2851969946503699,
+                -1.2534637355232003,
+                -1.2217304763960306,
+                -1.189997217268861,
+                -1.1582639581416914,
+                -1.1265306990145216,
+                -1.0947974398873521,
+                -1.0630641807601826,
+                -1.0313309216330129,
+                -0.9995976625058433,
+                -0.9678644033786736,
+                -0.936131144251504,
+                -0.9043978851243344,
+                -0.8726646259971648,
+                -0.8409313668699951,
+                -0.8091981077428254,
+                -0.7774648486156558,
+                -0.7457315894884862,
+                -0.7139983303613165,
+                -0.6822650712341469,
+                -0.6505318121069773,
+                -0.6187985529798077,
+                -0.5870652938526381,
+                -0.5553320347254684,
+                -0.5235987755982987,
+                -0.4918655164711292,
+                -0.46013225734395946,
+                -0.42839899821678995,
+                -0.3966657390896202,
+                -0.3649324799624507,
+                -0.333199220835281,
+                -0.30146596170811146,
+                -0.26973270258094173,
+                -0.23799944345377222,
+                -0.2062661843266025,
+                -0.17453292519943298,
+                -0.14279966607226324,
+                -0.11106640694509373,
+                -0.079333147817924,
+                -0.047599888690754266,
+                -0.015866629563584755,
+                0.015866629563584977,
+                0.04759988869075449,
+                0.07933314781792422,
+                0.11106640694509373,
+                0.14279966607226346,
+                0.17453292519943298,
+                0.2062661843266027,
+                0.23799944345377222,
+                0.26973270258094195,
+                0.30146596170811146,
+                0.3331992208352812,
+                0.3649324799624507,
+                0.39666573908962044,
+                0.42839899821678995,
+                0.4601322573439597,
+                0.4918655164711292,
+                0.5235987755982991,
+                0.5553320347254687,
+                0.5870652938526382,
+                0.6187985529798077,
+                0.6505318121069776,
+                0.6822650712341471,
+                0.7139983303613167,
+                0.7457315894884862,
+                0.7774648486156561,
+                0.8091981077428256,
+                0.8409313668699951,
+                0.8726646259971647,
+                0.9043978851243346,
+                0.9361311442515041,
+                0.9678644033786736,
+                0.9995976625058436,
+                1.031330921633013,
+                1.0630641807601826,
+                1.0947974398873521,
+                1.126530699014522,
+                1.1582639581416916,
+                1.189997217268861,
+                1.2217304763960306,
+                1.2534637355232006,
+                1.28519699465037,
+                1.3169302537775396,
+                1.348663512904709,
+                1.380396772031879,
+                1.4121300311590486,
+                1.443863290286218,
+                1.475596549413388,
+                1.5073298085405575,
+                1.539063067667727,
+                1.5707963267948966
+            ],
+            "phi": [
+                0.0,
+                1.5707963267948966
+            ]
+        },
+        {
+            "type": "FieldProjectionCartesianMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                2.0,
+                2.0
+            ],
+            "name": "proj_cartesian",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": true,
+            "freqs": [
+                250000000000000.0,
+                300000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null,
+            "custom_origin": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "far_field_approx": true,
+            "proj_axis": 2,
+            "proj_distance": 5.0,
+            "x": [
+                -1.0,
+                0.0,
+                1.0
+            ],
+            "y": [
+                -2.0,
+                -1.0,
+                0.0,
+                1.0,
+                2.0
+            ]
+        },
+        {
+            "type": "FieldProjectionKSpaceMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                2.0,
+                2.0
+            ],
+            "name": "proj_kspace",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": true,
+            "freqs": [
+                250000000000000.0,
+                300000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null,
+            "custom_origin": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "far_field_approx": true,
+            "proj_axis": 2,
+            "proj_distance": 1000000.0,
+            "ux": [
+                0.1,
+                0.2
+            ],
+            "uy": [
+                0.3,
+                0.4,
+                0.5
+            ]
+        },
+        {
+            "type": "FieldProjectionAngleMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                2.0,
+                2.0
+            ],
+            "name": "proj_angle_exact",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": true,
+            "freqs": [
+                250000000000000.0,
+                300000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null,
+            "custom_origin": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "far_field_approx": true,
+            "proj_distance": 1000000.0,
+            "theta": [
+                -1.5707963267948966,
+                -1.5390630676677268,
+                -1.5073298085405573,
+                -1.4755965494133876,
+                -1.443863290286218,
+                -1.4121300311590483,
+                -1.3803967720318788,
+                -1.348663512904709,
+                -1.3169302537775396,
+                -1.2851969946503699,
+                -1.2534637355232003,
+                -1.2217304763960306,
+                -1.189997217268861,
+                -1.1582639581416914,
+                -1.1265306990145216,
+                -1.0947974398873521,
+                -1.0630641807601826,
+                -1.0313309216330129,
+                -0.9995976625058433,
+                -0.9678644033786736,
+                -0.936131144251504,
+                -0.9043978851243344,
+                -0.8726646259971648,
+                -0.8409313668699951,
+                -0.8091981077428254,
+                -0.7774648486156558,
+                -0.7457315894884862,
+                -0.7139983303613165,
+                -0.6822650712341469,
+                -0.6505318121069773,
+                -0.6187985529798077,
+                -0.5870652938526381,
+                -0.5553320347254684,
+                -0.5235987755982987,
+                -0.4918655164711292,
+                -0.46013225734395946,
+                -0.42839899821678995,
+                -0.3966657390896202,
+                -0.3649324799624507,
+                -0.333199220835281,
+                -0.30146596170811146,
+                -0.26973270258094173,
+                -0.23799944345377222,
+                -0.2062661843266025,
+                -0.17453292519943298,
+                -0.14279966607226324,
+                -0.11106640694509373,
+                -0.079333147817924,
+                -0.047599888690754266,
+                -0.015866629563584755,
+                0.015866629563584977,
+                0.04759988869075449,
+                0.07933314781792422,
+                0.11106640694509373,
+                0.14279966607226346,
+                0.17453292519943298,
+                0.2062661843266027,
+                0.23799944345377222,
+                0.26973270258094195,
+                0.30146596170811146,
+                0.3331992208352812,
+                0.3649324799624507,
+                0.39666573908962044,
+                0.42839899821678995,
+                0.4601322573439597,
+                0.4918655164711292,
+                0.5235987755982991,
+                0.5553320347254687,
+                0.5870652938526382,
+                0.6187985529798077,
+                0.6505318121069776,
+                0.6822650712341471,
+                0.7139983303613167,
+                0.7457315894884862,
+                0.7774648486156561,
+                0.8091981077428256,
+                0.8409313668699951,
+                0.8726646259971647,
+                0.9043978851243346,
+                0.9361311442515041,
+                0.9678644033786736,
+                0.9995976625058436,
+                1.031330921633013,
+                1.0630641807601826,
+                1.0947974398873521,
+                1.126530699014522,
+                1.1582639581416916,
+                1.189997217268861,
+                1.2217304763960306,
+                1.2534637355232006,
+                1.28519699465037,
+                1.3169302537775396,
+                1.348663512904709,
+                1.380396772031879,
+                1.4121300311590486,
+                1.443863290286218,
+                1.475596549413388,
+                1.5073298085405575,
+                1.539063067667727,
+                1.5707963267948966
+            ],
+            "phi": [
+                0.0,
+                1.5707963267948966
+            ]
+        },
+        {
+            "type": "DiffractionMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                "Infinity",
+                "Infinity"
+            ],
+            "name": "diffraction",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": false,
+            "freqs": [
+                100000000000000.0,
+                200000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+"
+        }
+    ],
+    "grid_spec": {
+        "grid_x": {
+            "type": "AutoGrid",
+            "min_steps_per_wvl": 10.0,
+            "max_scale": 1.4,
+            "dl_min": 0.0,
+            "mesher": {
+                "type": "GradedMesher"
+            }
+        },
+        "grid_y": {
+            "type": "CustomGrid",
+            "dl": [
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04
+            ],
+            "custom_offset": null
+        },
+        "grid_z": {
+            "type": "UniformGrid",
+            "dl": 0.05
+        },
+        "wavelength": null,
+        "override_structures": [
+            {
+                "geometry": {
+                    "type": "Box",
+                    "center": [
+                        -1.0,
+                        0.0,
+                        0.0
+                    ],
+                    "size": [
+                        1.0,
+                        1.0,
+                        1.0
+                    ]
+                },
+                "name": null,
+                "type": "Structure",
+                "medium": {
+                    "name": null,
+                    "frequency_range": null,
+                    "allow_gain": false,
+                    "nonlinear_spec": null,
+                    "heat_spec": null,
+                    "type": "Medium",
+                    "permittivity": 2.0,
+                    "conductivity": 0.0
+                }
+            }
+        ],
+        "type": "GridSpec"
+    },
+    "shutoff": 0.0001,
+    "subpixel": false,
+    "normalize_index": 0,
+    "courant": 0.8,
+    "version": "2.5.0rc1"
+}

--- a/tests/test_components/test_bc_placement.py
+++ b/tests/test_components/test_bc_placement.py
@@ -1,0 +1,20 @@
+import pytest
+import pydantic.v1 as pd
+import numpy as np
+
+import tidy3d as td
+from tidy3d.components.bc_placement import (
+    StructureBoundary,
+    StructureStructureInterface,
+    SimulationBoundary,
+    StructureSimulationBoundary,
+    MediumMediumInterface,
+)
+
+
+def test_bc_placement():
+    _ = StructureBoundary(structure="box")
+    _ = SimulationBoundary()
+    _ = StructureSimulationBoundary(structure="box")
+    _ = StructureStructureInterface(structures=["box", "sphere"])
+    _ = MediumMediumInterface(mediums=["dieletric", "metal"])

--- a/tests/test_components/test_heat.py
+++ b/tests/test_components/test_heat.py
@@ -1,0 +1,364 @@
+import pytest
+import pydantic.v1 as pd
+import numpy as np
+from matplotlib import pyplot as plt
+
+import tidy3d as td
+
+from tidy3d import FluidSpec, SolidSpec
+from tidy3d import UniformHeatSource
+from tidy3d import (
+    TemperatureBC,
+    HeatFluxBC,
+    ConvectionBC,
+    HeatBoundarySpec,
+)
+from tidy3d import (
+    StructureBoundary,
+    StructureStructureInterface,
+    SimulationBoundary,
+    StructureSimulationBoundary,
+    MediumMediumInterface,
+)
+from tidy3d import UniformUnstructuredGrid, DistanceUnstructuredGrid
+from tidy3d import HeatSimulation
+from tidy3d import HeatSimulationData
+from tidy3d import TemperatureMonitor
+from tidy3d import TemperatureData
+
+from tidy3d.exceptions import DataError
+from ..utils import STL_GEO, assert_log_level, log_capture
+
+
+def make_heat_mediums():
+    fluid_medium = td.Medium(
+        permittivity=3,
+        heat_spec=FluidSpec(),
+        name="fluid_medium",
+    )
+    solid_medium = td.Medium(
+        permittivity=5,
+        conductivity=0.01,
+        heat_spec=SolidSpec(
+            capacity=2,
+            conductivity=3,
+        ),
+        name="solid_medium",
+    )
+
+    return fluid_medium, solid_medium
+
+
+def test_heat_medium():
+    _, solid_medium = make_heat_mediums()
+
+    with pytest.raises(pd.ValidationError):
+        _ = solid_medium.heat_spec.updated_copy(capacity=-1)
+
+    with pytest.raises(pd.ValidationError):
+        _ = solid_medium.heat_spec.updated_copy(conductivity=-1)
+
+
+def make_heat_structures():
+    fluid_medium, solid_medium = make_heat_mediums()
+
+    box = td.Box(center=(0, 0, 0), size=(1, 1, 1))
+
+    fluid_structure = td.Structure(
+        geometry=box,
+        medium=fluid_medium,
+        name="fluid_structure",
+    )
+
+    solid_structure = td.Structure(
+        geometry=box.updated_copy(center=(1, 1, 1)),
+        medium=solid_medium,
+        name="solid_structure",
+    )
+
+    return fluid_structure, solid_structure
+
+
+def test_heat_structures():
+    _, _ = make_heat_structures()
+
+
+def make_heat_bcs():
+    bc_temp = TemperatureBC(temperature=300)
+    bc_flux = HeatFluxBC(flux=20)
+    bc_conv = ConvectionBC(ambient_temperature=400, transfer_coeff=0.2)
+
+    return bc_temp, bc_flux, bc_conv
+
+
+def test_heat_bcs():
+    bc_temp, bc_flux, bc_conv = make_heat_bcs()
+
+    with pytest.raises(pd.ValidationError):
+        _ = TemperatureBC(temperature=-10)
+
+    with pytest.raises(pd.ValidationError):
+        _ = ConvectionBC(ambient_temperature=-400, transfer_coeff=0.2)
+
+    with pytest.raises(pd.ValidationError):
+        _ = ConvectionBC(ambient_temperature=400, transfer_coeff=-0.2)
+
+
+def make_heat_mnt():
+    return TemperatureMonitor(size=(1, 2, 3), name="test")
+
+
+def test_heat_mnt():
+    temp_mnt = make_heat_mnt()
+
+    with pytest.raises(pd.ValidationError):
+        _ = temp_mnt.updated_copy(name=None)
+
+    with pytest.raises(pd.ValidationError):
+        _ = temp_mnt.updated_copy(size=(-1, 2, 3))
+
+
+def make_heat_mnt_data():
+    temp_mnt = make_heat_mnt()
+
+    nx, ny, nz = 9, 6, 5
+    x = np.linspace(-1, 1, nx)
+    y = np.linspace(-2, 2, ny)
+    z = np.linspace(-3, 3, nz)
+    T = np.random.default_rng().uniform(300, 350, (nx, ny, nz))
+    coords = dict(x=x, y=y, z=z)
+    temperature_field = td.SpatialDataArray(T, coords=coords)
+
+    return TemperatureData(monitor=temp_mnt, temperature=temperature_field)
+
+
+def test_heat_mnt_data():
+    _ = make_heat_mnt_data
+
+
+def make_uniform_grid_spec():
+    return UniformUnstructuredGrid(dl=0.1, min_edges_per_circumference=5, min_edges_per_side=3)
+
+
+def make_distance_grid_spec():
+    return DistanceUnstructuredGrid(
+        dl_interface=0.1, dl_bulk=1, distance_interface=1, distance_bulk=2
+    )
+
+
+def test_grid_spec():
+    grid_spec = make_uniform_grid_spec()
+    with pytest.raises(pd.ValidationError):
+        _ = grid_spec.updated_copy(dl=0)
+    with pytest.raises(pd.ValidationError):
+        _ = grid_spec.updated_copy(min_edges_per_circumference=-1)
+    with pytest.raises(pd.ValidationError):
+        _ = grid_spec.updated_copy(min_edges_per_side=-1)
+
+    grid_spec = make_distance_grid_spec()
+    with pytest.raises(pd.ValidationError):
+        grid_spec.updated_copy(dl_interface=-1)
+    with pytest.raises(pd.ValidationError):
+        grid_spec.updated_copy(distance_interface=2, distance_bulk=1)
+
+
+def make_heat_source():
+    return UniformHeatSource(structures=["solid_structure"], rate=100)
+
+
+def test_heat_source():
+    _ = make_heat_source()
+
+
+def make_heat_sim():
+    fluid_medium, solid_medium = make_heat_mediums()
+    fluid_structure, solid_structure = make_heat_structures()
+    bc_temp, bc_flux, bc_conv = make_heat_bcs()
+    heat_source = make_heat_source()
+
+    pl1 = HeatBoundarySpec(
+        condition=bc_conv, placement=MediumMediumInterface(mediums=["fluid_medium", "solid_medium"])
+    )
+    pl2 = HeatBoundarySpec(
+        condition=bc_flux, placement=StructureBoundary(structure="solid_structure")
+    )
+    pl3 = HeatBoundarySpec(
+        condition=bc_flux,
+        placement=StructureStructureInterface(structures=["fluid_structure", "solid_structure"]),
+    )
+    pl4 = HeatBoundarySpec(condition=bc_temp, placement=SimulationBoundary())
+    pl5 = HeatBoundarySpec(
+        condition=bc_temp, placement=StructureSimulationBoundary(structure="fluid_structure")
+    )
+
+    grid_spec = make_uniform_grid_spec()
+
+    temp_mnt = make_heat_mnt()
+
+    heat_sim = HeatSimulation(
+        medium=fluid_medium,
+        structures=[fluid_structure, solid_structure],
+        center=(0, 0, 0),
+        size=(2, 2, 2),
+        boundary_spec=[pl1, pl2, pl3, pl4, pl5],
+        grid_spec=grid_spec,
+        sources=[heat_source],
+        monitors=[temp_mnt],
+    )
+
+    return heat_sim
+
+
+def test_heat_sim():
+    bc_temp, bc_flux, bc_conv = make_heat_bcs()
+    heat_sim = make_heat_sim()
+
+    _ = heat_sim.plot(x=0)
+
+    # wrong names given
+    for pl in [
+        HeatBoundarySpec(
+            condition=bc_temp, placement=MediumMediumInterface(mediums=["badname", "fluid_medium"])
+        ),
+        HeatBoundarySpec(condition=bc_flux, placement=StructureBoundary(structure="no_box")),
+        HeatBoundarySpec(
+            condition=bc_conv,
+            placement=StructureStructureInterface(structures=["no_box", "solid_structure"]),
+        ),
+        HeatBoundarySpec(
+            condition=bc_temp, placement=StructureSimulationBoundary(structure="no_mesh")
+        ),
+    ]:
+        with pytest.raises(pd.ValidationError):
+            _ = heat_sim.updated_copy(boundary_spec=[pl])
+
+    with pytest.raises(pd.ValidationError):
+        _ = heat_sim.updated_copy(sources=[UniformHeatSource(structures=["noname"])], rate=-10)
+
+    # polyslab support
+    vertices = np.array([(0, 0), (1, 0), (1, 1)])
+    p = td.PolySlab(vertices=vertices, axis=2, slab_bounds=(-1, 1))
+    _, structure = make_heat_structures()
+    structure = structure.updated_copy(geometry=p, name="polyslab")
+    _ = heat_sim.updated_copy(structures=list(heat_sim.structures) + [structure])
+
+    # test unsupported yet geometries
+    structure = structure.updated_copy(geometry=STL_GEO, name="stl")
+    with pytest.raises(pd.ValidationError):
+        _ = heat_sim.updated_copy(structures=list(heat_sim.structures) + [structure])
+
+    # test unsupported yet zero dimension domains
+    with pytest.raises(pd.ValidationError):
+        _ = heat_sim.updated_copy(center=(0, 0, 0), size=(0, 2, 2))
+
+    with pytest.raises(pd.ValidationError):
+        _ = heat_sim.updated_copy(center=(0, 0, 0), size=(1, 0, 0))
+
+    temp_mnt = make_heat_mnt()
+
+    with pytest.raises(pd.ValidationError):
+        heat_sim.updated_copy(monitors=[temp_mnt, temp_mnt])
+
+    _ = heat_sim.plot(x=0)
+    plt.close()
+
+    _ = heat_sim.plot_heat_conductivity(y=0)
+    plt.close()
+
+    heat_sim = heat_sim.updated_copy(symmetry=(0, 1, 1))
+    _ = heat_sim.plot_heat_conductivity(z=0, colorbar="source")
+    plt.close()
+
+    with pytest.raises(pd.ValidationError):
+        _ = heat_sim.updated_copy(symmetry=(-1, 0, 1))
+
+
+@pytest.mark.parametrize("shift_amount, log_level", ((1, None), (2, "WARNING")))
+def test_heat_sim_bounds(shift_amount, log_level, log_capture):
+    """make sure bounds are working correctly"""
+
+    # make sure all things are shifted to this central location
+    CENTER_SHIFT = (-1.0, 1.0, 100.0)
+
+    def place_box(center_offset):
+
+        shifted_center = tuple(c + s for (c, s) in zip(center_offset, CENTER_SHIFT))
+
+        _ = td.HeatSimulation(
+            size=(1.5, 1.5, 1.5),
+            center=CENTER_SHIFT,
+            structures=[
+                td.Structure(
+                    geometry=td.Box(size=(1, 1, 1), center=shifted_center), medium=td.Medium()
+                )
+            ],
+            grid_spec=td.UniformUnstructuredGrid(dl=0.1),
+        )
+
+    # create all permutations of squares being shifted 1, -1, or zero in all three directions
+    bin_strings = [list(format(i, "03b")) for i in range(8)]
+    bin_ints = [[int(b) for b in bin_string] for bin_string in bin_strings]
+    bin_ints = np.array(bin_ints)
+    bin_signs = 2 * (bin_ints - 0.5)
+
+    # test all cases where box is shifted +/- 1 in x,y,z and still intersects
+    for amp in bin_ints:
+        for sign in bin_signs:
+            center = shift_amount * amp * sign
+            if np.sum(center) < 1e-12:
+                continue
+            place_box(tuple(center))
+    assert_log_level(log_capture, log_level)
+
+
+@pytest.mark.parametrize(
+    "box_size,log_level",
+    [
+        ((1, 0.1, 0.1), "WARNING"),
+        ((0.1, 1, 0.1), "WARNING"),
+        ((0.1, 0.1, 1), "WARNING"),
+    ],
+)
+def test_sim_structure_extent(log_capture, box_size, log_level):
+    """Make sure we warn if structure extends exactly to simulation edges."""
+
+    box = td.Structure(geometry=td.Box(size=box_size), medium=td.Medium(permittivity=2))
+    _ = td.HeatSimulation(
+        size=(1, 1, 1),
+        structures=[box],
+        grid_spec=td.UniformUnstructuredGrid(dl=0.1),
+    )
+
+    assert_log_level(log_capture, log_level)
+
+
+def make_heat_sim_data():
+    heat_sim = make_heat_sim()
+    temp_data = make_heat_mnt_data()
+
+    heat_sim_data = HeatSimulationData(
+        simulation=heat_sim,
+        data=[temp_data],
+    )
+
+    return heat_sim_data
+
+
+def test_sim_data():
+    heat_sim_data = make_heat_sim_data()
+    _ = heat_sim_data.plot_field("test", z=0)
+    plt.close()
+
+    with pytest.raises(DataError):
+        _ = heat_sim_data.plot_field("test3", x=0)
+
+    with pytest.raises(pd.ValidationError):
+        _ = heat_sim_data.updated_copy(data=[heat_sim_data.data[0]] * 2)
+
+    temp_mnt = make_heat_mnt()
+    temp_mnt = temp_mnt.updated_copy(name="test2")
+
+    sim = heat_sim_data.simulation.updated_copy(monitors=[temp_mnt])
+
+    with pytest.raises(pd.ValidationError):
+        _ = heat_sim_data.updated_copy(simulation=sim)

--- a/tests/test_components/test_scene.py
+++ b/tests/test_components/test_scene.py
@@ -1,0 +1,274 @@
+"""Tests the scene and its validators."""
+import pytest
+import pydantic.v1 as pd
+import matplotlib.pyplot as plt
+
+import numpy as np
+import tidy3d as td
+from tidy3d.components.simulation import MAX_NUM_MEDIUMS
+from ..utils import assert_log_level, log_capture, SIM_FULL
+
+SCENE = td.Scene()
+
+SCENE_FULL = SIM_FULL.scene
+
+
+def test_scene_init():
+    """make sure a scene can be initialized"""
+
+    sim = td.Scene(
+        structures=[
+            td.Structure(
+                geometry=td.Box(size=(1, 1, 1), center=(-1, 0, 0)),
+                medium=td.Medium(permittivity=2.0),
+            ),
+            td.Structure(
+                geometry=td.Box(size=(1, 1, 1), center=(0, 0, 0)),
+                medium=td.Medium(permittivity=1.0, conductivity=3.0),
+            ),
+            td.Structure(
+                geometry=td.Sphere(radius=1.4, center=(1.0, 0.0, 1.0)), medium=td.Medium()
+            ),
+            td.Structure(
+                geometry=td.Cylinder(radius=1.4, length=2.0, center=(1.0, 0.0, -1.0), axis=1),
+                medium=td.Medium(),
+            ),
+        ],
+        medium=td.Medium(permittivity=3.0),
+    )
+
+    _ = sim.mediums
+    _ = sim.medium_map
+    _ = sim.background_structure
+
+
+def test_validate_components_none():
+
+    assert SCENE._validate_num_mediums(val=None) is None
+
+
+def test_plot_eps():
+    ax = SCENE_FULL.plot_eps(x=0)
+    SCENE_FULL._add_cbar_eps(eps_min=1, eps_max=2, ax=ax)
+    plt.close()
+
+
+def test_plot_eps_bounds():
+    _ = SCENE_FULL.plot_eps(x=0, hlim=[-0.45, 0.45])
+    plt.close()
+    _ = SCENE_FULL.plot_eps(x=0, vlim=[-0.45, 0.45])
+    plt.close()
+    _ = SCENE_FULL.plot_eps(x=0, hlim=[-0.45, 0.45], vlim=[-0.45, 0.45])
+    plt.close()
+
+
+def test_plot():
+    SCENE_FULL.plot(x=0)
+    plt.close()
+
+
+def test_plot_1d_scene():
+    s = td.Scene(structures=[td.Structure(geometry=td.Box(size=(0, 0, 1)), medium=td.Medium())])
+    _ = s.plot(y=0)
+    plt.close()
+
+
+def test_plot_bounds():
+    _ = SCENE_FULL.plot(x=0, hlim=[-0.45, 0.45])
+    plt.close()
+    _ = SCENE_FULL.plot(x=0, vlim=[-0.45, 0.45])
+    plt.close()
+    _ = SCENE_FULL.plot(x=0, hlim=[-0.45, 0.45], vlim=[-0.45, 0.45])
+    plt.close()
+
+
+def test_structure_alpha():
+    _ = SCENE_FULL.plot_structures_eps(x=0, alpha=None)
+    plt.close()
+    _ = SCENE_FULL.plot_structures_eps(x=0, alpha=-1)
+    plt.close()
+    _ = SCENE_FULL.plot_structures_eps(x=0, alpha=1)
+    plt.close()
+    _ = SCENE_FULL.plot_structures_eps(x=0, alpha=0.5)
+    plt.close()
+    _ = SCENE_FULL.plot_structures_eps(x=0, alpha=0.5, cbar=True)
+    plt.close()
+    new_structs = [
+        td.Structure(geometry=s.geometry, medium=SCENE_FULL.medium) for s in SCENE_FULL.structures
+    ]
+    S2 = SCENE_FULL.copy(update=dict(structures=new_structs))
+    _ = S2.plot_structures_eps(x=0, alpha=0.5)
+    plt.close()
+
+
+def test_filter_structures():
+    s1 = td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=SCENE.medium)
+    s2 = td.Structure(geometry=td.Box(size=(1, 1, 1), center=(1, 1, 1)), medium=SCENE.medium)
+    plane = td.Box(center=(0, 0, 1.5), size=(td.inf, td.inf, 0))
+    SCENE._filter_structures_plane_medium(structures=[s1, s2], plane=plane)
+
+
+def test_get_structure_plot_params():
+    pp = SCENE_FULL._get_structure_plot_params(mat_index=0, medium=SCENE_FULL.medium)
+    assert pp.facecolor == "white"
+    pp = SCENE_FULL._get_structure_plot_params(mat_index=1, medium=td.PEC)
+    assert pp.facecolor == "gold"
+    pp = SCENE_FULL._get_structure_eps_plot_params(
+        medium=SCENE_FULL.medium, freq=1, eps_min=1, eps_max=2
+    )
+    assert float(pp.facecolor) == 1.0
+    pp = SCENE_FULL._get_structure_eps_plot_params(medium=td.PEC, freq=1, eps_min=1, eps_max=2)
+    assert pp.facecolor == "gold"
+
+
+def test_num_mediums():
+    """Make sure we error if too many mediums supplied."""
+
+    structures = []
+    for i in range(MAX_NUM_MEDIUMS):
+        structures.append(
+            td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=td.Medium(permittivity=i + 1))
+        )
+    _ = td.Scene(
+        structures=structures,
+    )
+
+    with pytest.raises(pd.ValidationError):
+        structures.append(
+            td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=td.Medium(permittivity=i + 2))
+        )
+        _ = td.Scene(structures=structures)
+
+
+def _test_names_default():
+    """makes sure default names are set"""
+
+    scene = td.Scene(
+        size=(2.0, 2.0, 2.0),
+        structures=[
+            td.Structure(
+                geometry=td.Box(size=(1, 1, 1), center=(-1, 0, 0)),
+                medium=td.Medium(permittivity=2.0),
+            ),
+            td.Structure(
+                geometry=td.Box(size=(1, 1, 1), center=(0, 0, 0)),
+                medium=td.Medium(permittivity=2.0),
+            ),
+            td.Structure(
+                geometry=td.Sphere(radius=1.4, center=(1.0, 0.0, 1.0)), medium=td.Medium()
+            ),
+            td.Structure(
+                geometry=td.Cylinder(radius=1.4, length=2.0, center=(1.0, 0.0, -1.0), axis=1),
+                medium=td.Medium(),
+            ),
+        ],
+    )
+
+    for i, structure in enumerate(scene.structures):
+        assert structure.name == f"structures[{i}]"
+
+
+def test_names_unique():
+
+    with pytest.raises(pd.ValidationError):
+        _ = td.Scene(
+            structures=[
+                td.Structure(
+                    geometry=td.Box(size=(1, 1, 1), center=(-1, 0, 0)),
+                    medium=td.Medium(permittivity=2.0),
+                    name="struct1",
+                ),
+                td.Structure(
+                    geometry=td.Box(size=(1, 1, 1), center=(0, 0, 0)),
+                    medium=td.Medium(permittivity=2.0),
+                    name="struct1",
+                ),
+            ],
+        )
+
+
+def test_allow_gain():
+    """Test if simulation allows gain."""
+
+    medium = td.Medium(permittivity=2.0)
+    medium_gain = td.Medium(permittivity=2.0, allow_gain=True)
+    medium_ani = td.AnisotropicMedium(xx=medium, yy=medium, zz=medium)
+    medium_gain_ani = td.AnisotropicMedium(xx=medium, yy=medium_gain, zz=medium)
+
+    # Test simulation medium
+    scene = td.Scene(medium=medium)
+    assert not scene.allow_gain
+    scene = scene.updated_copy(medium=medium_gain)
+    assert scene.allow_gain
+
+    # Test structure with anisotropic gain medium
+    struct = td.Structure(geometry=td.Box(center=(0, 0, 0), size=(1, 1, 1)), medium=medium_ani)
+    struct_gain = struct.updated_copy(medium=medium_gain_ani)
+    scene = td.Scene(
+        medium=medium,
+        structures=[struct],
+    )
+    assert not scene.allow_gain
+    scene = scene.updated_copy(structures=[struct_gain])
+    assert scene.allow_gain
+
+
+def test_perturbed_mediums_copy():
+
+    # Non-dispersive
+    pp_real = td.ParameterPerturbation(
+        heat=td.LinearHeatPerturbation(
+            coeff=-0.01,
+            temperature_ref=300,
+            temperature_range=(200, 500),
+        ),
+    )
+
+    pp_complex = td.ParameterPerturbation(
+        heat=td.LinearHeatPerturbation(
+            coeff=0.01j,
+            temperature_ref=300,
+            temperature_range=(200, 500),
+        ),
+        charge=td.LinearChargePerturbation(
+            electron_coeff=-1e-21,
+            electron_ref=0,
+            electron_range=(0, 1e20),
+            hole_coeff=-2e-21,
+            hole_ref=0,
+            hole_range=(0, 0.5e20),
+        ),
+    )
+
+    coords = dict(x=[1, 2], y=[3, 4], z=[5, 6])
+    temperature = td.SpatialDataArray(300 * np.ones((2, 2, 2)), coords=coords)
+    electron_density = td.SpatialDataArray(1e18 * np.ones((2, 2, 2)), coords=coords)
+    hole_density = td.SpatialDataArray(2e18 * np.ones((2, 2, 2)), coords=coords)
+
+    pmed1 = td.PerturbationMedium(permittivity=3, permittivity_perturbation=pp_real)
+
+    pmed2 = td.PerturbationPoleResidue(
+        poles=[(1j, 3), (2j, 4)],
+        poles_perturbation=[(None, pp_real), (pp_complex, None)],
+    )
+
+    struct = td.Structure(geometry=td.Box(center=(0, 0, 0), size=(1, 1, 1)), medium=pmed2)
+
+    scene = td.Scene(
+        medium=pmed1,
+        structures=[struct],
+    )
+
+    # no perturbations provided -> regular mediums
+    new_scene = scene.perturbed_mediums_copy()
+
+    assert isinstance(new_scene.medium, td.Medium)
+    assert isinstance(new_scene.structures[0].medium, td.PoleResidue)
+
+    # perturbations provided -> custom mediums
+    new_scene = scene.perturbed_mediums_copy(temperature)
+    new_scene = scene.perturbed_mediums_copy(temperature, None, hole_density)
+    new_scene = scene.perturbed_mediums_copy(temperature, electron_density, hole_density)
+
+    assert isinstance(new_scene.medium, td.CustomMedium)
+    assert isinstance(new_scene.structures[0].medium, td.CustomPoleResidue)

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -1962,3 +1962,16 @@ def test_perturbed_mediums_copy():
 
     assert isinstance(new_sim.medium, td.CustomMedium)
     assert isinstance(new_sim.structures[0].medium, td.CustomPoleResidue)
+
+
+def test_scene_from_scene():
+    """Test .scene and .from_scene functionality."""
+
+    scene = SIM_FULL.scene
+
+    sim = td.Simulation.from_scene(
+        scene=scene,
+        **SIM_FULL.dict(exclude={"structures", "medium"}),
+    )
+
+    assert sim == SIM_FULL

--- a/tests/test_web/test_webapi_heat.py
+++ b/tests/test_web/test_webapi_heat.py
@@ -1,0 +1,350 @@
+# Tests webapi and things that depend on it
+
+import pytest
+import responses
+from _pytest import monkeypatch
+
+import tidy3d as td
+from responses import matchers
+from tidy3d import HeatSimulation
+from tidy3d.web.core.environment import Env
+from tidy3d.web.api.webapi import download, download_json, run, abort
+from tidy3d.web.api.webapi import estimate_cost, get_info, get_run_info
+from tidy3d.web.api.webapi import load_simulation, upload
+from tidy3d.web.api.container import Job, Batch
+from tidy3d.web.api.asynchronous import run_async
+
+from tidy3d.web.core.types import TaskType
+from ..test_components.test_heat import make_heat_sim
+
+TASK_NAME = "task_name_test"
+TASK_ID = "1234"
+FOLDER_ID = "1234"
+CREATED_AT = "2022-01-01T00:00:00.000Z"
+PROJECT_NAME = "default"
+FLEX_UNIT = 1.0
+EST_FLEX_UNIT = 11.11
+FILE_SIZE_GB = 4.0
+
+task_core_path = "tidy3d.web.core.task_core"
+api_path = "tidy3d.web.api.webapi"
+
+
+@pytest.fixture
+def set_api_key(monkeypatch):
+    """Set the api key."""
+    import tidy3d.web.core.http_util as http_module
+
+    monkeypatch.setattr(http_module, "api_key", lambda: "apikey")
+    monkeypatch.setattr(http_module, "get_version", lambda: td.version.__version__)
+
+
+@pytest.fixture
+def mock_upload(monkeypatch, set_api_key):
+    """Mocks webapi.upload."""
+    responses.add(
+        responses.GET,
+        f"{Env.current.web_api_endpoint}/tidy3d/project",
+        match=[matchers.query_param_matcher({"projectName": PROJECT_NAME})],
+        json={"data": {"projectId": FOLDER_ID, "projectName": PROJECT_NAME}},
+        status=200,
+    )
+
+    responses.add(
+        responses.POST,
+        f"{Env.current.web_api_endpoint}/tidy3d/projects/{FOLDER_ID}/tasks",
+        match=[
+            matchers.json_params_matcher(
+                {
+                    "taskType": TaskType.HEAT.name,
+                    "taskName": TASK_NAME,
+                    "callbackUrl": None,
+                    "simulationType": "tidy3d",
+                    "parentTasks": None,
+                    "fileType": "Gz",
+                }
+            )
+        ],
+        json={
+            "data": {
+                "taskId": TASK_ID,
+                "taskName": TASK_NAME,
+                "createdAt": CREATED_AT,
+            }
+        },
+        status=200,
+    )
+
+    def mock_download(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr("tidy3d.web.core.task_core.upload_file", mock_download)
+
+
+@pytest.fixture
+def mock_get_info(monkeypatch, set_api_key):
+    """Mocks webapi.get_info."""
+
+    responses.add(
+        responses.GET,
+        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/detail",
+        json={
+            "data": {
+                "taskId": TASK_ID,
+                "taskName": TASK_NAME,
+                "taskType": TaskType.HEAT.name,
+                "createdAt": CREATED_AT,
+                "realFlexUnit": FLEX_UNIT,
+                "estFlexUnit": EST_FLEX_UNIT,
+                "metadataStatus": "processed",
+                "status": "success",
+                "s3Storage": 1.0,
+            }
+        },
+        status=200,
+    )
+
+
+@pytest.fixture
+def mock_start(monkeypatch, set_api_key, mock_get_info):
+    """Mocks webapi.start."""
+
+    responses.add(
+        responses.POST,
+        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/submit",
+        match=[
+            matchers.json_params_matcher(
+                {
+                    "solverVersion": None,
+                    "workerGroup": None,
+                    "protocolVersion": td.version.__version__,
+                }
+            )
+        ],
+        json={
+            "data": {
+                "taskId": TASK_ID,
+                "taskName": TASK_NAME,
+                "createdAt": CREATED_AT,
+            }
+        },
+        status=200,
+    )
+
+
+@pytest.fixture
+def mock_monitor(monkeypatch):
+    status_count = [0]
+    statuses = ("upload", "running", "running", "running", "running", "running", "success")
+
+    def mock_get_status(task_id):
+        current_count = min(status_count[0], len(statuses) - 1)
+        current_status = statuses[current_count]
+        status_count[0] += 1
+        return current_status
+        # return TaskInfo(
+        #     status=current_status, taskName=TASK_NAME, taskId=task_id, realFlexUnit=1.0
+        #     )
+
+    run_count = [0]
+    perc_dones = (1, 10, 20, 30, 100)
+
+    def mock_get_run_info(task_id):
+        current_count = min(run_count[0], len(perc_dones) - 1)
+        perc_done = perc_dones[current_count]
+        run_count[0] += 1
+        return perc_done, 1
+
+    monkeypatch.setattr("tidy3d.web.api.connect_util.REFRESH_TIME", 0.00001)
+    monkeypatch.setattr(f"{api_path}.RUN_REFRESH_TIME", 0.00001)
+    monkeypatch.setattr(f"{api_path}.get_status", mock_get_status)
+    monkeypatch.setattr(f"{api_path}.get_run_info", mock_get_run_info)
+
+
+@pytest.fixture
+def mock_download(monkeypatch, set_api_key, mock_get_info, tmp_path):
+    """Mocks webapi.download."""
+
+    def _mock_download(*args, **kwargs):
+        file_path = kwargs["to_file"]
+        with open(file_path, "w") as f:
+            f.write("0.3,5.7")
+
+    monkeypatch.setattr(f"{task_core_path}.download_file", _mock_download)
+    download(TASK_ID, str(tmp_path / "web_test_tmp.json"))
+    with open(str(tmp_path / "web_test_tmp.json"), "r") as f:
+        assert f.read() == "0.3,5.7"
+
+
+@pytest.fixture
+def mock_load(monkeypatch, set_api_key, mock_get_info):
+    """Mocks webapi.load"""
+
+    def _mock_download(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(f"{task_core_path}.download_file", _mock_download)
+
+
+@pytest.fixture
+def mock_metadata(monkeypatch, set_api_key):
+    """Mocks call to metadata api"""
+    responses.add(
+        responses.POST,
+        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/metadata",
+        json={
+            "data": {
+                "createdAt": CREATED_AT,
+            }
+        },
+        status=200,
+    )
+
+
+@pytest.fixture
+def mock_get_run_info(monkeypatch, set_api_key):
+    """Mocks webapi.get_run_info"""
+    responses.add(
+        responses.GET,
+        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}/progress",
+        json={
+            "data": {
+                "perc_done": 100,
+                "field_decay": 0,
+            }
+        },
+        status=200,
+    )
+
+
+@pytest.fixture
+def mock_webapi(
+    mock_upload, mock_metadata, mock_get_info, mock_start, mock_monitor, mock_download, mock_load
+):
+    """Mocks all webapi operation."""
+
+
+@responses.activate
+def test_upload(mock_upload):
+    sim = make_heat_sim()
+    assert upload(sim, TASK_NAME, PROJECT_NAME)
+
+
+@responses.activate
+def test_get_info(mock_get_info):
+    assert get_info(TASK_ID).taskId == TASK_ID
+    assert get_info(TASK_ID).taskType == "HEAT"
+
+
+@responses.activate
+def test_get_run_info(mock_get_run_info):
+    assert get_run_info(TASK_ID) == (100, 0)
+
+
+@responses.activate
+def test_estimate_cost(set_api_key, mock_get_info, mock_metadata):
+    assert estimate_cost(TASK_ID) == EST_FLEX_UNIT
+
+
+@responses.activate
+def test_download_json(monkeypatch, mock_get_info, tmp_path):
+    sim = make_heat_sim()
+
+    def mock_download(*args, **kwargs):
+        pass
+
+    def get_str(*args, **kwargs):
+        return sim.json().encode("utf-8")
+
+    monkeypatch.setattr(f"{task_core_path}.download_file", mock_download)
+    monkeypatch.setattr(f"{task_core_path}._read_simulation_from_hdf5", get_str)
+
+    fname_tmp = str(tmp_path / "web_test_tmp.json")
+    download_json(TASK_ID, fname_tmp)
+    assert HeatSimulation.from_file(fname_tmp) == sim
+
+
+@responses.activate
+def test_load_simulation(monkeypatch, mock_get_info, tmp_path):
+    def mock_download(*args, **kwargs):
+        make_heat_sim().to_file(args[1])
+
+    monkeypatch.setattr(f"{task_core_path}.SimulationTask.get_simulation_json", mock_download)
+
+    assert load_simulation(TASK_ID, str(tmp_path / "web_test_tmp.json"))
+
+
+@responses.activate
+def test_run(mock_webapi, monkeypatch, tmp_path):
+    sim = make_heat_sim()
+    monkeypatch.setattr(f"{api_path}.load", lambda *args, **kwargs: True)
+    assert run(
+        sim,
+        task_name=TASK_NAME,
+        folder_name=PROJECT_NAME,
+        path=str(tmp_path / "web_test_tmp.json"),
+    )
+
+
+@responses.activate
+def test_abort_task(set_api_key, mock_get_info):
+    responses.add(
+        responses.PUT,
+        f"{Env.current.web_api_endpoint}/tidy3d/tasks/abort",
+        match=[
+            matchers.json_params_matcher(
+                {
+                    "taskId": TASK_ID,
+                    "taskType": TaskType.HEAT.name,
+                }
+            )
+        ],
+        json={"result": True},
+        status=200,
+    )
+    abort(TASK_ID)
+
+
+""" Containers """
+
+
+@responses.activate
+def test_job(mock_webapi, monkeypatch, tmp_path):
+    monkeypatch.setattr("tidy3d.web.api.container.Job.load", lambda *args, **kwargs: True)
+    sim = make_heat_sim()
+    j = Job(simulation=sim, task_name=TASK_NAME, folder_name=PROJECT_NAME)
+
+    _ = j.run(path=str(tmp_path / "web_test_tmp.json"))
+    _ = j.status
+    j.estimate_cost()
+    # j.download
+    _ = j.delete
+    assert j.real_cost() == FLEX_UNIT
+
+
+@pytest.fixture
+def mock_job_status(monkeypatch):
+    monkeypatch.setattr("tidy3d.web.api.container.Job.status", property(lambda self: "success"))
+    monkeypatch.setattr("tidy3d.web.api.container.Job.load", lambda *args, **kwargs: True)
+
+
+@responses.activate
+def test_batch(mock_webapi, mock_job_status, tmp_path):
+    # monkeypatch.setattr("tidy3d.web.api.container.Batch.monitor", lambda self: time.sleep(0.1))
+    # monkeypatch.setattr("tidy3d.web.api.container.Job.status", property(lambda self: "success"))
+
+    sims = {TASK_NAME: make_heat_sim()}
+    b = Batch(simulations=sims, folder_name=PROJECT_NAME)
+    b.estimate_cost()
+    _ = b.run(path_dir=str(tmp_path))
+    assert b.real_cost() == FLEX_UNIT * len(sims)
+
+
+""" Async """
+
+
+@responses.activate
+def test_async(mock_webapi, mock_job_status):
+    # monkeypatch.setattr("tidy3d.web.api.container.Job.status", property(lambda self: "success"))
+    sims = {TASK_NAME: make_heat_sim()}
+    _ = run_async(sims, folder_name=PROJECT_NAME)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -102,19 +102,25 @@ SIM_FULL = td.Simulation(
     structures=[
         td.Structure(
             geometry=td.Box(size=(1, 1, 1), center=(-1, 0, 0)),
-            medium=td.Medium(permittivity=2.0),
+            medium=td.Medium(permittivity=2.0, name="dieletric"),
+            name="dieletric_box",
         ),
         td.Structure(
             geometry=td.Box(size=(1, td.inf, 1), center=(-1, 0, 0)),
-            medium=td.Medium(permittivity=1.0, conductivity=3.0),
+            medium=td.Medium(permittivity=1.0, conductivity=3.0, name="lossy_dieletric"),
+            name="lossy_box",
         ),
         td.Structure(
             geometry=td.Sphere(radius=1.0, center=(1.0, 0.0, 1.0)),
-            medium=td.Sellmeier(coeffs=[(1.03961212, 0.00600069867), (0.231792344, 0.0200179144)]),
+            medium=td.Sellmeier(
+                coeffs=[(1.03961212, 0.00600069867), (0.231792344, 0.0200179144)], name="sellmeier"
+            ),
+            name="sellmeier_sphere",
         ),
         td.Structure(
             geometry=td.Box(size=(1, 1, 1), center=(-1, 0, 0)),
-            medium=td.Lorentz(eps_inf=2.0, coeffs=[(1, 2, 3)]),
+            medium=td.Lorentz(eps_inf=2.0, coeffs=[(1, 2, 3)], name="lorentz"),
+            name="lorentz_box",
         ),
         td.Structure(
             geometry=td.Box(size=(1, 1, 1), center=(-1, 0, 0)),
@@ -126,7 +132,8 @@ SIM_FULL = td.Simulation(
         ),
         td.Structure(
             geometry=td.Box(size=(1, 1, 1), center=(-1, 0, 0)),
-            medium=td.Drude(eps_inf=2.0, coeffs=[(1, 3)]),
+            medium=td.Drude(eps_inf=2.0, coeffs=[(1, 3)], name="drude"),
+            name="drude_box",
         ),
         td.Structure(
             geometry=td.Box(size=(1, 0, 1), center=(-1, 0, 0)),
@@ -135,6 +142,7 @@ SIM_FULL = td.Simulation(
         td.Structure(
             geometry=td.GeometryGroup(geometries=[td.Box(size=(1, 1, 1), center=(-1, 0, 0))]),
             medium=td.PEC,
+            name="pec_group",
         ),
         td.Structure(
             geometry=td.Cylinder(radius=1.0, length=2.0, center=(1.0, 0.0, -1.0), axis=1),
@@ -143,6 +151,7 @@ SIM_FULL = td.Simulation(
                 yy=td.Medium(permittivity=2),
                 zz=td.Medium(permittivity=3),
             ),
+            name="anisotopic_cylinder",
         ),
         td.Structure(
             geometry=td.PolySlab(
@@ -151,6 +160,7 @@ SIM_FULL = td.Simulation(
             medium=td.PoleResidue(
                 eps_inf=1.0, poles=((6206417594288582j, (-3.311074436985222e16j)),)
             ),
+            name="pole_slab",
         ),
         td.Structure(
             geometry=td.Box(
@@ -231,6 +241,7 @@ SIM_FULL = td.Simulation(
                 )
             ),
             medium=td.Medium(permittivity=5),
+            name="dieletric_mesh",
         ),
         td.Structure(
             geometry=td.TriangleMesh.from_stl(

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -107,6 +107,25 @@ from .version import __version__
 # updater
 from .updater import Updater
 
+# scene
+from .components.scene import Scene
+
+# boundary placement for other solvers
+from .components.bc_placement import StructureStructureInterface, StructureBoundary
+from .components.bc_placement import MediumMediumInterface
+from .components.bc_placement import StructureSimulationBoundary
+from .components.bc_placement import SimulationBoundary
+
+# heat
+from .components.heat_spec import FluidSpec, SolidSpec
+from .components.heat.simulation import HeatSimulation
+from .components.heat.data.sim_data import HeatSimulationData
+from .components.heat.data.monitor_data import TemperatureData
+from .components.heat.boundary import TemperatureBC, ConvectionBC, HeatFluxBC, HeatBoundarySpec
+from .components.heat.source import UniformHeatSource
+from .components.heat.monitor import TemperatureMonitor
+from .components.heat.grid import UniformUnstructuredGrid, DistanceUnstructuredGrid
+
 
 def set_logging_level(level: str) -> None:
     """Raise a warning here instead of setting the logging level."""
@@ -265,4 +284,23 @@ __all__ = [
     "config",
     "__version__",
     "Updater",
+    "Scene",
+    "StructureStructureInterface",
+    "StructureBoundary",
+    "MediumMediumInterface",
+    "StructureSimulationBoundary",
+    "SimulationBoundary",
+    "FluidSpec",
+    "SolidSpec",
+    "HeatSimulation",
+    "HeatSimulationData",
+    "TemperatureBC",
+    "ConvectionBC",
+    "HeatFluxBC",
+    "HeatBoundarySpec",
+    "UniformHeatSource",
+    "UniformUnstructuredGrid",
+    "DistanceUnstructuredGrid",
+    "TemperatureData",
+    "TemperatureMonitor",
 ]

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -705,6 +705,8 @@ class Tidy3dBaseModel(pydantic.BaseModel):
 
     def __eq__(self, other):
         """Define == for two Tidy3DBaseModels."""
+        if other is None:
+            return False
         return self._json_string == other._json_string
 
     @cached_property

--- a/tidy3d/components/base_sim/data/monitor_data.py
+++ b/tidy3d/components/base_sim/data/monitor_data.py
@@ -1,0 +1,25 @@
+"""Abstract base for monitor data structures."""
+from __future__ import annotations
+from abc import ABC
+
+import pydantic.v1 as pd
+
+from ..monitor import AbstractMonitor
+from ...data.dataset import Dataset
+
+
+class AbstractMonitorData(Dataset, ABC):
+    """Abstract base class of objects that store data pertaining to a single
+    :class:`AbstractMonitor`.
+    """
+
+    monitor: AbstractMonitor = pd.Field(
+        ...,
+        title="Monitor",
+        description="Monitor associated with the data.",
+    )
+
+    @property
+    def symmetry_expanded_copy(self) -> AbstractMonitorData:
+        """Return copy of self with symmetry applied."""
+        return self.copy()

--- a/tidy3d/components/base_sim/data/sim_data.py
+++ b/tidy3d/components/base_sim/data/sim_data.py
@@ -1,0 +1,125 @@
+"""Abstract base for simulation data structures."""
+from __future__ import annotations
+from typing import Dict, Tuple
+
+from abc import ABC
+
+import xarray as xr
+import pydantic.v1 as pd
+import numpy as np
+
+from .monitor_data import AbstractMonitorData
+from ..simulation import AbstractSimulation
+from ...base import Tidy3dBaseModel
+from ...types import FieldVal
+from ....exceptions import DataError, Tidy3dKeyError, ValidationError
+
+
+class AbstractSimulationData(Tidy3dBaseModel, ABC):
+    """Stores data from a collection of :class:`AbstractMonitor` objects in
+    a :class:`AbstractSimulation`.
+    """
+
+    simulation: AbstractSimulation = pd.Field(
+        ...,
+        title="Simulation",
+        description="Original :class:`AbstractSimulation` associated with the data.",
+    )
+
+    data: Tuple[AbstractMonitorData, ...] = pd.Field(
+        ...,
+        title="Monitor Data",
+        description="List of :class:`AbstractMonitorData` instances "
+        "associated with the monitors of the original :class:`AbstractSimulation`.",
+    )
+
+    log: str = pd.Field(
+        None,
+        title="Solver Log",
+        description="A string containing the log information from the simulation run.",
+    )
+
+    def __getitem__(self, monitor_name: str) -> AbstractMonitorData:
+        """Get a :class:`.AbstractMonitorData` by name. Apply symmetry if applicable."""
+        if monitor_name not in self.monitor_data:
+            raise DataError(f"'{self.type}' does not contain data for monitor '{monitor_name}'.")
+        monitor_data = self.monitor_data[monitor_name]
+        return monitor_data.symmetry_expanded_copy
+
+    @property
+    def monitor_data(self) -> Dict[str, AbstractMonitorData]:
+        """Dictionary mapping monitor name to its associated :class:`AbstractMonitorData`."""
+        return {monitor_data.monitor.name: monitor_data for monitor_data in self.data}
+
+    @pd.validator("data", always=True)
+    def data_monitors_match_sim(cls, val, values):
+        """Ensure each :class:`AbstractMonitorData` in ``.data`` corresponds to a monitor in
+        ``.simulation``.
+        """
+        sim = values.get("simulation")
+        if sim is None:
+            raise ValidationError("'.simulation' failed validation, can't validate data.")
+        for mnt_data in val:
+            try:
+                monitor_name = mnt_data.monitor.name
+                sim.get_monitor_by_name(monitor_name)
+            except Tidy3dKeyError as exc:
+                raise DataError(
+                    f"Data with monitor name '{monitor_name}' supplied "
+                    f"but not found in the original '{sim.type}'."
+                ) from exc
+        return val
+
+    @pd.validator("data", always=True)
+    def validate_no_ambiguity(cls, val, values):
+        """Ensure all :class:`AbstractMonitorData` entries in ``.data`` correspond to different
+        monitors in ``.simulation``.
+        """
+        sim = values.get("simulation")
+        if sim is None:
+            raise ValidationError("'.simulation' failed validation, can't validate data.")
+
+        names = [mnt_data.monitor.name for mnt_data in val]
+
+        if len(set(names)) != len(names):
+            raise ValidationError("Some entries of '.data' provide data for same monitor(s).")
+
+        return val
+
+    @staticmethod
+    def _field_component_value(field_component: xr.DataArray, val: FieldVal) -> xr.DataArray:
+        """return the desired value of a field component.
+
+        Parameter
+        ----------
+        field_component : xarray.DataArray
+            Field component from which to calculate the value.
+        val : Literal['real', 'imag', 'abs', 'abs^2', 'phase']
+            Which part of the field to return.
+
+        Returns
+        -------
+        xarray.DataArray
+            Value extracted from the field component.
+        """
+        if val == "real":
+            field_value = field_component.real
+            field_value.name = f"Re{{{field_component.name}}}"
+
+        elif val == "imag":
+            field_value = field_component.imag
+            field_value.name = f"Im{{{field_component.name}}}"
+
+        elif val == "abs":
+            field_value = np.abs(field_component)
+            field_value.name = f"|{field_component.name}|"
+
+        elif val == "abs^2":
+            field_value = np.abs(field_component) ** 2
+            field_value.name = f"|{field_component.name}|²"
+
+        elif val == "phase":
+            field_value = np.arctan2(field_component.imag, field_component.real)
+            field_value.name = f"∠{field_component.name}"
+
+        return field_value

--- a/tidy3d/components/base_sim/monitor.py
+++ b/tidy3d/components/base_sim/monitor.py
@@ -1,0 +1,233 @@
+"""Abstract bases for classes that define how data is recorded from simulation."""
+from abc import ABC, abstractmethod
+from typing import Tuple
+
+import pydantic.v1 as pd
+import numpy as np
+
+from ..types import ArrayFloat1D, Numpy
+from ..types import Direction, Axis, BoxSurface
+from ..geometry.base import Box
+from ..validators import assert_plane
+from ..base import cached_property
+from ..viz import PlotParams, plot_params_monitor
+from ...constants import SECOND
+from ...exceptions import SetupError
+from ...log import log
+
+
+class AbstractMonitor(Box, ABC):
+    """Abstract base class for steady-state monitors."""
+
+    name: str = pd.Field(
+        ...,
+        title="Name",
+        description="Unique name for monitor.",
+        min_length=1,
+    )
+
+    @cached_property
+    def plot_params(self) -> PlotParams:
+        """Default parameters for plotting a Monitor object."""
+        return plot_params_monitor
+
+    @cached_property
+    def geometry(self) -> Box:
+        """:class:`Box` representation of monitor.
+
+        Returns
+        -------
+        :class:`Box`
+            Representation of the monitor geometry as a :class:`Box`.
+        """
+        return Box(center=self.center, size=self.size)
+
+    @abstractmethod
+    def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
+        """Size of monitor storage given the number of points after discretization.
+
+        Parameters
+        ----------
+        num_cells : int
+            Number of grid cells within the monitor after discretization by a :class:`Simulation`.
+        tmesh : Array
+            The discretized time mesh of a :class:`Simulation`.
+
+        Returns
+        -------
+        int
+            Number of bytes to be stored in monitor.
+        """
+
+    def downsample(self, arr: Numpy, axis: Axis) -> Numpy:
+        """Downsample a 1D array making sure to keep the first and last entries, based on the
+        spatial interval defined for the ``axis``.
+
+        Parameters
+        ----------
+        arr : Numpy
+            A 1D array of arbitrary type.
+        axis : Axis
+            Axis for which to select the interval_space defined for the monitor.
+
+        Returns
+        -------
+        Numpy
+            Downsampled array.
+        """
+
+        size = len(arr)
+        interval = self.interval_space[axis]
+        # There should always be at least 3 indices for "surface" monitors. Also, if the
+        # size along this dim is already smaller than the interval, then don't downsample.
+        if size < 4 or (size - 1) <= interval:
+            return arr
+        # make sure the last index is always included
+        inds = np.arange(0, size, interval)
+        if inds[-1] != size - 1:
+            inds = np.append(inds, size - 1)
+        return arr[inds]
+
+    def downsampled_num_cells(self, num_cells: Tuple[int, int, int]) -> Tuple[int, int, int]:
+        """Given a tuple of the number of cells spanned by the monitor along each dimension,
+        return the number of cells one would have after downsampling based on ``interval_space``.
+        """
+        arrs = [np.arange(ncells) for ncells in num_cells]
+        return tuple((self.downsample(arr, axis=dim).size for dim, arr in enumerate(arrs)))
+
+
+class AbstractTimeMonitor(AbstractMonitor, ABC):
+    """Abstract base class for transient monitors."""
+
+    start: pd.NonNegativeFloat = pd.Field(
+        0.0,
+        title="Start time",
+        description="Time at which to start monitor recording.",
+        units=SECOND,
+    )
+
+    stop: pd.NonNegativeFloat = pd.Field(
+        None,
+        title="Stop time",
+        description="Time at which to stop monitor recording.  "
+        "If not specified, record until end of simulation.",
+        units=SECOND,
+    )
+
+    interval: pd.PositiveInt = pd.Field(
+        1,
+        title="Time interval",
+        description="Number of time step intervals between monitor recordings.",
+    )
+
+    @pd.validator("stop", always=True, allow_reuse=True)
+    def stop_greater_than_start(cls, val, values):
+        """Ensure sure stop is greater than or equal to start."""
+        start = values.get("start")
+        if val and val < start:
+            raise SetupError("Monitor start time is greater than stop time.")
+        return val
+
+    def time_inds(self, tmesh: ArrayFloat1D) -> Tuple[int, int]:
+        """Compute the starting and stopping index of the monitor in a given discrete time mesh."""
+
+        tmesh = np.array(tmesh)
+        tind_beg, tind_end = (0, 0)
+
+        if tmesh.size == 0:
+            return (tind_beg, tind_end)
+
+        # If monitor.stop is None, record until the end
+        t_stop = self.stop
+        if t_stop is None:
+            tind_end = int(tmesh.size)
+            t_stop = tmesh[-1]
+        else:
+            tend = np.nonzero(tmesh <= t_stop)[0]
+            if tend.size > 0:
+                tind_end = int(tend[-1] + 1)
+
+        # Step to compare to in order to handle t_start = t_stop
+        dt = 1e-20 if np.array(tmesh).size < 2 else tmesh[1] - tmesh[0]
+        # If equal start and stopping time, record one time step
+        if np.abs(self.start - t_stop) < dt and self.start <= tmesh[-1]:
+            tind_beg = max(tind_end - 1, 0)
+        else:
+            tbeg = np.nonzero(tmesh[:tind_end] >= self.start)[0]
+            tind_beg = tbeg[0] if tbeg.size > 0 else tind_end
+        return (tind_beg, tind_end)
+
+    def num_steps(self, tmesh: ArrayFloat1D) -> int:
+        """Compute number of time steps for a time monitor."""
+
+        tind_beg, tind_end = self.time_inds(tmesh)
+        return int((tind_end - tind_beg) / self.interval)
+
+
+class AbstractPlanarMonitor(AbstractMonitor, ABC):
+    """:class:`AbstractMonitor` that has a planar geometry."""
+
+    _plane_validator = assert_plane()
+
+    @cached_property
+    def normal_axis(self) -> Axis:
+        """Axis normal to the monitor's plane."""
+        return self.size.index(0.0)
+
+
+class AbstractSurfaceIntegrationMonitor(AbstractMonitor, ABC):
+    """Abstract class for monitors that perform surface integrals during the solver run."""
+
+    normal_dir: Direction = pd.Field(
+        None,
+        title="Normal vector orientation",
+        description="Direction of the surface monitor's normal vector w.r.t. "
+        "the positive x, y or z unit vectors. Must be one of ``'+'`` or ``'-'``. "
+        "Applies to surface monitors only, and defaults to ``'+'`` if not provided.",
+    )
+
+    exclude_surfaces: Tuple[BoxSurface, ...] = pd.Field(
+        None,
+        title="Excluded surfaces",
+        description="Surfaces to exclude in the integration, if a volume monitor.",
+    )
+
+    @property
+    def integration_surfaces(self):
+        """Surfaces of the monitor where fields will be recorded for subsequent integration."""
+        if self.size.count(0.0) == 0:
+            return self.surfaces_with_exclusion(**self.dict())
+        return [self]
+
+    @pd.root_validator(skip_on_failure=True)
+    def normal_dir_exists_for_surface(cls, values):
+        """If the monitor is a surface, set default ``normal_dir`` if not provided.
+        If the monitor is a box, warn that ``normal_dir`` is relevant only for surfaces."""
+        normal_dir = values.get("normal_dir")
+        name = values.get("name")
+        size = values.get("size")
+        if size.count(0.0) != 1:
+            if normal_dir is not None:
+                log.warning(
+                    "The ``normal_dir`` field is relevant only for surface monitors "
+                    f"and will be ignored for monitor {name}, which is a box."
+                )
+        else:
+            if normal_dir is None:
+                values["normal_dir"] = "+"
+        return values
+
+    @pd.root_validator(skip_on_failure=True)
+    def check_excluded_surfaces(cls, values):
+        """Error if ``exclude_surfaces`` is provided for a surface monitor."""
+        exclude_surfaces = values.get("exclude_surfaces")
+        if exclude_surfaces is None:
+            return values
+        name = values.get("name")
+        size = values.get("size")
+        if size.count(0.0) > 0:
+            raise SetupError(
+                f"Can't specify ``exclude_surfaces`` for surface monitor {name}; "
+                "valid for box monitors only."
+            )
+        return values

--- a/tidy3d/components/base_sim/simulation.py
+++ b/tidy3d/components/base_sim/simulation.py
@@ -1,0 +1,448 @@
+"""Abstract base for defining simulation classes of different solvers"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Tuple
+from math import isclose
+
+import pydantic.v1 as pd
+
+from .monitor import AbstractSurfaceIntegrationMonitor
+
+from ..base import cached_property
+from ..validators import assert_unique_names, assert_objects_in_sim_bounds
+from ..geometry.base import Box
+from ..types import Ax, Bound, Axis, Symmetry, TYPE_TAG_STR
+from ..structure import Structure
+from ..viz import add_ax_if_none, equal_aspect
+from ..scene import Scene
+
+from ..medium import Medium, MediumType3D
+
+from ..viz import PlotParams, plot_params_symmetry
+
+from ...version import __version__
+from ...exceptions import Tidy3dKeyError, SetupError
+from ...log import log
+
+
+class AbstractSimulation(Box, ABC):
+    """Base class for simulation classes of different solvers."""
+
+    medium: MediumType3D = pd.Field(
+        Medium(),
+        title="Background Medium",
+        description="Background medium of simulation, defaults to vacuum if not specified.",
+        discriminator=TYPE_TAG_STR,
+    )
+
+    structures: Tuple[Structure, ...] = pd.Field(
+        (),
+        title="Structures",
+        description="Tuple of structures present in simulation. "
+        "Note: Structures defined later in this list override the "
+        "simulation material properties in regions of spatial overlap.",
+    )
+
+    symmetry: Tuple[Symmetry, Symmetry, Symmetry] = pd.Field(
+        (0, 0, 0),
+        title="Symmetries",
+        description="Tuple of integers defining reflection symmetry across a plane "
+        "bisecting the simulation domain normal to the x-, y-, and z-axis "
+        "at the simulation center of each axis, respectively. "
+        "Each element can be ``0`` (no symmetry), ``1`` (even, i.e. 'PMC' symmetry) or "
+        "``-1`` (odd, i.e. 'PEC' symmetry). "
+        "Note that the vectorial nature of the fields must be taken into account to correctly "
+        "determine the symmetry value.",
+    )
+
+    sources: Tuple[None, ...] = pd.Field(
+        (),
+        title="Sources",
+        description="Sources in the simulation.",
+    )
+
+    boundary_spec: None = pd.Field(
+        None,
+        title="Boundaries",
+        description="Specification of boundary conditions.",
+    )
+
+    monitors: Tuple[None, ...] = pd.Field(
+        (),
+        title="Monitors",
+        description="Monitors in the simulation. ",
+    )
+
+    grid_spec: None = pd.Field(
+        None,
+        title="Grid Specification",
+        description="Specifications for the simulation grid.",
+    )
+
+    version: str = pd.Field(
+        __version__,
+        title="Version",
+        description="String specifying the front end version number.",
+    )
+
+    """ Validating setup """
+
+    # make sure all names are unique
+    _unique_monitor_names = assert_unique_names("monitors")
+    _unique_structure_names = assert_unique_names("structures")
+
+    _monitors_in_bounds = assert_objects_in_sim_bounds("monitors")
+    _structures_in_bounds = assert_objects_in_sim_bounds("structures", error=False)
+
+    @pd.validator("monitors", always=True)
+    def _integration_surfaces_in_bounds(cls, val, values):
+        """Error if any of the integration surfaces are outside of the simulation domain."""
+
+        if val is None:
+            return val
+
+        sim_center = values.get("center")
+        sim_size = values.get("size")
+        sim_box = Box(size=sim_size, center=sim_center)
+
+        for mnt in (mnt for mnt in val if isinstance(mnt, AbstractSurfaceIntegrationMonitor)):
+            if not any(sim_box.intersects(surf) for surf in mnt.integration_surfaces):
+                raise SetupError(
+                    f"All integration surfaces of monitor '{mnt.name}' are outside of the "
+                    "simulation bounds."
+                )
+
+        return val
+
+    @pd.validator("structures", always=True)
+    def _structures_not_at_edges(cls, val, values):
+        """Warn if any structures lie at the simulation boundaries."""
+
+        if val is None:
+            return val
+
+        sim_box = Box(size=values.get("size"), center=values.get("center"))
+        sim_bound_min, sim_bound_max = sim_box.bounds
+        sim_bounds = list(sim_bound_min) + list(sim_bound_max)
+
+        with log as consolidated_logger:
+            for istruct, structure in enumerate(val):
+                struct_bound_min, struct_bound_max = structure.geometry.bounds
+                struct_bounds = list(struct_bound_min) + list(struct_bound_max)
+
+                for sim_val, struct_val in zip(sim_bounds, struct_bounds):
+
+                    if isclose(sim_val, struct_val):
+                        consolidated_logger.warning(
+                            f"Structure at structures[{istruct}] has bounds that extend exactly to "
+                            "simulation edges. This can cause unexpected behavior. "
+                            "If intending to extend the structure to infinity along one dimension, "
+                            "use td.inf as a size variable instead to make this explicit."
+                        )
+
+        return val
+
+    """ Accounting """
+
+    @cached_property
+    def scene(self) -> Scene:
+        """Scene instance associated with the simulation."""
+
+        return Scene(medium=self.medium, structures=self.structures)
+
+    def get_monitor_by_name(self, name: str):  # -> Monitor:
+        """Return monitor named 'name'."""
+        for monitor in self.monitors:
+            if monitor.name == name:
+                return monitor
+        raise Tidy3dKeyError(f"No monitor named '{name}'")
+
+    @cached_property
+    def simulation_bounds(self) -> Bound:
+        """Simulation bounds including auxiliary boundary zones such as PML layers."""
+        # in this default implementation we just take self.bounds
+        # this should be changed in different solvers depending on whether automatic extensions
+        # (like pml) are present
+        return self.bounds
+
+    @cached_property
+    def simulation_geometry(self) -> Box:
+        """The entire simulation domain including auxiliary boundary zones such as PML layers.
+        It is identical to ``Simulation.geometry`` in the absence of such auxiliary zones.
+        """
+        rmin, rmax = self.simulation_bounds
+        return Box.from_bounds(rmin=rmin, rmax=rmax)
+
+    @cached_property
+    def simulation_structure(self) -> Structure:
+        """Returns structure representing the domain of the simulation. This differs from
+        ``Simulation.background_structure`` in that it has finite extent."""
+        return Structure(geometry=self.simulation_geometry, medium=self.medium)
+
+    @equal_aspect
+    @add_ax_if_none
+    def plot(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        ax: Ax = None,
+        source_alpha: float = None,
+        monitor_alpha: float = None,
+        hlim: Tuple[float, float] = None,
+        vlim: Tuple[float, float] = None,
+        **patch_kwargs,
+    ) -> Ax:
+        """Plot each of simulation's components on a plane defined by one nonzero x,y,z coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            position of plane in z direction, only one of x, y, z must be specified to define plane.
+        source_alpha : float = None
+            Opacity of the sources. If ``None``, uses Tidy3d default.
+        monitor_alpha : float = None
+            Opacity of the monitors. If ``None``, uses Tidy3d default.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        hlim : Tuple[float, float] = None
+            The x range if plotting on xy or xz planes, y range if plotting on yz plane.
+        vlim : Tuple[float, float] = None
+            The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+
+        hlim, vlim = Scene._get_plot_lims(
+            bounds=self.simulation_bounds, x=x, y=y, z=z, hlim=hlim, vlim=vlim
+        )
+
+        ax = self.scene.plot_structures(ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim)
+        ax = self.plot_sources(ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim, alpha=source_alpha)
+        ax = self.plot_monitors(ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim, alpha=monitor_alpha)
+        ax = Scene._set_plot_bounds(
+            bounds=self.simulation_bounds, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim
+        )
+        ax = self.plot_boundaries(ax=ax, x=x, y=y, z=z)
+        ax = self.plot_symmetries(ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim)
+        return ax
+
+    @equal_aspect
+    @add_ax_if_none
+    def plot_sources(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        hlim: Tuple[float, float] = None,
+        vlim: Tuple[float, float] = None,
+        alpha: float = None,
+        ax: Ax = None,
+    ) -> Ax:
+        """Plot each of simulation's sources on a plane defined by one nonzero x,y,z coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            position of plane in z direction, only one of x, y, z must be specified to define plane.
+        hlim : Tuple[float, float] = None
+            The x range if plotting on xy or xz planes, y range if plotting on yz plane.
+        vlim : Tuple[float, float] = None
+            The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
+        alpha : float = None
+            Opacity of the sources, If ``None`` uses Tidy3d default.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+        bounds = self.simulation_bounds
+        for source in self.sources:
+            ax = source.plot(x=x, y=y, z=z, alpha=alpha, ax=ax, sim_bounds=bounds)
+        ax = Scene._set_plot_bounds(
+            bounds=self.simulation_bounds, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim
+        )
+        return ax
+
+    @equal_aspect
+    @add_ax_if_none
+    def plot_monitors(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        hlim: Tuple[float, float] = None,
+        vlim: Tuple[float, float] = None,
+        alpha: float = None,
+        ax: Ax = None,
+    ) -> Ax:
+        """Plot each of simulation's monitors on a plane defined by one nonzero x,y,z coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            position of plane in z direction, only one of x, y, z must be specified to define plane.
+        hlim : Tuple[float, float] = None
+            The x range if plotting on xy or xz planes, y range if plotting on yz plane.
+        vlim : Tuple[float, float] = None
+            The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
+        alpha : float = None
+            Opacity of the sources, If ``None`` uses Tidy3d default.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+        bounds = self.simulation_bounds
+        for monitor in self.monitors:
+            ax = monitor.plot(x=x, y=y, z=z, alpha=alpha, ax=ax, sim_bounds=bounds)
+        ax = Scene._set_plot_bounds(
+            bounds=self.simulation_bounds, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim
+        )
+        return ax
+
+    @equal_aspect
+    @add_ax_if_none
+    def plot_symmetries(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        hlim: Tuple[float, float] = None,
+        vlim: Tuple[float, float] = None,
+        ax: Ax = None,
+    ) -> Ax:
+        """Plot each of simulation's symmetries on a plane defined by one nonzero x,y,z coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            position of plane in z direction, only one of x, y, z must be specified to define plane.
+        hlim : Tuple[float, float] = None
+            The x range if plotting on xy or xz planes, y range if plotting on yz plane.
+        vlim : Tuple[float, float] = None
+            The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+
+        normal_axis, _ = Box.parse_xyz_kwargs(x=x, y=y, z=z)
+
+        for sym_axis, sym_value in enumerate(self.symmetry):
+            if sym_value == 0 or sym_axis == normal_axis:
+                continue
+            sym_box = self._make_symmetry_box(sym_axis=sym_axis)
+            plot_params = self._make_symmetry_plot_params(sym_value=sym_value)
+            ax = sym_box.plot(x=x, y=y, z=z, ax=ax, **plot_params.to_kwargs())
+        ax = Scene._set_plot_bounds(
+            bounds=self.simulation_bounds, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim
+        )
+        return ax
+
+    def _make_symmetry_plot_params(self, sym_value: Symmetry) -> PlotParams:
+        """Make PlotParams for symmetry."""
+
+        plot_params = plot_params_symmetry.copy()
+
+        if sym_value == 1:
+            plot_params = plot_params.copy(
+                update={"facecolor": "lightsteelblue", "edgecolor": "lightsteelblue", "hatch": "++"}
+            )
+        elif sym_value == -1:
+            plot_params = plot_params.copy(
+                update={"facecolor": "goldenrod", "edgecolor": "goldenrod", "hatch": "--"}
+            )
+
+        return plot_params
+
+    def _make_symmetry_box(self, sym_axis: Axis) -> Box:
+        """Construct a :class:`.Box` representing the symmetry to be plotted."""
+        rmin, rmax = (list(bound) for bound in self.simulation_bounds)
+        rmax[sym_axis] = (rmin[sym_axis] + rmax[sym_axis]) / 2
+
+        return Box.from_bounds(rmin, rmax)
+
+    @abstractmethod
+    @equal_aspect
+    @add_ax_if_none
+    def plot_boundaries(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        ax: Ax = None,
+        **kwargs,
+    ) -> Ax:
+        """Plot the simulation boundary conditions as lines on a plane
+           defined by one nonzero x,y,z coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            position of plane in z direction, only one of x, y, z must be specified to define plane.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        **kwargs
+            Optional keyword arguments passed to the matplotlib ``LineCollection``.
+            For details on accepted values, refer to
+            `Matplotlib's documentation <https://tinyurl.com/2p97z4cn>`_.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+
+    @classmethod
+    def from_scene(cls, scene: Scene, **kwargs) -> AbstractSimulation:
+        """Create a simulation from a :class:.`Scene` instance. Must provide additional parameters
+        to define a valid simulation (for example, ``size``, ``run_time``, ``grid_spec``, etc).
+
+        Parameters
+        ----------
+        scene : :class:.`Scene`
+            Scene containing structures information.
+        **kwargs
+            Other arguments
+        """
+
+        return cls(
+            structures=scene.structures,
+            medium=scene.medium,
+            **kwargs,
+        )

--- a/tidy3d/components/bc_placement.py
+++ b/tidy3d/components/bc_placement.py
@@ -1,0 +1,117 @@
+"""Defines placements for boundary conditions."""
+from __future__ import annotations
+
+from abc import ABC
+from typing import Union, Tuple
+
+import pydantic.v1 as pd
+
+from .types import BoxSurface
+from .base import Tidy3dBaseModel
+from ..exceptions import SetupError
+
+
+class AbstractBCPlacement(ABC, Tidy3dBaseModel):
+    """Abstract placement for boundary conditions."""
+
+
+class StructureBoundary(AbstractBCPlacement):
+    """Placement of boundary conditions on the structure's boundary.
+
+    Example
+    -------
+    >>> bc_placement = StructureBoundary(structure="box")
+    """
+
+    structure: str = pd.Field(
+        title="Structure Name",
+        description="Name of the structure.",
+    )
+
+
+class StructureStructureInterface(AbstractBCPlacement):
+    """Placement of boundary conditions between two structures.
+
+    Example
+    -------
+    >>> bc_placement = StructureStructureInterface(structures=["box", "sphere"])
+    """
+
+    structures: Tuple[str, str] = pd.Field(
+        title="Structures",
+        description="Names of two structures.",
+    )
+
+    @pd.validator("structures", always=True)
+    def unique_names(cls, val):
+        """Error if the same structure is provided twice"""
+        if val[0] == val[1]:
+            raise SetupError(
+                "The same structure is provided twice in 'StructureStructureInterface'."
+            )
+        return val
+
+
+class MediumMediumInterface(AbstractBCPlacement):
+    """Placement of boundary conditions between two mediums.
+
+    Example
+    -------
+    >>> bc_placement = MediumMediumInterface(mediums=["dieletric", "metal"])
+    """
+
+    mediums: Tuple[str, str] = pd.Field(
+        title="Mediums",
+        description="Names of two mediums.",
+    )
+
+    @pd.validator("mediums", always=True)
+    def unique_names(cls, val):
+        """Error if the same structure is provided twice"""
+        if val[0] == val[1]:
+            raise SetupError("The same medium is provided twice in 'MediumMediumInterface'.")
+        return val
+
+
+class SimulationBoundary(AbstractBCPlacement):
+    """Placement of boundary conditions on the simulation box boundary.
+
+    Example
+    -------
+    >>> bc_placement = SimulationBoundary(surfaces=["x-", "x+"])
+    """
+
+    surfaces: Tuple[BoxSurface, ...] = pd.Field(
+        ("x-", "x+", "y-", "y+", "z-", "z+"),
+        title="Surfaces",
+        description="Surfaces of simulation domain where to apply boundary conditions.",
+    )
+
+
+class StructureSimulationBoundary(AbstractBCPlacement):
+    """Placement of boundary conditions on the simulation box boundary covered by the structure.
+
+    Example
+    -------
+    >>> bc_placement = StructureSimulationBoundary(structure="box", surfaces=["y-", "y+"])
+    """
+
+    structure: str = pd.Field(
+        title="Structure Name",
+        description="Name of the structure.",
+    )
+
+    surfaces: Tuple[BoxSurface, ...] = pd.Field(
+        ("x-", "x+", "y-", "y+", "z-", "z+"),
+        title="Surfaces",
+        description="Surfaces of simulation domain where to apply boundary conditions.",
+    )
+
+
+BCPlacementType = Union[
+    StructureBoundary,
+    StructureStructureInterface,
+    MediumMediumInterface,
+    SimulationBoundary,
+    StructureSimulationBoundary,
+]

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -296,7 +296,9 @@ class SpatialDataArray(DataArray):
         return self.isel(x=inds_list[0], y=inds_list[1], z=inds_list[2])
 
     def does_cover(self, bounds: Bound) -> bool:
-        """Check whether data fully covers specified by ``bounds`` spatial region.
+        """Check whether data fully covers specified by ``bounds`` spatial region. If data contains
+        only one point along a given direction, then it is assumed the data is constant along that
+        direction and coverage is not checked.
 
 
         Parameters
@@ -311,7 +313,7 @@ class SpatialDataArray(DataArray):
         """
 
         return all(
-            coord[0] <= smin and coord[-1] >= smax
+            (coord[0] <= smin and coord[-1] >= smax) or len(coord) == 1
             for coord, smin, smax in zip(self.coords.values(), bounds[0], bounds[1])
         )
 

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -195,7 +195,7 @@ class SimulationData(Tidy3dBaseModel):
         if not isinstance(mon_data, AbstractFieldData):
             raise DataError(
                 f"data for monitor '{monitor_name}' does not contain field data "
-                f"as it is a `{type(mon_data)}`."
+                f"as it is a '{type(mon_data)}'."
             )
         return mon_data
 

--- a/tidy3d/components/geometry/utils.py
+++ b/tidy3d/components/geometry/utils.py
@@ -80,7 +80,6 @@ def traverse_geometries(geometry: GeometryType) -> GeometryType:
     yield geometry
 
 
-# pylint:disable=too-many-arguments
 def from_shapely(
     shape: Shapely,
     axis: Axis,

--- a/tidy3d/components/heat/boundary.py
+++ b/tidy3d/components/heat/boundary.py
@@ -1,0 +1,93 @@
+"""Defines heat material specifications"""
+from __future__ import annotations
+
+from abc import ABC
+from typing import Union
+
+import pydantic.v1 as pd
+
+from ..base import Tidy3dBaseModel
+from ..bc_placement import BCPlacementType
+
+from ...constants import KELVIN, HEAT_FLUX, HEAT_TRANSFER_COEFF
+
+
+class HeatBC(ABC, Tidy3dBaseModel):
+    """Abstract thermal boundary conditions."""
+
+
+class TemperatureBC(HeatBC):
+    """Constant temperature thermal boundary conditions.
+
+    Example
+    -------
+    >>> bc = TemperatureBC(temperature=300)
+    """
+
+    temperature: pd.PositiveFloat = pd.Field(
+        title="Temperature",
+        description=f"Temperature value in units of {KELVIN}.",
+        units=KELVIN,
+    )
+
+
+class HeatFluxBC(HeatBC):
+    """Constant flux thermal boundary conditions.
+
+    Example
+    -------
+    >>> bc = HeatFluxBC(flux=1)
+    """
+
+    flux: float = pd.Field(
+        title="Heat Flux",
+        description=f"Heat flux value in units of {HEAT_FLUX}.",
+        units=HEAT_FLUX,
+    )
+
+
+class ConvectionBC(HeatBC):
+    """Convective thermal boundary conditions.
+
+    Example
+    -------
+    >>> bc = ConvectionBC(ambient_temperature=300, transfer_coeff=1)
+    """
+
+    ambient_temperature: pd.PositiveFloat = pd.Field(
+        title="Ambient Temperature",
+        description=f"Ambient temperature value in units of {KELVIN}.",
+        units=KELVIN,
+    )
+
+    transfer_coeff: pd.NonNegativeFloat = pd.Field(
+        title="Heat Transfer Coefficient",
+        description=f"Heat flux value in units of {HEAT_TRANSFER_COEFF}.",
+        units=HEAT_TRANSFER_COEFF,
+    )
+
+
+HeatBoundaryConditionType = Union[TemperatureBC, HeatFluxBC, ConvectionBC]
+
+
+class HeatBoundarySpec(Tidy3dBaseModel):
+    """Heat boundary conditions specification.
+
+    Example
+    -------
+    >>> from tidy3d import SimulationBoundary
+    >>> bc_spec = HeatBoundarySpec(
+    ...     placement=SimulationBoundary(),
+    ...     condition=ConvectionBC(ambient_temperature=300, transfer_coeff=1),
+    ... )
+    """
+
+    placement: BCPlacementType = pd.Field(
+        title="Boundary Conditions Placement",
+        description="Location to apply boundary conditions.",
+    )
+
+    condition: HeatBoundaryConditionType = pd.Field(
+        title="Boundary Conditions",
+        description="Boundary conditions to apply at the selected location.",
+    )

--- a/tidy3d/components/heat/data/monitor_data.py
+++ b/tidy3d/components/heat/data/monitor_data.py
@@ -1,0 +1,116 @@
+"""Monitor level data, store the DataArrays associated with a single heat monitor."""
+from __future__ import annotations
+from typing import Union, Tuple
+
+from abc import ABC
+
+import numpy as np
+import pydantic.v1 as pd
+
+from ..monitor import TemperatureMonitor, HeatMonitorType
+from ...base_sim.data.monitor_data import AbstractMonitorData
+from ...data.data_array import SpatialDataArray
+from ...types import ScalarSymmetry, Coordinate
+from ....constants import KELVIN
+
+
+class HeatMonitorData(AbstractMonitorData, ABC):
+    """Abstract base class of objects that store data pertaining to a single :class:`HeatMonitor`."""
+
+    monitor: HeatMonitorType = pd.Field(
+        ...,
+        title="Monitor",
+        description="Monitor associated with the data.",
+    )
+
+    symmetry: Tuple[ScalarSymmetry, ScalarSymmetry, ScalarSymmetry] = pd.Field(
+        (0, 0, 0),
+        title="Symmetry",
+        description="Symmetry of the original simulation in x, y, and z.",
+    )
+
+    symmetry_center: Coordinate = pd.Field(
+        (0, 0, 0),
+        title="Symmetry Center",
+        description="Symmetry center of the original simulation in x, y, and z.",
+    )
+
+    @property
+    def symmetry_expanded_copy(self) -> HeatMonitorData:
+        """Return copy of self with symmetry applied."""
+        return self.copy()
+
+
+class TemperatureData(HeatMonitorData):
+    """Data associated with a :class:`TemperatureMonitor`: spatial temperature field.
+
+    Example
+    -------
+    >>> from tidy3d import TemperatureMonitor, SpatialDataArray
+    >>> temp_data = SpatialDataArray(
+    ...     np.ones((2, 3, 4)), coords={"x": [0, 1], "y": [0, 1, 2], "z": [0, 1, 2, 3]}
+    ... )
+    >>> temp_mnt = TemperatureMonitor(size=(1, 2, 3), name="temperature")
+    >>> temp_mnt_data = TemperatureData(
+    ...     monitor=temp_mnt, temperature=temp_data, symmetry=(0, 1, 0), symmetry_center=(0, 0, 0)
+    ... )
+    >>> temp_mnt_data_expanded = temp_mnt_data.symmetry_expanded_copy
+    """
+
+    monitor: TemperatureMonitor = pd.Field(
+        ..., title="Monitor", description="Temperature monitor associated with the data."
+    )
+
+    temperature: SpatialDataArray = pd.Field(
+        ..., title="Temperature", description="Spatial temperature field.", units=KELVIN
+    )
+
+    @property
+    def symmetry_expanded_copy(self) -> TemperatureData:
+        """Return copy of self with symmetry applied."""
+
+        if all(sym == 0 for sym in self.symmetry):
+            return self.copy()
+
+        coords = list(self.temperature.coords.values())
+        data = np.array(self.temperature.data)
+
+        for dim in range(3):
+            if self.symmetry[dim] == 1:
+
+                sym_center = self.symmetry_center[dim]
+
+                if sym_center == coords[dim].data[0]:
+                    num_duplicates = 1
+                else:
+                    num_duplicates = 0
+
+                shape = np.array(np.shape(data))
+                old_len = shape[dim]
+                shape[dim] = 2 * old_len - num_duplicates
+
+                ind_left = [slice(shape[0]), slice(shape[1]), slice(shape[2])]
+                ind_right = [slice(shape[0]), slice(shape[1]), slice(shape[2])]
+
+                ind_left[dim] = slice(old_len - 1, None, -1)
+                ind_right[dim] = slice(old_len - num_duplicates, None)
+
+                new_data = np.zeros(shape)
+
+                new_data[ind_left[0], ind_left[1], ind_left[2]] = data
+                new_data[ind_right[0], ind_right[1], ind_right[2]] = data
+
+                new_coords = np.zeros(shape[dim])
+                new_coords[old_len - num_duplicates :] = coords[dim]
+                new_coords[old_len - 1 :: -1] = 2 * sym_center - coords[dim]
+
+                coords[dim] = new_coords
+                data = new_data
+
+        coords_dict = dict(zip("xyz", coords))
+        new_temperature = SpatialDataArray(data, coords=coords_dict)
+
+        return self.updated_copy(temperature=new_temperature, symmetry=(0, 0, 0))
+
+
+HeatMonitorDataType = Union[TemperatureData]

--- a/tidy3d/components/heat/data/sim_data.py
+++ b/tidy3d/components/heat/data/sim_data.py
@@ -1,0 +1,232 @@
+"""Defines heat simulation data class"""
+from __future__ import annotations
+from typing import Tuple
+
+import numpy as np
+import pydantic.v1 as pd
+
+from .monitor_data import HeatMonitorDataType, TemperatureData
+from ..simulation import HeatSimulation
+
+from ...base_sim.data.sim_data import AbstractSimulationData
+from ...types import Ax, RealFieldVal, Literal
+from ...viz import equal_aspect, add_ax_if_none
+from ....exceptions import DataError
+
+
+class HeatSimulationData(AbstractSimulationData):
+    """Stores results of a heat simulation.
+
+    Example
+    -------
+    >>> from tidy3d import Medium, SolidSpec, FluidSpec, UniformUnstructuredGrid, SpatialDataArray
+    >>> from tidy3d import Structure, Box, UniformUnstructuredGrid, UniformHeatSource
+    >>> from tidy3d import StructureBoundary, TemperatureBC, TemperatureMonitor, TemperatureData
+    >>> from tidy3d import HeatBoundarySpec
+    >>> import numpy as np
+    >>> temp_mnt = TemperatureMonitor(size=(1, 2, 3), name="sample")
+    >>> heat_sim = HeatSimulation(
+    ...     size=(3.0, 3.0, 3.0),
+    ...     structures=[
+    ...         Structure(
+    ...             geometry=Box(size=(1, 1, 1), center=(0, 0, 0)),
+    ...             medium=Medium(
+    ...                 permittivity=2.0, heat_spec=SolidSpec(
+    ...                     conductivity=1,
+    ...                     capacity=1,
+    ...                 )
+    ...             ),
+    ...             name="box",
+    ...         ),
+    ...     ],
+    ...     medium=Medium(permittivity=3.0, heat_spec=FluidSpec()),
+    ...     grid_spec=UniformUnstructuredGrid(dl=0.1),
+    ...     sources=[UniformHeatSource(rate=1, structures=["box"])],
+    ...     boundary_spec=[
+    ...         HeatBoundarySpec(
+    ...             placement=StructureBoundary(structure="box"),
+    ...             condition=TemperatureBC(temperature=500),
+    ...         )
+    ...     ],
+    ...     monitors=[temp_mnt],
+    ... )
+    >>> x = [1,2]
+    >>> y = [2,3,4]
+    >>> z = [3,4,5,6]
+    >>> coords = dict(x=x, y=y, z=z)
+    >>> temp_array = SpatialDataArray(300 * np.abs(np.random.random((2,3,4))), coords=coords)
+    >>> temp_mnt_data = TemperatureData(monitor=temp_mnt, temperature=temp_array)
+    >>> heat_sim_data = HeatSimulationData(
+    ...     simulation=heat_sim, data=[temp_mnt_data],
+    ... )
+    """
+
+    simulation: HeatSimulation = pd.Field(
+        title="Heat Simulation",
+        description="Original :class:`.HeatSimulation` associated with the data.",
+    )
+
+    data: Tuple[HeatMonitorDataType, ...] = pd.Field(
+        ...,
+        title="Monitor Data",
+        description="List of :class:`.MonitorData` instances "
+        "associated with the monitors of the original :class:`.Simulation`.",
+    )
+
+    @equal_aspect
+    @add_ax_if_none
+    def plot_field(
+        self,
+        monitor_name: str,
+        val: RealFieldVal = "real",
+        scale: Literal["lin", "log"] = "lin",
+        structures_alpha: float = 0.2,
+        robust: bool = True,
+        vmin: float = None,
+        vmax: float = None,
+        ax: Ax = None,
+        **sel_kwargs,
+    ) -> Ax:
+        """Plot the data for a monitor with simulation plot overlayed.
+
+        Parameters
+        ----------
+        field_monitor_name : str
+            Name of :class:`.TemperatureMonitorData` to plot.
+        val : Literal['real', 'abs', 'abs^2'] = 'real'
+            Which part of the field to plot.
+        scale : Literal['lin', 'dB']
+            Plot in linear or logarithmic (dB) scale.
+        structures_alpha : float = 0.2
+            Opacity of the structure permittivity.
+            Must be between 0 and 1 (inclusive).
+        robust : bool = True
+            If True and vmin or vmax are absent, uses the 2nd and 98th percentiles of the data
+            to compute the color limits. This helps in visualizing the field patterns especially
+            in the presence of a source.
+        vmin : float = None
+            The lower bound of data range that the colormap covers. If `None`, they are
+            inferred from the data and other keyword arguments.
+        vmax : float = None
+            The upper bound of data range that the colormap covers. If `None`, they are
+            inferred from the data and other keyword arguments.
+        ax : matplotlib.axes._subplots.Axes = None
+            matplotlib axes to plot on, if not specified, one is created.
+        sel_kwargs : keyword arguments used to perform `.sel()` selection in the monitor data.
+            These kwargs can select over the spatial dimensions (`x`, `y`, `z`),
+            or time dimension (`t`) if applicable.
+            For the plotting to work appropriately, the resulting data after selection must contain
+            only two coordinates with len > 1.
+            Furthermore, these should be spatial coordinates (`x`, `y`, or `z`).
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+
+        monitor_data = self[monitor_name]
+
+        if not isinstance(monitor_data, TemperatureData):
+            raise DataError(
+                f"Monitor '{monitor_name}' (type '{monitor_data.monitor.type}') is not a "
+                f"'TemperatureMonitor'."
+            )
+
+        field_data = self._field_component_value(monitor_data.temperature, val)
+
+        if scale == "log":
+            field_data = np.log10(np.abs(field_data))
+            cmap_type = "sequential"
+        elif val == "real":
+            cmap_type = "divergent"
+        else:
+            cmap_type = "sequential"
+
+        # interp out any monitor.size==0 dimensions
+        monitor = self.simulation.get_monitor_by_name(monitor_name)
+        thin_dims = {
+            "xyz"[dim]: monitor.center[dim]
+            for dim in range(3)
+            if monitor.size[dim] == 0 and "xyz"[dim] not in sel_kwargs
+        }
+        for axis, pos in thin_dims.items():
+            if field_data.coords[axis].size <= 1:
+                field_data = field_data.sel(**{axis: pos}, method="nearest")
+            else:
+                field_data = field_data.interp(**{axis: pos}, kwargs=dict(bounds_error=True))
+
+        # select the extra coordinates out of the data from user-specified kwargs
+        for coord_name, coord_val in sel_kwargs.items():
+            if field_data.coords[coord_name].size <= 1:
+                field_data = field_data.sel(**{coord_name: coord_val}, method=None)
+            else:
+                field_data = field_data.interp(
+                    **{coord_name: coord_val}, kwargs=dict(bounds_error=True)
+                )
+
+        field_data = field_data.squeeze(drop=True)
+        non_scalar_coords = {name: c for name, c in field_data.coords.items() if c.size > 1}
+
+        # assert the data is valid for plotting
+        if len(non_scalar_coords) != 2:
+            raise DataError(
+                f"Data after selection has {len(non_scalar_coords)} coordinates "
+                f"({list(non_scalar_coords.keys())}), "
+                "must be 2 spatial coordinates for plotting on plane. "
+                "Please add keyword arguments to `plot_monitor_data()` to select out the other coords."
+            )
+
+        spatial_coords_in_data = {
+            coord_name: (coord_name in non_scalar_coords) for coord_name in "xyz"
+        }
+
+        if sum(spatial_coords_in_data.values()) != 2:
+            raise DataError(
+                "All coordinates in the data after selection must be spatial (x, y, z), "
+                f" given {non_scalar_coords.keys()}."
+            )
+
+        # get the spatial coordinate corresponding to the plane
+        planar_coord = [name for name, c in spatial_coords_in_data.items() if c is False][0]
+        axis = "xyz".index(planar_coord)
+        position = float(field_data.coords[planar_coord])
+
+        # select the cross section data
+        interp_kwarg = {"xyz"[axis]: position}
+
+        if cmap_type == "divergent":
+            cmap = "RdBu_r"
+        elif cmap_type == "sequential":
+            cmap = "magma"
+
+        # plot the field
+        xy_coord_labels = list("xyz")
+        xy_coord_labels.pop(axis)
+        x_coord_label, y_coord_label = xy_coord_labels[0], xy_coord_labels[1]
+        field_data.plot(
+            ax=ax,
+            x=x_coord_label,
+            y=y_coord_label,
+            cmap=cmap,
+            vmin=vmin,
+            vmax=vmax,
+            robust=robust,
+            cbar_kwargs={"label": "temperature"},
+        )
+
+        # plot the simulation heat conductivity
+        ax = self.simulation.scene.plot_structures_heat_conductivity(
+            cbar=False,
+            alpha=structures_alpha,
+            ax=ax,
+            **interp_kwarg,
+        )
+
+        # set the limits based on the xarray coordinates min and max
+        x_coord_values = field_data.coords[x_coord_label]
+        y_coord_values = field_data.coords[y_coord_label]
+        ax.set_xlim(min(x_coord_values), max(x_coord_values))
+        ax.set_ylim(min(y_coord_values), max(y_coord_values))
+
+        return ax

--- a/tidy3d/components/heat/grid.py
+++ b/tidy3d/components/heat/grid.py
@@ -1,0 +1,119 @@
+"""Defines heat grid specifications"""
+from __future__ import annotations
+
+from typing import Union, Tuple
+import pydantic.v1 as pd
+
+from ..base import Tidy3dBaseModel
+from ...constants import MICROMETER
+from ...exceptions import ValidationError
+
+
+class UniformUnstructuredGrid(Tidy3dBaseModel):
+
+    """Uniform grid.
+
+    Example
+    -------
+    >>> heat_grid = UniformUnstructuredGrid(dl=0.1)
+    """
+
+    dl: pd.PositiveFloat = pd.Field(
+        ...,
+        title="Grid Size",
+        description="Grid size for uniform grid generation.",
+        units=MICROMETER,
+    )
+
+    min_edges_per_circumference: pd.PositiveFloat = pd.Field(
+        15,
+        title="Minimum Edges per Circumference",
+        description="Enforced minimum number of mesh segments per circumference of an object. "
+        "Applies to :class:`Cylinder` and :class:`Sphere`, for which the circumference "
+        "is taken as 2 * pi * radius.",
+    )
+
+    min_edges_per_side: pd.PositiveFloat = pd.Field(
+        2,
+        title="Minimum Edges per Side",
+        description="Enforced minimum number of mesh segments per any side of an object.",
+    )
+
+    non_refined_structures: Tuple[str, ...] = pd.Field(
+        (),
+        title="Structures Without Refinement",
+        description="List of structures for which ``min_edges_per_circumference`` and "
+        "``min_edges_per_side`` will not be enforced. The original ``dl`` is used instead.",
+    )
+
+
+class DistanceUnstructuredGrid(Tidy3dBaseModel):
+    """Adaptive grid based on distance to material interfaces. Currently not recommended for larger
+    simulations.
+
+    Example
+    -------
+    >>> heat_grid = DistanceUnstructuredGrid(
+    ...     dl_interface=0.1,
+    ...     dl_bulk=1,
+    ...     distance_interface=0.3,
+    ...     distance_bulk=2,
+    ... )
+    """
+
+    dl_interface: pd.PositiveFloat = pd.Field(
+        ...,
+        title="Interface Grid Size",
+        description="Grid size near material interfaces.",
+        units=MICROMETER,
+    )
+
+    dl_bulk: pd.PositiveFloat = pd.Field(
+        ...,
+        title="Bulk Grid Size",
+        description="Grid size away from material interfaces.",
+        units=MICROMETER,
+    )
+
+    distance_interface: pd.NonNegativeFloat = pd.Field(
+        ...,
+        title="Interface Distance",
+        description="Distance from interface within which ``dl_interface`` is enforced."
+        "Typically the same as ``dl_interface`` or its multiple.",
+        units=MICROMETER,
+    )
+
+    distance_bulk: pd.NonNegativeFloat = pd.Field(
+        ...,
+        title="Bulk Distance",
+        description="Distance from interface outside of which ``dl_bulk`` is enforced."
+        "Typically twice of ``dl_bulk`` or its multiple. Use larger values for a smoother "
+        "transition from ``dl_interface`` to ``dl_bulk``.",
+        units=MICROMETER,
+    )
+
+    sampling: pd.PositiveFloat = pd.Field(
+        100,
+        title="Surface Sampling",
+        description="An internal advanced parameter that defines number of sampling points per "
+        "surface when computing distance values.",
+    )
+
+    non_refined_structures: Tuple[str, ...] = pd.Field(
+        (),
+        title="Structures Without Refinement",
+        description="List of structures for which ``dl_interface`` will not be enforced. "
+        "``dl_bulk`` is used instead.",
+    )
+
+    @pd.validator("distance_bulk", always=True)
+    def names_exist_bcs(cls, val, values):
+        """Error if distance_bulk is less than distance_interface"""
+        distance_interface = values.get("distance_interface")
+        if distance_interface > val:
+            raise ValidationError("'distance_bulk' cannot be smaller than 'distance_interface'.")
+
+        return val
+
+
+HeatGridType = Union[UniformUnstructuredGrid, DistanceUnstructuredGrid]

--- a/tidy3d/components/heat/monitor.py
+++ b/tidy3d/components/heat/monitor.py
@@ -1,0 +1,27 @@
+"""Objects that define how data is recorded from simulation."""
+from abc import ABC
+from typing import Union
+
+from ..types import ArrayFloat1D
+from ..base_sim.monitor import AbstractMonitor
+
+
+BYTES_REAL = 4
+
+
+class HeatMonitor(AbstractMonitor, ABC):
+    """Abstract base class for heat monitors."""
+
+
+class TemperatureMonitor(HeatMonitor):
+    """Temperature monitor."""
+
+    def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
+        """Size of monitor storage given the number of points after discretization."""
+        # stores 1 real number per grid cell, per time step, per field
+        num_steps = self.num_steps(tmesh)
+        return BYTES_REAL * num_steps * num_cells * len(self.fields)
+
+
+# types of monitors that are accepted by heat simulation
+HeatMonitorType = Union[TemperatureMonitor]

--- a/tidy3d/components/heat/simulation.py
+++ b/tidy3d/components/heat/simulation.py
@@ -1,0 +1,867 @@
+"""Defines heat simulation class"""
+from __future__ import annotations
+
+from typing import Tuple, List, Dict
+from matplotlib import cm
+
+import pydantic.v1 as pd
+
+from .boundary import TemperatureBC, HeatFluxBC, ConvectionBC
+from .boundary import HeatBoundarySpec
+from .source import HeatSourceType, UniformHeatSource
+from .monitor import HeatMonitorType
+from .grid import HeatGridType
+from .viz import HEAT_BC_COLOR_TEMPERATURE, HEAT_BC_COLOR_FLUX, HEAT_BC_COLOR_CONVECTION
+from .viz import plot_params_heat_bc, plot_params_heat_source, HEAT_SOURCE_CMAP
+
+from ..base_sim.simulation import AbstractSimulation
+from ..base import cached_property
+from ..types import Ax, Shapely, TYPE_TAG_STR, ScalarSymmetry, Bound
+from ..viz import add_ax_if_none, equal_aspect, PlotParams
+from ..structure import Structure
+from ..geometry.base import Box, GeometryGroup
+from ..geometry.primitives import Sphere, Cylinder
+from ..geometry.polyslab import PolySlab
+from ..scene import Scene
+from ..heat_spec import SolidSpec
+
+from ..bc_placement import StructureBoundary, StructureStructureInterface
+from ..bc_placement import StructureSimulationBoundary, SimulationBoundary
+from ..bc_placement import MediumMediumInterface
+
+from ...exceptions import SetupError
+from ...constants import inf, VOLUMETRIC_HEAT_RATE
+
+from ...log import log
+
+HEAT_BACK_STRUCTURE_STR = "<<<HEAT_BACKGROUND_STRUCTURE>>>"
+
+HeatSingleGeometryType = (Box, Cylinder, Sphere, PolySlab)
+
+
+class HeatSimulation(AbstractSimulation):
+    """Contains all information about heat simulation.
+
+    Example
+    -------
+    >>> from tidy3d import Medium, SolidSpec, FluidSpec, UniformUnstructuredGrid, TemperatureMonitor
+    >>> heat_sim = HeatSimulation(
+    ...     size=(3.0, 3.0, 3.0),
+    ...     structures=[
+    ...         Structure(
+    ...             geometry=Box(size=(1, 1, 1), center=(0, 0, 0)),
+    ...             medium=Medium(
+    ...                 permittivity=2.0, heat_spec=SolidSpec(
+    ...                     conductivity=1,
+    ...                     capacity=1,
+    ...                 )
+    ...             ),
+    ...             name="box",
+    ...         ),
+    ...     ],
+    ...     medium=Medium(permittivity=3.0, heat_spec=FluidSpec()),
+    ...     grid_spec=UniformUnstructuredGrid(dl=0.1),
+    ...     sources=[UniformHeatSource(rate=1, structures=["box"])],
+    ...     boundary_spec=[
+    ...         HeatBoundarySpec(
+    ...             placement=StructureBoundary(structure="box"),
+    ...             condition=TemperatureBC(temperature=500),
+    ...         )
+    ...     ],
+    ...     monitors=[TemperatureMonitor(size=(1, 2, 3), name="sample")],
+    ... )
+    """
+
+    boundary_spec: Tuple[HeatBoundarySpec, ...] = pd.Field(
+        (),
+        title="Boundary Condition Specifications",
+        description="List of boundary condition specifications.",
+    )
+
+    sources: Tuple[HeatSourceType, ...] = pd.Field(
+        (),
+        title="Heat Sources",
+        description="List of heat sources.",
+    )
+
+    monitors: Tuple[HeatMonitorType, ...] = pd.Field(
+        (),
+        title="Monitors",
+        description="Monitors in the simulation.",
+    )
+
+    grid_spec: HeatGridType = pd.Field(
+        title="Grid Specification",
+        description="Grid specification for heat simulation.",
+        discriminator=TYPE_TAG_STR,
+    )
+
+    symmetry: Tuple[ScalarSymmetry, ScalarSymmetry, ScalarSymmetry] = pd.Field(
+        (0, 0, 0),
+        title="Symmetries",
+        description="Tuple of integers defining reflection symmetry across a plane "
+        "bisecting the simulation domain normal to the x-, y-, and z-axis "
+        "at the simulation center of each axis, respectively. "
+        "Each element can be ``0`` (symmetry off) or ``1`` (symmetry on).",
+    )
+
+    @pd.validator("structures", always=True)
+    def check_unsupported_geometries(cls, val):
+        """Error if structures contain unsupported yet geometries."""
+        for structure in val:
+            if isinstance(structure.geometry, GeometryGroup):
+                geometries = structure.geometry.geometries
+            else:
+                geometries = [structure.geometry]
+            for geom in geometries:
+                if isinstance(geom, (GeometryGroup)):
+                    raise SetupError(
+                        "'HeatSimulation' does not currently support recursive 'GeometryGroup's."
+                    )
+                if not isinstance(geom, HeatSingleGeometryType):
+                    geom_names = [f"'{cl.__name__}'" for cl in HeatSingleGeometryType]
+                    raise SetupError(
+                        "'HeatSimulation' does not currently support geometries of type "
+                        f"'{geom.type}'. Allowed geometries are "
+                        f"{', '.join(geom_names)}, "
+                        "and non-recursive 'GeometryGroup'."
+                    )
+        return val
+
+    @pd.validator("size", always=True)
+    def check_zero_dim_domain(cls, val, values):
+        """Error if heat domain have zero dimensions."""
+
+        if any(length == 0 for length in val):
+            raise SetupError(
+                "'HeatSimulation' does not currently support domains with dimensions of zero size."
+            )
+
+        return val
+
+    @pd.validator("boundary_spec", always=True)
+    def names_exist_bcs(cls, val, values):
+        """Error if boundary conditions point to non-existing structures/media."""
+
+        structures = values.get("structures")
+        structures_names = {s.name for s in structures}
+        mediums_names = {s.medium.name for s in structures}
+        mediums_names.add(values.get("medium").name)
+
+        for bc_ind, bc_spec in enumerate(val):
+            bc_place = bc_spec.placement
+            if isinstance(bc_place, (StructureBoundary, StructureSimulationBoundary)):
+                if bc_place.structure not in structures_names:
+                    raise SetupError(
+                        f"Structure '{bc_place.structure}' provided in "
+                        f"'boundary_spec[{bc_ind}].placement' (type '{bc_place.type}')"
+                        "is not found among simulation structures."
+                    )
+            if isinstance(bc_place, (StructureStructureInterface)):
+                for struct_name in bc_place.structures:
+                    if struct_name and struct_name not in structures_names:
+                        raise SetupError(
+                            f"Structure '{struct_name}' provided in "
+                            f"'boundary_spec[{bc_ind}].placement' (type '{bc_place.type}') "
+                            "is not found among simulation structures."
+                        )
+            if isinstance(bc_place, (MediumMediumInterface)):
+                for med_name in bc_place.mediums:
+                    if med_name not in mediums_names:
+                        raise SetupError(
+                            f"Material '{med_name}' provided in "
+                            f"'boundary_spec[{bc_ind}].placement' (type '{bc_place.type}') "
+                            "is not found among simulation mediums."
+                        )
+        return val
+
+    @pd.validator("grid_spec", always=True)
+    def names_exist_grid_spec(cls, val, values):
+        """Warn if UniformUnstructuredGrid points at a non-existing structure."""
+
+        structures = values.get("structures")
+        structures_names = {s.name for s in structures}
+
+        for structure_name in val.non_refined_structures:
+            if structure_name not in structures_names:
+                log.warning(
+                    f"Structure '{structure_name}' listed as a non-refined structure in "
+                    "'HeatSimulation.grid_spec' is not present in 'HeatSimulation.structures'"
+                )
+
+        return val
+
+    @pd.validator("sources", always=True)
+    def names_exist_sources(cls, val, values):
+        """Error if a heat source point to non-existing structures."""
+        structures = values.get("structures")
+        structures_names = {s.name for s in structures}
+
+        for source in val:
+            for name in source.structures:
+                if name not in structures_names:
+                    raise SetupError(
+                        f"Structure '{name}' provided in a '{source.type}' "
+                        "is not found among simulation structures."
+                    )
+        return val
+
+    """ Post-init validators """
+
+    def _post_init_validators(self) -> None:
+        """Call validators taking z`self` that get run after init."""
+        self._warn_multiple_zones()
+
+    def _warn_multiple_zones(self):
+        """Warn about current restriction on number of adjacent zones."""
+
+        struc_src_map = {}
+        for source in self.sources:
+            for name in source.structures:
+                struc_src_map[name] = source
+
+        unique_solid_zones = {
+            (struc.medium.heat_spec, struc_src_map.get(struc.name, None))
+            for struc in self.structures
+            if isinstance(struc.medium.heat_spec, SolidSpec)
+        }
+
+        if isinstance(self.medium.heat_spec, SolidSpec):
+            unique_solid_zones.add((self.medium.heat_spec, None))
+
+        if len(unique_solid_zones) > 2:
+            log.warning(
+                "More than 2 different solid zones (zone = medium + source) are detected in the heat "
+                "simulation. Make sure no more than 2 solid zones are adjacent to each other anywhere "
+                "in the simulation domain. The simulation results may be inaccurate otherwise. "
+                "This restriction will be removed in the upcoming Tidy3D versions."
+            )
+
+    @equal_aspect
+    @add_ax_if_none
+    def plot_heat_conductivity(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        ax: Ax = None,
+        alpha: float = None,
+        source_alpha: float = None,
+        monitor_alpha: float = None,
+        colorbar: str = "conductivity",
+        hlim: Tuple[float, float] = None,
+        vlim: Tuple[float, float] = None,
+    ) -> Ax:
+        """Plot each of simulation's components on a plane defined by one nonzero x,y,z coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            position of plane in z direction, only one of x, y, z must be specified to define plane.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        alpha : float = None
+            Opacity of the structures being plotted.
+            Defaults to the structure default alpha.
+        source_alpha : float = None
+            Opacity of the sources. If ``None``, uses Tidy3d default.
+        monitor_alpha : float = None
+            Opacity of the monitors. If ``None``, uses Tidy3d default.
+        colorbar: str = "conductivity"
+            Display colorbar for thermal conductivity ("conductivity") or heat source rate
+            ("source").
+        hlim : Tuple[float, float] = None
+            The x range if plotting on xy or xz planes, y range if plotting on yz plane.
+        vlim : Tuple[float, float] = None
+            The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+
+        hlim, vlim = Scene._get_plot_lims(
+            bounds=self.simulation_bounds, x=x, y=y, z=z, hlim=hlim, vlim=vlim
+        )
+
+        cbar_cond = colorbar == "conductivity"
+
+        ax = self.scene.plot_heat_conductivity(
+            ax=ax, x=x, y=y, z=z, cbar=cbar_cond, alpha=alpha, hlim=hlim, vlim=vlim
+        )
+        ax = self.plot_sources(ax=ax, x=x, y=y, z=z, alpha=source_alpha, hlim=hlim, vlim=vlim)
+        ax = self.plot_monitors(ax=ax, x=x, y=y, z=z, alpha=monitor_alpha, hlim=hlim, vlim=vlim)
+        ax = self.plot_boundaries(ax=ax, x=x, y=y, z=z)
+        ax = Scene._set_plot_bounds(
+            bounds=self.simulation_bounds, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim
+        )
+        ax = self.plot_symmetries(ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim)
+
+        if colorbar == "source":
+            self._add_heat_source_cbar(ax=ax)
+        return ax
+
+    @equal_aspect
+    @add_ax_if_none
+    def plot_boundaries(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        ax: Ax = None,
+    ) -> Ax:
+        """Plot each of simulation's boundary conditions on a plane defined by one nonzero x,y,z
+        coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            position of plane in z direction, only one of x, y, z must be specified to define plane.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+
+        # get structure list
+        structures = [self.simulation_structure]
+        structures += list(self.structures)
+
+        # construct slicing plane
+        axis, position = Box.parse_xyz_kwargs(x=x, y=y, z=z)
+        center = Box.unpop_axis(position, (0, 0), axis=axis)
+        size = Box.unpop_axis(0, (inf, inf), axis=axis)
+        plane = Box(center=center, size=size)
+
+        # get boundary conditions in the plane
+        boundaries = self._construct_heat_boundaries(
+            structures=structures,
+            plane=plane,
+            boundary_spec=self.boundary_spec,
+        )
+
+        # plot boundary conditions
+        for (bc_spec, shape) in boundaries:
+            ax = self._plot_boundary_condition(shape=shape, boundary_spec=bc_spec, ax=ax)
+
+        # clean up the axis display
+        axis, position = Box.parse_xyz_kwargs(x=x, y=y, z=z)
+        ax = self.add_ax_labels_lims(axis=axis, ax=ax)
+        ax.set_title(f"cross section at {'xyz'[axis]}={position:.2f}")
+
+        ax = Scene._set_plot_bounds(bounds=self.simulation_bounds, ax=ax, x=x, y=y, z=z)
+
+        return ax
+
+    def _get_bc_plot_params(self, boundary_spec: HeatBoundarySpec) -> PlotParams:
+        """Constructs the plot parameters for given boundary conditions."""
+
+        plot_params = plot_params_heat_bc
+        condition = boundary_spec.condition
+
+        if isinstance(condition, TemperatureBC):
+            plot_params = plot_params.updated_copy(facecolor=HEAT_BC_COLOR_TEMPERATURE)
+        elif isinstance(condition, HeatFluxBC):
+            plot_params = plot_params.updated_copy(facecolor=HEAT_BC_COLOR_FLUX)
+        elif isinstance(condition, ConvectionBC):
+            plot_params = plot_params.updated_copy(facecolor=HEAT_BC_COLOR_CONVECTION)
+
+        return plot_params
+
+    def _plot_boundary_condition(
+        self, shape: Shapely, boundary_spec: HeatBoundarySpec, ax: Ax
+    ) -> Ax:
+        """Plot a structure's cross section shape for a given boundary condition."""
+        plot_params_bc = self._get_bc_plot_params(boundary_spec=boundary_spec)
+        ax = self.plot_shape(shape=shape, plot_params=plot_params_bc, ax=ax)
+        return ax
+
+    @staticmethod
+    def _structure_to_bc_spec_map(
+        plane: Box, structures: Tuple[Structure, ...], boundary_spec: Tuple[HeatBoundarySpec, ...]
+    ) -> Dict[str, HeatBoundarySpec]:
+        """Construct structure name to bc spec inverse mapping. One structure may correspond to
+        multiple boundary conditions."""
+
+        named_structures_present = {structure.name for structure in structures if structure.name}
+
+        struct_to_bc_spec = {}
+        for bc_spec in boundary_spec:
+            bc_place = bc_spec.placement
+            if (
+                isinstance(bc_place, (StructureBoundary, StructureSimulationBoundary))
+                and bc_place.structure in named_structures_present
+            ):
+                if bc_place.structure in struct_to_bc_spec:
+                    struct_to_bc_spec[bc_place.structure] += [bc_spec]
+                else:
+                    struct_to_bc_spec[bc_place.structure] = [bc_spec]
+
+            if isinstance(bc_place, StructureStructureInterface):
+                for structure in bc_place.structures:
+                    if structure in named_structures_present:
+                        if structure in struct_to_bc_spec:
+                            struct_to_bc_spec[structure] += [bc_spec]
+                        else:
+                            struct_to_bc_spec[structure] = [bc_spec]
+
+            if isinstance(bc_place, SimulationBoundary):
+                struct_to_bc_spec[HEAT_BACK_STRUCTURE_STR] = [bc_spec]
+
+        return struct_to_bc_spec
+
+    @staticmethod
+    def _medium_to_bc_spec_map(
+        plane: Box, structures: Tuple[Structure, ...], boundary_spec: Tuple[HeatBoundarySpec, ...]
+    ) -> Dict[str, HeatBoundarySpec]:
+        """Construct medium name to bc spec inverse mapping. One medium may correspond to
+        multiple boundary conditions."""
+
+        named_mediums_present = {
+            structure.medium.name for structure in structures if structure.medium.name
+        }
+
+        med_to_bc_spec = {}
+        for bc_spec in boundary_spec:
+            bc_place = bc_spec.placement
+            if isinstance(bc_place, MediumMediumInterface):
+                for med in bc_place.mediums:
+                    if med in named_mediums_present:
+                        if med in med_to_bc_spec:
+                            med_to_bc_spec[med] += [bc_spec]
+                        else:
+                            med_to_bc_spec[med] = [bc_spec]
+
+        return med_to_bc_spec
+
+    @staticmethod
+    def _construct_forward_boundaries(
+        shapes: Tuple[Tuple[str, str, Shapely, Tuple[float, float, float, float]], ...],
+        struct_to_bc_spec: Dict[str, HeatBoundarySpec],
+        med_to_bc_spec: Dict[str, HeatBoundarySpec],
+        background_structure_shape: Shapely,
+    ) -> Tuple[Tuple[HeatBoundarySpec, Shapely], ...]:
+        """Construct Simulation, StructureSimulation, Structure, and MediumMedium boundaries."""
+
+        # forward foop to take care of Simulation, StructureSimulation, Structure,
+        # and MediumMediums
+        boundaries = []  # bc_spec, structure name, shape, bounds
+        background_shapes = []
+        for name, medium, shape, bounds in shapes:
+
+            # intersect existing boundaries (both structure based and medium based)
+            for index, (_bc_spec, _name, _bdry, _bounds) in enumerate(boundaries):
+
+                # simulation bc is overriden only by StructureSimulationBoundary
+                if isinstance(_bc_spec.placement, SimulationBoundary):
+                    if name not in struct_to_bc_spec:
+                        continue
+                    if any(
+                        not isinstance(bc_spec.placement, StructureSimulationBoundary)
+                        for bc_spec in struct_to_bc_spec[name]
+                    ):
+                        continue
+
+                if Box._do_not_intersect(bounds, _bounds, shape, _bdry):
+                    continue
+
+                diff_shape = _bdry - shape
+
+                boundaries[index] = (_bc_spec, _name, diff_shape, diff_shape.bounds)
+
+            # create new structure based boundary
+
+            if name in struct_to_bc_spec:
+                for bc_spec in struct_to_bc_spec[name]:
+
+                    if isinstance(bc_spec.placement, StructureBoundary):
+                        bdry = shape.exterior
+                        bdry = bdry.intersection(background_structure_shape)
+                        boundaries.append((bc_spec, name, bdry, bdry.bounds))
+
+                    if isinstance(bc_spec.placement, SimulationBoundary):
+                        boundaries.append((bc_spec, name, shape.exterior, shape.exterior.bounds))
+
+                    if isinstance(bc_spec.placement, StructureSimulationBoundary):
+                        bdry = background_structure_shape.exterior
+                        bdry = bdry.intersection(shape)
+                        boundaries.append((bc_spec, name, bdry, bdry.bounds))
+
+            # create new medium based boundary, and cut or merge relevant background shapes
+
+            # loop through background_shapes (note: all background are non-intersecting or merged)
+            # this is similar to _filter_structures_plane but only mediums participating in BCs
+            # are tracked
+            for index, (_medium, _shape, _bounds) in enumerate(background_shapes):
+
+                if Box._do_not_intersect(bounds, _bounds, shape, _shape):
+                    continue
+
+                diff_shape = _shape - shape
+
+                # different medium, remove intersection from background shape
+                if medium != _medium and len(diff_shape.bounds) > 0:
+                    background_shapes[index] = (_medium, diff_shape, diff_shape.bounds)
+
+                    # in case when there is a bc between two media
+                    # create a new boudnary segment
+                    for bc_spec in med_to_bc_spec[_medium.name]:
+                        if medium.name in bc_spec.placement.mediums:
+                            bdry = shape.exterior.intersection(_shape)
+                            bdry = bdry.intersection(background_structure_shape)
+                            boundaries.append((bc_spec, name, bdry, bdry.bounds))
+
+                # same medium, add diff shape to this shape and mark background shape for removal
+                # note: this only happens if this medium is listed in BCs
+                else:
+                    shape = shape | diff_shape
+                    background_shapes[index] = None
+
+            # after doing this with all background shapes, add this shape to the background
+            # but only if this medium is listed in BCs
+            if medium.name in med_to_bc_spec:
+                background_shapes.append((medium, shape, shape.bounds))
+
+            # remove any existing background shapes that have been marked as 'None'
+            background_shapes = [b for b in background_shapes if b is not None]
+
+        # filter out empty geometries
+        boundaries = [(bc_spec, bdry) for (bc_spec, name, bdry, _) in boundaries if bdry]
+
+        return boundaries
+
+    @staticmethod
+    def _construct_reverse_boundaries(
+        shapes: Tuple[Tuple[str, str, Shapely, Bound], ...],
+        struct_to_bc_spec: Dict[str, HeatBoundarySpec],
+        background_structure_shape: Shapely,
+    ) -> Tuple[Tuple[HeatBoundarySpec, Shapely], ...]:
+        """Construct StructureStructure boundaries."""
+
+        # backward foop to take care of StructureStructure
+        # we do it in this way because we define the boundary between
+        # two overlapping structures A and B, where A comes before B, as
+        # boundary(B) intersected by A
+        # So, in this loop as we go backwards through the structures we:
+        # - (1) when come upon B, create boundary(B)
+        # - (2) cut away from it by other structures
+        # - (3) when come upon A, intersect it with A and mark it as complete,
+        #   that is, no more further modifications
+        boundaries_reverse = []
+
+        for name, _, shape, bounds in shapes[:0:-1]:
+
+            minx, miny, maxx, maxy = bounds
+
+            # intersect existing boundaries
+            for index, (_bc_spec, _name, _bdry, _bounds, _completed) in enumerate(
+                boundaries_reverse
+            ):
+
+                if not _completed:
+
+                    if Box._do_not_intersect(bounds, _bounds, shape, _bdry):
+                        continue
+
+                    # event (3) from above
+                    if name in _bc_spec.placement.structures:
+                        new_bdry = _bdry.intersection(shape)
+                        boundaries_reverse[index] = (
+                            _bc_spec,
+                            _name,
+                            new_bdry,
+                            new_bdry.bounds,
+                            True,
+                        )
+
+                    # event (2) from above
+                    else:
+                        new_bdry = _bdry - shape
+                        boundaries_reverse[index] = (
+                            _bc_spec,
+                            _name,
+                            new_bdry,
+                            new_bdry.bounds,
+                            _completed,
+                        )
+
+            # create new boundary (event (1) from above)
+            if name in struct_to_bc_spec:
+                for bc_spec in struct_to_bc_spec[name]:
+                    if isinstance(bc_spec.placement, StructureStructureInterface):
+                        bdry = shape.exterior
+                        bdry = bdry.intersection(background_structure_shape)
+                        boundaries_reverse.append((bc_spec, name, bdry, bdry.bounds, False))
+
+        # filter and append completed boundaries to main list
+        filtered_boundaries = []
+        for bc_spec, _, bdry, _, is_completed in boundaries_reverse:
+            if bdry and is_completed:
+                filtered_boundaries.append((bc_spec, bdry))
+
+        return filtered_boundaries
+
+    @staticmethod
+    def _construct_heat_boundaries(
+        structures: List[Structure],
+        plane: Box,
+        boundary_spec: List[HeatBoundarySpec],
+    ) -> List[Tuple[HeatBoundarySpec, Shapely]]:
+        """Compute list of boundary lines to plot on plane.
+
+        Parameters
+        ----------
+        structures : List[:class:`.Structure`]
+            list of structures to filter on the plane.
+        plane : :class:`.Box`
+            target plane.
+        boundary_spec : List[HeatBoundarySpec]
+            list of boundary conditions associated with structures.
+
+        Returns
+        -------
+        List[Tuple[:class:`.HeatBoundarySpec`, shapely.geometry.base.BaseGeometry]]
+            List of boundary lines and boundary conditions on the plane after merging.
+        """
+
+        # get structures in the plane and present named structures and media
+        shapes = []  # structure name, structure medium, shape, bounds
+        for structure in structures:
+
+            # get list of Shapely shapes that intersect at the plane
+            shapes_plane = plane.intersections_with(structure.geometry)
+
+            # append each of them and their medium information to the list of shapes
+            for shape in shapes_plane:
+                shapes.append((structure.name, structure.medium, shape, shape.bounds))
+
+        background_structure_shape = shapes[0][2]
+
+        # construct an inverse mapping structure -> bc for present structures
+        struct_to_bc_spec = HeatSimulation._structure_to_bc_spec_map(
+            plane=plane, structures=structures, boundary_spec=boundary_spec
+        )
+
+        # construct an inverse mapping medium -> bc for present mediums
+        med_to_bc_spec = HeatSimulation._medium_to_bc_spec_map(
+            plane=plane, structures=structures, boundary_spec=boundary_spec
+        )
+
+        # construct boundaries in 2 passes:
+
+        # 1. forward foop to take care of Simulation, StructureSimulation, Structure,
+        # and MediumMediums
+        boundaries = HeatSimulation._construct_forward_boundaries(
+            shapes=shapes,
+            struct_to_bc_spec=struct_to_bc_spec,
+            med_to_bc_spec=med_to_bc_spec,
+            background_structure_shape=background_structure_shape,
+        )
+
+        # 2. reverse loop: construct structure-structure boundary
+        struct_struct_boundaries = HeatSimulation._construct_reverse_boundaries(
+            shapes=shapes,
+            struct_to_bc_spec=struct_to_bc_spec,
+            background_structure_shape=background_structure_shape,
+        )
+
+        return boundaries + struct_struct_boundaries
+
+    @equal_aspect
+    @add_ax_if_none
+    def plot_sources(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        hlim: Tuple[float, float] = None,
+        vlim: Tuple[float, float] = None,
+        alpha: float = None,
+        ax: Ax = None,
+    ) -> Ax:
+        """Plot each of simulation's sources on a plane defined by one nonzero x,y,z coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            position of plane in z direction, only one of x, y, z must be specified to define plane.
+        hlim : Tuple[float, float] = None
+            The x range if plotting on xy or xz planes, y range if plotting on yz plane.
+        vlim : Tuple[float, float] = None
+            The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
+        alpha : float = None
+            Opacity of the sources, If ``None`` uses Tidy3d default.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+
+        # background can't have source, so no need to add background structure
+        structures = self.structures
+
+        # alpha is None just means plot without any transparency
+        if alpha is None:
+            alpha = 1
+
+        if alpha <= 0:
+            return ax
+
+        # distribute source where there are assigned
+        structure_source_map = {}
+        for source in self.sources:
+            for name in source.structures:
+                structure_source_map[name] = source
+
+        source_list = [structure_source_map.get(structure.name, None) for structure in structures]
+
+        axis, position = Box.parse_xyz_kwargs(x=x, y=y, z=z)
+        center = Box.unpop_axis(position, (0, 0), axis=axis)
+        size = Box.unpop_axis(0, (inf, inf), axis=axis)
+        plane = Box(center=center, size=size)
+
+        source_shapes = self.scene._filter_structures_plane(
+            structures=structures, plane=plane, property_list=source_list
+        )
+
+        source_min, source_max = self.source_bounds
+        for (source, shape) in source_shapes:
+            if source is not None:
+                ax = self._plot_shape_structure_source(
+                    alpha=alpha,
+                    source=source,
+                    source_min=source_min,
+                    source_max=source_max,
+                    shape=shape,
+                    ax=ax,
+                )
+
+        # clean up the axis display
+        axis, position = self.parse_xyz_kwargs(x=x, y=y, z=z)
+        ax = self.add_ax_labels_lims(axis=axis, ax=ax)
+        ax.set_title(f"cross section at {'xyz'[axis]}={position:.2f}")
+
+        ax = Scene._set_plot_bounds(bounds=self.simulation_bounds, ax=ax, x=x, y=y, z=z)
+        return ax
+
+    def _add_heat_source_cbar(self, ax: Ax):
+        """Add colorbar for heat sources."""
+        source_min, source_max = self.source_bounds
+        self.scene._add_cbar(
+            vmin=source_min,
+            vmax=source_max,
+            label=f"Volumetric heat rate ({VOLUMETRIC_HEAT_RATE})",
+            cmap=HEAT_SOURCE_CMAP,
+            ax=ax,
+        )
+
+    @cached_property
+    def source_bounds(self) -> Tuple[float, float]:
+        """Compute range of heat sources present in the simulation."""
+
+        rate_list = [
+            source.rate for source in self.sources if isinstance(source, UniformHeatSource)
+        ]
+        rate_list.append(0)
+        rate_min = min(rate_list)
+        rate_max = max(rate_list)
+        return rate_min, rate_max
+
+    def _get_structure_source_plot_params(
+        self,
+        source: HeatSourceType,
+        source_min: float,
+        source_max: float,
+        alpha: float = None,
+    ) -> PlotParams:
+        """Constructs the plot parameters for a given medium in simulation.plot_eps()."""
+
+        plot_params = plot_params_heat_source
+        if alpha is not None:
+            plot_params = plot_params.copy(update={"alpha": alpha})
+
+        if isinstance(source, UniformHeatSource):
+            rate = source.rate
+            delta_rate = rate - source_min
+            delta_rate_max = source_max - source_min + 1e-5
+            rate_fraction = delta_rate / delta_rate_max
+            cmap = cm.get_cmap(HEAT_SOURCE_CMAP)
+            rgba = cmap(rate_fraction)
+            plot_params = plot_params.copy(update={"edgecolor": rgba})
+
+        return plot_params
+
+    def _plot_shape_structure_source(
+        self,
+        source: HeatSourceType,
+        shape: Shapely,
+        source_min: float,
+        source_max: float,
+        ax: Ax,
+        alpha: float = None,
+    ) -> Ax:
+        """Plot a structure's cross section shape for a given medium, grayscale for permittivity."""
+        plot_params = self._get_structure_source_plot_params(
+            source=source,
+            source_min=source_min,
+            source_max=source_max,
+            alpha=alpha,
+        )
+        ax = self.plot_shape(shape=shape, plot_params=plot_params, ax=ax)
+        return ax
+
+    @classmethod
+    def from_scene(cls, scene: Scene, **kwargs) -> HeatSimulation:
+        """Create a simulation from a :class:.`Scene` instance. Must provide additional parameters
+        to define a valid simulation (for example, ``size``, ``grid_spec``, etc).
+
+        Parameters
+        ----------
+        scene : :class:.`Scene`
+            Scene containing structures information.
+        **kwargs
+            Other arguments
+
+        Example
+        -------
+        >>> from tidy3d import Scene, Medium, Box, Structure, UniformUnstructuredGrid
+        >>> box = Structure(
+        ...     geometry=Box(center=(0, 0, 0), size=(1, 2, 3)),
+        ...     medium=Medium(permittivity=5),
+        ... )
+        >>> scene = Scene(
+        ...     structures=[box],
+        ...     medium=Medium(permittivity=3),
+        ... )
+        >>> sim = HeatSimulation.from_scene(
+        ...     scene=scene,
+        ...     center=(0, 0, 0),
+        ...     size=(5, 6, 7),
+        ...     grid_spec=UniformUnstructuredGrid(dl=0.4),
+        ... )
+        """
+
+        return cls(
+            structures=scene.structures,
+            medium=scene.medium,
+            **kwargs,
+        )

--- a/tidy3d/components/heat/source.py
+++ b/tidy3d/components/heat/source.py
@@ -1,0 +1,48 @@
+"""Defines heat material specifications"""
+from __future__ import annotations
+
+from abc import ABC
+from typing import Union, Tuple
+
+import pydantic.v1 as pd
+
+from .viz import plot_params_heat_source
+
+from ..base import Tidy3dBaseModel, cached_property
+from ..data.data_array import TimeDataArray
+from ..viz import PlotParams
+
+from ...constants import VOLUMETRIC_HEAT_RATE
+
+
+class HeatSource(ABC, Tidy3dBaseModel):
+    """Abstract heat source."""
+
+    structures: Tuple[str, ...] = pd.Field(
+        title="Target Structures",
+        description="Names of structures where to apply heat source.",
+    )
+
+    @cached_property
+    def plot_params(self) -> PlotParams:
+        """Default parameters for plotting a Source object."""
+        return plot_params_heat_source
+
+
+class UniformHeatSource(HeatSource):
+    """Volumetric heat source.
+
+    Example
+    -------
+    >>> heat_source = UniformHeatSource(rate=1, structures=["box"])
+    """
+
+    rate: Union[float, TimeDataArray] = pd.Field(
+        title="Volumetric Heat Rate",
+        description="Volumetric rate of heating or cooling (if negative) in units of "
+        f"{VOLUMETRIC_HEAT_RATE}.",
+        units=VOLUMETRIC_HEAT_RATE,
+    )
+
+
+HeatSourceType = Union[UniformHeatSource]

--- a/tidy3d/components/heat/viz.py
+++ b/tidy3d/components/heat/viz.py
@@ -1,0 +1,12 @@
+""" utilities for heat solver plotting """
+from ..viz import PlotParams
+
+""" Constants """
+
+HEAT_BC_COLOR_TEMPERATURE = "orange"
+HEAT_BC_COLOR_FLUX = "green"
+HEAT_BC_COLOR_CONVECTION = "brown"
+HEAT_SOURCE_CMAP = "coolwarm"
+
+plot_params_heat_bc = PlotParams(lw=3)
+plot_params_heat_source = PlotParams(edgecolor="red", lw=0, hatch="..", fill=False)

--- a/tidy3d/components/heat_spec.py
+++ b/tidy3d/components/heat_spec.py
@@ -1,0 +1,51 @@
+"""Defines heat material specifications"""
+from __future__ import annotations
+
+from abc import ABC
+
+import pydantic.v1 as pd
+
+from .types import Union
+from .base import Tidy3dBaseModel
+from ..constants import SPECIFIC_HEAT_CAPACITY, THERMAL_CONDUCTIVITY
+
+
+# Liquid class
+class AbstractHeatSpec(ABC, Tidy3dBaseModel):
+    """Abstract heat material specification."""
+
+
+class FluidSpec(AbstractHeatSpec):
+    """Fluid medium.
+
+    Example
+    -------
+    >>> solid = FluidSpec()
+    """
+
+
+class SolidSpec(AbstractHeatSpec):
+    """Solid medium.
+
+    Example
+    -------
+    >>> solid = SolidSpec(
+    ...     capacity=2,
+    ...     conductivity=3,
+    ... )
+    """
+
+    capacity: pd.PositiveFloat = pd.Field(
+        title="Heat capacity",
+        description=f"Volumetric heat capacity in unit of {SPECIFIC_HEAT_CAPACITY}.",
+        units=SPECIFIC_HEAT_CAPACITY,
+    )
+
+    conductivity: pd.PositiveFloat = pd.Field(
+        title="Thermal conductivity",
+        description=f"Thermal conductivity of material in units of {THERMAL_CONDUCTIVITY}.",
+        units=THERMAL_CONDUCTIVITY,
+    )
+
+
+HeatSpecType = Union[FluidSpec, SolidSpec]

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -6,7 +6,7 @@ import pydantic.v1 as pydantic
 import numpy as np
 
 from .types import Ax, EMField, ArrayFloat1D, FreqArray, FreqBound, Numpy
-from .types import Literal, Direction, Coordinate, Axis, ObsGridArray
+from .types import Literal, Direction, Coordinate, Axis, ObsGridArray, BoxSurface
 from .geometry.base import Box
 from .validators import assert_plane
 from .base import cached_property, Tidy3dBaseModel
@@ -496,7 +496,7 @@ class SurfaceIntegrationMonitor(Monitor, ABC):
         "Applies to surface monitors only, and defaults to ``'+'`` if not provided.",
     )
 
-    exclude_surfaces: Tuple[Literal["x-", "x+", "y-", "y+", "z-", "z+"], ...] = pydantic.Field(
+    exclude_surfaces: Tuple[BoxSurface, ...] = pydantic.Field(
         None,
         title="Excluded surfaces",
         description="Surfaces to exclude in the integration, if a volume monitor.",

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -1,0 +1,1280 @@
+""" Container holding about the geometry and medium properties common to all types of simulations.
+"""
+from __future__ import annotations
+from typing import Dict, Tuple, List, Set, Union
+
+import pydantic.v1 as pd
+import numpy as np
+import matplotlib.pylab as plt
+import matplotlib as mpl
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+
+from .base import cached_property, Tidy3dBaseModel
+from .validators import assert_unique_names
+from .geometry.base import Box
+from .geometry.mesh import TriangleMesh
+from .types import Ax, Shapely, TYPE_TAG_STR, Bound, Size, Coordinate, InterpMethod
+from .medium import Medium, MediumType, PECMedium
+from .medium import AbstractCustomMedium, Medium2D, MediumType3D
+from .medium import AnisotropicMedium, AbstractPerturbationMedium
+from .structure import Structure
+from .data.dataset import Dataset
+from .data.data_array import SpatialDataArray
+from .viz import add_ax_if_none, equal_aspect
+from .grid.grid import Coords
+from .heat_spec import SolidSpec
+
+from .viz import MEDIUM_CMAP, STRUCTURE_EPS_CMAP, PlotParams, polygon_path, STRUCTURE_HEAT_COND_CMAP
+from .viz import plot_params_structure, plot_params_fluid
+
+from ..constants import inf, THERMAL_CONDUCTIVITY
+from ..exceptions import SetupError, Tidy3dError
+from ..log import log
+
+# maximum number of mediums supported
+MAX_NUM_MEDIUMS = 65530
+
+
+class Scene(Tidy3dBaseModel):
+    """Contains generic information about the geometry and medium properties common to all types of
+    simulations.
+
+    Example
+    -------
+    >>> sim = Scene(
+    ...     structures=[
+    ...         Structure(
+    ...             geometry=Box(size=(1, 1, 1), center=(0, 0, 0)),
+    ...             medium=Medium(permittivity=2.0),
+    ...         ),
+    ...     ],
+    ...     medium=Medium(permittivity=3.0),
+    ... )
+    """
+
+    medium: MediumType3D = pd.Field(
+        Medium(),
+        title="Background Medium",
+        description="Background medium of scene, defaults to vacuum if not specified.",
+        discriminator=TYPE_TAG_STR,
+    )
+
+    structures: Tuple[Structure, ...] = pd.Field(
+        (),
+        title="Structures",
+        description="Tuple of structures present in scene. "
+        "Note: Structures defined later in this list override the "
+        "simulation material properties in regions of spatial overlap.",
+    )
+
+    """ Validating setup """
+
+    # make sure all names are unique
+    _unique_structure_names = assert_unique_names("structures")
+
+    @pd.validator("structures", always=True)
+    def _validate_num_mediums(cls, val):
+        """Error if too many mediums present."""
+
+        if val is None:
+            return val
+
+        mediums = {structure.medium for structure in val}
+        if len(mediums) > MAX_NUM_MEDIUMS:
+            raise SetupError(
+                f"Tidy3D only supports {MAX_NUM_MEDIUMS} distinct mediums."
+                f"{len(mediums)} were supplied."
+            )
+
+        return val
+
+    """ Accounting """
+
+    @cached_property
+    def bounds(self) -> Bound:
+        """Automatically defined scene's bounds based on present structures. Infinite dimensions
+        are ignored. If the scene contains no strucutres, the bounds are set to
+        (-1, -1, -1), (1, 1, 1). Similarly, if along a given axis all structures extend infinitely,
+        the bounds along that axis are set from -1 to 1.
+
+        Returns
+        -------
+        Tuple[float, float, float], Tuple[float, float, float]
+            Min and max bounds packaged as ``(minx, miny, minz), (maxx, maxy, maxz)``.
+        """
+
+        bounds = tuple(structure.geometry.bounds for structure in self.structures)
+        return (
+            tuple(min((b[i] for b, _ in bounds if b[i] != -inf), default=-1) for i in range(3)),
+            tuple(max((b[i] for _, b in bounds if b[i] != inf), default=1) for i in range(3)),
+        )
+
+    @cached_property
+    def size(self) -> Size:
+        """Automatically defined scene's size.
+
+        Returns
+        -------
+        Tuple[float, float, float]
+            Scene's size.
+        """
+
+        return tuple(bmax - bmin for bmin, bmax in zip(self.bounds[0], self.bounds[1]))
+
+    @cached_property
+    def center(self) -> Coordinate:
+        """Automatically defined scene's center.
+
+        Returns
+        -------
+        Tuple[float, float, float]
+            Scene's center.
+        """
+
+        return tuple(0.5 * (bmin + bmax) for bmin, bmax in zip(self.bounds[0], self.bounds[1]))
+
+    @cached_property
+    def box(self) -> Box:
+        """Automatically defined scene's :class:`.Box`.
+
+        Returns
+        -------
+        Box
+            Scene's box.
+        """
+
+        return Box(center=self.center, size=self.size)
+
+    @cached_property
+    def mediums(self) -> Set[MediumType]:
+        """Returns set of distinct :class:`.AbstractMedium` in scene.
+
+        Returns
+        -------
+        List[:class:`.AbstractMedium`]
+            Set of distinct mediums in the scene.
+        """
+        medium_dict = {self.medium: None}
+        medium_dict.update({structure.medium: None for structure in self.structures})
+        return list(medium_dict.keys())
+
+    @cached_property
+    def medium_map(self) -> Dict[MediumType, pd.NonNegativeInt]:
+        """Returns dict mapping medium to index in material.
+        ``medium_map[medium]`` returns unique global index of :class:`.AbstractMedium` in scene.
+
+        Returns
+        -------
+        Dict[:class:`.AbstractMedium`, int]
+            Mapping between distinct mediums to index in scene.
+        """
+
+        return {medium: index for index, medium in enumerate(self.mediums)}
+
+    @cached_property
+    def background_structure(self) -> Structure:
+        """Returns structure representing the background of the :class:`.Scene`."""
+        geometry = Box(size=(inf, inf, inf))
+        return Structure(geometry=geometry, medium=self.medium)
+
+    @staticmethod
+    def intersecting_media(
+        test_object: Box, structures: Tuple[Structure, ...]
+    ) -> Tuple[MediumType, ...]:
+        """From a given list of structures, returns a list of :class:`.AbstractMedium` associated
+        with those structures that intersect with the ``test_object``, if it is a surface, or its
+        surfaces, if it is a volume.
+
+        Parameters
+        -------
+        test_object : :class:`.Box`
+            Object for which intersecting media are to be detected.
+        structures : List[:class:`.AbstractMedium`]
+            List of structures whose media will be tested.
+
+        Returns
+        -------
+        List[:class:`.AbstractMedium`]
+            Set of distinct mediums that intersect with the given planar object.
+        """
+        if test_object.size.count(0.0) == 1:
+            # get all merged structures on the test_object, which is already planar
+            structures_merged = Scene._filter_structures_plane_medium(structures, test_object)
+            mediums = {medium for medium, _ in structures_merged}
+            return mediums
+
+        # if the test object is a volume, test each surface recursively
+        surfaces = test_object.surfaces_with_exclusion(**test_object.dict())
+        mediums = set()
+        for surface in surfaces:
+            _mediums = Scene.intersecting_media(surface, structures)
+            mediums.update(_mediums)
+        return mediums
+
+    @staticmethod
+    def intersecting_structures(
+        test_object: Box, structures: Tuple[Structure, ...]
+    ) -> Tuple[Structure, ...]:
+        """From a given list of structures, returns a list of :class:`.Structure` that intersect
+        with the ``test_object``, if it is a surface, or its surfaces, if it is a volume.
+
+        Parameters
+        -------
+        test_object : :class:`.Box`
+            Object for which intersecting media are to be detected.
+        structures : List[:class:`.AbstractMedium`]
+            List of structures whose media will be tested.
+
+        Returns
+        -------
+        List[:class:`.Structure`]
+            Set of distinct structures that intersect with the given surface, or with the surfaces
+            of the given volume.
+        """
+        if test_object.size.count(0.0) == 1:
+            # get all merged structures on the test_object, which is already planar
+            normal_axis_index = test_object.size.index(0.0)
+            dim = "xyz"[normal_axis_index]
+            pos = test_object.center[normal_axis_index]
+            xyz_kwargs = {dim: pos}
+
+            structures_merged = []
+            for structure in structures:
+                intersections = structure.geometry.intersections_plane(**xyz_kwargs)
+                if len(intersections) > 0:
+                    structures_merged.append(structure)
+            return structures_merged
+
+        # if the test object is a volume, test each surface recursively
+        surfaces = test_object.surfaces_with_exclusion(**test_object.dict())
+        structures_merged = []
+        for surface in surfaces:
+            structures_merged += Scene.intersecting_structures(surface, structures)
+        return structures_merged
+
+    """ Plotting General """
+
+    @staticmethod
+    def _get_plot_lims(
+        bounds: Bound,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        hlim: Tuple[float, float] = None,
+        vlim: Tuple[float, float] = None,
+    ) -> Tuple[Tuple[float, float], Tuple[float, float]]:
+
+        # if no hlim and/or vlim given, the bounds will then be the usual pml bounds
+        axis, _ = Box.parse_xyz_kwargs(x=x, y=y, z=z)
+        _, (hmin, vmin) = Box.pop_axis(bounds[0], axis=axis)
+        _, (hmax, vmax) = Box.pop_axis(bounds[1], axis=axis)
+
+        # account for unordered limits
+        if hlim is None:
+            hlim = (hmin, hmax)
+        if vlim is None:
+            vlim = (vmin, vmax)
+
+        if hlim[0] > hlim[1]:
+            raise Tidy3dError("Error: 'hmin' > 'hmax'")
+        if vlim[0] > vlim[1]:
+            raise Tidy3dError("Error: 'vmin' > 'vmax'")
+
+        return hlim, vlim
+
+    @equal_aspect
+    @add_ax_if_none
+    def plot(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        ax: Ax = None,
+        hlim: Tuple[float, float] = None,
+        vlim: Tuple[float, float] = None,
+        **patch_kwargs,
+    ) -> Ax:
+        """Plot each of scene's components on a plane defined by one nonzero x,y,z coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            position of plane in z direction, only one of x, y, z must be specified to define plane.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        hlim : Tuple[float, float] = None
+            The x range if plotting on xy or xz planes, y range if plotting on yz plane.
+        vlim : Tuple[float, float] = None
+            The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+
+        hlim, vlim = Scene._get_plot_lims(bounds=self.bounds, x=x, y=y, z=z, hlim=hlim, vlim=vlim)
+
+        ax = self.plot_structures(ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim)
+        ax = self._set_plot_bounds(bounds=self.bounds, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim)
+        return ax
+
+    @equal_aspect
+    @add_ax_if_none
+    def plot_structures(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        ax: Ax = None,
+        hlim: Tuple[float, float] = None,
+        vlim: Tuple[float, float] = None,
+    ) -> Ax:
+        """Plot each of scene's structures on a plane defined by one nonzero x,y,z coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            position of plane in z direction, only one of x, y, z must be specified to define plane.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        hlim : Tuple[float, float] = None
+            The x range if plotting on xy or xz planes, y range if plotting on yz plane.
+        vlim : Tuple[float, float] = None
+            The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+
+        medium_shapes = self._get_structures_plane(structures=self.structures, x=x, y=y, z=z)
+        medium_map = self.medium_map
+
+        for (medium, shape) in medium_shapes:
+            mat_index = medium_map[medium]
+            ax = self._plot_shape_structure(medium=medium, mat_index=mat_index, shape=shape, ax=ax)
+
+        ax = self._set_plot_bounds(bounds=self.bounds, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim)
+
+        # clean up the axis display
+        axis, position = Box.parse_xyz_kwargs(x=x, y=y, z=z)
+        ax = self.box.add_ax_labels_lims(axis=axis, ax=ax)
+        ax.set_title(f"cross section at {'xyz'[axis]}={position:.2f}")
+
+        return ax
+
+    def _plot_shape_structure(self, medium: Medium, mat_index: int, shape: Shapely, ax: Ax) -> Ax:
+        """Plot a structure's cross section shape for a given medium."""
+        plot_params_struct = self._get_structure_plot_params(medium=medium, mat_index=mat_index)
+        ax = self.box.plot_shape(shape=shape, plot_params=plot_params_struct, ax=ax)
+        return ax
+
+    def _get_structure_plot_params(self, mat_index: int, medium: Medium) -> PlotParams:
+        """Constructs the plot parameters for a given medium in scene.plot()."""
+
+        plot_params = plot_params_structure.copy(update={"linewidth": 0})
+
+        if mat_index == 0 or medium == self.medium:
+            # background medium
+            plot_params = plot_params.copy(update={"facecolor": "white", "edgecolor": "white"})
+        elif isinstance(medium, PECMedium):
+            # perfect electrical conductor
+            plot_params = plot_params.copy(
+                update={"facecolor": "gold", "edgecolor": "k", "linewidth": 1}
+            )
+        elif isinstance(medium, Medium2D):
+            # 2d material
+            plot_params = plot_params.copy(update={"edgecolor": "k", "linewidth": 1})
+        else:
+            # regular medium
+            facecolor = MEDIUM_CMAP[(mat_index - 1) % len(MEDIUM_CMAP)]
+            plot_params = plot_params.copy(update={"facecolor": facecolor})
+
+        return plot_params
+
+    @staticmethod
+    def _add_cbar(vmin: float, vmax: float, label: str, cmap: str, ax: Ax = None) -> None:
+        """Add a colorbar to plot."""
+        norm = mpl.colors.Normalize(vmin=vmin, vmax=vmax)
+        divider = make_axes_locatable(ax)
+        cax = divider.append_axes("right", size="5%", pad=0.15)
+        mappable = mpl.cm.ScalarMappable(norm=norm, cmap=cmap)
+        plt.colorbar(mappable, cax=cax, label=label)
+
+    @staticmethod
+    def _set_plot_bounds(
+        bounds: Bound,
+        ax: Ax,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        hlim: Tuple[float, float] = None,
+        vlim: Tuple[float, float] = None,
+    ) -> Ax:
+        """Sets the xy limits of the scene at a plane, useful after plotting.
+
+        Parameters
+        ----------
+        ax : matplotlib.axes._subplots.Axes
+            Matplotlib axes to set bounds on.
+        x : float = None
+            position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            position of plane in z direction, only one of x, y, z must be specified to define plane.
+        hlim : Tuple[float, float] = None
+            The x range if plotting on xy or xz planes, y range if plotting on yz plane.
+        vlim : Tuple[float, float] = None
+            The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The axes after setting the boundaries.
+        """
+
+        hlim, vlim = Scene._get_plot_lims(bounds=bounds, x=x, y=y, z=z, hlim=hlim, vlim=vlim)
+        ax.set_xlim(hlim)
+        ax.set_ylim(vlim)
+        return ax
+
+    @staticmethod
+    def _get_structures_plane(
+        structures: List[Structure], x: float = None, y: float = None, z: float = None
+    ) -> List[Tuple[Medium, Shapely]]:
+        """Compute list of shapes to plot on plane specified by {x,y,z}.
+
+        Parameters
+        ----------
+        structures : List[:class:`.Structure`]
+            list of structures to filter on the plane.
+        x : float = None
+            position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            position of plane in z direction, only one of x, y, z must be specified to define plane.
+
+        Returns
+        -------
+        List[Tuple[:class:`.AbstractMedium`, shapely.geometry.base.BaseGeometry]]
+            List of shapes and mediums on the plane.
+        """
+        medium_shapes = []
+        for structure in structures:
+            intersections = structure.geometry.intersections_plane(x=x, y=y, z=z)
+            if len(intersections) > 0:
+                for shape in intersections:
+                    shape = Box.evaluate_inf_shape(shape)
+                    medium_shapes.append((structure.medium, shape))
+        return medium_shapes
+
+    @staticmethod
+    def _filter_structures_plane_medium(
+        structures: List[Structure], plane: Box
+    ) -> List[Tuple[Medium, Shapely]]:
+        """Compute list of shapes to plot on plane. Overlaps are removed or merged depending on
+        medium.
+
+        Parameters
+        ----------
+        structures : List[:class:`.Structure`]
+            List of structures to filter on the plane.
+        plane : Box
+            Plane specification.
+
+        Returns
+        -------
+        List[Tuple[:class:`.AbstractMedium`, shapely.geometry.base.BaseGeometry]]
+            List of shapes and mediums on the plane after merging.
+        """
+
+        medium_list = [structure.medium for structure in structures]
+        return Scene._filter_structures_plane(
+            structures=structures, plane=plane, property_list=medium_list
+        )
+
+    @staticmethod
+    def _filter_structures_plane(
+        structures: List[Structure],
+        plane: Box,
+        property_list: List,
+    ) -> List[Tuple[Medium, Shapely]]:
+        """Compute list of shapes to plot on plane. Overlaps are removed or merged depending on
+        provided property_list.
+
+        Parameters
+        ----------
+        structures : List[:class:`.Structure`]
+            List of structures to filter on the plane.
+        plane : Box
+            Plane specification.
+        property_list : List = None
+            Property value for each structure.
+
+        Returns
+        -------
+        List[Tuple[:class:`.AbstractMedium`, shapely.geometry.base.BaseGeometry]]
+            List of shapes and their property value on the plane after merging.
+        """
+
+        if len(structures) != len(property_list):
+            raise SetupError(
+                "Number of provided property values is not equal to the number of structures."
+            )
+
+        shapes = []
+        for structure, prop in zip(structures, property_list):
+
+            # get list of Shapely shapes that intersect at the plane
+            shapes_plane = plane.intersections_with(structure.geometry)
+
+            # Append each of them and their property information to the list of shapes
+            for shape in shapes_plane:
+                shapes.append((prop, shape, shape.bounds))
+
+        background_shapes = []
+        for prop, shape, bounds in shapes:
+
+            minx, miny, maxx, maxy = bounds
+
+            # loop through background_shapes (note: all background are non-intersecting or merged)
+            for index, (_prop, _shape, _bounds) in enumerate(background_shapes):
+
+                _minx, _miny, _maxx, _maxy = _bounds
+
+                # do a bounding box check to see if any intersection to do anything about
+                if minx > _maxx or _minx > maxx or miny > _maxy or _miny > maxy:
+                    continue
+
+                # look more closely to see if intersected.
+                if _shape.is_empty or not shape.intersects(_shape):
+                    continue
+
+                diff_shape = _shape - shape
+
+                # different prop, remove intersection from background shape
+                if prop != _prop and len(diff_shape.bounds) > 0:
+                    background_shapes[index] = (_prop, diff_shape, diff_shape.bounds)
+
+                # same prop, add diff shape to this shape and mark background shape for removal
+                else:
+                    shape = shape | diff_shape
+                    background_shapes[index] = None
+
+            # after doing this with all background shapes, add this shape to the background
+            background_shapes.append((prop, shape, shape.bounds))
+
+            # remove any existing background shapes that have been marked as 'None'
+            background_shapes = [b for b in background_shapes if b is not None]
+
+        # filter out any remaining None or empty shapes (shapes with area completely removed)
+        return [(prop, shape) for (prop, shape, _) in background_shapes if shape]
+
+    """ Plotting Optical """
+
+    @equal_aspect
+    @add_ax_if_none
+    def plot_eps(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        freq: float = None,
+        alpha: float = None,
+        ax: Ax = None,
+        hlim: Tuple[float, float] = None,
+        vlim: Tuple[float, float] = None,
+    ) -> Ax:
+        """Plot each of scene's components on a plane defined by one nonzero x,y,z coordinate.
+        The permittivity is plotted in grayscale based on its value at the specified frequency.
+
+        Parameters
+        ----------
+        x : float = None
+            position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            position of plane in z direction, only one of x, y, z must be specified to define plane.
+        freq : float = None
+            Frequency to evaluate the relative permittivity of all mediums.
+            If not specified, evaluates at infinite frequency.
+        alpha : float = None
+            Opacity of the structures being plotted.
+            Defaults to the structure default alpha.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        hlim : Tuple[float, float] = None
+            The x range if plotting on xy or xz planes, y range if plotting on yz plane.
+        vlim : Tuple[float, float] = None
+            The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+
+        hlim, vlim = Scene._get_plot_lims(bounds=self.bounds, x=x, y=y, z=z, hlim=hlim, vlim=vlim)
+
+        ax = self.plot_structures_eps(
+            freq=freq, cbar=True, alpha=alpha, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim
+        )
+        ax = self._set_plot_bounds(bounds=self.bounds, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim)
+        return ax
+
+    @equal_aspect
+    @add_ax_if_none
+    def plot_structures_eps(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        freq: float = None,
+        alpha: float = None,
+        cbar: bool = True,
+        reverse: bool = False,
+        eps_lim: Tuple[Union[float, None], Union[float, None]] = (None, None),
+        ax: Ax = None,
+        hlim: Tuple[float, float] = None,
+        vlim: Tuple[float, float] = None,
+    ) -> Ax:
+        """Plot each of scene's structures on a plane defined by one nonzero x,y,z coordinate.
+        The permittivity is plotted in grayscale based on its value at the specified frequency.
+
+        Parameters
+        ----------
+        x : float = None
+            position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            position of plane in z direction, only one of x, y, z must be specified to define plane.
+        freq : float = None
+            Frequency to evaluate the relative permittivity of all mediums.
+            If not specified, evaluates at infinite frequency.
+        reverse : bool = False
+            If ``False``, the highest permittivity is plotted in black.
+            If ``True``, it is plotteed in white (suitable for black backgrounds).
+        cbar : bool = True
+            Whether to plot a colorbar for the relative permittivity.
+        alpha : float = None
+            Opacity of the structures being plotted.
+            Defaults to the structure default alpha.
+        eps_lim : Tuple[float, float] = None
+            Custom limits for eps coloring.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        hlim : Tuple[float, float] = None
+            The x range if plotting on xy or xz planes, y range if plotting on yz plane.
+        vlim : Tuple[float, float] = None
+            The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+
+        structures = self.structures
+        structures = [self.background_structure] + list(structures)
+
+        # alpha is None just means plot without any transparency
+        if alpha is None:
+            alpha = 1
+
+        if alpha <= 0:
+            return ax
+
+        if alpha < 1 and not isinstance(self.medium, AbstractCustomMedium):
+            axis, position = Box.parse_xyz_kwargs(x=x, y=y, z=z)
+            center = Box.unpop_axis(position, (0, 0), axis=axis)
+            size = Box.unpop_axis(0, (inf, inf), axis=axis)
+            plane = Box(center=center, size=size)
+            medium_shapes = self._filter_structures_plane_medium(structures=structures, plane=plane)
+        else:
+            medium_shapes = self._get_structures_plane(structures=structures, x=x, y=y, z=z)
+
+        eps_min, eps_max = eps_lim
+
+        if eps_min is None or eps_max is None:
+
+            eps_min_sim, eps_max_sim = self.eps_bounds(freq=freq)
+
+            if eps_min is None:
+                eps_min = eps_min_sim
+
+            if eps_max is None:
+                eps_max = eps_max_sim
+
+        for (medium, shape) in medium_shapes:
+            # if the background medium is custom medium, it needs to be rendered separately
+            if medium == self.medium and alpha < 1 and not isinstance(medium, AbstractCustomMedium):
+                continue
+            # no need to add patches for custom medium
+            if not isinstance(medium, AbstractCustomMedium):
+                ax = self._plot_shape_structure_eps(
+                    freq=freq,
+                    alpha=alpha,
+                    medium=medium,
+                    eps_min=eps_min,
+                    eps_max=eps_max,
+                    reverse=reverse,
+                    shape=shape,
+                    ax=ax,
+                )
+            else:
+                # For custom medium, apply pcolormesh clipped by the shape.
+                self._pcolormesh_shape_custom_medium_structure_eps(
+                    x, y, z, freq, alpha, medium, eps_min, eps_max, reverse, shape, ax
+                )
+
+        if cbar:
+            self._add_cbar_eps(eps_min=eps_min, eps_max=eps_max, ax=ax)
+        ax = self._set_plot_bounds(bounds=self.bounds, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim)
+
+        # clean up the axis display
+        axis, position = Box.parse_xyz_kwargs(x=x, y=y, z=z)
+        ax = self.box.add_ax_labels_lims(axis=axis, ax=ax)
+        ax.set_title(f"cross section at {'xyz'[axis]}={position:.2f}")
+
+        return ax
+
+    @staticmethod
+    def _add_cbar_eps(eps_min: float, eps_max: float, ax: Ax = None) -> None:
+        """Add a permittivity colorbar to plot."""
+        Scene._add_cbar(
+            vmin=eps_min, vmax=eps_max, label=r"$\epsilon_r$", cmap=STRUCTURE_EPS_CMAP, ax=ax
+        )
+
+    def eps_bounds(self, freq: float = None) -> Tuple[float, float]:
+        """Compute range of (real) permittivity present in the scene at frequency "freq".
+
+        Parameters
+        ----------
+        freq : float = None
+            Frequency to evaluate the relative permittivity of all mediums.
+            If not specified, evaluates at infinite frequency.
+
+        Returns
+        -------
+        Tuple[float, float]
+            Minimal and maximal values of relative permittivity in scene.
+        """
+
+        medium_list = [self.medium] + list(self.mediums)
+        medium_list = [medium for medium in medium_list if not isinstance(medium, PECMedium)]
+        # regular medium
+        eps_list = [
+            medium.eps_model(freq).real
+            for medium in medium_list
+            if not isinstance(medium, AbstractCustomMedium)
+        ]
+        eps_list.append(1)
+        eps_min = min(eps_list)
+        eps_max = max(eps_list)
+        # custom medium, the min and max in the supplied dataset over all components and
+        # spatial locations.
+        for mat in [medium for medium in medium_list if isinstance(medium, AbstractCustomMedium)]:
+            eps_dataarray = mat.eps_dataarray_freq(freq)
+            eps_min = min(
+                eps_min,
+                min(np.min(eps_comp.real.values.ravel()) for eps_comp in eps_dataarray),
+            )
+            eps_max = max(
+                eps_max,
+                max(np.max(eps_comp.real.values.ravel()) for eps_comp in eps_dataarray),
+            )
+        return eps_min, eps_max
+
+    def _pcolormesh_shape_custom_medium_structure_eps(
+        self,
+        x: float,
+        y: float,
+        z: float,
+        freq: float,
+        alpha: float,
+        medium: Medium,
+        eps_min: float,
+        eps_max: float,
+        reverse: bool,
+        shape: Shapely,
+        ax: Ax,
+    ):
+        """
+        Plot shape made of custom medium with ``pcolormesh``.
+        """
+        coords = "xyz"
+        normal_axis_ind, normal_position = Box.parse_xyz_kwargs(x=x, y=y, z=z)
+        normal_axis, plane_axes = Box.pop_axis(coords, normal_axis_ind)
+        plane_axes_inds = [0, 1, 2]
+        plane_axes_inds.pop(normal_axis_ind)
+
+        # make grid for eps interpolation
+        # we will do this by combining shape bounds and points where custom eps is provided
+        shape_bounds = shape.bounds
+        rmin, rmax = [*shape_bounds[:2]], [*shape_bounds[2:]]
+        rmin.insert(normal_axis_ind, normal_position)
+        rmax.insert(normal_axis_ind, normal_position)
+
+        # in case when different components of custom medium are defined on different grids
+        # we will combine all points along each dimension
+        eps_diag = medium.eps_dataarray_freq(frequency=freq)
+        if eps_diag[0].coords == eps_diag[1].coords and eps_diag[0].coords == eps_diag[2].coords:
+            coords_to_insert = [eps_diag[0].coords]
+        else:
+            coords_to_insert = [eps_diag[0].coords, eps_diag[1].coords, eps_diag[2].coords]
+
+        # actual combining of points along each of plane dimensions
+        plane_coord = []
+        for ind, comp in zip(plane_axes_inds, plane_axes):
+            # first start with an array made of shapes bounds
+            axis_coords = np.array([rmin[ind], rmax[ind]])
+            # now add points in between them
+            for coords in coords_to_insert:
+                comp_axis_coords = coords[comp]
+                inds_inside_shape = np.where(
+                    np.logical_and(comp_axis_coords > rmin[ind], comp_axis_coords < rmax[ind])
+                )[0]
+                if len(inds_inside_shape) > 0:
+                    axis_coords = np.concatenate((axis_coords, comp_axis_coords[inds_inside_shape]))
+            # remove duplicates
+            axis_coords = np.unique(axis_coords)
+
+            plane_coord.append(axis_coords)
+
+        # prepare `Coords` for interpolation
+        coord_dict = {
+            plane_axes[0]: plane_coord[0],
+            plane_axes[1]: plane_coord[1],
+            normal_axis: [normal_position],
+        }
+        coord_shape = Coords(**coord_dict)
+        # interpolate permittivity and take the average over components
+        eps_shape = np.mean(medium.eps_diagonal_on_grid(frequency=freq, coords=coord_shape), axis=0)
+        # remove the normal_axis and take real part
+        eps_shape = eps_shape.real.mean(axis=normal_axis_ind)
+        # reverse
+        if reverse:
+            eps_shape = eps_min + eps_max - eps_shape
+
+        # pcolormesh
+        plane_xp, plane_yp = np.meshgrid(plane_coord[0], plane_coord[1], indexing="ij")
+        ax.pcolormesh(
+            plane_xp,
+            plane_yp,
+            eps_shape,
+            clip_path=(polygon_path(shape), ax.transData),
+            cmap=STRUCTURE_EPS_CMAP,
+            vmin=eps_min,
+            vmax=eps_max,
+            alpha=alpha,
+            clip_box=ax.bbox,
+        )
+
+    def _get_structure_eps_plot_params(
+        self,
+        medium: Medium,
+        freq: float,
+        eps_min: float,
+        eps_max: float,
+        reverse: bool = False,
+        alpha: float = None,
+    ) -> PlotParams:
+        """Constructs the plot parameters for a given medium in scene.plot_eps()."""
+
+        plot_params = plot_params_structure.copy(update={"linewidth": 0})
+        if alpha is not None:
+            plot_params = plot_params.copy(update={"alpha": alpha})
+
+        if isinstance(medium, PECMedium):
+            # perfect electrical conductor
+            plot_params = plot_params.copy(
+                update={"facecolor": "gold", "edgecolor": "k", "linewidth": 1}
+            )
+        elif isinstance(medium, Medium2D):
+            # 2d material
+            plot_params = plot_params.copy(update={"edgecolor": "k", "linewidth": 1})
+        else:
+            # regular medium
+            eps_medium = medium.eps_model(frequency=freq).real
+            delta_eps = eps_medium - eps_min
+            delta_eps_max = eps_max - eps_min + 1e-5
+            eps_fraction = delta_eps / delta_eps_max
+            color = eps_fraction if reverse else 1 - eps_fraction
+            color = min(1, max(color, 0))  # clip in case of custom eps limits
+            plot_params = plot_params.copy(update={"facecolor": str(color)})
+
+        return plot_params
+
+    def _plot_shape_structure_eps(
+        self,
+        freq: float,
+        medium: Medium,
+        shape: Shapely,
+        eps_min: float,
+        eps_max: float,
+        ax: Ax,
+        reverse: bool = False,
+        alpha: float = None,
+    ) -> Ax:
+        """Plot a structure's cross section shape for a given medium, grayscale for permittivity."""
+        plot_params = self._get_structure_eps_plot_params(
+            medium=medium, freq=freq, eps_min=eps_min, eps_max=eps_max, alpha=alpha, reverse=reverse
+        )
+        ax = self.box.plot_shape(shape=shape, plot_params=plot_params, ax=ax)
+        return ax
+
+    """ Plotting Heat """
+
+    @equal_aspect
+    @add_ax_if_none
+    def plot_heat_conductivity(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        alpha: float = None,
+        cbar: bool = True,
+        ax: Ax = None,
+        hlim: Tuple[float, float] = None,
+        vlim: Tuple[float, float] = None,
+    ) -> Ax:
+        """Plot each of scebe's components on a plane defined by one nonzero x,y,z coordinate.
+        The thermal conductivity is plotted in grayscale based on its value.
+
+        Parameters
+        ----------
+        x : float = None
+            position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            position of plane in z direction, only one of x, y, z must be specified to define plane.
+        alpha : float = None
+            Opacity of the structures being plotted.
+            Defaults to the structure default alpha.
+        cbar : bool = True
+            Whether to plot a colorbar for the thermal conductivity.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        hlim : Tuple[float, float] = None
+            The x range if plotting on xy or xz planes, y range if plotting on yz plane.
+        vlim : Tuple[float, float] = None
+            The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+
+        hlim, vlim = Scene._get_plot_lims(bounds=self.bounds, x=x, y=y, z=z, hlim=hlim, vlim=vlim)
+
+        ax = self.plot_structures_heat_conductivity(
+            cbar=cbar, alpha=alpha, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim
+        )
+        ax = self._set_plot_bounds(bounds=self.bounds, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim)
+        return ax
+
+    @equal_aspect
+    @add_ax_if_none
+    def plot_structures_heat_conductivity(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        alpha: float = None,
+        cbar: bool = True,
+        reverse: bool = False,
+        ax: Ax = None,
+        hlim: Tuple[float, float] = None,
+        vlim: Tuple[float, float] = None,
+    ) -> Ax:
+        """Plot each of scene's structures on a plane defined by one nonzero x,y,z coordinate.
+        The thermal conductivity is plotted in grayscale based on its value.
+
+        Parameters
+        ----------
+        x : float = None
+            position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            position of plane in z direction, only one of x, y, z must be specified to define plane.
+        reverse : bool = False
+            If ``False``, the highest permittivity is plotted in black.
+            If ``True``, it is plotteed in white (suitable for black backgrounds).
+        cbar : bool = True
+            Whether to plot a colorbar for the relative permittivity.
+        alpha : float = None
+            Opacity of the structures being plotted.
+            Defaults to the structure default alpha.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        hlim : Tuple[float, float] = None
+            The x range if plotting on xy or xz planes, y range if plotting on yz plane.
+        vlim : Tuple[float, float] = None
+            The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+
+        structures = self.structures
+        structures = [self.background_structure] + list(structures)
+
+        # alpha is None just means plot without any transparency
+        if alpha is None:
+            alpha = 1
+
+        if alpha <= 0:
+            return ax
+
+        if alpha < 1:
+            axis, position = Box.parse_xyz_kwargs(x=x, y=y, z=z)
+            center = Box.unpop_axis(position, (0, 0), axis=axis)
+            size = Box.unpop_axis(0, (inf, inf), axis=axis)
+            plane = Box(center=center, size=size)
+            medium_shapes = self._filter_structures_plane_medium(structures=structures, plane=plane)
+        else:
+            medium_shapes = self._get_structures_plane(structures=structures, x=x, y=y, z=z)
+
+        heat_cond_min, heat_cond_max = self.heat_conductivity_bounds()
+        for (medium, shape) in medium_shapes:
+            ax = self._plot_shape_structure_heat_cond(
+                alpha=alpha,
+                medium=medium,
+                heat_cond_min=heat_cond_min,
+                heat_cond_max=heat_cond_max,
+                reverse=reverse,
+                shape=shape,
+                ax=ax,
+            )
+
+        if cbar:
+            self._add_cbar(
+                vmin=heat_cond_min,
+                vmax=heat_cond_max,
+                label=f"Thermal conductivity ({THERMAL_CONDUCTIVITY})",
+                cmap=STRUCTURE_HEAT_COND_CMAP,
+                ax=ax,
+            )
+        ax = self._set_plot_bounds(bounds=self.bounds, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim)
+
+        # clean up the axis display
+        axis, position = Box.parse_xyz_kwargs(x=x, y=y, z=z)
+        ax = self.box.add_ax_labels_lims(axis=axis, ax=ax)
+        ax.set_title(f"cross section at {'xyz'[axis]}={position:.2f}")
+
+        return ax
+
+    def heat_conductivity_bounds(self) -> Tuple[float, float]:
+        """Compute range of thermal conductivities present in the scene.
+
+        Returns
+        -------
+        Tuple[float, float]
+            Minimal and maximal values of thermal conductivity in scene.
+        """
+
+        medium_list = [self.medium] + list(self.mediums)
+        medium_list = [medium for medium in medium_list if isinstance(medium.heat_spec, SolidSpec)]
+        cond_list = [medium.heat_spec.conductivity for medium in medium_list]
+        cond_min = min(cond_list)
+        cond_max = max(cond_list)
+        return cond_min, cond_max
+
+    def _get_structure_heat_cond_plot_params(
+        self,
+        medium: Medium,
+        heat_cond_min: float,
+        heat_cond_max: float,
+        reverse: bool = False,
+        alpha: float = None,
+    ) -> PlotParams:
+        """Constructs the plot parameters for a given medium in
+        scene.plot_heat_conductivity().
+        """
+
+        plot_params = plot_params_structure.copy(update={"linewidth": 0})
+        if alpha is not None:
+            plot_params = plot_params.copy(update={"alpha": alpha})
+
+        if isinstance(medium.heat_spec, SolidSpec):
+            # regular medium
+            cond_medium = medium.heat_spec.conductivity
+            delta_cond = cond_medium - heat_cond_min
+            delta_cond_max = heat_cond_max - heat_cond_min + 1e-5 * heat_cond_min
+            cond_fraction = delta_cond / delta_cond_max
+            color = cond_fraction if reverse else 1 - cond_fraction
+            plot_params = plot_params.copy(update={"facecolor": str(color)})
+        else:
+            plot_params = plot_params_fluid
+            if alpha is not None:
+                plot_params = plot_params.copy(update={"alpha": alpha})
+
+        return plot_params
+
+    def _plot_shape_structure_heat_cond(
+        self,
+        medium: Medium,
+        shape: Shapely,
+        heat_cond_min: float,
+        heat_cond_max: float,
+        ax: Ax,
+        reverse: bool = False,
+        alpha: float = None,
+    ) -> Ax:
+        """Plot a structure's cross section shape for a given medium, grayscale for thermal
+        conductivity.
+        """
+        plot_params = self._get_structure_heat_cond_plot_params(
+            medium=medium,
+            heat_cond_min=heat_cond_min,
+            heat_cond_max=heat_cond_max,
+            alpha=alpha,
+            reverse=reverse,
+        )
+        ax = self.box.plot_shape(shape=shape, plot_params=plot_params, ax=ax)
+        return ax
+
+    """ Misc """
+
+    @property
+    def custom_datasets(self) -> List[Dataset]:
+        """List of custom datasets for verification purposes. If the list is not empty, then
+        the scene needs to be exported to hdf5 to store the data.
+        """
+        datasets_medium = [mat for mat in self.mediums if isinstance(mat, AbstractCustomMedium)]
+        datasets_geometry = [
+            struct.geometry.mesh_dataset
+            for struct in self.structures
+            if isinstance(struct.geometry, TriangleMesh)
+        ]
+        return datasets_medium + datasets_geometry
+
+    @cached_property
+    def allow_gain(self) -> bool:
+        """``True`` if any of the mediums in the scene allows gain."""
+
+        for medium in self.mediums:
+            if isinstance(medium, AnisotropicMedium):
+                if np.any([med.allow_gain for med in [medium.xx, medium.yy, medium.zz]]):
+                    return True
+            elif medium.allow_gain:
+                return True
+        return False
+
+    def perturbed_mediums_copy(
+        self,
+        temperature: SpatialDataArray = None,
+        electron_density: SpatialDataArray = None,
+        hole_density: SpatialDataArray = None,
+        interp_method: InterpMethod = "linear",
+    ) -> Scene:
+        """Return a copy of the scene with heat and/or charge data applied to all mediums
+        that have perturbation models specified. That is, such mediums will be replaced with
+        spatially dependent custom mediums that reflect perturbation effects. Any of temperature,
+        electron_density, and hole_density can be ``None``. All provided fields must have identical
+        coords.
+
+        Parameters
+        ----------
+        temperature : SpatialDataArray = None
+            Temperature field data.
+        electron_density : SpatialDataArray = None
+            Electron density field data.
+        hole_density : SpatialDataArray = None
+            Hole density field data.
+        interp_method : :class:`.InterpMethod`, optional
+            Interpolation method to obtain heat and/or charge values that are not supplied
+            at the Yee grids.
+
+        Returns
+        -------
+        Scene
+            Simulation after application of heat and/or charge data.
+        """
+
+        scene_dict = self.dict()
+        structures = self.structures
+        scene_bounds = self.bounds
+        array_dict = {
+            "temperature": temperature,
+            "electron_density": electron_density,
+            "hole_density": hole_density,
+        }
+
+        # For each structure made of mediums with perturbation models, convert those mediums into
+        # spatially dependent mediums by selecting minimal amount of heat and charge data points
+        # covering the structure, and create a new structure containing the resulting custom medium
+        new_structures = []
+        for s_ind, structure in enumerate(structures):
+            med = structure.medium
+            if isinstance(med, AbstractPerturbationMedium):
+                # get structure's bounding box
+                s_bounds = structure.geometry.bounds
+
+                bounds = [
+                    np.max([scene_bounds[0], s_bounds[0]], axis=0),
+                    np.min([scene_bounds[1], s_bounds[1]], axis=0),
+                ]
+
+                # for each structure select a minimal subset of data that covers it
+                restricted_arrays = {}
+
+                for name, array in array_dict.items():
+                    if array is not None:
+                        restricted_arrays[name] = array.sel_inside(bounds)
+
+                        # check provided data fully cover structure
+                        if not array.does_cover(bounds):
+                            log.warning(
+                                f"Provided '{name}' does not fully cover structures[{s_ind}]."
+                            )
+
+                new_medium = med.perturbed_copy(**restricted_arrays, interp_method=interp_method)
+                new_structure = structure.updated_copy(medium=new_medium)
+                new_structures.append(new_structure)
+            else:
+                new_structures.append(structure)
+
+        scene_dict["structures"] = new_structures
+
+        # do the same for background medium if it a medium with perturbation models.
+        med = self.medium
+        if isinstance(med, AbstractPerturbationMedium):
+
+            # get scene's bounding box
+            bounds = scene_bounds
+
+            # for each structure select a minimal subset of data that covers it
+            restricted_arrays = {}
+
+            for name, array in array_dict.items():
+                if array is not None:
+                    restricted_arrays[name] = array.sel_inside(bounds)
+
+                    # check provided data fully cover scene
+                    if not array.does_cover(bounds):
+                        log.warning(f"Provided '{name}' does not fully cover scene domain.")
+
+            scene_dict["medium"] = med.perturbed_copy(
+                **restricted_arrays, interp_method=interp_method
+            )
+
+        return Scene.parse_obj(scene_dict)

--- a/tidy3d/components/types.py
+++ b/tidy3d/components/types.py
@@ -178,6 +178,7 @@ class tidycomplex(complex):
 """ symmetry """
 
 Symmetry = Literal[0, -1, 1]
+ScalarSymmetry = Literal[0, 1]
 
 """ geometric """
 
@@ -192,6 +193,7 @@ Axis2D = Literal[0, 1]
 Shapely = BaseGeometry
 PlanePosition = Literal["bottom", "middle", "top"]
 ClipOperationType = Literal["union", "intersection", "difference", "symmetric_difference"]
+BoxSurface = Literal["x-", "x+", "y-", "y+", "z-", "z+"]
 
 """ medium """
 
@@ -224,6 +226,7 @@ ObsGridArray = Union[Tuple[float, ...], ArrayFloat1D]
 Ax = Axes
 PlotVal = Literal["real", "imag", "abs"]
 FieldVal = Literal["real", "imag", "abs", "abs^2", "phase"]
+RealFieldVal = Literal["real", "abs", "abs^2"]
 PlotScale = Literal["lin", "dB"]
 ColormapType = Literal["divergent", "sequential", "cyclic"]
 

--- a/tidy3d/components/viz.py
+++ b/tidy3d/components/viz.py
@@ -114,6 +114,7 @@ plot_params_symmetry = PlotParams(edgecolor="gray", facecolor="gray", alpha=0.6,
 plot_params_override_structures = PlotParams(
     linewidth=0.4, edgecolor="black", fill=False, zorder=inf
 )
+plot_params_fluid = PlotParams(facecolor="white", edgecolor="lightsteelblue", lw=0.4, hatch="xx")
 
 # stores color of simulation.structures for given index in simulation.medium_map
 MEDIUM_CMAP = [
@@ -129,6 +130,7 @@ MEDIUM_CMAP = [
 
 # colormap for structure's permittivity in plot_eps
 STRUCTURE_EPS_CMAP = "gist_yarg"
+STRUCTURE_HEAT_COND_CMAP = "gist_yarg"
 
 # default arrow style
 arrow_style = ArrowStyle.Simple(head_length=12, head_width=9, tail_width=4)

--- a/tidy3d/constants.py
+++ b/tidy3d/constants.py
@@ -48,6 +48,12 @@ KELVIN = "K"
 CMCUBE = "cm^3"
 PERCMCUBE = "1/cm^3"
 
+THERMAL_CONDUCTIVITY = "W/(um*K)"
+SPECIFIC_HEAT_CAPACITY = "J/(kg*K)"
+HEAT_FLUX = "W/um^2"
+VOLUMETRIC_HEAT_RATE = "W/um^3"
+HEAT_TRANSFER_COEFF = "W/(um^2*K)"
+
 # large number used for comparing infinity
 LARGE_NUMBER = 1e10
 

--- a/tidy3d/web/api/asynchronous.py
+++ b/tidy3d/web/api/asynchronous.py
@@ -16,12 +16,12 @@ def run_async(
     simulation_type: str = "tidy3d",
     parent_tasks: Dict[str, List[str]] = None,
 ) -> BatchData:
-    """Submits a set of Union[:class:`.Simulation`] objects to server, starts running,
-    monitors progress, downloads, and loads results as a :class:`.BatchData` object.
+    """Submits a set of Union[:class:`.Simulation`, :class:`.HeatSimulation`] objects to server,
+    starts running, monitors progress, downloads, and loads results as a :class:`.BatchData` object.
 
     Parameters
     ----------
-    simulations : Dict[str, Union[:class:`.Simulation`]]
+    simulations : Dict[str, Union[:class:`.Simulation`, :class:`.HeatSimulation`]]
         Mapping of task name to simulation.
     folder_name : str = "default"
         Name of folder to store each task on web UI.
@@ -38,8 +38,8 @@ def run_async(
     Returns
     ------
     :class:`BatchData`
-        Contains the Union[:class:`.SimulationData`] for each Union[:class:`.Simulation`]
-        in :class:`Batch`.
+        Contains the Union[:class:`.SimulationData`, :class:`.HeatSimulationData`] for each
+        Union[:class:`.Simulation`, :class:`.HeatSimulation`] in :class:`Batch`.
     """
 
     if simulation_type is None:

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -27,10 +27,15 @@ class WebContainer(Tidy3dBaseModel, ABC):
 
 
 class Job(WebContainer):
-    """Interface for managing the running of Union[:class:`.Simulation`] on server."""
+    """Interface for managing the running of Union[:class:`.Simulation`, :class:`.HeatSimulation`]
+    on server.
+    """
 
     simulation: SimulationType = pd.Field(
-        ..., title="simulation", description="Simulation to run as a 'task'."
+        ...,
+        title="simulation",
+        description="Simulation to run as a 'task'.",
+        discriminator="type",
     )
 
     task_name: TaskName = pd.Field(..., title="Task Name", description="Unique name of the task.")
@@ -94,8 +99,9 @@ class Job(WebContainer):
 
         Returns
         -------
-        Dict[str, Union[:class:`.SimulationData`]]
-            Dictionary mapping task name to Union[:class:`.SimulationData`] for :class:`Job`.
+        Dict[str, Union[:class:`.SimulationData`, :class:`.HeatSimulationData`]]
+            Dictionary mapping task name to
+            Union[:class:`.SimulationData`, :class:`.HeatSimulationData`] for :class:`Job`.
         """
 
         self.start()
@@ -173,13 +179,14 @@ class Job(WebContainer):
 
         Note
         ----
-        To load the data into Union[:class:`.SimulationData`] objets, can call :meth:`Job.load`.
+        To load the data into Union[:class:`.SimulationData`, :class:`.HeatSimulationData`] objets,
+        can call :meth:`Job.load`.
         """
         web.download(task_id=self.task_id, path=path, verbose=self.verbose)
 
     def load(self, path: str = DEFAULT_DATA_PATH) -> SimulationDataType:
         """Download results from simulation (if not already) and load them into
-        Union[:class:`.SimulationData`] object.
+        Union[:class:`.SimulationData`, :class:`.HeatSimulationData`] object.
 
         Parameters
         ----------
@@ -188,7 +195,7 @@ class Job(WebContainer):
 
         Returns
         -------
-        Union[:class:`.SimulationData`]
+        Union[:class:`.SimulationData`, :class:`.HeatSimulationData`]
             Object containing simulation results.
         """
         return web.load(task_id=self.task_id, path=path, verbose=self.verbose)
@@ -207,8 +214,8 @@ class Job(WebContainer):
         Returns
         -------
         float
-            Estimated maximum cost for Union[:class:`.Simulation`] associated with
-            the given :class:`.Job`.
+            Estimated maximum cost for Union[:class:`.Simulation`, :class:`.HeatSimulation`]
+            associated with the given :class:`.Job`.
 
         Note
         ----
@@ -224,7 +231,9 @@ class Job(WebContainer):
 
 
 class BatchData(Tidy3dBaseModel):
-    """Holds a collection of Union[:class:`.SimulationData`] returned by :class:`.Batch`."""
+    """Holds a collection of Union[:class:`.SimulationData`, :class:`.HeatSimulationData`] returned
+    by :class:`.Batch`.
+    """
 
     task_paths: Dict[TaskName, str] = pd.Field(
         ...,
@@ -241,7 +250,9 @@ class BatchData(Tidy3dBaseModel):
     )
 
     def load_sim_data(self, task_name: str) -> SimulationDataType:
-        """Load Union[:class:`.SimulationData`] from file by task name."""
+        """Load Union[:class:`.SimulationData`, :class:`.HeatSimulationData`] from file
+        by task name.
+        """
         task_data_path = self.task_paths[task_name]
         task_id = self.task_ids[task_name]
         web.get_info(task_id)
@@ -253,12 +264,16 @@ class BatchData(Tidy3dBaseModel):
         )
 
     def items(self) -> Tuple[TaskName, SimulationDataType]:
-        """Iterate through the Union[:class:`.SimulationData`] for each task_name."""
+        """Iterate through the Union[:class:`.SimulationData`, :class:`.HeatSimulationData`]
+        for each task_name.
+        """
         for task_name in self.task_paths.keys():
             yield task_name, self.load_sim_data(task_name)
 
     def __getitem__(self, task_name: TaskName) -> SimulationDataType:
-        """Get the Union[:class:`.SimulationData`] for a given ``task_name``."""
+        """Get the Union[:class:`.SimulationData`, :class:`.HeatSimulationData`] for
+        a given ``task_name``.
+        """
         return self.load_sim_data(task_name)
 
     @classmethod
@@ -274,8 +289,8 @@ class BatchData(Tidy3dBaseModel):
         Returns
         ------
         :class:`BatchData`
-            Contains Union[:class:`.SimulationData`] for each Union[:class:`.Simulation`]
-            in :class:`Batch`.
+            Contains Union[:class:`.SimulationData`, :class:`.HeatSimulationData`]
+            for each Union[:class:`.Simulation`, :class:`.HeatSimulation`] in :class:`Batch`.
         """
 
         batch_file = Batch._batch_path(path_dir=path_dir)
@@ -284,7 +299,9 @@ class BatchData(Tidy3dBaseModel):
 
 
 class Batch(WebContainer):
-    """Interface for submitting several Union[:class:`.Simulation`] objects to sever."""
+    """Interface for submitting several Union[:class:`.Simulation`, :class:`.HeatSimulation`]
+    objects to sever.
+    """
 
     simulations: Dict[TaskName, SimulationType] = pd.Field(
         ...,
@@ -354,8 +371,8 @@ class Batch(WebContainer):
         Returns
         ------
         :class:`BatchData`
-            Contains Union[:class:`.SimulationData`] of each Union[:class:`.Simulation`]
-            in :class:`Batch`.
+            Contains Union[:class:`.SimulationData`, :class:`.HeatSimulationData`] for
+            each Union[:class:`.Simulation`, :class:`.HeatSimulation`] in :class:`Batch`.
 
         Note
         ----
@@ -365,9 +382,10 @@ class Batch(WebContainer):
         >>> for task_name, sim_data in batch_data.items():
         ...     # do something with data.
 
-        ``bach_data`` does not store all of the Union[:class:`.SimulationData`] objects in memory,
-        rather it iterates over the task names
-        and loads the corresponding Union[:class:`.SimulationData`] from file one by one.
+        ``bach_data`` does not store all of
+        the Union[:class:`.SimulationData`, :class:`.HeatSimulationData`] objects in memory,
+        rather it iterates over the task names and loads the corresponding
+        Union[:class:`.SimulationData`, :class:`.HeatSimulationData`] from file one by one.
         If no file exists for that task, it downloads it.
         """
         self._check_path_dir(path_dir)
@@ -572,7 +590,8 @@ class Batch(WebContainer):
 
         Note
         ----
-        To load the data into Union[:class:`.SimulationData`] objets, can call :meth:`Batch.items`.
+        To load the data into Union[:class:`.SimulationData`, :class:`.HeatSimulationData`] objets,
+        can call :meth:`Batch.items`.
 
         The data for each task will be named as ``{path_dir}/{task_name}.hdf5``.
         The :class:`Batch` hdf5 file will be automatically saved as ``{path_dir}/batch.hdf5``,
@@ -601,8 +620,8 @@ class Batch(WebContainer):
         Returns
         ------
         :class:`BatchData`
-            Contains Union[:class:`.SimulationData`] of each Union[:class:`.Simulation`]
-            in :class:`Batch`.
+            Contains Union[:class:`.SimulationData`, :class:`.HeatSimulationData`] for each
+            Union[:class:`.Simulation`, :class:`.HeatSimulation`] in :class:`Batch`.
 
         The :class:`Batch` hdf5 file will be automatically saved as ``{path_dir}/batch.hdf5``,
         allowing one to load this :class:`Batch` later using ``batch = Batch.from_file()``.
@@ -645,8 +664,8 @@ class Batch(WebContainer):
         Returns
         -------
         float
-            Estimated maximum cost for each Union[:class:`.Simulation`] associated with
-            given :class:`.Batch`.
+            Estimated maximum cost for each Union[:class:`.Simulation`, :class:`.HeatSimulation`]
+            associated with given :class:`.Batch`.
 
         Note
         ----

--- a/tidy3d/web/environment.py
+++ b/tidy3d/web/environment.py
@@ -1,0 +1,4 @@
+""" preserve from tidy3d.web.environment import Env backward compatibility """
+from .core.environment import Env
+
+__all__ = ["Env"]


### PR DESCRIPTION
Since the old PR (https://github.com/flexcompute/tidy3d/pull/896) became very outdated, I've decided to open a new one.

Major changes/additions (directory structure is up for discussion, just whatever seemed to make sense for now):

### `components/heat_spec.py`: 
All medium classes can now have field `heat_spec` which can be either `SolidSpec` or `FuildSpec` for specifying thermal properties. To remind, there are three categories of properties:
1. optic (permittivity, conductivity, ...) - defined using standard `Medium`, `Lorentz`, etc classes
2. thermal (heat conductivity, capacity, ...) - added through field `heat_spec`.
3. response of optic properties to temperature (perturbations) - added when using `PerturbationMedium` and `PerturbationPoleResidue` classes.

And this is how different options interact with heat solver:
- Structures using medium instances with `heat_spec=None` or `heat_spec=FluidSpec()` will **not** be included in solution domain for the heat equation, and they will **not** be converted to custom mediums after applying temperature fields.
- Structures using non-perturbation medium instances with `heat_spec=SolidSpec(...)` will be included in solution domain for heat equation, but they will **not** be converted to custom mediums after applying temperature fields.
- Structures using perturbation medium instances (`PerturbationMedium` and `PerturbationPoleResidue`) with `heat_spec=SolidSpec(...)` will be included in solution domain for heat equation, and they will be converted to custom mediums after applying temperature fields. (the fullest material description)

### `components/scene.py`: 
Carved out geometric only information from `Simulation` into class `Scene` for easier transfer of geometric information between different solvers. Basically, it contains `structures`, `medium`, `center`, `size` + plotting functionality. 
- Point to discuss: plotting of custom media is dependent on simulation grid in `Simulation`. I think we should still have eps plotting in `Scene` class (along with thermal conductivity plotting, and perhaps other properties in future), so I adjusted the plotting of custom medium to use custom medium sample points + structure bounds instead of simulation grid. But now the question is whether `Simulation` in future should just directly borrow this plotting method or to have its own based on actual simulation grid?
- As discussed, for now we will not make any changes to `Simulation`, only added property `Simulation.scene` and class method `Simulation.from_scene(scene: Scene, **kwargs)` to transferring `Scene` between optic/heat simulation.
- Contrary, `HeatSimulation` does have field `scene: Scene` 

### `components/bc_placement.py`: 
This file defines classes for placement of boundary conditions on complex interfaces (`BCPlacementType=[StructureBoundary, StructureStructureInterface, MediumMediumInterface, etc]`). I realized this should be separated from heat solver components because it can be reused for other future solvers.

### `components/heat/`: 
The remaining of heat components are placed in this directory to keep everything tidy (yes, you see what I did here lol) and they include:
- `boundary.py` boundary conditions specifications: `TemperatureBC`, `HeatFluxBC`, `ConvectionBC` + `HeatBoundarySpec`
- `grid.py` heat grid specification: currently, `UniformHeatGrid` and `DistanceHeatGrid`. I can that this can go either way: we can introduce more classes to give the user more control or, contrary, unify everything into one spec so that the user don't have to think about what to select at all.
- `sim_data.py` defines `HeatSimulationData` which is currently simply `HeatSimulation` instance + temperature `SpatialDataArray`
- `simulation.py` defines `HeatSimulation`
- `source.py` heat source: currently only `UniformHeatSource`
- `viz.py` some parameters for plotting heat information


### Notebooks with demonstrations
There are two draft notebooks demonstrating:
- basic heat solver usage + comparison to analytical solutions https://github.com/flexcompute-readthedocs/tidy3d-docs/blob/daniil/heat-solver-draft/docs/source/notebooks/HeatSolverDraft.ipynb
- usage in the context of thermally tuning a ring resonator https://github.com/flexcompute-readthedocs/tidy3d-docs/blob/daniil/heat-solver-draft/docs/source/notebooks/ThermallyTunedRingResonatorDraft.ipynb
These are meant to provide more explanation on how every component is interacting with each other


### additional major things off the top of my head to discuss:
- Currently boundary conditions and heat source placement specifications are done through using structures and medium names. For example, `placement = td.StructureStructureInterface(structures=["box", "sphere"])`. This doesn't seem ideal. We could maybe just pass structures/mediums themselves. But that will increase size of `HeatSimulation` instances. Maybe an alternative is to just record hash of passed structures/mediums? But then it would be harder to point user which structure/medium is missing from a heat simulation.