### PR TITLE
Warn if too many frequencies; too many modes; or too many grid points in mode source or monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Warnings for too many frequencies in monitors; too many modes requested in a ``ModeSpec``; too many number of grid points in a mode monitor or mode source.
 
 ### Changed
 

--- a/tests/test_components/test_monitor.py
+++ b/tests/test_components/test_monitor.py
@@ -208,7 +208,7 @@ def test_monitor_colocate(log_capture):
 
     monitor = td.FieldMonitor(
         size=(td.inf, td.inf, td.inf),
-        freqs=np.linspace(0, 200e12, 10001),
+        freqs=np.linspace(0, 200e12, 1001),
         name="test",
         interval_space=(1, 2, 3),
     )
@@ -217,12 +217,38 @@ def test_monitor_colocate(log_capture):
 
     monitor = td.FieldMonitor(
         size=(td.inf, td.inf, td.inf),
-        freqs=np.linspace(0, 200e12, 10001),
+        freqs=np.linspace(0, 200e12, 1001),
         name="test",
         interval_space=(1, 2, 3),
         colocate=False,
     )
     assert monitor.colocate is False
+
+
+@pytest.mark.parametrize("freqs, log_level", [(np.arange(2500), "WARNING"), (np.arange(100), None)])
+def test_monitor_num_freqs(log_capture, freqs, log_level):
+    """test default colocate value, and warning if not set"""
+
+    monitor = td.FieldMonitor(
+        size=(td.inf, td.inf, td.inf),
+        freqs=freqs,
+        name="test",
+        colocate=True,
+    )
+    assert_log_level(log_capture, log_level)
+
+
+@pytest.mark.parametrize("num_modes, log_level", [(101, "WARNING"), (100, None)])
+def test_monitor_num_modes(log_capture, num_modes, log_level):
+    """test default colocate value, and warning if not set"""
+
+    monitor = td.ModeMonitor(
+        size=(td.inf, 0, td.inf),
+        freqs=np.linspace(1e14, 2e14, 100),
+        name="test",
+        mode_spec=td.ModeSpec(num_modes=num_modes),
+    )
+    assert_log_level(log_capture, log_level)
 
 
 def test_diffraction_validators():

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -1594,6 +1594,51 @@ def test_warn_large_epsilon(log_capture, size, num_struct, log_level):
     assert_log_level(log_capture, log_level)
 
 
+@pytest.mark.parametrize("dl, log_level", [(0.1, None), (0.005, "WARNING")])
+def test_warn_large_mode_monitor(log_capture, dl, log_level):
+    """Make sure we get a warning if the epsilon grid is too large."""
+
+    sim = td.Simulation(
+        size=(2.0, 2.0, 2.0),
+        grid_spec=td.GridSpec.uniform(dl=dl),
+        run_time=1e-12,
+        sources=[
+            td.ModeSource(
+                size=(0.1, 0.1, 0),
+                direction="+",
+                source_time=td.GaussianPulse(freq0=1, fwidth=0.1),
+            )
+        ],
+        monitors=[
+            td.ModeMonitor(
+                size=(td.inf, 0, td.inf), freqs=[1], name="test", mode_spec=td.ModeSpec()
+            )
+        ],
+    )
+    sim.validate_pre_upload()
+    assert_log_level(log_capture, log_level)
+
+
+@pytest.mark.parametrize("dl, log_level", [(0.1, None), (0.005, "WARNING")])
+def test_warn_large_mode_source(log_capture, dl, log_level):
+    """Make sure we get a warning if the epsilon grid is too large."""
+
+    sim = td.Simulation(
+        size=(2.0, 2.0, 2.0),
+        grid_spec=td.GridSpec.uniform(dl=dl),
+        run_time=1e-12,
+        sources=[
+            td.ModeSource(
+                size=(td.inf, td.inf, 0),
+                direction="+",
+                source_time=td.GaussianPulse(freq0=1, fwidth=0.1),
+            )
+        ],
+    )
+    sim.validate_pre_upload()
+    assert_log_level(log_capture, log_level)
+
+
 def test_dt():
     """make sure dt is reduced when there is a medium with eps_inf < 1."""
     sim = td.Simulation(

--- a/tests/test_package/test_log.py
+++ b/tests/test_package/test_log.py
@@ -70,7 +70,7 @@ def test_logging_warning_capture():
     # 1 warning: too long run_time
     run_time = 10000 / fwidth
 
-    # 1 warning: frequency outside of source frequency range
+    # 2 warnings: frequency outside of source frequency range; too many points
     mode_mnt = td.ModeMonitor(
         center=(0, 0, 0),
         size=(domain_size, 0, domain_size),
@@ -79,7 +79,7 @@ def test_logging_warning_capture():
         name="mode",
     )
 
-    # 1 warning: too high num_freqs
+    # 2 warnings: too high num_freqs; too many points
     mode_source = td.ModeSource(
         size=(domain_size, 0, domain_size),
         source_time=source_time,
@@ -214,7 +214,7 @@ def test_logging_warning_capture():
     sim.validate_pre_upload()
     warning_list = td.log.captured_warnings()
     print(json.dumps(warning_list, indent=4))
-    assert len(warning_list) == 30
+    assert len(warning_list) == 32
     td.log.set_capture(False)
 
     # check that capture doesn't change validation errors

--- a/tidy3d/components/source.py
+++ b/tidy3d/components/source.py
@@ -33,6 +33,8 @@ DFT_CUTOFF = 1e-8
 DATA_SPAN_TOL = 1e-8
 # width of Chebyshev grid used for broadband sources (in units of pulse width)
 CHEB_GRID_WIDTH = 1.5
+# Number of frequencies in a broadband source above which to issue a warning
+WARN_NUM_FREQS = 20
 
 
 class SourceTime(ABC, Tidy3dBaseModel):
@@ -743,12 +745,11 @@ class BroadbandSource(Source, ABC):
         if val is None:
             return val
 
-        if val >= 20:
+        if val >= WARN_NUM_FREQS:
             log.warning(
                 f"A large number ({val}) of frequency points is used in a broadband source. "
-                "This can slow down simulation time and is only needed if the mode fields are "
-                "expected to have a very sharp frequency dependence. 'num_freqs' < 20 is "
-                "sufficient in most cases.",
+                "This can lead to solver slow-down and increased cost, and even introduce "
+                "numerical noise. This may become a hard limit in future Tidy3D versions.",
                 custom_loc=["num_freqs"],
             )
 


### PR DESCRIPTION
I went with just warnings for now, including warnings that the behavior may change to a hard constraint in the future, if we decide to impose some strict limits e.g. in 2.5.