### PR TITLE
broadband adjoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Support for multiple frequencies in `output_monitors` in `adjoint` plugin.
 
 ### Changed
 
 ### Fixed
+- Properly handle `freqs` as a `np.ndarray` in `output_monitors`.
 
 ## [2.4.2] - 2023-9-28
 

--- a/tests/test_plugins/_test_broadband_adjoint.py
+++ b/tests/test_plugins/_test_broadband_adjoint.py
@@ -1,5 +1,21 @@
 #!/usr/bin/env python
 
+"""
+Notes:
+
+## single frequency
+* RMS error normalized (avg) = 0.3308823080089637 %
+
+## multi-freq (n=3, df = 0.1) [all fields at freq0]
+* RMS error normalized (avg) = 143.55391909049393 %
+NOTE: when the df gets very small (freq0/200_000), error goes to 0%.
+
+## multi-freq
+
+
+"""
+
+
 # NOTE: move to backend test later, uses webapi
 
 import numpy as np
@@ -280,15 +296,15 @@ def grad_error(freqs, freq0, fwidth, verbose=False):
 
         print("normalized gradients:")
         print("")
-        print(f"\tgrad_eps (tmm)  = {grad_eps_tmm_norm}")
-        print(f"\tgrad_eps (FDTD)  = {grad_eps_fdtd_norm}")
+        print(f"\tgrad_eps normalized (tmm)  = {grad_eps_tmm_norm}")
+        print(f"\tgrad_eps normalized (FDTD)  = {grad_eps_fdtd_norm}")
         print("")
-        print(f"\tgrad_ds  (tmm)  = {grad_ds_tmm_norm}")
-        print(f"\tgrad_ds  (FDTD)  = {grad_ds_fdtd_norm}")
+        print(f"\tgrad_ds normalized (tmm)  = {grad_ds_tmm_norm}")
+        print(f"\tgrad_ds normalized (FDTD)  = {grad_ds_fdtd_norm}")
         print("")
-        print(f"RMS error (eps) = {rms_eps_norm * 100} %")
-        print(f"RMS error (ds)  = {rms_ds_norm * 100} %")
-        print(f"RMS error (avg) = {rms_norm * 100} %")
+        print(f"RMS error normalized (eps) = {rms_eps_norm * 100} %")
+        print(f"RMS error normalized (ds)  = {rms_ds_norm * 100} %")
+        print(f"RMS error normalized (avg) = {rms_norm * 100} %")
         print(80 * "-", "\n")
 
     return rms, rms_norm, grad_tmm, grad_fdtd
@@ -297,15 +313,15 @@ def grad_error(freqs, freq0, fwidth, verbose=False):
 """ Main script """
 
 freq0 = 2e14
-df = 0.1e14
-num_freqs = 1
+df = 0.00001e14
+num_freqs = 3
+fwidth = freq0 / 10
 
 if num_freqs == 1:
     freqs = np.array([freq0])
-    fwidth = freq0 / 10
 else:
     freqs = np.linspace(freq0 - df, freq0 + df, num_freqs)
-    fwidth = np.max(freqs) - np.min(freqs)
+    fwidth = max(fwidth, np.max(freqs) - np.min(freqs))
 
 verbose = True
 grad_results = grad_error(freqs, freq0=freq0, fwidth=fwidth, verbose=verbose)

--- a/tests/test_plugins/_test_broadband_adjoint.py
+++ b/tests/test_plugins/_test_broadband_adjoint.py
@@ -247,7 +247,7 @@ def grad_error(freqs, freq0, fwidth, verbose=False):
     grad_eps_tmm, grad_ds_tmm = compute_average_grad_tmm(wavelengths)
 
     # set logging level to ERROR to avoid redundant warnings from adjoint run
-    # td.config.logging_level = "ERROR"
+    td.config.logging_level = "ERROR"
     T_fdtd, (grad_eps_fdtd, grad_ds_fdtd) = compute_T_and_grad_fdtd(slab_eps0, slab_ds0)
 
     grad_eps_fdtd = np.array(grad_eps_fdtd)
@@ -315,24 +315,24 @@ def grad_error(freqs, freq0, fwidth, verbose=False):
 
 """ Main script """
 
-# freq0 = 2e14
+freq0 = 2e14
 
 
-# df = df_factor * freq0
-# num_freqs = 3
-# fwidth = freq0 / 10
+df = 0.3 * freq0
+num_freqs = 3
+fwidth = None  # freq0 / 10
 
-# if num_freqs == 1:
-#     freqs = np.array([freq0])
-# else:
-#     freqs = np.linspace(freq0 - df, freq0 + df, num_freqs)
-#     # fwidth = np.max(freqs) - np.min(freqs)
+if num_freqs == 1:
+    freqs = np.array([freq0])
+else:
+    freqs = np.linspace(freq0 - df, freq0 + df, num_freqs)
+    # fwidth = np.max(freqs) - np.min(freqs)
 
-# verbose = False
-# grad_results = grad_error(freqs, freq0=freq0, fwidth=fwidth, verbose=verbose)
-# rms_raw, rms_norm, grad_tmm, grad_fdtd = grad_results
-# print(f"df_factor = {df_factor:.1e}")
-# print(f"rms_norm = {rms_norm:.2e}")
+verbose = True
+grad_results = grad_error(freqs, freq0=freq0, fwidth=fwidth, verbose=verbose)
+rms_raw, rms_norm, grad_tmm, grad_fdtd = grad_results
+print(f"df_factor = {df_factor:.1e}")
+print(f"rms_norm = {rms_norm:.2e}")
 
 """ Scan spacing between output freqs """
 # dfs_factors = np.logspace(-7, -1, 12)
@@ -368,37 +368,47 @@ def grad_error(freqs, freq0, fwidth, verbose=False):
 
 
 """ Scan fwidth of adjoint source """
-fwidth_factors = np.logspace(-2, -1, 7)
-rms_values_raw = np.zeros_like(fwidth_factors)
-rms_values_norm = np.zeros_like(fwidth_factors)
+# fwidth_factors = np.linspace(0.01, 0.5, 7)
+# rms_values_raw = np.zeros_like(fwidth_factors)
+# rms_values_norm = np.zeros_like(fwidth_factors)
 
-freq0 = 2e14
+# freq0 = 2e14
 
-for i, fwidth_factor in enumerate(fwidth_factors):
+# for i, fwidth_factor in enumerate(fwidth_factors):
 
-    df = 1e-4 * freq0
-    num_freqs = 3
-    fwidth = fwidth_factor * freq0
+#     df = 0.3 * freq0
+#     num_freqs = 3
+#     fwidth = fwidth_factor * freq0
 
-    if num_freqs == 1:
-        freqs = np.array([freq0])
-    else:
-        freqs = np.linspace(freq0 - df, freq0 + df, num_freqs)
-        # fwidth = np.max(freqs) - np.min(freqs)
+#     if num_freqs == 1:
+#         freqs = np.array([freq0])
+#     else:
+#         freqs = np.linspace(freq0 - df, freq0 + df, num_freqs)
+#         # fwidth = np.max(freqs) - np.min(freqs)
 
-    verbose = True
-    grad_results = grad_error(freqs, freq0=freq0, fwidth=fwidth, verbose=verbose)
-    rms_raw, rms_norm, grad_tmm, grad_fdtd = grad_results
-    rms_values_norm[i] = rms_norm
-    rms_values_raw[i] = rms_raw
-    print(f"fwidth_factor = {fwidth_factor:.1e}")
-    print(f"rms_raw = {rms_raw:.2e}")
+#     verbose = False
+#     grad_results = grad_error(freqs, freq0=freq0, fwidth=fwidth, verbose=verbose)
+#     rms_raw, rms_norm, grad_tmm, grad_fdtd = grad_results
+#     rms_values_norm[i] = rms_norm
+#     rms_values_raw[i] = rms_raw
+#     print(f"fwidth_factor = {fwidth_factor:.1e}")
+#     print(f"rms_raw = {rms_raw:.2e}")
 
