### PR TITLE
A few more adjoint fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Ensure same `Grid` is generated in forward and adjoint simulations by setting `GridSpec.wavelength` manually in adjoint.
-- Proper handling of `JaxBox` derivatives both for multi-cell and single cell thickness.
+- Properly handling of `JaxBox` derivatives both for multi-cell and single cell thickness.
+- Properly handle `JaxSimulation.monitors` with `.freqs` as `np.ndarray` in adjoint plugin.
+- Properly handle `JaxDataArray.sel()` with single coordinates and symmetry expansion.
+- Properly handle `JaxDataArray * xr.DataArray` broadcasting.
+- Stricter validation of `JaxDataArray` coordinates and values shape.
+
 
 ## [2.4.1] - 2023-9-20
 

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -35,6 +35,7 @@ from tidy3d.plugins.adjoint.utils.filter import ConicFilter, BinaryProjector, Ci
 from tidy3d.web.container import BatchData
 
 from ..utils import run_emulated, assert_log_level, log_capture, run_async_emulated
+from ..test_components.test_custom import CUSTOM_MEDIUM
 
 TMP_PATH = None
 FWD_SIM_DATA_FILE = "adjoint_grad_data_fwd.hdf5"
@@ -766,6 +767,27 @@ def test_jax_data_array():
     da1d = JaxDataArray(values=[0.0, 1.0, 2.0, 3.0], coords=dict(x=[0, 1, 2, 3]))
     assert np.isclose(da1d.interp(x=0.5), 0.5)
 
+    # duplicate coordinates
+    sel_a_coords = [1, 2, 3, 2, 1]
+    res = da.sel(a=sel_a_coords)
+    assert res.coords["a"] == sel_a_coords
+    assert res.values.shape[0] == len(sel_a_coords)
+
+    a = [1, 2, 3]
+    b = [2, 3, 4, 5]
+    c = [4, 6]
+    shape = (len(a), len(b), len(c))
+    values = np.random.random(shape)
+    coords = dict(a=a, b=b, c=c)
+    da = JaxDataArray(values=values, coords=coords)
+    da2 = da.sel(b=[3, 4])
+    assert da2.shape == (3, 2, 2)
+
+    da3 = da.interp(b=np.array([3, 4]))
+    assert da3.shape == (3, 2, 2)
+
+    assert da2 == da3
+
 
 def test_jax_sim_data(use_emulated_run):
     """Test mechanics of the JaxSimulationData."""
@@ -1460,7 +1482,8 @@ def test_sim_data_plot_field(use_emulated_run):
     assert len(ax.collections) == 1
 
 
-def test_polyslab_structures(use_emulated_run):
+def test_pytreedef_errors(use_emulated_run):
+    """Fix errors that occur when jax doesnt know how to handle array types in aux_data."""
 
     vertices = [(0, 0), (1, 0), (1, 1), (0, 1)]
     polyslab = td.PolySlab(vertices=vertices, slab_bounds=(0, 1), axis=2)
@@ -1482,11 +1505,23 @@ def test_polyslab_structures(use_emulated_run):
         medium=td.Medium(),
     )
 
+    flux_mnt = td.FieldMonitor(
+        center=(0, 0, 0),
+        size=(1, 1, 0),
+        freqs=1e14 * np.array([1, 2, 3]),  # this previously errored
+        name="flux",
+    )
+
     VERTICES = np.array(
         [[-1.5, -0.5, -0.5], [-0.5, -0.5, -0.5], [-1.5, 0.5, -0.5], [-1.5, -0.5, 0.5]]
     )
     FACES = np.array([[1, 2, 3], [0, 3, 2], [0, 1, 3], [0, 2, 1]])
     STL_GEO = td.TriangleMesh.from_trimesh(trimesh.Trimesh(VERTICES, FACES))
+
+    custom_medium = td.Structure(
+        geometry=td.Box(size=(1, 1, 1)),
+        medium=CUSTOM_MEDIUM,
+    )
 
     stl_struct = td.Structure(geometry=STL_GEO, medium=td.Medium())
 
