### PR TITLE
fix deepcopy bug in autograd

### DIFF
--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -261,13 +261,15 @@ class Tidy3dBaseModel(pydantic.BaseModel):
             sub_component = sub_component_list[index]
             sub_path = "/".join(path_components[2:])
 
-            sub_component_list[index] = sub_component.updated_copy(path=sub_path, **kwargs)
+            sub_component_list[index] = sub_component.updated_copy(
+                path=sub_path, deep=deep, **kwargs
+            )
             new_component = tuple(sub_component_list)
         else:
             sub_path = "/".join(path_components[1:])
-            new_component = sub_component.updated_copy(path=sub_path, **kwargs)
+            new_component = sub_component.updated_copy(path=sub_path, deep=deep, **kwargs)
 
-        return self._updated_copy(**{field_name: new_component})
+        return self._updated_copy(deep=deep, **{field_name: new_component})
 
     def _updated_copy(self, deep: bool = True, **kwargs) -> Tidy3dBaseModel:
         """Make copy of a component instance with ``**kwargs`` indicating updated field values."""

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -1414,8 +1414,7 @@ class PolySlab(base.Planar):
 
         # compute center positions between each edge
         edge_centers_plane = (vertices_next + vertices) / 2.0
-        edge_centers_axis = np.mean(self.slab_bounds) * np.ones(num_vertices)
-
+        edge_centers_axis = self.center_axis * np.ones(num_vertices)
         edge_centers_xyz = self.unpop_axis_vect(edge_centers_axis, edge_centers_plane)
 
         assert edge_centers_xyz.shape == (num_vertices, 3), "something bad happened"


### PR DESCRIPTION
Long story short, seems when we `deepcopy()` a `td.DataArray` containing autograd tracers, bad things can happen:
1. The `run_async` tracing ignores anything but the last `SimulationData` in the batch.
2. The gradient information can get corrupted..

This PR does two things:
1. Changes default behavior of `deepcopy(td.DataArray)` to do a shallow copy if there are tracers present.
2. Properly passes the `deep` kwarg in `Tidy3dBaseModel.copy()` and related methods.