### PR TITLE
adjoint refactor

### DIFF
--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -492,38 +492,38 @@ def test_adjoint_pipeline_tyler(local, use_emulated_run, tmp_path):
     # no gradients close to zero
     assert not all(np.all(np.isclose(x, 0)) for x in (df_deps, df_dsize, df_dvertices, d_eps_base)), "REALLY BAD"
     assert not any(np.any(np.isclose(x, 0)) for x in (df_deps, df_dsize, df_dvertices, d_eps_base))
-
+    assert np.isclose(df_deps, 1278130200000000.0)
     print("gradient: ", df_deps, df_dsize, df_dvertices, d_eps_base)
 
 
 
-@pytest.mark.parametrize("local", (True,))# False))
-def _test_adjoint_pipeline_tyler(local, use_emulated_run, tmp_path):
-    """Test computing gradient using jax."""
+# @pytest.mark.parametrize("local", (True,))# False))
+# def _test_adjoint_pipeline_tyler(local, use_emulated_run, tmp_path):
+#     """Test computing gradient using jax."""
 
-    td.config.logging_level="ERROR"
+#     td.config.logging_level="ERROR"
 
-    run_fn = run_local if local else run
+#     run_fn = run_local if local else run
 
-    sim = make_sim(permittivity=EPS, size=SIZE, vertices=VERTICES, base_eps_val=BASE_EPS_VAL)
-    _ = run_fn(sim, task_name="test", path=str(tmp_path / RUN_FILE))
+#     sim = make_sim(permittivity=EPS, size=SIZE, vertices=VERTICES, base_eps_val=BASE_EPS_VAL)
+#     _ = run_fn(sim, task_name="test", path=str(tmp_path / RUN_FILE))
 
-    def f(permittivity, size, vertices, base_eps_val):
-        sim = make_sim(
-            permittivity=permittivity, size=size, vertices=vertices, base_eps_val=base_eps_val
-        )
+#     def f(permittivity, size, vertices, base_eps_val):
+#         sim = make_sim(
+#             permittivity=permittivity, size=size, vertices=vertices, base_eps_val=base_eps_val
+#         )
 
-        sim_data = run_fn(sim, task_name="test", path=str(tmp_path / RUN_FILE))
-        amp = extract_amp(sim_data)
-        return objective(amp)
+#         sim_data = run_fn(sim, task_name="test", path=str(tmp_path / RUN_FILE))
+#         amp = extract_amp(sim_data)
+#         return objective(amp)
 
-    grad_f = grad(f, argnums=(0, 1, 2, 3))
-    df_deps, df_dsize, df_dvertices, d_eps_base = grad_f(EPS, SIZE, VERTICES, BASE_EPS_VAL)
+#     grad_f = grad(f, argnums=(0, 1, 2, 3))
+#     df_deps, df_dsize, df_dvertices, d_eps_base = grad_f(EPS, SIZE, VERTICES, BASE_EPS_VAL)
 
-    # no gradients close to zero
-    assert not any(np.any(np.isclose(x, 0)) for x in (df_deps, df_dsize, df_dvertices, d_eps_base))
+#     # no gradients close to zero
+#     assert not any(np.any(np.isclose(x, 0)) for x in (df_deps, df_dsize, df_dvertices, d_eps_base))
 
-    print("gradient: ", df_deps, df_dsize, df_dvertices, d_eps_base)
+#     print("gradient: ", df_deps, df_dsize, df_dvertices, d_eps_base)
 
 
 @pytest.mark.parametrize("local", (True, False))

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -490,7 +490,38 @@ def test_adjoint_pipeline_tyler(local, use_emulated_run, tmp_path):
     df_deps, df_dsize, df_dvertices, d_eps_base = grad_f(EPS, SIZE, VERTICES, BASE_EPS_VAL)
 
     # no gradients close to zero
-    # assert not any(np.any(np.isclose(x, 0)) for x in (df_deps, df_dsize, df_dvertices, d_eps_base))
+    assert not all(np.all(np.isclose(x, 0)) for x in (df_deps, df_dsize, df_dvertices, d_eps_base)), "REALLY BAD"
+    assert not any(np.any(np.isclose(x, 0)) for x in (df_deps, df_dsize, df_dvertices, d_eps_base))
+
+    print("gradient: ", df_deps, df_dsize, df_dvertices, d_eps_base)
+
+
+
+@pytest.mark.parametrize("local", (True,))# False))
+def _test_adjoint_pipeline_tyler(local, use_emulated_run, tmp_path):
+    """Test computing gradient using jax."""
+
+    td.config.logging_level="ERROR"
+
+    run_fn = run_local if local else run
+
+    sim = make_sim(permittivity=EPS, size=SIZE, vertices=VERTICES, base_eps_val=BASE_EPS_VAL)
+    _ = run_fn(sim, task_name="test", path=str(tmp_path / RUN_FILE))
+
+    def f(permittivity, size, vertices, base_eps_val):
+        sim = make_sim(
+            permittivity=permittivity, size=size, vertices=vertices, base_eps_val=base_eps_val
+        )
+
+        sim_data = run_fn(sim, task_name="test", path=str(tmp_path / RUN_FILE))
+        amp = extract_amp(sim_data)
+        return objective(amp)
+
+    grad_f = grad(f, argnums=(0, 1, 2, 3))
+    df_deps, df_dsize, df_dvertices, d_eps_base = grad_f(EPS, SIZE, VERTICES, BASE_EPS_VAL)
+
+    # no gradients close to zero
+    assert not any(np.any(np.isclose(x, 0)) for x in (df_deps, df_dsize, df_dvertices, d_eps_base))
 
     print("gradient: ", df_deps, df_dsize, df_dvertices, d_eps_base)
 

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -467,9 +467,11 @@ def test_run_flux(use_emulated_run):
         _ = get_flux_grad(1.0)
 
 
-@pytest.mark.parametrize("local", (True, False))
-def test_adjoint_pipeline(local, use_emulated_run, tmp_path):
+@pytest.mark.parametrize("local", (True,))# False))
+def test_adjoint_pipeline_tyler(local, use_emulated_run, tmp_path):
     """Test computing gradient using jax."""
+
+    td.config.logging_level="ERROR"
 
     run_fn = run_local if local else run
 
@@ -486,6 +488,9 @@ def test_adjoint_pipeline(local, use_emulated_run, tmp_path):
 
     grad_f = grad(f, argnums=(0, 1, 2, 3))
     df_deps, df_dsize, df_dvertices, d_eps_base = grad_f(EPS, SIZE, VERTICES, BASE_EPS_VAL)
+
+    # no gradients close to zero
+    # assert not any(np.any(np.isclose(x, 0)) for x in (df_deps, df_dsize, df_dvertices, d_eps_base))
 
     print("gradient: ", df_deps, df_dsize, df_dvertices, d_eps_base)
 

--- a/tidy3d/__main__.py
+++ b/tidy3d/__main__.py
@@ -109,5 +109,4 @@ def main(args):
 
 
 if __name__ == "__main__":
-
     main(sys.argv[1:])

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -501,7 +501,6 @@ class Tidy3dBaseModel(pydantic.BaseModel):
             """For every DataArray item in dictionary, load path of hdf5 group as value."""
 
             for key, value in model_dict.items():
-
                 subpath = f"{group_path}/{key}"
 
                 # apply custom validation to the key value pair and modify model_dict
@@ -523,7 +522,6 @@ class Tidy3dBaseModel(pydantic.BaseModel):
 
                 # if a list, assign each element a unique key, recurse
                 if isinstance(value, (list, tuple)):
-
                     value_dict = cls.tuple_to_dict(tuple_values=value)
                     load_data_from_file(model_dict=value_dict, group_path=subpath)
 
