### PR TITLE
Unstructured custom medium

### DIFF
--- a/tests/test_components/test_IO.py
+++ b/tests/test_components/test_IO.py
@@ -48,6 +48,11 @@ def set_datasets_to_none(sim):
                 if geometry["type"] == "TriangleMesh":
                     geometry["mesh_dataset"] = None
         if "Custom" in structure["medium"]["type"]:
+            # all UnstructuredGridDataset will be converted into SpatialDataArray (vacuum)
+            for field_name in ["permittivity", "conductivity", "eps_inf"]:
+                if field_name in structure["medium"]:
+                    if isinstance(structure["medium"][field_name], dict):
+                        structure["medium"][field_name] = "SpatialDataArray"
             if structure["medium"]["type"] == "CustomMedium":
                 structure["medium"]["eps_dataset"] = None
             elif structure["medium"]["type"] == "CustomPoleResidue":

--- a/tests/test_components/test_custom.py
+++ b/tests/test_components/test_custom.py
@@ -8,8 +8,12 @@ import pydantic.v1 as pydantic
 import xarray as xr
 import tidy3d as td
 
-from ..utils import assert_log_level, log_capture
-from tidy3d.components.data.dataset import PermittivityDataset
+from ..utils import assert_log_level, log_capture, cartesian_to_unstructured
+from tidy3d.components.data.dataset import (
+    PermittivityDataset,
+    _get_numpy_array,
+    UnstructuredGridDataset,
+)
 from tidy3d.components.medium import CustomMedium, CustomPoleResidue, CustomSellmeier
 from tidy3d.components.medium import CustomLorentz, CustomDrude, CustomDebye, AbstractCustomMedium
 from tidy3d.components.medium import CustomAnisotropicMedium
@@ -58,6 +62,15 @@ def make_custom_current_source():
             field_components[field + component] = make_scalar_data()
     current_dataset = td.FieldDataset(**field_components)
     return td.CustomCurrentSource(size=SIZE, source_time=ST, current_dataset=current_dataset)
+
+
+def make_spatial_data(value=0, dx=0, unstructured=False, seed=None):
+    """Makes a spatial data array."""
+    data = np.random.random((Nx, Ny, Nz)) + value
+    arr = td.SpatialDataArray(data, coords=dict(x=X + dx, y=Y, z=Z))
+    if unstructured:
+        return cartesian_to_unstructured(arr, seed=seed)
+    return arr
 
 
 # instance, which we use in the parameterized tests
@@ -160,7 +173,103 @@ def make_custom_medium(scalar_permittivity_data):
     return CustomMedium(eps_dataset=eps_dataset)
 
 
+def make_triangular_grid_custom_medium(permittivity, conductivity=0):
+    """Make a triangular grid custom medium."""
+    tri_grid_points = td.PointDataArray(
+        [[-1.0, -1.0], [1.0, -1.0], [-1.0, 1.0], [1.0, 1.0]],
+        dims=("index", "axis"),
+    )
+
+    tri_grid_cells = td.CellDataArray(
+        [[0, 1, 2], [1, 2, 3]],
+        dims=("cell_index", "vertex_index"),
+    )
+
+    perm_values = td.IndexedDataArray(
+        [permittivity, permittivity + 1, permittivity + 2, permittivity + 3],
+        dims=("index"),
+    )
+
+    perm_grid = td.TriangularGridDataset(
+        normal_axis=1,
+        normal_pos=0,
+        points=tri_grid_points,
+        cells=tri_grid_cells,
+        values=perm_values,
+    )
+
+    if conductivity != 0:
+        cond_values = td.IndexedDataArray(
+            [conductivity, 1.1 * conductivity, 0.8 * conductivity, 0.9 * conductivity],
+            dims=("index"),
+        )
+
+        cond_grid = td.TriangularGridDataset(
+            normal_axis=1,
+            normal_pos=0,
+            points=tri_grid_points,
+            cells=tri_grid_cells,
+            values=cond_values,
+        )
+
+        return CustomMedium(permittivity=perm_grid, conductivity=cond_grid)
+
+    return CustomMedium(permittivity=perm_grid)
+
+
+def make_tetrahedral_grid_custom_medium(permittivity, conductivity=0):
+    """Make a tetrahedral grid custom medium."""
+    tet_grid_points = td.PointDataArray(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+        dims=("index", "axis"),
+    )
+
+    tet_grid_cells = td.CellDataArray(
+        [[0, 1, 2, 4], [1, 2, 3, 4]],
+        dims=("cell_index", "vertex_index"),
+    )
+
+    perm_values = td.IndexedDataArray(
+        np.linspace(0.9, 1.1, 5) * permittivity,
+        dims=("index"),
+    )
+
+    perm_grid = td.TetrahedralGridDataset(
+        points=tet_grid_points,
+        cells=tet_grid_cells,
+        values=perm_values,
+    )
+
+    if conductivity != 0:
+        cond_values = td.IndexedDataArray(
+            np.linspace(1.1, 0.9, 5) * conductivity,
+            dims=("index"),
+        )
+
+        cond_grid = td.TetrahedralGridDataset(
+            points=tet_grid_points,
+            cells=tet_grid_cells,
+            values=cond_values,
+        )
+
+        return CustomMedium(permittivity=perm_grid, conductivity=cond_grid)
+
+    return CustomMedium(permittivity=perm_grid)
+
+
 CUSTOM_MEDIUM = make_custom_medium(make_scalar_data())
+CUSTOM_MEDIUM_TRIS = make_triangular_grid_custom_medium(permittivity=12)
+CUSTOM_MEDIUM_TETS = make_triangular_grid_custom_medium(permittivity=12)
+CUSTOM_MEDIUM_TRIS_LOSSY = make_tetrahedral_grid_custom_medium(permittivity=12, conductivity=0.1)
+CUSTOM_MEDIUM_TETS_LOSSY = make_tetrahedral_grid_custom_medium(permittivity=12, conductivity=0.2)
+
+CUSTOM_MEDIUM_LIST = [
+    CUSTOM_MEDIUM,
+    CUSTOM_MEDIUM_TRIS,
+    CUSTOM_MEDIUM_TETS,
+    CUSTOM_MEDIUM_TRIS_LOSSY,
+    CUSTOM_MEDIUM_TETS_LOSSY,
+]
 
 
 def test_medium_components():
@@ -169,12 +278,13 @@ def test_medium_components():
         _ = field.interp(x=0, y=0, z=0).sel(f=freqs[0])
 
 
-def test_custom_medium_simulation():
+@pytest.mark.parametrize("medium", CUSTOM_MEDIUM_LIST)
+def test_custom_medium_simulation(medium):
     """Test adding to simulation."""
 
     struct = td.Structure(
         geometry=td.Box(size=(0.5, 0.5, 0.5)),
-        medium=CUSTOM_MEDIUM,
+        medium=medium,
     )
 
     sim = td.Simulation(
@@ -190,64 +300,97 @@ def test_medium_raw():
     """Test from a raw permittivity evaluated at center."""
     eps_raw = make_scalar_data().real
     eps_raw_s = td.SpatialDataArray(eps_raw.squeeze(dim="f", drop=True))
+    eps_raw_u = cartesian_to_unstructured(eps_raw_s, pert=0.01, method="nearest")
 
     # lossless
     med = CustomMedium.from_eps_raw(eps_raw)
-    meds = CustomMedium.from_eps_raw(eps_raw_s)
-    assert med.eps_model(1e14) == meds.eps_model(1e14)
+    for field in [eps_raw_s, eps_raw_u]:
+        meds = CustomMedium.from_eps_raw(field)
+        assert med.eps_model(1e14) == meds.eps_model(1e14)
 
     # lossy
     data = np.random.random((Nx, Ny, Nz, 1)) + 1 + 1e-2 * 1j
     eps_raw = td.ScalarFieldDataArray(data, coords=dict(x=X, y=Y, z=Z, f=freqs))
     eps_raw_s = td.SpatialDataArray(eps_raw.squeeze(dim="f", drop=True))
+    eps_raw_u = cartesian_to_unstructured(eps_raw_s, pert=0.01, method="nearest")
     med = CustomMedium.from_eps_raw(eps_raw)
-    meds = CustomMedium.from_eps_raw(eps_raw_s, freq=freqs[0])
-    assert med.eps_model(1e14) == meds.eps_model(1e14)
+    for field in [eps_raw_s, eps_raw_u]:
+        meds = CustomMedium.from_eps_raw(field, freq=freqs[0])
+        assert med.eps_model(1e14) == meds.eps_model(1e14)
 
     # inconsistent freq
     with pytest.raises(td.exceptions.SetupError):
         med = CustomMedium.from_eps_raw(eps_raw, freq=freqs[0] * 1.1)
 
     # missing freq
-    with pytest.raises(td.exceptions.SetupError):
-        med = CustomMedium.from_eps_raw(eps_raw_s)
+    for field in [eps_raw_s, eps_raw_u]:
+        with pytest.raises(td.exceptions.SetupError):
+            med = CustomMedium.from_eps_raw(field)
 
 
-def test_medium_interp():
+@pytest.mark.parametrize("unstructured", [False, True])
+def test_medium_interp(unstructured):
     """Test if the interp works."""
     coord_interp = td.Coords(**{ax: np.linspace(-2, 2, 20 + ind) for ind, ax in enumerate("xyz")})
 
     # more than one entries per each axis
     orig_data = make_scalar_data()
+
+    if unstructured:
+        orig_data = cartesian_to_unstructured(orig_data.isel(f=0), pert=0.2, method="linear")
+
     data_fit_nearest = coord_interp.spatial_interp(orig_data, "nearest")
     data_fit_linear = coord_interp.spatial_interp(orig_data, "linear")
     assert np.allclose(data_fit_nearest.shape[:3], [len(f) for f in coord_interp.to_list])
     assert np.allclose(data_fit_linear.shape[:3], [len(f) for f in coord_interp.to_list])
     # maximal or minimal values shouldn't exceed that in the supplied data
-    assert max(data_fit_linear.values.ravel()) <= max(orig_data.values.ravel())
-    assert min(data_fit_linear.values.ravel()) >= min(orig_data.values.ravel())
-    assert max(data_fit_nearest.values.ravel()) <= max(orig_data.values.ravel())
-    assert min(data_fit_nearest.values.ravel()) >= min(orig_data.values.ravel())
+    assert max(_get_numpy_array(data_fit_linear).ravel()) <= max(
+        _get_numpy_array(orig_data).ravel()
+    )
+    assert min(_get_numpy_array(data_fit_linear).ravel()) >= min(
+        _get_numpy_array(orig_data).ravel()
+    )
+    assert max(_get_numpy_array(data_fit_nearest).ravel()) <= max(
+        _get_numpy_array(orig_data).ravel()
+    )
+    assert min(_get_numpy_array(data_fit_nearest).ravel()) >= min(
+        _get_numpy_array(orig_data).ravel()
+    )
 
     # single entry along some axis
     Nx = 1
     X = [1.1]
     data = np.random.random((Nx, Ny, Nz, 1))
     orig_data = td.ScalarFieldDataArray(data, coords=dict(x=X, y=Y, z=Z, f=freqs))
+
+    if unstructured:
+        orig_data = cartesian_to_unstructured(orig_data.isel(f=0), pert=0.2, method="linear")
+
     data_fit_nearest = coord_interp.spatial_interp(orig_data, "nearest")
     data_fit_linear = coord_interp.spatial_interp(orig_data, "linear")
     assert np.allclose(data_fit_nearest.shape[:3], [len(f) for f in coord_interp.to_list])
     assert np.allclose(data_fit_linear.shape[:3], [len(f) for f in coord_interp.to_list])
     # maximal or minimal values shouldn't exceed that in the supplied data
-    assert max(data_fit_linear.values.ravel()) <= max(orig_data.values.ravel())
-    assert min(data_fit_linear.values.ravel()) >= min(orig_data.values.ravel())
-    assert max(data_fit_nearest.values.ravel()) <= max(orig_data.values.ravel())
-    assert min(data_fit_nearest.values.ravel()) >= min(orig_data.values.ravel())
-    # original data are not modified
-    assert not np.allclose(orig_data.shape[:3], [len(f) for f in coord_interp.to_list])
+    assert max(_get_numpy_array(data_fit_linear).ravel()) <= max(
+        _get_numpy_array(orig_data).ravel()
+    )
+    assert min(_get_numpy_array(data_fit_linear).ravel()) >= min(
+        _get_numpy_array(orig_data).ravel()
+    )
+    assert max(_get_numpy_array(data_fit_nearest).ravel()) <= max(
+        _get_numpy_array(orig_data).ravel()
+    )
+    assert min(_get_numpy_array(data_fit_nearest).ravel()) >= min(
+        _get_numpy_array(orig_data).ravel()
+    )
+
+    if not unstructured:
+        # original data are not modified
+        assert not np.allclose(orig_data.shape[:3], [len(f) for f in coord_interp.to_list])
 
 
-def test_medium_smaller_than_one_positive_sigma():
+@pytest.mark.parametrize("unstructured", [False, True])
+def test_medium_smaller_than_one_positive_sigma(unstructured):
     """Error when any of eps_inf is lower than 1, or sigma is negative."""
     # single entry along some axis
 
@@ -255,6 +398,10 @@ def test_medium_smaller_than_one_positive_sigma():
     n_data = 1 + np.random.random((Nx, Ny, Nz, 1))
     n_data[0, 0, 0, 0] = 0.5
     n_dataarray = td.ScalarFieldDataArray(n_data, coords=dict(x=X, y=Y, z=Z, f=freqs))
+
+    if unstructured:
+        n_dataarray = cartesian_to_unstructured(n_dataarray.isel(f=0))
+
     with pytest.raises(pydantic.ValidationError):
         _ = CustomMedium.from_nk(n_dataarray)
 
@@ -264,27 +411,37 @@ def test_medium_smaller_than_one_positive_sigma():
     k_data[0, 0, 0, 0] = -0.1
     n_dataarray = td.ScalarFieldDataArray(n_data, coords=dict(x=X, y=Y, z=Z, f=freqs))
     k_dataarray = td.ScalarFieldDataArray(k_data, coords=dict(x=X, y=Y, z=Z, f=freqs))
+
+    if unstructured:
+        n_dataarray = cartesian_to_unstructured(n_dataarray.isel(f=0), seed=1)
+        k_dataarray = cartesian_to_unstructured(k_dataarray.isel(f=0), seed=1)
+
     with pytest.raises(pydantic.ValidationError):
-        _ = CustomMedium.from_nk(n_dataarray, k_dataarray)
+        _ = CustomMedium.from_nk(n_dataarray, k_dataarray, freq=freqs[0])
 
 
-def test_medium_eps_diagonal_on_grid():
+@pytest.mark.parametrize("medium", CUSTOM_MEDIUM_LIST)
+def test_medium_eps_diagonal_on_grid(medium):
     """Test if ``eps_diagonal_on_grid`` works."""
     coord_interp = td.Coords(**{ax: np.linspace(-1, 1, 20 + ind) for ind, ax in enumerate("xyz")})
     freq_interp = 1e14
 
-    eps_output = CUSTOM_MEDIUM.eps_diagonal_on_grid(freq_interp, coord_interp)
+    eps_output = medium.eps_diagonal_on_grid(freq_interp, coord_interp)
 
     for i in range(3):
         assert np.allclose(eps_output[i].shape, [len(f) for f in coord_interp.to_list])
 
 
-def test_medium_nk():
+@pytest.mark.parametrize("unstructured", [False, True])
+def test_medium_nk(unstructured):
     """Construct custom medium from n (and k) DataArrays."""
     n = make_scalar_data().real
     k = make_scalar_data().real * 0.001
     ns = td.SpatialDataArray(n.squeeze(dim="f", drop=True))
     ks = td.SpatialDataArray(k.squeeze(dim="f", drop=True))
+    if unstructured:
+        ns = cartesian_to_unstructured(array=ns, pert=0.01, method="nearest", seed=7546)
+        ks = cartesian_to_unstructured(array=ks, pert=0.01, method="nearest", seed=7546)
 
     # lossless
     med = CustomMedium.from_nk(n=n)
@@ -343,11 +500,11 @@ def test_grids():
         grid.sizes
 
 
-def test_n_cfl():
+@pytest.mark.parametrize("unstructured", [False, True])
+def test_n_cfl(unstructured):
     """CFL number for custom medium"""
-    data = np.random.random((Nx, Ny, Nz, 1)) + 2
-    ndata = td.ScalarFieldDataArray(data, coords=dict(x=X, y=Y, z=Z, f=freqs))
-    med = CustomMedium.from_nk(n=ndata, k=ndata * 0.001)
+    ndata = make_spatial_data(value=2, unstructured=unstructured)
+    med = CustomMedium.from_nk(n=ndata, k=ndata * 0.001, freq=freqs[0])
     assert med.n_cfl >= 2
 
 
@@ -377,7 +534,7 @@ def verify_custom_medium_methods(mat, reduced_fields=[]):
 
         # data fields in medium classes could be SpatialArrays or 2d tuples of spatial arrays
         # lets convert everything into 2d tuples of spatial arrays for uniform handling
-        if isinstance(original, td.SpatialDataArray):
+        if isinstance(original, (td.SpatialDataArray, UnstructuredGridDataset)):
             original = [
                 [
                     original,
@@ -393,9 +550,12 @@ def verify_custom_medium_methods(mat, reduced_fields=[]):
             assert len(or_set) == len(re_set)
 
             for ind in range(len(or_set)):
-                diff = (or_set[ind] - re_set[ind]).abs
-                assert diff.does_cover(subsection.bounds)
-                assert np.allclose(diff, 0)
+                if isinstance(or_set[ind], td.SpatialDataArray):
+                    diff = (or_set[ind] - re_set[ind]).abs
+                    assert diff.does_cover(subsection.bounds)
+                    assert np.allclose(diff, 0)
+                elif isinstance(or_set[ind], UnstructuredGridDataset):
+                    assert re_set[ind].does_cover(subsection.bounds)
 
     # construct sim
     struct = td.Structure(
@@ -446,34 +606,30 @@ def test_anisotropic_custom_medium():
         verify_custom_medium_methods(mat)
 
 
-def test_custom_isotropic_medium():
+@pytest.mark.parametrize("unstructured", [False, True])
+def test_custom_isotropic_medium(unstructured):
     """Custom isotropic non-dispersive medium."""
-    permittivity = td.SpatialDataArray(
-        1 + np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z)
-    )
-    conductivity = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
+    seed = 57345
+    permittivity = make_spatial_data(value=1, unstructured=unstructured, seed=seed)
+    conductivity = make_spatial_data(value=1, unstructured=unstructured, seed=seed)
 
     # some terms in permittivity are complex
     with pytest.raises(pydantic.ValidationError):
-        epstmp = td.SpatialDataArray(
-            1 + np.random.random((Nx, Ny, Nz)) + 0.1j, coords=dict(x=X, y=Y, z=Z)
-        )
+        epstmp = make_spatial_data(value=1 + 0.1j, unstructured=unstructured, seed=seed)
         mat = CustomMedium(permittivity=epstmp, conductivity=conductivity)
 
     # some terms in permittivity are < 1
     with pytest.raises(pydantic.ValidationError):
-        epstmp = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
+        epstmp = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
         mat = CustomMedium(permittivity=epstmp, conductivity=conductivity)
 
     # some terms in conductivity are complex
     with pytest.raises(pydantic.ValidationError):
-        sigmatmp = td.SpatialDataArray(
-            np.random.random((Nx, Ny, Nz)) + 0.1j, coords=dict(x=X, y=Y, z=Z)
-        )
+        sigmatmp = make_spatial_data(value=0.1j, unstructured=unstructured, seed=seed)
         mat = CustomMedium(permittivity=permittivity, conductivity=sigmatmp)
 
     # some terms in conductivity are negative
-    sigmatmp = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)) - 0.5, coords=dict(x=X, y=Y, z=Z))
+    sigmatmp = make_spatial_data(value=-0.5, unstructured=unstructured, seed=seed)
     with pytest.raises(pydantic.ValidationError):
         mat = CustomMedium(permittivity=permittivity, conductivity=sigmatmp)
     mat = CustomMedium(permittivity=permittivity, conductivity=sigmatmp, allow_gain=True)
