### PR TITLE
Add uniaxial medium lithium niobate to material library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Uniaxial medium Lithium niobate to material library.
 
 ### Changed
 

--- a/docs/api/material_library.rst
+++ b/docs/api/material_library.rst
@@ -212,8 +212,8 @@ References:
 
 #. \Horiba Technical Note 08: Lorentz Dispersion Model `[url] <http://www.horiba.com/fileadmin/uploads/Scientific/Downloads/OpticalSchool_CN/TN/ellipsometer/Lorentz_Dispersion_Model.pdf>`__
 
-Amorphous Silicon ("aSi")
-=========================
+Silicon (Amorphous) ("aSi")
+===========================
 
 .. table::
    :widths: auto
@@ -375,8 +375,8 @@ References:
 
 #. \A. D. Rakic, A. B. Djurisic, J. M. Elazar, and M. L. Majewski. Optical properties of metallic films for vertical-cavity optoelectronic devices, Appl. Opt. 37, 5271-5283 (1998) `[doi] <https://doi.org/10.1364/AO.37.005271>`__
 
-Crystalline Silicon ("cSi")
-===========================
+Silicon (Crystalline) ("cSi")
+=============================
 
 .. table::
    :widths: auto
@@ -673,6 +673,26 @@ Examples:
 References:
 
 #. \Horiba Technical Note 08: Lorentz Dispersion Model `[url] <http://www.horiba.com/fileadmin/uploads/Scientific/Downloads/OpticalSchool_CN/TN/ellipsometer/Lorentz_Dispersion_Model.pdf>`__
+
+Lithium niobate ("LiNbO3")
+==========================
+
+.. table::
+   :widths: auto
+
+   ========================== ======================== ========================== =============================================================================================================
+   Variant                    Valid for                Model Info                 Reference                                                                                                    
+   ========================== ======================== ========================== =============================================================================================================
+   ``'Zelmon1997'`` (default) 0.4 - 5.0 :math:`{\mu}m` :class:`AnisotropicMedium` [1] `[data] <https://refractiveindex.info/data_csv.php?datafile=database/data-nk/main/LiNbO3/Zelmon-e.yml>`__
+   ========================== ======================== ========================== =============================================================================================================
+
+Examples:
+
+>>> medium = material_library['LiNbO3']['Zelmon1997'](optical axis) # 'optical axis' can take value 0/1/2 for x/y/z axis.
+
+References:
+
+#. \D. E. Zelmon, D. L. Small and D. Jundt. Infrared corrected Sellmeier coefficients for congruently grown lithium niobate and 5 mol.% magnesium oxide-doped lithium niobate, J. Opt. Soc. Am. B 14, 3319-3322 (1997) `[doi] <https://doi.org/10.1364/JOSAB.14.003319>`__
 
 Magnesium Fluoride ("MgF2")
 ===========================

--- a/docs/generate_doc.py
+++ b/docs/generate_doc.py
@@ -3,7 +3,8 @@
 import numpy as np
 from tidy3d import material_library as lib
 from tidy3d.constants import C_0
-from tidy3d import Medium2D, PoleResidue
+from tidy3d.material_library.material_library import MaterialItemUniaxial, MaterialItem
+from tidy3d.material_library.material_library import MaterialItem2D
 
 LOW_LOSS_THRESHOLD = 2e-5
 
@@ -94,9 +95,15 @@ def generate_material_library_doc():
                     # Load medium
                     medium = var.medium
 
-                    if isinstance(medium, Medium2D):
+                    # for uniaxial medium, use optical_axis=0 and xx component as representative
+                    if isinstance(mat, MaterialItemUniaxial):
+                        medium = medium(0).xx
+
+                    if isinstance(mat, MaterialItem2D):
                         row["model"] = ":class:`Medium2D`"
-                    elif isinstance(medium, PoleResidue):
+                    elif isinstance(mat, MaterialItemUniaxial):
+                        row["model"] = ":class:`AnisotropicMedium`"
+                    elif isinstance(mat, MaterialItem):
                         # Pole number
                         row["model"] = str(len(medium.poles)) + "-pole"
                         # Lossy (based on model)
