### PR TITLE
adjoint refactor: stage 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - All solver output is now compressed. However, it is automatically unpacked to the same `simulation_data.hdf5` by default when loading simulation data from the server.
+- Internal refactor of `adjoint` plugin to separate `jax`-traced fields from regular `tidy3d` fields.
 
 ### Fixed
 

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -427,6 +427,11 @@ class PolySlab(base.Planar):
             raise ValidationError("'Medium2D' requires the 'PolySlab' bounds to be equal.")
         return self.axis
 
+    @cached_property
+    def is_ccw(self) -> bool:
+        """Is this ``PolySlab`` CCW-oriented?"""
+        return PolySlab._area(self.vertices) > 0
+
     def inside(
         self, x: np.ndarray[float], y: np.ndarray[float], z: np.ndarray[float]
     ) -> np.ndarray[bool]:

--- a/tidy3d/plugins/adjoint/components/base.py
+++ b/tidy3d/plugins/adjoint/components/base.py
@@ -5,6 +5,8 @@ from typing import Tuple, List, Any, Callable
 import json
 
 import numpy as np
+import jax
+import pydantic.v1 as pd
 
 from jax.tree_util import tree_flatten as jax_tree_flatten
 from jax.tree_util import tree_unflatten as jax_tree_unflatten
@@ -16,67 +18,78 @@ from .data.data_array import JaxDataArray, JAX_DATA_ARRAY_TAG
 class JaxObject(Tidy3dBaseModel):
     """Abstract class that makes a :class:`.Tidy3dBaseModel` jax-compatible through inheritance."""
 
-    """Shortcut to get names of all fields that have jax components."""
+    _tidy3d_class = Tidy3dBaseModel
+
+    """Shortcut to get names of fields with certain properties."""
+
+    @classmethod
+    def _get_field_names(cls, field_key: str) -> List[str]:
+        """Get all fields where ``field_key`` defined in the ``pydantic.Field``."""
+        fields = []
+        for field_name, model_field in cls.__fields__.items():
+            field_value = model_field.field_info.extra.get(field_key)
+            if field_value:
+                fields.append(field_name)
+        return fields
 
     @classmethod
     def get_jax_field_names(cls) -> List[str]:
-        """Returns list of field names that have a ``jax_field_type``."""
-        adjoint_fields = []
-        for field_name, model_field in cls.__fields__.items():
-            jax_field_type = model_field.field_info.extra.get("jax_field")
-            if jax_field_type:
-                adjoint_fields.append(field_name)
-        return adjoint_fields
+        """Returns list of field names where ``jax_field=True``."""
+        return cls._get_field_names("jax_field")
+
+    @classmethod
+    def get_jax_leaf_names(cls) -> List[str]:
+        """Returns list of field names where ``stores_jax_for`` defined."""
+        return cls._get_field_names("stores_jax_for")
+
+    @classmethod
+    def get_jax_field_names_all(cls) -> List[str]:
+        """Returns list of field names where ``jax_field=True`` or ``stores_jax_for`` defined."""
+        jax_field_names = cls.get_jax_field_names()
+        jax_leaf_names = cls.get_jax_leaf_names()
+        return list(set(jax_field_names + jax_leaf_names))
+
+    @property
+    def jax_fields(self) -> dict:
+        """Get dictionary of ``jax`` fields."""
+
+        # TODO: don't use getattr, define this dictionary better
+        jax_field_names = self.get_jax_field_names()
+        return {key: getattr(self, key) for key in jax_field_names}
 
     """Methods needed for jax to register arbitrary classes."""
 
     def tree_flatten(self) -> Tuple[list, dict]:
-        """How to flatten a :class:`.JaxObject` instance into a pytree."""
+        """How to flatten a :class:`.JaxObject` instance into a ``pytree``."""
         children = []
         aux_data = self.dict()
-        for field_name in self.get_jax_field_names():
+
+        for field_name in self.get_jax_field_names_all():
             field = getattr(self, field_name)
             sub_children, sub_aux_data = jax_tree_flatten(field)
             children.append(sub_children)
             aux_data[field_name] = sub_aux_data
 
-        def fix_polyslab(geo_dict: dict) -> None:
-            """Recursively Fix a dictionary possibly containing a polyslab geometry."""
-            if geo_dict["type"] == "PolySlab":
-                vertices = geo_dict["vertices"]
-                geo_dict["vertices"] = vertices.tolist()
-            elif geo_dict["type"] == "GeometryGroup":
-                for sub_geo_dict in geo_dict["geometries"]:
-                    fix_polyslab(sub_geo_dict)
-            elif geo_dict["type"] == "ClipOperation":
-                fix_polyslab(geo_dict["geometry_a"])
-                fix_polyslab(geo_dict["geometry_b"])
+        def fix_numpy(value: Any) -> Any:
+            """Recursively convert any ``numpy`` array in the value to nested list."""
+            if isinstance(value, (tuple, list)):
+                return [fix_numpy(val) for val in value]
+            if isinstance(value, np.ndarray):
+                return value.tolist()
+            if isinstance(value, dict):
+                return {key: fix_numpy(val) for key, val in value.items()}
+            else:
+                return value
 
