### PR TITLE
bump `jax` and `jaxlib` versions to `0.4.*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ModeData.dispersion` and `ModeSolverData.dispersion` are calculated together with the group index.
 - String matching feature `contains_str` to `assert_log_level` testing utility.
 
+### Changed
+- `jax` and `jaxlib` versions bumped to `0.4.*`.
+
 ## [2.5.0] - 2023-12-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `ModeData.dispersion` and `ModeSolverData.dispersion` are calculated together with the group index.
+- String matching feature `contains_str` to `assert_log_level` testing utility.
 
 ## [2.5.0] - 2023-12-13
 

--- a/requirements/jax.txt
+++ b/requirements/jax.txt
@@ -3,14 +3,14 @@
 -r core.txt
 
 # regular case (linux, macos)
-jaxlib>=0.3.14,<=0.4.14; platform_system != "Windows"
-jax[cpu]>=0.3.14,<=0.4.14; platform_system != "Windows"
+jaxlib>=0.3.14,==0.4.*; platform_system != "Windows"
+jax[cpu]>=0.3.14,==0.4.*; platform_system != "Windows"
 
 
 # we downgrade to 0.3 for windows users because the only binaries for windows are 0.3 currently.
 jaxlib==0.3.14; platform_system == "Windows" and python_version < "3.9"
 jax[cpu]==0.3.14; platform_system == "Windows" and python_version < "3.9"
 
-# windows users running python > 3.9 can install same jax version as unix
+# windows users running python > 3.9 must use older version for now
 jaxlib>=0.3.14,<=0.4.14; platform_system == "Windows" and python_version >= "3.9"
 jax[cpu]>=0.3.14,<=0.4.14; platform_system == "Windows" and python_version >= "3.9"

--- a/tests/test_package/test_log.py
+++ b/tests/test_package/test_log.py
@@ -9,6 +9,8 @@ import tidy3d as td
 from tidy3d.exceptions import Tidy3dError
 from tidy3d.log import DEFAULT_LEVEL, _get_level_int, set_logging_level
 
+from ..utils import assert_log_level, log_capture
+
 
 def test_log():
     td.log.debug("debug test")
@@ -269,3 +271,18 @@ def test_log_suppression():
         assert td.log._counts is None
 
     td.config.log_suppression = True
+
+
+def test_assert_log_level(log_capture):
+    """Test features of the assert_log_level"""
+
+    # log was captured
+    td.log.warning("ABC")
+    assert_log_level(log_capture, "WARNING", contains_str="ABC")
+    log_capture.clear()
+
+    # string was not matched
+    td.log.warning("ABC")
+    with pytest.raises(Exception):
+        assert_log_level(log_capture, "WARNING", contains_str="DEF")
+    log_capture.clear()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Dict, Tuple, List
 import pydantic.v1 as pd
 import trimesh
 
@@ -660,11 +660,25 @@ def log_capture(monkeypatch):
     return log_capture.records
 
 
-def assert_log_level(records, log_level_expected: str):
-    """ensure something got logged if log_level is not None.
-    note: I put this here rather than utils.py because if we import from utils.py,
-    it will validate the sims there and those get included in log.
+def assert_log_level(
+    records: List[Tuple[int, str]], log_level_expected: str, contains_str: str = None
+) -> None:
+    """Testing tool: Raises error if a log was not recorded as expected.
+
+    Parameters
+    ----------
+    records : List[Tuple[int, str]]
+        List of (log_level: int, message: str) holding all of the captured logs.
+    log_level_expected: str
+        String version of expected log level (all uppercase).
+    contains_str : str = None
+        If specified, errors if not found in the log message.
+
+    Returns
+    -------
+        None
     """
+
     import sys
 
     sys.stderr.write(str(records) + "\n")
@@ -685,9 +699,15 @@ def assert_log_level(records, log_level_expected: str):
     # both expected and got log, check the log levels match
     if records and log_level_expected:
         for log in records:
-            log_level = log[0]
+            log_level, log_message = log
             if log_level == log_level_expected_int:
                 # log level was triggered, exit
+
+                if contains_str:
+                    assert (
+                        contains_str in log_message
+                    ), f"log message '{log_message}' didnt contain '{contains_str}'."
+
                 return
         raise Exception
 


### PR DESCRIPTION
@daquinteroflex note: when we merge this, we should also update it in the docs refractor.