### PR TITLE
:wrench: Include invdes module in API docs

### DIFF
--- a/docs/api/plugins/index.rst
+++ b/docs/api/plugins/index.rst
@@ -11,8 +11,9 @@ Plugins
     resonance
     autograd
     adjoint
-    waveguide
     design
+    invdes
+    waveguide
     microwave
 
 
@@ -23,6 +24,7 @@ Plugins
 .. include:: /api/plugins/resonance.rst
 .. include:: /api/plugins/autograd.rst
 .. include:: /api/plugins/adjoint.rst
-.. include:: /api/plugins/waveguide.rst
+.. include:: /api/plugins/invdes.rst
 .. include:: /api/plugins/design.rst
+.. include:: /api/plugins/waveguide.rst
 .. include:: /api/plugins/microwave.rst


### PR DESCRIPTION
Pretty urgent pre-2.7 release patch to include the `invdes` module on the API docs. Possibly my bad in not catching this in review sorry!

Doing a thorough upgrade on docs https://github.com/flexcompute/tidy3d/pull/1745 and caught this in time