-plt.plot(fwidth_factors, rms_values_raw, label="raw")
-plt.plot(fwidth_factors, rms_values_norm, label="normalized")
-plt.xlabel("adjoint fwidth (freq0)")
-plt.ylabel("RMS error")
-plt.yscale("log")
-plt.xscale("log")
-plt.legend()
-plt.show()
+# plt.plot(fwidth_factors, rms_values_raw, color="black", label="raw")
+# plt.plot(fwidth_factors, rms_values_norm, color="blue", label="normalized")
+# plt.plot(
+#     [df / freq0, df / freq0],
+#     [
+#         min(min(rms_values_raw), min(rms_values_norm)),
+#         max(max(rms_values_raw), max(rms_values_norm)),
+#     ],
+#     color="r",
+#     linestyle="--",
+#     label="monitor freq spacing (freq0)",
+# )
+# plt.xlabel("adjoint fwidth (freq0)")
+# plt.ylabel("RMS error")
+# plt.yscale("log")
+# plt.xscale("log")
+# plt.legend()
+# plt.show()

--- a/tests/test_plugins/_test_broadband_adjoint.py
+++ b/tests/test_plugins/_test_broadband_adjoint.py
@@ -218,7 +218,7 @@ def make_sim(freq0, fwidth, slab_eps=slab_eps0, slab_ds=slab_ds0) -> tda.JaxSimu
 def post_process_T(sim_data: tda.JaxSimulationData) -> float:
     """Given some tda.JaxSimulationData from the run, return the transmission of "p" polarized light."""
     amps = sim_data.output_monitor_data["diffraction"].amps.sel(polarization="p")
-    return jnp.sum(abs(amps.values) ** 2)
+    return jnp.sum(abs(amps.values) ** 2) / len(amps.coords["f"])
 
 
 def compute_T_fdtd(slab_eps=slab_eps0, slab_ds=slab_ds0) -> float:
@@ -313,9 +313,10 @@ def grad_error(freqs, freq0, fwidth, verbose=False):
 """ Main script """
 
 freq0 = 2e14
-df = 0.00001e14
+df = 0.1e14
 num_freqs = 3
-fwidth = freq0 / 10
+fwidth = df/2
+# fwidth = freq0 / 10
 
 if num_freqs == 1:
     freqs = np.array([freq0])

