### PR TITLE
fix xarray data access in SpatialDataArray reflection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Simulation.to_gdspy()` and `Simulation.to_gdstk()` now place polygons in GDS layer `(0, 0)` when no `gds_layer_dtype_map` is provided instead of erroring.
 - `task_id` now properly stored in `JaxSimulationData`.
 - Bug in `FastDispersionFitter` when poles move close to input frequencies.
+- Bug in plotting polarization vector of angled sources.
+- Bug in `SpatialDataArray.reflect()` that was causing errors for older versions of `xarray`.
 
 ## [2.7.0rc1] - 2024-04-22
 

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -412,7 +412,7 @@ class SpatialDataArray(AbstractSpatialDataArray):
         coords = [sorted_self.x.values, sorted_self.y.values, sorted_self.z.values]
         data = np.array(sorted_self.data)
 
-        data_left_bound = coords[axis].data[0]
+        data_left_bound = coords[axis][0]
 
         if np.isclose(center, data_left_bound):
             num_duplicates = 1


### PR DESCRIPTION
thanks for spotting one too many xarray -> numpy data views. It seems like for newer versions of xarray (2024.3.0) this somehow was ok, but not for older ones (like 2023.2.0)