### PR TITLE
Fast Dispersion Fitter: keep poles slightly away from input freqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug in plotting and computing tilted plane intersections of transformed 0 thickness geometries.
 - `Simulation.to_gdspy()` and `Simulation.to_gdstk()` now place polygons in GDS layer `(0, 0)` when no `gds_layer_dtype_map` is provided instead of erroring.
 - `task_id` now properly stored in `JaxSimulationData`.
+- Bug in `FastDispersionFitter` when poles move close to input frequencies.
 
 ## [2.7.0rc1] - 2024-04-22
 

--- a/tests/test_plugins/test_dispersion_fitter.py
+++ b/tests/test_plugins/test_dispersion_fitter.py
@@ -123,6 +123,15 @@ def test_lossy_dispersion(random_data, mock_remote_api):
     )
     medium3, rms3 = fitter.fit(advanced_param=advanced_param)
 
+    # test that poles can be close but not exactly equal to provided freqs
+    N = 2
+    wvl_um = np.linspace(0.5, 0.6, N)
+    n_data = np.ones(N) * 2
+    k_data = np.ones(N) * 0.5
+
+    fitter = FastDispersionFitter(wvl_um=wvl_um, n_data=n_data, k_data=k_data)
+    medium, rms_error = fitter.fit(max_num_poles=2, tolerance_rms=1e-3)
+
 
 def test_constant_loss_tangent():
     """perform fitting on constant loss tangent material"""


### PR DESCRIPTION
Sometimes in the fitter, the poles move close to the input freqs. When they move too close, the response function is invalid and the fitter errors. This PR keeps them a certain distance (1e-10 rad/s) away.


This PR should fix this issue:
https://github.com/flexcompute/tidy3d/issues/1631