### PR TITLE
truly asyncronous task running via `web.run_fn_async`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Automatic subdivision of 2D materials with inhomogeneous substrate/superstrate.
 - Mode field profiles can be stored directly from a `ModeMonitor` by setting `store_fields_direction`.
+- `tidy3d.web.webapi_async.async_run` function uses `asyncio` to define an asynchronous run function that continues function execution while `await`-ing for tasks being monitored.
+- `tidy3d.plugins.design.Design.run_async(f)` that runs asynchronously over an asynchronous function `f` (using `td.web.async_run` internally).
 
 ### Changed
 - `DataArray.to_hdf5()` accepts both file handles and file paths.

--- a/tidy3d/plugins/design/design.py
+++ b/tidy3d/plugins/design/design.py
@@ -107,6 +107,11 @@ class DesignSpace(Tidy3dBaseModel):
         # package the result
         return self._package_run_results(fn_args=fn_args, fn_values=fn_values, fn_source=fn_source)
 
+    async def run_async(self, function: Callable, **kwargs) -> Result:
+        fn_args, fn_values = await self.method.run_async(parameters=self.parameters, fn=function)
+        fn_source = self.get_fn_source(function)
+        return self._package_run_results(fn_args=fn_args, fn_values=fn_values, fn_source=fn_source)
+
     @staticmethod
     def _make_batch_fn_source(fn_source_pre: str, fn_source_post: str) -> str:
         """How to make the full function source from the pre and post functions."""

--- a/tidy3d/web/__init__.py
+++ b/tidy3d/web/__init__.py
@@ -27,6 +27,8 @@ from .core import core_config
 from ..log import log, get_logging_console
 from ..version import __version__
 
+from .api.webapi_async import async_run
+
 migrate()
 
 core_config.set_config(log, get_logging_console(), __version__)
@@ -55,4 +57,6 @@ __all__ = [
     "configure",
     "run_async",
     "test",
+    "async_run",
+    "monitor_fn_async",
 ]

--- a/tidy3d/web/api/webapi_async.py
+++ b/tidy3d/web/api/webapi_async.py
@@ -1,0 +1,151 @@
+"""Provides lowest level, user-facing interface to server."""
+
+from typing import Callable
+import asyncio
+from functools import wraps, partial
+
+
+from .tidy3d_stub import SimulationType, SimulationDataType
+from .connect_util import wait_for_connection
+from ..core.environment import Env
+from .webapi import upload, start, load, monitor
+from ...log import log
+
+# time between checking run status
+RUN_REFRESH_TIME = 1.0
+REFRESH_TIME = 5.0
+
+# file names when uploading to S3
+SIM_FILE_JSON = "simulation.json"
+
+
+def _get_url(task_id: str) -> str:
+    """Get the URL for a task on our server."""
+    return f"{Env.current.website_endpoint}/workbench?taskId={task_id}"
+
+
+def to_async(func):
+    """Makes a function async."""
+
+    @wraps(func)
+    async def run(*args, loop=None, executor=None, **kwargs):
+        if loop is None:
+            loop = asyncio.get_event_loop()  # Make event loop of nothing exists
+        pfunc = partial(func, *args, **kwargs)  # Return function with variables (event) filled in
+        return await loop.run_in_executor(executor, pfunc)
+
+    return run
+
+
+@wait_for_connection
+async def async_run(
+    simulation: SimulationType,
+    task_name: str,
+    folder_name: str = "default",
+    path: str = "simulation_data.hdf5",
+    callback_url: str = None,
+    verbose: bool = False,
+    progress_callback_upload: Callable[[float], None] = None,
+    progress_callback_download: Callable[[float], None] = None,
+    solver_version: str = None,
+    worker_group: str = None,
+) -> SimulationDataType:
+    """
+    Submits a :class:`.Simulation` to server, starts running, monitors progress, downloads,
+    and loads results as a :class:`.SimulationDataType` object.
+
+    Parameters
+    ----------
+    simulation : Union[:class:`.Simulation`, :class:`.HeatSimulation`]
+        Simulation to upload to server.
+    task_name : str
+        Name of task.
+    folder_name : str = "default"
+        Name of folder to store task on web UI.
+    path : str = "simulation_data.hdf5"
+        Path to download results file (.hdf5), including filename.
+    callback_url : str = None
+        Http PUT url to receive simulation finish event. The body content is a json file with
+        fields ``{'id', 'status', 'name', 'workUnit', 'solverVersion'}``.
+    verbose : bool = False
+        Note: verbose must always be `False` otherwise the progressbars will crash.
+    progress_callback_upload : Callable[[float], None] = None
+        Optional callback function called when uploading file with ``bytes_in_chunk`` as argument.
+    progress_callback_download : Callable[[float], None] = None
+        Optional callback function called when downloading file with ``bytes_in_chunk`` as argument.
+    solver_version: str = None
+        target solver version.
+    worker_group: str = None
+        worker group
+
+    Returns
+    -------
+    Union[:class:`.SimulationData`, :class:`.HeatSimulationData`]
+        Object containing solver results for the supplied simulation.
+
+    Notes
+    -----
+
+        Submitting a simulation to our cloud server is very easily done by a simple web API call.
+
+        .. code-block:: python
+
+            sim_data = tidy3d.web.api.webapi.run(simulation, task_name='my_task', path='out/data.hdf5')
+
+        The :meth:`tidy3d.web.api.webapi.run()` method shows the simulation progress by default.  When uploading a
+        simulation to the server without running it, you can use the :meth:`tidy3d.web.api.webapi.monitor`,
+        :meth:`tidy3d.web.api.container.Job.monitor`, or :meth:`tidy3d.web.api.container.Batch.monitor` methods to
+        display the progress of your simulation(s).
+
+    Examples
+    --------
+
+        To access the original :class:`.Simulation` object that created the simulation data you can use:
+
+        .. code-block:: python
+
+            # Run the simulation.
+            sim_data = web.run(simulation, task_name='task_name', path='out/sim.hdf5')
+
+            # Get a copy of the original simulation object.
+            sim_copy = sim_data.simulation
+
+    See Also
+    --------
+
+    :meth:`tidy3d.web.api.webapi.monitor`
+        Print the real time task progress until completion.
+
+    :meth:`tidy3d.web.api.container.Job.monitor`
+        Monitor progress of running :class:`Job`.
+
+    :meth:`tidy3d.web.api.container.Batch.monitor`
+        Monitor progress of each of the running tasks.
+    """
+
+    if verbose is not False:
+        log.warning(
+            "'verbose' must be 'False' in the asynchronous run function as the progress bars are "
+            "not compatible with asynchronous execution. Setting 'verbose=False' internally. "
+        )
+        verbose = False
+
+    task_id = upload(
+        simulation=simulation,
+        task_name=task_name,
+        folder_name=folder_name,
+        callback_url=callback_url,
+        verbose=verbose,
+        progress_callback=progress_callback_upload,
+    )
+    start(
+        task_id,
+        solver_version=solver_version,
+        worker_group=worker_group,
+    )
+    log.info(f"Started asynchronous task with name '{task_name}'.")
+    await to_async(monitor)(task_id, verbose=verbose)
+    log.info(f"Finished asynchronous task with name '{task_name}'.")
+    return load(
+        task_id=task_id, path=path, verbose=verbose, progress_callback=progress_callback_download
+    )


