### PR TITLE
Handle all remaining lint errors in tests

### DIFF
--- a/docs/_ext/custom-robots.py
+++ b/docs/_ext/custom-robots.py
@@ -2,9 +2,6 @@ import os
 
 
 def process_robots_txt(app, exception):
-    # Get the path to the source directory
-    srcdir = app.builder.srcdir
-
     # Get the path to the robots.txt file
     robots_file = os.path.join(app.outdir, "robots.txt")
 

--- a/tests/_test_data/_test_datasets_no_vtk.py
+++ b/tests/_test_data/_test_datasets_no_vtk.py
@@ -1,9 +1,10 @@
 """Tests tidy3d/components/data/dataset.py"""
+
 import pytest
 import builtins
 from ..test_data.test_datasets import test_triangular_dataset as _test_triangular_dataset
 from ..test_data.test_datasets import test_tetrahedral_dataset as _test_tetrahedral_dataset
-from ..utils import log_capture
+from ..utils import log_capture  # noqa: F401
 
 
 @pytest.fixture
@@ -19,10 +20,10 @@ def hide_vtk(monkeypatch, request):
 
 
 @pytest.mark.usefixtures("hide_vtk")
-def test_triangular_dataset_no_vtk(tmp_path, log_capture):
+def test_triangular_dataset_no_vtk(tmp_path, log_capture):  # noqa: F811
     _test_triangular_dataset(log_capture, tmp_path, "test_name", no_vtk=True)
 
 
 @pytest.mark.usefixtures("hide_vtk")
-def test_tetrahedral_dataset_no_vtk(tmp_path, log_capture):
+def test_tetrahedral_dataset_no_vtk(tmp_path, log_capture):  # noqa: F811
     _test_tetrahedral_dataset(log_capture, tmp_path, "test_name", no_vtk=True)

--- a/tests/_test_local/_test_adjoint_performance.py
+++ b/tests/_test_local/_test_adjoint_performance.py
@@ -5,7 +5,6 @@ from memory_profiler import profile
 import matplotlib.pyplot as plt
 import time
 
-import jax.numpy as jnp
 from jax import grad
 
 import tidy3d as td
@@ -240,21 +239,21 @@ def test_simple_jax_data_array(use_emulated_run):
 
     Nx, Ny, Nz, Nf = 300, 300, 1, 1
     VALUES = 2 + np.random.random((Nx, Ny, Nz, Nf))
-    data_array = make_data_array(VALUES)
+    data_array = make_data_array(VALUES)  # noqa: F841
 
     # the first 3 are fast, last one is slow
 
-    def f(values):
-        data_array = make_data_array(values)
-        return jnp.sum(data_array.values)
+    # def f(values):
+    #     data_array = make_data_array(values)
+    #     return jnp.sum(data_array.values)
 
-    def f(values):
-        custom_medium = make_custom_medium(values)
-        return jnp.sum(custom_medium.eps_dataset.eps_xx.values)
+    # def f(values):
+    #     custom_medium = make_custom_medium(values)
+    #     return jnp.sum(custom_medium.eps_dataset.eps_xx.values)
 
-    def f(values):
-        custom_structure = make_custom_structure(values)
-        return jnp.sum(custom_structure.medium.eps_dataset.eps_xx.values)
+    # def f(values):
+    #     custom_structure = make_custom_structure(values)
+    #     return jnp.sum(custom_structure.medium.eps_dataset.eps_xx.values)
 
     def f(values):
         sim = make_sim(values)

--- a/tests/_test_local/_test_adjoint_performance_multi.py
+++ b/tests/_test_local/_test_adjoint_performance_multi.py
@@ -26,7 +26,6 @@ surface_area = 6 * (N_SIDE * BOX_LENGTH**2)
 def make_sim(box_length) -> tda.JaxSimulation:
     """Construct a simulation out of some input parameters."""
 
-    num_structures = int(N_SIDE**2)
     sim_length = N_SIDE * (BOX_LENGTH + SPACE)
     med = tda.JaxMedium(permittivity=2.0)
 
@@ -85,7 +84,7 @@ def test_large_custom_medium(use_emulated_run):
 
     with cProfile.Profile() as pr:
         grad_f = jax.grad(f)
-        df_eps_values = grad_f(BOX_LENGTH)
+        df_eps_values = grad_f(BOX_LENGTH)  # noqa: F841
         pr.print_stats(sort="cumtime")
         pr.dump_stats("results.prof")
 

--- a/tests/_test_local/_test_data_performance.py
+++ b/tests/_test_local/_test_data_performance.py
@@ -100,7 +100,7 @@ def test_core_profile_small_1_save():
 def test_core_profile_small_2_load():
     with Profile():
         print(f"file_size = {os.path.getsize(PATH):.2e} Bytes")
-        data = td.FieldTimeData.from_file(PATH)
+        td.FieldTimeData.from_file(PATH)
 
 
 def test_core_profile_large():
@@ -159,7 +159,7 @@ def test_speed_many_datasets():
 
     with Profile():
         sim_data.to_file(PATH)
-        sim_data2 = sim_data.from_file(PATH)
+        sim_data.from_file(PATH)
 
 
 if __name__ == "__main__":

--- a/tests/_test_local/_test_web.py
+++ b/tests/_test_local/_test_web.py
@@ -1,4 +1,5 @@
-""" tests converted webapi """
+"""tests converted webapi"""
+
 import os
 from unittest import TestCase, mock
 

--- a/tests/_test_notebooks/full_test_notebooks.py
+++ b/tests/_test_notebooks/full_test_notebooks.py
@@ -195,10 +195,9 @@ def _run_notebook(notebook_fname):
         # try running the notebook
         try:
             # run from the `notebooks/` directory
-            out = ep.preprocess(nb, {"metadata": {"path": f"{NOTEBOOK_DIR}"}})
+            ep.preprocess(nb, {"metadata": {"path": f"{NOTEBOOK_DIR}"}})
         except CellExecutionError:
             # if there is an error, print message and fail test
-            out = None
             msg = 'Error executing the notebook "%s".\n\n' % notebook_fname
             msg += 'See notebook "%s" for the traceback.' % notebook_fname
             print(msg)

--- a/tests/test_cli/full_test_develop.py
+++ b/tests/test_cli/full_test_develop.py
@@ -1,6 +1,7 @@
 """
 These scripts just test the CLI commands for the develop command, and verify that they run properly.
 """
+
 import pytest
 import os
 from click.testing import CliRunner

--- a/tests/test_components/test_IO.py
+++ b/tests/test_components/test_IO.py
@@ -1,4 +1,5 @@
 """Tests file export and loading."""
+
 import os
 import json
 
@@ -214,7 +215,7 @@ def test_simulation_updater(sim_file):
     assert sim_updated.version == __version__, "Simulation not converted properly"
 
     # just make sure the loaded sim does something properly using this version
-    sim_updated.grid
+    sim_updated.grid  # noqa: B018
 
 
 def test_yaml(tmp_path):

--- a/tests/test_components/test_apodization.py
+++ b/tests/test_components/test_apodization.py
@@ -1,4 +1,5 @@
 """Tests mode objects."""
+
 import pytest
 import pydantic.v1 as pydantic
 import tidy3d as td

--- a/tests/test_components/test_base.py
+++ b/tests/test_components/test_base.py
@@ -1,4 +1,6 @@
 """Tests the base model."""
+# ruff: noqa: B015
+
 import pytest
 import numpy as np
 
@@ -177,7 +179,7 @@ def test_equality():
 def test_special_characters_in_name():
     """Test error if special characters are in a component's name."""
     with pytest.raises(ValueError):
-        mnt = td.FluxMonitor(size=(1, 1, 0), freqs=np.array([1, 2, 3]) * 1e12, name="mnt/flux")
+        td.FluxMonitor(size=(1, 1, 0), freqs=np.array([1, 2, 3]) * 1e12, name="mnt/flux")
 
 
 def test_attrs(tmp_path):

--- a/tests/test_components/test_boundaries.py
+++ b/tests/test_components/test_boundaries.py
@@ -9,7 +9,8 @@ from tidy3d.components.boundary import Periodic, PECBoundary, PMCBoundary, Bloch
 from tidy3d.components.boundary import PML, StablePML, Absorber
 from tidy3d.components.source import GaussianPulse, PlaneWave, PointDipole
 from tidy3d.exceptions import SetupError, DataError
-from ..utils import assert_log_level, log_capture
+from ..utils import assert_log_level
+from ..utils import log_capture  # noqa: F401
 
 
 def test_bloch_phase():
