### PR TITLE
Moving scipy into core deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,8 @@ PyYAML = "*"
 dask = "*"
 toml = "*"
 autograd = "1.6.2"
-
-### NOT CORE
 scipy = "*"
+### NOT CORE
 boto3 = "^1.28.0"
 requests = "^2.31.0"
 pyjwt = "*"


### PR DESCRIPTION
Some of our validators now require scipy for STL structures. Since our validation/metadata lambdas have been increased in maximum allowed package size, we can move scipy into the core deps.