### PR TITLE
Introduced axial ratio to DirectivityMonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support for differentiation with respect to `ComplexPolySlab.vertices`.
-- Introduce RF material library. Users can now export `rf_material_library` from `tidy3d.plugins.microwave`.
+- Introduce RF material library. Users can now import `rf_material_library` from `tidy3d.plugins.microwave`.
 - Users can specify the background medium for a structure in automatic differentiation by supplying `Structure.autograd_background_permittivity`.
 - `DirectivityMonitor` to compute antenna directivity.
 - Added `plot_length_units` to `Simulation` and `Scene` to allow for specifying units, which improves axis labels and scaling when plotting.
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `WavePort` to the `TerminalComponentModeler` which is the suggested port type for exciting transmission lines.
 - Added plotting functionality to voltage and current path integrals in the `microwave` plugin.
 - Added convenience functions `from_terminal_positions` and `from_circular_path` to simplify setup of `VoltageIntegralAxisAligned` and `CustomCurrentIntegral2D`, respectively.
+- Added `axial_ratio` to `DirectivityData.axial_ratio` for the `DirectivityMonitor`, defined as the ratio of the major axis to the minor axis of the polarization ellipse. 
 
 ### Changed
 - Priority is given to `snapping_points` in `GridSpec` when close to structure boundaries, which reduces the chance of them being skipped.

--- a/docs/api/output_data.rst
+++ b/docs/api/output_data.rst
@@ -53,3 +53,4 @@ Individual Datasets
    tidy3d.FieldProjectionKSpaceDataArray
    tidy3d.DiffractionDataArray
    tidy3d.DirectivityDataArray
+   tidy3d.AxialRatioDataArray

--- a/tests/test_data/test_data_arrays.py
+++ b/tests/test_data/test_data_arrays.py
@@ -193,6 +193,11 @@ def make_directivity_data_array():
     return td.DirectivityDataArray(values, coords=dict(r=PD, theta=THETAS, phi=PHIS, f=FS))
 
 
+def make_axial_ratio_data_array():
+    values = np.random.random((len(PD), len(THETAS), len(PHIS), len(FS)))
+    return td.AxialRatioDataArray(values, coords=dict(r=PD, theta=THETAS, phi=PHIS, f=FS))
+
+
 def make_flux_time_data_array():
     values = np.random.random(len(TS))
     return td.FluxTimeDataArray(values, coords=dict(t=TS))
@@ -257,6 +262,11 @@ def test_flux_time_data_array():
 
 def test_directivity_data_array():
     data = make_directivity_data_array()
+    data = data.sel(f=1e14, phi=0)
+
+
+def test_axial_ratio_data_array():
+    data = make_axial_ratio_data_array()
     data = data.sel(f=1e14, phi=0)
 
 

