### PR TITLE
add BatchData to design.Results, if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `tidy3d.plugins.design.Results` store the `BatchData` for batch runs in the `.batch_data` field.
 
 ### Changed
 

--- a/tidy3d/plugins/design/design.py
+++ b/tidy3d/plugins/design/design.py
@@ -9,6 +9,7 @@ import pydantic.v1 as pd
 from ...components.base import Tidy3dBaseModel, cached_property
 from ...components.simulation import Simulation
 from ...components.data.sim_data import SimulationData
+from ...web.api.container import BatchData
 
 from .method import MethodType
 from .parameter import ParameterType
@@ -60,6 +61,7 @@ class DesignSpace(Tidy3dBaseModel):
         fn_values: List[Any],
         fn_source: str,
         task_ids: Tuple[str] = None,
+        batch_data: BatchData = None,
     ) -> Result:
         """How to package results from ``method.run`` and ``method.run_batch``"""
 
@@ -73,6 +75,7 @@ class DesignSpace(Tidy3dBaseModel):
             coords=fn_args_coords_T,
             fn_source=fn_source,
             task_ids=task_ids,
+            batch_data=batch_data,
         )
 
     @staticmethod
@@ -153,7 +156,7 @@ class DesignSpace(Tidy3dBaseModel):
         """
 
         # run the functions using the `method.run_batch`
-        fn_args, fn_values, task_ids = self.method.run_batch(
+        fn_args, fn_values, task_ids, batch_data = self.method.run_batch(
             parameters=self.parameters,
             fn_pre=fn_pre,
             fn_post=fn_post,
@@ -168,5 +171,9 @@ class DesignSpace(Tidy3dBaseModel):
 
         # package the result
         return self._package_run_results(
-            fn_args=fn_args, fn_values=fn_values, fn_source=fn_source, task_ids=task_ids
+            fn_args=fn_args,
+            fn_values=fn_values,
+            fn_source=fn_source,
+            task_ids=task_ids,
+            batch_data=batch_data,
         )

--- a/tidy3d/plugins/design/method.py
+++ b/tidy3d/plugins/design/method.py
@@ -161,7 +161,7 @@ class MethodIndependent(Method, ABC):
 
             result.append(val)
 
-        return fn_args, result, task_ids
+        return fn_args, result, task_ids, batch_data
 
 
 class MethodGrid(MethodIndependent):

--- a/tidy3d/plugins/design/result.py
+++ b/tidy3d/plugins/design/result.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas
 
 from ...components.base import Tidy3dBaseModel, cached_property
+from ...web.api.container import BatchData
 
 
 class Result(Tidy3dBaseModel):
@@ -62,9 +63,20 @@ class Result(Tidy3dBaseModel):
     task_ids: Tuple[Tuple[str, ...], ...] = pd.Field(
         None,
         title="Task IDs",
-        description="Task IDs for the simulation run in each data point. Can only be computed if "
+        description="Task IDs for the simulation run in each data point. Only available if "
         "the parameter sweep function is split into pre and post processing and run with "
-        "'Project.run_batch()'.",
+        "'Design.run_batch()', otherwise is ``None``. "
+        "To access all of the data, see ``batch_data``.",
+    )
+
+    batch_data: BatchData = pd.Field(
+        None,
+        title="Batch Data",
+        description=":class:`BatchData` object storing all of the data for the simulations "
+        " used in this ``Result``. Can be iterated through like a dictionary with "
+        "``for task_name, sim_data in batch_data.items()``. Only available if "
+        "the parameter sweep function is split into pre and post processing and run with "
+        "'Design.run_batch()', otherwise is ``None``.",
     )
 
     @pd.validator("coords", always=True)


### PR DESCRIPTION
Addresses #1428 , now the user can do

```py
sweep_results = design_space.run_batch(scs_pre, scs_post)

batch_data = sweep_results.batch_data
for task_name, data in batch_data.items():
        ...

```

The `Results.task_ids` were left in for backwards compatibility, even if it's only been a few hours.