### PR TITLE
Move dispersion fitter from plugins to tidy3d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Bug where boundary layers would be plotted too small in 2D simulations.
 
+### Changed
+- Dispersive medium fitter in `plugins.dispersion` has been moved to Tidy3D module.
+
 ## [2.7.0] - 2024-06-17
 
 ### Added

--- a/docs/api/mediums.rst
+++ b/docs/api/mediums.rst
@@ -25,8 +25,8 @@ Spatially varying
 
    tidy3d.CustomMedium
 
-Dispersive Mediums
-------------------
+Dispersive Medium
+-----------------
 
 Spatially uniform
 ^^^^^^^^^^^^^^^^^
@@ -52,6 +52,16 @@ Spatially varying
    tidy3d.CustomDrude
    tidy3d.CustomDebye
 
+Dispersive Medium Fitter
+------------------------
+
+.. autosummary::
+   :toctree: _autosummary/
+   :template: module.rst
+
+   tidy3d.FastDispersionFitter
+   tidy3d.AdvancedFastFitterParam
+   tidy3d.DispersionFitter
 
 Medium Perturbations
 --------------------
@@ -64,8 +74,8 @@ Medium Perturbations
    tidy3d.PerturbationPoleResidue
 
 
-General Mediums (can be both dispersive and non-dispersive)
------------------------------------------------------------
+General Medium (can be both dispersive and non-dispersive)
+----------------------------------------------------------
 
 Spatially uniform
 ^^^^^^^^^^^^^^^^^

--- a/docs/api/plugins/dispersion.rst
+++ b/docs/api/plugins/dispersion.rst
@@ -1,16 +1,13 @@
 
 .. currentmodule:: tidy3d
 
-Dispersive Model Fitting
-------------------------
+Remote Dispersive Model Fitting
+-------------------------------
 
 .. autosummary::
    :toctree: ../_autosummary/
    :template: module.rst
 
-   tidy3d.plugins.dispersion.FastDispersionFitter
-   tidy3d.plugins.dispersion.AdvancedFastFitterParam
-   tidy3d.plugins.dispersion.DispersionFitter
    tidy3d.plugins.dispersion.AdvancedFitterParam
    tidy3d.plugins.dispersion.web.run
    tidy3d.plugins.dispersion.StableDispersionFitter

