### PR TITLE
FEAT: Import timing improvements 2.5.1 patch 

### DIFF
--- a/tests/test_components/test_packaging.py
+++ b/tests/test_components/test_packaging.py
@@ -1,0 +1,58 @@
+"""
+Thank you, ChatGPT, for the core of the following test code.
+"""
+
+import pytest
+from tidy3d.packaging import check_import, verify_packages_import, Tidy3dImportError
+
+assert check_import("tidy3d") == True
+
+
+# Mock module import function to simulate availability
+def mock_check_import(module_name):
+    if module_name == "tidy3d":
+        return True
+    return False
+
+
+def test_verify_packages_import_all_required():
+    @verify_packages_import(["tidy3d", "module2"], required="all")
+    def my_function():
+        pass
+
+    with pytest.raises(Tidy3dImportError) as exc_info:
+        my_function()
+
+    # TODO assert here
+
+
+def test_verify_packages_import_either_required():
+    @verify_packages_import(["tidy3d", "module2"], required="either")
+    def my_function():
+        pass
+
+    # When at least one module is imported, it should not raise an error
+    my_function()
+
+    @verify_packages_import(["module2", "module3"], required="either")
+    def my_function2():
+        pass
+
+    with pytest.raises(Tidy3dImportError) as exc_info:
+        my_function2()
+
+    # TODO assert here
+
+
+def test_check_import():
+    # Mock the check_import function to use the mock_check_import function
+    import sys
+
+    sys.modules["tidy3d"].check_import = mock_check_import
+
+    assert mock_check_import("tidy3d") == True
+    assert mock_check_import("module2") == False
+
+
+if __name__ == "__main__":
+    pytest.main()

--- a/tests/test_data/_test_datasets_no_vtk.py
+++ b/tests/test_data/_test_datasets_no_vtk.py
@@ -22,7 +22,7 @@ def test_triangular_dataset_no_vtk(tmp_path):
     _test_triangular_dataset(tmp_path, "test_name")
 
     # double check that vtk was not imported
-    from tidy3d.components.types import vtk
+    from tidy3d.packaging import vtk
 
     assert vtk["mod"] is None
 
@@ -32,6 +32,6 @@ def test_tetrahedral_dataset_no_vtk(tmp_path):
     _test_tetrahedral_dataset(tmp_path, "test_name")
 
     # double check that vtk was not imported
-    from tidy3d.components.types import vtk
+    from tidy3d.packaging import vtk
 
     assert vtk["mod"] is None

--- a/tests/test_data/test_datasets.py
+++ b/tests/test_data/test_datasets.py
@@ -11,7 +11,7 @@ np.random.seed(4)
 @pytest.mark.parametrize("ds_name", ["test123", None])
 def test_triangular_dataset(tmp_path, ds_name):
     import tidy3d as td
-    from tidy3d.components.types import vtk
+    from tidy3d.packaging import vtk
     from tidy3d.exceptions import DataError, Tidy3dImportError
 
     # basic create
@@ -258,7 +258,7 @@ def test_triangular_dataset(tmp_path, ds_name):
 @pytest.mark.parametrize("ds_name", ["test123", None])
 def test_tetrahedral_dataset(tmp_path, ds_name):
     import tidy3d as td
-    from tidy3d.components.types import vtk
+    from tidy3d.packaging import vtk
     from tidy3d.exceptions import DataError, Tidy3dImportError
 
     # basic create

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -22,7 +22,7 @@ from ..viz import equal_aspect, add_ax_if_none, plot_params_grid
 from ..base import Tidy3dBaseModel, cached_property
 from ..base import skip_if_fields_missing
 from ..types import Axis, Bound, ArrayLike, Ax, Coordinate, Literal
-from ..types import vtk, requires_vtk
+from ...packaging import vtk, requires_vtk
 from ...exceptions import DataError, ValidationError, Tidy3dNotImplementedError
 from ...constants import PICOSECOND_PER_NANOMETER_PER_KILOMETER
 from ...log import log

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -16,7 +16,7 @@ from matplotlib import patches
 from ..base import Tidy3dBaseModel, cached_property
 from ..types import Ax, Axis, PlanePosition, Shapely, ClipOperationType, annotate_type
 from ..types import Bound, Size, Coordinate, Coordinate2D
