### PR TITLE
expose power wave amplitude computations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Users can specify the background medium for a structure in automatic differentiation by supplying `Structure.autograd_background_permittivity`.
 - `DirectivityMonitor` to compute antenna directivity.
 - Added `plot_length_units` to `Simulation` and `Scene` to allow for specifying units, which improves axis labels and scaling when plotting.
+- Added the helper function `compute_power_delivered_by_port`  to `TerminalComponentModeler` which computes power delivered to a microwave network from a port.
 
 ### Changed
 


### PR DESCRIPTION
I found that it might be necessary to get absolute values from an `smatrix` batch run. In my use case, it was to compute the radiation efficiency of an antenna. You need to compare the total radiated power (FieldProjectionMonitor) to the total power delivered to the antenna (coming from the port). Might be useful in the future to have access to these values as well for other computations.

I don't love the fact that I have to carry around the `SimulationData` and `BatchData` after running the `ComponentModeler` and `TerminalComponentModeler`. Maybe in the future we could create some kind of `ComponentModelerData`, which holds the `BatchData` along with post-processing results, as they are requested.