### PR TITLE
FEAT: Compute characteristic impedance from fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.6.1] - 2024-03-07
 
 ### Added
+- Introduced the `microwave` plugin which includes `ImpedanceCalculator` for computing the characteristic impedance of transmission lines.
 - `Simulation` now accepts `LumpedElementType`, which currently only supports the `LumpedResistor` type. `LumpedPort` together with `LumpedResistor` make up the new `TerminalComponentModeler` in the `smatrix` plugin.
 - Uniaxial medium Lithium niobate to material library.
 - Added support for conformal mesh methods near PEC structures that can be specified through the field `pec_conformal_mesh_spec` in the `Simulation` class.

--- a/docs/api/plugins/index.rst
+++ b/docs/api/plugins/index.rst
@@ -12,6 +12,7 @@ Plugins
     adjoint
     waveguide
     design
+    microwave
 
 
 .. include:: /api/plugins/mode_solver.rst
@@ -22,3 +23,4 @@ Plugins
 .. include:: /api/plugins/adjoint.rst
 .. include:: /api/plugins/waveguide.rst
 .. include:: /api/plugins/design.rst
+.. include:: /api/plugins/microwave.rst

--- a/docs/api/plugins/microwave.rst
+++ b/docs/api/plugins/microwave.rst
@@ -1,0 +1,13 @@
+.. currentmodule:: tidy3d
+
+Microwave
+----------------------------
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.plugins.microwave.AxisAlignedPathIntegral 
+   tidy3d.plugins.microwave.VoltageIntegralAxisAligned
+   tidy3d.plugins.microwave.CurrentIntegralAxisAligned
+   tidy3d.plugins.microwave.ImpedanceCalculator

