### PR TITLE
Support older version of xarray in EME smatrix_in_basis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug when plotting transformed geometries.
 - Bug when snapping `CoaxialLumpedPort` to grid cell boundaries.
 - Errors in `PolySlab` when using autograd differentiation with non-zero `sidewall_angle` and `dilation`.
+- Error in `EMESimulationData.smatrix_in_basis` when using older versions of xarray.
 
 ## [2.7.0] - 2024-06-17
 

--- a/tidy3d/components/eme/data/sim_data.py
+++ b/tidy3d/components/eme/data/sim_data.py
@@ -239,9 +239,21 @@ class EMESimulationData(AbstractYeeGridSimulationData):
                 S12 = S12.rename(mode_index_out="mode_index_out_old")
                 S21 = S21.rename(mode_index_in="mode_index_in_old")
 
-                S11 = O1out.dot(S11, dim="mode_index_out_old").dot(O1in, dim="mode_index_in_old")
-                S12 = O1out.dot(S12, dim="mode_index_out_old")
-                S21 = S21.dot(O1in, dim="mode_index_in_old")
+                # this exception handling is needed because xarray renamed dims kwarg to dim
+                # but we want to keep supporting old xarray
+                try:
+                    S11 = O1out.dot(S11, dim="mode_index_out_old").dot(
+                        O1in, dim="mode_index_in_old"
+                    )
+                    S12 = O1out.dot(S12, dim="mode_index_out_old")
+                    S21 = S21.dot(O1in, dim="mode_index_in_old")
+                except TypeError:
+                    S11 = O1out.dot(S11, dims="mode_index_out_old").dot(
+                        O1in, dims="mode_index_in_old"
+                    )
+                    S12 = O1out.dot(S12, dims="mode_index_out_old")
+                    S21 = S21.dot(O1in, dims="mode_index_in_old")
+
             if modes2_provided:
                 overlaps2 = modes2.outer_dot(port_modes2, conjugate=False)
                 if not modes_in_2:
@@ -256,9 +268,19 @@ class EMESimulationData(AbstractYeeGridSimulationData):
                     mode_index_in="mode_index_in_old", mode_index_out="mode_index_out_old"
                 )
 
-                S12 = S12.dot(O2in, dim="mode_index_in_old")
-                S21 = O2out.dot(S21, dim="mode_index_out_old")
-                S22 = O2out.dot(S22, dim="mode_index_out_old").dot(O2in, dim="mode_index_in_old")
+                # same for this exception handling
+                try:
+                    S12 = S12.dot(O2in, dim="mode_index_in_old")
+                    S21 = O2out.dot(S21, dim="mode_index_out_old")
+                    S22 = O2out.dot(S22, dim="mode_index_out_old").dot(
+                        O2in, dim="mode_index_in_old"
+                    )
+                except TypeError:
+                    S12 = S12.dot(O2in, dims="mode_index_in_old")
+                    S21 = O2out.dot(S21, dims="mode_index_out_old")
+                    S22 = O2out.dot(S22, dims="mode_index_out_old").dot(
+                        O2in, dims="mode_index_in_old"
+                    )
 
             data11[:, sweep_index, :, :] = S11.to_numpy()
             data12[:, sweep_index, :, :] = S12.to_numpy()


### PR DESCRIPTION
Several people have reported that the EME function `smatrix_in_basis`, for example in the MMI demo notebook, fails when using an old version of xarray (which we still want to support). The reason for the issue is the renaming `dims` -> `dim` in the arguments to `xr.DataArray.dot`; the new `dim` doesn't work under the old version of xarray.

This PR introduces a bit of error handling to support both versions of xarray. I would like to get it in as a patch since it affects the demo notebook.