### PR TITLE
fix obscure error if val not supported in SimData.plot_field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Add dispersion information to dataframe output when available from mode solver under the column "dispersion (ps/(nm km))".
 - Skip adjoint source for diffraction amplitudes of NaN.
+- Helpful error message if `val` supplied to `SimulationData.plot_field` not supported.
 
 ## [2.6.0rc1] - 2024-01-11
 

--- a/tests/test_data/test_sim_data.py
+++ b/tests/test_data/test_sim_data.py
@@ -163,6 +163,12 @@ def test_plot(phase):
     plt.close()
 
 
+def test_plot_field_missing_derived_data():
+    sim_data = make_sim_data()
+    with pytest.raises(Tidy3dKeyError):
+        sim_data.plot_field(field_monitor_name="field_time", field_name="E", val="int")
+
+
 @pytest.mark.parametrize("monitor_name", ["field", "field_time", "mode_solver"])
 def test_intensity(monitor_name):
     sim_data = make_sim_data()

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -377,6 +377,12 @@ class SimulationData(AbstractSimulationData):
             elif val == "phase":
                 raise Tidy3dKeyError(f"Phase is not defined for complex vector {field_name}")
 
+            else:
+                raise Tidy3dKeyError(
+                    f"'val' of {val} not supported. "
+                    "Must be one of 'real', 'imag', 'abs', 'abs^2', or 'phase'."
+                )
+
             return derived_data
 
         raise Tidy3dKeyError(


### PR DESCRIPTION
If `SimulationData.plot_field(..., val="int")`, it would through an obscure unbound local error. Now it throws a KeyError telling the user to change `val` to a supported value.