### PR TITLE
Reduced sim mode solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration of the `documentation` alongside the main codebase repository.
 - Integration of the `tidy3d-notebooks` repository.
 - `tidy3d develop` CLI and development guide on the main documentation.
+- Added a convenience method `Simulation.subsection()` to a create a new simulation based on a subregion of another one.
 
 ### Changed
 - `poetry` based installation. Removal of `setup.py` and `requirements.txt`.
 - Upgrade to sphinx 6 for the documentation build, and change of theme.
+- Remote mode solver web api automatically reduces the associated `Simulation` object to the mode solver plane before uploading it to server.
 
 ### Fixed
 

--- a/tests/test_components/test_time_modulation.py
+++ b/tests/test_components/test_time_modulation.py
@@ -32,6 +32,74 @@ ST = td.SpaceTimeModulation(
 # medium modulation spec
 MODULATION_SPEC = td.ModulationSpec()
 
+SUBSECTION = td.Box(size=(0.3, 0.4, 0.35), center=(0.4, 0.4, 0.4))
+
+
+def reduce(obj):
+
+    return obj.sel_inside(SUBSECTION.bounds)
+
+
+def check_reduction(obj, obj_reduced):
+
+    for field in ["amplitude", "phase"]:
+        original = getattr(obj, field)
+        reduced = getattr(obj_reduced, field)
+
+        if isinstance(original, float):
+            assert reduced == original
+            continue
+
+        diff = (original - reduced).abs
+        assert diff.does_cover(SUBSECTION.bounds)
+        assert np.allclose(diff, 0)
+
+
+def check_sp_reduction(sp):
+
+    check_reduction(sp, reduce(sp))
+
+
+def check_st_reduction(st):
+
+    check_reduction(st.space_modulation, reduce(st).space_modulation)
+
+
+def check_med_reduction(med):
+
+    med_red = reduce(med)
+
+    for field in ["permittivity", "conductivity"]:
+
+        field_mod = getattr(med.modulation_spec, field)
+        field_mod_red = getattr(med_red.modulation_spec, field)
+        if field_mod is None:
+            assert field_mod_red is None
+        else:
+            check_reduction(field_mod.space_modulation, field_mod_red.space_modulation)
+
+
+def check_ani_med_reduction(med):
+
+    reduced_med = reduce(med)
+
+    for comp, comp_red in zip(
+        [med.xx, med.yy, med.zz], [reduced_med.xx, reduced_med.yy, reduced_med.zz]
+    ):
+
+        if comp.modulation_spec is None:
+            assert comp_red.modulation_spec is None
+        else:
+
+            for field in ["permittivity", "conductivity"]:
+
+                field_mod = getattr(comp.modulation_spec, field)
+                field_mod_red = getattr(comp_red.modulation_spec, field)
+                if field_mod is None:
+                    assert field_mod_red is None
+                else:
+                    check_reduction(field_mod.space_modulation, field_mod_red.space_modulation)
+
 
 def test_time_modulation():
     """time modulation: only supporting CW for now."""
@@ -47,6 +115,7 @@ def test_space_modulation():
     """uniform or custom space modulation"""
     # uniform in both amplitude and phase
     assert isclose(SP_UNIFORM.max_modulation, 1)
+    check_sp_reduction(SP_UNIFORM)
 
     # uniform in phase, but custom in amplitude
     with pytest.raises(pydantic.ValidationError):
@@ -54,35 +123,42 @@ def test_space_modulation():
 
     sp = SP_UNIFORM.updated_copy(amplitude=ARRAY)
     assert isclose(sp.max_modulation, np.max(ARRAY))
+    check_sp_reduction(sp)
 
     # uniform in amplitude, but custom in phase
     with pytest.raises(pydantic.ValidationError):
         sp = SP_UNIFORM.updated_copy(phase=ARRAY_CMP)
     sp = SP_UNIFORM.updated_copy(phase=ARRAY)
     assert isclose(sp.max_modulation, 1)
+    check_sp_reduction(sp)
 
     # custom in both
     with pytest.raises(pydantic.ValidationError):
         sp = SP_UNIFORM.updated_copy(phase=ARRAY_CMP, amplitude=ARRAY_CMP)
     sp = SP_UNIFORM.updated_copy(phase=ARRAY, amplitude=ARRAY)
+    check_sp_reduction(sp)
 
 
 def test_space_time_modulation():
     # cw modulation, uniform in space
     assert isclose(ST.max_modulation, AMP_TIME)
     assert not ST.negligible_modulation
+    check_st_reduction(ST)
 
     # cw modulation, but 0 amplitude
     st = ST.updated_copy(time_modulation=CW.updated_copy(amplitude=0))
     assert st.negligible_modulation
+    check_st_reduction(st)
 
     st = ST.updated_copy(space_modulation=td.SpaceModulation(amplitude=0))
     assert st.negligible_modulation
+    check_st_reduction(st)
 
     # cw modulation, nonuniform in space
     st = ST.updated_copy(space_modulation=td.SpaceModulation(amplitude=ARRAY, phase=ARRAY))
     assert not st.negligible_modulation
     assert isclose(st.max_modulation, AMP_TIME * np.max(ARRAY))
+    check_st_reduction(st)
 
 
 def test_modulated_medium():
@@ -91,10 +167,12 @@ def test_modulated_medium():
     medium = td.Medium()
     assert medium.modulation_spec is None
     assert medium.time_modulated == False
+    reduce(medium)
 
     assert MODULATION_SPEC.applied_modulation == False
     medium = medium.updated_copy(modulation_spec=MODULATION_SPEC)
     assert medium.time_modulated == False
+    reduce(medium)
 
     # permittivity modulated
     modulation_spec = MODULATION_SPEC.updated_copy(permittivity=ST)
@@ -103,6 +181,7 @@ def test_modulated_medium():
         medium = td.Medium(modulation_spec=modulation_spec)
     medium = td.Medium(permittivity=2, modulation_spec=modulation_spec)
     assert isclose(medium.n_cfl, np.sqrt(2 - AMP_TIME))
+    check_med_reduction(medium)
 
     # conductivity modulated
     modulation_spec = MODULATION_SPEC.updated_copy(conductivity=ST)
@@ -111,6 +190,8 @@ def test_modulated_medium():
         medium = td.Medium(modulation_spec=modulation_spec)
     medium_sometimes_active = td.Medium(modulation_spec=modulation_spec, allow_gain=True)
     medium = td.Medium(conductivity=2, modulation_spec=modulation_spec)
+    check_med_reduction(medium)
+    check_med_reduction(medium_sometimes_active)
 
     # both modulated, but different time modulation: error
     st_freq2 = ST.updated_copy(
@@ -126,6 +207,7 @@ def test_modulated_medium():
         conductivity=1,
         modulation_spec=modulation_spec,
     )
+    check_med_reduction(medium)
 
 
 def test_unsupported_modulated_medium_types():
@@ -178,6 +260,8 @@ def test_supported_modulated_medium_types():
     with pytest.raises(pydantic.ValidationError):
         mat = mat_p.updated_copy(modulation_spec=modulation_both_spec)
     mat = mat_p.updated_copy(modulation_spec=modulation_both_spec, allow_gain=True)
+    check_med_reduction(mat)
+    check_med_reduction(mat_p)
 
     # custom
     permittivity = td.SpatialDataArray(np.ones((1, 1, 1)) * 2, coords=dict(x=[1], y=[1], z=[1]))
@@ -191,14 +275,18 @@ def test_supported_modulated_medium_types():
     with pytest.raises(pydantic.ValidationError):
         mat = mat_c.updated_copy(modulation_spec=modulation_both_spec)
     mat = mat_c.updated_copy(modulation_spec=modulation_both_spec, allow_gain=True)
+    check_med_reduction(mat_c)
+    check_med_reduction(mat)
 
     # anisotropic medium component
     mat = td.AnisotropicMedium(xx=td.Medium(), yy=mat_p, zz=td.Medium())
     assert mat.time_modulated
     assert isclose(mat.n_cfl, np.sqrt(2 - AMP_TIME))
+    check_ani_med_reduction(mat)
 
     # custom anistropic medium component
     mat_uc = td.CustomMedium(permittivity=permittivity)
     mat = td.CustomAnisotropicMedium(xx=mat_uc, yy=mat_c, zz=mat_uc)
     assert mat.time_modulated
     assert isclose(mat.n_cfl, np.sqrt(2 - AMP_TIME))
+    check_ani_med_reduction(mat)

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -983,7 +983,7 @@ class FieldProjectionAngleMonitor(AbstractFieldProjectionMonitor):
     ...     name='n2f_monitor',
     ...     custom_origin=(1,2,3),
     ...     phi=[0, np.pi/2],
-    ...     theta=np.linspace(-np.pi/2, np.pi/2, 100)
+    ...     theta=np.linspace(-np.pi/2, np.pi/2, 100),
     ...     far_field_approx=True,
     ...     )
 