--- a/tests/test_plugins/test_microwave.py
+++ b/tests/test_plugins/test_microwave.py
@@ -1,0 +1,305 @@
+import pytest
+import numpy as np
+
+import tidy3d as td
+from tidy3d import FieldData
+from tidy3d.constants import ETA_0
+from tidy3d.plugins.microwave import (
+    VoltageIntegralAxisAligned,
+    CurrentIntegralAxisAligned,
+    ImpedanceCalculator,
+)
+import pydantic.v1 as pydantic
+from tidy3d.exceptions import DataError
+from ..utils import run_emulated
+
+
+# Using similar code as "test_data/test_data_arrays.py"
+MON_SIZE = (2, 1, 0)
+FIELDS = ("Ex", "Ey", "Hx", "Hy")
+FSTART = 0.5e9
+FSTOP = 1.5e9
+F0 = (FSTART + FSTOP) / 2
+FWIDTH = FSTOP - FSTART
+FS = np.linspace(FSTART, FSTOP, 3)
+FIELD_MONITOR = td.FieldMonitor(
+    size=MON_SIZE, fields=FIELDS, name="strip_field", freqs=FS, colocate=False
+)
+STRIP_WIDTH = 1.5
+STRIP_HEIGHT = 0.5
+
+SIM_Z = td.Simulation(
+    size=(2, 1, 1),
+    grid_spec=td.GridSpec.uniform(dl=0.04),
+    monitors=[
+        FIELD_MONITOR,
+        td.FieldMonitor(center=(0, 0, 0), size=(1, 1, 1), freqs=FS, name="field"),
+        td.FieldMonitor(
+            center=(0, 0, 0), size=(1, 1, 1), freqs=FS, fields=["Ex", "Hx"], name="ExHx"
+        ),
+        td.FieldTimeMonitor(center=(0, 0, 0), size=(1, 1, 0), colocate=False, name="field_time"),
+        td.ModeSolverMonitor(
+            center=(0, 0, 0),
+            size=(1, 1, 0),
+            freqs=FS,
+            mode_spec=td.ModeSpec(num_modes=2),
+            name="mode",
+        ),
+    ],
+    sources=[
+        td.PointDipole(
+            center=(0, 0, 0),
+            polarization="Ex",
+            source_time=td.GaussianPulse(freq0=F0, fwidth=FWIDTH),
+        )
+    ],
+    run_time=5e-16,
+)
+
+SIM_Z_DATA = run_emulated(SIM_Z)
+
+""" Generate the data arrays for testing path integral computations """
+
+
+def get_xyz(
+    monitor: td.components.monitor.MonitorType, grid_key: str
+) -> tuple[list[float], list[float], list[float]]:
+    grid = SIM_Z.discretize_monitor(monitor)
+    x, y, z = grid[grid_key].to_list
+    return x, y, z
+
+
+def make_stripline_scalar_field_data_array(grid_key: str):
+    """Populate FIELD_MONITOR with a idealized stripline mode, where fringing fields are assumed 0."""
+    XS, YS, ZS = get_xyz(FIELD_MONITOR, grid_key)
+    XGRID, YGRID = np.meshgrid(XS, YS, indexing="ij")
+    XGRID = XGRID.reshape((len(XS), len(YS), 1, 1))
+    YGRID = YGRID.reshape((len(XS), len(YS), 1, 1))
+    values = np.zeros((len(XS), len(YS), len(ZS), len(FS)))
+    ones = np.ones((len(XS), len(YS), len(ZS), len(FS)))
+    XGRID = np.broadcast_to(XGRID, values.shape)
+    YGRID = np.broadcast_to(YGRID, values.shape)
+
+    # Numpy masks for quickly determining location
+    above_in_strip = np.logical_and(YGRID >= 0, YGRID <= STRIP_HEIGHT / 2)
+    below_in_strip = np.logical_and(YGRID < 0, YGRID >= -STRIP_HEIGHT / 2)
+    within_strip_width = np.logical_and(XGRID >= -STRIP_WIDTH / 2, XGRID < STRIP_WIDTH / 2)
+    above_and_within = np.logical_and(above_in_strip, within_strip_width)
+    below_and_within = np.logical_and(below_in_strip, within_strip_width)
+    # E field is perpendicular to strip surface and magnetic field is parallel
+    if grid_key == "Ey":
+        values = np.where(above_and_within, ones, values)
+        values = np.where(below_and_within, -ones, values)
+    elif grid_key == "Hx":
+        values = np.where(above_and_within, -ones / ETA_0, values)
+        values = np.where(below_and_within, ones / ETA_0, values)
+
+    return td.ScalarFieldDataArray(values, coords=dict(x=XS, y=YS, z=ZS, f=FS))
+
+
+def make_field_data():
+    return FieldData(
+        monitor=FIELD_MONITOR,
+        Ex=make_stripline_scalar_field_data_array("Ex"),
+        Ey=make_stripline_scalar_field_data_array("Ey"),
+        Hx=make_stripline_scalar_field_data_array("Hx"),
+        Hy=make_stripline_scalar_field_data_array("Hy"),
+        symmetry=SIM_Z.symmetry,
+        symmetry_center=SIM_Z.center,
+        grid_expanded=SIM_Z.discretize_monitor(FIELD_MONITOR),
+    )
+
+
+@pytest.mark.parametrize("axis", [0, 1, 2])
+def test_voltage_integral_axes(axis):
+    length = 0.5
+    size = [0, 0, 0]
+    size[axis] = length
+    center = [0, 0, 0]
+    voltage_integral = VoltageIntegralAxisAligned(
+        center=center,
+        size=size,
+        sign="+",
+    )
+
+    _ = voltage_integral.compute_voltage(SIM_Z_DATA["field"])
+
+
+@pytest.mark.parametrize("axis", [0, 1, 2])
+def test_current_integral_axes(axis):
+    length = 0.5
+    size = [length, length, length]
+    size[axis] = 0.0
+    center = [0, 0, 0]
+    current_integral = CurrentIntegralAxisAligned(
+        center=center,
+        size=size,
+        sign="+",
+    )
+    _ = current_integral.compute_current(SIM_Z_DATA["field"])
+
+
+def test_voltage_integral_toggles():
+    length = 0.5
+    size = [0, 0, 0]
+    size[0] = length
+    center = [0, 0, 0]
+    voltage_integral = VoltageIntegralAxisAligned(
+        center=center,
+        size=size,
+        extrapolate_to_endpoints=True,
+        snap_path_to_grid=True,
+        sign="-",
+    )
+    _ = voltage_integral.compute_voltage(SIM_Z_DATA["field"])
+
+
+def test_current_integral_toggles():
+    length = 0.5
+    size = [length, length, length]
+    size[0] = 0.0
+    center = [0, 0, 0]
+    current_integral = CurrentIntegralAxisAligned(
+        center=center,
+        size=size,
+        extrapolate_to_endpoints=True,
+        snap_contour_to_grid=True,
+        sign="-",
+    )
+    _ = current_integral.compute_current(SIM_Z_DATA["field"])
+
+
+def test_voltage_missing_fields():
+    length = 0.5
+    size = [0, 0, 0]
+    size[1] = length
+    center = [0, 0, 0]
+    voltage_integral = VoltageIntegralAxisAligned(
+        center=center,
+        size=size,
+        sign="+",
+    )
+
+    with pytest.raises(DataError):
+        _ = voltage_integral.compute_voltage(SIM_Z_DATA["ExHx"])
+
+
+def test_current_missing_fields():
+    length = 0.5
+    size = [length, length, length]
+    size[0] = 0.0
+    center = [0, 0, 0]
+    current_integral = CurrentIntegralAxisAligned(
+        center=center,
+        size=size,
+        sign="+",
+    )
+
+    with pytest.raises(DataError):
+        _ = current_integral.compute_current(SIM_Z_DATA["ExHx"])
+
+
+def test_time_monitor_voltage_integral():
+    length = 0.5
+    size = [0, 0, 0]
+    size[1] = length
+    center = [0, 0, 0]
+    voltage_integral = VoltageIntegralAxisAligned(
+        center=center,
+        size=size,
+        sign="+",
+    )
+
+    voltage_integral.compute_voltage(SIM_Z_DATA["field_time"])
+
+
+def test_mode_solver_monitor_voltage_integral():
+    length = 0.5
+    size = [0, 0, 0]
+    size[1] = length
+    center = [0, 0, 0]
+    voltage_integral = VoltageIntegralAxisAligned(
+        center=center,
+        size=size,
+        sign="+",
+    )
+
+    voltage_integral.compute_voltage(SIM_Z_DATA["mode"])
+
+
+def test_tiny_voltage_path():
+    length = 0.02
+    size = [0, 0, 0]
+    size[1] = length
+    center = [0, 0, 0]
+    voltage_integral = VoltageIntegralAxisAligned(
+        center=center, size=size, sign="+", extrapolate_to_endpoints=True
+    )
+
+    _ = voltage_integral.compute_voltage(SIM_Z_DATA["field"])
+
+
+def test_impedance_calculator():
+    with pytest.raises(pydantic.ValidationError):
+        _ = ImpedanceCalculator(voltage_integral=None, current_integral=None)
+
+
+def test_impedance_calculator_on_time_data():
+    # Setup path integrals
+    length = 0.5
+    size = [0, length, 0]
+    size[1] = length
+    center = [0, 0, 0]
+    voltage_integral = VoltageIntegralAxisAligned(
+        center=center, size=size, sign="+", extrapolate_to_endpoints=True
+    )
+
+    size = [length, length, 0]
+    current_integral = CurrentIntegralAxisAligned(center=center, size=size, sign="+")
+
+    # Compute impedance using the tool
+    Z_calc = ImpedanceCalculator(
+        voltage_integral=voltage_integral, current_integral=current_integral
+    )
+    _ = Z_calc.compute_impedance(SIM_Z_DATA["field_time"])
+    Z_calc = ImpedanceCalculator(voltage_integral=voltage_integral, current_integral=None)
+    _ = Z_calc.compute_impedance(SIM_Z_DATA["field_time"])
+    Z_calc = ImpedanceCalculator(voltage_integral=None, current_integral=current_integral)
+    _ = Z_calc.compute_impedance(SIM_Z_DATA["field_time"])
+
+
+def test_impedance_accuracy():
+    field_data = make_field_data()
+    # Setup path integrals
+    size = [0, STRIP_HEIGHT / 2, 0]
+    center = [0, -STRIP_HEIGHT / 4, 0]
+    voltage_integral = VoltageIntegralAxisAligned(
+        center=center, size=size, sign="+", extrapolate_to_endpoints=True
+    )
+
+    size = [STRIP_WIDTH * 1.25, STRIP_HEIGHT / 2, 0]
+    center = [0, 0, 0]
+    current_integral = CurrentIntegralAxisAligned(center=center, size=size, sign="+")
+
+    def impedance_of_stripline(width, height):
+        # Assuming no fringing fields, is the same as a parallel plate
+        # with half the height and carrying twice the current
+        Z0_parallel_plate = 0.5 * height / width * td.ETA_0
+        return Z0_parallel_plate / 2
+
+    analytic_impedance = impedance_of_stripline(STRIP_WIDTH, STRIP_HEIGHT)
+
+    # Compute impedance using the tool
+    Z_calc = ImpedanceCalculator(
+        voltage_integral=voltage_integral, current_integral=current_integral
+    )
+    Z1 = Z_calc.compute_impedance(field_data)
+    Z_calc = ImpedanceCalculator(voltage_integral=voltage_integral, current_integral=None)
+    Z2 = Z_calc.compute_impedance(field_data)
+    Z_calc = ImpedanceCalculator(voltage_integral=None, current_integral=current_integral)
+    Z3 = Z_calc.compute_impedance(field_data)
+
+    # Computation that uses the flux is less accurate, due to staircasing the field
+    assert np.all(np.isclose(Z1, analytic_impedance, rtol=0.02))
+    assert np.all(np.isclose(Z2, analytic_impedance, atol=3.5))
+    assert np.all(np.isclose(Z3, analytic_impedance, atol=3.5))