--- a/tests/test_plugins/_test_broadband_adjoint.py
+++ b/tests/test_plugins/_test_broadband_adjoint.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python
+
+# NOTE: move to backend test later, uses webapi
+
+import numpy as np
+import jax.numpy as jnp
+import jax
+import tmm
+import matplotlib.pyplot as plt
+from typing import Tuple, List
+
+import tidy3d as td
+from tidy3d.web import run as run_sim
+import tidy3d.plugins.adjoint as tda
+from tidy3d.plugins.adjoint.web import run_local as run_adjoint
+
+np.random.seed(0)
+
+""" Generic Settings """
+
+# background permittivity
+bck_eps = 1.3**2
+
+# space between each slab
+spc = 0.0
+
+# slab permittivities and thicknesses
+num_slabs = 12
+slab_d = 0.5
+
+eps_max = 2.0
+
+slab_eps0 = (1 + (eps_max - 1) * np.random.random(num_slabs)).tolist()
+slab_ds0 = (slab_d * np.ones(num_slabs)).tolist()
+
+# incidence angle
+theta = 0 * np.pi / 8
+
+# resolution
+dl = 0.01
+
+
+def compute_T_tmm(wavelength, slab_eps=slab_eps0, slab_ds=slab_ds0) -> float:
+    """Get transmission as a function of slab permittivities and thicknesses."""
+
+    # construct lists of permittivities and thicknesses including spaces between
+    new_slab_eps = []
+    new_slab_ds = []
+    for eps, d in zip(slab_eps, slab_ds):
+        new_slab_eps.append(eps)
+        new_slab_eps.append(bck_eps)
+        new_slab_ds.append(d)
+        new_slab_ds.append(spc)
+    slab_eps = new_slab_eps[:-1]
+    slab_ds = new_slab_ds[:-1]
+
+    # add the input and output spaces to the lists
+    eps_list = [bck_eps] + slab_eps + [bck_eps]
+    n_list = np.sqrt(eps_list)
+    d_list = [np.inf] + slab_ds + [np.inf]
+
+    # compute transmission with TMM
+    return tmm.coh_tmm("p", n_list, d_list, theta, wavelength)["T"]
+
+
+def compute_grad_tmm(
+    wavelength, slab_eps=slab_eps0, slab_ds=slab_ds0
+) -> np.ndarray[2, "num_slabs"]:
+    """Compute numerical gradient of transmission w.r.t. each of the slab permittivities and thicknesses using TMM."""
+
+    delta = 1e-4
+
+    # set up containers to store gradient and perturbed arguments
+    num_slabs = len(slab_eps)
+    grad_tmm = np.zeros((2, num_slabs), dtype=float)
+    args = np.stack((slab_eps, slab_ds), axis=0)
+
+    # loop through slab index and argument index (eps, d)
+    for arg_index in range(2):
+        for slab_index in range(num_slabs):
+            grad = 0.0
+
+            # perturb the argument by delta in each + and - direction
+            for pm in (-1, +1):
+                args_num = args.copy()
+                args_num[arg_index][slab_index] += delta * pm
+
+                # NEW: for slab thickness gradient, need to modify neighboring slabs too
+                if arg_index == 1 and spc == 0:
+                    if slab_index > 0:
+                        args_num[arg_index][slab_index - 1] -= delta * pm / 2
+                    if slab_index < num_slabs - 1:
+                        args_num[arg_index][slab_index + 1] -= delta * pm / 2
+
+                # compute argument perturbed T and add to finite difference gradient contribution
+                T_tmm = compute_T_tmm(wavelength, slab_eps=args_num[0], slab_ds=args_num[1])
+                grad += pm * T_tmm / 2 / delta
+
+            grad_tmm[arg_index][slab_index] = grad
+    return grad_tmm
+
+
+def compute_average_T_tmm(wavelengths, slab_eps=slab_eps0, slab_ds=slab_ds0) -> float:
+    """Get average transmission as a function of slab permittivities and thicknesses."""
+
+    Ts_tmm = [compute_T_tmm(wvl, slab_eps=slab_eps, slab_ds=slab_ds) for wvl in wavelengths]
+    return np.mean(Ts_tmm)
+
+
+def compute_average_grad_tmm(
+    wavelengths, slab_eps=slab_eps0, slab_ds=slab_ds0
+) -> np.ndarray[2, "num_slabs"]:
+    """Get average gradient as a function of slab permittivities and thicknesses."""
+
+    grads_tmm = [compute_grad_tmm(wvl, slab_eps=slab_eps, slab_ds=slab_ds) for wvl in wavelengths]
+    grads_tmm = np.stack(grads_tmm, axis=-1)
+    return np.mean(grads_tmm, axis=-1)
+
+
+""" FDTD parts """
+
+
+def make_sim(freq0, fwidth, slab_eps=slab_eps0, slab_ds=slab_ds0) -> tda.JaxSimulation:
+    """Create a tda.JaxSimulation given the slab permittivities and thicknesses."""
+
+    # geometry setup
+    bck_medium = td.Medium(permittivity=bck_eps)
+
+    space_above = 2
+    space_below = 2
+
+    length_x = 0.1
+    length_y = 0.1
+    length_z = space_below + sum(slab_ds0) + space_above + (len(slab_ds0) - 1) * spc
+    sim_size = (length_x, length_y, length_z)
+
+    # make structures
+    slabs = []
+    z_start = -length_z / 2 + space_below
+    for (d, eps) in zip(slab_ds, slab_eps):
+
+        # dont track the gradient through the center of each slab
+        # as tidy3d doesn't have enough information to properly process the interface between touching tda.JaxBox objects
+        z_center = jax.lax.stop_gradient(z_start + d / 2)
+        slab = tda.JaxStructure(
+            geometry=tda.JaxBox(center=[0, 0, z_center], size=[td.inf, td.inf, d]),
+            medium=tda.JaxMedium(permittivity=eps),
+        )
+        slabs.append(slab)
+        z_start += d + spc
+
+    # forward source setup
+    gaussian = td.GaussianPulse(freq0=freq0, fwidth=fwidth)
+    src_z = -length_z / 2 + space_below / 2.0
+    source = td.PlaneWave(
+        center=(0, 0, src_z),
+        size=(td.inf, td.inf, 0),
+        source_time=gaussian,
+        direction="+",
+        angle_theta=theta,
+        angle_phi=0,
+        pol_angle=0,
+    )
+
+    # boundaries
+    boundary_x = td.Boundary.bloch_from_source(
+        source=source, domain_size=sim_size[0], axis=0, medium=bck_medium
+    )
+    boundary_y = td.Boundary.bloch_from_source(
+        source=source, domain_size=sim_size[1], axis=1, medium=bck_medium
+    )
+    boundary_spec = td.BoundarySpec(x=boundary_x, y=boundary_y, z=td.Boundary.pml(num_layers=40))
+
+    # monitors
+    mnt_z = length_z / 2 - space_above / 2.0
+    monitor_1 = td.DiffractionMonitor(
+        center=[0.0, 0.0, mnt_z],
+        size=[td.inf, td.inf, 0],
+        freqs=freqs.tolist(),
+        name="diffraction",
+        normal_dir="+",
+    )
+
+    # NOTE: IMPORTANT
+    run_time = 10 / fwidth
+
+    # make simulation
+    return tda.JaxSimulation(
+        size=sim_size,
+        grid_spec=td.GridSpec.auto(min_steps_per_wvl=100),
+        input_structures=slabs,
+        sources=[source],
+        output_monitors=[monitor_1],
+        run_time=run_time,
+        boundary_spec=boundary_spec,
+        medium=bck_medium,
+        subpixel=True,
+        shutoff=1e-8,
+    )
+
+
+def post_process_T(sim_data: tda.JaxSimulationData) -> float:
+    """Given some tda.JaxSimulationData from the run, return the transmission of "p" polarized light."""
+    amps = sim_data.output_monitor_data["diffraction"].amps.sel(polarization="p")
+    return jnp.sum(abs(amps.values) ** 2)
+
+
+def compute_T_fdtd(slab_eps=slab_eps0, slab_ds=slab_ds0) -> float:
+    """Given the slab permittivities and thicknesses, compute T, making sure to use `tidy3d.plugins.adjoint.web.run_adjoint`."""
+    sim = make_sim(slab_eps=slab_eps, slab_ds=slab_ds, freq0=freq0, fwidth=fwidth)
+    print("running FDTD")
+    sim_data = run_adjoint(sim, task_name="slab", verbose=False)
+    return post_process_T(sim_data)
+
+
+compute_T_and_grad_fdtd = jax.value_and_grad(compute_T_fdtd, argnums=(0, 1))
+
+
+def grad_error(freqs, freq0, fwidth, verbose=False):
+
+    # do some variable switcheroo
+
+    # frequencies and wavelengths we want to simulate at
+    wavelengths = td.C_0 / freqs
+
+    T_tmm = compute_average_T_tmm(wavelengths, slab_eps=slab_eps0, slab_ds=slab_ds0)
+
+    grad_eps_tmm, grad_ds_tmm = compute_average_grad_tmm(wavelengths)
+
+    # set logging level to ERROR to avoid redundant warnings from adjoint run
+    td.config.logging_level = "ERROR"
+    T_fdtd, (grad_eps_fdtd, grad_ds_fdtd) = compute_T_and_grad_fdtd(slab_eps0, slab_ds0)
+
+    grad_eps_fdtd = np.array(grad_eps_fdtd)
+    grad_ds_fdtd = np.array(grad_ds_fdtd)
+
+    rms_eps = np.linalg.norm(grad_eps_tmm - grad_eps_fdtd) / np.linalg.norm(grad_eps_tmm)
+    rms_ds = np.linalg.norm(grad_ds_tmm - grad_ds_fdtd) / np.linalg.norm(grad_ds_tmm)
+
+    def normalize(arr):
+        return arr / np.linalg.norm(arr)
+
+    grad_eps_tmm_norm = normalize(grad_eps_tmm)
+    grad_ds_tmm_norm = normalize(grad_ds_tmm)
+    grad_eps_fdtd_norm = normalize(grad_eps_fdtd)
+    grad_ds_fdtd_norm = normalize(grad_ds_fdtd)
+
+    rms_eps_norm = np.linalg.norm(grad_eps_tmm_norm - grad_eps_fdtd_norm) / np.linalg.norm(
+        grad_eps_tmm_norm
+    )
+    rms_ds_norm = np.linalg.norm(grad_ds_tmm_norm - grad_ds_fdtd_norm) / np.linalg.norm(
+        grad_ds_tmm_norm
+    )
+
+    grad_tmm = np.mean([grad_eps_tmm, grad_ds_tmm])
+    grad_fdtd = np.mean([grad_eps_fdtd, grad_ds_fdtd])
+    rms = np.mean([rms_eps, rms_ds])
+    rms_norm = np.mean([rms_eps_norm, rms_ds_norm])
+
+    if verbose:
+        print("RESULTS:\n")
+        print(80 * "-", "\n")
+        print(f"T (tmm)  = {T_tmm}")
+        print(f"T (FDTD) = {T_fdtd}")
+        print(80 * "-", "\n")
+
+        print("un-normalized gradients:")
+        print("")
+        print(f"\tgrad_eps (tmm)  = {grad_eps_tmm}")
+        print(f"\tgrad_eps (FDTD)  = {grad_eps_fdtd}")
+        print("")
+        print(f"\tgrad_ds  (tmm)  = {grad_ds_tmm}")
+        print(f"\tgrad_ds  (FDTD)  = {grad_ds_fdtd}")
+        print("")
+        print(f"RMS error (eps) = {rms_eps * 100} %")
+        print(f"RMS error (ds)  = {rms_ds * 100} %")
+        print(f"RMS error (avg) = {rms * 100} %")
+        print("")
+        print(80 * "-", "\n")
+
+        print("normalized gradients:")
+        print("")
+        print(f"\tgrad_eps (tmm)  = {grad_eps_tmm_norm}")
+        print(f"\tgrad_eps (FDTD)  = {grad_eps_fdtd_norm}")
+        print("")
+        print(f"\tgrad_ds  (tmm)  = {grad_ds_tmm_norm}")
+        print(f"\tgrad_ds  (FDTD)  = {grad_ds_fdtd_norm}")
+        print("")
+        print(f"RMS error (eps) = {rms_eps_norm * 100} %")
+        print(f"RMS error (ds)  = {rms_ds_norm * 100} %")
+        print(f"RMS error (avg) = {rms_norm * 100} %")
+        print(80 * "-", "\n")
+
+    return rms, rms_norm, grad_tmm, grad_fdtd
+
+
+""" Main script """
+
+freq0 = 2e14
+df = 0.1e14
+num_freqs = 1
+
+if num_freqs == 1:
+    freqs = np.array([freq0])
+    fwidth = freq0 / 10
+else:
+    freqs = np.linspace(freq0 - df, freq0 + df, num_freqs)
+    fwidth = np.max(freqs) - np.min(freqs)
+
+verbose = True
+grad_results = grad_error(freqs, freq0=freq0, fwidth=fwidth, verbose=verbose)
+rms_raw, rms_norm, grad_tmm, grad_fdtd = grad_results

