### PR TITLE
Use simulation reduction automatically only in case of custom mediums

### DIFF
--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -3563,7 +3563,10 @@ class Simulation(AbstractSimulation):
             # adjust region bounds to perfectly coincide with the grid
             # note, sometimes (when a box already seems to perfrecty align with the grid)
             # this causes the new region to expand one more pixel because of numerical roundoffs
-            aux_box = Box.from_bounds(*new_bounds)
+            # To help to avoid that we shrink new region by a small amount.
+            center = [(bmin + bmax) / 2 for bmin, bmax in zip(*new_bounds)]
+            size = [max(0.0, bmax - bmin - 2 * fp_eps) for bmin, bmax in zip(*new_bounds)]
+            aux_box = Box(center=center, size=size)
             grid_inds = self.grid.discretize_inds(box=aux_box)
 
             new_bounds = [

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -973,7 +973,8 @@ class ModeSolver(Tidy3dBaseModel):
         This might significantly reduce upload time in the presence of custom mediums.
         """
 
-        # we preserve extracells along the normal direction to ensure
+        # we preserve extracells along the normal direction to ensure there is enough data for
+        # subpixel
         extended_grid = self._get_solver_grid(preserve_layer_behind=True, truncate_symmetry=False)
         grids_1d = extended_grid.boundaries
         new_sim_box = Box.from_bounds(

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -973,7 +973,7 @@ class ModeSolver(Tidy3dBaseModel):
         This might significantly reduce upload time in the presence of custom mediums.
         """
 
-        # we preserve extracells along the normal direction to ensure there is enough data for
+        # we preserve extra cells along the normal direction to ensure there is enough data for
         # subpixel
         extended_grid = self._get_solver_grid(preserve_layer_behind=True, truncate_symmetry=False)
         grids_1d = extended_grid.boundaries

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -14,6 +14,7 @@ from ..api import webapi as web
 from ..core.task_info import TaskInfo, RunInfo
 from ..core.constants import TaskId, TaskName
 from ...components.base import Tidy3dBaseModel
+from ...components.types import annotate_type
 from ...log import log, get_logging_console
 
 from ...exceptions import DataError
@@ -418,7 +419,7 @@ class Batch(WebContainer):
         * `Inverse taper edge coupler <../../notebooks/EdgeCoupler.html>`_
     """
 
-    simulations: Dict[TaskName, SimulationType] = pd.Field(
+    simulations: Dict[TaskName, annotate_type(SimulationType)] = pd.Field(
         ...,
         title="Simulations",
         description="Mapping of task names to Simulations to run as a batch.",

--- a/tidy3d/web/api/mode.py
+++ b/tidy3d/web/api/mode.py
@@ -86,9 +86,8 @@ def run(
         console = get_logging_console()
 
     if reduce_simulation == "auto":
-        sim = mode_solver.simulation
-        contains_custom = any(isinstance(s.medium, AbstractCustomMedium) for s in sim.structures)
-        contains_custom = contains_custom or isinstance(sim.medium, AbstractCustomMedium)
+        sim_mediums = mode_solver.simulation.scene.mediums
+        contains_custom = any(isinstance(med, AbstractCustomMedium) for med in sim_mediums)
         reduce_simulation = contains_custom
 
         if reduce_simulation:


### PR DESCRIPTION
- shrink bounds when performing `grid.discretize_inds` on new region to avoid including possible spurious pixel
- switch simulation reduction in mode solver to be automatic only for simulations with custom medium + display warning if that happens