### PR TITLE
Moved warning for 2d geometry without Medium2D to Simulation.structures

### DIFF
--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -336,18 +336,15 @@ def test_medium2d(log_capture):
         rtol=RTOL,
     )
 
-    # 2d geometry should raise a warning, but 3d should not
     td.Structure(medium=medium3d, geometry=td.Box(size=(1, 1, 1)))
+
+    # this should also not warn, since it could be used for override structure
+    td.Structure(medium=medium3d, geometry=td.Box(size=(1, 0, 1)))
 
     # no warnings so far
     assert_log_level(log_capture, None)
 
-    # these should give warnings
-    td.Structure(medium=medium3d, geometry=td.Box(size=(1, 0, 1)))
-    assert_log_level(log_capture, "WARNING")
-
-    log_capture.clear()
-
+    # this should give warning
     _ = medium.plot(freqs=[2e14, 3e14], ax=AX)
     plt.close()
     assert_log_level(log_capture, "WARNING")

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -1775,6 +1775,23 @@ def test_sim_volumetric_structures(log_capture, tmp_path):
     with pytest.raises(pydantic.ValidationError):
         _ = td.Structure(geometry=td.Sphere(radius=1), medium=box.medium)
 
+    log_capture.clear()
+    # test warning for 2d geometry in simulation without Medium2D
+    struct = td.Structure(medium=td.Medium(), geometry=td.Box(size=(1, 0, 1)))
+    sim = td.Simulation(
+        size=(10, 10, 10),
+        structures=[struct],
+        sources=[src],
+        boundary_spec=td.BoundarySpec(
+            x=td.Boundary.pml(num_layers=5),
+            y=td.Boundary.pml(num_layers=5),
+            z=td.Boundary.pml(num_layers=5),
+        ),
+        grid_spec=td.GridSpec.uniform(dl=grid_dl),
+        run_time=1e-12,
+    )
+    assert_log_level(log_capture, "WARNING")
+
 
 @pytest.mark.parametrize("normal_axis", (0, 1, 2))
 def test_pml_boxes_2D(normal_axis):

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -11,7 +11,6 @@ from .viz import add_ax_if_none, equal_aspect
 from .grid.grid import Coords
 from ..constants import MICROMETER
 from ..exceptions import SetupError
-from ..log import log
 
 
 class AbstractStructure(Tidy3dBaseModel):
@@ -114,25 +113,6 @@ class Structure(AbstractStructure):
             # if the geometry is not supported / not 2d
             _ = geom._normal_2dmaterial
 
-            # if we reached this, then the geometry is supported by 2d materials
-            return val
-
-        # if geometry failed validation but medium is not a Medium2D, then
-        # this has nothing to do with 2d materials, so we don't raise a further error
-        if geom is None:
-            return val
-
-        # finally, we want to warn if a geometry bounding box has zero size in a
-        # certain dimension, because this may lead to undesired behavior
-        zero_axes = [ind for ind, ele in enumerate(geom.bounding_box.size) if ele == 0.0]
-        if len(zero_axes) > 0:
-            log.warning(
-                "A structure was found with geometry having zero size along "
-                f"dimensions {zero_axes}, and with a medium that is not a 'Medium2D'. "
-                "This is probably not correct, since the resulting simulation will "
-                "depend on the details of the numerical grid. Consider either "
-                "giving the geometry a nonzero thickness or using a 'Medium2D'."
-            )
         return val
 
     def eps_comp(self, row: Axis, col: Axis, frequency: float, coords: Coords) -> complex:


### PR DESCRIPTION
Now, it does not warn if a structure has a 2d geometry without a Medium2D (e.g. for override_structures). It will only warn if the structure is added to Simulation.structures.

This is to fix this issue:

https://github.com/flexcompute/tidy3d/issues/1135