### PR TITLE
Modified zero-size validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- 2D heat simulations are now fully supported. 
 
 ## [2.6.1] - 2024-03-07
 

--- a/tests/test_components/test_heat.py
+++ b/tests/test_components/test_heat.py
@@ -305,10 +305,10 @@ def test_heat_sim():
     structure = structure.updated_copy(geometry=STL_GEO, name="stl")
     _ = heat_sim.updated_copy(structures=list(heat_sim.structures) + [structure])
 
-    # test unsupported yet zero dimension domains
-    with pytest.raises(pd.ValidationError):
-        _ = heat_sim.updated_copy(center=(0, 0, 0), size=(0, 2, 2))
+    # run 2D case
+    _ = heat_sim.updated_copy(center=(0, 0, 0), size=(0, 2, 2))
 
+    # test unsupported 1D heat domains
     with pytest.raises(pd.ValidationError):
         _ = heat_sim.updated_copy(center=(0, 0, 0), size=(1, 0, 0))
 

--- a/tidy3d/components/heat/simulation.py
+++ b/tidy3d/components/heat/simulation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Tuple, List, Dict
 from matplotlib import cm
+import numpy as np
 
 import pydantic.v1 as pd
 
@@ -132,10 +133,20 @@ class HeatSimulation(AbstractSimulation):
     def check_zero_dim_domain(cls, val, values):
         """Error if heat domain have zero dimensions."""
 
-        if any(length == 0 for length in val):
-            raise SetupError(
-                "'HeatSimulation' does not currently support domains with dimensions of zero size."
-            )
+        dim_names = ["x", "y", "z"]
+        zero_dimensions = [False, False, False]
+        zero_dim_str = ""
+        for n, v in enumerate(val):
+            if v == 0:
+                zero_dimensions[n] = True
+                zero_dim_str += f"{dim_names[n]}- "
+
+        num_zero_dims = np.sum(zero_dimensions)
+
+        if num_zero_dims > 1:
+            mssg = f"Your current HeatSimulation has zero size along the {zero_dim_str}dimensions. "
+            mssg += "Only 2- and 3-D simulations are currently supported."
+            raise SetupError(mssg)
 
         return val
 


### PR DESCRIPTION
it now accepts 2D simulations and only raises error when 1D.

This PR (along with its corresponding PR on tidy3d-core) addresses issue [#555](https://github.com/flexcompute/tidy3d-core/issues/550) of tidy3d-core repo