### PR TITLE
Improved mesh repair options in TriangleMesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Mode solver plugin now supports 'EMESimulation'.
+- `TriangleMesh` class: automatic removal of zero-area faces, and functions `fill_holes` and `fix_winding` to attempt mesh repair.
 
 ### Fixed
 - Error when loading a previously run `Batch` or `ComponentModeler` containing custom data.
 - Error when plotting mode plane PML and the simulation has symmetry.
+- Validators using `TriangleMesh.intersections_plane` will fall back on bounding box in case the method fails for a non-watertight mesh.
 
 ## [2.7.1]
 


### PR DESCRIPTION
Changes:

- Automatically process and validate mesh. In particular, this removes faces with area less than threshold, and merges close vertices. This was risky previously when the threshold was large, but now that the area threshold is 1e-36, it is hard for me to imagine a scenario where this causes difficulty. And automatic processing should make mesh import much more convenient.
- Adds functions `fix_winding` and `fill_holes` to make it easier to repair the mesh. I still didn't want to call these by default, as they can greatly change the mesh and may not always be desired. But they can make it easier to turn a non-watertight mesh into a watertight mesh with consistent winding.
- If `intersections_plane` fails, give an appropriate warning and use the bounding box instead. This makes certain validators more robust. Although I didn't have an example of a mesh that triggered the error, so I wasn't able to test this thoroughly.