### PR TITLE
Extended lower limit of frequency range for graphene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Bug in `Simulation.eps_bounds` that was always setting the lower bound to 1.
+- Extended lower limit of frequency range for `Graphene` to zero.
 
 ## [2.4.0rc2] - 2023-8-21
 

--- a/tests/test_package/test_parametric_variants.py
+++ b/tests/test_package/test_parametric_variants.py
@@ -11,6 +11,8 @@ from tidy3d.material_library.parametric_materials import Graphene
 
 from numpy.random import default_rng
 
+from ..utils import assert_log_level, log_capture
+
 # bounds for MU_C
 GRAPHENE_MU_C_MIN = 0
 GRAPHENE_MU_C_MAX = 3
@@ -30,7 +32,7 @@ def test_graphene_defaults():
 
 
 @pytest.mark.parametrize("rng_seed", np.arange(0, 15))
-def test_graphene(rng_seed):
+def test_graphene(rng_seed, log_capture):
     """test graphene for range of physical parameters"""
     rng = default_rng(rng_seed)
     gamma_min = GRAPHENE_GAMMA_MIN
@@ -40,7 +42,7 @@ def test_graphene(rng_seed):
     temp_min = GRAPHENE_TEMP_MIN
     temp_max = GRAPHENE_TEMP_MAX
 
-    freqs = np.linspace(GRAPHENE_FIT_FREQ_MIN, GRAPHENE_FIT_FREQ_MAX, GRAPHENE_FIT_NUM_FREQS)
+    freqs = np.linspace(1, GRAPHENE_FIT_FREQ_MAX, GRAPHENE_FIT_NUM_FREQS)
 
     gamma = gamma_min + (gamma_max - gamma_min) * rng.random()
     mu_c = mu_min + (mu_max - mu_min) * rng.random()

--- a/tidy3d/material_library/parametric_materials.py
+++ b/tidy3d/material_library/parametric_materials.py
@@ -130,9 +130,7 @@ class Graphene(ParametricVariantItem2D):
             interband_poles = interband.pole_residue.poles
             poles = intraband_poles + interband_poles
             pole_residue = self._filter_poles(
-                PoleResidue(
-                    poles=poles, frequency_range=(GRAPHENE_FIT_FREQ_MIN, GRAPHENE_FIT_FREQ_MAX)
-                )
+                PoleResidue(poles=poles, frequency_range=(0, GRAPHENE_FIT_FREQ_MAX))
             )
             return Medium2D(ss=pole_residue, tt=pole_residue)
         return Medium2D(ss=intraband, tt=intraband)
@@ -368,9 +366,7 @@ class Graphene(ParametricVariantItem2D):
                     flipped_poles += [(-1j * np.conj(1j * a), c)]
                 else:
                     flipped_poles += [(a, c)]
-            return PoleResidue(
-                poles=flipped_poles, frequency_range=(GRAPHENE_FIT_FREQ_MIN, GRAPHENE_FIT_FREQ_MAX)
-            )
+            return PoleResidue(poles=flipped_poles, frequency_range=(0, GRAPHENE_FIT_FREQ_MAX))
 
         # fitting works better with normalized quantities (THz and uS)
         omega_thz = 2 * np.pi * np.array(freqs) * 1e-12
@@ -386,9 +382,7 @@ class Graphene(ParametricVariantItem2D):
         # unnormalize, and convert from conductivity to permittivity
         poles = [(a * 1e12, -c / (a * EPSILON_0 * 1e6)) for (a, c) in pole_res.poles]
 
-        return PoleResidue(
-            poles=poles, frequency_range=(GRAPHENE_FIT_FREQ_MIN, GRAPHENE_FIT_FREQ_MAX)
-        )
+        return PoleResidue(poles=poles, frequency_range=(0, GRAPHENE_FIT_FREQ_MAX))
 
     def _filter_poles(self, medium: PoleResidue) -> PoleResidue:
         """Clean up poles, merging poles at zero frequency."""
@@ -403,5 +397,5 @@ class Graphene(ParametricVariantItem2D):
                 poles += [(a, c)]
         return PoleResidue(
             poles=poles + [(0, zero_res)],
-            frequency_range=(GRAPHENE_FIT_FREQ_MIN, GRAPHENE_FIT_FREQ_MAX),
+            frequency_range=(0, GRAPHENE_FIT_FREQ_MAX),
         )


### PR DESCRIPTION
Previously, a lower limit used for fitting the interband term was also used in frequency_range. It's better to set the lower limit of frequency_range to zero, since the Drude behavior is valid to DC