@@ -158,9 +165,19 @@ def generate_material_library_doc():
                             width[col] = len(row[col])
 
                     # Update example code
-                    code_string += (
-                        ">>> medium = material_library['" + abbr + "']['" + varname + "']\n\n"
-                    )
+                    if isinstance(mat, MaterialItemUniaxial):
+                        code_string += (
+                            ">>> medium = material_library['"
+                            + abbr
+                            + "']['"
+                            + varname
+                            + "'](optical axis)"
+                            + " # 'optical axis' can take value 0/1/2 for x/y/z axis.\n\n"
+                        )
+                    else:
+                        code_string += (
+                            ">>> medium = material_library['" + abbr + "']['" + varname + "']\n\n"
+                        )
 
                 # Write table
                 tab = "   "

--- a/tests/test_package/test_material_library.py
+++ b/tests/test_package/test_material_library.py
@@ -8,6 +8,8 @@ from tidy3d.material_library.material_library import (
     ReferenceData,
     material_library,
     export_matlib_to_file,
+    VariantItemUniaxial,
+    MaterialItemUniaxial,
 )
 import tidy3d as td
 
@@ -46,16 +48,77 @@ def test_library():
         if isinstance(material, type):
             continue
         for variant_name, variant in material.variants.items():
-            if variant.medium.frequency_range:
-                fmin, fmax = variant.medium.frequency_range
+            if not isinstance(variant, VariantItemUniaxial):
+                if variant.medium.frequency_range:
+                    fmin, fmax = variant.medium.frequency_range
+                else:
+                    fmin, fmax = 100e12, 300e12
+                freqs = np.linspace(fmin, fmax, 10011)
+                # two ways of access
+                eps_complex1 = variant.medium.eps_model(freqs)
+                eps_complex2 = material_library[material_name][variant_name].eps_model(freqs)
+                assert np.allclose(eps_complex1, eps_complex2)
             else:
-                fmin, fmax = 100e12, 300e12
-            freqs = np.linspace(fmin, fmax, 10011)
-            # two ways of access
-            eps_complex1 = variant.medium.eps_model(freqs)
-            eps_complex2 = material_library[material_name][variant_name].eps_model(freqs)
-            assert np.allclose(eps_complex1, eps_complex2)
+                for optical_axis in range(3):
+                    if variant.medium(optical_axis).frequency_range:
+                        fmin, fmax = variant.medium(optical_axis).frequency_range
+                    else:
+                        fmin, fmax = 100e12, 300e12
+                    freqs = np.linspace(fmin, fmax, 10011)
+                    # two ways of access
+                    eps_complex1 = variant.medium(optical_axis).eps_model(freqs)
+                    eps_complex2 = material_library[material_name][variant_name](
+                        optical_axis
+                    ).eps_model(freqs)
+                    assert np.allclose(eps_complex1, eps_complex2)
 
 
 def test_test_export(tmp_path):
     export_matlib_to_file(str(tmp_path / "matlib.json"))
+
+
+def test_uniaxial_variant():
+    """Test if the variant class is working as expected."""
+    eps_ordinary = 2
+    eps_extraordinary = 4
+    mat = VariantItemUniaxial(
+        ordinary=td.PoleResidue(eps_inf=eps_ordinary),
+        extraordinary=td.PoleResidue(eps_inf=eps_extraordinary),
+    )
+
+    # optical axis along x-axis
+    medium = mat.medium(0)
+    assert medium.xx.eps_inf == eps_extraordinary
+    assert medium.yy.eps_inf == eps_ordinary
+    assert medium.zz.eps_inf == eps_ordinary
+
+    # optical axis along y-axis
+    medium = mat.medium(1)
+    assert medium.xx.eps_inf == eps_ordinary
+    assert medium.yy.eps_inf == eps_extraordinary
+    assert medium.zz.eps_inf == eps_ordinary
+
+    # optical axis along z-axis
+    medium = mat.medium(2)
+    assert medium.xx.eps_inf == eps_ordinary
+    assert medium.yy.eps_inf == eps_ordinary
+    assert medium.zz.eps_inf == eps_extraordinary
+
+
+def test_uniaxial_material():
+    """Test if the uniaxial material class is working as expected."""
+    variant1 = VariantItemUniaxial(
+        ordinary=td.PoleResidue(eps_inf=2),
+        extraordinary=td.PoleResidue(eps_inf=4),
+    )
+
+    variant2 = VariantItemUniaxial(
+        ordinary=td.PoleResidue(eps_inf=3),
+        extraordinary=td.PoleResidue(eps_inf=6),
+    )
+    material = MaterialItemUniaxial(
+        name="material", variants=dict(v1=variant1, v2=variant2), default="v1"
+    )
+
+    for optical_axis in range(3):
+        assert material["v1"](optical_axis) == material.medium(optical_axis)

