### PR TITLE
adjoint run_local disables restrictive validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
 - 2D heat simulations are now fully supported. 
+- `tidy3d.plugins.adjoint.web.run_local` used in place of `run` will skip validators that restrict the size or number of `input_structures`.
 
 ### Fixed
 - Better error message when trying to transform a geometry with infinite bounds.

--- a/tidy3d/plugins/adjoint/components/base.py
+++ b/tidy3d/plugins/adjoint/components/base.py
@@ -15,6 +15,20 @@ from ....components.base import Tidy3dBaseModel
 from .data.data_array import JaxDataArray, JAX_DATA_ARRAY_TAG
 
 
+# end of the error message when a ``_validate_web_adjoint`` exception is raised
+WEB_ADJOINT_MESSAGE = (
+    "You can still run this simulation through "
+    "'tidy3d.plugins.adjoint.web.run_local' or 'tidy3d.plugins.adjoint.web.run_local' "
+    ", which are similar to 'run' / 'run_async', but "
+    "perform the gradient postprocessing calculation locally after the simulation runs. "
+    "Note that the postprocessing time can become "
+    "quite long (several minutes or more) if these restrictions are exceeded. "
+    "Furthermore, the local versions of 'adjoint' require downloading field data "
+    "inside of the 'input_structures', which can greatly increase the size of data "
+    "needing to be downloaded."
+)
+
+
 class JaxObject(Tidy3dBaseModel):
     """Abstract class that makes a :class:`.Tidy3dBaseModel` jax-compatible through inheritance."""
 
@@ -56,6 +70,10 @@ class JaxObject(Tidy3dBaseModel):
         # TODO: don't use getattr, define this dictionary better
         jax_field_names = self.get_jax_field_names()
         return {key: getattr(self, key) for key in jax_field_names}
+
+    def _validate_web_adjoint(self) -> None:
+        """Run validators for this component, only if using ``tda.web.run()``."""
+        pass
 
     """Methods needed for jax to register arbitrary classes."""
 

--- a/tidy3d/plugins/adjoint/components/geometry.py
+++ b/tidy3d/plugins/adjoint/components/geometry.py
@@ -21,7 +21,7 @@ from ....components.monitor import FieldMonitor, PermittivityMonitor
 from ....constants import fp_eps, MICROMETER
 from ....exceptions import AdjointError
 
-from .base import JaxObject
+from .base import JaxObject, WEB_ADJOINT_MESSAGE
 from .types import JaxFloat
 
 # number of integration points per unit wavelength in material
@@ -292,14 +292,17 @@ class JaxPolySlab(JaxGeometry, PolySlab, JaxObject):
             raise AdjointError("'JaxPolySlab' does not support dilation.")
         return val
 
-    @pd.validator("vertices", always=True)
-    def limit_number_of_vertices(cls, val):
+    def _validate_web_adjoint(self) -> None:
+        """Run validators for this component, only if using ``tda.web.run()``."""
+        self._limit_number_of_vertices()
+
+    def _limit_number_of_vertices(self) -> None:
         """Limit the maximum number of vertices."""
-        if len(val) > MAX_NUM_VERTICES:
+        if len(self.vertices_jax) > MAX_NUM_VERTICES:
             raise AdjointError(
-                f"For performance, a maximum of {MAX_NUM_VERTICES} are allowed in 'JaxPolySlab'."
+                f"For performance, a maximum of {MAX_NUM_VERTICES} are allowed in 'JaxPolySlab'. "
+                + WEB_ADJOINT_MESSAGE
             )
-        return val
 
     def edge_contrib(
         self,

--- a/tidy3d/plugins/adjoint/components/medium.py
+++ b/tidy3d/plugins/adjoint/components/medium.py
@@ -16,7 +16,7 @@ from ....components.data.monitor_data import FieldData
 from ....exceptions import SetupError
 from ....constants import CONDUCTIVITY
 
-from .base import JaxObject
+from .base import JaxObject, WEB_ADJOINT_MESSAGE
 from .types import JaxFloat
 from .data.data_array import JaxDataArray
 from .data.dataset import JaxPermittivityDataset
@@ -304,23 +304,27 @@ class JaxCustomMedium(CustomMedium, AbstractJaxMedium):
             )
         return values
 