@@ -77,14 +78,14 @@ def test_boundary_validators():
 
 
 @pytest.mark.parametrize("boundary, log_level", [(PMCBoundary(), None), (Periodic(), "WARNING")])
-def test_boundary_validator_warnings(log_capture, boundary, log_level):
+def test_boundary_validator_warnings(log_capture, boundary, log_level):  # noqa: F811
     """Test the validators in class `Boundary` which should show a warning but not an error"""
     boundary = Boundary(plus=PECBoundary(), minus=boundary)
     assert_log_level(log_capture, log_level)
 
 
 @pytest.mark.parametrize("boundary, log_level", [(PMCBoundary(), None), (Periodic(), "WARNING")])
-def test_boundary_validator_warnings_switched(log_capture, boundary, log_level):
+def test_boundary_validator_warnings_switched(log_capture, boundary, log_level):  # noqa: F811
     """Test the validators in class `Boundary` which should show a warning but not an error"""
     boundary = Boundary(minus=PECBoundary(), plus=boundary)
     assert_log_level(log_capture, log_level)
@@ -173,5 +174,5 @@ def test_boundaryspec_classmethods():
     boundary_spec = BoundarySpec.all_sides(boundary=PML())
     boundaries = boundary_spec.to_list
     assert all(
-        [isinstance(boundary, PML) for boundary_dim in boundaries for boundary in boundary_dim]
+        isinstance(boundary, PML) for boundary_dim in boundaries for boundary in boundary_dim
     )

--- a/tests/test_components/test_eme.py
+++ b/tests/test_components/test_eme.py
@@ -621,7 +621,7 @@ def _get_eme_mode_solver_data():
         monitor=monitor,
         grid_primal_correction=grid_primal_correction,
         grid_dual_correction=grid_dual_correction,
-        **kwargs
+        **kwargs,
     )
 
 

--- a/tests/test_components/test_field_projection.py
+++ b/tests/test_components/test_field_projection.py
@@ -1,4 +1,6 @@
 """Test near field to far field transformations."""
+# ruff: noqa: B018
+
 import numpy as np
 import tidy3d as td
 import pytest
@@ -334,7 +336,7 @@ def test_proj_clientside():
     far_fields_angular.fields_cartesian
     far_fields_angular.radar_cross_section
     far_fields_angular.power
-    for key, val in far_fields_angular.field_components.items():
+    for val in far_fields_angular.field_components.values():
         val.sel(f=f0)
     far_fields_angular.renormalize_fields(proj_distance=5e6)
 
@@ -345,7 +347,7 @@ def test_proj_clientside():
     far_fields_cartesian.fields_cartesian
     far_fields_cartesian.radar_cross_section
     far_fields_cartesian.power
-    for key, val in far_fields_cartesian.field_components.items():
+    for val in far_fields_cartesian.field_components.values():
         val.sel(f=f0)
     far_fields_cartesian.renormalize_fields(proj_distance=5e6)
 
@@ -356,7 +358,7 @@ def test_proj_clientside():
     far_fields_kspace.fields_cartesian
     far_fields_kspace.radar_cross_section
     far_fields_kspace.power
-    for key, val in far_fields_kspace.field_components.items():
+    for val in far_fields_kspace.field_components.values():
         val.sel(f=f0)
     far_fields_kspace.renormalize_fields(proj_distance=5e6)
 
@@ -367,7 +369,7 @@ def test_proj_clientside():
     exact_fields_cartesian.fields_cartesian
     exact_fields_cartesian.radar_cross_section
     exact_fields_cartesian.power
-    for key, val in exact_fields_cartesian.field_components.items():
+    for val in exact_fields_cartesian.field_components.values():
         val.sel(f=f0)
     with pytest.raises(DataError):
         exact_fields_cartesian.renormalize_fields(proj_distance=5e6)

--- a/tests/test_components/test_grid.py
+++ b/tests/test_components/test_grid.py
@@ -1,4 +1,5 @@
 """Tests grid operations."""
+
 import pytest
 import numpy as np
 

--- a/tests/test_components/test_grid_spec.py
+++ b/tests/test_components/test_grid_spec.py
@@ -1,4 +1,5 @@
 """Tests GridSpec."""
+
 import pytest
 import numpy as np
 
@@ -95,7 +96,6 @@ def test_autogrid_2dmaterials():
     sigma = 0.45
     thickness = 0.01
     medium = td.Medium2D.from_medium(td.Medium(conductivity=sigma), thickness=thickness)
-    grid_dl = 0.03
     box = td.Structure(geometry=td.Box(size=(td.inf, td.inf, 0), center=(0, 0, 1)), medium=medium)
     src = td.UniformCurrentSource(
         source_time=td.GaussianPulse(freq0=1.5e14, fwidth=0.5e14),
@@ -115,7 +115,7 @@ def test_autogrid_2dmaterials():
         run_time=1e-12,
     )
     assert np.isclose(sim.volumetric_structures[0].geometry.bounding_box.center[2], 1, rtol=RTOL)
-    grid_dl = sim.discretize(box.geometry).sizes.z[0]
+    sim.discretize(box.geometry).sizes.z[0]
     assert np.isclose(sim.volumetric_structures[0].geometry.bounding_box.size[2], 0, rtol=RTOL)
 
     # now if we increase conductivity, the in-plane grid size should decrease
@@ -135,8 +135,8 @@ def test_autogrid_2dmaterials():
         grid_spec=td.GridSpec.auto(),
         run_time=1e-12,
     )
-    grid_dl1_inplane = sim.discretize(box.geometry).sizes.x[0]
-    grid_dl2_inplane = sim2.discretize(box2.geometry).sizes.x[0]
+    grid_dl1_inplane = sim.discretize(box.geometry).sizes.x[0]  # noqa: F841
+    grid_dl2_inplane = sim2.discretize(box2.geometry).sizes.x[0]  # noqa: F841
     # This is commented out until inplane AutoGrid for 2D materials is enabled
     # assert grid_dl1_inplane > grid_dl2_inplane
 

--- a/tests/test_components/test_heat.py
+++ b/tests/test_components/test_heat.py
@@ -28,9 +28,8 @@ from tidy3d import TemperatureData
 from tidy3d.exceptions import DataError
 
 from ..utils import (
-    STL_GEO,
     assert_log_level,
-    log_capture,
+    log_capture,  # noqa: F401
     AssertLogLevel,
     cartesian_to_unstructured,
 )
@@ -401,7 +400,7 @@ def test_heat_sim():
 
 
 @pytest.mark.parametrize("shift_amount, log_level", ((1, None), (2, "WARNING")))
-def test_heat_sim_bounds(shift_amount, log_level, log_capture):
+def test_heat_sim_bounds(shift_amount, log_level, log_capture):  # noqa: F811
     """make sure bounds are working correctly"""
 
     # make sure all things are shifted to this central location
@@ -451,7 +450,7 @@ def test_heat_sim_bounds(shift_amount, log_level, log_capture):
         ((0.1, 0.1, 1), "WARNING"),
     ],
 )
-def test_sim_structure_extent(log_capture, box_size, log_level):
+def test_sim_structure_extent(log_capture, box_size, log_level):  # noqa: F811
     """Make sure we warn if structure extends exactly to simulation edges."""
 
     box = td.Structure(geometry=td.Box(size=box_size), medium=td.Medium(permittivity=2))
@@ -510,7 +509,7 @@ def test_sim_data():
         _ = heat_sim_data.updated_copy(simulation=sim)
 
 
-def test_relative_min_dl_warning(log_capture):
+def test_relative_min_dl_warning(log_capture):  # noqa: F811
     with AssertLogLevel(log_capture, "WARNING"):
         _ = td.HeatSimulation(
             size=(1, 1, 1),

--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -1,11 +1,13 @@
 """Tests mediums."""
+
 import numpy as np
 import pytest
 import pydantic.v1 as pydantic
 import matplotlib.pyplot as plt
 import tidy3d as td
 from tidy3d.exceptions import ValidationError, SetupError
-from ..utils import assert_log_level, log_capture, AssertLogLevel
+from ..utils import assert_log_level, AssertLogLevel
+from ..utils import log_capture  # noqa: F401
 from typing import Dict
 
 MEDIUM = td.Medium()
@@ -80,7 +82,7 @@ def test_medium_conversions():
     assert np.isclose(k, k_)
 
 
-def test_lorentz_medium_conversions(log_capture):
+def test_lorentz_medium_conversions(log_capture):  # noqa: F811
     freq = 3.0
 
     # lossless, eps_r > 1
@@ -350,7 +352,7 @@ def test_n_cfl():
     assert material.n_cfl == 2
 
 
-def test_gain_medium(log_capture):
+def test_gain_medium(log_capture):  # noqa: F811
     """Test passive and gain medium validations."""
     # non-dispersive
     with pytest.raises(pydantic.ValidationError):
@@ -394,7 +396,7 @@ def test_gain_medium(log_capture):
         _ = td.AnisotropicMedium(xx=td.Medium(), yy=mL, zz=mS, allow_gain=False)
 
 
-def test_medium2d(log_capture):
+def test_medium2d(log_capture):  # noqa: F811
     sigma = 0.45
     thickness = 0.01
     cond_med = td.Medium(conductivity=sigma)
@@ -500,7 +502,7 @@ def test_fully_anisotropic_media():
     )
 
     # check eps_model can be called with an array of frequencies
