### PR TITLE
Allow importing specific field from vtk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remote mode solver web api automatically reduces the associated `Simulation` object to the mode solver plane before uploading it to server.
 - All solver output is now compressed. However, it is automatically unpacked to the same `simulation_data.hdf5` by default when loading simulation data from the server.
 - Internal refactor of `adjoint` plugin to separate `jax`-traced fields from regular `tidy3d` fields.
-- Added argument `field` in class method `.from_vtu()` of `TriangularGridDataset` and `TetrahedralGridDataset` for specifying the name of data field to load.
+- Added an optional argument `field` in class method `.from_vtu()` of `TriangularGridDataset` and `TetrahedralGridDataset` for specifying the name of data field to load.
 
 ### Fixed
 - Removed spurious warnings realted to reloading simulation containing `PerturbationMedium` with `CustomChargePerturbation`/`CustomHeatPerturbation`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remote mode solver web api automatically reduces the associated `Simulation` object to the mode solver plane before uploading it to server.
 - All solver output is now compressed. However, it is automatically unpacked to the same `simulation_data.hdf5` by default when loading simulation data from the server.
 - Internal refactor of `adjoint` plugin to separate `jax`-traced fields from regular `tidy3d` fields.
+- Added argument `field` in class method `.from_vtu()` of `TriangularGridDataset` and `TetrahedralGridDataset` for specifying the name of data field to load.
 
 ### Fixed
+- Removed spurious warnings realted to reloading simulation containing `PerturbationMedium` with `CustomChargePerturbation`/`CustomHeatPerturbation`
 
 ## [2.5.1] - 2024-01-08
 

--- a/scripts/test_local.sh
+++ b/scripts/test_local.sh
@@ -5,5 +5,7 @@ black .
 ruff check tidy3d
 
 pytest -rA tests/
+# to test without vtk, one has to restart pytest
+pytest -rA tests/test_data/_test_datasets_no_vtk.py
 
 pytest --doctest-modules tidy3d/components

--- a/tests/test_data/_test_datasets_no_vtk.py
+++ b/tests/test_data/_test_datasets_no_vtk.py
@@ -19,19 +19,9 @@ def hide_vtk(monkeypatch, request):
 
 @pytest.mark.usefixtures("hide_vtk")
 def test_triangular_dataset_no_vtk(tmp_path):
-    _test_triangular_dataset(tmp_path, "test_name")
-
-    # double check that vtk was not imported
-    from tidy3d.components.types import vtk
-
-    assert vtk["mod"] is None
+    _test_triangular_dataset(tmp_path, "test_name", no_vtk=True)
 
 
 @pytest.mark.usefixtures("hide_vtk")
 def test_tetrahedral_dataset_no_vtk(tmp_path):
-    _test_tetrahedral_dataset(tmp_path, "test_name")
-
-    # double check that vtk was not imported
-    from tidy3d.components.types import vtk
-
-    assert vtk["mod"] is None
+    _test_tetrahedral_dataset(tmp_path, "test_name", no_vtk=True)

--- a/tests/test_data/test_datasets.py
+++ b/tests/test_data/test_datasets.py
@@ -119,6 +119,14 @@ def test_triangular_dataset(tmp_path, ds_name):
     assert tri_grid.bounds == ((0.0, 0.0, 0.0), (1.0, 0.0, 1.0))
     assert np.all(tri_grid._vtk_offsets == np.array([0, 3, 6]))
 
+    # since vtk is attempted to be imported during a dependent function call
+    # let's call one of those so that vtk dict is properly populated
+    try:
+        _ = tri_grid._vtk_cells
+        print("Testing with 'vtk'.")
+    except Tidy3dImportError:
+        print("Testing without 'vtk'.")
+
     if vtk["mod"] is None:
         with pytest.raises(Tidy3dImportError):
             _ = tri_grid._vtk_cells
@@ -240,9 +248,23 @@ def test_triangular_dataset(tmp_path, ds_name):
             tri_grid_loaded = td.TriangularGridDataset.from_vtu(tmp_path / "tri_grid_test.vtu")
     else:
         tri_grid.to_vtu(tmp_path / "tri_grid_test.vtu")
-        tri_grid_loaded = td.TriangularGridDataset.from_vtu(tmp_path / "tri_grid_test.vtu")
 
