### PR TITLE
Unified validation check for dependency fields

### DIFF
--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -505,11 +505,11 @@ def test_validate_components_none():
     assert SIM._source_homogeneous_isotropic(val=None, values=SIM.dict()) is None
 
 
-def test_sources_edge_case_validation():
+def test_sources_edge_case_validation(log_capture):
     values = SIM.dict()
     values.pop("sources")
-    with pytest.raises(ValidationError):
-        SIM._warn_monitor_simulation_frequency_range(val="test", values=values)
+    SIM._warn_monitor_simulation_frequency_range(val="test", values=values)
+    assert_log_level(log_capture, "WARNING")
 
 
 def test_validate_size_run_time(monkeypatch):

--- a/tidy3d/components/apodization.py
+++ b/tidy3d/components/apodization.py
@@ -3,7 +3,7 @@
 import pydantic.v1 as pd
 import numpy as np
 
-from .base import Tidy3dBaseModel
+from .base import Tidy3dBaseModel, skip_if_fields_missing
 from ..constants import SECOND
 from ..exceptions import SetupError
 from .types import ArrayFloat1D, Ax
@@ -40,6 +40,7 @@ class ApodizationSpec(Tidy3dBaseModel):
     )
 
     @pd.validator("end", always=True, allow_reuse=True)
+    @skip_if_fields_missing(["start"])
     def end_greater_than_start(cls, val, values):
         """Ensure end is greater than or equal to start."""
         start = values.get("start")
@@ -48,6 +49,7 @@ class ApodizationSpec(Tidy3dBaseModel):
         return val
 
     @pd.validator("width", always=True, allow_reuse=True)
+    @skip_if_fields_missing(["start", "end"])
     def width_provided(cls, val, values):
         """Check that width is provided if either start or end apodization is requested."""
         start = values.get("start")

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -86,6 +86,28 @@ def _get_valid_extension(fname: str) -> str:
     )
 
 
