### PR TITLE
On the fly vtk import

### DIFF
--- a/tests/test_data/_test_datasets_no_vtk.py
+++ b/tests/test_data/_test_datasets_no_vtk.py
@@ -24,7 +24,7 @@ def test_triangular_dataset_no_vtk(tmp_path):
     # double check that vtk was not imported
     from tidy3d.components.types import vtk
 
-    assert vtk is None
+    assert vtk["mod"] is None
 
 
 @pytest.mark.usefixtures("hide_vtk")
@@ -34,4 +34,4 @@ def test_tetrahedral_dataset_no_vtk(tmp_path):
     # double check that vtk was not imported
     from tidy3d.components.types import vtk
 
-    assert vtk is None
+    assert vtk["mod"] is None

--- a/tests/test_data/test_datasets.py
+++ b/tests/test_data/test_datasets.py
@@ -124,7 +124,7 @@ def test_triangular_dataset(tmp_path, ds_name):
     assert tri_grid.bounds == ((0.0, 0.0, 0.0), (1.0, 0.0, 1.0))
     assert np.all(tri_grid._vtk_offsets == np.array([0, 3, 6]))
 
-    if vtk is None:
+    if vtk["mod"] is None:
         with pytest.raises(Tidy3dImportError):
             _ = tri_grid._vtk_cells
         with pytest.raises(Tidy3dImportError):
@@ -137,7 +137,7 @@ def test_triangular_dataset(tmp_path, ds_name):
         _ = tri_grid._vtk_obj
 
     # plane slicing
-    if vtk is None:
+    if vtk["mod"] is None:
         with pytest.raises(Tidy3dImportError):
             _ = tri_grid.plane_slice(axis=2, pos=0.5)
     else:
@@ -154,7 +154,7 @@ def test_triangular_dataset(tmp_path, ds_name):
             _ = tri_grid.plane_slice(axis=0, pos=2)
 
     # clipping by a box
-    if vtk is None:
+    if vtk["mod"] is None:
         with pytest.raises(Tidy3dImportError):
             _ = tri_grid.box_clip([[0.1, -0.2, 0.1], [0.2, 0.2, 0.9]])
     else:
@@ -166,7 +166,7 @@ def test_triangular_dataset(tmp_path, ds_name):
             _ = tri_grid.box_clip([[0.1, 0.1, 0.3], [0.2, 0.2, 0.9]])
 
     # interpolation
-    if vtk is None:
+    if vtk["mod"] is None:
         with pytest.raises(Tidy3dImportError):
             invariant = tri_grid.interp(
                 x=0.4, y=[0, 1], z=np.linspace(0.2, 0.6, 10), fill_value=-333
@@ -224,7 +224,7 @@ def test_triangular_dataset(tmp_path, ds_name):
         _ = tri_grid.plot(field=False, grid=False)
 
     # generalized selection method
-    if vtk is None:
+    if vtk["mod"] is None:
         with pytest.raises(Tidy3dImportError):
             _ = tri_grid.sel(x=0.2)
     else:
@@ -238,7 +238,7 @@ def test_triangular_dataset(tmp_path, ds_name):
             _ = tri_grid.sel(x=np.linspace(0, 1, 3), y=1.2, z=[0.3, 0.4, 0.5])
 
     # writting/reading .vtu
-    if vtk is None:
+    if vtk["mod"] is None:
         with pytest.raises(Tidy3dImportError):
             tri_grid.to_vtu(tmp_path / "tri_grid_test.vtu")
         with pytest.raises(Tidy3dImportError):
@@ -362,7 +362,7 @@ def test_tetrahedral_dataset(tmp_path, ds_name):
     assert np.all(tet_grid._vtk_offsets == np.array([0, 4, 8]))
     assert tet_grid.name == ds_name
 
-    if vtk is None:
+    if vtk["mod"] is None:
         with pytest.raises(Tidy3dImportError):
             _ = tet_grid._vtk_cells
         with pytest.raises(Tidy3dImportError):
@@ -375,7 +375,7 @@ def test_tetrahedral_dataset(tmp_path, ds_name):
         _ = tet_grid._vtk_obj
 
     # plane slicing
-    if vtk is None:
+    if vtk["mod"] is None:
         with pytest.raises(Tidy3dImportError):
             _ = tet_grid.plane_slice(axis=2, pos=0.5)
     else:
@@ -387,7 +387,7 @@ def test_tetrahedral_dataset(tmp_path, ds_name):
             _ = tet_grid.plane_slice(axis=1, pos=2)
 
     # clipping by a box
-    if vtk is None:
+    if vtk["mod"] is None:
         with pytest.raises(Tidy3dImportError):
             _ = tet_grid.box_clip([[0.1, -0.2, 0.1], [0.2, 0.2, 0.9]])
     else:
@@ -399,7 +399,7 @@ def test_tetrahedral_dataset(tmp_path, ds_name):
             _ = tet_grid.box_clip([[0.1, 1.1, 0.3], [0.2, 1.2, 0.9]])
 
     # interpolation
-    if vtk is None:
+    if vtk["mod"] is None:
         with pytest.raises(Tidy3dImportError):
             _ = tet_grid.interp(x=0.4, y=[0, 1], z=np.linspace(0.2, 0.6, 10), fill_value=-333)
     else:
@@ -415,7 +415,7 @@ def test_tetrahedral_dataset(tmp_path, ds_name):
         assert no_intersection.name == ds_name
 
     # generalized selection method
-    if vtk is None:
+    if vtk["mod"] is None:
         with pytest.raises(Tidy3dImportError):
             _ = tet_grid.sel(x=0.2)
     else:
@@ -429,7 +429,7 @@ def test_tetrahedral_dataset(tmp_path, ds_name):
             _ = tet_grid.sel(x=0.2, z=[0.3, 0.4, 0.5])
 
     # writting/reading .vtu
-    if vtk is None:
+    if vtk["mod"] is None:
         with pytest.raises(Tidy3dImportError):
             tet_grid.to_vtu(tmp_path / "tet_grid_test.vtu")
         with pytest.raises(Tidy3dImportError):


### PR DESCRIPTION
For some reason couldn't make it work with plain global variables, so ended up using a dict that contains relevant info. One issue with it (and probably in general using this on the fly approach) is that we can't use imported modules members in definition of function signatures. For this particular case, it is not critical, but could be for others.