### PR TITLE
Avoid creating unecessary geometry groups of single elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Internal refactor of Web API functionality.
+- `Geometry.from_gds` doesn't create unecessary groups of single elements.
 
 ### Fixed
 
@@ -30,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug with truly anisotropic `JaxCustomMedium` in adjoint plugin.
 - Bug in adjoint plugin when `JaxBox` is less than 1 grid cell thick.
 - Bug in `adjoint` plugin where `JaxSimulation.structures` did not accept structures containing `td.PolySlab`.
-
 
 ## [2.4.0] - 2023-9-11
 

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -885,7 +885,7 @@ class Geometry(Tidy3dBaseModel, ABC):
         dilation: float = 0.0,
         sidewall_angle: float = 0,
         reference_plane: PlanePosition = "middle",
-    ) -> GeometryGroup:
+    ) -> Geometry:
         """Import a ``gdstk.Cell`` or a ``gdspy.Cell`` and extrude it into a GeometryGroup.
 
         Parameters
@@ -917,8 +917,8 @@ class Geometry(Tidy3dBaseModel, ABC):
 
         Returns
         -------
-        :class:`GeometryGroup`
-            Geometry group with geometries created from the 2D data.
+        :class:`Geometry`
+            Geometries created from the 2D data.
         """
 
         # switch the GDS cell loader function based on the class name string
@@ -951,7 +951,7 @@ class Geometry(Tidy3dBaseModel, ABC):
                     consolidated_logger.warning(str(error))
                 except Tidy3dError as error:
                     consolidated_logger.warning(str(error))
-        return GeometryGroup(geometries=geometries)
+        return geometries[0] if len(geometries) == 1 else GeometryGroup(geometries=geometries)
 
     @staticmethod
     def from_shapely(


### PR DESCRIPTION
Minor simplification in return from `Geometry.from_gds` to avoid creating a group with a single element.