@@ -595,7 +593,6 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         """
 
         with h5py.File(fname, "w") as f_handle:
-
             json_str = self._json_string
             for ind in range(ceil(len(json_str) / MAX_STRING_LENGTH)):
                 ind_start = int(ind * MAX_STRING_LENGTH)
@@ -606,7 +603,6 @@ class Tidy3dBaseModel(pydantic.BaseModel):
                 """For every DataArray item in dictionary, write path of hdf5 group as value."""
 
                 for key, value in data_dict.items():
-
                     # append the key to the path
                     subpath = f"{group_path}/{key}"
 
@@ -781,7 +777,6 @@ class Tidy3dBaseModel(pydantic.BaseModel):
 
                 # everything else
                 else:
-
                     # note: this logic is because != is handled differently in DataArrays apparently
                     if not val1 == val2:
                         return False
@@ -860,7 +855,6 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         # create the list of parameters (arguments) for the model
         doc += "\n\n    Parameters\n    ----------\n"
         for field_name, field in cls.__fields__.items():
-
             # ignore the type tag
             if field_name == TYPE_TAG_STR:
                 continue

--- a/tidy3d/components/base_sim/simulation.py
+++ b/tidy3d/components/base_sim/simulation.py
@@ -212,7 +212,6 @@ class AbstractSimulation(Box, ABC):
                 struct_bounds = list(struct_bound_min) + list(struct_bound_max)
 
                 for sim_val, struct_val in zip(sim_bounds, struct_bounds):
-
                     if isclose(sim_val, struct_val):
                         consolidated_logger.warning(
                             f"Structure at 'structures[{istruct}]' has bounds that extend exactly "

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -115,6 +115,9 @@ class DataArray(xr.DataArray):
         )
         field_schema.update(schema)
 
+    def dict(self, **kwargs) -> dict:
+        return dict(values=self.data, coords=self.coords)
+
     @classmethod
     def _json_encoder(cls, val):
         """What function to call when writing a DataArray to json."""

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -275,17 +275,14 @@ class SpatialDataArray(DataArray):
         inds_list = []
 
         for coord, smin, smax in zip(self.coords.values(), bounds[0], bounds[1]):
-
             length = len(coord)
 
             # if data does not cover structure at all take the closest index
             if smax < coord[0]:  # structure is completely on the left side
-
                 # take 2 if possible, so that linear iterpolation is possible
                 comp_inds = np.arange(0, max(2, length))
 
             elif smin > coord[-1]:  # structure is completely on the right side
-
                 # take 2 if possible, so that linear iterpolation is possible
                 comp_inds = np.arange(min(0, length - 2), length)
 

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -110,7 +110,6 @@ class AbstractFieldDataset(Dataset, ABC):
 
         # loop through field components
         for field_name, field_data in self.field_components.items():
-
             # loop through x, y, z dimensions and raise an error if only one element along dim
             for coord_name, coords_supplied in supplied_coord_map.items():
                 coord_data = np.array(field_data.coords[coord_name])

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -158,14 +158,12 @@ class AbstractFieldData(MonitorData, AbstractFieldDataset, ABC):
 
         update_dict = {}
         for field_name, scalar_data in self.field_components.items():
-
             eigenval_fn = self.symmetry_eigenvalues[field_name]
 
             # get grid locations for this field component on the expanded grid
             field_coords = self._expanded_grid_field_coords(field_name)
 
             for sym_dim, (sym_val, sym_loc) in enumerate(zip(self.symmetry, self.symmetry_center)):
-
                 dim_name = "xyz"[sym_dim]
 
                 # Continue if no symmetry along this dimension
@@ -1012,13 +1010,11 @@ class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
 
         # Sort in two directions from the base frequency
         for step, last_ind in zip([-1, 1], [-1, num_freqs]):
-
             # Start with the base frequency
             data_template = self._isel(f=[f0_ind])
 
             # March to lower/higher frequencies
             for freq_id in range(f0_ind + step, last_ind, step):
-
                 # Get next frequency to sort
                 data_to_sort = self._isel(f=[freq_id])
 
@@ -1094,7 +1090,6 @@ class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
         data_template_reduced = self._isel(mode_index=modes_to_sort)
 
         for i, mode_index in enumerate(modes_to_sort):
-
             # Get one mode from data_to_sort
 
             one_mode = data_to_sort._isel(mode_index=[mode_index])
@@ -1147,7 +1142,6 @@ class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
         # Create new dict with rearranged field components
         update_dict = {}
         for field_name, field in self.field_components.items():
-
             field_sorted = field.copy()
 
             # Rearrange modes

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -440,13 +440,11 @@ class SimulationData(AbstractSimulationData):
 
             # loop through data
             for monitor_index_str, _mnt_data in f_handle["data"].items():
-
                 # grab the monitor data for this data element
                 monitor_dict = monitor_list[int(monitor_index_str)]
 
                 # if a match on the monitor name
                 if monitor_dict["name"] == mnt_name:
-
                     # try to grab the monitor data type
                     monitor_type_str = monitor_dict["type"]
                     if monitor_type_str not in DATA_TYPE_NAME_MAP:

--- a/tidy3d/components/field_projection.py
+++ b/tidy3d/components/field_projection.py
@@ -154,7 +154,6 @@ class FieldProjector(Tidy3dBaseModel):
 
     @cached_property
     def currents(self):
-
         """Sets the surface currents."""
         sim_data = self.sim_data
         surfaces = self.surfaces
@@ -309,7 +308,6 @@ class FieldProjector(Tidy3dBaseModel):
         _, idx_uv = surface.monitor.pop_axis((0, 1, 2), axis=surface.axis)
 
         for idx in idx_uv:
-
             # pick sample points on the monitor and handle the possibility of an "infinite" monitor
             start = np.maximum(
                 surface.monitor.center[idx] - surface.monitor.size[idx] / 2.0,
@@ -416,7 +414,6 @@ class FieldProjector(Tidy3dBaseModel):
             """Perform integration for a given theta angle index"""
 
             for j_ph in np.arange(len(phi)):
-
                 phase[0] = np.exp(propagation_factor * pts[0] * sin_theta[i_th] * cos_phi[j_ph])
                 phase[1] = np.exp(propagation_factor * pts[1] * sin_theta[i_th] * sin_phi[j_ph])
                 phase[2] = np.exp(propagation_factor * pts[2] * cos_theta[i_th])
@@ -569,7 +566,6 @@ class FieldProjector(Tidy3dBaseModel):
         )
 
         for surface in self.surfaces:
-
             # apply windowing to currents
             currents = self.apply_window_to_currents(monitor, self.currents[surface.monitor.name])
 
@@ -660,7 +656,6 @@ class FieldProjector(Tidy3dBaseModel):
             )
 
             for surface in self.surfaces:
-
                 # apply windowing to currents
                 currents = self.apply_window_to_currents(
                     monitor, self.currents[surface.monitor.name]
@@ -733,7 +728,6 @@ class FieldProjector(Tidy3dBaseModel):
             theta, phi = monitor.kspace_2_sph(_ux, _uy, monitor.proj_axis)
 
             for surface in self.surfaces:
-
                 # apply windowing to currents
                 currents = self.apply_window_to_currents(
                     monitor, self.currents[surface.monitor.name]

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -1726,7 +1726,6 @@ class Box(Centered):
         surface_index = 0
         for dim_index in range(3):
             for min_max_index in range(2):
-
                 new_center = centers[surface_index]
                 new_size = sizes[surface_index]
 
@@ -1769,7 +1768,6 @@ class Box(Centered):
 
         surfaces = []
         for _cent, _size, _name, _normal_dir in zip(centers, sizes, names, normal_dirs):
-
             if "normal_dir" in cls.__dict__["__fields__"]:
                 kwargs["normal_dir"] = _normal_dir
 

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -427,6 +427,11 @@ class PolySlab(base.Planar):
             raise ValidationError("'Medium2D' requires the 'PolySlab' bounds to be equal.")
         return self.axis
 
+    @cached_property
+    def is_ccw(self) -> bool:
+        """Is this ``PolySlab`` CCW-oriented?"""
+        return PolySlab._area(self.vertices) > 0
+
     def inside(
         self, x: np.ndarray[float], y: np.ndarray[float], z: np.ndarray[float]
     ) -> np.ndarray[bool]:

--- a/tidy3d/components/heat/data/monitor_data.py
+++ b/tidy3d/components/heat/data/monitor_data.py
@@ -103,7 +103,6 @@ class TemperatureData(HeatMonitorData):
             # do not expand monitor with zero size along symmetry direction
             # this is done because 2d unstructured data does not support this
             if self.symmetry[dim] == 1 and self.monitor.size[dim] != 0:
-
                 new_temp = new_temp.reflect(axis=dim, center=self.symmetry_center[dim])
 
         return self.updated_copy(temperature=new_temp, symmetry=(0, 0, 0))

--- a/tidy3d/components/heat/data/sim_data.py
+++ b/tidy3d/components/heat/data/sim_data.py
@@ -162,7 +162,6 @@ class HeatSimulationData(AbstractSimulationData):
             )
 
         if isinstance(field_data, TriangularGridDataset):
-
             field_data.plot(
                 ax=ax,
                 cmap=cmap,
@@ -184,7 +183,6 @@ class HeatSimulationData(AbstractSimulationData):
             max_bounds.pop(axis)
 
         if isinstance(field_data, SpatialDataArray):
-
             # interp out any monitor.size==0 dimensions
             monitor = self.simulation.get_monitor_by_name(monitor_name)
             thin_dims = {

--- a/tidy3d/components/heat/simulation.py
+++ b/tidy3d/components/heat/simulation.py
@@ -321,7 +321,7 @@ class HeatSimulation(AbstractSimulation):
         )
 
         # plot boundary conditions
-        for (bc_spec, shape) in boundaries:
+        for bc_spec, shape in boundaries:
             ax = self._plot_boundary_condition(shape=shape, boundary_spec=bc_spec, ax=ax)
 
         # clean up the axis display
@@ -428,10 +428,8 @@ class HeatSimulation(AbstractSimulation):
         boundaries = []  # bc_spec, structure name, shape, bounds
         background_shapes = []
         for name, medium, shape, bounds in shapes:
-
             # intersect existing boundaries (both structure based and medium based)
             for index, (_bc_spec, _name, _bdry, _bounds) in enumerate(boundaries):
-
                 # simulation bc is overriden only by StructureSimulationBoundary
                 if isinstance(_bc_spec.placement, SimulationBoundary):
                     if name not in struct_to_bc_spec:
@@ -453,7 +451,6 @@ class HeatSimulation(AbstractSimulation):
 
             if name in struct_to_bc_spec:
                 for bc_spec in struct_to_bc_spec[name]:
-
                     if isinstance(bc_spec.placement, StructureBoundary):
                         bdry = shape.exterior
                         bdry = bdry.intersection(background_structure_shape)
@@ -473,7 +470,6 @@ class HeatSimulation(AbstractSimulation):
             # this is similar to _filter_structures_plane but only mediums participating in BCs
             # are tracked
             for index, (_medium, _shape, _bounds) in enumerate(background_shapes):
-
                 if Box._do_not_intersect(bounds, _bounds, shape, _shape):
                     continue
 
@@ -530,16 +526,13 @@ class HeatSimulation(AbstractSimulation):
         boundaries_reverse = []
 
         for name, _, shape, bounds in shapes[:0:-1]:
-
             minx, miny, maxx, maxy = bounds
 
             # intersect existing boundaries
             for index, (_bc_spec, _name, _bdry, _bounds, _completed) in enumerate(
                 boundaries_reverse
             ):
-
                 if not _completed:
-
                     if Box._do_not_intersect(bounds, _bounds, shape, _bdry):
                         continue
 
@@ -607,7 +600,6 @@ class HeatSimulation(AbstractSimulation):
         # get structures in the plane and present named structures and media
         shapes = []  # structure name, structure medium, shape, bounds
         for structure in structures:
-
             # get list of Shapely shapes that intersect at the plane
             shapes_plane = plane.intersections_with(structure.geometry)
 
@@ -712,7 +704,7 @@ class HeatSimulation(AbstractSimulation):
         )
 
         source_min, source_max = self.source_bounds
-        for (source, shape) in source_shapes:
+        for source, shape in source_shapes:
             if source is not None:
                 ax = self._plot_shape_structure_source(
                     alpha=alpha,

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -2190,7 +2190,7 @@ class PoleResidue(DispersiveMedium):
         """
         omega = 2 * np.pi * frequency
         eps = eps_inf
