### PR TITLE
fix adjoint bug for point monitor data from jax update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validates that certain incompatible material types do not have intersecting bounds.
 - Fixed handling of the `frequency` argument in PEC medium.
 - Corrected plotting cmap if `val='re'` passed to `SimulationData.plot_field`.
+- Bug when converting point `FieldMonitor` data to scalar amplitude for adjoint source in later jax versions.
 
 ## [2.6.0] - 2024-01-21
 

--- a/tidy3d/plugins/adjoint/components/data/monitor_data.py
+++ b/tidy3d/plugins/adjoint/components/data/monitor_data.py
@@ -241,7 +241,7 @@ class JaxFieldData(JaxMonitorData, FieldData):
                     omega0 = 2 * np.pi * freq0
                     scaling_factor = 1 / (MU_0 * omega0)
 
-                    forward_amp = complex(field_component.sel(f=freq0).values)
+                    forward_amp = complex(jnp.squeeze(field_component.sel(f=freq0).values))
 
                     adj_phase = 3 * np.pi / 2 + np.angle(forward_amp)
 


### PR DESCRIPTION
When jax is upgraded, the adjoint quickstart fails when constructing adjoint source because `complex()` doesn't work for multi-dimensional jax arrays (even if just one data point).

```py
>>> import jax.numpy as jnp
>>> a = jnp.array([[1]])

# jax == 0.4.4
>>> complex(a) 
(1+0j)

# jax == 0.4.24
>>> complex(a)
TypeError: Only scalar arrays can be converted to Python scalars; got arr.ndim=2

```