### PR TITLE
Good conductor draft (just for discussion)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tidy3d"
-version = "2.7.0"
+version = "2.9.0rc2"
 description = "A fast FDTD solver"
 authors = ["Tyler Hughes <tyler@flexcompute.com>"]
 license = "LGPLv2+"

--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -141,6 +141,27 @@ def test_PEC():
     _ = td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=td.PEC)
 
 
+def test_lossy_metal():
+    # frequency_range shouldn't be None
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.LossyMetal()
+    # frequency_range shouldn't contain non-postive values
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.LossyMetal(frequency_range=(0, 10))
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.LossyMetal(frequency_range=(-10, 10))
+
+    # frequency_range should be finite
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.LossyMetal(frequency_range=(10, np.inf))
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.LossyMetal(frequency_range=(-np.inf, 10))
+
+    # default fitting
+    mat = td.LossyMetal(conductivity=1.0, frequency_range=(1e14, 4e14))
+    model = mat.skin_depth_model
+
+
 def test_medium_dispersion():
     # construct media
     m_PR = td.PoleResidue(eps_inf=1.0, poles=[((-1 + 2j), (1 + 3j)), ((-2 + 4j), (1 + 5j))])

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -240,6 +240,7 @@ from .components.subpixel_spec import (
     PolarizedAveraging,
     Staircasing,
     SubpixelSpec,
+    SurfaceImpedance,
     VolumetricAveraging,
 )
 
