### PR TITLE
Fix Component Modeler Batch Path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for two-photon absorption via `TwoPhotonAbsorption` class. Added `KerrNonlinearity` that implements Kerr effect without third-harmonic generation.
 - Can create `PoleResidue` from LO-TO form via `PoleResidue.from_lo_to`.
-
 - Support for an anisotropic medium containing PEC components.
 - `SimulationData.mnt_data_from_file()` method to load only a single monitor data object from a simulation data `.hdf5` file.
+- `_hash_self` to base model, uses `hashlib` to hash a Tidy3D component the same way every session.
 
 ### Changed
 - Indent for the json string of Tidy3D models has been changed to `None` when used internally; kept as `indent=4` for writing to `json` and `yaml` files.
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved error handling if file can not be downloaded from server.
 - Fix for detection of file extensions for file names with dots.
 - Restrict to `matplotlib` >= 3.5, avoiding bug in plotting `CustomMedium`.
+- Fixes `ComponentModeler` batch file being different in different sessions by use of deterministic hash function for computing batch filename.
 
 ## [2.5.0rc2] - 2023-10-30
 

--- a/tests/test_plugins/test_component_modeler.py
+++ b/tests/test_plugins/test_component_modeler.py
@@ -369,3 +369,8 @@ def test_mapping_exclusion(monkeypatch, tmp_path):
 
     s_matrix = run_component_modeler(monkeypatch, modeler)
     _test_mappings(element_mappings, s_matrix)
+
+
+def test_batch_filename(tmp_path):
+    modeler = make_component_modeler(path_dir=str(tmp_path))
+    path = modeler._batch_path

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -8,6 +8,8 @@ import tempfile
 from functools import wraps
 from typing import List, Callable, Dict, Union, Tuple, Any
 from math import ceil
+import io
+import hashlib
 
 import rich
 import pydantic.v1 as pydantic
@@ -98,6 +100,12 @@ class Tidy3dBaseModel(pydantic.BaseModel):
             return super().__hash__(self)
         except TypeError:
             return hash(self.json())
+
+    def _hash_self(self) -> str:
+        """Hash this component with ``hashlib`` in a way that is the same every session."""
+        bf = io.BytesIO()
+        self.to_hdf5(bf)
+        return hashlib.sha256(bf.getvalue()).hexdigest()
 
     def __init__(self, **kwargs):
         """Init method, includes post-init validators."""

--- a/tidy3d/plugins/smatrix/smatrix.py
+++ b/tidy3d/plugins/smatrix/smatrix.py
@@ -349,7 +349,8 @@ class ComponentModeler(Tidy3dBaseModel):
     @cached_property
     def _batch_path(self) -> str:
         """Where we store the batch for this ComponentModeler instance after the run."""
-        return os.path.join(self.path_dir, "batch" + str(hash(self)) + ".json")
+        hash_str = self._hash_self()
+        return os.path.join(self.path_dir, "batch" + hash_str + ".json")
 
     def _run_sims(self, path_dir: str = DEFAULT_DATA_DIR) -> BatchData:
         """Run :class:`Simulations` for each port and return the batch after saving."""


### PR DESCRIPTION
Uses deterministic hash for the batch path that doesn't change between sessions