### PR TITLE
Fixed plot_pml to mode plane symmetry.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Error when loading a previously run `Batch` or `ComponentModeler` containing custom data.
+- Error when plotting mode plane PML and the simulation has symmetry.
 
 ## [2.7.1]
 


### PR DESCRIPTION
Fixed `plot_pml` to mode plane symmetry and infinite mode plane size when FDTD PML is on.