### PR TITLE
Fix near2far for 2d simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ModeSolver` methods to plot the mode plane simulation components, including `.plot()`, `.plot_eps()`, `.plot_structures_eps()`, `.plot_grid()`, and `.plot_pml()`.
 - Support for differentiation with respect to monitor attributes that require interpolation, such as flux and intensity.
 - Support for automatic differentiation with respect to `.eps_inf` and `.poles` contained in dispersive mediums `td.PoleResidue` and `td.CustomPoleResidue`.
+- Support for `FieldProjectionAngleMonitor` for 2D simulations with `far_field_approx = True`.
+
+### Changed
+- Error if field projection monitors found in 2D simulations, except `FieldProjectionAngleMonitor` with `far_field_approx = True`. Support for other monitors and for exact field projection will be coming in a subsequent Tidy3D version.
 
 ### Fixed
 - Bug where boundary layers would be plotted too small in 2D simulations.

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -2474,10 +2474,21 @@ def test_sim_subsection(unstructured, nz):
         # compare
         assert np.allclose(red_grid, full_grid[ind : ind + len(red_grid)])
 
+    subsection_monitors = [mnt for mnt in SIM_FULL.monitors if region_xy.intersects(mnt)]
     sim_red = SIM_FULL.subsection(
         region=region_xy,
         grid_spec="identical",
         boundary_spec=td.BoundarySpec.all_sides(td.Periodic()),
+        # Set theta to 'pi/2' for 2D simulation in the x-y plane
+        monitors=[
+            mnt.updated_copy(theta=np.pi / 2)
+            if isinstance(mnt, td.FieldProjectionAngleMonitor)
+            else mnt
+            for mnt in subsection_monitors
+            if not isinstance(
+                mnt, (td.FieldProjectionCartesianMonitor, td.FieldProjectionKSpaceMonitor)
+            )
+        ],
     )
     assert sim_red.size[2] == 0
     assert isinstance(sim_red.boundary_spec.z.minus, td.Periodic)

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -56,6 +56,7 @@ from .monitor import (
     DiffractionMonitor,
     FieldMonitor,
     FieldProjectionAngleMonitor,
+    FieldProjectionCartesianMonitor,
     FieldProjectionKSpaceMonitor,
     FieldTimeMonitor,
     FreqMonitor,
@@ -2654,6 +2655,85 @@ class Simulation(AbstractYeeGridSimulation):
                             "projections via the 'FieldProjector' class, where higher precision is "
                             "available.",
                             custom_loc=["monitors", idx, "proj_distance"],
+                        )
+        return val
+
+    @pydantic.validator("monitors", always=True)
+    @skip_if_fields_missing(["size"])
+    def _projection_monitors_2d(cls, val, values):
+        """
+        Validate if the field projection monitor is set up for a 2D simulation and
+        ensure the observation angle is configured correctly.
+
+        - For a 2D simulation in the x-y plane, 'theta' should be set to 'pi/2'.
+        - For a 2D simulation in the y-z plane, 'phi' should be set to 'pi/2'.
+        - For a 2D simulation in the x-z plane, 'phi' should be set to '0'.
+
+        Note: Exact far field projection is not available yet. Currently, only
+        'far_field_approx = True' is supported.
+        """
+
+        if val is None:
+            return val
+
+        sim_size = values.get("size")
+
+        # Validation if is 3D simulation
+        non_zero_dims = sum(1 for size in sim_size if size != 0)
+        if non_zero_dims == 3:
+            return val
+
+        plane = None
+        phi_value = None
+        theta_value = None
+
+        if sim_size[0] == 0:
+            plane = "y-z"
+            phi_value = np.pi / 2
+        elif sim_size[1] == 0:
+            plane = "x-z"
+            phi_value = 0
+        elif sim_size[2] == 0:
+            plane = "x-y"
+            theta_value = np.pi / 2
+
+        for monitor in val:
+            if isinstance(monitor, AbstractFieldProjectionMonitor):
+                if non_zero_dims == 1:
+                    raise SetupError(
+                        f"Monitor '{monitor.name}' is not supported in 1D simulations."
+                    )
+
+                if isinstance(
+                    monitor, (FieldProjectionCartesianMonitor, FieldProjectionKSpaceMonitor)
+                ):
+                    raise SetupError(
+                        f"Monitor '{monitor.name}' in 2D simulations is coming soon. "
+                        "Please use 'FieldProjectionAngleMonitor' instead."
+                    )
+
+                if isinstance(monitor, FieldProjectionAngleMonitor):
+                    if not monitor.far_field_approx:
+                        raise SetupError(
+                            "Exact far field projection in 2D simulations is coming soon."
+                            "Please set 'far_field_approx = True'."
+                        )
+                    if plane == "y-z" and (len(monitor.phi) != 1 or monitor.phi[0] != phi_value):
+                        raise SetupError(
+                            "For a 2D simulation in the y-z plane, the observation angle 'phi' "
+                            f"of monitor '{monitor.name}' should be set to 'np.pi/2'."
+                        )
+                    elif plane == "x-z" and (len(monitor.phi) != 1 or monitor.phi[0] != phi_value):
+                        raise SetupError(
+                            "For a 2D simulation in the x-z plane, the observation angle 'phi' "
+                            f"of monitor '{monitor.name}' should be set to '0'."
+                        )
+                    elif plane == "x-y" and (
+                        len(monitor.theta) != 1 or monitor.theta[0] != theta_value
+                    ):
+                        raise SetupError(
+                            "For a 2D simulation in the x-y plane, the observation angle 'theta' "
+                            f"of monitor '{monitor.name}' should be set to 'np.pi/2'."
                         )
         return val
 


### PR DESCRIPTION
Implemented a preliminary fix for the 'near2far' in 2D. The key differences between 2D and 3D of 'near2far' in math are as follows:

1. Field Components - In 3D, they include Er, Ephi, Etheta, Hr, Hphi, Htheta; in 2D, for TMz mode, they are Ez and Hphi, and for TEz mode, Ephi and Hz.
2. Parameters - In 3D, these are theta, phi, and f; in 2D, phi and f.
3. Propagation phase.
4. RCS coefficient.

Given these differences, my initial idea was to develop a 2D variant of the FieldProjectionAngleMonitor, omitting the theta parameter and inheriting from the AbstractFieldProjectionMonitor. However, since the AbstractFieldProjectionMonitor is heavily designed for 3D features and depends on theta, it seems a 2D monitor would require a ground-up redesign. My current approach involves a rudimentary adaptation where the 3D monitor is used as 2D by setting theta = pi/2, and I added a 2D version of the far-field computation. This mirrors the 3D code with adjustments for the propagation phase and the RCS coefficient. I am relatively new to contributing to a large project, any comments and suggestions on how to more efficiently integrate these changes would be greatly appreciated.