### PR TITLE
Revert forbidden " in component names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Revert forbidden `"` in component names.
 
 ### Fixed
 

--- a/tests/test_components/test_base.py
+++ b/tests/test_components/test_base.py
@@ -129,6 +129,3 @@ def test_special_characters_in_name():
     """Test error if special characters are in a component's name."""
     with pytest.raises(ValueError):
         mnt = td.FluxMonitor(size=(1, 1, 0), freqs=np.array([1, 2, 3]) * 1e12, name="mnt/flux")
-
-    with pytest.raises(ValueError):
-        med = td.Medium(permittivity=1, name='"my med"')

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -31,7 +31,7 @@ INDENT = None  # default indentation of json string used internally
 JSON_TAG = "JSON_STRING"
 # If json string is larger than ``MAX_STRING_LENGTH``, split the string when storing in hdf5
 MAX_STRING_LENGTH = 1e9
-FORBID_SPECIAL_CHARACTERS = ["/", '"']
+FORBID_SPECIAL_CHARACTERS = ["/"]
 
 
 def cache(prop):


### PR DESCRIPTION
Prohibiting `"` was interfering with some medium names from our material library. Since there has been no issue before, I'm reverting this change. The thinking was to exclude some specific characters to avoid future issues, but I guess let's take the opposite path - allow all characters *until* we hit an issue (currently the reason `/` is still excluded).