@@ -481,16 +637,8 @@ def test_custom_isotropic_medium():
 
     # inconsistent coords
     with pytest.raises(pydantic.ValidationError):
-        sigmatmp = td.SpatialDataArray(
-            np.random.random((Nx, Ny, Nz)), coords=dict(x=X + 1, y=Y, z=Z)
-        )
+        sigmatmp = make_spatial_data(value=0, dx=1, unstructured=unstructured, seed=seed)
         mat = CustomMedium(permittivity=permittivity, conductivity=sigmatmp)
-
-    mat = CustomMedium(permittivity=permittivity, conductivity=conductivity)
-    verify_custom_medium_methods(mat, ["permittivity", "conductivity"])
-
-    mat = CustomMedium(permittivity=permittivity)
-    verify_custom_medium_methods(mat, ["permittivity", "conductivity"])
 
 
 def verify_custom_dispersive_medium_methods(mat, reduced_fields=[]):
@@ -498,7 +646,11 @@ def verify_custom_dispersive_medium_methods(mat, reduced_fields=[]):
     verify_custom_medium_methods(mat, reduced_fields)
     freq = 1.0
     for i in range(3):
-        assert mat.eps_dataarray_freq(freq)[i].shape == (Nx, Ny, Nz)
+        eps_comp = mat.eps_dataarray_freq(freq)[i]
+        if isinstance(eps_comp, xr.DataArray):
+            assert eps_comp.shape == (Nx, Ny, Nz)
+        elif isinstance(eps_comp, UnstructuredGridDataset):
+            assert len(eps_comp.points) == Nx * Ny * Nz
     np.testing.assert_allclose(mat.eps_model(freq), mat.pole_residue.eps_model(freq))
     coord_interp = td.Coords(**{ax: np.linspace(-1, 1, 20 + ind) for ind, ax in enumerate("xyz")})
     np.testing.assert_allclose(
@@ -521,38 +673,39 @@ def verify_custom_dispersive_medium_methods(mat, reduced_fields=[]):
         assert c.shape == coord_shape
 
 
-def test_custom_pole_residue():
+@pytest.mark.parametrize("unstructured", [False, True])
+def test_custom_pole_residue(unstructured):
     """Custom pole residue medium."""
-    a = td.SpatialDataArray(-np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
-    c = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)) * 1j, coords=dict(x=X, y=Y, z=Z))
+    seed = 98345
+    eps_inf = make_spatial_data(value=1, unstructured=unstructured, seed=seed)
+    a = -make_spatial_data(value=0, unstructured=unstructured, seed=seed)
+    c = 1j * make_spatial_data(value=1, unstructured=unstructured, seed=seed)
 
     # some terms in eps_inf are negative
     with pytest.raises(pydantic.ValidationError):
-        eps_inf = td.SpatialDataArray(
-            np.random.random((Nx, Ny, Nz)) - 0.5, coords=dict(x=X, y=Y, z=Z)
-        )
-        mat = CustomPoleResidue(eps_inf=eps_inf, poles=((a, c),))
+        epstmp = make_spatial_data(value=-0.5, unstructured=unstructured, seed=seed)
+        mat = CustomPoleResidue(eps_inf=epstmp, poles=((a, c),))
 
     # some terms in eps_inf are complex
     with pytest.raises(pydantic.ValidationError):
-        eps_inf = td.SpatialDataArray(
-            np.random.random((Nx, Ny, Nz)) + 0.1j, coords=dict(x=X, y=Y, z=Z)
-        )
-        mat = CustomPoleResidue(eps_inf=eps_inf, poles=((a, c),))
+        epstmp = make_spatial_data(value=0.1j, unstructured=unstructured, seed=seed)
+        mat = CustomPoleResidue(eps_inf=epstmp, poles=((a, c),))
 
     # inconsistent coords of eps_inf with a,c
     with pytest.raises(pydantic.ValidationError):
-        eps_inf = td.SpatialDataArray(
-            np.random.random((Nx, Ny, Nz)) + 1, coords=dict(x=X + 1, y=Y, z=Z)
-        )
-        mat = CustomPoleResidue(eps_inf=eps_inf, poles=((a, c),))
+        epstmp = make_spatial_data(value=1, dx=1, unstructured=unstructured, seed=seed)
+        mat = CustomPoleResidue(eps_inf=epstmp, poles=((a, c),))
+
+    # mixing Cartesian and unstructured data
+    with pytest.raises(pydantic.ValidationError):
+        epstmp = make_spatial_data(value=1, dx=1, unstructured=(not unstructured), seed=seed)
+        mat = CustomPoleResidue(eps_inf=epstmp, poles=((a, c),))
 
     # break causality
     with pytest.raises(pydantic.ValidationError):
-        atmp = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
-        mat = CustomPoleResidue(eps_inf=xr.ones_like(a), poles=((atmp, c),))
+        atmp = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
+        mat = CustomPoleResidue(eps_inf=eps_inf, poles=((atmp, c),))
 
-    eps_inf = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)) + 1, coords=dict(x=X, y=Y, z=Z))
     mat = CustomPoleResidue(eps_inf=eps_inf, poles=((a, c),))
     verify_custom_dispersive_medium_methods(mat, ["eps_inf", "poles"])
     assert mat.n_cfl > 1
@@ -562,7 +715,7 @@ def test_custom_pole_residue():
     with pytest.raises(td.exceptions.ValidationError):
         mat_medium = mat.to_medium()
     # non-dispersive but gain
-    a = xr.zeros_like(c)
+    a = 0 * c
     mat = CustomPoleResidue(eps_inf=eps_inf, poles=((a, c - 0.1),))
     with pytest.raises(pydantic.ValidationError):
         mat_medium = mat.to_medium()
@@ -577,35 +730,33 @@ def test_custom_pole_residue():
     assert mat.n_cfl > 1
 
 
-def test_custom_sellmeier():
+@pytest.mark.parametrize("unstructured", [False, True])
+def test_custom_sellmeier(unstructured):
     """Custom Sellmeier medium."""
-    b1 = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
-    c1 = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
+    seed = 897245
+    b1 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
+    c1 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
 
-    b2 = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
-    c2 = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
+    b2 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
+    c2 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
 
     # complex b
     with pytest.raises(pydantic.ValidationError):
-        btmp = td.SpatialDataArray(
-            np.random.random((Nx, Ny, Nz)) - 0.5j, coords=dict(x=X, y=Y, z=Z)
-        )
+        btmp = make_spatial_data(value=-0.5j, unstructured=unstructured, seed=seed)
         mat = CustomSellmeier(coeffs=((b1, c1), (btmp, c2)))
 
     # complex c
     with pytest.raises(pydantic.ValidationError):
-        ctmp = td.SpatialDataArray(
-            np.random.random((Nx, Ny, Nz)) - 0.5j, coords=dict(x=X, y=Y, z=Z)
-        )
+        ctmp = make_spatial_data(value=-0.5j, unstructured=unstructured, seed=seed)
         mat = CustomSellmeier(coeffs=((b1, c1), (b2, ctmp)))
 
     # negative c
     with pytest.raises(pydantic.ValidationError):
-        ctmp = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)) - 0.5, coords=dict(x=X, y=Y, z=Z))
+        ctmp = make_spatial_data(value=-0.5, unstructured=unstructured, seed=seed)
         mat = CustomSellmeier(coeffs=((b1, c1), (b2, ctmp)))
 
     # negative b
-    btmp = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)) - 0.5, coords=dict(x=X, y=Y, z=Z))
+    btmp = make_spatial_data(value=-0.5, unstructured=unstructured, seed=seed)
     with pytest.raises(pydantic.ValidationError):
         mat = CustomSellmeier(coeffs=((b1, c1), (btmp, c2)))
     mat = CustomSellmeier(coeffs=((b1, c1), (btmp, c2)), allow_gain=True)
@@ -613,7 +764,12 @@ def test_custom_sellmeier():
 
     # inconsistent coord
     with pytest.raises(pydantic.ValidationError):
-        btmp = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X + 1, y=Y, z=Z))
+        btmp = make_spatial_data(value=0, dx=1, unstructured=unstructured, seed=seed)
+        mat = CustomSellmeier(coeffs=((b1, c2), (btmp, c2)))
+
+    # mixing Cartesian and unstructured data
+    with pytest.raises(pydantic.ValidationError):
+        btmp = make_spatial_data(value=0, dx=1, unstructured=(not unstructured), seed=seed)
         mat = CustomSellmeier(coeffs=((b1, c2), (btmp, c2)))
 
     mat = CustomSellmeier(coeffs=((b1, c1), (b2, c2)))
@@ -621,58 +777,55 @@ def test_custom_sellmeier():
     assert mat.n_cfl == 1
 
     # from dispersion
-    n = td.SpatialDataArray(2 + np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
-    dn_dwvl = td.SpatialDataArray(-np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
+    n = make_spatial_data(value=2, unstructured=unstructured, seed=seed)
+    dn_dwvl = -make_spatial_data(value=0, unstructured=unstructured, seed=seed)
     mat = CustomSellmeier.from_dispersion(n=n, dn_dwvl=dn_dwvl, freq=2, interp_method="linear")
     verify_custom_dispersive_medium_methods(mat, ["coeffs"])
     assert mat.n_cfl == 1
 
 
-def test_custom_lorentz():
+@pytest.mark.parametrize("unstructured", [False, True])
+def test_custom_lorentz(unstructured):
     """Custom Lorentz medium."""
-    eps_inf = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)) + 1, coords=dict(x=X, y=Y, z=Z))
+    seed = 31342
+    eps_inf = make_spatial_data(value=1, unstructured=unstructured, seed=seed)
 
-    de1 = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
-    f1 = td.SpatialDataArray(1 + np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
-    delta1 = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
+    de1 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
+    f1 = make_spatial_data(value=1, unstructured=unstructured, seed=seed)
+    delta1 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
 
-    de2 = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
-    f2 = td.SpatialDataArray(1 + np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
-    delta2 = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
+    de2 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
+    f2 = make_spatial_data(value=1, unstructured=unstructured, seed=seed)
+    delta2 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
 
     # complex de
     with pytest.raises(pydantic.ValidationError):
-        detmp = td.SpatialDataArray(
-            np.random.random((Nx, Ny, Nz)) - 0.5j, coords=dict(x=X, y=Y, z=Z)
-        )
+        detmp = make_spatial_data(value=-0.5j, unstructured=unstructured, seed=seed)
         mat = CustomLorentz(eps_inf=eps_inf, coeffs=((de1, f1, delta1), (detmp, f2, delta2)))
 
     # mixed delta > f and delta < f over spatial points
     with pytest.raises(pydantic.ValidationError):
-        deltatmp = td.SpatialDataArray(
-            1 + np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z)
-        )
+        deltatmp = make_spatial_data(value=1, unstructured=unstructured, seed=seed)
         mat = CustomLorentz(eps_inf=eps_inf, coeffs=((de1, f1, delta1), (de2, f2, deltatmp)))
 
     # inconsistent coords
     with pytest.raises(pydantic.ValidationError):
-        ftmp = td.SpatialDataArray(
-            1 + np.random.random((Nx, Ny, Nz)), coords=dict(x=X + 1, y=Y, z=Z)
-        )
+        ftmp = make_spatial_data(value=1, dx=1, unstructured=unstructured, seed=seed)
+        mat = CustomLorentz(eps_inf=eps_inf, coeffs=((de1, f1, delta1), (de2, ftmp, delta2)))
+
+    # mixing Cartesian and unstructured data
+    with pytest.raises(pydantic.ValidationError):
+        ftmp = make_spatial_data(value=1, dx=1, unstructured=(not unstructured), seed=seed)
         mat = CustomLorentz(eps_inf=eps_inf, coeffs=((de1, f1, delta1), (de2, ftmp, delta2)))
 
     # break causality with negative delta
     with pytest.raises(pydantic.ValidationError):
-        deltatmp = td.SpatialDataArray(
-            np.random.random((Nx, Ny, Nz)) - 0.5, coords=dict(x=X, y=Y, z=Z)
-        )
+        deltatmp = make_spatial_data(value=-0.5, unstructured=unstructured, seed=seed)
         mat = CustomLorentz(eps_inf=eps_inf, coeffs=((de1, f1, delta1), (de2, f2, deltatmp)))
 
     # gain medium with negative delta epsilon
     with pytest.raises(pydantic.ValidationError):
-        detmp = td.SpatialDataArray(
-            np.random.random((Nx, Ny, Nz)) - 0.5, coords=dict(x=X, y=Y, z=Z)
-        )
+        detmp = make_spatial_data(value=-0.5, unstructured=unstructured, seed=seed)
         mat = CustomLorentz(eps_inf=eps_inf, coeffs=((de1, f1, delta1), (detmp, f2, delta2)))
     mat = CustomLorentz(
         eps_inf=eps_inf, coeffs=((de1, f1, delta1), (detmp, f2, delta2)), allow_gain=True
@@ -688,35 +841,36 @@ def test_custom_lorentz():
     assert mat.pole_residue.subpixel
 
 
-def test_custom_drude():
+@pytest.mark.parametrize("unstructured", [False, True])
+def test_custom_drude(unstructured):
     """Custom Drude medium."""
-    eps_inf = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)) + 1, coords=dict(x=X, y=Y, z=Z))
+    seed = 2342
+    eps_inf = make_spatial_data(value=1, unstructured=unstructured, seed=seed)
 
-    f1 = td.SpatialDataArray(1 + np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
-    delta1 = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
+    f1 = make_spatial_data(value=1, unstructured=unstructured, seed=seed)
+    delta1 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
 
-    f2 = td.SpatialDataArray(1 + np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
-    delta2 = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
+    f2 = make_spatial_data(value=1, unstructured=unstructured, seed=seed)
+    delta2 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
 
     # complex delta
     with pytest.raises(pydantic.ValidationError):
-        deltatmp = td.SpatialDataArray(
-            np.random.random((Nx, Ny, Nz)) - 0.5j, coords=dict(x=X, y=Y, z=Z)
-        )
+        deltatmp = make_spatial_data(value=-0.5j, unstructured=unstructured, seed=seed)
         mat = CustomDrude(eps_inf=eps_inf, coeffs=((f1, delta1), (f2, deltatmp)))
 
     # negative delta
     with pytest.raises(pydantic.ValidationError):
-        deltatmp = td.SpatialDataArray(
-            np.random.random((Nx, Ny, Nz)) - 0.5, coords=dict(x=X, y=Y, z=Z)
-        )
+        deltatmp = make_spatial_data(value=-0.5, unstructured=unstructured, seed=seed)
         mat = CustomDrude(eps_inf=eps_inf, coeffs=((f1, delta1), (f2, deltatmp)))
 
     # inconsistent coords
     with pytest.raises(pydantic.ValidationError):
-        ftmp = td.SpatialDataArray(
-            1 + np.random.random((Nx, Ny, Nz)), coords=dict(x=X + 1, y=Y, z=Z)
-        )
+        ftmp = make_spatial_data(value=1, dx=1, unstructured=unstructured, seed=seed)
+        mat = CustomDrude(eps_inf=eps_inf, coeffs=((f1, delta1), (ftmp, delta2)))
+
+    # mixing Cartesian and unstructured data
+    with pytest.raises(pydantic.ValidationError):
+        ftmp = make_spatial_data(value=1, dx=1, unstructured=(not unstructured), seed=seed)
         mat = CustomDrude(eps_inf=eps_inf, coeffs=((f1, delta1), (ftmp, delta2)))
 
     mat = CustomDrude(eps_inf=eps_inf, coeffs=((f1, delta1), (f2, delta2)))
@@ -724,47 +878,46 @@ def test_custom_drude():
     assert mat.n_cfl > 1
 
 
-def test_custom_debye():
+@pytest.mark.parametrize("unstructured", [False, True])
+def test_custom_debye(unstructured):
     """Custom Debye medium."""
-    eps_inf = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)) + 1, coords=dict(x=X, y=Y, z=Z))
+    seed = 2342
+    eps_inf = make_spatial_data(value=1, unstructured=unstructured, seed=seed)
 
-    eps1 = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
-    tau1 = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
+    eps1 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
+    tau1 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
 
-    eps2 = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
-    tau2 = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
+    eps2 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
+    tau2 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
 
     # complex eps
     with pytest.raises(pydantic.ValidationError):
-        epstmp = td.SpatialDataArray(
-            np.random.random((Nx, Ny, Nz)) - 0.5j, coords=dict(x=X, y=Y, z=Z)
-        )
+        epstmp = make_spatial_data(value=-0.5j, unstructured=unstructured, seed=seed)
         mat = CustomDebye(eps_inf=eps_inf, coeffs=((eps1, tau1), (epstmp, tau2)))
 
     # complex tau
     with pytest.raises(pydantic.ValidationError):
-        tautmp = td.SpatialDataArray(
-            np.random.random((Nx, Ny, Nz)) - 0.5j, coords=dict(x=X, y=Y, z=Z)
-        )
+        tautmp = make_spatial_data(value=-0.5j, unstructured=unstructured, seed=seed)
         mat = CustomDebye(eps_inf=eps_inf, coeffs=((eps1, tau1), (eps2, tautmp)))
 
     # negative tau
     with pytest.raises(pydantic.ValidationError):
-        tautmp = td.SpatialDataArray(
-            np.random.random((Nx, Ny, Nz)) - 0.5, coords=dict(x=X, y=Y, z=Z)
-        )
+        tautmp = make_spatial_data(value=-0.5, unstructured=unstructured, seed=seed)
         mat = CustomDebye(eps_inf=eps_inf, coeffs=((eps1, tau1), (eps2, tautmp)))
 
     # inconsistent coords
     with pytest.raises(pydantic.ValidationError):
-        epstmp = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X + 1, y=Y, z=Z))
+        epstmp = make_spatial_data(value=0, dx=1, unstructured=unstructured, seed=seed)
+        mat = CustomDebye(eps_inf=eps_inf, coeffs=((eps1, tau1), (epstmp, tau2)))
+
+    # mixing Cartesian and unstructured data
+    with pytest.raises(pydantic.ValidationError):
+        epstmp = make_spatial_data(value=0, dx=1, unstructured=(not unstructured), seed=seed)
         mat = CustomDebye(eps_inf=eps_inf, coeffs=((eps1, tau1), (epstmp, tau2)))
 
     # negative delta epsilon
     with pytest.raises(pydantic.ValidationError):
