### PR TITLE
2D material subdivision

### DIFF
--- a/tests/sims/simulation_2_4_2.json
+++ b/tests/sims/simulation_2_4_2.json
@@ -770,6 +770,7 @@
             },
             "name": null,
             "interpolate": true,
+            "confine_to_bounds": false,
             "polarization": "Hx"
         },
         {
@@ -795,6 +796,7 @@
             },
             "name": null,
             "interpolate": true,
+            "confine_to_bounds": false,
             "polarization": "Ex"
         },
         {
@@ -988,6 +990,7 @@
             },
             "name": null,
             "interpolate": true,
+            "confine_to_bounds": false,
             "current_dataset": {
                 "type": "FieldDataset",
                 "Ex": "ScalarFieldDataArray",
@@ -1052,6 +1055,7 @@
             },
             "name": null,
             "interpolate": true,
+            "confine_to_bounds": false,
             "polarization": "Hx"
         }
     ],
@@ -1196,7 +1200,7 @@
                 1,
                 1
             ],
-            "colocate": true,
+            "colocate": 1,
             "freqs": [
                 200000000000000.0,
                 250000000000000.0
@@ -1228,7 +1232,7 @@
                 1,
                 1
             ],
-            "colocate": true,
+            "colocate": 1,
             "start": 0.0,
             "stop": null,
             "interval": 1,
@@ -1377,7 +1381,7 @@
                 1,
                 1
             ],
-            "colocate": true,
+            "colocate": 1,
             "freqs": [
                 250000000000000.0,
                 300000000000000.0
@@ -1522,7 +1526,7 @@
                 1,
                 1
             ],
-            "colocate": true,
+            "colocate": 1,
             "freqs": [
                 250000000000000.0,
                 300000000000000.0
@@ -1574,7 +1578,7 @@
                 1,
                 1
             ],
-            "colocate": true,
+            "colocate": 1,
             "freqs": [
                 250000000000000.0,
                 300000000000000.0
@@ -1623,7 +1627,7 @@
                 1,
                 1
             ],
-            "colocate": true,
+            "colocate": 1,
             "freqs": [
                 250000000000000.0,
                 300000000000000.0
@@ -1782,6 +1786,7 @@
             "normal_dir": "+"
         }
     ],
+    "lumped_elements": [],
     "grid_spec": {
         "grid_x": {
             "type": "AutoGrid",

--- a/tests/sims/simulation_2_5_0rc3.json
+++ b/tests/sims/simulation_2_5_0rc3.json
@@ -1011,14 +1011,14 @@
                 },
                 "transform": [
                     [
-                        0.9659258262890683,
-                        -0.25881904510252074,
+                        0.9659258262890684,
+                        -0.2588190451025208,
                         0.0,
                         0.0
                     ],
                     [
-                        0.25881904510252074,
-                        0.9659258262890683,
+                        0.2588190451025208,
+                        0.9659258262890684,
                         0.0,
                         0.0
                     ],
@@ -1080,6 +1080,7 @@
                 "remove_dc_component": true
             },
             "interpolate": true,
+            "confine_to_bounds": false,
             "polarization": "Hx"
         },
         {
@@ -1105,6 +1106,7 @@
                 "remove_dc_component": true
             },
             "interpolate": true,
+            "confine_to_bounds": false,
             "polarization": "Ex"
         },
         {
@@ -1298,6 +1300,7 @@
                 "remove_dc_component": true
             },
             "interpolate": true,
+            "confine_to_bounds": false,
             "current_dataset": {
                 "type": "FieldDataset",
                 "Ex": "ScalarFieldDataArray",
@@ -1362,6 +1365,7 @@
                 }
             },
             "interpolate": true,
+            "confine_to_bounds": false,
             "polarization": "Hx"
         }
     ],
@@ -1506,7 +1510,7 @@
                 1,
                 1
             ],
-            "colocate": true,
+            "colocate": 1,
             "freqs": [
                 200000000000000.0,
                 250000000000000.0
@@ -1538,7 +1542,7 @@
                 1,
                 1
             ],
-            "colocate": true,
+            "colocate": 1,
             "start": 0.0,
             "stop": null,
             "interval": 1,
@@ -1687,7 +1691,7 @@
                 1,
                 1
             ],
-            "colocate": true,
+            "colocate": 1,
             "freqs": [
                 250000000000000.0,
                 300000000000000.0
@@ -1836,7 +1840,7 @@
                 1,
                 1
             ],
-            "colocate": true,
+            "colocate": 1,
             "freqs": [
                 250000000000000.0,
                 300000000000000.0
@@ -1892,7 +1896,7 @@
                 1,
                 1
             ],
-            "colocate": true,
+            "colocate": 1,
             "freqs": [
                 250000000000000.0,
                 300000000000000.0
@@ -1945,7 +1949,7 @@
                 1,
                 1
             ],
-            "colocate": true,
+            "colocate": 1,
             "freqs": [
                 250000000000000.0,
                 300000000000000.0
@@ -2263,6 +2267,7 @@
     },
     "version": "2.5.0rc3",
     "run_time": 1e-12,
+    "lumped_elements": [],
     "shutoff": 0.0001,
     "subpixel": false,
     "normalize_index": 0,

--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -674,3 +674,45 @@ def test_nonlinear_medium(log_capture):
     with pytest.raises(ValidationError):
         structure = structure.updated_copy(medium=medium_active)
         sim.updated_copy(structures=[structure])
+
+
+def test_lumped_resistor():
+
+    resistor = td.LumpedResistor(
+        resistance=50.0,
+        center=[0, 0, 0],
+        size=[2, 0, 3],
+        voltage_axis=0,
+        name="R",
+    )
+    _ = resistor.effective_conductance
+    normal_axis = resistor.normal_axis
+    assert normal_axis == 1
+
+    # error if voltage axis is not in plane with the resistor
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.LumpedResistor(
+            resistance=50.0,
+            center=[0, 0, 0],
+            size=[2, 0, 3],
+            voltage_axis=1,
+            name="R",
+        )
+
+    # error if not planar
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.LumpedResistor(
+            resistance=50.0,
+            center=[0, 0, 0],
+            size=[0, 0, 3],
+            voltage_axis=2,
+            name="R",
+        )
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.LumpedResistor(
+            resistance=50.0,
+            center=[0, 0, 0],
+            size=[2, 1, 3],
+            voltage_axis=2,
+            name="R",
+        )

