### PR TITLE
Using zipped solver data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 
+### Changed
+- All solver output is now compressed. However, it is automatically unpacked to the same `simulation_data.hdf5` by default when loading simulation data from the server.
+
+### Fixed
+
+
 ## [2.5.0] - 2023-12-13
 
 ### Added

--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -38,7 +38,7 @@ def mock_remote_api(monkeypatch):
     def void(*args, **kwargs):
         return None
 
-    def mock_download(task_id, remote_path, to_file, *args, **kwargs):
+    def mock_download(resource_id, remote_filename, to_file, *args, **kwargs):
         simulation = td.Simulation(
             size=SIM_SIZE,
             grid_spec=td.GridSpec(wavelength=1.0),
@@ -68,6 +68,7 @@ def mock_remote_api(monkeypatch):
     monkeypatch.setattr(httputil, "api_key", lambda: "api_key")
     monkeypatch.setattr(httputil, "get_version", lambda: td.version.__version__)
     monkeypatch.setattr("tidy3d.web.api.mode.upload_file", void)
+    monkeypatch.setattr("tidy3d.web.api.mode.download_gz_file", mock_download)
     monkeypatch.setattr("tidy3d.web.api.mode.download_file", mock_download)
 
     responses.add(

--- a/tests/test_web/test_tidy3d_task.py
+++ b/tests/test_web/test_tidy3d_task.py
@@ -89,7 +89,7 @@ def test_get_simulation_json(monkeypatch, set_api_key, tmp_path):
         to_file = kwargs["to_file"]
         sim.to_file(to_file)
 
-    monkeypatch.setattr("tidy3d.web.core.task_core.download_file", mock_download)
+    monkeypatch.setattr("tidy3d.web.core.task_core.download_gz_file", mock_download)
 
     responses.add(
         responses.GET,

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -225,6 +225,7 @@ def mock_download(monkeypatch, set_api_key, mock_get_info, tmp_path):
         with open(file_path, "w") as f:
             f.write("0.3,5.7")
 
+    monkeypatch.setattr(f"{task_core_path}.download_gz_file", _mock_download)
     monkeypatch.setattr(f"{task_core_path}.download_file", _mock_download)
     download(TASK_ID, str(tmp_path / "web_test_tmp.json"))
     with open(str(tmp_path / "web_test_tmp.json")) as f:
@@ -356,7 +357,7 @@ def test_download_json(monkeypatch, mock_get_info, tmp_path):
     def get_str(*args, **kwargs):
         return sim.json().encode("utf-8")
 
-    monkeypatch.setattr(f"{task_core_path}.download_file", mock_download)
+    monkeypatch.setattr(f"{task_core_path}.download_gz_file", mock_download)
     monkeypatch.setattr(f"{task_core_path}.read_simulation_from_hdf5", get_str)
 
     fname_tmp = str(tmp_path / "web_test_tmp.json")

--- a/tests/test_web/test_webapi_heat.py
+++ b/tests/test_web/test_webapi_heat.py
@@ -3,6 +3,7 @@
 import pytest
 import responses
 from _pytest import monkeypatch
+from botocore.exceptions import ClientError
 
 import tidy3d as td
 from responses import matchers
@@ -170,6 +171,12 @@ def mock_download(monkeypatch, set_api_key, mock_get_info, tmp_path):
         with open(file_path, "w") as f:
             f.write("0.3,5.7")
 
+    def _mock_download_gz(*args, **kwargs):
+        raise ClientError(
+            error_response={"Error": {"Message": "File not found"}}, operation_name="download"
+        )
+
+    monkeypatch.setattr(f"{task_core_path}.download_gz_file", _mock_download_gz)
     monkeypatch.setattr(f"{task_core_path}.download_file", _mock_download)
     download(TASK_ID, str(tmp_path / "web_test_tmp.json"))
     with open(str(tmp_path / "web_test_tmp.json"), "r") as f:
@@ -256,7 +263,7 @@ def test_download_json(monkeypatch, mock_get_info, tmp_path):
     def get_str(*args, **kwargs):
         return sim.json().encode("utf-8")
 
-    monkeypatch.setattr(f"{task_core_path}.download_file", mock_download)
+    monkeypatch.setattr(f"{task_core_path}.download_gz_file", mock_download)
     monkeypatch.setattr(f"{task_core_path}.read_simulation_from_hdf5", get_str)
 
     fname_tmp = str(tmp_path / "web_test_tmp.json")

--- a/tidy3d/version.py
+++ b/tidy3d/version.py
@@ -1,3 +1,2 @@
 """Defines the front end version of tidy3d"""
-
 __version__ = "2.6.0rc1"

--- a/tidy3d/web/core/constants.py
+++ b/tidy3d/web/core/constants.py
@@ -21,6 +21,7 @@ TaskName = str
 
 SIMULATION_JSON = "simulation.json"
 SIMULATION_DATA_HDF5 = "output/monitor_data.hdf5"
+SIMULATION_DATA_HDF5_GZ = "output/simulation_data.hdf5.gz"
 RUNNING_INFO = "output/solver_progress.csv"
 SIM_LOG_FILE = "output/tidy3d.log"
 SIM_FILE_HDF5 = "simulation.hdf5"

--- a/tidy3d/web/core/task_core.py
+++ b/tidy3d/web/core/task_core.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from typing import List, Optional, Callable, Tuple
 import pydantic.v1 as pd
 from pydantic.v1 import Extra, Field, parse_obj_as
+from botocore.exceptions import ClientError
 
 from . import http_util
 from .core_config import get_logger_console
@@ -15,14 +16,13 @@ from .exceptions import WebError
 
 from .cache import FOLDER_CACHE
 from .http_util import http
-from .s3utils import download_file, upload_file
+from .s3utils import download_file, download_gz_file, upload_file
 from .stub import TaskStub
 from .types import Queryable, ResourceLifecycle, Submittable
 from .types import Tidy3DResource
 
-
-from .constants import SIM_FILE_HDF5_GZ, SIMULATION_DATA_HDF5, SIM_LOG_FILE
-from .file_util import extract_gzip_file, read_simulation_from_hdf5
+from .constants import SIM_FILE_HDF5_GZ, SIMULATION_DATA_HDF5, SIMULATION_DATA_HDF5_GZ, SIM_LOG_FILE
+from .file_util import read_simulation_from_hdf5
 
 
 class Folder(Tidy3DResource, Queryable, extra=Extra.allow):
@@ -453,7 +453,7 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
     def get_sim_data_hdf5(
         self, to_file: str, verbose: bool = True, progress_callback: Callable[[float], None] = None
     ) -> pathlib.Path:
-        """Get output/monitor_data.hdf5 file from Server.
+        """Get simulation data file from Server.
 
         Parameters
         ----------
@@ -472,18 +472,36 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
         if not self.task_id:
             raise WebError("Expected field 'task_id' is unset.")
 
+        file = None
         try:
-            return download_file(
-                self.task_id,
-                SIMULATION_DATA_HDF5,
+            file = download_gz_file(
+                resource_id=self.task_id,
+                remote_filename=SIMULATION_DATA_HDF5_GZ,
                 to_file=to_file,
                 verbose=verbose,
                 progress_callback=progress_callback,
             )
-        except Exception:
-            raise WebError(
-                f"Failed to download file '{SIMULATION_DATA_HDF5}' from server. Please confirm that the task was successful."
-            )
+        except ClientError:
+            if verbose:
+                console = get_logger_console()
+                console.log(f"Unable to download '{SIMULATION_DATA_HDF5_GZ}'.")
+
+        if not file:
+            try:
+                file = download_file(
+                    resource_id=self.task_id,
+                    remote_filename=SIMULATION_DATA_HDF5,
+                    to_file=to_file,
+                    verbose=verbose,
+                    progress_callback=progress_callback,
+                )
+            except Exception as e:
+                raise WebError(
+                    "Failed to download the simulation data file from the server. "
+                    "Please confirm that the task was successfully run."
+                ) from e
+
+        return file
 
     def get_simulation_hdf5(
         self, to_file: str, verbose: bool = True, progress_callback: Callable[[float], None] = None
@@ -507,31 +525,13 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
         if not self.task_id:
             raise WebError("Expected field 'task_id' is unset.")
 
-        if to_file.lower().endswith(".gz"):
-            download_file(
-                self.task_id,
-                SIM_FILE_HDF5_GZ,
-                to_file=to_file,
-                verbose=verbose,
-                progress_callback=progress_callback,
-            )
-        else:
-            hdf5_gz_file, hdf5_gz_file_path = tempfile.mkstemp(".hdf5.gz")
-            os.close(hdf5_gz_file)
-            try:
-                download_file(
-                    self.task_id,
-                    SIM_FILE_HDF5_GZ,
-                    to_file=hdf5_gz_file_path,
-                    verbose=verbose,
-                    progress_callback=progress_callback,
-                )
-                if os.path.exists(hdf5_gz_file_path):
-                    extract_gzip_file(hdf5_gz_file_path, to_file)
-                else:
-                    raise WebError("Failed to download simulation.hdf5")
-            finally:
-                os.unlink(hdf5_gz_file_path)
+        return download_gz_file(
+            resource_id=self.task_id,
+            remote_filename=SIM_FILE_HDF5_GZ,
+            to_file=to_file,
+            verbose=verbose,
+            progress_callback=progress_callback,
+        )
 
     def get_running_info(self) -> Tuple[float, float]:
         """Gets the % done and field_decay for a running task.


### PR DESCRIPTION
So I've modified the solver to zip the result files, and I've verified that I can both run and load a simulation with this new solver, and that I can load old simulations from the server. However, I can't get all the tests that use mock functions to run. I don't exactly understand what's happening, but it has to do with my trying to make things a bit more general, and introducing `download_gz_file` in `s3utils.py`. Then it seems like instead of mocking `download_file` in `task_core` or `mode.web`, respectively, we should just be mocking it in `s3utils`. But I either get errors or even the tests hang when I try locally. @tylerflex could you help?