--- a/tidy3d/components/validators.py
+++ b/tidy3d/components/validators.py
@@ -171,7 +171,7 @@ def assert_objects_in_sim_bounds(field_name: str, error: bool = True):
             if not sim_box.intersects(geometric_object.geometry):
 
                 message = (
-                    f"'{geometric_object}' (at `simulation.{field_name}[{position_index}]`) "
+                    f"'simulation.{field_name}[{position_index}]'"
                     "is completely outside of simulation domain."
                 )
                 custom_loc = [field_name, position_index]

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -12,6 +12,7 @@ import xarray as xr
 
 from ...log import log
 from ...components.base import Tidy3dBaseModel, cached_property
+from ...components.boundary import PECBoundary, BoundarySpec, Boundary, PML, StablePML, Absorber
 from ...components.geometry.base import Box
 from ...components.simulation import Simulation
 from ...components.grid.grid import Grid
@@ -139,20 +140,33 @@ class ModeSolver(Tidy3dBaseModel):
         _, solver_sym = self.plane.pop_axis(mode_symmetry, axis=self.normal_axis)
         return solver_sym
 
-    @cached_property
-    def _solver_grid(self) -> Grid:
-        """Grid for the mode solver, not snapped to plane or simulation zero dims, and also with
-        a small correction for symmetries. We don't do the snapping yet because 0-sized cells are
-        currently confusing to the subpixel averaging. The final data coordinates along the
-        plane normal dimension and dimensions where the simulation domain is 2D will be correctly
-        set after the solve."""
+    def _get_solver_grid(
+        self, preserve_layer_behind: bool = False, truncate_symmetry: bool = True
+    ) -> Grid:
+        """Grid for the mode solver, not snapped to plane or simulation zero dims, and optionally
+        corrected for symmetries.
+
+        Parameters
+        ----------
+        preserve_layer_behind : bool = False
+            Do not discard the layer of cells behind the main layer of cells. Together they
+            represent the region where custom medium data is needed for proper subpixel.
+        truncate_symmetry : bool = True
+            Truncate to symmetry quadrant if symmetry present.
+
+        Returns
+        -------
+        :class:.`Grid`
+            The resulting grid.
+        """
 
         monitor = self.to_mode_solver_monitor(name=MODE_MONITOR_NAME, colocate=False)
 
         span_inds = self.simulation._discretize_inds_monitor(monitor)
 
         # Remove extension along monitor normal