--- a/tidy3d/components/validators.py
+++ b/tidy3d/components/validators.py
@@ -46,6 +46,19 @@ from ..log import log
 MIN_FREQUENCY = 1e5
 
 
+def assert_line():
+    """makes sure a field's ``size`` attribute has exactly 2 zeros"""
+
+    @pydantic.validator("size", allow_reuse=True, always=True)
+    def is_line(cls, val):
+        """Raise validation error if not 1 dimensional."""
+        if val.count(0.0) != 2:
+            raise ValidationError(f"'{cls.__name__}' object must be a line, given size={val}")
+        return val
+
+    return is_line
+
+
 def assert_plane():
     """makes sure a field's ``size`` attribute has exactly 1 zero"""
 

--- a/tidy3d/plugins/microwave/__init__.py
+++ b/tidy3d/plugins/microwave/__init__.py
@@ -1,0 +1,15 @@
+""" Imports from microwave plugin. """
+
+from .path_integrals import (
+    AxisAlignedPathIntegral,
+    VoltageIntegralAxisAligned,
+    CurrentIntegralAxisAligned,
+)
+from .impedance_calculator import ImpedanceCalculator
+
+__all__ = [
+    "AxisAlignedPathIntegral",
+    "VoltageIntegralAxisAligned",
+    "CurrentIntegralAxisAligned",
+    "ImpedanceCalculator",
+]

