### PR TITLE
Space-time modulation of all types of materials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for multiple frequencies in `output_monitors` in `adjoint` plugin.
 - GDSII export functions to `Simulation`, `Structure`, and `Geometry`.
 - ``verbose`` argument to `estimate_cost` and `real_cost` functions such that the cost is logged if `verbose==True` (default). Additional helpful messages may also be logged.
+- Added support for space-time modulation of permittivity and electric conductivity via `ModulationSpec` class. The modulation function must be separable in space and time. Modulations with user-supplied distributions in space and harmonic modulation in time are supported.
 
 ### Changed
 - Update versions of `boto3`, `requests`, and `click`.

--- a/tests/test_components/test_time_modulation.py
+++ b/tests/test_components/test_time_modulation.py
@@ -1,0 +1,205 @@
+"""Tests space time modulation."""
+import numpy as np
+import pytest
+from math import isclose
+import pydantic.v1 as pydantic
+import tidy3d as td
+from tidy3d.exceptions import ValidationError
+
+np.random.seed(4)
+
+# space
+NX, NY, NZ = 10, 9, 8
+X = np.linspace(-1, 1, NX)
+Y = np.linspace(-1, 1, NY)
+Z = np.linspace(-1, 1, NZ)
+COORDS = dict(x=X, y=Y, z=Z)
+ARRAY_CMP = td.SpatialDataArray(np.random.random((NX, NY, NZ)) + 0.1j, coords=COORDS)
+ARRAY = td.SpatialDataArray(np.random.random((NX, NY, NZ)), coords=COORDS)
+
+SP_UNIFORM = td.SpaceModulation()
+
+# time
+FREQ_MODULATE = 1e12
+AMP_TIME = 1.1
+PHASE_TIME = 0
+CW = td.ContinuousWaveTimeModulation(freq0=FREQ_MODULATE, amplitude=AMP_TIME, phase=PHASE_TIME)
+
+# combined
+ST = td.SpaceTimeModulation(
+    time_modulation=CW,
+)
+
+# medium modulation spec
+MODULATION_SPEC = td.ModulationSpec()
+
+
+def test_time_modulation():
+    """time modulation: only supporting CW for now."""
+    assert isclose(np.real(CW.amp_time(1 / FREQ_MODULATE)), AMP_TIME)
+    assert isclose(CW.max_modulation, AMP_TIME)
+
+    cw = CW.updated_copy(phase=np.pi / 4, amplitude=10)
+    assert isclose(np.real(cw.amp_time(1 / FREQ_MODULATE)), np.sqrt(2) / 2 * 10)
+    assert isclose(cw.max_modulation, 10)
+
+
+def test_space_modulation():
+    """uniform or custom space modulation"""
+    # uniform in both amplitude and phase
+    assert isclose(SP_UNIFORM.max_modulation, 1)
+
+    # uniform in phase, but custom in amplitude
+    with pytest.raises(pydantic.ValidationError):
+        sp = SP_UNIFORM.updated_copy(amplitude=ARRAY_CMP)
+
+    sp = SP_UNIFORM.updated_copy(amplitude=ARRAY)
+    assert isclose(sp.max_modulation, np.max(ARRAY))
+
+    # uniform in amplitude, but custom in phase
+    with pytest.raises(pydantic.ValidationError):
+        sp = SP_UNIFORM.updated_copy(phase=ARRAY_CMP)
+    sp = SP_UNIFORM.updated_copy(phase=ARRAY)
+    assert isclose(sp.max_modulation, 1)
+
+    # custom in both
+    with pytest.raises(pydantic.ValidationError):
+        sp = SP_UNIFORM.updated_copy(phase=ARRAY_CMP, amplitude=ARRAY_CMP)
+    sp = SP_UNIFORM.updated_copy(phase=ARRAY, amplitude=ARRAY)
+
+
+def test_space_time_modulation():
+    # cw modulation, uniform in space
+    assert isclose(ST.max_modulation, AMP_TIME)
+    assert not ST.negligible_modulation
+
+    # cw modulation, but 0 amplitude
+    st = ST.updated_copy(time_modulation=CW.updated_copy(amplitude=0))
+    assert st.negligible_modulation
+
+    st = ST.updated_copy(space_modulation=td.SpaceModulation(amplitude=0))
+    assert st.negligible_modulation
+
+    # cw modulation, nonuniform in space
+    st = ST.updated_copy(space_modulation=td.SpaceModulation(amplitude=ARRAY, phase=ARRAY))
+    assert not st.negligible_modulation
+    assert isclose(st.max_modulation, AMP_TIME * np.max(ARRAY))
+
+
+def test_modulated_medium():
+    """time modulated medium"""
+    # unmodulated
+    medium = td.Medium()
+    assert medium.modulation_spec is None
+    assert medium.time_modulated == False
+
+    assert MODULATION_SPEC.applied_modulation == False
+    medium = medium.updated_copy(modulation_spec=MODULATION_SPEC)
+    assert medium.time_modulated == False
+
+    # permittivity modulated
+    modulation_spec = MODULATION_SPEC.updated_copy(permittivity=ST)
+    # modulated permitivity <= 0
+    with pytest.raises(pydantic.ValidationError):
+        medium = td.Medium(modulation_spec=modulation_spec)
+    medium = td.Medium(permittivity=2, modulation_spec=modulation_spec)
+    assert isclose(medium.n_cfl, np.sqrt(2 - AMP_TIME))
+
+    # conductivity modulated
+    modulation_spec = MODULATION_SPEC.updated_copy(conductivity=ST)
+    # modulated conductivity <= 0
+    with pytest.raises(pydantic.ValidationError):
+        medium = td.Medium(modulation_spec=modulation_spec)
+    medium_sometimes_active = td.Medium(modulation_spec=modulation_spec, allow_gain=True)
+    medium = td.Medium(conductivity=2, modulation_spec=modulation_spec)
+
+    # both modulated, but different time modulation: error
+    st_freq2 = ST.updated_copy(
+        time_modulation=td.ContinuousWaveTimeModulation(freq0=2e12, amplitude=2)
+    )
+    with pytest.raises(pydantic.ValidationError):
+        modulation_spec = MODULATION_SPEC.updated_copy(permittivity=ST, conductivity=st_freq2)
+    # both modulated, but different space modulation: fine
+    st_space2 = ST.updated_copy(space_modulation=td.SpaceModulation(amplitude=0.1))
+    modulation_spec = MODULATION_SPEC.updated_copy(permittivity=ST, conductivity=st_space2)
+    medium = td.Medium(
+        permittivity=3,
+        conductivity=1,
+        modulation_spec=modulation_spec,
+    )
+
+
+def test_unsupported_modulated_medium_types():
+    """Unsupported types of time modulated medium"""
+    modulation_spec = MODULATION_SPEC.updated_copy(permittivity=ST)
+
+    # PEC cannot be modulated
+    with pytest.raises(pydantic.ValidationError):
+        mat = td.PECMedium(modulation_spec=modulation_spec)
+
+    # For Anisotropic medium, one should modulate the components, not the whole medium
+    with pytest.raises(pydantic.ValidationError):
+        mat = td.AnisotropicMedium(
+            xx=td.Medium(), yy=td.Medium(), zz=td.Medium(), modulation_spec=modulation_spec
+        )
+
+    # Modulation to fully Anisotropic medium unsupported
+    with pytest.raises(pydantic.ValidationError):
+        mat = td.FullyAnisotropicMedium(modulation_spec=modulation_spec)
+
+    # 2D material
+    with pytest.raises(pydantic.ValidationError):
+        drude_medium = td.Drude(eps_inf=2.0, coeffs=[(1, 2), (3, 4)])
+        medium2d = td.Medium2D(ss=drude_medium, tt=drude_medium, modulation_spec=modulation_spec)
+
+    # together with nonlinear_spec
+    with pytest.raises(pydantic.ValidationError):
+        mat = td.Medium(
+            permittivity=2,
+            nonlinear_spec=td.NonlinearSusceptibility(chi3=1),
+            modulation_spec=modulation_spec,
+        )
+
+
+def test_supported_modulated_medium_types():
+    """Supported types of time modulated medium"""
+    modulation_spec = MODULATION_SPEC.updated_copy(permittivity=ST)
+    modulation_both_spec = modulation_spec.updated_copy(conductivity=ST)
+
+    # Dispersive
+    mat_p = td.PoleResidue(
+        eps_inf=2.0, poles=[((-1 + 2j), (3 + 4j))], modulation_spec=modulation_spec
+    )
+    assert mat_p.time_modulated
+    assert isclose(mat_p.n_cfl, np.sqrt(2 - AMP_TIME))
+    # too much modulation resulting in eps_inf < 0
+    with pytest.raises(pydantic.ValidationError):
+        mat = mat_p.updated_copy(eps_inf=1.0)
+    # conductivity modulation
+    with pytest.raises(pydantic.ValidationError):
+        mat = mat_p.updated_copy(modulation_spec=modulation_both_spec)
+    mat = mat_p.updated_copy(modulation_spec=modulation_both_spec, allow_gain=True)
+
+    # custom
+    permittivity = td.SpatialDataArray(np.ones((1, 1, 1)) * 2, coords=dict(x=[1], y=[1], z=[1]))
+    mat_c = td.CustomMedium(permittivity=permittivity, modulation_spec=modulation_spec)
+    assert mat_c.time_modulated
+    assert isclose(mat_c.n_cfl, np.sqrt(2 - AMP_TIME))
+    # too much modulation resulting in eps_inf < 0
+    with pytest.raises(pydantic.ValidationError):
+        mat = mat_c.updated_copy(permittivity=permittivity * 0.5)
+    # conductivity modulation
+    with pytest.raises(pydantic.ValidationError):
+        mat = mat_c.updated_copy(modulation_spec=modulation_both_spec)
+    mat = mat_c.updated_copy(modulation_spec=modulation_both_spec, allow_gain=True)
+
+    # anisotropic medium component
+    mat = td.AnisotropicMedium(xx=td.Medium(), yy=mat_p, zz=td.Medium())
+    assert mat.time_modulated
+    assert isclose(mat.n_cfl, np.sqrt(2 - AMP_TIME))
+
+    # custom anistropic medium component
+    mat_uc = td.CustomMedium(permittivity=permittivity)
+    mat = td.CustomAnisotropicMedium(xx=mat_uc, yy=mat_c, zz=mat_uc)
+    assert mat.time_modulated
+    assert isclose(mat.n_cfl, np.sqrt(2 - AMP_TIME))

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -23,6 +23,10 @@ from .components.parameter_perturbation import ParameterPerturbation
 from .components.parameter_perturbation import LinearHeatPerturbation, CustomHeatPerturbation
 from .components.parameter_perturbation import LinearChargePerturbation, CustomChargePerturbation
 