--- a/tests/test_components/test_dispersion_fitter.py
+++ b/tests/test_components/test_dispersion_fitter.py
@@ -1,0 +1,255 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import pydantic.v1 as pydantic
+import pytest
+import responses
+from tidy3d import (
+    AdvancedFastFitterParam,
+    DispersionFitter,
+    FastDispersionFitter,
+)
+from tidy3d.exceptions import SetupError, ValidationError
+
+advanced_param = AdvancedFastFitterParam(num_iters=1, passivity_num_iters=1)
+
+
+_, AX = plt.subplots()
+
+
+@pytest.fixture
+def random_data():
+    data_points = 11
+    wvl_um = np.linspace(1, 2, data_points)
+    n_data = np.random.random(data_points)
+    k_data = np.random.random(data_points)
+    return wvl_um, n_data, k_data
+
+
+def test_coeffs():
+    """make sure pack_coeffs and unpack_coeffs are reciprocal"""
+    num_poles = 10
+    coeffs = np.random.random(4 * num_poles)
+    a, c = DispersionFitter._unpack_coeffs(coeffs)
+    coeffs_ = DispersionFitter._pack_coeffs(a, c)
+    a_, c_ = DispersionFitter._unpack_coeffs(coeffs_)
+    assert np.allclose(coeffs, coeffs_)
+    assert np.allclose(a, a_)
+    assert np.allclose(c, c_)
+
+    assert np.isclose(DispersionFitter._eV_to_Hz(DispersionFitter._Hz_to_eV(1.0)), 1.0)
+
+
+def test_pole_coeffs():
+    """make sure coeffs_to_poles and poles_to_coeffs are reciprocal"""
+    num_poles = 10
+    coeffs = np.random.random(4 * num_poles)
+    poles = DispersionFitter._coeffs_to_poles(coeffs)
+    coeffs_ = DispersionFitter._poles_to_coeffs(poles)
+    poles_ = DispersionFitter._coeffs_to_poles(coeffs_)
+    assert np.allclose(coeffs, coeffs_)
+    assert np.allclose(poles, poles_)
+
+
+@responses.activate
+def test_lossless_dispersion(random_data):
+    """perform fitting on random data"""
+
+    # wrong input data
+    with pytest.raises(pydantic.ValidationError):
+        fitter = DispersionFitter(wvl_um=[], n_data=())
+
+    with pytest.raises(pydantic.ValidationError):
+        fitter = DispersionFitter(wvl_um=[1.0], n_data=(1.0, 1.1))
+
+    with pytest.raises(pydantic.ValidationError):
+        fitter = DispersionFitter(wvl_um=[1.0], n_data=(1.0), k_data=(0, 1))
+
+    with pytest.raises(SetupError):
+        fitter = DispersionFitter(wvl_um=[1.0], n_data=(1.0), wvl_range=(2, 3))
+        medium, rms = fitter.fit(num_tries=2)
+
+    wvl_um, n_data, _ = random_data
+    fitter = DispersionFitter(wvl_um=wvl_um.tolist(), n_data=tuple(n_data))
+    medium, rms = fitter._fit_single()
+    medium, rms = fitter.fit(num_tries=2)
+
+    fitter = FastDispersionFitter(wvl_um=wvl_um.tolist(), n_data=tuple(n_data))
+    medium, rms = fitter.fit(advanced_param=advanced_param)
+
+    # from permittivity data
+    fitter = FastDispersionFitter.from_complex_permittivity(wvl_um, n_data**2)
+    medium2, rms2 = fitter.fit(advanced_param=advanced_param)
+
+
+@responses.activate
+def test_lossy_dispersion(random_data):
+    """perform fitting on random lossy data"""
+    wvl_um, n_data, k_data = random_data
+    fitter = DispersionFitter(wvl_um=wvl_um, n_data=n_data, k_data=k_data)
+    medium, rms = fitter._fit_single()
+    medium, rms = fitter.fit(num_tries=2)
+
+    fitter = FastDispersionFitter(wvl_um=wvl_um.tolist(), n_data=n_data, k_data=k_data)
+    medium, rms = fitter.fit(advanced_param=advanced_param)
+
+    # from permittivity data
+    eps_complex = (n_data + 1j * k_data) ** 2
+    fitter = FastDispersionFitter.from_complex_permittivity(
+        wvl_um, eps_complex.real, eps_complex.imag
+    )
+    medium2, rms2 = fitter.fit(advanced_param=advanced_param)
+
+    # from loss tangent
+    fitter = FastDispersionFitter.from_loss_tangent(
+        wvl_um, eps_complex.real, eps_complex.imag / eps_complex.real
+    )
+    medium3, rms3 = fitter.fit(advanced_param=advanced_param)
+
+    # test that poles can be close but not exactly equal to provided freqs
+    N = 2
+    wvl_um = np.linspace(0.5, 0.6, N)
+    n_data = np.ones(N) * 2
+    k_data = np.ones(N) * 0.5
+
+    fitter = FastDispersionFitter(wvl_um=wvl_um, n_data=n_data, k_data=k_data)
+    medium, rms_error = fitter.fit(max_num_poles=2, tolerance_rms=1e-3)
+
+
+def test_constant_loss_tangent():
+    """perform fitting on constant loss tangent material"""
+
+    eps_real = 2.5
+    loss_tangent = 1e-2
+    frequency_range = (1e9, 6e9)
+    mat = FastDispersionFitter.constant_loss_tangent_model(eps_real, loss_tangent, frequency_range)
+
+    # validate
+    sampling_frequency = np.linspace(frequency_range[0], frequency_range[1], 29)
+    eps_out, loss_tangent_out = mat.loss_tangent_model(sampling_frequency)
+    assert np.max(np.abs(eps_out - eps_real)) < 2e-2
+    assert np.max(np.abs(loss_tangent_out - loss_tangent)) / loss_tangent < 2e-2
+
+
+@responses.activate
+def test_dispersion_load_url():
+    """loads dispersion model from url"""
+
+    def _test_nk(mock_data):
+        responses.add(responses.GET, "http://test.com/nk_data.csv", body=b"\n".join(mock_data))
+        return DispersionFitter.from_url("http://test.com/nk_data.csv")
+
+    # doesn't start with "wl, n"
+    with pytest.raises(ValidationError):
+        mock_data = [b"wavelength,n", b"1,2", b"3,1*"]
+        _test_nk(mock_data)
+
+    # contains strings other than "wl,n", "wl,k"
+    with pytest.raises(ValidationError):
+        mock_data = [b"wl,n", b"1,2", b"3,1", b"wl,loss", b"1,2", b"3,1*"]
+        _test_nk(mock_data)
+
+    # mixed symbols with numbers
+    with pytest.raises(ValidationError):
+        mock_data = [b"wl,n", b"1,2", b"3,1*"]
+        _test_nk(mock_data)
+
+    # number of n/k data unmatched
+    with pytest.raises(ValidationError):
+        mock_data = [b"wl,n", b"1,2", b"3,2.1", b"wl,k", b"1,0"]
+        _test_nk(mock_data)
+
+    # has k data more than once
+    with pytest.raises(ValidationError):
+        mock_data = [b"wl,n", b"1,2", b"3,2.1", b"wl,k", b"1,0", b"wl,k", b"1,0"]
+        _test_nk(mock_data)
+
+    # n only
+    mock_data = [b"wl,n", b"1,2", b"2,2"]
+    fitter = _test_nk(mock_data)
+    medium, rms = fitter.fit(num_tries=10)
+
+    # n and k
+    mock_data = [b"wl,n", b"1,2", b"3,2.1", b"wl,k", b"1,0", b"3,0.1"]
+    fitter = _test_nk(mock_data)
+    medium, rms = fitter.fit(num_tries=2)
+
+
+def test_dispersion_load_file():
+    """loads dispersion model from nk data file"""
+
+    fitter = DispersionFitter.from_file("tests/data/nk_data.csv", skiprows=1, delimiter=",")
+    medium, rms = fitter.fit(num_tries=2)
+
+    fitter = DispersionFitter.from_file("tests/data/n_data.csv", skiprows=1, delimiter=",")
+    medium, rms = fitter.fit(num_tries=20)
+
+    fitter = FastDispersionFitter.from_file("tests/data/nk_data.csv", skiprows=1, delimiter=",")
+    medium, rms = fitter.fit(advanced_param=advanced_param)
+
+
+def test_dispersion_plot(random_data):
+    """plots a medium fit from file"""
+    wvl_um, n_data, k_data = random_data
+
+    fitter = DispersionFitter(wvl_um=wvl_um, n_data=n_data)
+    fitter.plot(ax=AX)
+    plt.close()
+    medium, rms = fitter.fit(num_tries=2)
+    fitter.plot(medium, ax=AX)
+    plt.close()
+
+    fitter = DispersionFitter(wvl_um=wvl_um, n_data=n_data, k_data=k_data)
+    fitter.plot()
+    plt.close()
+    medium, rms = fitter.fit(num_tries=2)
+    fitter.plot(medium, ax=AX)
+    plt.close()
+
+
+def test_dispersion_set_wvg_range(random_data):
+    """set wavelength range function"""
+    wvl_um, n_data, k_data = random_data
+    fitter = DispersionFitter(wvl_um=wvl_um, n_data=n_data)
+    fastfitter = FastDispersionFitter(wvl_um=wvl_um, n_data=n_data)
+
+    wvl_range = [1.2, 1.8]
+    fitter = fitter.copy(update={"wvl_range": wvl_range})
+    assert len(fitter.freqs) == 7
+    medium, rms = fitter.fit(num_tries=2)
+    fastfitter = fastfitter.copy(update={"wvl_range": wvl_range})
+    assert len(fastfitter.freqs) == 7
+    medium, rms = fastfitter.fit(advanced_param=advanced_param)
+
+    wvl_range = [1.2, 2.8]
+    fitter = fitter.copy(update={"wvl_range": wvl_range, "k_data": k_data})
+    assert len(fitter.freqs) == 9
+    medium, rms = fitter.fit(num_tries=2)
+    fastfitter = fastfitter.copy(update={"wvl_range": wvl_range})
+    assert len(fastfitter.freqs) == 9
+    medium, rms = fastfitter.fit(advanced_param=advanced_param)
+
+    wvl_range = [0.2, 1.8]
+    fitter = fitter.copy(update={"wvl_range": wvl_range})
+    assert len(fitter.freqs) == 9
+    medium, rms = fitter.fit(num_tries=2)
+    fastfitter = fastfitter.copy(update={"wvl_range": wvl_range})
+    assert len(fastfitter.freqs) == 9
+    medium, rms = fastfitter.fit(advanced_param=advanced_param)
+
+    wvl_range = [0.2, 2.8]
+    fitter = fitter.copy(update={"wvl_range": wvl_range, "k_data": k_data})
+    assert len(fitter.freqs) == 11
+    medium, rms = fitter.fit(num_tries=2)
+    fastfitter = fastfitter.copy(update={"wvl_range": wvl_range})
+    assert len(fastfitter.freqs) == 11
+    medium, rms = fastfitter.fit(advanced_param=advanced_param)
+
+
+def test_dispersion_guess(random_data):
+    """plots a medium fit from file"""
+    wvl_um, n_data, k_data = random_data
+
+    fitter = DispersionFitter(wvl_um=wvl_um, n_data=n_data)
+    medium, rms = fitter.fit(num_tries=2)
+
+    medium_new, rms_new = fitter.fit(num_tries=1, guess=medium)

