### PR TITLE
:book: DOCS: Improve constants representations

### DIFF
--- a/docs/api/constants.rst
+++ b/docs/api/constants.rst
@@ -10,13 +10,13 @@ Physical Constants
    :toctree: _autosummary/
    :template: module.rst
 
-   tidy3d.C_0
-   tidy3d.HBAR
-   tidy3d.Q_e
-   tidy3d.ETA_0
-   tidy3d.EPSILON_0
-   tidy3d.MU_0
-   tidy3d.K_B
+   tidy3d.constants.C_0
+   tidy3d.constants.HBAR
+   tidy3d.constants.Q_e
+   tidy3d.constants.ETA_0
+   tidy3d.constants.EPSILON_0
+   tidy3d.constants.MU_0
+   tidy3d.constants.K_B
 
 
 Tidy3D Special Constants
@@ -26,8 +26,8 @@ Tidy3D Special Constants
    :toctree: _autosummary/
    :template: module.rst
 
-   tidy3d.inf
-   tidy3d.PEC
+   tidy3d.constants.inf
+   tidy3d.constants.PEC
 
 Tidy3D Configuration
 --------------------

--- a/tidy3d/constants.py
+++ b/tidy3d/constants.py
@@ -194,6 +194,9 @@ Large number used for comparing infinity.
 """
 
 inf = np.inf
+"""
+Representation of infinity used within tidy3d.
+"""
 
 # if |np.pi/2 - angle_theta| < GLANCING_CUTOFF in an angled source or in mode spec, raise warning
 GLANCING_CUTOFF = 0.1


### PR DESCRIPTION
![image](https://github.com/flexcompute/tidy3d/assets/149674618/fae23890-ab3b-4ee4-bdb3-387ec6e76d8c)

Related to https://github.com/flexcompute/tidy3d/issues/1602 on why it can't be eg `td.C_O` instead of `td.constants.C_0` due to the way that sphinx reads the docstrings. Unless we move all the docstrings into the top init pys, it works like this. I had an attempt to sort this before and it is very sphinx internal configuration. Hopefully with the custom extension all this internal build representations are things we will be able to control and represent nicer.