### PR TITLE
Support conformal mesh for PEC structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Users can toggle https ssl version through `from tidy3d.web.core.environment import Env` and `Env.set_ssl_version(ssl_version: ssl.TLSVersion)`
 - Free-carrier absorption (FCA) and free-carrier plasma dispersion (FCPD) nonlinearities inside `TwoPhotonAbsorption` class.
 - `log_path` argument in `set_logging_file`, set to `False` by default.
+- Added support for conformal mesh methods near PEC structures that can be specified through the field `pec_conformal_mesh_spec` in the `Simulation` class.
 
 ### Changed
 - `DataArray.to_hdf5()` accepts both file handles and file paths.

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -1875,6 +1875,34 @@ def test_dt():
     assert sim_new.dt == 0.4 * dt
 
 
+def test_conformal_dt():
+    """make sure dt is reduced when BenklerConformalMeshSpec is applied."""
+    sim = td.Simulation(
+        size=(2.0, 2.0, 2.0),
+        run_time=1e-12,
+        grid_spec=td.GridSpec.uniform(dl=0.1),
+    )
+    dt = sim.dt
+
+    # Benkler
+    sim_conformal = sim.updated_copy(pec_conformal_mesh_spec=td.BenklerConformalMeshSpec())
+    assert sim_conformal.dt < dt
+
+    # Benkler: same courant
+    sim_conformal2 = sim.updated_copy(
+        pec_conformal_mesh_spec=td.BenklerConformalMeshSpec(timestep_reduction=0)
+    )
+    assert sim_conformal2.dt == dt
+
+    # staircasing
+    sim_staircasing = sim.updated_copy(pec_conformal_mesh_spec=td.StaircasingConformalMeshSpec())
+    assert sim_staircasing.dt == dt
+
+    # heuristic
+    sim_heuristic = sim.updated_copy(pec_conformal_mesh_spec=td.StaircasingConformalMeshSpec())
+    assert sim_heuristic.dt == dt
+
+
 def test_sim_volumetric_structures(log_capture, tmp_path):  # noqa F811
     """Test volumetric equivalent of 2D materials."""
     sigma = 0.45

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -3,6 +3,8 @@
 # grid
 from .components.grid.grid import Grid, Coords
 from .components.grid.grid_spec import GridSpec, UniformGrid, CustomGrid, AutoGrid
+from .components.grid.grid_spec import BenklerConformalMeshSpec, StaircasingConformalMeshSpec
+from .components.grid.grid_spec import HeuristicConformalMeshSpec
 
 # geometry
 from .components.geometry.base import Box, Transformed, ClipOperation, GeometryGroup
@@ -327,4 +329,7 @@ __all__ = [
     "TriangularGridDataset",
     "TetrahedralGridDataset",
     "medium_from_nk",
+    "BenklerConformalMeshSpec",
+    "StaircasingConformalMeshSpec",
+    "HeuristicConformalMeshSpec",
 ]

--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -9,7 +9,7 @@ import pydantic.v1 as pd
 
 from .grid import Coords1D, Coords, Grid
 from .mesher import GradedMesher, MesherType
-from ..base import Tidy3dBaseModel
+from ..base import Tidy3dBaseModel, cached_property
 from ..types import Axis, Symmetry, annotate_type, TYPE_TAG_STR
 from ..source import SourceType
 from ..structure import Structure, StructureType
@@ -17,6 +17,61 @@ from ..geometry.base import Box
 from ...log import log
 from ...exceptions import SetupError
 from ...constants import MICROMETER, C_0, fp_eps
+
+# Default Courant number reduction rate in Benkler's scheme
+DEFAULT_COURANT_REDUCTION_BENKLER = 0.3
+
+
+class ConformalMeshSpec(Tidy3dBaseModel, ABC):
+    """Base class defining conformal mesh specifications."""
+
+    @cached_property
+    def courant_ratio(self) -> float:
+        """The scaling ratio applied to Courant number so that the courant number
+        in the simulation is ``sim.courant * courant_ratio``.
+        """
+        return 1.0
+
+
+class StaircasingConformalMeshSpec(ConformalMeshSpec):
+    """Simple staircasing scheme based on
+    [Taflove, The Electrical Engineering Handbook 3.629-670 (2005): 15.].
+    """
+
+
+class HeuristicConformalMeshSpec(ConformalMeshSpec):
+    """Slightly different from the staircasing scheme: the field component near PEC
+    is considered to be outside PEC if it's substantially normal to the interface.
+    """
+
+
+class BenklerConformalMeshSpec(ConformalMeshSpec):
+    """Conformal mesh scheme based on
+    [S. Benkler, IEEE Transactions on Antennas and Propagation 54.6, 1843 (2006)], which is similar
+    to the approach described in [S. Dey, R. Mittra, IEEE Microwave and Guided Wave Letters 7.9, 273 (1997)].
+    """
+
+    timestep_reduction: float = pd.Field(
+        DEFAULT_COURANT_REDUCTION_BENKLER,
+        title="Time Step Size Reduction Rate",
+        description="Reduction factor between 0 and 1 such that the simulation's time step number "
+        "will be '1-courant_reduction_rate' times its default value. "
+        "Accuracy can be improved with a smaller time step size; but simulation time increased as well.",
+        lt=1,
+        ge=0,
+    )
+
+    @cached_property
+    def courant_ratio(self) -> float:
+        """The scaling ratio applied to Courant number so that the courant number
+        in the simulation is ``sim.courant * courant_ratio``.
+        """
+        return 1 - self.timestep_reduction
+
+
+ConformalMeshSpecType = Union[
+    BenklerConformalMeshSpec, StaircasingConformalMeshSpec, HeuristicConformalMeshSpec
+]
 
 
 class GridSpec1d(Tidy3dBaseModel, ABC):