@@ -1499,10 +1534,11 @@ def test_polyslab_structures(use_emulated_run):
 
         sim = JaxSimulation(
             size=(2.0, 2.0, 2.0),
-            structures=[ps, gg, ggg, gggg, stl_struct],
+            structures=[ps, gg, ggg, gggg, stl_struct, custom_medium],
             input_structures=[js],
             run_time=1e-12,
             output_monitors=[mnt],
+            monitors=[flux_mnt],
             grid_spec=td.GridSpec.uniform(dl=0.1),
             boundary_spec=td.BoundarySpec.pml(x=False, y=False, z=False),
         )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -488,7 +488,7 @@ def run_emulated(simulation: td.Simulation, path=None, **kwargs) -> td.Simulatio
 
         return td.FieldData(
             monitor=monitor,
-            symmetry=simulation.symmetry,
+            symmetry=(0, 0, 0),
             symmetry_center=simulation.center,
             grid_expanded=grid,
             **field_cmps,

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -186,7 +186,8 @@ class AbstractFieldData(MonitorData, AbstractFieldDataset, ABC):
 
                 # Interpolate. There generally shouldn't be values out of bounds except potentially
                 # when handling modes, in which case they should be at the boundary and close to 0.
-                scalar_data = scalar_data.sel({dim_name: coords_interp}, method="nearest")
+
+                scalar_data = scalar_data.sel(**{dim_name: coords_interp}, method="nearest")
                 scalar_data = scalar_data.assign_coords({dim_name: coords})
 
                 # apply the symmetry eigenvalue (if defined) to the flipped values

--- a/tidy3d/plugins/adjoint/components/base.py
+++ b/tidy3d/plugins/adjoint/components/base.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from typing import Tuple, List, Any, Callable
 import json
 
+import numpy as np
+
 from jax.tree_util import tree_flatten as jax_tree_flatten
 from jax.tree_util import tree_unflatten as jax_tree_unflatten
 
@@ -56,6 +58,12 @@ class JaxObject(Tidy3dBaseModel):
             for _i, structure in enumerate(structures):
                 geometry = structure["geometry"]
                 fix_polyslab(geometry)
+            monitors = aux_data["monitors"]
+            for _i, monitor in enumerate(monitors):
+                if "freqs" in monitor:
+                    freqs = monitor["freqs"]
+                    if isinstance(freqs, np.ndarray):
+                        monitor["freqs"] = freqs.tolist()
 
         return children, aux_data
 

--- a/tidy3d/plugins/adjoint/components/data/sim_data.py
+++ b/tidy3d/plugins/adjoint/components/data/sim_data.py
@@ -125,8 +125,7 @@ class JaxSimulationData(SimulationData, JaxObject):
             mnt_data_type = JAX_MONITOR_DATA_MAP[mnt_data_type_str]
             jax_mnt_data = mnt_data_type.from_monitor_data(mnt_data)
             output_data_list.append(jax_mnt_data)
-            data_dict["output_data"] = output_data_list
-
+        data_dict["output_data"] = output_data_list
         self_dict.update(data_dict)
         self_dict.update(dict(task_id=task_id))
 


### PR DESCRIPTION
1. When `FieldMonitor` objects were in `JaxSimulation.output_monitors` and `.flux` was called with symmetry, the symmetry covered areas were being included in the flux calculation and therefore giving `nan` as the interpolation coordinates were outside of the data range. Temporarily fixed this to avoid errors by converting `nan` values to `0`, but not sure if this is the appropriate way to handle it. For example, may undercount flux by 2x, 4x, 8x, depending on how many symmetry planes there are. Seems the deeper problem is that the fields are not getting copied over to the symmetry regions. spent a while trying to figure it out but got quite confused by the FieldData internals.
2. Same obscure `PytreeDef` error was occurring when a regular `JaxSimulation.monitor` had a `.freqs` field as a `np.ndarray`.  Added the previous fix to this and it seems to rectify issue.
3. Fix the DataArray selection to handle vectorized inputs, and also fixed the symmetry expansion to properly pass kwargs instead of dicts, which JaxDataArray can't handle currently.

thanks @e-g-melo for catching these and your patience..