--- a/tests/test_plugins/terminal_component_modeler_def.py
+++ b/tests/test_plugins/terminal_component_modeler_def.py
@@ -1,0 +1,161 @@
+import pytest
+import numpy as np
+import pydantic.v1 as pydantic
+import matplotlib.pyplot as plt
+import gdstk
+
+import tidy3d as td
+from tidy3d.plugins.smatrix.smatrix import (
+    LumpedPort,
+    TerminalComponentModeler,
+    AbstractComponentModeler,
+)
+
+# Microstrip dimensions
+unit = 1e6
+default_strip_length = 75e-3 * unit
+strip_width = 3e-3 * unit
+gap = 1e-3 * unit
+gnd_width = strip_width * 8
+metal_thickness = 0.2e-3 * unit
+
+# Microstrip materials
+pec = td.PECMedium()
+pec_cond = td.Medium(conductivity=1e10)
+pec2d = td.Medium2D(ss=pec_cond, tt=pec_cond)
+diel = td.Medium(permittivity=4.4)
+
+# Frequency setup
+freq_start = 1e8
+freq_stop = 10e9
+
+
+def make_simulation(planar_pec: bool, length: float = None):
+
+    if length:
+        strip_length = length
+    else:
+        strip_length = default_strip_length
+
+    if planar_pec:
+        height = 0
+        metal = pec2d
+    else:
+        height = metal_thickness
+        metal = pec
+
+    # wavelength / frequency
+    freq0 = (freq_start + freq_stop) / 2
+    fwidth = freq_stop - freq_start
+    wavelength0 = td.C_0 / freq0
+    run_time = 60 / fwidth
+
+    # Spatial grid specification
+    grid_spec = td.GridSpec.auto(min_steps_per_wvl=10, wavelength=td.C_0 / freq_stop)
+
+    # Make structures
+    strip = td.Structure(
+        geometry=td.Box(
+            center=[0, 0, height + gap + height / 2],
+            size=[strip_length, strip_width, height],
+        ),
+        medium=metal,
+    )
+
+    ground = td.Structure(
+        geometry=td.Box(
+            center=[0, 0, height / 2],
+            size=[strip_length, gnd_width, height],
+        ),
+        medium=metal,
+    )
+
+    substrate = td.Structure(
+        geometry=td.Box(
+            center=[0, 0, height + gap / 2],
+            size=[strip_length, gnd_width, gap],
+        ),
+        medium=diel,
+    )
+
+    structures = [substrate, strip, ground]
+
+    # Make simulation
+    center_sim = [0, 0, height + gap / 2 + gap * 2]
+    size_sim = [
+        strip_length + 0.5 * wavelength0,
+        gnd_width + 0.5 * wavelength0,
+        2 * height + gap + 0.5 * wavelength0,
+    ]
+
+    sim = td.Simulation(
+        center=center_sim,
+        size=size_sim,
+        grid_spec=grid_spec,
+        structures=structures,
+        sources=[],
+        monitors=[],
+        run_time=run_time,
+        boundary_spec=td.BoundarySpec.all_sides(boundary=td.PML()),
+        shutoff=1e-4,
+    )
+
+    return sim
+
+
+def make_component_modeler(
+    planar_pec: bool, reference_impedance: complex = 50, length: float = None
+):
+
+    if length:
+        strip_length = length
+    else:
+        strip_length = default_strip_length
+
+    sim = make_simulation(planar_pec, length=length)
+
+    if planar_pec:
+        height = 0
+    else:
+        height = metal_thickness
+
+    center_src1 = [-strip_length / 2, 0, height + gap / 2]
+    size_src1 = [0, strip_width, gap]
+
+    center_src2 = [strip_length / 2, 0, height + gap / 2]
+    size_src2 = [0, strip_width, gap]
+
+    port_cells = np.ceil(gap / (metal_thickness / 1))
+
+    port_1 = LumpedPort(
+        center=center_src1,
+        size=size_src1,
+        voltage_axis=2,
+        name="lumped_port_1",
+        refine_mesh=True,
+        num_grid_cells=port_cells,
+        impedance=reference_impedance,
+    )
+
+    port_2 = LumpedPort(
+        center=center_src2,
+        size=size_src2,
+        voltage_axis=2,
+        name="lumped_port_2",
+        refine_mesh=True,
+        num_grid_cells=port_cells,
+        impedance=reference_impedance,
+    )
+
+    ports = [port_1, port_2]
+    freqs = np.linspace(freq_start, freq_stop, 100)
+
+    modeler = TerminalComponentModeler(
+        simulation=sim,
+        ports=ports,
+        freqs=freqs,
+        remove_dc_component=False,
+        verbose=True,
+    )
+
+    return modeler

--- a/tests/test_plugins/test_terminal_component_modeler.py
+++ b/tests/test_plugins/test_terminal_component_modeler.py
@@ -1,0 +1,78 @@
+import pytest
+import numpy as np
+import pydantic.v1 as pydantic
+import matplotlib.pyplot as plt
+import gdstk
+
+import tidy3d as td
+from tidy3d.web.api.container import Batch
+from tidy3d.plugins.smatrix.smatrix import (
+    LumpedPort,
+    TerminalComponentModeler,
+    AbstractComponentModeler,
+)
+from tidy3d.exceptions import SetupError, Tidy3dKeyError
+from ..utils import run_emulated
+from .terminal_component_modeler_def import make_component_modeler
+
+
+def run_component_modeler(monkeypatch, modeler: TerminalComponentModeler):
+    sim_dict = modeler.sim_dict
+    batch_data = {task_name: run_emulated(sim) for task_name, sim in sim_dict.items()}
+    monkeypatch.setattr(TerminalComponentModeler, "_run_sims", lambda self, path_dir: batch_data)
+    # for the random data, the power wave matrix might be singular, leading to an error
+    # during inversion, so monkeypatch the inv method so that it operates on a dummy
+    # identity matrix
+    monkeypatch.setattr(AbstractComponentModeler, "inv", lambda matrix: np.eye(len(modeler.ports)))
+    s_matrix = modeler.run(path_dir=modeler.path_dir)
+    return s_matrix
+
+
+def test_validate_no_sources(tmp_path):
+    modeler = make_component_modeler(planar_pec=True, path_dir=str(tmp_path))
+    source = td.PointDipole(
+        source_time=td.GaussianPulse(freq0=2e14, fwidth=1e14), polarization="Ex"
+    )
+    sim_w_source = modeler.simulation.copy(update=dict(sources=(source,)))
+    with pytest.raises(pydantic.ValidationError):
+        _ = modeler.copy(update=dict(simulation=sim_w_source))
+
+
+def test_no_port(tmp_path):
+    modeler = make_component_modeler(planar_pec=True, path_dir=str(tmp_path))
+    _ = modeler.ports
+    with pytest.raises(Tidy3dKeyError):
+        modeler.get_port_by_name(port_name="NOT_A_PORT")
+
+
+def test_plot_sim(tmp_path):
+    modeler = make_component_modeler(planar_pec=False, path_dir=str(tmp_path))
+    modeler.plot_sim(z=0)
+    plt.close()
+
+
+def test_make_component_modeler(tmp_path):
+    _ = make_component_modeler(planar_pec=False, path_dir=str(tmp_path))
+
+
+def test_run(monkeypatch, tmp_path):
+    modeler = make_component_modeler(planar_pec=True, path_dir=str(tmp_path))
+    monkeypatch.setattr(TerminalComponentModeler, "run", lambda self, path_dir: None)
+    modeler.run(path_dir=str(tmp_path))
+
+
+def test_run_component_modeler(monkeypatch, tmp_path):
+    modeler = make_component_modeler(planar_pec=True, path_dir=str(tmp_path))
+    s_matrix = run_component_modeler(monkeypatch, modeler)
+
+    for port_in in modeler.ports:
+
+        for port_out in modeler.ports:
+
+            coords_in = dict(port_in=port_in.name)
+            coords_out = dict(port_out=port_out.name)
+
+            assert np.all(s_matrix.sel(**coords_in) != 0), "source index not present in S matrix"
+            assert np.all(
+                s_matrix.sel(**coords_in).sel(**coords_out) != 0
+            ), "monitor index not present in S matrix"

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -50,6 +50,9 @@ from .components.monitor import FieldProjectionAngleMonitor, FieldProjectionCart
 from .components.monitor import FieldProjectionKSpaceMonitor, FieldProjectionSurface
 from .components.monitor import DiffractionMonitor
 