-        def fix_monitor(mnt_dict: dict) -> None:
-            """Fix a frequency containing monitor."""
-            if "freqs" in mnt_dict:
-                freqs = mnt_dict["freqs"]
-                if isinstance(freqs, np.ndarray):
-                    mnt_dict["freqs"] = freqs.tolist()
-
-        # fixes bug with jax handling 2D numpy array in polyslab vertices
-        if aux_data.get("type", "") == "JaxSimulation":
-            structures = aux_data["structures"]
-            for _i, structure in enumerate(structures):
-                geometry = structure["geometry"]
-                fix_polyslab(geometry)
-            for monitor in aux_data["monitors"]:
-                fix_monitor(monitor)
-            for monitor in aux_data["output_monitors"]:
-                fix_monitor(monitor)
+        aux_data = fix_numpy(aux_data)
 
         return children, aux_data
 
     @classmethod
     def tree_unflatten(cls, aux_data: dict, children: list) -> JaxObject:
-        """How to unflatten a pytree into a :class:`.JaxObject` instance."""
+        """How to unflatten a ``pytree`` into a :class:`.JaxObject` instance."""
         self_dict = aux_data.copy()
-        for field_name, sub_children in zip(cls.get_jax_field_names(), children):
+        for field_name, sub_children in zip(cls.get_jax_field_names_all(), children):
             sub_aux_data = aux_data[field_name]
             field = jax_tree_unflatten(sub_aux_data, sub_children)
             self_dict[field_name] = field
@@ -85,13 +98,85 @@ class JaxObject(Tidy3dBaseModel):
 
     """Type conversion helpers."""
 
+    def to_tidy3d(self: JaxObject) -> Tidy3dBaseModel:
+        """Convert :class:`.JaxObject` instance to :class:`.Tidy3dBaseModel` instance."""
+
+        self_dict = self.dict(exclude=self.exclude_fields_leafs_only)
+
+        for key in self.get_jax_field_names():
+            sub_field = self.jax_fields[key]
+
+            # TODO: simplify this logic
+            if isinstance(sub_field, (tuple, list)):
+                self_dict[key] = [x.to_tidy3d() for x in sub_field]
+            else:
+                self_dict[key] = sub_field.to_tidy3d()
+            # end TODO
+
+        return self._tidy3d_class.parse_obj(self_dict)
+
     @classmethod
     def from_tidy3d(cls, tidy3d_obj: Tidy3dBaseModel) -> JaxObject:
         """Convert :class:`.Tidy3dBaseModel` instance to :class:`.JaxObject`."""
         obj_dict = tidy3d_obj.dict(exclude={"type"})
+
+        for key in cls.get_jax_field_names():
+            sub_field_type = cls.__fields__[key].type_
+            tidy3d_sub_field = getattr(tidy3d_obj, key)
+
+            # TODO: simplify this logic
+            if isinstance(tidy3d_sub_field, (tuple, list)):
+                obj_dict[key] = [sub_field_type.from_tidy3d(x) for x in tidy3d_sub_field]
+            else:
+                obj_dict[key] = sub_field_type.from_tidy3d(tidy3d_sub_field)
+            # end TODO
+
         return cls.parse_obj(obj_dict)
 
+    @property
+    def exclude_fields_leafs_only(self) -> set:
+        """Fields to exclude from ``self.dict()``, ``"type"`` and all ``jax`` leafs."""
+        return set(["type"] + self.get_jax_leaf_names())
+
+    """Accounting with jax and regular fields."""
+
+    @pd.root_validator(pre=True)
+    def handle_jax_kwargs(cls, values: dict) -> dict:
+        """Pass jax inputs to the jax fields and pass untraced values to the regular fields."""
+
+        # for all jax-traced fields
+        for jax_name in cls.get_jax_leaf_names():
+            # if a value was passed to the object for the regular field
+            orig_name = cls.__fields__[jax_name].field_info.extra.get("stores_jax_for")
+            val = values.get(orig_name)
+            if val is not None:
+
+                # try adding the sanitized (no trace) version to the regular field
+                try:
+                    values[orig_name] = jax.lax.stop_gradient(val)
+
+                # if it doesnt work, just pass the raw value (necessary to handle inf strings)
+                except TypeError:
+                    values[orig_name] = val
+
+                # if the jax name was not specified directly, use the original traced value
+                if jax_name not in values:
+                    values[jax_name] = val
+
+        return values
+
+    @pd.root_validator(pre=True)
+    def handle_array_jax_leafs(cls, values: dict) -> dict:
+        """Convert jax_leafs that are passed as numpy arrays."""
+        for jax_name in cls.get_jax_leaf_names():
+            val = values.get(jax_name)
+            if isinstance(val, np.ndarray):
+                values[jax_name] = val.tolist()
+        return values
+
     """ IO """
