### PR TITLE
Improved warnings with Medium2D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Bug in `Simulation.eps_bounds` that was always setting the lower bound to 1.
 - Extended lower limit of frequency range for `Graphene` to zero.
+- Improved warnings for `Medium2D`.
 
 ## [2.4.0rc2] - 2023-8-21
 

--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -312,14 +312,12 @@ def test_gain_medium(log_capture):
     assert_log_level(log_capture, "WARNING")
 
 
-def test_medium2d():
+def test_medium2d(log_capture):
     sigma = 0.45
     thickness = 0.01
     cond_med = td.Medium(conductivity=sigma)
     medium = td.Medium2D.from_medium(cond_med, thickness=thickness)
 
-    _ = medium.plot(freqs=[2e14, 3e14], ax=AX)
-    plt.close()
     _ = medium.plot_sigma(freqs=[2e14, 3e14], ax=AX)
     plt.close()
     assert np.isclose(medium.ss.to_medium().conductivity, sigma * thickness, rtol=RTOL)
@@ -337,6 +335,22 @@ def test_medium2d():
         sigma / 3,
         rtol=RTOL,
     )
+
+    # 2d geometry should raise a warning, but 3d should not
+    td.Structure(medium=medium3d, geometry=td.Box(size=(1, 1, 1)))
+
+    # no warnings so far
+    assert_log_level(log_capture, None)
+
+    # these should give warnings
+    td.Structure(medium=medium3d, geometry=td.Box(size=(1, 0, 1)))
+    assert_log_level(log_capture, "WARNING")
+
+    log_capture.clear()
+
+    _ = medium.plot(freqs=[2e14, 3e14], ax=AX)
+    plt.close()
+    assert_log_level(log_capture, "WARNING")
 
 
 def test_rotation():

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -1117,7 +1117,7 @@ def test_sim_structure_extent(log_capture, box_size, log_level):
 @pytest.mark.parametrize(
     "box_length,absorb_type,log_level",
     [
-        (0, "PML", None),
+        (0.0001, "PML", None),
         (1, "PML", "WARNING"),
         (1.5, "absorber", None),
         (2.0, "PML", None),
@@ -1612,7 +1612,7 @@ def test_dt():
     assert sim_new.dt == 0.4 * dt
 
 
-def test_sim_volumetric_structures(tmp_path):
+def test_sim_volumetric_structures(log_capture, tmp_path):
     """Test volumetric equivalent of 2D materials."""
     sigma = 0.45
     thickness = 0.01
@@ -1693,6 +1693,9 @@ def test_sim_volumetric_structures(tmp_path):
         LARGE_NUMBER * thickness / grid_dl,
         rtol=RTOL,
     )
+
+    log_capture.clear()
+
     # check that plotting 2d material doesn't raise an error
     sim_data = run_emulated(sim)
     sim_data.plot_field(field_monitor_name="field_xz", field_name="Ex", val="real")
@@ -1701,6 +1704,9 @@ def test_sim_volumetric_structures(tmp_path):
     plt.close()
     _ = sim.plot(x=0)
     plt.close()
+
+    # plotting should not raise warning
+    assert_log_level(log_capture, None)
 
     # nonuniform sub/super-strate should error
     below_half = td.Structure(

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -3579,7 +3579,11 @@ class Medium2D(AbstractMedium):
     @ensure_freq_in_range
     def eps_diagonal(self, frequency: float) -> Tuple[complex, complex]:
         """Main diagonal of the complex-valued permittivity tensor as a function of frequency."""
-        log.warning("Evaluating permittivity of a 'Medium2D' is unphysical.")
+        log.warning(
+            "The permittivity of a 'Medium2D' is unphysical. "
+            "Use 'Medium2D.to_anisotropic_medium' or 'Medium2D.to_pole_residue' first "
+            "to obtain the physical refractive index."
+        )
 
         eps_ss = self.ss.eps_model(frequency)
         eps_tt = self.tt.eps_model(frequency)

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -1632,7 +1632,7 @@ class Simulation(Box):
         eps_list = [
             medium.eps_model(freq).real
             for medium in medium_list
-            if not isinstance(medium, AbstractCustomMedium)
+            if not isinstance(medium, AbstractCustomMedium) and not isinstance(medium, Medium2D)
         ]
         eps_min = min(eps_list, default=1)
         eps_max = max(eps_list, default=1)

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -11,6 +11,7 @@ from .viz import add_ax_if_none, equal_aspect
 from .grid.grid import Coords
 from ..constants import MICROMETER
 from ..exceptions import SetupError
+from ..log import log
 
 
 class AbstractStructure(Tidy3dBaseModel):
@@ -99,14 +100,39 @@ class Structure(AbstractStructure):
     @pydantic.validator("medium", always=True)
     def _check_2d_geometry(cls, val, values):
         """Medium2D is only consistent with certain geometry types"""
+        geom = values.get("geometry")
+
         if isinstance(val, Medium2D):
-            # validate that the geometry is actually 2d
-            geom = values.get("geometry")
+            # the geometry needs to be supported by 2d materials
             if not geom:
                 raise SetupError(
-                    "Can't validate 2D structure because its geometry did not pass validation."
+                    "Found a 'Structure' with a 'Medium2D' medium, "
+                    "but the geometry already did not pass validation."
                 )
+            # _normal_2dmaterial checks that the geometry is supported by 2d materials
+            # and gives helpful error messages depending on the geometry details
+            # if the geometry is not supported / not 2d
             _ = geom._normal_2dmaterial
+
+            # if we reached this, then the geometry is supported by 2d materials
+            return val
+
+        # if geometry failed validation but medium is not a Medium2D, then
+        # this has nothing to do with 2d materials, so we don't raise a further error
+        if geom is None:
+            return val
+
+        # finally, we want to warn if a geometry bounding box has zero size in a
+        # certain dimension, because this may lead to undesired behavior
+        zero_axes = [ind for ind, ele in enumerate(geom.bounding_box.size) if ele == 0.0]
+        if len(zero_axes) > 0:
+            log.warning(
+                "A structure was found with geometry having zero size along "
+                f"dimensions {zero_axes}, and with a medium that is not a 'Medium2D'. "
+                "This is probably not correct, since the resulting simulation will "
+                "depend on the details of the numerical grid. Consider either "
+                "giving the geometry a nonzero thickness or using a 'Medium2D'."
+            )
         return val
 
     def eps_comp(self, row: Axis, col: Axis, frequency: float, coords: Coords) -> complex:

--- a/tidy3d/plugins/adjoint/components/geometry.py
+++ b/tidy3d/plugins/adjoint/components/geometry.py
@@ -57,6 +57,17 @@ class JaxGeometry(Geometry, ABC):
 
         return tuple(get_center(pt_min, pt_max) for (pt_min, pt_max) in zip(rmin, rmax))
 
+    @cached_property
+    def bounding_box(self):
+        """Returns :class:`JaxBox` representation of the bounding box of a :class:`JaxGeometry`.
+
+        Returns
+        -------
+        :class:`JaxBox`
+            Geometric object representing bounding box.
+        """
+        return JaxBox.from_bounds(*self.bounds)
+
     def make_grad_monitors(
         self, freq: float, name: str
     ) -> Tuple[FieldMonitor, PermittivityMonitor]:

--- a/tidy3d/plugins/adjoint/components/structure.py
+++ b/tidy3d/plugins/adjoint/components/structure.py
@@ -56,6 +56,11 @@ class JaxStructure(Structure, JaxObject):
 
         return cls.parse_obj(struct_dict)
 
+    @pd.validator("medium", always=True)
+    def _check_2d_geometry(cls, val, values):
+        """Override validator checking 2D geometry, which triggers unnecessarily for gradients."""
+        return val
+
     def store_vjp(
         self,
         grad_data_fwd: FieldData,


### PR DESCRIPTION
This adds a warning when a 2D geometry doesn't have a 2D medium.
@tylerflex it seems to break the adjoint tests, which has 0-thickness structures in a 2D sim. Is it possible to change these thicknesses to some other value, like td.inf? This may be more robust anyway without changing the intended behavior.

@tomflexcompute , this should also fix the plot_eps warning