+def skip_if_fields_missing(fields: List[str]):
+    """Decorate ``validator`` to check that other fields have passed validation."""
+
+    def actual_decorator(validator):
+        @wraps(validator)
+        def _validator(cls, val, values):
+            """New validator function."""
+            for field in fields:
+                if field not in values:
+                    log.warning(
+                        f"Could not execute validator '{validator.__name__}' because field "
+                        f"'{field}' failed validation."
+                    )
+                    return val
+
+            return validator(cls, val, values)
+
+        return _validator
+
+    return actual_decorator
+
+
 class Tidy3dBaseModel(pydantic.BaseModel):
     """Base pydantic model that all Tidy3d components inherit from.
     Defines configuration for handling data structures

--- a/tidy3d/components/base_sim/simulation.py
+++ b/tidy3d/components/base_sim/simulation.py
@@ -9,7 +9,7 @@ import pydantic.v1 as pd
 
 from .monitor import AbstractMonitor
 
-from ..base import cached_property
+from ..base import cached_property, skip_if_fields_missing
 from ..validators import assert_unique_names, assert_objects_in_sim_bounds
 from ..geometry.base import Box
 from ..types import Ax, Bound, Axis, Symmetry, TYPE_TAG_STR
@@ -97,6 +97,7 @@ class AbstractSimulation(Box, ABC):
     _structures_in_bounds = assert_objects_in_sim_bounds("structures", error=False)
 
     @pd.validator("structures", always=True)
+    @skip_if_fields_missing(["size", "center"])
     def _structures_not_at_edges(cls, val, values):
         """Warn if any structures lie at the simulation boundaries."""
 

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -20,6 +20,7 @@ from .data_array import PointDataArray, IndexedDataArray, CellDataArray, Spatial
 
 from ..viz import equal_aspect, add_ax_if_none, plot_params_grid
 from ..base import Tidy3dBaseModel, cached_property
+from ..base import skip_if_fields_missing
 from ..types import Axis, Bound, ArrayLike, Ax, Coordinate, Literal
 from ..types import vtk, requires_vtk
 from ...exceptions import DataError, ValidationError, Tidy3dNotImplementedError
@@ -524,13 +525,12 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
         return CellDataArray(val.data.astype(vtk["id_type"], copy=False), coords=val.coords)
 
     @pd.validator("values", always=True)
+    @skip_if_fields_missing(["points"])
     def number_of_values_matches_points(cls, val, values):
         """Check that the number of data values matches the number of grid points."""
         num_values = len(val)
 
         points = values.get("points")
-        if points is None:
-            raise ValidationError("Cannot validate '.values' because '.points' failed validation.")
         num_points = len(points)
 
         if num_points != num_values:
@@ -565,6 +565,7 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
         return val
 
     @pd.validator("cells", always=True)
+    @skip_if_fields_missing(["points"])
     def check_cell_vertex_range(cls, val, values):
         """Check that cell connections use only defined points."""
         all_point_indices_used = val.data.ravel()
@@ -572,8 +573,6 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
         max_index_used = np.max(all_point_indices_used)
 
         points = values.get("points")
-        if points is None:
-            raise ValidationError("Cannot validate '.values' because '.points' failed validation.")
         num_points = len(points)
 
         if max_index_used != num_points - 1 or min_index_used != 0:

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -20,7 +20,7 @@ from .data_array import ScalarFieldDataArray, ScalarFieldTimeDataArray
 from .data_array import FreqDataArray, TimeDataArray, FreqModeDataArray
 from .dataset import Dataset, AbstractFieldDataset, ElectromagneticFieldDataset
 from .dataset import FieldDataset, FieldTimeDataset, ModeSolverDataset, PermittivityDataset
-from ..base import TYPE_TAG_STR, cached_property
+from ..base import TYPE_TAG_STR, cached_property, skip_if_fields_missing
 from ..types import Coordinate, Symmetry, ArrayFloat1D, ArrayFloat2D, Size, Numpy, TrackFreq
 from ..types import EpsSpecType, Literal
 from ..grid.grid import Grid, Coords
@@ -926,6 +926,7 @@ class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
     )
 
     @pd.validator("eps_spec", always=True)
+    @skip_if_fields_missing(["monitor"])
     def eps_spec_match_mode_spec(cls, val, values):
         """Raise validation error if frequencies in eps_spec does not match frequency list"""
         if val:

--- a/tidy3d/components/field_projection.py
+++ b/tidy3d/components/field_projection.py
@@ -19,7 +19,7 @@ from .monitor import FieldMonitor, AbstractFieldProjectionMonitor, FieldProjecti
 from .monitor import FieldProjectionCartesianMonitor, FieldProjectionKSpaceMonitor
 from .types import Direction, Coordinate, ArrayComplex4D
 from .medium import MediumType
-from .base import Tidy3dBaseModel, cached_property
+from .base import Tidy3dBaseModel, cached_property, skip_if_fields_missing
 from ..exceptions import SetupError
 from ..constants import C_0, MICROMETER, ETA_0, EPSILON_0, MU_0
 from ..log import get_logging_console
@@ -72,6 +72,7 @@ class FieldProjector(Tidy3dBaseModel):
     )
 
     @pydantic.validator("origin", always=True)
+    @skip_if_fields_missing(["surfaces"])
     def set_origin(cls, val, values):
         """Sets .origin as the average of centers of all surface monitors if not provided."""
         if val is None:

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -11,6 +11,7 @@ import shapely
 from matplotlib import path
 
 from ..base import cached_property
+from ..base import skip_if_fields_missing
 from ..types import Axis, Bound, PlanePosition, ArrayFloat2D, Coordinate
 from ..types import MatrixReal4x4, Shapely, trimesh
 from ...log import log
@@ -105,6 +106,7 @@ class PolySlab(base.Planar):
         return val
 
     @pydantic.validator("vertices", always=True)
+    @skip_if_fields_missing(["dilation"])
     def no_complex_self_intersecting_polygon_at_reference_plane(cls, val, values):
         """At the reference plane, check if the polygon is self-intersecting.
 
@@ -154,6 +156,7 @@ class PolySlab(base.Planar):
         return val
 
     @pydantic.validator("vertices", always=True)
