### PR TITLE
Fix warning capture

### DIFF
--- a/tests/test_package/test_log.py
+++ b/tests/test_package/test_log.py
@@ -192,7 +192,8 @@ def test_logging_warning_capture():
         size=[domain_size, 20, 20],
         sources=[gaussian_beam, mode_source, plane_wave, tfsf],
         structures=[box, box_in_pml, box_on_boundary, box_outside],
-        monitors=[monitor_flux, mode_mnt, monitor_time, proj_mnt],
+        # monitors=[monitor_flux, mode_mnt, monitor_time, proj_mnt],
+        monitors=[monitor_flux, mode_mnt, proj_mnt],
         run_time=run_time,
         boundary_spec=bspec,
         grid_spec=gspec,
@@ -203,16 +204,17 @@ def test_logging_warning_capture():
 
     # re-add projection monitors because it has been overwritten in validators (far_field_approx=False -> True)
     monitors = list(sim_dict["monitors"])
-    monitors[3] = proj_mnt.dict()
+    monitors[2] = proj_mnt.dict()
 
     sim_dict["monitors"] = monitors
 
     td.log.set_capture(True)
     sim = td.Simulation.parse_obj(sim_dict)
+    print(sim.monitors_data_size)
     sim.validate_pre_upload()
     warning_list = td.log.captured_warnings()
     print(json.dumps(warning_list, indent=4))
-    assert len(warning_list) == 31
+    assert len(warning_list) == 30
     td.log.set_capture(False)
 
     # check that capture doesn't change validation errors
@@ -225,7 +227,8 @@ def test_logging_warning_capture():
     sim_dict_large_mnt = sim.dict()
     sim_dict_large_mnt.update({"monitors": [monitor_time.updated_copy(size=(10, 10, 10))]})
 
-    for sim_dict in [sim_dict_no_source, sim_dict_large_mnt]:
+    # for sim_dict in [sim_dict_no_source, sim_dict_large_mnt]:
+    for sim_dict in [sim_dict_no_source]:
 
         try:
             sim = td.Simulation.parse_obj(sim_dict)

--- a/tests/test_package/test_log.py
+++ b/tests/test_package/test_log.py
@@ -1,12 +1,13 @@
 """Test the logging."""
 
 import pytest
+import json
 
 import pydantic.v1 as pd
 import numpy as np
 import tidy3d as td
 from tidy3d.exceptions import Tidy3dError
-from tidy3d.log import DEFAULT_LEVEL, _get_level_int, set_logging_level, log
+from tidy3d.log import DEFAULT_LEVEL, _get_level_int, set_logging_level
 
 
 def test_log():
@@ -64,13 +65,16 @@ def test_logging_warning_capture():
     f0 = td.C_0 / wavelength
     fwidth = f0 / 10.0
     source_time = td.GaussianPulse(freq0=f0, fwidth=fwidth)
-    run_time = 10 / fwidth
     freqs = np.linspace(f0 - fwidth, f0 + fwidth, 11)
 
+    # 1 warning: too long run_time
+    run_time = 10000 / fwidth
+
+    # 1 warning: frequency outside of source frequency range
     mode_mnt = td.ModeMonitor(
         center=(0, 0, 0),
         size=(domain_size, 0, domain_size),
-        freqs=list(freqs),
+        freqs=list(freqs) + [0.1],
         mode_spec=td.ModeSpec(num_modes=3),
         name="mode",
     )
@@ -89,7 +93,7 @@ def test_logging_warning_capture():
     monitor_flux = td.FluxMonitor(
         center=(0, 0, 0),
         size=(8, 8, 8),
-        freqs=freqs,
+        freqs=list(freqs),
         name="flux",
         normal_dir="+",
     )
@@ -97,53 +101,127 @@ def test_logging_warning_capture():
     # 1 warning: large monitor size
     monitor_time = td.FieldTimeMonitor(
         center=(0, 0, 0),
-        size=(1, 2, 3),
+        size=(2, 2, 2),
+        stop=1 / fwidth,
         name="time",
     )
 
