### PR TITLE
unpin boto3

### DIFF
--- a/requirements/web.txt
+++ b/requirements/web.txt
@@ -1,6 +1,6 @@
 # to use the web interface (needed to run tasks)
 
-boto3==1.23.1
+boto3
 requests
 pyjwt
 click==8.0.3


### PR DESCRIPTION
Unpin boto3

allows you to have a more recent version of urlib

some of the gdsfactory plugins require a newer version of urlib

I think pinning to old dependencies is a bad practice, ideally one has a lower and max range where things get tested

```
File /opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/botocore/utils.py:34
     32 import botocore
     33 import botocore.awsrequest
---> 34 import botocore.httpsession
     36 # IP Regexes retained for backwards compatibility
     37 from botocore.compat import HEX_PAT  # noqa: F401

File /opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/botocore/httpsession.py:21
     19 from urllib3.exceptions import SSLError as URLLib3SSLError
     20 from urllib3.util.retry import Retry
---> 21 from urllib3.util.ssl_ import (
     22     DEFAULT_CIPHERS,
     23     OP_NO_COMPRESSION,
     24     PROTOCOL_TLS,
     25     OP_NO_SSLv2,
     26     OP_NO_SSLv3,
     27     is_ipaddress,
     28     ssl,
     29 )
     30 from urllib3.util.url import parse_url
     32 try:

ImportError: cannot import name 'DEFAULT_CIPHERS' from 'urllib3.util.ssl_' (/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/site-packages/urllib3/util/ssl_.py)
```
