### PR TITLE
Fix bug in loading previously run Batch and ComponentModeler from file when custom medium present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Error when loading a previously run `Batch` or `ComponentModeler` containing custom data.
+
 ## [2.7.1]
 
 ### Added


### PR DESCRIPTION
Fixes https://github.com/flexcompute/tidy3d/issues/1816. 
