### PR TITLE
batch refactoring / multi-threading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added new validators in `HeatSimulation`: no structures with dimensions of zero size, no all-Neumann boundary conditions, non-empty simulation domain.
+- `web.Batch` uses multi-threading for upload and download operations. The total time for many tasks is reduced by an order of magnitude.
 
 ### Changed
 - Revert forbidden `"` in component names.
@@ -57,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Characters `"` and `/` not allowed in component names.
 - Change error when `JaxPolySlab.sidewall_angle != 0.0` to a warning, enabling optimization with slanted sidewalls if a lower accuracy gradient is acceptable.
+- Simplified output and logging in `web.Batch` with `verbose=True`.
 
 ### Fixed
 - Compute time stepping speed shown `tidy3d.log` using only the number of time steps that was run in the case of early shutoff. Previously, it was using the total number of time steps.

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -510,7 +510,13 @@ def test_job(mock_webapi, monkeypatch, tmp_path):
     sim = make_sim()
     j = Job(simulation=sim, task_name=TASK_NAME, folder_name=PROJECT_NAME)
 
-    _ = j.run(path=str(tmp_path / "web_test_tmp.json"))
+    fname = str(tmp_path / "web_test_tmp.json")
+
+    j.to_file(fname)
+
+    j = j.from_file(fname)
+
+    _ = j.run(path=fname)
     _ = j.status
     j.estimate_cost()
     # j.download
@@ -525,14 +531,21 @@ def mock_job_status(monkeypatch):
 
 
 @responses.activate
-def test_batch(mock_webapi, mock_job_status, tmp_path):
+def test_batch(mock_webapi, mock_job_status, mock_load, tmp_path):
     # monkeypatch.setattr("tidy3d.web.api.container.Batch.monitor", lambda self: time.sleep(0.1))
     # monkeypatch.setattr("tidy3d.web.api.container.Job.status", property(lambda self: "success"))
 
     sims = {TASK_NAME: make_sim()}
     b = Batch(simulations=sims, folder_name=PROJECT_NAME)
+
+    fname = str(tmp_path / "batch.json")
+
+    b.to_file(fname)
+    b = b.from_file(fname)
+
     b.estimate_cost()
-    _ = b.run(path_dir=str(tmp_path))
+    data = b.run(path_dir=str(tmp_path))
+    _ = b.get_info()
     assert b.real_cost() == FLEX_UNIT * len(sims)
 
 


### PR DESCRIPTION
## Goals:
1. Simplifies how `Batch` and `Job` work internally.
2. Improves the visual output from `Batch`.
3. Implements multi-threading for batch operations (upload, download, etc).

<img width="566" alt="image" src="https://github.com/flexcompute/tidy3d/assets/92756888/3d1db1cd-b008-4f61-b3b2-b9d0f42ff5a5">


## Refactor

Previously, `Job` objects were defined like this

```py
class Job:
    ...
    task_id = None

    @pd.root_validator()
    def _upload(cls, values) -> None:
          # upload task
          # set task id internally
```

This meant that when you created a `Job`, the task is immediately uploaded.
Also when you save a `Job.to_file()` the task info is contained.

This design made it a bit annoying to do normal multi-threading over job upload.

In the refactored version, I set it up to have `upload` in its own method.

```py
class Job:
    ...
    task_id_cached = None

    @cached_property
    def task_id(self):
        # return self.task_id_cached or call `self.upload()` 

    def upload(self):
         ...

    def json(self):
          # extend json to add `cached_properties["task_id"] to json file for backwards compatibility when loading from file

```

Now a similar refactoring was done for `Batch` to move the `upload()` bits to their own method.

Before, the `Batch` created all `Job` objects and uploaded them at initialization time in a validator.

```py
class Batch:
    ...
    jobs : Dict[str, Job] = None

    @pd.root_validator
    def _upload():
        # for each simulation in the batch, make a job (which automatically uploads it).

```

instead, now that we have the `Job` with its own `upload` method, I simplified this to.

```py
class Batch:
    ...
    jobs : Dict[str, Job] = None

    @cached_property
    def jobs():
        # construct all of the Jobs for this Batch

    def upload(self):
        # upload each Job in a for loop
```

## Multithreading

Implemented basic multi-threading for `Batch.upload()` and `Batch.download()`. Works as expected on the Design plugin notebook.

Also made it so that `Batch.run()` will download by default.

## Output / Logging

- The batch upload, download, and BatchData loading all just log a single output instead of one line for every file.


