### PR TITLE
add new validators for heat simulation

### DIFF
--- a/tests/test_components/test_heat.py
+++ b/tests/test_components/test_heat.py
@@ -351,6 +351,21 @@ def test_heat_sim():
             structures=[heat_sim.structures[0]], boundary_spec=[bc_spec], sources=[]
         )
 
+    # 1D and 2D structures
+    struct_1d = td.Structure(
+        geometry=td.Box(size=(1, 0, 0)),
+        medium=solid_med,
+    )
+    struct_2d = td.Structure(
+        geometry=td.Box(size=(1, 0, 1)),
+        medium=heat_sim.medium,
+    )
+    with pytest.raises(pd.ValidationError):
+        _ = heat_sim.updated_copy(structures=list(heat_sim.structures) + [struct_1d])
+
+    with pytest.raises(pd.ValidationError):
+        _ = heat_sim.updated_copy(structures=list(heat_sim.structures) + [struct_2d])
+
 
 @pytest.mark.parametrize("shift_amount, log_level", ((1, None), (2, "WARNING")))
 def test_heat_sim_bounds(shift_amount, log_level, log_capture):

--- a/tidy3d/components/heat/simulation.py
+++ b/tidy3d/components/heat/simulation.py
@@ -109,7 +109,13 @@ class HeatSimulation(AbstractSimulation):
     @pd.validator("structures", always=True)
     def check_unsupported_geometries(cls, val):
         """Error if structures contain unsupported yet geometries."""
-        for structure in val:
+        for ind, structure in enumerate(val):
+            bbox = structure.geometry.bounding_box
+            if any(s == 0 for s in bbox.size):
+                raise SetupError(
+                    f"'HeatSimulation' does not currently support structures with dimensions of zero size ('structures[{ind}]')."
+                )
+
             if isinstance(structure.geometry, GeometryGroup):
                 geometries = structure.geometry.geometries
             else:
@@ -117,13 +123,13 @@ class HeatSimulation(AbstractSimulation):
             for geom in geometries:
                 if isinstance(geom, (GeometryGroup)):
                     raise SetupError(
-                        "'HeatSimulation' does not currently support recursive 'GeometryGroup's."
+                        "'HeatSimulation' does not currently support recursive 'GeometryGroup's ('structures[{ind}]')."
                     )
                 if not isinstance(geom, HeatSingleGeometryType):
                     geom_names = [f"'{cl.__name__}'" for cl in HeatSingleGeometryType]
                     raise SetupError(
                         "'HeatSimulation' does not currently support geometries of type "
-                        f"'{geom.type}'. Allowed geometries are "
+                        f"'{geom.type}'  ('structures[{ind}]'). Allowed geometries are "
                         f"{', '.join(geom_names)}, "
                         "and non-recursive 'GeometryGroup'."
                     )

--- a/tidy3d/components/heat/source.py
+++ b/tidy3d/components/heat/source.py
@@ -14,6 +14,7 @@ from ..data.data_array import TimeDataArray
 from ..viz import PlotParams
 
 from ...constants import VOLUMETRIC_HEAT_RATE
+from ...exceptions import SetupError
 
 
 class HeatSource(AbstractSource, ABC):
@@ -28,6 +29,14 @@ class HeatSource(AbstractSource, ABC):
     def plot_params(self) -> PlotParams:
         """Default parameters for plotting a Source object."""
         return plot_params_heat_source
+
+    @pd.validator("structures", always=True)
+    def check_non_empty_structures(cls, val):
+        """Error if source doesn't point at any structures."""
+        if len(val) == 0:
+            raise SetupError("List of structures for heat source is empty.")
+
+        return val
 
 
 class UniformHeatSource(HeatSource):


### PR DESCRIPTION
Added three new validators for heat simulations:
- do not let define a heat source with empty list of structures
- do not let define a heat simulation without containing at least one `SolidSpec` material (note, this is not full-proof validation, since we can have another `FluidSpec` structure to completely overlap any `SolidSpec` material)
- do not let define a heat simulation with only Neumann BC. This leads to an undefined solutions. 