### PR TITLE
Bugfixes related to simulation.subsection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handle special case when vertices overlap in `JaxPolySlab` to give 0 grad contribution from edge.
 - Corrected some mistakes in the estimation of the solver data size for each monitor type, which affects the restrictions on the maximum monitor size that can be submitted.
 - Bug in visualizing a slanted cylinder along certain axes in 2D.
+- Bug in `ModeSolver.reduced_simulation_copy` that was causing mode profiles to be all `NaN`.
+- Bug in `Simulation.subsection()` that was causing zero-size dimensions not to be preserved.
+- Behavior of `UniformGrid` is made consistent with `AutoGrid` in case of zero-size dimensions.
 
 ## [2.6.0] - 2024-01-21
 

--- a/tests/test_components/test_grid_spec.py
+++ b/tests/test_components/test_grid_spec.py
@@ -1,6 +1,7 @@
 """Tests GridSpec."""
 import pytest
 import numpy as np
+import pydantic.v1 as pydantic
 
 import tidy3d as td
 from tidy3d.exceptions import SetupError
@@ -160,3 +161,51 @@ def test_autogrid_2dmaterials():
     # Commented until inplane AutoGrid for 2D materials is enabled
     # with pytest.raises(ValidationError):
     #    _ = sim.grid
+
+
+def test_zerosize_dimensions():
+    wvl = 1.55
+    res = 20
+    dl = wvl / res
+
+    # auto grid
+    sim = td.Simulation(
+        size=(0, 10, 10),
+        boundary_spec=td.BoundarySpec.pec(
+            x=True,
+            y=True,
+            z=True,
+        ),
+        grid_spec=td.GridSpec.auto(wavelength=wvl, min_steps_per_wvl=res),
+        run_time=1e-12,
+    )
+
+    assert np.allclose(sim.grid.boundaries.x, [-dl / 2, dl / 2])
+
+    # uniform grid
+    sim = td.Simulation(
+        size=(5, 0, 10),
+        boundary_spec=td.BoundarySpec.pec(
+            x=True,
+            y=True,
+            z=True,
+        ),
+        grid_spec=td.GridSpec.uniform(dl=dl),
+        run_time=1e-12,
+    )
+
+    assert np.allclose(sim.grid.boundaries.y, [-dl / 2, dl / 2])
+
+    # custom grid
+    custom_grid = td.CustomGrid(dl=tuple([0.25] * 40))
+    with pytest.raises(pydantic.ValidationError):
+        sim = td.Simulation(
+            size=(5, 0, 10),
+            boundary_spec=td.BoundarySpec.pec(
+                x=True,
+                y=True,
+                z=True,
+            ),
+            grid_spec=td.GridSpec(grid_x=custom_grid, grid_y=custom_grid, grid_z=custom_grid),
+            run_time=1e-12,
+        )

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -2310,6 +2310,8 @@ def test_to_gds(tmp_path):
 
 def test_sim_subsection():
     region = td.Box(size=(0.3, 0.5, 0.7), center=(0.1, 0.05, 0.02))
+    region_xy = td.Box(size=(0.3, 0.5, 0), center=(0.1, 0.05, 0.02))
+    region_yz = td.Box(size=(0, 0.5, 0.7), center=(0.1, 0.05, 0.02))
 
     sim_red = SIM_FULL.subsection(region=region)
     assert sim_red.structures != SIM_FULL.structures
@@ -2376,6 +2378,15 @@ def test_sim_subsection():
         # compare
         assert np.allclose(red_grid, full_grid[ind : ind + len(red_grid)])
 
+    sim_red = SIM_FULL.subsection(
+        region=region_xy,
+        grid_spec="identical",
+        boundary_spec=td.BoundarySpec.all_sides(td.Periodic()),
+    )
+    assert sim_red.size[2] == 0
+    assert isinstance(sim_red.boundary_spec.z.minus, td.Periodic)
+    assert isinstance(sim_red.boundary_spec.z.plus, td.Periodic)
+
     # check behavior for zero-size dimensions
     sim_2d = SIM.updated_copy(
         size=(SIM.size[0], 0, SIM.size[2]),
@@ -2385,6 +2396,18 @@ def test_sim_subsection():
         region=region, remove_outside_structures=True, remove_outside_custom_mediums=True
     )
     assert sim_2d_red.size[1] == 0