+    @skip_if_fields_missing(["sidewall_angle", "dilation", "slab_bounds", "reference_plane"])
     def no_self_intersecting_polygon_during_extrusion(cls, val, values):
         """In this simple polyslab, we don't support self-intersecting polygons yet, meaning that
         any normal cross section of the PolySlab cannot be self-intersecting. This part checks
@@ -168,8 +171,6 @@ class PolySlab(base.Planar):
         To detect this, we sample _N_SAMPLE_POLYGON_INTERSECT cross sections to see if any creation
         of polygons/holes, and changes in vertices number.
         """
-        if "sidewall_angle" not in values:
-            raise ValidationError("'sidewall_angle' failed validation.")
 
         # no need to valiate anything here
         if isclose(values["sidewall_angle"], 0):

--- a/tidy3d/components/geometry/primitives.py
+++ b/tidy3d/components/geometry/primitives.py
@@ -8,7 +8,7 @@ import pydantic.v1 as pydantic
 import numpy as np
 import shapely
 
-from ..base import cached_property
+from ..base import cached_property, skip_if_fields_missing
 from ..types import Axis, Bound, Coordinate, MatrixReal4x4, Shapely, trimesh
 from ...exceptions import SetupError, ValidationError
 from ...constants import MICROMETER, LARGE_NUMBER
@@ -191,6 +191,7 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
     )
 
     @pydantic.validator("length", always=True)
