### PR TITLE
Add lossless Green2008 cSi and modify default SiO2 in material_library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `RectangularWaveguide.plot_field` optionally draws geometry edges over fields. 
 - `RectangularWaveguide` supports layered cladding above and below core.
 - `SubpixelSpec` accepted by `Simulation.subpixel` to select subpixel averaging methods separately for dielectric, metal, and PEC materials. Specifically, added support for conformal mesh methods near PEC structures that can be specified through the field `pec` in the `SubpixelSpec` class. Note: previously, `subpixel=False` was implementing staircasing for every material except PEC. Now, `subpixel=False` implements direct staircasing for all materials. For PEC, the behavior of `subpixel=False` in Tidy3D < 2.7 is now achieved through `subpixel=SubpixelSpec(pec=HeuristicPECStaircasing())`, while `subpixel=True` in Tidy3D < 2.7 is now achieved through `subpixel=SubpixelSpec(pec=Staircasing())`. The default is `subpixel=SubpixelSpec(pec=PECConformal())` for more accurate PEC modelling.
+- Lossless `Green2008` variant for crystalline silicon added to material library.
+
+### Changed
+- Default variant for silicon dioxide in material library switched from `Horiba` to `Palik_Lossless`.
 
 ### Changed
 - Sources and monitors which are exactly at the simulation domain boundaries will now error. They can still be placed very close to the boundaries, but need to be on the inside of the region.

--- a/docs/api/material_library.rst
+++ b/docs/api/material_library.rst
@@ -385,6 +385,7 @@ Silicon (Crystalline) ("cSi")
    Variant                   Valid for                  Model Info       Reference                                                                                                   
    ========================= ========================== ================ ============================================================================================================
    ``'Green2008'`` (default) 0.25 - 1.45 :math:`{\mu}m` 5-pole, lossy    [1] `[data] <https://refractiveindex.info/data_csv.php?datafile=database/data-nk/main/Si/Green-2008.yml>`__ 
+   ``'Green2008_Lossless'``  1.2 - 1.45 :math:`{\mu}m`  1-pole, lossless [1] `[data] <https://refractiveindex.info/data_csv.php?datafile=database/data-nk/main/Si/Green-2008.yml>`__ 
    ``'Li1993_293K'``         1.2 - 14.0 :math:`{\mu}m`  1-pole, lossless [2] `[data] <https://refractiveindex.info/data_csv.php?datafile=database/data-nk/main/Si/Li-293K.yml>`__    
    ``'Palik_Lossless'``      1.2 - 250.0 :math:`{\mu}m` 1-pole, low loss [3]                                                                                                         
    ``'Palik_Lossy'``         0.1 - 1.4 :math:`{\mu}m`   5-pole, lossy    [3]                                                                                                         
@@ -394,6 +395,8 @@ Silicon (Crystalline) ("cSi")
 Examples:
 
 >>> medium = material_library['cSi']['Green2008']
+
+>>> medium = material_library['cSi']['Green2008_Lossless']
 
 >>> medium = material_library['cSi']['Li1993_293K']
 
@@ -1112,13 +1115,13 @@ Silicon Dioxide ("SiO2")
 .. table::
    :widths: auto
 
-   ====================== ========================== ================ ===========
-   Variant                Valid for                  Model Info       Reference  
-   ====================== ========================== ================ ===========
-   ``'Horiba'`` (default) 0.25 - 1.77 :math:`{\mu}m` 1-pole, lossy    [1]        
-   ``'Palik_Lossless'``   0.15 - 5.0 :math:`{\mu}m`  2-pole, low loss [2]        
-   ``'Palik_Lossy'``      4.0 - 250.0 :math:`{\mu}m` 5-pole, lossy    [2]        
-   ====================== ========================== ================ ===========
+   ============================== ========================== ================ ===========
+   Variant                        Valid for                  Model Info       Reference  
+   ============================== ========================== ================ ===========
+   ``'Horiba'``                   0.25 - 1.77 :math:`{\mu}m` 1-pole, lossy    [1]        
+   ``'Palik_Lossless'`` (default) 0.15 - 5.0 :math:`{\mu}m`  2-pole, low loss [2]        
+   ``'Palik_Lossy'``              4.0 - 250.0 :math:`{\mu}m` 5-pole, lossy    [2]        
+   ============================== ========================== ================ ===========
 
 Examples:
 

--- a/tests/test_package/test_material_library.py
+++ b/tests/test_package/test_material_library.py
@@ -1,6 +1,8 @@
 import pytest
 import numpy as np
 import pydantic.v1 as pydantic
