### PR TITLE
Truncate circular filter in edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed the duplication of log messages in Jupyter when `set_logging_file` is used.
+- If input to circular filters in adjoint have size smaller than the diameter, instead of erroring, warn user and truncate the filter kernel accordingly.
 
 ## [2.5.0rc2] - 2023-10-30
 

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -1473,6 +1473,20 @@ def test_adjoint_utils(strict_binarize):
     _ = radius_penalty.evaluate(polyslab.vertices)
 
 
+@pytest.mark.parametrize(
+    "input_size_y, log_level_expected", [(13, None), (12, "WARNING"), (11, "WARNING"), (14, None)]
+)
+def test_adjoint_filter_sizes(log_capture, input_size_y, log_level_expected):
+    """Warn if filter size along a dim is smaller than radius."""
+
+    signal_in = np.ones((266, input_size_y))
+
+    _filter = ConicFilter(radius=0.08, design_region_dl=0.015)
+    _filter.evaluate(signal_in)
+
+    assert_log_level(log_capture, log_level_expected)
+
+
 def test_sim_data_plot_field(use_emulated_run):
     """Test splitting of regular simulation data into user and server data."""
 


### PR DESCRIPTION
If the filter radius was larger than the input array (in pixels) along any dimension, scipy raised an error.

Now, we log a warning and truncate the kernel along that dimension to match the input shape (note that the kernel is odd, so it might be 1 smaller if the input shape is even)

I also added a switch if we want to instead raise, maybe this is unnecessary.