--- a/tidy3d/material_library/material_library.py
+++ b/tidy3d/material_library/material_library.py
@@ -3,8 +3,9 @@ import json
 from typing import Dict, List
 import pydantic.v1 as pd
 
-from ..components.medium import PoleResidue, Medium2D
+from ..components.medium import PoleResidue, Medium2D, AnisotropicMedium, Sellmeier
 from ..components.base import Tidy3dBaseModel
+from ..components.types import Axis
 from ..exceptions import SetupError
 from .material_reference import material_refs, ReferenceData
 from .parametric_materials import Graphene
@@ -18,21 +19,30 @@ def export_matlib_to_file(fname: str = "matlib.json") -> None:
             var_name: json.loads(var.medium._json_string) for var_name, var in mat.variants.items()
         }
         for mat_name, mat in material_library.items()
-        if not isinstance(mat, type)
+        if not isinstance(mat, (type, MaterialItemUniaxial))
     }
+
+    # Uniaxial medium treated differently
+    mat_lib_dict.update(
+        {
+            f'{mat.name} ("{mat_name}")': {
+                var_name: {
+                    "ordinary": json.loads(var.ordinary._json_string),
+                    "extraordinary": json.loads(var.extraordinary._json_string),
+                }
+                for var_name, var in mat.variants.items()
+            }
+            for mat_name, mat in material_library.items()
+            if isinstance(mat, MaterialItemUniaxial)
+        }
+    )
 
     with open(fname, "w") as f:
         json.dump(mat_lib_dict, f)
 
 
-class VariantItem(Tidy3dBaseModel):
-    """Reference, data_source, and material model for a variant of a material."""
-
-    medium: PoleResidue = pd.Field(
-        ...,
-        title="Material dispersion model",
-        description="A dispersive medium described by the pole-residue pair model.",
-    )
+class AbstractVariantItem(Tidy3dBaseModel):
+    """Reference, and data_source for a variant of a material."""
 
     reference: List[ReferenceData] = pd.Field(
         None,
@@ -45,6 +55,16 @@ class VariantItem(Tidy3dBaseModel):
         title="Dispersion data URL",
         description="The URL to access the dispersion data upon which the material "
         "model is fitted.",
+    )
+
+
+class VariantItem(AbstractVariantItem):
+    """Reference, data_source, and material model for a variant of a material."""
+
+    medium: PoleResidue = pd.Field(
+        ...,
+        title="Material dispersion model",
+        description="A dispersive medium described by the pole-residue pair model.",
     )
 
 
@@ -82,7 +102,7 @@ class MaterialItem(Tidy3dBaseModel):
         return self.variants[self.default].medium
 
 
-class VariantItem2D(VariantItem):
+class VariantItem2D(AbstractVariantItem):
     """Reference, data_source, and material model for a variant of a 2D material."""
 
     medium: Medium2D = pd.Field(
@@ -104,6 +124,68 @@ class MaterialItem2D(MaterialItem):
         "that maps from a key to the variant model.",
     )
 
