### PR TITLE
RELEASE: Upgrade release flow and tiny fix :zap:

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+    - name: Exit if any RC release
+      if: contains(github.ref, 'rc') == false
+      uses: everlytic/branch-merge@1.1.2
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        source_ref: "develop"
+        target_branch: "latest"
+        commit_message_template: 'RELEASE: :shipit: :boom: :tada: Merged {source_ref} into target {target_branch}'
     - name: Release
       uses: softprops/action-gh-release@v1
       with:

--- a/.github/workflows/sync-to-readthedocs-repo.yaml
+++ b/.github/workflows/sync-to-readthedocs-repo.yaml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - latest
+      - develop
       - 'pre/*'
       - 'v*'
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -165,9 +165,8 @@ This will produce the following plot, which visualizes the electromagnetic field
 .. image:: _static/quickstart_fields.png
    :width: 1200
 
-a) Postprocess simulation data using the same python session, or
 
-b) View the results of this simulation on our web-based `graphical user interface <https://tidy3d.simulation.cloud>`_.
+You can now postprocess simulation data using the same python session, or view the results of this simulation on our web-based `graphical user interface <https://tidy3d.simulation.cloud>`_.
 
 .. `TODO: open example in colab <https://github.com/flexcompute/tidy3d>`_
 


### PR DESCRIPTION
This upgrades:

- [X] So that `sync-readthedocs-repo` gets live updated from develop
- [X] A tiny aesthetic fix on the first docs page.
- [x] When a release is tagged, it merges develop to latest branch. This will trigger the documentation sync flow on the main website.