### PR TITLE
shallow copy all autograd Box used in tidy3d

### DIFF
--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -1,5 +1,6 @@
 # test autograd integration into tidy3d
 
+import copy
 import cProfile
 import typing
 from importlib import reload
@@ -684,6 +685,34 @@ def test_too_many_traced_structures(monkeypatch, log_capture, use_emulated_run):
 
     with pytest.raises(ValueError):
         ag.grad(objective)(params0)
+
+
+def test_autograd_deepcopy():
+    """make sure deepcopy works as expected in autograd."""
+
+    def post(x, y):
+        return 3 * x + y
+
+    def f1(x):
+        y = copy.deepcopy(x)
+        return post(x, y)
+
+    def f2(x):
+        y = copy.copy(x)
+        return post(x, y)
+
+    def f3(x):
+        y = x
+        return post(x, y)
+
+    x0 = 12.0
+
+    val1, grad1 = ag.value_and_grad(f1)(x0)
+    val2, grad2 = ag.value_and_grad(f2)(x0)
+    val3, grad3 = ag.value_and_grad(f3)(x0)
+
+    assert val1 == val2 == val3
+    assert grad1 == grad2 == grad3
 
 
 # @pytest.mark.timeout(18.0)

--- a/tidy3d/components/autograd.py
+++ b/tidy3d/components/autograd.py
@@ -1,5 +1,6 @@
 # utilities for working with autograd
 
+import copy
 import typing
 
 import numpy as np
@@ -12,9 +13,11 @@ from tidy3d.components.type_util import _add_schema
 
 from .types import ArrayFloat2D, ArrayLike, Bound, Size1D
 
+# add schema to the Box
 _add_schema(Box, title="AutogradBox", field_type_str="autograd.tracer.Box")
 
-# TODO: should we use ArrayBox? Box is more general
+# make sure Boxes in tidy3d do shallow copy, otherwise corrupts computational graph
+Box.__deepcopy__ = lambda self, memo: copy.copy(self)
 
 # Types for floats, or collections of floats that can also be autograd tracers
 TracedFloat = typing.Union[float, Box]

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -79,16 +79,6 @@ class DataArray(xr.DataArray):
             # NOTE: this is done because if we pass the traced array directly, it will create a
             # numpy array of `ArrayBox`, which is extremely slow
 
-    def __deepcopy__(self, memo):
-        """Define the behavior of ``deepcopy()`` a ``xr.DataArray``."""
-
-        # if we detect that this has tracers, we need to shallow copy
-        # otherwise it confuses autograd..
-        if self.has_tracers:
-            return self.__copy__()
-
-        return super().__deepcopy__(memo)
-
     @property
     def has_tracers(self) -> bool:
         """Whether the ``DataArray`` has ``autograd`` derivative information."""


### PR DESCRIPTION
This is a more elegant and general solution to fixing the deepcopy bug in autograd.

It overrides the behavior of `deepcopy(autograd.Box)` in tidy3d so that it returns a shallow copy, tested on the notebooks with previous issues and it mitigates them. Also handles `updated_copy()` in simulation / pre-processing.

Still a bit of black magic, but is nice because it avoids
* A new autograd fork
* Shallow copies everywhere in tidy3d

Don't mind waiting for 2.7.1, only caveat with not having this is that an updated copy of a tidy3d component, eg `polyslab.updated_copy(slab_bounds=(1,1))` will ruin the gradient, so it could be an annoying bug.

Note: it doesn't solve the autograd bug generally, so something like
```
def objective(params):
    p = deepcopy(params)
```
outside of tidy3d will still cause issues, but this is sort of expected.