### PR TITLE
fix adjoint utils docstrings

### DIFF
--- a/tidy3d/plugins/adjoint/utils/filter.py
+++ b/tidy3d/plugins/adjoint/utils/filter.py
@@ -168,7 +168,7 @@ class BinaryProjector(Filter):
     ----
     .. math::
 
-        v_{min} + (v_{max} - v_{min})
+        v(x) = v_{min} + (v_{max} - v_{min})
         \\frac{\\mathrm{tanh}(\\beta \\eta) + \\mathrm{tanh}(\\beta (x - \\eta))}
         {\\mathrm{tanh}(\\beta \\eta) + \\mathrm{tanh}(\\beta (1 - \\eta))}
 

--- a/tidy3d/plugins/adjoint/utils/penalty.py
+++ b/tidy3d/plugins/adjoint/utils/penalty.py
@@ -26,7 +26,7 @@ class RadiusPenalty(Penalty):
     ----
     .. math::
 
-        p(r) = \\frac{exp(-\\mathrm{kappa}(r - r_{min}))}{1 + exp(-\\mathrm{kappa}(r - r_{min}))}
+        p(r) = \\frac{\\mathrm{exp}(-\\kappa(r - r_{min}))}{1 + \\mathrm{exp}(-\\kappa(r - r_{min}))}
 
     Note
     ----


### PR DESCRIPTION
sorry for another PR / commit here.

I just compiled the docs locally and noticed a couple things in the docstrings to improve.

Now they look like below and should be ok.

<img width="816" alt="image" src="https://github.com/flexcompute/tidy3d/assets/92756888/4defd8a3-6ef9-4da5-9abb-5a96396830b8">

<img width="815" alt="image" src="https://github.com/flexcompute/tidy3d/assets/92756888/e1b1dd90-14ce-4302-8131-ef90f9a5460a">
