### PR TITLE
fix pec freq arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix to 3D surface integration monitors with some surfaces completely outside of the simulation domain which would sometimes still record fields.
 - Better error handling if remote `ModeSolver` creation gives response of `None`.
 - Validates that certain incompatible material types do not have intersecting bounds.
+- Fixed handling of the `frequency` argument in PEC medium.
 
 ## [2.6.0] - 2024-01-21
 

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -1205,6 +1205,7 @@ class PECMedium(AbstractMedium):
             )
         return val
 
+    @ensure_freq_in_range
     def eps_model(self, frequency: float) -> complex:
         # return something like frequency with value of pec_val + 0j
         return 0j * frequency + pec_val


### PR DESCRIPTION
Small bug when trying to plot epsilon with coord_key not equals to `centers` and `freq=None`. Other media assume an infinite frequency but PEC results in TypeError at multiplication

`eps_sample = sim.epsilon(box=box, coord_key="Ex")`