### PR TITLE
fix adjoint jax structure with fully anisotropic medium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Set `imoprtlib-metadata`, `boto3`, `requests`, and `click` version requirements to how they were in Tidy3D v2.5.
+- Bug in `td.FullyAnisotropicMedium` when added to `adjoint.JaxStructureStaticMedium`.
 
 ## [2.6.3] - 2024-04-02
 

--- a/tidy3d/plugins/adjoint/components/structure.py
+++ b/tidy3d/plugins/adjoint/components/structure.py
@@ -91,7 +91,7 @@ class AbstractJaxStructure(Structure, JaxObject):
         grad_data_eps: PermittivityData,
     ) -> Dict[str, float]:
         """Compute params in the material of this structure."""
-        freq_max = max(grad_data_eps.eps_xx.f)
+        freq_max = float(max(grad_data_eps.eps_xx.f))
         eps_in = self.medium.eps_model(frequency=freq_max)
         ref_ind = np.sqrt(np.max(np.real(eps_in)))
         wvl_free_space = C_0 / freq_max


### PR DESCRIPTION
Fixes a bug that happened server-side when a `FullyAnisotropicMedium` was added to a `JaxStructureStaticMedium`.

Guess if 2.6.4 is not released yet, we could merge into develop. let me know if you want me to rebase to 2.7 as it's probably not urgent based on the user communications (note: `td.AnisotropicMedium` still works fine in adjoint)