### PR TITLE
Validate Medium2D components to be either both PEC or non-PEC

### DIFF
--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -433,6 +433,9 @@ def test_medium2d(log_capture):  # noqa: F811
     plt.close()
     assert_log_level(log_capture, "WARNING")
 
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.Medium2D(ss=td.PECMedium(), tt=td.Medium())
+
 
 def test_rotation():
     # check that transpose is inverse

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -5473,6 +5473,17 @@ class Medium2D(AbstractMedium):
             )
         return val
 
+    @skip_if_fields_missing(["ss"])
+    @pd.validator("tt", always=True)
+    def _validate_inplane_pec(cls, val, values):
+        """ss/tt components must be both PEC or non-PEC."""
+        if isinstance(val, PECMedium) != isinstance(values["ss"], PECMedium):
+            raise ValidationError(
+                "Materials describing ss- and tt-components must be "
+                "either both 'PECMedium', or non-'PECMedium'."
+            )
+        return val
+
     @classmethod
     def _weighted_avg(
         cls, meds: List[IsotropicUniformMediumType], weights: List[float]


### PR DESCRIPTION
In principle, we should warn in AnisotropicMedium if the 3 components are not simultaneously PEC or non-PEC. This is because the solver will just convert the anisotropic medium to PECMedium if any of its component is PEC. But since hopefully it is unlikely to be used directly in AnistropicMedium, let's just add a validator in Medium2D. 