-        epstmp = td.SpatialDataArray(
-            np.random.random((Nx, Ny, Nz)) - 0.5, coords=dict(x=X, y=Y, z=Z)
-        )
+        epstmp = make_spatial_data(value=-0.5, unstructured=unstructured, seed=seed)
         mat = CustomDebye(eps_inf=eps_inf, coeffs=((eps1, tau1), (epstmp, tau2)))
     mat = CustomDebye(eps_inf=eps_inf, coeffs=((eps1, tau1), (epstmp, tau2)), allow_gain=True)
     verify_custom_dispersive_medium_methods(mat, ["eps_inf", "coeffs"])
@@ -775,30 +928,30 @@ def test_custom_debye():
     assert mat.n_cfl > 1
 
 
-def test_custom_anisotropic_medium(log_capture):
+@pytest.mark.parametrize("unstructured", [True])
+def test_custom_anisotropic_medium(log_capture, unstructured):
     """Custom anisotropic medium."""
+    seed = 43243
 
     # xx
-    permittivity = td.SpatialDataArray(
-        1 + np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z)
-    )
-    conductivity = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
+    permittivity = make_spatial_data(value=1, unstructured=unstructured, seed=seed)
+    conductivity = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
     mat_xx = CustomMedium(permittivity=permittivity, conductivity=conductivity)
 
     # yy
-    eps_inf = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)) + 1, coords=dict(x=X, y=Y, z=Z))
-    eps1 = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
-    tau1 = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
-    eps2 = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
-    tau2 = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
+    eps_inf = make_spatial_data(value=1, unstructured=unstructured, seed=seed)
+    eps1 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
+    tau1 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
+    eps2 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
+    tau2 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
     mat_yy = CustomDebye(eps_inf=eps_inf, coeffs=((eps1, tau1), (eps2, tau2)))
 
     # zz
-    eps_inf = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)) + 1, coords=dict(x=X, y=Y, z=Z))
-    f1 = td.SpatialDataArray(1 + np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
-    delta1 = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
-    f2 = td.SpatialDataArray(1 + np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
-    delta2 = td.SpatialDataArray(np.random.random((Nx, Ny, Nz)), coords=dict(x=X, y=Y, z=Z))
+    eps_inf = make_spatial_data(value=1, unstructured=unstructured, seed=seed)
+    f1 = make_spatial_data(value=1, unstructured=unstructured, seed=seed)
+    f2 = make_spatial_data(value=1, unstructured=unstructured, seed=seed)
+    delta1 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
+    delta2 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
     mat_zz = CustomDrude(eps_inf=eps_inf, coeffs=((f1, delta1), (f2, delta2)))
 
     # anisotropic
@@ -812,10 +965,12 @@ def test_custom_anisotropic_medium(log_capture):
     # 1) xx-component is using `interp_method = nearest`, and mat using `None`;
     # so that xx-component is using "nearest"
     freq = 2e14
-    dist_coeff = 0.6
+    dist_coeff = 0.7
     coord_test = td.Coords(x=[X[0] * dist_coeff + X[1] * (1 - dist_coeff)], y=Y[0], z=Z[0])
     eps_nearest = mat.eps_sigma_to_eps_complex(
-        permittivity.sel(x=X[0], y=Y[0], z=Z[0]), conductivity.sel(x=X[0], y=Y[0], z=Z[0]), freq
+        permittivity.interp(x=X[0], y=Y[0], z=Z[0], method="nearest"),
+        conductivity.interp(x=X[0], y=Y[0], z=Z[0], method="nearest"),
+        freq,
     )
     eps_interp = mat.eps_comp_on_grid(0, 0, freq, coord_test)[0, 0, 0]
     assert eps_interp == eps_nearest.data
@@ -826,30 +981,31 @@ def test_custom_anisotropic_medium(log_capture):
     eps_interp = mat.eps_comp_on_grid(0, 0, freq, coord_test)[0, 0, 0]
     assert eps_interp == eps_nearest.data
 
-    # 3) xx-component is using `interp_method = nearest`, and mat using `linear`;
-    # so that xx-component is using "linear" (overridden by the one in mat)
-    mat = CustomAnisotropicMedium(xx=mat_xx, yy=mat_yy, zz=mat_zz, interp_method="linear")
-    eps_second_nearest = mat.eps_sigma_to_eps_complex(
-        permittivity.sel(x=X[1], y=Y[0], z=Z[0]), conductivity.sel(x=X[1], y=Y[0], z=Z[0]), freq
-    )
-    eps_manual_interp = eps_nearest * dist_coeff + eps_second_nearest * (1 - dist_coeff)
-    eps_interp = mat.eps_comp_on_grid(0, 0, freq, coord_test)[0, 0, 0]
-    assert np.isclose(eps_interp, eps_manual_interp.data)
+    if not unstructured:
+        # 3) xx-component is using `interp_method = nearest`, and mat using `linear`;
+        # so that xx-component is using "linear" (overridden by the one in mat)
+        mat = CustomAnisotropicMedium(xx=mat_xx, yy=mat_yy, zz=mat_zz, interp_method="linear")
+        eps_second_nearest = mat.eps_sigma_to_eps_complex(
+            permittivity.sel(x=X[1], y=Y[0], z=Z[0]), conductivity.sel(x=X[1], y=Y[0], z=Z[0]), freq
+        )
+        eps_manual_interp = eps_nearest * dist_coeff + eps_second_nearest * (1 - dist_coeff)
+        eps_interp = mat.eps_comp_on_grid(0, 0, freq, coord_test)[0, 0, 0]
+        assert np.isclose(eps_interp, eps_manual_interp.data)
 
-    # 4) xx-component is using `interp_method = linear`, and mat using `None`;
-    # so that xx-component is using "linear"
-    mat_xx = CustomMedium(
-        permittivity=permittivity, conductivity=conductivity, interp_method="linear"
-    )
-    mat = CustomAnisotropicMedium(xx=mat_xx, yy=mat_yy, zz=mat_zz)
-    eps_interp = mat.eps_comp_on_grid(0, 0, freq, coord_test)[0, 0, 0]
-    assert np.isclose(eps_interp, eps_manual_interp.data)
+        # 4) xx-component is using `interp_method = linear`, and mat using `None`;
+        # so that xx-component is using "linear"
+        mat_xx = CustomMedium(
+            permittivity=permittivity, conductivity=conductivity, interp_method="linear"
+        )
+        mat = CustomAnisotropicMedium(xx=mat_xx, yy=mat_yy, zz=mat_zz)
+        eps_interp = mat.eps_comp_on_grid(0, 0, freq, coord_test)[0, 0, 0]
+        assert np.isclose(eps_interp, eps_manual_interp.data)
 
-    # 5) xx-component is using `interp_method = linear`, and mat using `linear`;
-    # so that xx-component is still using "linear"
-    mat = CustomAnisotropicMedium(xx=mat_xx, yy=mat_yy, zz=mat_zz, interp_method="linear")
-    eps_interp = mat.eps_comp_on_grid(0, 0, freq, coord_test)[0, 0, 0]
-    assert np.isclose(eps_interp, eps_manual_interp.data)
+        # 5) xx-component is using `interp_method = linear`, and mat using `linear`;
+        # so that xx-component is still using "linear"
+        mat = CustomAnisotropicMedium(xx=mat_xx, yy=mat_yy, zz=mat_zz, interp_method="linear")
+        eps_interp = mat.eps_comp_on_grid(0, 0, freq, coord_test)[0, 0, 0]
+        assert np.isclose(eps_interp, eps_manual_interp.data)
 
     # 6) xx-component is using `interp_method = linear`, and mat using `nearest`;
     # so that xx-component is using "nearest" (overridden by the one in mat)
@@ -869,7 +1025,9 @@ def test_custom_anisotropic_medium(log_capture):
         mat = CustomAnisotropicMedium(xx=mat_xx, yy=mat_yy, zz=mat_tmp)
 
 
-def test_io_dispersive(tmp_path):
+@pytest.mark.parametrize("z_custom", [[0.0], [0.0, 1.0]])
+@pytest.mark.parametrize("unstructured", [True, False])
+def test_io_dispersive(tmp_path, unstructured, z_custom):
     Mx_custom = 1.0
     My_custom = 2.1
     Nx = 10
@@ -877,7 +1035,7 @@ def test_io_dispersive(tmp_path):
 
     x_custom = np.linspace(-Mx_custom / 2, Mx_custom / 2, Nx)
     y_custom = np.linspace(-My_custom / 2, My_custom / 2, Ny)
-    z_custom = [0]
+    z_custom = [0.0, 1.0]
 
     delep_data = np.ones([len(x_custom), len(y_custom), len(z_custom)])
     delep_dataset = td.SpatialDataArray(
@@ -888,6 +1046,14 @@ def test_io_dispersive(tmp_path):
         np.ones_like(delep_data) * 3e14, coords={"x": x_custom, "y": y_custom, "z": z_custom}
     )
     eps_inf_dataset = xr.ones_like(delep_dataset)
+
+    if unstructured:
+        seed = 3232
+        eps_inf_dataset = cartesian_to_unstructured(eps_inf_dataset, seed=seed)
+        delep_dataset = cartesian_to_unstructured(delep_dataset, seed=seed)
+        f0_dataset = cartesian_to_unstructured(f0_dataset, seed=seed)
+        gamma_dataset = cartesian_to_unstructured(gamma_dataset, seed=seed)
+
     mat_custom = td.CustomLorentz(
         eps_inf=eps_inf_dataset, coeffs=((delep_dataset, f0_dataset, gamma_dataset),)
     )

--- a/tests/test_components/test_meshgenerate.py
+++ b/tests/test_components/test_meshgenerate.py
@@ -7,7 +7,7 @@ import tidy3d as td
 from tidy3d.constants import fp_eps
 from tidy3d.components.grid.mesher import GradedMesher
 
-from ..utils import assert_log_level, log_capture
+from ..utils import assert_log_level, log_capture, cartesian_to_unstructured
 
 np.random.seed(4)
 
@@ -707,7 +707,9 @@ def test_shapely_strtree_warnings():
         )
 
 
-def test_anisotropic_material_meshing():
+@pytest.mark.parametrize("z", [[0, 1], [0]])
+@pytest.mark.parametrize("unstructured", [True, False])
+def test_anisotropic_material_meshing(unstructured, z):
     """Make sure the largest propagation index defines refinement in all directions."""
     perm_diag = [3, 2, 1]
     cond_diag = [0.2, 0.15, 0.1]
@@ -731,18 +733,21 @@ def test_anisotropic_material_meshing():
         ),
     )
 
-    coords = dict(x=[0], y=[0], z=[0])
+    coords = dict(x=[0, 1], y=[0, 1], z=z)
+    ones = td.SpatialDataArray(np.ones((2, 2, len(z))), coords=coords)
+    if unstructured:
+        ones = cartesian_to_unstructured(ones, seed=951)
     custom_medium_xx = td.CustomMedium(
-        permittivity=td.SpatialDataArray(perm_diag[0] * np.ones((1, 1, 1)), coords=coords),
-        conductivity=td.SpatialDataArray(cond_diag[0] * np.ones((1, 1, 1)), coords=coords),
+        permittivity=perm_diag[0] * ones,
+        conductivity=cond_diag[0] * ones,
     )
     custom_medium_yy = td.CustomMedium(
-        permittivity=td.SpatialDataArray(perm_diag[1] * np.ones((1, 1, 1)), coords=coords),
-        conductivity=td.SpatialDataArray(cond_diag[1] * np.ones((1, 1, 1)), coords=coords),
+        permittivity=perm_diag[1] * ones,
+        conductivity=cond_diag[1] * ones,
     )
     custom_medium_zz = td.CustomMedium(
-        permittivity=td.SpatialDataArray(perm_diag[2] * np.ones((1, 1, 1)), coords=coords),
-        conductivity=td.SpatialDataArray(cond_diag[2] * np.ones((1, 1, 1)), coords=coords),
+        permittivity=perm_diag[2] * ones,
+        conductivity=cond_diag[2] * ones,
     )
     box_diag_custom = td.Structure(
         geometry=box,

--- a/tests/test_components/test_parameter_perturbation.py
+++ b/tests/test_components/test_parameter_perturbation.py
@@ -4,6 +4,14 @@ import matplotlib.pyplot as plt
 import pytest
 import pydantic.v1 as pydantic
 import tidy3d as td
+from ..utils import cartesian_to_unstructured
+
+sp_arr = td.SpatialDataArray(300 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6]))
+sp_arr_u = cartesian_to_unstructured(sp_arr)
+sp_arr_2d = td.SpatialDataArray(300 * np.ones((2, 1, 2)), coords=dict(x=[1, 2], y=[3.5], z=[5, 6]))
+sp_arr_2d_u = cartesian_to_unstructured(sp_arr_2d)
+
+sp_arrs = [sp_arr, sp_arr_u, sp_arr_2d, sp_arr_2d_u]
 
 
 def test_heat_perturbation():
@@ -40,10 +48,10 @@ def test_heat_perturbation():
     assert isinstance(sampled, np.ndarray)
     sampled = perturb.sample(np.array([310, 320]))
     assert isinstance(sampled, np.ndarray)
-    sampled = perturb.sample(
-        td.SpatialDataArray(300 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6]))
-    )
-    assert isinstance(sampled, td.SpatialDataArray)
+
+    for arr in sp_arrs:
+        sampled = perturb.sample(arr)
+        assert isinstance(sampled, type(arr))
 
     # complex temperature
     with pytest.raises(ValueError):
@@ -80,10 +88,10 @@ def test_heat_perturbation():
         assert isinstance(sampled, np.ndarray)
         sampled = perturb.sample(np.array([310, 320]))
         assert isinstance(sampled, np.ndarray)
-        sampled = perturb.sample(
-            td.SpatialDataArray(300 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6]))
-        )
-        assert isinstance(sampled, td.SpatialDataArray)
+
+        for arr in sp_arrs:
+            sampled = perturb.sample(arr)
+            assert isinstance(sampled, type(arr))
 
         # test plotting
         perturb.plot(temperature=np.linspace(200, 400, 10), val="real", ax=ax)
@@ -143,41 +151,49 @@ def test_charge_perturbation():
             hole_range=(0, 0.5e20),
         )
 
+    def test_sample(perturb):
+        sampled = perturb.sample(electron_density=[1e17, 1e18, 1e19], hole_density=[2e17, 2e18])
+        assert isinstance(sampled, np.ndarray)
+        assert np.shape(sampled) == (3, 2)
+        sampled = perturb.sample(electron_density=1e17, hole_density=[2e17, 2e18])
+        assert isinstance(sampled, np.ndarray)
+
+        for arr in sp_arrs:
+            sampled = perturb.sample(electron_density=1e15 * arr, hole_density=2e15 * arr)
+            assert isinstance(sampled, type(arr))
+            sampled = perturb.sample(electron_density=1e15 * arr, hole_density=0)
+            assert isinstance(sampled, type(arr))
+            sampled = perturb.sample(electron_density=1e15, hole_density=2e15 * arr)
+            assert isinstance(sampled, type(arr))
+
+        # test mixing spatial data array and simple array
+        for arr in sp_arrs:
+            with pytest.raises(td.exceptions.DataError):
+                _ = perturb.sample(
+                    electron_density=arr,
+                    hole_density=[2e17, 2e18],
+                )
+
+        with pytest.raises(td.exceptions.DataError):
+            _ = perturb.sample(electron_density=sp_arr, hole_density=sp_arr_u)
+
+        with pytest.raises(td.exceptions.DataError):
+            _ = perturb.sample(electron_density=sp_arr, hole_density=sp_arr_2d)
+
+        with pytest.raises(td.exceptions.DataError):
+            _ = perturb.sample(electron_density=sp_arr_2d_u, hole_density=sp_arr_u)
+
+        with pytest.raises(ValueError):
+            _ = perturb.sample(electron_density=1e19j, hole_density=2e19)
+
     # test sample function on different arguments
+    test_sample(perturb)
+    shape = (3, 4)
+    sampled = perturb.sample(electron_density=np.ones(shape), hole_density=np.zeros(shape))
+    assert isinstance(sampled, np.ndarray)
+    assert np.shape(sampled) == shape
     sampled = perturb.sample(electron_density=1e19, hole_density=2e19)
     assert isinstance(sampled, float)
-    sampled = perturb.sample(electron_density=[1e17, 1e18, 1e19], hole_density=[2e17, 2e18])
-    assert isinstance(sampled, np.ndarray)
-    sampled = perturb.sample(electron_density=1e17, hole_density=[2e17, 2e18])
-    assert isinstance(sampled, np.ndarray)
-    sampled = perturb.sample(
-        electron_density=td.SpatialDataArray(
-            1e18 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6])
-        ),
-        hole_density=td.SpatialDataArray(
-            2e18 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6])
-        ),
-    )
-    assert isinstance(sampled, td.SpatialDataArray)
-    sampled = perturb.sample(
-        electron_density=0,
-        hole_density=td.SpatialDataArray(
-            2e18 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6])
-        ),
-    )
-    assert isinstance(sampled, td.SpatialDataArray)
-
-    # test mixing spatial data array and simple array
-    with pytest.raises(ValueError):
-        _ = perturb.sample(
-            electron_density=td.SpatialDataArray(
-                1e18 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6])
-            ),
-            hole_density=[2e17, 2e18],
-        )
-
-    with pytest.raises(ValueError):
-        _ = perturb.sample(electron_density=1e19j, hole_density=2e19)
 
     # test plotting
     ax_2d = perturb.plot(
@@ -226,39 +242,9 @@ def test_charge_perturbation():
         assert perturb.is_complex
 
         # test sample function on different arguments
-        test_value_in = perturb.sample(electron_density=1.5e18, hole_density=9e17)
-        assert isinstance(test_value_in, complex)
-        test_value_out = perturb.sample(electron_density=1e19, hole_density=2e19)
-        assert isinstance(test_value_out, complex)
-        sampled = perturb.sample(electron_density=[1e17, 1e18, 1e19], hole_density=[2e17, 2e18])
-        assert isinstance(sampled, np.ndarray)
-        sampled = perturb.sample(electron_density=1e17, hole_density=[2e17, 2e18])
-        assert isinstance(sampled, np.ndarray)
-        sampled = perturb.sample(
-            electron_density=td.SpatialDataArray(
-                1e18 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6])
-            ),
-            hole_density=td.SpatialDataArray(
-                2e18 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6])
-            ),
-        )
-        assert isinstance(sampled, td.SpatialDataArray)
-        sampled = perturb.sample(
-            electron_density=0,
-            hole_density=td.SpatialDataArray(
-                2e18 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6])
-            ),
-        )
-        assert isinstance(sampled, td.SpatialDataArray)
-
-        # test mixing spatial data array and simple array
-        with pytest.raises(ValueError):
-            _ = perturb.sample(
-                electron_density=td.SpatialDataArray(
-                    1e18 * np.ones((2, 2, 2)), coords=dict(x=[1, 2], y=[3, 4], z=[5, 6])
-                ),
-                hole_density=[2e17, 2e18],
-            )
+        sampled = perturb.sample(electron_density=1e19, hole_density=2e19)
+        assert isinstance(sampled, complex)
+        test_sample(perturb)
 
         # test plotting
         _ = perturb.plot(
@@ -283,6 +269,11 @@ def test_charge_perturbation():
         )
 
         # check interpolation works as expected
