### PR TITLE
fix bug with PolySlab in JaxSimulation.structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 the nonuniform grid, as well as and the propagation axis direction for modes in angled waveguides. In practice, the results should be similar in most cases.
 - Bug with truly anisotropic `JaxCustomMedium` in adjoint plugin.
 - Bug in adjoint plugin when `JaxBox` is less than 1 grid cell thick.
+- Bug in `adjoint` plugin where `JaxSimulation.structures` did not accept structures containing `td.PolySlab`.
 
 ## [2.4.0] - 2023-9-11
 


### PR DESCRIPTION
This should work with your particle swarm notebook now. I just tried it. 

Basically what this does is converts the `polyslab.vertices` to a list in the intermediate representation that jax handles. this was because jax was not able to handle an untracked multi-dimensional array