### PR TITLE
relax `sidwall_angle` validator -> warning in adjoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Characters `"` and `/` not allowed in component names.
+- Change error when `JaxPolySlab.sidewall_angle != 0.0` to a warning, enabling optimization with slanted sidewalls if a lower accuracy gradient is acceptable.
 
 ### Fixed
 - Compute time stepping speed shown `tidy3d.log` using only the number of time steps that was run in the case of early shutoff. Previously, it was using the total number of time steps.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,11 +156,11 @@ exclude = '''
 
 
 [tool.ruff]
-ignore-init-module-imports = true
-typing-modules = ["tidy3d.components.types"] # without this Literal["something fails"]
+lint.ignore-init-module-imports = true
+lint.typing-modules = ["tidy3d.components.types"] # without this Literal["something fails"]
 line-length = 100
 fix = true
-ignore = [
+lint.ignore = [
   "E501",  # line too long, handled by black
   "B008",  # do not perform function calls in argument defaults
   "C901",  # too complex
@@ -174,13 +174,14 @@ ignore = [
   "UP035", # TODO decide what to do here
 ]
 
-select = [
+lint.select = [
   "E",  # pycodestyle errors
   "W",  # pycodestyle warnings
   "F",  # pyflakes
   "C",  # flake8-comprehensions
   "B",  # flake8-bugbear
-  "UP"
+  "UP",
+  "NPY201", # numpy 2.* compatibility check
 ]
 
 [tool.bumpversion]

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -1759,3 +1759,13 @@ def test_inf_IO(tmp_path):
     box.to_file(fname)
     box2 = JaxBox.from_file(fname)
     assert box == box2
+
+
+@pytest.mark.parametrize("sidewall_angle, log_expected", ([0.0, None], [0.1, "WARNING"]))
+def test_sidewall_angle_validator(log_capture, sidewall_angle, log_expected):
+    """Test that the sidewall angle warning works as expected."""
+
+    jax_polyslab1 = JaxPolySlab(axis=POLYSLAB_AXIS, vertices=VERTICES, slab_bounds=(-1, 1))
+
+    with AssertLogLevel(log_capture, log_expected, contains_str="sidewall"):
+        jax_polyslab1.updated_copy(sidewall_angle=sidewall_angle)

--- a/tidy3d/plugins/adjoint/components/geometry.py
+++ b/tidy3d/plugins/adjoint/components/geometry.py
@@ -20,6 +20,7 @@ from ....components.data.data_array import ScalarFieldDataArray
 from ....components.monitor import FieldMonitor, PermittivityMonitor
 from ....constants import fp_eps, MICROMETER
 from ....exceptions import AdjointError
+from ....log import log
 
 from .base import JaxObject
 from .types import JaxFloat
@@ -280,9 +281,17 @@ class JaxPolySlab(JaxGeometry, PolySlab, JaxObject):
 
     @pd.validator("sidewall_angle", always=True)
     def no_sidewall(cls, val):
-        """Don't allow sidewall."""
+        """Warn if sidewall angle present."""
         if not np.isclose(val, 0.0):
-            raise AdjointError("'JaxPolySlab' does not support slanted sidewall.")
+            log.warning(
+                "'JaxPolySlab' does not yet perform the full adjoint gradient treatment "
+                "for slanted sidewalls. "
+                "A straight sidewall angle is assumed when computing the gradient with respect "
+                "to shifting boundaries of the geometry. Therefore, as 'sidewall_angle' becomes "
+                "further from '0.0', the gradient error can be significant. "
+                "If high gradient accuracy is needed, please either reduce your 'sidewall_angle' "
+                "or wait until this feature is supported fully in a later version."
+            )
         return val
 
     @pd.validator("dilation", always=True)


### PR DESCRIPTION
note: `docs/notebooks` also updated to latest `develop`