--- a/tests/test_plugins/test_dispersion_fitter.py
+++ b/tests/test_plugins/test_dispersion_fitter.py
@@ -1,30 +1,9 @@
-import matplotlib.pyplot as plt
 import numpy as np
-import pydantic.v1 as pydantic
 import pytest
 import responses
 import tidy3d as td
-from tidy3d.exceptions import SetupError, ValidationError
-from tidy3d.plugins.dispersion import (
-    AdvancedFastFitterParam,
-    DispersionFitter,
-    FastDispersionFitter,
-)
+from tidy3d import DispersionFitter
 from tidy3d.plugins.dispersion.web import run as run_fitter
-
-advanced_param = AdvancedFastFitterParam(num_iters=1, passivity_num_iters=1)
-
-
-_, AX = plt.subplots()
-
-
-@pytest.fixture
-def random_data():
-    data_points = 11
-    wvl_um = np.linspace(1, 2, data_points)
-    n_data = np.random.random(data_points)
-    k_data = np.random.random(data_points)
-    return wvl_um, n_data, k_data
 
 
 @pytest.fixture
@@ -42,233 +21,19 @@ def mock_remote_api(monkeypatch):
     )
 
 
-def test_coeffs():
-    """make sure pack_coeffs and unpack_coeffs are reciprocal"""
-    num_poles = 10
-    coeffs = np.random.random(4 * num_poles)
-    a, c = DispersionFitter._unpack_coeffs(coeffs)
-    coeffs_ = DispersionFitter._pack_coeffs(a, c)
-    a_, c_ = DispersionFitter._unpack_coeffs(coeffs_)
-    assert np.allclose(coeffs, coeffs_)
-    assert np.allclose(a, a_)
-    assert np.allclose(c, c_)
-
-    assert np.isclose(DispersionFitter._eV_to_Hz(DispersionFitter._Hz_to_eV(1.0)), 1.0)
-
-
-def test_pole_coeffs():
-    """make sure coeffs_to_poles and poles_to_coeffs are reciprocal"""
-    num_poles = 10
-    coeffs = np.random.random(4 * num_poles)
-    poles = DispersionFitter._coeffs_to_poles(coeffs)
-    coeffs_ = DispersionFitter._poles_to_coeffs(poles)
-    poles_ = DispersionFitter._coeffs_to_poles(coeffs_)
-    assert np.allclose(coeffs, coeffs_)
-    assert np.allclose(poles, poles_)
-
-
 @responses.activate