### PR DESCRIPTION
Kind of an experimental feature, basically adds a `web.run()` that is compatible with [asyncio](https://realpython.com/async-io-python/). So users can write their own asynchronous functions wrapping this function and tasks will run concurrently.

The initial idea of this was to provide users of the Design plugin a way to define their measurement functions without needing pre/post, while allowing for concurrent task running. It solves that problem but still has a learning curve.

### main things I'm still unsure about
1. Naming: unfortunately `run_async` is already taken by essentially the `Batch` wrapper, so I went with `async_run`.
2. Will anyone actually use this? it seems powerful but `asyncio` is pretty difficult to use properly. Wouldn't hurt to have but a bit worried about it being hard to set up. Tried my best to explain stuff in the [notebooks](https://github.com/flexcompute/tidy3d-notebooks/pull/35).
3. Is there a better way to do what I want that completely hides asyncio? Couldn't come up with anything but I am sort of new at this tool.

Any other comments appreciated

### Basic Explanation

When used in an `async` function, the `web.async_run` will continue execution while waiting for `web.monitor()`. This means submission of several tasks can happen while waiting for previously submitted tasks to be monitored. Enables a batch-like functionality without needing to explicitly package `simulations`.

```py
    async def run_task(sim):
        """Async version of running a task."""
        return await async_run(sim, task_name="blah")

    async def main():
        """Call the `run_task` on a collection of simulations and gather results."""
        return await asyncio.gather(*(run_task(sim) for sim in sims))

    # will submit all sims first until they start finishing, then downloads as they become ready.
    asyncio.run(main())
```

```
11:54:50 CST INFO: Started asynchronous task with name 'async_1e-12'.                 
11:54:53 CST INFO: Started asynchronous task with name 'async_2e-12'.                 
11:54:55 CST INFO: Started asynchronous task with name 'async_3e-12'.                 
11:55:16 CST INFO: Finished asynchronous task with name 'async_1e-12'.                
11:55:17 CST INFO: Finished asynchronous task with name 'async_2e-12'.                
11:55:19 CST INFO: Finished asynchronous task with name 'async_3e-12'. 
```

This was also integrated into the `design` plugin so that one can define an asynchronous function `f` involving a `web.run_fn_async()` and pass it to `tdd.Design.run_async(f)` to run asynchronously without having to explicitly batch or write the function in terms of pre and post processing steps.

```py
async def f_async(num: int, t: float):
    sim = pre(num=num, t=t)
    data = await td.web.async_run(sim, task_name=f"num={num}_t={t}", verbose=False)
    return post(data)

result_async = await design_space.run_async(f_async)
```

Notebook / tutorial changes:
https://github.com/flexcompute/tidy3d-notebooks/pull/35