--- a/tidy3d/plugins/microwave/impedance_calculator.py
+++ b/tidy3d/plugins/microwave/impedance_calculator.py
@@ -1,0 +1,75 @@
+"""Class for computing characteristic impedance of transmission lines."""
+
+from __future__ import annotations
+
+
+import pydantic.v1 as pd
+import numpy as np
+from typing import Optional
+from ...components.data.monitor_data import FieldData, FieldTimeData, ModeSolverData
+
+from ...components.base import Tidy3dBaseModel
+from ...exceptions import DataError, ValidationError
+
+from .path_integrals import VoltageIntegralAxisAligned, CurrentIntegralAxisAligned
+from .path_integrals import MonitorDataTypes, IntegralResultTypes
+
+
+class ImpedanceCalculator(Tidy3dBaseModel):
+    """Tool for computing the characteristic impedance of a transmission line."""
+
+    voltage_integral: Optional[VoltageIntegralAxisAligned] = pd.Field(
+        ...,
+        title="Voltage Integral",
+        description="Definition of path integral for computing voltage.",
+    )
+
+    current_integral: Optional[CurrentIntegralAxisAligned] = pd.Field(
+        ...,
+        title="Current Integral",
+        description="Definition of contour integral for computing current.",
+    )
+
+    def compute_impedance(self, em_field: MonitorDataTypes) -> IntegralResultTypes:
+        """Compute impedance for the supplied ``em_field`` using ``voltage_integral`` and
+        ``current_integral``. If only a single integral has been defined, impedance is
+        computed using the total flux in ``em_field``."""
+        if not isinstance(em_field, (FieldData, FieldTimeData, ModeSolverData)):
+            raise DataError("'em_field' type not supported by impedance calculator.")
+
+        # If both voltage and current integrals have been defined then impedance is computed directly
+        if self.voltage_integral:
+            voltage = self.voltage_integral.compute_voltage(em_field)
+        if self.current_integral:
+            current = self.current_integral.compute_current(em_field)
+
+        # If only one of the integrals has been provided then fall back to using total power (flux)
+        # with Ohm's law. The input field should cover an area large enough to render the flux
+        # computation accurate. If the input field is a time signal, then it is real and flux
+        # corresponds to the instantaneous power. Otherwise the input field is in frequency domain,
+        # where flux indicates the time-averaged power 0.5*Re(V*conj(I))
+        if not self.voltage_integral:
+            flux = em_field.flux
+            if isinstance(em_field, FieldTimeData):
+                voltage = flux / current
+            else:
+                voltage = 2 * flux / np.conj(current)
+        if not self.current_integral:
+            flux = em_field.flux
+            if isinstance(em_field, FieldTimeData):
+                current = flux / voltage
+            else:
+                current = np.conj(2 * flux / voltage)
+
+        impedance = voltage / current
+        return impedance
+
+    @pd.validator("current_integral", always=True)
+    def check_voltage_or_current(cls, val, values):
+        """Raise validation error if both ``voltage_integral`` and ``current_integral``
+        were not provided."""
+        if not values.get("voltage_integral") and not val:
+            raise ValidationError(
+                "Atleast one of 'voltage_integral' or 'current_integral' must be provided."
+            )
+        return val