-def test_lossless_dispersion(random_data, mock_remote_api):
+def test_run_fit(mock_remote_api):
     """perform fitting on random data"""
 
-    # wrong input data
-    with pytest.raises(pydantic.ValidationError):
-        fitter = DispersionFitter(wvl_um=[], n_data=())
+    data_points = 11
+    wvl_um = np.linspace(1, 2, data_points)
+    n_data = np.random.random(data_points)
+    k_data = np.random.random(data_points)
 
-    with pytest.raises(pydantic.ValidationError):
-        fitter = DispersionFitter(wvl_um=[1.0], n_data=(1.0, 1.1))
-
-    with pytest.raises(pydantic.ValidationError):
-        fitter = DispersionFitter(wvl_um=[1.0], n_data=(1.0), k_data=(0, 1))
-
-    with pytest.raises(SetupError):
-        fitter = DispersionFitter(wvl_um=[1.0], n_data=(1.0), wvl_range=(2, 3))
-        medium, rms = fitter.fit(num_tries=2)
-
-    wvl_um, n_data, _ = random_data
+    # lossless
     fitter = DispersionFitter(wvl_um=wvl_um.tolist(), n_data=tuple(n_data))
-    medium, rms = fitter._fit_single()
-    medium, rms = fitter.fit(num_tries=2)
     medium, rms = run_fitter(fitter)
 
