### PR TITLE
Compute loss upper bound in PoleResidue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `ModeSolverData.pol_fraction` and `ModeSolverData.pol_fraction_waveguide` properties to compute polarization fraction of modes using two different definitions.
 - `ModeSolverData.to_dataframe()` and `ModeSolverData.modes_info` for a convenient summary of various modal properties of the computed modes.
+- Loss upper bound estimation in PoleResidue material model.
 
 ### Changed
 - Output task URL before and after simulation run and make URLs blue underline formatting.

--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -168,6 +168,28 @@ def eps_compare(medium: td.Medium, expected: Dict, tol: float = 1e-5):
         assert np.abs(medium.eps_model(freq) - val) < tol
 
 
+def test_pole_residue_loss_upper_bound():
+    """Test if `loss_upper_bound` in PoleResidue behaves correctly."""
+    mat_lorentz = td.Lorentz(coeffs=((15, 1e14, 0.3e14), (10, 1.5e14, 0.2e14)))
+    mat_sellmeier = td.Sellmeier(coeffs=((2, 4),))
+    mat_combined = td.PoleResidue(
+        poles=(mat_lorentz.pole_residue.poles + mat_sellmeier.pole_residue.poles)
+    )
+    # compute overall Im[eps] upper bound when `frequency_range = None`
+    assert mat_combined.loss_upper_bound > 40
+    # Im[eps] upper bound within the frequency range
+    mat_new = mat_combined.copy(update={"frequency_range": (6e13, 1.2e14)})
+    assert mat_new.loss_upper_bound > 30 and mat_new.loss_upper_bound < 35
+
+    # low loss Palik material from material library
+    loss_threshold = 2e-5
+    assert td.material_library["GaAs"]["Palik_Lossless"].loss_upper_bound < loss_threshold
+    assert td.material_library["Ge"]["Palik_Lossless"].loss_upper_bound < loss_threshold
+    assert td.material_library["InP"]["Palik_Lossless"].loss_upper_bound < loss_threshold
+    assert td.material_library["SiO2"]["Palik_Lossless"].loss_upper_bound < loss_threshold
+    assert td.material_library["cSi"]["Palik_Lossless"].loss_upper_bound < loss_threshold
+
+
 def test_epsilon_eval():
     """Compare epsilon evaluated from a dispersive various models to expected."""
 


### PR DESCRIPTION
- Computes max Im[eps] of a pole residue model in its frequency_range. If frequency_range is None, over all frequencies. The extrema finder function is moved from fit_fast. @caseyflex could you please verify if anything in this PR breaks fitter?

Note that the old extrema finder has an issue: previously my focus was only to find if Im[eps] can be negative, so I wasn't paying attention if it's the extrema of Im[eps] or any quantity proportional to Im[eps]. As I checked today, the old extrema is for Im[eps]/freq, so it'll be off if you care more than just the sign of Im[eps]. It should be fixed now in this PR. 
- Fix Sellemier model `eps_model` error when wavelength ** 2 < C_i
- @e-g-melo For Palik lossless medium, please checkout the added tests. The first two materials have large loss: around 1e-5. 