### PR TITLE
Avoiding double upload when using Job.run

### DIFF
--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -215,7 +215,13 @@ class Job(WebContainer):
         # upload kwargs with all fields except task_id
         self_dict = self.dict()
         upload_kwargs = {key: self_dict.get(key) for key in self._upload_fields}
-        return web.upload(**upload_kwargs)
+        # set the cached task_id
+        self.Config.frozen = False
+        self.Config.allow_mutation = True
+        self.task_id_cached = web.upload(**upload_kwargs)
+        self.Config.allow_mutation = False
+        self.Config.frozen = True
+        return self.task_id
 
     def get_info(self) -> TaskInfo:
         """Return information about a :class:`Job`.

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -209,19 +209,19 @@ class Job(WebContainer):
         """The task ID for this ``Job``. Uploads the ``Job`` if it hasn't already been uploaded."""
         if self.task_id_cached:
             return self.task_id_cached
-        return self.upload()
+        return self._upload()
 
-    def upload(self) -> TaskId:
+    def _upload(self) -> TaskId:
+        """Upload this job and return the task ID for handling."""
         # upload kwargs with all fields except task_id
         self_dict = self.dict()
         upload_kwargs = {key: self_dict.get(key) for key in self._upload_fields}
-        # set the cached task_id
-        self.Config.frozen = False
-        self.Config.allow_mutation = True
-        self.task_id_cached = web.upload(**upload_kwargs)
-        self.Config.allow_mutation = False
-        self.Config.frozen = True
-        return self.task_id
+        task_id = web.upload(**upload_kwargs)
+        return task_id
+
+    def upload(self) -> None:
+        """Upload this ``Job``."""
+        _ = self.task_id
 
     def get_info(self) -> TaskInfo:
         """Return information about a :class:`Job`.


### PR DESCRIPTION
It seems that some of the container reorganizations made the `web.Job` workflow upload a task twice. The underlying reason is that `Job.task_id_cached` is not set internally when the first upload happens - it is currently only used for file operations. However, `Job.task_id` assumes that `task_id_cached` *had* actually been set, and if not, uploads the task again. So in `Job.run` first `web.upload` is called, then `web.run` with `self.task_id`, which does a second upload.

This fix works but is probably not how we want to handle it? I'm leaving it to @tylerflex though as you should know better what the internals here are.