### PR TITLE
move `adjoint` into main components

### DIFF
--- a/tests/test_components/test_adjoint.py
+++ b/tests/test_components/test_adjoint.py
@@ -4,20 +4,75 @@ import tidy3d as td
 import jax
 import jax.numpy as jnp
 
+
+def make_box(x: float) -> td.Box:
+    """Make a box storing (x,x,x) in its size."""
+    return td.Box(
+        center=(0, 0, 0),
+        size=(x, x, x),
+    )
+
+
+def make_structure(x: float) -> td.Structure:
+    """Make a structure with a geometry of a Box storing (x,x,x) in its size."""
+    b = make_box(x)
+    return td.Structure(geometry=b, medium=td.Medium(permittivity=2.0))
+
+
 def test_jax_field():
+    """Test storage of jax fields in tidy3d objects."""
+
+    def f(x):
+        b = make_box(x)
+        return jnp.sum(jnp.array(b.jax_info["size"]))
+
+    val = f(1.0)
+    grad = jax.grad(f)(1.0)
+
+    assert val >= 0.0
+    assert abs(grad) >= 0.0
 
 
-	def f(x):
-		b = td.Box(
-			center=(0,0,0),
-			size=(x, x, x),
-		)
+def test_jax_field_nested():
+    """Test storage of jax fields in nested tidy3d objects."""
 
-		return jnp.sum(jnp.array(b.jax_info["size"]))
+    def f(x):
+        s = make_structure(x)
+        return jnp.sum(jnp.array(s.geometry.jax_info["size"]))
 
-	val = f(1.0)
-	grad = jax.grad(f)(1.0)
+    val = f(1.0)
+    grad = jax.grad(f)(1.0)
 
-	assert val >= 0.0
-	assert abs(grad) >= 0.0
+    assert val >= 0.0
+    assert abs(grad) >= 0.0
 
+
+def test_passing_objects():
+    """Test passing tidy3d objects into jax functions."""
+
+    def g(s: td.Structure) -> float:
+        return jnp.sum(jnp.array(s.geometry.jax_info["size"])) ** 2
+
+    def f(x: float) -> float:
+        s = make_structure(x)
+        return g(s)
+
+    x0 = 1.0
+
+    val = f(x0)
+    grad = jax.grad(f)(x0)
+
+    assert val == (3 * x0) ** 2
+    assert grad == 2 * 3 * (3 * x0)
+
+
+def test_flatten():
+    """Test flatten / unflatten operations on tidy3d objects."""
+
+    x = jnp.array(1.0)
+    s1 = make_structure(x)
+
+    leaves, treedef = jax.tree_util.tree_flatten(s1)
+    s2 = jax.tree_util.tree_unflatten(treedef, leaves)
+
+    assert s1 == s2

--- a/tests/test_components/test_adjoint.py
+++ b/tests/test_components/test_adjoint.py
@@ -83,10 +83,10 @@ def test_passing_objects():
     """Test passing tidy3d objects into jax functions."""
 
     def g(s: td.Structure) -> float:
-        return sum_size(s.geometry) ** 2
+        return sum_size(s.structures[0].geometry) ** 2
 
     def f(x: float) -> float:
-        s = make_structure(x)
+        s = make_sim(x)
         return g(s)
 
     val = f(x0)

--- a/tests/test_components/test_adjoint.py
+++ b/tests/test_components/test_adjoint.py
@@ -1,0 +1,23 @@
+# tests adjoint parts of components
+
+import tidy3d as td
+import jax
+import jax.numpy as jnp
+
+def test_jax_field():
+
+
+	def f(x):
+		b = td.Box(
+			center=(0,0,0),
+			size=(x, x, x),
+		)
+
+		return jnp.sum(jnp.array(b.jax_info["size"]))
+
+	val = f(1.0)
+	grad = jax.grad(f)(1.0)
+
+	assert val >= 0.0
+	assert abs(grad) >= 0.0
+

--- a/tests/test_components/test_adjoint.py
+++ b/tests/test_components/test_adjoint.py
@@ -100,7 +100,7 @@ def test_flatten():
     """Test flatten / unflatten operations on tidy3d objects."""
 
     x = jnp.array(x0)
-    s1 = make_structure(x)
+    s1 = make_sim(x)
 
     leaves, treedef = jax.tree_util.tree_flatten(s1)
     s2 = jax.tree_util.tree_unflatten(treedef, leaves)

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -18,6 +18,8 @@ import yaml
 import numpy as np
 import h5py
 import xarray as xr
