### PR TITLE
add `RunTimeSpec` to API ref

### DIFF
--- a/docs/api/simulation.rst
+++ b/docs/api/simulation.rst
@@ -8,3 +8,4 @@ Simulation
    :template: module.rst
 
    tidy3d.Simulation
+   tidy3d.RunTimeSpec


### PR DESCRIPTION
Added under the `Simulation` category, since this is really the only place it's used.