### PR TITLE
remove line number in webapi output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Output task URL before and after simulation run and make URLs blue underline formatting.
 - Support to load and save compressed HDF5 files (`.hdf5.gz`) directly from `BaseModel`.
+- No longer print line numbers in webapi log output.
 
 ### Fixed
 - Filtering based on `ModeSpec.filter_pol` now uses the user-exposed `ModeSolverData.pol_fraction` property. This also fixes the previous internal handling which was not taking

--- a/tidy3d/log.py
+++ b/tidy3d/log.py
@@ -330,7 +330,7 @@ def set_logging_console(stderr: bool = False) -> None:
     else:
         previous_level = DEFAULT_LEVEL
     log.handlers["console"] = LogHandler(
-        Console(stderr=stderr, width=CONSOLE_WIDTH), previous_level
+        Console(stderr=stderr, width=CONSOLE_WIDTH, log_path=False), previous_level
     )
 
 


### PR DESCRIPTION
request from zongfu to remove the line number output in the webapi functions, eg the stuff on the right
<img width="763" alt="image" src="https://github.com/flexcompute/tidy3d/assets/92756888/288a3131-d529-41db-bfd0-47d5f2aed63f">

Seems this info is irrelevant and clutters the output a bit