### PR TITLE
release workflow auto generates release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: "tidy3d-release"
 
+permissions:
+  contents: write
+
 on:
   push:
     tags:
@@ -12,6 +15,8 @@ jobs:
     - uses: actions/checkout@master
     - name: Release
       uses: softprops/action-gh-release@v1
+      with:
+        generate_release_notes: true      
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   pypi-release:


### PR DESCRIPTION
We used to have to manually generate release notes on GitHub through clicking

<img width="1090" alt="image" src="https://github.com/flexcompute/tidy3d/assets/92756888/c66b7c37-b50b-419f-9800-0ea7f9ac1db1">

This workflow change makes this happen automatically:

## IMPORTANT:
from my testing on a dummy repo, I needed       
```
permissions:
  contents: write
```
to get the release action to run at all, but maybe this is not related to the release notes and should be removed. 