### PR TITLE
Small reorganization of web.monitor logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prompting user to check solver log when loading solver data if warnings were found in the log, or if the simulation diverged or errored.
 
 ### Changed
+- Slightly reorganized `web.run` logging when `verbose=True` to make it clearer.
 
 ### Fixed
 - Fix to 3D surface integration monitors with some surfaces completely outside of the simulation domain which would sometimes still record fields.

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -422,7 +422,12 @@ def monitor(task_id: TaskId, verbose: bool = True) -> None:
 
         # preprocessing
         if verbose:
-            with console.status(f"[bold green]Starting '{task_name}'...", spinner="runner"):
+            console.log(
+                "To cancel the simulation, use 'web.abort(task_id)' or 'web.delete(task_id)' "
+                "or abort/delete the task in the web "
+                "UI. Terminating the Python script will not stop the job running on the cloud."
+            )
+            with console.status(f"[bold green]Waiting for '{task_name}'...", spinner="runner"):
                 monitor_preprocess()
         else:
             monitor_preprocess()
@@ -440,11 +445,6 @@ def monitor(task_id: TaskId, verbose: bool = True) -> None:
         if verbose:
             # verbose case, update progressbar
             console.log("running solver")
-            console.log(
-                "To cancel the simulation, use 'web.abort(task_id)' or 'web.delete(task_id)' "
-                "or abort/delete the task in the web "
-                "UI. Terminating the Python script will not stop the job running on the cloud."
-            )
             with Progress(console=console) as progress:
                 pbar_pd = progress.add_task("% done", total=100)
                 perc_done, _ = get_run_info(task_id)


### PR DESCRIPTION
Tom pointed out that if a task is queued for a bit, some users don't realize what is happening, and terminate the notebook execution (while the task still runs eventually and users get charged). This is an attempt to improve our messaging. Here's what it looks like when a task is in queue now:

![image](https://github.com/flexcompute/tidy3d/assets/92756559/6f88edab-f436-4e97-9264-1606331b65e9)
