### PR TITLE
Ensuring mode solver fields are returned in requested precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restrict to `matplotlib` >= 3.5, avoiding bug in plotting `CustomMedium`.
 - Fixes `ComponentModeler` batch file being different in different sessions by use of deterministic hash function for computing batch filename.
 - Can pass `kwargs` to `ComponentModeler.plot_sim()` to use in `Simulation.plot()`.
-- Fixed a couple bugs in the handling of 2D PEC materials.
-
+- Ensure that mode solver fields are returned in single precision if `ModeSolver.ModeSpec.precision == "single"`.
 
 ## [2.5.0rc2] - 2023-10-30
 

--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -162,7 +162,7 @@ def compare_colocation(ms):
     for key, field in data_col.field_components.items():
 
         # Check the colocated data is the same
-        assert np.allclose(data_at_boundaries[key], field)
+        assert np.allclose(data_at_boundaries[key], field, atol=1e-7)
 
         # Also check coordinates
         for dim, coords1 in field.coords.items():
@@ -201,6 +201,15 @@ def verify_pol_fraction(ms):
             pol_frac_wg[filter_pol].isel(mode_index=0).values
             > pol_frac_wg[other_pol].isel(mode_index=0).values
         )
+
+
+def verify_dtype(ms):
+    """Verify that the returned fields have the correct dtype w.r.t. the specified precision."""
+
+    dtype = np.complex64 if ms.mode_spec.precision == "single" else np.complex128
+    for field in ms.data.field_components.values():
+        print(dtype, field.dtype, type(field.dtype))
+        assert dtype == field.dtype
 
 
 def test_mode_solver_validation():
@@ -295,6 +304,7 @@ def test_mode_solver_simple(mock_remote_api, local):
     if local:
         compare_colocation(ms)
         verify_pol_fraction(ms)
+        verify_dtype(ms)
         dataframe = ms.data.to_dataframe()
 
     else:
@@ -458,6 +468,7 @@ def test_mode_solver_angle_bend():
     )
     compare_colocation(ms)
     verify_pol_fraction(ms)
+    verify_dtype(ms)
     dataframe = ms.data.to_dataframe()
 
     # Plot field
@@ -493,6 +504,7 @@ def test_mode_solver_2D():
     )
     compare_colocation(ms)
     verify_pol_fraction(ms)
+    verify_dtype(ms)
     dataframe = ms.data.to_dataframe()
 
     mode_spec = td.ModeSpec(

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -1121,7 +1121,8 @@ class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
                 ]
 
             # Apply phase shift
-            field_sorted.data = field_sorted.data * np.exp(-1j * phase[None, None, None, :, :])
+            phase_fact = np.exp(-1j * phase[None, None, None, :, :]).astype(field_sorted.data.dtype)
+            field_sorted.data = field_sorted.data * phase_fact
 
             update_dict[field_name] = field_sorted
 

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -570,7 +570,10 @@ class ModeSolverMonitor(AbstractModeMonitor):
 
     def storage_size(self, num_cells: int, tmesh: int) -> int:
         """Size of monitor storage given the number of points after discretization."""
-        return 6 * BYTES_COMPLEX * num_cells * len(self.freqs) * self.mode_spec.num_modes
+        bytes_single = 6 * BYTES_COMPLEX * num_cells * len(self.freqs) * self.mode_spec.num_modes
+        if self.mode_spec.precision == "double":
+            return 2 * bytes_single
+        return bytes_single
 
 
 class FieldProjectionSurface(Tidy3dBaseModel):

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -310,7 +310,7 @@ class ModeSolver(Tidy3dBaseModel):
         # Colocate input data to new coordinates
         data_dict_colocated = {}
         for key, field in mode_solver_data.symmetry_expanded.field_components.items():
-            data_dict_colocated[key] = field.interp(**colocate_coords)
+            data_dict_colocated[key] = field.interp(**colocate_coords).astype(field.dtype)
 
         # Update data
         mode_solver_monitor = self.to_mode_solver_monitor(name=MODE_MONITOR_NAME)

--- a/tidy3d/plugins/mode/solver.py
+++ b/tidy3d/plugins/mode/solver.py
@@ -198,6 +198,10 @@ class EigSolver(Tidy3dBaseModel):
 
         fields = np.stack((E, H), axis=0)
 
+        if mode_spec.precision == "single":
+            # Recast to single precision which may have changed due to earlier manipulations
+            fields = fields.astype(np.complex64)
+
         return fields, neff + 1j * keff, eps_spec
 
     @classmethod


### PR DESCRIPTION
This was motivated by two things when using the default single precision:
- Smaller file size for download
- Smaller chance of OOM which can sometimes happen for very large mode solves in the post-processing (colocating, normalizing, sorting modes).