+
+class VariantItemUniaxial(AbstractVariantItem):
+    """Reference, data_source, and material model for a variant of an uniaxial material."""
+
+    ordinary: PoleResidue = pd.Field(
+        ..., title="Ordinary Component", description="Medium describing the ordinary component."
+    )
+
+    extraordinary: PoleResidue = pd.Field(
+        ...,
+        title="Extraordinary Component",
+        description="Medium describing the extraordinary component.",
+    )
+
+    def medium(self, optical_axis: Axis) -> AnisotropicMedium:
+        """
+        Generate anisotropic medium.
+
+        Parameters
+        ----------
+        optical_axis : Axis
+            Optical axis of the uniaxial medium.
+
+        Returns
+        -------
+        :class:`.AnisotropicMedium`
+            The anisotropic medium representing the uniaxial medium.
+        """
+
+        components = ["xx", "yy", "zz"]
+        mat_dict = {comp: self.ordinary for comp in components}
+        mat_dict.update({components[optical_axis]: self.extraordinary})
+        return AnisotropicMedium.parse_obj(mat_dict)
+
+
+class MaterialItemUniaxial(MaterialItem):
+    """A material that includes several variants."""
+
+    variants: Dict[str, VariantItemUniaxial] = pd.Field(
+        ...,
+        title="Dictionary of available variants for this material",
+        description="A dictionary of available variants for this material "
+        "that maps from a key to the variant model.",
+    )
+
+    def medium(self, optical_axis: Axis):
+        """The default medium."""
+        return self.variants[self.default].medium(optical_axis)
+
+
+LiNbO3_Zelmon1997 = VariantItemUniaxial(
+    ordinary=Sellmeier(
+        coeffs=((2.6734, 0.01764), (1.2290, 0.05914), (12.614, 474.60)),
+        frequency_range=(59958491600000.0, 749481145000000.0),
+    ).pole_residue,
+    extraordinary=Sellmeier(
+        coeffs=((2.9804, 0.02047), (0.5981, 0.0666), (8.9543, 416.08)),
+        frequency_range=(59958491600000.0, 749481145000000.0),
+    ).pole_residue,
+    reference=[material_refs["Zelmon1997"]],
+    data_url="https://refractiveindex.info/data_csv.php?datafile=database/data-nk/main/LiNbO3/Zelmon-e.yml",
+)
 
 Ag_Rakic1998BB = VariantItem(
     medium=PoleResidue(
@@ -2132,6 +2214,11 @@ material_library = dict(
             Green2008=cSi_Green2008,
         ),
         default="Green2008",
+    ),
+    LiNbO3=MaterialItemUniaxial(
+        name="Lithium niobate",
+        variants=dict(Zelmon1997=LiNbO3_Zelmon1997),
+        default="Zelmon1997",
     ),
     graphene=Graphene,
 )

--- a/tidy3d/material_library/material_reference.py
+++ b/tidy3d/material_library/material_reference.py
@@ -144,6 +144,12 @@ material_refs = dict(
         "Jpn. J. Appl. Phys. 7, 404-408 (1968)",
         doi="https://doi.org/10.1143/JJAP.7.404",
     ),
+    Zelmon1997=ReferenceData(
+        journal="D. E. Zelmon, D. L. Small and D. Jundt. Infrared corrected Sellmeier "
+        "coefficients for congruently grown lithium niobate and 5 mol.% magnesium oxide-doped "
+        "lithium niobate, J. Opt. Soc. Am. B 14, 3319-3322 (1997)",
+        doi="https://doi.org/10.1364/JOSAB.14.003319",
+    ),
     Zelmon1998=ReferenceData(
         journal="D. E. Zelmon, D. L. Small and R. Page. Refractive-index measurements "
         "of undoped yttrium aluminum garnet from 0.4 to 5.0 μm, Appl. Opt. 37, 4933-4935 (1998)",


### PR DESCRIPTION
Resolves #1413 

The doc page for LiNiO3:
![Screenshot from 2024-02-20 18-02-52](https://github.com/flexcompute/tidy3d/assets/92755338/3109d294-8d9d-4774-86ba-619db755235a)


One question to @daquinteroflex: now I need to manually run `python generate_doc.py` to update material_library.rst, so that the doc page can include updated material library. Is that the expected behavior?