### PR TITLE
:package: BUILD: Sync tags to readthedocs repo

### DIFF
--- a/.github/workflows/sync-to-readthedocs-repo.yaml
+++ b/.github/workflows/sync-to-readthedocs-repo.yaml
@@ -9,8 +9,9 @@ on:
       - latest
       - develop
       - 'pre/*'
-      - 'v*'
       - 'production/test/*'
+    tags:
+      - 'v*'
 jobs:
   extract_branch:
     outputs:


### PR DESCRIPTION
Avoids having to create tags onto the tidy3d-docs repo, and only having to enable a prerelease on the readthedocs admin panel. FYI so you know @momchil-flex 