+    @skip_if_fields_missing(["sidewall_angle", "reference_plane"])
     def _only_middle_for_infinite_length_slanted_cylinder(cls, val, values):
         """For a slanted cylinder of infinite length, ``reference_plane`` can only
         be ``middle``; otherwise, the radius at ``center`` is either td.inf or 0.

--- a/tidy3d/components/heat/data/monitor_data.py
+++ b/tidy3d/components/heat/data/monitor_data.py
@@ -7,6 +7,7 @@ from abc import ABC
 import pydantic.v1 as pd
 
 from ..monitor import TemperatureMonitor, HeatMonitorType
+from ...base import skip_if_fields_missing
 from ...base_sim.data.monitor_data import AbstractMonitorData
 from ...data.data_array import SpatialDataArray
 from ...data.dataset import TriangularGridDataset, TetrahedralGridDataset
@@ -74,6 +75,7 @@ class TemperatureData(HeatMonitorData):
     )
 
     @pd.validator("temperature", always=True)
+    @skip_if_fields_missing(["monitor"])
     def warn_no_data(cls, val, values):
         """Warn if no data provided."""
 

--- a/tidy3d/components/heat/grid.py
+++ b/tidy3d/components/heat/grid.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import Union, Tuple
 import pydantic.v1 as pd
 
-from ..base import Tidy3dBaseModel
+from ..base import Tidy3dBaseModel, skip_if_fields_missing
 from ...constants import MICROMETER
 from ...exceptions import ValidationError
 
@@ -107,6 +107,7 @@ class DistanceUnstructuredGrid(Tidy3dBaseModel):
     )
 
     @pd.validator("distance_bulk", always=True)
+    @skip_if_fields_missing(["distance_interface"])
     def names_exist_bcs(cls, val, values):
         """Error if distance_bulk is less than distance_interface"""
         distance_interface = values.get("distance_interface")

--- a/tidy3d/components/heat/simulation.py
+++ b/tidy3d/components/heat/simulation.py
@@ -15,7 +15,7 @@ from .viz import HEAT_BC_COLOR_TEMPERATURE, HEAT_BC_COLOR_FLUX, HEAT_BC_COLOR_CO
 from .viz import plot_params_heat_bc, plot_params_heat_source, HEAT_SOURCE_CMAP
 
 from ..base_sim.simulation import AbstractSimulation
-from ..base import cached_property
+from ..base import cached_property, skip_if_fields_missing
 from ..types import Ax, Shapely, TYPE_TAG_STR, ScalarSymmetry, Bound
 from ..viz import add_ax_if_none, equal_aspect, PlotParams
 from ..structure import Structure
@@ -139,6 +139,7 @@ class HeatSimulation(AbstractSimulation):
         return val
 
     @pd.validator("boundary_spec", always=True)
+    @skip_if_fields_missing(["structures", "medium"])
     def names_exist_bcs(cls, val, values):
         """Error if boundary conditions point to non-existing structures/media."""
 
@@ -175,6 +176,7 @@ class HeatSimulation(AbstractSimulation):
         return val
 
     @pd.validator("grid_spec", always=True)
+    @skip_if_fields_missing(["structures"])
     def names_exist_grid_spec(cls, val, values):
         """Warn if UniformUnstructuredGrid points at a non-existing structure."""
 
@@ -191,6 +193,7 @@ class HeatSimulation(AbstractSimulation):
         return val
 
     @pd.validator("sources", always=True)
+    @skip_if_fields_missing(["structures"])
     def names_exist_sources(cls, val, values):
         """Error if a heat source point to non-existing structures."""
         structures = values.get("structures")

--- a/tidy3d/components/mode.py
+++ b/tidy3d/components/mode.py
@@ -7,7 +7,7 @@ import pydantic.v1 as pd
 import numpy as np
 
 from ..constants import MICROMETER, RADIAN, GLANCING_CUTOFF, fp_eps
-from .base import Tidy3dBaseModel
+from .base import Tidy3dBaseModel, skip_if_fields_missing
 from .types import Axis2D, Literal, TrackFreq
 from ..log import log
 from ..exceptions import SetupError, ValidationError
@@ -115,6 +115,7 @@ class ModeSpec(Tidy3dBaseModel):
     )
 
     @pd.validator("bend_axis", always=True)
+    @skip_if_fields_missing(["bend_radius"])
     def bend_axis_given(cls, val, values):
         """Check that ``bend_axis`` is provided if ``bend_radius`` is not ``None``"""
         if val is None and values.get("bend_radius") is not None:

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -8,7 +8,7 @@ import numpy as np
 from .types import Ax, EMField, ArrayFloat1D, FreqArray, FreqBound, Bound, Size
 from .types import Literal, Direction, Coordinate, Axis, ObsGridArray, BoxSurface
 from .validators import assert_plane, validate_freqs_not_empty, validate_freqs_min
-from .base import cached_property, Tidy3dBaseModel
+from .base import cached_property, Tidy3dBaseModel, skip_if_fields_missing
 from .mode import ModeSpec
 from .apodization import ApodizationSpec
 from .medium import MediumType
@@ -137,6 +137,7 @@ class TimeMonitor(Monitor, ABC):
     )
 
     @pydantic.validator("interval", always=True)
+    @skip_if_fields_missing(["start", "stop"])
     def _warn_interval_default(cls, val, values):
         """If all defaults used for time sampler, warn and set ``interval=1`` internally."""
 
@@ -163,6 +164,7 @@ class TimeMonitor(Monitor, ABC):
         return val
 
     @pydantic.validator("stop", always=True, allow_reuse=True)
+    @skip_if_fields_missing(["start"])
     def stop_greater_than_start(cls, val, values):
         """Ensure sure stop is greater than or equal to start."""
         start = values.get("start")
@@ -700,6 +702,7 @@ class AbstractFieldProjectionMonitor(SurfaceIntegrationMonitor, FreqMonitor):
     )
 
     @pydantic.validator("window_size", always=True)
+    @skip_if_fields_missing(["size", "name"])
     def window_size_for_surface(cls, val, values):
         """Ensures that windowing is applied for surface monitors only."""
         size = values.get("size")
@@ -714,6 +717,7 @@ class AbstractFieldProjectionMonitor(SurfaceIntegrationMonitor, FreqMonitor):
         return val
 
     @pydantic.validator("window_size", always=True)
+    @skip_if_fields_missing(["name"])
     def window_size_leq_one(cls, val, values):
         """Ensures that each component of the window size is less than or equal to 1."""
         name = values.get("name")

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -3,7 +3,7 @@ from typing import Union, Tuple, Optional
 import pydantic.v1 as pydantic
 import numpy as np
 
-from .base import Tidy3dBaseModel
+from .base import Tidy3dBaseModel, skip_if_fields_missing
 from .validators import validate_name_str
 from .geometry.utils import GeometryType, validate_no_transformed_polyslabs
 from .medium import MediumType, AbstractCustomMedium, Medium2D
@@ -116,6 +116,7 @@ class Structure(AbstractStructure):
         return self.medium.eps_diagonal(frequency=frequency)
 
     @pydantic.validator("medium", always=True)
+    @skip_if_fields_missing(["geometry"])
     def _check_2d_geometry(cls, val, values):
         """Medium2D is only consistent with certain geometry types"""
         geom = values.get("geometry")

--- a/tidy3d/components/time_modulation.py
+++ b/tidy3d/components/time_modulation.py
@@ -8,7 +8,7 @@ from math import isclose
 import pydantic.v1 as pd
 import numpy as np
 
-from .base import Tidy3dBaseModel, cached_property
+from .base import Tidy3dBaseModel, cached_property, skip_if_fields_missing
 from .types import InterpMethod
 from .time import AbstractTimeDependence
 from .data.data_array import SpatialDataArray
@@ -231,6 +231,7 @@ class ModulationSpec(Tidy3dBaseModel):
     )
 
     @pd.validator("conductivity", always=True)
+    @skip_if_fields_missing(["permittivity"])
     def _same_modulation_frequency(cls, val, values):
         """Assert same time-modulation applied to permittivity and conductivity."""
         permittivity = values.get("permittivity")

--- a/tidy3d/components/validators.py
+++ b/tidy3d/components/validators.py
@@ -1,5 +1,4 @@
 """ Defines various validation functions that get used to ensure inputs are legit """
-from typing import Any
 
 import pydantic.v1 as pydantic
 import numpy as np
@@ -7,7 +6,7 @@ import numpy as np
 from .geometry.base import Box
 from ..exceptions import ValidationError, SetupError
 from .data.dataset import Dataset, FieldDataset
-from .base import DATA_ARRAY_MAP
+from .base import DATA_ARRAY_MAP, skip_if_fields_missing
 from .types import Tuple
 from ..log import log
 
@@ -45,14 +44,6 @@ from ..log import log
 
 # Lowest frequency supported (Hz)
 MIN_FREQUENCY = 1e5
-
-
-def get_value(key: str, values: dict) -> Any:
-    """Grab value from values dictionary. If not present, raise an error before continuing."""
-    val = values.get(key)
-    if val is None:
-        raise ValidationError(f"value {key} not defined, must be present to validate.")
-    return val
 
 
 def assert_plane():
@@ -118,6 +109,7 @@ def validate_mode_objects_symmetry(field_name: str):
     obj_type = "ModeSource" if field_name == "sources" else "ModeMonitor"
 
     @pydantic.validator(field_name, allow_reuse=True, always=True)
+    @skip_if_fields_missing(["center", "symmetry"])
     def check_symmetry(cls, val, values):
         """check for intersection of each structure with simulation bounds."""
         sim_center = values.get("center")
@@ -161,6 +153,7 @@ def assert_objects_in_sim_bounds(field_name: str, error: bool = True):
     """Makes sure all objects in field are at least partially inside of simulation bounds."""
 
     @pydantic.validator(field_name, allow_reuse=True, always=True)
+    @skip_if_fields_missing(["center", "size"])
     def objects_in_sim_bounds(cls, val, values):
         """check for intersection of each structure with simulation bounds."""
         sim_center = values.get("center")
@@ -203,6 +196,7 @@ def required_if_symmetry_present(field_name: str):
     """Make a field required (not None) if any non-zero symmetry eigenvalue is present."""
 
     @pydantic.validator(field_name, allow_reuse=True, always=True)
+    @skip_if_fields_missing(["symmetry"])
     def _make_required(cls, val, values):
         """Ensure val is not None if the symmetry is non-zero along any dimension."""
         symmetry = values.get("symmetry")
@@ -232,11 +226,12 @@ def assert_single_freq_in_range(field_name: str):
     """Assert only one frequency supplied in source and it's in source time range."""
 
     @pydantic.validator(field_name, always=True, allow_reuse=True)
