### PR TITLE
validate single pixel mode source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JaxDataArray` now supports selection by nearest value via `JaxDataArray.sel(..., method="nearest")`.
 - Convenience method `constant_loss_tangent_model` in `FastDispersionFitter` to fit constant loss tangent material model.
 - Classmethods in `DispersionFitter` to load complex-valued permittivity or loss tangent data.
+- Pre-upload validator to check that mode sources overlap with more than 2 grid cells.
 
 ### Changed
 - `tidy3d convert` from `.lsf` files to tidy3d scripts is moved to another repository at `https://github.com/hirako22/Lumerical-to-Tidy3D-Converter`.


### PR DESCRIPTION
Validate that mode sources have at least 3 cells (even with size 0 it is possible to pick up 2 cells, so I chose 2 as the limit).

Also included are some changes to make ruff happy and fix some other tests that were affected by this new validation step.