--- a/tests/test_plugins/_test_broadband_adjoint.py
+++ b/tests/test_plugins/_test_broadband_adjoint.py
@@ -1,22 +1,4 @@
-#!/usr/bin/env python
-
-"""
-Notes:
-
-## single frequency
-* RMS error normalized (avg) = 0.3308823080089637 %
-
-## multi-freq (n=3, df = 0.1) [all fields at freq0]
-* RMS error normalized (avg) = 143.55391909049393 %
-NOTE: when the df gets very small (freq0/200_000), error goes to 0%.
-
-## multi-freq
-
-
-"""
-
-
-# NOTE: move to backend test later, uses webapi
+"""Tests that multi-frequency adjoint gradient matches TMM gradient."""
 
 import numpy as np
 import jax.numpy as jnp

--- a/tests/test_plugins/_test_broadband_adjoint_async.py
+++ b/tests/test_plugins/_test_broadband_adjoint_async.py
@@ -1,0 +1,127 @@
+"""Tests that multi-frequency adjoint gradient matches one based on run_async."""
+
+# grads must match to this tolerance (error is fwidth and diff(freqs) dependent).
+RELATIVE_TOLERANCE = 1e-3
+
+
+import numpy as np
+import jax.numpy as jnp
+import jax
+
+import tidy3d as td
+import tidy3d.plugins.adjoint as tda
+from tidy3d.plugins.adjoint.web import run, run_local, run_async
+
+
+freq_min = 1.8e14
+freq_max = 2.2e14
+num_freqs = 2
+freqs = np.linspace(freq_min, freq_max, num_freqs)
+freq0 = np.mean(freqs)
+
+wavelength_max = td.C_0 / freq_min
+freqs = freqs.tolist()
+
+permittivity_val = 2.0
+
+lx = wavelength_max
+ly = wavelength_max
+lz = wavelength_max
+
+buffer = 2 * wavelength_max
+
+Lx = lx + 2 * buffer
+Ly = ly + 2 * buffer
+Lz = lz + 2 * buffer
+
+src_pos_x = -Lx / 2 + buffer / 2
+mnt_pos_x = +Lx / 2 - buffer / 2
+
+
+def make_sim(permittivity: float, freqs: list) -> tda.JaxSimulation:
+    """Make a simulation as a function of the box permittivity and the frequency."""
+
+    box = tda.JaxStructure(
+        geometry=tda.JaxBox(center=(0.0, 0.0, 0.0), size=(lx, ly, lz)),
+        medium=tda.JaxMedium(permittivity=permittivity),
+    )
+
+    src = td.PointDipole(
+        center=(src_pos_x, 0, 0),
+        polarization="Ey",
+        source_time=td.GaussianPulse(
+            freq0=freq0,
+            fwidth=freq0 / 6,
+        ),
+    )
+
+    mnt = td.DiffractionMonitor(
+        center=(mnt_pos_x, 0, 0),
+        size=(0, td.inf, td.inf),
+        freqs=freqs,
+        name="diffraction",
+    )
+
+    return tda.JaxSimulation(
+        size=(Lx, Ly, Lz),
+        input_structures=[box],
+        output_monitors=[mnt],
+        sources=[src],
+        grid_spec=td.GridSpec.auto(wavelength=td.C_0 / freq0),
+        boundary_spec=td.BoundarySpec(
+            x=td.Boundary.pml(), y=td.Boundary.periodic(), z=td.Boundary.periodic()
+        ),
+        run_time=200 / src.source_time.fwidth,
+    )
+
+
+jax_sim = make_sim(permittivity=permittivity_val, freqs=freqs)
+ax = jax_sim.plot(z=0)
+
+
+def post_process(sim_data: tda.JaxSimulationData) -> float:
+    """O-th order diffracted power."""
+    amp = sim_data["diffraction"].amps.sel(orders_x=0, orders_y=0)
+    return jnp.sum(jnp.abs(amp.values) ** 2)
+
+
+def objective(permittivity: float, freqs: list) -> float:
+    """Average of O-th order diffracted power over all frequencies."""
+    sim = make_sim(permittivity, freqs)
+    sim_data = run_local(sim, task_name="MULTIFREQ", verbose=False)
+    power = post_process(sim_data)
+    return jnp.sum(jnp.array(power)) / len(freqs)
+
+
+power_average = objective(permittivity=permittivity_val, freqs=freqs)
+print(f"average power (freq) = {power_average:.2e}")
+
+grad_objective = jax.grad(objective)
+
+grad_power_average = grad_objective(permittivity_val, freqs=freqs)
+print(f"derivative of average power wrt permittivity = {grad_power_average:.2e}")
+
+
+def grad_manual(permittivity: float) -> float:
+    """Average of O-th order diffracted power over all frequencies."""
+
+    total_grad = 0.0
+    for freq in freqs:
+        print(f"working on freq = {freq:.2e} (Hz)")
+        obj_fn = lambda x: objective(x, freqs=[freq])
+        grad_fn = jax.grad(obj_fn)
+        gradient = grad_fn(permittivity)
+        total_grad += gradient
+
+    return total_grad / len(freqs)
+
+
+grad_man = grad_manual(permittivity_val)
+
+
+print(f"gradient (batched) = {grad_power_average:.4e}")
+print(f"gradient (looped) = {grad_man:.4e}")
+
+assert np.isclose(
+    grad_man, grad_power_average, rtol=RELATIVE_TOLERANCE
+), "Async Multifrequency grads dont match."

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -565,53 +565,53 @@ def _test_adjoint_setup_adj(use_emulated_run):
 #     assert jax_sim_data.simulation == jax_sim
 
 
-def test_multiple_freqs():
-    """Test that sim validation fails when output monitors have multiple frequencies."""
+# def test_multiple_freqs():
+#     """Test that sim validation fails when output monitors have multiple frequencies."""
 
-    output_mnt = td.ModeMonitor(
-        size=(10, 10, 0),
-        mode_spec=td.ModeSpec(num_modes=3),
-        freqs=[1e14, 2e14],
-        name=MNT_NAME,
-    )
+#     output_mnt = td.ModeMonitor(
+#         size=(10, 10, 0),
+#         mode_spec=td.ModeSpec(num_modes=3),
+#         freqs=[1e14, 2e14],
+#         name=MNT_NAME,
+#     )
 
-    with pytest.raises(pydantic.ValidationError):
-        _ = JaxSimulation(
-            size=(10, 10, 10),
-            run_time=1e-12,
-            grid_spec=td.GridSpec(wavelength=1.0),
-            monitors=(),
-            structures=(),
-            output_monitors=(output_mnt,),
-            input_structures=(),
-        )
+#     with pytest.raises(pydantic.ValidationError):
+#         _ = JaxSimulation(
+#             size=(10, 10, 10),
+#             run_time=1e-12,
+#             grid_spec=td.GridSpec(wavelength=1.0),
+#             monitors=(),
+#             structures=(),
+#             output_monitors=(output_mnt,),
+#             input_structures=(),
+#         )
 
 
-def test_different_freqs():
-    """Test that sim validation fails when output monitors have different frequencies."""
+# def test_different_freqs():
+#     """Test that sim validation fails when output monitors have different frequencies."""
 