+    @skip_if_fields_missing(["source_time"])
     def _single_frequency_in_range(cls, val: FieldDataset, values: dict) -> FieldDataset:
         """Assert only one frequency supplied and it's in source time range."""
         if val is None:
             return val
-        source_time = get_value(key="source_time", values=values)
+        source_time = values.get("source_time")
         fmin, fmax = source_time.frequency_range()
         for name, scalar_field in val.field_components.items():
             freqs = scalar_field.f

--- a/tidy3d/plugins/adjoint/components/data/data_array.py
+++ b/tidy3d/plugins/adjoint/components/data/data_array.py
@@ -11,7 +11,7 @@ import jax
 from jax.tree_util import register_pytree_node_class
 import xarray as xr
 
-from .....components.base import Tidy3dBaseModel, cached_property
+from .....components.base import Tidy3dBaseModel, cached_property, skip_if_fields_missing
 from .....exceptions import DataError, Tidy3dKeyError, AdjointError
 
 
@@ -48,6 +48,7 @@ class JaxDataArray(Tidy3dBaseModel):
         return val
 
     @pd.validator("coords", always=True)
+    @skip_if_fields_missing(["values"])
     def _coords_match_values(cls, val, values):
         """Make sure the coordinate dimensions and shapes match the values data."""
 

