### PR TITLE
add WavePorts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `plot_length_units` to `Simulation` and `Scene` to allow for specifying units, which improves axis labels and scaling when plotting.
 - Added the helper function `compute_power_delivered_by_port`  to `TerminalComponentModeler` which computes power delivered to a microwave network from a port.
 - Added the account function `account` to check credit balance and daily free simulation balance.
+- Added `WavePort` to the `TerminalComponentModeler` which is the suggested port type for exciting transmission lines.
+- Added plotting functionality to voltage and current path integrals in the `microwave` plugin.
+- Added convenience functions `from_terminal_positions` and `from_circular_path` to simplify setup of `VoltageIntegralAxisAligned` and `CustomCurrentIntegral2D`, respectively.
 
 ### Changed
 - Priority is given to `snapping_points` in `GridSpec` when close to structure boundaries, which reduces the chance of them being skipped.

--- a/docs/api/plugins/smatrix.rst
+++ b/docs/api/plugins/smatrix.rst
@@ -11,6 +11,7 @@ Scattering Matrix Calculator
    tidy3d.plugins.smatrix.Port
    tidy3d.plugins.smatrix.ModalPortDataArray
    tidy3d.plugins.smatrix.TerminalComponentModeler
+   tidy3d.plugins.smatrix.TerminalPortDataArray
    tidy3d.plugins.smatrix.LumpedPort
-   tidy3d.plugins.smatrix.LumpedPortDataArray
    tidy3d.plugins.smatrix.CoaxialLumpedPort
+   tidy3d.plugins.smatrix.WavePort

--- a/tests/test_plugins/terminal_component_modeler_def.py
+++ b/tests/test_plugins/terminal_component_modeler_def.py
@@ -1,9 +1,13 @@
+from typing import Union
+
 import numpy as np
 import tidy3d as td
+import tidy3d.plugins.microwave as microwave
 from tidy3d.plugins.smatrix import (
     CoaxialLumpedPort,
     LumpedPort,
     TerminalComponentModeler,
+    WavePort,
 )
 
 # Microstrip dimensions
@@ -240,6 +244,10 @@ def make_coaxial_component_modeler(
     length: float = None,
     port_refinement: bool = True,
     grid_spec: td.GridSpec = None,
+    port_types: tuple[Union[CoaxialLumpedPort, WavePort], Union[CoaxialLumpedPort, WavePort]] = (
+        CoaxialLumpedPort,
+        CoaxialLumpedPort,
+    ),
     **kwargs,
 ):
     if not length:
@@ -247,24 +255,55 @@ def make_coaxial_component_modeler(
 
     sim = make_coaxial_simulation(length=length, grid_spec=grid_spec)
 
+    def make_port(center, direction, type, name) -> Union[CoaxialLumpedPort, WavePort]:
+        if type is CoaxialLumpedPort:
+            port_cells = None
+            if port_refinement:
+                port_cells = 21
+            port = CoaxialLumpedPort(
+                center=center,
+                outer_diameter=2 * Router,
+                inner_diameter=2 * Rinner,
+                normal_axis=2,
+                direction=direction,
+                name=name,
+                num_grid_cells=port_cells,
+                impedance=reference_impedance,
+            )
+        else:
+            mean_radius = (Router + Rinner) / 2
+            voltage_center = list(center)
+            voltage_center[0] += mean_radius
+            voltage_size = [Router - Rinner, 0, 0]
+
+            port = WavePort(
+                center=center,
+                size=[2 * Router, 2 * Router, 0],
+                direction=direction,
+                name=name,
+                mode_spec=td.ModeSpec(num_modes=1),
+                mode_index=0,
+                voltage_integral=microwave.VoltageIntegralAxisAligned(
+                    center=voltage_center,
+                    size=voltage_size,
+                    extrapolate_to_endpoints=True,
+                    snap_path_to_grid=True,
+                    sign="+",
+                ),
+                current_integral=microwave.CustomCurrentIntegral2D.from_circular_path(
+                    center=center,
+                    radius=mean_radius,
+                    num_points=41,
+                    normal_axis=2,
+                    clockwise=False,
+                ),
+            )
+        return port
+
     center_src1 = [0, 0, -length / 2]
-
-    port_cells = None
-    if port_refinement:
-        port_cells = 21
-
-    port_1 = CoaxialLumpedPort(
-        center=center_src1,
-        outer_diameter=2 * Router,
-        inner_diameter=2 * Rinner,
-        normal_axis=2,
-        direction="+",
-        name="coax_port_1",
-        num_grid_cells=port_cells,
-        impedance=reference_impedance,
-    )
+    port_1 = make_port(center_src1, direction="+", type=port_types[0], name="coax_port_1")
     center_src2 = [0, 0, length / 2]
-    port_2 = port_1.updated_copy(name="coax_port_2", center=center_src2, direction="-")
+    port_2 = make_port(center_src2, direction="-", type=port_types[1], name="coax_port_2")
     ports = [port_1, port_2]
     freqs = np.linspace(freq_start, freq_stop, 100)
 

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -1394,7 +1394,11 @@ class ModeData(ModeSolverDataset, ElectromagneticFieldData):
         newly created data."""
 
         update_dict = dict(self._grid_correction_dict, **self.field_components)
-        update_dict = {key: field.isel(**isel_kwargs) for key, field in update_dict.items()}
+        update_dict = {
+            key: field.isel(**isel_kwargs)
+            for key, field in update_dict.items()
+            if isinstance(field, DataArray)
+        }
         return self._updated(update=update_dict)
 
     def _assign_coords(self, **assign_coords_kwargs):

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -735,6 +735,29 @@ class Geometry(Tidy3dBaseModel, ABC):
         return axis, position
 
     @staticmethod
+    def parse_two_xyz_kwargs(**xyz) -> List[Tuple[Axis, float]]:
+        """Turns x,y,z kwargs into indices of axes and the position along each axis.
+
+        Parameters
+        ----------
+        x : float = None
+            Position in x direction, only two of x,y,z can be specified to define line.
+        y : float = None
+            Position in y direction, only two of x,y,z can be specified to define line.
+        z : float = None
+            Position in z direction, only two of x,y,z can be specified to define line.
+
+        Returns
+        -------
+        [(int, float), (int, float)]
+            Index into xyz axis (0,1,2) and position along that axis.
+        """
+        xyz_filtered = {k: v for k, v in xyz.items() if v is not None}
+        assert len(xyz_filtered) == 2, "exactly two kwarg in [x,y,z] must be specified."
+        xyz_list = list(xyz_filtered.items())
+        return [("xyz".index(axis_label), position) for axis_label, position in xyz_list]
+
+    @staticmethod
     def rotate_points(points: ArrayFloat3D, axis: Coordinate, angle: float) -> ArrayFloat3D:
         """Rotate a set of points in 3D.
 

--- a/tidy3d/components/viz.py
+++ b/tidy3d/components/viz.py
@@ -75,18 +75,15 @@ def equal_aspect(plot):
 """ plot parameters """
 
 
-class PlotParams(Tidy3dBaseModel):
-    """Stores plotting parameters / specifications for a given model."""
+class AbstractPlotParams(Tidy3dBaseModel):
+    """Abstract class for storing plotting parameters.
+    Corresponds with select properties of ``matplotlib.artist.Artist``.
+    """
 
     alpha: Any = pd.Field(1.0, title="Opacity")
-    edgecolor: Any = pd.Field(None, title="Edge Color", alias="ec")
-    facecolor: Any = pd.Field(None, title="Face Color", alias="fc")
-    fill: bool = pd.Field(True, title="Is Filled")
-    hatch: str = pd.Field(None, title="Hatch Style")
     zorder: float = pd.Field(None, title="Display Order")
-    linewidth: pd.NonNegativeFloat = pd.Field(1, title="Line Width", alias="lw")
 
-    def include_kwargs(self, **kwargs) -> PlotParams:
+    def include_kwargs(self, **kwargs) -> AbstractPlotParams:
         """Update the plot params with supplied kwargs."""
         update_dict = {
             key: value
@@ -101,6 +98,32 @@ class PlotParams(Tidy3dBaseModel):
         for ignore_key in ("type", "attrs"):
             kwarg_dict.pop(ignore_key)
         return kwarg_dict
+
+
+class PathPlotParams(AbstractPlotParams):
+    """Stores plotting parameters / specifications for a path.
+    Corresponds with select properties of ``matplotlib.lines.Line2D``.
+    """
+
+    color: Any = pd.Field(None, title="Color", alias="c")
+    linewidth: pd.NonNegativeFloat = pd.Field(2, title="Line Width", alias="lw")
+    linestyle: str = pd.Field("--", title="Line Style", alias="ls")
+    marker: Any = pd.Field("o", title="Marker Style")
+    markeredgecolor: Any = pd.Field(None, title="Marker Edge Color", alias="mec")
+    markerfacecolor: Any = pd.Field(None, title="Marker Face Color", alias="mfc")
+    markersize: pd.NonNegativeFloat = pd.Field(10, title="Marker Size", alias="ms")
+
+
+class PlotParams(AbstractPlotParams):
+    """Stores plotting parameters / specifications for a given model.
+    Corresponds with select properties of ``matplotlib.patches.Patch``.
+    """
+
+    edgecolor: Any = pd.Field(None, title="Edge Color", alias="ec")
+    facecolor: Any = pd.Field(None, title="Face Color", alias="fc")
+    fill: bool = pd.Field(True, title="Is Filled")
+    hatch: str = pd.Field(None, title="Hatch Style")
+    linewidth: pd.NonNegativeFloat = pd.Field(1, title="Line Width", alias="lw")
 
 
 # defaults for different tidy3d objects

--- a/tidy3d/constants.py
+++ b/tidy3d/constants.py
@@ -166,7 +166,12 @@ Picosecond per (nanometer kilometer).
 
 OHM = "ohm"
 """
-SI unit of resistance..
+SI unit of resistance.
+"""
+
+AMP = "A"
+"""
+SI unit of electric current.
 """
 
 THERMAL_CONDUCTIVITY = "W/(um*K)"

--- a/tidy3d/plugins/microwave/__init__.py
+++ b/tidy3d/plugins/microwave/__init__.py
@@ -6,7 +6,7 @@ from .custom_path_integrals import (
     CustomPathIntegral2D,
     CustomVoltageIntegral2D,
 )
-from .impedance_calculator import ImpedanceCalculator
+from .impedance_calculator import CurrentIntegralTypes, ImpedanceCalculator, VoltageIntegralTypes
 from .path_integrals import (
     AxisAlignedPathIntegral,
     CurrentIntegralAxisAligned,
@@ -21,6 +21,8 @@ __all__ = [
     "CurrentIntegralAxisAligned",
     "CustomVoltageIntegral2D",
     "CustomCurrentIntegral2D",
+    "VoltageIntegralTypes",
+    "CurrentIntegralTypes",
     "ImpedanceCalculator",
     "models",
     "rf_material_library",

--- a/tidy3d/plugins/microwave/custom_path_integrals.py
+++ b/tidy3d/plugins/microwave/custom_path_integrals.py
@@ -11,10 +11,26 @@ import xarray as xr
 from ...components.base import cached_property
 from ...components.data.data_array import FreqDataArray, FreqModeDataArray, TimeDataArray
 from ...components.data.monitor_data import FieldData, FieldTimeData, ModeSolverData
-from ...components.types import ArrayFloat2D, Axis
+from ...components.geometry.base import Geometry
+from ...components.types import ArrayFloat2D, Ax, Axis, Bound, Coordinate
+from ...components.viz import add_ax_if_none
 from ...constants import MICROMETER, fp_eps
 from ...exceptions import DataError, SetupError
-from .path_integrals import AbstractAxesRH, IntegralResultTypes, MonitorDataTypes
+from .path_integrals import (
+    AbstractAxesRH,
+    CurrentIntegralAxisAligned,
+    IntegralResultTypes,
+    MonitorDataTypes,
+    VoltageIntegralAxisAligned,
+    _check_em_field_supported,
+)
+from .viz import (
+    ARROW_CURRENT,
+    plot_params_current_path,
+    plot_params_voltage_minus,
+    plot_params_voltage_path,
+    plot_params_voltage_plus,
+)
 
 FieldParameter = Literal["E", "H"]
 
@@ -72,8 +88,6 @@ class CustomPathIntegral2D(AbstractAxesRH):
         :class:`.IntegralResultTypes`
             Result of integral over remaining dimensions (frequency, time, mode indices).
         """
-        if not isinstance(em_field, (FieldData, FieldTimeData, ModeSolverData)):
-            raise DataError("'em_field' type not supported.")
 
         (dim1, dim2, dim3) = self.local_dims
 
@@ -138,8 +152,61 @@ class CustomPathIntegral2D(AbstractAxesRH):
             dl[0] = dl[-1] = grad_end[1]
         return dl
 
+    @classmethod
+    def from_circular_path(
+        cls, center: Coordinate, radius: float, num_points: int, normal_axis: Axis, clockwise: bool
+    ) -> CustomPathIntegral2D:
+        """Creates a ``CustomPathIntegral2D`` from a circular path given a desired number of points
+        along the perimeter.
+
+        Parameters
+        ----------
+        center : Coordinate
+            The center of the circle.
+        radius : float
+            The radius of the circle.
+        num_points : int
+            THe number of equidistant points to use along the perimeter of the circle.
+        normal_axis : Axis
+            The axis normal to the defined circle.
+        clockwise : bool
+            When ``True``, the points will be ordered clockwise with respect to the positive
+            direction of the ``normal_axis``.
+
+        Returns
+        -------
+        :class:`.CustomPathIntegral2D`
+            A path integral defined on a circular path.
+        """
+
+        def generate_circle_coordinates(radius: float, num_points: int, clockwise: bool):
+            """Helper for generating x,y vertices around a circle in the local coordinate frame."""
+            sign = 1.0
+            if clockwise:
+                sign = -1.0
+            angles = np.linspace(0, sign * 2 * np.pi, num_points, endpoint=True)
+            xt = radius * np.cos(angles)
+            yt = radius * np.sin(angles)
+            return (xt, yt)
+
+        # Get transverse axes
+        normal_center, trans_center = Geometry.pop_axis(center, normal_axis)
+
+        # These x,y coordinates in the local coordinate frame
+        if normal_axis == 1:
+            # Handle special case when y is the axis that is popped
+            clockwise = not clockwise
+        xt, yt = generate_circle_coordinates(radius, num_points, clockwise)
+        xt += trans_center[0]
+        yt += trans_center[1]
+        circle_vertices = np.column_stack((xt, yt))
+        # Close the contour exactly
+        circle_vertices[-1, :] = circle_vertices[0, :]
+        return cls(axis=normal_axis, position=normal_center, vertices=circle_vertices)
+
     @cached_property
     def is_closed_contour(self) -> bool:
+        """Returns ``true`` when the first vertex equals the last vertex."""
         return np.isclose(
             self.vertices[0, :],
             self.vertices[-1, :],
@@ -162,6 +229,15 @@ class CustomPathIntegral2D(AbstractAxesRH):
                 f"Given array with shape of '{val.shape}'."
             )
         return val
+
+    @cached_property
+    def bounds(self) -> Bound:
+        """Helper to get the geometric bounding box of the path integral."""
+        path_min = np.amin(self.vertices, axis=0)
+        path_max = np.amax(self.vertices, axis=0)
+        min_bound = Geometry.unpop_axis(self.position, path_min, self.axis)
+        max_bound = Geometry.unpop_axis(self.position, path_max, self.axis)
+        return (min_bound, max_bound)
 
 
 class CustomVoltageIntegral2D(CustomPathIntegral2D):
@@ -189,8 +265,59 @@ class CustomVoltageIntegral2D(CustomPathIntegral2D):
         :class:`.IntegralResultTypes`
             Result of voltage computation over remaining dimensions (frequency, time, mode indices).
         """
+        _check_em_field_supported(em_field=em_field)
         voltage = -1.0 * self.compute_integral(field="E", em_field=em_field)
+        voltage = VoltageIntegralAxisAligned._set_data_array_attributes(voltage)
         return voltage
+
+    @add_ax_if_none
+    def plot(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        ax: Ax = None,
+        **path_kwargs,
+    ) -> Ax:
+        """Plot path integral at single (x,y,z) coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            Position of plane in x direction, only one of x,y,z can be specified to define plane.
+        y : float = None
+            Position of plane in y direction, only one of x,y,z can be specified to define plane.
+        z : float = None
+            Position of plane in z direction, only one of x,y,z can be specified to define plane.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        **path_kwargs
+            Optional keyword arguments passed to the matplotlib plotting of the line.
+            For details on accepted values, refer to
+            `Matplotlib's documentation <https://tinyurl.com/36marrat>`_.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+        axis, position = Geometry.parse_xyz_kwargs(x=x, y=y, z=z)
+        if axis != self.main_axis or not np.isclose(position, self.position, rtol=fp_eps):
+            return ax
+
+        plot_params = plot_params_voltage_path.include_kwargs(**path_kwargs)
+        plot_kwargs = plot_params.to_kwargs()
+        xs = self.vertices[:, 0]
+        ys = self.vertices[:, 1]
+        ax.plot(xs, ys, markevery=[0, -1], **plot_kwargs)
+
+        # Plot special end points
+        end_kwargs = plot_params_voltage_plus.include_kwargs(**path_kwargs).to_kwargs()
+        start_kwargs = plot_params_voltage_minus.include_kwargs(**path_kwargs).to_kwargs()
+        ax.plot(xs[0], ys[0], **start_kwargs)
+        ax.plot(xs[-1], ys[-1], **end_kwargs)
+
+        return ax
 
 
 class CustomCurrentIntegral2D(CustomPathIntegral2D):
@@ -211,5 +338,57 @@ class CustomCurrentIntegral2D(CustomPathIntegral2D):
         :class:`.IntegralResultTypes`
             Result of current computation over remaining dimensions (frequency, time, mode indices).
         """
+        _check_em_field_supported(em_field=em_field)
         current = self.compute_integral(field="H", em_field=em_field)
+        current = CurrentIntegralAxisAligned._set_data_array_attributes(current)
         return current
+
+    @add_ax_if_none
+    def plot(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        ax: Ax = None,
+        **path_kwargs,
+    ) -> Ax:
+        """Plot path integral at single (x,y,z) coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            Position of plane in x direction, only one of x,y,z can be specified to define plane.
+        y : float = None
+            Position of plane in y direction, only one of x,y,z can be specified to define plane.
+        z : float = None
+            Position of plane in z direction, only one of x,y,z can be specified to define plane.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        **path_kwargs
+            Optional keyword arguments passed to the matplotlib plotting of the line.
+            For details on accepted values, refer to
+            `Matplotlib's documentation <https://tinyurl.com/36marrat>`_.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+        axis, position = Geometry.parse_xyz_kwargs(x=x, y=y, z=z)
+        if axis != self.main_axis or not np.isclose(position, self.position, rtol=fp_eps):
+            return ax
+
+        plot_params = plot_params_current_path.include_kwargs(**path_kwargs)
+        plot_kwargs = plot_params.to_kwargs()
+        xs = self.vertices[:, 0]
+        ys = self.vertices[:, 1]
+        ax.plot(xs, ys, **plot_kwargs)
+
+        # Add arrow at start of contour
+        ax.annotate(
+            "",
+            xytext=(xs[0], ys[0]),
+            xy=(xs[1], ys[1]),
+            arrowprops=ARROW_CURRENT,
+        )
+        return ax

--- a/tidy3d/plugins/microwave/impedance_calculator.py
+++ b/tidy3d/plugins/microwave/impedance_calculator.py
@@ -8,14 +8,16 @@ import numpy as np
 import pydantic.v1 as pd
 
 from ...components.base import Tidy3dBaseModel
-from ...components.data.monitor_data import FieldData, FieldTimeData, ModeSolverData
-from ...exceptions import DataError, ValidationError
+from ...components.data.monitor_data import FieldTimeData
+from ...constants import OHM
+from ...exceptions import ValidationError
 from .custom_path_integrals import CustomCurrentIntegral2D, CustomVoltageIntegral2D
 from .path_integrals import (
     CurrentIntegralAxisAligned,
     IntegralResultTypes,
     MonitorDataTypes,
     VoltageIntegralAxisAligned,
+    _check_em_field_supported,
 )
 
 VoltageIntegralTypes = Union[VoltageIntegralAxisAligned, CustomVoltageIntegral2D]
@@ -53,9 +55,7 @@ class ImpedanceCalculator(Tidy3dBaseModel):
         :class:`.IntegralResultTypes`
             Result of impedance computation over remaining dimensions (frequency, time, mode indices).
         """
-
-        if not isinstance(em_field, (FieldData, FieldTimeData, ModeSolverData)):
-            raise DataError("'em_field' type not supported by impedance calculator.")
+        _check_em_field_supported(em_field=em_field)
 
         # If both voltage and current integrals have been defined then impedance is computed directly
         if self.voltage_integral:
@@ -63,11 +63,12 @@ class ImpedanceCalculator(Tidy3dBaseModel):
         if self.current_integral:
             current = self.current_integral.compute_current(em_field)
 
-        # If only one of the integrals has been provided then fall back to using total power (flux)
-        # with Ohm's law. The input field should cover an area large enough to render the flux
-        # computation accurate. If the input field is a time signal, then it is real and flux
-        # corresponds to the instantaneous power. Otherwise the input field is in frequency domain,
-        # where flux indicates the time-averaged power 0.5*Re(V*conj(I))
+        # If only one of the integrals has been provided, then the computation falls back to using
+        # total power (flux) with Ohm's law to compute the missing quantity. The input field should
+        # cover an area large enough to render the flux computation accurate. If the input field is
+        # a time signal, then it is real and flux corresponds to the instantaneous power. Otherwise
+        # the input field is in frequency domain, where flux indicates the time-averaged power
+        # 0.5*Re(V*conj(I)).
         if not self.voltage_integral:
             flux = em_field.flux
             if isinstance(em_field, FieldTimeData):
@@ -82,14 +83,21 @@ class ImpedanceCalculator(Tidy3dBaseModel):
                 current = np.conj(2 * flux / voltage)
 
         impedance = voltage / current
+        impedance = ImpedanceCalculator._set_data_array_attributes(impedance)
         return impedance
 
     @pd.validator("current_integral", always=True)
     def check_voltage_or_current(cls, val, values):
         """Raise validation error if both ``voltage_integral`` and ``current_integral``
-        were not provided."""
+        are not provided."""
         if not values.get("voltage_integral") and not val:
             raise ValidationError(
-                "Atleast one of 'voltage_integral' or 'current_integral' must be provided."
+                "At least one of 'voltage_integral' or 'current_integral' must be provided."
             )
         return val
+
+    @staticmethod
+    def _set_data_array_attributes(data_array: IntegralResultTypes) -> IntegralResultTypes:
+        """Helper to set additional metadata for ``IntegralResultTypes``."""
+        data_array.name = "Z0"
+        return data_array.assign_attrs(units=OHM, long_name="characteristic impedance")

--- a/tidy3d/plugins/microwave/path_integrals.py
+++ b/tidy3d/plugins/microwave/path_integrals.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Union
+from typing import Any, Union
 
 import numpy as np
 import pydantic.v1 as pd
+import shapely as shapely
 
 from ...components.base import Tidy3dBaseModel, cached_property
 from ...components.data.data_array import (
@@ -18,14 +19,32 @@ from ...components.data.data_array import (
     TimeDataArray,
 )
 from ...components.data.monitor_data import FieldData, FieldTimeData, ModeSolverData
-from ...components.geometry.base import Box
-from ...components.types import Axis, Direction
+from ...components.geometry.base import Box, Geometry
+from ...components.types import Ax, Axis, Coordinate2D, Direction
 from ...components.validators import assert_line, assert_plane
+from ...components.viz import add_ax_if_none
+from ...constants import AMP, VOLT, fp_eps
 from ...exceptions import DataError, Tidy3dError
+from .viz import (
+    ARROW_CURRENT,
+    plot_params_current_path,
+    plot_params_voltage_minus,
+    plot_params_voltage_path,
+    plot_params_voltage_plus,
+)
 
 MonitorDataTypes = Union[FieldData, FieldTimeData, ModeSolverData]
 EMScalarFieldType = Union[ScalarFieldDataArray, ScalarFieldTimeDataArray, ScalarModeFieldDataArray]
 IntegralResultTypes = Union[FreqDataArray, FreqModeDataArray, TimeDataArray]
+
+
+def _check_em_field_supported(em_field: Any):
+    """Function for validating correct data arrays."""
+    if not isinstance(em_field, (FieldData, FieldTimeData, ModeSolverData)):
+        raise DataError(
+            "'em_field' type not supported. Supported types are "
+            "'FieldData', 'FieldTimeData', 'ModeSolverData'."
+        )
 
 
 class AbstractAxesRH(Tidy3dBaseModel, ABC):
@@ -171,6 +190,17 @@ class AxisAlignedPathIntegral(AbstractAxesRH, Box):
                 return index
         raise Tidy3dError("Failed to identify axis.")
 
+    def _vertices_2D(self, axis: Axis) -> tuple[Coordinate2D, Coordinate2D]:
+        """Returns the two vertices of this path in the plane defined by ``axis``."""
+        min = self.bounds[0]
+        max = self.bounds[1]
+        _, min = Box.pop_axis(min, axis)
+        _, max = Box.pop_axis(max, axis)
+
+        u = [min[0], max[0]]
+        v = [min[1], max[1]]
+        return (u, v)
+
 
 class VoltageIntegralAxisAligned(AxisAlignedPathIntegral):
     """Class for computing the voltage between two points defined by an axis-aligned line."""
@@ -183,21 +213,137 @@ class VoltageIntegralAxisAligned(AxisAlignedPathIntegral):
 
     def compute_voltage(self, em_field: MonitorDataTypes) -> IntegralResultTypes:
         """Compute voltage along path defined by a line."""
-        if not isinstance(em_field, (FieldData, FieldTimeData, ModeSolverData)):
-            raise DataError("'em_field' type not supported.")
+        _check_em_field_supported(em_field=em_field)
         e_component = "xyz"[self.main_axis]
         field_name = f"E{e_component}"
         # Validate that the field is present
         if field_name not in em_field.field_components:
             raise DataError(f"'field_name' '{field_name}' not found.")
         e_field = em_field.field_components[field_name]
-        # V = -integral(E)
+
         voltage = self.compute_integral(e_field)
 
         if self.sign == "+":
             voltage *= -1
+
+        voltage = VoltageIntegralAxisAligned._set_data_array_attributes(voltage)
         # Return data array of voltage while keeping coordinates of frequency|time|mode index
         return voltage
+
+    @staticmethod
+    def _set_data_array_attributes(data_array: IntegralResultTypes) -> IntegralResultTypes:
+        """Add explanatory attributes to the data array."""
+        data_array.name = "V"
+        return data_array.assign_attrs(units=VOLT, long_name="voltage")
+
+    @staticmethod
+    def from_terminal_positions(
+        plus_terminal: float,
+        minus_terminal: float,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        extrapolate_to_endpoints: bool = True,
+        snap_path_to_grid: bool = True,
+    ) -> VoltageIntegralAxisAligned:
+        """Helper to create a :class:`VoltageIntegralAxisAligned` from two coordinates that
+        define a line and two positions indicating the endpoints of the path integral.
+
+        Parameters
+        ----------
+        plus_terminal : float
+            Position along the voltage axis of the positive terminal.
+        minus_terminal : float
+            Position along the voltage axis of the negative terminal.
+        x : float = None
+            Position in x direction, only two of x,y,z can be specified to define line.
+        y : float = None
+            Position in y direction, only two of x,y,z can be specified to define line.
+        z : float = None
+            Position in z direction, only two of x,y,z can be specified to define line.
+        extrapolate_to_endpoints: bool = True
+            Passed directly to :class:`VoltageIntegralAxisAligned`
+        snap_path_to_grid: bool = True
+            Passed directly to :class:`VoltageIntegralAxisAligned`
+
+        Returns
+        -------
+        VoltageIntegralAxisAligned
+            The created path integral for computing voltage between the two terminals.
+        """
+        axis_positions = Geometry.parse_two_xyz_kwargs(x=x, y=y, z=z)
+        # Calculate center and size of the future box
+        midpoint = (plus_terminal + minus_terminal) / 2
+        length = np.abs(plus_terminal - minus_terminal)
+        center = [midpoint, midpoint, midpoint]
+        size = [length, length, length]
+        for axis, position in axis_positions:
+            size[axis] = 0
+            center[axis] = position
+
+        direction = "+"
+        if plus_terminal < minus_terminal:
+            direction = "-"
+
+        return VoltageIntegralAxisAligned(
+            center=center,
+            size=size,
+            extrapolate_to_endpoints=extrapolate_to_endpoints,
+            snap_path_to_grid=snap_path_to_grid,
+            sign=direction,
+        )
+
+    @add_ax_if_none
+    def plot(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        ax: Ax = None,
+        **path_kwargs,
+    ) -> Ax:
+        """Plot path integral at single (x,y,z) coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            Position of plane in x direction, only one of x,y,z can be specified to define plane.
+        y : float = None
+            Position of plane in y direction, only one of x,y,z can be specified to define plane.
+        z : float = None
+            Position of plane in z direction, only one of x,y,z can be specified to define plane.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        **path_kwargs
+            Optional keyword arguments passed to the matplotlib plotting of the line.
+            For details on accepted values, refer to
+            `Matplotlib's documentation <https://tinyurl.com/36marrat>`_.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+        axis, position = self.parse_xyz_kwargs(x=x, y=y, z=z)
+        if axis == self.main_axis or not np.isclose(position, self.center[axis], rtol=fp_eps):
+            return ax
+
+        (xs, ys) = self._vertices_2D(axis)
+        # Plot the path
+        plot_params = plot_params_voltage_path.include_kwargs(**path_kwargs)
+        plot_kwargs = plot_params.to_kwargs()
+        ax.plot(xs, ys, markevery=[0, -1], **plot_kwargs)
+
+        # Plot special end points
+        end_kwargs = plot_params_voltage_plus.include_kwargs(**path_kwargs).to_kwargs()
+        start_kwargs = plot_params_voltage_minus.include_kwargs(**path_kwargs).to_kwargs()
+
+        if self.sign == "-":
+            start_kwargs, end_kwargs = end_kwargs, start_kwargs
+
+        ax.plot(xs[0], ys[0], **start_kwargs)
+        ax.plot(xs[1], ys[1], **end_kwargs)
+        return ax
 
 
 class CurrentIntegralAxisAligned(AbstractAxesRH, Box):
@@ -214,19 +360,18 @@ class CurrentIntegralAxisAligned(AbstractAxesRH, Box):
     extrapolate_to_endpoints: bool = pd.Field(
         False,
         title="Extrapolate to Endpoints",
-        description="This parameter is passed to ``AxisAlignedPathIntegral`` objects when computing the contour integral.",
+        description="This parameter is passed to :class:`AxisAlignedPathIntegral` objects when computing the contour integral.",
     )
 
     snap_contour_to_grid: bool = pd.Field(
         False,
         title="Snap Contour to Grid",
-        description="This parameter is passed to ``AxisAlignedPathIntegral`` objects when computing the contour integral.",
+        description="This parameter is passed to :class:`AxisAlignedPathIntegral` objects when computing the contour integral.",
     )
 
     def compute_current(self, em_field: MonitorDataTypes) -> IntegralResultTypes:
         """Compute current flowing in loop defined by the outer edge of a rectangle."""
-        if not isinstance(em_field, (FieldData, FieldTimeData, ModeSolverData)):
-            raise DataError("'em_field' type not supported.")
+        _check_em_field_supported(em_field=em_field)
         ax1 = self.remaining_axes[0]
         ax2 = self.remaining_axes[1]
         h_component = "xyz"[ax1]
@@ -253,7 +398,7 @@ class CurrentIntegralAxisAligned(AbstractAxesRH, Box):
 
         if self.sign == "-":
             current *= -1
-
+        current = CurrentIntegralAxisAligned._set_data_array_attributes(current)
         return current
 
     @cached_property
@@ -264,13 +409,17 @@ class CurrentIntegralAxisAligned(AbstractAxesRH, Box):
                 return index
         raise Tidy3dError("Failed to identify axis.")
 
-    def _to_path_integrals(self, h_horizontal, h_vertical) -> tuple[AxisAlignedPathIntegral, ...]:
+    def _to_path_integrals(
+        self, h_horizontal=None, h_vertical=None
+    ) -> tuple[AxisAlignedPathIntegral, ...]:
         """Returns four ``AxisAlignedPathIntegral`` instances, which represent a contour
         integral around the surface defined by ``self.size``."""
         ax1 = self.remaining_axes[0]
         ax2 = self.remaining_axes[1]
 
-        if self.snap_contour_to_grid:
+        horizontal_passed = h_horizontal is not None
+        vertical_passed = h_vertical is not None
+        if self.snap_contour_to_grid and horizontal_passed and vertical_passed:
             (coord1, coord2) = self.remaining_dims
 
             # Locations where horizontal paths will be snapped
@@ -339,3 +488,87 @@ class CurrentIntegralAxisAligned(AbstractAxesRH, Box):
         )
 
         return (bottom, right, top, left)
+
+    @staticmethod
+    def _set_data_array_attributes(data_array: IntegralResultTypes) -> IntegralResultTypes:
+        """Add explanatory attributes to the data array."""
+        data_array.name = "I"
+        return data_array.assign_attrs(units=AMP, long_name="current")
+
+    @add_ax_if_none
+    def plot(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        ax: Ax = None,
+        **path_kwargs,
+    ) -> Ax:
+        """Plot path integral at single (x,y,z) coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            Position of plane in x direction, only one of x,y,z can be specified to define plane.
+        y : float = None
+            Position of plane in y direction, only one of x,y,z can be specified to define plane.
+        z : float = None
+            Position of plane in z direction, only one of x,y,z can be specified to define plane.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        **path_kwargs
+            Optional keyword arguments passed to the matplotlib plotting of the line.
+            For details on accepted values, refer to
+            `Matplotlib's documentation <https://tinyurl.com/36marrat>`_.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+        axis, position = self.parse_xyz_kwargs(x=x, y=y, z=z)
+        if axis != self.main_axis or not np.isclose(position, self.center[axis], rtol=fp_eps):
+            return ax
+
+        plot_params = plot_params_current_path.include_kwargs(**path_kwargs)
+        plot_kwargs = plot_params.to_kwargs()
+        path_integrals = self._to_path_integrals()
+        # Plot the path
+        for path in path_integrals:
+            (xs, ys) = path._vertices_2D(axis)
+            ax.plot(xs, ys, **plot_kwargs)
+
+        (ax1, ax2) = self.remaining_axes
+
+        # Add arrow to bottom path, unless right path is longer
+        arrow_path = path_integrals[0]
+        if self.size[ax2] > self.size[ax1]:
+            arrow_path = path_integrals[1]
+
+        (xs, ys) = arrow_path._vertices_2D(axis)
+        X = (xs[0] + xs[1]) / 2
+        Y = (ys[0] + ys[1]) / 2
+        center = np.array([X, Y])
+        dx = xs[1] - xs[0]
+        dy = ys[1] - ys[0]
+        direction = np.array([dx, dy])
+        segment_length = np.linalg.norm(direction)
+        unit_dir = direction / segment_length
+
+        # Change direction of arrow depending on sign of current definition
+        if self.sign == "-":
+            unit_dir *= -1.0
+        # Change direction of arrow when the "y" axis is dropped,
+        # since the plotted coordinate system will be left-handed (x, z)
+        if self.main_axis == 1:
+            unit_dir *= -1.0
+
+        start = center - unit_dir * segment_length
+        end = center
+        ax.annotate(
+            "",
+            xytext=(start[0], start[1]),
+            xy=(end[0], end[1]),
+            arrowprops=ARROW_CURRENT,
+        )
+        return ax

--- a/tidy3d/plugins/microwave/viz.py
+++ b/tidy3d/plugins/microwave/viz.py
@@ -1,0 +1,54 @@
+"""Utilities for plotting microwave components"""
+
+from numpy import inf
+
+from ...components.viz import PathPlotParams
+
+""" Constants """
+VOLTAGE_COLOR = "red"
+CURRENT_COLOR = "blue"
+PATH_LINEWIDTH = 2
+ARROW_CURRENT = dict(
+    arrowstyle="-|>",
+    mutation_scale=32,
+    linestyle="",
+    lw=PATH_LINEWIDTH,
+    color=CURRENT_COLOR,
+)
+
+plot_params_voltage_path = PathPlotParams(
+    alpha=1.0,
+    zorder=inf,
+    color=VOLTAGE_COLOR,
+    linestyle="--",
+    linewidth=PATH_LINEWIDTH,
+    marker="o",
+    markersize=10,
+    markeredgecolor=VOLTAGE_COLOR,
+    markerfacecolor="white",
+)
+
+plot_params_voltage_plus = PathPlotParams(
+    alpha=1.0,
+    zorder=inf,
+    color=VOLTAGE_COLOR,
+    marker="+",
+    markersize=6,
+)
+
+plot_params_voltage_minus = PathPlotParams(
+    alpha=1.0,
+    zorder=inf,
+    color=VOLTAGE_COLOR,
+    marker="_",
+    markersize=6,
+)
+
+plot_params_current_path = PathPlotParams(
+    alpha=1.0,
+    zorder=inf,
+    color=CURRENT_COLOR,
+    linestyle="--",
+    linewidth=PATH_LINEWIDTH,
+    marker="",
+)

--- a/tidy3d/plugins/smatrix/__init__.py
+++ b/tidy3d/plugins/smatrix/__init__.py
@@ -1,10 +1,15 @@
 """Imports from scattering matrix plugin."""
 
 from .component_modelers.modal import AbstractComponentModeler, ComponentModeler, ModalPortDataArray
-from .component_modelers.terminal import LumpedPortDataArray, TerminalComponentModeler
+from .component_modelers.terminal import (
+    PortDataArray,
+    TerminalComponentModeler,
+    TerminalPortDataArray,
+)
 from .ports.coaxial_lumped import CoaxialLumpedPort
 from .ports.modal import Port
 from .ports.rectangular_lumped import LumpedPort
+from .ports.wave import WavePort
 
 __all__ = [
     "AbstractComponentModeler",
@@ -14,5 +19,7 @@ __all__ = [
     "TerminalComponentModeler",
     "CoaxialLumpedPort",
     "LumpedPort",
-    "LumpedPortDataArray",
+    "WavePort",
+    "TerminalPortDataArray",
+    "PortDataArray",
 ]

--- a/tidy3d/plugins/smatrix/component_modelers/modal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/modal.py
@@ -194,45 +194,6 @@ class ComponentModeler(AbstractComponentModeler):
             name=port.name,
         )
 
-    def _shift_value_signed(self, port: Port) -> float:
-        """How far (signed) to shift the source from the monitor."""
-
-        # get the grid boundaries and sizes along port normal from the simulation
-        normal_axis = port.size.index(0.0)
-        grid = self.simulation.grid
-        grid_boundaries = grid.boundaries.to_list[normal_axis]
-        grid_centers = grid.centers.to_list[normal_axis]
-
-        # get the index of the grid cell where the port lies
-        port_position = port.center[normal_axis]
-        port_pos_gt_grid_bounds = np.argwhere(port_position > grid_boundaries)
-
-        # no port index can be determined
-        if len(port_pos_gt_grid_bounds) == 0:
-            raise SetupError(f"Port position '{port_position}' outside of simulation bounds.")
-        port_index = port_pos_gt_grid_bounds[-1]
-
-        # shift the port to the left
-        if port.direction == "+":
-            shifted_index = port_index - 2
-            if shifted_index < 0:
-                raise SetupError(
-                    f"Port {port.name} normal is too close to boundary "
-                    f"on -{'xyz'[normal_axis]} side."
-                )
-
-        # shift the port to the right
-        else:
-            shifted_index = port_index + 2
-            if shifted_index >= len(grid_centers):
-                raise SetupError(
-                    f"Port {port.name} normal is too close to boundary "
-                    f"on +{'xyz'[normal_axis]} side."
-                )
-
-        new_pos = grid_centers[shifted_index]
-        return new_pos - port_position
-
     def shift_port(self, port: Port) -> Port:
         """Generate a new port shifted by the shift amount in normal direction."""
 

--- a/tidy3d/plugins/smatrix/ports/base_terminal.py
+++ b/tidy3d/plugins/smatrix/ports/base_terminal.py
@@ -1,0 +1,72 @@
+"""Class and custom data array for representing a scattering-matrix port, which is defined by a pair of terminals."""
+
+from abc import ABC, abstractmethod
+
+import pydantic.v1 as pd
+
+from ....components.base import Tidy3dBaseModel, cached_property
+from ....components.data.data_array import DataArray, FreqDataArray
+from ....components.data.sim_data import SimulationData
+from ....components.grid.grid import Grid
+from ....components.monitor import FieldMonitor
+from ....components.source import GaussianPulse, Source
+from ....components.types import FreqArray
+
+
+class TerminalPortDataArray(DataArray):
+    """Port parameter matrix elements for terminal-based ports.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> ports_in = ['port1', 'port2']
+    >>> ports_out = ['port1', 'port2']
+    >>> f = [2e14]
+    >>> coords = dict(
+    ...     f=f,
+    ...     port_out=ports_out,
+    ...     port_in=ports_in,
+    ... )
+    >>> fd = TerminalPortDataArray((1 + 1j) * np.random.random((1, 2, 2)), coords=coords)
+    """
+
+    __slots__ = ()
+    _dims = ("f", "port_out", "port_in")
+    _data_attrs = {"long_name": "terminal-based port matrix element"}
+
+
+class AbstractTerminalPort(Tidy3dBaseModel, ABC):
+    """Class representing a single terminal-based port. All terminal ports must provide methods
+    for computing voltage and current. These quantities represent the voltage between the
+    terminals, and the current flowing from one terminal into the other.
+    """
+
+    name: str = pd.Field(
+        ...,
+        title="Name",
+        description="Unique name for the port.",
+        min_length=1,
+    )
+
+    @cached_property
+    @abstractmethod
+    def injection_axis(self):
+        """Injection axis of the port."""
+
+    @abstractmethod
+    def to_source(
+        self, source_time: GaussianPulse, snap_center: float = None, grid: Grid = None
+    ) -> Source:
+        """Create a current source from a terminal-based port."""
+
+    @abstractmethod
+    def to_field_monitors(self, freqs: FreqArray, snap_center: float = None) -> list[FieldMonitor]:
+        """Field monitors to compute port voltage and current."""
+
+    @abstractmethod
+    def compute_voltage(self, sim_data: SimulationData) -> FreqDataArray:
+        """Helper to compute voltage across the port."""
+
+    @abstractmethod
+    def compute_current(self, sim_data: SimulationData) -> FreqDataArray:
+        """Helper to compute current flowing into the port."""

--- a/tidy3d/plugins/smatrix/ports/rectangular_lumped.py
+++ b/tidy3d/plugins/smatrix/ports/rectangular_lumped.py
@@ -21,7 +21,7 @@ from .base_lumped import AbstractLumpedPort
 
 
 class LumpedPort(AbstractLumpedPort, Box):
-    """Class representing a single rectangular lumped port
+    """Class representing a single rectangular lumped port.
 
     Example
     -------
@@ -61,7 +61,7 @@ class LumpedPort(AbstractLumpedPort, Box):
         return 3 - self.injection_axis - self.voltage_axis
 
     def to_source(
-        self, source_time: GaussianPulse, snap_center: float, grid: Grid
+        self, source_time: GaussianPulse, snap_center: float = None, grid: Grid = None
     ) -> UniformCurrentSource:
         """Create a current source from the lumped port."""
         # Discretized source amps are manually zeroed out later if they
@@ -80,7 +80,7 @@ class LumpedPort(AbstractLumpedPort, Box):
             confine_to_bounds=True,
         )
 
-    def to_load(self, snap_center: float) -> LumpedResistor:
+    def to_load(self, snap_center: float = None) -> LumpedResistor:
         """Create a load resistor from the lumped port."""
         # 2D materials are currently snapped to the grid, so snapping here is not needed.
         # It is done here so plots of the simulation will more accurately portray the setup
@@ -96,7 +96,7 @@ class LumpedPort(AbstractLumpedPort, Box):
             voltage_axis=self.voltage_axis,
         )
 
-    def to_voltage_monitor(self, freqs: FreqArray, snap_center: float) -> FieldMonitor:
+    def to_voltage_monitor(self, freqs: FreqArray, snap_center: float = None) -> FieldMonitor:
         """Field monitor to compute port voltage."""
         center = list(self.center)
         if snap_center:
@@ -117,7 +117,7 @@ class LumpedPort(AbstractLumpedPort, Box):
             colocate=False,
         )
 
-    def to_current_monitor(self, freqs: FreqArray, snap_center: float) -> FieldMonitor:
+    def to_current_monitor(self, freqs: FreqArray, snap_center: float = None) -> FieldMonitor:
         """Field monitor to compute port current."""
         center = list(self.center)
         if snap_center:
@@ -249,7 +249,7 @@ class LumpedPort(AbstractLumpedPort, Box):
         return (min_idx, max_idx - 1)
 
     def _check_grid_size(self, yee_grid: YeeGrid):
-        """Raises :class:``SetupError`` if the grid is too coarse at port locations."""
+        """Raises :class:`SetupError` if the grid is too coarse at port locations"""
         e_component = "xyz"[self.voltage_axis]
         e_yee_grid = yee_grid.grid_dict[f"E{e_component}"]
         coords = e_yee_grid.to_dict[e_component]

--- a/tidy3d/plugins/smatrix/ports/wave.py
+++ b/tidy3d/plugins/smatrix/ports/wave.py
@@ -1,0 +1,187 @@
+"""Class and custom data array for representing a scattering matrix wave port."""
+
+from typing import Optional, Union
+
+import numpy as np
+import pydantic.v1 as pd
+
+from ....components.base import cached_property
+from ....components.data.data_array import FreqDataArray, FreqModeDataArray
+from ....components.data.monitor_data import ModeSolverData
+from ....components.data.sim_data import SimulationData
+from ....components.geometry.base import Box
+from ....components.monitor import FieldMonitor, ModeSolverMonitor
+from ....components.simulation import Simulation
+from ....components.source import GaussianPulse, ModeSource, ModeSpec
+from ....components.types import Bound, Direction, FreqArray
+from ....exceptions import ValidationError
+from ...microwave import CurrentIntegralTypes, ImpedanceCalculator, VoltageIntegralTypes
+from ...mode import ModeSolver
+from .base_terminal import AbstractTerminalPort
+
+
+class WavePort(AbstractTerminalPort, Box):
+    """Class representing a single wave port"""
+
+    direction: Direction = pd.Field(
+        ...,
+        title="Direction",
+        description="'+' or '-', defining which direction is considered 'input'.",
+    )
+
+    mode_spec: ModeSpec = pd.Field(
+        ModeSpec(),
+        title="Mode Specification",
+        description="Parameters to feed to mode solver which determine modes measured by monitor.",
+    )
+
+    mode_index: pd.NonNegativeInt = pd.Field(
+        0,
+        title="Mode Index",
+        description="Index into the collection of modes returned by mode solver. "
+        " Specifies which mode to inject using this source. "
+        "If larger than ``mode_spec.num_modes``, "
+        "``num_modes`` in the solver will be set to ``mode_index + 1``.",
+    )
+
+    voltage_integral: Optional[VoltageIntegralTypes] = pd.Field(
+        None,
+        title="Voltage Integral",
+        description="Definition of voltage integral used to compute voltage and the characteristic impedance.",
+    )
+
+    current_integral: Optional[CurrentIntegralTypes] = pd.Field(
+        None,
+        title="Current Integral",
+        description="Definition of current integral used to compute current and the characteristic impedance.",
+    )
+
+    @cached_property
+    def injection_axis(self):
+        """Injection axis of the port."""
+        return self.size.index(0.0)
+
+    @cached_property
+    def _field_monitor_name(self) -> str:
+        """Return the name of the :class:`.FieldMonitor` associated with this port."""
+        return f"{self.name}_field"
+
+    @cached_property
+    def _mode_monitor_name(self) -> str:
+        """Return the name of the :class:`.ModeMonitor` associated with this port."""
+        return f"{self.name}_mode"
+
+    def to_source(self, source_time: GaussianPulse, snap_center: float = None) -> ModeSource:
+        """Create a mode source from the wave port."""
+        center = list(self.center)
+        if snap_center:
+            center[self.injection_axis] = snap_center
+        return ModeSource(
+            center=center,
+            size=self.size,
+            source_time=source_time,
+            mode_spec=self.mode_spec,
+            mode_index=self.mode_index,
+            direction=self.direction,
+            name=self.name,
+        )
+
+    def to_field_monitors(self, freqs: FreqArray, snap_center: float = None) -> list[FieldMonitor]:
+        """Field monitor to compute port voltage and current."""
+        center = list(self.center)
+        if snap_center:
+            center[self.injection_axis] = snap_center
+        field_mon = FieldMonitor(
+            center=center,
+            size=self.size,
+            freqs=freqs,
+            name=self._field_monitor_name,
+            colocate=False,
+        )
+        return [field_mon]
+
+    def to_mode_solver_monitor(self, freqs: FreqArray) -> ModeSolverMonitor:
+        """Mode solver monitor to compute modes that will be used to
+        compute characteristic impedances."""
+        mode_mon = ModeSolverMonitor(
+            center=self.center,
+            size=self.size,
+            freqs=freqs,
+            name=self._mode_monitor_name,
+            colocate=False,
+            mode_spec=self.mode_spec,
+            direction=self.direction,
+        )
+        return mode_mon
+
+    def to_mode_solver(self, simulation: Simulation, freqs: FreqArray) -> ModeSolver:
+        """Helper to create a :class:`.ModeSolver` instance."""
+        mode_solver = ModeSolver(
+            simulation=simulation,
+            plane=self,
+            mode_spec=self.mode_spec,
+            freqs=freqs,
+            direction=self.direction,
+            colocate=False,
+        )
+        return mode_solver
+
+    def compute_voltage(self, sim_data: SimulationData) -> FreqDataArray:
+        """Helper to compute voltage across the port."""
+        field_monitor = sim_data[self._field_monitor_name]
+        return self.voltage_integral.compute_voltage(field_monitor)
+
+    def compute_current(self, sim_data: SimulationData) -> FreqDataArray:
+        """Helper to compute current flowing through the port."""
+        field_monitor = sim_data[self._field_monitor_name]
+        return self.current_integral.compute_current(field_monitor)
+
+    def compute_port_impedance(
+        self, sim_mode_data: Union[SimulationData, ModeSolverData]
+    ) -> FreqModeDataArray:
+        """Helper to compute impedance of port. The port impedance is computed from the
+        transmission line mode, which should be TEM or at least quasi-TEM."""
+        impedance_calc = ImpedanceCalculator(
+            voltage_integral=self.voltage_integral, current_integral=self.current_integral
+        )
+        if isinstance(sim_mode_data, SimulationData):
+            mode_solver_data = sim_mode_data[self._mode_monitor_name]
+        else:
+            mode_solver_data = sim_mode_data
+
+        # Filter out unwanted modes to reduce impedance computation effort
+        mode_solver_data = mode_solver_data._isel(mode_index=[self.mode_index])
+        impedance_array = impedance_calc.compute_impedance(mode_solver_data)
+        return impedance_array
+
+    @staticmethod
+    def _within_port_bounds(path_bounds: Bound, port_bounds: Bound) -> bool:
+        """Helper to check if one bounding box is completely within the other."""
+        path_min = np.array(path_bounds[0])
+        path_max = np.array(path_bounds[1])
+        bound_min = np.array(port_bounds[0])
+        bound_max = np.array(port_bounds[1])
+        return (bound_min <= path_min).all() and (bound_max >= path_max).all()
+
+    @pd.validator("voltage_integral", "current_integral")
+    def _validate_path_integrals_within_port(cls, val, values):
+        """Raise ``ValidationError`` when the supplied path integrals are not within the port bounds."""
+        center = values["center"]
+        size = values["size"]
+        box = Box(center=center, size=size)
+        if val and not WavePort._within_port_bounds(val.bounds, box.bounds):
+            raise ValidationError(
+                f"'{cls.__name__}' must be setup with all path integrals defined within the bounds "
+                f"of the port. Path bounds are '{val.bounds}', but port bounds are '{box.bounds}'."
+            )
+        return val
+
+    @pd.validator("current_integral", always=True)
+    def _check_voltage_or_current(cls, val, values):
+        """Raise validation error if both ``voltage_integral`` and ``current_integral``
+        were not provided."""
+        if not values.get("voltage_integral") and not val:
+            raise ValidationError(
+                "At least one of 'voltage_integral' or 'current_integral' must be provided."
+            )
+        return val


### PR DESCRIPTION
add a new type of port to the TerminalComponentModeler. WavePorts are  the optimal port for exciting transmission lines, and they function like a hybrid between LumpedPorts and the modal-based Port.

Still a work in progress. 

Here are some thoughts:
- Not sure the best way to make the computed port impedances available to users. Computing the port impedances requires mode solving which is launched through `ModeSolverMonitor`s along with the tidy3d simulations. However, some users might want to know the impedances beforehand or inspect modes before launching the simulations.
- I have changed some of the naming to reflect that the ports of the `TerminalComponentModeler` are based on pairs of terminals ( a positive and negative connection or node in the circuit). `LumpedPort`s and `WavePort` are then both `TerminalPort`s
- I realized it is helpful to add `name`s and possibly `attrs` to `DataArray`s that I am creating. Maybe I should put all of these `DataArray`s into the microwave plugin or the Tidy3D files.
