### PR TITLE
Change default EME constraint to 'passive'

### DIFF
--- a/tidy3d/components/eme/simulation.py
+++ b/tidy3d/components/eme/simulation.py
@@ -205,7 +205,7 @@ class EMESimulation(AbstractYeeGridSimulation):
     )
 
     constraint: Optional[Literal["passive", "unitary"]] = pd.Field(
-        None,
+        "passive",
         title="EME Constraint",
         description="Constraint for EME propagation, imposed at cell interfaces. "
         "A constraint of 'passive' means that energy can be dissipated but not created at "


### PR DESCRIPTION
A default value of `sim.constraint=passive` results in nicer mode matching results and avoids strange behavior in field monitors (caused by some modal amplitudes being large)