### PR TITLE
fix bug with freqs as np.ndarray in output monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Properly handle `.freqs` in `output_monitors` of adjoint plugin.
 
 ## [2.4.2] - 2023-9-28
 

--- a/tidy3d/plugins/adjoint/components/base.py
+++ b/tidy3d/plugins/adjoint/components/base.py
@@ -52,18 +52,23 @@ class JaxObject(Tidy3dBaseModel):
                 fix_polyslab(geo_dict["geometry_a"])
                 fix_polyslab(geo_dict["geometry_b"])
 
+        def fix_monitor(mnt_dict: dict) -> None:
+            """Fix a frequency containing monitor."""
+            if "freqs" in mnt_dict:
+                freqs = mnt_dict["freqs"]
+                if isinstance(freqs, np.ndarray):
+                    mnt_dict["freqs"] = freqs.tolist()
+
         # fixes bug with jax handling 2D numpy array in polyslab vertices
         if aux_data.get("type", "") == "JaxSimulation":
             structures = aux_data["structures"]
             for _i, structure in enumerate(structures):
                 geometry = structure["geometry"]
                 fix_polyslab(geometry)
-            monitors = aux_data["monitors"]
-            for _i, monitor in enumerate(monitors):
-                if "freqs" in monitor:
-                    freqs = monitor["freqs"]
-                    if isinstance(freqs, np.ndarray):
-                        monitor["freqs"] = freqs.tolist()
+            for monitor in aux_data["monitors"]:
+                fix_monitor(monitor)
+            for monitor in aux_data["output_monitors"]:
+                fix_monitor(monitor)
 
         return children, aux_data
 


### PR DESCRIPTION
adjoint has the same error as before if an `output_monitor` has `freqs` as a np.ndarray.

we can either fix this in 2.4.3 or try to get it into the 2.5 pre-release