### PR TITLE
Alec/mesh message

### DIFF
--- a/tidy3d/components/geometry/mesh.py
+++ b/tidy3d/components/geometry/mesh.py
@@ -59,7 +59,8 @@ class TriangleMesh(base.Geometry, ABC):
         if not all(np.array(mesh.area_faces) > fp_eps):
             raise ValidationError(
                 "The provided mesh has triangles with zero area. "
-                "Consider using 'trimesh.Trimesh.remove_degenerate_faces' to fix this."
+                "Consider using numpy-stl's 'from_file' import with 'remove_empty_areas' set "
+                "to True and a suitable 'AREA_SIZE_THRESHOLD' to remove them."
             )
         if not mesh.is_winding_consistent:
             log.warning(


### PR DESCRIPTION
This is updating the error message when a mesh has triangles of zero area. I'd like to change the suggestion to a more up-to-date and potentially easier fix, described here: https://flow360.atlassian.net/browse/TID-421