+
+    # TODO: replace with JaxObject json encoder
 
     def _json(self, *args, **kwargs) -> str:
         """Overwritten method to get the json string to store in the files."""
@@ -99,23 +184,23 @@ class JaxObject(Tidy3dBaseModel):
         json_string_og = super()._json(*args, **kwargs)
         json_dict = json.loads(json_string_og)
 
-        def strip_data_array(sub_dict: dict) -> None:
-            """Strip any elements of the dictionary with type "JaxDataArray", replace with tag."""
+        def strip_data_array(val: Any) -> Any:
+            """Recursively strip any elements with type "JaxDataArray", replace with tag."""
 
-            for key, val in sub_dict.items():
+            if isinstance(val, dict):
+                if "type" in val and val["type"] == "JaxDataArray":
+                    return JAX_DATA_ARRAY_TAG
+                return {k: strip_data_array(v) for k, v in val.items()}
 
-                if isinstance(val, dict):
-                    if "type" in val and val["type"] == "JaxDataArray":
-                        sub_dict[key] = JAX_DATA_ARRAY_TAG
-                    else:
-                        strip_data_array(val)
-                elif isinstance(val, (list, tuple)):
-                    val_dict = dict(zip(range(len(val)), val))
-                    strip_data_array(val_dict)
-                    sub_dict[key] = list(val_dict.values())
+            elif isinstance(val, (tuple, list)):
+                return [strip_data_array(v) for v in val]
 
-        strip_data_array(json_dict)
+            return val
+
+        json_dict = strip_data_array(json_dict)
         return json.dumps(json_dict)