-    output_mnt1 = td.ModeMonitor(
-        size=(10, 10, 0),
-        mode_spec=td.ModeSpec(num_modes=3),
-        freqs=[1e14],
-        name=MNT_NAME + "1",
-    )
-    output_mnt2 = td.ModeMonitor(
-        size=(10, 10, 0),
-        mode_spec=td.ModeSpec(num_modes=3),
-        freqs=[2e14],
-        name=MNT_NAME + "2",
-    )
-    with pytest.raises(pydantic.ValidationError):
-        _ = JaxSimulation(
-            size=(10, 10, 10),
-            run_time=1e-12,
-            grid_spec=td.GridSpec(wavelength=1.0),
-            monitors=(),
-            structures=(),
-            output_monitors=(output_mnt1, output_mnt2),
-            input_structures=(),
-        )
+#     output_mnt1 = td.ModeMonitor(
+#         size=(10, 10, 0),
+#         mode_spec=td.ModeSpec(num_modes=3),
+#         freqs=[1e14],
+#         name=MNT_NAME + "1",
+#     )
+#     output_mnt2 = td.ModeMonitor(
+#         size=(10, 10, 0),
+#         mode_spec=td.ModeSpec(num_modes=3),
+#         freqs=[2e14],
+#         name=MNT_NAME + "2",
+#     )
+#     with pytest.raises(pydantic.ValidationError):
+#         _ = JaxSimulation(
+#             size=(10, 10, 10),
+#             run_time=1e-12,
+#             grid_spec=td.GridSpec(wavelength=1.0),
+#             monitors=(),
+#             structures=(),
+#             output_monitors=(output_mnt1, output_mnt2),
+#             input_structures=(),
+#         )
 
 
 def test_get_freq_adjoint():

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -255,7 +255,7 @@ def make_sim(
     output_mnt1 = td.ModeMonitor(
         size=(10, 10, 0),
         mode_spec=td.ModeSpec(num_modes=3),
-        freqs=[FREQ0],
+        freqs=[FREQ0, FREQ0 * 1.1],
         name=MNT_NAME + "1",
     )
 

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -628,7 +628,7 @@ def test_get_freq_adjoint():
     )
 
     with pytest.raises(AdjointError):
-        _ = sim.freq_adjoint
+        _ = sim.freqs_adjoint
 
     freq0 = 2e14
     output_mnt1 = td.ModeMonitor(
@@ -652,7 +652,7 @@ def test_get_freq_adjoint():
         output_monitors=(output_mnt1, output_mnt2),
         input_structures=(),
     )
-    assert sim.freq_adjoint == freq0
+    assert sim.freqs_adjoint == [freq0]
 
 
 def test_get_fwidth_adjoint():

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -1561,7 +1561,7 @@ fwidth_run_time_expected = [
     (None, None, RUN_TIME_FACTOR / (src.source_time.fwidth)),  # nothing supplied, use source fwidth
     (FREQ0 / 10, 1e-11, 1e-11),  # run time supplied explicitly, use that
     (FREQ0 / 10, None, RUN_TIME_FACTOR / (FREQ0 / 10)),  # no run_time, use fwidth supplied
-    (FREQ0 / 20, None, RUN_TIME_FACTOR / (FREQ0 / 20)), # no run_time, use fwidth supplied
+    (FREQ0 / 20, None, RUN_TIME_FACTOR / (FREQ0 / 20)),  # no run_time, use fwidth supplied
 ]
 
 

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -698,7 +698,7 @@ def test_get_fwidth_adjoint():
     src_times = [td.GaussianPulse(freq0=freq0, fwidth=fwidth) for fwidth in fwidths]
     srcs = [td.PointDipole(source_time=src_time, polarization="Ex") for src_time in src_times]
     sim = make_sim(sources=srcs, fwidth_adjoint=None)
-    assert np.isclose(sim._fwidth_adjoint, np.mean(fwidths))
+    assert np.isclose(sim._fwidth_adjoint, np.max(fwidths))
 
     # a few sources, with custom fwidth specified
     fwidth_custom = 3e13
