### PR TITLE
🗻 autograd: server-side gradient processing 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `tidy3d.plugins.design.Results` store the `BatchData` for batch runs in the `.batch_data` field.
 - Prompting user to check solver log when loading solver data if warnings were found in the log, or if the simulation diverged or errored.
+- `autograd` gradient calculations are done server side by default. Behavior can be changed by passing `local_gradient = True` into `web.run()`.
 
 ### Changed
 - Slightly reorganized `web.run` logging when `verbose=True` to make it clearer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for differentiation with respect to `GeometryGroup.geometries` elements.
 - Users can now export `SimulationData` to MATLAB `.mat` files with the `to_mat_file` method.
+- Introduce RF material library. Users can now export `rf_material_library` from `tidy3d.plugins.microwave`.
+- `autograd` gradient calculations are done server side by default. Behavior can be changed by passing `local_gradient = True` into `web.run()`.
 
 ### Changed
 
@@ -126,7 +128,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `tidy3d.plugins.design.Results` store the `BatchData` for batch runs in the `.batch_data` field.
 - Prompting user to check solver log when loading solver data if warnings were found in the log, or if the simulation diverged or errored.
-- `autograd` gradient calculations are done server side by default. Behavior can be changed by passing `local_gradient = True` into `web.run()`.
 
 ### Changed
 - Slightly reorganized `web.run` logging when `verbose=True` to make it clearer.

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -11,10 +11,7 @@ import matplotlib.pylab as plt
 import numpy as np
 import pytest
 import tidy3d as td
-from tidy3d.web import run_async
-from tidy3d.plugins.polyslab import ComplexPolySlab
-from tidy3d.web import Job, run_async
-from tidy3d.web.api.autograd.autograd import run
+from tidy3d.web.api.autograd.autograd import run, run_async
 
 from ..utils import SIM_FULL, AssertLogLevel, run_emulated
 
@@ -116,6 +113,8 @@ _run_was_emulated = [False]
 def use_emulated_run(monkeypatch):
     """If this fixture is used, the `tests.utils.run_emulated` function is used for simulation."""
 
+    from tidy3d.web.api.container import Job
+
     if TEST_MODE in ("pipeline", "speed"):
         VJP = "VJP"
         task_id_fwd = "task_fwd"
@@ -198,7 +197,9 @@ def use_emulated_run(monkeypatch):
         monkeypatch.setattr(Job, "run", emulated_job_run)
         monkeypatch.setattr(Job, "task_id", task_id_fwd)
 
-        reload(webapi)
+        import tidy3d
+
+        reload(tidy3d.web.api.autograd.autograd)
 
         _run_was_emulated[0] = True
 

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -119,7 +119,7 @@ def use_emulated_run(monkeypatch):
     if TEST_MODE in ("pipeline", "speed"):
         VJP = "VJP"
         task_id_fwd = "task_fwd"
