### PR TITLE
fix source discretization

### DIFF
--- a/tidy3d/components/geometry/utils.py
+++ b/tidy3d/components/geometry/utils.py
@@ -5,6 +5,7 @@ from math import isclose
 
 import numpy as np
 
+from ...constants import inf
 from ..types import Axis, PlanePosition, Shapely, ArrayFloat2D, MatrixReal4x4
 from ...exceptions import Tidy3dError
 
@@ -208,3 +209,21 @@ def validate_no_transformed_polyslabs(geometry: GeometryType, transform: MatrixR
     elif isinstance(geometry, base.ClipOperation):
         validate_no_transformed_polyslabs(geometry.geometry_a, transform)
         validate_no_transformed_polyslabs(geometry.geometry_b, transform)
+
+
+def increment_float(val: np.float32, sign) -> np.float32:
+    """Applies a small positive or negative shift to a 32bit float using numpy.nextafter,"""
+    """but additionally handles some corner cases."""
+    # Infinity is left unchanged
+    if val == inf or val == -inf:
+        return val
+
+    if sign >= 0:
+        sign = 1
+    else:
+        sign = -1
+    # Numpy seems to skip over the increment from -0.0 and +0.0
+    # which is different from c++
+    val_inc = np.nextafter(val, sign * inf, dtype=np.float32)
+
+    return np.float32(val_inc)

--- a/tidy3d/components/geometry/utils_2d.py
+++ b/tidy3d/components/geometry/utils_2d.py
@@ -4,11 +4,11 @@ import shapely
 from typing import Tuple, List
 
 from ..types import Axis
-from ...constants import inf
 from ...exceptions import ValidationError
 from ..geometry.base import Geometry, Box, ClipOperation
 from ..geometry.primitives import Cylinder
 from ..geometry.polyslab import PolySlab
+from ..geometry.utils import increment_float
 from ..grid.grid import Grid
 from ..scene import Scene
 from ..structure import Structure
@@ -16,24 +16,6 @@ from ..structure import Structure
 # for 2d materials. to find neighboring media, search a distance on either side
 # equal to this times the grid size
 DIST_NEIGHBOR_REL_2D_MED = 1e-5
-
-
-def increment_float(val: np.float32, sign) -> np.float32:
-    """Applies a small positive or negative shift to a 32bit float using numpy.nextafter,"""
-    """but additionally handles some corner cases."""
-    # Infinity is left unchanged
-    if val == inf or val == -inf:
-        return val
-
-    if sign >= 0:
-        sign = 1
-    else:
-        sign = -1
-    # Numpy seems to skip over the increment from -0.0 and +0.0
-    # which is different from c++
-    val_inc = np.nextafter(val, sign * inf, dtype=np.float32)
-
-    return np.float32(val_inc)
 
 
 def snap_coordinate_to_grid(grid: Grid, center: float, axis: Axis) -> float:

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -17,8 +17,8 @@ from .validators import assert_objects_in_sim_bounds
 from .validators import validate_mode_objects_symmetry
 from .geometry.base import Geometry, Box
 from .geometry.mesh import TriangleMesh
-from .geometry.utils import flatten_groups, traverse_geometries
-from .geometry.utils_2d import get_bounds, increment_float, set_bounds, get_thickened_geom
+from .geometry.utils import flatten_groups, increment_float, traverse_geometries
+from .geometry.utils_2d import get_bounds, set_bounds, get_thickened_geom
 from .geometry.utils_2d import subdivide, snap_coordinate_to_grid
 from .types import Ax, FreqBound, Axis, annotate_type, InterpMethod, Symmetry
 from .types import Literal, TYPE_TAG_STR
@@ -961,10 +961,8 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
 
         # Expand monitor size slightly to break numerical precision in favor of always having
         # enough data to span the full monitor.
-        expand_size = [size + fp_eps if size > fp_eps else size for size in monitor.size]
-        box_expanded = Box(center=monitor.center, size=expand_size)
         # Discretize without extension for now
-        span_inds = np.array(self.grid.discretize_inds(box_expanded, extend=False))
+        span_inds = np.array(self.grid.discretize_inds(monitor, extend=False, expand_box=True))
 
         if any(ind[0] >= ind[1] for ind in span_inds):
             # At least one dimension has no indexes inside the grid, e.g. monitor is entirely

--- a/tidy3d/plugins/smatrix/ports/lumped.py
+++ b/tidy3d/plugins/smatrix/ports/lumped.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from ....constants import OHM
 from ....components.geometry.base import Box
-from ....components.geometry.utils_2d import increment_float
+from ....components.geometry.utils import increment_float
 from ....components.types import Complex, FreqArray, Axis
 from ....components.base import cached_property
 from ....components.lumped_element import LumpedResistor


### PR DESCRIPTION
related to the backend [PR](https://github.com/flexcompute/tidy3d-core/pull/594).

Essentially unifies some code that optionally slightly enlarges the box when using `grid.discretize_inds`