--- a/tidy3d/plugins/adjoint/components/simulation.py
+++ b/tidy3d/plugins/adjoint/components/simulation.py
@@ -10,7 +10,7 @@ import numpy as np
 from jax.tree_util import register_pytree_node_class
 
 from ....log import log
-from ....components.base import cached_property, Tidy3dBaseModel
+from ....components.base import cached_property, Tidy3dBaseModel, skip_if_fields_missing
 from ....components.monitor import FieldMonitor, PermittivityMonitor
 from ....components.monitor import ModeMonitor, DiffractionMonitor, Monitor
 from ....components.simulation import Simulation
@@ -189,6 +189,7 @@ class JaxSimulation(Simulation, JaxObject):
         return val
 
     @pd.validator("input_structures", always=True)
+    @skip_if_fields_missing(["structures"])
     def _warn_overlap(cls, val, values):
         """Print appropriate warning if structures intersect in ways that cause gradient error."""
 

--- a/tidy3d/plugins/dispersion/fit.py
+++ b/tidy3d/plugins/dispersion/fit.py
@@ -13,6 +13,7 @@ from pydantic.v1 import Field, validator
 
 from ...log import log, get_logging_console
 from ...components.base import Tidy3dBaseModel, cached_property
+from ...components.base import skip_if_fields_missing
 from ...components.medium import PoleResidue, AbstractMedium
 from ...components.viz import add_ax_if_none
 from ...components.types import Ax, ArrayFloat1D
@@ -60,20 +61,18 @@ class DispersionFitter(Tidy3dBaseModel):
         return val
 
     @validator("n_data", always=True)
+    @skip_if_fields_missing(["wvl_um"])
     def _ndata_length_match_wvl(cls, val, values):
         """Validate n_data"""
-        if "wvl_um" not in values:
-            raise ValidationError("'wvl_um' failed validation.")
 
         if val.shape != values["wvl_um"].shape:
             raise ValidationError("The length of 'n_data' doesn't match 'wvl_um'.")
         return val
 
     @validator("k_data", always=True)
+    @skip_if_fields_missing(["wvl_um"])
     def _kdata_setup_and_length_match(cls, val, values):
         """Validate the length of k_data, or setup k if it's None."""
-        if "wvl_um" not in values:
-            raise ValidationError("'wvl_um' failed validation.")
 
         if val is None:
             return np.zeros_like(values["wvl_um"])

--- a/tidy3d/plugins/dispersion/fit_fast.py
+++ b/tidy3d/plugins/dispersion/fit_fast.py
@@ -10,7 +10,7 @@ import scipy
 
 from .fit import DispersionFitter
 from ...log import log, get_logging_console