+
+    sim_red = sim_2d.subsection(
+        region=region_xy,
+        grid_spec="identical",
+        boundary_spec=td.BoundarySpec.all_sides(td.Periodic()),
+    )
+    assert sim_red.size[1] == 0
+    assert sim_red.size[2] == 0
+    assert isinstance(sim_red.boundary_spec.y.minus, td.Periodic)
+    assert isinstance(sim_red.boundary_spec.y.plus, td.Periodic)
+    assert isinstance(sim_red.boundary_spec.z.minus, td.Periodic)
+    assert isinstance(sim_red.boundary_spec.z.plus, td.Periodic)
 
     sim_1d = SIM.updated_copy(
         size=(0, SIM.size[1], 0),

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -2376,6 +2376,26 @@ def test_sim_subsection():
         # compare
         assert np.allclose(red_grid, full_grid[ind : ind + len(red_grid)])
 
+    # check behavior for zero-size dimensions
+    sim_2d = SIM.updated_copy(
+        size=(SIM.size[0], 0, SIM.size[2]),
+        boundary_spec=td.BoundarySpec.pml(x=True, z=True),
+    )
+    sim_2d_red = sim_2d.subsection(
+        region=region, remove_outside_structures=True, remove_outside_custom_mediums=True
+    )
+    assert sim_2d_red.size[1] == 0
+
+    sim_1d = SIM.updated_copy(
+        size=(0, SIM.size[1], 0),
+        boundary_spec=td.BoundarySpec.pml(y=True),
+    )
+    sim_1d_red = sim_1d.subsection(
+        region=region, remove_outside_structures=True, remove_outside_custom_mediums=True
+    )
+    assert sim_1d_red.size[0] == 0
+    assert sim_1d_red.size[2] == 0
+
 
 def test_2d_material_subdivision():
     units = 1e3

--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -184,6 +184,10 @@ class UniformGrid(GridSpec1d):
 
         center, size = structures[0].geometry.center[axis], structures[0].geometry.size[axis]
 
+        # to be consistent with AutoGrid behavior in case of 0-size dimensions
+        if size == 0:
+            return np.array([center - self.dl / 2, center + self.dl / 2])
+
         # Take a number of steps commensurate with the size; make dl a bit smaller if needed
         num_cells = int(np.ceil(size / self.dl))
 
@@ -191,7 +195,7 @@ class UniformGrid(GridSpec1d):
         num_cells = max(num_cells, 1)
 
         # Adjust step size to fit simulation size exactly
-        dl_snapped = size / num_cells if size > 0 else self.dl
+        dl_snapped = size / num_cells
 
         return center - size / 2 + np.arange(num_cells + 1) * dl_snapped
 

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -142,15 +142,15 @@ class ModeSolver(Tidy3dBaseModel):
         return solver_sym
 
     def _get_solver_grid(
-        self, preserve_layer_behind: bool = False, truncate_symmetry: bool = True
+        self, keep_additional_layers: bool = False, truncate_symmetry: bool = True
     ) -> Grid:
         """Grid for the mode solver, not snapped to plane or simulation zero dims, and optionally
         corrected for symmetries.
 
         Parameters
         ----------
-        preserve_layer_behind : bool = False
-            Do not discard the layer of cells behind the main layer of cells. Together they
+        keep_additional_layers : bool = False
+            Do not discard layers of cells in front and behind the main layer of cells. Together they
             represent the region where custom medium data is needed for proper subpixel.
         truncate_symmetry : bool = True
             Truncate to symmetry quadrant if symmetry present.
@@ -166,9 +166,9 @@ class ModeSolver(Tidy3dBaseModel):
         span_inds = self.simulation._discretize_inds_monitor(monitor)
 
         # Remove extension along monitor normal
-        if not preserve_layer_behind:
+        if not keep_additional_layers:
             span_inds[self.normal_axis, 0] += 1
-        span_inds[self.normal_axis, 1] -= 1
+            span_inds[self.normal_axis, 1] -= 1
 
         # Do not extend if simulation has a single pixel along a dimension
         for dim, num_cells in enumerate(self.simulation.grid.num_cells):
@@ -192,7 +192,7 @@ class ModeSolver(Tidy3dBaseModel):
         plane normal dimension and dimensions where the simulation domain is 2D will be correctly
         set after the solve."""
 
-        return self._get_solver_grid(preserve_layer_behind=False, truncate_symmetry=True)
+        return self._get_solver_grid(keep_additional_layers=False, truncate_symmetry=True)
 
     @cached_property
     def _num_cells_freqs_modes(self) -> Tuple[int, int, int]:
@@ -975,7 +975,7 @@ class ModeSolver(Tidy3dBaseModel):
 
         # we preserve extra cells along the normal direction to ensure there is enough data for
         # subpixel
-        extended_grid = self._get_solver_grid(preserve_layer_behind=True, truncate_symmetry=False)
+        extended_grid = self._get_solver_grid(keep_additional_layers=True, truncate_symmetry=False)
         grids_1d = extended_grid.boundaries
         new_sim_box = Box.from_bounds(
             rmin=(grids_1d.x[0], grids_1d.y[0], grids_1d.z[0]),
@@ -987,7 +987,7 @@ class ModeSolver(Tidy3dBaseModel):
 
         new_bspec_dict = {}
         for axis in "xyz":
-            bcomp = bspec["x"]
+            bcomp = bspec[axis]
             for bside, sign in zip([bcomp.plus, bcomp.minus], "+-"):
                 if isinstance(bside, (PML, StablePML, Absorber)):
                     new_bspec_dict[axis + sign] = PECBoundary()


### PR DESCRIPTION
- Bug in `ModeSolver.reduced_simulation_copy` that was causing mode profiles to be all `NaN`.
- Bug in `Simulation.subsection()` that was causing zero-size dimensions not to be preserved.
- Behavior of `UniformGrid` is made consistent with `AutoGrid` in case of zero-size dimensions. That is, grid is created as `[center - dl / 2, center + dl / 2]` instead of `[center, center + dl]`