### PR TITLE
Fixes to some monitors' solver storage estimate, and to corresponding tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corrected plotting cmap if `val='re'` passed to `SimulationData.plot_field`.
 - Bug when converting point `FieldMonitor` data to scalar amplitude for adjoint source in later jax versions.
 - Handle special case when vertices overlap in `JaxPolySlab` to give 0 grad contribution from edge.
+- Corrected some mistakes in the estimation of the solver data size for each monitor type, which affects the restrictions on the maximum monitor size that can be submitted.
 
 ## [2.6.0] - 2024-01-21
 


### PR DESCRIPTION
So initially I wanted to make a small modification: for field monitors, if a subset of the field components is requested, the `storage_size` is just proportional to the number of requested components. However, the solver stores all of E if at least one E component is requested, and same for H. So the internal storage size for field monitors can be larger.

Then I noticed that the test for this was not working as expected: it was successful because of a completely unrelated error. Fixing the test led me to also fixing `DiffractionMonitor` solver storage estimate.