### PR TITLE
Switch the order of bend and angle transformations in mode solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.7.0] - 2024-06-13
+## [2.7.0] - 2024-06-17
 
 ### Added
 - EME solver through `EMESimulation` class.
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default variant for silicon dioxide in material library switched from `Horiba` to `Palik_Lossless`.
 - Sources and monitors which are exactly at the simulation domain boundaries will now error. They can still be placed very close to the boundaries, but need to be on the inside of the region.
 - Relaxed `dt` stability criterion for 1D and 2D simulations.
+- Switched order of angle and bend transformations in mode solver when both are present.
 
 ### Fixed
 - Bug in PolySlab intersection if slab bounds are `inf` on one side.

--- a/tidy3d/plugins/mode/solver.py
+++ b/tidy3d/plugins/mode/solver.py
@@ -139,11 +139,11 @@ class EigSolver(Tidy3dBaseModel):
         jac_e = np.real(np.copy(identity_tensor))
         jac_h = np.real(np.copy(identity_tensor))
 
-        if bend_radius is not None:
-            new_coords, jac_e, jac_h = radial_transform(new_coords, bend_radius, bend_axis)
-
         if np.abs(angle_theta) > 0:
-            new_coords, jac_e_tmp, jac_h_tmp = angled_transform(new_coords, angle_theta, angle_phi)
+            new_coords, jac_e, jac_h = angled_transform(new_coords, angle_theta, angle_phi)
+
+        if bend_radius is not None:
+            new_coords, jac_e_tmp, jac_h_tmp = radial_transform(new_coords, bend_radius, bend_axis)
             jac_e = np.einsum("ij...,jp...->ip...", jac_e_tmp, jac_e)
             jac_h = np.einsum("ij...,jp...->ip...", jac_h_tmp, jac_h)
 

--- a/tidy3d/plugins/mode/transforms.py
+++ b/tidy3d/plugins/mode/transforms.py
@@ -16,9 +16,9 @@ def radial_transform(coords, radius, bend_axis):
     offsetting the plane such that its center is a distance of ``radius`` away from the center of
     curvature, we have, e.g. for ``bend_axis=='y'``:
 
-        u = (x**2 + z**2)
+        u = sqrt(x**2 + z**2)
         v = y
-        w = R acos(x / u)
+        w = R asin(z / u)
 
     These are all evaluated at z = 0 below.
 
@@ -39,9 +39,6 @@ def radial_transform(coords, radius, bend_axis):
         Jacobian of the transformation at the E-field positions, shape ``(3, 3, Nx * Ny)``.
     jac_h: np.ndarrray
         Jacobian of the transformation at the H-field positions, shape ``(3, 3, Nx * Ny)``.
-    k_to_kp: np.ndarray
-        A matrix of shape (3, 3) that transforms the k-vector from the original coordinates to the
-        transformed ones.
     """
 
     Nx, Ny = coords[0].size - 1, coords[1].size - 1
@@ -101,7 +98,7 @@ def angled_transform(coords, angle_theta, angle_phi):
     Nx, Ny = coords[0].size - 1, coords[1].size - 1
 
     # The new coordinates are exactly the same at z = 0
-    new_coords = (np.copy(c) for c in coords)
+    new_coords = [np.copy(c) for c in coords]
 
     # The only nontrivial derivatives are dudz, dvdz and they are constant everywhere
     jac = np.zeros((3, 3, Nx * Ny))


### PR DESCRIPTION
We've observed a small amount of mode conversion that seems to happen when we decompose into modes along an arc, when both an angle and a bend radius needs to be defined in the mode solver. Currently, we compose the two separate transformations. Each of those two transformations are into coordinates which make the transformed frame invariant in the propagation direction. However, their *composition* breaks this, which is largely related to the fact that the modal planes need to be oriented w.r.t. one of the main simulation axes, rather than along the bend radial direction. One way to think of it is that the bend angle is a function of the radial position along the arc, thus the transformed system is not translationally invariant along that dimension.

Generally, things still work pretty well, because the system looks *locally* invariant. However, it depends on the precision one is after. In the test below, I could not get the higher-order mode conversion significantly below 1e-4. I tried multiple things both with pencil-and-paper and experimenting with the code, but nothing worked better than what we already had, except the small modification of switching the order of the two transformations seemed to improve the result a little. The two transformations do not commute. Actually after thinking about it it kind of seemed to me that the radius of curvature needs to be decreased too, by a factor of `cos(theta)`, but once again this produced worse results (pictured, the middle plot actually shows the error in |TE00|^2 deviating from 1):

![image](https://github.com/flexcompute/tidy3d/assets/92756559/cc6a1fb0-a7e9-480f-aaea-04a21e7cea80)

Since I've already spent quite some energy on this, I made this small PR to at least incorporate that change, as well as a few small fixes to the docstrings. I don't think I have the energy to explore coordinate transformations further. I don't even know if the problem is fundamental, stemming from our need to have angled planes. I think modifying sources and monitors to not be along the main axes would be quite a challenge, but one other thing I want to try is solving the fields at 0 angle and then propagating along the bend. There are a number of intricacies that make this not too straightforward to implement automatically, but would be interesting to try manually for starters. What I had in mind is this: instead of placing a mode monitor at a given location along the arc (defining both a bend radius and an angle), you could just place a FieldMonitor at the desired location. Then, you could use our mode solver to solve the modes at 0 angle, and propagate the fields to construct a ModeSolverData at the same coords as the FieldData from the field monitor, using the mode fields at 0 angle and a phase of exp(1i * n_eff * R * theta). However, because of the different orientations of the mode planes w.r.t. the radial direction, that requires some coordinate reconstruction and interpolation that is kind of nontrivial.