-    eps = m.eps_model(np.linspace(1e12, 2e12, 10))
+    m.eps_model(np.linspace(1e12, 2e12, 10))
 
     assert np.allclose(m.permittivity, perm)
     assert np.allclose(m.conductivity, cond)
@@ -605,7 +607,7 @@ def test_perturbation_medium():
         )
 
 
-def test_nonlinear_medium(log_capture):
+def test_nonlinear_medium(log_capture):  # noqa: F811
     med = td.Medium(
         nonlinear_spec=td.NonlinearSpec(
             models=[
@@ -736,9 +738,9 @@ def test_nonlinear_medium(log_capture):
     modulation_spec = MODULATION_SPEC.updated_copy(permittivity=ST)
     modulated = td.Medium(permittivity=2, modulation_spec=modulation_spec)
     with pytest.raises(ValidationError):
-        medium2d = td.Medium2D(ss=medium, tt=medium)
+        td.Medium2D(ss=medium, tt=medium)
     with pytest.raises(ValidationError):
-        medium2d = td.Medium2D(ss=modulated, tt=modulated)
+        td.Medium2D(ss=modulated, tt=modulated)
 
 
 def test_lumped_resistor():

--- a/tests/test_components/test_meshgenerate.py
+++ b/tests/test_components/test_meshgenerate.py
@@ -1,4 +1,5 @@
 """Tests generating meshes."""
+
 import numpy as np
 import warnings
 import pytest
@@ -7,7 +8,8 @@ import tidy3d as td
 from tidy3d.constants import fp_eps
 from tidy3d.components.grid.mesher import GradedMesher
 
-from ..utils import assert_log_level, log_capture, cartesian_to_unstructured
+from ..utils import assert_log_level, cartesian_to_unstructured
+from ..utils import log_capture  # noqa: F401
 
 np.random.seed(4)
 
@@ -72,7 +74,7 @@ def validate_dl_in_interval(
 def test_uniform_grid_in_interval():
     """Uniform mesh in an interval"""
 
-    for i in range(100):
+    for _ in range(100):
         len_interval = 10.0 - np.random.random(1)[0]
         # max_scale = 1, but left_dl != right_dl
         left_dl = np.random.random(1)[0]
@@ -131,7 +133,7 @@ def test_asending_grid_in_interval():
     validate_dl_in_interval(dl, max_scale, left_dl, right_dl, max_dl, len_interval)
 
     # randoms
-    for i in range(100):
+    for _ in range(100):
         max_scale = 1 + np.random.random(1)[0]
         left_dl = np.random.random(1)[0]
         right_dl = 10
@@ -170,7 +172,7 @@ def test_asending_plateau_grid_in_interval():
     validate_dl_in_interval(dl, max_scale, left_dl, right_dl, max_dl, len_interval)
 
     # randoms
-    for i in range(100):
+    for _ in range(100):
         max_scale = 1 + np.random.random(1)[0]
         left_dl = np.random.random(1)[0]
         right_dl = 10
@@ -205,7 +207,7 @@ def test_asending_plateau_desending_grid_in_interval():
     validate_dl_in_interval(dl, max_scale, left_dl, right_dl, max_dl, len_interval)
 
     # randoms
-    for i in range(100):
+    for _ in range(100):
         max_scale = 1 + np.random.random(1)[0]
         left_dl = np.random.random(1)[0]
         right_dl = np.random.random(1)[0]
@@ -243,7 +245,7 @@ def test_asending_desending_grid_in_interval():
     # print(dl)
 
     # randoms
-    for i in range(100):
+    for _ in range(100):
         max_scale = 1 + np.random.random(1)[0]
         left_dl = np.random.random(1)[0]
         right_dl = np.random.random(1)[0]
@@ -266,7 +268,7 @@ def test_grid_in_interval():
     """Nonuniform mesh in an interval"""
 
     # randoms
-    for i in range(100):
+    for _ in range(100):
         max_scale = 1 + np.random.random(1)[0]
         left_dl = np.random.randint(1, 10) * np.random.random(1)[0]
         right_dl = np.random.randint(1, 10) * np.random.random(1)[0]
@@ -309,7 +311,7 @@ def test_grid_refinement():
 
     num_intervals = 100
     max_shrink = 1
-    for i in range(50):
+    for _ in range(50):
         max_dl_list = np.random.random(num_intervals)
         len_interval_list = np.random.random(num_intervals) * 10
         too_short_ind = len_interval_list < max_dl_list
@@ -621,7 +623,7 @@ def test_mesher_timeout():
     mediums = [td.Medium(permittivity=n**2) for n in (1 + (n_max - 1) * np.random.rand(100))]
 
     boxes = []
-    for i in range(num_boxes):
+    for _ in range(num_boxes):
         center = sim_size * (np.random.rand(3) - 0.5)
         center[0] = 0
         size = np.abs(box_scale * np.random.randn(3))
@@ -649,7 +651,7 @@ def test_mesher_timeout():
     _ = sim.grid
 
 
-def test_small_structure_size(log_capture):
+def test_small_structure_size(log_capture):  # noqa: F811
     """Test that a warning is raised if a structure size is small during the auto meshing"""
     box_size = 0.03
     medium = td.Medium(permittivity=4)
@@ -673,7 +675,7 @@ def test_small_structure_size(log_capture):
     # Warning not raised if structure is higher index
     log_capture.clear()
     box2 = box.updated_copy(medium=td.Medium(permittivity=300))
-    sim2 = sim.updated_copy(structures=[box2])
+    sim.updated_copy(structures=[box2])
     assert len(log_capture) == 0
 
     # Warning not raised if structure is covered by an override structure
@@ -691,7 +693,7 @@ def test_small_structure_size(log_capture):
     box3 = td.Structure(
         geometry=td.Box(center=(box_size, 0, 0), size=(box_size, td.inf, td.inf)), medium=medium
     )
-    sim4 = sim.updated_copy(structures=[box3, box])
+    sim.updated_copy(structures=[box3, box])
     assert_log_level(log_capture, "WARNING")
 
 

--- a/tests/test_components/test_mode.py
+++ b/tests/test_components/test_mode.py
@@ -1,4 +1,5 @@
 """Tests mode objects."""
+
 import pytest
 import pydantic.v1 as pydantic
 import numpy as np

--- a/tests/test_components/test_monitor.py
+++ b/tests/test_components/test_monitor.py
@@ -1,10 +1,13 @@
 """Tests monitors."""
+# ruff: noqa: B018
+
 import pytest
 import pydantic.v1 as pydantic
 import numpy as np
 import tidy3d as td
 from tidy3d.exceptions import SetupError, ValidationError
-from ..utils import assert_log_level, log_capture
+from ..utils import assert_log_level
+from ..utils import log_capture  # noqa: F401
 
 
 def test_stop_start():
@@ -23,7 +26,7 @@ time_sampling_tests = [
 
 
 @pytest.mark.parametrize("interval, start, stop, log_desired", time_sampling_tests)
-def test_monitor_interval_warn(log_capture, interval, start, stop, log_desired):
+def test_monitor_interval_warn(log_capture, interval, start, stop, log_desired):  # noqa: F811
     """Assert time monitor interval warning handled as expected."""
 
     mnt = td.FluxTimeMonitor(size=(1, 1, 0), name="f", interval=interval, stop=stop, start=start)
@@ -244,7 +247,7 @@ def test_monitor_freqs_empty():
         )
 
 
-def test_monitor_colocate(log_capture):
+def test_monitor_colocate(log_capture):  # noqa: F811
     """test default colocate value, and warning if not set"""
 
     monitor = td.FieldMonitor(
@@ -269,10 +272,10 @@ def test_monitor_colocate(log_capture):
 @pytest.mark.parametrize(
     "freqs, log_level", [(np.arange(1, 2500), "WARNING"), (np.arange(1, 100), None)]
 )
-def test_monitor_num_freqs(log_capture, freqs, log_level):
+def test_monitor_num_freqs(log_capture, freqs, log_level):  # noqa: F811
     """test default colocate value, and warning if not set"""
 
-    monitor = td.FieldMonitor(
+    td.FieldMonitor(
         size=(td.inf, td.inf, td.inf),
         freqs=freqs * 1e12,
         name="test",
@@ -282,10 +285,10 @@ def test_monitor_num_freqs(log_capture, freqs, log_level):
 
 
 @pytest.mark.parametrize("num_modes, log_level", [(101, "WARNING"), (100, None)])
-def test_monitor_num_modes(log_capture, num_modes, log_level):
+def test_monitor_num_modes(log_capture, num_modes, log_level):  # noqa: F811
     """test default colocate value, and warning if not set"""
 
-    monitor = td.ModeMonitor(
+    td.ModeMonitor(
         size=(td.inf, 0, td.inf),
         freqs=np.linspace(1e14, 2e14, 100),
         name="test",

--- a/tests/test_components/test_parameter_perturbation.py
+++ b/tests/test_components/test_parameter_perturbation.py
@@ -1,4 +1,5 @@
 """Tests parameter perturbations."""
+
 import numpy as np
 import matplotlib.pyplot as plt
 import pytest

--- a/tests/test_components/test_scene.py
+++ b/tests/test_components/test_scene.py
@@ -1,4 +1,5 @@
 """Tests the scene and its validators."""
+
 import pytest
 import pydantic.v1 as pd
 import matplotlib.pyplot as plt

--- a/tests/test_components/test_sidewall.py
+++ b/tests/test_components/test_sidewall.py
@@ -1,4 +1,5 @@
-"""test slanted polyslab can be correctly setup and visualized. """
+"""test slanted polyslab can be correctly setup and visualized."""
+
 import pytest
 import numpy as np
 import pydantic.v1 as pydantic
@@ -309,7 +310,7 @@ def test_shift_height_poly(execution_number):
     # avoid vertex-edge crossing case
     try:
         s = setup_polyslab(vertices, dilation, angle, bounds)
-    except:
+    except Exception:
         s = None
     if s is not None:
         for axis in (0, 1):
@@ -338,7 +339,7 @@ def test_intersection_with_inside_poly():
     # multiple vertices touching axis
     vertices_list.append([[0, -1], [0, 0], [0, 1], [0, 2], [-1, 2], [-1, -1]])
     # random vertices
-    for i in range(Ntest):
+    for _ in range(Ntest):
         vertices_list.append(np.array(convert_valid_polygon(np.random.random((N, 2)) * Lx)))
 
     # different polyslab axis
@@ -362,7 +363,7 @@ def test_intersection_with_inside_poly():
                 # avoid vertex-edge crossing case
                 try:
                     s_bottom = setup_polyslab(vertices, dilation, angle, bounds, axis=axis)
-                except:
+                except Exception:
                     continue
                 s_top = convert_polyslab_other_reference_plane(s_bottom, "top")
                 s_middle = convert_polyslab_other_reference_plane(s_bottom, "middle")
@@ -473,7 +474,7 @@ def test_bound_poly(execution_number):
         # avoid vertex-edge crossing case
         try:
             s = setup_polyslab(vertices, dilation, angle, bounds, reference_plane=reference_plane)
-        except:
+        except Exception:
             continue
         validate_poly_bound(s)
 
@@ -490,7 +491,7 @@ def test_bound_poly(execution_number):
         # avoid vertex-edge crossing case
         try:
             s = setup_polyslab(vertices, dilation, angle, bounds)
-        except:
+        except Exception:
             continue
         s = convert_polyslab_other_reference_plane(s, reference_plane)
         validate_poly_bound(s)

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -1,4 +1,5 @@
 """Tests the simulation and its validators."""
+
 import pytest
 import pydantic.v1 as pydantic
 import matplotlib.pyplot as plt
@@ -10,8 +11,14 @@ from tidy3d.exceptions import SetupError, Tidy3dKeyError
 from tidy3d.components import simulation
 from tidy3d.components.simulation import MAX_NUM_SOURCES
 from tidy3d.components.scene import MAX_NUM_MEDIUMS, MAX_GEOMETRY_COUNT
-from ..utils import assert_log_level, SIM_FULL, run_emulated, AssertLogLevel
-from ..utils import cartesian_to_unstructured, log_capture  # noqa: F401
+from ..utils import (
+    assert_log_level,
+    SIM_FULL,
+    run_emulated,
+    AssertLogLevel,
+    cartesian_to_unstructured,
+)
+from ..utils import log_capture  # noqa: F401
 
 SIM = td.Simulation(size=(1, 1, 1), run_time=1e-12, grid_spec=td.GridSpec(wavelength=1.0))
 
@@ -1278,7 +1285,10 @@ def test_sim_structure_extent(log_capture, box_size, log_level):  # noqa F811
     ],
 )
 def test_sim_validate_structure_bounds_pml(
-    log_capture, box_length, absorb_type, log_level  # noqa: F811
+    log_capture,  # noqa: F811
+    box_length,
+    absorb_type,
+    log_level,
 ):
     """Make sure we warn if structure bounds are within the PML exactly to simulation edges."""
 
@@ -1594,10 +1604,16 @@ def test_tfsf_boundaries(log_capture):  # noqa F811
         sources=[source],
         boundary_spec=td.BoundarySpec(
             x=td.Boundary.bloch_from_source(
-                source=source, domain_size=0.5 * 1.1, axis=0, medium=None  # wrong domain size
+                source=source,
+                domain_size=0.5 * 1.1,
+                axis=0,
+                medium=None,  # wrong domain size
             ),
             y=td.Boundary.bloch_from_source(
-                source=source, domain_size=0.5 * 1.1, axis=1, medium=None  # wrong domain size
+                source=source,
+                domain_size=0.5 * 1.1,
+                axis=1,
+                medium=None,  # wrong domain size
             ),
             z=td.Boundary.pml(),
         ),

--- a/tests/test_components/test_source.py
+++ b/tests/test_components/test_source.py
@@ -1,4 +1,5 @@
 """Tests sources."""
+
 import pytest
 import pydantic.v1 as pydantic
 import matplotlib.pyplot as plt
@@ -6,7 +7,8 @@ import numpy as np
 import tidy3d as td
 from tidy3d.exceptions import SetupError
 from tidy3d.components.source import DirectionalSource, CHEB_GRID_WIDTH
-from ..utils import assert_log_level, log_capture, AssertLogLevel
+from ..utils import assert_log_level, AssertLogLevel
+from ..utils import log_capture  # noqa: F401
 
 ST = td.GaussianPulse(freq0=2e14, fwidth=1e14)
 S = td.PointDipole(source_time=ST, polarization="Ex")
@@ -261,7 +263,7 @@ def test_broadband_source():
         )
 
 
-def test_custom_source_time(log_capture):
+def test_custom_source_time(log_capture):  # noqa: F811
     ts = np.linspace(0, 30e-12, 1001)
     amp_time = ts / max(ts)
     freq0 = 1e12
@@ -287,7 +289,6 @@ def test_custom_source_time(log_capture):
 
     # test out of range handling
     source = td.PointDipole(center=(0, 0, 0), source_time=cst, polarization="Ex")
-    monitor = td.FieldMonitor(size=(td.inf, td.inf, 0), freqs=[1e12], name="field")
     sim = td.Simulation(
         size=(10, 10, 10),
         run_time=1e-12,

--- a/tests/test_components/test_time_modulation.py
+++ b/tests/test_components/test_time_modulation.py
@@ -1,4 +1,5 @@
 """Tests space time modulation."""
+
 import numpy as np
 import pytest
 from math import isclose
@@ -157,12 +158,12 @@ def test_modulated_medium():
     # unmodulated
     medium = td.Medium()
     assert medium.modulation_spec is None
-    assert medium.is_time_modulated == False
+    assert not medium.is_time_modulated
     reduce(medium)
 
-    assert MODULATION_SPEC.applied_modulation == False
+    assert not MODULATION_SPEC.applied_modulation
     medium = medium.updated_copy(modulation_spec=MODULATION_SPEC)
-    assert medium.is_time_modulated == False
+    assert not medium.is_time_modulated
     reduce(medium)
 
     # permittivity modulated
@@ -207,26 +208,26 @@ def test_unsupported_modulated_medium_types():
 
     # PEC cannot be modulated
     with pytest.raises(pydantic.ValidationError):
-        mat = td.PECMedium(modulation_spec=modulation_spec)
+        td.PECMedium(modulation_spec=modulation_spec)
 
     # For Anisotropic medium, one should modulate the components, not the whole medium
     with pytest.raises(pydantic.ValidationError):
-        mat = td.AnisotropicMedium(
+        td.AnisotropicMedium(
             xx=td.Medium(), yy=td.Medium(), zz=td.Medium(), modulation_spec=modulation_spec
         )
 
     # Modulation to fully Anisotropic medium unsupported
     with pytest.raises(pydantic.ValidationError):
-        mat = td.FullyAnisotropicMedium(modulation_spec=modulation_spec)
+        td.FullyAnisotropicMedium(modulation_spec=modulation_spec)
 
     # 2D material
     with pytest.raises(pydantic.ValidationError):
         drude_medium = td.Drude(eps_inf=2.0, coeffs=[(1, 2), (3, 4)])
-        medium2d = td.Medium2D(ss=drude_medium, tt=drude_medium, modulation_spec=modulation_spec)
+        td.Medium2D(ss=drude_medium, tt=drude_medium, modulation_spec=modulation_spec)
 
     # together with nonlinear_spec
     with pytest.raises(pydantic.ValidationError):
-        mat = td.Medium(
+        td.Medium(
             permittivity=2,
             nonlinear_spec=td.NonlinearSusceptibility(chi3=1),
             modulation_spec=modulation_spec,

--- a/tests/test_components/test_types.py
+++ b/tests/test_components/test_types.py
@@ -1,4 +1,5 @@
 """Tests type definitions."""
+
 import pytest
 import pydantic.v1 as pydantic
 from tidy3d.components.types import ArrayLike, Complex, constrained_array, Tuple

--- a/tests/test_components/test_viz.py
+++ b/tests/test_components/test_viz.py
@@ -1,4 +1,5 @@
 """Tests visualization operations."""
+
 import pytest
 import matplotlib.pyplot as plt
 import tidy3d as td
@@ -7,7 +8,7 @@ from tidy3d.components.viz import Polygon
 
 def test_make_polygon_dict():
     p = Polygon(context={"coordinates": [(1, 0), (0, 1), (0, 0)]})
-    p.interiors
+    p.interiors  # noqa: B018
 
 
 @pytest.mark.parametrize("center_z, len_collections", ((0, 1), (0.1, 0)))

--- a/tests/test_data/test_data_arrays.py
+++ b/tests/test_data/test_data_arrays.py
@@ -1,4 +1,5 @@
 """Tests tidy3d/components/data/data_array.py"""
+
 import pytest
 import numpy as np
 from typing import Tuple, List

--- a/tests/test_data/test_datasets.py
+++ b/tests/test_data/test_datasets.py
@@ -1,17 +1,19 @@
 """Tests tidy3d/components/data/dataset.py"""
+
 import pytest
 import numpy as np
 import pydantic.v1 as pd
 from matplotlib import pyplot as plt
 from ..utils import cartesian_to_unstructured
-from ..utils import log_capture, AssertLogLevel
+from ..utils import AssertLogLevel
+from ..utils import log_capture  # noqa: F401
 
 
 np.random.seed(4)
 
 
 @pytest.mark.parametrize("ds_name", ["test123", None])
-def test_triangular_dataset(log_capture, tmp_path, ds_name, no_vtk=False):
+def test_triangular_dataset(log_capture, tmp_path, ds_name, no_vtk=False):  # noqa: F811
     import tidy3d as td
     from tidy3d.exceptions import DataError, Tidy3dImportError
 
@@ -189,7 +191,7 @@ def test_triangular_dataset(log_capture, tmp_path, ds_name, no_vtk=False):
     # interpolation
     if no_vtk:
         with pytest.raises(Tidy3dImportError):
-            invariant = tri_grid.interp(
+            tri_grid.interp(
                 x=0.4, y=[0, 1], z=np.linspace(0.2, 0.6, 10), fill_value=-333, use_vtk=True
             )
     else:
@@ -285,7 +287,7 @@ def test_triangular_dataset(log_capture, tmp_path, ds_name, no_vtk=False):
         )
         assert tri_grid == tri_grid_loaded
 
-        with pytest.raises(Exception):
+        with pytest.raises(AttributeError):
             tri_grid_loaded = td.TriangularGridDataset.from_vtu(
                 tmp_path / "tri_grid_test.vtu", field=custom_name + "blah"
             )
@@ -302,7 +304,7 @@ def test_triangular_dataset(log_capture, tmp_path, ds_name, no_vtk=False):
 
 
 @pytest.mark.parametrize("ds_name", ["test123", None])
-def test_tetrahedral_dataset(log_capture, tmp_path, ds_name, no_vtk=False):
+def test_tetrahedral_dataset(log_capture, tmp_path, ds_name, no_vtk=False):  # noqa: F811
     import tidy3d as td
     from tidy3d.exceptions import DataError, Tidy3dImportError
 
@@ -539,8 +541,8 @@ def test_tetrahedral_dataset(log_capture, tmp_path, ds_name, no_vtk=False):
         )
         assert tet_grid == tet_grid_loaded
 
-        with pytest.raises(Exception):
-            tet_grid_loaded = td.TetrahedralGridDataset.from_vtu(
+        with pytest.raises(AttributeError):
+            td.TetrahedralGridDataset.from_vtu(
                 tmp_path / "tet_grid_test.vtu", field=custom_name + "blah"
             )
 

--- a/tests/test_data/test_monitor_data.py
+++ b/tests/test_data/test_monitor_data.py
@@ -1,4 +1,5 @@
 """Tests tidy3d/components/data/monitor_data.py"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 import pytest
@@ -361,7 +362,7 @@ def test_empty_array():
         symmetry=SIM.symmetry,
         symmetry_center=SIM.center,
         grid_expanded=SIM.discretize_monitor(monitor),
-        **fields
+        **fields,
     )
 
 
@@ -375,7 +376,7 @@ def _test_empty_list():
         symmetry=SIM.symmetry,
         symmetry_center=SIM.center,
         grid_expanded=SIM.discretize_monitor(monitor),
-        **fields
+        **fields,
     )
 
 
@@ -389,7 +390,7 @@ def _test_empty_tuple():
         symmetry=SIM.symmetry,
         symmetry_center=SIM.center,
         grid_expanded=SIM.discretize_monitor(monitor),
-        **fields
+        **fields,
     )
 
 
@@ -402,7 +403,7 @@ def test_empty_io(tmp_path):
         symmetry=SIM.symmetry,
         symmetry_center=SIM.center,
         grid_expanded=SIM.discretize_monitor(monitor),
-        **fields
+        **fields,
     )
     field_data.to_file(str(tmp_path / "field_data.hdf5"))
     field_data = td.FieldTimeData.from_file(str(tmp_path / "field_data.hdf5"))
@@ -431,7 +432,7 @@ def test_field_data_symmetry_present():
             monitor=monitor,
             symmetry=(1, -1, 0),
             grid_expanded=SIM.discretize_monitor(monitor),
-            **fields
+            **fields,
         )
 
     # fails if symmetry specified but missing etended grid
@@ -530,11 +531,11 @@ def test_outer_dot():
     dot = mode_data.outer_dot(mode_data)
     assert "mode_index_0" in dot.coords and "mode_index_1" in dot.coords
     dot = field_data.outer_dot(mode_data)
-    assert not "mode_index_0" in dot.coords and "mode_index_1" in dot.coords
+    assert "mode_index_0" not in dot.coords and "mode_index_1" in dot.coords
     dot = mode_data.outer_dot(field_data)
-    assert "mode_index_0" in dot.coords and not "mode_index_1" in dot.coords
+    assert "mode_index_0" in dot.coords and "mode_index_1" not in dot.coords
     dot = field_data.outer_dot(field_data)
-    assert not "mode_index_0" in dot.coords and not "mode_index_1" in dot.coords
+    assert "mode_index_0" not in dot.coords and "mode_index_1" not in dot.coords
 
     # test that only common freqs are kept
     inds1 = [0, 1, 3]
@@ -581,4 +582,4 @@ def test_no_nans():
         **{key: eps_nan for key in ["eps_xx", "eps_yy", "eps_zz"]}
     )
     with pytest.raises(pydantic.ValidationError):
-        cm = td.CustomMedium(eps_dataset=eps_dataset_nan)
+        td.CustomMedium(eps_dataset=eps_dataset_nan)

--- a/tests/test_data/test_sim_data.py
+++ b/tests/test_data/test_sim_data.py
@@ -1,4 +1,5 @@
 """Tests SimulationData"""
+
 import pytest
 import numpy as np
 import matplotlib.pyplot as plt

--- a/tests/test_package/test_config.py
+++ b/tests/test_package/test_config.py
@@ -1,4 +1,4 @@
-""" test the grid operations """
+"""test the grid operations"""
 
 import pytest
 import pydantic.v1 as pydantic

--- a/tests/test_package/test_convert.py
+++ b/tests/test_package/test_convert.py
@@ -1,7 +1,6 @@
 """Test converting .lsf files to Tidy3D python files."""
 
 import pytest
-import os
 
 from tidy3d.web.cli.app import convert
 

--- a/tests/test_package/test_log.py
+++ b/tests/test_package/test_log.py
@@ -9,7 +9,8 @@ import tidy3d as td
 from tidy3d.exceptions import Tidy3dError
 from tidy3d.log import DEFAULT_LEVEL, _get_level_int, set_logging_level
 
-from ..utils import assert_log_level, log_capture, AssertLogLevel
+from ..utils import assert_log_level, AssertLogLevel
+from ..utils import log_capture  # noqa: F401
 
 
 def test_log():
@@ -258,21 +259,21 @@ def test_logging_warning_capture():
 def test_log_suppression():
     with td.log as suppressed_log:
         assert td.log._counts is not None
-        for i in range(4):
+        for _ in range(4):
             suppressed_log.warning("Warning message")
         assert td.log._counts[30] == 3
 
     td.config.log_suppression = False
     with td.log as suppressed_log:
         assert td.log._counts is None
-        for i in range(4):
+        for _ in range(4):
             suppressed_log.warning("Warning message")
         assert td.log._counts is None
 
     td.config.log_suppression = True
 
 
-def test_assert_log_level(log_capture):
+def test_assert_log_level(log_capture):  # noqa: F811
     """Test features of the assert_log_level"""
 
     # log was captured
@@ -281,18 +282,18 @@ def test_assert_log_level(log_capture):
 
     # string was not matched (manually clear because not sure any other way using context manager)
     td.log.warning("ABC")
-    with pytest.raises(Exception):
+    with pytest.raises(AssertionError):
         assert_log_level(log_capture, "WARNING", contains_str="DEF")
     log_capture.clear()
 
     # string was matched at the wrong level
     td.log.info("ABC")
-    with pytest.raises(Exception):
+    with pytest.raises(AssertionError):
         assert_log_level(log_capture, "WARNING", contains_str="ABC")
     log_capture.clear()
 
     # log exceeds expected level
     td.log.warning("ABC")
-    with pytest.raises(Exception):
+    with pytest.raises(AssertionError):
         assert_log_level(log_capture, "INFO")
     log_capture.clear()

--- a/tests/test_package/test_make_script.py
+++ b/tests/test_package/test_make_script.py
@@ -1,4 +1,5 @@
 """Tests generation of pythons script from simulation file."""
+
 import tidy3d as td
 from make_script import main
 

--- a/tests/test_package/test_parametric_variants.py
+++ b/tests/test_package/test_parametric_variants.py
@@ -11,7 +11,7 @@ from tidy3d.material_library.parametric_materials import Graphene
 
 from numpy.random import default_rng
 
-from ..utils import assert_log_level, log_capture
+from ..utils import log_capture  # noqa: F401
 
 # bounds for MU_C
 GRAPHENE_MU_C_MIN = 0
@@ -32,7 +32,7 @@ def test_graphene_defaults():
 
 
 @pytest.mark.parametrize("rng_seed", np.arange(0, 15))
-def test_graphene(rng_seed, log_capture):
+def test_graphene(rng_seed, log_capture):  # noqa: F811
     """test graphene for range of physical parameters"""
     rng = default_rng(rng_seed)
     gamma_min = GRAPHENE_GAMMA_MIN

--- a/tests/test_plugins/terminal_component_modeler_def.py
+++ b/tests/test_plugins/terminal_component_modeler_def.py
@@ -106,7 +106,7 @@ def make_component_modeler(
     length: float = None,
     port_refinement: bool = True,
     auto_grid: bool = True,
-    **kwargs
+    **kwargs,
 ):
     if length:
         strip_length = length

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -191,7 +191,7 @@ def run_async_emulated_bwd(
 
     sim_vjps_orig = []
 
-    for i, (sim, jax_info, parent_tasks_i) in enumerate(zip(simulations, jax_infos, parent_tasks)):
+    for i, (sim, jax_info, _) in enumerate(zip(simulations, jax_infos, parent_tasks)):
         sim_vjp = run_emulated_bwd(
             sim_adj=sim,
             jax_info_adj=jax_info,
@@ -923,7 +923,7 @@ def test_jax_sim_data(use_emulated_run):
         _ = sim_data[mnt_name]
 
 
-def test_intersect_structures(log_capture):
+def test_intersect_structures(log_capture):  # noqa: F811
     """Test validators for structures touching and intersecting."""
 
     SIZE_X = 1.0
@@ -1112,8 +1112,8 @@ def _test_polyslab_box(use_emulated_run):
         amp = extract_amp(sim_data)
         return objective(amp)
 
-    f_b = lambda size, center: f(size, center, is_box=True)
-    f_p = lambda size, center: f(size, center, is_box=False)
+    f_b = lambda size, center: f(size, center, is_box=True)  # noqa: E731
+    f_p = lambda size, center: f(size, center, is_box=False)  # noqa: E731
 
     g_b = grad(f_b, argnums=(0, 1))
     g_p = grad(f_p, argnums=(0, 1))
@@ -1208,7 +1208,7 @@ def test_polyslab_2d(sim_size_axis, use_emulated_run):
         amp = extract_amp(sim_data)
         return objective(amp)
 
-    f_b = lambda size, center: f(size, center)
+    f_b = lambda size, center: f(size, center)  # noqa: E731
 
     g_b = grad(f_b, argnums=(0, 1))
 
@@ -1230,11 +1230,7 @@ def test_adjoint_run_async(local, use_emulated_run_async):
     def f(x):
         """Objective function to differentiate."""
 
-        sims = []
-        for i in range(1):
-            permittivity = x + 1.0
-            sims.append(make_sim_simple(permittivity=permittivity))
-
+        sims = [make_sim_simple(permittivity=x + 1.0)]
         sim_data_list = run_fn(sims, path_dir=str(TMP_PATH))
 
         result = 0.0
@@ -1367,7 +1363,7 @@ def _test_polyslab_scale(use_emulated_run):
             size_axis, (size_1, size_2) = JaxPolySlab.pop_axis(SIZE, axis=POLYSLAB_AXIS)
             cent_axis, (cent_1, cent_2) = JaxPolySlab.pop_axis(CENTER, axis=POLYSLAB_AXIS)
 
-            vertices_jax = [(scale * x, scale * y) for x, y in vertices]
+            vertices_jax = [(scale * x, scale * y) for x, y in vertices]  # noqa: B023
             # vertices_jax = [(x, y) for x, y in vertices]
 
             slab_bounds = (cent_axis - size_axis / 2, cent_axis + size_axis / 2)
@@ -1580,9 +1576,9 @@ def test_num_input_structures(use_emulated_run, tmp_path):
 
     # make sure that the remote web API fails whereas the local one passes
     with pytest.raises(AdjointError):
-        sim_data = run(sim, task_name="test", path=str(tmp_path / RUN_FILE))
+        run(sim, task_name="test", path=str(tmp_path / RUN_FILE))
 
-    sim_data = run_local(sim, task_name="test", path=str(tmp_path / RUN_FILE))
+    run_local(sim, task_name="test", path=str(tmp_path / RUN_FILE))
 
 
 @pytest.mark.parametrize("strict_binarize", (True, False))
@@ -1623,7 +1619,7 @@ def test_adjoint_utils(strict_binarize):
 @pytest.mark.parametrize(
     "input_size_y, log_level_expected", [(13, None), (12, "WARNING"), (11, "WARNING"), (14, None)]
 )
-def test_adjoint_filter_sizes(log_capture, input_size_y, log_level_expected):
+def test_adjoint_filter_sizes(log_capture, input_size_y, log_level_expected):  # noqa: F811
     """Warn if filter size along a dim is smaller than radius."""
 
     signal_in = np.ones((266, input_size_y))
@@ -1749,17 +1745,17 @@ def test_adjoint_run_time(use_emulated_run, tmp_path, fwidth, run_time, run_time
 
 @pytest.mark.parametrize("has_adj_src, log_level_expected", [(True, None), (False, "WARNING")])
 def test_no_adjoint_sources(
-    monkeypatch, use_emulated_run, tmp_path, log_capture, has_adj_src, log_level_expected
+    monkeypatch,
+    use_emulated_run,
+    tmp_path,
+    log_capture,  # noqa: F811
+    has_adj_src,
+    log_level_expected,
 ):
     """Make sure warning (not error) if no adjoint sources."""
 
     def make_sim(eps):
         """Make a sim with given sources and fwidth_adjoint specified."""
-        struct = JaxStructure(
-            geometry=JaxBox(center=(0, 0, 0), size=(1, 1, 1)),
-            medium=JaxMedium(permittivity=eps),
-        )
-
         freq0 = 2e14
         mnt = td.ModeMonitor(
             size=(10, 10, 0),
@@ -1790,10 +1786,10 @@ def test_no_adjoint_sources(
     with AssertLogLevel(log_capture, log_level_expected, contains_str="No adjoint sources"):
         data.make_adjoint_simulation(fwidth=src.source_time.fwidth, run_time=sim.run_time)
 
-    power = jnp.sum(jnp.abs(jnp.array(data["mnt"].amps.values)) ** 2)
+    jnp.sum(jnp.abs(jnp.array(data["mnt"].amps.values)) ** 2)
 
 
-def test_nonlinear_warn(log_capture):
+def test_nonlinear_warn(log_capture):  # noqa: F811
     """Test that simulations warn if nonlinearity is used."""
 
     struct = JaxStructure(
@@ -1829,15 +1825,15 @@ def test_nonlinear_warn(log_capture):
 
     # nonlinear simulation.medium (error)
     with AssertLogLevel(log_capture, "WARNING"):
-        sim = sim_base.updated_copy(medium=nl_medium)
+        sim_base.updated_copy(medium=nl_medium)
 
     # nonlinear structure (warn)
     with AssertLogLevel(log_capture, "WARNING"):
-        sim = sim_base.updated_copy(structures=[struct_static_nl])
+        sim_base.updated_copy(structures=[struct_static_nl])
 
     # nonlinear input_structure (warn)
     with AssertLogLevel(log_capture, "WARNING"):
-        sim = sim_base.updated_copy(input_structures=[input_struct_nl])
+        sim_base.updated_copy(input_structures=[input_struct_nl])
 
 
 @pytest.fixture
@@ -1861,13 +1857,13 @@ def try_tracer_import() -> None:
 
 
 @pytest.mark.usefixtures("hide_jax")
-def test_jax_tracer_import_fail(tmp_path, log_capture):
+def test_jax_tracer_import_fail(tmp_path, log_capture):  # noqa: F811
     """Make sure if import error with JVPTracer, a warning is logged and module still imports."""
     try_tracer_import()
     assert_log_level(log_capture, "WARNING")
 
 
-def test_jax_tracer_import_pass(tmp_path, log_capture):
+def test_jax_tracer_import_pass(tmp_path, log_capture):  # noqa: F811
     """Make sure if no import error with JVPTracer, nothing is logged and module imports."""
     try_tracer_import()
     assert_log_level(log_capture, None)
@@ -1884,7 +1880,7 @@ def test_inf_IO(tmp_path):
 
 
 @pytest.mark.parametrize("sidewall_angle, log_expected", ([0.0, None], [0.1, "WARNING"]))
-def test_sidewall_angle_validator(log_capture, sidewall_angle, log_expected):
+def test_sidewall_angle_validator(log_capture, sidewall_angle, log_expected):  # noqa: F811
     """Test that the sidewall angle warning works as expected."""
 
     jax_polyslab1 = JaxPolySlab(axis=POLYSLAB_AXIS, vertices=VERTICES, slab_bounds=(-1, 1))
@@ -1906,7 +1902,7 @@ def test_package_flux():
     assert res_multi == da_multi
 
 
-def test_vertices_warning(log_capture):
+def test_vertices_warning(log_capture):  # noqa: F811
     sim = make_sim(permittivity=EPS, size=SIZE, vertices=VERTICES, base_eps_val=BASE_EPS_VAL)
 
     polyslab = sim.input_structures[3].geometry
@@ -1914,19 +1910,19 @@ def test_vertices_warning(log_capture):
     radius_penalty = RadiusPenalty(min_radius=0.2, wrap=True)
 
     with AssertLogLevel(log_capture, "WARNING"):
-        z = radius_penalty.evaluate(polyslab.vertices)
+        radius_penalty.evaluate(polyslab.vertices)
 
     with AssertLogLevel(log_capture, "WARNING"):
-        z = radius_penalty.evaluate(np.array(jax.lax.stop_gradient(polyslab.vertices)))
+        radius_penalty.evaluate(np.array(jax.lax.stop_gradient(polyslab.vertices)))
 
     def f(vertices):
         return radius_penalty.evaluate(vertices)
 
     with AssertLogLevel(log_capture, None):
-        z = jax.grad(f)(np.random.random((5, 2)))
+        jax.grad(f)(np.random.random((5, 2)))
 
     with AssertLogLevel(log_capture, None):
-        z = jax.grad(f)(np.random.random((5, 2)).tolist())
+        jax.grad(f)(np.random.random((5, 2)).tolist())
 
 
 def test_no_poynting(use_emulated_run):

--- a/tests/test_plugins/test_component_modeler.py
+++ b/tests/test_plugins/test_component_modeler.py
@@ -385,4 +385,4 @@ def test_batch_filename(tmp_path):
 
 
 def test_import_smatrix_smatrix():
-    from tidy3d.plugins.smatrix.smatrix import Port, ComponentModeler
+    from tidy3d.plugins.smatrix.smatrix import Port, ComponentModeler  # noqa: F401

--- a/tests/test_plugins/test_design.py
+++ b/tests/test_plugins/test_design.py
@@ -1,4 +1,5 @@
 """Test the parameter sweep plugin."""
+
 import pytest
 import numpy as np
 import tidy3d as td
@@ -6,12 +7,12 @@ import matplotlib.pyplot as plt
 import scipy.stats.qmc as qmc
 
 import tidy3d.web as web
-from tidy3d.components.base import Tidy3dBaseModel
 
 from tidy3d.plugins import design as tdd
 from tidy3d.plugins.design.method import MethodIndependent
 
-from ..utils import run_emulated, log_capture, assert_log_level
+from ..utils import run_emulated, assert_log_level
+from ..utils import log_capture  # noqa: F401
 
 
 SWEEP_METHODS = dict(
@@ -22,8 +23,8 @@ SWEEP_METHODS = dict(
 )
 
 
-@pytest.mark.parametrize("sweep_method", SWEEP_METHODS.values(), ids=SWEEP_METHODS.keys())
-def test_sweep(sweep_method, monkeypatch, ids=[]):
+@pytest.mark.parametrize("sweep_method", SWEEP_METHODS.values())
+def test_sweep(sweep_method, monkeypatch):
     # Problem, simulate scattering cross section of sphere ensemble
     # 	simulation consists of `num_spheres` spheres of radius `radius`.
     #   use defines `scs` function to set up and run simulation as function of inputs.
@@ -44,7 +45,7 @@ def test_sweep(sweep_method, monkeypatch, ids=[]):
             # task_paths: dict
 
             def items(self):
-                for task_name, sim_data in self.data_dict.items():
+                for task_name, sim_data in self.data_dict.items():  # noqa: UP028
                     yield task_name, sim_data
 
             def __getitem__(self, task_name):
@@ -62,7 +63,7 @@ def test_sweep(sweep_method, monkeypatch, ids=[]):
         # set up simulation
         spheres = []
 
-        for i in range(int(num_spheres)):
+        for _ in range(int(num_spheres)):
             spheres.append(
                 td.Structure(
                     geometry=td.Sphere(radius=radius),
@@ -157,20 +158,20 @@ def test_sweep(sweep_method, monkeypatch, ids=[]):
     sweep_results2 = design_space.run_batch(scs_pre, scs_post)
 
     bd = sweep_results2.batch_data
-    for task_name, data in bd.items():
+    for task_name, data in bd.items():  # noqa: B007
         continue
 
-    sweep_results3 = design_space.run_batch(scs_pre_multi, scs_post_multi)
+    design_space.run_batch(scs_pre_multi, scs_post_multi)
 
-    sweep_results4 = design_space.run_batch(scs_pre_dict, scs_post_dict)
+    design_space.run_batch(scs_pre_dict, scs_post_dict)
 
     sel_kwargs_0 = dict(zip(sweep_results.dims, sweep_results.coords[0]))
     sweep_results.sel(**sel_kwargs_0)
 
     print(sweep_results.to_dataframe().head(10))
 
-    im = sweep_results.to_dataframe().plot.hexbin(x="num_spheres", y="radius", C="output")
-    im = sweep_results.to_dataframe().plot.scatter(x="num_spheres", y="radius", c="output")
+    sweep_results.to_dataframe().plot.hexbin(x="num_spheres", y="radius", C="output")
+    sweep_results.to_dataframe().plot.scatter(x="num_spheres", y="radius", c="output")
     plt.close()
 
     design_space2 = tdd.DesignSpace(
@@ -181,8 +182,9 @@ def test_sweep(sweep_method, monkeypatch, ids=[]):
 
     sweep_results_other = design_space2.run(scs)
 
-    results_combined = sweep_results.combine(sweep_results_other)
-    results_combined = sweep_results + sweep_results_other
+    # test combining results
+    sweep_results.combine(sweep_results_other)
+    sweep_results + sweep_results_other
 
     # STEP4: modify the sweep results
 
@@ -245,14 +247,14 @@ def test_method_custom_validators():
         def random(self, n):
             return np.random.random((n, d))
 
-    tdd.MethodRandomCustom(num_points=5, sampler=SamplerWorks()),
+    tdd.MethodRandomCustom(num_points=5, sampler=SamplerWorks())
 
     # missing random method case
     class SamplerNoRandom:
         pass
 
     with pytest.raises(ValueError):
-        tdd.MethodRandomCustom(num_points=5, sampler=SamplerNoRandom()),
+        tdd.MethodRandomCustom(num_points=5, sampler=SamplerNoRandom())
 
     # random method gives a list
     class SamplerList:
@@ -260,7 +262,7 @@ def test_method_custom_validators():
             return np.random.random((n, d)).tolist()
 
     with pytest.raises(ValueError):
-        tdd.MethodRandomCustom(num_points=5, sampler=SamplerList()),
+        tdd.MethodRandomCustom(num_points=5, sampler=SamplerList())
 
     # random method gives wrong number of dimensions
     class SamplerWrongDims:
@@ -268,7 +270,7 @@ def test_method_custom_validators():
             return np.random.random((n, d, d))
 
     with pytest.raises(ValueError):
-        tdd.MethodRandomCustom(num_points=5, sampler=SamplerWrongDims()),
+        tdd.MethodRandomCustom(num_points=5, sampler=SamplerWrongDims())
 
     # random method gives wrong first dimension length
     class SamplerWrongShape:
@@ -276,7 +278,7 @@ def test_method_custom_validators():
             return np.random.random((n + 1, d))
 
     with pytest.raises(ValueError):
-        tdd.MethodRandomCustom(num_points=5, sampler=SamplerWrongShape()),
+        tdd.MethodRandomCustom(num_points=5, sampler=SamplerWrongShape())
 
     # random method gives floats outside of range of 0, 1
     class SamplerOutOfRange:
@@ -284,7 +286,7 @@ def test_method_custom_validators():
             return 3 * np.random.random((n, d)) - 1
 
     with pytest.raises(ValueError):
-        tdd.MethodRandomCustom(num_points=5, sampler=SamplerOutOfRange()),
+        tdd.MethodRandomCustom(num_points=5, sampler=SamplerOutOfRange())
 
 
 @pytest.mark.parametrize(
@@ -292,10 +294,10 @@ def test_method_custom_validators():
     [(True, "WARNING"), (False, None)],
     ids=["warn_monte_carlo", "no_warn_monte_carlo"],
 )
-def test_method_random_warning(log_capture, monte_carlo_warning, log_level_expected):
+def test_method_random_warning(log_capture, monte_carlo_warning, log_level_expected):  # noqa: F811
     """Test that method random validation / warning works as expected."""
 
-    method = tdd.MethodRandom(num_points=10, monte_carlo_warning=monte_carlo_warning)
+    tdd.MethodRandom(num_points=10, monte_carlo_warning=monte_carlo_warning)
     assert_log_level(log_capture, log_level_expected)
 
 

--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -12,7 +12,8 @@ from tidy3d.plugins.mode.mode_solver import MODE_MONITOR_NAME
 from tidy3d.plugins.mode.derivatives import create_sfactor_b, create_sfactor_f
 from tidy3d.plugins.mode.solver import compute_modes
 from tidy3d.exceptions import SetupError
-from ..utils import assert_log_level, log_capture, cartesian_to_unstructured  # noqa: F401
+from ..utils import assert_log_level, cartesian_to_unstructured
+from ..utils import log_capture  # noqa: F401
 from tidy3d import ScalarFieldDataArray
 from tidy3d.web.core.environment import Env
 

--- a/tests/test_plugins/test_polyslab.py
+++ b/tests/test_plugins/test_polyslab.py
@@ -4,7 +4,8 @@ import gdstk
 import tidy3d as td
 
 from tidy3d.plugins.polyslab import ComplexPolySlab
-from ..utils import assert_log_level, log_capture
+from ..utils import assert_log_level
+from ..utils import log_capture  # noqa: F401
 
 
 def test_divide_simple_events():
@@ -30,7 +31,7 @@ def test_divide_simple_events():
                 _ = s.geometry_group
 
 
-def test_many_sub_polyslabs(log_capture):
+def test_many_sub_polyslabs(log_capture):  # noqa: F811
     """warn when too many subpolyslabs are generated."""
 
     # generate vertices that can generate at least this number
@@ -116,7 +117,7 @@ def test_gds_import(tmp_path):
         # bend interpolator
         interp = tanh_interp(3)
         delta = wg_width + wg_spacing_coup - wg_spacing_in
-        offset = lambda u: wg_spacing_in + interp(u) * delta
+        offset = lambda u: wg_spacing_in + interp(u) * delta  # noqa: E731
 
         coup = gdstk.RobustPath(
             (-0.5 * length, 0),

--- a/tests/test_web/test_env.py
+++ b/tests/test_web/test_env.py
@@ -4,10 +4,10 @@ from tidy3d.web.core.environment import Env
 
 def test_tidy3d_env():
     Env.enable_caching(True)
-    assert Env.current.enable_caching == True
+    assert Env.current.enable_caching is True
 
     Env.enable_caching(False)
-    assert Env.current.enable_caching == False
+    assert Env.current.enable_caching is False
 
 
 def test_set_ssl_version():

--- a/tests/test_web/test_material_fitter.py
+++ b/tests/test_web/test_material_fitter.py
@@ -69,7 +69,8 @@ def test_material_fitter(tmp_path, monkeypatch, set_api_key):
         "tidy3d.web.api.material_fitter.MaterialFitterTask.sync_status", lambda self: None
     )
     task.sync_status()
-    task.status == "running"
+    # FIXME: Check what this tests is supposed to accomplish
+    task.status == "running"  # noqa: B015
 
     responses.add(
         responses.POST,

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -544,7 +544,7 @@ def test_batch(mock_webapi, mock_job_status, mock_load, tmp_path):
     b = b.from_file(fname)
 
     b.estimate_cost()
-    data = b.run(path_dir=str(tmp_path))
+    b.run(path_dir=str(tmp_path))
     _ = b.get_info()
     assert b.real_cost() == FLEX_UNIT * len(sims)
 

--- a/tidy3d/components/source.py
+++ b/tidy3d/components/source.py
@@ -415,7 +415,7 @@ class Source(Box, AbstractSource, ABC):
         _assert_min_freq(val.freq0, msg_start="'source_time.freq0'")
         return val
 
-    def plot(  #  pylint:disable=too-many-arguments
+    def plot(
         self,
         x: float = None,
         y: float = None,
@@ -1131,7 +1131,7 @@ class TFSF(AngledFieldSource, VolumeSource):
         center[self.injection_axis] += sign * size[self.injection_axis] / 2
         return tuple(center)
 
-    def plot(  #  pylint:disable=too-many-arguments
+    def plot(
         self,
         x: float = None,
         y: float = None,


### PR DESCRIPTION
Tests were still throwing a lot of lint errors, which made writing new ones a bit of a pain due to our pre-commit config.

Before (181 errors total):

![image](https://github.com/flexcompute/tidy3d/assets/168471015/1ed69838-e04b-497d-957d-0cbb837fd6f7)

After:

![image](https://github.com/flexcompute/tidy3d/assets/168471015/027b3e66-9bfa-4182-912d-e96e85830dfd)
