### PR TITLE
Improved efficiency of outer_dot

### DIFF
--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -677,61 +677,31 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
         h_1 = "H" + dim1
         h_2 = "H" + dim2
 
-        # Prepare array with proper dimensions for the dot product data
-        arrays = (fields_self[e_1], fields_other[e_1])
-        coords = (arrays[0].coords, arrays[1].coords)
+        keys = (e_1, e_2, h_1, h_2)
 
-        # Common frequencies to both data arrays
-        f = np.array(sorted(set(coords[0]["f"].values).intersection(coords[1]["f"].values)))
+        def get_field_data(fields: dict, key: str, is_self: bool):
+            """Grab a field from a dictionary of field components, renaming `mode_index` coord if present."""
+            arr = fields[key]
+            if "mode_index" in arr.coords:
+                new_key = "mode_index_0" if is_self else "mode_index_1"
+                arr = arr.rename(mode_index=new_key)
+            return arr
 
-        # Mode indices, if available
-        modes_in_self = "mode_index" in coords[0]
-        mode_index_0 = coords[0]["mode_index"].values if modes_in_self else np.zeros(1, dtype=int)
-        modes_in_other = "mode_index" in coords[1]
-        mode_index_1 = coords[1]["mode_index"].values if modes_in_other else np.zeros(1, dtype=int)
+        e_self_1, e_self_2, h_self_1, h_self_2 = (
+            get_field_data(fields_self, key, is_self=True) for key in keys
+        )
+        e_other_1, e_other_2, h_other_1, h_other_2 = (
+            get_field_data(fields_other, key, is_self=False) for key in keys
+        )
 
-        dtype = np.promote_types(arrays[0].dtype, arrays[1].dtype)
-        dot = np.empty((f.size, mode_index_0.size, mode_index_1.size), dtype=dtype)
+        # Cross products of fields
+        e_self_x_h_other = e_self_1 * h_other_2 - e_self_2 * h_other_1
+        h_self_x_e_other = h_self_1 * e_other_2 - h_self_2 * e_other_1
 
-        # Calculate overlap for each common frequency and each mode pair
-        for i, freq in enumerate(f):
-            indexer_self = {"f": freq}
-            indexer_other = {"f": freq}
-            for mi0 in mode_index_0:
-                if modes_in_self:
-                    indexer_self["mode_index"] = mi0
-                e_self_1 = fields_self[e_1].sel(indexer_self, drop=True)
-                e_self_2 = fields_self[e_2].sel(indexer_self, drop=True)
-                h_self_1 = fields_self[h_1].sel(indexer_self, drop=True)
-                h_self_2 = fields_self[h_2].sel(indexer_self, drop=True)
-
-                for mi1 in mode_index_1:
-                    if modes_in_other:
-                        indexer_other["mode_index"] = mi1
-                    e_other_1 = fields_other[e_1].sel(indexer_other, drop=True)
-                    e_other_2 = fields_other[e_2].sel(indexer_other, drop=True)
-                    h_other_1 = fields_other[h_1].sel(indexer_other, drop=True)
-                    h_other_2 = fields_other[h_2].sel(indexer_other, drop=True)
-
-                    # Cross products of fields
-                    e_self_x_h_other = e_self_1 * h_other_2 - e_self_2 * h_other_1
-                    h_self_x_e_other = h_self_1 * e_other_2 - h_self_2 * e_other_1
-
-                    # Integrate over plane
-                    d_area = self._diff_area
-                    integrand = (e_self_x_h_other - h_self_x_e_other) * d_area
-                    dot[i, mi0, mi1] = 0.25 * integrand.sum(dim=d_area.dims)
-
-        coords = {"f": f, "mode_index_0": mode_index_0, "mode_index_1": mode_index_1}
-        result = xr.DataArray(dot, coords=coords)
-
-        # Remove mode index coordinate if the input did not have it
-        if not modes_in_self:
-            result = result.isel(mode_index_0=0, drop=True)
-        if not modes_in_other:
-            result = result.isel(mode_index_1=0, drop=True)
-
-        return result
+        # Integrate over plane
+        d_area = self._diff_area
+        summand = (e_self_x_h_other - h_self_x_e_other) * d_area
+        return 0.25 * summand.sum(dim=tan_dims)
 
     @property
     def time_reversed_copy(self) -> FieldData:


### PR DESCRIPTION
Older version of this new PR: https://github.com/flexcompute/tidy3d/pull/1464
This older PR reduces overhead and vectorizes. Vectorizing increases memory usage though, which may be unacceptable. The new PR reduces overhead but does not vectorize.

This seems to greatly improve the efficiency of `outer_dot`. 

The efficiency of mode sorting could possibly be improved as well by switching from `dot` to `outer_dot`, but that is not yet included in this PR.