### PR TITLE
warn instead of error if task already submitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Warn instead of error if a task, `Job` or `Batch` is started twice.
+
 
 ## [2.6.2] - 2024-03-21
 

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -707,7 +707,7 @@ class Batch(WebContainer):
         ----
         To load and iterate through the data, use :meth:`Batch.items()`.
 
-        The data for each task will be named as ``{path_dir}/{task_name}.hdf5``.
+        The data for each task will be named as ``{path_dir}/{task_id}.hdf5``.
         The :class:`Batch` hdf5 file will be automatically saved as ``{path_dir}/batch.hdf5``,
         allowing one to load this :class:`Batch` later using ``batch = Batch.from_file()``.
         """

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -19,6 +19,7 @@ from ..core.environment import Env
 from ..core.constants import SIM_FILE_HDF5, TaskId
 from ..core.task_core import SimulationTask, Folder
 from ..core.task_info import TaskInfo, ChargeType
+from ..core.exceptions import WebError as WebErrorCore
 from ...components.types import Literal
 from ...log import log, get_logging_console
 from ...exceptions import WebError
@@ -273,10 +274,15 @@ def start(
     task = SimulationTask.get(task_id)
     if not task:
         raise ValueError("Task not found.")
-    task.submit(
-        solver_version=solver_version,
-        worker_group=worker_group,
-    )
+
+    # note: this try block breaks if task has already been submitted, bypasses error.
+    try:
+        task.submit(
+            solver_version=solver_version,
+            worker_group=worker_group,
+        )
+    except WebErrorCore:
+        log.warning("Task has already been started, skipping.")
 
 
 @wait_for_connection


### PR DESCRIPTION
seems to work fine this way, and running `web.start(x)` twice doesn't error anymore.

There is some output (eg the error message) that I'm not sure how to clear though.