-from ..types import ArrayFloat2D, ArrayFloat3D, MatrixReal4x4, trimesh
+from ..types import ArrayFloat2D, ArrayFloat3D, MatrixReal4x4
 from ..viz import add_ax_if_none, equal_aspect, PLOT_BUFFER, ARROW_LENGTH
 from ..viz import PlotParams, plot_params_geometry, polygon_patch, arrow_style
 from ..transformation import RotationAroundAxis
@@ -24,37 +24,10 @@ from ...log import log
 from ...exceptions import SetupError, ValidationError
 from ...exceptions import Tidy3dKeyError, Tidy3dError, Tidy3dImportError
 from ...constants import MICROMETER, LARGE_NUMBER, RADIAN, inf, fp_eps
-
-try:
-    gdstk_available = True
-    import gdstk
-except ImportError:
-    gdstk_available = False
-
-try:
-    gdspy_available = True
-    import gdspy
-except ImportError:
-    gdspy_available = False
+from ...packaging import verify_packages_import
 
 
 POLY_GRID_SIZE = 1e-12
-
-
-def requires_trimesh(fn):
-    """When decorating a method, requires that trimesh is available."""
-
-    @functools.wraps(fn)
-    def _fn(*args, **kwargs):
-        if trimesh is None:
-            raise Tidy3dImportError(
-                "The package 'trimesh' is required for this operation, but it was not found. "
-                "Please install the 'trimesh' dependencies using, for example, "
-                "'pip install -r requirements/trimesh.txt'."
-            )
-        return fn(*args, **kwargs)
-
-    return _fn
 
 
 _shapely_operations = {
@@ -956,6 +929,7 @@ class Geometry(Tidy3dBaseModel, ABC):
         return theta, phi
 
     @staticmethod
+    @verify_packages_import(["gdstk", "gdspy"], required="either")
     def load_gds_vertices_gdstk(
         gds_cell, gds_layer: int, gds_dtype: int = None, gds_scale: pydantic.PositiveFloat = 1.0
     ) -> List[ArrayFloat2D]:
@@ -1004,6 +978,7 @@ class Geometry(Tidy3dBaseModel, ABC):
         return all_vertices
 
     @staticmethod
+    @verify_packages_import(["gdstk", "gdspy"], required="either")
     def load_gds_vertices_gdspy(
         gds_cell, gds_layer: int, gds_dtype: int = None, gds_scale: pydantic.PositiveFloat = 1.0
     ) -> List[ArrayFloat2D]:
@@ -1046,6 +1021,7 @@ class Geometry(Tidy3dBaseModel, ABC):
         return all_vertices
 
     @staticmethod
+    @verify_packages_import(["gdstk", "gdspy"], required="either")
     def from_gds(
         gds_cell,
         axis: Axis,
@@ -1091,23 +1067,30 @@ class Geometry(Tidy3dBaseModel, ABC):
         :class:`Geometry`
             Geometries created from the 2D data.
         """
+        try:
+            import gdstk
 
-        if gdstk_available and isinstance(gds_cell, gdstk.Cell):
-            gds_loader_fn = Geometry.load_gds_vertices_gdstk
-        elif gdspy_available and isinstance(gds_cell, gdspy.Cell):
-            gds_loader_fn = Geometry.load_gds_vertices_gdspy
-        elif "gdstk" in gds_cell.__class__ and not gdstk_available:
-            raise Tidy3dImportError(
-                "Module 'gdstk' not found. It is required to import gdstk cells."
-            )
-        elif "gdspy" in gds_cell.__class__ and not gdspy_available:
-            raise Tidy3dImportError(
-                "Module 'gdspy' not found. It is required to import to gdspy cells."
-            )
-        else:
-            raise Tidy3dError(
-                "Argument 'gds_cell' must be an instance of 'gdstk.Cell' or 'gdspy.Cell'."
-            )
+            if isinstance(gds_cell, gdstk.Cell):
+                gds_loader_fn = Geometry.load_gds_vertices_gdstk
+            else:
+                raise Tidy3dError(
+                    "Argument 'gds_cell' must be an instance of 'gdstk.Cell' or 'gdspy.Cell'."
+                )
+        except ImportError:
+            try:
+                import gdspy
+
+                if isinstance(gds_cell, gdspy.Cell):
+                    gds_loader_fn = Geometry.load_gds_vertices_gdspy
+                else:
+                    raise Tidy3dError(
+                        "Argument 'gds_cell' must be an instance of 'gdstk.Cell' or 'gdspy.Cell'."
+                    )
+            except ImportError:
+                raise Tidy3dImportError(
+                    "Python modules 'gdspy' and 'gdstk' not found. To export geometries to .gds "
+                    "files, please install one of those those modules."
+                )
 
         geometries = []
         with log as consolidated_logger:
@@ -1165,6 +1148,7 @@ class Geometry(Tidy3dBaseModel, ABC):
         """
         return from_shapely(shape, axis, slab_bounds, dilation, sidewall_angle, reference_plane)
 
+    @verify_packages_import(["gdstk"])
     def to_gdstk(
         self,
         x: float = None,
@@ -1193,11 +1177,7 @@ class Geometry(Tidy3dBaseModel, ABC):
         List
             List of `gdstk.Polygon`.
         """
-        if not gdstk_available:
-            raise Tidy3dImportError(
-                "Python module 'gdstk' not found. Install the module to be able to export shapes "
-                "using it."
-            )
+        import gdstk
 
         shapes = self.intersections_plane(x=x, y=y, z=z)
         polygons = []
@@ -1217,6 +1197,7 @@ class Geometry(Tidy3dBaseModel, ABC):
                     )
         return polygons
 
+    @verify_packages_import(["gdspy"])
     def to_gdspy(
         self,
         x: float = None,
@@ -1245,11 +1226,7 @@ class Geometry(Tidy3dBaseModel, ABC):
         List
             List of `gdspy.Polygon` and `gdspy.PolygonSet`.
         """
-        if not gdspy_available:
-            raise Tidy3dImportError(
-                "Python module 'gdspy' not found. Install the module to be able to export shapes "
-                "using it."
-            )
+        import gdspy
 
         shapes = self.intersections_plane(x=x, y=y, z=z)
         polygons = []
@@ -1269,6 +1246,7 @@ class Geometry(Tidy3dBaseModel, ABC):
                     )
         return polygons
 
+    @verify_packages_import(["gdstk", "gdspy"], required="either")
     def to_gds(
         self,
         cell,
@@ -1295,29 +1273,34 @@ class Geometry(Tidy3dBaseModel, ABC):
         gds_dtype : int = 0
             Data-type index to use for the shapes stored in the .gds file.
         """
-        if gdstk_available and isinstance(cell, gdstk.Cell):
-            polygons = self.to_gdstk(x=x, y=y, z=z, gds_layer=gds_layer, gds_dtype=gds_dtype)
-            if len(polygons) > 0:
-                cell.add(*polygons)
+        try:
+            import gdstk
 
-        elif gdspy_available and isinstance(cell, gdspy.Cell):
-            polygons = self.to_gdspy(x=x, y=y, z=z, gds_layer=gds_layer, gds_dtype=gds_dtype)
-            if len(polygons) > 0:
-                cell.add(polygons)
+            if isinstance(cell, gdstk.Cell):
+                polygons = self.to_gdstk(x=x, y=y, z=z, gds_layer=gds_layer, gds_dtype=gds_dtype)
+                if len(polygons) > 0:
+                    cell.add(*polygons)
+        except ImportError:
+            try:
+                import gdspy
 
-        elif "gdstk" in cell.__class__ and not gdstk_available:
-            raise Tidy3dImportError(
-                "Module 'gdstk' not found. It is required to export shapes to gdstk cells."
-            )
-        elif "gdspy" in cell.__class__ and not gdspy_available:
-            raise Tidy3dImportError(
-                "Module 'gdspy' not found. It is required to export shapes to gdspy cells."
-            )
-        else:
-            raise Tidy3dError(
-                "Argument 'cell' must be an instance of 'gdstk.Cell' or 'gdspy.Cell'."
-            )
+                if isinstance(cell, gdspy.Cell):
+                    polygons = self.to_gdspy(
+                        x=x, y=y, z=z, gds_layer=gds_layer, gds_dtype=gds_dtype
+                    )
+                    if len(polygons) > 0:
+                        cell.add(polygons)
+                else:
+                    raise Tidy3dError(
+                        "Argument 'cell' must be an instance of 'gdstk.Cell' or 'gdspy.Cell'."
+                    )
+            except ImportError:
+                raise Tidy3dImportError(
+                    "Either 'gdstk' or 'gdspy' must be installed to export geometries to .gds files. "
+                    "Try `pip install tidy3d[gdstk]` or `pip install tidy3d[gdspy]"
+                )
 
+    @verify_packages_import(["gdstk", "gdspy"], required="either")
     def to_gds_file(
         self,
         fname: str,
@@ -1347,15 +1330,23 @@ class Geometry(Tidy3dBaseModel, ABC):
         gds_cell_name : str = 'MAIN'
             Name of the cell created in the .gds file to store the geometry.
         """
-        if gdstk_available:
+
+        # Fundamental import structure for custom commands depending on which package is available.
+        try:
+            import gdstk
+
             library = gdstk.Library()
-        elif gdspy_available:
-            library = gdspy.GdsLibrary()
-        else:
-            raise Tidy3dImportError(
-                "Python modules 'gdspy' and 'gdstk' not found. To export geometries to .gds "
-                "files, please install one of those those modules."
-            )
+        except ImportError:
+            try:
+                import gdspy
+
+                library = gdspy.GdsLibrary()
+            except ImportError:
+                raise Tidy3dImportError(
+                    "Python modules 'gdspy' and 'gdstk' not found. To export geometries to .gds "
+                    "files, please install one of those those modules."
+                )
+
         cell = library.new_cell(gds_cell_name)
         self.to_gds(cell, x=x, y=y, z=z, gds_layer=gds_layer, gds_dtype=gds_dtype)
         library.write_gds(fname)
@@ -1809,7 +1800,7 @@ class Box(Centered):
             surfaces = [surf for surf in surfaces if surf.name[-2:] not in exclude_surfaces]
         return surfaces
 
-    @requires_trimesh
+    @verify_packages_import(["trimesh"])
     def intersections_tilted_plane(
         self, normal: Coordinate, origin: Coordinate, to_2D: MatrixReal4x4
     ) -> List[Shapely]:
@@ -1831,6 +1822,8 @@ class Box(Centered):
             For more details refer to
             `Shapely's Documentaton <https://shapely.readthedocs.io/en/stable/project.html>`_.
         """
+        import trimesh
+
         (x0, y0, z0), (x1, y1, z1) = self.bounds
         vertices = [
             (x0, y0, z0),  # 0

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -13,10 +13,11 @@ from matplotlib import path
 from ..base import cached_property
 from ..base import skip_if_fields_missing
 from ..types import Axis, Bound, PlanePosition, ArrayFloat2D, Coordinate
-from ..types import MatrixReal4x4, Shapely, trimesh
+from ..types import MatrixReal4x4, Shapely
 from ...log import log
 from ...exceptions import SetupError, ValidationError
 from ...constants import MICROMETER, fp_eps
+from ...packaging import verify_packages_import
 
 from . import base
 from . import triangulation
@@ -525,7 +526,7 @@ class PolySlab(base.Planar):
             inside_polygon = face_polygon.covers(point)
         return inside_height * inside_polygon
 
-    @base.requires_trimesh
+    @verify_packages_import(["trimesh"])
     def intersections_tilted_plane(
         self, normal: Coordinate, origin: Coordinate, to_2D: MatrixReal4x4
     ) -> List[Shapely]:
@@ -547,6 +548,8 @@ class PolySlab(base.Planar):
             For more details refer to
             `Shapely's Documentaton <https://shapely.readthedocs.io/en/stable/project.html>`_.
         """
+        import trimesh
+
         if len(self.base_polygon) > _MAX_POLYSLAB_VERTICES_FOR_TRIANGULATION:
             log.warning(
                 "Processing of PolySlabs with large numbers of vertices can be slow.", log_once=True

--- a/tidy3d/components/geometry/primitives.py
+++ b/tidy3d/components/geometry/primitives.py
@@ -9,10 +9,10 @@ import numpy as np
 import shapely
 
 from ..base import cached_property, skip_if_fields_missing
-from ..types import Axis, Bound, Coordinate, MatrixReal4x4, Shapely, trimesh
+from ..types import Axis, Bound, Coordinate, MatrixReal4x4, Shapely
 from ...exceptions import SetupError, ValidationError
 from ...constants import MICROMETER, LARGE_NUMBER
-
+from ...packaging import verify_packages_import
 from . import base
 
 # for sampling conical frustum in visualization
@@ -224,7 +224,7 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
             raise ValidationError("'Medium2D' requires the 'Cylinder' length to be zero.")
         return self.axis
 
-    @base.requires_trimesh
+    @verify_packages_import(["trimesh"])
     def intersections_tilted_plane(
         self, normal: Coordinate, origin: Coordinate, to_2D: MatrixReal4x4
     ) -> List[Shapely]:
@@ -246,6 +246,8 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
             For more details refer to
             `Shapely's Documentaton <https://shapely.readthedocs.io/en/stable/project.html>`_.
         """
+        import trimesh
+
         z0, (x0, y0) = self.pop_axis(self.center, self.axis)
 
         angles = np.linspace(0, 2 * np.pi, _N_SHAPELY_QUAD_SEGS * 4 + 1)[:-1]

--- a/tidy3d/components/types.py
+++ b/tidy3d/components/types.py
@@ -1,7 +1,7 @@
 """ Defines 'types' that various fields can be """
 
-from typing import Tuple, Union, Any
-import functools
+from typing import Tuple, Union
+
 
 # Literal only available in python 3.8 + so try import otherwise use extensions
 try:
@@ -14,56 +14,7 @@ import pydantic.v1 as pydantic
 import numpy as np
 from matplotlib.axes import Axes
 from shapely.geometry.base import BaseGeometry
-from ..exceptions import ValidationError, Tidy3dImportError
-
-
-try:
-    import trimesh
-except ImportError:
-    trimesh = None
-
-vtk = {
-    "mod": None,
-    "id_type": np.int64,
-    "vtk_to_numpy": None,
-    "numpy_to_vtkIdTypeArray": None,
-    "numpy_to_vtk": None,
-}
-
-
-def requires_vtk(fn):
-    """When decorating a method, requires that vtk is available."""
-
-    @functools.wraps(fn)
-    def _fn(*args, **kwargs):
-        if vtk["mod"] is None:
-            try:
-                import vtk as vtk_mod
-                from vtk.util.numpy_support import vtk_to_numpy, numpy_to_vtk
-                from vtk.util.numpy_support import numpy_to_vtkIdTypeArray
-                from vtkmodules.vtkCommonCore import vtkLogger
-
-                vtk["mod"] = vtk_mod
-                vtk["vtk_to_numpy"] = vtk_to_numpy
-                vtk["numpy_to_vtkIdTypeArray"] = numpy_to_vtkIdTypeArray
-                vtk["numpy_to_vtk"] = numpy_to_vtk
-
-                vtkLogger.SetStderrVerbosity(vtkLogger.VERBOSITY_WARNING)
-
-                if vtk["mod"].vtkIdTypeArray().GetDataTypeSize() == 4:
-                    vtk["id_type"] = np.int32
-
-            except ImportError:
-                raise Tidy3dImportError(
-                    "The package 'vtk' is required for this operation, but it was not found. "
-                    "Please install the 'vtk' dependencies using, for example, "
-                    "'pip install -r requirements/vtk.txt'."
-                )
-
-        return fn(*args, **kwargs)
-
-    return _fn
-
+from ..exceptions import ValidationError
 
 # type tag default name
 TYPE_TAG_STR = "type"
@@ -245,7 +196,7 @@ Shapely = BaseGeometry
 PlanePosition = Literal["bottom", "middle", "top"]
 ClipOperationType = Literal["union", "intersection", "difference", "symmetric_difference"]
 BoxSurface = Literal["x-", "x+", "y-", "y+", "z-", "z+"]
-TrimeshType = Any if trimesh is None else trimesh.Trimesh
+
 
 """ medium """
 

--- a/tidy3d/components/types_extra.py
+++ b/tidy3d/components/types_extra.py
@@ -1,0 +1,11 @@
+from typing import Any
+from ..packaging import check_import
+
+# TODO Complicated as trimesh should be a core package unless decoupled implementation types in functional location.
+#  We need to restructure.
+if check_import("trimesh"):
+    import trimesh  # Won't add much overhead if already imported
+
+    TrimeshType = trimesh.Trimesh
+else:
+    TrimeshType = Any

--- a/tidy3d/packaging.py
+++ b/tidy3d/packaging.py
@@ -1,0 +1,148 @@
+"""
+This file contains a set of functions relating to packaging tidy3d for distribution. Sections of the codebase should depend on this file, but this file should not depend on any other part of the codebase.
+
+This section should only depend on the standard core installation in the pyproject.toml, and should not depend on any other part of the codebase optional imports.
+"""
+import functools
+import numpy as np
+from typing import Literal
+
+from .exceptions import Tidy3dImportError
+
+vtk = {
+    "mod": None,
+    "id_type": np.int64,
+    "vtk_to_numpy": None,
+    "numpy_to_vtkIdTypeArray": None,
+    "numpy_to_vtk": None,
+}
+
+
+def check_import(module_name: str) -> bool:
+    """
+    Check if a module or submodule section has been imported. This is a functional way of loading packages that will still load the corresponding module into the total space.
+
+    Parameters
+    ----------
+    module_name
+
+    Returns
+    -------
+    bool
+        True if the module has been imported, False otherwise.
+
+    """
+    try:
+        __import__(module_name)
+        return True
+    except ImportError:
+        return False
+
+
+def verify_packages_import(modules: list, required: Literal["either", "all"] = "all"):
+    def decorator(func):
+        """
+        When decorating a method, requires that the specified modules are available. It will raise an error if the
+        module is not available depending on the value of the 'required' parameter which represents the type of
+        import required.
+
+        There are a few options to choose for the 'required' parameter:
+        - 'all': All the modules must be available for the operation to continue without raising an error
+        - 'either': At least one of the modules must be available for the operation to continue without raising an error
+
+        Parameters
+        ----------
+        func
+            The function to decorate.
+
+        Returns
+        -------
+        checks_modules_import
+            The decorated function.
+
+        """
+
+        def checks_modules_import(*args, **kwargs):
+            """
+            Checks if the modules are available. If they are not available, it will raise an error depending on the value.
+            """
+            available_modules_status = []
+            maximum_amount_modules = len(modules)
+
+            module_id_i = 0
+            for module in modules:
+                # Starts counting from one so that it can be compared to len(modules)
+                module_id_i += 1
+                import_available = check_import(module)
+                available_modules_status.append(
+                    import_available
+                )  # Stores the status of the module import
+
+                if not import_available:
+                    if required == "all":
+                        raise Tidy3dImportError(
+                            f"The package '{module}' is required for this operation, but it was not found. "
+                            f"Please install the '{module}' dependencies using, for example, "
+                            f"'pip install tidy3d[<see_options_in_pyproject.toml>]"
+                        )
+                    elif required == "either":
+                        # Means we need to verify that at least one of the modules is available
+                        if any(available_modules_status):
+                            # Means that at least one of the modules is available, so we can just continue with the
+                            # operation
+                            pass
+                        else:
+                            if module_id_i == maximum_amount_modules:
+                                # Means that we have reached the last module and none of them were available
+                                raise Tidy3dImportError(
+                                    f"The package '{module}' is required for this operation, but it was not found. "
+                                    f"Please install the '{module}' dependencies using, for example, "
+                                    f"'pip install tidy3d[<see_options_in_pyproject.toml>]"
+                                )
+                    else:
+                        raise ValueError(
+                            f"The value '{required}' is not a valid value for the 'required' parameter. "
+                            f"Please use either 'all' or 'either'."
+                        )
+                else:
+                    # Means that the module is available, so we can just continue with the operation
+                    pass
+            return func(*args, **kwargs)
+
+        return checks_modules_import
+
+    return decorator
+
+
+def requires_vtk(fn):
+    """When decorating a method, requires that vtk is available."""
+
+    @functools.wraps(fn)
+    def _fn(*args, **kwargs):
+        if vtk["mod"] is None:
+            try:
+                import vtk as vtk_mod
+                from vtk.util.numpy_support import vtk_to_numpy, numpy_to_vtk
+                from vtk.util.numpy_support import numpy_to_vtkIdTypeArray
+                from vtkmodules.vtkCommonCore import vtkLogger
+
+                vtk["mod"] = vtk_mod
+                vtk["vtk_to_numpy"] = vtk_to_numpy
+                vtk["numpy_to_vtkIdTypeArray"] = numpy_to_vtkIdTypeArray
+                vtk["numpy_to_vtk"] = numpy_to_vtk
+
+                vtkLogger.SetStderrVerbosity(vtkLogger.VERBOSITY_WARNING)
+
+                if vtk["mod"].vtkIdTypeArray().GetDataTypeSize() == 4:
+                    vtk["id_type"] = np.int32
+
+            except ImportError:
+                raise Tidy3dImportError(
+                    "The package 'vtk' is required for this operation, but it was not found. "
+                    "Please install the 'vtk' dependencies using, for example, "
+                    "'pip install .[vtk]'."
+                )
+
+        return fn(*args, **kwargs)
+
+    return _fn


### PR DESCRIPTION
So I've benchmarked this reproducibly and it's definitely faster than before, so maybe fixes some of the 2.5.1 issues. 

See further details of the benchmarking outputs in https://github.com/flexcompute/tidy3d/pull/1353 when I merged into my personal dario/test_refactor 2.6 branch to test this using the reproducible utility I created and we can use on our different hardwares.