### PR TITLE
Polarization fraction of modes; and collected information as a dataframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
+
+### Added
+- `ModeSolverData.pol_fraction` and `ModeSolverData.pol_fraction_waveguide` properties to compute polarization fraction of modes using two different definitions.
+- `ModeSolverData.to_dataframe()` and `ModeSolverData.modes_info` for a convenient summary of various modal properties of the computed modes.
 
 ### Changed
 - Output task URL before and after simulation run and make URLs blue underline formatting.
 - Support to load and save compressed HDF5 files (`.hdf5.gz`) directly from `BaseModel`.
+
+### Fixed
+- Filtering based on `ModeSpec.filter_pol` now uses the user-exposed `ModeSolverData.pol_fraction` property. This also fixes the previous internal handling which was not taking
+the nonuniform grid, as well as and the propagation axis direction for modes in angled waveguides. In practice, the results should be similar in most cases.
 
 ## [2.4.0] - 2023-9-11
 

--- a/tests/sims/simulation_2_4_1.json
+++ b/tests/sims/simulation_2_4_1.json
@@ -1,0 +1,1941 @@
+{
+    "type": "Simulation",
+    "center": [
+        0.0,
+        0.0,
+        0.0
+    ],
+    "size": [
+        8.0,
+        8.0,
+        8.0
+    ],
+    "run_time": 1e-12,
+    "medium": {
+        "name": null,
+        "frequency_range": null,
+        "allow_gain": false,
+        "nonlinear_spec": null,
+        "type": "Medium",
+        "permittivity": 1.0,
+        "conductivity": 0.0
+    },
+    "symmetry": [
+        0,
+        0,
+        0
+    ],
+    "structures": [
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "type": "Medium",
+                "permittivity": 2.0,
+                "conductivity": 0.0
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    "Infinity",
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "type": "Medium",
+                "permittivity": 1.0,
+                "conductivity": 3.0
+            }
+        },
+        {
+            "geometry": {
+                "type": "Sphere",
+                "radius": 1.0,
+                "center": [
+                    1.0,
+                    0.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "type": "Sellmeier",
+                "coeffs": [
+                    [
+                        1.03961212,
+                        0.00600069867
+                    ],
+                    [
+                        0.231792344,
+                        0.0200179144
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "type": "Lorentz",
+                "eps_inf": 2.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        2.0,
+                        3.0
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "type": "Debye",
+                "eps_inf": 2.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        3.0
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "TriangleMesh",
+                "mesh_dataset": {
+                    "type": "TriangleMeshDataset",
+                    "surface_mesh": "TriangleMeshDataArray"
+                }
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "type": "Debye",
+                "eps_inf": 2.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        3.0
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "type": "Drude",
+                "eps_inf": 2.0,
+                "coeffs": [
+                    [
+                        1.0,
+                        3.0
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.0,
+                    0.0
+                ],
+                "size": [
+                    1.0,
+                    0.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "type": "Medium2D",
+                "ss": {
+                    "name": null,
+                    "frequency_range": null,
+                    "allow_gain": false,
+                    "nonlinear_spec": null,
+                    "type": "PoleResidue",
+                    "eps_inf": 1.0,
+                    "poles": [
+                        [
+                            {
+                                "real": 0.0,
+                                "imag": 0.0
+                            },
+                            {
+                                "real": 254117040158918.28,
+                                "imag": 0.0
+                            }
+                        ]
+                    ]
+                },
+                "tt": {
+                    "name": null,
+                    "frequency_range": null,
+                    "allow_gain": false,
+                    "nonlinear_spec": null,
+                    "type": "PoleResidue",
+                    "eps_inf": 1.0,
+                    "poles": [
+                        [
+                            {
+                                "real": 0.0,
+                                "imag": 0.0
+                            },
+                            {
+                                "real": 254117040158918.28,
+                                "imag": 0.0
+                            }
+                        ]
+                    ]
+                }
+            }
+        },
+        {
+            "geometry": {
+                "type": "GeometryGroup",
+                "geometries": [
+                    {
+                        "type": "Box",
+                        "center": [
+                            -1.0,
+                            0.0,
+                            0.0
+                        ],
+                        "size": [
+                            1.0,
+                            1.0,
+                            1.0
+                        ]
+                    }
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": "PEC",
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "type": "PECMedium"
+            }
+        },
+        {
+            "geometry": {
+                "type": "Cylinder",
+                "axis": 1,
+                "sidewall_angle": 0.0,
+                "reference_plane": "middle",
+                "radius": 1.0,
+                "center": [
+                    1.0,
+                    0.0,
+                    -1.0
+                ],
+                "length": 2.0
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": null,
+                "nonlinear_spec": null,
+                "type": "AnisotropicMedium",
+                "xx": {
+                    "name": null,
+                    "frequency_range": null,
+                    "allow_gain": false,
+                    "nonlinear_spec": null,
+                    "type": "Medium",
+                    "permittivity": 1.0,
+                    "conductivity": 0.0
+                },
+                "yy": {
+                    "name": null,
+                    "frequency_range": null,
+                    "allow_gain": false,
+                    "nonlinear_spec": null,
+                    "type": "Medium",
+                    "permittivity": 2.0,
+                    "conductivity": 0.0
+                },
+                "zz": {
+                    "name": null,
+                    "frequency_range": null,
+                    "allow_gain": false,
+                    "nonlinear_spec": null,
+                    "type": "Medium",
+                    "permittivity": 3.0,
+                    "conductivity": 0.0
+                }
+            }
+        },
+        {
+            "geometry": {
+                "type": "PolySlab",
+                "axis": 2,
+                "sidewall_angle": 0.0,
+                "reference_plane": "middle",
+                "slab_bounds": [
+                    -1.0,
+                    1.0
+                ],
+                "dilation": 0.0,
+                "vertices": [
+                    [
+                        -1.5,
+                        -1.5
+                    ],
+                    [
+                        -0.5,
+                        -1.5
+                    ],
+                    [
+                        -0.5,
+                        -0.5
+                    ]
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "type": "PoleResidue",
+                "eps_inf": 1.0,
+                "poles": [
+                    [
+                        {
+                            "real": 0.0,
+                            "imag": 6206417594288582.0
+                        },
+                        {
+                            "real": -0.0,
+                            "imag": -3.311074436985222e+16
+                        }
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.5,
+                    0.5
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "type": "CustomMedium",
+                "interp_method": "nearest",
+                "subpixel": false,
+                "permittivity": "SpatialDataArray",
+                "conductivity": null,
+                "eps_dataset": null
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.5,
+                    0.5
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "type": "CustomDrude",
+                "eps_inf": "SpatialDataArray",
+                "coeffs": [
+                    [
+                        "SpatialDataArray",
+                        "SpatialDataArray"
+                    ]
+                ],
+                "interp_method": "nearest",
+                "subpixel": false
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.5,
+                    0.5
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "type": "CustomLorentz",
+                "eps_inf": "SpatialDataArray",
+                "coeffs": [
+                    [
+                        "SpatialDataArray",
+                        "SpatialDataArray",
+                        "SpatialDataArray"
+                    ]
+                ],
+                "interp_method": "nearest",
+                "subpixel": false
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.5,
+                    0.5
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "type": "CustomDebye",
+                "eps_inf": "SpatialDataArray",
+                "coeffs": [
+                    [
+                        "SpatialDataArray",
+                        "SpatialDataArray"
+                    ]
+                ],
+                "interp_method": "nearest",
+                "subpixel": false
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.5,
+                    0.5
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "type": "CustomPoleResidue",
+                "eps_inf": "SpatialDataArray",
+                "poles": [
+                    [
+                        "SpatialDataArray",
+                        "SpatialDataArray"
+                    ]
+                ],
+                "interp_method": "nearest",
+                "subpixel": false
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.5,
+                    0.5
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "type": "CustomSellmeier",
+                "coeffs": [
+                    [
+                        "SpatialDataArray",
+                        "SpatialDataArray"
+                    ]
+                ],
+                "interp_method": "nearest",
+                "subpixel": false
+            }
+        },
+        {
+            "geometry": {
+                "type": "Box",
+                "center": [
+                    -1.0,
+                    0.5,
+                    0.5
+                ],
+                "size": [
+                    1.0,
+                    1.0,
+                    1.0
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": {
+                    "numiters": 20,
+                    "type": "NonlinearSusceptibility",
+                    "chi3": 0.1
+                },
+                "type": "Medium",
+                "permittivity": 1.0,
+                "conductivity": 0.0
+            }
+        },
+        {
+            "geometry": {
+                "type": "PolySlab",
+                "axis": 2,
+                "sidewall_angle": 0.0,
+                "reference_plane": "middle",
+                "slab_bounds": [
+                    -1.0,
+                    1.0
+                ],
+                "dilation": 0.0,
+                "vertices": [
+                    [
+                        -1.5,
+                        -1.5
+                    ],
+                    [
+                        -0.5,
+                        -1.5
+                    ],
+                    [
+                        -0.5,
+                        -0.5
+                    ]
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "type": "PoleResidue",
+                "eps_inf": 1.0,
+                "poles": [
+                    [
+                        {
+                            "real": 0.0,
+                            "imag": 6206417594288582.0
+                        },
+                        {
+                            "real": -0.0,
+                            "imag": -3.311074436985222e+16
+                        }
+                    ]
+                ]
+            }
+        },
+        {
+            "geometry": {
+                "type": "TriangleMesh",
+                "mesh_dataset": {
+                    "type": "TriangleMeshDataset",
+                    "surface_mesh": "TriangleMeshDataArray"
+                }
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "type": "Medium",
+                "permittivity": 5.0,
+                "conductivity": 0.0
+            }
+        },
+        {
+            "geometry": {
+                "type": "GeometryGroup",
+                "geometries": [
+                    {
+                        "type": "TriangleMesh",
+                        "mesh_dataset": {
+                            "type": "TriangleMeshDataset",
+                            "surface_mesh": "TriangleMeshDataArray"
+                        }
+                    },
+                    {
+                        "type": "TriangleMesh",
+                        "mesh_dataset": {
+                            "type": "TriangleMeshDataset",
+                            "surface_mesh": "TriangleMeshDataArray"
+                        }
+                    }
+                ]
+            },
+            "name": null,
+            "type": "Structure",
+            "medium": {
+                "name": null,
+                "frequency_range": null,
+                "allow_gain": false,
+                "nonlinear_spec": null,
+                "type": "Medium",
+                "permittivity": 5.0,
+                "conductivity": 0.0
+            }
+        }
+    ],
+    "sources": [
+        {
+            "type": "UniformCurrentSource",
+            "center": [
+                0.0,
+                0.5,
+                0.0
+            ],
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0,
+                "remove_dc_component": true
+            },
+            "name": null,
+            "interpolate": true,
+            "polarization": "Hx"
+        },
+        {
+            "type": "PointDipole",
+            "center": [
+                0.0,
+                0.5,
+                0.0
+            ],
+            "size": [
+                0,
+                0,
+                0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0,
+                "remove_dc_component": true
+            },
+            "name": null,
+            "interpolate": true,
+            "polarization": "Ex"
+        },
+        {
+            "type": "ModeSource",
+            "center": [
+                0.0,
+                0.5,
+                0.0
+            ],
+            "size": [
+                2.0,
+                0.0,
+                2.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0,
+                "remove_dc_component": true
+            },
+            "name": null,
+            "num_freqs": 1,
+            "direction": "-",
+            "mode_spec": {
+                "num_modes": 1,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "filter_pol": null,
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "precision": "single",
+                "bend_radius": null,
+                "bend_axis": null,
+                "track_freq": "central",
+                "group_index_step": false,
+                "type": "ModeSpec"
+            },
+            "mode_index": 0
+        },
+        {
+            "type": "PlaneWave",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                "Infinity",
+                "Infinity"
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0,
+                "remove_dc_component": true
+            },
+            "name": null,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 0.1
+        },
+        {
+            "type": "GaussianBeam",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                3.0,
+                3.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0,
+                "remove_dc_component": true
+            },
+            "name": null,
+            "num_freqs": 1,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 1.5707963267948966,
+            "waist_radius": 1.0,
+            "waist_distance": 0.0
+        },
+        {
+            "type": "AstigmaticGaussianBeam",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                3.0,
+                3.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0,
+                "remove_dc_component": true
+            },
+            "name": null,
+            "num_freqs": 1,
+            "direction": "+",
+            "angle_theta": 0.0,
+            "angle_phi": 0.0,
+            "pol_angle": 1.5707963267948966,
+            "waist_sizes": [
+                1.0,
+                2.0
+            ],
+            "waist_distances": [
+                3.0,
+                4.0
+            ]
+        },
+        {
+            "type": "CustomFieldSource",
+            "center": [
+                0.0,
+                1.0,
+                2.0
+            ],
+            "size": [
+                2.0,
+                2.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0,
+                "remove_dc_component": true
+            },
+            "name": null,
+            "field_dataset": {
+                "type": "FieldDataset",
+                "Ex": "ScalarFieldDataArray",
+                "Ey": null,
+                "Ez": null,
+                "Hx": null,
+                "Hy": null,
+                "Hz": null
+            }
+        },
+        {
+            "type": "CustomCurrentSource",
+            "center": [
+                0.0,
+                1.0,
+                2.0
+            ],
+            "size": [
+                2.0,
+                2.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0,
+                "remove_dc_component": true
+            },
+            "name": null,
+            "interpolate": true,
+            "current_dataset": {
+                "type": "FieldDataset",
+                "Ex": "ScalarFieldDataArray",
+                "Ey": null,
+                "Ez": null,
+                "Hx": null,
+                "Hy": null,
+                "Hz": null
+            }
+        },
+        {
+            "type": "TFSF",
+            "center": [
+                1.0,
+                2.0,
+                -3.0
+            ],
+            "size": [
+                2.5,
+                2.5,
+                0.5
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "GaussianPulse",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 5.0,
+                "remove_dc_component": true
+            },
+            "name": null,
+            "direction": "+",
+            "angle_theta": 0.5235987755982988,
+            "angle_phi": 0.6283185307179586,
+            "pol_angle": 0.0,
+            "injection_axis": 2
+        },
+        {
+            "type": "UniformCurrentSource",
+            "center": [
+                0.0,
+                0.5,
+                0.0
+            ],
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "source_time": {
+                "amplitude": 1.0,
+                "phase": 0.0,
+                "type": "CustomSourceTime",
+                "freq0": 200000000000000.0,
+                "fwidth": 40000000000000.0,
+                "offset": 0.0,
+                "source_time_dataset": {
+                    "type": "TimeDataset",
+                    "values": "TimeDataArray"
+                }
+            },
+            "name": null,
+            "interpolate": true,
+            "polarization": "Hx"
+        }
+    ],
+    "boundary_spec": {
+        "x": {
+            "plus": {
+                "name": null,
+                "type": "PML",
+                "num_layers": 20,
+                "parameters": {
+                    "sigma_order": 3,
+                    "sigma_min": 0.0,
+                    "sigma_max": 1.5,
+                    "type": "PMLParams",
+                    "kappa_order": 3,
+                    "kappa_min": 1.0,
+                    "kappa_max": 3.0,
+                    "alpha_order": 1,
+                    "alpha_min": 0.0,
+                    "alpha_max": 0.0
+                }
+            },
+            "minus": {
+                "name": null,
+                "type": "Absorber",
+                "num_layers": 100,
+                "parameters": {
+                    "sigma_order": 3,
+                    "sigma_min": 0.0,
+                    "sigma_max": 6.4,
+                    "type": "AbsorberParams"
+                }
+            },
+            "type": "Boundary"
+        },
+        "y": {
+            "plus": {
+                "name": null,
+                "type": "BlochBoundary",
+                "bloch_vec": 1.0
+            },
+            "minus": {
+                "name": null,
+                "type": "BlochBoundary",
+                "bloch_vec": 1.0
+            },
+            "type": "Boundary"
+        },
+        "z": {
+            "plus": {
+                "name": null,
+                "type": "Periodic"
+            },
+            "minus": {
+                "name": null,
+                "type": "Periodic"
+            },
+            "type": "Boundary"
+        },
+        "type": "BoundarySpec"
+    },
+    "monitors": [
+        {
+            "type": "FieldMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "name": "field",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": true,
+            "freqs": [
+                150000000000000.0,
+                200000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "fields": [
+                "Ex"
+            ]
+        },
+        {
+            "type": "FieldTimeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "name": "field_time",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": true,
+            "start": 0.0,
+            "stop": null,
+            "interval": 100,
+            "fields": [
+                "Ex",
+                "Ey",
+                "Ez",
+                "Hx",
+                "Hy",
+                "Hz"
+            ]
+        },
+        {
+            "type": "FluxMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "flux",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": true,
+            "freqs": [
+                200000000000000.0,
+                250000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null
+        },
+        {
+            "type": "FluxTimeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "flux_time",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": true,
+            "start": 0.0,
+            "stop": null,
+            "interval": 1,
+            "normal_dir": "+",
+            "exclude_surfaces": null
+        },
+        {
+            "type": "PermittivityMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.1
+            ],
+            "name": "eps",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": false,
+            "freqs": [
+                100000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            }
+        },
+        {
+            "type": "ModeMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "mode",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": false,
+            "freqs": [
+                200000000000000.0,
+                250000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "mode_spec": {
+                "num_modes": 1,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "filter_pol": null,
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "precision": "single",
+                "bend_radius": null,
+                "bend_axis": null,
+                "track_freq": "central",
+                "group_index_step": false,
+                "type": "ModeSpec"
+            }
+        },
+        {
+            "type": "ModeSolverMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                1.0,
+                1.0,
+                0.0
+            ],
+            "name": "mode_solver",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": true,
+            "freqs": [
+                200000000000000.0,
+                250000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "mode_spec": {
+                "num_modes": 1,
+                "target_neff": null,
+                "num_pml": [
+                    0,
+                    0
+                ],
+                "filter_pol": null,
+                "angle_theta": 0.0,
+                "angle_phi": 0.0,
+                "precision": "single",
+                "bend_radius": null,
+                "bend_axis": null,
+                "track_freq": "central",
+                "group_index_step": false,
+                "type": "ModeSpec"
+            },
+            "direction": "+"
+        },
+        {
+            "type": "FieldProjectionAngleMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                2.0,
+                2.0
+            ],
+            "name": "proj_angle",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": true,
+            "freqs": [
+                250000000000000.0,
+                300000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null,
+            "custom_origin": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "far_field_approx": true,
+            "proj_distance": 1000000.0,
+            "theta": [
+                -1.5707963267948966,
+                -1.5390630676677268,
+                -1.5073298085405573,
+                -1.4755965494133876,
+                -1.443863290286218,
+                -1.4121300311590483,
+                -1.3803967720318788,
+                -1.348663512904709,
+                -1.3169302537775396,
+                -1.2851969946503699,
+                -1.2534637355232003,
+                -1.2217304763960306,
+                -1.189997217268861,
+                -1.1582639581416914,
+                -1.1265306990145216,
+                -1.0947974398873521,
+                -1.0630641807601826,
+                -1.0313309216330129,
+                -0.9995976625058433,
+                -0.9678644033786736,
+                -0.936131144251504,
+                -0.9043978851243344,
+                -0.8726646259971648,
+                -0.8409313668699951,
+                -0.8091981077428254,
+                -0.7774648486156558,
+                -0.7457315894884862,
+                -0.7139983303613165,
+                -0.6822650712341469,
+                -0.6505318121069773,
+                -0.6187985529798077,
+                -0.5870652938526381,
+                -0.5553320347254684,
+                -0.5235987755982987,
+                -0.4918655164711292,
+                -0.46013225734395946,
+                -0.42839899821678995,
+                -0.3966657390896202,
+                -0.3649324799624507,
+                -0.333199220835281,
+                -0.30146596170811146,
+                -0.26973270258094173,
+                -0.23799944345377222,
+                -0.2062661843266025,
+                -0.17453292519943298,
+                -0.14279966607226324,
+                -0.11106640694509373,
+                -0.079333147817924,
+                -0.047599888690754266,
+                -0.015866629563584755,
+                0.015866629563584977,
+                0.04759988869075449,
+                0.07933314781792422,
+                0.11106640694509373,
+                0.14279966607226346,
+                0.17453292519943298,
+                0.2062661843266027,
+                0.23799944345377222,
+                0.26973270258094195,
+                0.30146596170811146,
+                0.3331992208352812,
+                0.3649324799624507,
+                0.39666573908962044,
+                0.42839899821678995,
+                0.4601322573439597,
+                0.4918655164711292,
+                0.5235987755982991,
+                0.5553320347254687,
+                0.5870652938526382,
+                0.6187985529798077,
+                0.6505318121069776,
+                0.6822650712341471,
+                0.7139983303613167,
+                0.7457315894884862,
+                0.7774648486156561,
+                0.8091981077428256,
+                0.8409313668699951,
+                0.8726646259971647,
+                0.9043978851243346,
+                0.9361311442515041,
+                0.9678644033786736,
+                0.9995976625058436,
+                1.031330921633013,
+                1.0630641807601826,
+                1.0947974398873521,
+                1.126530699014522,
+                1.1582639581416916,
+                1.189997217268861,
+                1.2217304763960306,
+                1.2534637355232006,
+                1.28519699465037,
+                1.3169302537775396,
+                1.348663512904709,
+                1.380396772031879,
+                1.4121300311590486,
+                1.443863290286218,
+                1.475596549413388,
+                1.5073298085405575,
+                1.539063067667727,
+                1.5707963267948966
+            ],
+            "phi": [
+                0.0,
+                1.5707963267948966
+            ]
+        },
+        {
+            "type": "FieldProjectionCartesianMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                2.0,
+                2.0
+            ],
+            "name": "proj_cartesian",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": true,
+            "freqs": [
+                250000000000000.0,
+                300000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null,
+            "custom_origin": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "far_field_approx": true,
+            "proj_axis": 2,
+            "proj_distance": 5.0,
+            "x": [
+                -1.0,
+                0.0,
+                1.0
+            ],
+            "y": [
+                -2.0,
+                -1.0,
+                0.0,
+                1.0,
+                2.0
+            ]
+        },
+        {
+            "type": "FieldProjectionKSpaceMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                2.0,
+                2.0
+            ],
+            "name": "proj_kspace",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": true,
+            "freqs": [
+                250000000000000.0,
+                300000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null,
+            "custom_origin": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "far_field_approx": true,
+            "proj_axis": 2,
+            "proj_distance": 1000000.0,
+            "ux": [
+                0.1,
+                0.2
+            ],
+            "uy": [
+                0.3,
+                0.4,
+                0.5
+            ]
+        },
+        {
+            "type": "FieldProjectionAngleMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                2.0,
+                2.0
+            ],
+            "name": "proj_angle_exact",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": true,
+            "freqs": [
+                250000000000000.0,
+                300000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+",
+            "exclude_surfaces": null,
+            "custom_origin": [
+                1.0,
+                2.0,
+                3.0
+            ],
+            "far_field_approx": true,
+            "proj_distance": 1000000.0,
+            "theta": [
+                -1.5707963267948966,
+                -1.5390630676677268,
+                -1.5073298085405573,
+                -1.4755965494133876,
+                -1.443863290286218,
+                -1.4121300311590483,
+                -1.3803967720318788,
+                -1.348663512904709,
+                -1.3169302537775396,
+                -1.2851969946503699,
+                -1.2534637355232003,
+                -1.2217304763960306,
+                -1.189997217268861,
+                -1.1582639581416914,
+                -1.1265306990145216,
+                -1.0947974398873521,
+                -1.0630641807601826,
+                -1.0313309216330129,
+                -0.9995976625058433,
+                -0.9678644033786736,
+                -0.936131144251504,
+                -0.9043978851243344,
+                -0.8726646259971648,
+                -0.8409313668699951,
+                -0.8091981077428254,
+                -0.7774648486156558,
+                -0.7457315894884862,
+                -0.7139983303613165,
+                -0.6822650712341469,
+                -0.6505318121069773,
+                -0.6187985529798077,
+                -0.5870652938526381,
+                -0.5553320347254684,
+                -0.5235987755982987,
+                -0.4918655164711292,
+                -0.46013225734395946,
+                -0.42839899821678995,
+                -0.3966657390896202,
+                -0.3649324799624507,
+                -0.333199220835281,
+                -0.30146596170811146,
+                -0.26973270258094173,
+                -0.23799944345377222,
+                -0.2062661843266025,
+                -0.17453292519943298,
+                -0.14279966607226324,
+                -0.11106640694509373,
+                -0.079333147817924,
+                -0.047599888690754266,
+                -0.015866629563584755,
+                0.015866629563584977,
+                0.04759988869075449,
+                0.07933314781792422,
+                0.11106640694509373,
+                0.14279966607226346,
+                0.17453292519943298,
+                0.2062661843266027,
+                0.23799944345377222,
+                0.26973270258094195,
+                0.30146596170811146,
+                0.3331992208352812,
+                0.3649324799624507,
+                0.39666573908962044,
+                0.42839899821678995,
+                0.4601322573439597,
+                0.4918655164711292,
+                0.5235987755982991,
+                0.5553320347254687,
+                0.5870652938526382,
+                0.6187985529798077,
+                0.6505318121069776,
+                0.6822650712341471,
+                0.7139983303613167,
+                0.7457315894884862,
+                0.7774648486156561,
+                0.8091981077428256,
+                0.8409313668699951,
+                0.8726646259971647,
+                0.9043978851243346,
+                0.9361311442515041,
+                0.9678644033786736,
+                0.9995976625058436,
+                1.031330921633013,
+                1.0630641807601826,
+                1.0947974398873521,
+                1.126530699014522,
+                1.1582639581416916,
+                1.189997217268861,
+                1.2217304763960306,
+                1.2534637355232006,
+                1.28519699465037,
+                1.3169302537775396,
+                1.348663512904709,
+                1.380396772031879,
+                1.4121300311590486,
+                1.443863290286218,
+                1.475596549413388,
+                1.5073298085405575,
+                1.539063067667727,
+                1.5707963267948966
+            ],
+            "phi": [
+                0.0,
+                1.5707963267948966
+            ]
+        },
+        {
+            "type": "DiffractionMonitor",
+            "center": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "size": [
+                0.0,
+                "Infinity",
+                "Infinity"
+            ],
+            "name": "diffraction",
+            "interval_space": [
+                1,
+                1,
+                1
+            ],
+            "colocate": false,
+            "freqs": [
+                100000000000000.0,
+                200000000000000.0
+            ],
+            "apodization": {
+                "start": null,
+                "end": null,
+                "width": null,
+                "type": "ApodizationSpec"
+            },
+            "normal_dir": "+"
+        }
+    ],
+    "grid_spec": {
+        "grid_x": {
+            "type": "AutoGrid",
+            "min_steps_per_wvl": 10.0,
+            "max_scale": 1.4,
+            "dl_min": 0.0,
+            "mesher": {
+                "type": "GradedMesher"
+            }
+        },
+        "grid_y": {
+            "type": "CustomGrid",
+            "dl": [
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04,
+                0.04
+            ],
+            "custom_offset": null
+        },
+        "grid_z": {
+            "type": "UniformGrid",
+            "dl": 0.05
+        },
+        "wavelength": null,
+        "override_structures": [
+            {
+                "geometry": {
+                    "type": "Box",
+                    "center": [
+                        -1.0,
+                        0.0,
+                        0.0
+                    ],
+                    "size": [
+                        1.0,
+                        1.0,
+                        1.0
+                    ]
+                },
+                "name": null,
+                "type": "Structure",
+                "medium": {
+                    "name": null,
+                    "frequency_range": null,
+                    "allow_gain": false,
+                    "nonlinear_spec": null,
+                    "type": "Medium",
+                    "permittivity": 2.0,
+                    "conductivity": 0.0
+                }
+            }
+        ],
+        "type": "GridSpec"
+    },
+    "shutoff": 0.0001,
+    "subpixel": false,
+    "normalize_index": 0,
+    "courant": 0.8,
+    "version": "2.4.1"
+}

--- a/tidy3d/plugins/mode/solver.py
+++ b/tidy3d/plugins/mode/solver.py
@@ -64,7 +64,6 @@ class EigSolver(Tidy3dBaseModel):
             solver's plane ("diagonal", "tensorial_real", or "tensorial_complex").
         """
 
-        # freq += 0.0001j
         num_modes = mode_spec.num_modes
         bend_radius = mode_spec.bend_radius
         bend_axis = mode_spec.bend_axis
@@ -188,22 +187,6 @@ class EigSolver(Tidy3dBaseModel):
             mode_spec.precision,
             direction,
         )
-
-        # Filter polarization if needed
-        if mode_spec.filter_pol is not None:
-            te_int = np.sum(np.abs(E[0]) ** 2, axis=0) / np.sum(np.abs(E[:2]) ** 2, axis=(0, 1))
-            if mode_spec.filter_pol == "te":
-                sort_inds = np.concatenate(
-                    (np.nonzero(te_int >= 0.5)[0], np.nonzero(te_int < 0.5)[0])
-                )
-            elif mode_spec.filter_pol == "tm":
-                sort_inds = np.concatenate(
-                    (np.nonzero(te_int <= 0.5)[0], np.nonzero(te_int > 0.5)[0])
-                )
-            E = E[..., sort_inds]
-            H = H[..., sort_inds]
-            neff = neff[..., sort_inds]
-            keff = keff[..., sort_inds]
 
         # Transform back to original axes, E = J^T E'
         E = np.sum(jac_e[..., None] * E[:, None, ...], axis=0)


### PR DESCRIPTION
We've had a `filter_pol` option in the mode spec for a while, but until now this was always computing the polarization fraction under the hood. Furthermore, this was not even taking the nonuniform grid into account, nor the fact that for angled modes, the field components need to be rotated to the frame in which the propagation axis is z in order to compute polarization fraction properly (i.e. TE/TM is defined w.r.t. the plane normal to the propagation direction, which is not the same as the mode plane normal in the case of angled modes).

I also added a `ModeSolverData.to_dataframe()` method that conveniently gathers all sorts of mode information:
![image](https://github.com/flexcompute/tidy3d/assets/92756559/7864a3e6-edff-4c2c-a7f0-a3d4eb1daa26)

There is one remaining problem. I added a test that compares all properties between nominally identical waveguides, one with an angle and one straight. The properties agree (up to some tolerance, because of the numerical grid), apart from the mode area. @lucas-flexcompute it is not immediately obvious to me how the modal area computation should be modified for angled modes, given that in that case the fields are recorded on a plane which is not normal to the propagation direction. Do you have any thoughts? Actually in some sense I'm not even sure if the polarization fraction computation is correct in that case, but the test at least passes for these quantities.

Meanwhile @tomflexcompute could you check again that the quantities in the dataframe agree well with Lumerical for some setup?