### PR TITLE
`JaxComplexPolySlab` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pre-upload validator to check that mode sources overlap with more than 2 grid cells.
 - Support `2DMedium` for `Transformed`/`GeometryGroup`/`ClipOperation` geometries.
 - `num_proc` argument to `tidy3d.plugins.adjoint.web.run_local` to control the number of processes used on the local machine for gradient processing.
+- Support for complex polyslabs in adjoint module via `JaxComplexPolySlab`.
 
 ### Changed
 - `tidy3d convert` from `.lsf` files to tidy3d scripts is moved to another repository at `https://github.com/hirako22/Lumerical-to-Tidy3D-Converter`.

--- a/tidy3d/plugins/adjoint/__init__.py
+++ b/tidy3d/plugins/adjoint/__init__.py
@@ -12,7 +12,7 @@ except ImportError as e:
         "for example: $pip install 'tidy3d[jax]'."
     ) from e
 
-from .components.geometry import JaxBox, JaxPolySlab, JaxGeometryGroup
+from .components.geometry import JaxBox, JaxPolySlab, JaxComplexPolySlab, JaxGeometryGroup
 from .components.medium import JaxMedium, JaxAnisotropicMedium, JaxCustomMedium
 from .components.structure import (
     JaxStructure,
@@ -29,6 +29,7 @@ from .web import run, run_async
 __all__ = [
     "JaxBox",
     "JaxPolySlab",
+    "JaxComplexPolySlab",
     "JaxGeometryGroup",
     "JaxMedium",
     "JaxAnisotropicMedium",

--- a/tidy3d/plugins/adjoint/__init__.py
+++ b/tidy3d/plugins/adjoint/__init__.py
@@ -2,18 +2,9 @@
 
 # import the jax version of tidy3d components
 try:
-    from .components.geometry import JaxBox, JaxPolySlab, JaxGeometryGroup
-    from .components.medium import JaxMedium, JaxAnisotropicMedium, JaxCustomMedium
-    from .components.structure import (
-        JaxStructure,
-        JaxStructureStaticGeometry,
-        JaxStructureStaticMedium,
-    )
-    from .components.simulation import JaxSimulation
-    from .components.data.sim_data import JaxSimulationData
-    from .components.data.monitor_data import JaxModeData
-    from .components.data.dataset import JaxPermittivityDataset
-    from .components.data.data_array import JaxDataArray
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
 except ImportError as e:
     raise ImportError(
         "The 'jax' package is required for adjoint plugin. We were not able to import it. "
@@ -21,10 +12,19 @@ except ImportError as e:
         "for example: $pip install 'tidy3d[jax]'."
     ) from e
 
-try:
-    from .web import run, run_async
-except ImportError:
-    pass
+from .components.geometry import JaxBox, JaxPolySlab, JaxGeometryGroup
+from .components.medium import JaxMedium, JaxAnisotropicMedium, JaxCustomMedium
+from .components.structure import (
+    JaxStructure,
+    JaxStructureStaticGeometry,
+    JaxStructureStaticMedium,
+)
+from .components.simulation import JaxSimulation
+from .components.data.sim_data import JaxSimulationData
+from .components.data.monitor_data import JaxModeData
+from .components.data.dataset import JaxPermittivityDataset
+from .components.data.data_array import JaxDataArray
+from .web import run, run_async
 
 __all__ = [
     "JaxBox",

--- a/tidy3d/plugins/adjoint/components/__init__.py
+++ b/tidy3d/plugins/adjoint/components/__init__.py
@@ -1,7 +1,7 @@
 """Component imports for adjoint plugin. from tidy3d.plugins.adjoint.components import *"""
 
 # import the jax version of tidy3d components
-from .geometry import JaxBox, JaxPolySlab
+from .geometry import JaxBox, JaxPolySlab, JaxComplexPolySlab
 from .medium import JaxMedium, JaxAnisotropicMedium, JaxCustomMedium
 from .structure import JaxStructure, JaxStructureStaticMedium, JaxStructureStaticGeometry
 from .simulation import JaxSimulation
@@ -13,6 +13,7 @@ from .data.data_array import JaxDataArray
 __all__ = [
     "JaxBox",
     "JaxPolySlab",
+    "JaxComplexPolySlab",
     "JaxGeometryGroup",
     "JaxMedium",
     "JaxAnisotropicMedium",


### PR DESCRIPTION
Closes #1675 

Initial version of `JaxComplexPolySlab`. Works in principle, but still needs tests. Supports differentiation w.r.t. both `vertices` and `slab_bounds`.