### PR TITLE
Removing special direction='-' handling in adjoint sources after solv…

### DIFF
--- a/tidy3d/plugins/adjoint/components/data/monitor_data.py
+++ b/tidy3d/plugins/adjoint/components/data/monitor_data.py
@@ -91,8 +91,6 @@ class JaxModeData(JaxMonitorData, ModeData):
             k0 = 2 * np.pi * freq / C_0
             grad_const = k0 / 4 / ETA_0
             src_amp = grad_const * amp
-            if direction == "-":
-                src_amp *= -1
 
             src_direction = self.flip_direction(str(direction))
 


### PR DESCRIPTION
No longer needed after the fix [here](https://github.com/flexcompute/tidy3d-core/pull/451).