### PR TITLE
more accurate adjoint run_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Uniaxial medium Lithium niobate to material library.
 
 ### Changed
+- `run_time` of the adjoint simulation is set more robustly based on the adjoint sources and the forward simulation `run_time` as `sim_fwd.run_time + c / fwdith_adj` where `c=10`.
 
 ### Fixed
 

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -55,7 +55,7 @@ VERTICES = ((-1.0, -1.0), (0.0, 0.0), (-1.0, 0.0))
 POLYSLAB_AXIS = 2
 FREQ0 = 2e14
 BASE_EPS_VAL = 2.0
-
+SIM_RUN_TIME = 1e-12
 # name of the output monitor used in tests
 MNT_NAME = "mode"
 
@@ -308,7 +308,7 @@ def make_sim(
 
     sim = JaxSimulation(
         size=(10, 10, 10),
-        run_time=1e-12,
+        run_time=SIM_RUN_TIME,
         grid_spec=td.GridSpec(wavelength=4.0),
         monitors=(extraneous_field_monitor,),
         structures=(extraneous_structure,),
@@ -600,7 +600,7 @@ def test_multiple_freqs():
 
     _ = JaxSimulation(
         size=(10, 10, 10),
-        run_time=1e-12,
+        run_time=SIM_RUN_TIME,
         grid_spec=td.GridSpec(wavelength=1.0),
         monitors=(),
         structures=(),
@@ -626,7 +626,7 @@ def test_different_freqs():
     )
     _ = JaxSimulation(
         size=(10, 10, 10),
-        run_time=1e-12,
+        run_time=SIM_RUN_TIME,
         grid_spec=td.GridSpec(wavelength=1.0),
         monitors=(),
         structures=(),
@@ -640,7 +640,7 @@ def test_get_freq_adjoint():
 
     sim = JaxSimulation(
         size=(10, 10, 10),
-        run_time=1e-12,
+        run_time=SIM_RUN_TIME,
         grid_spec=td.GridSpec(wavelength=1.0),
         monitors=(),
         structures=(),
@@ -668,7 +668,7 @@ def test_get_freq_adjoint():
     )
     sim = JaxSimulation(
         size=(10, 10, 10),
-        run_time=1e-12,
+        run_time=SIM_RUN_TIME,
         grid_spec=td.GridSpec(wavelength=1.0),
         monitors=(),
         structures=(),
@@ -699,7 +699,7 @@ def test_get_fwidth_adjoint():
         """Make a sim with given sources and fwidth_adjoint specified."""
         return JaxSimulation(
             size=(10, 10, 10),
-            run_time=1e-12,
+            run_time=SIM_RUN_TIME,
             grid_spec=td.GridSpec(wavelength=1.0),
             monitors=(),
             structures=(),
@@ -850,7 +850,7 @@ def test_intersect_structures(log_capture):
             size=(2, 2, 2),
             input_structures=(struct1, struct2),
             grid_spec=td.GridSpec(wavelength=1.0),
-            run_time=1e-12,
+            run_time=SIM_RUN_TIME,
             sources=(src,),
             boundary_spec=td.BoundarySpec.pml(x=True, y=True, z=True),
         )
@@ -878,7 +878,7 @@ def test_structure_overlaps():
         size=(2, 0, 2),
         input_structures=(struct,),
         grid_spec=td.GridSpec(wavelength=1.0),
-        run_time=1e-12,
+        run_time=SIM_RUN_TIME,
         sources=(src,),
         boundary_spec=td.BoundarySpec(
             x=td.Boundary.pml(),
@@ -893,7 +893,7 @@ def test_validate_subpixel():
     with pytest.raises(pydantic.ValidationError):
         _ = JaxSimulation(
             size=(10, 10, 10),
-            run_time=1e-12,
+            run_time=SIM_RUN_TIME,
             grid_spec=td.GridSpec(wavelength=1.0),
             subpixel=False,
         )
@@ -921,7 +921,7 @@ def test_plot_sims():
 
     sim = JaxSimulation(
         size=(10, 10, 10),
-        run_time=1e-12,
+        run_time=SIM_RUN_TIME,
         grid_spec=td.GridSpec(wavelength=1.0),
     )
     sim.plot(x=0)
@@ -1000,7 +1000,7 @@ def _test_polyslab_box(use_emulated_run):
 
         sim = JaxSimulation(
             size=(10, 10, 10),
-            run_time=1e-12,
+            run_time=SIM_RUN_TIME,
             grid_spec=td.GridSpec(wavelength=1.0),
             boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
             output_monitors=(output_mnt1, output_mnt2),
@@ -1096,7 +1096,7 @@ def test_polyslab_2d(sim_size_axis, use_emulated_run):
 
         sim = JaxSimulation(
             size=(10, 10, sim_size_axis),
-            run_time=1e-12,
+            run_time=SIM_RUN_TIME,
             grid_spec=td.GridSpec(wavelength=1.0),
             boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
             output_monitors=(output_mnt1, output_mnt2, output_mnt3, output_mnt4),
@@ -1302,7 +1302,7 @@ def _test_polyslab_scale(use_emulated_run):
 
             sim = JaxSimulation(
                 size=(10, 10, 10),
-                run_time=1e-12,
+                run_time=SIM_RUN_TIME,
                 grid_spec=td.GridSpec(wavelength=1.0),
                 boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
                 output_monitors=(output_mnt1, output_mnt2),
@@ -1445,7 +1445,7 @@ def test_jax_sim_io(tmp_path):
     sim = JaxSimulation(
         size=(2, 2, 2),
         input_structures=[struct],
-        run_time=1e-12,
+        run_time=SIM_RUN_TIME,
         grid_spec=td.GridSpec.auto(wavelength=1.0),
     )
 
@@ -1588,7 +1588,7 @@ def test_pytreedef_errors(use_emulated_run):
             size=(2.0, 2.0, 2.0),
             structures=[ps, gg, ggg, gggg, stl_struct, custom_medium],
             input_structures=[js],
-            run_time=1e-12,
+            run_time=SIM_RUN_TIME,
             output_monitors=[mnt],
             monitors=[flux_mnt],
             grid_spec=td.GridSpec.uniform(dl=0.1),
@@ -1604,8 +1604,16 @@ def test_pytreedef_errors(use_emulated_run):
 
 fwidth_run_time_expected = [
     (FREQ0 / 10, 1e-11, 1e-11),  # run time supplied explicitly, use that
-    (FREQ0 / 10, None, RUN_TIME_FACTOR / (FREQ0 / 10)),  # no run_time, use fwidth supplied
-    (FREQ0 / 20, None, RUN_TIME_FACTOR / (FREQ0 / 20)),  # no run_time, use fwidth supplied
+    (
+        FREQ0 / 10,
+        None,
+        SIM_RUN_TIME + RUN_TIME_FACTOR / (FREQ0 / 10),
+    ),  # no run_time, use fwidth supplied
+    (
+        FREQ0 / 20,
+        None,
+        SIM_RUN_TIME + RUN_TIME_FACTOR / (FREQ0 / 20),
+    ),  # no run_time, use fwidth supplied
 ]
 
 
@@ -1648,7 +1656,7 @@ def test_no_adjoint_sources(
 
         return JaxSimulation(
             size=(10, 10, 10),
-            run_time=1e-12,
+            run_time=SIM_RUN_TIME,
             grid_spec=td.GridSpec(wavelength=1.0),
             monitors=(),
             structures=(),
@@ -1686,7 +1694,7 @@ def test_nonlinear_warn(log_capture):
 
     sim_base = JaxSimulation(
         size=(10, 10, 0),
-        run_time=1e-12,
+        run_time=SIM_RUN_TIME,
         grid_spec=td.GridSpec(wavelength=1.0),
         monitors=(),
         structures=(struct_static,),

--- a/tidy3d/plugins/adjoint/components/simulation.py
+++ b/tidy3d/plugins/adjoint/components/simulation.py
@@ -36,8 +36,8 @@ FWIDTH_FACTOR = 1.0 / 10
 # bandwidth of adjoint sources in units of the minimum difference between output frequencies
 FWIDTH_FACTOR_MULTIFREQ = 0.1
 
-# the adjoint run time is RUN_TIME_FACTOR / fwidth
-RUN_TIME_FACTOR = 100
+# the adjoint run time is the forward simulation run time + RUN_TIME_FACTOR / fwidth
+RUN_TIME_FACTOR = 10
 
 # how many processors to use for server and client side adjoint
 NUM_PROC_LOCAL = 1
@@ -350,7 +350,8 @@ class JaxSimulation(Simulation, JaxObject):
         if self.run_time_adjoint is not None:
             return self.run_time_adjoint
 
-        run_time_adjoint = RUN_TIME_FACTOR / self._fwidth_adjoint
+        run_time_fwd = self.run_time
+        run_time_adjoint = run_time_fwd + RUN_TIME_FACTOR / self._fwidth_adjoint
 
         if self._is_multi_freq:
             log.warning(


### PR DESCRIPTION
Previously it was
```py
run_time_adj = 100 / fwidth_adj
```
Now it is
```py
run_time_adj = run_time_fwd + 10 / fwidth_adj
```

#1403 