### PR TITLE
extra geometries for 2d material

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Convenience method `constant_loss_tangent_model` in `FastDispersionFitter` to fit constant loss tangent material model.
 - Classmethods in `DispersionFitter` to load complex-valued permittivity or loss tangent data.
 - Pre-upload validator to check that mode sources overlap with more than 2 grid cells.
+- Support `2DMedium` for `Transformed`/`GeometryGroup`/`ClipOperation` geometries.
 
 ### Changed
 - `tidy3d convert` from `.lsf` files to tidy3d scripts is moved to another repository at `https://github.com/hirako22/Lumerical-to-Tidy3D-Converter`.

--- a/tests/test_components/test_structure.py
+++ b/tests/test_components/test_structure.py
@@ -135,3 +135,79 @@ def test_invalid_polyslab(axis):
 
     geo7 = td.GeometryGroup(geometries=[(ps - box).rotated(np.pi / 4, j)]).rotated(-np.pi / 4, j)
     _ = td.Structure(geometry=geo7, medium=medium)
+
+
+def test_validation_of_structures_with_2d_materials():
+    med2d = td.Medium2D(ss=td.PEC, tt=td.PEC)
+
+    box2d = td.Box(size=(1, 0, 1))
+    polyslab2d = td.PolySlab(
+        vertices=((0, 0), (1, 0), (1, 1), (0, 1)), slab_bounds=(0.5, 0.5), axis=2
+    )
+    cylinder2d = td.Cylinder(axis=2, length=0, radius=1, center=(0, 0, 0.5))
+    geo_group2d = td.GeometryGroup(geometries=(cylinder2d, polyslab2d))
+    clip2d = td.ClipOperation(operation="union", geometry_a=cylinder2d, geometry_b=polyslab2d)
+
+    # Some test transformations that preserve the normal
+    translate = td.Transformed.translation(x=0, y=0, z=1)
+    rotate = td.Transformed.rotation(angle=np.pi * (1 / 8), axis=2)
+    scale = td.Transformed.scaling(x=2, y=2, z=1)
+    shift = td.Transformed(geometry=cylinder2d, transform=translate)
+    shift_rotate = td.Transformed(geometry=shift, transform=rotate)
+    transformed_2d = td.Transformed(geometry=shift_rotate, transform=scale)
+
+    allowed_geometries = [
+        box2d,
+        cylinder2d,
+        polyslab2d,
+        geo_group2d,
+        clip2d,
+        shift,
+        shift_rotate,
+        transformed_2d,
+    ]
+
+    for geom in allowed_geometries:
+        _ = td.Structure(geometry=geom, medium=med2d)
+
+    # Of course 3d objects should be NOT compatible with 2d materials
+    box3d = td.Box(size=(1, 1, 1))
+    polyslab3d = td.PolySlab(
+        vertices=((0, 0), (1, 0), (1, 1), (0, 1)), slab_bounds=(0, 0.5), axis=2
+    )
+    cylinder3d = td.Cylinder(axis=2, length=1.0, radius=1)
+    sphere = td.Sphere(center=(0, 1, 2), radius=2)
+
+    # Some test transformations that do NOT preserve the normal
+    rotate_bad = td.Transformed.rotation(angle=np.pi * (1 / 8), axis=0)
+    transformed_2d_bad = td.Transformed(geometry=cylinder2d, transform=rotate_bad)
+
+    # Geometries composed of sub geometries that are not coplanar
+    cylinder2d = td.Cylinder(axis=2, length=0, radius=1, center=(0, 0, 0.0))
+    geo_group2d_not_coplanar = td.GeometryGroup(geometries=(cylinder2d, polyslab2d))
+    clip2d_not_coplanar = td.ClipOperation(
+        operation="union", geometry_a=cylinder2d, geometry_b=polyslab2d
+    )
+
+    # Geometries composed of sub geometries that do not have the same normal
+    cylinder2d = td.Cylinder(axis=0, length=0, radius=1, center=(0, 0, 0.5))
+    geo_group2d_not_aligned = td.GeometryGroup(geometries=(cylinder2d, polyslab2d))
+    clip2d_not_aligned = td.ClipOperation(
+        operation="union", geometry_a=cylinder2d, geometry_b=polyslab2d
+    )
+
+    not_allowed_geometries = [
+        box3d,
+        polyslab3d,
+        cylinder3d,
+        sphere,
+        transformed_2d_bad,
+        geo_group2d_not_coplanar,
+        clip2d_not_coplanar,
+        geo_group2d_not_aligned,
+        clip2d_not_aligned,
+    ]
+
+    for geom in not_allowed_geometries:
+        with pytest.raises(pd.ValidationError):
+            _ = td.Structure(geometry=geom, medium=med2d)

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -431,6 +431,16 @@ class PolySlab(base.Planar):
             raise ValidationError("'Medium2D' requires the 'PolySlab' bounds to be equal.")
         return self.axis
 
