### PR TITLE
Determine whether repeated tasks will be run.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Determine whether repeated tasks will be run.
 ## [2.5.0] - 2023-12-13
 
 ### Added

--- a/tidy3d/web/core/exceptions.py
+++ b/tidy3d/web/core/exceptions.py
@@ -10,3 +10,13 @@ class WebError(Exception):
         log = get_logger()
         super().__init__(message)
         log.error(message)
+
+
+class TaskRepeatedError(Exception):
+    """Repeated task in tidy3d"""
+
+    def __init__(self, message: str = None):
+        """Log just the error message and then raise the Exception."""
+        # log = get_logger()
+        super().__init__(message)
+        # log.error(message)


### PR DESCRIPTION
When user run a task from python client, API Server will check whether there is a task which run successfully and contains the same simulation file by file md5. if exist repeated task, API server will  delete the new task and s3 file and throw specified error and python client needs to deal the error.