### PR TITLE
Enforcing limits on the internal memory needed by monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - API for specifying one or more nonlinear models via `NonlinearSpec.models`.
 - `freqs` and `direction` are optional in `ModeSolver` methods converting to monitor and source, respectively. If not supplied, uses the values from the `ModeSolver` instance calling the method.
 - Removed spurious ``-1`` factor in field amplitudes injected by field sources in some cases. The injected ``E``-field should now exactly match the analytic, mode, or custom fields that the source is expected to inject, both in the forward and in the backward direction.
+- Restriction on the maximum memory that a monitor would need internally during the solver run, even if the final monitor data is smaller.
+- Restriction on the maximum size of mode solver data produced by a `ModeSolver` server call.
 
 ### Fixed
 - Fixed the duplication of log messages in Jupyter when `set_logging_file` is used.

--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -11,6 +11,7 @@ from tidy3d.plugins.mode import ModeSolver
 from tidy3d.plugins.mode.mode_solver import MODE_MONITOR_NAME
 from tidy3d.plugins.mode.derivatives import create_sfactor_b, create_sfactor_f
 from tidy3d.plugins.mode.solver import compute_modes
+from tidy3d.exceptions import SetupError
 from ..utils import assert_log_level, log_capture
 from tidy3d import ScalarFieldDataArray
 from tidy3d.web.core.environment import Env
@@ -242,6 +243,17 @@ def test_mode_solver_validation():
         freqs=[1e12],
         direction="+",
     )
+
+    # mode data too large
+    simulation = td.Simulation(
+        size=SIM_SIZE,
+        grid_spec=td.GridSpec.uniform(dl=0.001),
+        run_time=1e-12,
+    )
+    ms = ms.updated_copy(simulation=simulation, freqs=np.linspace(1e12, 2e12, 50))
+
+    with pytest.raises(SetupError):
+        ms.validate_pre_upload()
 
 
 @pytest.mark.parametrize("group_index_step, log_level", ((1e-7, "WARNING"), (1e-5, "INFO")))

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -1077,7 +1077,7 @@ class Simulation(AbstractSimulation):
         num_cells = self.discretize_monitor(monitor).num_cells
         # take monitor downsampling into account
         num_cells = monitor.downsampled_num_cells(num_cells)
-        return np.prod(num_cells)
+        return np.prod(np.array(num_cells, dtype=np.int64))
 
     def _validate_datasets_not_none(self) -> None:
         """Ensures that all custom datasets are defined."""

--- a/tidy3d/web/api/mode.py
+++ b/tidy3d/web/api/mode.py
@@ -183,6 +183,7 @@ class ModeSolverTask(ResourceLifecycle, Submittable, extra=pydantic.Extra.allow)
         """
         folder = Folder.get(folder_name, create=True)
 
+        mode_solver.validate_pre_upload()
         mode_solver.simulation.validate_pre_upload(source_required=False)
         resp = http.post(
             MODESOLVER_API,


### PR DESCRIPTION
Currently, monitors that produce a small amount of data but may need a large amount of memory internally are not really validated to prevent OOM on our servers. I was thinking on imposing some limits like max number of freqs, or product of num_freqs x num_points x num_modes for mode monitors, etc. but I realized what probably makes the most sense is restricting the data size of the associated *field* monitor, which is always needed internally.