### PR TITLE
Local caching of simulations

### DIFF
--- a/tests/test_components/test_base.py
+++ b/tests/test_components/test_base.py
@@ -1,11 +1,36 @@
 """Tests the base model."""
 
+from time import perf_counter
+
 import numpy as np
 import pytest
 import tidy3d as td
 from tidy3d.components.base import Tidy3dBaseModel
 
+from ..utils import AssertLogLevel
+
 M = td.Medium()
+
+
+def test_cached_property():
+    t0 = perf_counter()
+    a = M.sha256
+    t1 = perf_counter() - t0
+    t0 = perf_counter()
+    b = M.sha256
+    t2 = perf_counter() - t0
+    assert t2 < 10 * t1  # lookup should be several orders of magnitude faster
+
+
+def test_hash_self(log_capture):
+    with AssertLogLevel(log_capture, "WARNING", contains_str="deprecated"):
+        assert M._hash_self() == M.sha256
+
+
+def test_sha256():
+    a = M.sha256
+    b = M.updated_copy(permittivity=2).sha256
+    assert a != b
 
 
 def test_shallow_copy():

--- a/tests/test_web/test_webapi_eme.py
+++ b/tests/test_web/test_webapi_eme.py
@@ -307,6 +307,7 @@ def test_run(mock_webapi, monkeypatch, tmp_path):
         task_name=TASK_NAME,
         folder_name=PROJECT_NAME,
         path=str(tmp_path / "web_test_tmp.json"),
+        use_local_cache=False,
     )
 
 

--- a/tests/test_web/test_webapi_heat.py
+++ b/tests/test_web/test_webapi_heat.py
@@ -297,6 +297,7 @@ def test_run(mock_webapi, monkeypatch, tmp_path):
         task_name=TASK_NAME,
         folder_name=PROJECT_NAME,
         path=str(tmp_path / "web_test_tmp.json"),
+        use_local_cache=False,
     )
 
 

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -134,11 +134,17 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         except TypeError:
             return hash(self.json())
 
-    def _hash_self(self) -> str:
+    @cached_property  # cached because model is immutable
+    def sha256(self) -> str:
         """Hash this component with ``hashlib`` in a way that is the same every session."""
         bf = io.BytesIO()
         self.to_hdf5(bf)
         return hashlib.sha256(bf.getvalue()).hexdigest()
+
+    def _hash_self(self) -> str:
+        """Deprecated method. Use the `sha256` property instead."""
+        log.warning("The '_hash_self' method is deprecated. Use the 'sha256' property instead.")
+        return self.sha256
 
     def __init__(self, **kwargs):
         """Init method, includes post-init validators."""

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -7,6 +7,7 @@ import os
 import time
 from abc import ABC
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 from typing import Dict, Optional, Tuple
 
 import pydantic.v1 as pd
@@ -160,6 +161,12 @@ class Job(WebContainer):
         "fields that were not used to create the task will cause errors.",
     )
 
+    use_local_cache: bool = pd.Field(
+        True,
+        title="Use Local Cache",
+        description="If ``True``, checks for and loads a local copy of the simulation results if available.",
+    )
+
     _upload_fields = (
         "simulation",
         "task_name",
@@ -200,7 +207,12 @@ class Job(WebContainer):
         Union[:class:`.SimulationData`, :class:`.HeatSimulationData`, :class:`.EMESimulationData`]
             Object containing simulation results.
         """
-
+        if (
+            self.use_local_cache
+            and Path(path).is_file()
+            and (local_data := web._get_local_cache(self.simulation, path))
+        ):
+            return local_data
         self.upload()
         self.start()
         self.monitor()

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -210,7 +210,7 @@ class Job(WebContainer):
         if (
             self.use_local_cache
             and Path(path).is_file()
-            and (local_data := web._get_local_cache(self.simulation, path))
+            and (local_data := web._get_local_cache(self.simulation, path)) is not None
         ):
             return local_data
         self.upload()


### PR DESCRIPTION
Introduces caching of local simulations. Checks whether `SimulationData.simulation` from a local simulation data file has the same sha256 hash as the submitted simulation and returns the local copy if true.

The check is currently performed by hashing both the local and the submitted simulation, which is potentially a bit slow. We could also add the simulation hash as an attribute to the simulation data as suggested by @tylerflex so we can directly compare that, but that would need to be implemented on the backend?

Do we also want to support async/Batch?