### PR TITLE
feat: Support selection by nearest value in `JaxDataArray`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tidy3D objects may store arbitrary metadata in an `.attrs` dictionary.
 - `JaxSimulation` now supports the following GDS export methods: `to_gds()`, `to_gds_file()`, `to_gdspy()`, and `to_gdstk()`.
 - `RunTimeSpec` accepted by `Simulation.run_time` to adaptively set the run time based on Q-factor, propagation length, and other factors.
+- `JaxDataArray` now supports selection by nearest value via `JaxDataArray.sel(..., method="nearest")`.
 
 ### Changed
 - `tidy3d convert` from `.lsf` files to tidy3d scripts is moved to another repository at `https://github.com/hirako22/Lumerical-to-Tidy3D-Converter`.


### PR DESCRIPTION
Closes #1617

Also took the liberty to rework the mechanics of the old selection by vectorizing everything using numpy.
Note that there is a slight difference between xarray's exact selection and ours now, because I base selections off of `np.isclose` instead of doing exact float comparisions (`x == y`). I think this is more intuitive, as otherwise something like `x == 0.2` fails if `x` is a numpy float (`0.20000000000000018`).
I can change this  back to match xarray's behavior exactly if that's what we want to do.