### PR TITLE
Docstring - HeatCharge docstring error

### DIFF
--- a/tidy3d/components/heat_charge/heat/simulation.py
+++ b/tidy3d/components/heat_charge/heat/simulation.py
@@ -19,7 +19,7 @@ class HeatSimulation(HeatChargeSimulation):
     Example
     -------
     >>> import tidy3d as td
-    >>> heat_sim = td.HeatSimulation(
+    >>> heat_sim = td.HeatSimulation( # doctest: +SKIP
     ...     size=(3.0, 3.0, 3.0),
     ...     structures=[
     ...         td.Structure(

--- a/tidy3d/components/heat_charge/source.py
+++ b/tidy3d/components/heat_charge/source.py
@@ -83,7 +83,7 @@ class UniformHeatSource(HeatSource):
 
     Example
     -------
-    >>> heat_source = UniformHeatSource(rate=1, structures=["box"])
+    >>> heat_source = UniformHeatSource(rate=1, structures=["box"]) # doctest: +SKIP
     """
 
     # NOTE: wrapper for backwards compatibility.

--- a/tidy3d/components/heat_charge_spec.py
+++ b/tidy3d/components/heat_charge_spec.py
@@ -56,7 +56,7 @@ class InsulatorSpec(AbstractHeatChargeSpec):
 
     Example
     -------
-    >>> solid = InsulatingSpec()
+    >>> solid = InsulatorSpec()
     """
 
 


### PR DESCRIPTION
This PR fixes one docstring error. The test still doesn't pass because some routines raise warnings. 

These warnings are there by design so we may want to consider relaxing this test so that warnings are ignored? @daquintero @momchil-flex 