### PR TITLE
unpin boto and click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GDSII export functions to `Simulation`, `Structure`, and `Geometry`.
 
 ### Changed
+- Update versions of `boto3`, `requests`, and `click`.
 
 ### Fixed
 

--- a/requirements/web.txt
+++ b/requirements/web.txt
@@ -1,7 +1,7 @@
 # to use the web interface (needed to run tasks)
 
-boto3==1.23.1
-requests
+boto3==1.28.*
+requests==2.31.*
 pyjwt
-click==8.0.3
+click==8.1.*
 responses


### PR DESCRIPTION
This unpins the versions of boto and click, see #1209 

I tested with our webapi notebook with
```
click==8.0.3
boto3==1.23.1
```
 and it worked fine 

@magiWei do you see any issues with this?