+        tri_grid_loaded = td.TriangularGridDataset.from_vtu(tmp_path / "tri_grid_test.vtu")
         assert tri_grid == tri_grid_loaded
+
+        custom_name = "newname"
+        tri_grid_renamed = tri_grid.rename(custom_name)
+        tri_grid_renamed.to_vtu(tmp_path / "tri_grid_test.vtu")
+
+        tri_grid_loaded = td.TriangularGridDataset.from_vtu(
+            tmp_path / "tri_grid_test.vtu", field=custom_name
+        )
+        assert tri_grid == tri_grid_loaded
+
+        with pytest.raises(Exception):
+            tri_grid_loaded = td.TriangularGridDataset.from_vtu(
+                tmp_path / "tri_grid_test.vtu", field=custom_name + "blah"
+            )
 
     # test ariphmetic operations
     def operation(arr):
@@ -352,6 +374,14 @@ def test_tetrahedral_dataset(tmp_path, ds_name):
     assert np.all(tet_grid._vtk_offsets == np.array([0, 4, 8]))
     assert tet_grid.name == ds_name
 
+    # since vtk is attempted to be imported during a dependent function call
+    # let's call one of those so that vtk dict is properly populated
+    try:
+        _ = tet_grid._vtk_cells
+        print("Testing with 'vtk'.")
+    except Tidy3dImportError:
+        print("Testing without 'vtk'.")
+
     if vtk["mod"] is None:
         with pytest.raises(Tidy3dImportError):
             _ = tet_grid._vtk_cells
@@ -429,6 +459,20 @@ def test_tetrahedral_dataset(tmp_path, ds_name):
         tet_grid_loaded = td.TetrahedralGridDataset.from_vtu(tmp_path / "tet_grid_test.vtu")
 
         assert tet_grid == tet_grid_loaded
+
+        custom_name = "newname"
+        tet_grid_renamed = tet_grid.rename(custom_name)
+        tet_grid_renamed.to_vtu(tmp_path / "tet_grid_test.vtu")
+
+        tet_grid_loaded = td.TetrahedralGridDataset.from_vtu(
+            tmp_path / "tet_grid_test.vtu", field=custom_name
+        )
+        assert tet_grid == tet_grid_loaded
+
+        with pytest.raises(Exception):
+            tet_grid_loaded = td.TetrahedralGridDataset.from_vtu(
+                tmp_path / "tet_grid_test.vtu", field=custom_name + "blah"
+            )
 
     # test ariphmetic operations
     def operation(arr):

--- a/tests/test_data/test_datasets.py
+++ b/tests/test_data/test_datasets.py
@@ -9,9 +9,8 @@ np.random.seed(4)
 
 
 @pytest.mark.parametrize("ds_name", ["test123", None])
-def test_triangular_dataset(tmp_path, ds_name):
+def test_triangular_dataset(tmp_path, ds_name, no_vtk=False):
     import tidy3d as td
-    from tidy3d.components.types import vtk
     from tidy3d.exceptions import DataError, Tidy3dImportError
 
     # basic create
@@ -119,15 +118,7 @@ def test_triangular_dataset(tmp_path, ds_name):
     assert tri_grid.bounds == ((0.0, 0.0, 0.0), (1.0, 0.0, 1.0))
     assert np.all(tri_grid._vtk_offsets == np.array([0, 3, 6]))
 
-    # since vtk is attempted to be imported during a dependent function call
-    # let's call one of those so that vtk dict is properly populated
-    try:
-        _ = tri_grid._vtk_cells
-        print("Testing with 'vtk'.")
-    except Tidy3dImportError:
-        print("Testing without 'vtk'.")
-
-    if vtk["mod"] is None:
+    if no_vtk:
         with pytest.raises(Tidy3dImportError):
             _ = tri_grid._vtk_cells
         with pytest.raises(Tidy3dImportError):
@@ -140,7 +131,7 @@ def test_triangular_dataset(tmp_path, ds_name):
         _ = tri_grid._vtk_obj
 
     # plane slicing
-    if vtk["mod"] is None:
+    if no_vtk:
         with pytest.raises(Tidy3dImportError):
             _ = tri_grid.plane_slice(axis=2, pos=0.5)
     else:
@@ -157,7 +148,7 @@ def test_triangular_dataset(tmp_path, ds_name):
             _ = tri_grid.plane_slice(axis=0, pos=2)
 
     # clipping by a box
