### PR TITLE
Add metadata to Tidy3D components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for `.gz` files in `Simulation` version updater.
 - Warning if a nonuniform custom medium is intersecting `PlaneWave`, `GaussianBeam`, `AstigmaticGaussianBeam`, `FieldProjectionCartesianMonitor`, `FieldProjectionAngleMonitor`, `FieldProjectionKSpaceMonitor`, and `DiffractionMonitor`.
+- Tidy3D objects may store arbitrary metadata in an `.attrs` dictionary.
 
 ### Changed
 

--- a/tests/test_components/test_grid.py
+++ b/tests/test_components/test_grid.py
@@ -4,7 +4,6 @@ import numpy as np
 
 import tidy3d as td
 from tidy3d.components.grid.grid import Coords, FieldGrid, Grid
-from tidy3d.components.types import TYPE_TAG_STR
 from tidy3d.exceptions import SetupError
 
 
@@ -42,7 +41,8 @@ def test_grid():
     assert np.all(g.centers.y == np.array([-1.5, -0.5, 0.5, 1.5]))
     assert np.all(g.centers.z == np.array([-2.5, -1.5, -0.5, 0.5, 1.5, 2.5]))
 
-    for s in g.sizes.dict(exclude={TYPE_TAG_STR}).values():
+    for dim in "xyz":
+        s = g.sizes.dict()[dim]
         assert np.all(np.array(s) == 1.0)
 
     assert np.all(g.yee.E.x.x == np.array([-0.5, 0.5]))
@@ -211,9 +211,12 @@ def test_sim_grid():
         boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
     )
 
-    for c in sim.grid.centers.dict(exclude={TYPE_TAG_STR}).values():
+    for dim in "xyz":
+        c = sim.grid.centers.dict()[dim]
         assert np.all(c == np.array([-1.5, -0.5, 0.5, 1.5]))
-    for b in sim.grid.boundaries.dict(exclude={TYPE_TAG_STR}).values():
+
+    for dim in "xyz":
+        b = sim.grid.boundaries.dict()[dim]
         assert np.all(b == np.array([-2, -1, 0, 1, 2]))
 
 
@@ -261,9 +264,12 @@ def test_sim_pml_grid():
         run_time=1e-12,
     )
 
-    for c in sim.grid.centers.dict(exclude={TYPE_TAG_STR}).values():
+    for dim in "xyz":
+        c = sim.grid.centers.dict()[dim]
         assert np.all(c == np.array([-3.5, -2.5, -1.5, -0.5, 0.5, 1.5, 2.5, 3.5]))
-    for b in sim.grid.boundaries.dict(exclude={TYPE_TAG_STR}).values():
+
+    for dim in "xyz":
+        b = sim.grid.boundaries.dict()[dim]
         assert np.all(b == np.array([-4, -3, -2, -1, 0, 1, 2, 3, 4]))
 
 
@@ -279,10 +285,12 @@ def test_sim_discretize_vol():
 
     subgrid = sim.discretize(vol)
 
-    for b in subgrid.boundaries.dict(exclude={TYPE_TAG_STR}).values():
+    for dim in "xyz":
+        b = subgrid.boundaries.dict()[dim]
         assert np.all(b == np.array([-1, 0, 1]))
 
-    for c in subgrid.centers.dict(exclude={TYPE_TAG_STR}).values():
+    for dim in "xyz":
+        c = subgrid.centers.dict()[dim]
         assert np.all(c == np.array([-0.5, 0.5]))
 
     _ = td.Box(size=(6, 6, 0))

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -192,6 +192,19 @@ class Tidy3dBaseModel(pydantic.BaseModel):
                     )
         return values
 
+    attrs: dict = pydantic.Field(
+        {},
+        title="Attributes",
+        description="Dictionary storing arbitrary metadata for a Tidy3D object. "
+        "This dictionary can be freely used by the user for storing data without affecting the "
+        "operation of Tidy3D as it is not used internally. "
+        "Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. "
+        "For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. "
+        "Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects "
+        "that can not be serialized. One can check if ``attrs`` are serializable "
+        "by calling ``obj.json()``.",
+    )
+
     def copy(self, **kwargs) -> Tidy3dBaseModel:
         """Copy a Tidy3dBaseModel.  With ``deep=True`` as default."""
         if "deep" in kwargs and kwargs["deep"] is False:

