### PR TITLE
Heat solver improvements

### DIFF
--- a/tests/_test_data/_test_datasets_no_vtk.py
+++ b/tests/_test_data/_test_datasets_no_vtk.py
@@ -3,6 +3,7 @@ import pytest
 import builtins
 from ..test_data.test_datasets import test_triangular_dataset as _test_triangular_dataset
 from ..test_data.test_datasets import test_tetrahedral_dataset as _test_tetrahedral_dataset
+from ..utils import log_capture
 
 
 @pytest.fixture
@@ -18,10 +19,10 @@ def hide_vtk(monkeypatch, request):
 
 
 @pytest.mark.usefixtures("hide_vtk")
-def test_triangular_dataset_no_vtk(tmp_path):
-    _test_triangular_dataset(tmp_path, "test_name", no_vtk=True)
+def test_triangular_dataset_no_vtk(tmp_path, log_capture):
+    _test_triangular_dataset(log_capture, tmp_path, "test_name", no_vtk=True)
 
 
 @pytest.mark.usefixtures("hide_vtk")
-def test_tetrahedral_dataset_no_vtk(tmp_path):
-    _test_tetrahedral_dataset(tmp_path, "test_name", no_vtk=True)
+def test_tetrahedral_dataset_no_vtk(tmp_path, log_capture):
+    _test_tetrahedral_dataset(log_capture, tmp_path, "test_name", no_vtk=True)

--- a/tests/test_data/test_data_arrays.py
+++ b/tests/test_data/test_data_arrays.py
@@ -308,6 +308,10 @@ def test_spatial_data_array():
         coords=dict(x=[0, 1], y=[1, 2], z=[2, 3]),
     )
 