-    if vtk["mod"] is None:
+    if no_vtk:
         with pytest.raises(Tidy3dImportError):
             _ = tri_grid.box_clip([[0.1, -0.2, 0.1], [0.2, 0.2, 0.9]])
     else:
@@ -169,7 +160,7 @@ def test_triangular_dataset(tmp_path, ds_name):
             _ = tri_grid.box_clip([[0.1, 0.1, 0.3], [0.2, 0.2, 0.9]])
 
     # interpolation
-    if vtk["mod"] is None:
+    if no_vtk:
         with pytest.raises(Tidy3dImportError):
             invariant = tri_grid.interp(
                 x=0.4, y=[0, 1], z=np.linspace(0.2, 0.6, 10), fill_value=-333
@@ -227,7 +218,7 @@ def test_triangular_dataset(tmp_path, ds_name):
         _ = tri_grid.plot(field=False, grid=False)
 
     # generalized selection method
-    if vtk["mod"] is None:
+    if no_vtk:
         with pytest.raises(Tidy3dImportError):
             _ = tri_grid.sel(x=0.2)
     else:
@@ -241,7 +232,7 @@ def test_triangular_dataset(tmp_path, ds_name):
             _ = tri_grid.sel(x=np.linspace(0, 1, 3), y=1.2, z=[0.3, 0.4, 0.5])
 
     # writing/reading .vtu
-    if vtk["mod"] is None:
+    if no_vtk:
         with pytest.raises(Tidy3dImportError):
             tri_grid.to_vtu(tmp_path / "tri_grid_test.vtu")
         with pytest.raises(Tidy3dImportError):
@@ -278,9 +269,8 @@ def test_triangular_dataset(tmp_path, ds_name):
 
 
 @pytest.mark.parametrize("ds_name", ["test123", None])
-def test_tetrahedral_dataset(tmp_path, ds_name):
+def test_tetrahedral_dataset(tmp_path, ds_name, no_vtk=False):
     import tidy3d as td
-    from tidy3d.components.types import vtk
     from tidy3d.exceptions import DataError, Tidy3dImportError
 
     # basic create
@@ -374,15 +364,7 @@ def test_tetrahedral_dataset(tmp_path, ds_name):
     assert np.all(tet_grid._vtk_offsets == np.array([0, 4, 8]))
     assert tet_grid.name == ds_name
 
-    # since vtk is attempted to be imported during a dependent function call
-    # let's call one of those so that vtk dict is properly populated
-    try:
-        _ = tet_grid._vtk_cells
-        print("Testing with 'vtk'.")
-    except Tidy3dImportError:
-        print("Testing without 'vtk'.")
-
-    if vtk["mod"] is None:
+    if no_vtk:
         with pytest.raises(Tidy3dImportError):
             _ = tet_grid._vtk_cells
         with pytest.raises(Tidy3dImportError):
@@ -395,7 +377,7 @@ def test_tetrahedral_dataset(tmp_path, ds_name):
         _ = tet_grid._vtk_obj
 
     # plane slicing
-    if vtk["mod"] is None:
+    if no_vtk:
         with pytest.raises(Tidy3dImportError):
             _ = tet_grid.plane_slice(axis=2, pos=0.5)
     else:
@@ -407,7 +389,7 @@ def test_tetrahedral_dataset(tmp_path, ds_name):
             _ = tet_grid.plane_slice(axis=1, pos=2)
 
     # clipping by a box
-    if vtk["mod"] is None:
+    if no_vtk:
         with pytest.raises(Tidy3dImportError):
             _ = tet_grid.box_clip([[0.1, -0.2, 0.1], [0.2, 0.2, 0.9]])
     else:
@@ -419,7 +401,7 @@ def test_tetrahedral_dataset(tmp_path, ds_name):
             _ = tet_grid.box_clip([[0.1, 1.1, 0.3], [0.2, 1.2, 0.9]])
 
     # interpolation
-    if vtk["mod"] is None:
+    if no_vtk:
         with pytest.raises(Tidy3dImportError):
             _ = tet_grid.interp(x=0.4, y=[0, 1], z=np.linspace(0.2, 0.6, 10), fill_value=-333)
     else:
@@ -435,7 +417,7 @@ def test_tetrahedral_dataset(tmp_path, ds_name):
         assert no_intersection.name == ds_name
 
     # generalized selection method
-    if vtk["mod"] is None:
+    if no_vtk:
         with pytest.raises(Tidy3dImportError):
             _ = tet_grid.sel(x=0.2)
     else:
@@ -449,7 +431,7 @@ def test_tetrahedral_dataset(tmp_path, ds_name):
             _ = tet_grid.sel(x=0.2, z=[0.3, 0.4, 0.5])
 
     # writing/reading .vtu
-    if vtk["mod"] is None:
+    if no_vtk:
         with pytest.raises(Tidy3dImportError):
             tet_grid.to_vtu(tmp_path / "tet_grid_test.vtu")
         with pytest.raises(Tidy3dImportError):

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -789,7 +789,7 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
         ----------
         fname : str
             Full path to the .vtu file to load the unstructured data from.
-        field : str
+        field : str = None
             Name of the field to load.
 
         Returns

--- a/tidy3d/components/parameter_perturbation.py
+++ b/tidy3d/components/parameter_perturbation.py
@@ -311,12 +311,6 @@ class CustomHeatPerturbation(HeatPerturbation):
     @pd.root_validator(skip_on_failure=True)
     def compute_temperature_range(cls, values):
         """Compute and set temperature range based on provided ``perturbation_values``."""
-        if values["temperature_range"] is not None:
-            log.warning(
-                "Temperature range for 'CustomHeatPerturbation' is calculated automatically "
-                "based on provided 'perturbation_values'. Provided 'temperature_range' will be "
-                "overwritten."
-            )
 
         perturbation_values = values["perturbation_values"]
 
@@ -325,6 +319,16 @@ class CustomHeatPerturbation(HeatPerturbation):
             np.min(perturbation_values.coords["T"]).item(),
             np.max(perturbation_values.coords["T"]).item(),
         )