+# lumped elements
+from .components.lumped_element import LumpedResistor
+
 # simulation
 from .components.simulation import Simulation
 
@@ -298,6 +301,7 @@ __all__ = [
     "config",
     "__version__",
     "Updater",
+    "LumpedResistor",
     "Scene",
     "StructureStructureInterface",
     "StructureBoundary",

--- a/tidy3d/components/lumped_element.py
+++ b/tidy3d/components/lumped_element.py
@@ -1,0 +1,83 @@
+"""Defines lumped elements that should be included in the simulation."""
+
+
+from __future__ import annotations
+from abc import ABC
+from typing import Union
+
+import pydantic.v1 as pydantic
+
+from .base import cached_property
+
+from .geometry.base import Box
+from .types import Axis
+from .viz import PlotParams, plot_params_lumped_element
+from ..constants import OHM
+from ..components.validators import validate_name_str, assert_plane
+from ..exceptions import ValidationError
+
+
+class LumpedElement(Box, ABC):
+    """Base class describing lumped elements."""
+
+    name: str = pydantic.Field(
+        ...,
+        title="Name",
+        description="Unique name for the lumped element.",
+        min_length=1,
+    )
+
+    voltage_axis: Axis = pydantic.Field(
+        ...,
+        title="Voltage Drop Axis",
+        description="Specifies the axis along which the component is oriented and along which the "
+        "associated voltage drop will occur. Must be in the plane of the element.",
+    )
+
+    _name_validator = validate_name_str()
+    _plane_validator = assert_plane()
+
+    @cached_property
+    def normal_axis(self):
+        """Normal axis of the lumped element."""
+        return self.size.index(0.0)
+
+    @cached_property
+    def plot_params(self) -> PlotParams:
+        """Default parameters for plotting a LumpedElement object."""
+        return plot_params_lumped_element
+
+    @pydantic.validator("voltage_axis", always=True)
+    def _voltage_axis_in_plane(cls, val, values):
+        """Ensure voltage drop axis is in the plane of the lumped element."""
+        name = values.get("name")
+        size = values.get("size")
+        if size and size.count(0.0) == 1 and size.index(0.0) == val:
+            # if not planar, then a separate validator should be triggered, not this one
+            raise ValidationError(
+                f"'voltage_axis' must be in the plane of lumped element '{name}'."
+            )
+        return val
+
+
+class LumpedResistor(LumpedElement):
+    """Base class describing lumped elements."""
+
+    resistance: pydantic.NonNegativeFloat = pydantic.Field(
+        ...,
+        title="Resistance",
+        description="Resistance value in ohms.",
+        unit=OHM,
+    )
+
+    @cached_property
+    def sheet_conductance(self):
+        """Effective sheet conductance."""
+        lateral_axis = 3 - self.voltage_axis - self.normal_axis
+        return self.size[self.voltage_axis] / self.size[lateral_axis] / self.resistance
+
+
+# lumped elements allowed in Simulation.lumped_elements
+LumpedElementType = Union[
+    LumpedResistor,
+]

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -3046,10 +3046,10 @@ class Simulation(AbstractSimulation):
                     for _, poly_geom in enumerate(polygon.geoms):
                         all_polygons.append(poly_geom)
                     continue
-                if len(polygon.exterior.coords) == 0:
-                    continue
                 if not isinstance(polygon, shapely.LineString):
                     all_polygons.append(shapely.LineString(list(polygon.exterior.coords)))
+                elif len(polygon.exterior.coords) == 0:
+                    continue
                 else:
                     all_polygons.append(polygon)
 

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -3047,9 +3047,9 @@ class Simulation(AbstractSimulation):
                         all_polygons.append(poly_geom)
                     continue
                 if not isinstance(polygon, shapely.LineString):
+                    if len(polygon.exterior.coords) == 0:
+                        continue
                     all_polygons.append(shapely.LineString(list(polygon.exterior.coords)))
-                elif len(polygon.exterior.coords) == 0:
-                    continue
                 else:
                     all_polygons.append(polygon)
 

--- a/tidy3d/components/source.py
+++ b/tidy3d/components/source.py
@@ -466,6 +466,14 @@ class ReverseInterpolatedSource(Source):
         "placement at the specified location using linear interpolation.",
     )
 
