### PR TITLE
fix plotting of 2d objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Bug in plotting and computing tilted plane intersections of transformed 0 thickness geometries.
 
 ## [2.7.0rc1] - 2024-04-22
 

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -534,7 +534,7 @@ class PolySlab(base.Planar):
         return inside_height * inside_polygon
 
     @verify_packages_import(["trimesh"])
-    def intersections_tilted_plane(
+    def _do_intersections_tilted_plane(
         self, normal: Coordinate, origin: Coordinate, to_2D: MatrixReal4x4
     ) -> List[Shapely]:
         """Return a list of shapely geometries at the plane specified by normal and origin.

--- a/tidy3d/components/geometry/primitives.py
+++ b/tidy3d/components/geometry/primitives.py
@@ -234,7 +234,7 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
         return self.axis
 
     @verify_packages_import(["trimesh"])
-    def intersections_tilted_plane(
+    def _do_intersections_tilted_plane(
         self, normal: Coordinate, origin: Coordinate, to_2D: MatrixReal4x4
     ) -> List[Shapely]:
         """Return a list of shapely geometries at the plane specified by normal and origin.


### PR DESCRIPTION
Found and issue with plotting `Transformed` objects that happen to have 0 thickness. The problem was that no intersections were found when using Trimesh to compute intersections. This is because all of the triangles were directly coincident on the intersection plane. This will not happen for fully 3D geometries.

I fixed it by reverting to simple intersection computations when the plane happens to be aligned with an axis. Another option would have been to give the object a very small thickness before meshing.

With this fix, I can correctly display geometries like:

![image](https://github.com/flexcompute/tidy3d/assets/155486263/d95ee136-288a-464c-b10f-5e8a6db94076)