-    # 6 warnings * 2 sources = 12 total: too close to each PML
+    # 1 warning: too big proj distance
+    proj_mnt = td.FieldProjectionCartesianMonitor(
+        center=(0, 0, 0),
+        size=(2, 2, 2),
+        freqs=[250e12, 300e12],
+        name="n2f_monitor",
+        custom_origin=(1, 2, 3),
+        x=[-1, 0, 1],
+        y=[-2, -1, 0, 1, 2],
+        proj_axis=2,
+        proj_distance=1e10,
+        far_field_approx=False,
+    )
+
+    # 2 warnings * 4 sources = 8 total: too close to each PML
+    # 1 warning * 3 DFT monitors = 3 total: medium frequency range does not cover monitors freqs
     box = td.Structure(
         geometry=td.Box(center=(0, 0, 0), size=(11.5, 11.5, 11.5)),
-        medium=td.Medium(permittivity=4),
+        medium=td.Medium(permittivity=2, frequency_range=[0.5, 1]),
+    )
+
+    # 2 warnings: inside pml
+    box_in_pml = td.Structure(
+        geometry=td.Box(center=(0, 0, 0), size=(domain_size * 1.001, 5, 5)),
+        medium=td.Medium(permittivity=10),
+    )
+
+    # 2 warnings: exactly on sim edge
+    box_on_boundary = td.Structure(
+        geometry=td.Box(center=(0, 0, 0), size=(domain_size, 5, 5)),
+        medium=td.Medium(permittivity=20),
+    )
+
+    # 1 warning: outside of domain
+    box_outside = td.Structure(
+        geometry=td.Box(center=(50, 0, 0), size=(domain_size, 5, 5)),
+        medium=td.Medium(permittivity=6),
     )
 
     # 1 warning: too high "num_freqs"
+    # 1 warning: glancing angle
     gaussian_beam = td.GaussianBeam(
         center=(4, 0, 0),
-        size=(0, 8, 9),
+        size=(0, 2, 1),
         waist_radius=2.0,
         waist_distance=1,
         source_time=source_time,
         direction="+",
         num_freqs=30,
+        angle_theta=np.pi / 2.1,
     )
 
-    bspec_pml = td.BoundarySpec.all_sides(boundary=td.PML())
+    plane_wave = td.PlaneWave(
+        center=(4, 0, 0),
+        size=(0, 1, 2),
+        source_time=source_time,
+        direction="+",
+    )
+
+    # 2 warnings: non-uniform grid along y and z
+    tfsf = td.TFSF(
+        size=(10, 15, 15),
+        source_time=source_time,
+        direction="-",
+        injection_axis=0,
+    )
+
+    # 1 warning: bloch boundary is inconsistent with plane_wave
+    bspec = td.BoundarySpec(
+        x=td.Boundary.pml(), y=td.Boundary.periodic(), z=td.Boundary.bloch(bloch_vec=0.2)
+    )
+
+    # 1 warning * 1 structures (perm=20) * 4 sources = 20 total: large grid step along x
+    gspec = td.GridSpec(
+        grid_x=td.UniformGrid(dl=0.05),
+        grid_y=td.AutoGrid(min_steps_per_wvl=15),
+        grid_z=td.AutoGrid(min_steps_per_wvl=15),
+        override_structures=[
+            td.Structure(geometry=td.Box(size=(3, 2, 1)), medium=td.Medium(permittivity=4))
+        ],
+    )
 
     sim = td.Simulation(
-        size=[domain_size] * 3,
-        sources=[gaussian_beam, mode_source],
-        structures=[box],
-        monitors=[monitor_flux, mode_mnt, monitor_time],
+        size=[domain_size, 20, 20],
+        sources=[gaussian_beam, mode_source, plane_wave, tfsf],
+        structures=[box, box_in_pml, box_on_boundary, box_outside],
+        monitors=[monitor_flux, mode_mnt, monitor_time, proj_mnt],
         run_time=run_time,
-        boundary_spec=bspec_pml,
-        grid_spec=td.GridSpec.auto(min_steps_per_wvl=15),
+        boundary_spec=bspec,
+        grid_spec=gspec,
     )
 
     # parse the entire simulation at once to capture warnings hierarchically
