### PR TITLE
fix adjoint for very thin box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Filtering based on `ModeSpec.filter_pol` now uses the user-exposed `ModeSolverData.pol_fraction` property. This also fixes the previous internal handling which was not taking
 the nonuniform grid, as well as and the propagation axis direction for modes in angled waveguides. In practice, the results should be similar in most cases.
 - Bug with truly anisotropic `JaxCustomMedium` in adjoint plugin.
+- Bug in adjoint plugin when `JaxBox` is less than 1 grid cell thick.
 
 ## [2.4.0] - 2023-9-11
 

--- a/tidy3d/plugins/adjoint/components/geometry.py
+++ b/tidy3d/plugins/adjoint/components/geometry.py
@@ -237,7 +237,7 @@ class JaxBox(JaxGeometry, Box, JaxObject):
                     eps_data = grad_data_eps.field_components[eps_field_name].isel(f=0)
 
                     # get the permittivity values just inside and outside the edge
-                    n_cells_in = 3
+                    n_cells_in = 2
                     isel_out = 0 if min_max_index == 0 else -1
                     isel_ins = n_cells_in if min_max_index == 0 else -n_cells_in - 1
                     eps2 = eps_data.isel(**{dim_normal: isel_out})

--- a/tidy3d/plugins/adjoint/components/medium.py
+++ b/tidy3d/plugins/adjoint/components/medium.py
@@ -102,9 +102,13 @@ class AbstractJaxMedium(ABC, JaxObject):
         interp_kwargs = {key: value for key, value in vol_coords.items() if key not in isel_kwargs}
 
         fields_eval = e_dotted.isel(**isel_kwargs).interp(**interp_kwargs, assume_sorted=True)
+
         inside_mask = inside_mask.isel(**isel_kwargs)
 
-        return inside_mask * d_vol * fields_eval
+        mask_dV = inside_mask * d_vol
+        fields_eval = fields_eval.assign_coords(**mask_dV.coords)
+
+        return mask_dV * fields_eval
 
     def d_eps_map(
         self,


### PR DESCRIPTION
It was previously trying to measure the permittivity inside by looking two grid cells inside of the boundary. This was causing errors when the PermittivityData for the box was less than 1 grid cell thick. This PR fixes this.