@@ -1558,7 +1558,6 @@ def test_pytreedef_errors(use_emulated_run):
 
 
 fwidth_run_time_expected = [
-    (None, None, RUN_TIME_FACTOR / (src.source_time.fwidth)),  # nothing supplied, use source fwidth
     (FREQ0 / 10, 1e-11, 1e-11),  # run time supplied explicitly, use that
     (FREQ0 / 10, None, RUN_TIME_FACTOR / (FREQ0 / 10)),  # no run_time, use fwidth supplied
     (FREQ0 / 20, None, RUN_TIME_FACTOR / (FREQ0 / 20)),  # no run_time, use fwidth supplied

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -282,13 +282,13 @@ def make_sim(
 
     output_mnt4 = td.FieldMonitor(
         size=(0, 0, 0),
-        freqs=[FREQ0],
+        freqs=np.array([FREQ0, FREQ0 * 1.1]),
         name=MNT_NAME + "4",
     )
 
     extraneous_field_monitor = td.FieldMonitor(
         size=(10, 10, 0),
-        freqs=[1e14, 2e14],
+        freqs=np.array([1e14, 2e14]),
         name="field",
     )
 

--- a/tidy3d/components/source.py
+++ b/tidy3d/components/source.py
@@ -105,6 +105,8 @@ class SourceTime(ABC, Tidy3dBaseModel):
         stop_ind = relevant_time_inds[0][-1]
         time_amps = time_amps[start_ind:stop_ind]
         times_cut = times[start_ind:stop_ind]
+        # TODO: this fails if tim_amps is all 0 (for example if amplitude=0.0)
+        # maybe if this case is detected, we automatically return `np.zeros_like(freqs)`?
 
         # only need to compute DTFT kernel for distinct dts
         # usually, there is only one dt, if times is simulation time mesh

--- a/tidy3d/plugins/adjoint/components/base.py
+++ b/tidy3d/plugins/adjoint/components/base.py
@@ -52,6 +52,13 @@ class JaxObject(Tidy3dBaseModel):
                 fix_polyslab(geo_dict["geometry_a"])
                 fix_polyslab(geo_dict["geometry_b"])
 
+        def fix_monitor(mnt_dict: dict) -> None:
+            """Fix a frequency containing monitor."""
+            if "freqs" in mnt_dict:
+                freqs = mnt_dict["freqs"]
+                if isinstance(freqs, np.ndarray):
+                    mnt_dict["freqs"] = freqs.tolist()
+
         # fixes bug with jax handling 2D numpy array in polyslab vertices
         if aux_data.get("type", "") == "JaxSimulation":
             structures = aux_data["structures"]
@@ -59,11 +66,10 @@ class JaxObject(Tidy3dBaseModel):
                 geometry = structure["geometry"]
                 fix_polyslab(geometry)
             monitors = aux_data["monitors"]
-            for _i, monitor in enumerate(monitors):
-                if "freqs" in monitor:
-                    freqs = monitor["freqs"]
-                    if isinstance(freqs, np.ndarray):
-                        monitor["freqs"] = freqs.tolist()
+            for monitor in monitors:
+                fix_monitor(monitor)
+            for monitor in aux_data["output_monitors"]:
+                fix_monitor(monitor)
 
         return children, aux_data
 

--- a/tidy3d/plugins/adjoint/components/data/monitor_data.py
+++ b/tidy3d/plugins/adjoint/components/data/monitor_data.py
@@ -232,90 +232,93 @@ class JaxFieldData(JaxMonitorData, FieldData):
     def to_adjoint_sources(self, fwidth: float) -> List[CustomFieldSource]:
         """Converts a :class:`.JaxFieldData` to a list of adjoint :class:`.CustomFieldSource."""
 
-        # parse the frequency from the scalar field data
-        freqs = [scalar_fld.coords["f"] for _, scalar_fld in self.field_components.items()]
-        if any(len(fs) != 1 for fs in freqs):
-            raise AdjointError("FieldData must have only one frequency.")
-        freqs = [fs[0] for fs in freqs]
-        if len(set(freqs)) != 1:
-            raise AdjointError("FieldData must all contain the same frequency.")
-        freq0 = freqs[0]
-
-        omega0 = 2 * np.pi * freq0
-        scaling_factor = 1 / (MU_0 * omega0)
-
         interpolate_source = True
+        sources = []
 
-        # dipole case
         if np.allclose(np.array(self.monitor.size), np.zeros(3)):
-            dipoles = []
             for polarization, field_component in self.field_components.items():
+
                 if field_component is None:
                     continue
 
-                forward_amp = complex(field_component.as_ndarray)
-                adj_phase = 3 * np.pi / 2 + np.angle(forward_amp)
+                for freq0 in field_component.coords["f"]:
 
-                adj_amp = scaling_factor * forward_amp
+                    omega0 = 2 * np.pi * freq0
+                    scaling_factor = 1 / (MU_0 * omega0)
 
-                src_adj = PointDipole(
-                    center=self.monitor.center,
-                    polarization=polarization,
+                    forward_amp = complex(field_component.sel(f=freq0).values)
+
+                    adj_phase = 3 * np.pi / 2 + np.angle(forward_amp)
+
+                    adj_amp = scaling_factor * forward_amp
+
+                    src_adj = PointDipole(
+                        center=self.monitor.center,
+                        polarization=polarization,
+                        source_time=GaussianPulse(
+                            freq0=freq0, fwidth=fwidth, amplitude=abs(adj_amp), phase=adj_phase
+                        ),
+                        interpolate=interpolate_source,
+                    )
+
+                    sources.append(src_adj)
+        else:
+
+            # Define source geometry based on coordinates in the data
+            data_mins = []
+            data_maxs = []
+
+            def shift_value(coords) -> float:
+                """How much to shift the geometry by along a dimension (only if > 1D)."""
+                return 1e-5 if len(coords) > 1 else 0
+
+            for _, field_component in self.field_components.items():
+                coords = field_component.coords
+                data_mins.append({key: min(val) + shift_value(val) for key, val in coords.items()})
+                data_maxs.append({key: max(val) + shift_value(val) for key, val in coords.items()})
+
+            rmin = []
+            rmax = []
+            for dim in "xyz":
+                rmin.append(max(val[dim] for val in data_mins))
+                rmax.append(min(val[dim] for val in data_maxs))
+
+            source_geo = Box.from_bounds(rmin=rmin, rmax=rmax)
+
+            # Define source dataset
+            # Offset coordinates by source center since local coords are assumed in CustomCurrentSource
+
+            for freq0 in tuple(self.field_components.values())[0].coords["f"]:
+
+                src_field_components = {}
+                for name, field_component in self.field_components.items():
+                    field_component = field_component.sel(f=freq0)
+                    forward_amps = field_component.as_ndarray
+                    values = -1j * forward_amps
+                    coords = field_component.coords
+                    for dim, key in enumerate("xyz"):
+                        coords[key] = np.array(coords[key]) - source_geo.center[dim]
+                    coords["f"] = np.array([freq0])
+                    values = np.expand_dims(values, axis=-1)
+                    if not np.all(values == 0):
+                        src_field_components[name] = ScalarFieldDataArray(values, coords=coords)
+
+                dataset = FieldDataset(**src_field_components)
+
+                custom_source = CustomCurrentSource(
+                    center=source_geo.center,
+                    size=source_geo.size,
                     source_time=GaussianPulse(
-                        freq0=freq0, fwidth=fwidth, amplitude=abs(adj_amp), phase=adj_phase
+                        freq0=freq0,
+                        fwidth=fwidth,
                     ),
+                    current_dataset=dataset,
                     interpolate=interpolate_source,
                 )
 
-                dipoles.append(src_adj)
-            return dipoles
+                sources.append(custom_source)
 
-        # Define source geometry based on coordinates in the data
-        data_mins = []
-        data_maxs = []
-
-        def shift_value(coords) -> float:
-            """How much to shift the geometry by along a dimension (only if > 1D)."""
-            return 1e-5 if len(coords) > 1 else 0
-
-        for _, field_component in self.field_components.items():
-            coords = field_component.coords
-            data_mins.append({key: min(val) + shift_value(val) for key, val in coords.items()})
-            data_maxs.append({key: max(val) + shift_value(val) for key, val in coords.items()})
-
-        rmin = []
-        rmax = []
-        for dim in "xyz":
-            rmin.append(max(val[dim] for val in data_mins))
-            rmax.append(min(val[dim] for val in data_maxs))
-
-        source_geo = Box.from_bounds(rmin=rmin, rmax=rmax)
-
-        # Define source dataset
-        # Offset coordinates by source center since local coords are assumed in CustomCurrentSource
-        src_field_components = {}
-        for name, field_component in self.field_components.items():
-            forward_amps = field_component.as_ndarray
-            values = -1j * forward_amps
-            coords = field_component.coords
-            for dim, key in enumerate("xyz"):
-                coords[key] = np.array(coords[key]) - source_geo.center[dim]
-            if not np.all(values == 0):
-                src_field_components[name] = ScalarFieldDataArray(values, coords=coords)
-
-        dataset = FieldDataset(**src_field_components)
-        custom_source = CustomCurrentSource(
-            center=source_geo.center,
-            size=source_geo.size,
-            source_time=GaussianPulse(
-                freq0=freq0,
-                fwidth=fwidth,
-            ),
-            current_dataset=dataset,
-            interpolate=interpolate_source,
-        )
-
-        return [custom_source]
+        return sources
 
 
 @register_pytree_node_class

--- a/tidy3d/plugins/adjoint/components/data/sim_data.py
+++ b/tidy3d/plugins/adjoint/components/data/sim_data.py
@@ -179,7 +179,7 @@ class JaxSimulationData(SimulationData, JaxObject):
             monitors=(),
             output_monitors=(),
             run_time=run_time,
-            # normalize_index=None, # normalize later, frequency-by-frequency
+            normalize_index=None,  # normalize later, frequency-by-frequency
         )
 
         update_dict.update(

--- a/tidy3d/plugins/adjoint/components/data/sim_data.py
+++ b/tidy3d/plugins/adjoint/components/data/sim_data.py
@@ -157,7 +157,7 @@ class JaxSimulationData(SimulationData, JaxObject):
 
         return user_sim_data, adjoint_sim_data
 
-    def make_adjoint_simulation(self, fwidth: float) -> JaxSimulation:
+    def make_adjoint_simulation(self, fwidth: float, run_time: float) -> JaxSimulation:
         """Make an adjoint simulation out of the data provided (generally, the vjp sim data)."""
 
         sim_fwd = self.simulation
@@ -171,7 +171,15 @@ class JaxSimulationData(SimulationData, JaxObject):
             for adj_source in mnt_data_vjp.to_adjoint_sources(fwidth=fwidth):
                 adj_srcs.append(adj_source)
 
-        update_dict = dict(boundary_spec=bc_adj, sources=adj_srcs, monitors=(), output_monitors=())
+        update_dict = dict(
+            boundary_spec=bc_adj,
+            sources=adj_srcs,
+            monitors=(),
+            output_monitors=(),
+            run_time=run_time,
+            # normalize_index=None, # normalize later, frequency-by-frequency
+        )
+
         update_dict.update(
             sim_fwd.get_grad_monitors(
                 input_structures=sim_fwd.input_structures,

--- a/tidy3d/plugins/adjoint/components/data/sim_data.py
+++ b/tidy3d/plugins/adjoint/components/data/sim_data.py
@@ -175,7 +175,7 @@ class JaxSimulationData(SimulationData, JaxObject):
         update_dict.update(
             sim_fwd.get_grad_monitors(
                 input_structures=sim_fwd.input_structures,
-                freq_adjoint=sim_fwd.freq_adjoint,
+                freqs_adjoint=sim_fwd.freqs_adjoint,
                 include_eps_mnts=False,
             )
         )

--- a/tidy3d/plugins/adjoint/components/geometry.py
+++ b/tidy3d/plugins/adjoint/components/geometry.py
@@ -447,7 +447,6 @@ class JaxPolySlab(JaxGeometry, PolySlab, JaxObject):
 
             def evaluate(scalar_field: ScalarFieldDataArray) -> float:
                 """Evaluate a scalar field at a coordinate along the edge."""
-                scalar_field = scalar_field.sum(dim="f")
 
                 # if only 1 z coordinate, just isel the data.
                 if len(z) == 1:
@@ -505,7 +504,7 @@ class JaxPolySlab(JaxGeometry, PolySlab, JaxObject):
             dz = 1.0
 
         # integrate by summing over axis edge (z) and parameterization point (s)
-        integrand = compute_integrand(s=s_vals, z=z_vals)
+        integrand = compute_integrand(s=s_vals, z=z_vals).sum(dim="f")
         integral_result = np.sum(integrand.fillna(0).values)
 
         # project to the normal direction

--- a/tidy3d/plugins/adjoint/components/medium.py
+++ b/tidy3d/plugins/adjoint/components/medium.py
@@ -524,14 +524,18 @@ class JaxCustomMedium(CustomMedium, AbstractJaxMedium):
 
             # grab the correpsonding dotted fields at these interp_coords and sum over len-1 pixels
             field_name = "E" + dim
-            e_dotted = self.e_mult_volume(
-                field=field_name,
-                grad_data_fwd=grad_data_fwd,
-                grad_data_adj=grad_data_adj,
-                vol_coords=interp_coords,
-                d_vol=d_vols,
-                inside_fn=inside_fn,
-            ).sum(sum_axes)
+            e_dotted = (
+                self.e_mult_volume(
+                    field=field_name,
+                    grad_data_fwd=grad_data_fwd,
+                    grad_data_adj=grad_data_adj,
+                    vol_coords=interp_coords,
+                    d_vol=d_vols,
+                    inside_fn=inside_fn,
+                )
+                .sum(sum_axes)
+                .sum(dim="f")
+            )
 
             # reshape values to the expected vjp shape to be more safe
             vjp_shape = tuple(len(coord) for _, coord in coords.items())

--- a/tidy3d/plugins/adjoint/components/medium.py
+++ b/tidy3d/plugins/adjoint/components/medium.py
@@ -193,8 +193,14 @@ class JaxMedium(Medium, AbstractJaxMedium):
 
         vjp_eps_complex = np.sum(d_eps_map.values)
 
-        freq = d_eps_map.coords["f"][0]
-        vjp_eps, vjp_sigma = self.eps_complex_to_eps_sigma(vjp_eps_complex, freq)
+        vjp_eps = 0.0
+        vjp_sigma = 0.0
+
+        for freq in d_eps_map.coords["f"]:
+
+            _vjp_eps, _vjp_sigma = self.eps_complex_to_eps_sigma(vjp_eps_complex, freq)
+            vjp_eps += _vjp_eps
+            vjp_sigma += _vjp_sigma
 
         return self.copy(
             update=dict(
@@ -276,7 +282,14 @@ class JaxAnisotropicMedium(AnisotropicMedium, AbstractJaxMedium):
 
             vjp_eps_complex_ii = np.sum(e_mult_dim.values)
             freq = e_mult_dim.coords["f"][0]
-            vjp_eps_ii, vjp_sigma_ii = self.eps_complex_to_eps_sigma(vjp_eps_complex_ii, freq)
+
+            vjp_eps_ii = 0.0
+            vjp_sigma_ii = 0.0
+
+            for freq in e_mult_dim.coords["f"]:
+                _vjp_eps_ii, _vjp_sigma_ii = self.eps_complex_to_eps_sigma(vjp_eps_complex_ii, freq)
+                vjp_eps_ii += _vjp_eps_ii
+                vjp_sigma_ii += _vjp_sigma_ii
 
             vjp_fields[component_name] = JaxMedium(
                 permittivity=vjp_eps_ii,

--- a/tidy3d/plugins/adjoint/components/medium.py
+++ b/tidy3d/plugins/adjoint/components/medium.py
@@ -288,7 +288,9 @@ class JaxAnisotropicMedium(AnisotropicMedium, AbstractJaxMedium):
 
             for freq in e_mult_dim.coords["f"]:
                 vjp_eps_complex_ii_f = vjp_eps_complex_ii.sel(f=freq)
-                _vjp_eps_ii, _vjp_sigma_ii = self.eps_complex_to_eps_sigma(vjp_eps_complex_ii_f, freq)
+                _vjp_eps_ii, _vjp_sigma_ii = self.eps_complex_to_eps_sigma(
+                    vjp_eps_complex_ii_f, freq
+                )
                 vjp_eps_ii += _vjp_eps_ii
                 vjp_sigma_ii += _vjp_sigma_ii
 

--- a/tidy3d/plugins/adjoint/components/medium.py
+++ b/tidy3d/plugins/adjoint/components/medium.py
@@ -191,14 +191,14 @@ class JaxMedium(Medium, AbstractJaxMedium):
             inside_fn=inside_fn,
         )
 
-        vjp_eps_complex = np.sum(d_eps_map.values)
+        vjp_eps_complex = d_eps_map.sum(dim=("x", "y", "z"))
 
         vjp_eps = 0.0
         vjp_sigma = 0.0
 
         for freq in d_eps_map.coords["f"]:
-
-            _vjp_eps, _vjp_sigma = self.eps_complex_to_eps_sigma(vjp_eps_complex, freq)
+            vjp_eps_complex_f = vjp_eps_complex.sel(f=freq)
+            _vjp_eps, _vjp_sigma = self.eps_complex_to_eps_sigma(vjp_eps_complex_f, freq)
             vjp_eps += _vjp_eps
             vjp_sigma += _vjp_sigma
 
@@ -280,14 +280,15 @@ class JaxAnisotropicMedium(AnisotropicMedium, AbstractJaxMedium):
                 inside_fn=inside_fn,
             )
 
-            vjp_eps_complex_ii = np.sum(e_mult_dim.values)
+            vjp_eps_complex_ii = e_mult_dim.sum(dim=("x", "y", "z"))
             freq = e_mult_dim.coords["f"][0]
 
             vjp_eps_ii = 0.0
             vjp_sigma_ii = 0.0
 
             for freq in e_mult_dim.coords["f"]:
-                _vjp_eps_ii, _vjp_sigma_ii = self.eps_complex_to_eps_sigma(vjp_eps_complex_ii, freq)
+                vjp_eps_complex_ii_f = vjp_eps_complex_ii.sel(f=freq)
+                _vjp_eps_ii, _vjp_sigma_ii = self.eps_complex_to_eps_sigma(vjp_eps_complex_ii_f, freq)
                 vjp_eps_ii += _vjp_eps_ii
                 vjp_sigma_ii += _vjp_sigma_ii
 

--- a/tidy3d/plugins/adjoint/components/simulation.py
+++ b/tidy3d/plugins/adjoint/components/simulation.py
@@ -32,7 +32,7 @@ FWIDTH_FACTOR = 1.0 / 10
 FWIDTH_FACTOR_MULTIFREQ = 0.1
 
 # the adjoint run time is RUN_TIME_FACTOR / fwidth
-RUN_TIME_FACTOR = 20
+RUN_TIME_FACTOR = 100
 
 # how many processors to use for server and client side adjoint
 NUM_PROC_LOCAL = 1

--- a/tidy3d/plugins/adjoint/components/simulation.py
+++ b/tidy3d/plugins/adjoint/components/simulation.py
@@ -110,28 +110,28 @@ class JaxSimulation(Simulation, JaxObject):
         units=HERTZ,
     )
 
-    @pd.validator("output_monitors", always=True)
-    def _output_monitors_single_freq(cls, val):
-        """Assert all output monitors have just one frequency."""
-        for mnt in val:
-            if len(mnt.freqs) != 1:
-                raise AdjointError(
-                    "All output monitors must have single frequency for adjoint feature. "
-                    f"Monitor '{mnt.name}' had {len(mnt.freqs)} frequencies."
-                )
-        return val
+    # @pd.validator("output_monitors", always=True)
+    # def _output_monitors_single_freq(cls, val):
+    #     """Assert all output monitors have just one frequency."""
+    #     for mnt in val:
+    #         if len(mnt.freqs) != 1:
+    #             raise AdjointError(
+    #                 "All output monitors must have single frequency for adjoint feature. "
+    #                 f"Monitor '{mnt.name}' had {len(mnt.freqs)} frequencies."
+    #             )
+    #     return val
 
-    @pd.validator("output_monitors", always=True)
-    def _output_monitors_same_freq(cls, val):
-        """Assert all output monitors have the same frequency."""
-        freqs = [mnt.freqs[0] for mnt in val]
-        if len(set(freqs)) > 1:
-            raise AdjointError(
-                "All output monitors must have the same frequency, "
-                f"given frequencies of {[f'{f:.2e}' for f in freqs]} (Hz) "
-                f"for monitors named '{[mnt.name for mnt in val]}', respectively."
-            )
-        return val
+    # @pd.validator("output_monitors", always=True)
+    # def _output_monitors_same_freq(cls, val):
+    #     """Assert all output monitors have the same frequency."""
+    #     freqs = [mnt.freqs[0] for mnt in val]
+    #     if len(set(freqs)) > 1:
+    #         raise AdjointError(
+    #             "All output monitors must have the same frequency, "
+    #             f"given frequencies of {[f'{f:.2e}' for f in freqs]} (Hz) "
+    #             f"for monitors named '{[mnt.name for mnt in val]}', respectively."
+    #         )
+    #     return val
 
     @pd.validator("output_monitors", always=True)
     def _output_monitors_colocate_false(cls, val):

--- a/tidy3d/plugins/adjoint/components/simulation.py
+++ b/tidy3d/plugins/adjoint/components/simulation.py
@@ -600,8 +600,8 @@ class JaxSimulation(Simulation, JaxObject):
     ) -> JaxStructure:
         """Store the vjp for a single structure."""
 
-        freq = float(eps_data.eps_xx.coords["f"])
-        eps_out = self.medium.eps_model(frequency=freq)
+        freq_max = float(max(eps_data.eps_xx.coords["f"]))
+        eps_out = self.medium.eps_model(frequency=freq_max)
         return structure.store_vjp(
             grad_data_fwd=fld_fwd,
             grad_data_adj=fld_adj,

--- a/tidy3d/plugins/adjoint/web.py
+++ b/tidy3d/plugins/adjoint/web.py
@@ -165,7 +165,8 @@ def run_bwd(
 
     fwd_task_id = res[0].fwd_task_id
     fwidth_adj = sim_data_vjp.simulation._fwidth_adjoint
-    jax_sim_adj = sim_data_vjp.make_adjoint_simulation(fwidth=fwidth_adj)
+    run_time_adj = sim_data_vjp.simulation._run_time_adjoint
+    jax_sim_adj = sim_data_vjp.make_adjoint_simulation(fwidth=fwidth_adj, run_time=run_time_adj)
     sim_adj, jax_info_adj = jax_sim_adj.to_simulation()
 
     sim_vjp = webapi_run_adjoint_bwd(
@@ -484,7 +485,8 @@ def run_async_bwd(
     for sim_data_vjp, fwd_task_id in zip(batch_data_vjp, fwd_task_ids):
         parent_tasks_adj.append([str(fwd_task_id)])
         fwidth_adj = sim_data_vjp.simulation._fwidth_adjoint
-        jax_sim_adj = sim_data_vjp.make_adjoint_simulation(fwidth=fwidth_adj)
+        run_time_adj = sim_data_vjp.simulation._run_time_adjoint
+        jax_sim_adj = sim_data_vjp.make_adjoint_simulation(fwidth=fwidth_adj, run_time=run_time_adj)
         sim_adj, jax_info_adj = jax_sim_adj.to_simulation()
         sims_adj.append(sim_adj)
         jax_infos_adj.append(jax_info_adj)
@@ -682,7 +684,8 @@ def run_local_bwd(
 
     # make and run adjoint simulation
     fwidth_adj = sim_data_fwd.simulation._fwidth_adjoint
-    sim_adj = sim_data_vjp.make_adjoint_simulation(fwidth=fwidth_adj)
+    run_time_adj = sim_data_fwd.simulation._run_time_adjoint
+    sim_adj = sim_data_vjp.make_adjoint_simulation(fwidth=fwidth_adj, run_time=run_time_adj)
     sim_data_adj = run(
         simulation=sim_adj,
         task_name=_task_name_adj(task_name),
@@ -857,8 +860,9 @@ def run_async_local_bwd(
     sims_adj = []
     for i, sim_data_fwd in enumerate(batch_data_fwd):
         fwidth_adj = sim_data_fwd.simulation._fwidth_adjoint
+        run_time_adj = sim_data_fwd.simulation._run_time_adjoint
         sim_data_vjp = batch_data_vjp[i]
-        sim_adj = sim_data_vjp.make_adjoint_simulation(fwidth=fwidth_adj)
+        sim_adj = sim_data_vjp.make_adjoint_simulation(fwidth=fwidth_adj, run_time=run_time_adj)
         sims_adj.append(sim_adj)
 
     batch_data_adj = run_async_local(

--- a/tidy3d/plugins/adjoint/web.py
+++ b/tidy3d/plugins/adjoint/web.py
@@ -694,6 +694,9 @@ def run_local_bwd(
         callback_url=callback_url,
         verbose=verbose,
     )
+
+    sim_data_adj = sim_data_adj.normalize_adjoint_fields()
+
     grad_data_adj = sim_data_adj.grad_data_symmetry
 
     # get gradient and insert into the resulting simulation structure medium
@@ -877,6 +880,8 @@ def run_async_local_bwd(
 
     sims_vjp = []
     for i, (sim_data_fwd, sim_data_adj) in enumerate(zip(batch_data_fwd, batch_data_adj)):
+
+        sim_data_adj = sim_data_adj.normalize_adjoint_fields()
 
         grad_data_fwd = sim_data_fwd.grad_data_symmetry
         grad_data_adj = sim_data_adj.grad_data_symmetry

--- a/tidy3d/plugins/adjoint/web.py
+++ b/tidy3d/plugins/adjoint/web.py
@@ -647,7 +647,7 @@ def run_local_fwd(
 
     # add the gradient monitors and run the forward simulation
     grad_mnts = simulation.get_grad_monitors(
-        input_structures=simulation.input_structures, freq_adjoint=simulation.freq_adjoint
+        input_structures=simulation.input_structures, freqs_adjoint=simulation.freqs_adjoint
     )
     sim_fwd = simulation.updated_copy(**grad_mnts)
     sim_data_fwd = run(
@@ -804,7 +804,7 @@ def run_async_local_fwd(
     for simulation in simulations:
 
         grad_mnts = simulation.get_grad_monitors(
-            input_structures=simulation.input_structures, freq_adjoint=simulation.freq_adjoint
+            input_structures=simulation.input_structures, freqs_adjoint=simulation.freqs_adjoint
         )
         sim_fwd = simulation.updated_copy(**grad_mnts)
         sims_fwd.append(sim_fwd)


### PR DESCRIPTION
Things to do still:
- [ ] Suppress warning about individual adjoint source spectra not covering all monitor frequencies (this is by design).
- [ ] Fix `RuntimeWarning: invalid value encountered` in `interp` in the WDM notebook.
- [ ] Fix up the WDM example text to be consistent with it using multi-frequency adjoint.
- [ ] Test multi-frequency in the other notebooks to ensure they work properly.

Docs PR: [link](https://github.com/flexcompute-readthedocs/tidy3d-docs/compare/tyler/adjoint/broadband2?expand=1)