+
+    # TODO: replace with implementing these in DataArray
 
     def to_hdf5(self, fname: str, custom_encoders: List[Callable] = None) -> None:
         """Exports :class:`JaxObject` instance to .hdf5 file.

--- a/tidy3d/plugins/adjoint/components/data/data_array.py
+++ b/tidy3d/plugins/adjoint/components/data/data_array.py
@@ -40,6 +40,17 @@ class JaxDataArray(Tidy3dBaseModel):
         description="Dictionary storing the coordinates, namely ``(direction, f, mode_index)``.",
     )
 
+    def to_tidy3d(self: JaxDataArray) -> xr.DataArray:
+        """Convert :class:`.JaxDataArray` instance to ``xr.DataArray`` instance."""
+        coords = {k: np.array(v).tolist() for k, v in self.coords.items()}
+        return xr.DataArray(np.array(self.values), coords=coords, dims=self.coords.keys())
+
+    @classmethod
+    def from_tidy3d(cls, tidy3d_obj: xr.DataArray) -> JaxDataArray:
+        """Convert ``xr.DataArray`` instance to :class:`.JaxDataArray`."""
+        coords = {k: np.array(v).tolist() for k, v in tidy3d_obj.coords.items()}
+        return cls(values=tidy3d_obj.data, coords=coords)
+
     @pd.validator("values", always=True)
     def _convert_values_to_np(cls, val):
         """Convert supplied values to numpy if they are list (from file)."""

--- a/tidy3d/plugins/adjoint/components/data/dataset.py
+++ b/tidy3d/plugins/adjoint/components/data/dataset.py
@@ -12,6 +12,8 @@ from ..base import JaxObject
 class JaxPermittivityDataset(PermittivityDataset, JaxObject):
     """A :class:`.PermittivityDataset` registered with jax."""
 
+    _tidy3d_class = PermittivityDataset
+
     eps_xx: JaxDataArray = pd.Field(
         ...,
         title="Epsilon xx",

--- a/tidy3d/plugins/adjoint/components/data/monitor_data.py
+++ b/tidy3d/plugins/adjoint/components/data/monitor_data.py
@@ -32,7 +32,7 @@ class JaxMonitorData(MonitorData, JaxObject, ABC):
     def from_monitor_data(cls, mnt_data: MonitorData) -> JaxMonitorData:
         """Construct a :class:`.JaxMonitorData` instance from a :class:`.MonitorData`."""
         self_dict = mnt_data.dict(exclude={"type"}).copy()
-        for field_name in cls.get_jax_field_names():
+        for field_name in cls.get_jax_field_names_all():
             data_array = self_dict[field_name]
             if data_array is not None:
                 coords = {

--- a/tidy3d/plugins/adjoint/components/geometry.py
+++ b/tidy3d/plugins/adjoint/components/geometry.py
@@ -22,7 +22,7 @@ from ....constants import fp_eps, MICROMETER
 from ....exceptions import AdjointError
 
 from .base import JaxObject
-from .types import JaxFloat, validate_jax_tuple, validate_jax_tuple_tuple
+from .types import JaxFloat
 
 # number of integration points per unit wavelength in material
 PTS_PER_WVL_INTEGRATION = 50
@@ -89,13 +89,6 @@ class JaxGeometry(Geometry, ABC):
         )
         return field_mnt, eps_mnt
 
-    def to_tidy3d(self) -> Geometry:
-        """Convert :class:`.JaxGeometry` instance to :class:`.Geometry`"""
-        self_dict = self.dict(exclude={"type"})
-        map_reverse = {v: k for k, v in JAX_GEOMETRY_MAP.items()}
-        tidy3d_type = map_reverse[type(self)]
-        return tidy3d_type.parse_obj(self_dict)
-
     @staticmethod
     def compute_dotted_e_d_fields(
         grad_data_fwd: FieldData, grad_data_adj: FieldData, grad_data_eps: PermittivityData
@@ -131,36 +124,23 @@ class JaxGeometry(Geometry, ABC):
 class JaxBox(JaxGeometry, Box, JaxObject):
     """A :class:`.Box` registered with jax."""
 
-    size: Tuple[JaxFloat, JaxFloat, JaxFloat] = pd.Field(
-        ...,
-        title="Size",
-        description="Size of the box in (x,y,z). May contain ``jax`` ``Array`` instances.",
-        jax_field=True,
+    _tidy3d_class = Box
+
+    center_jax: Tuple[JaxFloat, JaxFloat, JaxFloat] = pd.Field(
+        (0.0, 0.0, 0.0),
+        title="Center (Jax)",
+        description="Jax traced value for the center of the box in (x, y, z).",
+        units=MICROMETER,
+        stores_jax_for="center",
     )
 
-    center: Tuple[JaxFloat, JaxFloat, JaxFloat] = pd.Field(
+    size_jax: Tuple[JaxFloat, JaxFloat, JaxFloat] = pd.Field(
         ...,
-        title="Center",
-        description="Center of the box in (x,y,z). May contain ``jax`` ``Array`` instances.",
-        jax_field=True,
+        title="Size (Jax)",
+        description="Jax-traced value for the size of the box in (x, y, z).",
+        units=MICROMETER,
+        stores_jax_for="size",
     )
-
-    _sanitize_size = validate_jax_tuple("size")
-    _sanitize_center = validate_jax_tuple("center")
-
-    @cached_property
-    def bounds(self):
-        """Bounds of this box."""
-        size = jax.lax.stop_gradient(self.size)
-        center = jax.lax.stop_gradient(self.center)
-        coord_min = tuple(c - s / 2 for (s, c) in zip(size, center))
-        coord_max = tuple(c + s / 2 for (s, c) in zip(size, center))
-        return (coord_min, coord_max)
-
-    @pd.validator("center", always=True)
-    def _center_not_inf(cls, val):
-        """Overrides validator enforcing that val is not inf."""
-        return val
 
     def store_vjp(
         self,
@@ -285,88 +265,38 @@ class JaxBox(JaxGeometry, Box, JaxObject):
         # convert surface vjps to center, size vjps. Note, convert these to jax types w/ np.sum()
         vjp_center = tuple(np.sum(vjp_surfs[dim][1] - vjp_surfs[dim][0]) for dim in "xyz")
         vjp_size = tuple(np.sum(0.5 * (vjp_surfs[dim][1] + vjp_surfs[dim][0])) for dim in "xyz")
-        return self.copy(update=dict(center=vjp_center, size=vjp_size))
+        return self.copy(update=dict(center_jax=vjp_center, size_jax=vjp_size))
 
 
 @register_pytree_node_class
 class JaxPolySlab(JaxGeometry, PolySlab, JaxObject):
     """A :class:`.PolySlab` registered with jax."""
 
-    vertices: Tuple[Tuple[JaxFloat, JaxFloat], ...] = pd.Field(
+    _tidy3d_class = PolySlab
+
+    vertices_jax: Tuple[Tuple[JaxFloat, JaxFloat], ...] = pd.Field(
         ...,
-        title="Vertices",
-        description="List of (d1, d2) defining the 2 dimensional positions of the polygon "
-        "face vertices at the ``reference_plane``. "
+        title="Vertices (Jax)",
+        description="Jax-traced list of (d1, d2) defining the 2 dimensional positions of the "
+        "polygon face vertices at the ``reference_plane``. "
         "The index of dimension should be in the ascending order: e.g. if "
         "the slab normal axis is ``axis=y``, the coordinate of the vertices will be in (x, z)",
         units=MICROMETER,
-        jax_field=True,
+        stores_jax_for="vertices",
     )
-
-    @pd.validator("vertices", pre=True, always=True)
-    def convert_to_numpy(cls, val):
-        """Overwrite to not convert vertices to numpy."""
-        return val
-
-    @pd.validator("vertices", pre=True, always=True)
-    def to_list(cls, val):
-        """Convert any numpy to list."""
-        if isinstance(val, np.ndarray):
-            return val.tolist()
-        return val
-
-    _sanitize_vertices = validate_jax_tuple_tuple("vertices")
-
-    @cached_property
-    def bounds(self) -> Bound:
-        """Returns bounding box min and max coordinates. The dilation and slant angle are not
-        taken into account exactly for speed. Instead, the polygon may be slightly smaller than
-        the returned bounds, but it should always be fully contained.
-
-        Returns
-        -------
-        Tuple[float, float, float], Tuple[float, float float]
-            Min and max bounds packaged as ``(minx, miny, minz), (maxx, maxy, maxz)``.
-        """
-
-        xmin, ymin = np.amin(jax.lax.stop_gradient(self.vertices), axis=0)
-        xmax, ymax = np.amax(jax.lax.stop_gradient(self.vertices), axis=0)
-
-        # get bounds in (local) z
-        zmin, zmax = self.slab_bounds
-
-        # rearrange axes
-        coords_min = self.unpop_axis(zmin, (xmin, ymin), axis=self.axis)
-        coords_max = self.unpop_axis(zmax, (xmax, ymax), axis=self.axis)
-        return (tuple(coords_min), tuple(coords_max))
 
     @pd.validator("sidewall_angle", always=True)
     def no_sidewall(cls, val):
-        """Overrides validator enforcing that val is not inf."""
+        """Don't allow sidewall."""
         if not np.isclose(val, 0.0):
             raise AdjointError("'JaxPolySlab' does not support slanted sidewall.")
         return val
 
     @pd.validator("dilation", always=True)
     def no_dilation(cls, val):
