### PR TITLE
smatrix backwards compatible import

### DIFF
--- a/tests/test_plugins/test_component_modeler.py
+++ b/tests/test_plugins/test_component_modeler.py
@@ -382,3 +382,7 @@ def test_batch_filename(tmp_path):
     modeler = make_component_modeler(path_dir=str(tmp_path))
     path = modeler._batch_path
     assert path
+
+
+def test_import_smatrix_smatrix():
+    from tidy3d.plugins.smatrix.smatrix import Port, ComponentModeler

--- a/tidy3d/plugins/smatrix/smatrix.py
+++ b/tidy3d/plugins/smatrix/smatrix.py
@@ -1,0 +1,6 @@
+# backwards compatibility support for ``from tidy3d.plugins.smatrix.smatrix import ``
+
+from .ports.modal import Port
+from .component_modelers.modal import ComponentModeler
+
+__all__ = ["Port", "ComponentModeler"]


### PR DESCRIPTION
smatrix notebooks had
```
from tidy3d.plugins.smatrix.smatrix import Port
```

this makes that still possible for backwards compatibility.