### PR TITLE
Fix bug in eps_model for integer frequency arrays

### DIFF
--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -113,6 +113,9 @@ def test_medium_dispersion():
         eps_c = medium.eps_model(freqs)
         assert np.all(eps_c.imag >= 0)
 
+    # test eps_model for int arguments
+    m_SM.eps_model(np.array([1, 2]))
+
 
 def test_medium_dispersion_conversion():
 

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -58,6 +58,7 @@ def ensure_freq_in_range(eps_model: Callable[[float], complex]) -> Callable[[flo
             frequency = FREQ_EVAL_INF
 
         if isinstance(frequency, np.ndarray):
+            frequency = frequency.astype(float)
             frequency[np.where(np.isinf(frequency))] = FREQ_EVAL_INF
 
         # if frequency range not present just return original function


### PR DESCRIPTION
Previously, the following
```
import tidy3d as td
td.Medium(permittivity=2).eps_model(np.array([1,2]))
```
gave an error:
```
OverflowError: Python int too large to convert to C long
```