+
+# TODO: move this import elsewhere and catch if it breaks?
 import jax
 
 from .types import ComplexNumber, Literal, TYPE_TAG_STR

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Union
 from abc import ABC
 
 import xarray as xr
-import numpy as np
+import jax.numpy as np
 import dask
 import h5py
 

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -217,6 +217,7 @@ class FieldDataset(ElectromagneticFieldDataset):
         None,
         title="Ex",
         description="Spatial distribution of the x-component of the electric field.",
+        jax_field=True,
     )
     Ey: ScalarFieldDataArray = pd.Field(
         None,

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -1669,6 +1669,7 @@ class Box(Centered):
         title="Size",
         description="Size in x, y, and z directions.",
         units=MICROMETER,
+        jax_field=True,
     )
 
     @classmethod

--- a/tidy3d/components/grid/grid.py
+++ b/tidy3d/components/grid/grid.py
@@ -42,7 +42,10 @@ class Coords(Tidy3dBaseModel):
     @property
     def to_dict(self):
         """Return a dict of the three Coord1D objects as numpy arrays."""
-        return {key: np.array(value) for key, value in self.dict(exclude={TYPE_TAG_STR}).items()}
+        return {
+            key: np.array(value)
+            for key, value in self.dict(exclude={TYPE_TAG_STR, "jax_info", "jax_info"}).items()
+        }
 
     @property
     def to_list(self):
@@ -300,7 +303,8 @@ class Grid(Tidy3dBaseModel):
         >>> Nx, Ny, Nz = grid.num_cells
         """
         return [
-            len(coords1d) - 1 for coords1d in self.boundaries.dict(exclude={TYPE_TAG_STR}).values()
+            len(coords1d) - 1
+            for coords1d in self.boundaries.dict(exclude={TYPE_TAG_STR, "jax_info"}).values()
         ]
 
     @property
@@ -325,7 +329,7 @@ class Grid(Tidy3dBaseModel):
             applied.
         """
 
-        primal_steps = self._primal_steps.dict(exclude={TYPE_TAG_STR})
+        primal_steps = self._primal_steps.dict(exclude={TYPE_TAG_STR, "jax_info"})
         dsteps = {key: (psteps + np.roll(psteps, 1)) / 2 for (key, psteps) in primal_steps.items()}
 
         return Coords(**dsteps)


### PR DESCRIPTION
## Goal

instead of needing to import and use `tda.Jax_` components and add jax objects to `JaxSimulation.input_structures`, this PR attempts to add `jax` differentiability support to regular `td.` components. So you could in principle write an objective function completely in the `td.` namespace and then differentiate it with `jax`.


## Intro

Note for @yaugenst. I gave this a try, which would enable running regular `td.Simulation` with adjoint support. It was going ok but then I ran into an issue with defining a test `data = run(sim)`. `jax` does not want to call my `run_bwd` function for my `@custom_vjp` when computing the derivative of this step. I think it doesn't detect that the data is flowing through `data = run(sim)` as the gradient is just 0.0.

I ran into this same issue in the 2.7 refactor #1551 and don't remember exactly how I resolved it in the end..

Don't feel like you need to look into this, especially not until you join officially, but eventually I might need a 2nd pair of eyes on it eventually, so thought I'd publish as a draft PR.

## The Strategy

1. Add a new field to `Tidy3DBaseModel` called `jax_info : dict = {}`.  This dictionary should basically store all `jax`-traceable data for an instance, keeping it separate from the original fields, which might contain other types.
2. When we initialize a `Tidy3DBaseModel`any `pd.Field()` annotated as `jax_field=True` will store the passed data into `jax_info`. The passed data is also sanitized with `jax.lax.stop_gradient()` and passed to the original field.
3. Define `Simulation` and `SimulationData` as `@register_pytree_node_class` classes and define their tree flatten/unflatten operations. Basically the children are just the `jax_field` and everything else goes into the `aux_data`.
#
## A different strategy
Another approach could be to simply try to get all existing fields to work with `jax` types, as needed. The main challenge is the data objects I think. These are based on `xarray`, which seems fundamentally incompatible with `jax` unfortunately.

## Priority
This would definitely improve the usability of tidy3d for adjoint, but there's a ton of other stuff to do within the existing framework. So we need to balance the priority and not sink too much time into this. I'd say it's worth considering the feasibility and seeing if we can get this simple test working with an emulated `run()` function.  if it shows promise, we might want to build off of this new approach going forward and deprecate the `adjoint` plugin (still support it but not add any new features)