+    def _update_from_bounds(self, bounds: Tuple[float, float], axis: Axis) -> PolySlab:
+        """Returns an updated geometry which has been transformed to fit within ``bounds``
+        along the ``axis`` direction."""
+        if axis != self.axis:
+            raise ValueError(
+                f"'_update_from_bounds' may only be applied along axis '{self.axis}', "
+                f"but was given axis '{axis}'."
+            )
+        return self.updated_copy(slab_bounds=bounds)
+
     @cached_property
     def is_ccw(self) -> bool:
         """Is this ``PolySlab`` CCW-oriented?"""

--- a/tidy3d/components/geometry/primitives.py
+++ b/tidy3d/components/geometry/primitives.py
@@ -10,7 +10,7 @@ import numpy as np
 import shapely
 
 from ..base import cached_property, skip_if_fields_missing
-from ..types import Axis, Bound, Coordinate, MatrixReal4x4, Shapely
+from ..types import Axis, Bound, Coordinate, MatrixReal4x4, Shapely, Tuple
 from ...exceptions import SetupError, ValidationError
 from ...constants import MICROMETER, LARGE_NUMBER
 from ...packaging import verify_packages_import
@@ -232,6 +232,19 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
         if self.length != 0:
             raise ValidationError("'Medium2D' requires the 'Cylinder' length to be zero.")
         return self.axis