+        test_value_in = perturb.sample(electron_density=1.5e18, hole_density=9e17)
+        assert isinstance(test_value_in, complex)
+        test_value_out = perturb.sample(electron_density=1e19, hole_density=2e19)
+        assert isinstance(test_value_out, complex)
+
         if interp_method == "linear":
             assert test_value_in != perturb_data[-1, -1].item()
         elif interp_method == "nearest":
@@ -301,7 +292,8 @@ def test_charge_perturbation():
     plt.close("all")
 
 
-def test_parameter_perturbation():
+@pytest.mark.parametrize("unstructured", [True, False])
+def test_parameter_perturbation(unstructured):
     heat = td.LinearHeatPerturbation(
         coeff=0.01,
         temperature_ref=300,
@@ -320,11 +312,18 @@ def test_parameter_perturbation():
 
     coords = dict(x=[1, 2], y=[3, 4], z=[5, 6])
     coords2 = dict(x=[1, 2], y=[3, 4], z=[5])
-    temperature = td.SpatialDataArray(300 * np.ones((2, 2, 2)), coords=coords)
-    electron_density = td.SpatialDataArray(1e18 * np.ones((2, 2, 2)), coords=coords)
-    hole_density = td.SpatialDataArray(2e18 * np.ones((2, 2, 2)), coords=coords)
+    temperature = td.SpatialDataArray(300 * np.random.random((2, 2, 2)), coords=coords)
+    electron_density = td.SpatialDataArray(1e18 * np.random.random((2, 2, 2)), coords=coords)
+    hole_density = td.SpatialDataArray(2e18 * np.random.random((2, 2, 2)), coords=coords)
 
-    temperature2 = td.SpatialDataArray(300 * np.ones((2, 2, 1)), coords=coords2)
+    temperature2 = td.SpatialDataArray(300 * np.random.random((2, 2, 1)), coords=coords2)
+
+    if unstructured:
+        seed = 321
+        temperature = cartesian_to_unstructured(temperature, seed=seed)
+        electron_density = cartesian_to_unstructured(electron_density, seed=seed)
+        hole_density = cartesian_to_unstructured(hole_density, seed=seed)
+        temperature2 = cartesian_to_unstructured(temperature2, seed=seed)
 
     param_perturb = td.ParameterPerturbation(
         heat=heat,

--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -12,7 +12,7 @@ from tidy3d.plugins.mode.mode_solver import MODE_MONITOR_NAME
 from tidy3d.plugins.mode.derivatives import create_sfactor_b, create_sfactor_f
 from tidy3d.plugins.mode.solver import compute_modes
 from tidy3d.exceptions import SetupError
-from ..utils import assert_log_level, log_capture  # noqa: F401
+from ..utils import assert_log_level, log_capture, cartesian_to_unstructured  # noqa: F401
 from tidy3d import ScalarFieldDataArray
 from tidy3d.web.core.environment import Env
 
@@ -375,8 +375,8 @@ def test_mode_solver_custom_medium(mock_remote_api, local, tmp_path):
         precision="double" if local else "single",
     )
 
-    plane_left = td.Box(center=(-0.5, 0, 0), size=(0.9, 0, 0.9))
-    plane_right = td.Box(center=(0.5, 0, 0), size=(0.9, 0, 0.9))
+    plane_left = td.Box(center=(-0.5, 0, 0), size=(0, 0.9, 0.9))
+    plane_right = td.Box(center=(0.5, 0, 0), size=(0, 0.9, 0.9))
 
     n_eff = []
     for plane in [plane_left, plane_right]:
@@ -402,6 +402,69 @@ def test_mode_solver_custom_medium(mock_remote_api, local, tmp_path):
         assert n_eff[0] < 1.5
         assert n_eff[1] > 4
         assert n_eff[1] < 5
+
+
+@pytest.mark.parametrize("interp,tol", [("linear", 1e-3), ("nearest", 1e-3)])
+@pytest.mark.parametrize("cond_factor", [0, 0.01])
+@pytest.mark.parametrize("nx", [1, 3])
+def test_mode_solver_unstructured_custom_medium(nx, cond_factor, interp, tol, tmp_path):
+    """Test mode solver can work with unstructured custom medium. We compare mode solver results
+    with unstructured custom medium to the results with usual Cartesian custom medium.
+    """
+
+    freq0 = td.C_0 / 1.0
+
+    # Cartesian
+    x_custom = np.linspace(-0.6, 0.6, nx)
+    y_custom = np.linspace(-0.3, 0.3, 21)
+    z_custom = np.linspace(-0.3, 0.3, 22)
+    n = 2.5 + (x_custom[:, None, None] + 0.6) / 1.2 * np.sin(y_custom[None, :, None]) * np.cos(
+        z_custom[None, None, :]
+    )
+    n_data = td.SpatialDataArray(n, coords=dict(x=x_custom, y=y_custom, z=z_custom))
+
+    # unperturbed unstructured grid
+    n_data_u = cartesian_to_unstructured(n_data, pert=0, seed=987, method="direct")
+
+    # more perturbed unstructured grid
+    n_data_up = cartesian_to_unstructured(n_data, pert=0.15, seed=987)
+
+    md = []
+
+    for n_arr in [n_data, n_data_u, n_data_up]:
+        mat_custom = td.CustomMedium.from_nk(
+            n=n_arr, k=cond_factor * n_arr, freq=freq0, interp_method=interp
+        )
+        waveguide = td.Structure(geometry=td.Box(size=(100, 0.5, 0.5)), medium=mat_custom)
+        simulation = td.Simulation(
+            size=(2, 2, 2),
+            grid_spec=td.GridSpec(wavelength=1.0),
+            structures=[waveguide],
+            run_time=1e-12,
+        )
+        mode_spec = td.ModeSpec(num_modes=1)
+
+        plane = td.Box(center=(0, 0, 0), size=(0.0, 0.9, 0.9))
+        ms = ModeSolver(
+            simulation=simulation,
+            plane=plane,
+            mode_spec=mode_spec,
+            freqs=[freq0],
+            direction="+",
+        )
+        modes = ms.solve()
+        md.append(modes)
+
+    # ms.plot_field(mode_index=0, f=freq0, field_name="Ez")
+    # plt.show()
+
+    error_u = np.abs(md[0].n_eff - md[1].n_eff).values.item()
+    error_up = np.abs(md[0].n_eff - md[2].n_eff).values.item()
+
+    print(nx, cond_factor, interp, tol, error_u, error_up)
+
+    assert error_u < 5e-5
+    assert error_up < tol
 
 
 def test_mode_solver_straight_vs_angled():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -507,7 +507,7 @@ SIM_FULL = td.Simulation(
         td.Structure(
             geometry=td.Box(
                 size=(0.1, 1, 1),
-                center=(-3.0, 0.5, 0.5),
+                center=(-1.0, 0.5, 0.5),
             ),
             medium=custom_medium_u,
         ),
@@ -549,7 +549,7 @@ SIM_FULL = td.Simulation(
         td.Structure(
             geometry=td.Box(
                 size=(1, 1, 1),
-                center=(-1.0, 0.5, 0.5),
+                center=(-3.0, 0.5, 0.5),
             ),
             medium=td.Medium(
                 nonlinear_spec=td.NonlinearSusceptibility(chi3=0.1, numiters=20),

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -168,11 +168,11 @@ class DataArray(xr.DataArray):
         with h5py.File(fname, "r") as f:
             sub_group = f[group_path]
             values = np.array(sub_group[DATA_ARRAY_VALUE_NAME])
-            coords = {dim: np.array(sub_group[dim]) for dim in cls._dims}
+            coords = {dim: np.array(sub_group[dim]) for dim in cls._dims if dim in sub_group}
             for key, val in coords.items():
                 if val.dtype == "O":
                     coords[key] = [byte_string.decode() for byte_string in val.tolist()]
-            return cls(values, coords=coords)
+            return cls(values, coords=coords, dims=cls._dims)
 
     @classmethod
     def from_file(cls, fname: str, group_path: str) -> DataArray:

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -2,16 +2,17 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Union, Dict, Callable, Any
+from typing import Union, Dict, Callable, Any, Tuple
 
 import xarray as xr
 import numpy as np
+from scipy.interpolate import NearestNDInterpolator
 import pydantic.v1 as pd
 from matplotlib.tri import Triangulation
 from matplotlib import pyplot as plt
 import numbers
 
-from .data_array import DataArray
+from .data_array import DataArray, DATA_ARRAY_MAP
 from .data_array import ScalarFieldDataArray, ScalarFieldTimeDataArray, ScalarModeFieldDataArray
 from .data_array import ModeIndexDataArray, GroupIndexDataArray, ModeDispersionDataArray
 from .data_array import TriangleMeshDataArray
@@ -21,11 +22,15 @@ from .data_array import PointDataArray, IndexedDataArray, CellDataArray, Spatial
 from ..viz import equal_aspect, add_ax_if_none, plot_params_grid
 from ..base import Tidy3dBaseModel, cached_property
 from ..base import skip_if_fields_missing
-from ..types import Axis, Bound, ArrayLike, Ax, Coordinate, Literal
+from ..types import Axis, Bound, ArrayLike, Ax, Coordinate, Literal, annotate_type
 from ...packaging import vtk, requires_vtk
 from ...exceptions import DataError, ValidationError, Tidy3dNotImplementedError
-from ...constants import PICOSECOND_PER_NANOMETER_PER_KILOMETER
+from ...constants import PICOSECOND_PER_NANOMETER_PER_KILOMETER, inf
 from ...log import log
+
+
+DEFAULT_MAX_SAMPLES_PER_STEP = 1e4
+DEFAULT_MAX_CELLS_PER_STEP = 1e4
 
 
 class Dataset(Tidy3dBaseModel, ABC):
@@ -528,6 +533,11 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
         # we redirect name to values.name
         return self.values.name
 
+    @property
+    def is_complex(self) -> bool:
+        """Data type."""
+        return np.iscomplexobj(self.values)
+
     @pd.validator("cells", always=True)
     def match_cells_to_vtk_type(cls, val):
         """Check that cell connections does not have duplicate points."""
@@ -582,29 +592,56 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
     def check_cell_vertex_range(cls, val, values):
         """Check that cell connections use only defined points."""
         all_point_indices_used = val.data.ravel()
-        min_index_used = np.min(all_point_indices_used)
-        max_index_used = np.max(all_point_indices_used)
+        # skip validation if zero size data
+        if len(all_point_indices_used) > 0:
+            min_index_used = np.min(all_point_indices_used)
+            max_index_used = np.max(all_point_indices_used)
 
-        points = values.get("points")
-        num_points = len(points)
+            points = values.get("points")
+            num_points = len(points)
 
-        if max_index_used != num_points - 1 or min_index_used != 0:
-            raise ValidationError(
-                "Cell connections array uses undefined point indices in the range "
-                f"[{min_index_used}, {max_index_used}]. The valid range of point indices is "
-                f"[0, {num_points-1}]."
-            )
+            if max_index_used != num_points - 1 or min_index_used != 0:
+                raise ValidationError(
+                    "Cell connections array uses undefined point indices in the range "
+                    f"[{min_index_used}, {max_index_used}]. The valid range of point indices is "
+                    f"[0, {num_points-1}]."
+                )
         return val
 
     @pd.validator("cells", always=True)
     def check_valid_cells(cls, val):
         """Check that cell connections does not have duplicate points."""
         indices = val.data
-        for i in range(cls._cell_num_vertices() - 1):
-            for j in range(i + 1, cls._cell_num_vertices()):
-                if np.any(indices[:, i] == indices[:, j]):
-                    log.warning("Unstructured grid contains degenerate cells.")
+        # skip validation if zero size data
+        if len(indices) > 0:
+            for i in range(cls._cell_num_vertices() - 1):
+                for j in range(i + 1, cls._cell_num_vertices()):
+                    if np.any(indices[:, i] == indices[:, j]):
+                        log.warning("Unstructured grid contains degenerate cells.")
         return val
+
+    @pd.root_validator(pre=True, allow_reuse=True)
+    def _warn_if_none(cls, values):
+        """Warn if any of data arrays are not loaded."""
+
+        no_data_fields = []
+        for field_name in ["points", "cells", "values"]:
+            field = values.get(field_name)
+            if isinstance(field, str) and field in DATA_ARRAY_MAP.keys():
+                no_data_fields.append(field_name)
+        if len(no_data_fields) > 0:
+            formatted_names = [f"'{fname}'" for fname in no_data_fields]
+            log.warning(
+                f"Loading {', '.join(formatted_names)} without data. Constructing an empty dataset."
+            )
+            values["points"] = PointDataArray(
+                np.zeros((0, cls._point_dims())), dims=["index", "axis"]
+            )
+            values["cells"] = CellDataArray(
+                np.zeros((0, cls._cell_num_vertices())), dims=["cell_index", "vertex_index"]
+            )
+            values["values"] = IndexedDataArray(np.zeros(0), dims=["index"])
+        return values
 
     def rename(self, name: str) -> UnstructuredGridDataset:
         """Return a renamed array."""
@@ -664,7 +701,7 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
 
     @cached_property
     @abstractmethod
-    def _points_3d_array(self) -> Bound:
+    def _points_3d_array(self):
         """3D coordinates of grid points."""
 
     @classmethod
@@ -715,7 +752,13 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
 
         grid.SetPoints(self._vtk_points)
         grid.SetCells(self._vtk_cell_type(), self._vtk_cells)
-        point_data_vtk = vtk["numpy_to_vtk"](self.values.data)
+        if self.is_complex:
+            # vtk doesn't support complex numbers
+            # so we will store our complex array as a two-component vtk array
+            data_values = self.values.values.view("(2,)float")
+        else:
+            data_values = self.values.values
+        point_data_vtk = vtk["numpy_to_vtk"](data_values)
         point_data_vtk.SetName(self.values.name)
         grid.GetPointData().AddArray(point_data_vtk)
 
@@ -791,7 +834,7 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
     @classmethod
     @abstractmethod
     @requires_vtk
-    def _from_vtk_obj(cls, vtk_obj, field=None) -> UnstructuredGridDataset:
+    def _from_vtk_obj(cls, vtk_obj, field: str = None) -> UnstructuredGridDataset:
         """Initialize from a vtk object."""
 
     @classmethod
@@ -861,22 +904,31 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
                     "'.values' while the rest will be ignored."
                 )
 
-            # currently we assume data is scalar
+            # currently we assume data is real or complex scalar
             num_components = array_vtk.GetNumberOfComponents()
-            if num_components > 1:
+            if num_components > 2:
                 raise DataError(
-                    f"Found point data array in a VTK object is expected to have only 1 component. Found {num_components} components."
+                    "Found point data array in a VTK object is expected to have maximum 2 "
+                    "components (1 is for real data, 2 is for complex data). "
+                    f"Found {num_components} components."
                 )
 
             # check that number of values matches number of grid points
             num_tuples = array_vtk.GetNumberOfTuples()
             if num_tuples != num_points:
                 raise DataError(
-                    f"The length of found point data array ({num_tuples}) does not match the number of grid points ({num_points})."
+                    f"The length of found point data array ({num_tuples}) does not match the number"
+                    f" of grid points ({num_points})."
                 )
 
             values_numpy = vtk["vtk_to_numpy"](array_vtk)
             values_name = array_vtk.GetName()
+
+            # vtk doesn't support complex numbers
+            # we store our complex array as a two-component vtk array
+            # so here we convert that into a single component complex array
+            if num_components == 2:
+                values_numpy = values_numpy.view("complex")[:, 0]
 
         values = IndexedDataArray(
             values_numpy, coords=dict(index=np.arange(len(values_numpy))), name=values_name
@@ -924,15 +976,156 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
 
         return self._from_vtk_obj(clean_clip)
 
-    @requires_vtk
     def interp(
         self,
         x: Union[float, ArrayLike],
         y: Union[float, ArrayLike],
         z: Union[float, ArrayLike],
-        fill_value: float = 0,
+        fill_value: Union[float, Literal["extrapolate"]] = "extrapolate",
+        use_vtk: bool = False,
+        method: Literal["linear", "nearest"] = "linear",
+        max_samples_per_step: int = DEFAULT_MAX_SAMPLES_PER_STEP,
+        max_cells_per_step: int = DEFAULT_MAX_CELLS_PER_STEP,
     ) -> SpatialDataArray:
         """Interpolate data at provided x, y, and z.
+
+        Parameters
+        ----------
+        x : Union[float, ArrayLike]
+            x-coordinates of sampling points.
+        y : Union[float, ArrayLike]
+            y-coordinates of sampling points.
+        z : Union[float, ArrayLike]
+            z-coordinates of sampling points.
+        fill_value : Union[float, Literal["extrapolate"]] = "extrapolate"
+            Value to use when filling points without interpolated values. If ``extrapolate`` then
+            nearest values are used.
+        use_vtk : bool = False
+            Use vtk's interpolationfunctionality or Tidy3D's own implementation.
+        method: Literal["linear", "nearest"] = "linear"
+            Interpolation method to use.
+        max_samples_per_step : int = 1e4
+            Max number of points to interpolate at per iteration (used only if `use_vtk=False`).
+        max_cells_per_step : int = 1e4
+            Max number of cells to interpolate from per iteration (used only if `use_vtk=False`).
+
+        Returns
+        -------
+        SpatialDataArray
+            Interpolated data.
+        """
+
+        # calculate the resulting array shape
+        x = np.atleast_1d(x)
+        y = np.atleast_1d(y)
+        z = np.atleast_1d(z)
+
+        if method == "nearest":
+            interpolated_values = self._interp_nearest(x=x, y=y, z=z)
+        else:
+            if fill_value == "extrapolate" and method != "nearest":
+                fill_value_actual = np.nan
+            else:
+                fill_value_actual = fill_value
+
+            if use_vtk:
+                interpolated_values = self._interp_vtk(x=x, y=y, z=z, fill_value=fill_value_actual)
+            else:
+                interpolated_values = self._interp_py(
+                    x=x,
+                    y=y,
+                    z=z,
+                    fill_value=fill_value_actual,
+                    max_samples_per_step=max_samples_per_step,
+                    max_cells_per_step=max_cells_per_step,
+                )
+
+            if fill_value == "extrapolate" and method != "nearest":
+                interpolated_values = self._fill_nans_from_nearests(
+                    interpolated_values, x=x, y=y, z=z
+                )
+
+        return SpatialDataArray(
+            interpolated_values, coords=dict(x=x, y=y, z=z), name=self.values.name
+        )
+
+    def _interp_nearest(
+        self,
+        x: ArrayLike,
+        y: ArrayLike,
+        z: ArrayLike,
+    ) -> ArrayLike:
+        """Interpolate data at provided x, y, and z using Scipy's nearest neighbor interpolator.
+
+        Parameters
+        ----------
+        x : ArrayLike
+            x-coordinates of sampling points.
+        y : ArrayLike
+            y-coordinates of sampling points.
+        z : ArrayLike
+            z-coordinates of sampling points.
+
+        Returns
+        -------
+        ArrayLike
+            Interpolated data.
+        """
+
+        # use scipy's nearest neighbor interpolator
+        X, Y, Z = np.meshgrid(x, y, z, indexing="ij")
+        interp = NearestNDInterpolator(self._points_3d_array, self.values.values)
+        values = interp(X, Y, Z)
+
+        return values
+
+    def _fill_nans_from_nearests(
+        self,
+        values: ArrayLike,
+        x: ArrayLike,
+        y: ArrayLike,
+        z: ArrayLike,
+    ) -> ArrayLike:
+        """Replace nan's in ``values`` with nearest data points.
+
+        Parameters
+        ----------
+        values : ArrayLike
+            3D array containing nan's
+        x : ArrayLike
+            x-coordinates of sampling points.
+        y : ArrayLike
+            y-coordinates of sampling points.
+        z : ArrayLike
+            z-coordinates of sampling points.
+
+        Returns
+        -------
+        ArrayLike
+            Data without nan's.
+        """
+
+        # locate all nans
+        nans = np.isnan(values)
+
+        if np.sum(nans) > 0:
+            # use scipy's nearest neighbor interpolator
+            X, Y, Z = np.meshgrid(x, y, z, indexing="ij")
+            interp = NearestNDInterpolator(self._points_3d_array, self.values.values)
+            values_to_replace_nans = interp(X[nans], Y[nans], Z[nans])
+            values[nans] = values_to_replace_nans
+
+        return values
+
+    @requires_vtk
+    def _interp_vtk(
+        self,
+        x: ArrayLike,
+        y: ArrayLike,
+        z: ArrayLike,
+        fill_value: float,
+    ) -> ArrayLike:
+        """Interpolate data at provided x, y, and z using vtk package.
 
         Parameters
         ----------
@@ -947,14 +1140,10 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
 
         Returns
         -------
-        SpatialDataArray
+        ArrayLike
             Interpolated data.
         """
 
-        # calculate the resulting array shape
-        x = np.atleast_1d(x)
-        y = np.atleast_1d(y)
-        z = np.atleast_1d(z)
         shape = (len(x), len(y), len(z))
 
         # create a VTK rectilinear grid to sample onto
@@ -985,7 +1174,404 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
         # VTK arrays are the z-y-x order, reorder interpolation results to x-y-z order
         values_reordered = np.transpose(np.reshape(values_numpy, shape[::-1]), (2, 1, 0))
 
-        return SpatialDataArray(values_reordered, coords=dict(x=x, y=y, z=z), name=self.values.name)
+        return values_reordered
+
+    def _interp_py(
+        self,
+        x: ArrayLike,
+        y: ArrayLike,
+        z: ArrayLike,
+        fill_value: float,
+        max_samples_per_step: int = DEFAULT_MAX_SAMPLES_PER_STEP,
+        max_cells_per_step: int = DEFAULT_MAX_CELLS_PER_STEP,
+        rel_tol: float = 1e-10,
+        axis_ignore: Union[Axis, None] = None,
+    ) -> ArrayLike:
+        """Interpolate data at provided x, y, and z using vectorized python implementation.
+
+        Parameters
+        ----------
+        x : Union[float, ArrayLike]
+            x-coordinates of sampling points.
+        y : Union[float, ArrayLike]
+            y-coordinates of sampling points.
+        z : Union[float, ArrayLike]
+            z-coordinates of sampling points.
+        fill_value : float
+            Value to use when filling points without interpolated values.
+        max_samples_per_step : int = 1e4
+            Max number of points to interpolate at per iteration.
+        max_cells_per_step : int = 1e4
+            Max number of cells to interpolate from per iteration.
+        rel_tol : float = 1e-10
+            Relative tolerance when comparing coordinates.
+        axis_ignore : Union[Axis, None] = None
+            For interpolati
+
+        Returns
+        -------
+        ArrayLike
+            Interpolated data.
+        """
+
+        # get dimensionality of data
+        num_dims = self._point_dims()
+
+        if num_dims == 2 and axis_ignore is None:
+            raise DataError("Must porvide 'axis_ignore' when interpolating from a 2d dataset.")
+
+        xyz_grid = [x, y, z]
+
+        if axis_ignore is not None:
+            xyz_grid.pop(axis_ignore)
+
+        # get numpy arrays for points and cells
+        cell_connections = (
+            self.cells.values
+        )  # (num_cells, num_cell_vertices), num_cell_vertices=num_cell_faces
+        points = self.points.values  # (num_points, num_dims)
+
+        num_cells = len(cell_connections)
+        num_points = len(points)
+
+        # compute tolerances based on total size of unstructured grid
+        bounds = self.bounds
+        size = np.subtract(bounds[1], bounds[0])
+        tol = size * rel_tol
+        diag_tol = np.linalg.norm(tol)
+
+        # compute (index) positions of unstructured points w.r.t. target Cartesian grid points
+        # (i.e. between which Cartesian grid points a given unstructured grid point is located)
+        # we perturb grid values in both directions to make sure we don't miss any points
+        # due to numerical precision
+        xyz_pos_l = np.zeros((num_dims, num_points), dtype=int)
+        xyz_pos_r = np.zeros((num_dims, num_points), dtype=int)
+
+        for dim in range(num_dims):
+            xyz_pos_l[dim] = np.searchsorted(xyz_grid[dim] + tol[dim], points[:, dim])
+            xyz_pos_r[dim] = np.searchsorted(xyz_grid[dim] - tol[dim], points[:, dim])
+
+        # now we transfer this information to each cell. That is, each cell knows how its vertices
+        # positioned relative to Cartesian grid points.
+        # (num_dims, num_cells, num_vertices=num_cell_faces)
+        xyz_pos_l_per_cell = xyz_pos_l[:, cell_connections]
+        xyz_pos_r_per_cell = xyz_pos_r[:, cell_connections]
+
+        # taking min/max among all cell vertices (per each dimension separately)
+        # we get min and max indices of Cartesian grid points that may receive their values
+        # from a given cell.
+        # (num_dims, num_cells)
+        cell_ind_min = np.min(xyz_pos_l_per_cell, axis=2)
+        cell_ind_max = np.max(xyz_pos_r_per_cell, axis=2)
+
+        # calculate number of Cartesian grid points where we will perform interpolation for a given
+        # cell. Note that this number is much larger than actually needed, because essentially for
+        # each cell we consider all Cartesian grid points that fall into the cell's bounding box.
+        # We use word "sample" to represent such Cartesian grid points.
+        # (num_cells,)
+        num_samples_per_cell = np.prod(cell_ind_max - cell_ind_min, axis=0)
+
+        # find cells that have non-zero number of samples
+        # we use "ne" as a shortcut for "non empty"
+        ne_cells = num_samples_per_cell > 0  # (num_cells,)
+        num_ne_cells = np.sum(ne_cells)
+        # indices of cells with non-zero number of samples in the original list of cells
+        ne_cell_inds = np.arange(num_cells)[ne_cells]  # (num_cells,)
+
+        # restrict to non-empty cells only
+        num_samples_per_ne_cell = num_samples_per_cell[ne_cells]
+        cum_num_samples_per_ne_cell = np.cumsum(num_samples_per_ne_cell)
+
+        ne_cell_ind_min = cell_ind_min[:, ne_cells]
+        ne_cell_ind_max = cell_ind_max[:, ne_cells]
+
+        # Next we need to perform actual interpolation at all sample points
+        # this is computationally expensive operation and because we try to do everything
+        # in the vectorized form, it can require a lot of memory, sometimes even causing OOM errors.
+        # To avoid that, we impose restrictions on how many cells/samples can be processed at a time
+        # effectivelly performing these operations in chunks.
+        # Note that currently this is done sequentially, but could be relatively easy to parallelize
+
+        # let's allocate an array for resulting values
+        # every time we process a chunk of samples, we will write into this array
+        interpolated_values = fill_value + np.zeros(
+            [len(xyz_comp) for xyz_comp in xyz_grid], dtype=self.values.dtype
+        )
+
+        # start counters of how many cells/samples have been processed
+        processed_samples = 0
+        processed_cells = 0
+
+        while processed_cells < num_ne_cells:
+            # how many cells we would like to process by the end of this step
+            target_processed_cells = min(num_ne_cells, processed_cells + max_cells_per_step)
+
+            # find how many cells we can processed based on number of allowed samples
+            target_processed_samples = processed_samples + max_samples_per_step
+            target_processed_cells_from_samples = (
+                np.searchsorted(cum_num_samples_per_ne_cell, target_processed_samples) + 1
+            )
+
+            # take min between the two
+            target_processed_cells = min(
+                target_processed_cells, target_processed_cells_from_samples
+            )
+
+            # select cells and corresponding samples to process
+            step_ne_cell_ind_min = ne_cell_ind_min[:, processed_cells:target_processed_cells]
+            step_ne_cell_ind_max = ne_cell_ind_max[:, processed_cells:target_processed_cells]
+            step_ne_cell_inds = ne_cell_inds[processed_cells:target_processed_cells]
+
+            # process selected cells and points
+            xyz_inds, interpolated = self._interp_py_chunk(
+                xyz_grid=xyz_grid,
+                cell_inds=step_ne_cell_inds,
+                cell_ind_min=step_ne_cell_ind_min,
+                cell_ind_max=step_ne_cell_ind_max,
+                sdf_tol=diag_tol,
+            )
+
+            if num_dims == 3:
+                interpolated_values[xyz_inds[0], xyz_inds[1], xyz_inds[2]] = interpolated
+            else:
+                interpolated_values[xyz_inds[0], xyz_inds[1]] = interpolated
+
+            processed_cells = target_processed_cells
+            processed_samples = cum_num_samples_per_ne_cell[target_processed_cells - 1]
+
+        # in case of 2d grid broadcast results along normal direction assuming translational
+        # invariance
+        if num_dims == 2:
+            orig_shape = [len(x), len(y), len(z)]
+            flat_shape = orig_shape.copy()
+            flat_shape[axis_ignore] = 1
+            interpolated_values = np.reshape(interpolated_values, flat_shape)
+            interpolated_values = np.broadcast_to(
+                interpolated_values, (len(x), len(y), len(z))
+            ).copy()
+
+        return interpolated_values
+
+    def _interp_py_chunk(
+        self,
+        xyz_grid: Tuple[ArrayLike[float], ...],
+        cell_inds: ArrayLike[int],
+        cell_ind_min: ArrayLike[int],
+        cell_ind_max: ArrayLike[int],
+        sdf_tol: float,
+    ) -> Tuple[Tuple[ArrayLike, ...], ArrayLike]:
+        """For each cell listed in ``cell_inds`` perform interpolation at a rectilinear subarray of
+        xyz_grid given by a (3D) index span (cell_ind_min, cell_ind_max).
+
+        Parameters
+        ----------
+        xyz_grid : Tuple[ArrayLike[float], ...]
+            x, y, and z coordiantes defining rectilinear grid.
+        cell_inds : ArrayLike[int]
+            Indices of cells to perfrom interpolation from.
+        cell_ind_min : ArrayLike[int]
+            Starting x, y, and z indices of points for interpolation for each cell.
+        cell_ind_max : ArrayLike[int]
+            End x, y, and z indices of points for interpolation for each cell.
+        sdf_tol : float
+            Effective zero level set value, below which a point is considered to be inside a cell.
+
+        Returns
+        -------
+        Tuple[Tuple[ArrayLike, ...], ArrayLike]
+            x, y, and z indices of interpolated values and values themselves.
+        """
+
+        # get dimensionality of data
+        num_dims = self._point_dims()
+        num_cell_faces = self._cell_num_vertices()
+
+        # get mesh info as numpy arrays
+        points = self.points.values  # (num_points, num_dims)
+        data_values = self.values.values  # (num_points,)
+        cell_connections = self.cells.values[cell_inds]
+
+        # compute number of samples to generate per cell
+        num_samples_per_cell = np.prod(cell_ind_max - cell_ind_min, axis=0)
+
+        # at this point we know how many samples we need to perform per each cell and we also
+        # know span indices of these samples (in x, y, and z arrays)
+
+        # we would like to perform all interpolations in a vectorized form, however, we have
+        # a different number of interpolation samples for different cells. Thus, we need to
+        # arange all samples in a linear way (flatten). Basically, we want to have data in this
+        # form:
+        # cell_ind | x_ind | y_ind | z_ind
+        # --------------------------------
+        #        0 |    23 |     5 |    11
+        #        0 |    23 |     5 |    12
+        #        0 |    23 |     6 |    11
+        #        0 |    23 |     6 |    12
+        #        1 |    41 |    11 |     0
+        #        1 |    42 |    11 |     0
+        #      ... |   ... |   ... |   ...
+
+        # to do that we start with performing arange for each cell, but in vectorized way
+        # this gives us something like this
+        # [0, 1, 2, 3,   0, 1,   0, 1, 2, 3, 4, 5, 6,   ...]
+        # |<-cell 0->|<-cell 1->|<-     cell 2    ->|<- ...
+
+        num_cells = len(num_samples_per_cell)
+        num_samples_cumul = num_samples_per_cell.cumsum()
+        num_samples_total = num_samples_cumul[-1]
+
+        # one big arange array
+        inds_flat = np.arange(num_samples_total)
+        # now subtract previous number of samples
+        inds_flat[num_samples_per_cell[0] :] -= np.repeat(
+            num_samples_cumul[:-1], num_samples_per_cell[1:]
+        )
+
+        # convert flat indices into 3d/2d indices as:
+        # x_ind = [23, 23, 23, 23,   41, 41,      ...]
+        # y_ind = [ 5,  5,  5,  5,    6,  6,      ...]
+        # z_ind = [11, 12, 11, 12,    0,  0,      ...]
+        #         |<-  cell 0  ->|<- cell 1 ->|<- ...
+        num_samples_y = np.repeat(cell_ind_max[1] - cell_ind_min[1], num_samples_per_cell)
+
+        # note: in 2d x, y correspond to (x, y, z).pop(normal_axis)
+        if num_dims == 3:
+            num_samples_z = np.repeat(cell_ind_max[2] - cell_ind_min[2], num_samples_per_cell)
+            inds_flat, z_inds = np.divmod(inds_flat, num_samples_z)
+
+        x_inds, y_inds = np.divmod(inds_flat, num_samples_y)
+
+        start_inds = np.repeat(cell_ind_min, num_samples_per_cell, axis=1)
+        x_inds = x_inds + start_inds[0]
+        y_inds = y_inds + start_inds[1]
+        if num_dims == 3:
+            z_inds = z_inds + start_inds[2]
+
+        # finally, we repeat cell indices corresponding number of times to obtain how
+        # (x_ind, y_ind, z_ind) map to cell indices. So, now we have four arras:
+        # x_ind    = [23, 23, 23, 23,   41, 41,      ...]
+        # y_ind    = [ 5,  5,  5,  5,    6,  6,      ...]
+        # z_ind    = [11, 12, 11, 12,    0,  0,      ...]
+        # cell_map = [ 0,  0,  0,  0,    1,  1,      ...]
+        #            |<-  cell 0  ->|<- cell 1 ->|<- ...
+        step_cell_map = np.repeat(np.arange(num_cells), num_samples_per_cell)
+
+        # let's put these arrays aside for a moment and perform the second preparatory step
+        # specifically, for each face of each cell we will compute normal vector and distance
+        # to the opposing cell vertex. This will allows us quickly calculate SDF of a cell at
+        # each sample point as well as perform linear interpolation.
+
+        # first, we collect coordinates of cell vertices into a single array
+        # (num_cells, num_cell_vertices, num_dims)
+        cell_vertices = points[cell_connections, :]
+
+        # array for resulting normals and distances
+        normal = np.zeros((num_cell_faces, num_cells, num_dims))
+        dist = np.zeros((num_cell_faces, num_cells))
+
+        # loop face by face
+        # note that by face_ind we denote both index of face in a cell and index of the opposing vertex
+        for face_ind in range(num_cell_faces):
+            # select vertices forming the given face
+            face_pinds = list(np.arange(num_cell_faces))
+            face_pinds.pop(face_ind)
+
+            # calculate normal to the face
+            # in 3D: cross product of two vectors lying in the face plane
+            # in 2D: (-ty, tx) for a vector (tx, ty) along the face
+            p0 = cell_vertices[:, face_pinds[0]]
+            p01 = cell_vertices[:, face_pinds[1]] - p0
+            p0Opp = cell_vertices[:, face_ind] - p0
+            if num_dims == 3:
+                p02 = cell_vertices[:, face_pinds[2]] - p0
+                n = np.cross(p01, p02)
+            else:
+                n = np.roll(p01, 1, axis=1)
+                n[:, 0] = -n[:, 0]
+            n = n / np.linalg.norm(n, axis=1)[:, None]
+
+            # compute distance to the opposing vertex by taking a dot product between normal
+            # and a vector connecting the opposing vertex and the face
+            d = np.einsum("ij,ij->i", n, p0Opp)
+
+            # obtained normal direction is arbitrary here. We will orient it such that it points
+            # away from the triangle (and distance to the opposing vertex is negative).
+            to_flip = d > 0
+            d[to_flip] *= -1
+            n[to_flip, :] *= -1
+
+            # record obtained info
+            normal[face_ind] = n
+            dist[face_ind] = d
+
+        # now we all set up to proceed with actual interpolation at each sample point
+        # the main idea here is that:
+        # - we use `cell_map` to grab normals and distances
+        #   of cells in which the given sample point is (potentially) located.
+        # - use `x_ind, y_ind, z_ind` to find actual coordinates of a given sample point
+        # - combine the above two to calculate cell SDF and interpolated value at a given sample
+        #   point
+        # - having cell SDF at the sample point actually tells us whether its inside the cell
+        #   (keep value) or outside of it (discard interpolated value)
+
+        # to perform SDF calculation and interpolation we will loop face by face and recording
+        # their contributions. That is,
+        # cell_sdf = max(face0_sdf, face1_sdf, ...)
+        # interpolated_value = value0 * face0_sdf / dist0_sdf + ...
+        # (because face0_sdf / dist0_sdf is linear shape function for vertex0)
+        sdf = -inf * np.ones(num_samples_total)
+        interpolated = np.zeros(num_samples_total, dtype=self.values.dtype)
+
+        # coordinates of each sample point
+        sample_xyz = np.zeros((num_samples_total, num_dims))
+        sample_xyz[:, 0] = xyz_grid[0][x_inds]
+        sample_xyz[:, 1] = xyz_grid[1][y_inds]
+        if num_dims == 3:
+            sample_xyz[:, 2] = xyz_grid[2][z_inds]
+
+        # loop face by face
+        for face_ind in range(num_cell_faces):
+            # find a vector connecting sample point and face
+            if face_ind == 0:
+                vertex_ind = 1  # anythin other than 0
+                vec = sample_xyz - cell_vertices[step_cell_map, vertex_ind, :]
+
+            if face_ind == 1:  # since three faces share a point only do this once
+                vertex_ind = 0  # it belongs to every face 1, 2, and 3
+                vec = sample_xyz - cell_vertices[step_cell_map, 0, :]
+
+            # compute distance from every sample point to the face of corresponding cell
+            # using dot product
+            tmp = normal[face_ind, step_cell_map, :] * vec
+            d = np.sum(tmp, axis=1)
+
+            # take max between distance to obtain the overall SDF of a cell
+            sdf = np.maximum(sdf, d)
+
+            # perform linear interpolation. Here we use the fact that when computing face SDF
+            # at a given point and dividing it by the distance to the opposing vertex we get
+            # a linear shape function for that vertex. So, we just need to multiply that by
+            # the data value at that vertex to find its contribution into intepolated value.
+            # (decomposed in an attempt to reduce memory consumption)
+            tmp = data_values[cell_connections[step_cell_map, face_ind]]
+            tmp *= d
+            tmp /= dist[face_ind, step_cell_map]
+            interpolated += tmp
+
+        # The resulting array of interpolated values contain multiple candidate values for
+        # every Cartesian point because bounding boxes of cells overlap.
+        # Thus, we need to keep only those that come cell actually containing a given point.
+        # This can be easily determined by the sign of the cell SDF sampled at a given point.
+        valid_samples = sdf < sdf_tol
+
+        interpolated_valid = interpolated[valid_samples]
+        xyz_valid_inds = []
+        xyz_valid_inds.append(x_inds[valid_samples])
+        xyz_valid_inds.append(y_inds[valid_samples])
+        if num_dims == 3:
+            xyz_valid_inds.append(z_inds[valid_samples])
+
+        return xyz_valid_inds, interpolated_valid
 
     @abstractmethod
     @requires_vtk
@@ -1012,6 +1598,92 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
         Union[TriangularGridDataset, SpatialDataArray]
             Extracted data.
         """
+
+    @requires_vtk
+    def sel_inside(self, bounds: Bound) -> UnstructuredGridDataset:
+        """Return a new UnstructuredGridDataset that contains the minimal amount data necessary to
+        cover a spatial region defined by ``bounds``.
+
+
+        Parameters
+        ----------
+        bounds : Tuple[float, float, float], Tuple[float, float float]
+            Min and max bounds packaged as ``(minx, miny, minz), (maxx, maxy, maxz)``.
+
+        Returns
+        -------
+        UnstructuredGridDataset
+            Extracted spatial data array.
+        """
+
+        data_bounds = self.bounds
+        tol = 1e-6
+
+        # For extracting cells covering target region we use vtk's filter that extract cells based
+        # on provided implicit function. However, when we provide to it the implicit function of
+        # the entire box, it has a couple of issues coming from the fact that the algorithm
+        # eliminates every cells for which the implicit function has positive sign at all vertices.
+        # As result, sometimes there are cells that despite overlaping with the target domain still
+        # being eliminated. Two common cases:
+        # - near corners of the target domain
+        # - target domain is very thin
+        # That's why we perform selection by sequentially eliminating cells on the outer side of
+        # each of the 6 surfaces of the bounding box separately.
+        tmp = self._vtk_obj
+        for direction in range(2):
+            for dim in range(3):
+                sign = -1 + 2 * direction
+                plane_pos = bounds[direction][dim]
+
+                # Dealing with situation when target region does intersect with any cell:
+                # in this case we shift target region so that it barely touches at least some
+                # of cells
+                if sign < 0 and plane_pos > data_bounds[1][dim] - tol:
+                    plane_pos = data_bounds[1][dim] - tol
+                if sign > 0 and plane_pos < data_bounds[0][dim] + tol:
+                    plane_pos = data_bounds[0][dim] + tol
+
+                # if all cells are on the inside side of the plane for a given surface
+                # we don't need to check for intersection
+                if plane_pos <= data_bounds[1][dim] and plane_pos >= data_bounds[0][dim]:
+                    plane = vtk["mod"].vtkPlane()
+                    center = [0, 0, 0]
+                    normal = [0, 0, 0]
+                    center[dim] = plane_pos
+                    normal[dim] = sign
+                    plane.SetOrigin(center)
+                    plane.SetNormal(normal)
+                    extractor = vtk["mod"].vtkExtractGeometry()
+                    extractor.SetImplicitFunction(plane)
+                    extractor.ExtractInsideOn()
+                    extractor.ExtractBoundaryCellsOn()
+                    extractor.SetInputData(tmp)
+                    extractor.Update()
+                    tmp = extractor.GetOutput()
+
+        return self._from_vtk_obj(tmp)
+
+    def does_cover(self, bounds: Bound) -> bool:
+        """Check whether data fully covers specified by ``bounds`` spatial region. If data contains
+        only one point along a given direction, then it is assumed the data is constant along that
+        direction and coverage is not checked.
+
+
+        Parameters
+        ----------
+        bounds : Tuple[float, float, float], Tuple[float, float float]
+            Min and max bounds packaged as ``(minx, miny, minz), (maxx, maxy, maxz)``.
+
+        Returns
+        -------
+        bool
+            Full cover check outcome.
+        """
+
+        return all(
+            (dmin <= smin and dmax >= smax)
+            for dmin, dmax, smin, smax in zip(self.bounds[0], self.bounds[1], bounds[0], bounds[1])
+        )
 
     @requires_vtk
     def reflect(
@@ -1256,6 +1928,7 @@ class TriangularGridDataset(UnstructuredGridDataset):
         vmax: float = None,
         shading: Literal["gourand", "flat"] = "gouraud",
         cbar_kwargs: Dict = None,
+        pcolor_kwargs: Dict = None,
     ) -> Ax:
         """Plot the data field and/or the unstructured grid.
 
@@ -1290,6 +1963,8 @@ class TriangularGridDataset(UnstructuredGridDataset):
 
         if cbar_kwargs is None:
             cbar_kwargs = {}
+        if pcolor_kwargs is None:
+            pcolor_kwargs = {}
         if not (field or grid):
             raise DataError("Nothing to plot ('field == False', 'grid == False').")
 
@@ -1302,6 +1977,7 @@ class TriangularGridDataset(UnstructuredGridDataset):
                 cmap=cmap,
                 vmin=vmin,
                 vmax=vmax,
+                **pcolor_kwargs,
             )
 
             if cbar:
@@ -1332,8 +2008,12 @@ class TriangularGridDataset(UnstructuredGridDataset):
         x: Union[float, ArrayLike],
         y: Union[float, ArrayLike],
         z: Union[float, ArrayLike],
-        fill_value: float = 0,
+        fill_value: Union[float, Literal["extrapolate"]] = "extrapolate",
+        use_vtk: bool = False,
+        method: Literal["linear", "nearest"] = "linear",
         ignore_normal_pos: bool = True,
+        max_samples_per_step: int = DEFAULT_MAX_SAMPLES_PER_STEP,
+        max_cells_per_step: int = DEFAULT_MAX_CELLS_PER_STEP,
     ) -> SpatialDataArray:
         """Interpolate data at provided x, y, and z.
 
@@ -1345,10 +2025,19 @@ class TriangularGridDataset(UnstructuredGridDataset):
             y-coordinates of sampling points.
         z : Union[float, ArrayLike]
             z-coordinates of sampling points.
-        fill_value : float = 0
-            Value to use when filling points without interpolated values.
+        fill_value : Union[float, Literal["extrapolate"]] = "extrapolate"
+            Value to use when filling points without interpolated values. If ``extrapolate`` then
+            nearest values are used.
+        use_vtk : bool = False
+            Use vtk's interpolationfunctionality or Tidy3D's own implementation.
+        method: Literal["linear", "nearest"] = "linear"
+            Interpolation method to use.
         ignore_normal_pos : bool = True
-            Assume data is invariant along the normal direction to the grid plane.
+            (Depreciated) Assume data is invariant along the normal direction to the grid plane.
+        max_samples_per_step : int = 1e4
+            Max number of points to interpolate at per iteration (used only if `use_vtk=False`).
+        max_cells_per_step : int = 1e4
+            Max number of cells to interpolate from per iteration (used only if `use_vtk=False`).
 
         Returns
         -------
@@ -1356,23 +2045,80 @@ class TriangularGridDataset(UnstructuredGridDataset):
             Interpolated data.
         """
 
+        if not ignore_normal_pos:
+            log.warning(
+                "Parameter 'ignore_normal_pos' is depreciated. It is always assumed that data "
+                "contained in 'TriangularGridDataset' is invariant in the normal direction. "
+                "That is, 'ignore_normal_pos=True' is used."
+            )
+
         x = np.atleast_1d(x)
         y = np.atleast_1d(y)
         z = np.atleast_1d(z)
 
-        if ignore_normal_pos:
-            xyz = [x, y, z]
-            xyz[self.normal_axis] = [self.normal_pos]
-            interp_inplane = super().interp(**dict(zip("xyz", xyz)), fill_value=fill_value)
-            interp_broadcasted = np.broadcast_to(
-                interp_inplane, [len(np.atleast_1d(comp)) for comp in [x, y, z]]
-            )
+        xyz = [x, y, z]
+        xyz[self.normal_axis] = [self.normal_pos]
+        interp_inplane = super().interp(
+            **dict(zip("xyz", xyz)),
+            fill_value=fill_value,
+            use_vtk=use_vtk,
+            method=method,
+            max_samples_per_step=max_samples_per_step,
+            max_cells_per_step=max_cells_per_step,
+        )
+        interp_broadcasted = np.broadcast_to(
+            interp_inplane, [len(np.atleast_1d(comp)) for comp in [x, y, z]]
+        )
 
-            return SpatialDataArray(
-                interp_broadcasted, coords=dict(x=x, y=y, z=z), name=self.values.name
-            )
+        return SpatialDataArray(
+            interp_broadcasted, coords=dict(x=x, y=y, z=z), name=self.values.name
+        )
 
-        return super().interp(x=x, y=y, z=z, fill_value=fill_value)
+    def _interp_py(
+        self,
+        x: ArrayLike,
+        y: ArrayLike,
+        z: ArrayLike,
+        fill_value: float,
+        max_samples_per_step: int = DEFAULT_MAX_SAMPLES_PER_STEP,
+        max_cells_per_step: int = DEFAULT_MAX_CELLS_PER_STEP,
+        rel_tol: float = 1e-10,
+    ) -> ArrayLike:
+        """Interpolate data at provided x, y, and z using vectorized python implementation.
+
+        Parameters
+        ----------
+        x : Union[float, ArrayLike]
+            x-coordinates of sampling points.
+        y : Union[float, ArrayLike]
+            y-coordinates of sampling points.
+        z : Union[float, ArrayLike]
+            z-coordinates of sampling points.
+        fill_value : float
+            Value to use when filling points without interpolated values.
+        max_samples_per_step : int = 1e4
+            Max number of points to interpolate at per iteration.
+        max_cells_per_step : int = 1e4
+            Max number of cells to interpolate from per iteration.
+        rel_tol : float = 1e-10
+            Relative tolerance when comparing coordinates.
+
+        Returns
+        -------
+        SpatialDataArray
+            Interpolated data.
+        """
+
+        return super()._interp_py(
+            x=x,
+            y=y,
+            z=z,
+            fill_value=fill_value,
+            max_samples_per_step=max_samples_per_step,
+            max_cells_per_step=max_cells_per_step,
+            rel_tol=rel_tol,
+            axis_ignore=self.normal_axis,
+        )
 
     @requires_vtk
     def sel(
@@ -1457,6 +2203,56 @@ class TriangularGridDataset(UnstructuredGridDataset):
             raise DataError("Reflection in the normal direction to the grid is prohibited.")
 
         return super().reflect(axis=axis, center=center, reflection_only=reflection_only)
+
+    @requires_vtk
+    def sel_inside(self, bounds: Bound) -> TriangularGridDataset:
+        """Return a new ``TriangularGridDataset`` that contains the minimal amount data necessary to
+        cover a spatial region defined by ``bounds``.
+
+
+        Parameters
+        ----------
+        bounds : Tuple[float, float, float], Tuple[float, float float]
+            Min and max bounds packaged as ``(minx, miny, minz), (maxx, maxy, maxz)``.
+
+        Returns
+        -------
+        TriangularGridDataset
+            Extracted spatial data array.
+        """
+
+        # expand along normal direction
+        new_bounds = [list(bounds[0]), list(bounds[1])]
+
+        new_bounds[0][self.normal_axis] = -inf
+        new_bounds[1][self.normal_axis] = inf
+
+        return super().sel_inside(new_bounds)
+
+    def does_cover(self, bounds: Bound) -> bool:
+        """Check whether data fully covers specified by ``bounds`` spatial region. If data contains
+        only one point along a given direction, then it is assumed the data is constant along that
+        direction and coverage is not checked.
+
+
+        Parameters
+        ----------
+        bounds : Tuple[float, float, float], Tuple[float, float float]
+            Min and max bounds packaged as ``(minx, miny, minz), (maxx, maxy, maxz)``.
+
+        Returns
+        -------
+        bool
+            Full cover check outcome.
+        """
+
+        # expand along normal direction
+        new_bounds = [list(bounds[0]), list(bounds[1])]
+
+        new_bounds[0][self.normal_axis] = self.normal_pos
+        new_bounds[1][self.normal_axis] = self.normal_pos
+
+        return super().does_cover(new_bounds)
 
 
 class TetrahedralGridDataset(UnstructuredGridDataset):
@@ -1678,3 +2474,69 @@ class TetrahedralGridDataset(UnstructuredGridDataset):
 
 
 UnstructuredGridDatasetType = Union[TriangularGridDataset, TetrahedralGridDataset]
+CustomSpatialDataType = Union[SpatialDataArray, TriangularGridDataset, TetrahedralGridDataset]
+CustomSpatialDataTypeAnnotated = Union[
+    SpatialDataArray, annotate_type(Union[TriangularGridDataset, TetrahedralGridDataset])
+]
+
+
+def _get_numpy_array(data_array: Union[ArrayLike, DataArray, UnstructuredGridDataset]) -> ArrayLike:
+    """Get numpy representation of dataarray/dataset values."""
+    if isinstance(data_array, UnstructuredGridDataset):
+        return data_array.values.values
+    if isinstance(data_array, xr.DataArray):
+        return data_array.values
+    return np.array(data_array)
+
+
+def _zeros_like(
+    data_array: Union[ArrayLike, xr.DataArray, UnstructuredGridDataset]
+) -> Union[ArrayLike, xr.DataArray, UnstructuredGridDataset]:
+    """Get a zeroed replica of dataarray/dataset."""
+    if isinstance(data_array, UnstructuredGridDataset):
+        return data_array.updated_copy(values=xr.zeros_like(data_array.values))
+    if isinstance(data_array, xr.DataArray):
+        return xr.zeros_like(data_array)
+    return np.zeros_like(data_array)
+
+
+def _ones_like(
+    data_array: Union[ArrayLike, xr.DataArray, UnstructuredGridDataset]
+) -> Union[ArrayLike, xr.DataArray, UnstructuredGridDataset]:
+    """Get a unity replica of dataarray/dataset."""
+    if isinstance(data_array, UnstructuredGridDataset):
+        return data_array.updated_copy(values=xr.ones_like(data_array.values))
+    if isinstance(data_array, xr.DataArray):
+        return xr.ones_like(data_array)
+    return np.ones_like(data_array)
+
+
+def _check_same_coordinates(
+    a: Union[ArrayLike, xr.DataArray, UnstructuredGridDataset],
+    b: Union[ArrayLike, xr.DataArray, UnstructuredGridDataset],
+) -> bool:
+    """Check whether two array are defined at the same coordinates."""
+
+    # we can have xarray.DataArray's of different types but still same coordinates
+    # we will deal with that case separately
+    both_xarrays = isinstance(a, xr.DataArray) and isinstance(b, xr.DataArray)
+    if (not both_xarrays) and type(a) != type(b):
+        return False
+
+    if isinstance(a, UnstructuredGridDataset):
+        if not np.allclose(a.points, b.points) or not np.all(a.cells == b.cells):
+            return False
+
+        if isinstance(a, TriangularGridDataset):
+            if a.normal_axis != b.normal_axis or a.normal_pos != b.normal_pos:
+                return False
+
+    elif isinstance(a, xr.DataArray):
+        if a.coords.keys() != b.coords.keys() or a.coords != b.coords:
+            return False
+
+    else:
+        if np.shape(a) != np.shape(b):
+            return False
+
+    return True

--- a/tidy3d/components/grid/grid.py
+++ b/tidy3d/components/grid/grid.py
@@ -7,6 +7,7 @@ import pydantic.v1 as pd
 
 from ..base import Tidy3dBaseModel
 from ..data.data_array import DataArray, SpatialDataArray, ScalarFieldDataArray
+from ..data.dataset import UnstructuredGridDatasetType, UnstructuredGridDataset
 from ..types import ArrayFloat1D, Axis, TYPE_TAG_STR, InterpMethod, Literal
 from ..geometry.base import Box
 
@@ -49,7 +50,7 @@ class Coords(Tidy3dBaseModel):
         """Return a list of the three Coord1D objects as numpy arrays."""
         return list(self.to_dict.values())
 
-    def spatial_interp(
+    def _interp_from_xarray(
         self,
         array: Union[SpatialDataArray, ScalarFieldDataArray],
         interp_method: InterpMethod,
@@ -83,17 +84,6 @@ class Coords(Tidy3dBaseModel):
         This method is called from a :class:`Coords` instance with the array to be interpolated as
         an argument, not the other way around.
         """
-
-        # Check for empty dimensions
-        result_coords = dict(self.to_dict)
-        if any(len(v) == 0 for v in result_coords.values()):
-            for c in array.coords:
-                if c not in result_coords:
-                    result_coords[c] = array.coords[c].values
-            result_shape = tuple(len(v) for v in result_coords.values())
-            result = DataArray(np.empty(result_shape, dtype=array.dtype), coords=result_coords)
-            return result
-
         # Check which axes need interpolation or selection
         interp_ax = []
         isel_ax = []
@@ -138,6 +128,103 @@ class Coords(Tidy3dBaseModel):
             )
 
         return interp_array
+
+    def _interp_from_unstructured(
+        self,
+        array: UnstructuredGridDatasetType,
+        interp_method: InterpMethod,
+        fill_value: Union[Literal["extrapolate"], float] = "extrapolate",
+    ) -> SpatialDataArray:
+        """
+        Interpolate from untructured grid onto a Cartesian one.
+
+        Parameters
+        ----------
+        array : Union[class:`.TriangularGridDataset`, class:`.TetrahedralGridDataset`]
+            Supplied scalar dataset
+        interp_method : :class:`.InterpMethod`
+            Interpolation method.
+        fill_value : Union[Literal['extrapolate'], float] = "extrapolate"
+            Value used to fill in for points outside the data range. If set to 'extrapolate',
+            values will be extrapolated into those regions using the "nearest" method.
+
+        Returns
+        -------
+        :class:`.SpatialDataArray`
+            The interpolated spatial dataset.
+
+        Note
+        ----
+        This method is called from a :class:`Coords` instance with the array to be interpolated as
+        an argument, not the other way around.
+        """
+        interp_array = array.interp(
+            **{ax: self.to_dict[ax] for ax in "xyz"}, method=interp_method, fill_value=fill_value
+        )
+
+        return interp_array
+
+    def spatial_interp(
+        self,
+        array: Union[SpatialDataArray, ScalarFieldDataArray, UnstructuredGridDatasetType],
+        interp_method: InterpMethod,
+        fill_value: Union[Literal["extrapolate"], float] = "extrapolate",
+    ) -> Union[SpatialDataArray, ScalarFieldDataArray]:
+        """
+        Similar to ``xarrray.DataArray.interp`` with 2 enhancements:
+
+            1) (if input data is an ``xarrray.DataArray``) Check if the coordinate of the supplied
+            data are in monotonically increasing order. If they are, apply the faster
+            ``assume_sorted=True``.
+
+            2) Data is assumed invariant along zero-size dimensions (if any).
+
+        Parameters
+        ----------
+        array : Union[
+                :class:`.SpatialDataArray`,
+                :class:`.ScalarFieldDataArray`,
+                :class:`.TriangularGridDataset`,
+                :class:`.TetrahedralGridDataset`,
+        ]
+            Supplied scalar dataset
+        interp_method : :class:`.InterpMethod`
+            Interpolation method.
+        fill_value : Union[Literal['extrapolate'], float] = "extrapolate"
+            Value used to fill in for points outside the data range. If set to 'extrapolate',
+            values will be extrapolated into those regions using the "nearest" method.
+
+        Returns
+        -------
+        Union[:class:`.SpatialDataArray`, :class:`.ScalarFieldDataArray`]
+            The interpolated spatial dataset.
+
+        Note
+        ----
+        This method is called from a :class:`Coords` instance with the array to be interpolated as
+        an argument, not the other way around.
+        """
+
+        # Check for empty dimensions
+        result_coords = dict(self.to_dict)
+        if any(len(v) == 0 for v in result_coords.values()):
+            if isinstance(array, (SpatialDataArray, ScalarFieldDataArray)):
+                for c in array.coords:
+                    if c not in result_coords:
+                        result_coords[c] = array.coords[c].values
+            result_shape = tuple(len(v) for v in result_coords.values())
+            result = DataArray(np.empty(result_shape, dtype=array.dtype), coords=result_coords)
+            return result
+
+        # interpolation
+        if isinstance(array, UnstructuredGridDataset):
+            return self._interp_from_unstructured(
+                array=array, interp_method=interp_method, fill_value=fill_value
+            )
+        else:
+            return self._interp_from_xarray(
+                array=array, interp_method=interp_method, fill_value=fill_value
+            )
 
 
 class FieldGrid(Tidy3dBaseModel):

--- a/tidy3d/components/parameter_perturbation.py
+++ b/tidy3d/components/parameter_perturbation.py
@@ -7,16 +7,18 @@ import functools
 
 import pydantic.v1 as pd
 import numpy as np
-import xarray as xr
 import matplotlib.pyplot as plt
 
-from .data.data_array import SpatialDataArray, HeatDataArray, ChargeDataArray
+from .data.data_array import SpatialDataArray, HeatDataArray, ChargeDataArray, IndexedDataArray
+from .data.dataset import UnstructuredGridDataset, CustomSpatialDataType
+from .data.dataset import _get_numpy_array, _zeros_like, _check_same_coordinates
 from .base import Tidy3dBaseModel, cached_property
 from ..constants import KELVIN, CMCUBE, PERCMCUBE, inf
 from ..log import log
 from ..components.types import Ax, ArrayLike, Complex, FieldVal, InterpMethod, TYPE_TAG_STR
 from ..components.viz import add_ax_if_none
 from ..components.data.validators import validate_no_nans
+from ..exceptions import DataError
 
 """ Generic perturbation classes """
 
@@ -43,8 +45,8 @@ class AbstractPerturbation(ABC, Tidy3dBaseModel):
 
     @staticmethod
     def _get_val(
-        field: Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray], val: FieldVal
-    ) -> Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]:
+        field: Union[ArrayLike[float], ArrayLike[Complex], CustomSpatialDataType], val: FieldVal
+    ) -> Union[ArrayLike[float], ArrayLike[Complex], CustomSpatialDataType]:
         """Get specified value from a field."""
 
         if val == "real":
@@ -67,41 +69,32 @@ class AbstractPerturbation(ABC, Tidy3dBaseModel):
             "'abs^2', or 'phase'."
         )
 
-    @staticmethod
-    def _array_type(value: Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]) -> str:
-        """Check whether variable is scalar, array, or spatial array."""
-        if isinstance(value, SpatialDataArray):
-            return "spatial"
-        if np.ndim(value) == 0:
-            return "scalar"
-        return "array"
-
 
 """ Elementary heat perturbation classes """
 
 
 def ensure_temp_in_range(
     sample: Callable[
-        Union[ArrayLike[float], SpatialDataArray],
-        Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray],
+        Union[ArrayLike[float], CustomSpatialDataType],
+        Union[ArrayLike[float], ArrayLike[Complex], CustomSpatialDataType],
     ]
 ) -> Callable[
-    Union[ArrayLike[float], SpatialDataArray],
-    Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray],
+    Union[ArrayLike[float], CustomSpatialDataType],
+    Union[ArrayLike[float], ArrayLike[Complex], CustomSpatialDataType],
 ]:
     """Decorate ``sample`` to log warning if temperature supplied is out of bounds."""
 
     @functools.wraps(sample)
     def _sample(
-        self, temperature: Union[ArrayLike[float], SpatialDataArray]
-    ) -> Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]:
+        self, temperature: Union[ArrayLike[float], CustomSpatialDataType]
+    ) -> Union[ArrayLike[float], ArrayLike[Complex], CustomSpatialDataType]:
         """New sample function."""
 
         if np.iscomplexobj(temperature):
-            raise ValueError("Cannot pass complex 'temperature' to 'sample()'")
+            raise DataError("Cannot pass complex 'temperature' to 'sample()'")
 
         temp_min, temp_max = self.temperature_range
-        temperature_numpy = np.array(temperature)
+        temperature_numpy = _get_numpy_array(temperature)
         if np.any(temperature_numpy < temp_min) or np.any(temperature_numpy > temp_max):
             log.warning(
                 "Temperature passed to 'HeatPerturbation.sample()'"
@@ -124,18 +117,29 @@ class HeatPerturbation(AbstractPerturbation):
 
     @abstractmethod
     def sample(
-        self, temperature: Union[ArrayLike[float], SpatialDataArray]
-    ) -> Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]:
+        self, temperature: Union[ArrayLike[float], CustomSpatialDataType]
+    ) -> Union[ArrayLike[float], ArrayLike[Complex], CustomSpatialDataType]:
         """Sample perturbation.
 
         Parameters
         ----------
-        temperature : Union[ArrayLike[float], SpatialDataArray]
+        temperature : Union[
+                ArrayLike[float],
+                :class:`.SpatialDataArray`,
+                :class:`.TriangularGridDataset`,
+                :class:`.TetrahedralGridDataset`,
+            ]
             Temperature sample point(s).
 
         Returns
         -------
-        Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]
+        Union[
+            ArrayLike[float],
+            ArrayLike[complex],
+            :class:`.SpatialDataArray`,
+            :class:`.TriangularGridDataset`,
+            :class:`.TetrahedralGridDataset`,
+        ]
             Sampled perturbation value(s).
         """
 
@@ -228,25 +232,37 @@ class LinearHeatPerturbation(HeatPerturbation):
 
     @ensure_temp_in_range
     def sample(
-        self, temperature: Union[ArrayLike[float], SpatialDataArray]
-    ) -> Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]:
+        self, temperature: Union[ArrayLike[float], CustomSpatialDataType]
+    ) -> Union[ArrayLike[float], ArrayLike[Complex], CustomSpatialDataType]:
         """Sample perturbation at temperature points.
 
         Parameters
         ----------
-        temperature : Union[ArrayLike[float], SpatialDataArray]
+        temperature : Union[
+            ArrayLike[float],
+            :class:`.SpatialDataArray`,
+            :class:`.TriangularGridDataset`,
+            :class:`.TetrahedralGridDataset`,
+        ]
             Temperature sample point(s).
 
         Returns
         -------
-        Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]
+        Union[
+            ArrayLike[float],
+            ArrayLike[complex],
+            :class:`.SpatialDataArray`,
+            :class:`.TriangularGridDataset`,
+            :class:`.TetrahedralGridDataset`,
+        ]
             Sampled perturbation value(s).
         """
 
-        # convert to numpy if not spatial data array
-        t_vals = np.array(temperature) if self._array_type(temperature) == "array" else temperature
+        temp_vals = temperature
+        if isinstance(temperature, (list, tuple)):
+            temp_vals = np.array(temperature)
 
-        return self.coeff * (t_vals - self.temperature_ref)
+        return self.coeff * (temp_vals - self.temperature_ref)
 
     @cached_property
     def is_complex(self) -> bool:
@@ -339,30 +355,49 @@ class CustomHeatPerturbation(HeatPerturbation):
 
     @ensure_temp_in_range
     def sample(
-        self, temperature: Union[ArrayLike[float], SpatialDataArray]
-    ) -> Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]:
+        self, temperature: Union[ArrayLike[float], CustomSpatialDataType]
+    ) -> Union[ArrayLike[float], ArrayLike[Complex], CustomSpatialDataType]:
         """Sample perturbation at provided temperature points.
 
         Parameters
         ----------
-        temperature : Union[ArrayLike[float], SpatialDataArray]
+        temperature : Union[
+                ArrayLike[float],
+                :class:`.SpatialDataArray`,
+                :class:`.TriangularGridDataset`,
+                :class:`.TetrahedralGridDataset`,
+            ]
             Temperature sample point(s).
 
         Returns
         -------
-        Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]
+        Union[
+            ArrayLike[float],
+            ArrayLike[complex],
+            :class:`.SpatialDataArray`,
+            :class:`.TriangularGridDataset`,
+            :class:`.TetrahedralGridDataset`,
+        ]
             Sampled perturbation value(s).
         """
 
         t_range = self.temperature_range
-        temperature_clip = np.clip(temperature, t_range[0], t_range[1])
-        data = self.perturbation_values.interp(T=temperature_clip, method=self.interp_method)
+        temp_clip = np.clip(_get_numpy_array(temperature), t_range[0], t_range[1])
+        sampled = self.perturbation_values.interp(
+            T=temp_clip.ravel(), method=self.interp_method
+        ).values
+        sampled = np.reshape(sampled, np.shape(temp_clip))
+
         # preserve input type
         if isinstance(temperature, SpatialDataArray):
-            return SpatialDataArray(data.drop_vars("T"))
+            return SpatialDataArray(sampled, coords=temperature.coords)
+        if isinstance(temperature, UnstructuredGridDataset):
+            return temperature.updated_copy(
+                values=IndexedDataArray(sampled, coords=temperature.values.coords)
+            )
         if np.ndim(temperature) == 0:
-            return data.item()
-        return data.data
+            return sampled.item()
+        return sampled
 
     @cached_property
     def is_complex(self) -> bool:
@@ -378,34 +413,40 @@ HeatPerturbationType = Union[LinearHeatPerturbation, CustomHeatPerturbation]
 
 def ensure_charge_in_range(
     sample: Callable[
-        [Union[ArrayLike[float], SpatialDataArray], Union[ArrayLike[float], SpatialDataArray]],
-        Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray],
+        [
+            Union[ArrayLike[float], CustomSpatialDataType],
+            Union[ArrayLike[float], CustomSpatialDataType],
+        ],
+        Union[ArrayLike[float], ArrayLike[Complex], CustomSpatialDataType],
     ]
 ) -> Callable[
-    [Union[ArrayLike[float], SpatialDataArray], Union[ArrayLike[float], SpatialDataArray]],
-    Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray],
+    [
+        Union[ArrayLike[float], CustomSpatialDataType],
+        Union[ArrayLike[float], CustomSpatialDataType],
+    ],
+    Union[ArrayLike[float], ArrayLike[Complex], CustomSpatialDataType],
 ]:
     """Decorate ``sample`` to log warning if charge supplied is out of bounds."""
 
     @functools.wraps(sample)
     def _sample(
         self,
-        electron_density: Union[ArrayLike[float], SpatialDataArray],
-        hole_density: Union[ArrayLike[float], SpatialDataArray],
-    ) -> Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]:
+        electron_density: Union[ArrayLike[float], CustomSpatialDataType],
+        hole_density: Union[ArrayLike[float], CustomSpatialDataType],
+    ) -> Union[ArrayLike[float], ArrayLike[Complex], CustomSpatialDataType]:
         """New sample function."""
 
         # disable complex input
         if np.iscomplexobj(electron_density):
-            raise ValueError("Cannot pass complex 'electron_density' to 'sample()'")
+            raise DataError("Cannot pass complex 'electron_density' to 'sample()'")
 
         if np.iscomplexobj(hole_density):
-            raise ValueError("Cannot pass complex 'hole_density' to 'sample()'")
+            raise DataError("Cannot pass complex 'hole_density' to 'sample()'")
 
         # check ranges
         e_min, e_max = self.electron_range
 
-        electron_numpy = np.array(electron_density)
+        electron_numpy = _get_numpy_array(electron_density)
         if np.any(electron_numpy < e_min) or np.any(electron_numpy > e_max):
             log.warning(
                 "Electron density values passed to 'ChargePerturbation.sample()'"
@@ -414,7 +455,7 @@ def ensure_charge_in_range(
 
         h_min, h_max = self.hole_range
 
-        hole_numpy = np.array(hole_density)
+        hole_numpy = _get_numpy_array(hole_density)
         if np.any(hole_numpy < h_min) or np.any(hole_numpy > h_max):
             log.warning(
                 "Hole density values passed to 'ChargePerturbation.sample()'"
@@ -444,27 +485,42 @@ class ChargePerturbation(AbstractPerturbation):
     @abstractmethod
     def sample(
         self,
-        electron_density: Union[ArrayLike[float], SpatialDataArray],
-        hole_density: Union[ArrayLike[float], SpatialDataArray],
-    ) -> Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]:
+        electron_density: Union[ArrayLike[float], CustomSpatialDataType],
+        hole_density: Union[ArrayLike[float], CustomSpatialDataType],
+    ) -> Union[ArrayLike[float], ArrayLike[Complex], CustomSpatialDataType]:
         """Sample perturbation.
 
         Parameters
         ----------
-        electron_density : Union[ArrayLike[float], SpatialDataArray]
+        electron_density : Union[
+                ArrayLike[float],
+                :class:`.SpatialDataArray`,
+                :class:`.TriangularGridDataset`,
+                :class:`.TetrahedralGridDataset`,
+            ]
             Electron density sample point(s).
-        hole_density : Union[ArrayLike[float], SpatialDataArray]
+        hole_density : Union[
+                ArrayLike[float],
+                :class:`.SpatialDataArray`,
+                :class:`.TriangularGridDataset`,
+                :class:`.TetrahedralGridDataset`,
+            ]
             Hole density sample point(s).
 
         Note
         ----
-        Cannot provide a :class:`.SpatialDataArray` for one argument and a regular array
-        (``list``, ``tuple``, ``numpy.nd_array``) for the other. Additionally, if both arguments are
-        regular arrays they must be one-dimensional arrays.
+        Provided ``electron_density`` and ``hole_density`` must be of the same type and match
+        shapes/coordinates, unless one of them is a scalar.
 
         Returns
         -------
-        Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]
+        Union[
+            ArrayLike[float],
+            ArrayLike[complex],
+            :class:`.SpatialDataArray`,
+            :class:`.TriangularGridDataset`,
+            :class:`.TetrahedralGridDataset`,
+        ]
             Sampled perturbation value(s).
         """
 
@@ -480,9 +536,9 @@ class ChargePerturbation(AbstractPerturbation):
 
         Parameters
         ----------
-        electron_density : Union[ArrayLike[float], SpatialDataArray]
+        electron_density : Union[ArrayLike[float], CustomSpatialDataType]
             Array of electron density sample points.
-        hole_density : Union[ArrayLike[float], SpatialDataArray]
+        hole_density : Union[ArrayLike[float], CustomSpatialDataType]
             Array of hole density sample points.
         val : Literal['real', 'imag', 'abs', 'abs^2', 'phase'] = 'real'
             Which part of the field to plot.
@@ -525,30 +581,6 @@ class ChargePerturbation(AbstractPerturbation):
         ax.set_aspect("auto")
 
         return ax
-
-    @staticmethod
-    def _get_eh_types(electron_density, hole_density):
-        """Get types of provided arguments and check that no mixing between spatial and regular
-        arrays.
-        """
-        e_type = AbstractPerturbation._array_type(electron_density)
-        h_type = AbstractPerturbation._array_type(hole_density)
-
-        one_array = e_type == "array" or h_type == "array"
-        one_spatial = e_type == "spatial" or h_type == "spatial"
-
-        if one_array and one_spatial:
-            raise ValueError(
-                "Cannot mix 'SpatialDataArray' and regular python arrays for 'electron_density'"
-                "'hole_density'."
-            )
-
-        if e_type == "array" and h_type == "array" and (np.ndim(e_type) > 1 or np.ndim(h_type) > 1):
-            raise ValueError(
-                "Cannot mix multidimensional arrays for 'electron_density' and 'hole_density'."
-            )
-
-        return e_type, h_type
 
 
 class LinearChargePerturbation(ChargePerturbation):
@@ -631,40 +663,77 @@ class LinearChargePerturbation(ChargePerturbation):
     @ensure_charge_in_range
     def sample(
         self,
-        electron_density: Union[ArrayLike[float], SpatialDataArray],
-        hole_density: Union[ArrayLike[float], SpatialDataArray],
-    ) -> Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]:
+        electron_density: Union[ArrayLike[float], CustomSpatialDataType],
+        hole_density: Union[ArrayLike[float], CustomSpatialDataType],
+    ) -> Union[ArrayLike[float], ArrayLike[Complex], CustomSpatialDataType]:
         """Sample perturbation at electron and hole density points.
 
         Parameters
         ----------