+    confine_to_bounds: bool = pydantic.Field(
+        False,
+        title="Confine to Analytical Bounds",
+        description="If ``True``, any source amplitudes which, after discretization, fall beyond "
+        "the analytical bounds of the source are zeroed out, but only along directions where "
+        "the source has a non-zero extent.",
+    )
+
 
 class UniformCurrentSource(CurrentSource, ReverseInterpolatedSource):
     """Source in a rectangular volume with uniform time dependence. size=(0,0,0) gives point source.

--- a/tidy3d/components/viz.py
+++ b/tidy3d/components/viz.py
@@ -116,6 +116,9 @@ plot_params_override_structures = PlotParams(
 )
 plot_params_fluid = PlotParams(facecolor="white", edgecolor="lightsteelblue", lw=0.4, hatch="xx")
 plot_params_grid = PlotParams(edgecolor="black", lw=0.2)
+plot_params_lumped_element = PlotParams(
+    alpha=0.4, facecolor="mediumblue", edgecolor="mediumblue", lw=3
+)
 
 # stores color of simulation.structures for given index in simulation.medium_map
 MEDIUM_CMAP = [

--- a/tidy3d/constants.py
+++ b/tidy3d/constants.py
@@ -49,6 +49,7 @@ CMCUBE = "cm^3"
 PERCMCUBE = "1/cm^3"
 WATT = "W"
 VOLT = "V"
+OHM = "ohm"
 
 THERMAL_CONDUCTIVITY = "W/(um*K)"
 SPECIFIC_HEAT_CAPACITY = "J/(kg*K)"

--- a/tidy3d/plugins/smatrix/__init__.py
+++ b/tidy3d/plugins/smatrix/__init__.py
@@ -1,5 +1,13 @@
 """ Imports from scattering matrix plugin. """
 
-from .smatrix import ComponentModeler, Port, SMatrixDataArray
+from .smatrix import ComponentModeler, Port, ModalPortDataArray
+from .smatrix import TerminalComponentModeler, LumpedPort, LumpedPortDataArray
 
-__all__ = ["ComponentModeler", "Port", "SMatrixDataArray"]
+__all__ = [
+    "ComponentModeler",
+    "Port",
+    "ModalPortDataArray",
+    "TerminalComponentModeler",
+    "LumpedPort",
+    "LumpedPortDataArray",
+]

--- a/tidy3d/plugins/smatrix/smatrix.py
+++ b/tidy3d/plugins/smatrix/smatrix.py
@@ -298,16 +298,16 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
         batch = self.batch
 
         # TEMP
-        import sys
-        TIDY3D_CORE_PATH = '/home/shashwat/flexcompute/repositories/tidy3d-core'
-        sys.path.insert(0, TIDY3D_CORE_PATH)
-        from tidy3d_backend.run import run_sim
-        batch_data = {}
-        for name, sim in self.sim_dict.items():
-            batch_data[name] = run_sim(sim, mpi=1)
+        # import sys
+        # TIDY3D_CORE_PATH = '/home/shashwat/flexcompute/repositories/tidy3d-core'
+        # sys.path.insert(0, TIDY3D_CORE_PATH)
+        # from tidy3d_backend.run import run_sim
+        # batch_data = {}
+        # for name, sim in self.sim_dict.items():
+        #     batch_data[name] = run_sim(sim, mpi=1)
 
         # TEMP
-        # batch_data = batch.run(path_dir=path_dir)
+        batch_data = batch.run(path_dir=path_dir)
         
         batch.to_file(self._batch_path)
         return batch_data

--- a/tidy3d/plugins/smatrix/smatrix.py
+++ b/tidy3d/plugins/smatrix/smatrix.py
@@ -1,30 +1,37 @@
 """Tools for generating an S matrix automatically from tidy3d simulation and port definitions."""
+# TODO: The names "ComponentModeler" and "Port" should be changed to "ModalComponentModeler" and
+# "ModalPort" to explicitly differentiate these from "TerminalComponentModeler" and "LumpedPort".
 from __future__ import annotations
 
-from typing import List, Tuple, Optional, Dict
+from typing import List, Tuple, Optional, Dict, Union
 import os
+from abc import ABC, abstractmethod
 
 import pydantic.v1 as pd
 import numpy as np
 
-from ...constants import HERTZ
+from ...constants import HERTZ, OHM, C_0
 from ...components.simulation import Simulation
 from ...components.geometry.base import Box
+from ...components.structure import MeshOverrideStructure
 from ...components.mode import ModeSpec
-from ...components.monitor import ModeMonitor
-from ...components.source import ModeSource, GaussianPulse
+from ...components.monitor import ModeMonitor, FieldMonitor
+from ...components.source import ModeSource, GaussianPulse, UniformCurrentSource
 from ...components.data.sim_data import SimulationData
 from ...components.data.data_array import DataArray
-from ...components.types import Direction, Ax, Complex, FreqArray
+from ...components.types import Direction, Ax, Complex, FreqArray, Axis
 from ...components.viz import add_ax_if_none, equal_aspect
 from ...components.base import Tidy3dBaseModel, cached_property
-from ...exceptions import SetupError, Tidy3dKeyError
+from ...components.validators import assert_plane
+from ...components.lumped_element import LumpedResistor
+from ...exceptions import SetupError, Tidy3dKeyError, ValidationError
 from ...log import log
 from ...web.api.container import BatchData, Batch
 
 # fwidth of gaussian pulse in units of central frequency
 FWIDTH_FRAC = 1.0 / 10
 DEFAULT_DATA_DIR = "."
+DEFAULT_PORT_NUM_CELLS = 3
 
 
 class Port(Box):
@@ -48,12 +55,71 @@ class Port(Box):
     )
 
 
+class LumpedPort(Box):
+    """Lumped port source."""
+
+    name: str = pd.Field(
+        ...,
+        title="Name",
+        description="Unique name for the port.",
+        min_length=1,
+    )
+
+    voltage_axis: Axis = pd.Field(
+        ...,
+        title="Voltage Integration Axis",
+        description="Specifies the axis along which the E-field line integral is performed when "
+        "computing the port voltage. The integration axis must lie in the plane of the port.",
+    )
+
+    impedance: Complex = pd.Field(
+        50,
+        title="Reference impedance",
+        description="Reference port impedance for scattering parameter computation.",
+        units=OHM,
+    )
+
+    refine_mesh: bool = pd.Field(
+        True,
+        title="Port mesh refinement",
+        description="If ``True``, enables mesh refinement in the port region to ensure that "
+        "the port voltage and current are computed accurately.",
+    )
+
+    num_grid_cells: pd.PositiveInt = pd.Field(
+        DEFAULT_PORT_NUM_CELLS,
+        title="Port grid cells",
+        description="Number of mesh grid cells associated with the port along each direction. "
+        "This is used only if ``refine_mesh`` is ``True``.",
+    )
+
+    _plane_validator = assert_plane()
+
+    @cached_property
+    def injection_axis(self):
+        """Injection axis of the port."""
+        return self.size.index(0.0)
+
+    @pd.validator("voltage_axis", always=True)
+    def _voltage_axis_in_plane(cls, val, values):
+        """Ensure voltage integration axis is in the port's plane."""
+        size = values.get("size")
+        if val == size.index(0.0):
+            raise ValidationError("'voltage_axis' must lie in the port's plane.")
+        return val
+
+    @cached_property
+    def current_axis(self) -> Axis:
+        """Integration axis for computing the port current via the magnetic field."""
+        return 3 - self.injection_axis - self.voltage_axis
+
+
 MatrixIndex = Tuple[str, pd.NonNegativeInt]  # the 'i' in S_ij
 Element = Tuple[MatrixIndex, MatrixIndex]  # the 'ij' in S_ij
 
 
-class SMatrixDataArray(DataArray):
-    """Scattering matrix elements.
+class ModalPortDataArray(DataArray):
+    """Port parameter matrix elements for modal ports.
 
     Example
     -------
@@ -69,33 +135,67 @@ class SMatrixDataArray(DataArray):
     ...     mode_index_out=mode_index_out,
     ...     f=f
     ... )
