### PR TITLE
schema-backed postprocess option for `invdes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Postprocessing functions in `invdes` plugin can be optionally specified by supplying a `postprocess` instance to the `InverseDesign` object.
+
 ### Fixed
 - Error when loading a previously run `Batch` or `ComponentModeler` containing custom data.
 

--- a/tests/test_plugins/test_invdes.py
+++ b/tests/test_plugins/test_invdes.py
@@ -140,9 +140,9 @@ def post_process_fn(sim_data: td.SimulationData, **kwargs) -> float:
     return anp.sum(intensity.values)
 
 
-postprocess_obj = tdi.WeightedSum(
-    powers=[
-        tdi.GetPowerMode(monitor_name=MNT_NAME2, direction="+", mode_index=0, weight=0.5),
+postprocess_obj = tdi.Sum(
+    operations=[
+        tdi.ModePower(monitor_name=MNT_NAME2, direction="+", mode_index=0, weight=0.5),
     ]
 )
 
@@ -380,8 +380,8 @@ def test_continue_run_from_file(use_emulated_run_autograd):
 def test_postprocess_init(use_emulated_run):  # noqa: F811
     """Test the intiialization of an ``InverseDesign`` with different ``postprocess`` options."""
 
-    power_obj = tdi.GetPowerMode(monitor_name=MNT_NAME2, direction="+", mode_index=0, weight=0.5)
-    postprocess_obj = tdi.WeightedSum(powers=[power_obj])
+    power_obj = tdi.ModePower(monitor_name=MNT_NAME2, direction="+", mode_index=0, weight=0.5)
+    postprocess_obj = tdi.Sum(operations=[power_obj])
 
     def fn(sim_data):
         return power_obj.evaluate(sim_data)

--- a/tests/test_plugins/test_invdes.py
+++ b/tests/test_plugins/test_invdes.py
@@ -386,11 +386,16 @@ def test_postprocess_init(use_emulated_run):  # noqa: F811
     def fn(sim_data):
         return power_obj.evaluate(sim_data)
 
+    # basline
     invdes = make_invdes()
     params = invdes.design_region.params_random
     sim_data = invdes.to_simulation_data(params=params, task_name="test")
+    obj_fn_val = fn(sim_data)
 
+    # supply postprocess object directly
     invdes_obj = invdes.updated_copy(postprocess=postprocess_obj)
+
+    # supply invdes with a function from classmethod constructor
     invdes_from_fn = invdes.from_function(
         fn,
         **invdes.dict(
@@ -399,12 +404,13 @@ def test_postprocess_init(use_emulated_run):  # noqa: F811
             }
         ),
     )
+
+    # use the custom postprocess operation.
     invdes_from_custom = invdes.updated_copy(
         postprocess=tdi.CustomPostprocessOperation.from_function(fn)
     )
 
-    obj_fn_val = fn(sim_data)
-
+    # check that they all give the same objective function values, and calling evaluate works
     for invdes_ in (invdes_obj, invdes_from_fn, invdes_from_custom):
         obj_fn_val_ = invdes_.postprocess.evaluate(sim_data)
         assert np.isclose(obj_fn_val, obj_fn_val_)

--- a/tidy3d/plugins/invdes/__init__.py
+++ b/tidy3d/plugins/invdes/__init__.py
@@ -4,6 +4,7 @@ from . import utils
 from .design import InverseDesign, InverseDesignMulti
 from .optimizer import AdamOptimizer
 from .penalty import ErosionDilationPenalty
+from .postprocess import GetPowerMode, WeightedSum
 from .region import TopologyDesignRegion
 from .result import InverseDesignResult
 from .transformation import FilterProject
@@ -16,5 +17,7 @@ __all__ = (
     "TopologyDesignRegion",
     "AdamOptimizer",
     "InverseDesignResult",
+    "WeightedSum",
+    "GetPowerMode",
     "utils",
 )

--- a/tidy3d/plugins/invdes/__init__.py
+++ b/tidy3d/plugins/invdes/__init__.py
@@ -4,7 +4,7 @@ from . import utils
 from .design import InverseDesign, InverseDesignMulti
 from .optimizer import AdamOptimizer
 from .penalty import ErosionDilationPenalty
-from .postprocess import CustomPostprocessOperation, ModePower, Sum
+from .postprocess import CustomPostProcessOperation, ModePower, Sum
 from .region import TopologyDesignRegion
 from .result import InverseDesignResult
 from .transformation import FilterProject
@@ -17,7 +17,7 @@ __all__ = (
     "TopologyDesignRegion",
     "AdamOptimizer",
     "InverseDesignResult",
-    "CustomPostprocessOperation",
+    "CustomPostProcessOperation",
     "Sum",
     "ModePower",
     "utils",

--- a/tidy3d/plugins/invdes/__init__.py
+++ b/tidy3d/plugins/invdes/__init__.py
@@ -4,7 +4,7 @@ from . import utils
 from .design import InverseDesign, InverseDesignMulti
 from .optimizer import AdamOptimizer
 from .penalty import ErosionDilationPenalty
-from .postprocess import GetPowerMode, WeightedSum
+from .postprocess import CustomPostprocessOperation, GetPowerMode, WeightedSum
 from .region import TopologyDesignRegion
 from .result import InverseDesignResult
 from .transformation import FilterProject
@@ -17,6 +17,7 @@ __all__ = (
     "TopologyDesignRegion",
     "AdamOptimizer",
     "InverseDesignResult",
+    "CustomPostprocessOperation",
     "WeightedSum",
     "GetPowerMode",
     "utils",

--- a/tidy3d/plugins/invdes/__init__.py
+++ b/tidy3d/plugins/invdes/__init__.py
@@ -4,7 +4,7 @@ from . import utils
 from .design import InverseDesign, InverseDesignMulti
 from .optimizer import AdamOptimizer
 from .penalty import ErosionDilationPenalty
-from .postprocess import CustomPostprocessOperation, GetPowerMode, WeightedSum
+from .postprocess import CustomPostprocessOperation, ModePower, Sum
 from .region import TopologyDesignRegion
 from .result import InverseDesignResult
 from .transformation import FilterProject
@@ -18,7 +18,7 @@ __all__ = (
     "AdamOptimizer",
     "InverseDesignResult",
     "CustomPostprocessOperation",
-    "WeightedSum",
-    "GetPowerMode",
+    "Sum",
+    "ModePower",
     "utils",
 )

--- a/tidy3d/plugins/invdes/design.py
+++ b/tidy3d/plugins/invdes/design.py
@@ -12,7 +12,7 @@ import tidy3d.web as web
 from tidy3d.components.autograd import get_static
 
 from .base import InvdesBaseModel
-from .postprocess import CustomPostprocessOperation, PostProcessFnType, PostprocessOperationType
+from .postprocess import CustomPostProcessOperation, PostProcessFnType, PostProcessOperationType
 from .region import DesignRegionType
 from .validators import check_pixel_size
 
@@ -32,9 +32,9 @@ class AbstractInverseDesign(InvdesBaseModel, abc.ABC):
         description="Task name to use in the objective function when running the ``JaxSimulation``.",
     )
 
-    postprocess: PostprocessOperationType = pd.Field(
+    postprocess: PostProcessOperationType = pd.Field(
         None,
-        title="Postprocess Object",
+        title="PostProcess Object",
         description="Optional object specifying how to perform weighted sum of ``ModeData`` "
         "outputs. Can be used instead of passing a generic postprocess function "
         "to ``Optimizer.run()``.",
@@ -50,7 +50,7 @@ class AbstractInverseDesign(InvdesBaseModel, abc.ABC):
     def from_function(cls, fn: PostProcessFnType, **kwargs) -> AbstractInverseDesign:
         """Create an ``InverseDesign`` object from a user-supplied postprocessing function."""
 
-        postprocess = CustomPostprocessOperation.from_function(fn)
+        postprocess = CustomPostProcessOperation.from_function(fn)
         return cls(postprocess=postprocess, **kwargs)
 
     def _get_postprocess_fn(

--- a/tidy3d/plugins/invdes/optimizer.py
+++ b/tidy3d/plugins/invdes/optimizer.py
@@ -85,7 +85,7 @@ class AbstractOptimizer(InvdesBaseModel, abc.ABC):
         return InverseDesignResult(design=self.design, opt_state=[state], params=[params0])
 
     def run(
-        self, post_process_fn: typing.Callable, params0: anp.ndarray = None
+        self, post_process_fn: typing.Callable = None, params0: anp.ndarray = None
     ) -> InverseDesignResult:
         """Run this inverse design problem from an optional initial set of parameters."""
         self.design.design_region._check_params(params0)
@@ -93,7 +93,7 @@ class AbstractOptimizer(InvdesBaseModel, abc.ABC):
         return self.continue_run(result=starting_result, post_process_fn=post_process_fn)
 
     def continue_run(
-        self, result: InverseDesignResult, post_process_fn: typing.Callable
+        self, result: InverseDesignResult, post_process_fn: typing.Callable = None
     ) -> InverseDesignResult:
         """Run optimizer for a series of steps with an initialized state."""
 
@@ -158,13 +158,15 @@ class AbstractOptimizer(InvdesBaseModel, abc.ABC):
         return InverseDesignResult(design=result.design, **history)
 
     def continue_run_from_file(
-        self, fname: str, post_process_fn: typing.Callable
+        self, fname: str, post_process_fn: typing.Callable = None
     ) -> InverseDesignResult:
         """Continue the optimization run from a ``.pkl`` file with an ``InverseDesignResult``."""
         result = InverseDesignResult.from_file(fname)
         return self.continue_run(result=result, post_process_fn=post_process_fn)
 
-    def continue_run_from_history(self, post_process_fn: typing.Callable) -> InverseDesignResult:
+    def continue_run_from_history(
+        self, post_process_fn: typing.Callable = None
+    ) -> InverseDesignResult:
         """Continue the optimization run from a ``.pkl`` file with an ``InverseDesignResult``."""
         return self.continue_run_from_file(
             fname=self.results_cache_fname, post_process_fn=post_process_fn

--- a/tidy3d/plugins/invdes/postprocess.py
+++ b/tidy3d/plugins/invdes/postprocess.py
@@ -1,0 +1,97 @@
+# defines postprocessing classes for `InverseDesign` objects.
+
+import abc
+import typing
+
+import autograd.numpy as anp
+import pydantic.v1 as pd
+
+import tidy3d as td
+
+from .base import InvdesBaseModel
+
+
+class PostprocessOperation(InvdesBaseModel, abc.ABC):
+    """Abstract base class defining components that make up postprocessing classes."""
+
+    @abc.abstractmethod
+    def evaluate(self, sim_data: td.SimulationData) -> float:
+        """How to evaluate this operation on a ``SimulationData`` object."""
+
+
+class GetPowerMode(PostprocessOperation):
+    """Grab the power from a ``ModeMonitor`` and apply an optional weight."""
+
+    monitor_name: str = pd.Field(
+        ...,
+        title="Monitor Name",
+        description="Name of the ``ModeMonitor`` corresponding to the ``ModeData`` "
+        "that we want to compute power for.",
+    )
+
+    direction: td.components.types.Direction = pd.Field(
+        None,
+        title="Direction",
+        description="If specified, selects a specific direction ``'-'`` or ``'+'`` from the "
+        "``ModeData`` to include in power. Otherwise, sums over all directions.",
+    )
+
+    mode_index: pd.NonNegativeInt = pd.Field(
+        None,
+        title="Mode Index",
+        description="If specified, selects a specific mode index from the ``ModeData`` "
+        "to include in power. Otherwise, sums over all mode indices.",
+    )
+
+    f: float = pd.Field(
+        None,
+        title="Frequency",
+        description="If specified, selects a specific frequency from the ``ModeData`` "
+        "to include in power. Otherwise, sums over all frequencies.",
+    )
+
+    weight: float = pd.Field(
+        1.0,
+        title="Weight",
+        description="Weight specifying the contribution of this power to the objective function. ",
+    )
+
+    @property
+    def sel_kwargs(self) -> dict[str, typing.Any]:
+        """Selection kwargs corresponding to the fields."""
+        sel_kwargs_all = dict(direction=self.direction, mode_index=self.mode_index, f=self.f)
+        return {key: sel for key, sel in sel_kwargs_all.items() if sel is not None}
+
+    def evaluate(self, sim_data: td.SimulationData) -> float:
+        """Evaluate this instance when passed a simulation dataset."""
+
+        mnt_data = sim_data[self.monitor_name]
+
+        if not isinstance(mnt_data, td.ModeData):
+            raise ValueError(
+                "'GetPowerMode' only works with 'ModeData' corresponding to 'ModeMonitor'. "
+                f"Monitor name of '{self.monitor_name}' returned data of type {type(mnt_data)}."
+            )
+
+        amps = mnt_data.amps
+        amp = amps.sel(**self.sel_kwargs)
+        powers = abs(amp.values) ** 2
+        power = anp.sum(powers)
+        return self.weight * power
+
+
+class WeightedSum(PostprocessOperation):
+    """Weighted sum of ``GetPower`` objects."""
+
+    powers: tuple[GetPowerMode, ...] = pd.Field(
+        (),
+        title="Powers",
+        description="Set of objects specifying how to compute and weigh the power from ``ModeData`` outputs.",
+    )
+
+    def evaluate(self, sim_data: td.SimulationData) -> float:
+        value = 0.0
+        for get_power in self.powers:
+            value = value + get_power.evaluate(sim_data)
+
+        return value


### PR DESCRIPTION
Currently it's almost the most simple thing imaginable while still being somewhat useful.

There's a `GetPowerMode` object that grabs `ModeData` from a `SimulationData`, selects data, computes power, and sums with a weight.
There's a `WeightedSum` that just sums each of these over a single `SimulationData`.
This object can be added to `InverseDesign`, meaning that the `Optimizer.run()` doesn't need to be passed a postprocess function.


```py
postprocess_obj = tdi.WeightedSum(
    powers=[
        tdi.GetPowerMode(monitor_name=MNT_NAME2, direction="+", mode_index=0, weight=0.5),
    ]
)

des = tdi.InverseDesign(
    ...,
    postprocess= postprocess_obj
)
```


This makes it possible to do the following (assuming users use this approach):
1. Upload `Optimizer` to our server through web API and get a `Result` back.
2. Do everything through GUI.

Kind of a tentative working prototype, let me know what you think of the design / naming etc. Don't hold back any criticism, mostly for discussion.

