### PR TITLE
Fix pol vector

### DIFF
--- a/tests/test_components/test_source.py
+++ b/tests/test_components/test_source.py
@@ -168,20 +168,20 @@ def test_pol_arrow():
     assert np.allclose(get_pol_dir(axis=0), (0, 1, 0))
     assert np.allclose(get_pol_dir(axis=1), (1, 0, 0))
     assert np.allclose(get_pol_dir(axis=2), (1, 0, 0))
-    assert np.allclose(get_pol_dir(axis=0, angle_phi=np.pi / 2), (0, 0, +1))
-    assert np.allclose(get_pol_dir(axis=1, angle_phi=np.pi / 2), (0, 0, -1))
-    assert np.allclose(get_pol_dir(axis=2, angle_phi=np.pi / 2), (0, +1, 0))
-    assert np.allclose(get_pol_dir(axis=0, pol_angle=np.pi / 2), (0, 0, +1))
-    assert np.allclose(get_pol_dir(axis=1, pol_angle=np.pi / 2), (0, 0, -1))
-    assert np.allclose(get_pol_dir(axis=2, pol_angle=np.pi / 2), (0, +1, 0))
+    assert np.allclose(get_pol_dir(axis=0, angle_phi=np.pi / 2), (0, 0, 1))
+    assert np.allclose(get_pol_dir(axis=1, angle_phi=np.pi / 2), (0, 0, 1))
+    assert np.allclose(get_pol_dir(axis=2, angle_phi=np.pi / 2), (0, 1, 0))
+    assert np.allclose(get_pol_dir(axis=0, pol_angle=np.pi / 2), (0, 0, 1))
+    assert np.allclose(get_pol_dir(axis=1, pol_angle=np.pi / 2), (0, 0, 1))
+    assert np.allclose(get_pol_dir(axis=2, pol_angle=np.pi / 2), (0, 1, 0))
     assert np.allclose(
-        get_pol_dir(axis=0, angle_theta=np.pi / 4), (+1 / np.sqrt(2), -1 / np.sqrt(2), 0)
+        get_pol_dir(axis=0, angle_theta=np.pi / 4), (-1 / np.sqrt(2), +1 / np.sqrt(2), 0)
     )
     assert np.allclose(
-        get_pol_dir(axis=1, angle_theta=np.pi / 4), (-1 / np.sqrt(2), +1 / np.sqrt(2), 0)
+        get_pol_dir(axis=1, angle_theta=np.pi / 4), (+1 / np.sqrt(2), -1 / np.sqrt(2), 0)
     )
     assert np.allclose(
-        get_pol_dir(axis=2, angle_theta=np.pi / 4), (-1 / np.sqrt(2), 0, +1 / np.sqrt(2))
+        get_pol_dir(axis=2, angle_theta=np.pi / 4), (+1 / np.sqrt(2), 0, -1 / np.sqrt(2))
     )
 
 

--- a/tidy3d/components/source.py
+++ b/tidy3d/components/source.py
@@ -853,26 +853,41 @@ class AngledFieldSource(DirectionalSource, ABC):
     @cached_property
     def _dir_vector(self) -> Tuple[float, float, float]:
         """Source direction normal vector in cartesian coordinates."""
+
+        # Propagation vector assuming propagation along z
         radius = 1.0 if self.direction == "+" else -1.0
         dx = radius * np.cos(self.angle_phi) * np.sin(self.angle_theta)
         dy = radius * np.sin(self.angle_phi) * np.sin(self.angle_theta)
         dz = radius * np.cos(self.angle_theta)
+
+        # Move to original injection axis
         return self.unpop_axis(dz, (dx, dy), axis=self._injection_axis)
 
     @cached_property
     def _pol_vector(self) -> Tuple[float, float, float]:
         """Source polarization normal vector in cartesian coordinates."""
-        normal_dir = [0.0, 0.0, 0.0]
-        normal_dir[int(self._injection_axis)] = 1.0
-        propagation_dir = list(self._dir_vector)
-        if self.angle_theta == 0.0:
-            pol_vector_p = np.array((0, 1, 0)) if self._injection_axis == 0 else np.array((1, 0, 0))
-            pol_vector_p = self.rotate_points(pol_vector_p, normal_dir, angle=self.angle_phi)
-        else:
-            pol_vector_s = np.cross(normal_dir, propagation_dir)
-            pol_vector_p = np.cross(propagation_dir, pol_vector_s)
-            pol_vector_p = np.array(pol_vector_p) / np.linalg.norm(pol_vector_p)
-        return self.rotate_points(pol_vector_p, propagation_dir, angle=self.pol_angle)
+
+        # Polarization vector assuming propagation along z
+        pol_vector_z_normal = np.array([1.0, 0.0, 0.0])
+
+        # Rotate polarization
+        pol_vector_z_normal = self.rotate_points(
+            pol_vector_z_normal, axis=[0, 0, 1], angle=self.pol_angle
+        )
+
+        # Rotate the fields back to the original propagation axes
+        pol_vector_z_normal = self.rotate_points(
+            pol_vector_z_normal, axis=[0, 1, 0], angle=self.angle_theta
+        )
+        pol_vector_z_normal = self.rotate_points(
+            pol_vector_z_normal, axis=[0, 0, 1], angle=self.angle_phi
+        )
+
+        # Move to original injection axis
+        pol_vector = self.unpop_axis(
+            pol_vector_z_normal[2], pol_vector_z_normal[:2], axis=self._injection_axis
+        )
+        return pol_vector
 
 
 class ModeSource(DirectionalSource, PlanarSource, BroadbandSource):


### PR DESCRIPTION
Related to https://github.com/flexcompute/tidy3d/issues/1683

It seems like our frontend polarization visualization was inconsistent with actual fields being injected. Frontend arrow was calculated sometimes based on summation and sometimes based on subtraction of `angle_phi` and `pol_angle`, while on backend it is always summation. That is, rotation for `angle_phi` and `pol_angle` are always with respect to the positive direction of injection axis. Moreover the visualization was discontinuous between theta < 0, theta = 0, and theta > 0. 

Here's comparison between the visualized polarization vector (red) and extracted from actual fields (blue)
<img width="1116" alt="pol_vector_old" src="https://github.com/flexcompute/tidy3d/assets/109110435/616fe04e-b8d7-4f5f-adf5-71217957c211">

Now we just repeat the same steps for computing `_pol_vector` as the backend does for field computations. This seems to resolve all inconsistencies
<img width="1116" alt="pol_vector_new" src="https://github.com/flexcompute/tidy3d/assets/109110435/c1d5a5a0-a17c-4b22-99a3-ed208ac70b28">

