### PR TITLE
fixed bug when coaxial ports are snapped to grid cell boundaries. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Bug where boundary layers would be plotted too small in 2D simulations.
 - Bug when plotting transformed geometries.
-- Bug when placing path integrals in the `CoaxialLumpedPort`.
+- Bug when snapping `CoaxialLumpedPort` to grid cell boundaries.
 
 ## [2.7.0] - 2024-06-17
 

--- a/tidy3d/plugins/smatrix/ports/base_lumped.py
+++ b/tidy3d/plugins/smatrix/ports/base_lumped.py
@@ -8,11 +8,12 @@ import pydantic.v1 as pd
 from ....components.base import Tidy3dBaseModel, cached_property
 from ....components.data.data_array import DataArray, FreqDataArray
 from ....components.data.sim_data import SimulationData
+from ....components.geometry.utils_2d import snap_coordinate_to_grid
 from ....components.grid.grid import Grid, YeeGrid
 from ....components.lumped_element import AbstractLumpedResistor
 from ....components.monitor import FieldMonitor
 from ....components.source import GaussianPulse, UniformCurrentSource
-from ....components.types import Complex, FreqArray
+from ....components.types import Complex, Coordinate, FreqArray
 from ....constants import OHM
 
 DEFAULT_PORT_NUM_CELLS = 3
@@ -73,6 +74,17 @@ class AbstractLumpedPort(Tidy3dBaseModel, ABC):
     @cached_property
     def _current_monitor_name(self) -> str:
         return f"{self.name}_current"
+
+    def snapped_center(self, grid: Grid) -> Coordinate:
+        """Get the exact center of this port after snapping along the injection axis.
+        Ports are snapped to the nearest Yee cell boundary to match the exact position
+        of the ``AbstractLumpedResistor".
+        """
+        center = list(self.center)
+        normal_axis = self.injection_axis
+        normal_port_center = center[normal_axis]
+        center[normal_axis] = snap_coordinate_to_grid(grid, normal_port_center, normal_axis)
+        return tuple(center)
 
     @cached_property
     @abstractmethod


### PR DESCRIPTION
The previous [fix](https://github.com/flexcompute/tidy3d/pull/1780) I had made, only fixed one symptom of the true bug. The real issue was incorrectly placing some of the monitors and path integrals in cases where the load resistor was snapped to a grid cell boundary.

I added more testing for the lumped ports to ensure that snapping takes place correctly.