### PR TITLE
fix smatrix component task_ids to/from file 

### DIFF
--- a/tests/test_plugins/test_component_modeler.py
+++ b/tests/test_plugins/test_component_modeler.py
@@ -12,6 +12,18 @@ from tidy3d.plugins.smatrix import (
 )
 from tidy3d.exceptions import SetupError, Tidy3dKeyError
 from ..utils import run_emulated
+from ..test_web.test_webapi import (
+    mock_upload,
+    mock_metadata,
+    mock_get_info,
+    mock_start,
+    mock_monitor,
+    mock_download,
+    mock_load,
+    mock_job_status,
+    mock_load,
+    set_api_key,
+)
 
 # Waveguide height
 wg_height = 0.22
@@ -386,3 +398,19 @@ def test_batch_filename(tmp_path):
 
 def test_import_smatrix_smatrix():
     from tidy3d.plugins.smatrix.smatrix import Port, ComponentModeler  # noqa: F401
+
+
+def test_to_from_file_batch(monkeypatch, tmp_path):
+    modeler = make_component_modeler(path_dir=str(tmp_path))
+    s_matrix = run_component_modeler(monkeypatch, modeler)
+
+    batch = td.web.Batch(simulations=dict())
+
+    modeler._cached_properties["batch"] = batch
+
+    fname = str(tmp_path) + "/modeler.json"
+
+    modeler.to_file(fname)
+    modeler2 = modeler.from_file(fname)
+
+    assert modeler2.batch_cached == modeler2.batch == batch

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -541,12 +541,14 @@ def test_batch(mock_webapi, mock_job_status, mock_load, tmp_path):
     fname = str(tmp_path / "batch.json")
 
     b.to_file(fname)
-    b = b.from_file(fname)
+    b2 = b.from_file(fname)
 
-    b.estimate_cost()
-    b.run(path_dir=str(tmp_path))
-    _ = b.get_info()
-    assert b.real_cost() == FLEX_UNIT * len(sims)
+    assert all(j.task_id == j2.task_id for j, j2 in zip(b.jobs.values(), b2.jobs.values()))
+
+    b2.estimate_cost()
+    b2.run(path_dir=str(tmp_path))
+    _ = b2.get_info()
+    assert b2.real_cost() == FLEX_UNIT * len(sims)
 
 
 """ Async """


### PR DESCRIPTION
No changelog needed I think because the PR that broke this hasn't been released.

 I refactored Batch and Job recently #1630 . Before, the Job had task_id as a field that was created in a validator by uploading the task. Similarly, Batch.jobs was a field that was created in a validator by uploading all of the tasks. This meant that these fields were saved to file automatically. In the new refactor, these fields are just properties that are created when the Job/Batch is .upload() ed for the first time. So they aren’t saved to file natively, I needed to patch that into the .json() methods. Turned out I had done it so that a Batch worked properly when saved to file, but I needed to handle a component modeler too.