### PR TITLE
prioritize snapping points in AutoGrid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the helper function `compute_power_delivered_by_port`  to `TerminalComponentModeler` which computes power delivered to a microwave network from a port.
 
 ### Changed
+- Priority is given to `snapping_points` in `GridSpec` when close to structure boundaries, which reduces the chance of them being skipped.
 
 ### Fixed
 - Bug where boundary layers would be plotted too small in 2D simulations.

--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -420,7 +420,7 @@ class AutoGrid(GridSpec1d):
         )
         # insert snapping_points
         interval_coords, max_dl_list = self.mesher.insert_snapping_points(
-            axis, interval_coords, max_dl_list, snapping_points
+            self.dl_min, axis, interval_coords, max_dl_list, snapping_points
         )
 
         # Put just a single pixel if 2D-like simulation


### PR DESCRIPTION
I found the snapping_points idea very useful, but also that the default value for the `min_step` was too restrictive. Here I propose some changes that give priority to the snapping points over the computed interval boundaries.

1. I changed the behavior so that when `dl_min` is defined, it becomes the size used as the `min_step`. This is needed for Simulations with PECs since the calculated `max_dl` is much too large to be useful.
2. If the snapping_point is close to an existing boundary it will replace it. The logic I used should still result in intervals that satisfy the `min_step` requirement though.
