### PR TITLE
Issue #1416 and #1708 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Users can now export `SimulationData` to MATLAB `.mat` files with the `to_mat_file` method.
+
+### Fixed
+- Bug where boundary layers would be plotted too small in 2D simulations.
+
 ## [2.7.0] - 2024-06-17
 
 ### Added

--- a/tests/test_components/test_viz.py
+++ b/tests/test_components/test_viz.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 import pytest
 import tidy3d as td
 from tidy3d.components.viz import Polygon
+from tidy3d.constants import inf
 
 
 def test_make_polygon_dict():
@@ -36,3 +37,45 @@ def test_0d_plot(center_z, len_collections):
     assert len(ax.collections) == len_collections
 
     plt.close()
+
+
+def test_2d_boundary_plot():
+    """
+    Test that boundary box structures are drawn to full size for 2D plots where the simulation size is 0
+    """
+
+    # Dummy objects to pad the simulation
+    freq0 = td.C_0 / 0.75
+
+    # create source
+    source = td.PointDipole(
+        center=(0, 0, 0),
+        source_time=td.GaussianPulse(freq0=freq0, fwidth=freq0 / 10.0),
+        polarization="Ez",
+    )
+
+    # Simulation details
+    per_boundary = td.Boundary.periodic()
+    pml_boundary = td.Boundary.pml(num_layers=2)
+
+    sim = td.Simulation(
+        size=(0, 1, 1),
+        grid_spec=td.GridSpec.auto(min_steps_per_wvl=25),
+        structures=[],
+        sources=[source],
+        monitors=[],
+        run_time=120 / freq0,
+        boundary_spec=td.BoundarySpec(x=per_boundary, y=pml_boundary, z=pml_boundary),
+    )
+
+    pml_box = sim._make_pml_box(pml_axis=1, pml_height=1, sign=1)
+
+    # Should have infinite size in x
+    assert pml_box.size[0] == inf
+
+    # Create new 3D simulation
+    sim = sim.updated_copy(size=(1, 1, 1))
+    pml_box = sim._make_pml_box(pml_axis=1, pml_height=1, sign=1)
+
+    # should have a non-infinite size as x is specified
+    assert pml_box.size[0] != inf

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1158,3 +1158,39 @@ def get_test_root_dir():
     """return the root folder of test code"""
 
     return Path(__file__).parent
+
+
+def get_nested_shape(nested_obj: Any) -> Any:
+    """
+    Recursively iterate through a nested object replacing values with None.
+    Empty list/tuple/dict are replaced with None.
+    Builds the structure for comparison to other nested objects.
+    Used to check structure hasn't changed when nested_obj data has been altered.
+    Similar concept to .shape method for numpy arrays.
+
+    Parameters
+    ----------
+    nested_obj : Any
+        A nested object to be reduced to its shape.
+
+    Returns
+    -------
+    Any
+        The nested object with values replaced with None whilst keeping the same nested structure.
+    """
+    if isinstance(nested_obj, dict):
+        if len(nested_obj) == 0:
+            return None
+        else:
+            return {key: get_nested_shape(nested_obj[key]) for key in nested_obj}
+
+    # Tuple of dicts, enter and continue iteration
+    elif isinstance(nested_obj, (tuple, list)):
+        if len(nested_obj) == 0:
+            return None
+        else:
+            return type(nested_obj)(get_nested_shape(val) for val in nested_obj)
+
+    # Replace everything else with None
+    else:
+        return None

--- a/tidy3d/components/file_util.py
+++ b/tidy3d/components/file_util.py
@@ -2,6 +2,9 @@
 
 import gzip
 import shutil
+from typing import Any
+
+import numpy as np
 
 
 def compress_file_to_gzip(input_file, output_gz_file):
@@ -28,3 +31,37 @@ def extract_gzip_file(input_gz_file, output_file):
     with gzip.open(input_gz_file, "rb") as file_in:
         with open(output_file, "wb") as file_out:
             shutil.copyfileobj(file_in, file_out)
+
+
+def replace_values(values: Any, search_value: Any, replace_value: Any) -> Any:
+    """
+    Create a copy of ``values`` where any elements equal to ``search_value`` are replaced by ``replace_value``.
+
+    Parameters
+    ----------
+    values : Any
+        The input object to iterate through.
+    search_value : Any
+        An object to match for in ``values``.
+    replace_value : Any
+        A replacement object for the matched value in ``values``.
+
+    Returns
+    -------
+    Any
+        values type object with ``search_value`` terms replaced by ``replace_value``.
+    """
+    # np.all allows for arrays to be evaluated
+    if np.all(values == search_value):
+        return replace_value
+    if isinstance(values, dict):
+        return {
+            key: replace_values(val, search_value, replace_value) for key, val in values.items()
+        }
+    elif isinstance(
+        values, (tuple, list)
+    ):  # Parts of the nested dict structure include tuples with more dicts
+        return type(values)(replace_values(val, search_value, replace_value) for val in values)
+
+    # Used to maintain values that are not search_value or containers
+    return values

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -134,7 +134,7 @@ NUM_CELLS_WARN_EPSILON = 100_000_000
 NUM_STRUCTURES_WARN_EPSILON = 10_000
 
 # height of the PML plotting boxes along any dimensions where sim.size[dim] == 0
-PML_HEIGHT_FOR_0_DIMS = 0.02
+PML_HEIGHT_FOR_0_DIMS = inf
 
 
 class AbstractYeeGridSimulation(AbstractSimulation, ABC):


### PR DESCRIPTION
Modified simulation.py so 2D simulation plots have correctly drawn boundaries as in Issue #1708 .
Before  and after example plots
<p float="left">
  <img src="https://github.com/flexcompute/tidy3d/assets/72206172/337db6b6-3d4d-484d-9745-161da54eac89" />
  <img src="https://github.com/flexcompute/tidy3d/assets/72206172/7fd3c8fd-573d-4564-b58b-4c0b11292bcc" /> 
</p>
Added test for 2D boundary width in test_viz.py which checks the width of plot objects is significantly larger than the plot width

Added ability to output `SimulationData` to .mat file as requested in Issue #1416
Implemented as `to_mat` method in sim_data.py with formatting functions included in mat.py
Test for formatting added to test_sim_data.py and utils.py

These are small standalone changes so they can likely be added to 2.7.0 without much issue.
