### PR TITLE
Updates to help unify backend logging (Reset back to original #1457)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `DataArray.to_hdf5()` accepts both file handles and file paths.
 - `ModeSolverMonitor` is deprecated. Mode field profiles can be retrieved directly from `ModeMonitor` with `store_fields_direction` set.
+- The log file for a simulation run has been modified to include more information including warnings collected during execution.
 
 ### Fixed
 - Add dispersion information to dataframe output when available from mode solver under the column "dispersion (ps/(nm km))".

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -99,13 +99,15 @@ class AbstractFieldData(MonitorData, AbstractFieldDataset, ABC):
         title="Expanded Grid",
         description=":class:`.Grid` discretization of the associated monitor in the simulation "
         "which created the data. Required if symmetries are present, as "
-        "well as in order to use some functionalities like getting poynting and flux.",
+        "well as in order to use some functionalities like getting Poynting vector and flux.",
     )
 
     @pd.validator("grid_expanded", always=True)
-    def warn_missing_grid_expanded(cls, val):
-        """If ``colocate`` not provided, set to true, but warn that behavior has changed."""
-        if val is None:
+    def warn_missing_grid_expanded(cls, val, values):
+        """If ``grid_expanded`` not provided and fields data is present, warn that some methods
+        will break."""
+        field_comps = ["Ex", "Ey", "Ez", "Hx", "Hy", "Hz"]
+        if val is None and any(field_comp in values.keys() for field_comp in field_comps):
             log.warning(
                 "Monitor data requires 'grid_expanded' to be defined to compute values like "
                 "flux, Poynting and dot product with other data."

--- a/tidy3d/config.py
+++ b/tidy3d/config.py
@@ -22,7 +22,8 @@ class Tidy3dConfig(pd.BaseModel):
         DEFAULT_LEVEL,
         title="Logging Level",
         description="The lowest level of logging output that will be displayed. "
-        'Can be "DEBUG", "INFO", "WARNING", "ERROR", or "CRITICAL".',
+        'Can be "DEBUG", "SUPPORT", "USER", INFO", "WARNING", "ERROR", or "CRITICAL". '
+        'Note: "SUPPORT" and "USER" levels are only used in backend solver logging.',
     )
 
     log_suppression: bool = pd.Field(

--- a/tidy3d/plugins/adjoint/components/simulation.py
+++ b/tidy3d/plugins/adjoint/components/simulation.py
@@ -214,7 +214,8 @@ class JaxSimulation(Simulation, JaxObject):
                         consolidated_logger.warning(
                             f"'JaxSimulation.input_structures[{i}]' overlaps or touches "
                             f"'JaxSimulation.input_structures[{j}]'. Geometric gradients for "
-                            "overlapping input structures may contain errors."
+                            "overlapping input structures may contain errors.",
+                            log_once=True,
                         )
 
             # check JaxPolySlab intersections with background structures


### PR DESCRIPTION
I am extremely sorry @momchil-flex ! I accidentally deleted your branch whilst working on top of it to fix the Github actions issue. I will not do something like that again, and have learnt my lesson.

The old relevant PR is https://github.com/flexcompute/tidy3d/pull/1457 and I have just reset back to your commit as you can see. I will sort out the github actions issue in another branch. I am extremely sorry as I thought it was just a minor script update, but was not.

Relevant comments from Lucas were:
> I understand the changes required because of the backend log, so this looks fine. But thinking about the frontend only, is there any reason to use "USER" level instead of "INFO"? Or "SUPPORT" instead of "DEBUG"? I wonder if we should add a general comment for the future instructing frontend devs to only issue log messages using the standard levels, because that's what users would normally expect.

What I should have done was to branch out and make another PR to fix the github action separately - which is what I've done now. The weird thing is that we can see I haven't changed anything, and yet the github action is working fine. But I think I found out why the error was happening which is related to the VENV caching and am working to fix it from happening again. This is why your commit doesn't error in the new PR I've made (and you can see it's the same commit state). Bug fixed in https://github.com/flexcompute/tidy3d/pull/1469