-        for (omega_lo, gamma_lo, omega_to, gamma_to) in poles:
+        for omega_lo, gamma_lo, omega_to, gamma_to in poles:
             eps *= omega_lo**2 - omega**2 - 1j * omega * gamma_lo
             eps /= omega_to**2 - omega**2 - 1j * omega * gamma_to
         return eps

--- a/tidy3d/components/parameter_perturbation.py
+++ b/tidy3d/components/parameter_perturbation.py
@@ -650,7 +650,6 @@ class LinearChargePerturbation(ChargePerturbation):
         e_type, h_type = self._get_eh_types(electron_density, hole_density)
 
         if e_type == "array" and h_type == "array":
-
             e_mesh, h_mesh = np.meshgrid(electron_density, hole_density, indexing="ij")
 
             return self.electron_coeff * (e_mesh - self.electron_ref) + self.hole_coeff * (
@@ -933,7 +932,6 @@ class ParameterPerturbation(Tidy3dBaseModel):
             result = result + self.heat.sample(temperature)
 
         if (electron_density is not None or hole_density is not None) and self.charge is not None:
-
             if electron_density is None:
                 electron_density = 0
 

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -289,7 +289,6 @@ class Scene(Tidy3dBaseModel):
         hlim: Tuple[float, float] = None,
         vlim: Tuple[float, float] = None,
     ) -> Tuple[Tuple[float, float], Tuple[float, float]]:
-
         # if no hlim and/or vlim given, the bounds will then be the usual pml bounds
         axis, _ = Box.parse_xyz_kwargs(x=x, y=y, z=z)
         _, (hmin, vmin) = Box.pop_axis(bounds[0], axis=axis)
@@ -387,7 +386,7 @@ class Scene(Tidy3dBaseModel):
             structures=self.structures, x=x, y=y, z=z, hlim=hlim, vlim=vlim
         )
         medium_map = self.medium_map
-        for (medium, shape) in medium_shapes:
+        for medium, shape in medium_shapes:
             mat_index = medium_map[medium]
             ax = self._plot_shape_structure(medium=medium, mat_index=mat_index, shape=shape, ax=ax)
         ax = self._set_plot_bounds(bounds=self.bounds, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim)
@@ -596,7 +595,6 @@ class Scene(Tidy3dBaseModel):
 
         shapes = []
         for structure, prop in zip(structures, property_list):
-
             # get list of Shapely shapes that intersect at the plane
             shapes_plane = plane.intersections_with(structure.geometry)
 
@@ -606,12 +604,10 @@ class Scene(Tidy3dBaseModel):
 
         background_shapes = []
         for prop, shape, bounds in shapes:
-
             minx, miny, maxx, maxy = bounds
 
             # loop through background_shapes (note: all background are non-intersecting or merged)
             for index, (_prop, _shape, _bounds) in enumerate(background_shapes):
-
                 _minx, _miny, _maxx, _maxy = _bounds
 
                 # do a bounding box check to see if any intersection to do anything about
@@ -773,7 +769,6 @@ class Scene(Tidy3dBaseModel):
         eps_min, eps_max = eps_lim
 
         if eps_min is None or eps_max is None:
-
             eps_min_sim, eps_max_sim = self.eps_bounds(freq=freq)
 
             if eps_min is None:
@@ -782,7 +777,7 @@ class Scene(Tidy3dBaseModel):
             if eps_max is None:
                 eps_max = eps_max_sim
 
-        for (medium, shape) in medium_shapes:
+        for medium, shape in medium_shapes:
             # if the background medium is custom medium, it needs to be rendered separately
             if medium == self.medium and alpha < 1 and not isinstance(medium, AbstractCustomMedium):
                 continue
@@ -1141,7 +1136,7 @@ class Scene(Tidy3dBaseModel):
             )
 
         heat_cond_min, heat_cond_max = self.heat_conductivity_bounds()
