### PR TITLE
:package: BUILD: Fix bump-to-version matching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,6 @@ parse = """(?x)
     (?P<minor>0|[1-9]\\d*)\\.
     (?P<patch>0|[1-9]\\d*)
     (?:
-        -                             # dash seperator for pre-release section
         (?P<pre_l>[a-zA-Z-]+)         # pre-release label
         (?P<pre_n>0|[1-9]\\d*)        # pre-release version number
     )?                                # pre-release section is optional
@@ -199,7 +198,7 @@ serialize = [
 search = "{current_version}"
 replace = "{new_version}"
 regex = false
-ignore_missing_version = false
+ignore_missing_version = true
 ignore_missing_files = false
 tag = false
 sign_tags = false
@@ -211,7 +210,7 @@ message = "Bump version: {current_version} → {new_version}"
 commit_args = ""
 
 [tool.bumpversion.parts.pre_l]
-values = ["dev", "rc"]
+values = ["rc", ""]
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"


### PR DESCRIPTION
This should do it:

```
± |dario/fix-bump-to-version {3} ✓| → bump-my-version show-bump 2.7.0rc1
2.7.0rc1 ── bump ─┬─ major ─ 3.0.0
                  ├─ minor ─ 2.8.0
                  ├─ patch ─ 2.7.1
                  ├─ pre_l ─ 2.7.0
                  ╰─ pre_n ─ 2.7.0rc2
```