+# time modulation
+from .components.time_modulation import SpaceTimeModulation, SpaceModulation
+from .components.time_modulation import ContinuousWaveTimeModulation, ModulationSpec
+
 # structures
 from .components.structure import Structure, MeshOverrideStructure
 
@@ -303,4 +307,8 @@ __all__ = [
     "DistanceUnstructuredGrid",
     "TemperatureData",
     "TemperatureMonitor",
+    "SpaceTimeModulation",
+    "SpaceModulation",
+    "ContinuousWaveTimeModulation",
+    "ModulationSpec",
 ]

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -1887,6 +1887,11 @@ class Simulation(Box):
             plot_params = plot_params.copy(
                 update={"facecolor": "gold", "edgecolor": "k", "linewidth": 1}
             )
+        elif medium.time_modulated:
+            # time modulated medium
+            plot_params = plot_params.copy(
+                update={"facecolor": "red", "linewidth": 0, "hatch": "x*"}
+            )
         elif isinstance(medium, Medium2D):
             # 2d material
             plot_params = plot_params.copy(update={"edgecolor": "k", "linewidth": 1})
@@ -3315,7 +3320,11 @@ class Simulation(Box):
         datasets_current_source = [
             src.current_dataset for src in self.sources if isinstance(src, CustomCurrentSource)
         ]
