### PR TITLE
Validate sources and monitors that are exactly at the simulation domain bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `RectangularWaveguide` supports layered cladding above and below core.
 - `SubpixelSpec` accepted by `Simulation.subpixel` to select subpixel averaging methods separately for dielectric, metal, and PEC materials. Specifically, added support for conformal mesh methods near PEC structures that can be specified through the field `pec` in the `SubpixelSpec` class. Note: previously, `subpixel=False` was implementing staircasing for every material except PEC. Now, `subpixel=False` implements direct staircasing for all materials. For PEC, the behavior of `subpixel=False` in Tidy3D < 2.7 is now achieved through `subpixel=SubpixelSpec(pec=HeuristicPECStaircasing())`, while `subpixel=True` in Tidy3D < 2.7 is now achieved through `subpixel=SubpixelSpec(pec=Staircasing())`. The default is `subpixel=SubpixelSpec(pec=PECConformal())` for more accurate PEC modelling.
 
+### Changed
+- Sources and monitors which are exactly at the simulation domain boundaries will now error. They can still be placed very close to the boundaries, but need to be on the inside of the region.
+
 ### Fixed
 - `ModeSolver.plot_field` correctly returning the plot axes.
 - Avoid error if non-positive refractive index used for integration resolution in adjoint.

--- a/tests/test_components/test_eme.py
+++ b/tests/test_components/test_eme.py
@@ -394,6 +394,11 @@ def test_eme_simulation(log_capture):  # noqa: F811
     with pytest.raises(SetupError):
         _ = sim.updated_copy(monitors=[monitor])
 
+    # test monitor at simulation bounds
+    monitor = sim.monitors[-1].updated_copy(center=[0, 0, -sim.size[2] / 2])
+    with pytest.raises(pd.ValidationError):
+        _ = sim.updated_copy(monitors=[monitor])
+
     # test boundary and source validation
     with pytest.raises(SetupError):
         _ = sim.updated_copy(boundary_spec=td.BoundarySpec.all_sides(td.Periodic()))

--- a/tests/test_components/test_heat.py
+++ b/tests/test_components/test_heat.py
@@ -113,10 +113,10 @@ def make_heat_mnts():
     temp_mnt1 = TemperatureMonitor(size=(1.6, 2, 3), name="test")
     temp_mnt2 = TemperatureMonitor(size=(1.6, 2, 3), name="tet", unstructured=True)
     temp_mnt3 = TemperatureMonitor(
-        center=(0, 1, 0), size=(1.6, 0, 3), name="tri", unstructured=True, conformal=True
+        center=(0, 0.9, 0), size=(1.6, 0, 3), name="tri", unstructured=True, conformal=True
     )
     temp_mnt4 = TemperatureMonitor(
-        center=(0, 1, 0), size=(1.6, 0, 3), name="empty", unstructured=True, conformal=False
+        center=(0, 0.9, 0), size=(1.6, 0, 3), name="empty", unstructured=True, conformal=False
     )
     temp_mnt5 = TemperatureMonitor(center=(0, 0.7, 0.8), size=(3, 0, 0), name="line")
     temp_mnt6 = TemperatureMonitor(center=(0.7, 0.6, 0.8), size=(0, 0, 0), name="point")

--- a/tidy3d/components/base_sim/simulation.py
+++ b/tidy3d/components/base_sim/simulation.py
@@ -114,7 +114,7 @@ class AbstractSimulation(Box, ABC):
     _unique_structure_names = assert_unique_names("structures")
     _unique_source_names = assert_unique_names("sources")
 
-    _monitors_in_bounds = assert_objects_in_sim_bounds("monitors")
+    _monitors_in_bounds = assert_objects_in_sim_bounds("monitors", strict_inequality=True)
     _structures_in_bounds = assert_objects_in_sim_bounds("structures", error=False)
 
     @pd.validator("structures", always=True)

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -1988,7 +1988,7 @@ class Simulation(AbstractYeeGridSimulation):
             _ = val.wavelength_from_sources(sources=values.get("sources"))
         return val
 
-    _sources_in_bounds = assert_objects_in_sim_bounds("sources")
+    _sources_in_bounds = assert_objects_in_sim_bounds("sources", strict_inequality=True)
     _mode_sources_symmetries = validate_mode_objects_symmetry("sources")
     _mode_monitors_symmetries = validate_mode_objects_symmetry("monitors")
 


### PR DESCRIPTION
Fixes #1732, #1666 (fyi @QimingFlex)

We do strict validation because such simulations error in some cases, and it's hard to fix everything internally. It may also nudge people not to put their sources and monitors right where they will be affected by the PML and produce slightly unphysical results.

@dbochkov since this is a modification on the base `Simulation` class, some heat tests are failing. Do you think this change makes sense for heat still, i.e. I could just modify the tests - or do you think there are cases in which we actually don't want to error?