-        electron_density : Union[ArrayLike[float], SpatialDataArray]
+        electron_density : Union[
+                ArrayLike[float],
+                :class:`.SpatialDataArray`,
+                :class:`.TriangularGridDataset`,
+                :class:`.TetrahedralGridDataset`,
+            ]
             Electron density sample point(s).
-        hole_density : Union[ArrayLike[float], SpatialDataArray]
+        hole_density : Union[
+                ArrayLike[float],
+                :class:`.SpatialDataArray`,
+                :class:`.TriangularGridDataset`,
+                :class:`.TetrahedralGridDataset`,
+            ]
             Hole density sample point(s).
 
         Note
         ----
-        Cannot provide a :class:`.SpatialDataArray` for one argument and a regular array
-        (``list``, ``tuple``, ``numpy.nd_array``) for the other. Additionally, if both arguments are
-        regular arrays they must be one-dimensional arrays.
+        Provided ``electron_density`` and ``hole_density`` must be of the same type and match
+        shapes/coordinates, unless one of them is a scalar or both are 1d arrays, in which case
+        values are broadcasted.
 
         Returns
         -------
-        Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]
+        Union[
+            ArrayLike[float],
+            ArrayLike[complex],
+            :class:`.SpatialDataArray`,
+            :class:`.TriangularGridDataset`,
+            :class:`.TetrahedralGridDataset`,
+        ]
             Sampled perturbation value(s).
         """
-        e_type, h_type = self._get_eh_types(electron_density, hole_density)
+        inputs = [electron_density, hole_density]
 
-        if e_type == "array" and h_type == "array":
-            e_mesh, h_mesh = np.meshgrid(electron_density, hole_density, indexing="ij")
+        no_scalars = all(np.ndim(_get_numpy_array(arr)) > 0 for arr in inputs)
+        both_1d = all(
+            isinstance(arr, (list, tuple, np.ndarray)) and np.ndim(arr) == 1 for arr in inputs
+        )
 
-            return self.electron_coeff * (e_mesh - self.electron_ref) + self.hole_coeff * (
-                h_mesh - self.hole_ref
+        # we allow combining a scalar with any other type
+        # or 2 1d arrays (broadcasting)
+        # otherwise we require match in shape/coords
+        if (
+            no_scalars
+            and not both_1d
+            and not _check_same_coordinates(electron_density, hole_density)
+        ):
+            raise DataError(
+                "Provided electron and hole density data must be of the same type and shape."
             )
 
-        e_vals = np.array(electron_density) if e_type == "array" else electron_density
-        h_vals = np.array(hole_density) if h_type == "array" else hole_density
+        e_vals = electron_density
+        h_vals = hole_density
+
+        # convert python arrays into numpy
+        if isinstance(electron_density, (list, tuple)):
+            e_vals = np.array(electron_density)
+
+        if isinstance(hole_density, (list, tuple)):
+            h_vals = np.array(hole_density)
+
+        # broadcast if both are 1d arrays
+        if both_1d:
+            e_vals, h_vals = np.meshgrid(e_vals, h_vals, indexing="ij")
 
         return self.electron_coeff * (e_vals - self.electron_ref) + self.hole_coeff * (
             h_vals - self.hole_ref
@@ -783,41 +852,100 @@ class CustomChargePerturbation(ChargePerturbation):
     @ensure_charge_in_range
     def sample(
         self,
-        electron_density: Union[ArrayLike[float], SpatialDataArray],
-        hole_density: Union[ArrayLike[float], SpatialDataArray],
-    ) -> Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]:
+        electron_density: Union[ArrayLike[float], CustomSpatialDataType],
+        hole_density: Union[ArrayLike[float], CustomSpatialDataType],
+    ) -> Union[ArrayLike[float], ArrayLike[Complex], CustomSpatialDataType]:
         """Sample perturbation at electron and hole density points.
 
         Parameters
         ----------