--- a/tidy3d/plugins/microwave/path_integrals.py
+++ b/tidy3d/plugins/microwave/path_integrals.py
@@ -1,0 +1,325 @@
+"""Helper classes for performing path integrals with fields on the Yee grid"""
+
+from __future__ import annotations
+
+import pydantic.v1 as pd
+import numpy as np
+from abc import ABC, abstractmethod
+from typing import List, Tuple, Union
+
+from ...components.data.monitor_data import FieldData, FieldTimeData, ModeSolverData
+from ...components.data.data_array import (
+    ScalarFieldDataArray,
+    ScalarFieldTimeDataArray,
+    ScalarModeFieldDataArray,
+)
+from ...components.data.data_array import FreqDataArray, TimeDataArray, FreqModeDataArray
+from ...components.base import cached_property, Tidy3dBaseModel
+from ...components.types import Axis, Direction
+from ...components.geometry.base import Box
+from ...components.validators import assert_line, assert_plane
+from ...exceptions import Tidy3dError, DataError
+
+MonitorDataTypes = Union[FieldData, FieldTimeData, ModeSolverData]
+EMScalarFieldType = Union[ScalarFieldDataArray, ScalarFieldTimeDataArray, ScalarModeFieldDataArray]
+IntegralResultTypes = Union[FreqDataArray, FreqModeDataArray, TimeDataArray]
+
+
+class AbstractAxesRH(Tidy3dBaseModel, ABC):
+    """Represents an axis-aligned right-handed coordinate system with one axis preferred."""
+
+    @cached_property
+    @abstractmethod
+    def main_axis(self) -> Axis:
+        """Get the preferred axis."""
+
+    @cached_property
+    def remaining_axes(self) -> Tuple[Axis, Axis]:
+        """Get in-plane axes, ordered to maintain a right-handed coordinate system."""
+        axes: List[Axis] = [0, 1, 2]
+        axes.pop(self.main_axis)
+        if self.main_axis == 1:
+            return (axes[1], axes[0])
+        else:
+            return (axes[0], axes[1])
+
+
+class AxisAlignedPathIntegral(AbstractAxesRH, Box):
+    """Class for defining the simplest type of path integral, which is aligned with Cartesian axes."""
+
+    _line_validator = assert_line()
+
+    extrapolate_to_endpoints: bool = pd.Field(
+        False,
+        title="Extrapolate to Endpoints",
+        description="If the endpoints of the path integral terminate at or near a material interface, "
+        "the field is likely discontinuous. When this field is ``True``, fields that are outside and on the bounds "
+        "of the integral are ignored. Should be enabled when computing voltage between two conductors.",
+    )
+
+    snap_path_to_grid: bool = pd.Field(
+        False,
+        title="Snap Path to Grid",
+        description="It might be desireable to integrate exactly along the Yee grid associated with "
+        "a field. When this field is ``True``, the integration path will be snapped to the grid.",
+    )
+
+    def compute_integral(self, scalar_field: EMScalarFieldType) -> IntegralResultTypes:
+        """Computes the defined integral given the input ``scalar_field``."""
+
+        if not scalar_field.does_cover(self.bounds):
+            raise DataError("Scalar field does not cover the integration domain.")
+        coord = "xyz"[self.main_axis]
+
+        scalar_field = self._get_field_along_path(scalar_field)
+        # Get the boundaries
+        min_bound = self.bounds[0][self.main_axis]
+        max_bound = self.bounds[1][self.main_axis]
+
+        if self.extrapolate_to_endpoints:
+            # Remove field outside the boundaries
+            scalar_field = scalar_field.sel({coord: slice(min_bound, max_bound)})
+            # Ignore values on the boundary (sel is inclusive)
+            scalar_field = scalar_field.drop_sel({coord: (min_bound, max_bound)}, errors="ignore")
+            coordinates = scalar_field.coords[coord].values
+        else:
+            coordinates = scalar_field.coords[coord].sel({coord: slice(min_bound, max_bound)})
+
+        # Integration is along the original coordinates plus ensure that
+        # endpoints corresponding to the precise bounds of the port are included
+        coords_interp = np.array([min_bound])
+        coords_interp = np.concatenate((coords_interp, coordinates))
+        coords_interp = np.concatenate((coords_interp, [max_bound]))
+        coords_interp = {coord: coords_interp}
+
+        # Use extrapolation for the 2 additional endpoints, unless there is only a single sample point
+        method = "linear"
+        if len(coordinates) == 1 and self.extrapolate_to_endpoints:
+            method = "nearest"
+        scalar_field = scalar_field.interp(
+            coords_interp, method=method, kwargs={"fill_value": "extrapolate"}
+        )
+        result = scalar_field.integrate(coord=coord)
+        if isinstance(scalar_field, ScalarFieldDataArray):
+            return FreqDataArray(data=result.data, coords=result.coords)
+        elif isinstance(scalar_field, ScalarFieldTimeDataArray):
+            return TimeDataArray(data=result.data, coords=result.coords)
+        else:
+            assert isinstance(scalar_field, ScalarModeFieldDataArray)
+            return FreqModeDataArray(data=result.data, coords=result.coords)
+
+    def _get_field_along_path(self, scalar_field: EMScalarFieldType) -> EMScalarFieldType:
+        """Returns a selection of the input ``scalar_field`` ready for integration."""
+        axis1 = self.remaining_axes[0]
+        axis2 = self.remaining_axes[1]
+        coord1 = "xyz"[axis1]
+        coord2 = "xyz"[axis2]
+
+        if self.snap_path_to_grid:
+            # Coordinates that are not integrated
+            remaining_coords = {
+                coord1: self.center[axis1],
+                coord2: self.center[axis2],
+            }
+            # Select field nearest to center of integration line
+            scalar_field = scalar_field.sel(
+                remaining_coords,
+                method="nearest",
+                drop=False,
+            )
+        else:
+            # Try to interpolate unless there is only a single coordinate
+            coord1dict = {coord1: self.center[axis1]}
+            if scalar_field.sizes[coord1] == 1:
+                scalar_field = scalar_field.sel(coord1dict, method="nearest")
+            else:
+                scalar_field = scalar_field.interp(
+                    coord1dict, method="linear", kwargs={"bounds_error": True}
+                )
+            coord2dict = {coord2: self.center[axis2]}
+            if scalar_field.sizes[coord2] == 1:
+                scalar_field = scalar_field.sel(coord2dict, method="nearest")
+            else:
+                scalar_field = scalar_field.interp(
+                    coord2dict, method="linear", kwargs={"bounds_error": True}
+                )
+        # Remove unneeded coordinates
+        scalar_field = scalar_field.reset_coords(drop=True)
+        return scalar_field
+
+    @cached_property
+    def main_axis(self) -> Axis:
+        """Axis for performing integration."""
+        for index, value in enumerate(self.size):
+            if value != 0:
+                return index
+        raise Tidy3dError("Failed to identify axis.")
+
+
+class VoltageIntegralAxisAligned(AxisAlignedPathIntegral):
+    """Class for computing the voltage between two points defined by an axis-aligned line."""
+
+    sign: Direction = pd.Field(
+        ...,
+        title="Direction of Path Integral",
+        description="Positive indicates V=Vb-Va where position b has a larger coordinate along the axis of integration.",
+    )
+
+    def compute_voltage(self, em_field: MonitorDataTypes) -> IntegralResultTypes:
+        """Compute voltage along path defined by a line."""
+        if not isinstance(em_field, (FieldData, FieldTimeData, ModeSolverData)):
+            raise DataError("'em_field' type not supported.")
+        e_component = "xyz"[self.main_axis]
+        field_name = f"E{e_component}"
+        # Validate that the field is present
+        if field_name not in em_field.field_components:
+            raise DataError(f"'field_name' '{field_name}' not found.")
+        e_field = em_field.field_components[field_name]
+        # V = -integral(E)
+        voltage = self.compute_integral(e_field)
+
+        if self.sign == "+":
+            voltage *= -1
+        # Return data array of voltage while keeping coordinates of frequency|time|mode index
+        return voltage
+
+
+class CurrentIntegralAxisAligned(AbstractAxesRH, Box):
+    """Class for computing conduction current via Ampère's circuital law on an axis-aligned loop."""
+
+    _plane_validator = assert_plane()
+
+    sign: Direction = pd.Field(
+        ...,
+        title="Direction of Contour Integral",
+        description="Positive indicates current flowing in the positive normal axis direction.",
+    )
+
+    extrapolate_to_endpoints: bool = pd.Field(
+        False,
+        title="Extrapolate to Endpoints",
+        description="This parameter is passed to ``AxisAlignedPathIntegral`` objects when computing the contour integral.",
+    )
+
+    snap_contour_to_grid: bool = pd.Field(
+        False,
+        title="Snap Contour to Grid",
+        description="This parameter is passed to ``AxisAlignedPathIntegral`` objects when computing the contour integral.",
+    )
+
+    def compute_current(self, em_field: MonitorDataTypes) -> IntegralResultTypes:
+        """Compute current flowing in loop defined by the outer edge of a rectangle."""
+        if not isinstance(em_field, (FieldData, FieldTimeData, ModeSolverData)):
+            raise DataError("'em_field' type not supported.")
+        ax1 = self.remaining_axes[0]
+        ax2 = self.remaining_axes[1]
+        h_component = "xyz"[ax1]
+        v_component = "xyz"[ax2]
+        h_field_name = f"H{h_component}"
+        v_field_name = f"H{v_component}"
+        # Validate that fields are present
+        if h_field_name not in em_field.field_components:
+            raise DataError(f"'field_name' '{h_field_name}' not found.")
+        if v_field_name not in em_field.field_components:
+            raise DataError(f"'field_name' '{v_field_name}' not found.")
+        h_horizontal = em_field.field_components[h_field_name]
+        h_vertical = em_field.field_components[v_field_name]
+
+        # Decompose contour into path integrals
+        (bottom, right, top, left) = self._to_path_integrals(h_horizontal, h_vertical)
+
+        current = 0
+        # Compute and add contributions from each part of the contour
+        current += bottom.compute_integral(h_horizontal)
+        current += right.compute_integral(h_vertical)
+        current -= top.compute_integral(h_horizontal)
+        current -= left.compute_integral(h_vertical)
+
+        if self.sign == "-":
+            current *= -1
+
+        return current
+
+    @cached_property
+    def main_axis(self) -> Axis:
+        """Axis normal to loop"""
+        for index, value in enumerate(self.size):
+            if value == 0:
+                return index
+        raise Tidy3dError("Failed to identify axis.")
+
+    def _to_path_integrals(self, h_horizontal, h_vertical) -> Tuple[AxisAlignedPathIntegral, ...]:
+        """Returns four ``AxisAlignedPathIntegral`` instances, which represent a contour
+        integral around the surface defined by ``self.size``."""
+        ax1 = self.remaining_axes[0]
+        ax2 = self.remaining_axes[1]
+
+        if self.snap_contour_to_grid:
+            coord1 = "xyz"[ax1]
+            coord2 = "xyz"[ax2]
+            # Locations where horizontal paths will be snapped
+            v_bounds = [
+                self.center[ax2] - self.size[ax2] / 2,
+                self.center[ax2] + self.size[ax2] / 2,
+            ]
+            h_snaps = h_horizontal.sel({coord2: v_bounds}, method="nearest").coords[coord2].values
+            # Locations where vertical paths will be snapped
+            h_bounds = [
+                self.center[ax1] - self.size[ax1] / 2,
+                self.center[ax1] + self.size[ax1] / 2,
+            ]
+            v_snaps = h_vertical.sel({coord1: h_bounds}, method="nearest").coords[coord1].values
+
+            bottom_bound = h_snaps[0]
+            top_bound = h_snaps[1]
+            left_bound = v_snaps[0]
+            right_bound = v_snaps[1]
+        else:
+            bottom_bound = self.bounds[0][ax2]
+            top_bound = self.bounds[1][ax2]
+            left_bound = self.bounds[0][ax1]
+            right_bound = self.bounds[1][ax1]
+
+        # Horizontal paths
+        path_size = list(self.size)
+        path_size[ax1] = right_bound - left_bound
+        path_size[ax2] = 0
+        path_center = list(self.center)
+        path_center[ax2] = bottom_bound
+
+        bottom = AxisAlignedPathIntegral(
+            center=path_center,
+            size=path_size,
+            extrapolate_to_endpoints=self.extrapolate_to_endpoints,
+            snap_path_to_grid=self.snap_contour_to_grid,
+        )
+        path_center[ax2] = top_bound
+        top = AxisAlignedPathIntegral(
+            center=path_center,
+            size=path_size,
+            extrapolate_to_endpoints=self.extrapolate_to_endpoints,
+            snap_path_to_grid=self.snap_contour_to_grid,
+        )
+
+        # Vertical paths
+        path_size = list(self.size)
+        path_size[ax1] = 0
+        path_size[ax2] = top_bound - bottom_bound
+        path_center = list(self.center)
+
+        path_center[ax1] = left_bound
+        left = AxisAlignedPathIntegral(
+            center=path_center,
+            size=path_size,
+            extrapolate_to_endpoints=self.extrapolate_to_endpoints,
+            snap_path_to_grid=self.snap_contour_to_grid,
+        )
+        path_center[ax1] = right_bound
+        right = AxisAlignedPathIntegral(
+            center=path_center,
+            size=path_size,
+            extrapolate_to_endpoints=self.extrapolate_to_endpoints,
+            snap_path_to_grid=self.snap_contour_to_grid,
+        )
+
+        return (bottom, right, top, left)

