### PR TITLE
Add field data to ModeMonitor (#1274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Mode field profiles can be stored directly from a `ModeMonitor` by setting `store_fields_direction`.
 
 ### Changed
 - `DataArray.to_hdf5()` accepts both file handles and file paths.
+- `ModeSolverMonitor` is deprecated. Mode field profiles can be retrieved directly from `ModeMonitor` with `store_fields_direction` set.
 
 ### Fixed
 - Add dispersion information to dataframe output when available from mode solver under the column "dispersion (ps/(nm km))".

--- a/tests/sims/simulation_2_6_0rc1.json
+++ b/tests/sims/simulation_2_6_0rc1.json
@@ -1619,55 +1619,8 @@
                 "track_freq": "central",
                 "group_index_step": false,
                 "type": "ModeSpec"
-            }
-        },
-        {
-            "type": "ModeSolverMonitor",
-            "center": [
-                0.0,
-                0.0,
-                0.0
-            ],
-            "size": [
-                1.0,
-                1.0,
-                0.0
-            ],
-            "name": "mode_solver",
-            "interval_space": [
-                1,
-                1,
-                1
-            ],
-            "colocate": true,
-            "freqs": [
-                200000000000000.0,
-                250000000000000.0
-            ],
-            "apodization": {
-                "start": null,
-                "end": null,
-                "width": null,
-                "type": "ApodizationSpec"
             },
-            "mode_spec": {
-                "num_modes": 1,
-                "target_neff": null,
-                "num_pml": [
-                    0,
-                    0
-                ],
-                "filter_pol": null,
-                "angle_theta": 0.0,
-                "angle_phi": 0.0,
-                "precision": "single",
-                "bend_radius": null,
-                "bend_axis": null,
-                "track_freq": "central",
-                "group_index_step": false,
-                "type": "ModeSpec"
-            },
-            "direction": "+"
+            "store_fields_direction": null
         },
         {
             "type": "FieldProjectionAngleMonitor",

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -6,12 +6,12 @@ import gdstk
 
 import numpy as np
 import tidy3d as td
-from tidy3d.exceptions import SetupError, ValidationError, Tidy3dKeyError
+from tidy3d.exceptions import SetupError, Tidy3dKeyError
 from tidy3d.components import simulation
 from tidy3d.components.simulation import MAX_NUM_SOURCES
 from tidy3d.components.scene import MAX_NUM_MEDIUMS, MAX_GEOMETRY_COUNT
-from ..utils import assert_log_level, SIM_FULL, log_capture, run_emulated, AssertLogLevel
-from tidy3d.constants import LARGE_NUMBER
+from ..utils import assert_log_level, SIM_FULL, run_emulated, AssertLogLevel
+from ..utils import log_capture  # noqa: F401
 
 SIM = td.Simulation(size=(1, 1, 1), run_time=1e-12, grid_spec=td.GridSpec(wavelength=1.0))
 
@@ -164,7 +164,7 @@ def test_monitors_data_size():
     assert len(datas) == 2
 
 
-def test_deprecation_defaults(log_capture):
+def test_deprecation_defaults(log_capture):  # noqa: F811
     """Make sure deprecation warnings NOT thrown if defaults used."""
     _ = td.Simulation(
         size=(1, 1, 1),
@@ -182,7 +182,7 @@ def test_deprecation_defaults(log_capture):
 
 
 @pytest.mark.parametrize("shift_amount, log_level", ((1, None), (2, "WARNING")))
-def test_sim_bounds(shift_amount, log_level, log_capture):
+def test_sim_bounds(shift_amount, log_level, log_capture):  # noqa: F811
     """make sure bounds are working correctly"""
 
     # make sure all things are shifted to this central location
@@ -276,7 +276,7 @@ def _test_monitor_size():
 
 
 @pytest.mark.parametrize("freq, log_level", [(1.5, "WARNING"), (2.5, "INFO"), (3.5, "WARNING")])
-def test_monitor_medium_frequency_range(log_capture, freq, log_level):
+def test_monitor_medium_frequency_range(log_capture, freq, log_level):  # noqa: F811
     # monitor frequency above or below a given medium's range should throw a warning
 
     medium = td.Medium(frequency_range=(2e12, 3e12))
@@ -299,7 +299,7 @@ def test_monitor_medium_frequency_range(log_capture, freq, log_level):
 
 
 @pytest.mark.parametrize("fwidth, log_level", [(0.1e12, "WARNING"), (2e12, "INFO")])
-def test_monitor_simulation_frequency_range(log_capture, fwidth, log_level):
+def test_monitor_simulation_frequency_range(log_capture, fwidth, log_level):  # noqa: F811
     # monitor frequency outside of the simulation's frequency range should throw a warning
 
     src = td.UniformCurrentSource(
@@ -378,7 +378,7 @@ def test_validate_normalize_index():
         )
 
 
-def test_validate_plane_wave_boundaries(log_capture):
+def test_validate_plane_wave_boundaries(log_capture):  # noqa: F811
     src1 = td.PlaneWave(
         source_time=td.GaussianPulse(freq0=2.5e14, fwidth=1e13),
         center=(0, 0, 0),
@@ -456,7 +456,7 @@ def test_validate_plane_wave_boundaries(log_capture):
         )
 
 
-def test_validate_zero_dim_boundaries(log_capture):
+def test_validate_zero_dim_boundaries(log_capture):  # noqa: F811
     # zero-dim simulation with an absorbing boundary in that direction should error
     src = td.PlaneWave(
         source_time=td.GaussianPulse(freq0=2.5e14, fwidth=1e13),
@@ -500,7 +500,7 @@ def test_validate_components_none():
     assert SIM._source_homogeneous_isotropic(val=None, values=SIM.dict()) is None
 
 
-def test_sources_edge_case_validation(log_capture):
+def test_sources_edge_case_validation(log_capture):  # noqa F811
     values = SIM.dict()
     values.pop("sources")
     SIM._warn_monitor_simulation_frequency_range(val="test", values=values)
@@ -521,7 +521,7 @@ def test_validate_size_spatial_and_time(monkeypatch):
         s._validate_size()
 
 
-def test_validate_mnt_size(monkeypatch, log_capture):
+def test_validate_mnt_size(monkeypatch, log_capture):  # noqa F811
     # warning for monitor size
     monkeypatch.setattr(simulation, "WARN_MONITOR_DATA_SIZE_GB", 1 / 2**30)
     s = SIM.copy(update=dict(monitors=(td.FieldMonitor(name="f", freqs=[1e12], size=(1, 1, 1)),)))
@@ -582,7 +582,7 @@ def test_plot_structure():
 
 
 def test_plot_eps():
-    ax = SIM_FULL.plot_eps(x=0)
+    _ = SIM_FULL.plot_eps(x=0)
     plt.close()
 
 
@@ -721,12 +721,12 @@ def test_nyquist():
     assert td.Simulation.nyquist_step.fget(m) == 1
 
 
-def test_discretize_non_intersect(log_capture):
+def test_discretize_non_intersect(log_capture):  # noqa F811
     SIM.discretize(box=td.Box(center=(-20, -20, -20), size=(1, 1, 1)))
     assert_log_level(log_capture, "ERROR")
 
 
-def test_warn_sim_background_medium_freq_range(log_capture):
+def test_warn_sim_background_medium_freq_range(log_capture):  # noqa F811
     _ = SIM.copy(
         update=dict(
             sources=(
@@ -742,7 +742,7 @@ def test_warn_sim_background_medium_freq_range(log_capture):
 
 
 @pytest.mark.parametrize("grid_size,log_level", [(0.001, None), (3, "WARNING")])
-def test_large_grid_size(log_capture, grid_size, log_level):
+def test_large_grid_size(log_capture, grid_size, log_level):  # noqa F811
     # small fwidth should be inside range, large one should throw warning
 
     medium = td.Medium(permittivity=2, frequency_range=(2e14, 3e14))
@@ -764,7 +764,7 @@ def test_large_grid_size(log_capture, grid_size, log_level):
 
 
 @pytest.mark.parametrize("box_size,log_level", [(0.1, "INFO"), (9.9, "WARNING"), (20, "INFO")])
-def test_sim_structure_gap(log_capture, box_size, log_level):
+def test_sim_structure_gap(log_capture, box_size, log_level):  # noqa F811
     """Make sure the gap between a structure and PML is not too small compared to lambda0."""
     medium = td.Medium(permittivity=2)
     box = td.Structure(geometry=td.Box(size=(box_size, box_size, box_size)), medium=medium)
@@ -951,7 +951,7 @@ def test_sim_monitor_homogeneous():
     )
 
 
-def test_proj_monitor_distance(log_capture):
+def test_proj_monitor_distance(log_capture):  # noqa F811
     """Make sure a warning is issued if the projection distance for exact projections
     is very large compared to the simulation domain size.
     """
@@ -1029,7 +1029,7 @@ def test_proj_monitor_distance(log_capture):
     )
 
 
-def test_proj_monitor_warnings(log_capture):
+def test_proj_monitor_warnings(log_capture):  # noqa F811
     """Test the validator that warns if projecting backwards."""
 
     src = td.PlaneWave(
@@ -1239,7 +1239,7 @@ def test_diffraction_medium():
         ((0.1, 0.1, 1), "WARNING"),
     ],
 )
-def test_sim_structure_extent(log_capture, box_size, log_level):
+def test_sim_structure_extent(log_capture, box_size, log_level):  # noqa F811
     """Make sure we warn if structure extends exactly to simulation edges."""
 
     src = td.UniformCurrentSource(
@@ -1268,7 +1268,9 @@ def test_sim_structure_extent(log_capture, box_size, log_level):
         (2.0, "PML", None),
     ],
 )
-def test_sim_validate_structure_bounds_pml(log_capture, box_length, absorb_type, log_level):
+def test_sim_validate_structure_bounds_pml(
+    log_capture, box_length, absorb_type, log_level  # noqa: F811
+):
     """Make sure we warn if structure bounds are within the PML exactly to simulation edges."""
 
     boundary = td.PML() if absorb_type == "PML" else td.Absorber()
@@ -1534,7 +1536,7 @@ def test_tfsf_symmetry():
         )
 
 
-def test_tfsf_boundaries(log_capture):
+def test_tfsf_boundaries(log_capture):  # noqa F811
     """Test that a TFSF source is allowed to cross boundaries only in particular cases."""
     src_time = td.GaussianPulse(freq0=td.C_0, fwidth=0.1e12)
 
@@ -1617,7 +1619,7 @@ def test_tfsf_boundaries(log_capture):
         )
 
 