--- a/tidy3d/plugins/mode/solver.py
+++ b/tidy3d/plugins/mode/solver.py
@@ -34,6 +34,8 @@ class EigSolver(Tidy3dBaseModel):
         coords,
         freq,
         mode_spec,
+        mu_cross=None,
+        split_curl_scaling=None,
         symmetry=(0, 0),
         direction="+",
     ) -> Tuple[Numpy, Numpy, EpsSpecType]:
@@ -54,6 +56,18 @@ class EigSolver(Tidy3dBaseModel):
             (Hertz) Frequency at which the eigenmodes are computed.
         mode_spec : ModeSpec
             ``ModeSpec`` object containing specifications of the mode solver.
+        mu_cross : array_like or tuple of array_like
+            Either a single 2D array defining the relative permeability in the cross-section,
+            or nine 2D arrays defining the permeability at the Hx, Hy, and Hz locations
+            of the Yee grid in the order xx, xy, xz, yx, yy, yz, zx, zy, zz.
+            Set to 1 if `None`.
+        split_curl_scaling : tuple of array_like
+            Split curl coefficient to Curl E. Three 2D arrays defining the scaling factor
+            at the Ex, Ey, and Ez locations of the Yee grid in the order xx, yy, zz.
+            Following Benkler's approach, we formulate it as the following:
+            1) during mode solver: eps_cross -> eps_corss / scaling, so eigenvector is E * scaling
+            2) in postprocessing: apply scaling^-1 to eigenvector to obtain E
+        direction : Union["+", "-"]
         direction : Union["+", "-"]
             Direction of mode propagation.
 
@@ -72,15 +86,14 @@ class EigSolver(Tidy3dBaseModel):
         angle_phi = mode_spec.angle_phi
         omega = 2 * np.pi * freq
         k0 = omega / C_0
+        enable_incidence_matrices = split_curl_scaling is not None or mu_cross is not None
 
-        if isinstance(eps_cross, Numpy):
-            eps_xx, eps_xy, eps_xz, eps_yx, eps_yy, eps_yz, eps_zx, eps_zy, eps_zz = eps_cross
-        elif len(eps_cross) == 9:
-            eps_xx, eps_xy, eps_xz, eps_yx, eps_yy, eps_yz, eps_zx, eps_zy, eps_zz = (
-                np.copy(e) for e in eps_cross
-            )
-        else:
-            raise ValueError("Wrong input to mode solver pemittivity!")
+        eps_formated = cls.format_medium_data(eps_cross)
+        eps_xx, eps_xy, eps_xz, eps_yx, eps_yy, eps_yz, eps_zx, eps_zy, eps_zz = eps_formated
+
+        mu_formated = None
+        if mu_cross is not None:
+            mu_formated = cls.format_medium_data(mu_cross)
 
         Nx, Ny = eps_xx.shape
         N = eps_xx.size
