### PR TITLE
Adding validate_pre_upload to AbstractSimulation

### DIFF
--- a/tidy3d/components/base_sim/simulation.py
+++ b/tidy3d/components/base_sim/simulation.py
@@ -230,6 +230,10 @@ class AbstractSimulation(Box, ABC):
         """Call validators taking z`self` that get run after init."""
         _ = self.scene
 
+    def validate_pre_upload(self) -> None:
+        """Validate the fully initialized simulation is ok for upload to our servers."""
+        pass
+
     """ Accounting """
 
     @cached_property


### PR DESCRIPTION
This is just for convenience so we can call it regardless of the simulation type.