### PR TITLE
FEAT: Automatic release from branch v*

### DIFF
--- a/.github/workflows/sync-to-readthedocs-repo.yaml
+++ b/.github/workflows/sync-to-readthedocs-repo.yaml
@@ -7,6 +7,7 @@ on:
       - main
       - latest
       - 'pre/*'
+      - 'v*'
   workflow_dispatch:
     inputs:
       env:
@@ -35,7 +36,11 @@ jobs:
     steps:
       - id: setenv
         run: |
-          if test -n "${{ github.event.inputs.env }}"
+          if [[ "${{ needs.extract_branch.outputs.branch }}" =~ ^v.*$ ]]
+          then
+            echo "::set-output name=env::version"
+            echo "ENV=version" >> $GITHUB_ENV
+          elif test -n "${{ github.event.inputs.env }}"
           then
             echo "::set-output name=env::${{ github.event.inputs.env }}"
             echo "ENV=${{ github.event.inputs.env }}" >> $GITHUB_ENV
@@ -55,12 +60,16 @@ jobs:
         run: |
           echo "The destination branch is ${{ needs.extract_branch.outputs.branch }}"
           case ${{ env.ENV }} in
+            version)
+              new_branch_name="${{ needs.extract_branch.outputs.branch }}"
+              echo "::set-output name=branch::${new_branch_name}"
+              ;;
             dev)
-            echo "::set-output name=branch::${{ needs.extract_branch.outputs.branch }}"
-            ;;
+              echo "::set-output name=branch::${{ needs.extract_branch.outputs.branch }}"
+              ;;
             prod)
-            echo "::set-output name=branch::main" 
-            ;;
+              echo "::set-output name=branch::main" 
+              ;;
           esac
   build-and-deploy:
     needs: set_env
@@ -68,6 +77,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Create new branch if version pattern
+        uses: GuillaumeFalourd/create-other-repo-branch-action@v1.5
+        with:
+          repository_owner: flexcompute-readthedocs
+          repository_name: tidy3d-docs
+          new_branch_name: ${{ needs.set_env.outputs.dest-branch }}
+          access_token: ${{ secrets.GH_PAT }}
+          ignore_branch_exists: true
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: .

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "docs/notebooks"]
 	path = docs/notebooks
-	url = https://github.com/flexcompute/tidy3d-notebooks.git
+	url = git@github.com:flexcompute/tidy3d-notebooks.git
 	branch = develop

--- a/tests/full_test_notebooks.py
+++ b/tests/full_test_notebooks.py
@@ -33,8 +33,6 @@ for _, path in enumerate(notebook_filenames_all):
 run_only = []
 
 skip = [
-    "8ChannelDemultiplexer",
-    "90BendPolarizationSplitterRotator",
     "AdjointPlugin5BoundaryGradients",
     "AdjointPlugin6GratingCoupler",
     "AdjointPlugin7Metalens",


### PR DESCRIPTION
Hi Momchil,

I've improved the release process. 

So now:
-  You make a branch in `tidy3d/` that starts with the letter "v" like this example branch
- When you commit to this branch, the `sync-to-readthedocs` action will automatically make a branch in `tidy3d-docs` with the same name
- It will push the contents into that branch. 

You can see this worked well:
* https://github.com/flexcompute/tidy3d/actions/runs/7448894014/job/20264267298
* https://github.com/flexcompute-readthedocs/tidy3d-docs/tree/v_test_release

Then you can easily just build the documentation for that branch in the readthedocs admin page.

(I am unsure what happens when it is overwritten)