### PR TITLE
add tracking of `simulation_type` for smatrix and design plugins

### DIFF
--- a/tidy3d/plugins/design/method.py
+++ b/tidy3d/plugins/design/method.py
@@ -87,7 +87,7 @@ class MethodIndependent(Method, ABC):
         self, simulations: Dict[str, Simulation], path_dir: str = None, **kwargs
     ) -> BatchData:
         """Create a batch of simulations and run it. Mainly separated out for ease of testing."""
-        batch = web.Batch(simulations=simulations, **kwargs)
+        batch = web.Batch(simulations=simulations, simulation_type="tidy3d_design", **kwargs)
         if path_dir:
             kwargs["path_dir"] = path_dir
         return batch.run(**kwargs)

--- a/tidy3d/plugins/smatrix/smatrix.py
+++ b/tidy3d/plugins/smatrix/smatrix.py
@@ -350,6 +350,7 @@ class ComponentModeler(Tidy3dBaseModel):
             folder_name=self.folder_name,
             callback_url=self.callback_url,
             verbose=self.verbose,
+            simulation_type="tidy3d_smatrix",
         )
 
     @cached_property

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -47,6 +47,7 @@ def run(
     progress_callback_download: Callable[[float], None] = None,
     solver_version: str = None,
     worker_group: str = None,
+    simulation_type: str = "tidy3d",
 ) -> SimulationDataType:
     """
     Submits a :class:`.Simulation` to server, starts running, monitors progress, downloads,
@@ -67,6 +68,8 @@ def run(
         fields ``{'id', 'status', 'name', 'workUnit', 'solverVersion'}``.
     verbose : bool = True
         If ``True``, will print progressbars and status, otherwise, will run silently.
+    simulation_type : str = "tidy3d"
+        Type of simulation being uploaded.
     progress_callback_upload : Callable[[float], None] = None
         Optional callback function called when uploading file with ``bytes_in_chunk`` as argument.
     progress_callback_download : Callable[[float], None] = None
@@ -127,6 +130,7 @@ def run(
         callback_url=callback_url,
         verbose=verbose,
         progress_callback=progress_callback_upload,
+        simulation_type=simulation_type,
     )
     start(
         task_id,
@@ -169,7 +173,7 @@ def upload(
         If ``True``, will print progressbars and status, otherwise, will run silently.
     progress_callback : Callable[[float], None] = None
         Optional callback function called when uploading file with ``bytes_in_chunk`` as argument.
-    simulation_type : str
+    simulation_type : str = "tidy3d"
         Type of simulation being uploaded.
     parent_tasks : List[str]
         List of related task ids.


### PR DESCRIPTION
@momchil-flex @lei-flex 

I need to get statistics about how many tasks are run from `adjoint`, `design` and `smatrix` plugins.

One simple way is to pass the plugin name through `simulation_type`, similar to how we do it for `adjoint`.

I'm proposing a change here that passes `simulation_type` for batches run in `design` and `smatrix`. and then in the backend we can treat these as regular `"tidy3d"` simulation types?

Let me know if you have a better solution. 

One thing that could make this easier is to do eg. `"tidy3d_design"` `"tidy3d_smatrix"` and then in the backend, we do the normal pipeline `if "tidy3d" in simulation_type`

let me know what you think

