### PR TITLE
JaxSimulation properties to check adjoint run_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Uniaxial medium Lithium Niobate to material library.
 - Added support for conformal mesh methods near PEC structures that can be specified through the field `pec_conformal_mesh_spec` in the `Simulation` class.
 - EME solver through `EMESimulation` class.
+- Properties `num_time_steps_adjoint` and `tmesh_adjoint` to `JaxSimulation` to estimate adjoint run time.
 
 ### Changed
 - `run_time` of the adjoint simulation is set more robustly based on the adjoint sources and the forward simulation `run_time` as `sim_fwd.run_time + c / fwdith_adj` where `c=10`.

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -1643,6 +1643,11 @@ def test_adjoint_run_time(use_emulated_run, tmp_path, fwidth, run_time, run_time
     run_time_adj = sim._run_time_adjoint
     fwidth_adj = sim._fwidth_adjoint
 
+    # number of adjoint time steps approximately scaled by the adjoint run_time compared to sim
+    num_time_steps_adjoint = sim.num_time_steps_adjoint
+    num_time_steps_scaled = sim.num_time_steps * (sim._run_time_adjoint / sim.run_time)
+    assert np.isclose(num_time_steps_adjoint, num_time_steps_scaled, rtol=1e-2)
+
     sim_adj = sim_data.make_adjoint_simulation(fwidth=fwidth_adj, run_time=run_time_adj)
 
     assert sim_adj.run_time == run_time_expected

--- a/tidy3d/plugins/adjoint/components/simulation.py
+++ b/tidy3d/plugins/adjoint/components/simulation.py
@@ -372,6 +372,23 @@ class JaxSimulation(Simulation, JaxObject):
 
         return run_time_adjoint
 
+    @cached_property
+    def tmesh_adjoint(self) -> np.ndarray:
+        """FDTD time stepping points.
+
+        Returns
+        -------
+        np.ndarray
+            Times (seconds) that the simulation time steps through.
+        """
+        dt = self.dt
+        return np.arange(0.0, self._run_time_adjoint + dt, dt)
+
+    @cached_property
+    def num_time_steps_adjoint(self) -> int:
+        """Number of time steps in the adjoint simulation."""
+        return len(self.tmesh_adjoint)
+
     def to_simulation(self) -> Tuple[Simulation, JaxInfo]:
         """Convert :class:`.JaxSimulation` instance to :class:`.Simulation` with an info dict."""
 


### PR DESCRIPTION
adds `JaxSimulation.tmesh_adjoint` and `JaxSimulation.num_time_steps_adjoint` for helping estimate.

Note: users can also currently see `._run_time_adjoint` but it's a private method so not documented prominently.