@@ -95,16 +108,31 @@ class EigSolver(Tidy3dBaseModel):
         (2N, 2N), and the full tensorial case, in which case it has shape (4N, 4N)."""
         eps_tensor = np.zeros((3, 3, N), dtype=np.complex128)
         mu_tensor = np.zeros((3, 3, N), dtype=np.complex128)
+        identity_tensor = np.zeros((3, 3, N), dtype=np.complex128)
         for row, eps_row in enumerate(
             [[eps_xx, eps_xy, eps_xz], [eps_yx, eps_yy, eps_yz], [eps_zx, eps_zy, eps_zz]]
         ):
-            mu_tensor[row, row, :] = 1.0
+            identity_tensor[row, row, :] = 1.0
             for col, eps in enumerate(eps_row):
+                if split_curl_scaling is not None and col == row:
+                    outside_pec = ~np.isclose(split_curl_scaling[col], 0)
+                    eps[outside_pec] /= split_curl_scaling[col][outside_pec]
+
                 eps_tensor[row, col, :] = eps.ravel()
 
+        if mu_formated is not None:
+            mu_xx, mu_xy, mu_xz, mu_yx, mu_yy, mu_yz, mu_zx, mu_zy, mu_zz = mu_formated
+            for row, mu_row in enumerate(
+                [[mu_xx, mu_xy, mu_xz], [mu_yx, mu_yy, mu_yz], [mu_zx, mu_zy, mu_zz]]
+            ):
+                for col, mu in enumerate(mu_row):
+                    mu_tensor[row, col, :] = mu.ravel()
+        else:
+            mu_tensor = np.copy(identity_tensor)
+
         # Get Jacobian of all coordinate transformations. Initialize as identity (same as mu so far)
-        jac_e = np.real(np.copy(mu_tensor))
-        jac_h = np.real(np.copy(mu_tensor))
+        jac_e = np.real(np.copy(identity_tensor))
+        jac_h = np.real(np.copy(identity_tensor))
 
         if bend_radius is not None:
             new_coords, jac_e, jac_h = radial_transform(new_coords, bend_radius, bend_axis)
@@ -187,10 +215,13 @@ class EigSolver(Tidy3dBaseModel):
             target_neff_p,
             mode_spec.precision,
             direction,
+            enable_incidence_matrices,
         )
 
         # Transform back to original axes, E = J^T E'
         E = np.sum(jac_e[..., None] * E[:, None, ...], axis=0)
+        if split_curl_scaling is not None:
+            E = cls.split_curl_field_postprocess(split_curl_scaling, E)
         E = E.reshape((3, Nx, Ny, 1, num_modes))
         H = np.sum(jac_h[..., None] * H[:, None, ...], axis=0)
         H = H.reshape((3, Nx, Ny, 1, num_modes))
@@ -217,6 +248,7 @@ class EigSolver(Tidy3dBaseModel):
         neff_guess,
         mat_precision,
         direction,
+        enable_incidence_matrices,
     ):
         """Solve for the electromagnetic modes of a system defined by in-plane permittivity and
         permeability and assuming translational invariance in the normal direction.
@@ -289,7 +321,9 @@ class EigSolver(Tidy3dBaseModel):
 
         if not is_tensorial:
             eps_spec = "diagonal"
-            E, H, neff, keff = cls.solver_diagonal(**kwargs)
+            E, H, neff, keff = cls.solver_diagonal(
+                **kwargs, enable_incidence_matrices=enable_incidence_matrices
+            )
             if direction == "-":
                 H[0] *= -1
                 H[1] *= -1
@@ -343,11 +377,20 @@ class EigSolver(Tidy3dBaseModel):
         mat.eliminate_zeros()
 
     @classmethod
-    def solver_diagonal(cls, eps, mu, der_mats, num_modes, neff_guess, vec_init, mat_precision):
+    def solver_diagonal(
+        cls,
+        eps,
+        mu,
+        der_mats,
+        num_modes,
+        neff_guess,
+        vec_init,
+        mat_precision,
+        enable_incidence_matrices,
+    ):
         """EM eigenmode solver assuming ``eps`` and ``mu`` are diagonal everywhere."""
 
         # code associated with these options is included below in case it's useful in the future
-        enable_incidence_matrices = False
         enable_preconditioner = False
         analyze_conditioning = False
 
@@ -738,6 +781,38 @@ class EigSolver(Tidy3dBaseModel):
             return neff, keff
 
         raise RuntimeError(f"Unidentified 'mode_solver_type={mode_solver_type}'.")
+
+    @staticmethod
+    def format_medium_data(mat_data):
+        """
+        mat_data can be either permittivity or permeability. It's either a single 2D array
+        defining the relative property in the cross-section, or nine 2D arrays defining
+        the property at the E(H)x, E(H)y, and E(H)z locations of the Yee grid in the order
+        xx, xy, xz, yx, yy, yz, zx, zy, zz.
+        """
+        if isinstance(mat_data, Numpy):
+            return (mat_data[i, :, :] for i in range(9))
+        if len(mat_data) == 9:
+            return (np.copy(e) for e in mat_data)
+        raise ValueError("Wrong input to mode solver pemittivity/permeability!")
+
+    @staticmethod
+    def split_curl_field_postprocess(split_curl, E):
+        """E has the shape (3, N, num_modes)"""
+        _, Nx, Ny = split_curl.shape
+        field_shape = E.shape
+
+        # set a dummy value of split curl inside PEC to avoid division by 0 warning (it's 0/0, since
+        # E field inside PEC is also 0); then by the end, zero out E inside PEC again just to be safe.
+        outside_pec = ~np.isclose(split_curl, 0)
+        split_curl_scaling = np.copy(split_curl)
+        split_curl_scaling[~outside_pec] = 1.0
+
+        E = E.reshape(3, Nx, Ny, field_shape[-1])
+        E /= split_curl_scaling[:, :, :, np.newaxis]
+        E *= outside_pec[:, :, :, np.newaxis]
+        E = E.reshape(field_shape)
+        return E
 
 
 def compute_modes(*args, **kwargs) -> Tuple[Numpy, Numpy, str]:


### PR DESCRIPTION
Mode solver: the formulation of mode solver will follow the treatment in Benkler's paper (10.1109/TAP.2006.875909), where the split curl is treated as scaled permittivity and E-field. In the end of the mode solver, the E-field is scaled back. 

We also enable `incidence_matrix` when PEC subpixel is applied.

- [x] Support mu_cross
- [x] Support split_curl coefficient
- [x] Set fields to be 0 inside PEC