### PR TITLE
fix: GDS export wrappers in `JaxSimulation` (#1334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `.gz` files in `Simulation` version updater.
 - Warning if a nonuniform custom medium is intersecting `PlaneWave`, `GaussianBeam`, `AstigmaticGaussianBeam`, `FieldProjectionCartesianMonitor`, `FieldProjectionAngleMonitor`, `FieldProjectionKSpaceMonitor`, and `DiffractionMonitor`.
 - Tidy3D objects may store arbitrary metadata in an `.attrs` dictionary.
+- `JaxSimulation` now supports the following GDS export methods: `to_gds()`, `to_gds_file()`, `to_gdspy()`, and `to_gdstk()`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Bug in plotting and computing tilted plane intersections of transformed 0 thickness geometries.
+- `Simulation.to_gdspy()` and `Simulation.to_gdstk()` now place polygons in GDS layer `(0, 0)` when no `gds_layer_dtype_map` is provided instead of erroring.
 
 ## [2.7.0rc1] - 2024-04-22
 

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -3378,6 +3378,9 @@ class Simulation(AbstractYeeGridSimulation):
         List
             List of `gdstk.Polygon`.
         """
+        if gds_layer_dtype_map is None:
+            gds_layer_dtype_map = {}
+
         axis, _ = self.geometry.parse_xyz_kwargs(x=x, y=y, z=z)
         _, bmin = self.pop_axis(self.bounds[0], axis)
         _, bmax = self.pop_axis(self.bounds[1], axis)
@@ -3438,6 +3441,9 @@ class Simulation(AbstractYeeGridSimulation):
         List
             List of `gdspy.Polygon` and `gdspy.PolygonSet`.
         """
+        if gds_layer_dtype_map is None:
+            gds_layer_dtype_map = {}
+
         axis, _ = self.geometry.parse_xyz_kwargs(x=x, y=y, z=z)
         _, bmin = self.pop_axis(self.bounds[0], axis)
         _, bmax = self.pop_axis(self.bounds[1], axis)

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -1,4 +1,5 @@
-""" Container holding all information about simulation and its components"""
+"""Container holding all information about simulation and its components"""
+
 from __future__ import annotations
 
 from typing import Dict, Tuple, List, Set, Union
@@ -3365,11 +3366,11 @@ class Simulation(AbstractYeeGridSimulation):
             Position of plane in y direction, only one of x,y,z can be specified to define plane.
         z : float = None
             Position of plane in z direction, only one of x,y,z can be specified to define plane.
-        permittivity_threshold : float = 1.001
-            Permitivitty value used to define the shape boundaries for structures with custom
+        permittivity_threshold : float = 1
+            Permittivity value used to define the shape boundaries for structures with custom
             medim
         frequency : float = 0
-            Frequency for permittivity evaluaiton in case of custom medium (Hz).
+            Frequency for permittivity evaluation in case of custom medium (Hz).
         gds_layer_dtype_map : Dict
             Dictionary mapping mediums to GDSII layer and data type tuples.
 
@@ -3497,11 +3498,11 @@ class Simulation(AbstractYeeGridSimulation):
             Position of plane in y direction, only one of x,y,z can be specified to define plane.
         z : float = None
             Position of plane in z direction, only one of x,y,z can be specified to define plane.
-        permittivity_threshold : float = 1.001
-            Permitivitty value used to define the shape boundaries for structures with custom
+        permittivity_threshold : float = 1
+            Permittivity value used to define the shape boundaries for structures with custom
             medim
         frequency : float = 0
-            Frequency for permittivity evaluaiton in case of custom medium (Hz).
+            Frequency for permittivity evaluation in case of custom medium (Hz).
         gds_layer_dtype_map : Dict
             Dictionary mapping mediums to GDSII layer and data type tuples.
         """
@@ -3563,11 +3564,11 @@ class Simulation(AbstractYeeGridSimulation):
             Position of plane in y direction, only one of x,y,z can be specified to define plane.
         z : float = None
             Position of plane in z direction, only one of x,y,z can be specified to define plane.
-        permittivity_threshold : float = 1.001
-            Permitivitty value used to define the shape boundaries for structures with custom
+        permittivity_threshold : float = 1
+            Permittivity value used to define the shape boundaries for structures with custom
             medim
         frequency : float = 0
-            Frequency for permittivity evaluaiton in case of custom medium (Hz).
+            Frequency for permittivity evaluation in case of custom medium (Hz).
         gds_layer_dtype_map : Dict
             Dictionary mapping mediums to GDSII layer and data type tuples.
         gds_cell_name : str = 'MAIN'

--- a/tidy3d/plugins/adjoint/components/simulation.py
+++ b/tidy3d/plugins/adjoint/components/simulation.py
@@ -1,4 +1,5 @@
 """Defines a jax-compatible simulation."""
+
 from __future__ import annotations
 
 from typing import Tuple, Union, List, Dict, Literal
@@ -17,6 +18,7 @@ from ....components.monitor import ModeMonitor, DiffractionMonitor, Monitor
 from ....components.simulation import Simulation
 from ....components.data.monitor_data import FieldData, PermittivityData
 from ....components.structure import Structure
+from ....components.medium import AbstractMedium
 from ....components.types import Ax, annotate_type
 from ....components.geometry.base import Box
 from ....constants import HERTZ, SECOND
@@ -432,6 +434,118 @@ class JaxSimulation(Simulation, JaxObject):
         )
 
         return sim, jax_info
+
+    def to_gds(
+        self,
+        cell,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        permittivity_threshold: pd.NonNegativeFloat = 1,
+        frequency: pd.PositiveFloat = 0,
+        gds_layer_dtype_map: Dict[
+            AbstractMedium, Tuple[pd.NonNegativeInt, pd.NonNegativeInt]
+        ] = None,
+    ) -> None:
+        """Append the simulation structures to a .gds cell.
+        Parameters
+        ----------
+        cell : ``gdstk.Cell`` or ``gdspy.Cell``
+            Cell object to which the generated polygons are added.
+        x : float = None
+            Position of plane in x direction, only one of x,y,z can be specified to define plane.
+        y : float = None
+            Position of plane in y direction, only one of x,y,z can be specified to define plane.
+        z : float = None
+            Position of plane in z direction, only one of x,y,z can be specified to define plane.
+        permittivity_threshold : float = 1
+            Permittivity value used to define the shape boundaries for structures with custom
+            medim
+        frequency : float = 0
+            Frequency for permittivity evaluation in case of custom medium (Hz).
+        gds_layer_dtype_map : Dict
+            Dictionary mapping mediums to GDSII layer and data type tuples.
+        """
+        sim, _ = self.to_simulation()
+        return sim.to_gds(
+            cell=cell,
+            x=x,
+            y=y,
+            z=z,
+            permittivity_threshold=permittivity_threshold,
+            frequency=frequency,
+            gds_layer_dtype_map=gds_layer_dtype_map,
+        )
+
+    def to_gdstk(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        permittivity_threshold: pd.NonNegativeFloat = 1,
+        frequency: pd.PositiveFloat = 0,
+        gds_layer_dtype_map: Dict[
+            AbstractMedium, Tuple[pd.NonNegativeInt, pd.NonNegativeInt]
+        ] = None,
+    ) -> List:
+        """Convert a simulation's planar slice to a .gds type polygon list.
+        Parameters
+        ----------
+        x : float = None
+            Position of plane in x direction, only one of x,y,z can be specified to define plane.
+        y : float = None
+            Position of plane in y direction, only one of x,y,z can be specified to define plane.
+        z : float = None
+            Position of plane in z direction, only one of x,y,z can be specified to define plane.
+        permittivity_threshold : float = 1
+            Permittivity value used to define the shape boundaries for structures with custom
+            medim
+        frequency : float = 0
+            Frequency for permittivity evaluation in case of custom medium (Hz).
+        gds_layer_dtype_map : Dict
+            Dictionary mapping mediums to GDSII layer and data type tuples.
+        Return
+        ------
+        List
+            List of `gdstk.Polygon`.
+        """
+        sim, _ = self.to_simulation()
+        return sim.to_gdstk(
+            x=x,
+            y=y,
+            z=z,
+            permittivity_threshold=permittivity_threshold,
+            frequency=frequency,
+            gds_layer_dtype_map=gds_layer_dtype_map,
+        )
+
+    def to_gdspy(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        gds_layer_dtype_map: Dict[
+            AbstractMedium, Tuple[pd.NonNegativeInt, pd.NonNegativeInt]
+        ] = None,
+    ) -> List:
+        """Convert a simulation's planar slice to a .gds type polygon list.
+        Parameters
+        ----------
+        x : float = None
+            Position of plane in x direction, only one of x,y,z can be specified to define plane.
+        y : float = None
+            Position of plane in y direction, only one of x,y,z can be specified to define plane.
+        z : float = None
+            Position of plane in z direction, only one of x,y,z can be specified to define plane.
+        gds_layer_dtype_map : Dict
+            Dictionary mapping mediums to GDSII layer and data type tuples.
+        Return
+        ------
+        List
+            List of `gdspy.Polygon` and `gdspy.PolygonSet`.
+        """
+        sim, _ = self.to_simulation()
+        return sim.to_gdspy(x=x, y=y, z=z, gds_layer_dtype_map=gds_layer_dtype_map)
 
     def plot(
         self,


### PR DESCRIPTION
Fixes #1334 by overriding `to_gds()` in `JaxSimulation` to call `self.to_simulation()` first. Addresses both `to_gds()` and `to_gds_file()` this way.