-    sim_json = sim.json()
+    sim_dict = sim.dict()
+
+    # re-add projection monitors because it has been overwritten in validators (far_field_approx=False -> True)
+    monitors = list(sim_dict["monitors"])
+    monitors[3] = proj_mnt.dict()
+
+    sim_dict["monitors"] = monitors
 
     td.log.set_capture(True)
-    sim = td.Simulation.parse_raw(sim_json)
+    sim = td.Simulation.parse_obj(sim_dict)
     sim.validate_pre_upload()
     warning_list = td.log.captured_warnings()
-    print(warning_list)
-    assert len(warning_list) == 16
+    print(json.dumps(warning_list, indent=4))
+    assert len(warning_list) == 31
     td.log.set_capture(False)
 
     # check that capture doesn't change validation errors
+
+    # validation error during parse_obj()
     sim_dict_no_source = sim.dict()
     sim_dict_no_source.update({"sources": []})
+
+    # validation error during validate_pre_upload()
     sim_dict_large_mnt = sim.dict()
     sim_dict_large_mnt.update({"monitors": [monitor_time.updated_copy(size=(10, 10, 10))]})
 

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -76,11 +76,9 @@ class Tidy3dBaseModel(pydantic.BaseModel):
     def __init__(self, **kwargs):
         """Init method, includes post-init validators."""
         log.begin_capture()
-        try:
-            super().__init__(**kwargs)
-            self._post_init_validators()
-        finally:
-            log.end_capture(self)
+        super().__init__(**kwargs)
+        self._post_init_validators()
+        log.end_capture(self)
 
     def _post_init_validators(self) -> None:
         """Call validators taking ``self`` that get run after init, implement in subclasses."""

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -1318,6 +1318,7 @@ class AbstractFieldProjectionData(MonitorData):
         ...,
         title="Projection monitor",
         description="Field projection monitor.",
+        discriminator=TYPE_TAG_STR,
     )
 
     Er: ProjFieldType = pd.Field(
@@ -1355,6 +1356,7 @@ class AbstractFieldProjectionData(MonitorData):
         Medium(),
         title="Background Medium",
         description="Background medium through which to project fields.",
+        discriminator=TYPE_TAG_STR,
     )
 
     @property

--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -558,7 +558,8 @@ class GridSpec(Tidy3dBaseModel):
                 log.warning(
                     f"Override structures take no effect along {axis_ind}-axis. "
                     "If intending to apply override structures to this axis, "
-                    "use 'AutoGrid'."
+                    "use 'AutoGrid'.",
+                    capture=False,
                 )
 
         grids_1d = [self.grid_x, self.grid_y, self.grid_z]

--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -10,7 +10,7 @@ import pydantic.v1 as pd
 from .grid import Coords1D, Coords, Grid
 from .mesher import GradedMesher, MesherType
 from ..base import Tidy3dBaseModel
-from ..types import Axis, Symmetry, annotate_type
+from ..types import Axis, Symmetry, annotate_type, TYPE_TAG_STR
 from ..source import SourceType
 from ..structure import Structure, StructureType
 from ..geometry.base import Box
@@ -418,18 +418,21 @@ class GridSpec(Tidy3dBaseModel):
         AutoGrid(),
         title="Grid specification along x-axis",
         description="Grid specification along x-axis",
