### PR TITLE
added plot_units to simulation and scene classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce RF material library. Users can now export `rf_material_library` from `tidy3d.plugins.microwave`.
 - Users can specify the background medium for a structure in automatic differentiation by supplying `Structure.autograd_background_permittivity`.
 - `DirectivityMonitor` to compute antenna directivity.
+- Added `plot_length_units` to `Simulation` and `Scene` to allow for specifying units, which improves axis labels and scaling when plotting.
 
 ### Changed
 

--- a/scripts/make_script.py
+++ b/scripts/make_script.py
@@ -69,14 +69,16 @@ def main(args):
     sim_string = re.sub(pattern, "(", sim_string)
 
     # write sim_string to a temporary file
-    with tempfile.NamedTemporaryFile(delete=False, mode="w+", suffix=".py") as temp_file:
+    with tempfile.NamedTemporaryFile(
+        delete=False, mode="w+", suffix=".py", encoding="utf-8"
+    ) as temp_file:
         temp_file.write(sim_string)
         temp_file_path = temp_file.name
     try:
         # run ruff to format the temporary file
         subprocess.run(["ruff", "format", temp_file_path], check=True)
         # read the formatted content back
-        with open(temp_file_path) as temp_file:
+        with open(temp_file_path, encoding="utf-8") as temp_file:
             sim_string = temp_file.read()
     except subprocess.CalledProcessError:
         raise RuntimeError(
@@ -87,7 +89,7 @@ def main(args):
         # remove the temporary file
         os.remove(temp_file_path)
 
-    with open(out_file, "w+") as f:
+    with open(out_file, "w+", encoding="utf-8") as f:
         f.write(sim_string)
 
 

--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -78,6 +78,11 @@ def test_plot(component):
     plt.close()
 
 
+def test_plot_with_units():
+    _ = BOX.plot(z=0, ax=AX, plot_length_units="nm")
+    plt.close()
+
+
 def test_base_inside():
     assert td.Geometry.inside(GEO, x=0, y=0, z=0)
     assert np.all(td.Geometry.inside(GEO, np.array([0, 0]), np.array([0, 0]), np.array([0, 0])))

--- a/tests/test_components/test_scene.py
+++ b/tests/test_components/test_scene.py
@@ -101,6 +101,11 @@ def test_structure_alpha():
     plt.close()
 
 
+def test_plot_with_units():
+    scene_with_units = SCENE_FULL.updated_copy(plot_length_units="nm")
+    scene_with_units.plot(x=-0.5)
+
+
 def test_filter_structures():
     s1 = td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=SCENE.medium)
     s2 = td.Structure(geometry=td.Box(size=(1, 1, 1), center=(1, 1, 1)), medium=SCENE.medium)

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -615,6 +615,11 @@ def test_plot():
     plt.close()
 
 
+def test_plot_with_units():
+    sim_with_units = SIM_FULL.updated_copy(plot_length_units="nm")
+    sim_with_units.plot(x=-0.5)
+
+
 def test_plot_1d_sim():
     mesh1d = td.UniformGrid(dl=2e-4)
     grid_spec = td.GridSpec(grid_x=mesh1d, grid_y=mesh1d, grid_z=mesh1d)

--- a/tests/test_components/test_viz.py
+++ b/tests/test_components/test_viz.py
@@ -3,8 +3,9 @@
 import matplotlib.pyplot as plt
 import pytest
 import tidy3d as td
-from tidy3d.components.viz import Polygon
+from tidy3d.components.viz import Polygon, set_default_labels_and_title
 from tidy3d.constants import inf
+from tidy3d.exceptions import Tidy3dKeyError
 
 
 def test_make_polygon_dict():
@@ -79,3 +80,23 @@ def test_2d_boundary_plot():
 
     # should have a non-infinite size as x is specified
     assert pml_box.size[0] != inf
+
+
+def test_set_default_labels_title():
+    """
+    Ensure labels are correctly added to axes, and test that plot_units are validated.
+    """
+    box = td.Box(center=(0, 0, 0), size=(0.01, 0.01, 0.01))
+    ax = box.plot(z=0)
+    axis_labels = box._get_plot_labels(2)
+
+    ax = set_default_labels_and_title(axis_labels=axis_labels, axis=2, position=0, ax=ax)
+
+    ax = set_default_labels_and_title(
+        axis_labels=axis_labels, axis=2, position=0, ax=ax, plot_length_units="nm"
+    )
+
+    with pytest.raises(Tidy3dKeyError):
+        ax = set_default_labels_and_title(
+            axis_labels=axis_labels, axis=2, position=0, ax=ax, plot_length_units="inches"
+        )