+    # make it non sorted
+    arr = arr.isel(x=[1, 0], z=[1, 0])
+
+    # reflection with a gap
     reflected = arr.reflect(axis=0, center=-0.5)
 
     reflected_expected = td.SpatialDataArray(
@@ -317,6 +321,17 @@ def test_spatial_data_array():
 
     assert reflected == reflected_expected
 
+    # reflection with a gap, only reflection
+    reflected = arr.reflect(axis=0, center=-0.5, reflection_only=True)
+
+    reflected_expected = td.SpatialDataArray(
+        [[[4, 5], [6, 7]], [[0, 1], [2, 3]]],
+        coords=dict(x=[-2, -1], y=[1, 2], z=[2, 3]),
+    )
+
+    assert reflected == reflected_expected
+
+    # reflection with no gap
     reflected = arr.reflect(axis=1, center=1)
 
     reflected_expected = td.SpatialDataArray(
@@ -326,5 +341,43 @@ def test_spatial_data_array():
 
     assert reflected == reflected_expected
 
+    # reflection with no gap, only reflection
+    reflected = arr.reflect(axis=1, center=1, reflection_only=True)
+
+    reflected_expected = td.SpatialDataArray(
+        [[[2, 3], [0, 1]], [[6, 7], [4, 5]]],
+        coords=dict(x=[0, 1], y=[0, 1], z=[2, 3]),
+    )
+
+    assert reflected == reflected_expected
+
     with pytest.raises(DataError):
         reflected = arr.reflect(axis=2, center=2.5)
+
+
+@pytest.mark.parametrize("nx", [10, 1])
+def test_sel_inside(nx):
+    ny = 11
+    nz = 12
+    arr = td.SpatialDataArray(
+        np.random.random((nx, ny, nz)),
+        coords=dict(
+            x=np.linspace(0, 1, nx),
+            y=np.linspace(2, 3, ny),
+            z=np.linspace(0, 2, nz),
+        ),
+    )
+
+    bounds_small = [[0.1, 2, 2], [1, 2.5, 2]]
+    bounds_large = [[0.1, 2, 2], [1, 4, 2]]
+    assert arr.does_cover(bounds_small)
+    assert not arr.does_cover(bounds_large)
+
+    arr_selected = arr.sel_inside(bounds_small)
+    assert arr_selected.does_cover(bounds_small)
+
+    arr_selected = arr.sel_inside(bounds_large)
+    assert not arr_selected.does_cover(bounds_large)
+
+    with pytest.raises(DataError):
+        _ = arr.does_cover([[0.1, 3, 2], [1, 2.5, 2]])

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -265,9 +265,24 @@ class AbstractSpatialDataArray(DataArray, ABC):
     _dims = ("x", "y", "z")
     _data_attrs = {"long_name": "field value"}
 
+    @property
+    def _spatially_sorted(self) -> SpatialDataArray:
+        """Check whether sorted and sort if not."""
+        needs_sorting = []
+        for axis in "xyz":
+            axis_coords = self.coords[axis].values
+            if len(axis_coords) > 1 and np.any(axis_coords[1:] < axis_coords[:-1]):
+                needs_sorting.append(axis)
+
+        if len(needs_sorting) > 0:
+            return self.sortby(needs_sorting)
+
+        return self
+
     def sel_inside(self, bounds: Bound) -> SpatialDataArray:
         """Return a new SpatialDataArray that contains the minimal amount data necessary to cover
-        a spatial region defined by ``bounds``.
+        a spatial region defined by ``bounds``. Note that the returned data is sorted with respect
+        to spatial coordinates.
 
 
         Parameters
@@ -280,10 +295,17 @@ class AbstractSpatialDataArray(DataArray, ABC):
         SpatialDataArray
             Extracted spatial data array.
         """
+        if any(bmin > bmax for bmin, bmax in zip(*bounds)):
+            raise DataError(
+                "Min and max bounds must be packaged as '(minx, miny, minz), (maxx, maxy, maxz)'."
+            )
+
+        # make sure data is sorted with respect to coordinates
+        sorted_self = self._spatially_sorted
 
         inds_list = []
 
-        coords = (self.x, self.y, self.z)
+        coords = (sorted_self.x, sorted_self.y, sorted_self.z)
 
         for coord, smin, smax in zip(coords, bounds[0], bounds[1]):
             length = len(coord)
@@ -316,7 +338,7 @@ class AbstractSpatialDataArray(DataArray, ABC):
 
             inds_list.append(comp_inds)
 
-        return self.isel(x=inds_list[0], y=inds_list[1], z=inds_list[2])
+        return sorted_self.isel(x=inds_list[0], y=inds_list[1], z=inds_list[2])
 
     def does_cover(self, bounds: Bound) -> bool:
         """Check whether data fully covers specified by ``bounds`` spatial region. If data contains
@@ -334,10 +356,14 @@ class AbstractSpatialDataArray(DataArray, ABC):
         bool
             Full cover check outcome.
         """
+        if any(bmin > bmax for bmin, bmax in zip(*bounds)):
+            raise DataError(
+                "Min and max bounds must be packaged as '(minx, miny, minz), (maxx, maxy, maxz)'."
+            )
 
         coords = (self.x, self.y, self.z)
         return all(
-            (coord[0] <= smin and coord[-1] >= smax) or len(coord) == 1
+            (np.min(coord) <= smin and np.max(coord) >= smax) or len(coord) == 1
             for coord, smin, smax in zip(coords, bounds[0], bounds[1])
         )
 
@@ -356,9 +382,9 @@ class SpatialDataArray(AbstractSpatialDataArray):
 
     __slots__ = ()
 
-    def reflect(self, axis: Axis, center: float) -> SpatialDataArray:
+    def reflect(self, axis: Axis, center: float, reflection_only: bool = False) -> SpatialDataArray:
         """Reflect data across the plane define by parameters ``axis`` and ``center`` from right to
-        left.
+        left. Note that the returned data is sorted with respect to spatial coordinates.
 
         Parameters
         ----------
@@ -366,6 +392,8 @@ class SpatialDataArray(AbstractSpatialDataArray):
             Normal direction of the reflection plane.
         center : float
             Location of the reflection plane along its normal direction.
+        reflection_only : bool = False
+            Return only reflected data.
 
         Returns
         -------
@@ -373,15 +401,27 @@ class SpatialDataArray(AbstractSpatialDataArray):
             Data after reflection is performed.
         """
 
-        coords = list(self.coords.values())
-        data = np.array(self.data)
+        sorted_self = self._spatially_sorted
 
-        if np.isclose(center, coords[axis].data[0]):
+        coords = [sorted_self.x.values, sorted_self.y.values, sorted_self.z.values]
+        data = np.array(sorted_self.data)
+
+        data_left_bound = coords[axis].data[0]
+
+        if np.isclose(center, data_left_bound):
             num_duplicates = 1
-        elif center > coords[axis].data[0]:
-            raise DataError("Reflection center must be outside and on the left of the data region.")
+        elif center > data_left_bound:
+            raise DataError("Reflection center must be outside and to the left of the data region.")
         else:
             num_duplicates = 0
+
+        if reflection_only:
+            coords[axis] = 2 * center - coords[axis]
+            coords_dict = dict(zip("xyz", coords))
+
+            tmp_arr = SpatialDataArray(sorted_self.data, coords=coords_dict)
+
+            return tmp_arr.sortby("xyz"[axis])
 
         shape = np.array(np.shape(data))
         old_len = shape[axis]

--- a/tidy3d/components/heat/boundary.py
+++ b/tidy3d/components/heat/boundary.py
@@ -8,6 +8,7 @@ import pydantic.v1 as pd
 
 from ..base import Tidy3dBaseModel
 from ..bc_placement import BCPlacementType
+from ..types import TYPE_TAG_STR
 
 from ...constants import KELVIN, HEAT_FLUX, HEAT_TRANSFER_COEFF
 
@@ -85,9 +86,11 @@ class HeatBoundarySpec(Tidy3dBaseModel):
     placement: BCPlacementType = pd.Field(
         title="Boundary Conditions Placement",
         description="Location to apply boundary conditions.",
+        discriminator=TYPE_TAG_STR,
     )
 
     condition: HeatBoundaryConditionType = pd.Field(
         title="Boundary Conditions",
         description="Boundary conditions to apply at the selected location.",
+        discriminator=TYPE_TAG_STR,
     )

--- a/tidy3d/components/heat/data/monitor_data.py
+++ b/tidy3d/components/heat/data/monitor_data.py
@@ -5,9 +5,10 @@ from typing import Union, Tuple, Optional
 from abc import ABC
 
 import pydantic.v1 as pd
+import numpy as np
 
 from ..monitor import TemperatureMonitor, HeatMonitorType
-from ...base import skip_if_fields_missing
+from ...base import skip_if_fields_missing, cached_property
 from ...base_sim.data.monitor_data import AbstractMonitorData
 from ...data.data_array import SpatialDataArray
 from ...data.dataset import TriangularGridDataset, TetrahedralGridDataset
@@ -38,7 +39,7 @@ class HeatMonitorData(AbstractMonitorData, ABC):
         description="Symmetry center of the original simulation in x, y, and z.",
     )
 
-    @property
+    @cached_property
     def symmetry_expanded_copy(self) -> HeatMonitorData:
         """Return copy of self with symmetry applied."""
         return self.copy()
@@ -89,23 +90,70 @@ class TemperatureData(HeatMonitorData):
 
         return val
 
-    @property
+    @cached_property
     def symmetry_expanded_copy(self) -> TemperatureData:
         """Return copy of self with symmetry applied."""
 
+        # case when no info was recorded (bad placement of monitor and not caught by frontend)
         if self.temperature is None:
             return self.updated_copy(symmetry=(0, 0, 0))
 
+        # no symmetry
         if all(sym == 0 for sym in self.symmetry):
             return self.copy()
 
         new_temp = self.temperature
 
+        mnt_bounds = np.array(self.monitor.bounds)
+
+        if isinstance(new_temp, SpatialDataArray):
+            data_bounds = [
+                [np.min(new_temp.x), np.min(new_temp.y), np.min(new_temp.z)],
+                [np.max(new_temp.x), np.max(new_temp.y), np.max(new_temp.z)],
+            ]
+        else:
+            data_bounds = new_temp.bounds
+
+        dims_need_clipping_left = []
+        dims_need_clipping_right = []
         for dim in range(3):
             # do not expand monitor with zero size along symmetry direction
             # this is done because 2d unstructured data does not support this
-            if self.symmetry[dim] == 1 and self.monitor.size[dim] != 0:
-                new_temp = new_temp.reflect(axis=dim, center=self.symmetry_center[dim])
+            if self.symmetry[dim] == 1:
+                center = self.symmetry_center[dim]
+
+                if mnt_bounds[1][dim] < data_bounds[0][dim]:
+                    # (note that mnt_bounds[0][dim] < 2 * center - data_bounds[0][dim] will be satisfied based on backend behavior)
+                    # simple reflection
+                    new_temp = new_temp.reflect(axis=dim, center=center, reflection_only=True)
+                elif mnt_bounds[0][dim] < 2 * center - data_bounds[0][dim]:
+                    # expand only if monitor bounds missing data
+                    # if we do expand, simply reflect symmetrically the whole data
+                    new_temp = new_temp.reflect(axis=dim, center=center)
+
+                    # if it turns out that we expanded too much, we will trim unnecessary data later
+                    if mnt_bounds[0][dim] > 2 * center - data_bounds[1][dim]:
+                        dims_need_clipping_left.append(dim)
+
+                    # likewise, if some of original data was only for symmetry expansion, thim excess on the right
+                    if mnt_bounds[1][dim] < data_bounds[1][dim]:
+                        dims_need_clipping_right.append(dim)
+
+        # trim over-expanded data
+        if len(dims_need_clipping_left) > 0 or len(dims_need_clipping_right) > 0:
+            # enlarge clipping domain on positive side arbitrary by 1
+            # should not matter by how much
+            clip_bounds = [mnt_bounds[0] - 1, mnt_bounds[1] + 1]
+            for dim in dims_need_clipping_left:
+                clip_bounds[0][dim] = mnt_bounds[0][dim]
+
+            for dim in dims_need_clipping_right:
+                clip_bounds[1][dim] = mnt_bounds[1][dim]
+
+            if isinstance(new_temp, SpatialDataArray):
+                new_temp = new_temp.sel_inside(clip_bounds)
+            else:
+                new_temp = new_temp.box_clip(bounds=clip_bounds)
 
         return self.updated_copy(temperature=new_temp, symmetry=(0, 0, 0))
 

--- a/tidy3d/components/heat/grid.py
+++ b/tidy3d/components/heat/grid.py
@@ -1,6 +1,7 @@
 """Defines heat grid specifications"""
 from __future__ import annotations
 
+from abc import ABC
 from typing import Union, Tuple
 import pydantic.v1 as pd
 
@@ -9,8 +10,18 @@ from ...constants import MICROMETER
 from ...exceptions import ValidationError
 
 
-class UniformUnstructuredGrid(Tidy3dBaseModel):
+class UnstructuredGrid(Tidy3dBaseModel, ABC):
+    """Abstract unstructured grid."""
 
+    relative_min_dl: pd.NonNegativeFloat = pd.Field(
+        1e-3,
+        title="Relative Mesh Size Limit",
+        description="The minimal allowed mesh size relative to the largest dimension of the simulation domain."
+        "Use ``relative_min_dl=0`` to remove this constraint.",
+    )
+
+
+class UniformUnstructuredGrid(UnstructuredGrid):
     """Uniform grid.
 
     Example
@@ -47,7 +58,7 @@ class UniformUnstructuredGrid(Tidy3dBaseModel):
     )
 
 
-class DistanceUnstructuredGrid(Tidy3dBaseModel):
+class DistanceUnstructuredGrid(UnstructuredGrid):
     """Adaptive grid based on distance to material interfaces. Currently not recommended for larger
     simulations.
 


### PR DESCRIPTION
changes associated with backed https://github.com/flexcompute/tidy3d-core/pull/616 and additional ones:
- allow any geometry type in heat simulations
- `relative_min_dl` parameter to restrict minimal mesh size
- missing pydantic discriminators causing false warnings
- functions to clean unstructured data from degenerate cells and unused points
- safeguards in spatial data arrays against unsorted data
- validators to check that monitor cross solid medium
- correct way to handle monitors overlapping symmetry regions
- more careful slicing of unstructured datasets along edges

fyi @e-g-melo 