### PR TITLE
Fix to mesher error in very specific cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `ModeData.dispersion` and `ModeSolverData.dispersion` are calculated together with the group index.
 - String matching feature `contains_str` to `assert_log_level` testing utility.
+- Warning in automatic grid generation if a structure has a non-zero size along a given direction that is too small compared to a single mesh step.
 
 ### Changed
 - `jax` and `jaxlib` versions bumped to `0.4.*`.
+
+### Fixed
+- Error in automatic grid generation in specific cases with multiple thin structures.
 
 ## [2.5.0] - 2023-12-13
 

--- a/tests/test_components/test_meshgenerate.py
+++ b/tests/test_components/test_meshgenerate.py
@@ -5,8 +5,9 @@ import pytest
 
 import tidy3d as td
 from tidy3d.constants import fp_eps
-
 from tidy3d.components.grid.mesher import GradedMesher
+
+from ..utils import assert_log_level, log_capture
 
 np.random.seed(4)
 
@@ -648,6 +649,52 @@ def test_mesher_timeout():
     )
 
     _ = sim.grid
+
+
+def test_small_structure_size(log_capture):
+    """Test that a warning is raised if a structure size is small during the auto meshing"""
+    box_size = 0.03
+    medium = td.Medium(permittivity=4)
+    box = td.Structure(geometry=td.Box(size=(box_size, td.inf, td.inf)), medium=medium)
+    src = td.UniformCurrentSource(
+        source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
+        size=(0, 0, 0),
+        polarization="Ex",
+    )
+    sim = td.Simulation(
+        size=(10, 10, 10),
+        sources=[src],
+        structures=[box],
+        run_time=1e-12,
+        grid_spec=td.GridSpec.auto(wavelength=1),
+    )
+
+    # Warning raised as structure is too thin
+    assert_log_level(log_capture, "WARNING")
+
+    # Warning not raised if structure is higher index
+    log_capture.clear()
+    box2 = box.updated_copy(medium=td.Medium(permittivity=300))
+    sim2 = sim.updated_copy(structures=[box2])
+    assert len(log_capture) == 0
+
+    # Warning not raised if structure is covered by an override structure
+    log_capture.clear()
+    override = td.MeshOverrideStructure(geometry=box.geometry, dl=(box_size, td.inf, td.inf))
+    sim3 = sim.updated_copy(grid_spec=sim.grid_spec.updated_copy(override_structures=[override]))
+    assert len(log_capture) == 0
+    # Also check that the structure boundaries are in the grid
+    ind_mid_cell = int(sim3.grid.num_cells[0] // 2)
+    bounds = [-box_size / 2, box_size / 2]
+    assert np.allclose(bounds, sim3.grid.boundaries.x[ind_mid_cell : ind_mid_cell + 2])
+
+    # Test that the error coming from two thin slabs on top of each other is resolved
+    log_capture.clear()
+    box3 = td.Structure(
+        geometry=td.Box(center=(box_size, 0, 0), size=(box_size, td.inf, td.inf)), medium=medium
+    )
+    sim4 = sim.updated_copy(structures=[box3, box])
+    assert_log_level(log_capture, "WARNING")
 
 
 def test_shapely_strtree_warnings():

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -769,7 +769,7 @@ def test_large_grid_size(log_capture, grid_size, log_level):
     assert_log_level(log_capture, log_level)
 
 
-@pytest.mark.parametrize("box_size,log_level", [(0.001, "INFO"), (9.9, "WARNING"), (20, "INFO")])
+@pytest.mark.parametrize("box_size,log_level", [(0.1, "INFO"), (9.9, "WARNING"), (20, "INFO")])
 def test_sim_structure_gap(log_capture, box_size, log_level):
     """Make sure the gap between a structure and PML is not too small compared to lambda0."""
     medium = td.Medium(permittivity=2)


### PR DESCRIPTION
Warn when structures are too small compared to the generated mesh.

Also realized that e.g. placing a thin `MeshOverrideStructure` of size dl and mesh step dl will *not* place boundaries on both sides of that structure (i.e. a single mesh step) because of the way the `isclose` check is done. Changed tolerances a bit to fix this as it should be expected behavior.

I also added more docstrings explaining how that part of the mesher works. I must admit it's still a bit of a mess, but I don't have time for a complete overhaul (and it's not clear what that might look like).