-        task_id_bwd = "task_fwd"
+        task_id_bwd = "task_bwd"
         cache = {}
 
         monkeypatch.setattr(
@@ -155,6 +155,7 @@ def use_emulated_run(monkeypatch):
 
                 # store the data in aux_data (see commented out lines below)
                 aux_data = {}
+
                 _ = postprocess_fwd(
                     sim_data_combined=sim_data_combined,
                     sim_original=sim_original,
@@ -164,6 +165,7 @@ def use_emulated_run(monkeypatch):
                 # sim_data_orig = aux_data[AUX_KEY_SIM_DATA_ORIGINAL]
                 # sim_data_fwd = aux_data[AUX_KEY_SIM_DATA_FWD]
 
+                # todo: split into return (original data) and store (fwd data)
                 # cache it locally for test
                 cache[task_id_fwd] = copy.copy(aux_data)
 

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -12,7 +12,6 @@ import numpy as np
 import pytest
 import tidy3d as td
 from tidy3d.web import run_async
-
 from tidy3d.plugins.polyslab import ComplexPolySlab
 from tidy3d.web import Job, run_async
 from tidy3d.web.api.autograd.autograd import run
@@ -143,17 +142,18 @@ def use_emulated_run(monkeypatch):
 
         def emulated_job_run(self: Job) -> td.SimulationData:
             """What gets called instead of ``web.run()``."""
+
             sim_data = run_emulated(self.simulation, task_name="test")
 
             if self.simulation_type == "autograd_fwd":
-                sim_data_combined = sim_data
+                sim_original = self.simulation
 
-                # a bit of a hack i guess
-                orig_monitors = [
-                    mnt for mnt in sim_data.simulation.monitors if "adjoint" not in mnt.name
-                ]
-                sim_original = self.simulation.updated_copy(monitors=orig_monitors)
+                # add gradient monitors and make combined simulation
+                sim_fields = setup_run(sim_original)
+                sim_combined = sim_original.with_adjoint_monitors(sim_fields)
+                sim_data_combined = run_emulated(sim_combined, task_name="test")
 
+                # store the data in aux_data (see commented out lines below)
                 aux_data = {}
                 _ = postprocess_fwd(
                     sim_data_combined=sim_data_combined,
@@ -161,25 +161,25 @@ def use_emulated_run(monkeypatch):
                     aux_data=aux_data,
                 )
 
-                sim_data_orig = aux_data[AUX_KEY_SIM_DATA_ORIGINAL]
-                sim_data_fwd = aux_data[AUX_KEY_SIM_DATA_FWD]
+                # sim_data_orig = aux_data[AUX_KEY_SIM_DATA_ORIGINAL]
+                # sim_data_fwd = aux_data[AUX_KEY_SIM_DATA_FWD]
 
+                # cache it locally for test
                 cache[task_id_fwd] = copy.copy(aux_data)
 
             elif self.simulation_type == "autograd_bwd":
-                sim_data_adj = sim_data
+                # run the adjoint sim
+                sim_data_adj = run_emulated(self.simulation, task_name="test")
 
+                # grab the fwd and original data from the cache
                 aux_data_fwd = cache[task_id_fwd]
-
                 sim_data_orig = aux_data_fwd[AUX_KEY_SIM_DATA_ORIGINAL]
                 sim_data_fwd = aux_data_fwd[AUX_KEY_SIM_DATA_FWD]
 
-                orig_monitors = [
-                    mnt for mnt in sim_data.simulation.monitors if "adjoint" not in mnt.name
-                ]
-                sim_original = self.simulation.updated_copy(monitors=orig_monitors)
+                # get the original traced fields
                 sim_fields_original = setup_run(simulation=sim_data_orig.simulation)
 
+                # postprocess (compute adjoint gradients)
                 traced_fields_vjp = postprocess_adj(
                     sim_data_adj=sim_data_adj,
                     sim_data_orig=sim_data_orig,
@@ -187,6 +187,7 @@ def use_emulated_run(monkeypatch):
                     sim_fields_original=sim_fields_original,
                 )
 
+                # cache the results in the VJP key of the cache
                 cache[task_id_bwd][VJP] = traced_fields_vjp
 
             return sim_data
@@ -194,6 +195,8 @@ def use_emulated_run(monkeypatch):
         monkeypatch.setattr(webapi, "run", run_emulated)
         monkeypatch.setattr(Job, "run", emulated_job_run)
         monkeypatch.setattr(Job, "task_id", task_id_fwd)
+
+        reload(webapi)
 
         _run_was_emulated[0] = True
 

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -745,6 +745,7 @@ def test_web_incompatible_inputs(log_capture, monkeypatch):
         raise AssertionError()
 
     monkeypatch.setattr(td.web.api.webapi, "run", catch)
+    monkeypatch.setattr(td.web.api.container.Job, "run", catch)
     monkeypatch.setattr(td.web.api.asynchronous, "run_async", catch)
 
     from tidy3d.web.api.autograd import autograd

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -118,20 +118,84 @@ def use_emulated_run(monkeypatch):
     """If this fixture is used, the `tests.utils.run_emulated` function is used for simulation."""
 
     if TEST_MODE in ("pipeline", "speed"):
+        VJP = "VJP"
+        task_id_fwd = "task_fwd"
+        task_id_bwd = "task_fwd"
+        cache = {}
+
+        monkeypatch.setattr(
+            "tidy3d.web.api.autograd.autograd.get_fwd_sim_data",
+            lambda task_id: cache[task_id_fwd][AUX_KEY_SIM_DATA_FWD],
+        )
+        monkeypatch.setattr(
+            "tidy3d.web.api.autograd.autograd.get_vjp_traced_fields",
+            lambda task_id: cache[task_id_bwd][VJP],
+        )
+
         import tidy3d.web.api.webapi as webapi
+        from tidy3d.web.api.autograd.autograd import (
+            AUX_KEY_SIM_DATA_FWD,
+            AUX_KEY_SIM_DATA_ORIGINAL,
+            postprocess_adj,
+            postprocess_fwd,
+            setup_run,
+        )
+
+        def emulated_job_run(self: Job) -> td.SimulationData:
+            """What gets called instead of ``web.run()``."""
+            sim_data = run_emulated(self.simulation, task_name="test")
+
+            if self.simulation_type == "autograd_fwd":
+                sim_data_combined = sim_data
+
+                # a bit of a hack i guess
+                orig_monitors = [
+                    mnt for mnt in sim_data.simulation.monitors if "adjoint" not in mnt.name
+                ]
+                sim_original = self.simulation.updated_copy(monitors=orig_monitors)
+
+                aux_data = {}
+                _ = postprocess_fwd(
+                    sim_data_combined=sim_data_combined,
+                    sim_original=sim_original,
+                    aux_data=aux_data,
+                )
+
+                sim_data_orig = aux_data[AUX_KEY_SIM_DATA_ORIGINAL]
+                sim_data_fwd = aux_data[AUX_KEY_SIM_DATA_FWD]
+
+                cache[task_id_fwd] = copy.copy(aux_data)
+
+            elif self.simulation_type == "autograd_bwd":
+                sim_data_adj = sim_data
+
+                aux_data_fwd = cache[task_id_fwd]
+
+                sim_data_orig = aux_data_fwd[AUX_KEY_SIM_DATA_ORIGINAL]
+                sim_data_fwd = aux_data_fwd[AUX_KEY_SIM_DATA_FWD]
+
+                orig_monitors = [
+                    mnt for mnt in sim_data.simulation.monitors if "adjoint" not in mnt.name
+                ]
+                sim_original = self.simulation.updated_copy(monitors=orig_monitors)
+                sim_fields_original = setup_run(simulation=sim_data_orig.simulation)
+
+                traced_fields_vjp = postprocess_adj(
+                    sim_data_adj=sim_data_adj,
+                    sim_data_orig=sim_data_orig,
+                    sim_data_fwd=sim_data_fwd,
+                    sim_fields_original=sim_fields_original,
+                )
+
+                cache[task_id_bwd][VJP] = traced_fields_vjp
+
+            return sim_data
 
         monkeypatch.setattr(webapi, "run", run_emulated)
-        monkeypatch.setattr(
-            Job, "run", lambda self: run_emulated(self.simulation, task_name="test")
-        )
-        monkeypatch.setattr(Job, "task_id", "test")
+        monkeypatch.setattr(Job, "run", emulated_job_run)
+        monkeypatch.setattr(Job, "task_id", task_id_fwd)
 
         _run_was_emulated[0] = True
-
-        # import here so it uses emulated run
-        from tidy3d.web.api.autograd import autograd
-
-        reload(autograd)
 
 
 @pytest.fixture
@@ -549,6 +613,28 @@ def test_autograd_speed_num_structures(use_emulated_run):
         pr.print_stats(sort="cumtime")
         pr.dump_stats("results.prof")
         print(f"{num_structures_test} structures took {t2:.2e} seconds")
+
+
+@pytest.mark.parametrize("structure_key, monitor_key", (("custom_med", "mode"),))
+def test_autograd_server(use_emulated_run, structure_key, monitor_key):
+    """Test an objective function through tidy3d autograd."""
+
+    fn_dict = get_functions(structure_key, monitor_key)
+    make_sim = fn_dict["sim"]
+    postprocess = fn_dict["postprocess"]
+
+    def objective(*args):
+        """Objective function."""
+        sim = make_sim(*args)
+        data = run(sim, task_name="autograd_test", verbose=False, local_gradient=False)
+        value = postprocess(data)
+        return value
+
+        val, grad = ag.value_and_grad(objective)(params0)
+        print(val, grad)
+        assert anp.all(grad != 0.0), "some gradients are 0"
+
+    val, grad = ag.value_and_grad(objective)(params0)
 
 
 @pytest.mark.parametrize("structure_key", ("custom_med",))

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -12,6 +12,9 @@ import numpy as np
 import pytest
 import tidy3d as td
 from tidy3d.web import run_async
+
+from tidy3d.plugins.polyslab import ComplexPolySlab
+from tidy3d.web import Job, run_async
 from tidy3d.web.api.autograd.autograd import run
 
 from ..utils import SIM_FULL, AssertLogLevel, run_emulated
@@ -118,6 +121,11 @@ def use_emulated_run(monkeypatch):
         import tidy3d.web.api.webapi as webapi
 
         monkeypatch.setattr(webapi, "run", run_emulated)
+        monkeypatch.setattr(
+            Job, "run", lambda self: run_emulated(self.simulation, task_name="test")
+        )
+        monkeypatch.setattr(Job, "task_id", "test")
+
         _run_was_emulated[0] = True
 
         # import here so it uses emulated run

--- a/tests/test_plugins/test_invdes.py
+++ b/tests/test_plugins/test_invdes.py
@@ -6,10 +6,9 @@ import pytest
 import tidy3d as td
 import tidy3d.plugins.invdes as tdi
 
-from ..utils import AssertLogLevel, run_async_emulated, run_emulated
-
 # use single threading pipeline
-from .test_adjoint import use_emulated_run, use_emulated_run_async  # noqa: F401
+from ..test_components.test_autograd import use_emulated_run, use_emulated_run_async  # noqa: F401
+from ..utils import AssertLogLevel, run_async_emulated, run_emulated
 
 FREQ0 = 1e14
 L_SIM = 1.0

--- a/tidy3d/components/autograd/utils.py
+++ b/tidy3d/components/autograd/utils.py
@@ -10,6 +10,13 @@ def get_static(x: typing.Any) -> typing.Any:
     return getval(x)
 
 
+def split_list(x: list[typing.Any], index: int) -> (list[typing.Any], list[typing.Any]):
+    """Split a list at a given index."""
+    x = list(x)
+    return x[:index], x[index:]
+
+
 __all__ = [
     "get_static",
+    "split_list",
 ]

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -439,7 +439,6 @@ def _run_async_primitive(
             sim_data_combined=sim_data_combined,
             sim_original=sim_original,
             aux_data=aux_data,
-            local_gradient=False,  # TODO: fix once we start supporting
         )
 
     return field_map_fwd_dict
@@ -498,12 +497,12 @@ def postprocess_fwd(
 
 def get_fwd_sim_data(task_id_fwd: str) -> td.SimulationData:
     """Function to grab the forward simulation data from the server from a task_id."""
-    raise NotImplementedError()
+    raise NotImplementedError("Must implement grabbing fwd task id for server side autograd.")
 
 
 def get_vjp_traced_fields(task_id_adj: str) -> AutogradFieldMap:
     """Function to grab the VJP result for the simulation fields from the adjoint task ID."""
-    raise NotImplementedError()
+    raise NotImplementedError("Must implement grabbing fwd task id for server side autograd.")
 
 
 def _run_bwd(

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -13,7 +13,7 @@ from tidy3d.components.autograd.derivative_utils import DerivativeInfo
 
 from ..asynchronous import DEFAULT_DATA_DIR
 from ..asynchronous import run_async as run_async_webapi
-from ..container import BatchData
+from ..container import BatchData, Job
 from ..tidy3d_stub import SimulationDataType, SimulationType
 from ..webapi import run as run_webapi
 from .utils import get_derivative_maps, split_data_list, split_list
@@ -21,6 +21,8 @@ from .utils import get_derivative_maps, split_data_list, split_list
 # keys for data into auxiliary dictionary
 AUX_KEY_SIM_DATA_ORIGINAL = "sim_data"
 AUX_KEY_SIM_DATA_FWD = "sim_data_fwd_adjoint"
+AUX_KEY_FWD_TASK_ID = "task_id_fwd"
+
 ISSUE_URL = (
     "https://github.com/flexcompute/tidy3d/issues/new?"
     "assignees=tylerflex&labels=adjoint&projects=&template=autograd_bug.md"
@@ -28,6 +30,9 @@ ISSUE_URL = (
 URL_LINK = f"[blue underline][link={ISSUE_URL}]'{ISSUE_URL}'[/link][/blue underline]"
 
 MAX_NUM_TRACED_STRUCTURES = 500
+
+# default value for whether to do local gradient calculation (True) or server side (False)
+LOCAL_GRADIENT = True
 
 
 def warn_autograd(fn_name: str, exc: Exception) -> str:
@@ -93,6 +98,7 @@ def run(
     worker_group: str = None,
     simulation_type: str = "tidy3d",
     parent_tasks: list[str] = None,
+    local_gradient: bool = LOCAL_GRADIENT,
 ) -> SimulationDataType:
     """
     Submits a :class:`.Simulation` to server, starts running, monitors progress, downloads,
@@ -123,6 +129,9 @@ def run(
         target solver version.
     worker_group: str = None
         worker group
+    local_gradient: bool = False
+        Whether to perform gradient calculation locally, requiring more downloads but potentially
+        more stable with experimental features.
 
     Returns
     -------
@@ -184,6 +193,7 @@ def run(
                 worker_group=worker_group,
                 simulation_type="tidy3d_autograd",
                 parent_tasks=parent_tasks,
+                local_gradient=local_gradient,
             )
         except Exception as exc:
             warn_autograd("web.run()", exc=exc)
@@ -281,7 +291,9 @@ def run_async(
 """ User-facing ``run`` and `run_async`` functions, compatible with ``autograd`` """
 
 
-def _run(simulation: td.Simulation, task_name: str, **run_kwargs) -> td.SimulationData:
+def _run(
+    simulation: td.Simulation, task_name: str, local_gradient: bool = LOCAL_GRADIENT, **run_kwargs
+) -> td.SimulationData:
     """User-facing ``web.run`` function, compatible with ``autograd`` differentiation."""
 
     traced_fields_sim = setup_run(simulation=simulation)
@@ -294,7 +306,8 @@ def _run(simulation: td.Simulation, task_name: str, **run_kwargs) -> td.Simulati
             "to the 'Simulation'. If this is unexpected, double check your objective function "
             "pre-processing. Running regular tidy3d simulation."
         )
-        return _run_tidy3d(simulation, task_name=task_name, **run_kwargs)
+        data, _ = _run_tidy3d(simulation, task_name=task_name, **run_kwargs)
+        return data
 
     # will store the SimulationData for original and forward so we can access them later
     aux_data = {}
@@ -305,6 +318,7 @@ def _run(simulation: td.Simulation, task_name: str, **run_kwargs) -> td.Simulati
         sim_original=simulation.to_static(),
         task_name=task_name,
         aux_data=aux_data,
+        local_gradient=local_gradient,
         **run_kwargs,
     )
 
@@ -374,16 +388,30 @@ def _run_primitive(
     sim_original: td.Simulation,
     task_name: str,
     aux_data: dict,
+    local_gradient: bool,
     **run_kwargs,
 ) -> AutogradFieldMap:
     """Autograd-traced 'run()' function: runs simulation, strips tracer data, caches fwd data."""
 
     td.log.info("running primitive '_run_primitive()'")
     sim_combined = setup_fwd(sim_fields=sim_fields, sim_original=sim_original)
-    sim_data_combined = _run_tidy3d(sim_combined, task_name=task_name, **run_kwargs)
-    return postprocess_fwd(
-        sim_data_combined=sim_data_combined, sim_original=sim_original, aux_data=aux_data
+
+    if not local_gradient:
+        run_kwargs["simulation_type"] = "autograd_fwd"
+
+    sim_data_combined, task_id_fwd = _run_tidy3d(sim_combined, task_name=task_name, **run_kwargs)
+
+    # TODO: put this in postprocess?
+    aux_data[AUX_KEY_FWD_TASK_ID] = task_id_fwd
+
+    # TODO: make sure this function works if the combined sim data has no grad monitors
+    field_map = postprocess_fwd(
+        sim_data_combined=sim_data_combined,
+        sim_original=sim_original,
+        aux_data=aux_data,
+        local_gradient=local_gradient,
     )
+    return field_map
 
 
 @primitive
@@ -409,7 +437,10 @@ def _run_async_primitive(
         sim_original = sims_original[task_name]
         aux_data = aux_data_dict[task_name]
         field_map_fwd_dict[task_name] = postprocess_fwd(
-            sim_data_combined=sim_data_combined, sim_original=sim_original, aux_data=aux_data
+            sim_data_combined=sim_data_combined,
+            sim_original=sim_original,
+            aux_data=aux_data,
+            local_gradient=False,  # TODO: fix once we start supporting
         )
 
     return field_map_fwd_dict
@@ -423,7 +454,10 @@ def setup_fwd(sim_fields: AutogradFieldMap, sim_original: td.Simulation) -> td.S
 
 
 def postprocess_fwd(
-    sim_data_combined: td.SimulationData, sim_original: td.Simulation, aux_data: dict
+    sim_data_combined: td.SimulationData,
+    sim_original: td.Simulation,
+    aux_data: dict,
+    local_gradient: bool,
 ) -> AutogradFieldMap:
     """Postprocess the combined simulation data into an Autograd field map."""
 
@@ -441,20 +475,20 @@ def postprocess_fwd(
     sim_data_original = sim_data_combined.updated_copy(
         simulation=sim_original, data=data_original, deep=False
     )
-
-    # construct the 'forward' simulation and its data, which is only used for for gradient calc.
-    sim_fwd = sim_combined.updated_copy(monitors=monitors_fwd)
-    sim_data_fwd = sim_data_combined.updated_copy(
-        simulation=sim_fwd,
-        data=data_fwd,
-        deep=False,
-    )
-
-    # cache these two SimulationData objects for later (note: the Simulations are already inside)
     aux_data[AUX_KEY_SIM_DATA_ORIGINAL] = sim_data_original
-    aux_data[AUX_KEY_SIM_DATA_FWD] = sim_data_fwd
 
-    # strip out the tracer AutogradFieldMap for the .data from the original sim
+    if local_gradient:
+        # construct the 'forward' simulation and its data, which is only used for for gradient calc.
+        sim_fwd = sim_combined.updated_copy(monitors=monitors_fwd)
+        sim_data_fwd = sim_data_combined.updated_copy(
+            simulation=sim_fwd,
+            data=data_fwd,
+            deep=False,
+        )
+        aux_data[AUX_KEY_SIM_DATA_FWD] = sim_data_fwd
+
+        # strip out the tracer AutogradFieldMap for the .data from the original sim
+
     data_traced = sim_data_original.strip_traced_fields(
         include_untraced_data_arrays=True, starting_path=("data",)
     )
@@ -472,13 +506,14 @@ def _run_bwd(
     sim_original: td.Simulation,
     task_name: str,
     aux_data: dict,
+    local_gradient: bool,
     **run_kwargs,
 ) -> typing.Callable[[AutogradFieldMap], AutogradFieldMap]:
     """VJP-maker for ``_run_primitive()``. Constructs and runs adjoint simulation, computes grad."""
 
     # get the fwd epsilon and field data from the cached aux_data
     sim_data_orig = aux_data[AUX_KEY_SIM_DATA_ORIGINAL]
-    sim_data_fwd = aux_data[AUX_KEY_SIM_DATA_FWD]
+    sim_data_fwd = aux_data.get(AUX_KEY_SIM_DATA_FWD)
 
     td.log.info("constructing custom vjp function for backwards pass.")
 
@@ -509,7 +544,20 @@ def _run_bwd(
 
         # run adjoint simulation
         task_name_adj = str(task_name) + "_adjoint"
-        sim_data_adj = _run_tidy3d(sim_adj, task_name=task_name_adj, **run_kwargs)
+
+        if not local_gradient:
+            run_kwargs["simulation_type"] = "autograd_bwd"
+            task_id_fwd = aux_data[AUX_KEY_FWD_TASK_ID]
+            run_kwargs["parent_tasks"] = [task_id_fwd]
+            # TODO: run the adjoint special web API? get the field map
+            # job = Job(...)
+            # job.upload()
+            # job.start()
+            # job.monitor()
+            # traced_fields_vjp = download_sim_vjp_autograd(job.task_id)
+            # return traced_fields_vjp
+
+        sim_data_adj, _ = _run_tidy3d(sim_adj, task_name=task_name_adj, **run_kwargs)
 
         return postprocess_adj(
             sim_data_adj=sim_data_adj,
@@ -685,12 +733,17 @@ defvjp(_run_async_primitive, _run_async_bwd, argnums=[0])
 """ The fundamental Tidy3D run and run_async functions used above. """
 
 
-def _run_tidy3d(simulation: td.Simulation, task_name: str, **run_kwargs) -> td.SimulationData:
+def _run_tidy3d(
+    simulation: td.Simulation, task_name: str, **run_kwargs
+) -> (td.SimulationData, str):
     """Run a simulation without any tracers using regular web.run()."""
     td.log.info("running regular simulation with '_run_tidy3d()'")
     # TODO: set task_type to "tidy3d adjoint autograd?"
-    data = run_webapi(simulation, task_name=task_name, **run_kwargs)
-    return data
+
+    run_kwargs = {k: v for k, v in run_kwargs.items() if k in Job._upload_fields}
+    job = Job(simulation=simulation, task_name=task_name, **run_kwargs)
+    data = job.run()
+    return data, job.task_id
 
 
 def _run_async_tidy3d(simulations: dict[str, td.Simulation], **run_async_kwargs) -> BatchData:

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -425,7 +425,7 @@ def _run_primitive(
 
         # TODO: put this in postprocess?
         aux_data[AUX_KEY_FWD_TASK_ID] = task_id_fwd
-
+        aux_data[AUX_KEY_SIM_DATA_ORIGINAL] = sim_data_orig
         field_map = sim_data_orig.strip_traced_fields(
             include_untraced_data_arrays=True, starting_path=("data",)
         )
@@ -673,9 +673,10 @@ def setup_adj(
     # make adjoint simulation from that SimulationData
     data_vjp_paths = set(data_fields_vjp.keys())
 
-    adjoint_monitors = sim_data_orig.simulation.updated_copy(monitors=[]).with_adjoint_monitors(
-        sim_fields_original
-    )
+    num_monitors = len(sim_data_orig.simulation.monitors)
+    adjoint_monitors = sim_data_orig.simulation.with_adjoint_monitors(sim_fields_original).monitors[
+        num_monitors:
+    ]
 
     sim_adj = sim_data_vjp.make_adjoint_sim(
         data_vjp_paths=data_vjp_paths,

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -496,7 +496,7 @@ def postprocess_fwd(
 
 
 def get_fwd_sim_data(task_id_fwd: str) -> td.SimulationData:
-    """Function to grab the forward simulation data from the server from a task_id."""
+    """Function to grab the forward simulation data from the server from a task ID."""
     raise NotImplementedError("Must implement grabbing fwd task id for server side autograd.")
 
 

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -451,7 +451,7 @@ def _run_async_primitive(
 def setup_fwd(
     sim_fields: AutogradFieldMap,
     sim_original: td.Simulation,
-    local_gradient: bool,
+    local_gradient: bool = LOCAL_GRADIENT,
 ) -> td.Simulation:
     """Set up the combined forward simulation."""
 

--- a/tidy3d/web/api/autograd/utils.py
+++ b/tidy3d/web/api/autograd/utils.py
@@ -4,30 +4,6 @@ import typing
 
 import tidy3d as td
 
-""" generic data manipulation """
-
-
-def split_data_list(sim_data: td.SimulationData, num_mnts_original: int) -> tuple[list, list]:
-    """Split data list into original, adjoint field, and adjoint permittivity."""
-
-    data_all = list(sim_data.data)
-    num_mnts_adjoint = (len(data_all) - num_mnts_original) // 2
-
-    td.log.info(
-        f" -> {num_mnts_original} monitors, {num_mnts_adjoint} adjoint field monitors, {num_mnts_adjoint} adjoint eps monitors."
-    )
-
-    data_original, data_adjoint = split_list(data_all, index=num_mnts_original)
-
-    return data_original, data_adjoint
-
-
-def split_list(x: list[typing.Any], index: int) -> (list[typing.Any], list[typing.Any]):
-    """Split a list at a given index."""
-    x = list(x)
-    return x[:index], x[index:]
-
-
 """ E and D field gradient map calculation helpers. """
 
 


### PR DESCRIPTION
currently a WIP, needs backend bits and pieces.

For now, organizes the autograd pipeline into a local and a remote pathway, depending on a kwarg passed to `run()`.

The local one operates the same as before, the remote one has the basics of what we need to implement server side. Specifically, I would need the following Web API implemented.

```py
sim_data = web.run(sim_combined, simulation_type="autograd_fwd")
```
on the `sim_combined` (sim with original + grad monitors) should split the data into `original` and `fwd` and store the `fwd` associated with this task ID. Then return just the original `SimulationData`.

```py
sim_data = web.run(sim_adj, simulation_type="autograd_bwd", parent_tasks=[task_id_fwd])
```

should run the adjoint simulation `sim_adj` and compute the gradient information combined with the cached forward `SimulationData` associated with `task_id_fwd `

```py
fields_vjp = download_vjp_fields_autograd(task_id_adj)
```

should download the result of the adjoint post processing associated with the task ID from the `autograd_bwd` call above.

I will work to make exactly what Neds to happen in each of these tasks explicit. it's just reorganizing bits of the existing front end code.