-def test_tfsf_structures_grid(log_capture):
+def test_tfsf_structures_grid(log_capture):  # noqa F811
     """Test that a TFSF source is allowed to intersect structures only in particular cases."""
     src_time = td.GaussianPulse(freq0=td.C_0, fwidth=0.1e12)
 
@@ -1724,7 +1726,7 @@ def test_tfsf_structures_grid(log_capture):
 @pytest.mark.parametrize(
     "size, num_struct, log_level", [(1, 1, None), (50, 1, "WARNING"), (1, 11000, "WARNING")]
 )
-def test_warn_large_epsilon(log_capture, size, num_struct, log_level):
+def test_warn_large_epsilon(log_capture, size, num_struct, log_level):  # noqa F811
     """Make sure we get a warning if the epsilon grid is too large."""
 
     structures = [
@@ -1755,7 +1757,7 @@ def test_warn_large_epsilon(log_capture, size, num_struct, log_level):
 
 
 @pytest.mark.parametrize("dl, log_level", [(0.1, None), (0.005, "WARNING")])
-def test_warn_large_mode_monitor(log_capture, dl, log_level):
+def test_warn_large_mode_monitor(log_capture, dl, log_level):  # noqa F811
     """Make sure we get a warning if the mode monitor grid is too large."""
 
     sim = td.Simulation(
@@ -1780,7 +1782,7 @@ def test_warn_large_mode_monitor(log_capture, dl, log_level):
 
 
 @pytest.mark.parametrize("dl, log_level", [(0.1, None), (0.005, "WARNING")])
-def test_warn_large_mode_source(log_capture, dl, log_level):
+def test_warn_large_mode_source(log_capture, dl, log_level):  # noqa F811
     """Make sure we get a warning if the mode source grid is too large."""
 
     sim = td.Simulation(
@@ -1811,7 +1813,6 @@ def test_error_large_monitors():
     mnt_size = (td.inf, 0, td.inf)
     mnt_test = [
         td.ModeMonitor(size=mnt_size, freqs=[1e12], name="test", mode_spec=td.ModeSpec()),
-        td.ModeSolverMonitor(size=mnt_size, freqs=[1e12], name="test", mode_spec=td.ModeSpec()),
         td.FluxMonitor(size=mnt_size, freqs=[1e12], name="test"),
         td.FluxTimeMonitor(size=mnt_size, name="test"),
         td.DiffractionMonitor(size=mnt_size, freqs=[1e12], name="test"),
@@ -1827,7 +1828,7 @@ def test_error_large_monitors():
 
 
 @pytest.mark.parametrize("start, log_level", [(1e-12, None), (1, "WARNING")])
-def test_warn_time_monitor_outside_run_time(log_capture, start, log_level):
+def test_warn_time_monitor_outside_run_time(log_capture, start, log_level):  # noqa F811
     """Make sure we get a warning if the mode monitor grid is too large."""
 
     sim = td.Simulation(
@@ -1865,7 +1866,7 @@ def test_dt():
     assert sim_new.dt == 0.4 * dt
 
 
-def test_sim_volumetric_structures(log_capture, tmp_path):
+def test_sim_volumetric_structures(log_capture, tmp_path):  # noqa F811
     """Test volumetric equivalent of 2D materials."""
     sigma = 0.45
     thickness = 0.01
@@ -2270,11 +2271,7 @@ def test_sim_subsection():
     sim_red = SIM_FULL.subsection(
         region=region,
         symmetry=(1, 0, -1),
-        monitors=[
-            mnt
-            for mnt in SIM_FULL.monitors
-            if not isinstance(mnt, (td.ModeMonitor, td.ModeSolverMonitor))
-        ],
+        monitors=[mnt for mnt in SIM_FULL.monitors if not isinstance(mnt, td.ModeMonitor)],
     )
     assert sim_red.symmetry == (1, 0, -1)
     sim_red = SIM_FULL.subsection(

--- a/tests/test_data/test_data_arrays.py
+++ b/tests/test_data/test_data_arrays.py
@@ -50,11 +50,11 @@ FIELD_MONITOR_2D = td.FieldMonitor(size=SIZE_2D, fields=FIELDS, name="field_2d",
 FIELD_TIME_MONITOR_2D = td.FieldTimeMonitor(
     size=SIZE_2D, fields=FIELDS, name="field_time_2d", interval=INTERVAL
 )
-MODE_SOLVE_MONITOR = td.ModeSolverMonitor(
-    size=SIZE_2D, name="mode_solver", mode_spec=MODE_SPEC, freqs=FS
-)
 PERMITTIVITY_MONITOR = td.PermittivityMonitor(size=SIZE_3D, name="permittivity", freqs=FREQS)
 MODE_MONITOR = td.ModeMonitor(size=SIZE_2D, name="mode", mode_spec=MODE_SPEC, freqs=FREQS)
+MODE_MONITOR_WITH_FIELDS = td.ModeMonitor(
+    size=SIZE_2D, name="mode_solver", mode_spec=MODE_SPEC, freqs=FS, store_fields_direction="+"
+)
 FLUX_MONITOR = td.FluxMonitor(size=SIZE_2D, freqs=FREQS, name="flux")
 FLUX_TIME_MONITOR = td.FluxTimeMonitor(size=SIZE_2D, interval=INTERVAL, name="flux_time")
 DIFFRACTION_MONITOR = td.DiffractionMonitor(
@@ -67,7 +67,7 @@ DIFFRACTION_MONITOR = td.DiffractionMonitor(
 MONITORS = [
     FIELD_MONITOR,
     FIELD_TIME_MONITOR,
-    MODE_SOLVE_MONITOR,
+    MODE_MONITOR_WITH_FIELDS,
     PERMITTIVITY_MONITOR,
     MODE_MONITOR,
     FLUX_MONITOR,
@@ -131,7 +131,7 @@ def make_scalar_field_time_data_array(grid_key: str, symmetry=True):
 
 
 def make_scalar_mode_field_data_array(grid_key: str, symmetry=True):
-    XS, YS, ZS = get_xyz(MODE_SOLVE_MONITOR, grid_key, symmetry)
+    XS, YS, ZS = get_xyz(MODE_MONITOR_WITH_FIELDS, grid_key, symmetry)
     values = (1 + 0.1j) * np.random.random((len(XS), 1, len(ZS), len(FS), len(MODE_INDICES)))
 
     return td.ScalarModeFieldDataArray(
@@ -140,7 +140,7 @@ def make_scalar_mode_field_data_array(grid_key: str, symmetry=True):
 
 
 def make_scalar_mode_field_data_array_smooth(grid_key: str, symmetry=True, rot: float = 0):
-    XS, YS, ZS = get_xyz(MODE_SOLVE_MONITOR, grid_key, symmetry)
+    XS, YS, ZS = get_xyz(MODE_MONITOR_WITH_FIELDS, grid_key, symmetry)
 
     values = np.array([1 + 0.1j])[None, :, None, None, None] * np.sin(
         0.5

--- a/tests/test_data/test_sim_data.py
+++ b/tests/test_data/test_sim_data.py
@@ -10,7 +10,7 @@ from tidy3d.exceptions import DataError, Tidy3dKeyError
 from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.data.data_array import ScalarFieldTimeDataArray
 from tidy3d.components.data.monitor_data import FieldTimeData
-from tidy3d.components.monitor import FieldMonitor, FieldTimeMonitor, ModeSolverMonitor
+from tidy3d.components.monitor import FieldMonitor, FieldTimeMonitor, ModeMonitor
 
 from .test_monitor_data import make_field_data, make_field_time_data, make_permittivity_data
 from .test_monitor_data import make_mode_data, make_mode_solver_data
@@ -115,7 +115,9 @@ def test_getitem():
 def test_centers():
     sim_data = make_sim_data()
     for mon in sim_data.simulation.monitors:
-        if isinstance(mon, (FieldMonitor, FieldTimeMonitor, ModeSolverMonitor)):
+        if isinstance(mon, (FieldMonitor, FieldTimeMonitor)) or (
+            isinstance(mon, ModeMonitor) and mon.store_fields_direction
+        ):
             _ = sim_data.at_centers(mon.name)
 
 

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -1649,16 +1649,15 @@ def test_no_adjoint_sources(
     if not has_adj_src:
         monkeypatch.setattr(JaxModeData, "to_adjoint_sources", lambda *args, **kwargs: [])
 
-    def J(x):
-        sim = make_sim(eps=x)
-        data = run(sim, task_name="test", path=str(tmp_path / RUN_FILE))
-        data.make_adjoint_simulation(fwidth=src.source_time.fwidth, run_time=sim.run_time)
-        power = jnp.sum(jnp.abs(jnp.array(data["mnt"].amps.values)) ** 2)
-        return power
+    x = 2.0
+    sim = make_sim(eps=x)
+    data = run(sim, task_name="test", path=str(tmp_path / RUN_FILE))
 
-    grad_J = grad(J)
-    grad_J(2.0)
-    assert_log_level(log_capture, log_level_expected)
+    # check whether we got a warning for no sources?
+    with AssertLogLevel(log_capture, log_level_expected, contains_str="No adjoint sources"):
+        data.make_adjoint_simulation(fwidth=src.source_time.fwidth, run_time=sim.run_time)
+
+    power = jnp.sum(jnp.abs(jnp.array(data["mnt"].amps.values)) ** 2)
 
 
 def test_nonlinear_warn(log_capture):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -424,13 +424,6 @@ SIM_FULL = td.Simulation(
             freqs=[2e14, 2.5e14],
             mode_spec=td.ModeSpec(),
         ),
-        td.ModeSolverMonitor(
-            size=(1, 1, 0),
-            center=(0, 0, 0),
-            name="mode_solver",
-            freqs=[2e14, 2.5e14],
-            mode_spec=td.ModeSpec(),
-        ),
         td.FieldProjectionAngleMonitor(
             center=(0, 0, 0),
             size=(0, 2, 2),
@@ -583,7 +576,12 @@ def run_emulated(simulation: td.Simulation, path=None, **kwargs) -> td.Simulatio
         coords_amps = dict(direction=["+", "-"])
         coords_amps.update(coords_ind)
         amps = make_data(coords=coords_amps, data_array_type=td.ModeAmpsDataArray, is_complex=True)
-        return td.ModeData(monitor=monitor, n_complex=n_complex, amps=amps)
+        return td.ModeData(
+            monitor=monitor,
+            n_complex=n_complex,
+            amps=amps,
+            grid_expanded=simulation.discretize_monitor(monitor),
+        )
 
     MONITOR_MAKER_MAP = {
         td.FieldMonitor: make_field_data,

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -170,7 +170,14 @@ class ElectromagneticFieldDataset(AbstractFieldDataset, ABC):
     @property
     def field_components(self) -> Dict[str, DataArray]:
         """Maps the field components to their associated data."""
-        fields = dict(Ex=self.Ex, Ey=self.Ey, Ez=self.Ez, Hx=self.Hx, Hy=self.Hy, Hz=self.Hz)
+        fields = {
+            "Ex": self.Ex,
+            "Ey": self.Ey,
+            "Ez": self.Ez,
+            "Hx": self.Hx,
+            "Hy": self.Hy,
+            "Hz": self.Hz,
+        }
         return {field_name: field for field_name, field in fields.items() if field is not None}
 
     @property
@@ -319,32 +326,32 @@ class ModeSolverDataset(ElectromagneticFieldDataset):
     """
 
     Ex: ScalarModeFieldDataArray = pd.Field(
-        ...,
+        None,
         title="Ex",
         description="Spatial distribution of the x-component of the electric field of the mode.",
     )
     Ey: ScalarModeFieldDataArray = pd.Field(
-        ...,
+        None,
         title="Ey",
         description="Spatial distribution of the y-component of the electric field of the mode.",
     )
     Ez: ScalarModeFieldDataArray = pd.Field(
-        ...,
+        None,
         title="Ez",
         description="Spatial distribution of the z-component of the electric field of the mode.",
     )
     Hx: ScalarModeFieldDataArray = pd.Field(
-        ...,
+        None,
         title="Hx",
         description="Spatial distribution of the x-component of the magnetic field of the mode.",
     )
     Hy: ScalarModeFieldDataArray = pd.Field(
-        ...,
+        None,
         title="Hy",
         description="Spatial distribution of the y-component of the magnetic field of the mode.",
     )
     Hz: ScalarModeFieldDataArray = pd.Field(
-        ...,
+        None,
         title="Hz",
         description="Spatial distribution of the z-component of the magnetic field of the mode.",
     )
@@ -372,8 +379,15 @@ class ModeSolverDataset(ElectromagneticFieldDataset):
     @property
     def field_components(self) -> Dict[str, DataArray]:
         """Maps the field components to their associated data."""
-
-        return {field: getattr(self, field) for field in ["Ex", "Ey", "Ez", "Hx", "Hy", "Hz"]}
+        fields = {
+            "Ex": self.Ex,
+            "Ey": self.Ey,
+            "Ez": self.Ez,
+            "Hx": self.Hx,
+            "Hy": self.Hy,
+            "Hz": self.Hz,
+        }
+        return {field_name: field for field_name, field in fields.items() if field is not None}
 
     @property
     def n_eff(self) -> ModeIndexDataArray:

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -12,7 +12,7 @@ from pandas import DataFrame
 
 from .data_array import FluxTimeDataArray, FluxDataArray
 from .data_array import MixedModeDataArray, ModeAmpsDataArray
-from .data_array import ModeIndexDataArray, GroupIndexDataArray, ModeDispersionDataArray
+from .data_array import GroupIndexDataArray, ModeDispersionDataArray
 from .data_array import FieldProjectionAngleDataArray, FieldProjectionCartesianDataArray
 from .data_array import FieldProjectionKSpaceDataArray
 from .data_array import DataArray, DiffractionDataArray
@@ -33,7 +33,7 @@ from ..monitor import DiffractionMonitor
 from ..source import SourceTimeType, CustomFieldSource
 from ..medium import Medium, MediumType
 from ...exceptions import SetupError, DataError, Tidy3dNotImplementedError, ValidationError
-from ...constants import ETA_0, C_0, MICROMETER, PICOSECOND_PER_NANOMETER_PER_KILOMETER
+from ...constants import ETA_0, C_0, MICROMETER
 from ...log import log
 
 from ..base_sim.data.monitor_data import AbstractMonitorData
@@ -80,7 +80,7 @@ class MonitorData(AbstractMonitorData, ABC):
 class AbstractFieldData(MonitorData, AbstractFieldDataset, ABC):
     """Collection of scalar fields with some symmetry properties."""
 
-    monitor: Union[FieldMonitor, FieldTimeMonitor, PermittivityMonitor, ModeSolverMonitor]
+    monitor: Union[FieldMonitor, FieldTimeMonitor, PermittivityMonitor, ModeMonitor]
 
     symmetry: Tuple[Symmetry, Symmetry, Symmetry] = pd.Field(
         (0, 0, 0),
@@ -519,9 +519,11 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
 
     @cached_property
     def mode_area(self) -> FreqModeDataArray:
-        """Effective mode area corresponding to a 2D monitor.
+        r"""Effective mode area corresponding to a 2D monitor.
 
-        Effective mode area is calculated as: (∫|E|²dA)² / (∫|E|⁴dA)
+        .. math:
+
+           \frac{\left(\int |E|^2 \, {\rm d}S\right)^2}{\int |E|^4 \, {\rm d}S}
         """
         intensity = self.intensity
         # integrate over the plane
@@ -536,25 +538,30 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
         return FreqModeDataArray(area)
 
     def dot(
-        self, field_data: Union[FieldData, ModeSolverData], conjugate: bool = True
+        self, field_data: Union[FieldData, ModeData, ModeSolverData], conjugate: bool = True
     ) -> ModeAmpsDataArray:
-        """Dot product (modal overlap) with another :class:`.FieldData` object. Both datasets have
+        r"""Dot product (modal overlap) with another :class:`.FieldData` object. Both datasets have
         to be frequency-domain data associated with a 2D monitor. Along the tangential directions,
         the datasets have to have the same discretization. Along the normal direction, the monitor
         position may differ and is ignored. Other coordinates (``frequency``, ``mode_index``) have
         to be either identical or broadcastable. Broadcasting is also supported in the case in
-        which the other ``field_data`` has a dimension of size ``1`` whose coordinate is not in the
-        list of coordinates in the ``self`` dataset along the corresponding dimension. In that case,
-        the coordinates of the ``self`` dataset are used in the output.
+        which the other ``field_data`` has a dimension of size 1 whose coordinate is not in the list
+        of coordinates in the ``self`` dataset along the corresponding dimension. In that case, the
+        coordinates of the ``self`` dataset are used in the output.
+
+        The dot product is defined as:
+
+        .. math:
+
+           \frac{1}{4} \int \left( E_0 \times H_1^* + H_0^* \times E_1 \) \, {\rm d}S
 
         Parameters
         ----------
         field_data : :class:`ElectromagneticFieldData`
             A data instance to compute the dot product with.
         conjugate : bool, optional
-            If ``True`` (default), the dot product is defined as ``1 / 4`` times the integral of
-            ``E_self* x H_other - H_self* x E_other``, where ``x`` is the cross product and ``*`` is
-            complex conjugation. If ``False``, the complex conjugation is skipped.
+            If ``True`` (default), the dot product is defined as above. If ``False``, the definition
+            is similar, but without the complex conjugation of the $H$ fields.
 
         Note
         ----
@@ -615,24 +622,29 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
         return fields
 
     def outer_dot(
-        self, field_data: Union[FieldData, ModeSolverData], conjugate: bool = True
+        self, field_data: Union[FieldData, ModeData], conjugate: bool = True
     ) -> MixedModeDataArray:
-        """Dot product (modal overlap) with another :class:`.FieldData` object.
+        r"""Dot product (modal overlap) with another :class:`.FieldData` object.
 
         The tangential fields from ``field_data`` are interpolated to this object's grid, so the
         data arrays don't need to have the same discretization.  The calculation is performed for
         all common frequencies between data arrays.  In the output, ``mode_index_0`` and
         ``mode_index_1`` are the mode indices from this object and ``field_data``, respectively, if
-        they are instances of ``ModeSolverData``.
+        they are instances of ``ModeData``.
+
+        The dot product is defined as:
+
+        .. math:
+
+           \frac{1}{4} \int \left( E_0 \times H_1^* + H_0^* \times E_1 \) \, {\rm d}S
 
         Parameters
         ----------
         field_data : :class:`ElectromagneticFieldData`
             A data instance to compute the dot product with.
         conjugate : bool = True
-            If ``True`` (default), the dot product is defined as ``1 / 4`` times the integral of
-            ``E_self* x H_other - H_self* x E_other``, where ``x`` is the cross product and ``*`` is
-            complex conjugation. If ``False``, the complex conjugation is skipped.
+            If ``True`` (default), the dot product is defined as above. If ``False``, the definition
+            is similar, but without the complex conjugation of the $H$ fields.
 
         Returns
         -------
@@ -725,8 +737,8 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
     def time_reversed_copy(self) -> FieldData:
         """Make a copy of the data with time-reversed fields."""
 
-        # Time reversal for frequency-domain fields; overwritten in :class:`FieldTimeData`
-        # and :class:`ModeSolverData`.
+        # Time reversal for frequency-domain fields; overwritten in :class:`FieldTimeData`,
+        # :class:`ModeData`, and :class:`ModeSolverData`.
         new_data = {}
         for comp, field in self.field_components.items():
             if comp[0] == "H":
@@ -904,9 +916,8 @@ class FieldTimeData(FieldTimeDataset, ElectromagneticFieldData):
         return self.copy(update=new_data)
 
 
-class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
-    """
-    Data associated with a :class:`.ModeSolverMonitor`: scalar components of E and H fields.
+class PermittivityData(PermittivityDataset, AbstractFieldData):
+    """Data for a :class:`.PermittivityMonitor`: diagonal components of the permittivity tensor.
 
     Notes
     -----
@@ -916,39 +927,70 @@ class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
 
     Example
     -------
-    >>> from tidy3d import ModeSpec
-    >>> from tidy3d import ScalarModeFieldDataArray, ModeIndexDataArray
+    >>> from tidy3d import ScalarFieldDataArray
     >>> x = [-1,1,3]
-    >>> y = [-2,0]
+    >>> y = [-2,0,2,4]
     >>> z = [-3,-1,1,3,5]
     >>> f = [2e14, 3e14]
-    >>> mode_index = np.arange(5)
+    >>> coords = dict(x=x[:-1], y=y[:-1], z=z[:-1], f=f)
     >>> grid = Grid(boundaries=Coords(x=x, y=y, z=z))
-    >>> field_coords = dict(x=x[:-1], y=y[:-1], z=z[:-1], f=f, mode_index=mode_index)
-    >>> field = ScalarModeFieldDataArray((1+1j)*np.random.random((2,1,4,2,5)), coords=field_coords)
-    >>> index_coords = dict(f=f, mode_index=mode_index)
-    >>> index_data = ModeIndexDataArray((1+1j) * np.random.random((2,5)), coords=index_coords)
-    >>> monitor = ModeSolverMonitor(
-    ...    size=(2,0,6),
-    ...    freqs=[2e14, 3e14],
-    ...    mode_spec=ModeSpec(num_modes=5),
-    ...    name='mode_solver',
-    ... )
-    >>> data = ModeSolverData(
-    ...     monitor=monitor,
-    ...     Ex=field,
-    ...     Ey=field,
-    ...     Ez=field,
-    ...     Hx=field,
-    ...     Hy=field,
-    ...     Hz=field,
-    ...     n_complex=index_data,
-    ...     grid_expanded=grid
+    >>> sclr_fld = ScalarFieldDataArray((1+1j) * np.random.random((2,3,4,2)), coords=coords)
+    >>> monitor = PermittivityMonitor(size=(2,4,6), freqs=[2e14, 3e14], name='eps')
+    >>> data = PermittivityData(
+    ...     monitor=monitor, eps_xx=sclr_fld, eps_yy=sclr_fld, eps_zz=sclr_fld, grid_expanded=grid
     ... )
     """
 
-    monitor: ModeSolverMonitor = pd.Field(
-        ..., title="Monitor", description="Mode solver monitor associated with the data."
+    monitor: PermittivityMonitor = pd.Field(
+        ..., title="Monitor", description="Permittivity monitor associated with the data."
+    )
+
+
+class ModeData(ModeSolverDataset, ElectromagneticFieldData):
+    """
+    Data associated with a :class:`.ModeMonitor`: modal amplitudes, propagation indices and mode profiles.
+
+    Notes
+    -----
+
+        The data is stored as a `DataArray <https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html>`_
+        object using the `xarray <https://docs.xarray.dev/en/stable/index.html>`_ package.
+
+        The mode monitor data contains the complex effective indices and the complex mode amplitudes at the monitor
+        position calculated by mode decomposition. The data structure of the complex effective
+        indices :attr`n_complex` contains two coordinates: ``f`` and ``mode_index``, both of which are specified when
+        defining the :class:``ModeMonitor`` in the simulation.
+
+        Besides the effective index, :class:``ModeMonitor`` is primarily used to calculate the transmission of
+        certain modes in certain directions. We can extract the complex amplitude and square it to compute the mode
+        transmission power.
+
+    Example
+    -------
+    >>> from tidy3d import ModeSpec
+    >>> from tidy3d import ModeAmpsDataArray, ModeIndexDataArray
+    >>> direction = ["+", "-"]
+    >>> f = [1e14, 2e14, 3e14]
+    >>> mode_index = np.arange(5)
+    >>> index_coords = dict(f=f, mode_index=mode_index)
+    >>> index_data = ModeIndexDataArray((1+1j) * np.random.random((3, 5)), coords=index_coords)
+    >>> amp_coords = dict(direction=direction, f=f, mode_index=mode_index)
+    >>> amp_data = ModeAmpsDataArray((1+1j) * np.random.random((2, 3, 5)), coords=amp_coords)
+    >>> monitor = ModeMonitor(
+    ...    size=(2,0,6),
+    ...    freqs=[2e14, 3e14],
+    ...    mode_spec=ModeSpec(num_modes=5),
+    ...    name='mode',
+    ... )
+    >>> data = ModeData(monitor=monitor, amps=amp_data, n_complex=index_data)
+    """
+
+    monitor: ModeMonitor = pd.Field(
+        ..., title="Monitor", description="Mode monitor associated with the data."
+    )
+
+    amps: ModeAmpsDataArray = pd.Field(
+        ..., title="Amplitudes", description="Complex-valued amplitudes associated with the mode."
     )
 
     eps_spec: List[EpsSpecType] = pd.Field(
@@ -970,11 +1012,17 @@ class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
                 )
         return val
 
+    def normalize(self, source_spectrum_fn) -> ModeData:
+        """Return copy of self after normalization is applied using source spectrum function."""
+        source_freq_amps = source_spectrum_fn(self.amps.f)[None, :, None]
+        new_amps = (self.amps / source_freq_amps).astype(self.amps.dtype)
+        return self.copy(update=dict(amps=new_amps))
+
     def overlap_sort(
         self,
         track_freq: TrackFreq,
         overlap_thresh: float = 0.9,
-    ) -> ModeSolverData:
+    ) -> ModeData:
         """Starting from the base frequency defined by parameter ``track_freq``, sort modes at each
         frequency according to their overlap values with the modes at the previous frequency.
         That is, it attempts to rearrange modes in such a way that a given ``mode_index``
@@ -992,6 +1040,8 @@ class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
             modes is less than this threshold, a warning about a possible discontinuity is
             displayed.
         """
+        if len(self.field_components) == 0:
+            return self.copy()
         num_freqs = len(self.monitor.freqs)
         num_modes = self.monitor.mode_spec.num_modes
 
@@ -1065,7 +1115,7 @@ class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
 
     def _find_ordering_one_freq(
         self,
-        data_to_sort: ModeSolverData,
+        data_to_sort: ModeData,
         overlap_thresh: float,
     ) -> Tuple[Numpy, Numpy]:
         """Find new ordering of modes in data_to_sort based on their similarity to own modes."""
@@ -1075,7 +1125,7 @@ class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
         # Current pairs and their overlaps
         pairs = np.arange(num_modes)
         complex_amps = self.dot(data_to_sort).data.ravel()
-        if self.monitor.direction == "-":
+        if self.monitor.store_fields_direction == "-":
             complex_amps *= -1
 
         # Check whether modes already match
@@ -1097,7 +1147,7 @@ class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
 
             # Project to all modes of interest from data_template
             amps_reduced[:, i] = data_template_reduced.dot(one_mode).data.ravel()
-            if self.monitor.direction == "-":
+            if self.monitor.store_fields_direction == "-":
                 amps_reduced[:, i] *= -1
 
         # Find the most similar modes and corresponding overlap values
@@ -1134,7 +1184,7 @@ class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
         sorting: Numpy,
         phase: Numpy,
         track_freq: TrackFreq,
-    ) -> ModeSolverData:
+    ) -> ModeData:
         """Rearrange modes for the i-th frequency according to sorting[i, :] and apply phase
         shifts."""
 
@@ -1172,7 +1222,7 @@ class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
 
         return self.copy(update=update_dict)
 
-    def _group_index_post_process(self, frequency_step: float) -> ModeSolverData:
+    def _group_index_post_process(self, frequency_step: float) -> ModeData:
         """Calculate group index and remove added frequencies used only for this calculation.
 
         Parameters
@@ -1182,7 +1232,7 @@ class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
 
         Returns
         -------
-        :class:`.ModeSolverData`
+        :class:`.ModeData`
             Filtered data with calculated group index.
         """
 
@@ -1258,8 +1308,8 @@ class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
 
         # switch direction in the monitor
         mnt = self.monitor
-        new_direction = "+" if mnt.direction == "-" else "-"
-        new_data["monitor"] = mnt.updated_copy(direction=new_direction)
+        new_dir = "+" if mnt.store_fields_direction == "-" else "-"
+        new_data["monitor"] = mnt.updated_copy(store_fields_direction=new_dir)
         return self.copy(update=new_data)
 
     def _colocated_propagation_axes_field(self, field_name: Literal["E", "H"]) -> xr.DataArray:
@@ -1292,14 +1342,24 @@ class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
 
     @cached_property
     def pol_fraction(self) -> xr.Dataset:
-        """Compute the TE and TM polarization fraction defined as the field intensity along the
-        first or the second of the two tangential axes. More precisely, if ``E1`` and ``E2`` are
-        the electric field components along the two tangential axes, the TE fraction is defined as
-        ``integrate(E1.abs**2) / integrate(E1.abs**2 + E2.abs**2)``, and the ``TM`` fraction
-        is equal to one minus the TE fraction. The tangential axes are defined by popping the
-        normal axis from the list of ``x, y, z``, so e.g. ``x`` and ``z`` for propagation
-        in the ``y`` direction.
+        r"""Compute the TE and TM polarization fraction defined as the field intensity along the
+        first or the second of the two tangential axes. More precisely, if $E_1$ and $E_2$ are
+        the electric field components along the two tangential axes, the TE fraction is defined as:
+
+        .. math::
+
+           \frac{\int |E_1|^2 \, {\rm d}S}{\int \left(|E_1|^2 + |E_2|^2\right) \, {\rm d}S}
+
+        and the TM fraction is equal to one minus the TE fraction. The tangential axes are defined
+        by popping the normal axis from the list of ``x, y, z``, so e.g. ``x`` and ``z`` for
+        propagation in the ``y`` direction.
         """
+        if len(self.field_components) == 0:
+            raise DataError(
+                "Field data not included in this ModeData onbject. Set "
+                "'ModeMonitor.store_fields_direction' to the desired propagation direction to "
+                "include the mode field profiles in the corresponding 'ModeData'."
+            )
 
         tan_dims = self._tangential_dims
         e_field = self._colocated_propagation_axes_field("E")
@@ -1312,13 +1372,18 @@ class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
 
     @cached_property
     def pol_fraction_waveguide(self) -> xr.Dataset:
-        """Compute the TE and TM polarization fraction using the waveguide definition. If ``E1`` and
-        ``E2`` are the electric field components along the two tangential axes and ``En`` is the
-        component along the propagation direction, the TE fraction is defined as
-        ``1 - integrate(En.abs**2) / integrate(E1.abs**2 + E2.abs**2 + En.abs**2)``,
-        and the ``TM`` fraction is defined as
-        ``1 - integrate(Hn.abs**2) / integrate(H1.abs**2 + H2.abs**2 + Hn.abs**2)``,
-        with ``H`` denoting the magnetic field components.
+        r"""Compute the TE and TM polarization fraction using the waveguide definition. If $n$ is
+        the propagation direction, the TE fraction is defined as:
+
+        .. math::
+
+           1 - \frac{\int |E \cdot n|^2 \, {\rm d}S}{\int |E|^2 \, {\rm d}S}
+
+        and the TM fraction is defined as
+
+        .. math::
+
+           1 - \frac{\int |H \cdot n|^2 \, {\rm d}S}{\int |H|^2 \, {\rm d}S}
 
         Note
         ----
@@ -1326,6 +1391,12 @@ class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
             are completely transverse (zero electric and magnetic field in the propagation
             direction) have TE fraction and TM fraction both equal to one.
         """
+        if len(self.field_components) == 0:
+            raise DataError(
+                "Field data not included in this ModeData onbject. Set "
+                "'ModeMonitor.store_fields_direction' to the desired propagation direction to "
+                "include the mode field profiles in the corresponding 'ModeData'."
+            )
 
         tan_dims = self._tangential_dims
         e_field = self._colocated_propagation_axes_field("E")
@@ -1366,6 +1437,15 @@ class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
             "dispersion (ps/(nm km))": self.dispersion_raw,  # Use raw field to avoid issuing a warning
         }
 
+        if self.n_group_raw is not None:
+            info["group index"] = self.n_group_raw
+
+        if len(self.field_components) == 6:
+            info["mode area"] = self.mode_area
+            info[f"TE (E{self._tangential_dims[0]}) fraction"] = self.pol_fraction["te"]
+            info["wg TE fraction"] = self.pol_fraction_waveguide["te"]
+            info["wg TM fraction"] = self.pol_fraction_waveguide["tm"]
+
         return xr.Dataset(data_vars=info)
 
     def to_dataframe(self) -> DataFrame:
@@ -1385,145 +1465,79 @@ class ModeSolverData(ModeSolverDataset, ElectromagneticFieldData):
         return dataset.drop_vars(drop).to_dataframe()
 
 
-class PermittivityData(PermittivityDataset, AbstractFieldData):
-    """Data for a :class:`.PermittivityMonitor`: diagonal components of the permittivity tensor.
+class ModeSolverData(ModeData):
+    """
+    Data associated with a :class:`.ModeSolverMonitor`: scalar components of E and H fields.
 
     Notes
     -----
 
         The data is stored as a `DataArray <https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html>`_
         object using the `xarray <https://docs.xarray.dev/en/stable/index.html>`_ package.
-
-    Example
-    -------
-    >>> from tidy3d import ScalarFieldDataArray
-    >>> x = [-1,1,3]
-    >>> y = [-2,0,2,4]
-    >>> z = [-3,-1,1,3,5]
-    >>> f = [2e14, 3e14]
-    >>> coords = dict(x=x[:-1], y=y[:-1], z=z[:-1], f=f)
-    >>> grid = Grid(boundaries=Coords(x=x, y=y, z=z))
-    >>> sclr_fld = ScalarFieldDataArray((1+1j) * np.random.random((2,3,4,2)), coords=coords)
-    >>> monitor = PermittivityMonitor(size=(2,4,6), freqs=[2e14, 3e14], name='eps')
-    >>> data = PermittivityData(
-    ...     monitor=monitor, eps_xx=sclr_fld, eps_yy=sclr_fld, eps_zz=sclr_fld, grid_expanded=grid
-    ... )
-    """
-
-    monitor: PermittivityMonitor = pd.Field(
-        ..., title="Monitor", description="Permittivity monitor associated with the data."
-    )
-
-
-class ModeData(MonitorData):
-    """
-    Data associated with a :class:`.ModeMonitor`: modal amplitudes and propagation indices.
-
-    Notes
-    -----
-
-        The data is stored as a `DataArray <https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html>`_
-        object using the `xarray <https://docs.xarray.dev/en/stable/index.html>`_ package.
-
-        The mode monitor data contains the complex effective indices and the complex mode amplitudes at the monitor
-        position calculated by mode decomposition. The data structure of the complex effective
-        indices :attr`n_complex` contains two coordinates: ``f`` and ``mode_index``, both of which are specified when
-        defining the :class:``ModeMonitor`` in the simulation.
-
-        Besides the effective index, :class:``ModeMonitor`` is primarily used to calculate the transmission of
-        certain modes in certain directions. We can extract the complex amplitude and square it to compute the mode
-        transmission power.
 
     Example
     -------
     >>> from tidy3d import ModeSpec
-    >>> from tidy3d import ModeAmpsDataArray, ModeIndexDataArray
-    >>> direction = ["+", "-"]
-    >>> f = [1e14, 2e14, 3e14]
+    >>> from tidy3d import ScalarModeFieldDataArray, ModeIndexDataArray
+    >>> x = [-1,1,3]
+    >>> y = [-2,0]
+    >>> z = [-3,-1,1,3,5]
+    >>> f = [2e14, 3e14]
     >>> mode_index = np.arange(5)
+    >>> grid = Grid(boundaries=Coords(x=x, y=y, z=z))
+    >>> field_coords = dict(x=x[:-1], y=y[:-1], z=z[:-1], f=f, mode_index=mode_index)
+    >>> field = ScalarModeFieldDataArray((1+1j)*np.random.random((2,1,4,2,5)), coords=field_coords)
     >>> index_coords = dict(f=f, mode_index=mode_index)
-    >>> index_data = ModeIndexDataArray((1+1j) * np.random.random((3, 5)), coords=index_coords)
-    >>> amp_coords = dict(direction=direction, f=f, mode_index=mode_index)
-    >>> amp_data = ModeAmpsDataArray((1+1j) * np.random.random((2, 3, 5)), coords=amp_coords)
-    >>> monitor = ModeMonitor(
+    >>> index_data = ModeIndexDataArray((1+1j) * np.random.random((2,5)), coords=index_coords)
+    >>> monitor = ModeSolverMonitor(
     ...    size=(2,0,6),
     ...    freqs=[2e14, 3e14],
     ...    mode_spec=ModeSpec(num_modes=5),
-    ...    name='mode',
+    ...    name='mode_solver',
     ... )
-    >>> data = ModeData(monitor=monitor, amps=amp_data, n_complex=index_data)
+    >>> data = ModeSolverData(
+    ...     monitor=monitor,
+    ...     Ex=field,
+    ...     Ey=field,
+    ...     Ez=field,
+    ...     Hx=field,
+    ...     Hy=field,
+    ...     Hz=field,
+    ...     n_complex=index_data,
+    ...     grid_expanded=grid
+    ... )
     """
 
-    monitor: ModeMonitor = pd.Field(
-        ..., title="Monitor", description="Mode monitor associated with the data."
+    monitor: ModeSolverMonitor = pd.Field(
+        ..., title="Monitor", description="Mode solver monitor associated with the data."
     )
 
     amps: ModeAmpsDataArray = pd.Field(
-        ..., title="Amplitudes", description="Complex-valued amplitudes associated with the mode."
+        None, title="Amplitudes", description="Unused for ModeSolverData."
     )
 
-    n_complex: ModeIndexDataArray = pd.Field(
-        ...,
-        title="Propagation Index",
-        description="Complex-valued effective propagation constants associated with the mode.",
-    )
-
-    n_group_raw: GroupIndexDataArray = pd.Field(
-        None,
-        alias="n_group",  # This is for backwards compatibility only when loading old data
-        title="Group Index",
-        description="Index associated with group velocity of the mode.",
-    )
-
-    dispersion_raw: ModeDispersionDataArray = pd.Field(
-        None,
-        title="Dispersion",
-        description="Dispersion parameter for the mode.",
-        units=PICOSECOND_PER_NANOMETER_PER_KILOMETER,
-    )
-
-    @property
-    def n_eff(self) -> ModeIndexDataArray:
-        """Real part of the propagation index."""
-        return self.n_complex.real
-
-    @property
-    def k_eff(self) -> ModeIndexDataArray:
-        """Imaginary part of the propagation index."""
-        return self.n_complex.imag
-
-    @property
-    def n_group(self) -> GroupIndexDataArray:
-        """Group index."""
-        if self.n_group_raw is None:
-            log.warning(
-                "The group index was not computed. To calculate group index, pass "
-                "'group_index_step = True' in the 'ModeSpec'.",
-                log_once=True,
-            )
-        return self.n_group_raw
-
-    @property
-    def dispersion(self) -> ModeDispersionDataArray:
-        r"""Dispersion parameter.
-
-        .. math::
-
-           D = -\frac{\lambda}{c_0} \frac{{\rm d}^2 n_{\text{eff}}}{{\rm d}\lambda^2}
-        """
-        if self.dispersion_raw is None:
-            log.warning(
-                "The dispersion was not computed. To calculate dispersion, pass "
-                "'group_index_step = True' in the 'ModeSpec'.",
-                log_once=True,
-            )
-        return self.dispersion_raw
-
-    def normalize(self, source_spectrum_fn) -> ModeData:
+    def normalize(self, source_spectrum_fn: Callable[[float], complex]) -> ModeSolverData:
         """Return copy of self after normalization is applied using source spectrum function."""
-        source_freq_amps = source_spectrum_fn(self.amps.f)[None, :, None]
-        new_amps = (self.amps / source_freq_amps).astype(self.amps.dtype)
-        return self.copy(update=dict(amps=new_amps))
+        return self.copy()
+
+    @property
+    def time_reversed_copy(self) -> FieldData:
+        """Make a copy of the data with direction-reversed fields. In lossy or gyrotropic systems,
+        the time-reversed fields will not be the same as the backward-propagating modes."""
+
+        # Time reversal
+        new_data = {}
+        for comp, field in self.field_components.items():
+            if comp[0] == "H":
+                new_data[comp] = -np.conj(field)
+            else:
+                new_data[comp] = np.conj(field)
+
+        # switch direction in the monitor
+        mnt = self.monitor
+        new_dir = "+" if mnt.store_fields_direction == "-" else "-"
+        new_data["monitor"] = mnt.updated_copy(direction=new_dir, store_fields_direction=new_dir)
+        return self.copy(update=new_data)
 
 
 class FluxData(MonitorData):
@@ -2320,7 +2334,7 @@ class DiffractionData(AbstractFieldProjectionData):
 
     @staticmethod
     def compute_angles(
-        reciprocal_vectors: Tuple[np.ndarray, np.ndarray]
+        reciprocal_vectors: Tuple[np.ndarray, np.ndarray],
     ) -> Tuple[np.ndarray, np.ndarray]:
         """Compute the polar and azimuth angles associated with the given reciprocal vectors."""
         # some wave number pairs are outside the light cone, leading to warnings from numpy.arcsin


### PR DESCRIPTION
The implementation proposed here merges `ModeSolverData` and into `ModeData`. It also deprecates the use of `ModeSolverMonitor` and changes the implementation on `ModeSolverData` to be derived from `ModeData` (to avoid most code duplication and make deprecation later easier). There are 2 issues at this point:
1. `ModeSolverData` ended up inheriting the `amps` field, which will be unused.
2. This warning: https://github.com/flexcompute/tidy3d/blob/fa402883fafa3de37fbe0b22cbfb3b04e2263552/tidy3d/components/data/monitor_data.py#L105-L112 is being emitted (unnecessarily?) and getting caught in [an adjoint test](https://github.com/flexcompute/tidy3d/blob/fa402883fafa3de37fbe0b22cbfb3b04e2263552/tests/test_plugins/test_adjoint.py#L1618).

Thoughts, @tylerflex and @momchil-flex?