-        for (medium, shape) in medium_shapes:
+        for medium, shape in medium_shapes:
             ax = self._plot_shape_structure_heat_cond(
                 alpha=alpha,
                 medium=medium,
@@ -1320,7 +1315,6 @@ class Scene(Tidy3dBaseModel):
         # do the same for background medium if it a medium with perturbation models.
         med = self.medium
         if isinstance(med, AbstractPerturbationMedium):
-
             # get scene's bounding box
             bounds = scene_bounds
 

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -956,7 +956,6 @@ class Simulation(AbstractSimulation):
                 fmin_mon = freqs.min()
                 fmax_mon = freqs.max()
                 for medium_index, medium in enumerate(mediums):
-
                     # skip mediums that have no freq range (all freqs valid)
                     if medium.frequency_range is None:
                         continue
@@ -1255,7 +1254,6 @@ class Simulation(AbstractSimulation):
                 freq0 = source.source_time.freq0
 
                 for medium_index, medium in enumerate(mediums):
-
                     # min wavelength in PEC is meaningless and we'll get divide by inf errors
                     if medium.is_pec:
                         continue
@@ -2764,7 +2762,6 @@ class Simulation(AbstractSimulation):
         with log as consolidated_logger:
             for structure in self.structures:
                 if isinstance(structure.medium, Medium2D):
-
                     normal = structure.geometry._normal_2dmaterial
                     grid_axes[normal] = True
                     for axis, grid_axis in enumerate(
@@ -3388,7 +3385,6 @@ class Simulation(AbstractSimulation):
         # do the same for background medium if it a medium with perturbation models.
         med = self.medium
         if isinstance(med, AbstractPerturbationMedium):
-
             # get simulation's bounding box
             bounds = sim_bounds
 

--- a/tidy3d/components/source.py
+++ b/tidy3d/components/source.py
@@ -1088,7 +1088,6 @@ class TFSF(AngledFieldSource, VolumeSource):
         ax: Ax = None,
         **patch_kwargs,
     ) -> Ax:
-
         # call Source.plot but with the base of the arrow centered on the injection plane
         patch_kwargs["arrow_base"] = self.injection_plane_center
         ax = Source.plot(self, x=x, y=y, z=z, ax=ax, **patch_kwargs)

--- a/tidy3d/components/validators.py
+++ b/tidy3d/components/validators.py
@@ -169,7 +169,6 @@ def assert_objects_in_sim_bounds(field_name: str, error: bool = True):
 
         for position_index, geometric_object in enumerate(val):
             if not sim_box.intersects(geometric_object.geometry):
-
                 message = (
                     f"'{geometric_object}' (at `simulation.{field_name}[{position_index}]`) "
                     "is completely outside of simulation domain."
@@ -293,7 +292,6 @@ def validate_parameter_perturbation(
                     )
                 ):
                     if perturb is not None:
-
                         # check real/complex type
                         if perturb.is_complex and not allowed_complex:
                             raise SetupError(
@@ -312,7 +310,6 @@ def validate_parameter_perturbation(
                             [real_range, imag_range], [np.real, np.imag], ["Re", "Im"]
                         ):
                             if part_range is not None:
-
                                 min_allowed, max_allowed = part_range
 
                                 if min_allowed is not None and part_func(min_val) < min_allowed:

--- a/tidy3d/components/viz.py
+++ b/tidy3d/components/viz.py
@@ -234,7 +234,6 @@ def plot_sim_3d(sim, width=800, height=800) -> None:
     """Make 3D display of simulation in ipyython notebook."""
 
     try:
-
         from IPython.display import display, HTML
     except ImportError as e:
         raise SetupError(

--- a/tidy3d/log.py
+++ b/tidy3d/log.py
@@ -378,7 +378,6 @@ def set_logging_file(
             del log.handlers["file"]
 
     try:
-
         file = open(fname, filemode)
     except Exception:  # TODO: catch specific exception
         log.error(f"File {fname} could not be opened")

--- a/tidy3d/material_library/parametric_materials.py
+++ b/tidy3d/material_library/parametric_materials.py
@@ -257,7 +257,6 @@ class Graphene(ParametricVariantItem2D):
         integration_min = GRAPHENE_INT_MIN
         integration_max = GRAPHENE_INT_MAX
         for i, omega in enumerate(omegas):
-
             integral, _ = integrate.quad(
                 integrand, integration_min, integration_max, args=(omega,), epsabs=GRAPHENE_INT_TOL
             )
@@ -299,7 +298,7 @@ class Graphene(ParametricVariantItem2D):
             Each item in ``coeffslist`` is a list of four coefficients corresponding to
             a single Pade term."""
             res = np.zeros(len(omega), dtype=complex)
-            for (alpha0, alpha1, beta1, beta2) in coeffslist:
+            for alpha0, alpha1, beta1, beta2 in coeffslist:
                 res += (alpha0 + alpha1 * 1j * omega) / (
                     1 + beta1 * 1j * omega + beta2 * (1j * omega) ** 2
                 )
@@ -347,7 +346,7 @@ class Graphene(ParametricVariantItem2D):
         def get_pole_residue(coeffslist: List[List[float]]) -> PoleResidue:
             """Convert a list of Pade coefficients into a :class:`.PoleResidue` model."""
             poles = []
-            for (alpha0, alpha1, beta1, beta2) in coeffslist:
+            for alpha0, alpha1, beta1, beta2 in coeffslist:
                 disc = beta1**2 - 4 * beta2
                 root1 = (beta1 + np.sqrt(complex(disc))) / (2 * beta2)
                 root2 = (beta1 - np.sqrt(complex(disc))) / (2 * beta2)
@@ -355,13 +354,13 @@ class Graphene(ParametricVariantItem2D):
                 res2 = alpha1 / beta2 - res1
 
                 if disc > 0:
-                    for (root, res) in zip([root1, root2], [res1, res2]):
+                    for root, res in zip([root1, root2], [res1, res2]):
                         poles.append((root, res / 2))
                 else:
                     poles.append((root1, res1))
 
             flipped_poles = []
-            for (a, c) in poles:
+            for a, c in poles:
                 if np.real(a) > 0:
                     flipped_poles += [(-1j * np.conj(1j * a), c)]
                 else:
@@ -388,7 +387,7 @@ class Graphene(ParametricVariantItem2D):
         """Clean up poles, merging poles at zero frequency."""
         zero_res = 0
         poles = []
-        for (a, c) in medium.poles:
+        for a, c in medium.poles:
             if a == 0:
                 zero_res += c
             elif abs(a) > 1e17:

--- a/tidy3d/plugins/adjoint/components/base.py
+++ b/tidy3d/plugins/adjoint/components/base.py
@@ -1,8 +1,7 @@
 """Base model for Tidy3D components that are compatible with jax."""
 from __future__ import annotations
 
-from typing import Tuple, List, Any, Callable
-import json
+from typing import Tuple, List, Any
 
 import numpy as np
 import jax
@@ -12,6 +11,7 @@ from jax.tree_util import tree_flatten as jax_tree_flatten
 from jax.tree_util import tree_unflatten as jax_tree_unflatten
 
 from ....components.base import Tidy3dBaseModel
+
 # from .data.data_array import JaxDataArray, JAX_DATA_ARRAY_TAG
 
 

--- a/tidy3d/plugins/adjoint/components/base.py
+++ b/tidy3d/plugins/adjoint/components/base.py
@@ -6,7 +6,6 @@ import json
 
 import numpy as np
 import jax
-import jax.numpy as jnp
 import pydantic.v1 as pd
 
 from jax.tree_util import tree_flatten as jax_tree_flatten
@@ -55,7 +54,6 @@ class JaxObject(Tidy3dBaseModel):
             sub_children, sub_aux_data = jax_tree_flatten(field)
             children.append(sub_children)
             aux_data[field_name] = sub_aux_data
-
 
         def fix_numpy(value: Any) -> Any:
             """Recursively convert any numpy array in the value to nested list."""
@@ -133,13 +131,11 @@ class JaxObject(Tidy3dBaseModel):
         """Pass jax inputs to the jax fields and pass untraced values to the regular fields."""
 
         for jax_name in cls.get_jax_leaf_names():
-
             # if a value was passed to the object for the regular field
             orig_name = cls.get_orig_field(jax_name)
             val = values.get(orig_name)
 
             if val is not None:
-
                 # add the sanitized (no trace) version to the regular field
                 values[orig_name] = jax.lax.stop_gradient(val)
 
@@ -152,7 +148,7 @@ class JaxObject(Tidy3dBaseModel):
     @pd.root_validator(pre=True)
     def handle_array_jax_leafs(cls, values: dict) -> dict:
         """Handle jax_leafs that are numpy arrays."""
-        for jax_name in cls.get_jax_leaf_names():    
+        for jax_name in cls.get_jax_leaf_names():
             val = values.get(jax_name)
             if isinstance(val, np.ndarray):
                 values[jax_name] = val.tolist()
@@ -183,7 +179,6 @@ class JaxObject(Tidy3dBaseModel):
             """Strip any elements of the dictionary with type "JaxDataArray", replace with tag."""
 
             for key, val in sub_dict.items():
-
                 if isinstance(val, dict):
                     if "type" in val and val["type"] == "JaxDataArray":
                         sub_dict[key] = JAX_DATA_ARRAY_TAG

--- a/tidy3d/plugins/adjoint/components/base.py
+++ b/tidy3d/plugins/adjoint/components/base.py
@@ -141,12 +141,14 @@ class JaxObject(Tidy3dBaseModel):
     def handle_jax_kwargs(cls, values: dict) -> dict:
         """Pass jax inputs to the jax fields and pass untraced values to the regular fields."""
 
+        # for all jax-traced fields
         for jax_name in cls.get_jax_leaf_names():
+
             # if a value was passed to the object for the regular field
             orig_name = cls.get_orig_field(jax_name)
             val = values.get(orig_name)
-
             if val is not None:
+
                 # add the sanitized (no trace) version to the regular field
                 values[orig_name] = jax.lax.stop_gradient(val)
 
@@ -158,7 +160,7 @@ class JaxObject(Tidy3dBaseModel):
 
     @pd.root_validator(pre=True)
     def handle_array_jax_leafs(cls, values: dict) -> dict:
-        """Handle jax_leafs that are numpy arrays."""
+        """Convert jax_leafs that are passed as numpy arrays."""
         for jax_name in cls.get_jax_leaf_names():
             val = values.get(jax_name)
             if isinstance(val, np.ndarray):

--- a/tidy3d/plugins/adjoint/components/data/data_array.py
+++ b/tidy3d/plugins/adjoint/components/data/data_array.py
@@ -189,7 +189,6 @@ class JaxDataArray(Tidy3dBaseModel):
         if isinstance(other, JaxDataArray):
             new_values = self.as_jnp_array * other.as_jnp_array
         elif isinstance(other, xr.DataArray):
-
             # handle case where other is missing dims present in self
             new_shape = list(self.shape)
             for dim_index, dim in enumerate(self.coords.keys()):
@@ -273,7 +272,6 @@ class JaxDataArray(Tidy3dBaseModel):
 
         # return just the values if no coordinate remain
         if not new_coords:
-
             if new_values.shape:
                 raise AdjointError(
                     "All coordinates selected out, but raw data values are still multi-dimensional."

--- a/tidy3d/plugins/adjoint/components/data/data_array.py
+++ b/tidy3d/plugins/adjoint/components/data/data_array.py
@@ -12,7 +12,7 @@ from jax.tree_util import register_pytree_node_class
 import xarray as xr
 
 from ..base import JaxObject
-from .....components.base import Tidy3dBaseModel, cached_property
+from .....components.base import cached_property
 from .....components.data.data_array import DataArray
 from .....exceptions import DataError, Tidy3dKeyError, AdjointError
 
@@ -37,7 +37,7 @@ class JaxDataArray(JaxObject):
     values: Any = pd.Field(
         ...,
         jax_leaf=True,
-    )    
+    )
 
     coords: Dict[str, list] = pd.Field(
         ...,
@@ -48,7 +48,6 @@ class JaxDataArray(JaxObject):
     def to_tidy3d(self):
         values = np.array(jax.lax.stop_gradient(self.values))
         return DataArray(values, coords=self.coords)
-
 
     @pd.validator("values", pre=True, always=True)
     def _convert_values_to_jnp_array(cls, val):

--- a/tidy3d/plugins/adjoint/components/data/dataset.py
+++ b/tidy3d/plugins/adjoint/components/data/dataset.py
@@ -12,6 +12,8 @@ from ..base import JaxObject
 class JaxPermittivityDataset(PermittivityDataset, JaxObject):
     """A :class:`.PermittivityDataset` registered with jax."""
 
+    _tidy3d_class = PermittivityDataset
+
     eps_xx: JaxDataArray = pd.Field(
         ...,
         title="Epsilon xx",

--- a/tidy3d/plugins/adjoint/components/data/monitor_data.py
+++ b/tidy3d/plugins/adjoint/components/data/monitor_data.py
@@ -86,7 +86,6 @@ class JaxModeData(JaxMonitorData, ModeData):
 
         adjoint_sources = []
         for amp, direction, freq, mode_index in zip(amps, directions, freqs, mode_indices):
-
             # TODO: figure out where this factor comes from
             k0 = 2 * np.pi * freq / C_0
             grad_const = k0 / 4 / ETA_0
@@ -235,12 +234,10 @@ class JaxFieldData(JaxMonitorData, FieldData):
 
         if np.allclose(np.array(self.monitor.size), np.zeros(3)):
             for polarization, field_component in self.field_components.items():
-
                 if field_component is None:
                     continue
 
                 for freq0 in field_component.coords["f"]:
-
                     omega0 = 2 * np.pi * freq0
                     scaling_factor = 1 / (MU_0 * omega0)
 
@@ -261,7 +258,6 @@ class JaxFieldData(JaxMonitorData, FieldData):
 
                     sources.append(src_adj)
         else:
-
             # Define source geometry based on coordinates in the data
             data_mins = []
             data_maxs = []
@@ -287,7 +283,6 @@ class JaxFieldData(JaxMonitorData, FieldData):
             # Offset coordinates by source center since local coords are assumed in CustomCurrentSource
 
             for freq0 in tuple(self.field_components.values())[0].coords["f"]:
-
                 src_field_components = {}
                 for name, field_component in self.field_components.items():
                     field_component = field_component.sel(f=freq0)
@@ -412,7 +407,6 @@ class JaxDiffractionData(JaxMonitorData, DiffractionData):
 
         adjoint_sources = []
         for amp, order_x, order_y, freq, pol in zip(amp_vals, orders_x, orders_y, freqs, pols):
-
             # select the propagation angles from the data
             angle_sel_kwargs = dict(orders_x=int(order_x), orders_y=int(order_y), f=float(freq))
             angle_theta = float(theta_data.sel(**angle_sel_kwargs))

--- a/tidy3d/plugins/adjoint/components/data/monitor_data.py
+++ b/tidy3d/plugins/adjoint/components/data/monitor_data.py
@@ -32,7 +32,7 @@ class JaxMonitorData(MonitorData, JaxObject, ABC):
     def from_monitor_data(cls, mnt_data: MonitorData) -> JaxMonitorData:
         """Construct a :class:`.JaxMonitorData` instance from a :class:`.MonitorData`."""
         self_dict = mnt_data.dict(exclude={"type"}).copy()
-        for field_name in cls.get_jax_field_names():
+        for field_name in cls.get_jax_field_names_all():
             data_array = self_dict[field_name]
             if data_array is not None:
                 coords = {

--- a/tidy3d/plugins/adjoint/components/geometry.py
+++ b/tidy3d/plugins/adjoint/components/geometry.py
@@ -301,6 +301,16 @@ class JaxPolySlab(JaxGeometry, PolySlab, JaxObject):
 
     #     return tuple(vertices)
 
+    # @pd.validator("vertices", pre=True)
+    # def _parse_vertices_jax_array(cls, val) -> Tuple[Tuple[float, float], ...]:
+    #     """parse jax vertices when it's an array."""
+    #     vertices_jax = []
+    #     for (vx, vy) in val:
+    #         vertices_jax.append((vx, vy))
+
+    #     return tuple(vertices_jax)
+
+
     @pd.validator("vertices_jax", pre=True, always=True)
     def _parse_vertices_jax_array(cls, val) -> Tuple[Tuple[float, float], ...]:
         """parse jax vertices when it's an array."""
@@ -634,7 +644,6 @@ class JaxPolySlab(JaxGeometry, PolySlab, JaxObject):
 
         args = self._make_vertex_args(e_mult_xyz, d_mult_xyz, sim_bounds, wvl_mat, eps_out, eps_in)
         vertices_vjp = tuple(map(self.vertex_vjp, *args))
-        vertices_vjp = tuple(tuple(x) for x in vertices_vjp)
         return self.updated_copy(vertices_jax=vertices_vjp)
 
     def store_vjp_parallel(
@@ -652,8 +661,6 @@ class JaxPolySlab(JaxGeometry, PolySlab, JaxObject):
         args = self._make_vertex_args(e_mult_xyz, d_mult_xyz, sim_bounds, wvl_mat, eps_out, eps_in)
         with Pool(num_proc) as pool:
             vertices_vjp = pool.starmap(self.vertex_vjp, zip(*args))
-        vertices_vjp = tuple(tuple(x) for x in vertices_vjp)
-        import pdb ; pdb.set_trace()
         return self.updated_copy(vertices_jax=vertices_vjp)
 
 

--- a/tidy3d/plugins/adjoint/components/geometry.py
+++ b/tidy3d/plugins/adjoint/components/geometry.py
@@ -130,7 +130,6 @@ class JaxBox(JaxGeometry, Box, JaxObject):
         title="Center (Jax)",
         description="Jax traced value for the center of the box in (x, y, z).",
         units=MICROMETER,
-        jax_field=True,
         jax_leaf=True,
     )
 
@@ -139,7 +138,6 @@ class JaxBox(JaxGeometry, Box, JaxObject):
         title="Size (Jax)",
         description="Jax-traced value for the size of the box in (x, y, z).",
         units=MICROMETER,
-        jax_field=True,
         jax_leaf=True,
     )
 
@@ -277,7 +275,6 @@ class JaxPolySlab(JaxGeometry, PolySlab, JaxObject):
         "The index of dimension should be in the ascending order: e.g. if "
         "the slab normal axis is ``axis=y``, the coordinate of the vertices will be in (x, z)",
         units=MICROMETER,
-        jax_field=True,
         jax_leaf=True,
     )
 

--- a/tidy3d/plugins/adjoint/components/medium.py
+++ b/tidy3d/plugins/adjoint/components/medium.py
@@ -298,6 +298,8 @@ class JaxCustomMedium(CustomMedium, AbstractJaxMedium):
     #     "frequency omega is given by conductivity/omega.",
     # )
 
+    _tidy3d_class = CustomMedium
+
     eps_dataset: Optional[JaxPermittivityDataset] = pd.Field(
         None,
         title="Permittivity Dataset",
@@ -383,40 +385,40 @@ class JaxCustomMedium(CustomMedium, AbstractJaxMedium):
         as_custom_medium = self.to_tidy3d()
         return as_custom_medium.eps_dataarray_freq(frequency)
 
-    def to_tidy3d(self) -> CustomMedium:
-        """Convert :class:`.JaxMedium` instance to :class:`.Medium`"""
-        self_dict = self.dict(exclude={"type"})
-        eps_field_components = {}
-        for dim in "xyz":
-            field_name = f"eps_{dim}{dim}"
-            data_array = self_dict["eps_dataset"][field_name]
-            values = np.array(data_array["values"])
-            coords = data_array["coords"]
-            scalar_field = ScalarFieldDataArray(values, coords=coords)
-            eps_field_components[field_name] = scalar_field
-        eps_dataset = PermittivityDataset(**eps_field_components)
-        self_dict["eps_dataset"] = eps_dataset
-        self_dict["permittivity"] = None
-        self_dict["conductivity"] = None
-        return CustomMedium.parse_obj(self_dict)
+    # def to_tidy3d(self) -> CustomMedium:
+    #     """Convert :class:`.JaxMedium` instance to :class:`.Medium`"""
+    #     self_dict = self.dict(exclude={"type"})
+    #     eps_field_components = {}
+    #     for dim in "xyz":
+    #         field_name = f"eps_{dim}{dim}"
+    #         data_array = self_dict["eps_dataset"][field_name]
+    #         values = np.array(data_array["values"])
+    #         coords = data_array["coords"]
+    #         scalar_field = ScalarFieldDataArray(values, coords=coords)
+    #         eps_field_components[field_name] = scalar_field
+    #     eps_dataset = PermittivityDataset(**eps_field_components)
+    #     self_dict["eps_dataset"] = eps_dataset
+    #     self_dict["permittivity"] = None
+    #     self_dict["conductivity"] = None
+    #     return CustomMedium.parse_obj(self_dict)
 
-    @classmethod
-    def from_tidy3d(cls, tidy3d_obj: CustomMedium) -> JaxCustomMedium:
-        """Convert :class:`.Tidy3dBaseModel` instance to :class:`.JaxObject`."""
-        obj_dict = tidy3d_obj.dict(exclude={"type", "eps_dataset", "permittivity", "conductivity"})
-        eps_dataset = tidy3d_obj.eps_dataset
-        field_components = {}
-        for dim in "xyz":
-            field_name = f"eps_{dim}{dim}"
-            data_array = eps_dataset.field_components[field_name]
-            values = data_array.values.tolist()
-            coords = {key: np.array(val).tolist() for key, val in data_array.coords.items()}
-            field_components[field_name] = JaxDataArray(values=values, coords=coords)
-        eps_dataset = JaxPermittivityDataset(**field_components)
-        obj_dict["eps_dataset"] = eps_dataset
-        obj_dict["permittivity"] = None
-        obj_dict["conductivity"] = None
-        return cls.parse_obj(obj_dict)
+    # @classmethod
+    # def from_tidy3d(cls, tidy3d_obj: CustomMedium) -> JaxCustomMedium:
+    #     """Convert :class:`.Tidy3dBaseModel` instance to :class:`.JaxObject`."""
+    #     obj_dict = tidy3d_obj.dict(exclude={"type", "eps_dataset", "permittivity", "conductivity"})
+    #     eps_dataset = tidy3d_obj.eps_dataset
+    #     field_components = {}
+    #     for dim in "xyz":
+    #         field_name = f"eps_{dim}{dim}"
+    #         data_array = eps_dataset.field_components[field_name]
+    #         values = data_array.values.tolist()
+    #         coords = {key: np.array(val).tolist() for key, val in data_array.coords.items()}
+    #         field_components[field_name] = JaxDataArray(values=values, coords=coords)
+    #     eps_dataset = JaxPermittivityDataset(**field_components)
+    #     obj_dict["eps_dataset"] = eps_dataset
+    #     obj_dict["permittivity"] = None
+    #     obj_dict["conductivity"] = None
+    #     return cls.parse_obj(obj_dict)
 
     def store_vjp(
         self,

--- a/tidy3d/plugins/adjoint/components/medium.py
+++ b/tidy3d/plugins/adjoint/components/medium.py
@@ -13,8 +13,6 @@ from ....components.types import Bound, Literal
 from ....components.medium import Medium, AnisotropicMedium, CustomMedium
 from ....components.geometry.base import Geometry
 from ....components.data.monitor_data import FieldData
-from ....components.data.dataset import PermittivityDataset
-from ....components.data.data_array import ScalarFieldDataArray
 from ....exceptions import SetupError
 from ....constants import CONDUCTIVITY
 

--- a/tidy3d/plugins/adjoint/components/medium.py
+++ b/tidy3d/plugins/adjoint/components/medium.py
@@ -360,25 +360,25 @@ class JaxCustomMedium(CustomMedium, AbstractJaxMedium):
 
         return val
 
-    # @pd.validator("eps_dataset", always=True)
-    # def _eps_dataset_single_frequency(cls, val):
-    #     """Override of inherited validator."""
-    #     return val
+    @pd.validator("eps_dataset", always=True)
+    def _eps_dataset_single_frequency(cls, val):
+        """Override of inherited validator."""
+        return val
 
-    # @pd.validator("eps_dataset", always=True)
-    # def _eps_dataset_eps_inf_greater_no_less_than_one_sigma_positive(cls, val, values):
-    #     """Override of inherited validator."""
-    #     return val
+    @pd.validator("eps_dataset", always=True)
+    def _eps_dataset_eps_inf_greater_no_less_than_one_sigma_positive(cls, val, values):
+        """Override of inherited validator."""
+        return val
 
-    # @pd.validator("permittivity", always=True)
-    # def _eps_inf_greater_no_less_than_one(cls, val):
-    #     """Override of inherited validator."""
-    #     return val
+    @pd.validator("permittivity", always=True)
+    def _eps_inf_greater_no_less_than_one(cls, val):
+        """Override of inherited validator."""
+        return val
 
-    # @pd.validator("conductivity", always=True)
-    # def _conductivity_non_negative_correct_shape(cls, val, values):
-    #     """Override of inherited validator."""
-    #     return val
+    @pd.validator("conductivity", always=True)
+    def _conductivity_non_negative_correct_shape(cls, val, values):
+        """Override of inherited validator."""
+        return val
 
     def eps_dataarray_freq(self, frequency: float):
         """ "Permittivity array at ``frequency``"""

--- a/tidy3d/plugins/adjoint/components/medium.py
+++ b/tidy3d/plugins/adjoint/components/medium.py
@@ -19,7 +19,7 @@ from ....exceptions import SetupError
 from ....constants import CONDUCTIVITY
 
 from .base import JaxObject
-from .types import JaxFloat, validate_jax_float
+from .types import JaxFloat
 from .data.data_array import JaxDataArray
 from .data.dataset import JaxPermittivityDataset
 
@@ -55,7 +55,6 @@ class AbstractJaxMedium(ABC, JaxObject):
         d_vol = 1.0
         vol_coords = {}
         for coord_name, min_edge, max_edge in zip("xyz", rmin, rmax):
-
             size = max_edge - min_edge
 
             # don't discretize this dimension if there is no thickness along it
@@ -313,19 +312,19 @@ class JaxCustomMedium(CustomMedium, AbstractJaxMedium):
     with respect to the field variation.
     """
 
-    permittivity: Optional[JaxDataArray] = pd.Field(
-        None,
-        title="Permittivity",
-        description="Spatial profile of relative permittivity.",
-    )
+    # permittivity: Optional[JaxDataArray] = pd.Field(
+    #     None,
+    #     title="Permittivity",
+    #     description="Spatial profile of relative permittivity.",
+    # )
 
-    conductivity: Optional[JaxDataArray] = pd.Field(
-        None,
-        title="Conductivity",
-        description="Spatial profile Electric conductivity.  Defined such "
-        "that the imaginary part of the complex permittivity at angular "
-        "frequency omega is given by conductivity/omega.",
-    )
+    # conductivity: Optional[JaxDataArray] = pd.Field(
+    #     None,
+    #     title="Conductivity",
+    #     description="Spatial profile Electric conductivity.  Defined such "
+    #     "that the imaginary part of the complex permittivity at angular "
+    #     "frequency omega is given by conductivity/omega.",
+    # )
 
     eps_dataset: Optional[JaxPermittivityDataset] = pd.Field(
         None,
@@ -341,7 +340,7 @@ class JaxCustomMedium(CustomMedium, AbstractJaxMedium):
         """Don't allow permittivity as a field until we support it."""
         if values.get("permittivity"):
             raise SetupError(
-                "'permittivity' is not yet supported in adjoint plugin. "
+                "'permittivity' and 'conductivity' are not yet supported in adjoint plugin. "
                 "Please continue to use the 'eps_dataset' field to define the component "
                 "of the permittivity tensor."
             )
@@ -466,7 +465,6 @@ class JaxCustomMedium(CustomMedium, AbstractJaxMedium):
 
         vjp_field_components = {}
         for dim in "xyz":
-
             eps_field_name = f"eps_{dim}{dim}"
 
             # grab the original data and its coordinatess
@@ -483,7 +481,6 @@ class JaxCustomMedium(CustomMedium, AbstractJaxMedium):
             sum_axes = []
 
             for dim_index, dim_pt in enumerate("xyz"):
-
                 coord_dim = coords[dim_pt]
 
                 # if it's uniform / single pixel along this dim
@@ -499,7 +496,6 @@ class JaxCustomMedium(CustomMedium, AbstractJaxMedium):
 
                     # compute the length element along the dim, handling case of sim.size=0
                     if size > 0:
-
                         # discretize according to PTS_PER_WVL
                         num_cells_dim = int(size * PTS_PER_WVL_INTEGRATION / wvl_mat) + 1
                         d_len = size / num_cells_dim
@@ -508,7 +504,6 @@ class JaxCustomMedium(CustomMedium, AbstractJaxMedium):
                         )
 
                     else:
-
                         # just interpolate at the single position, dL=1 to normalize out
                         d_len = 1.0
                         coords_interp = np.array([(r_min + r_max) / 2.0])

--- a/tidy3d/plugins/adjoint/components/medium.py
+++ b/tidy3d/plugins/adjoint/components/medium.py
@@ -360,25 +360,25 @@ class JaxCustomMedium(CustomMedium, AbstractJaxMedium):
 
         return val
 
-    @pd.validator("eps_dataset", always=True)
-    def _eps_dataset_single_frequency(cls, val):
-        """Override of inherited validator."""
-        return val
+    # @pd.validator("eps_dataset", always=True)
+    # def _eps_dataset_single_frequency(cls, val):
+    #     """Override of inherited validator."""
+    #     return val
 
-    @pd.validator("eps_dataset", always=True)
-    def _eps_dataset_eps_inf_greater_no_less_than_one_sigma_positive(cls, val, values):
-        """Override of inherited validator."""
-        return val
+    # @pd.validator("eps_dataset", always=True)
+    # def _eps_dataset_eps_inf_greater_no_less_than_one_sigma_positive(cls, val, values):
+    #     """Override of inherited validator."""
+    #     return val
 
-    @pd.validator("permittivity", always=True)
-    def _eps_inf_greater_no_less_than_one(cls, val):
-        """Override of inherited validator."""
-        return val
+    # @pd.validator("permittivity", always=True)
+    # def _eps_inf_greater_no_less_than_one(cls, val):
+    #     """Override of inherited validator."""
+    #     return val
 
-    @pd.validator("conductivity", always=True)
-    def _conductivity_non_negative_correct_shape(cls, val, values):
-        """Override of inherited validator."""
-        return val
+    # @pd.validator("conductivity", always=True)
+    # def _conductivity_non_negative_correct_shape(cls, val, values):
+    #     """Override of inherited validator."""
+    #     return val
 
     def eps_dataarray_freq(self, frequency: float):
         """ "Permittivity array at ``frequency``"""

--- a/tidy3d/plugins/adjoint/components/medium.py
+++ b/tidy3d/plugins/adjoint/components/medium.py
@@ -148,7 +148,6 @@ class JaxMedium(Medium, AbstractJaxMedium):
         1.0,
         title="Permittivity",
         description="Relative permittivity of the medium. May be a ``jax`` ``Array``.",
-        jax_field=True,
         jax_leaf=True,
     )
 
@@ -158,7 +157,6 @@ class JaxMedium(Medium, AbstractJaxMedium):
         description="Electric conductivity. Defined such that the imaginary part of the complex "
         "permittivity at angular frequency omega is given by conductivity/omega.",
         units=CONDUCTIVITY,
-        jax_field=True,
         jax_leaf=True,
     )
 

--- a/tidy3d/plugins/adjoint/components/simulation.py
+++ b/tidy3d/plugins/adjoint/components/simulation.py
@@ -351,7 +351,6 @@ class JaxSimulation(Simulation, JaxObject):
         run_time_adjoint = RUN_TIME_FACTOR / self._fwidth_adjoint
 
         if self._is_multi_freq:
-
             log.warning(
                 f"{len(self.freqs_adjoint)} unique frequencies detected in the output monitors "
                 f"with a minimum spacing of {self._min_delta_freq:.3e} (Hz). "

--- a/tidy3d/plugins/adjoint/components/structure.py
+++ b/tidy3d/plugins/adjoint/components/structure.py
@@ -30,6 +30,7 @@ class AbstractJaxStructure(Structure, JaxObject):
 
     # which of "geometry" or "medium" is differentiable for this class
     _differentiable_fields = ()
+    # TODO: make this a @classmethod, automatically generated from the `jax_field` tags
 
     @pd.validator("medium", always=True)
     def _check_2d_geometry(cls, val, values):

--- a/tidy3d/plugins/adjoint/components/types.py
+++ b/tidy3d/plugins/adjoint/components/types.py
@@ -39,19 +39,8 @@ _add_schema(JVPTracer, title="JVPTracer", field_type_str="jax.interpreters.ad.JV
 
 # define types usable as floats including the jax tracers
 JaxArrayLike = Union[NumpyArrayType, JaxArrayType]
-JaxFloat = Union[float, JaxArrayLike, JVPTracer]
-
-"""
-Note, currently set up for jax 0.3.x, which is the only installable version for windows.
-To get Array like in 0.3:
-# from jax.experimental.array import ArrayLike
-
-for jax 0.4.x, need to use
-# from jax._src.typing import ArrayLike
-
-and can make JaxFloat like
-# JaxFloat = Union[float, ArrayLike]
-"""
+JaxFloat = Union[float, JaxArrayLike, JVPTracer, object]
+# note: object is included here because sometimes jax passes just `object` (i think when untraced)
 
 
 def sanitize_validator_fn(cls, val):

--- a/tidy3d/plugins/adjoint/utils/filter.py
+++ b/tidy3d/plugins/adjoint/utils/filter.py
@@ -68,7 +68,6 @@ class AbstractCircularFilter(Filter, ABC):
         input_shape = signal_in.shape
 
         if any((k_shape > in_shape for k_shape, in_shape in zip(kernel_shape, input_shape))):
-
             # remove some pixels from the kernel to make things right
             new_kernel = kernel.copy()
             for axis, (len_kernel, len_input) in enumerate(zip(kernel_shape, input_shape)):

--- a/tidy3d/plugins/adjoint/web.py
+++ b/tidy3d/plugins/adjoint/web.py
@@ -808,7 +808,6 @@ def run_async_local_fwd(
 
     sims_fwd = []
     for simulation in simulations:
-
         grad_mnts = simulation.get_grad_monitors(
             input_structures=simulation.input_structures, freqs_adjoint=simulation.freqs_adjoint
         )
@@ -880,7 +879,6 @@ def run_async_local_bwd(
 
     sims_vjp = []
     for i, (sim_data_fwd, sim_data_adj) in enumerate(zip(batch_data_fwd, batch_data_adj)):
-
         sim_data_adj = sim_data_adj.normalize_adjoint_fields()
 
         grad_data_fwd = sim_data_fwd.grad_data_symmetry

--- a/tidy3d/plugins/dispersion/fit.py
+++ b/tidy3d/plugins/dispersion/fit.py
@@ -287,13 +287,11 @@ class DispersionFitter(Tidy3dBaseModel):
         best_rms = np.inf
 
         with Progress(console=get_logging_console()) as progress:
-
             task = progress.add_task(
                 f"Fitting with {num_poles} to RMS of {tolerance_rms}...", total=num_tries
             )
 
             while not progress.finished:
-
                 # if guess is provided use it in the first optimization run
                 if guess is not None and progress.tasks[0].completed == 0:
                     medium, rms_error = self._fit_single(num_poles=num_poles, guess=guess)

--- a/tidy3d/plugins/dispersion/fit_fast.py
+++ b/tidy3d/plugins/dispersion/fit_fast.py
@@ -289,7 +289,7 @@ class FastFitterData(AdvancedFastFitterParam):
     def evaluate(self, omega: float) -> complex:
         """Evaluate model at omega in eV."""
         eps = self.eps_inf
-        for (pole, res) in zip(self.poles, self.residues):
+        for pole, res in zip(self.poles, self.residues):
             eps += -res / (1j * omega + pole) - np.conj(res) / (1j * omega + np.conj(pole))
         return eps
 
@@ -613,7 +613,6 @@ class FastDispersionFitter(DispersionFitter):
                     and len(model.poles) <= num_poles_range[1]
                     and model.rms_error < best_model.rms_error
                 ):
-
                     best_model = model
             return best_model
 
@@ -715,7 +714,6 @@ class FastDispersionFitter(DispersionFitter):
         configs = make_configs()
 
         with Progress(console=get_logging_console()) as progress:
-
             task = progress.add_task(
                 f"Fitting to weighted RMS of {tolerance_rms}...",
                 total=len(configs),
@@ -723,7 +721,6 @@ class FastDispersionFitter(DispersionFitter):
             )
 
             while not progress.finished:
-
                 # try different initial pole configurations
                 for num_poles, relaxed, smooth, logspacing, optimize_eps_inf in configs:
                     model = init_model.updated_copy(

--- a/tidy3d/plugins/mode/solver.py
+++ b/tidy3d/plugins/mode/solver.py
@@ -287,7 +287,6 @@ class EigSolver(Tidy3dBaseModel):
         is_eps_complex = cls.isinstance_complex(eps_tensor)
 
         if not is_tensorial:
-
             eps_spec = "diagonal"
             E, H, neff, keff = cls.solver_diagonal(**kwargs)
             if direction == "-":
@@ -296,7 +295,6 @@ class EigSolver(Tidy3dBaseModel):
                 E[2] *= -1
 
         elif not is_eps_complex:
-
             eps_spec = "tensorial_real"
             E, H, neff, keff = cls.solver_tensorial(**kwargs, direction="+")
             if direction == "-":
@@ -304,7 +302,6 @@ class EigSolver(Tidy3dBaseModel):
                 H = -np.conj(H)
 
         else:
-
             eps_spec = "tensorial_complex"
             E, H, neff, keff = cls.solver_tensorial(**kwargs, direction=direction)
 

--- a/tidy3d/plugins/resonance/resonance.py
+++ b/tidy3d/plugins/resonance/resonance.py
@@ -316,7 +316,6 @@ class ResonanceFinder(Tidy3dBaseModel):
 
         u_matrices = np.zeros((3, nfreqs, nfreqs), dtype=complex)
         for pval in range(3):
-
             u_matrices[pval, :, :] = prefactor * (
                 np.outer(zvals, zinvl[:, : half_len + 1] @ signal[pval:][: half_len + 1])
                 + np.outer(

--- a/tidy3d/plugins/smatrix/smatrix.py
+++ b/tidy3d/plugins/smatrix/smatrix.py
@@ -169,8 +169,7 @@ class ComponentModeler(Tidy3dBaseModel):
         sim_dict = {}
         mode_monitors = [self.to_monitor(port=port) for port in self.ports]
 
-        for (port_name, mode_index) in self.matrix_indices_run_sim:
-
+        for port_name, mode_index in self.matrix_indices_run_sim:
             port = self.get_port_by_name(port_name=port_name)
 
             port_source = self.shift_port(port=port)
@@ -211,7 +210,6 @@ class ComponentModeler(Tidy3dBaseModel):
         # loop through rows of the full s matrix and record rows that still need running.
         source_indices_needed = []
         for col_index in self.matrix_indices_source:
-
             # loop through columns and keep track of whether each element is covered by mapping.
             matrix_elements_covered = []
             for row_index in self.matrix_indices_monitor:
@@ -456,14 +454,12 @@ class ComponentModeler(Tidy3dBaseModel):
 
         # loop through source ports
         for col_index in self.matrix_indices_run_sim:
-
             port_name_in, mode_index_in = col_index
             port_in = self.get_port_by_name(port_name=port_name_in)
 
             sim_data = batch_data[self._task_name(port=port_in, mode_index=mode_index_in)]
 
             for row_index in self.matrix_indices_monitor:
-
                 port_name_out, mode_index_out = row_index
                 port_out = self.get_port_by_name(port_name=port_name_out)
 
@@ -485,8 +481,7 @@ class ComponentModeler(Tidy3dBaseModel):
                 ] = s_matrix_elements
 
         # element can be determined by user-defined mapping
-        for ((row_in, col_in), (row_out, col_out), mult_by) in self.element_mappings:
-
+        for (row_in, col_in), (row_out, col_out), mult_by in self.element_mappings:
             port_out_from, mode_index_out_from = row_in
             port_in_from, mode_index_in_from = col_in
             coords_from = dict(

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -525,7 +525,6 @@ class Batch(WebContainer):
         solver_version = values.get("solver_version")
         jobs = {}
         for task_name, simulation in values.get("simulations").items():
-
             upload_kwargs = {key: values.get(key) for key in JobType._upload_fields}
             upload_kwargs["task_name"] = task_name
             upload_kwargs["simulation"] = simulation

--- a/tidy3d/web/api/tidy3d_stub.py
+++ b/tidy3d/web/api/tidy3d_stub.py
@@ -28,7 +28,6 @@ SimulationDataType = Union[SimulationData, HeatSimulationData]
 
 
 class Tidy3dStub(BaseModel, TaskStub):
-
     simulation: SimulationType = pd.Field(discriminator="type")
 
     @classmethod

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -345,7 +345,6 @@ def monitor(task_id: TaskId, verbose: bool = True) -> None:
     task_info = get_info(task_id)
 
     if task_info.taskType in ("MODE_SOLVER", "HEAT"):
-
         log_level = "DEBUG" if verbose else "INFO"
         solver_name = "Mode" if task_info.taskType == "MODE_SOLVER" else "Heat"
 
@@ -373,7 +372,6 @@ def monitor(task_id: TaskId, verbose: bool = True) -> None:
             return None
 
     elif task_info.taskType == "FDTD":
-
         task_name = task_info.taskName
 
         break_statuses = ("success", "error", "diverged", "deleted", "draft", "abort")


### PR DESCRIPTION
this one works. Still improving things though and fixing a couple tests.

## Main changes:
- [x] jax tracer for field `x` moved to a new field `x_jax`. 
    - [ ] When values passed to `x`, the traced version is copied to `x_jax` and an untraced copy is saved in `x`.
    - [ ] No need to patch or remove validators or existing methods (`.bounds`) as they used the untraced copies.
- [ ] `jax_leaf:bool` flag added in the `pd.Field` to specify that this field is specifically a leaf node (contains tracers). `jax_field` only means that the field contains either a `JaxObject` or `tuple` of them.
- [x] `.to_tidy3d()` and `.from_tidy3d()` conversions generalized to base class. 
    - [ ] `to_simulation()` conversion still requires a bit of manual work for now.
- [ ] Made `JaxDataArray` a `JaxObject` and simplified the internals a lot as it uses existing methods now.
- [ ] ran black with the updated version, which created a lot of changes.

## Status
- [ ] Pipeline tests mostly passing where it counts.
- [ ] Notebooks 2 and 3 run successfully.
- [ ] Some adjoint tests fail.

## To do later
- [ ] Fix a couple tests that are failing because of serializing `JaxDataArray`

## To do in another stage / PR of the refactor? 
- [ ] move from defining jax fields in `pd.Field` to using class attrs.
- [ ] simplify `to_simulation()` by adding "transformations" to `to_tidy3d()` and `from_tidy3d()`.
- [ ] have web API accept JaxSimulation directly? no need for conversion?