### PR TITLE
Test initialization speed of a metalens with 10_000 structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `Geometry.zero_dims` method that uses `Geometry.bounds` and speeds up the validator for zero-sized geometries.
 
 ### Changed
 

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -272,6 +272,15 @@ class Geometry(Tidy3dBaseModel, ABC):
         """
         return Box.from_bounds(*self.bounds)
 
+    @cached_property
+    def zero_dims(self) -> List[Axis]:
+        """A list of axes along which the :class:`Geometry` is zero-sized based on its bounds."""
+        zero_dims = []
+        for dim in range(3):
+            if self.bounds[1][dim] == self.bounds[0][dim]:
+                zero_dims.append(dim)
+        return zero_dims
+
     def _pop_bounds(self, axis: Axis) -> Tuple[Coordinate2D, Tuple[Coordinate2D, Coordinate2D]]:
         """Returns min and max bounds in plane normal to and tangential to ``axis``.
 

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -508,11 +508,11 @@ class Simulation(Box):
             if isinstance(structure.medium, Medium2D):
                 continue
             for geom in flatten_groups(structure.geometry):
-                zero_axes = [ind for ind, ele in enumerate(geom.bounding_box.size) if ele == 0.0]
-                if len(zero_axes) > 0:
+                zero_dims = geom.zero_dims
+                if len(zero_dims) > 0:
                     log.warning(
                         f"Structure at 'structures[{i}]' has geometry with zero size along "
-                        f"dimensions {zero_axes}, and with a medium that is not a 'Medium2D'. "
+                        f"dimensions {zero_dims}, and with a medium that is not a 'Medium2D'. "
                         "This is probably not correct, since the resulting simulation will "
                         "depend on the details of the numerical grid. Consider either "
                         "giving the geometry a nonzero thickness or using a 'Medium2D'."


### PR DESCRIPTION
I was playing with a large metalens file and wanted to profile the initialization time (~2.5 minutes). One thing I noticed is that the new `_validate_2d_geometry_has_2d_medium` validator was taking a noticeable chunk of the time (~50s), essentially because it was working with `geometry.bounding_box` instead of `geometry.bounds`. The former constructs a `Box` object which adds a lot of overhead when dealing with hundreds of thousands of geometries.

This PR does a few things:
- Adds a test for generating a metalens simulation with 10k structures, and the test will fail if this doesn't work within 3s. Currently, it succeeds in about 2.1s, so if something heavy gets added inadvertently, this should alert us.
- Introduces a `Profile` context in `tests/utils.py` and uses that in the test to display output (if run with `pytest -rA`) that can help us figure out what can be improved.
- Fixes the inefficiency of the 2d geometry validator.

Here are the first lines of profiling at the current state. The main thing that we may want to look at at some point is `correct_shape`. This is specific to the usage of PolySlab. I also looked at just cylinders, and there the pydantic built-ins were dominating, like this `validate_singleton`. I don't know what this is about.

```
10026/10005    0.027    0.000    2.119    0.000 /home/momchil/Drive/flexcompute/tidy3d-core/tidy3d_frontend/tidy3d/components/base.py:90(__init__)
10028/10015    0.019    0.000    2.063    0.000 /home/momchil/miniconda3/envs/flex/lib/python3.9/site-packages/pydantic/v1/main.py:332(__init__)
10028/10015    0.154    0.000    2.018    0.000 /home/momchil/miniconda3/envs/flex/lib/python3.9/site-packages/pydantic/v1/main.py:1032(validate_model)
110223/70072    0.082    0.000    1.801    0.000 /home/momchil/miniconda3/envs/flex/lib/python3.9/site-packages/pydantic/v1/fields.py:852(validate)
110202/110116    0.077    0.000    1.582    0.000 /home/momchil/miniconda3/envs/flex/lib/python3.9/site-packages/pydantic/v1/fields.py:1152(_apply_validators)
    20028    0.012    0.000    0.982    0.000 /home/momchil/miniconda3/envs/flex/lib/python3.9/site-packages/pydantic/v1/class_validators.py:304(<lambda>)
    10000    0.081    0.000    0.889    0.000 /home/momchil/Drive/flexcompute/tidy3d-core/tidy3d_frontend/tidy3d/components/geometry/polyslab.py:76(correct_shape)
    80040    0.167    0.000    0.668    0.000 /home/momchil/miniconda3/envs/flex/lib/python3.9/site-packages/shapely/decorators.py:62(wrapped)
110182/90163    0.036    0.000    0.431    0.000 /home/momchil/miniconda3/envs/flex/lib/python3.9/site-packages/pydantic/v1/fields.py:1056(_validate_singleton)
    10013    0.018    0.000    0.351    0.000 /home/momchil/miniconda3/envs/flex/lib/python3.9/site-packages/shapely/geometry/polygon.py:221(__new__)
   130175    0.043    0.000    0.267    0.000 /home/momchil/miniconda3/envs/flex/lib/python3.9/site-packages/pydantic/v1/class_validators.py:337(<lambda>)
20034/20032    0.009    0.000    0.234    0.000 /home/momchil/miniconda3/envs/flex/lib/python3.9/site-packages/pydantic/v1/class_validators.py:306(<lambda>)
80054/10028    0.021    0.000    0.200    0.000 /home/momchil/Drive/flexcompute/tidy3d-core/tidy3d_frontend/tidy3d/components/base.py:36(cached_property_getter)
    10013    0.026    0.000    0.169    0.000 /home/momchil/miniconda3/envs/flex/lib/python3.9/site-packages/shapely/geometry/polygon.py:62(__new__)
        3    0.000    0.000    0.144    0.048 /home/momchil/Drive/flexcompute/tidy3d-core/tidy3d_frontend/tidy3d/components/validators.py:160(objects_in_sim_bounds)
        8    0.000    0.000    0.144    0.018 /home/momchil/Drive/flexcompute/tidy3d-core/tidy3d_frontend/tidy3d/components/geometry/base.py:180(intersects)
        1    0.001    0.001    0.143    0.143 /home/momchil/Drive/flexcompute/tidy3d-core/tidy3d_frontend/tidy3d/components/geometry/base.py:1994(bounds)
    10001    0.003    0.000    0.134    0.000 /home/momchil/Drive/flexcompute/tidy3d-core/tidy3d_frontend/tidy3d/components/geometry/base.py:2004(<genexpr>)
    10001    0.009    0.000    0.133    0.000 /home/momchil/miniconda3/envs/flex/lib/python3.9/site-packages/shapely/geometry/polygon.py:248(interiors)
    10000    0.040    0.000    0.125    0.000 /home/momchil/Drive/flexcompute/tidy3d-core/tidy3d_frontend/tidy3d/components/geometry/polyslab.py:875(bounds)
```