### PR TITLE
:package: BUILD: Fix the trigger develop cli action to sync branches

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -112,22 +112,11 @@ jobs:
     #  -----  install & configure poetry  -----
     #----------------------------------------------
     - name: Install Poetry
-      uses: abatilo/actions-poetry@v2
+      uses: snok/install-poetry@v1
       with:
-        version: 1.7.1
-
-    # After installing Poetry add to PATH
-    - name: Add Poetry's bin directory to PATH
-      run: |
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
-        echo $(which poetry)
-        echo $(poetry --version)
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: "poetry" # caching poetry dependencies
+        version: 1.8.2
+        virtualenvs-create: true
+        virtualenvs-in-project: true
 
     #----------------------------------------------
     # install your root project, if required

--- a/.github/workflows/test_develop_cli.yaml
+++ b/.github/workflows/test_develop_cli.yaml
@@ -4,29 +4,46 @@ on:
   workflow_dispatch:
   workflow_run:
     workflows: [ "tidy3d-frontend-tests" ]
-    types:
-      - completed
+    types: [ completed ]
 
 jobs:
+  on-success:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - run: echo 'The triggering workflow passed'
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo 'The triggering workflow failed'
+
   test-dev-commands:
+    needs: [on-success]
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.workflow_run.head_commit.id }}
+
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
 
     - name: Install Dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -e .[dev]
+        echo $(which python)
+        echo $(which python3)
+        python3 -m pip install --upgrade pip
+        python3 -m pip install -e .[dev]
+        python3 -m pip list
 
     - name: Ubuntu install Pandoc
       if: matrix.os == 'ubuntu-latest'
@@ -51,7 +68,7 @@ jobs:
     - name: Install Poetry
       uses: snok/install-poetry@v1
       with:
-        version: 1.7.1
+        version: 1.8.2
         virtualenvs-create: true
         virtualenvs-in-project: true
 


### PR DESCRIPTION
Hello! I think we need to merge this as soon as we can in order for the develop actions to begin running from the branch that triggered the build.

Also I found a bug on tidy3d-develop-cli that was testing the develop installation only on the develop  branch, but not on the actual branches where the commit was created in which I'm fixing.

Note that the develop action won't be fixed until we merge this into develop