### PR TITLE
remove multi-threading from adjoint plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tidy3D objects may store arbitrary metadata in an `.attrs` dictionary.
 
 ### Changed
+- Removed multi-processing ability in adjoint plugin gradient calculation.
 
 ### Fixed
 - Bug in plotting and computing tilted plane intersections of transformed 0 thickness geometries.

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -51,7 +51,6 @@ TMP_PATH = None
 FWD_SIM_DATA_FILE = "adjoint_grad_data_fwd.hdf5"
 SIM_VJP_FILE = "adjoint_sim_vjp_file.hdf5"
 RUN_FILE = "simulation.hdf5"
-NUM_PROC_PARALLEL = 2
 
 EPS = 2.0
 SIZE = (1.0, 2.0, 3.0)
@@ -115,7 +114,6 @@ def run_emulated_bwd(
     folder_name: str,
     callback_url: str,
     verbose: bool,
-    num_proc: int = NUM_PROC_PARALLEL,
 ) -> JaxSimulation:
     """Runs adjoint simulation on our servers, grabs the gradient data from fwd for processing."""
 
@@ -135,9 +133,7 @@ def run_emulated_bwd(
     grad_data_adj = jax_sim_data_adj.grad_data_symmetry
 
     # get gradient and insert into the resulting simulation structure medium
-    sim_vjp = jax_sim_data_adj.simulation.store_vjp(
-        grad_data_fwd, grad_data_adj, grad_eps_data_fwd, num_proc=num_proc
-    )
+    sim_vjp = jax_sim_data_adj.simulation.store_vjp(grad_data_fwd, grad_data_adj, grad_eps_data_fwd)
 
     # write VJP sim to and from file to emulate webapi download and loading
     sim_vjp.to_file(str(TMP_PATH / SIM_VJP_FILE))
@@ -198,7 +194,6 @@ def run_async_emulated_bwd(
             folder_name=folder_name,
             callback_url=callback_url,
             verbose=verbose,
-            num_proc=NUM_PROC_PARALLEL,
         )
         sim_vjps_orig.append(sim_vjp)
 

--- a/tidy3d/plugins/adjoint/components/structure.py
+++ b/tidy3d/plugins/adjoint/components/structure.py
@@ -112,7 +112,6 @@ class AbstractJaxStructure(Structure, JaxObject):
         grad_data_eps: PermittivityData,
         sim_bounds: Bound,
         eps_out: complex,
-        num_proc: int = 1,
     ) -> JaxGeometryType:
         """Compute the VJP for the structure geometry."""
 
@@ -126,7 +125,6 @@ class AbstractJaxStructure(Structure, JaxObject):
             wvl_mat=medium_params["wvl_mat"],
             eps_out=eps_out,
             eps_in=medium_params["eps_in"],
-            num_proc=num_proc,
         )
 
     def medium_vjp(
@@ -156,7 +154,6 @@ class AbstractJaxStructure(Structure, JaxObject):
         grad_data_eps: PermittivityData,
         sim_bounds: Bound,
         eps_out: complex,
-        num_proc: int = 1,
     ) -> JaxStructure:
         """Returns the gradient of the structure parameters given forward and adjoint field data."""
 
@@ -174,7 +171,6 @@ class AbstractJaxStructure(Structure, JaxObject):
                 grad_data_eps=grad_data_eps,
                 sim_bounds=sim_bounds,
                 eps_out=eps_out,
-                num_proc=num_proc,
             )
 
         if "medium" in self._differentiable_fields:


### PR DESCRIPTION
May require a backend PR.

Turns out the multi-threading logic was causing the seg faulting in invdes plugin on ubuntu. I don't understand why.

Making this PR in case we need it later but will continue looking into it