### PR TITLE
2.5 changes

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,11 +15,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        exclude:
-          - platform: macos-latest
-            python-version: '3.7'       
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Internal refactor of Web API functionality.
 - `Geometry.from_gds` doesn't create unecessary groups of single elements.
+- python 3.7 no longer tested.
+- All monitors now have `colocate=True` by default.
 
 ### Fixed
 - Properly handle `.freqs` in `output_monitors` of adjoint plugin.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Internal refactor of Web API functionality.
-- `Geometry.from_gds` doesn't create unecessary groups of single elements.
-- python 3.7 no longer tested.
+- `Geometry.from_gds` doesn't create unnecessary groups of single elements.
+- python 3.7 no longer tested nor supported.
 - All monitors now have `colocate=True` by default.
 
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setuptools.setup(
     ],
     packages=setuptools.find_packages(),
     include_package_data=True,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=core_required,
     extras_require={
         "dev": dev_required,

--- a/tests/test_components/test_monitor.py
+++ b/tests/test_components/test_monitor.py
@@ -235,7 +235,7 @@ def test_monitor_colocate(log_capture):
         interval_space=(1, 2, 3),
     )
     assert monitor.colocate is True
-    assert_log_level(log_capture, "WARNING")
+    assert_log_level(log_capture, None)
 
     monitor = td.FieldMonitor(
         size=(td.inf, td.inf, td.inf),

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -290,24 +290,11 @@ class AbstractFieldMonitor(Monitor, ABC):
     )
 
     colocate: bool = pydantic.Field(
-        None,
+        True,
         title="Colocate fields",
         description="Toggle whether fields should be colocated to grid cell boundaries (i.e. "
-        "primal grid nodes). Default is ``True``.",
+        "primal grid nodes).",
     )
-
-    # TODO: remove after 2.4
-    @pydantic.validator("colocate", always=True)
-    def warn_set_colocate(cls, val):
-        """If ``colocate`` not provided, set to true, but warn that behavior has changed."""
-        if val is None:
-            log.warning(
-                "Default value for the field monitor 'colocate' setting has changed to "
-                "'True' in Tidy3D 2.4.0. All field components will be colocated to the grid "
-                "boundaries. Set to 'False' to get the raw fields on the Yee grid instead."
-            )
-            return True
-        return val
 
 
 class PlanarMonitor(Monitor, ABC):
@@ -653,7 +640,7 @@ class ModeSolverMonitor(AbstractModeMonitor):
         True,
         title="Colocate fields",
         description="Toggle whether fields should be colocated to grid cell boundaries (i.e. "
-        "primal grid nodes). Default is ``True``.",
+        "primal grid nodes).",
     )
 
     def storage_size(self, num_cells: int, tmesh: int) -> int:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    python3.7
     python3.8
     python3.9
     python3.10
@@ -8,7 +7,6 @@ envlist =
 
 [gh-actions]
 python =
-    3.7: python3.7
     3.8: python3.8
     3.9: python3.9
     3.10: python3.10


### PR DESCRIPTION
Just a few things we were going to change for 2.5, before I forget. Might be more, so we can keep this open and add to it as needed or merge whenever.

- Python 3.7 no longer guaranteed to be supported.
- Remove colocation deprecation warning.