### PR TITLE
Fix PolySlab intersections when bounds contain inf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `tidy3d.plugins.design.Results` store the `BatchData` for batch runs in the `.batch_data` field.
 - Prompting user to check solver log when loading solver data if warnings were found in the log, or if the simulation diverged or errored.
+- Bug in PolySlab intersection if slab bounds are `inf` on one side.
 
 ### Changed
 - Slightly reorganized `web.run` logging when `verbose=True` to make it clearer.

--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -11,6 +11,7 @@ import trimesh
 import warnings
 
 import tidy3d as td
+from tidy3d.constants import LARGE_NUMBER
 from tidy3d.exceptions import SetupError, Tidy3dKeyError, ValidationError
 from tidy3d.components.geometry.base import Planar
 from tidy3d.components.geometry.utils import flatten_groups, traverse_geometries
@@ -708,6 +709,22 @@ def test_polyslab_axis(axis):
     assert not ps.intersects_plane(x=plane_coord[0], y=plane_coord[1], z=plane_coord[2])
     plane_coord[axis] = -3
     assert not ps.intersects_plane(x=plane_coord[0], y=plane_coord[1], z=plane_coord[2])
+
+
+def test_polyslab_intersection_inf_bounds():
+    """Test if intersection returns correct shapes when one of the slab_bounds is Inf."""
+    # 1) [0, inf]
+    poly = td.PolySlab(
+        vertices=[[2, -1], [-2, -1], [-2, 1], [2, 1]],
+        slab_bounds=[0, td.inf],
+    )
+    assert len(poly.intersections_plane(x=0)) == 1
+    assert poly.intersections_plane(x=0)[0] == shapely.box(-1, 0.0, 1, LARGE_NUMBER)
+
+    # 2) [-inf, 0]
+    poly = poly.updated_copy(slab_bounds=[-td.inf, 0])
+    assert len(poly.intersections_plane(x=0)) == 1
+    assert poly.intersections_plane(x=0)[0] == shapely.box(-1, -LARGE_NUMBER, 1, 0)
 
 
 def test_from_shapely():


### PR DESCRIPTION
Resolves #1539

Two main changes:
- In computing `center_axis`, replace `inf` with `LARGE_NUMBER`;
- Use `.finite_length_axis` instead of `.length_axis` .