-        electron_density : Union[ArrayLike[float], SpatialDataArray]
+        electron_density : Union[
+                ArrayLike[float],
+                :class:`.SpatialDataArray`,
+                :class:`.TriangularGridDataset`,
+                :class:`.TetrahedralGridDataset`,
+            ]
             Electron density sample point(s).
-        hole_density : Union[ArrayLike[float], SpatialDataArray]
+        hole_density : Union[
+                ArrayLike[float],
+                :class:`.SpatialDataArray`,
+                :class:`.TriangularGridDataset`,
+                :class:`.TetrahedralGridDataset`,
+            ]
             Hole density sample point(s).
 
         Note
         ----
-        Cannot provide a :class:`.SpatialDataArray` for one argument and a regular array
-        (``list``, ``tuple``, ``numpy.nd_array``) for the other. Additionally, if both arguments are
-        regular arrays they must be one-dimensional arrays.
+        Provided ``electron_density`` and ``hole_density`` must be of the same type and match
+        shapes/coordinates, unless one of them is a scalar or both are 1d arrays, in which case
+        values are broadcasted.
 
         Returns
         -------
-        Union[ArrayLike[float], ArrayLike[Complex], SpatialDataArray]
+        Union[
+            ArrayLike[float],
+            ArrayLike[complex],
+            :class:`.SpatialDataArray`,
+            :class:`.TriangularGridDataset`,
+            :class:`.TetrahedralGridDataset`,
+        ]
             Sampled perturbation value(s).
         """
-        e_type, h_type = self._get_eh_types(electron_density, hole_density)
+        inputs = [electron_density, hole_density]
 
-        e_clip = np.clip(electron_density, self.electron_range[0], self.electron_range[1])
-        h_clip = np.clip(hole_density, self.hole_range[0], self.hole_range[1])
+        no_scalars = all(np.ndim(_get_numpy_array(arr)) > 0 for arr in inputs)
+        both_1d = all(
+            isinstance(arr, (list, tuple, np.ndarray)) and np.ndim(_get_numpy_array(arr)) == 1
+            for arr in inputs
+        )
 
-        data = self.perturbation_values.interp(n=e_clip, p=h_clip, method=self.interp_method)
+        # we allow combining a scalar with any other type
+        # or 2 1d arrays (broadcasting)
+        # otherwise we require match in shape/coords
+        if (
+            no_scalars
+            and not both_1d
+            and not _check_same_coordinates(electron_density, hole_density)
+        ):
+            raise DataError(
+                "Provided electron and hole density data must be of the same type and shape."
+            )
 
-        if e_type == "scalar" and h_type == "scalar":
-            return data.item()
-        if e_type == "spatial" or h_type == "spatial":
-            return SpatialDataArray(data.drop_vars(["n", "p"]))
-        return data.data
+        # clip to allowed values
+        # (this also implicitly convert python arrays into numpy
+        e_vals = np.core.umath.clip(
+            electron_density, self.electron_range[0], self.electron_range[1]
+        )
+        h_vals = np.core.umath.clip(hole_density, self.hole_range[0], self.hole_range[1])
+
+        # we cannot pass UnstructuredGridDataset directly into xarray interp
+        # thus we need to explicitly grad the underlying xarray
+        if isinstance(e_vals, UnstructuredGridDataset):
+            e_vals = e_vals.values
+        if isinstance(h_vals, UnstructuredGridDataset):
+            h_vals = h_vals.values
+
+        # note that the dimensionality of this operation differs depending on whether xarrays
+        # or simple unlabeled arrays are provided:
+        # - for unlabeled arrays, values are broadcasted
+        # - for xarrays, values are considered pairwise based on xarrays' coords
+        sampled = self.perturbation_values.interp(n=e_vals, p=h_vals, method=self.interp_method)
+
+        # grab the result without any labels
+        sampled = sampled.values
+
+        # preserve input type
+        for arr in inputs:
+            if isinstance(arr, SpatialDataArray):
+                return SpatialDataArray(sampled, coords=arr.coords)
+
+            if isinstance(arr, UnstructuredGridDataset):
+                return arr.updated_copy(values=IndexedDataArray(sampled, coords=arr.values.coords))
+
+        if all(np.ndim(_get_numpy_array(arr)) == 0 for arr in inputs):
+            return sampled.item()
+
+        return sampled
 
     @cached_property
     def is_complex(self) -> bool:
@@ -888,51 +1016,67 @@ class ParameterPerturbation(Tidy3dBaseModel):
 
     @staticmethod
     def _zeros_like(
-        T: SpatialDataArray = None,
-        n: SpatialDataArray = None,
-        p: SpatialDataArray = None,
+        T: CustomSpatialDataType = None,
+        n: CustomSpatialDataType = None,
+        p: CustomSpatialDataType = None,
     ):
         """Check that fields have the same coordinates and return an array field with zeros."""
         template = None
         for field in [T, n, p]:
             if field is not None:
-                if template is not None and field.coords != template.coords:
-                    raise ValueError(
+                if template is not None and not _check_same_coordinates(field, template):
+                    raise DataError(
                         "'temperature', 'electron_density', and 'hole_density' must have the same "
                         "coordinates if provided."
                     )
                 template = field
 
         if template is None:
-            raise ValueError(
+            raise DataError(
                 "At least one of 'temperature', 'electron_density', or 'hole_density' must be "
                 "provided."
             )
 
-        return xr.zeros_like(template)
+        return _zeros_like(template)
 
     def apply_data(
         self,
-        temperature: SpatialDataArray = None,
-        electron_density: SpatialDataArray = None,
-        hole_density: SpatialDataArray = None,
-    ) -> SpatialDataArray:
+        temperature: CustomSpatialDataType = None,
+        electron_density: CustomSpatialDataType = None,
+        hole_density: CustomSpatialDataType = None,
+    ) -> CustomSpatialDataType:
         """Sample perturbations on provided heat and/or charge data. At least one of
         ``temperature``, ``electron_density``, and ``hole_density`` must be not ``None``.
         All provided fields must have identical coords.
 
         Parameters
         ----------
