### PR TITLE
Bringing back basic requirements file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,12 +34,14 @@ pydantic = "^2.0"
 PyYAML = "*"
 dask = "*"
 toml = "*"
+### NOT CORE
 scipy = "*"
 boto3 = "1.23.1"
 requests = "*"
 pyjwt = "*"
 click = "8.0.3"
 responses = "*"
+### END NOT CORE
 
 ### Optional dependencies ### 
 # development core


### PR DESCRIPTION
We need a set of basic requirements to be able to build minimal webservices used for validation. I brought this file back from the grave it was sent to in 2.6. I am not sure if this is the best place for it, and also I guess it would be good if we can test somehow that these reqs are sufficient. I guess we could have a separate github action that only installs those and tries to run some of the tests that should work?