### PR TITLE
Creating parent directory for 'to_file' when downloading a gz file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug in `ModeSolver.reduced_simulation_copy` that was causing mode profiles to be all `NaN`.
 - Bug in `Simulation.subsection()` that was causing zero-size dimensions not to be preserved.
 - Bug in `CustomGrid` that was causing an error when using for zero-size dimensions.
+- When downloading gzip-ed solver data, automatically create the parent folder of the `to_file` path if it does not exist.
 
 ## [2.6.0] - 2024-01-21
 

--- a/tidy3d/web/core/s3utils.py
+++ b/tidy3d/web/core/s3utils.py
@@ -391,6 +391,10 @@ def download_gz_file(
     # The tempfile is set as ``hdf5.gz`` so that the mock download in the webapi tests works
     tmp_file, tmp_file_path = tempfile.mkstemp(".hdf5.gz")
     os.close(tmp_file)
+
+    # make the leading directories in the 'to_file', if any
+    to_file = pathlib.Path(to_file)
+    to_file.parent.mkdir(parents=True, exist_ok=True)
     try:
         download_file(
             resource_id,


### PR DESCRIPTION
In 2.6 solver output is gziped, and it turns out that if we have something like `to_file="data/simulation_data.hdf5"` in web.run and the `data` folder does not exist, this would error. This had already been taken care of in the regular file download, now also fixing it for the gziped one which uses a tempfile when calling `download_file`, so the parent directory is not created there.