### PR TITLE
Fixing real_cost to only show the early shutoff message for FDTD runs

### DIFF
--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -919,7 +919,7 @@ def real_cost(task_id: str, verbose=True) -> float:
         if verbose:
             console = get_logging_console()
             console.log(f"Billed flex credit cost: {flex_unit:1.3f}.")
-            if flex_unit != ori_flex_unit:
+            if flex_unit != ori_flex_unit and task_info.taskType == "FDTD":
                 console.log(
                     "Note: the task cost pro-rated due to early shutoff was below the minimum "
                     "threshold, due to fast shutoff. Decreasing the simulation 'run_time' should "


### PR DESCRIPTION
Because of how we've implemented this, the message was shown for other tasks like EME, HEAT and MODE since they don't set an `ori_flex_unit`. 