--- a/tidy3d/components/grid/grid.py
+++ b/tidy3d/components/grid/grid.py
@@ -8,7 +8,7 @@ import pydantic.v1 as pd
 from ..base import Tidy3dBaseModel
 from ..data.data_array import DataArray, SpatialDataArray, ScalarFieldDataArray
 from ..data.dataset import UnstructuredGridDatasetType, UnstructuredGridDataset
-from ..types import ArrayFloat1D, Axis, TYPE_TAG_STR, InterpMethod, Literal
+from ..types import ArrayFloat1D, Axis, InterpMethod, Literal
 from ..geometry.base import Box
 
 from ...exceptions import SetupError
@@ -43,7 +43,7 @@ class Coords(Tidy3dBaseModel):
     @property
     def to_dict(self):
         """Return a dict of the three Coord1D objects as numpy arrays."""
-        return {key: np.array(value) for key, value in self.dict(exclude={TYPE_TAG_STR}).items()}
+        return {key: self.dict()[key] for key in "xyz"}
 
     @property
     def to_list(self):
@@ -386,9 +386,7 @@ class Grid(Tidy3dBaseModel):
         >>> grid = Grid(boundaries=coords)
         >>> Nx, Ny, Nz = grid.num_cells
         """
-        return [
-            len(coords1d) - 1 for coords1d in self.boundaries.dict(exclude={TYPE_TAG_STR}).values()
-        ]
+        return [len(self.boundaries.dict()[dim]) - 1 for dim in "xyz"]
 
     @property
     def _primal_steps(self) -> Coords:
@@ -412,7 +410,7 @@ class Grid(Tidy3dBaseModel):
             applied.
         """
 
-        primal_steps = self._primal_steps.dict(exclude={TYPE_TAG_STR})
+        primal_steps = {dim: self._primal_steps.dict()[dim] for dim in "xyz"}
         dsteps = {key: (psteps + np.roll(psteps, 1)) / 2 for (key, psteps) in primal_steps.items()}
 
         return Coords(**dsteps)

--- a/tidy3d/components/viz.py
+++ b/tidy3d/components/viz.py
@@ -95,7 +95,7 @@ class PlotParams(Tidy3dBaseModel):
     def to_kwargs(self) -> dict:
         """Export the plot parameters as kwargs dict that can be supplied to plot function."""
         kwarg_dict = self.dict()
-        for ignore_key in ("type",):
+        for ignore_key in ("type", "attrs"):
             kwarg_dict.pop(ignore_key)
         return kwarg_dict
 


### PR DESCRIPTION
Addresses #1352 

How do you all feel about this?

1. Used the name `.attrs`, because it follows the same [convention](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.attrs.html) as `xarray`, `pandas`, maybe others.
2. `attrs` are dictionaries (mutable) so they can be set on the fly, `sim.attrs['foo'] = bar`.
3. we still can't set the attrs directly since tidy3d objects dont support item assignment, eg.`sim.attrs = {}` doesn't work.
4. in `xarray`, attrs remain when the objects are copied and updated. but are removed when the objects are modified. We only need to handle the copy part since we can't modify tidy3d objects. therefore if `sim.copy()`, then the new object's attrs are the same.
5. Important point, since `attrs` are mutable, we want to ensure our internal code doesn't depend on attrs in any way. Otherwise we introduce state. So as a rule, we don't use `attrs` for any calculation? That being said, maybe we can set attrs internally if it makes sense to, but never code like `if obj.attrs["something"] == something: ...`

All of the logic is spelled out in the [test](https://github.com/flexcompute/tidy3d/pull/1493/files#diff-d8a2875091a9aff89fbeb80d849d5ee59a5f67a08a88919e0a63036f4126cdb1).

Also please check the [description](https://github.com/flexcompute/tidy3d/pull/1493/files#diff-d331aef8c3290adc3733d4ce375c5a4b139ad41bd5634113ca404cc827e3d949) and see if it is clear.

Thanks