### PR TITLE
Fix `JaxSimulation.epsilon` to include all `input_structures`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Bug in PolySlab intersection if slab bounds are `inf` on one side.
 - Better error message when trying to transform a geometry with infinite bounds.
+- `JaxSimulation.epsilon` properly handles `input_structures`.
+
 
 ## [2.6.3] - 2024-04-02
 

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -3659,6 +3659,17 @@ class Simulation(AbstractYeeGridSimulation):
 
         return len(self.tmesh)
 
+    @cached_property
+    def self_structure(self) -> Structure:
+        """The simulation background as a ``Structure``."""
+        geometry = Box(size=(inf, inf, inf), center=self.center)
+        return Structure(geometry=geometry, medium=self.medium)
+
+    @cached_property
+    def all_structures(self) -> List[Structure]:
+        """List of all structures in the simulation (including the ``Simulation.medium``)."""
+        return [self.self_structure] + list(self.structures)
+
     def _grid_corrections_2dmaterials(self, grid: Grid) -> Grid:
         """Correct the grid if 2d materials are present, using their volumetric equivalents."""
         if not any(isinstance(structure.medium, Medium2D) for structure in self.structures):
@@ -3723,7 +3734,9 @@ class Simulation(AbstractYeeGridSimulation):
         """
         freq_max = max(source.source_time.freq0 for source in self.sources)
         wvl_min = C_0 / freq_max
-        eps_max = max(abs(structure.medium.eps_model(freq_max)) for structure in self.structures)
+
+        all_structures = self.all_structures
+        eps_max = max(abs(structure.medium.eps_model(freq_max)) for structure in all_structures)
         n_max, _ = AbstractMedium.eps_complex_to_nk(eps_max)
         return wvl_min / n_max
 


### PR DESCRIPTION
Fixes #1459 

Also includes a minor refactor to make it more convenient to compute all structures, including the simulation's effective structure