-    fitter = FastDispersionFitter(wvl_um=wvl_um.tolist(), n_data=tuple(n_data))
-    medium, rms = fitter.fit(advanced_param=advanced_param)
-
-    # from permittivity data
-    fitter = FastDispersionFitter.from_complex_permittivity(wvl_um, n_data**2)
-    medium2, rms2 = fitter.fit(advanced_param=advanced_param)
-
-
-@responses.activate
-def test_lossy_dispersion(random_data, mock_remote_api):
-    """perform fitting on random lossy data"""
-    wvl_um, n_data, k_data = random_data
+    # lossy
     fitter = DispersionFitter(wvl_um=wvl_um, n_data=n_data, k_data=k_data)
-    medium, rms = fitter._fit_single()
-    medium, rms = fitter.fit(num_tries=2)
     medium, rms = run_fitter(fitter)
-
-    fitter = FastDispersionFitter(wvl_um=wvl_um.tolist(), n_data=n_data, k_data=k_data)
-    medium, rms = fitter.fit(advanced_param=advanced_param)
-
-    # from permittivity data
-    eps_complex = (n_data + 1j * k_data) ** 2
-    fitter = FastDispersionFitter.from_complex_permittivity(
-        wvl_um, eps_complex.real, eps_complex.imag
-    )
-    medium2, rms2 = fitter.fit(advanced_param=advanced_param)
-
-    # from loss tangent
-    fitter = FastDispersionFitter.from_loss_tangent(
-        wvl_um, eps_complex.real, eps_complex.imag / eps_complex.real
-    )
-    medium3, rms3 = fitter.fit(advanced_param=advanced_param)
-
-    # test that poles can be close but not exactly equal to provided freqs
-    N = 2
-    wvl_um = np.linspace(0.5, 0.6, N)
-    n_data = np.ones(N) * 2
-    k_data = np.ones(N) * 0.5
-
-    fitter = FastDispersionFitter(wvl_um=wvl_um, n_data=n_data, k_data=k_data)
-    medium, rms_error = fitter.fit(max_num_poles=2, tolerance_rms=1e-3)
-
-
-def test_constant_loss_tangent():
-    """perform fitting on constant loss tangent material"""
-
-    eps_real = 2.5
-    loss_tangent = 1e-2
-    frequency_range = (1e9, 6e9)
-    mat = FastDispersionFitter.constant_loss_tangent_model(eps_real, loss_tangent, frequency_range)
-
-    # validate
-    sampling_frequency = np.linspace(frequency_range[0], frequency_range[1], 29)
-    eps_out, loss_tangent_out = mat.loss_tangent_model(sampling_frequency)
-    assert np.max(np.abs(eps_out - eps_real)) < 2e-2
-    assert np.max(np.abs(loss_tangent_out - loss_tangent)) / loss_tangent < 2e-2
-
-
-@responses.activate
-def test_dispersion_load_url():
-    """loads dispersion model from url"""
-
-    def _test_nk(mock_data):
-        responses.add(responses.GET, "http://test.com/nk_data.csv", body=b"\n".join(mock_data))
-        return DispersionFitter.from_url("http://test.com/nk_data.csv")
-
-    # doesn't start with "wl, n"
-    with pytest.raises(ValidationError):
-        mock_data = [b"wavelength,n", b"1,2", b"3,1*"]
-        _test_nk(mock_data)
-
-    # contains strings other than "wl,n", "wl,k"
-    with pytest.raises(ValidationError):
-        mock_data = [b"wl,n", b"1,2", b"3,1", b"wl,loss", b"1,2", b"3,1*"]
-        _test_nk(mock_data)
-
-    # mixed symbols with numbers
-    with pytest.raises(ValidationError):
-        mock_data = [b"wl,n", b"1,2", b"3,1*"]
-        _test_nk(mock_data)
-
-    # number of n/k data unmatched
-    with pytest.raises(ValidationError):
-        mock_data = [b"wl,n", b"1,2", b"3,2.1", b"wl,k", b"1,0"]
-        _test_nk(mock_data)
-
-    # has k data more than once
-    with pytest.raises(ValidationError):
-        mock_data = [b"wl,n", b"1,2", b"3,2.1", b"wl,k", b"1,0", b"wl,k", b"1,0"]
-        _test_nk(mock_data)
-
-    # n only
-    mock_data = [b"wl,n", b"1,2", b"2,2"]
-    fitter = _test_nk(mock_data)
-    medium, rms = fitter.fit(num_tries=10)
-
-    # n and k
-    mock_data = [b"wl,n", b"1,2", b"3,2.1", b"wl,k", b"1,0", b"3,0.1"]
-    fitter = _test_nk(mock_data)
-    medium, rms = fitter.fit(num_tries=2)
-
-
-def test_dispersion_load_file():
-    """loads dispersion model from nk data file"""
-
-    fitter = DispersionFitter.from_file("tests/data/nk_data.csv", skiprows=1, delimiter=",")
-    medium, rms = fitter.fit(num_tries=2)
-
-    fitter = DispersionFitter.from_file("tests/data/n_data.csv", skiprows=1, delimiter=",")
-    medium, rms = fitter.fit(num_tries=20)
-
-    fitter = FastDispersionFitter.from_file("tests/data/nk_data.csv", skiprows=1, delimiter=",")
-    medium, rms = fitter.fit(advanced_param=advanced_param)
-
-
-def test_dispersion_plot(random_data):
-    """plots a medium fit from file"""
-    wvl_um, n_data, k_data = random_data
-
-    fitter = DispersionFitter(wvl_um=wvl_um, n_data=n_data)
-    fitter.plot(ax=AX)
-    plt.close()
-    medium, rms = fitter.fit(num_tries=2)
-    fitter.plot(medium, ax=AX)
-    plt.close()
-
-    fitter = DispersionFitter(wvl_um=wvl_um, n_data=n_data, k_data=k_data)
-    fitter.plot()
-    plt.close()
-    medium, rms = fitter.fit(num_tries=2)
-    fitter.plot(medium, ax=AX)
-    plt.close()
-
-
-def test_dispersion_set_wvg_range(random_data):
-    """set wavelength range function"""
-    wvl_um, n_data, k_data = random_data
-    fitter = DispersionFitter(wvl_um=wvl_um, n_data=n_data)
-    fastfitter = FastDispersionFitter(wvl_um=wvl_um, n_data=n_data)
-
-    wvl_range = [1.2, 1.8]
-    fitter = fitter.copy(update={"wvl_range": wvl_range})
-    assert len(fitter.freqs) == 7
-    medium, rms = fitter.fit(num_tries=2)
-    fastfitter = fastfitter.copy(update={"wvl_range": wvl_range})
-    assert len(fastfitter.freqs) == 7
-    medium, rms = fastfitter.fit(advanced_param=advanced_param)
-
-    wvl_range = [1.2, 2.8]
-    fitter = fitter.copy(update={"wvl_range": wvl_range, "k_data": k_data})
-    assert len(fitter.freqs) == 9
-    medium, rms = fitter.fit(num_tries=2)
-    fastfitter = fastfitter.copy(update={"wvl_range": wvl_range})
-    assert len(fastfitter.freqs) == 9
-    medium, rms = fastfitter.fit(advanced_param=advanced_param)
-
-    wvl_range = [0.2, 1.8]
-    fitter = fitter.copy(update={"wvl_range": wvl_range})
-    assert len(fitter.freqs) == 9
-    medium, rms = fitter.fit(num_tries=2)
-    fastfitter = fastfitter.copy(update={"wvl_range": wvl_range})
-    assert len(fastfitter.freqs) == 9
-    medium, rms = fastfitter.fit(advanced_param=advanced_param)
-
-    wvl_range = [0.2, 2.8]
-    fitter = fitter.copy(update={"wvl_range": wvl_range, "k_data": k_data})
-    assert len(fitter.freqs) == 11
-    medium, rms = fitter.fit(num_tries=2)
-    fastfitter = fastfitter.copy(update={"wvl_range": wvl_range})
-    assert len(fastfitter.freqs) == 11
-    medium, rms = fastfitter.fit(advanced_param=advanced_param)
-
-
-def test_dispersion_guess(random_data):
-    """plots a medium fit from file"""
-    wvl_um, n_data, k_data = random_data
-
-    fitter = DispersionFitter(wvl_um=wvl_um, n_data=n_data)
-    medium, rms = fitter.fit(num_tries=2)
-
-    medium_new, rms_new = fitter.fit(num_tries=1, guess=medium)

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -113,6 +113,10 @@ from .components.eme.sweep import EMEFreqSweep, EMELengthSweep, EMEModeSweep
 # field projection
 from .components.field_projection import FieldProjector
 