-        """Overrides validator enforcing that val is not inf."""
+        """Don't allow dilation."""
         if not np.isclose(val, 0.0):
             raise AdjointError("'JaxPolySlab' does not support dilation.")
-        return val
-
-    @pd.validator("vertices", always=True)
-    def correct_shape(cls, val):
-        """Overrides validator enforcing that val is not inf."""
-        return val
-
-    @pd.validator("vertices", always=True)
-    def no_self_intersecting_polygon_during_extrusion(cls, val, values):
-        """Overrides validator enforcing that val is not inf."""
-        return val
-
-    @pd.validator("vertices", always=True)
-    def no_complex_self_intersecting_polygon_at_reference_plane(cls, val, values):
-        """Overrides validator enforcing that val is not inf."""
         return val
 
     @pd.validator("vertices", always=True)
@@ -377,12 +307,6 @@ class JaxPolySlab(JaxGeometry, PolySlab, JaxObject):
                 f"For performance, a maximum of {MAX_NUM_VERTICES} are allowed in 'JaxPolySlab'."
             )
         return val
-
-    @cached_property
-    def is_ccw(self) -> bool:
-        """Is this PolySlab CCW oriented?"""
-        vertices = np.array(jax.lax.stop_gradient(self.vertices))
-        return PolySlab._area(vertices) > 0
 
     def edge_contrib(
         self,
@@ -627,8 +551,10 @@ class JaxPolySlab(JaxGeometry, PolySlab, JaxObject):
         # Construct arguments to pass to the parallel vertices_vjp computation
 
         args = self._make_vertex_args(e_mult_xyz, d_mult_xyz, sim_bounds, wvl_mat, eps_out, eps_in)
-        vertices_vjp = list(map(self.vertex_vjp, *args))
-        return self.copy(update=dict(vertices=vertices_vjp))
+        vertices_vjp = tuple(map(self.vertex_vjp, *args))
+        vertices_vjp = tuple(tuple(x) for x in vertices_vjp)
+
+        return self.updated_copy(vertices_jax=vertices_vjp)
 
     def store_vjp_parallel(
         self,
@@ -645,7 +571,8 @@ class JaxPolySlab(JaxGeometry, PolySlab, JaxObject):
         args = self._make_vertex_args(e_mult_xyz, d_mult_xyz, sim_bounds, wvl_mat, eps_out, eps_in)
         with Pool(num_proc) as pool:
             vertices_vjp = pool.starmap(self.vertex_vjp, zip(*args))
-        return self.copy(update=dict(vertices=vertices_vjp))
+        vertices_vjp = tuple(tuple(x) for x in vertices_vjp)
+        return self.updated_copy(vertices_jax=vertices_vjp)
 
 
 JaxSingleGeometryType = Union[JaxBox, JaxPolySlab]
@@ -654,6 +581,8 @@ JaxSingleGeometryType = Union[JaxBox, JaxPolySlab]
 @register_pytree_node_class
 class JaxGeometryGroup(JaxGeometry, GeometryGroup, JaxObject):
     """A collection of Geometry objects that can be called as a single geometry object."""
+
+    _tidy3d_class = GeometryGroup
 
     geometries: Tuple[JaxPolySlab, ...] = pd.Field(
         ...,
@@ -664,33 +593,6 @@ class JaxGeometryGroup(JaxGeometry, GeometryGroup, JaxObject):
         "is supported.",
         jax_field=True,
     )
-
-    def to_tidy3d(self) -> GeometryGroup:
-        """Convert :class:`.JaxGeometryGroup` instance to :class:`.GeometryGroup`"""
-        self_dict = self.dict(exclude={"type"})
-        self_dict["geometries"] = [geo.to_tidy3d() for geo in self.geometries]
-        map_reverse = {v: k for k, v in JAX_GEOMETRY_MAP.items()}
-        tidy3d_type = map_reverse[type(self)]
-        return tidy3d_type.parse_obj(self_dict)
-
-    @classmethod
-    def from_tidy3d(cls, tidy3d_obj: GeometryGroup) -> JaxGeometryGroup:
-        """Convert :class:`.GeometryGroup` instance to :class:`.GeometryGroup`"""
-        obj_dict = tidy3d_obj.dict(exclude={"type"})
-        jax_geometries = []
-
-        tidy3d_type_map = {k.__name__: k for k, v in JAX_GEOMETRY_MAP.items()}
-        jax_type_map = {k.__name__: v for k, v in JAX_GEOMETRY_MAP.items()}
-
-        for geo in obj_dict["geometries"]:
-            type_str = geo["type"]
-            tidy3d_type = tidy3d_type_map[type_str]
-            jax_type = jax_type_map[type_str]
-            geo_tidy3d = tidy3d_type.parse_obj(geo)
-            geo_jax = jax_type.from_tidy3d(geo_tidy3d)
-            jax_geometries.append(geo_jax)
-        obj_dict["geometries"] = jax_geometries
-        return cls.parse_obj(obj_dict)
 
     @staticmethod
     def _store_vjp_geometry(

--- a/tidy3d/plugins/adjoint/components/medium.py
+++ b/tidy3d/plugins/adjoint/components/medium.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from typing import Dict, Tuple, Union, Callable, Optional
-from abc import ABC, abstractmethod
+from abc import ABC
 
 import pydantic.v1 as pd
 import numpy as np
@@ -13,13 +13,11 @@ from ....components.types import Bound, Literal
 from ....components.medium import Medium, AnisotropicMedium, CustomMedium
 from ....components.geometry.base import Geometry
 from ....components.data.monitor_data import FieldData
-from ....components.data.dataset import PermittivityDataset
-from ....components.data.data_array import ScalarFieldDataArray
 from ....exceptions import SetupError
 from ....constants import CONDUCTIVITY
 
 from .base import JaxObject
-from .types import JaxFloat, validate_jax_float
+from .types import JaxFloat
 from .data.data_array import JaxDataArray
 from .data.dataset import JaxPermittivityDataset
 
@@ -33,14 +31,6 @@ MAX_NUM_CELLS_CUSTOM_MEDIUM = 250_000
 
 class AbstractJaxMedium(ABC, JaxObject):
     """Holds some utility functions for Jax medium types."""
-
-    def to_tidy3d(self) -> AbstractJaxMedium:
-        """Convert self to tidy3d component."""
-        return self.to_medium()
-
-    @abstractmethod
-    def to_medium(self) -> AbstractJaxMedium:
-        """Convert self to medium."""
 
     def _get_volume_disc(
         self, grad_data: FieldData, sim_bounds: Bound, wvl_mat: float
@@ -151,34 +141,23 @@ class AbstractJaxMedium(ABC, JaxObject):
 class JaxMedium(Medium, AbstractJaxMedium):
     """A :class:`.Medium` registered with jax."""
 
-    permittivity: JaxFloat = pd.Field(
+    _tidy3d_class = Medium
+
+    permittivity_jax: JaxFloat = pd.Field(
         1.0,
         title="Permittivity",
         description="Relative permittivity of the medium. May be a ``jax`` ``Array``.",
-        jax_field=True,
+        stores_jax_for="permittivity",
     )
 
-    conductivity: JaxFloat = pd.Field(
+    conductivity_jax: JaxFloat = pd.Field(
         0.0,
         title="Conductivity",
         description="Electric conductivity. Defined such that the imaginary part of the complex "
         "permittivity at angular frequency omega is given by conductivity/omega.",
         units=CONDUCTIVITY,
-        jax_field=True,
+        stores_jax_for="conductivity",
     )
-
-    @pd.validator("conductivity", always=True)
-    def _passivity_validation(cls, val, values):
-        """Override of inherited validator."""
-        return val
-
-    _sanitize_permittivity = validate_jax_float("permittivity")
-    _sanitize_conductivity = validate_jax_float("conductivity")
-
-    def to_medium(self) -> Medium:
-        """Convert :class:`.JaxMedium` instance to :class:`.Medium`"""
-        self_dict = self.dict(exclude={"type"})
-        return Medium.parse_obj(self_dict)
 
     def store_vjp(
         self,
@@ -212,8 +191,8 @@ class JaxMedium(Medium, AbstractJaxMedium):
 
         return self.copy(
             update=dict(
-                permittivity=vjp_eps,
-                conductivity=vjp_sigma,
+                permittivity_jax=vjp_eps,
+                conductivity_jax=vjp_sigma,
             )
         )
 
@@ -221,6 +200,8 @@ class JaxMedium(Medium, AbstractJaxMedium):
 @register_pytree_node_class
 class JaxAnisotropicMedium(AnisotropicMedium, AbstractJaxMedium):
     """A :class:`.Medium` registered with jax."""
+
+    _tidy3d_class = AnisotropicMedium
 
     xx: JaxMedium = pd.Field(
         ...,
@@ -242,23 +223,6 @@ class JaxAnisotropicMedium(AnisotropicMedium, AbstractJaxMedium):
         description="Medium describing the zz-component of the diagonal permittivity tensor.",
         jax_field=True,
     )
-
-    def to_medium(self) -> AnisotropicMedium:
-        """Convert :class:`.JaxMedium` instance to :class:`.Medium`"""
-        self_dict = self.dict(exclude={"type", "xx", "yy", "zz"})
-        for component in "xyz":
-            field_name = component + component
-            jax_medium = self.components[field_name]
-            self_dict[field_name] = jax_medium.to_medium()
-        return AnisotropicMedium.parse_obj(self_dict)
-
-    @classmethod
-    def from_tidy3d(cls, tidy3d_obj: AnisotropicMedium) -> JaxAnisotropicMedium:
-        """Convert :class:`.Tidy3dBaseModel` instance to :class:`.JaxObject`."""
-        obj_dict = tidy3d_obj.dict(exclude={"type", "xx", "yy", "zz"})
-        for component, tidy3d_medium in tidy3d_obj.components.items():
-            obj_dict[component] = JaxMedium.from_tidy3d(tidy3d_medium)
-        return cls.parse_obj(obj_dict)
 
     def store_vjp(
         self,
@@ -302,9 +266,10 @@ class JaxAnisotropicMedium(AnisotropicMedium, AbstractJaxMedium):
                 vjp_eps_ii += _vjp_eps_ii
                 vjp_sigma_ii += _vjp_sigma_ii
 
-            vjp_fields[component_name] = JaxMedium(
-                permittivity=vjp_eps_ii,
-                conductivity=vjp_sigma_ii,
+            vjp_medium = self.components[component_name]
+            vjp_fields[component_name] = vjp_medium.updated_copy(
+                permittivity_jax=vjp_eps_ii,
+                conductivity_jax=vjp_sigma_ii,
             )
 
         return self.copy(update=vjp_fields)
@@ -318,19 +283,7 @@ class JaxCustomMedium(CustomMedium, AbstractJaxMedium):
     with respect to the field variation.
     """
 
-    permittivity: Optional[JaxDataArray] = pd.Field(
-        None,
-        title="Permittivity",
-        description="Spatial profile of relative permittivity.",
-    )
-
-    conductivity: Optional[JaxDataArray] = pd.Field(
-        None,
-        title="Conductivity",
-        description="Spatial profile Electric conductivity.  Defined such "
-        "that the imaginary part of the complex permittivity at angular "
-        "frequency omega is given by conductivity/omega.",
-    )
+    _tidy3d_class = CustomMedium
 
     eps_dataset: Optional[JaxPermittivityDataset] = pd.Field(
         None,
@@ -344,35 +297,13 @@ class JaxCustomMedium(CustomMedium, AbstractJaxMedium):
     @pd.root_validator(pre=True)
     def _pre_deprecation_dataset(cls, values):
         """Don't allow permittivity as a field until we support it."""
-        if values.get("permittivity"):
+        if values.get("permittivity") or values.get("conductivity"):
             raise SetupError(
-                "'permittivity' is not yet supported in adjoint plugin. "
+                "'permittivity' and 'conductivity' are not yet supported in adjoint plugin. "
                 "Please continue to use the 'eps_dataset' field to define the component "
                 "of the permittivity tensor."
             )
         return values
-
-    @pd.root_validator(pre=True)
-    def _deprecation_dataset(cls, values):
-        """Raise deprecation warning if dataset supplied and convert to dataset."""
-        return values
-
-    # @pd.validator("eps_dataset", always=True)
-    # def _is_not_3d(cls, val):
-    #     """Ensure the custom medium pixels contain at least one dimension with one pixel thick."""
-    #     for field_dim in "xyz":
-    #         field_name = f"eps_{field_dim}{field_dim}"
-    #         data_array = val.field_components[field_name]
-    #         coord_lens = [len(data_array.coords[key]) for key in "xyz"]
-    #         dims_len1 = [val == 1 for val in coord_lens]
-    #         if sum(dims_len1) == 0:
-    #             raise SetupError(
-    #                 "For adjoint plugin, the 'JaxCustomMedium' is restricted to a 1D or 2D "
-    #                 "pixellated grid. It may not contain multiple pixels along all 3 dimensions. "
-    #                 f"Detected 3D pixelated grid in '{field_name}' component of 'eps_dataset'."
-    #             )
-
-    #     return val
 
     @pd.validator("eps_dataset", always=True)
     def _is_not_too_large(cls, val):
@@ -394,63 +325,13 @@ class JaxCustomMedium(CustomMedium, AbstractJaxMedium):
 
     @pd.validator("eps_dataset", always=True)
     def _eps_dataset_single_frequency(cls, val):
-        """Override of inherited validator."""
+        """Override of inherited validator. (still needed)"""
         return val
 
     @pd.validator("eps_dataset", always=True)
     def _eps_dataset_eps_inf_greater_no_less_than_one_sigma_positive(cls, val, values):
         """Override of inherited validator."""
         return val
-
-    @pd.validator("permittivity", always=True)
-    def _eps_inf_greater_no_less_than_one(cls, val):
-        """Override of inherited validator."""
-        return val
-
-    @pd.validator("conductivity", always=True)
-    def _conductivity_non_negative_correct_shape(cls, val, values):
-        """Override of inherited validator."""
-        return val
-
-    def eps_dataarray_freq(self, frequency: float):
-        """ "Permittivity array at ``frequency``"""
-        as_custom_medium = self.to_medium()
-        return as_custom_medium.eps_dataarray_freq(frequency)
-
-    def to_medium(self) -> CustomMedium:
-        """Convert :class:`.JaxMedium` instance to :class:`.Medium`"""
-        self_dict = self.dict(exclude={"type"})
-        eps_field_components = {}
-        for dim in "xyz":
-            field_name = f"eps_{dim}{dim}"
-            data_array = self_dict["eps_dataset"][field_name]
-            values = np.array(data_array["values"])
-            coords = data_array["coords"]
-            scalar_field = ScalarFieldDataArray(values, coords=coords)
-            eps_field_components[field_name] = scalar_field
-        eps_dataset = PermittivityDataset(**eps_field_components)
-        self_dict["eps_dataset"] = eps_dataset
-        self_dict["permittivity"] = None
-        self_dict["conductivity"] = None
-        return CustomMedium.parse_obj(self_dict)
-
-    @classmethod
-    def from_tidy3d(cls, tidy3d_obj: CustomMedium) -> JaxCustomMedium:
-        """Convert :class:`.Tidy3dBaseModel` instance to :class:`.JaxObject`."""
-        obj_dict = tidy3d_obj.dict(exclude={"type", "eps_dataset", "permittivity", "conductivity"})
-        eps_dataset = tidy3d_obj.eps_dataset
-        field_components = {}
-        for dim in "xyz":
-            field_name = f"eps_{dim}{dim}"
-            data_array = eps_dataset.field_components[field_name]
-            values = data_array.values.tolist()
-            coords = {key: np.array(val).tolist() for key, val in data_array.coords.items()}
-            field_components[field_name] = JaxDataArray(values=values, coords=coords)
-        eps_dataset = JaxPermittivityDataset(**field_components)
-        obj_dict["eps_dataset"] = eps_dataset
-        obj_dict["permittivity"] = None
-        obj_dict["conductivity"] = None
-        return cls.parse_obj(obj_dict)
 
     def store_vjp(
         self,

--- a/tidy3d/plugins/adjoint/components/structure.py
+++ b/tidy3d/plugins/adjoint/components/structure.py
@@ -25,11 +25,13 @@ GEO_MED_MAPPINGS = dict(geometry=JAX_GEOMETRY_MAP, medium=JAX_MEDIUM_MAP)
 class AbstractJaxStructure(Structure, JaxObject):
     """A :class:`.Structure` registered with jax."""
 
-    geometry: Union[JaxGeometryType, GeometryType]
-    medium: Union[JaxMediumType, MediumType]
+    _tidy3d_class = Structure
 
     # which of "geometry" or "medium" is differentiable for this class
     _differentiable_fields = ()
+
+    geometry: Union[JaxGeometryType, GeometryType]
+    medium: Union[JaxMediumType, MediumType]
 
     @pd.validator("medium", always=True)
     def _check_2d_geometry(cls, val, values):


### PR DESCRIPTION
This will be stage 1 of some future adjoint refactors. This one finally works though, and successfully separates the jax tracers from the original tidy3d fields. The main advantage of this is that we dont have to worry about the jax tracers interactively badly with the existing tidy3d validators and methods (eg. `Box.bounds()`). 

## Summary of changes:
- [x] jax tracer for field `x` moved to a new field `x_jax`. 
    - [x] When values passed to `x`, the traced version is copied to `x_jax` and an untraced copy is saved in `x`.
    - [x] No need to patch or remove validators or existing methods (`.bounds`) as they used the untraced copies.
- [x] `stores_jax_for:str` flag added in the `pd.Field` to specify which field this field stores jax for. `jax_field=True` now only means that the field contains either a `JaxObject` or `tuple` of them.
- [x] `.to_tidy3d()` and `.from_tidy3d()` conversions generalized to base class. 
    - [x] `to_simulation()` conversion still requires a bit of manual work for now.
- [x] Simplified handlings generally throughout the code
    - [x] JaxDataArray
    - [x] Converting numpy to list to not break jax serialization.
    - [x] Saving to json.
- [x] More gracefully handle if the `JVPTracer` import fails in future jax versions (which could break the plugin if it changes).


## Tests
- [x] Adjoint tests all pass, give same gradients as pre/2.6
- [x] Notebooks 2, 3 and 5 give same results when running locally.

## To do in another stage
- [ ] handle logic for mixed JaxObject and tidy3d object in a `jax_field`. 
- [ ] simplify `to_simulation()` by adding "transformations" to `to_tidy3d()` and `from_tidy3d()`.
- [ ] Simplify JaxDataArray internals.
- [ ] have web API accept JaxSimulation directly? no need for conversion?