-    >>> fd = SMatrixDataArray((1 + 1j) * np.random.random((2, 2, 2, 2, 1)), coords=coords)
+    >>> fd = ModalPortDataArray((1 + 1j) * np.random.random((2, 2, 2, 2, 1)), coords=coords)
     """
 
     __slots__ = ()
     _dims = ("port_out", "mode_index_out", "port_in", "mode_index_in", "f")
-    _data_attrs = {"long_name": "scattering matrix element"}
+    _data_attrs = {"long_name": "modal port matrix element"}
 
 
-class ComponentModeler(Tidy3dBaseModel):
-    """Tool for modeling devices and computing scattering matrix elements."""
+class LumpedPortDataArray(DataArray):
+    """Port parameter matrix elements for lumped ports.
+
+    Example
+    -------
+    >>> port_in = ['port1', 'port2']
+    >>> port_out = ['port1', 'port2']
+    >>> f = [2e14]
+    >>> coords = dict(
+    ...     port_in=ports_in,
+    ...     port_out=ports_out,
+    ...     f=f
+    ... )
+    >>> fd = LumpedPortDataArray((1 + 1j) * np.random.random((2, 2, 1)), coords=coords)
+    """
+
+    __slots__ = ()
+    _dims = ("port_out", "port_in", "f")
+    _data_attrs = {"long_name": "lumped port matrix element"}
+
+
+class AbstractComponentModeler(ABC, Tidy3dBaseModel):
+    """Tool for modeling devices and computing port parameters."""
 
     simulation: Simulation = pd.Field(
         ...,
         title="Simulation",
         description="Simulation describing the device without any sources present.",
     )
-    ports: Tuple[Port, ...] = pd.Field(
+
+    ports: Tuple[Union[Port, LumpedPort], ...] = pd.Field(
         (),
         title="Ports",
         description="Collection of ports describing the scattering matrix elements. "
         "For each input mode, one simulation will be run with a modal source.",
     )
+
     freqs: FreqArray = pd.Field(
         ...,
         title="Frequencies",
-        description="Array or list of frequencies at which to evaluate the scattering matrix.",
+        description="Array or list of frequencies at which to compute port parameters.",
         units=HERTZ,
+    )
+
+    remove_dc_component: bool = pd.Field(
+        True,
+        title="Remove DC Component",
+        description="Whether to remove the DC component in the Gaussian pulse spectrum. "
+        "If ``True``, the Gaussian pulse is modified at low frequencies to zero out the "
+        "DC component, which is usually desirable so that the fields will decay. However, "
+        "for broadband simulations, it may be better to have non-vanishing source power "
+        "near zero frequency. Setting this to ``False`` results in an unmodified Gaussian "
+        "pulse spectrum which can have a nonzero DC component.",
     )
 
     folder_name: str = pd.Field(
@@ -103,6 +203,192 @@ class ComponentModeler(Tidy3dBaseModel):
         title="Folder Name",
         description="Name of the folder for the tasks on web.",
     )
+
+    verbose: bool = pd.Field(
+        False,
+        title="Verbosity",
+        description="Whether the :class:`.ComponentModeler` should print status and progressbars.",
+    )
+
+    callback_url: str = pd.Field(
+        None,
+        title="Callback URL",
+        description="Http PUT url to receive simulation finish event. "
+        "The body content is a json file with fields "
+        "``{'id', 'status', 'name', 'workUnit', 'solverVersion'}``.",
+    )
+
+    path_dir: str = pd.Field(
+        DEFAULT_DATA_DIR,
+        title="Directory Path",
+        description="Base directory where data and batch will be downloaded.",
+    )
+
+    solver_version: str = pd.Field(
+        None,
+        title="Solver Version",
+        description_str="Custom solver version to use, "
+        "otherwise uses default for the current front end version.",
+    )
+
+    @pd.validator("simulation", always=True)
+    def _sim_has_no_sources(cls, val):
+        """Make sure simulation has no sources as they interfere with tool."""
+        if len(val.sources) > 0:
+            raise SetupError("'AbstractComponentModeler.simulation' must not have any sources.")
+        return val
+
+    @staticmethod
+    def _task_name(port: Port, mode_index: int = None) -> str:
+        """The name of a task, determined by the port of the source and mode index, if given."""
+        if mode_index is not None:
+            return f"smatrix_{port.name}_{mode_index}"
+        return f"smatrix_{port.name}"
+
+    @cached_property
+    def sim_dict(self) -> Dict[str, Simulation]:
+        """Generate all the :class:`Simulation` objects for the S matrix calculation."""
+
+    @cached_property
+    def batch(self) -> Batch:
+        """Batch associated with this component modeler."""
+
+        # first try loading the batch from file, if it exists
+        batch_path = self._batch_path
+        if os.path.exists(batch_path):
+            return Batch.from_file(fname=batch_path)
+
+        return Batch(
+            simulations=self.sim_dict,
+            folder_name=self.folder_name,
+            callback_url=self.callback_url,
+            verbose=self.verbose,
+            solver_version=self.solver_version,
+        )
+
+    @cached_property
+    def batch_path(self) -> str:
+        """Path to the batch saved to file."""
+
+        return self.batch._batch_path(path_dir=DEFAULT_DATA_DIR)
+
+    def get_path_dir(self, path_dir: str) -> None:
+        """Check whether the supplied 'path_dir' matches the internal field value."""
+
+        if path_dir not in (DEFAULT_DATA_DIR, self.path_dir):
+            log.warning(
+                f"'ComponentModeler' method was supplied a 'path_dir' of '{path_dir}' "
+                f"when its internal 'path_dir' field was set to '{self.path_dir}'. "
+                "The passed value will be deprecated in later versions. "
+                "Please set the internal 'path_dir' field to the desired value and "
+                "remove the 'path_dir' from the method argument. "
+                f"Using supplied '{path_dir}'."
+            )
+            return path_dir
+
+        return self.path_dir
+
+    @cached_property
+    def _batch_path(self) -> str:
+        """Where we store the batch for this ComponentModeler instance after the run."""
+        return os.path.join(self.path_dir, "batch" + str(hash(self)) + ".json")
+
+    def _run_sims(self, path_dir: str = DEFAULT_DATA_DIR) -> BatchData:
+        """Run :class:`Simulations` for each port and return the batch after saving."""
+        batch = self.batch
+
+        # TEMP
+        import sys
+        TIDY3D_CORE_PATH = '/home/shashwat/flexcompute/repositories/tidy3d-core'
+        sys.path.insert(0, TIDY3D_CORE_PATH)
+        from tidy3d_backend.run import run_sim
+        batch_data = {}
+        for name, sim in self.sim_dict.items():
+            batch_data[name] = run_sim(sim, mpi=1)
+
+        # TEMP
+        # batch_data = batch.run(path_dir=path_dir)
+        
+        batch.to_file(self._batch_path)
+        return batch_data
+
+    def get_port_by_name(self, port_name: str) -> Port:
+        """Get the port from the name."""
+        ports = [port for port in self.ports if port.name == port_name]
+        if len(ports) == 0:
+            raise Tidy3dKeyError(f'Port "{port_name}" not found.')
+        return ports[0]
+
+    @abstractmethod
+    def _construct_smatrix(self, batch_data: BatchData) -> DataArray:
+        """Post process `BatchData` to generate scattering matrix."""
+
+    def run(self, path_dir: str = DEFAULT_DATA_DIR) -> DataArray:
+        """Solves for the scattering matrix of the system."""
+        path_dir = self.get_path_dir(path_dir)
+
+        batch_data = self._run_sims(path_dir=path_dir)
+        return self._construct_smatrix(batch_data=batch_data)
+
+    def load(self, path_dir: str = DEFAULT_DATA_DIR) -> DataArray:
+        """Load a scattering matrix from saved `BatchData` object."""
+        path_dir = self.get_path_dir(path_dir)
+
+        batch_data = BatchData.load(path_dir=path_dir)
+        return self._construct_smatrix(batch_data=batch_data)
+
+    @staticmethod
+    def s_to_z(s_matrix: DataArray, reference: Complex) -> DataArray:
+        """Get the impedance matrix given the scattering matrix and a reference impedance."""
+
+        # move the input and output port dimensions to the end, for ease of matrix operations
+        dims = list(s_matrix.dims)
+        dims.append(dims.pop(dims.index("port_out")))
+        dims.append(dims.pop(dims.index("port_in")))
+        z_matrix = s_matrix.copy(deep=True).transpose(*dims)
+        s_vals = z_matrix.values
+
+        eye = np.eye(len(s_matrix.port_out.values), len(s_matrix.port_in.values))
+        z_vals = np.matmul(AbstractComponentModeler.inv(eye - s_vals), (eye + s_vals)) * reference
+
+        z_matrix.data = z_vals
+        return z_matrix
+
+    @staticmethod
+    def ab_to_s(a_matrix: DataArray, b_matrix: DataArray) -> DataArray:
+        """Get the scattering matrix given the power wave matrices."""
+
+        # move the input and output port dimensions to the end, for ease of matrix operations
+        assert a_matrix.dims == b_matrix.dims
+        dims = list(a_matrix.dims)
+        dims.append(dims.pop(dims.index("port_out")))
+        dims.append(dims.pop(dims.index("port_in")))
+
+        s_matrix = a_matrix.copy(deep=True).transpose(*dims)
+        a_vals = s_matrix.copy(deep=True).transpose(*dims).values
+        b_vals = b_matrix.copy(deep=True).transpose(*dims).values
+
+        s_vals = np.matmul(b_vals, AbstractComponentModeler.inv(a_vals))
+
+        s_matrix.data = s_vals
+        return s_matrix
+
+    @staticmethod
+    def inv(matrix: DataArray):
+        """Helper to invert a port matrix."""
+        return np.linalg.inv(matrix)
+
+
+class ComponentModeler(AbstractComponentModeler):
+    """Tool for modeling devices and computing scattering matrix elements with modal ports."""
+
+    ports: Tuple[Port, ...] = pd.Field(
+        (),
+        title="Ports",
+        description="Collection of ports describing the scattering matrix elements. "
+        "For each input mode, one simulation will be run with a modal source.",
+    )
+
     element_mappings: Tuple[Tuple[Element, Element, Complex], ...] = pd.Field(
         (),
         title="Element Mappings",
@@ -115,6 +401,7 @@ class ComponentModeler(Tidy3dBaseModel):
         " ``element_mappings``, the simulation corresponding to this column "
         "is skipped automatically.",
     )
+
     run_only: Optional[Tuple[MatrixIndex, ...]] = pd.Field(
         None,
         title="Run Only",
@@ -123,30 +410,6 @@ class ComponentModeler(Tidy3dBaseModel):
         "If this option is used, "
         "the data corresponding to other inputs will be missing in the resulting matrix.",
     )
-    verbose: bool = pd.Field(
-        False,
-        title="Verbosity",
-        description="Whether the :class:`.ComponentModeler` should print status and progressbars.",
-    )
-    callback_url: str = pd.Field(
-        None,
-        title="Callback URL",
-        description="Http PUT url to receive simulation finish event. "
-        "The body content is a json file with fields "
-        "``{'id', 'status', 'name', 'workUnit', 'solverVersion'}``.",
-    )
-    path_dir: str = pd.Field(
-        DEFAULT_DATA_DIR,
-        title="Directory Path",
-        description="Base directory where data and batch will be downloaded.",
-    )
-
-    @pd.validator("simulation", always=True)
-    def _sim_has_no_sources(cls, val):
-        """Make sure simulation has no sources as they interfere with tool."""
-        if len(val.sources) > 0:
-            raise SetupError("'ComponentModeler.simulation' must not have any sources.")
-        return val
 
     @cached_property
     def sim_dict(self) -> Dict[str, Simulation]:
@@ -211,12 +474,22 @@ class ComponentModeler(Tidy3dBaseModel):
 
         return source_indices_needed
 
-    def get_port_by_name(self, port_name: str) -> Port:
-        """Get the port from the name."""
-        ports = [port for port in self.ports if port.name == port_name]
-        if len(ports) == 0:
-            raise Tidy3dKeyError(f'Port "{port_name}" not found.')
-        return ports[0]
+    @cached_property
+    def port_names(self) -> Tuple[List[str], List[str]]:
+        """List of port names for inputs and outputs, respectively."""
+
+        def get_port_names(matrix_elements: Tuple[str, int]) -> List[str]:
+            """Get the port names from a list of (port name, mode index)."""
+            port_names = []
+            for port_name, _ in matrix_elements:
+                if port_name not in port_names:
+                    port_names.append(port_name)
+            return port_names
+
+        port_names_in = get_port_names(self.matrix_indices_source)
+        port_names_out = get_port_names(self.matrix_indices_monitor)
+
+        return port_names_out, port_names_in
 
     def to_monitor(self, port: Port) -> ModeMonitor:
         """Creates a mode monitor from a given port."""
@@ -291,16 +564,9 @@ class ComponentModeler(Tidy3dBaseModel):
         port_shifted = port.copy(update=dict(center=center_shifted))
         return port_shifted
 
-    @staticmethod
-    def _task_name(port: Port, mode_index: int) -> str:
-        """The name of a task, determined by the port of the source and mode index."""
-        return f"smatrix_{port.name}_{mode_index}"
-
     @equal_aspect
     @add_ax_if_none
-    def plot_sim(
-        self, x: float = None, y: float = None, z: float = None, ax: Ax = None, **kwargs
-    ) -> Ax:
+    def plot_sim(self, x: float = None, y: float = None, z: float = None, ax: Ax = None) -> Ax:
         """Plot a :class:`Simulation` with all sources added for each port, for troubleshooting."""
 
         plot_sources = []
@@ -308,72 +574,7 @@ class ComponentModeler(Tidy3dBaseModel):
             mode_source_0 = self.to_source(port=port_source, mode_index=0)
             plot_sources.append(mode_source_0)
         sim_plot = self.simulation.copy(update=dict(sources=plot_sources))
-        return sim_plot.plot(x=x, y=y, z=z, ax=ax, **kwargs)
-
-    @equal_aspect
-    @add_ax_if_none
-    def plot_sim_eps(
-        self, x: float = None, y: float = None, z: float = None, ax: Ax = None, **kwargs
-    ) -> Ax:
-        """Plot permittivity of the :class:`Simulation` with all sources added for each port."""
-
-        plot_sources = []
-        for port_source in self.ports:
-            mode_source_0 = self.to_source(port=port_source, mode_index=0)
-            plot_sources.append(mode_source_0)
-        sim_plot = self.simulation.copy(update=dict(sources=plot_sources))
-        return sim_plot.plot_eps(x=x, y=y, z=z, ax=ax, **kwargs)
-
-    @cached_property
-    def batch(self) -> Batch:
-        """Batch associated with this component modeler."""
-
-        # first try loading the batch from file, if it exists
-        batch_path = self._batch_path
-        if os.path.exists(batch_path):
-            return Batch.from_file(fname=batch_path)
-
-        return Batch(
-            simulations=self.sim_dict,
-            folder_name=self.folder_name,
-            callback_url=self.callback_url,
-            verbose=self.verbose,
-        )
-
-    @cached_property
-    def batch_path(self) -> str:
-        """Path to the batch saved to file."""
-
-        return self.batch._batch_path(path_dir=DEFAULT_DATA_DIR)
-
-    def get_path_dir(self, path_dir: str) -> None:
-        """Check whether the supplied 'path_dir' matches the internal field value."""
-
-        if path_dir not in (DEFAULT_DATA_DIR, self.path_dir):
-            log.warning(
-                f"'ComponentModeler' method was supplied a 'path_dir' of '{path_dir}' "
-                f"when its internal 'path_dir' field was set to '{self.path_dir}'. "
-                "The passed value will be deprecated in later versions. "
-                "Please set the internal 'path_dir' field to the desired value and "
-                "remove the 'path_dir' from the method argument. "
-                f"Using supplied '{path_dir}'."
-            )
-            return path_dir
-
-        return self.path_dir
-
-    @cached_property
-    def _batch_path(self) -> str:
-        """Where we store the batch for this ComponentModeler instance after the run."""
-        hash_str = self._hash_self()
-        return os.path.join(self.path_dir, "batch" + hash_str + ".json")
-
-    def _run_sims(self, path_dir: str = DEFAULT_DATA_DIR) -> BatchData:
-        """Run :class:`Simulations` for each port and return the batch after saving."""
-        batch = self.batch
-        batch_data = batch.run(path_dir=path_dir)
-        batch.to_file(self._batch_path)
-        return batch_data
+        return sim_plot.plot(x=x, y=y, z=z, ax=ax)
 
     def _normalization_factor(self, port_source: Port, sim_data: SimulationData) -> complex:
         """Compute the normalization amplitude based on the measured input mode amplitude."""
@@ -402,24 +603,7 @@ class ComponentModeler(Tidy3dBaseModel):
 
         return max_mode_index_out, max_mode_index_in
 
-    @cached_property
-    def port_names(self) -> Tuple[List[str], List[str]]:
-        """List of port names for inputs and outputs, respectively."""
-
-        def get_port_names(matrix_elements: Tuple[str, int]) -> List[str]:
-            """Get the port names from a list of (port name, mode index)."""
-            port_names = []
-            for port_name, _ in matrix_elements:
-                if port_name not in port_names:
-                    port_names.append(port_name)
-            return port_names
-
-        port_names_in = get_port_names(self.matrix_indices_source)
-        port_names_out = get_port_names(self.matrix_indices_monitor)
-
-        return port_names_out, port_names_in
-
-    def _construct_smatrix(self, batch_data: BatchData) -> SMatrixDataArray:
+    def _construct_smatrix(self, batch_data: BatchData) -> ModalPortDataArray:
         """Post process `BatchData` to generate scattering matrix."""
 
         max_mode_index_out, max_mode_index_in = self.max_mode_index
@@ -438,7 +622,7 @@ class ComponentModeler(Tidy3dBaseModel):
             mode_index_in=range(num_modes_in),
             f=np.array(self.freqs),
         )
-        s_matrix = SMatrixDataArray(values, coords=coords)
+        s_matrix = ModalPortDataArray(values, coords=coords)
 
         # loop through source ports
         for col_index in self.matrix_indices_run_sim:
@@ -494,16 +678,290 @@ class ComponentModeler(Tidy3dBaseModel):
 
         return s_matrix
 
-    def run(self, path_dir: str = DEFAULT_DATA_DIR) -> SMatrixDataArray:
-        """Solves for the scattering matrix of the system."""
-        path_dir = self.get_path_dir(path_dir)
 
-        batch_data = self._run_sims(path_dir=path_dir)
-        return self._construct_smatrix(batch_data=batch_data)
+class TerminalComponentModeler(AbstractComponentModeler):
+    """Tool for modeling two-terminal multiport devices and computing port parameters
+    with lumped ports."""
 
-    def load(self, path_dir: str = DEFAULT_DATA_DIR) -> SMatrixDataArray:
-        """Load a scattering matrix from saved `BatchData` object."""
-        path_dir = self.get_path_dir(path_dir)
+    ports: Tuple[LumpedPort, ...] = pd.Field(
+        (),
+        title="Lumped ports",
+        description="Collection of lumped ports associated with the network. "
+        "For each port, one simulation will be run with a lumped port source.",
+    )
 
-        batch_data = BatchData.load(path_dir=path_dir)
-        return self._construct_smatrix(batch_data=batch_data)
+    @equal_aspect
+    @add_ax_if_none
+    def plot_sim(self, x: float = None, y: float = None, z: float = None, ax: Ax = None) -> Ax:
+        """Plot a :class:`Simulation` with all sources added for each port, for troubleshooting."""
+
+        plot_sources = []
+        for port_source in self.ports:
+            source_0 = self.to_source(port=port_source)
+            plot_sources.append(source_0)
+        sim_plot = self.simulation.copy(update=dict(sources=plot_sources))
+        return sim_plot.plot(x=x, y=y, z=z, ax=ax)
+
+    def to_source(self, port: LumpedPort) -> UniformCurrentSource:
+        """Create a current source from a given lumped port."""
+        # The source is expanded slightly to make sure that, when discretized, it covers the
+        # entire source region. Discretized source amps are manually zeroed out later if they
+        # fall on Yee grid locations outside the analytical source region.
+        freq0 = np.mean(self.freqs)
+        fdiff = max(self.freqs) - min(self.freqs)
+        fwidth = max(fdiff, freq0 * FWIDTH_FRAC)
+        component = "xyz"[port.voltage_axis]
+        return UniformCurrentSource(
+            center=port.center,
+            size=port.size,
+            source_time=GaussianPulse(
+                freq0=freq0, fwidth=fwidth, remove_dc_component=self.remove_dc_component
+            ),
+            polarization=f"E{component}",
+            name=port.name,
+            interpolate=True,
+            confine_to_bounds=True,
+        )
+
+    def to_monitor(self, port: LumpedPort) -> FieldMonitor:
+        """Field monitor to compute port voltage and current."""
+
+        e_component = "xyz"[port.voltage_axis]
+        h_component = "xyz"[port.current_axis]
+
+        mon_size = list(port.size)
+        mon_size[port.injection_axis] = 1e-10  # * port.size[port.current_axis]
+
+        return FieldMonitor(
+            center=port.center,
+            size=mon_size,
+            freqs=self.freqs,
+            fields=[f"E{e_component}", f"H{h_component}"],
+            name=f"{port.name}_E{e_component}_H{h_component}",
+            colocate=False,
+        )
+
+    @cached_property
+    def sim_dict(self) -> Dict[str, Simulation]:
+        """Generate all the :class:`Simulation` objects for the port parameter calculation."""
+
+        sim_dict = {}
+
+        port_monitors = [self.to_monitor(port=port) for port in self.ports]
+
+        lumped_resistors = [
+            LumpedResistor(
+                center=port.center,
+                size=port.size,
+                resistance=np.real(port.impedance),
+                name=f"{port.name}_resistor",
+                voltage_axis=port.voltage_axis,
+            )
+            for port in self.ports
+        ]
+
+        # Create a mesh override for each port in case refinement is needed.
+        # The port is a flat surface, but when computing the port current,
+        # we'll eventually integrate the magnetic field just above and below
+        # this surface, so the mesh override needs to ensure that the mesh
+        # is fine enough not only in plane, but also in the normal direction.
+        # So in the normal direction, we'll make sure there are at least
+        # 2 cell layers above and below whose size is the same as the in-plane
+        # cell size in the override region. Also, to ensure that the port itself
+        # is aligned with a grid boundary in the normal direction, two separate
+        # override regions are defined, one above and one below the analytical
+        # port region.
+        mesh_overrides = []
+
+        for port in self.ports:
+            if port.refine_mesh:
+                override_dl = [port.size[port.voltage_axis] / port.num_grid_cells] * 3
+                override_dl[port.injection_axis] /= 2
+
+                override_size = list(port.size)
+                override_size[override_size.index(0)] = 2 * override_dl[port.injection_axis]
+
+                override_center_above = list(port.center)
+                override_center_above[port.injection_axis] += override_dl[port.injection_axis]
+
+                override_center_below = list(port.center)
+                override_center_below[port.injection_axis] -= override_dl[port.injection_axis]
+
+                mesh_overrides.append(
+                    MeshOverrideStructure(
+                        geometry=Box(center=override_center_below, size=override_size),
+                        dl=override_dl,
+                    )
+                )
+                mesh_overrides.append(
+                    MeshOverrideStructure(
+                        geometry=Box(center=override_center_above, size=override_size),
+                        dl=override_dl,
+                    )
+                )
+
+        new_mnts = list(self.simulation.monitors) + port_monitors
+
+        # also, use the highest frequency in the simulation to define the grid, rather than the
+        # source's central frequency, to ensure an accurate solution over the entire range
+        grid_spec = self.simulation.grid_spec.copy(
+            update={
+                "wavelength": C_0 / np.max(self.freqs),
+                "override_structures": list(self.simulation.grid_spec.override_structures)
+                + mesh_overrides,
+            }
+        )
+
+        for port in self.ports:
+
+            port_source = self.to_source(port=port)
+            update_dict = dict(
+                sources=[port_source],
+                monitors=new_mnts,
+                lumped_elements=lumped_resistors,
+                grid_spec=grid_spec,
+            )
+
+            sim_copy = self.simulation.copy(update=update_dict)
+            task_name = self._task_name(port=port)
+            sim_dict[task_name] = sim_copy
+        return sim_dict
+
+    def _construct_smatrix(self, batch_data: BatchData) -> LumpedPortDataArray:
+        """Post process `BatchData` to generate scattering matrix."""
+
+        port_names = [port.name for port in self.ports]
+
+        values = np.zeros(
+            (len(port_names), len(port_names), len(self.freqs)),
+            dtype=complex,
+        )
+        coords = dict(
+            port_out=port_names,
+            port_in=port_names,
+            f=np.array(self.freqs),
+        )
+        a_matrix = LumpedPortDataArray(values, coords=coords)
+        b_matrix = a_matrix.copy(deep=True)
+
+        def port_iv(port: LumpedPort, sim_data: SimulationData):
+            """Helper to compute the port current and voltage."""
+            e_component = "xyz"[port.voltage_axis]
+            h_component = "xyz"[port.current_axis]
+            orth_component = "xyz"[port.injection_axis]
+
+            field_data = sim_data[f"{port.name}_E{e_component}_H{h_component}"]
+
+            e_field = field_data.field_components[f"E{e_component}"]
+            e_coords = [e_field.x, e_field.y, e_field.z]
+
+            h_field = field_data.field_components[f"H{h_component}"]
+            h_coords = [h_field.x, h_field.y, h_field.z]
+
+            # the tangential E field should be sampled at the source plane, and
+            # the tangential H field should be sampled just above and below the source plane
+            # and then subtracted, to compute the surface current density
+
+            orth_index = np.argmin(
+                np.abs(e_coords[port.injection_axis].values - port.center[port.injection_axis])
+            )
+            assert orth_index > 0
+
+            # for the line integrals, the E and H fields should be sampled near the port's center
+            e_index = np.argmin(
+                np.abs(h_coords[port.voltage_axis].values - port.center[port.voltage_axis])
+            )
+            h_index = np.argmin(
+                np.abs(e_coords[port.current_axis].values - port.center[port.current_axis])
+            )
+
+            e_field = e_field.isel(
+                indexers={
+                    orth_component: orth_index,
+                    h_component: h_index,
+                }
+            )
+
+            h1_field = h_field.isel(
+                indexers={
+                    orth_component: orth_index - 1,
+                    e_component: e_index,
+                }
+            )
+            h2_field = h_field.isel(
+                indexers={
+                    orth_component: orth_index,
+                    e_component: e_index,
+                }
+            )
+            h_field = h1_field - h2_field
+
+            # interpolate E and H locations to coincide with port bounds along the integration path
+            e_coords_interp = {
+                e_component: np.linspace(
+                    port.bounds[0][port.voltage_axis],
+                    port.bounds[1][port.voltage_axis],
+                    len(e_coords[port.voltage_axis]),
+                )
+            }
+            h_coords_interp = {
+                h_component: np.linspace(
+                    port.bounds[0][port.current_axis],
+                    port.bounds[1][port.current_axis],
+                    len(h_coords[port.current_axis]),
+                )
+            }
+
+            e_field = e_field.interp(**e_coords_interp)
+            h_field = h_field.interp(**h_coords_interp)
+
+            voltage = -e_field.integrate(coord=e_component).squeeze()
+            current = h_field.integrate(coord=h_component).squeeze()
+
+            if port.current_axis != (port.voltage_axis + 1) % 3:
+                current *= -1
+
+            # print("=== Port data ===")
+            # print("--- orth_index ---")
+            # print(orth_index)
+            # print("--- e_field ---")
+            # print(e_field)
+            # print("--- h_field ---")
+            # print(h_field)
+            # print("======")
+
+            return voltage, current
+
+        def port_ab(port: LumpedPort, sim_data: SimulationData):
+            """Helper to compute the port incident and reflected power waves."""
+            voltage, current = port_iv(port, sim_data)
+            power_a = (voltage + port.impedance * current) / 2 / np.sqrt(np.real(port.impedance))
+            power_b = (voltage - port.impedance * current) / 2 / np.sqrt(np.real(port.impedance))
+            return power_a, power_b
+
+        # loop through source ports
+        for port_in in self.ports:
+
+            sim_data = batch_data[self._task_name(port=port_in)]
+
+            for port_out in self.ports:
+
+                a_out, b_out = port_ab(port_out, sim_data)
+
+                a_matrix.loc[
+                    dict(
+                        port_in=port_in.name,
+                        port_out=port_out.name,
+                    )
+                ] = a_out
+
+                b_matrix.loc[
+                    dict(
+                        port_in=port_in.name,
+                        port_out=port_out.name,
+                    )
+                ] = b_out
+
+        s_matrix = self.ab_to_s(a_matrix, b_matrix)
+
+        return s_matrix

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -232,7 +232,7 @@ class Job(WebContainer):
         Cost is calculated assuming the simulation runs for
         the full ``run_time``. If early shut-off is triggered, the cost is adjusted proportionately.
         """