+
+    def _update_from_bounds(self, bounds: Tuple[float, float], axis: Axis) -> Cylinder:
+        """Returns an updated geometry which has been transformed to fit within ``bounds``
+        along the ``axis`` direction."""
+        if axis != self.axis:
+            raise ValueError(
+                f"'_update_from_bounds' may only be applied along axis '{self.axis}', "
+                f"but was given axis '{axis}'."
+            )
+        new_center = list(self.center)
+        new_center[axis] = (bounds[0] + bounds[1]) / 2
+        new_length = bounds[1] - bounds[0]
+        return self.updated_copy(center=new_center, length=new_length)
 
     @verify_packages_import(["trimesh"])
     def _do_intersections_tilted_plane(

--- a/tidy3d/components/geometry/utils_2d.py
+++ b/tidy3d/components/geometry/utils_2d.py
@@ -5,17 +5,11 @@ from typing import Tuple, List
 
 from ..types import Axis
 from ...constants import inf
-from ...exceptions import ValidationError
 from ..geometry.base import Geometry, Box, ClipOperation
-from ..geometry.primitives import Cylinder
 from ..geometry.polyslab import PolySlab
 from ..grid.grid import Grid
 from ..scene import Scene
 from ..structure import Structure
-
-# for 2d materials. to find neighboring media, search a distance on either side
-# equal to this times the grid size
-DIST_NEIGHBOR_REL_2D_MED = 1e-5
 
 
 def increment_float(val: np.float32, sign) -> np.float32:
@@ -48,32 +42,12 @@ def get_bounds(geom: Geometry, axis: Axis) -> Tuple[float, float]:
     return (geom.bounds[0][axis], geom.bounds[1][axis])
 
 
-def set_bounds(geom: Geometry, bounds: Tuple[float, float], axis: Axis) -> Geometry:
-    """Set the bounds of a geometry in the axis direction."""
-    if isinstance(geom, Box):
-        new_center = list(geom.center)
-        new_center[axis] = (bounds[0] + bounds[1]) / 2
-        new_size = list(geom.size)
-        new_size[axis] = bounds[1] - bounds[0]
-        return geom.updated_copy(center=new_center, size=new_size)
-    if isinstance(geom, PolySlab):
-        return geom.updated_copy(slab_bounds=bounds)
-    if isinstance(geom, Cylinder):
-        new_center = list(geom.center)
-        new_center[axis] = (bounds[0] + bounds[1]) / 2
-        new_length = bounds[1] - bounds[0]
-        return geom.updated_copy(center=new_center, length=new_length)
-    raise ValidationError(
-        "'Medium2D' is only compatible with 'Box', 'PolySlab', or 'Cylinder' geometry."
-    )
-
-
 def get_thickened_geom(geom: Geometry, axis: Axis, axis_dl: float):
     """Helper to return a slightly thickened version of a planar geometry."""
     center = get_bounds(geom, axis)[0]
-    neg_thickness = axis_dl * DIST_NEIGHBOR_REL_2D_MED
-    pos_thickness = axis_dl * DIST_NEIGHBOR_REL_2D_MED
-    return set_bounds(geom, bounds=(center - neg_thickness, center + pos_thickness), axis=axis)
+    neg_thickness = increment_float(center, -1.0)
+    pos_thickness = increment_float(center, 1.0)
+    return geom._update_from_bounds(bounds=(neg_thickness, pos_thickness), axis=axis)
 
 
 def get_neighbors(
@@ -85,14 +59,16 @@ def get_neighbors(
     """Find the neighboring structures and return the tested positions above and below."""
     center = get_bounds(geom, axis)[0]
     check_delta = [
-        -axis_dl * DIST_NEIGHBOR_REL_2D_MED,
-        axis_dl * DIST_NEIGHBOR_REL_2D_MED,
+        increment_float(center, -1.0) - center,
+        increment_float(center, 1.0) - center,
     ]
 
     neighbors_below = []
     neighbors_above = []
     for _, position in enumerate(check_delta):
-        geom_shifted = set_bounds(geom, bounds=(center + position, center + position), axis=axis)
+        geom_shifted = geom._update_from_bounds(
+            bounds=(center + position, center + position), axis=axis
+        )
 
         # to prevent false positives due to 2D materials touching different materials
         # along their sides, shrink the bounds along the tangential directions by

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -19,7 +19,7 @@ from .validators import validate_mode_objects_symmetry
 from .geometry.base import Geometry, Box
 from .geometry.mesh import TriangleMesh
 from .geometry.utils import flatten_groups, traverse_geometries
-from .geometry.utils_2d import get_bounds, set_bounds, get_thickened_geom
+from .geometry.utils_2d import get_bounds, get_thickened_geom
 from .geometry.utils_2d import subdivide, snap_coordinate_to_grid
 from .types import Ax, FreqBound, Axis, annotate_type, InterpMethod, Symmetry
 from .types import Literal, TYPE_TAG_STR
@@ -1192,7 +1192,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
             center = get_bounds(geom, axis)[0]
             assert get_bounds(geom, axis)[0] == get_bounds(geom, axis)[1]
             snapped_center = snap_coordinate_to_grid(self.grid, center, axis)
-            return set_bounds(geom, (snapped_center, snapped_center), axis)
+            return geom._update_from_bounds(bounds=(snapped_center, snapped_center), axis=axis)
 
         lumped_structures = []
         for lumped_element in self.lumped_elements:
@@ -1259,7 +1259,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
                 )
 
                 new_bounds = (snapped_center, snapped_center)
-                new_geometry = set_bounds(snapped_geometry, bounds=new_bounds, axis=axis)
+                new_geometry = snapped_geometry._update_from_bounds(bounds=new_bounds, axis=axis)
                 new_structure = structure.updated_copy(geometry=new_geometry, medium=new_medium)
 
                 new_structures.append(new_structure)


### PR DESCRIPTION
Added the ability for Transformed/GeometryGroup/ClipOperation geometries to be composed of 2D materials.

Solves [issue 576](https://github.com/flexcompute/tidy3d-core/issues/576)