### PR TITLE
Correctly handle 2D/1D custom medium when exporting to GDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - If input to circular filters in adjoint have size smaller than the diameter, instead of erroring, warn user and truncate the filter kernel accordingly.
 - When writing the json string of a model to an `hdf5` file, the string is split into chunks if it has more than a set (very large) number of characters. This fixes potential error if the string size is more than 4GB.
 - Proper equality checking between `Tidy3dBaseModel` instances, which takes `DataArray` values and coords into account and handles `np.ndarray` types.
+- Correctly set the contour length scale when exporting 2D (or 1D) structures with custom medium to GDSII.
 
 
 ## [2.5.0rc2] - 2023-10-30


### PR DESCRIPTION
The 0D case is also handled just to avoid an obscure error.