-        datasets_medium = [mat for mat in self.mediums if isinstance(mat, AbstractCustomMedium)]
+        datasets_medium = [
+            mat
+            for mat in self.mediums
+            if isinstance(mat, AbstractCustomMedium) or mat.time_modulated
+        ]
         datasets_geometry = []
 
         for struct in self.structures:

--- a/tidy3d/components/source.py
+++ b/tidy3d/components/source.py
@@ -9,8 +9,8 @@ from typing_extensions import Literal
 import pydantic.v1 as pydantic
 import numpy as np
 
-from .base import Tidy3dBaseModel, cached_property
-
+from .base import cached_property
+from .time import AbstractTimeDependence
 from .types import Coordinate, Direction, Polarization, Ax, FreqBound
 from .types import ArrayFloat1D, Axis, PlotVal, ArrayComplex1D, TYPE_TAG_STR
 from .validators import assert_plane, assert_volumetric, validate_name_str, get_value
@@ -26,8 +26,6 @@ from ..constants import inf
 from ..exceptions import SetupError, ValidationError
 from ..log import log
 
-# in spectrum computation, discard amplitudes with relative magnitude smaller than cutoff
-DFT_CUTOFF = 1e-8
 # when checking if custom data spans the source plane, allow for a small tolerance
 # due to numerical precision
 DATA_SPAN_TOL = 1e-8
@@ -37,132 +35,8 @@ CHEB_GRID_WIDTH = 1.5
 WARN_NUM_FREQS = 20
 
 
