### PR TITLE
fix box gradients < 3d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Errors in `PolySlab` when using autograd differentiation with non-zero `sidewall_angle` and `dilation`.
 - Error in `EMESimulationData.smatrix_in_basis` when using older versions of xarray.
 - Support for automatic differentiation with respect to `.eps_inf` and `.poles` contained in dispersive mediums `td.PoleResidue` and `td.CustomPoleResidue`.
+- Gradients for `Box` objects when simulation size is < 3D.
 
 ## [2.7.0] - 2024-06-17
 

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -118,7 +118,9 @@ def integrate_within_bounds(arr: xr.DataArray, dims: list[str], bounds: Bound) -
 
     # uses trapezoidal rule
     # https://docs.xarray.dev/en/stable/generated/xarray.DataArray.integrate.html
-    return _arr.integrate(coord=dims)
+
+    dims_integrate = [dim for dim in dims if len(_arr.coords[dim]) > 1]
+    return _arr.integrate(coord=dims_integrate)
 
 
 __all__ = [


### PR DESCRIPTION
Fixes a bug that occurred in 2D autograd with `Box`, where `xr.DataArray.integrate` gives 0 for any dimensions with 1 coordinate, making the whole gradient `0`. This simply ignores such dimensions in the integration.