-from ...components.base import Tidy3dBaseModel, cached_property
+from ...components.base import Tidy3dBaseModel, cached_property, skip_if_fields_missing
 from ...components.medium import PoleResidue, LOSS_CHECK_MIN, LOSS_CHECK_MAX, LOSS_CHECK_NUM
 from ...components.types import ArrayFloat1D, ArrayComplex1D, ArrayFloat2D, ArrayComplex2D
 from ...exceptions import ValidationError
@@ -178,6 +178,7 @@ class FastFitterData(AdvancedFastFitterParam):
     )
 
     @validator("eps_inf", always=True)
+    @skip_if_fields_missing(["optimize_eps_inf"])
     def _eps_inf_geq_one(cls, val, values):
         """Must have eps_inf >= 1 unless it is being optimized.
         In the latter case, it will be made >= 1 later."""
@@ -186,6 +187,7 @@ class FastFitterData(AdvancedFastFitterParam):
         return val
 
     @validator("poles", always=True)
+    @skip_if_fields_missing(["logspacing", "smooth", "num_poles", "omega", "num_poles"])
     def _generate_initial_poles(cls, val, values):
         """Generate initial poles."""
         if val is not None:
@@ -213,6 +215,7 @@ class FastFitterData(AdvancedFastFitterParam):
         return poles
 
     @validator("residues", always=True)
+    @skip_if_fields_missing(["poles"])
     def _generate_initial_residues(cls, val, values):
         """Generate initial residues."""
         if val is not None:

--- a/tidy3d/plugins/dispersion/web.py
+++ b/tidy3d/plugins/dispersion/web.py
@@ -10,7 +10,7 @@ import pydantic.v1 as pydantic
 from pydantic.v1 import PositiveInt, NonNegativeFloat, PositiveFloat, Field, validator
 
 from ...log import log
-from ...components.base import Tidy3dBaseModel
+from ...components.base import Tidy3dBaseModel, skip_if_fields_missing
 from ...components.types import Literal
 from ...components.medium import PoleResidue
 from ...constants import MICROMETER, HERTZ
@@ -97,6 +97,7 @@ class AdvancedFitterParam(Tidy3dBaseModel):
     )
 
     @validator("bound_f_lower", always=True)
+    @skip_if_fields_missing(["bound_f"])
     def _validate_lower_frequency_bound(cls, val, values):
         """bound_f_lower cannot be larger than bound_f."""
         if values["bound_f"] is not None and val > values["bound_f"]:

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -11,7 +11,7 @@ import pydantic.v1 as pydantic
 import xarray as xr
 
 from ...log import log
-from ...components.base import Tidy3dBaseModel, cached_property
+from ...components.base import Tidy3dBaseModel, cached_property, skip_if_fields_missing
 from ...components.geometry.base import Box
 from ...components.simulation import Simulation
 from ...components.grid.grid import Grid
@@ -100,6 +100,7 @@ class ModeSolver(Tidy3dBaseModel):
     _freqs_lower_bound = validate_freqs_min()
 
     @pydantic.validator("plane", always=True)
+    @skip_if_fields_missing(["simulation"])
     def plane_in_sim_bounds(cls, val, values):
         """Check that the plane is at least partially inside the simulation bounds."""
         sim_center = values.get("simulation").center


### PR DESCRIPTION
After playing a little bit with it, managed to implement what we wanted as a convenient decorator. The usage as follows: instead of doing something like 
```
@pydantic.validator("monitors", always=True)
def _warn_monitor_simulation_frequency_range(cls, val, values):
    """Warn if any DFT monitors have frequencies outside of the simulation frequency range."""

    if "sources" not in values:
        raise ValidationError(
            "could not validate `_warn_monitor_simulation_frequency_range` "
            "as `sources` failed validation"
        )

    ...
```
we can just do 
```
@pydantic.validator("monitors", always=True)
@check_previous_fields_validation(["sources"])
def _warn_monitor_simulation_frequency_range(cls, val, values):
    """Warn if any DFT monitors have frequencies outside of the simulation frequency range."""
    ...
```
this check whether dependency fields have passed validation, and, if not, it skips (not errors) the current validator and prints something like
```
WARNING: Could not execute validator                               
'_warn_monitor_simulation_frequency_range' because field 'sources' 
failed validation.
```