@@ -480,6 +481,7 @@ __all__ = [
     "PolarizedAveraging",
     "HeuristicPECStaircasing",
     "PECConformal",
+    "SurfaceImpedance",
     "EMESimulation",
     "EMESimulationData",
     "EMEMonitor",

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -122,6 +122,7 @@ from .components.geometry.base import Box, ClipOperation, Geometry, GeometryGrou
 from .components.geometry.mesh import TriangleMesh
 from .components.geometry.polyslab import PolySlab
 from .components.geometry.primitives import Cylinder, Sphere
+from .components.good_conductor import LossyMetal, SkinDepthFitterParam
 from .components.grid.grid import Coords, Coords1D, FieldGrid, Grid, YeeGrid
 from .components.grid.grid_spec import AutoGrid, CustomGrid, GridSpec, UniformGrid
 from .components.heat.boundary import ConvectionBC, HeatBoundarySpec, HeatFluxBC, TemperatureBC
@@ -333,6 +334,8 @@ __all__ = [
     "NonlinearSusceptibility",
     "TwoPhotonAbsorption",
     "KerrNonlinearity",
+    "LossyMetal",
+    "SkinDepthFitterParam",
     "Structure",
     "MeshOverrideStructure",
     "ModeSpec",

--- a/tidy3d/components/base_sim/simulation.py
+++ b/tidy3d/components/base_sim/simulation.py
@@ -13,7 +13,8 @@ from ...log import log
 from ...version import __version__
 from ..base import cached_property, skip_if_fields_missing
 from ..geometry.base import Box
-from ..medium import Medium, MediumType3D
+from ..good_conductor import MediumType3D
+from ..medium import Medium
 from ..scene import Scene
 from ..structure import Structure
 from ..types import TYPE_TAG_STR, Ax, Axis, Bound, Symmetry

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -17,8 +17,9 @@ from ...log import log
 from ..base import TYPE_TAG_STR, cached_property, skip_if_fields_missing
 from ..base_sim.data.monitor_data import AbstractMonitorData
 from ..geometry.base import Box
+from ..good_conductor import MediumType
 from ..grid.grid import Coords, Grid
-from ..medium import Medium, MediumType
+from ..medium import Medium
 from ..monitor import (
     DiffractionMonitor,
     FieldMonitor,

--- a/tidy3d/components/field_projection.py
+++ b/tidy3d/components/field_projection.py
@@ -26,7 +26,7 @@ from .data.monitor_data import (
     FieldProjectionKSpaceData,
 )
 from .data.sim_data import SimulationData
-from .medium import MediumType
+from .good_conductor import MediumType
 from .monitor import (
     AbstractFieldProjectionMonitor,
     FieldMonitor,

--- a/tidy3d/components/good_conductor.py
+++ b/tidy3d/components/good_conductor.py
@@ -1,0 +1,159 @@
+"""Defines properties of good conductor"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import numpy as np
+from pydantic.v1 import Field, NonNegativeFloat, PositiveInt, validator
+
+from ..constants import C_0, HERTZ
+from ..exceptions import SetupError, ValidationError
+from .base import Tidy3dBaseModel, cached_property
+from .fitter.fit_fast import DEFAULT_MAX_POLES, DEFAULT_TOLERANCE_RMS, FastDispersionFitter
+from .medium import Medium, MediumType3DTmp, MediumTypeTmp, PoleResidue
+from .types import Ax, FreqBound
+from .viz import add_ax_if_none
+
+DEFAULT_SAMPLING_FREQUENCY = 20
+SCALED_REAL_PART = 10.0
+
+
+class SkinDepthFitterParam(Tidy3dBaseModel):
+    """Advanced parameters for fitting complex-valued skin depth ``2j/k`` over its frequency
+    bandwidth, where k is the complex-valued wavenumber inside the lossy metal. Real part
+    of this quantity corresponds to physical skin depth.
+    """
+
+    max_num_poles: PositiveInt = Field(
+        DEFAULT_MAX_POLES,
+        title="Maximal number of poles",
+        description="Maximal number of poles in complex-conjugate poles residue model for "
+        "fitting complex-valued skin depth.",
+    )
+
+    tolerance_rms: NonNegativeFloat = Field(
+        DEFAULT_TOLERANCE_RMS,
+        title="Tolerance in fitting",
+        description="Tolerance in fitting complex-valued skin depth.",
+    )
+
+    frequency_sampling_points: PositiveInt = Field(
+        DEFAULT_SAMPLING_FREQUENCY,
+        title="Number of sampling frequencies",
+        description="Number of sampling frequencies used in fitting.",
+    )
+
+
+class LossyMetal(Medium):
+    """Material with high DC-conductivity that can be modeled with surface
+    impedance boundary condition (SIBC). The model is accurate when the skin depth
+    is much smaller than the structure feature size.
+    """
+
+    frequency_range: FreqBound = Field(
+        ...,
+        title="Frequency Range",
+        description="Frequency range of validity for the medium.",
+        units=(HERTZ, HERTZ),
+    )
+
+    fit_param: SkinDepthFitterParam = Field(
+        SkinDepthFitterParam(),
+        title="Complex-valued skin depth fitting parameters",
+        description="Parameters for fitting complex-valued dispersive skin depth over "
+        "the frequency range by using pole-residue pair model.",
+    )
+
+    @validator("frequency_range")
+    def _validate_frequency_range(cls, val):
+        """Validate that frequency range is finite and non-zero."""
+        for freq in val:
+            if not np.isfinite(freq):
+                raise ValidationError("Values in 'frequency_range' must be finite.")
+            if freq <= 0:
+                raise ValidationError("Values in 'frequency_range' must be positive.")
+        return val
+
+    @cached_property
+    def skin_depth_model(self) -> PoleResidue:
+        """Fit complex-valued skin depth using pole-residue pair model within ``frequency_range``."""
+        wvl_um = C_0 / self.sampling_frequencies
+        skin_depth = self.complex_skin_depth(self.sampling_frequencies)
+
+        # let's use scaled `skin_depth` in fitting: minimal real part equals ``SCALED_REAL_PART``
+        min_skin_depth_real = np.min(skin_depth.real)
+        if min_skin_depth_real <= 0:
+            raise SetupError("Physical skin depth cannot be non-positive. Something is wrong.")
+
+        scaling_factor = SCALED_REAL_PART / min_skin_depth_real
+        skin_depth *= scaling_factor
+
+        fitter = FastDispersionFitter.from_complex_permittivity(
+            wvl_um, skin_depth.real, skin_depth.imag
+        )
+        material, _ = fitter.fit(
+            max_num_poles=self.fit_param.max_num_poles, tolerance_rms=self.fit_param.tolerance_rms
+        )
+        return material._scaled_permittivity(1.0 / scaling_factor)
+
+    @cached_property
+    def num_poles(self) -> int:
+        """Number of poles in the fitted model."""
+        return len(self.skin_depth_model.poles)
+
+    def complex_skin_depth(self, frequencies):
+        """Compute complex-valued skin_depth."""
+        # compute complex-valued skin depth
+        n, k = self.nk_model(frequencies)
+        wavenumber = 2 * np.pi * frequencies * (n + 1j * k) / C_0
+        return 2j / wavenumber
+
+    @cached_property
+    def sampling_frequencies(self):
+        """Sampling frequencies used in fitting."""
+        if self.fit_param.frequency_sampling_points < 2:
+            return np.array([np.mean(self.frequency_range)])
+
+        return np.logspace(
+            np.log10(self.frequency_range[0]),
+            np.log10(self.frequency_range[1]),
+            self.fit_param.frequency_sampling_points,
+        )
+
+    @add_ax_if_none
+    def plot(
+        self,
+        ax: Ax = None,
+    ) -> Ax:
+        """Make plot of model vs data, at a set of wavelengths (if supplied).
+
+        Parameters
+        ----------
+        ax : matplotlib.axes._subplots.Axes = None
+            Axes to plot the data on, if None, a new one is created.
+
+        Returns
+        -------
+        matplotlib.axis.Axes
+            Matplotlib axis corresponding to plot.
+        """
+        frequencies = self.sampling_frequencies
+        skin_depth = self.complex_skin_depth(frequencies)
+
+        ax.plot(frequencies, skin_depth.real, "x", label="Real")
+        ax.plot(frequencies, skin_depth.imag, "+", label="Imag")
+
+        skin_depth_from_model = self.skin_depth_model.eps_model(frequencies)
+        ax.plot(frequencies, skin_depth_from_model.real, label="Real (model)")
+        ax.plot(frequencies, skin_depth_from_model.imag, label="Imag (model)")
+
+        ax.set_ylabel("Skin depth")
+        ax.set_xlabel("Frequency (Hz)")
+        ax.legend()
+
+        return ax
+
+
+MediumType = Union[MediumTypeTmp, LossyMetal]
+MediumType3D = Union[MediumType3DTmp, LossyMetal]

--- a/tidy3d/components/grid/mesher.py
+++ b/tidy3d/components/grid/mesher.py
@@ -17,6 +17,7 @@ from ...constants import C_0, fp_eps
 from ...exceptions import SetupError, ValidationError
 from ...log import log
 from ..base import Tidy3dBaseModel
+from ..good_conductor import LossyMetal
 from ..medium import AnisotropicMedium, Medium2D, PECMedium
 from ..structure import MeshOverrideStructure, Structure, StructureType
 from ..types import ArrayFloat1D, Axis, Bound, Coordinate
@@ -497,9 +498,13 @@ class GradedMesher(Mesher):
         min_steps = []
         for structure in structures:
             if isinstance(structure, Structure):
-                if isinstance(structure.medium, (PECMedium, Medium2D)) or (
-                    isinstance(structure.medium, AnisotropicMedium)
-                    and structure.medium.is_comp_pec(axis)
+                if (
+                    isinstance(structure.medium, (PECMedium, Medium2D))
+                    or isinstance(structure.medium, LossyMetal)
+                    or (
+                        isinstance(structure.medium, AnisotropicMedium)
+                        and structure.medium.is_comp_pec(axis)
+                    )
                 ):
                     # for 2d medium, will always ignore even if not PEC;
                     # later, this will be handled by _grid_corrections_2dmaterials

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -2863,6 +2863,12 @@ class PoleResidue(DispersiveMedium):
             frequency_range=self.frequency_range,
         )
 
+    def _scaled_permittivity(self, scaling: pd.PositiveFloat) -> PoleResidue:
+        """Applying scaling to material parameters so that its permittivity is scaled by ``scaling``."""
+        eps_inf = self.eps_inf * scaling
+        poles = [(a, c * scaling) for (a, c) in self.poles]
+        return PoleResidue(eps_inf=eps_inf, poles=poles)
+
     @staticmethod
     def lo_to_eps_model(
         poles: Tuple[Tuple[float, float, float, float], ...],
@@ -5842,7 +5848,7 @@ class PerturbationPoleResidue(PoleResidue, AbstractPerturbationMedium):
 # types of mediums that can be used in Simulation and Structures
 
 
-MediumType3D = Union[
+MediumType3DTmp = Union[
     Medium,
     AnisotropicMedium,
     PECMedium,
@@ -5947,7 +5953,7 @@ class Medium2D(AbstractMedium):
     def volumetric_equivalent(
         self,
         axis: Axis,
-        adjacent_media: Tuple[MediumType3D, MediumType3D],
+        adjacent_media: Tuple[MediumType3DTmp, MediumType3DTmp],
         adjacent_dls: Tuple[float, float],
     ) -> AnisotropicMedium:
         """Produces a 3D volumetric equivalent medium. The new medium has thickness equal to
@@ -5978,7 +5984,7 @@ class Medium2D(AbstractMedium):
             The 3D material corresponding to this 2D material.
         """
 
-        def get_component(med: MediumType3D, comp: Axis) -> IsotropicUniformMediumType:
+        def get_component(med: MediumType3DTmp, comp: Axis) -> IsotropicUniformMediumType:
             """Extract the ``comp`` component of ``med``."""
             if isinstance(med, AnisotropicMedium):
                 dim = "xyz"[comp]
@@ -6252,7 +6258,7 @@ PEC2D = Medium2D(ss=PEC, tt=PEC)
 
 # types of mediums that can be used in Simulation and Structures
 
-MediumType = Union[MediumType3D, Medium2D, AnisotropicMediumFromMedium2D]
+MediumTypeTmp = Union[MediumType3DTmp, Medium2D, AnisotropicMediumFromMedium2D]
 
 
 # Utility function

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -12,7 +12,7 @@ from ..log import log
 from .apodization import ApodizationSpec
 from .base import Tidy3dBaseModel, cached_property, skip_if_fields_missing
 from .base_sim.monitor import AbstractMonitor
-from .medium import MediumType
+from .good_conductor import MediumType
 from .mode import ModeSpec
 from .types import (
     ArrayFloat1D,

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -23,6 +23,7 @@ from .data.dataset import (
 )
 from .geometry.base import Box, ClipOperation, GeometryGroup
 from .geometry.utils import flatten_groups, traverse_geometries
+from .good_conductor import MediumType, MediumType3D
 from .grid.grid import Coords, Grid
 from .heat_spec import SolidSpec
 from .medium import (
@@ -30,8 +31,6 @@ from .medium import (
     AbstractPerturbationMedium,
     Medium,
     Medium2D,
-    MediumType,
-    MediumType3D,
 )
 from .structure import Structure
 from .types import TYPE_TAG_STR, Ax, Bound, Coordinate, InterpMethod, Shapely, Size

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -36,6 +36,7 @@ from .geometry.base import Box, Geometry
 from .geometry.mesh import TriangleMesh
 from .geometry.utils import flatten_groups, traverse_geometries
 from .geometry.utils_2d import get_bounds, get_thickened_geom, snap_coordinate_to_grid, subdivide
+from .good_conductor import LossyMetal, MediumType, MediumType3D
 from .grid.grid import Coords, Coords1D, Grid
 from .grid.grid_spec import AutoGrid, CustomGrid, GridSpec, UniformGrid
 from .lumped_element import LumpedElementType
@@ -47,8 +48,6 @@ from .medium import (
     FullyAnisotropicMedium,
     Medium,
     Medium2D,
-    MediumType,
-    MediumType3D,
 )
 from .monitor import (
     AbstractFieldProjectionMonitor,
@@ -3772,8 +3771,10 @@ class Simulation(AbstractYeeGridSimulation):
 
         mediums = self.scene.mediums
         contain_pec_structures = any(medium.is_pec for medium in mediums)
+        contain_sibc_structures = any(isinstance(medium, LossyMetal) for medium in mediums)
         return self.courant * self._subpixel.courant_ratio(
-            contain_pec_structures=contain_pec_structures
+            contain_pec_structures=contain_pec_structures,
+            contain_sibc_structures=contain_sibc_structures,
         )
 
     @cached_property

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -15,8 +15,9 @@ from .autograd import get_static
 from .base import Tidy3dBaseModel, skip_if_fields_missing
 from .data.monitor_data import FieldData, PermittivityData
 from .geometry.utils import GeometryType, validate_no_transformed_polyslabs
+from .good_conductor import MediumType
 from .grid.grid import Coords
-from .medium import AbstractCustomMedium, Medium2D, MediumType
+from .medium import AbstractCustomMedium, Medium2D
 from .monitor import FieldMonitor, PermittivityMonitor
 from .types import TYPE_TAG_STR, Ax, Axis, Bound
 from .validators import validate_name_str

--- a/tidy3d/components/subpixel_spec.py
+++ b/tidy3d/components/subpixel_spec.py
@@ -150,7 +150,7 @@ class SubpixelSpec(Tidy3dBaseModel):
     )
 
     lossy_metal: GoodConductorSubpixelType = pd.Field(
-        VolumetricAveraging(),
+        SurfaceImpedance(),
         title="Subpixel averaging method on good conductor interfaces",
         description="Subpixel averaging method applied to `td.LossyMetal` structure interfaces.",
         discriminator=TYPE_TAG_STR,
@@ -159,7 +159,12 @@ class SubpixelSpec(Tidy3dBaseModel):
     @classmethod
     def staircasing(cls) -> SubpixelSpec:
         """Apply staircasing on all material boundaries."""
-        return cls(dielectric=Staircasing(), metal=Staircasing(), pec=Staircasing())
+        return cls(
+            dielectric=Staircasing(),
+            metal=Staircasing(),
+            pec=Staircasing(),
+            lossy_metal=Staircasing(),
+        )
 
     def courant_ratio(self, contain_pec_structures: bool, contain_sibc_structures: bool) -> float:
         """The scaling ratio applied to Courant number so that the courant number

--- a/tidy3d/components/subpixel_spec.py
+++ b/tidy3d/components/subpixel_spec.py
@@ -10,6 +10,8 @@ from .types import TYPE_TAG_STR
 
 # Default Courant number reduction rate in PEC conformal's scheme
 DEFAULT_COURANT_REDUCTION_PEC_CONFORMAL = 0.3
+# Default Courant number reduction rate in Surface impedance conformal's scheme
+DEFAULT_COURANT_REDUCTION_SIBC_CONFORMAL = 0.0
 
 
 class AbstractSubpixelAveragingMethod(Tidy3dBaseModel):
@@ -118,6 +120,16 @@ class SurfaceImpedance(PECConformal):
     """Apply 1st order (Leontovich) surface impedance boundary condition to
     structure made of ``td.LossyMetal``.
     """
+
+    timestep_reduction: float = pd.Field(
+        DEFAULT_COURANT_REDUCTION_SIBC_CONFORMAL,
+        title="Time Step Size Reduction Rate",
+        description="Reduction factor between 0 and 1 such that the simulation's time step size "
+        "will be ``1 - timestep_reduction`` times its default value. "
+        "Accuracy can be improved with a smaller time step size, but simulation time increased as well.",
+        lt=1,
+        ge=0,
+    )
 
 
 GoodConductorSubpixelType = Union[Staircasing, VolumetricAveraging, SurfaceImpedance]

--- a/tidy3d/plugins/mode/solver.py
+++ b/tidy3d/plugins/mode/solver.py
@@ -90,7 +90,7 @@ class EigSolver(Tidy3dBaseModel):
         angle_phi = mode_spec.angle_phi
         omega = 2 * np.pi * freq
         k0 = omega / C_0
-        enable_incidence_matrices = split_curl_scaling is not None or mu_cross is not None
+        enable_incidence_matrices = False  # Experimental feature, always off for now
 
         eps_formated = cls.format_medium_data(eps_cross)
         eps_xx, eps_xy, eps_xz, eps_yx, eps_yy, eps_yz, eps_zx, eps_zy, eps_zz = eps_formated
@@ -331,6 +331,7 @@ class EigSolver(Tidy3dBaseModel):
             return eps
 
         eps_tensor = conductivity_model_for_pec(eps_tensor)
+        mu_tensor = conductivity_model_for_pec(mu_tensor)
 
         # Determine if ``eps`` and ``mu`` are diagonal or tensorial
         off_diagonals = (np.ones((3, 3)) - np.eye(3)).astype(bool)

--- a/tidy3d/version.py
+++ b/tidy3d/version.py
@@ -1,3 +1,3 @@
 """DO NOT EDIT: Modified automatically with .bump2version.cfg"""
 
-__version__ = "2.7.0"
+__version__ = "2.9.0rc2"


### PR DESCRIPTION
Here is a draft on SIBC just to give more context on https://github.com/flexcompute/tidy3d/pull/1773 and hopefully be helpful in making decisions on how to structure the code. In this draft, I just added it in a separate file for now,  to avoid massive difference in the code. One plan later is to split Medium.py. 

As you can see, `SubpixelSpec` now has four fields: dielectric, metal, PEC, and lossy_metal. When lossy_metal takes SIBC, solver will apply SIBC to structures made of `td.LossyMetal`. We don't validate if the metal is lossy enough, as it heavily depends on the geometries.

## Example
```
mat = td.LossyMetal(conductivity=1e2, frequency_range=(2e14, 3e14))
mat.plot()
```
And the result:
![image](https://github.com/flexcompute/tidy3d/assets/92755338/4bacbc1a-cb17-4461-9425-38e5a29270ee)

The fitting is applied to the medium `frequency_range`. So the `frequency_range` must not be None, and it must be finite and positive.
