### PR TITLE
Make TIDY3D_DIR configurable via environment variable

### DIFF
--- a/tidy3d/web/cli/constants.py
+++ b/tidy3d/web/cli/constants.py
@@ -1,7 +1,14 @@
 """Constants for the CLI."""
-from os import getenv
+
+import os
 from os.path import expanduser
 
-TIDY3D_DIR = getenv("TIDY3D_DIR", f"{expanduser('~')}/.tidy3d")
+TIDY3D_BASE_DIR = os.getenv("TIDY3D_BASE_DIR", f"{expanduser('~')}")
+
+if os.access(TIDY3D_BASE_DIR, os.W_OK):
+    TIDY3D_DIR = f"{TIDY3D_BASE_DIR}/.tidy3d"
+else:
+    TIDY3D_DIR = "/tmp/.tidy3d"
+
 CONFIG_FILE = TIDY3D_DIR + "/config"
 CREDENTIAL_FILE = TIDY3D_DIR + "/auth.json"

--- a/tidy3d/web/cli/constants.py
+++ b/tidy3d/web/cli/constants.py
@@ -1,6 +1,7 @@
 """Constants for the CLI."""
+from os import getenv
 from os.path import expanduser
 
-TIDY3D_DIR = f"{expanduser('~')}/.tidy3d"
+TIDY3D_DIR = getenv("TIDY3D_DIR", f"{expanduser('~')}/.tidy3d")
 CONFIG_FILE = TIDY3D_DIR + "/config"
 CREDENTIAL_FILE = TIDY3D_DIR + "/auth.json"


### PR DESCRIPTION
Tries to read the `TIDY3D_DIR` environment variable to set tidy3d's base directory and defaults to the current behavior. Partially solves #1131 and is what I am currently using.