### PR TITLE
Warn if periodic boundaries are used with an angled source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add dispersion information to dataframe output when available from mode solver under the column "dispersion (ps/(nm km))".
 - Skip adjoint source for diffraction amplitudes of NaN.
 - Helpful error message if `val` supplied to `SimulationData.plot_field` not supported.
+- Fixed validator that warns if angled plane wave does not match simulation boundaries, which was not warning for periodic boundaries.
 
 ## [2.6.0rc1] - 2024-01-11
 

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -415,7 +415,7 @@ def test_validate_plane_wave_boundaries(log_capture):  # noqa: F811
     )
 
     bspec4 = td.BoundarySpec(
-        x=td.Boundary.bloch(bloch_vec=-3 + bspec2.x.plus.bloch_vec),
+        x=td.Boundary.bloch(bloch_vec=-3.1 + bspec2.x.plus.bloch_vec),
         y=td.Boundary.bloch(bloch_vec=1.8 + bspec2.y.plus.bloch_vec),
         z=td.Boundary.stable_pml(),
     )
@@ -437,8 +437,17 @@ def test_validate_plane_wave_boundaries(log_capture):  # noqa: F811
             boundary_spec=bspec1,
         )
 
+    # angled incidence plane wave with periodic boundaries should warn
+    with AssertLogLevel(log_capture, "WARNING", contains_str="incorrectly set"):
+        td.Simulation(
+            size=(1, 1, 1),
+            run_time=1e-12,
+            sources=[src2],
+            boundary_spec=td.BoundarySpec.all_sides(td.Periodic()),
+        )
+
     # angled incidence plane wave with an integer-offset Bloch vector should warn
-    with AssertLogLevel(log_capture, "WARNING"):
+    with AssertLogLevel(log_capture, "WARNING", contains_str="integer reciprocal"):
         td.Simulation(
             size=(1, 1, 1),
             run_time=1e-12,
@@ -447,7 +456,7 @@ def test_validate_plane_wave_boundaries(log_capture):  # noqa: F811
         )
 
     # angled incidence plane wave with wrong Bloch vector should warn
-    with AssertLogLevel(log_capture, "WARNING"):
+    with AssertLogLevel(log_capture, "WARNING", contains_str="incorrectly set"):
         td.Simulation(
             size=(1, 1, 1),
             run_time=1e-12,

--- a/tidy3d/components/boundary.py
+++ b/tidy3d/components/boundary.py
@@ -27,6 +27,14 @@ class BoundaryEdge(ABC, Tidy3dBaseModel):
 class Periodic(BoundaryEdge):
     """Periodic boundary condition class."""
 
+    @property
+    def bloch_vec(self):
+        """Periodic boundaries are effectively Bloch boundaries with ``bloch_vec == 0``.
+        In practice, periodic boundaries do not force the use of complex fields, while Bloch
+        boundaries do, even with ``bloch_vec == 0``. Thus, it is more efficient to use periodic.
+        """
+        return 0
+
 
 # PEC keyword
 class PECBoundary(BoundaryEdge):

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -726,7 +726,7 @@ class Simulation(AbstractSimulation):
                     )
 
                 # check the Bloch boundary + angled plane wave case
-                num_bloch = sum(isinstance(bnd, BlochBoundary) for bnd in boundary)
+                num_bloch = sum(isinstance(bnd, (Periodic, BlochBoundary)) for bnd in boundary)
                 if num_bloch > 0:
                     cls._check_bloch_vec(
                         source=source,
@@ -784,20 +784,14 @@ class Simulation(AbstractSimulation):
             for tan_dir in tan_dirs:
                 boundary = boundaries[tan_dir]
 
-                # if the boundary is periodic, the source is allowed to cross the boundary
-                # so nothing needs to be done
-                num_pbc = sum(isinstance(bnd, Periodic) for bnd in boundary)
-                if num_pbc == 2:
-                    continue
-
-                # crossing may be allowed for Bloch boundaries, but not others
+                # crossing may be allowed for periodic or Bloch boundaries, but not others
                 if (
                     src_bounds[0][tan_dir] <= sim_bounds[0][tan_dir]
                     or src_bounds[1][tan_dir] >= sim_bounds[1][tan_dir]
                 ):
                     # if the boundary is Bloch periodic, crossing is allowed, but check that the
                     # Bloch vector has been correctly set, similar to the check for plane waves
-                    num_bloch = sum(isinstance(bnd, BlochBoundary) for bnd in boundary)
+                    num_bloch = sum(isinstance(bnd, (Periodic, BlochBoundary)) for bnd in boundary)
                     if num_bloch == 2:
                         cls._check_bloch_vec(
                             source=source,


### PR DESCRIPTION
Fixes #1444 

Interestingly, we already had such a validator. We warn in various cases, e.g. if the bloch vector of the boundaries does not match the angle of the source. However we were missing the case of periodic boundaries, which are a separate class from Bloch.

It would perhaps make sense to change the warning to error. I am not sure if there's any use case in which we want the simulation to run with a mismatched source angle. But, in order to avoid anything unexpected, I think keeping it a warning is also fine.