--- a/tests/test_data/test_monitor_data.py
+++ b/tests/test_data/test_monitor_data.py
@@ -33,6 +33,7 @@ from .test_data_arrays import (
     PERMITTIVITY_MONITOR,
     SIM,
     SIM_SYM,
+    make_axial_ratio_data_array,
     make_diffraction_data_array,
     make_directivity_data_array,
     make_flux_data_array,
@@ -54,6 +55,7 @@ GRID_CORRECTION = FreqModeDataArray(
     1 + 0.01 * np.random.rand(*N_COMPLEX.shape), coords=N_COMPLEX.coords
 )
 DIRECTIVITY = make_directivity_data_array()
+AXIALRATIO = make_axial_ratio_data_array()
 
 """ Make the montor data """
 
@@ -188,7 +190,9 @@ def make_flux_data():
 
 
 def make_directivity_data():
-    return DirectivityData(monitor=DIRECTIVITY_MONITOR, directivity=DIRECTIVITY.copy())
+    return DirectivityData(
+        monitor=DIRECTIVITY_MONITOR, directivity=DIRECTIVITY.copy(), axial_ratio=AXIALRATIO.copy()
+    )
 
 
 def make_flux_time_data():
@@ -318,6 +322,7 @@ def test_flux_time_data():
 def test_directivity_data():
     data = make_directivity_data()
     _ = data.directivity
+    _ = data.axial_ratio
 
 
 def test_diffraction_data():

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -37,6 +37,7 @@ from .components.boundary import (
 
 # data
 from .components.data.data_array import (
+    AxialRatioDataArray,
     CellDataArray,
     ChargeDataArray,
     DiffractionDataArray,
@@ -387,6 +388,7 @@ __all__ = [
     "FieldProjectionKSpaceDataArray",
     "DiffractionDataArray",
     "DirectivityDataArray",
+    "AxialRatioDataArray",
     "HeatDataArray",
     "ChargeDataArray",
     "FieldDataset",

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -779,9 +779,9 @@ class FieldProjectionAngleDataArray(DataArray):
 
 
 class DirectivityDataArray(DataArray):
-    """Directivity in the frequency domain as a function of angles theta and phi. Directivity is a
-    dimensionless quantity defined as the ratio of the radiation intensity in a given direction
-    to the average radiation intensity over all directions.
+    """Directivity in the frequency domain as a function of angles theta and phi.
+    Directivity is a dimensionless quantity defined as the ratio of the radiation
+    intensity in a given direction to the average radiation intensity over all directions.
 
     Example
     -------
@@ -797,6 +797,34 @@ class DirectivityDataArray(DataArray):
     __slots__ = ()
     _dims = ("r", "theta", "phi", "f")
     _data_attrs = {"long_name": "radiation intensity"}
+
+
+class AxialRatioDataArray(DataArray):
+    """Axial Ratio (AR) in the frequency domain as a function of angles theta and phi.
+    AR is a dimensionless quantity defined as the ratio of the major axis to the minor
+    axis of the polarization ellipse.
+
+    Note
+    ----
+    The axial ratio computation is based on:
+
+    Balanis, Constantine A., "Antenna Theory: Analysis and Design,"
+    John Wiley & Sons, Chapter 2.12 (2016).
+
+    Example
+    -------
+    >>> f = np.linspace(1e14, 2e14, 10)
+    >>> r = np.atleast_1d(5)
+    >>> theta = np.linspace(0, np.pi, 10)
+    >>> phi = np.linspace(0, 2*np.pi, 20)
+    >>> coords = dict(r=r, theta=theta, phi=phi, f=f)
+    >>> values = np.random.random((len(r), len(theta), len(phi), len(f)))
+    >>> data = AxialRatioDataArray(values, coords=coords)
+    """
+
+    __slots__ = ()
+    _dims = ("r", "theta", "phi", "f")
+    _data_attrs = {"long_name": "axial ratio"}
 
 
 class FieldProjectionCartesianDataArray(DataArray):
@@ -1097,6 +1125,7 @@ DATA_ARRAY_TYPES = [
     FieldProjectionKSpaceDataArray,
     DiffractionDataArray,
     DirectivityDataArray,
+    AxialRatioDataArray,
     FreqModeDataArray,
     FreqDataArray,
     TimeDataArray,

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -58,6 +58,7 @@ from ..types import (
 )
 from ..validators import enforce_monitor_fields_present, required_if_symmetry_present
 from .data_array import (
+    AxialRatioDataArray,
     DataArray,
     DiffractionDataArray,
     DirectivityDataArray,
@@ -1989,16 +1990,17 @@ class DirectivityData(MonitorData):
 
     Example
     -------
-    >>> from tidy3d import DirectivityDataArray
+    >>> from tidy3d import DirectivityDataArray, AxialRatioDataArray
     >>> f = np.linspace(1e14, 2e14, 10)
-    >>> r = np.atleast_1d(5)
+    >>> r = np.atleast_1d(1e6)
     >>> theta = np.linspace(0, np.pi, 10)
     >>> phi = np.linspace(0, 2*np.pi, 20)
     >>> coords = dict(r=r, theta=theta, phi=phi, f=f)
     >>> values = np.random.random((len(r), len(theta), len(phi), len(f)))
-    >>> scalar_field = DirectivityDataArray(values, coords=coords)
+    >>> scalar_directivity_field = DirectivityDataArray(values, coords=coords)
+    >>> scalar_axial_ratio_field = AxialRatioDataArray(values, coords=coords)
     >>> monitor = DirectivityMonitor(center=(1,2,3), size=(2,2,2), freqs=f, name='n2f_monitor', phi=phi, theta=theta)
-    >>> data = DirectivityData(monitor=monitor,directivity=scalar_field)
+    >>> data = DirectivityData(monitor=monitor, directivity=scalar_directivity_field, axial_ratio=scalar_axial_ratio_field)
     """
 
     monitor: DirectivityMonitor = pd.Field(
@@ -2009,6 +2011,10 @@ class DirectivityData(MonitorData):
 
     directivity: DirectivityDataArray = pd.Field(
         ..., title="Directivity", description="Directivity with an angle-based projection grid."
+    )
+
+    axial_ratio: AxialRatioDataArray = pd.Field(
+        ..., title="Axial Ratio", description="Axial ratio with an angle-based projection grid."
     )
 
 

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -1088,8 +1088,23 @@ class FieldProjectionAngleMonitor(AbstractFieldProjectionMonitor):
 
 
 class DirectivityMonitor(FieldProjectionAngleMonitor, FluxMonitor):
-    """:class:`Monitor` that records the directivity of antennas in the frequency domain
+    """
+    :class:`Monitor` that records the radiation characteristics of antennas in the frequency domain
     at specified observation angles.
+
+    Note
+    ----
+    For directivity, the computation is based on the ratio of the radiation
+    intensity in a given direction to the average radiation intensity
+    over all directions:
+
+        Balanis, Constantine A., "Antenna Theory: Analysis and Design,"
+        John Wiley & Sons, Chapter 2.6 (2016).
+
+    For axial ratio, the computation is based on:
+
+        Balanis, Constantine A., "Antenna Theory: Analysis and Design,"
+        John Wiley & Sons, Chapter 2.12 (2016).
     """
 
     def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:


### PR DESCRIPTION
Introduced field axial_ratio in the DirectivityMonitor.

@dmarek-flex suggested renaming the DirectivityMonitor class to RadiationMonitor as radiation is more general and can include many characteristics such as directivity, gain, axial ratio, etc. I think this is reasonable and better. What do you think, @weiliangjin2021? Do you have other suggestions?