-        span_inds[self.normal_axis, 0] += 1
+        if not preserve_layer_behind:
+            span_inds[self.normal_axis, 0] += 1
         span_inds[self.normal_axis, 1] -= 1
 
         # Do not extend if simulation has a single pixel along a dimension
@@ -161,12 +175,23 @@ class ModeSolver(Tidy3dBaseModel):
                 span_inds[dim] = [0, 1]
 
         # Truncate to symmetry quadrant if symmetry present
-        _, plane_inds = monitor.pop_axis([0, 1, 2], self.normal_axis)
-        for dim, sym in enumerate(self.solver_symmetry):
-            if sym != 0:
-                span_inds[plane_inds[dim], 0] += np.diff(span_inds[plane_inds[dim]]) // 2
+        if truncate_symmetry:
+            _, plane_inds = Box.pop_axis([0, 1, 2], self.normal_axis)
+            for dim, sym in enumerate(self.solver_symmetry):
+                if sym != 0:
+                    span_inds[plane_inds[dim], 0] += np.diff(span_inds[plane_inds[dim]]) // 2
 
         return self.simulation._subgrid(span_inds=span_inds)
+
+    @cached_property
+    def _solver_grid(self) -> Grid:
+        """Grid for the mode solver, not snapped to plane or simulation zero dims, and also with
+        a small correction for symmetries. We don't do the snapping yet because 0-sized cells are
+        currently confusing to the subpixel averaging. The final data coordinates along the
+        plane normal dimension and dimensions where the simulation domain is 2D will be correctly
+        set after the solve."""
+
+        return self._get_solver_grid(preserve_layer_behind=False, truncate_symmetry=True)
 
     @cached_property
     def _num_cells_freqs_modes(self) -> Tuple[int, int, int]:
