### PR TITLE
Recursive `updated_copy()` of nested components with `path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for conformal mesh methods near PEC structures that can be specified through the field `pec_conformal_mesh_spec` in the `Simulation` class.
 - EME solver through `EMESimulation` class.
 - Properties `num_time_steps_adjoint` and `tmesh_adjoint` to `JaxSimulation` to estimate adjoint run time.
+- Ability to add `path` to `updated_copy()` method to recursively update sub-components of a tidy3d model. For example `sim2 = sim.updated_copy(size=new_size, path="structures/0/geometry")` creates a recursively updated copy of `sim` where `sim.structures[0].geometry` is updated with `size=new_size`.
 
 ### Changed
 - `run_time` of the adjoint simulation is set more robustly based on the adjoint sources and the forward simulation `run_time` as `sim_fwd.run_time + c / fwdith_adj` where `c=10`.

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -200,7 +200,61 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         new_copy = pydantic.BaseModel.copy(self, **kwargs)
         return self.validate(new_copy.dict())
 
-    def updated_copy(self, **kwargs) -> Tidy3dBaseModel:
+    def updated_copy(self, path: str = None, **kwargs) -> Tidy3dBaseModel:
+        """Make copy of a component instance with ``**kwargs`` indicating updated field values.
+
+        Note
+        ----
+        If ``path`` supplied, applies the updated copy with the update performed on the sub-
+        component corresponding to the path. For indexing into a tuple or list, use the integer
+        value.
+
+        Example
+        -------
+        >>> sim = simulation.updated_copy(size=new_size, path=f"structures/{i}/geometry") # doctest: +SKIP
+        """
+
+        if not path:
+            return self._updated_copy(**kwargs)
+
+        path_components = path.split("/")
+
+        field_name = path_components[0]
+
+        try:
+            sub_component = getattr(self, field_name)
+        except AttributeError as e:
+            raise AttributeError(
+                f"Could not field field '{field_name}' in the sub-component `path`. "
+                f"Found fields of '{tuple(self.__fields__.keys())}'. "
+                "Please double check the `path` passed to `.updated_copy()`."
+            ) from e
+
+        if isinstance(sub_component, (list, tuple)):
+            integer_index_path = path_components[1]
+
+            try:
+                index = int(integer_index_path)
+            except ValueError:
+                raise ValueError(
+                    f"Could not grab integer index from path '{path}'. "
+                    f"Please correct the sub path containing '{integer_index_path}' to be an "
+                    f"integer index into '{field_name}' (containing {len(sub_component)} elements)."
+                )
+
+            sub_component_list = list(sub_component)
+            sub_component = sub_component_list[index]
+            sub_path = "/".join(path_components[2:])
+
+            sub_component_list[index] = sub_component.updated_copy(path=sub_path, **kwargs)
+            new_component = tuple(sub_component_list)
+        else:
+            sub_path = "/".join(path_components[1:])
+            new_component = sub_component.updated_copy(path=sub_path, **kwargs)
+
+        return self._updated_copy(**{field_name: new_component})
+
+    def _updated_copy(self, **kwargs) -> Tidy3dBaseModel:
         """Make copy of a component instance with ``**kwargs`` indicating updated field values."""
         return self.copy(update=kwargs)
 


### PR DESCRIPTION
Enables

```py
new_simulation = simulation.updated_copy(size=new_size, path="structures/0/geometry")
```

to recursively perform
```
new_box = simulation.structures[i].geometry.updated_copy(size=new_size)
new_structure = simulation.structures[i].updated_copy(geometry=geometry)
new_structures = list(simulation.structures)
new_structures[i] = new_structure
new_simulation = simulation.updated_copy(structures=new_structures)
```