### PR TITLE
Plot transposing for simulation plotting

### DIFF
--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -2934,3 +2934,55 @@ def test_validate_sources_monitors_in_bounds():
             grid_spec=td.GridSpec(wavelength=1.0),
             monitors=[mode_monitor],
         )
+
+
+def test_plot_transpose():
+    """Transpose the axes on a simulation.plot call"""
+    L = 5  # length of simulation on all sides
+
+    # make random list of structures
+    structures = [
+        td.Structure(
+            geometry=td.Sphere(center=(0 + i / 10, 0 + i / 10, 0 + i / 10), radius=1),
+            medium=td.Medium(permittivity=np.random.choice([2.0, 2.5, 3.0, 3.5, 4.0])),
+        )
+        for i in range(10)
+    ]
+
+    source = td.UniformCurrentSource(
+        center=(0, 0, -L / 3),
+        size=(L, L / 2, 0),
+        polarization="Ex",
+        source_time=td.GaussianPulse(
+            freq0=100e14,
+            fwidth=10e14,
+        ),
+    )
+
+    monitor = td.FieldMonitor(
+        center=(-L / 4, 0, 0), size=(L / 2, L, 0), freqs=[100e14], name="fields"
+    )
+
+    # make simulation from structures
+    sim = td.Simulation(
+        size=(L, L, L),
+        grid_spec=td.GridSpec.auto(wavelength=4),
+        boundary_spec=td.BoundarySpec(
+            x=td.Boundary.pml(num_layers=10),
+            y=td.Boundary.periodic(),
+            z=td.Boundary.pml(num_layers=10),
+        ),
+        structures=structures,
+        sources=[source],
+        monitors=[monitor],
+        run_time=1e-12,
+    )
+
+    # plot_out = sim.plot(x=0)
+    # plt.show()
+
+    t_plot_out = sim.plot(x=0, transpose=True)
+    plt.show()
+
+    # sim.plot_eps(x=0)
+    # sim.plot_eps(x=0, transpose=True)

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -325,6 +325,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         lumped_element_alpha: float = None,
         hlim: Tuple[float, float] = None,
         vlim: Tuple[float, float] = None,
+        transpose: bool = False,
         **patch_kwargs,
     ) -> Ax:
         """Plot each of simulation's components on a plane defined by one nonzero x,y,z coordinate.
@@ -362,6 +363,19 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
             * `Visualizing geometries in Tidy3D: Plotting Materials <../../notebooks/VizSimulation.html#Plotting-Materials>`_
 
         """
+        # if transpose:
+        #     from matplotlib.transforms import Affine2D
+        #     import mpl_toolkits.axisartist.floating_axes as floating_axes
+        #     # Rotate
+        #     fig, ax = mpl.pyplot.subplots(1, 1, tight_layout=True)
+
+        #     transform = Affine2D().rotate_deg(90)
+        #     helper = floating_axes.GridHelperCurveLinear(transform, (self.simulation_bounds[0][1], self.simulation_bounds[1][1], self.simulation_bounds[0][2], self.simulation_bounds[1][2]))
+        #     ax = floating_axes.FloatingSubplot(fig, 111, grid_helper=helper)
+
+        #     # Mirror
+        #     ax.invert_xaxis()
+
         hlim, vlim = Scene._get_plot_lims(
             bounds=self.simulation_bounds, x=x, y=y, z=z, hlim=hlim, vlim=vlim
         )

--- a/tidy3d/components/viz.py
+++ b/tidy3d/components/viz.py
@@ -32,6 +32,21 @@ ARROW_LENGTH = 0.3
 """ Decorators """
 
 
+def make_floating_ax() -> Ax:
+    """makes an empty ``ax``."""
+    from matplotlib.transforms import Affine2D
+    from mpl_toolkits.axisartist import Subplot
+    from mpl_toolkits.axisartist.grid_helper_curvelinear import GridHelperCurveLinear
+
+    fig = plt.figure()
+
+    transform = Affine2D().rotate_deg(90)
+    helper = GridHelperCurveLinear(transform, (-6, 6, -4, 4))
+    ax = Subplot(fig, 111, grid_helper=helper)
+    fig.add_subplot(ax)
+    return ax
+
+
 def make_ax() -> Ax:
     """makes an empty ``ax``."""
     _, ax = plt.subplots(1, 1, tight_layout=True)


### PR DESCRIPTION
Addressing #1072 need for transposing 2D plots produced from Simulations.

There is no simple matplotlib method for transposing Axes objects. It seems to have been overlooked as our use case of building axes by iteratively adding is rather uncommon. My current thinking leaves two options:

A. Manually perform a transposition on the finished axes object by rotating 90 degrees and mirroring the x axis.
B. Transpose each individual component of the simulation.

B seems an obscene amount of effort and opens up all sorts of risks of modifying in-place and copying the simulation so that the original simulation is unchanged for downstream operations. 

The mirroring in A is simple because the `axes.invert_xaxis()` method handles this. The rotation is proving more challenging because you have to use `floating_axes` from matplotlibs `axisartist` module. These either aren't playing nice with the existing design, or I've not implemented them correctly, because the best I can do is part of the target subplot embedded within a larger blank figure. Will continue to consider other options and try explore this further.