### PR TITLE
🗻 autograd specify background permittivity of structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for differentiation with respect to `ComplexPolySlab.vertices`.
 - Users can now export `SimulationData` to MATLAB `.mat` files with the `to_mat_file` method.
 - Introduce RF material library. Users can now export `rf_material_library` from `tidy3d.plugins.microwave`.
+- Users can specify the background medium for a structure in automatic differentiation by supplying `Structure.autograd_background_permittivity`.
 
 ### Changed
 

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -183,6 +183,7 @@ def make_structures(params: anp.ndarray) -> dict[str, td.Structure]:
     size_element = td.Structure(
         geometry=td.Box(center=(0, 0, 0), size=(1, size_y, 1)),
         medium=med,
+        autograd_background_permittivity=5.0,
     )
 
     # custom medium with variable permittivity data

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -1036,6 +1036,10 @@ class SimulationData(AbstractYeeGridSimulationData):
         # Get SimData object as dictionary
         sim_dict = self.dict()
 
+        # set long field names true by default, otherwise it wont save fields with > 31 characters
+        if "long_field_names" not in kwargs:
+            kwargs["long_field_names"] = True
+
         # Remove NoneType values from dict
         # Built from theory discussed in https://github.com/scipy/scipy/issues/3488
         modified_sim_dict = replace_values(sim_dict, None, [])

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -9,7 +9,7 @@ from typing import Callable, Optional, Tuple, Union
 import numpy as np
 import pydantic.v1 as pydantic
 
-from ..constants import MICROMETER
+from ..constants import MICROMETER, PERMITTIVITY
 from ..exceptions import SetupError, Tidy3dError, Tidy3dImportError
 from .autograd.derivative_utils import DerivativeInfo
 from .autograd.types import AutogradFieldMap
@@ -49,6 +49,15 @@ class AbstractStructure(Tidy3dBaseModel):
     )
 
     name: str = pydantic.Field(None, title="Name", description="Optional name for the structure.")
+
+    autograd_background_permittivity: float = pydantic.Field(
+        None,
+        ge=1.0,
+        title="Background Permittivity",
+        description="Relative permittivity used for the background of this structure "
+        "when performing shape optimization with autograd.",
+        units=PERMITTIVITY,
+    )
 
     _name_validator = validate_name_str()
 

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -654,7 +654,8 @@ def postprocess_adj(
 
         # replace C_0 with some frequency info
         eps_in = np.mean(structure.medium.eps_model(td.C_0))
-        eps_out = np.mean(sim_data_orig.simulation.medium.eps_model(td.C_0))
+        eps_sim = np.mean(sim_data_orig.simulation.medium.eps_model(td.C_0))
+        eps_out = structure.autograd_background_permittivity or eps_sim
 
         derivative_info = DerivativeInfo(
             paths=structure_paths,


### PR DESCRIPTION
adds `Structure.autograd_background_permittivity : float = None` that can be used for permittivity outside.

Useful for structures that are holes in another material as the default permittivity outside is the simulation.medium