### PR TITLE
handle case with no adjoint sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove warning that monitors now have `colocate=True` by default.
 
 ### Fixed
+- If no adjoint sources for one simulation in an objective function, make a mock source with zero amplitude and warn user.
 
 ## [2.5.0rc1] - 2023-10-10
 


### PR DESCRIPTION
This is a quick and dirty way of fixing things, but it should work. If no adjoint sources detected:
* make a point dipole at the center of the simulation with amplitude=0
* set the run time to something around 1/fwidth to avoid unnecessary long runtime.

This assumes that the simulation will still run if the only source has an amplitude of 0. @momchil-flex do you know? If there was some auto-detection of this case (or when no sources are present) that returned zero'd out data that could be another way to handle things.

Main downside of this is that it charges a useless simulation to the user, but I think to do this properly would require a lot of construction, so I wanted to throw this out there to discuss as a medium-short term fix to this relatively uncommon edge case.

I also am not sure how to set a reliably small run_time. Maybe something >0 but small like 1e-20 would be another approach? 

#1217 