-        temperature : SpatialDataArray = None
+        temperature : Union[
+                :class:`.SpatialDataArray`,
+                :class:`.TriangularGridDataset`,
+                :class:`.TetrahedralGridDataset`,
+            ] = None
             Temperature field data.
-        electron_density : SpatialDataArray = None
+        electron_density : Union[
+                :class:`.SpatialDataArray`,
+                :class:`.TriangularGridDataset`,
+                :class:`.TetrahedralGridDataset`,
+            ] = None
             Electron density field data.
-        hole_density : SpatialDataArray = None
+        hole_density : Union[
+                :class:`.SpatialDataArray`,
+                :class:`.TriangularGridDataset`,
+                :class:`.TetrahedralGridDataset`,
+            ] = None
             Hole density field data.
 
         Returns
         -------
-        SpatialDataArray
+        Union[
+            :class:`.SpatialDataArray`,
+            :class:`.TriangularGridDataset`,
+            :class:`.TetrahedralGridDataset`,
+        ] = None
             Sampled perturbation field.
         """
 

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -19,7 +19,8 @@ from .medium import AbstractCustomMedium, Medium2D, MediumType3D
 from .medium import AbstractPerturbationMedium
 from .grid.grid import Grid
 from .structure import Structure
-from .data.data_array import SpatialDataArray
+from .data.dataset import _get_numpy_array, CustomSpatialDataType
+from .data.dataset import UnstructuredGridDataset, TetrahedralGridDataset, TriangularGridDataset
 from .viz import add_ax_if_none, equal_aspect
 from .grid.grid import Coords
 from .heat_spec import SolidSpec
@@ -850,11 +851,11 @@ class Scene(Tidy3dBaseModel):
             eps_dataarray = mat.eps_dataarray_freq(freq)
             eps_min = min(
                 eps_min,
-                min(np.min(eps_comp.real.values.ravel()) for eps_comp in eps_dataarray),
+                min(np.min(_get_numpy_array(eps_comp.real).ravel()) for eps_comp in eps_dataarray),
             )
             eps_max = max(
                 eps_max,
-                max(np.max(eps_comp.real.values.ravel()) for eps_comp in eps_dataarray),
+                max(np.max(_get_numpy_array(eps_comp.real).ravel()) for eps_comp in eps_dataarray),
             )
         return eps_min, eps_max
 
@@ -891,9 +892,51 @@ class Scene(Tidy3dBaseModel):
             plane_axes_inds = [0, 1, 2]
             plane_axes_inds.pop(normal_axis_ind)
 
+            eps_diag = medium.eps_dataarray_freq(frequency=freq)
+
+            # handle unstructured data case
+            if isinstance(eps_diag[0], UnstructuredGridDataset):
+                if (
+                    isinstance(eps_diag[0], TriangularGridDataset)
+                    and eps_diag[0].normal_axis != normal_axis_ind
+                ):
+                    # if we trying to visualize 2d unstructured data not along its normal direction
+                    # we need to extract line slice that lies in the visualization plane
+                    # note that after this eps_diag[] will be SpatialDataArray's
+                    eps_diag = list(eps_diag)
+                    for dim in range(3):
+                        eps_diag[dim] = eps_diag[dim].plane_slice(
+                            axis=normal_axis_ind, pos=normal_position
+                        )
+                else:
+                    eps_mean = (eps_diag[0] + eps_diag[1] + eps_diag[2]) / 3
+
+                    if isinstance(eps_mean, TetrahedralGridDataset):
+                        # extract slice if volumetric unstructured data
+                        eps_mean = eps_mean.plane_slice(axis=normal_axis_ind, pos=normal_position)
+
+                    if reverse:
+                        eps_mean = eps_min + eps_max - eps_mean
+
+                    # at this point eps_mean is TriangularGridDataset and we just plot it directly
+                    # with applying shape mask
+                    eps_mean.plot(
+                        grid=False,
+                        ax=ax,
+                        cbar=False,
+                        cmap=STRUCTURE_EPS_CMAP,
+                        vmin=eps_min,
+                        vmax=eps_max,
+                        pcolor_kwargs=dict(
+                            clip_path=(polygon_path(shape), ax.transData),
+                            clip_box=ax.bbox,
+                            alpha=alpha,
+                        ),
+                    )
+                    return
+
             # in case when different components of custom medium are defined on different grids
             # we will combine all points along each dimension
-            eps_diag = medium.eps_dataarray_freq(frequency=freq)
             if (
                 eps_diag[0].coords == eps_diag[1].coords
                 and eps_diag[0].coords == eps_diag[2].coords
@@ -1240,9 +1283,9 @@ class Scene(Tidy3dBaseModel):
 
     def perturbed_mediums_copy(
         self,
-        temperature: SpatialDataArray = None,
-        electron_density: SpatialDataArray = None,
-        hole_density: SpatialDataArray = None,
+        temperature: CustomSpatialDataType = None,
+        electron_density: CustomSpatialDataType = None,
+        hole_density: CustomSpatialDataType = None,
         interp_method: InterpMethod = "linear",
     ) -> Scene:
         """Return a copy of the scene with heat and/or charge data applied to all mediums