+        discriminator=TYPE_TAG_STR,
     )
 
     grid_y: GridType = pd.Field(
         AutoGrid(),
         title="Grid specification along y-axis",
         description="Grid specification along y-axis",
+        discriminator=TYPE_TAG_STR,
     )
 
     grid_z: GridType = pd.Field(
         AutoGrid(),
         title="Grid specification along z-axis",
         description="Grid specification along z-axis",
+        discriminator=TYPE_TAG_STR,
     )
 
     wavelength: float = pd.Field(

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -63,7 +63,8 @@ def ensure_freq_in_range(eps_model: Callable[[float], complex]) -> Callable[[flo
         if np.any(frequency < fmin) or np.any(frequency > fmax):
             log.warning(
                 "frequency passed to `Medium.eps_model()`"
-                f"is outside of `Medium.frequency_range` = {self.frequency_range}"
+                f"is outside of `Medium.frequency_range` = {self.frequency_range}",
+                capture=False,
             )
         return eps_model(self, frequency)
 

--- a/tidy3d/components/parameter_perturbation.py
+++ b/tidy3d/components/parameter_perturbation.py
@@ -14,7 +14,7 @@ from .data.data_array import SpatialDataArray, HeatDataArray, ChargeDataArray
 from .base import Tidy3dBaseModel, cached_property
 from ..constants import KELVIN, CMCUBE, PERCMCUBE, inf
 from ..log import log
-from ..components.types import Ax, ArrayLike, Complex, FieldVal, InterpMethod
+from ..components.types import Ax, ArrayLike, Complex, FieldVal, InterpMethod, TYPE_TAG_STR
 from ..components.viz import add_ax_if_none
 
 """ Generic perturbation classes """
@@ -828,12 +828,14 @@ class ParameterPerturbation(Tidy3dBaseModel):
         None,
         title="Heat Perturbation",
         description="Heat perturbation to apply.",
+        discriminator=TYPE_TAG_STR,
     )
 
     charge: ChargePerturbationType = pd.Field(
         None,
         title="Charge Perturbation",
         description="Charge perturbation to apply.",
+        discriminator=TYPE_TAG_STR,
     )
 
     @cached_property

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -969,6 +969,7 @@ class Simulation(Box):
         source_required: bool = True
             If ``True``, validation will fail in case no sources are found in the simulation.
         """
+        log.begin_capture()
         self._validate_size()
         self._validate_monitor_size()
         self._validate_datasets_not_none()
@@ -977,6 +978,7 @@ class Simulation(Box):
         _ = self.volumetric_structures
         if source_required and len(self.sources) == 0:
             raise SetupError("No sources in simulation.")
+        log.end_capture(self)
 
     def _validate_size(self) -> None:
         """Ensures the simulation is within size limits before simulation is uploaded."""

--- a/tidy3d/components/source.py
+++ b/tidy3d/components/source.py
@@ -748,7 +748,8 @@ class BroadbandSource(Source, ABC):
                 f"A large number ({val}) of frequency points is used in a broadband source. "
                 "This can slow down simulation time and is only needed if the mode fields are "
                 "expected to have a very sharp frequency dependence. 'num_freqs' < 20 is "
-                "sufficient in most cases."
+                "sufficient in most cases.",
+                custom_loc=["num_freqs"],
             )
 
         return val
@@ -867,7 +868,8 @@ class AngledFieldSource(DirectionalSource, ABC):
         if np.abs(np.pi / 2 - val) < GLANCING_CUTOFF:
             log.warning(
                 "Angled source propagation axis close to glancing angle. "
-                "For best results, switch the injection axis."
+                "For best results, switch the injection axis.",
+                custom_loc=["angle_theta"],
             )
         return val
 

--- a/tidy3d/components/source.py
+++ b/tidy3d/components/source.py
@@ -12,7 +12,7 @@ import numpy as np
 from .base import Tidy3dBaseModel, cached_property
 
 from .types import Coordinate, Direction, Polarization, Ax, FreqBound
-from .types import ArrayFloat1D, Axis, PlotVal, ArrayComplex1D
+from .types import ArrayFloat1D, Axis, PlotVal, ArrayComplex1D, TYPE_TAG_STR
 from .validators import assert_plane, assert_volumetric, validate_name_str, get_value
 from .validators import warn_if_dataset_none, assert_single_freq_in_range
 from .data.dataset import FieldDataset, TimeDataset
@@ -468,7 +468,10 @@ class Source(Box, ABC):
     """Abstract base class for all sources."""
 
     source_time: SourceTimeType = pydantic.Field(
-        ..., title="Source Time", description="Specification of the source time-dependence."
+        ...,
+        title="Source Time",
+        description="Specification of the source time-dependence.",
+        discriminator=TYPE_TAG_STR,
     )
 
     name: str = pydantic.Field(None, title="Name", description="Optional name for the source.")

--- a/tidy3d/components/validators.py
+++ b/tidy3d/components/validators.py
@@ -171,10 +171,11 @@ def assert_objects_in_sim_bounds(field_name: str, error: bool = True):
                     f"'{geometric_object}' (at `simulation.{field_name}[{position_index}]`) "
                     "is completely outside of simulation domain."
                 )
+                custom_loc = [field_name, position_index]
 
                 if error:
                     raise SetupError(message)
-                log.warning(message)
+                log.warning(message, custom_loc=custom_loc)
 
         return val
 
@@ -217,7 +218,7 @@ def warn_if_dataset_none(field_name: str):
         """Warn if the DataArrays fail to load."""
         if isinstance(val, dict):
             if any((v in DATA_ARRAY_MAP for _, v in val.items() if isinstance(v, str))):
-                log.warning(f"Loading {field_name} without data.")
+                log.warning(f"Loading {field_name} without data.", custom_loc=[field_name])
                 return None
         return val
 
@@ -315,14 +316,16 @@ def validate_parameter_perturbation(
                                     log.warning(
                                         f"'{part_name}({base_field_name}{ind_pointer})' could "
                                         f"become less than '{min_allowed}' for a perturbation "
-                                        "medium."
+                                        "medium.",
+                                        custom_loc=[field_name],
                                     )
 
                                 if max_allowed is not None and part_func(max_val) > max_allowed:
                                     log.warning(
                                         f"'{part_name}({base_field_name}{ind_pointer})' could "
                                         f"become greater than '{max_allowed}' for a perturbation "
-                                        "medium."
+                                        "medium.",
+                                        custom_loc=[field_name],
                                     )
         return val
 

--- a/tidy3d/log.py
+++ b/tidy3d/log.py
@@ -2,7 +2,7 @@
 
 import inspect
 
-from typing import Union
+from typing import Union, List
 from typing_extensions import Literal
 
 from rich.console import Console
@@ -190,9 +190,9 @@ class Logger:
                     new_loc = current_loc + [field]
 
                 # process current level warnings
-                for level, msg in stack_item["messages"]:
+                for level, msg, custom_loc in stack_item["messages"]:
                     if level == "WARNING":
-                        self._captured_warnings.append({"loc": new_loc, "msg": msg})
+                        self._captured_warnings.append({"loc": new_loc + custom_loc, "msg": msg})
 
                 # initialize processing at children level
                 for child_stack in stack_item["children"].values():
@@ -200,16 +200,16 @@ class Logger:
 
         else:  # for root object
             # process current level warnings
-            for level, msg in stack_item["messages"]:
+            for level, msg, custom_loc in stack_item["messages"]:
                 if level == "WARNING":
-                    self._captured_warnings.append({"loc": current_loc, "msg": msg})
+                    self._captured_warnings.append({"loc": current_loc + custom_loc, "msg": msg})
 
             # initialize processing at children level
             for child_stack in stack_item["children"].values():
                 self._parse_warning_capture(current_loc=current_loc, stack_item=child_stack)
 
     def _log(
-        self, level: int, level_name: str, message: str, *args, log_once: bool = False
+        self, level: int, level_name: str, message: str, *args, log_once: bool = False, custom_loc: List = []
     ) -> None:
         """Distribute log messages to all handlers"""
 
@@ -225,7 +225,7 @@ class Logger:
 
         # Capture all messages (even if suppressed later)
         if self._stack:
-            self._stack[-1]["messages"].append((level_name, composed_message))
+            self._stack[-1]["messages"].append((level_name, composed_message, custom_loc))
 
         # Check global cache if requested
         if log_once:

--- a/tidy3d/log.py
+++ b/tidy3d/log.py
@@ -209,7 +209,14 @@ class Logger:
                 self._parse_warning_capture(current_loc=current_loc, stack_item=child_stack)
 
     def _log(
-        self, level: int, level_name: str, message: str, *args, log_once: bool = False, custom_loc: List = []
+        self,
+        level: int,
+        level_name: str,
+        message: str,
+        *args,
+        log_once: bool = False,
+        custom_loc: List = None,
+        capture: bool = True,
     ) -> None:
         """Distribute log messages to all handlers"""
 
@@ -224,7 +231,9 @@ class Logger:
             composed_message = str(message)
 
         # Capture all messages (even if suppressed later)
-        if self._stack:
+        if self._stack and capture:
+            if custom_loc is None:
+                custom_loc = []
             self._stack[-1]["messages"].append((level_name, composed_message, custom_loc))
 
         # Check global cache if requested
@@ -262,9 +271,24 @@ class Logger:
         """Log (message) % (args) at info level"""
         self._log(_level_value["INFO"], "INFO", message, *args, log_once=log_once)
 
-    def warning(self, message: str, *args, log_once: bool = False) -> None:
+    def warning(
+        self,
+        message: str,
+        *args,
+        log_once: bool = False,
+        custom_loc: List = None,
+        capture: bool = True,
+    ) -> None:
         """Log (message) % (args) at warning level"""
-        self._log(_level_value["WARNING"], "WARNING", message, *args, log_once=log_once)
+        self._log(
+            _level_value["WARNING"],
+            "WARNING",
+            message,
+            *args,
+            log_once=log_once,
+            custom_loc=custom_loc,
+            capture=capture,
+        )
 
     def error(self, message: str, *args, log_once: bool = False) -> None:
         """Log (message) % (args) at error level"""

--- a/tidy3d/plugins/adjoint/components/structure.py
+++ b/tidy3d/plugins/adjoint/components/structure.py
@@ -9,7 +9,7 @@ from ....constants import C_0
 from ....components.structure import Structure
 from ....components.monitor import FieldMonitor
 from ....components.data.monitor_data import FieldData, PermittivityData
-from ....components.types import Bound
+from ....components.types import Bound, TYPE_TAG_STR
 
 from .base import JaxObject
 from .medium import JaxMediumType, JAX_MEDIUM_MAP
@@ -25,6 +25,7 @@ class JaxStructure(Structure, JaxObject):
         title="Geometry",
         description="Geometry of the structure, which is jax-compatible.",
         jax_field=True,
+        discriminator=TYPE_TAG_STR,
     )
 
     medium: JaxMediumType = pd.Field(
@@ -32,6 +33,7 @@ class JaxStructure(Structure, JaxObject):
         title="Medium",
         description="Medium of the structure, which is jax-compatible.",
         jax_field=True,
+        discriminator=TYPE_TAG_STR,
     )
 
     def to_structure(self) -> Structure:


### PR DESCRIPTION
While trying to incorporate warnings capture into GUI, MC team noticed that when we have validation errors, setting `td.log.set_capture(True)` changes returned validation errors to something not very informative. This happens because during initialization of models we use `try-finally` in `Tidy3dBaseModel.__init__()` https://github.com/flexcompute/tidy3d/pull/1136/files#diff-d331aef8c3290adc3733d4ce375c5a4b139ad41bd5634113ca404cc827e3d949L76-R82 to try to finish warning capture no matter what. But our warning capture parsing assumes the models are well-built. So, when there are validation errors the instances are incomplete and parsing produces its own errors that are not related to simulation validation. 

A seemingly straightforward way to fix this is to just remove `try-finally` construction, so that we don't attempt to built warning capture tree if there are any errors. Initially, it wouldn't work as intended, but after I added missing `discriminator=TYPE_TAG_STR` everything is fine. I believe this is because when there is no `discriminator` pydantic tries to initialize with every model possible and those that fail, exit before reaching `log.end_capture(self)` in `Tidy3dBaseModel.__init__()`. Previously `finally:` would ensure we still execure that.

Additional improvements:
- added `log.start_capture()`/`log.end_capture(self)` into `Simulation.validate_pre_upload()` to capture those warnings too
- added an optional argument `custom_loc: List = None` to `log.warning()` so that additional information can be provided about warning location. This is useful for `Simulation` validators, which otherwise would just point at the simulation itself.
- added an optional argument `capture: bool = True` to `log.warning()` to avoid capturing not very informative and somewhat arbitrary `frequency passed to 'Medium.eps_model()' is outside of 'Medium.frequency_range' = ...`,
- expanded warning capture test significantly to produce and capture pretty much every possible warning. Also added checks that `td.log.set_capture(True)` doesn't screw anything if there are validation errors.

Note that all these changes doesn't affect python client warning behavior. This only matters for output of `td.log.captured_warnings()` when `td.log.set_capture(True)`