### PR TITLE
adds `SimulationData.mnt_data_from_file()` method to load individual `MonitorData`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Can create `PoleResidue` from LO-TO form via `PoleResidue.from_lo_to`.
 
 - Support for an anisotropic medium containing PEC components.
+- `SimulationData.mnt_data_from_file()` method to load only a single monitor data object from a simulation data `.hdf5` file.
 
 ### Changed
 - Indent for the json string of Tidy3D models has been changed to `None` when used internally; kept as `indent=4` for writing to `json` and `yaml` files.


### PR DESCRIPTION
Syntax:
```py
mnt_data = SimulationData.mnt_data_from_file(fname, mnt_name, **kwargs)
```
loads a monitor data from a subgroup in the `SimulationData` file.

1. grabs the `JSON_STRING` to get the monitor type info.
2. Looks up the proper `MonitorDataType`
3. Iterates through the hdf5 file until a match is found on monitor name
4. Uses `MonitorData.from_file()` with a constructed group path to do the loading.

Some error checking thrown in, only works with `.hdf5` files at the moment.