+
+        if (
+            values["temperature_range"] is not None
+            and values["temperature_range"] != temperature_range
+        ):
+            log.warning(
+                "Temperature range for 'CustomHeatPerturbation' is calculated automatically "
+                "based on provided 'perturbation_values'. Provided 'temperature_range' will be "
+                "overwritten."
+            )
 
         values.update({"temperature_range": temperature_range})
 
@@ -740,19 +744,6 @@ class CustomChargePerturbation(ChargePerturbation):
         """Compute and set electron and hole density ranges based on provided
         ``perturbation_values``.
         """
-        if values["electron_range"] is not None:
-            log.warning(
-                "Electron density range for 'CustomChargePerturbation' is calculated automatically "
-                "based on provided 'perturbation_values'. Provided 'electron_range' will be "
-                "overwritten."
-            )
-
-        if values["hole_range"] is not None:
-            log.warning(
-                "Hole density range for 'CustomChargePerturbation' is calculated automatically "
-                "based on provided 'perturbation_values'. Provided 'hole_range' will be "
-                "overwritten."
-            )
 
         perturbation_values = values["perturbation_values"]
 
@@ -765,6 +756,20 @@ class CustomChargePerturbation(ChargePerturbation):
             np.min(perturbation_values.coords["p"]).item(),
             np.max(perturbation_values.coords["p"]).item(),
         )
+
+        if values["electron_range"] is not None and electron_range != values["electron_range"]:
+            log.warning(
+                "Electron density range for 'CustomChargePerturbation' is calculated automatically "
+                "based on provided 'perturbation_values'. Provided 'electron_range' will be "
+                "overwritten."
+            )
+
+        if values["hole_range"] is not None and hole_range != values["hole_range"]:
+            log.warning(
+                "Hole density range for 'CustomChargePerturbation' is calculated automatically "
+                "based on provided 'perturbation_values'. Provided 'hole_range' will be "
+                "overwritten."
+            )
 
         values.update({"electron_range": electron_range, "hole_range": hole_range})
 


### PR DESCRIPTION
A small PR that came out of working on the charge example https://github.com/flexcompute/tidy3d-notebooks/pull/25 and it does two things:
- allows importing data fields from `.vtu` files with specific names if such files contain multiple fields (e.g. "Electrons", "Holes", etc)
- removes spurious warnings when reloading simulations containing `PerturbationMedium` with `CustomChargePerturbation`/`CustomHeatPerturbation`