--- a/tidy3d/plugins/smatrix/ports/lumped.py
+++ b/tidy3d/plugins/smatrix/ports/lumped.py
@@ -1,10 +1,12 @@
 """Class and custom data array for representing a scattering matrix port based on lumped circuit elements."""
+
 import pydantic.v1 as pd
 import numpy as np
 from typing import Optional
 
 from ....constants import OHM
 from ....components.geometry.base import Box
+from ....components.geometry.utils_2d import increment_float
 from ....components.types import Complex, FreqArray, Axis
 from ....components.base import cached_property
 from ....components.lumped_element import LumpedResistor
@@ -159,8 +161,9 @@ class LumpedPort(Box):
         h_cap_component = "xyz"[self.injection_axis]
         # Size of current monitor needs to encompass the current carrying 2D sheet
         # Needs to have a nonzero thickness so a closed loop of gridpoints around the 2D sheet can be formed
+        dl = 2 * (increment_float(center[self.injection_axis], 1.0) - center[self.injection_axis])
         current_mon_size = list(self.size)
-        current_mon_size[self.injection_axis] = 1e-10
+        current_mon_size[self.injection_axis] = dl
         current_mon_size[self.voltage_axis] = 0.0
         # Create a current monitor
         return FieldMonitor(


### PR DESCRIPTION
Addresses  [Issue 517](https://github.com/flexcompute/tidy3d-core/issues/517). Most of computations are done, now it is just a question of the best way to expose this functionality to users. I wonder if @weiliangjin2021 or @tylerflex have any input on whether we should start a "microwave" plugin that includes functionality that might not be commonly used in photonics. I mention that because it would be very easy to add time domain Voltage and Current monitors now.

Some tasks remaining:
- [x] Update smatrix plugin to reuse path integrals
- [x] Add tests