@@ -940,3 +965,48 @@ class ModeSolver(Tidy3dBaseModel):
 
     def validate_pre_upload(self, source_required: bool = True):
         self._validate_modes_size()
+
+    @cached_property
+    def reduced_simulation_copy(self):
+        """Strip objects not used by the mode solver from simulation object.
+        This might significantly reduce upload time in the presence of custom mediums.
+        """
+
+        # we preserve extracells along the normal direction to ensure
+        extended_grid = self._get_solver_grid(preserve_layer_behind=True, truncate_symmetry=False)
+        grids_1d = extended_grid.boundaries
+        new_sim_box = Box.from_bounds(
+            rmin=(grids_1d.x[0], grids_1d.y[0], grids_1d.z[0]),
+            rmax=(grids_1d.x[-1], grids_1d.y[-1], grids_1d.z[-1]),
+        )
+
+        # remove PML, Absorers, etc, to avoid unnecessary cells
+        bspec = self.simulation.boundary_spec
+
+        new_bspec_dict = {}
+        for axis in "xyz":
+            bcomp = bspec["x"]
+            for bside, sign in zip([bcomp.plus, bcomp.minus], "+-"):
+                if isinstance(bside, (PML, StablePML, Absorber)):
+                    new_bspec_dict[axis + sign] = PECBoundary()
+                else:
+                    new_bspec_dict[axis + sign] = bside
+
+        new_bspec = BoundarySpec(
+            x=Boundary(plus=new_bspec_dict["x+"], minus=new_bspec_dict["x-"]),
+            y=Boundary(plus=new_bspec_dict["y+"], minus=new_bspec_dict["y-"]),
+            z=Boundary(plus=new_bspec_dict["z+"], minus=new_bspec_dict["z-"]),
+        )
+
+        # extract sub-simulation removing everything irrelevant
+        new_sim = self.simulation.subsection(
+            region=new_sim_box,
+            monitors=[],
+            sources=[],
+            grid_spec="identical",
+            boundary_spec=new_bspec,
+            remove_outside_custom_mediums=True,
+            remove_outside_structures=True,
+        )
+
+        return self.updated_copy(simulation=new_sim)