--- a/tidy3d/components/heat_charge/simulation.py
+++ b/tidy3d/components/heat_charge/simulation.py
@@ -657,11 +657,12 @@ class HeatChargeSimulation(AbstractSimulation):
             ax = self._plot_boundary_condition(shape=shape, boundary_spec=bc_spec, ax=ax)
 
         # clean up the axis display
-        axis, position = Box.parse_xyz_kwargs(x=x, y=y, z=z)
-        ax = self.add_ax_labels_lims(axis=axis, ax=ax)
-        ax.set_title(f"cross section at {'xyz'[axis]}={position:.2f}")
-
+        ax = self.add_ax_lims(axis=axis, ax=ax)
         ax = Scene._set_plot_bounds(bounds=self.simulation_bounds, ax=ax, x=x, y=y, z=z)
+        # Add the default axis labels, tick labels, and title
+        ax = Box.add_ax_labels_and_title(
+            ax=ax, x=x, y=y, z=z, plot_length_units=self.plot_length_units
+        )
 
         return ax
 
@@ -1064,11 +1065,12 @@ class HeatChargeSimulation(AbstractSimulation):
                 )
 
         # clean up the axis display
-        axis, position = self.parse_xyz_kwargs(x=x, y=y, z=z)
-        ax = self.add_ax_labels_lims(axis=axis, ax=ax)
-        ax.set_title(f"cross section at {'xyz'[axis]}={position:.2f}")
-
+        ax = self.add_ax_lims(axis=axis, ax=ax)
         ax = Scene._set_plot_bounds(bounds=self.simulation_bounds, ax=ax, x=x, y=y, z=z)
+        # Add the default axis labels, tick labels, and title
+        ax = Box.add_ax_labels_and_title(
+            ax=ax, x=x, y=y, z=z, plot_length_units=self.plot_length_units
+        )
         return ax
 
     def _add_source_cbar(self, ax: Ax, property: str = "heat_conductivity"):

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Set, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 import autograd.numpy as np
 import matplotlib as mpl
@@ -34,7 +34,16 @@ from .medium import (
     MediumType3D,
 )
 from .structure import Structure
-from .types import TYPE_TAG_STR, Ax, Bound, Coordinate, InterpMethod, Shapely, Size
+from .types import (
+    TYPE_TAG_STR,
+    Ax,
+    Bound,
+    Coordinate,
+    InterpMethod,
+    LengthUnit,
+    Shapely,
+    Size,
+)
 from .validators import assert_unique_names
 from .viz import (
     MEDIUM_CMAP,
@@ -85,6 +94,14 @@ class Scene(Tidy3dBaseModel):
         description="Tuple of structures present in scene. "
         "Note: Structures defined later in this list override the "
         "simulation material properties in regions of spatial overlap.",
+    )
+
+    plot_length_units: Optional[LengthUnit] = pd.Field(
+        "μm",
+        title="Plot Units",
+        description="When set to a supported ``LengthUnit``, "
+        "plots will be produced with proper scaling of axes and "
+        "include the desired unit specifier in labels.",
     )
 
     """ Validating setup """
@@ -408,12 +425,13 @@ class Scene(Tidy3dBaseModel):
             ax = self._plot_shape_structure(medium=medium, mat_index=mat_index, shape=shape, ax=ax)
 
         # clean up the axis display
-        axis, position = Box.parse_xyz_kwargs(x=x, y=y, z=z)
-        ax = self.box.add_ax_labels_lims(axis=axis, ax=ax)
-        ax.set_title(f"cross section at {'xyz'[axis]}={position:.2f}")
-
+        axis, _ = Box.parse_xyz_kwargs(x=x, y=y, z=z)
+        ax = self.box.add_ax_lims(axis=axis, ax=ax)
         ax = self._set_plot_bounds(bounds=self.bounds, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim)
-
+        # Add the default axis labels, tick labels, and title
+        ax = Box.add_ax_labels_and_title(
+            ax=ax, x=x, y=y, z=z, plot_length_units=self.plot_length_units
+        )
         return ax
 
     def _plot_shape_structure(self, medium: Medium, mat_index: int, shape: Shapely, ax: Ax) -> Ax:
@@ -821,12 +839,13 @@ class Scene(Tidy3dBaseModel):
             self._add_cbar_eps(eps_min=eps_min, eps_max=eps_max, ax=ax)
 
         # clean up the axis display
-        axis, position = Box.parse_xyz_kwargs(x=x, y=y, z=z)
-        ax = self.box.add_ax_labels_lims(axis=axis, ax=ax)
-        ax.set_title(f"cross section at {'xyz'[axis]}={position:.2f}")
-
+        axis, _ = Box.parse_xyz_kwargs(x=x, y=y, z=z)
+        ax = self.box.add_ax_lims(axis=axis, ax=ax)
         ax = self._set_plot_bounds(bounds=self.bounds, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim)