-class SourceTime(ABC, Tidy3dBaseModel):
+class SourceTime(AbstractTimeDependence):
     """Base class describing the time dependence of a source."""
-
-    amplitude: pydantic.NonNegativeFloat = pydantic.Field(
-        1.0, title="Amplitude", description="Real-valued maximum amplitude of the time dependence."
-    )
-
-    phase: float = pydantic.Field(
-        0.0, title="Phase", description="Phase shift of the time dependence.", units=RADIAN
-    )
-
-    @abstractmethod
-    def amp_time(self, time: float) -> complex:
-        """Complex-valued source amplitude as a function of time.
-
-        Parameters
-        ----------
-        time : float
-            Time in seconds.
-
-        Returns
-        -------
-        complex
-            Complex-valued source amplitude at that time..
-        """
-
-    def spectrum(
-        self,
-        times: ArrayFloat1D,
-        freqs: ArrayFloat1D,
-        dt: float,
-        complex_fields: bool = False,
-    ) -> complex:
-        """Complex-valued source spectrum as a function of frequency
-
-        Parameters
-        ----------
-        times : np.ndarray
-            Times to use to evaluate spectrum Fourier transform.
-            (Typically the simulation time mesh).
-        freqs : np.ndarray
-            Frequencies in Hz to evaluate spectrum at.
-        dt : float or np.ndarray
-            Time step to weight FT integral with.
-            If array, use to weigh each of the time intervals in ``times``.
-        complex_fields : bool
-            Whether time domain fields are complex, e.g., for Bloch boundaries
-
-        Returns
-        -------
-        np.ndarray
-            Complex-valued array (of len(freqs)) containing spectrum at those frequencies.
-        """
-
-        times = np.array(times)
-        freqs = np.array(freqs)
-        time_amps = self.amp_time(times)
-
-        if not complex_fields:
-            time_amps = np.real(time_amps)
-
-        # if all time amplitudes are zero, just return (complex-valued) zeros for spectrum
-        if np.allclose(time_amps, 0.0):
-            return (0.0 + 0.0j) * np.zeros_like(freqs)
-
-        # Cut to only relevant times
-        relevant_time_inds = np.where(np.abs(time_amps) / np.amax(np.abs(time_amps)) > DFT_CUTOFF)
-        # find first and last index where the filter is True
-        start_ind = relevant_time_inds[0][0]
-        stop_ind = relevant_time_inds[0][-1]
-        time_amps = time_amps[start_ind:stop_ind]
-        times_cut = times[start_ind:stop_ind]
-
-        # only need to compute DTFT kernel for distinct dts
-        # usually, there is only one dt, if times is simulation time mesh
-        dts = np.diff(times_cut)
-        dts_unique, kernel_indices = np.unique(dts, return_inverse=True)
-
-        dft_kernels = [np.exp(2j * np.pi * freqs * curr_dt) for curr_dt in dts_unique]
-        running_kernel = np.exp(2j * np.pi * freqs * times_cut[0])
-        dft = np.zeros(len(freqs), dtype=complex)
-        for amp, kernel_index in zip(time_amps, kernel_indices):
-            dft += running_kernel * amp
-            running_kernel *= dft_kernels[kernel_index]
-
-        # kernel_indices was one index shorter than time_amps
-        dft += running_kernel * time_amps[-1]
-
-        return dt * dft / np.sqrt(2 * np.pi)
-
-    @add_ax_if_none
-    def plot(self, times: ArrayFloat1D, val: PlotVal = "real", ax: Ax = None) -> Ax:
-        """Plot the complex-valued amplitude of the source time-dependence.
-
-        Parameters
-        ----------
-        times : np.ndarray
-            Array of times (seconds) to plot source at.
-            To see source time amplitude for a specific :class:`Simulation`,
-            pass ``simulation.tmesh``.
-        val : Literal['real', 'imag', 'abs'] = 'real'
-            Which part of the spectrum to plot.
-        ax : matplotlib.axes._subplots.Axes = None
-            Matplotlib axes to plot on, if not specified, one is created.
-
-        Returns
-        -------
-        matplotlib.axes._subplots.Axes
-            The supplied or created matplotlib axes.
-        """
-        times = np.array(times)
-        amp_complex = self.amp_time(times)
-
-        if val == "real":
-            ax.plot(times, amp_complex.real, color="blueviolet", label="real")
-        elif val == "imag":
-            ax.plot(times, amp_complex.imag, color="crimson", label="imag")
-        elif val == "abs":
-            ax.plot(times, np.abs(amp_complex), color="k", label="abs")
-        else:
-            raise ValueError(f"Plot 'val' option of '{val}' not recognized.")
-        ax.set_xlabel("time (s)")
-        ax.set_title("source amplitude")
-        ax.legend()
-        ax.set_aspect("auto")
-        return ax
 
     @add_ax_if_none
     def plot_spectrum(
@@ -194,32 +68,11 @@ class SourceTime(ABC, Tidy3dBaseModel):
         matplotlib.axes._subplots.Axes
             The supplied or created matplotlib axes.
         """
-        times = np.array(times)
-
-        dts = np.diff(times)
-        if not np.allclose(dts, dts[0] * np.ones_like(dts), atol=1e-17):
-            raise SetupError("Supplied times not evenly spaced.")
-
-        dt = np.mean(dts)
 
         fmin, fmax = self.frequency_range()
-        freqs = np.linspace(fmin, fmax, num_freqs)
-
-        spectrum = self.spectrum(times=times, dt=dt, freqs=freqs, complex_fields=complex_fields)
-
-        if val == "real":
-            ax.plot(freqs, spectrum.real, color="blueviolet", label="real")
-        elif val == "imag":
-            ax.plot(freqs, spectrum.imag, color="crimson", label="imag")
-        elif val == "abs":
-            ax.plot(freqs, np.abs(spectrum), color="k", label="abs")
-        else:
-            raise ValueError(f"Plot 'val' option of '{val}' not recognized.")
-        ax.set_xlabel("frequency (Hz)")
-        ax.set_title("source spectrum")
-        ax.legend()
-        ax.set_aspect("auto")
-        return ax
+        self.plot_spectrum_in_frequency_range(
+            times, fmin, fmax, num_freqs=num_freqs, val=val, ax=ax, complex_fields=complex_fields
+        )
 
     @abstractmethod
     def frequency_range(self, num_fwidth: float = 4.0) -> FreqBound:

--- a/tidy3d/components/time.py
+++ b/tidy3d/components/time.py
@@ -1,0 +1,206 @@
+""" Defines time dependence """
+from __future__ import annotations
+from abc import ABC, abstractmethod
+
+import pydantic.v1 as pydantic
+import numpy as np
+
+from .base import Tidy3dBaseModel
+
+from .types import Ax
+from .types import ArrayFloat1D, PlotVal
+from .viz import add_ax_if_none
+from ..constants import RADIAN
+from ..exceptions import SetupError
+
+# in spectrum computation, discard amplitudes with relative magnitude smaller than cutoff
+DFT_CUTOFF = 1e-8
+
+
+class AbstractTimeDependence(ABC, Tidy3dBaseModel):
+    """Base class describing time dependence."""
+
+    amplitude: pydantic.NonNegativeFloat = pydantic.Field(
+        1.0, title="Amplitude", description="Real-valued maximum amplitude of the time dependence."
+    )
+
+    phase: float = pydantic.Field(
+        0.0, title="Phase", description="Phase shift of the time dependence.", units=RADIAN
+    )
+
+    @abstractmethod
+    def amp_time(self, time: float) -> complex:
+        """Complex-valued amplitude as a function of time.
+
+        Parameters
+        ----------
+        time : float
+            Time in seconds.
+
+        Returns
+        -------
+        complex
+            Complex-valued amplitude at that time..
+        """
+
+    def spectrum(
+        self,
+        times: ArrayFloat1D,
+        freqs: ArrayFloat1D,
+        dt: float,
+        complex_fields: bool = False,
+    ) -> complex:
+        """Complex-valued spectrum as a function of frequency
+
+        Parameters
+        ----------
+        times : np.ndarray
+            Times to use to evaluate spectrum Fourier transform.
+            (Typically the simulation time mesh).
+        freqs : np.ndarray
+            Frequencies in Hz to evaluate spectrum at.
+        dt : float or np.ndarray
+            Time step to weight FT integral with.
+            If array, use to weigh each of the time intervals in ``times``.
+        complex_fields : bool
+            Whether time domain fields are complex, e.g., for Bloch boundaries
+
+        Returns
+        -------
+        np.ndarray
+            Complex-valued array (of len(freqs)) containing spectrum at those frequencies.
+        """
+
+        times = np.array(times)
+        freqs = np.array(freqs)
+        time_amps = self.amp_time(times)
+
+        if not complex_fields:
+            time_amps = np.real(time_amps)
+
+        # if all time amplitudes are zero, just return (complex-valued) zeros for spectrum
+        if np.allclose(time_amps, 0.0):
+            return (0.0 + 0.0j) * np.zeros_like(freqs)
+
+        # Cut to only relevant times
+        relevant_time_inds = np.where(np.abs(time_amps) / np.amax(np.abs(time_amps)) > DFT_CUTOFF)
+        # find first and last index where the filter is True
+        start_ind = relevant_time_inds[0][0]
+        stop_ind = relevant_time_inds[0][-1]
+        time_amps = time_amps[start_ind:stop_ind]
+        times_cut = times[start_ind:stop_ind]
+
+        # only need to compute DTFT kernel for distinct dts
+        # usually, there is only one dt, if times is simulation time mesh
+        dts = np.diff(times_cut)
+        dts_unique, kernel_indices = np.unique(dts, return_inverse=True)
+
+        dft_kernels = [np.exp(2j * np.pi * freqs * curr_dt) for curr_dt in dts_unique]
+        running_kernel = np.exp(2j * np.pi * freqs * times_cut[0])
+        dft = np.zeros(len(freqs), dtype=complex)
+        for amp, kernel_index in zip(time_amps, kernel_indices):
+            dft += running_kernel * amp
+            running_kernel *= dft_kernels[kernel_index]
+
+        # kernel_indices was one index shorter than time_amps
+        dft += running_kernel * time_amps[-1]
+
+        return dt * dft / np.sqrt(2 * np.pi)
+
+    @add_ax_if_none
+    def plot_spectrum_in_frequency_range(
+        self,
+        times: ArrayFloat1D,
+        fmin: float,
+        fmax: float,
+        num_freqs: int = 101,
+        val: PlotVal = "real",
+        ax: Ax = None,
+        complex_fields: bool = False,
+    ) -> Ax:
+        """Plot the complex-valued amplitude of the time-dependence.
+
+        Parameters
+        ----------
+        times : np.ndarray
+            Array of evenly-spaced times (seconds) to evaluate time-dependence at.
+            The spectrum is computed from this value and the time frequency content.
+            To see spectrum for a specific :class:`Simulation`,
+            pass ``simulation.tmesh``.
+        fmin : float
+            Lower bound of frequency for the spectrum plot.
+        fmax : float
+            Upper bound of frequency for the spectrum plot.
+        num_freqs : int = 101
+            Number of frequencies to plot within the [fmin, fmax].
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        complex_fields : bool
+            Whether time domain fields are complex, e.g., for Bloch boundaries
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+        times = np.array(times)
+
+        dts = np.diff(times)
+        if not np.allclose(dts, dts[0] * np.ones_like(dts), atol=1e-17):
+            raise SetupError("Supplied times not evenly spaced.")
+
+        dt = np.mean(dts)
+        freqs = np.linspace(fmin, fmax, num_freqs)
+
+        spectrum = self.spectrum(times=times, dt=dt, freqs=freqs, complex_fields=complex_fields)
+
+        if val == "real":
+            ax.plot(freqs, spectrum.real, color="blueviolet", label="real")
+        elif val == "imag":
+            ax.plot(freqs, spectrum.imag, color="crimson", label="imag")
+        elif val == "abs":
+            ax.plot(freqs, np.abs(spectrum), color="k", label="abs")
+        else:
+            raise ValueError(f"Plot 'val' option of '{val}' not recognized.")
+        ax.set_xlabel("frequency (Hz)")
+        ax.set_title("source spectrum")
+        ax.legend()
+        ax.set_aspect("auto")
+        return ax
+
+    @add_ax_if_none
+    def plot(self, times: ArrayFloat1D, val: PlotVal = "real", ax: Ax = None) -> Ax:
+        """Plot the complex-valued amplitude of the time-dependence.
+
+        Parameters
+        ----------
+        times : np.ndarray
+            Array of times (seconds) to plot source at.
+            To see source time amplitude for a specific :class:`Simulation`,
+            pass ``simulation.tmesh``.
+        val : Literal['real', 'imag', 'abs'] = 'real'
+            Which part of the spectrum to plot.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+        times = np.array(times)
+        amp_complex = self.amp_time(times)
+
+        if val == "real":
+            ax.plot(times, amp_complex.real, color="blueviolet", label="real")
+        elif val == "imag":
+            ax.plot(times, amp_complex.imag, color="crimson", label="imag")
+        elif val == "abs":
+            ax.plot(times, np.abs(amp_complex), color="k", label="abs")
+        else:
+            raise ValueError(f"Plot 'val' option of '{val}' not recognized.")
+        ax.set_xlabel("time (s)")
+        ax.set_title("source amplitude")
+        ax.legend()
+        ax.set_aspect("auto")
+        return ax

--- a/tidy3d/components/time_modulation.py
+++ b/tidy3d/components/time_modulation.py
@@ -1,0 +1,247 @@
+""" Defines time modulation to the medium"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Union
+from math import isclose
+
+import pydantic.v1 as pd
+import numpy as np
+
+from .base import Tidy3dBaseModel, cached_property
+from .types import InterpMethod
+from .time import AbstractTimeDependence
+from .data.data_array import SpatialDataArray
+from ..exceptions import ValidationError
+from ..constants import HERTZ, RADIAN
+
+
+class AbstractTimeModulation(AbstractTimeDependence, ABC):
+    """Base class for modulation in time.
+
+    Note
+    ----
+    This class describes the time dependence part of the separable space-time modulation type
+    as shown below,
+
+    .. math::
+
+        amp(r, t) = \\Re[amp\\_time(t) \\cdot amp\\_space(r)]
+
+    """
+
+    @cached_property
+    @abstractmethod
+    def max_modulation(self) -> float:
+        """Estimated maximum modulation amplitude."""
+
+
+class ContinuousWaveTimeModulation(AbstractTimeDependence):
+    """Class describing modulation with a harmonic time dependence.
+
+    Note
+    ----
+    .. math::
+
+        amp\\_time(t) = amplitude \\cdot \\
+                e^{i \\cdot phase - 2 \\pi i \\cdot freq0 \\cdot t}
+
+    Note
+    ----
+    The full space-time modulation is,
+
+    .. math::
+
+        amp(r, t) = \\Re[amp\\_time(t) \\cdot amp\\_space(r)]
+
+
+    Example
+    -------
+    >>> cw = ContinuousWaveTimeModulation(freq0=200e12, amplitude=1, phase=0)
+    """
+
+    freq0: pd.PositiveFloat = pd.Field(
+        ..., title="Modulation Frequency", description="Modulation frequency.", units=HERTZ
+    )
+
+    def amp_time(self, time: float) -> complex:
+        """Complex-valued source amplitude as a function of time."""
+
+        omega = 2 * np.pi * self.freq0
+        return self.amplitude * np.exp(-1j * omega * time + 1j * self.phase)
+
+    @cached_property
+    def max_modulation(self) -> float:
+        """Estimated maximum modulation amplitude."""
+        return abs(self.amplitude)
+
+
+TimeModulationType = Union[ContinuousWaveTimeModulation]
+
+
+class AbstractSpaceModulation(ABC, Tidy3dBaseModel):
+    """Base class for modulation in space.
+
+    Note
+    ----
+    This class describes the 2nd term in the full space-time modulation below,
+    .. math::
+
+        amp(r, t) = \\Re[amp\\_time(t) \\cdot amp\\_space(r)]
+
+    """
+
+    @cached_property
+    @abstractmethod
+    def max_modulation(self) -> float:
+        """Estimated maximum modulation amplitude."""
+
+
+class SpaceModulation(AbstractSpaceModulation):
+    """The modulation profile with a user-supplied spatial distribution of
+    amplitude and phase.
+
+    Note
+    ----
+    .. math::
+
+        amp\\_space(r) = amplitude(r) \\cdot e^{i \\cdot phase(r)}
+
+    The full space-time modulation is,
+
+    .. math::
+
+        amp(r, t) = \\Re[amp\\_time(t) \\cdot amp\\_space(r)]
+
+    Example
+    -------
+    >>> Nx, Ny, Nz = 10, 9, 8
+    >>> X = np.linspace(-1, 1, Nx)
+    >>> Y = np.linspace(-1, 1, Ny)
+    >>> Z = np.linspace(-1, 1, Nz)
+    >>> coords = dict(x=X, y=Y, z=Z)
+    >>> amp = SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=coords)
+    >>> phase = SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=coords)
+    >>> space = SpaceModulation(amplitude=amp, phase=phase)
+    """
+
+    amplitude: Union[float, SpatialDataArray] = pd.Field(
+        1,
+        title="Amplitude of modulation in space",
+        description="Amplitude of modulation that can vary spatially. "
+        "It takes the unit of whatever is being modulated.",
+    )
+
+    phase: Union[float, SpatialDataArray] = pd.Field(
+        0,
+        title="Phase of modulation in space",
+        description="Phase of modulation that can vary spatially.",
+        units=RADIAN,
+    )
+
+    interp_method: InterpMethod = pd.Field(
+        "nearest",
+        title="Interpolation method",
+        description="Method of interpolation to use to obtain values at spatial locations on the Yee grids.",
+    )
+
+    @pd.validator("amplitude", always=True)
+    def _real_amplitude(cls, val):
+        """Assert that the amplitude is real."""
+        if np.iscomplexobj(val):
+            raise ValidationError("'amplitude' must be real.")
+        return val
+
+    @pd.validator("phase", always=True)
+    def _real_phase(cls, val):
+        """Assert that the phase is real."""
+        if np.iscomplexobj(val):
+            raise ValidationError("'phase' must be real.")
+        return val
+
+    @cached_property
+    def max_modulation(self) -> float:
+        """Estimated maximum modulation amplitude."""
+        return np.max(abs(np.array(self.amplitude)))
+
+
+SpaceModulationType = Union[SpaceModulation]
+
+
+class SpaceTimeModulation(Tidy3dBaseModel):
+    """Space-time modulation applied to a medium, adding
+    on top of the time-independent part.
+
+
+    Note
+    ----
+    The space-time modulation must be separable in space and time.
+    e.g. when applied to permittivity,
+
+    .. math::
+
+        \\delta \\epsilon(r, t) = \\Re[amp\\_time(t) \\cdot amp\\_space(r)]
+    """
+
+    space_modulation: SpaceModulationType = pd.Field(
+        SpaceModulation(),
+        title="Space modulation",
+        description="Space modulation part from the separable SpaceTimeModulation.",
+        # discriminator=TYPE_TAG_STR,
+    )
+
+    time_modulation: TimeModulationType = pd.Field(
+        ...,
+        title="Time modulation",
+        description="Time modulation part from the separable SpaceTimeModulation.",
+        # discriminator=TYPE_TAG_STR,
+    )
+
+    @cached_property
+    def max_modulation(self) -> float:
+        """Estimated maximum modulation amplitude."""
+        return self.time_modulation.max_modulation * self.space_modulation.max_modulation
+
+    @cached_property
+    def negligible_modulation(self) -> bool:
+        """whether the modulation is weak enough to be regarded as zero."""
+        # if isclose(np.diff(time_modulation.range), 0) and
+        if isclose(self.max_modulation, 0):
+            return True
+        return False
+
+
+class ModulationSpec(Tidy3dBaseModel):
+    """Specification adding space-time modulation to the non-dispersive part of medium
+    including relative permittivity at infinite frequency and electric conductivity.
+    """
+
+    permittivity: SpaceTimeModulation = pd.Field(
+        None,
+        title="Space-time modulation of relative permittivity",
+        description="Space-time modulation of relative permittivity at infinite frequency "
+        "applied on top of the base permittivity at infinite frequency.",
+    )
+
+    conductivity: SpaceTimeModulation = pd.Field(
+        None,
+        title="Space-time modulation of conductivity",
+        description="Space-time modulation of electric conductivity "
+        "applied on top of the base conductivity.",
+    )
+
+    @pd.validator("conductivity", always=True)
+    def _same_modulation_frequency(cls, val, values):
+        """Assert same time-modulation applied to permittivity and conductivity."""
+        permittivity = values.get("permittivity")
+        if val is not None and permittivity is not None:
+            if val.time_modulation != permittivity.time_modulation:
+                raise ValidationError(
+                    "'permittivity' and 'conductivity' should have the same time modulation."
+                )
+        return val
+
+    @cached_property
+    def applied_modulation(self) -> bool:
+        """Check if any modulation has been applied to `permittivity` or `conductivity`."""
+        return self.permittivity is not None or self.conductivity is not None


### PR DESCRIPTION
TODO:

- [x] classes related to space-time modulation
- [x] modulation_spec to base material class
- [x] Validate several types of materials that are yet to support time modulation
- [x] Adjust CFL number etc. when permittivity is modulation

This PR adds two fields ~~`permittivity_modulation` and `conductivity_modulation`~~ `modulation_spec` to `Medium`. 

With modulation, the permittivity (conductivity) of a medium is a linear summation of time-independent and dynamic parts. As for the dynamic part, it can be a function of both space and time: `modulation_amp(r, t)`. Similar to source, i think we can just support the case where space and time are separable: `modulation_amp(r, t) = Re[amp_time(t) amp_space(r)]`. This should cover most applications, and is more efficient to support in the backend.

- `modulation_amp(r, t)` is described by the class `SpaceTimeModulation` that has two fields: `space_modulation` and `time_modulation`. The default `space_modulation` is uniform in space 
- `SpaceModulation` class defines `amp_space(r) = amplitude(r) \\cdot \\e^{i \\cdot phase(r)}`, where amplitude and phase can be either a float, or custom data array in space
- Similarly, there is a class for time modulation. Right now, we only have `ContinuousWaveTimeModulation`. In the future, we can support custom time modulation.

Back to the medium, because of some considerations in the backend, when both permittivity and conductivity are modulated, currently we restrict that their "time modulation" must be identical.