### PR TITLE
Small fix to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Mode solver plugin now supports 'EMESimulation'.
 - `TriangleMesh` class: automatic removal of zero-area faces, and functions `fill_holes` and `fix_winding` to attempt mesh repair.
+- Added progress bar for EME simulations.
+
+### Changed
+- Error if field projection monitors found in 2D simulations, except `FieldProjectionAngleMonitor` with `far_field_approx = True`. Support for other monitors and for exact field projection will be coming in a subsequent Tidy3D version.
 
 ### Fixed
 - Error when loading a previously run `Batch` or `ComponentModeler` containing custom data.
@@ -23,9 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for differentiation with respect to monitor attributes that require interpolation, such as flux and intensity.
 - Support for automatic differentiation with respect to `.eps_inf` and `.poles` contained in dispersive mediums `td.PoleResidue` and `td.CustomPoleResidue`.
 - Support for `FieldProjectionAngleMonitor` for 2D simulations with `far_field_approx = True`.
-
-### Changed
-- Error if field projection monitors found in 2D simulations, except `FieldProjectionAngleMonitor` with `far_field_approx = True`. Support for other monitors and for exact field projection will be coming in a subsequent Tidy3D version.
 
 ### Fixed
 - Bug where boundary layers would be plotted too small in 2D simulations.


### PR DESCRIPTION
One item that was not yet released had made it in 2.7.1 changelog instead of in the unreleased section.

I updated this changelog to be in line with the one in the pre/2.8 branch after we just merged develop there. There's generally a bit of an issue with the changelog when we do such merges. Both branches have Unreleased section where we put new things. When we do a merge, those two get merged and the items that should go in the next patch vs. the next minor release get intertwined.

This is probably at least partly caused by [this merge strategy](https://github.com/flexcompute/tidy3d/blob/fde0d20a1c6992dd1d040528eeff44950ad67f83/.gitattributes#L12-L13) I introduced a long time ago when the changelog was causing conflicts in almost every PR (maybe exacerbated by us using rebase rather than merge workflow).

We could try removing this and then probably manually resolving things more often, but at least will hopefully not be reaching a point where it's not clear what item came from where?

Or we could try to use a different strategy, like have avoiding putting the things under the same `Unreleased` header, and use the next version header instead even if unreleased? This is what I did here by explicitly introducing the 2.7.2 section.