-
+        # Add the default axis labels, tick labels, and title
+        ax = Box.add_ax_labels_and_title(
+            ax=ax, x=x, y=y, z=z, plot_length_units=self.plot_length_units
+        )
         return ax
 
     @staticmethod
@@ -1298,13 +1317,15 @@ class Scene(Tidy3dBaseModel):
                 cmap=STRUCTURE_HEAT_COND_CMAP,
                 ax=ax,
             )
-        ax = self._set_plot_bounds(bounds=self.bounds, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim)
 
         # clean up the axis display
-        axis, position = Box.parse_xyz_kwargs(x=x, y=y, z=z)
-        ax = self.box.add_ax_labels_lims(axis=axis, ax=ax)
-        ax.set_title(f"cross section at {'xyz'[axis]}={position:.2f}")
-
+        axis, _ = Box.parse_xyz_kwargs(x=x, y=y, z=z)
+        ax = self.box.add_ax_lims(axis=axis, ax=ax)
+        ax = self._set_plot_bounds(bounds=self.bounds, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim)
+        # Add the default axis labels, tick labels, and title
+        ax = Box.add_ax_labels_and_title(
+            ax=ax, x=x, y=y, z=z, plot_length_units=self.plot_length_units
+        )
         return ax
 
     def heat_charge_property_bounds(self, property) -> Tuple[float, float]:

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -575,6 +575,10 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         ax = Scene._set_plot_bounds(
             bounds=self.simulation_bounds, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim
         )
+        # Add the default axis labels, tick labels, and title
+        ax = Box.add_ax_labels_and_title(
+            ax=ax, x=x, y=y, z=z, plot_length_units=self.plot_length_units
+        )
         return ax
 
     # candidate for removal in 3.0
@@ -783,7 +787,10 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         ax = Scene._set_plot_bounds(
             bounds=self.simulation_bounds, ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim
         )
-
+        # Add the default axis labels, tick labels, and title
+        ax = Box.add_ax_labels_and_title(
+            ax=ax, x=x, y=y, z=z, plot_length_units=self.plot_length_units
+        )
         return ax
 
     @equal_aspect
@@ -900,7 +907,10 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         # ax = self._set_plot_bounds(ax=ax, x=x, y=y, z=z)
         ax.set_xlim([ulim_minus, ulim_plus])
         ax.set_ylim([vlim_minus, vlim_plus])
-
+        # Add the default axis labels, tick labels, and title
+        ax = Box.add_ax_labels_and_title(
+            ax=ax, x=x, y=y, z=z, plot_length_units=self.plot_length_units
+        )
         return ax
 
     # TODO: not yet supported

--- a/tidy3d/components/types.py
+++ b/tidy3d/components/types.py
@@ -194,7 +194,7 @@ Shapely = BaseGeometry
 PlanePosition = Literal["bottom", "middle", "top"]
 ClipOperationType = Literal["union", "intersection", "difference", "symmetric_difference"]
 BoxSurface = Literal["x-", "x+", "y-", "y+", "z-", "z+"]
-
+LengthUnit = Literal["nm", "μm", "um", "mm", "cm", "m"]
 
 """ medium """
 

--- a/tidy3d/constants.py
+++ b/tidy3d/constants.py
@@ -10,6 +10,8 @@ Attributes:
     Q_e (float): funamental charge [C]
 """
 
+from types import MappingProxyType
+
 import numpy as np
 
 # fundamental constants (https://physics.nist.gov)
@@ -212,3 +214,15 @@ GLANCING_CUTOFF = 0.1
 """
 if |np.pi/2 - angle_theta| < GLANCING_CUTOFF in an angled source or in mode spec, raise warning.
 """
+
+UnitScaling = MappingProxyType(
+    {
+        "nm": 1e3,
+        "μm": 1e0,
+        "um": 1e0,
+        "mm": 1e-3,
+        "cm": 1e-4,
+        "m": 1e-6,
+    }
+)
+"""Immutable dictionary for converting a unit specification to a scaling factor."""


### PR DESCRIPTION
While working in the RF world I have been manually modifying plots so that the axes look good. But it is probably best to add that ability directly to tidy3d. I added an optional parameter to the Simulation and Scene classes that will automatically set the axes labels and title, along with a proper scaling of the tick labels. 

Here is an example without setting plot_units:

![Screenshot from 2024-07-09 14-28-45](https://github.com/flexcompute/tidy3d/assets/155486263/a56b2806-966d-45e8-8615-05d9fc409c2f)

And here when using "mm":

![Screenshot from 2024-07-09 14-28-27](https://github.com/flexcompute/tidy3d/assets/155486263/00a629a0-6647-465a-ac79-900022fdf8b9)