+# material fitter
+from .components.fitter.fit import DispersionFitter
+from .components.fitter.fit_fast import AdvancedFastFitterParam, FastDispersionFitter
+
 # geometry
 from .components.geometry.base import Box, ClipOperation, Geometry, GeometryGroup, Transformed
 from .components.geometry.mesh import TriangleMesh
@@ -464,6 +468,9 @@ __all__ = [
     "TriangularGridDataset",
     "TetrahedralGridDataset",
     "medium_from_nk",
+    "DispersionFitter",
+    "AdvancedFastFitterParam",
+    "FastDispersionFitter",
     "SubpixelSpec",
     "Staircasing",
     "VolumetricAveraging",

--- a/tidy3d/components/fitter/fit.py
+++ b/tidy3d/components/fitter/fit.py
@@ -12,15 +12,13 @@ import scipy.optimize as opt
 from pydantic.v1 import Field, validator
 from rich.progress import Progress
 
-from tidy3d.web.core.environment import Env
-
-from ...components.base import Tidy3dBaseModel, cached_property, skip_if_fields_missing
-from ...components.medium import AbstractMedium, PoleResidue
-from ...components.types import ArrayFloat1D, Ax
-from ...components.viz import add_ax_if_none
 from ...constants import C_0, HBAR, MICROMETER
 from ...exceptions import SetupError, ValidationError, WebError
 from ...log import get_logging_console, log
+from ..base import Tidy3dBaseModel, cached_property, skip_if_fields_missing
+from ..medium import AbstractMedium, PoleResidue
+from ..types import ArrayFloat1D, Ax
+from ..viz import add_ax_if_none
 
 
 class DispersionFitter(Tidy3dBaseModel):
@@ -614,7 +612,7 @@ class DispersionFitter(Tidy3dBaseModel):
         :class:`DispersionFitter`
             A :class:`DispersionFitter` instance.
         """
-        resp = requests.get(url_file, verify=Env.current.ssl_verify)
+        resp = requests.get(url_file)
 
         try:
             resp.raise_for_status()

--- a/tidy3d/components/fitter/fit_fast.py
+++ b/tidy3d/components/fitter/fit_fast.py
@@ -9,12 +9,12 @@ import scipy
 from pydantic.v1 import Field, NonNegativeFloat, PositiveFloat, PositiveInt, validator
 from rich.progress import Progress
 
-from ...components.base import Tidy3dBaseModel, cached_property, skip_if_fields_missing
-from ...components.medium import LOSS_CHECK_MAX, LOSS_CHECK_MIN, LOSS_CHECK_NUM, PoleResidue
-from ...components.types import ArrayComplex1D, ArrayComplex2D, ArrayFloat1D, ArrayFloat2D
 from ...constants import C_0
 from ...exceptions import ValidationError
 from ...log import get_logging_console, log
+from ..base import Tidy3dBaseModel, cached_property, skip_if_fields_missing
+from ..medium import LOSS_CHECK_MAX, LOSS_CHECK_MIN, LOSS_CHECK_NUM, PoleResidue
+from ..types import ArrayComplex1D, ArrayComplex2D, ArrayFloat1D, ArrayFloat2D
 from .fit import DispersionFitter
 
 # numerical tolerance for pole relocation for fast fitter

--- a/tidy3d/plugins/dispersion/__init__.py
+++ b/tidy3d/plugins/dispersion/__init__.py
@@ -1,8 +1,14 @@
 """Imports from dispersion fitter plugin."""
 
-from .fit import DispersionFitter
-from .fit_fast import AdvancedFastFitterParam, FastDispersionFitter
+from ...components.fitter.fit import DispersionFitter
+from ...components.fitter.fit_fast import AdvancedFastFitterParam, FastDispersionFitter
+from ...log import log
 from .web import AdvancedFitterParam, StableDispersionFitter
+
+log.warning(
+    "Dispersive material fitter in the module 'plugins.dispersion' has "
+    "been moved to Tidy3D module. 'plugins.dispersion' will be removed in future versions."
+)
 
 __all__ = [
     "DispersionFitter",

--- a/tidy3d/plugins/dispersion/web.py
+++ b/tidy3d/plugins/dispersion/web.py
@@ -14,12 +14,12 @@ from tidy3d.web.core.environment import Env
 from tidy3d.web.core.http_util import get_headers
 
 from ...components.base import Tidy3dBaseModel, skip_if_fields_missing
+from ...components.fitter.fit import DispersionFitter
 from ...components.medium import PoleResidue
 from ...components.types import Literal
 from ...constants import HERTZ, MICROMETER
 from ...exceptions import SetupError, Tidy3dError, WebError
 from ...log import log
-from .fit import DispersionFitter
 
 BOUND_MAX_FACTOR = 10
 
@@ -330,7 +330,7 @@ def run(
         Number of optimizations to run with random initial guess.
     tolerance_rms : NonNegativeFloat, optional
         RMS error below which the fit is successful and the result is returned.
-    advanced_param : :class:`AdvancedFitterParam`, optional
+    advanced_param : :class:`.AdvancedFitterParam`, optional
         Advanced parameters passed on to the server.
 
     Returns


### PR DESCRIPTION
In surface impedance treatment, the impedance is dispersive. Previously Debye model has been used to fit the impedance. CCPR model should require fewer number of poles. The plan is to add the fitter as a method (or cached property) to the good conductor material class, so that before submitting the simulation, one can examine if the fitted impedance looks good with the default fitting parameters.