-    @pd.validator("eps_dataset", always=True)
-    def _is_not_too_large(cls, val):
+    def _validate_web_adjoint(self) -> None:
+        """Run validators for this component, only if using ``tda.web.run()``."""
+        self._is_not_too_large()
+
+    def _is_not_too_large(self):
         """Ensure number of pixels does not surpass a set amount."""
+
+        field_components = self.eps_dataset.field_components
 
         for field_dim in "xyz":
             field_name = f"eps_{field_dim}{field_dim}"
-            data_array = val.field_components[field_name]
+            data_array = field_components[field_name]
             coord_lens = [len(data_array.coords[key]) for key in "xyz"]
             num_cells_dim = np.prod(coord_lens)
             if num_cells_dim > MAX_NUM_CELLS_CUSTOM_MEDIUM:
                 raise SetupError(
                     "For the adjoint plugin, each component of the 'JaxCustomMedium.eps_dataset' "
                     f"is restricted to have a maximum of {MAX_NUM_CELLS_CUSTOM_MEDIUM} cells. "
-                    f"Detected {num_cells_dim} grid cells in the '{field_name}' component ."
+                    f"Detected {num_cells_dim} grid cells in the '{field_name}' component. "
+                    + WEB_ADJOINT_MESSAGE
                 )
-
-        return val
 
     @pd.validator("eps_dataset", always=True)
     def _eps_dataset_single_frequency(cls, val):

--- a/tidy3d/plugins/adjoint/components/structure.py
+++ b/tidy3d/plugins/adjoint/components/structure.py
@@ -38,6 +38,13 @@ class AbstractJaxStructure(Structure, JaxObject):
         """Override validator checking 2D geometry, which triggers unnecessarily for gradients."""
         return val
 
+    def _validate_web_adjoint(self) -> None:
+        """Run validators for this component, only if using ``tda.web.run()``."""
+        if "geometry" in self._differentiable_fields:
+            self.geometry._validate_web_adjoint()
+        if "medium" in self._differentiable_fields:
+            self.medium._validate_web_adjoint()
+
     @property
     def jax_fields(self):
         """The fields that are jax-traced for this class."""

--- a/tidy3d/plugins/adjoint/web.py
+++ b/tidy3d/plugins/adjoint/web.py
@@ -111,6 +111,8 @@ def run(
         Object containing solver results for the supplied :class:`.JaxSimulation`.
     """
 
+    simulation._validate_web_adjoint()
+
     sim, jax_info = simulation.to_simulation()
 
     sim_data = tidy3d_run_fn(
@@ -133,6 +135,8 @@ def run_fwd(
     verbose: bool,
 ) -> Tuple[JaxSimulationData, Tuple[RunResidual]]:
     """Run forward pass and stash extra objects for the backwards pass."""
+
+    simulation._validate_web_adjoint()
 
     sim_fwd, jax_info_fwd, jax_info_orig = simulation.to_simulation_fwd()
 
@@ -396,6 +400,9 @@ def run_async(
         Contains the :class:`.JaxSimulationData` of each :class:`.JaxSimulation`.
     """
 
+    for simulation in simulations:
+        simulation._validate_web_adjoint()
+
     # get task names, the td.Simulation, and JaxInfo for all supplied simulations
     task_names = [str(_task_name_orig(i)) for i in range(len(simulations))]
     task_info = [jax_sim.to_simulation() for jax_sim in simulations]
@@ -436,6 +443,9 @@ def run_async_fwd(
     num_workers: int,
 ) -> Tuple[Tuple[JaxSimulationData, ...], RunResidualBatch]:
     """Run forward pass and stash extra objects for the backwards pass."""
+
+    for simulation in simulations:
+        simulation._validate_web_adjoint()
 
     jax_infos_orig = []
     sims_fwd = []


### PR DESCRIPTION
Moves some validators to methods implemented in `JaxObject._validate_web_adjoint`, which only get called in `tda.web.run()` and `tda.web.run_async` calls. Error message includes instruction to try `tda.web.run_local` or `tda.web.run_async_local`.

Fixes #1574 and #1575 