+from ..utils import assert_log_level
+from ..utils import log_capture  # noqa: F401
 
 from tidy3d.material_library.material_library import (
     VariantItem,
@@ -12,6 +14,18 @@ from tidy3d.material_library.material_library import (
     MaterialItemUniaxial,
 )
 import tidy3d as td
+
+
+def test_warning_default_variant_switching(log_capture):  # noqa: F811
+    """Issue warning for switching default medium variant."""
+
+    # no warning for most materials with no default change
+    _ = td.material_library["cSi"].medium
+    assert_log_level(log_capture, None)
+
+    # issue warning for SiO2
+    _ = td.material_library["SiO2"].medium
+    assert_log_level(log_capture, "WARNING")
 
 
 def test_VariantItem():

--- a/tidy3d/material_library/material_library.py
+++ b/tidy3d/material_library/material_library.py
@@ -6,6 +6,7 @@ import pydantic.v1 as pd
 from ..components.medium import PoleResidue, Medium2D, AnisotropicMedium, Sellmeier
 from ..components.base import Tidy3dBaseModel
 from ..components.types import Axis
+from ..log import log
 from ..exceptions import SetupError
 from .material_reference import material_refs, ReferenceData
 from .parametric_materials import Graphene
@@ -99,6 +100,11 @@ class MaterialItem(Tidy3dBaseModel):
     @property
     def medium(self):
         """The default medium."""
+        if self.name == "Silicon Dioxide":
+            log.warning(
+                "Since Tidy3D 2.7, the default variant for silicon dioxide has been switched from "
+                "'Horiba' to 'Palik_Lossless'."
+            )
         return self.variants[self.default].medium
 
 
@@ -1731,6 +1737,22 @@ cSi_Green2008 = VariantItem(
     "main/Si/Green-2008.yml",
 )
 
+cSi_Green2008Lossless = VariantItem(
+    medium=PoleResidue(
+        eps_inf=8.735527704181576,
+        poles=[
+            (
+                (-3618638294867195j),
+                (5372233772327493j),
+            ),
+        ],
+        frequency_range=(206753419710997.8, 249827048333333.34),
+    ),
+    reference=[material_refs["Green2008"]],
+    data_url="https://refractiveindex.info/data_csv.php?datafile=database/data-nk/"
+    "main/Si/Green-2008.yml",
+)
+
 cSi_PalikLossy = VariantItem(
     medium=PoleResidue(
         eps_inf=1.0,
@@ -2121,7 +2143,7 @@ material_library = dict(
             Palik_Lossy=SiO2_Palik_Lossy,
             Horiba=SiO2_Horiba,
         ),
-        default="Horiba",
+        default="Palik_Lossless",
     ),
     SiON=MaterialItem(
         name="Silicon Oxynitride",
@@ -2212,6 +2234,7 @@ material_library = dict(
             SalzbergVilla1957=cSi_SalzbergVilla1957,
             Li1993_293K=cSi_Li1993_293K,
             Green2008=cSi_Green2008,
+            Green2008_Lossless=cSi_Green2008Lossless,
         ),
         default="Green2008",
     ),

--- a/tidy3d/plugins/dispersion/fit_fast.py
+++ b/tidy3d/plugins/dispersion/fit_fast.py
@@ -809,7 +809,12 @@ class FastDispersionFitter(DispersionFitter):
                                 best_model.unweighted_rms_error,
                             )
 
-                        return best_model.pole_residue, best_model.rms_error
+                        return (
+                            best_model.pole_residue.updated_copy(
+                                frequency_range=self.frequency_range
+                            ),
+                            best_model.rms_error,
+                        )
 
         # if exited loop, did not reach tolerance (warn)
         progress.update(
@@ -829,7 +834,10 @@ class FastDispersionFitter(DispersionFitter):
                 best_model.unweighted_rms_error,
             )
 
-        return best_model.pole_residue, best_model.rms_error
+        return (
+            best_model.pole_residue.updated_copy(frequency_range=self.frequency_range),
+            best_model.rms_error,
+        )
 
     @classmethod
     def constant_loss_tangent_model(


### PR DESCRIPTION
Address https://github.com/flexcompute/tidy3d/issues/1529:

- Switch the default variant from `Horiba` to `Palik_Lossess` for SiO2;
- Add Lossless Green2008 for cSi. The default remains unchanged as only Green2008 covers visible spectrum