-        return web.estimate_cost(self.task_id, verbose=verbose)
+        return web.estimate_cost(self.task_id, verbose=verbose, solver_version=self.solver_version)
 
 
 class BatchData(Tidy3dBaseModel):

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -706,7 +706,7 @@ def get_tasks(
 
 
 @wait_for_connection
-def estimate_cost(task_id: str, verbose: bool = True) -> float:
+def estimate_cost(task_id: str, verbose: bool = True, solver_version: str = None) -> float:
     """Compute the maximum FlexCredit charge for a given task.
 
     Parameters
@@ -715,6 +715,8 @@ def estimate_cost(task_id: str, verbose: bool = True) -> float:
         Unique identifier of task on server.  Returned by :meth:`upload`.
     verbose : bool = True
         Whether to log the cost and helpful messages.
+    solver_version : str = None
+        Target solver version.
 
     Returns
     -------
@@ -742,7 +744,7 @@ def estimate_cost(task_id: str, verbose: bool = True) -> float:
     if not task:
         raise ValueError("Task not found.")
 
-    task.estimate_cost()
+    task.estimate_cost(solver_version=solver_version)
     task_info = get_info(task_id)
     status = task_info.metadataStatus
 


### PR DESCRIPTION

**2D Material Changes**
I've incorporated the [subdivision strategy](https://github.com/flexcompute/tidy3d/pull/1263) proposed by @caseyflex , and made a few changes on top of that. If you'd like to merge the subdivision stuff separately, I'd recommend copying over `_volumetric_structures_grid` from this PR into Casey's, removing lumped-port specific stuff. However, since the 2D materials handling is likely to change significantly, I'm not sure whether to revert to old handling for now or leave it here as is for internal testing.

There are two main challenges with the existing 2D materials implementation that I have come across so far:
1. Inhomogeneity of the substrate and superstrate is likely to be a common occurrence in applications where metal traces are modeled as 2D PEC sheets, but this inhomogeneity is not allowed in the existing implementation. This PR (based on Casey's) attempts to resolve this using [Shapely](https://shapely.readthedocs.io/en/stable/manual.html)'s geometry operations, but is not very robust.
2. The case of two 2D sheets meeting at a T or L junction does not seem to be handled correctly in the present implementation - it's not necessarily an incorrect logic, but rather due to numerical precision or discretization issues where, after discretization, the 2D materials forming an L or T junction become numerically separated / detached from each other. This becomes particularly apparent when the sheets are conductive and part of a microwave / RF circuit, where a closed circuit is needed for current to flow as expected. As a temporary measure, this PR slightly expands the subdivided shapely polygons by a tiny factor to ensure that an extra layer (or two?) of FDTD cells are included as part of the 2D materials, so that a closed circuit is maintained. It's not a good final solution, but useful to check that the features introduced in this PR are otherwise working.