@@ -1253,11 +1296,23 @@ class Scene(Tidy3dBaseModel):
 
         Parameters
         ----------
-        temperature : SpatialDataArray = None
+        temperature : Union[
+                :class:`.SpatialDataArray`,
+                :class:`.TriangularGridDataset`,
+                :class:`.TetrahedralGridDataset`,
+            ] = None
             Temperature field data.
-        electron_density : SpatialDataArray = None
+        electron_density : Union[
+                :class:`.SpatialDataArray`,
+                :class:`.TriangularGridDataset`,
+                :class:`.TetrahedralGridDataset`,
+            ] = None
             Electron density field data.
-        hole_density : SpatialDataArray = None
+        hole_density : Union[
+                :class:`.SpatialDataArray`,
+                :class:`.TriangularGridDataset`,
+                :class:`.TetrahedralGridDataset`,
+            ] = None
             Hole density field data.
         interp_method : :class:`.InterpMethod`, optional
             Interpolation method to obtain heat and/or charge values that are not supplied
@@ -1265,7 +1320,7 @@ class Scene(Tidy3dBaseModel):
 
         Returns
         -------
-        Scene
+        :class:`.Scene`
             Simulation after application of heat and/or charge data.
         """
 

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -38,7 +38,6 @@ from .monitor import PermittivityMonitor, DiffractionMonitor, AbstractFieldProje
 from .monitor import FieldProjectionAngleMonitor, FieldProjectionKSpaceMonitor
 from .lumped_element import LumpedElementType, LumpedResistor
 from .data.dataset import Dataset, CustomSpatialDataType
-from .data.data_array import SpatialDataArray
 from .viz import add_ax_if_none, equal_aspect
 from .scene import Scene, MAX_NUM_MEDIUMS
 

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -37,7 +37,7 @@ from .monitor import AbstractModeMonitor, FieldMonitor, TimeMonitor
 from .monitor import PermittivityMonitor, DiffractionMonitor, AbstractFieldProjectionMonitor
 from .monitor import FieldProjectionAngleMonitor, FieldProjectionKSpaceMonitor
 from .lumped_element import LumpedElementType, LumpedResistor
-from .data.dataset import Dataset
+from .data.dataset import Dataset, CustomSpatialDataType
 from .data.data_array import SpatialDataArray
 from .viz import add_ax_if_none, equal_aspect
 from .scene import Scene, MAX_NUM_MEDIUMS
@@ -3672,9 +3672,9 @@ class Simulation(AbstractSimulation):
 
     def perturbed_mediums_copy(
         self,
-        temperature: SpatialDataArray = None,
-        electron_density: SpatialDataArray = None,
-        hole_density: SpatialDataArray = None,
+        temperature: CustomSpatialDataType = None,
+        electron_density: CustomSpatialDataType = None,
+        hole_density: CustomSpatialDataType = None,
         interp_method: InterpMethod = "linear",
     ) -> Simulation:
         """Return a copy of the simulation with heat and/or charge data applied to all mediums
@@ -3685,11 +3685,23 @@ class Simulation(AbstractSimulation):
 
         Parameters
         ----------
-        temperature : SpatialDataArray = None
+        temperature : Union[
+                :class:`.SpatialDataArray`,
+                :class:`.TriangularGridDataset`,
+                :class:`.TetrahedralGridDataset`,
+            ] = None
             Temperature field data.
-        electron_density : SpatialDataArray = None
+        electron_density : Union[
+                :class:`.SpatialDataArray`,
+                :class:`.TriangularGridDataset`,
+                :class:`.TetrahedralGridDataset`,
+            ] = None
             Electron density field data.
-        hole_density : SpatialDataArray = None
+        hole_density : Union[
+                :class:`.SpatialDataArray`,
+                :class:`.TriangularGridDataset`,
+                :class:`.TetrahedralGridDataset`,
+            ] = None
             Hole density field data.
         interp_method : :class:`.InterpMethod`, optional
             Interpolation method to obtain heat and/or charge values that are not supplied

--- a/tidy3d/version.py
+++ b/tidy3d/version.py
@@ -1,2 +1,2 @@
 """Defines the front end version of tidy3d"""
-__version__ = "2.7.0unstructured"
+__version__ = "2.7.0rc1"

--- a/tidy3d/version.py
+++ b/tidy3d/version.py
@@ -1,2 +1,2 @@
 """Defines the front end version of tidy3d"""
-__version__ = "2.7.0rc1"
+__version__ = "2.7.0unstructured"


### PR DESCRIPTION
This PR allows to use unstructured grid datasets (`TriangularGridDataset` and `TetrahedralGridDataset`) in unstructured medium classes. All necessary associated functionality is extended and tested, which includes:
- unstructured grid dataset interpolation improvement:
-- new vectorized interpolation
-- option `extrapolate` by nearest neighbor values
-- nearest neighbor interpolation
- loading `DataArray`  without coordinates (for example, when `arr = td.PointDataArray(np.ones((3, 2)), dims=["x", "y"])`, that is `dims` provided but not `coords`)
- `sel_inside` and `does_cover` for unstructured grid datasets
- `Coords.spatial_interp` is extended to work both with `SpatialDataArray` and `UnstructuredGridDataset`

There are quite a lot of changes, so maybe what would make sense is:
- for @tylerflex to review on the high level
- for @weiliangjin2021 to review more in detail parts related to custom medium classes and their testing
- for @caseyflex to review new interpolation method for unstructured grid datasets, that is, file [tidy3d/components/data/dataset.py](https://github.com/flexcompute/tidy3d/pull/1498/files#diff-3d6bc96fe49f31f2d21f3f369c8e3262ea0264f353d8c092ef5065c9e8db9d04) 

what do you think?

Example notebooks on heat and charge will be converted to use only unstructured data after this PR is merged. Previews:
- https://github.com/flexcompute/tidy3d-notebooks/blob/daniil/unstructured-medium-heat/ThermallyTunedRingResonator.ipynb
- https://github.com/flexcompute/tidy3d-notebooks/blob/daniil/unstructured-medium-heat/MetalHeaterPhaseShifter.ipynb
- https://github.com/flexcompute/tidy3d-notebooks/blob/daniil/unstructured-medium-heat/MachZehnderModulator.ipynb