--- a/tidy3d/web/api/mode.py
+++ b/tidy3d/web/api/mode.py
@@ -46,6 +46,7 @@ def run(
     verbose: bool = True,
     progress_callback_upload: Callable[[float], None] = None,
     progress_callback_download: Callable[[float], None] = None,
+    reduce_simulation: bool = True,
 ) -> ModeSolverData:
     """Submits a :class:`.ModeSolver` to server, starts running, monitors progress, downloads,
     and loads results as a :class:`.ModeSolverData` object.
@@ -68,6 +69,9 @@ def run(
         Optional callback function called when uploading file with ``bytes_in_chunk`` as argument.
     progress_callback_download : Callable[[float], None] = None
         Optional callback function called when downloading file with ``bytes_in_chunk`` as argument.
+    reduce_simulation : bool = True
+        Restrict simulation to mode solver region. This can help reduce the amount of uploaded and
+        dowloaded data.
 
     Returns
     -------
@@ -78,6 +82,9 @@ def run(
     log_level = "DEBUG" if verbose else "INFO"
     if verbose:
         console = get_logging_console()
+
+    if reduce_simulation:
+        mode_solver = mode_solver.reduced_simulation_copy
 
     task = ModeSolverTask.create(mode_solver, task_name, mode_solver_name, folder_name)
     if verbose:


### PR DESCRIPTION
Implements https://github.com/flexcompute/tidy3d/issues/1191. That is, there is a new simulation method `.subsection(region: Box, ...)` that can be used to create a smaller simulation based on original one. 
- Most of simulation fields are inherited, but could be optionally overridden
- Grid can be requested to be the same as in the parent simulation (`grid_spec="identical"`). In this case it's converted into a custom grid and the requested region is expanded to match parent grid lines. One small issue here is that if the parent grid already matches the requested region, than due to numerical precision one additional cell might be included. But that doesn't seem cause any real issues.
- Similarly, due to numerical precision issues, even when child grid is essentially the same as the parent grid, some of structures might become slightly misaligned with grid lines. Most prominently it shows when calling `ModeSolver._solver_eps()` of local mode solver. That is, effective boundaries of structures might differ by one pixel between parent and child simulations.
- Regarding inheriting symmetry: we discussed in https://github.com/flexcompute/tidy3d/issues/1191 that probably we can just not allow selecting a not compatible region which is not centered around symmetry plane. But I realized this could happen in the background of a remote mode solver call and that would cause an error. So, I implemented it in a way so that an incompatible region is automatically expanded to be centered around a symmetry plane.
- `.subsection(region: Box, ...)` is used internally in mode solver web api call and whether it is used or not is controlled by flag `reduce_simulation`. I set it by default to `True`, that is, all mode solver calls will use a reduced simulation. We can change it either to `False`, or make it so that only simulation containing custom mediums are reduced and also display a warning/info notifying that this is done. What do you think?
- This does significantly help to reduce data transfer for remote mode solver. For example, in this notebook https://github.com/flexcompute-readthedocs/tidy3d-docs/blob/096b84d99d301de4e3690fb6b4aa373064a2bb91/docs/source/notebooks/ThermallyTunedRingResonator.ipynb I couldn't really use remote mode solver because each solve would require around 500mb of upload, now it's less than 1mb. I also expect it to be useful for regular optic simulations in the context of heat solver. I do use it in the same notebook to remove irrelevant structures from optic simulation, but I anticipate more impactful usage eventually. (in this notebook, we are already restricted to a single component. Imagine performing heat simulation on a large scale circuit and then use `.subsection()` to  cut out individual components for optic simulations)
- On basic level, this feature extends method `.sel_inside()` from `SpatialDataArray` to other spatial data arrays (`ScalarFieldDataArray`, `ScalarFieldTimeDataArray`), custom medium classes and space time modulation classes. I realize that the name I used `.sel_inside(bounds: Bound)` might be a bit misleading, because we extract data not just inside but that covers `bounds`. An alternative could be `.reduce_to_cover(bounds: Bound)`, `.sel_to_cover(bounds: Bound)`. Any other suggestions?

I put three of you as reviewers, but I don't think all of you need to review the entire thing. Maybe @weiliangjin2021 can looks through changes to custom medium classes and modulation classes, while @tylerflex and/or @momchil-flex can comment on overall implementation?
