### PR TITLE
Add subsection for EMESimulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More convenient mesh importing from another simulation through `grid_spec = GridSpec.from_grid(sim.grid)`.
 - `autograd` gradient calculations can be performed on the server by passing `local_gradient = False` into `web.run()` or `web.run_async()`.
 - Automatic differentiation with `autograd` supports multiple frequencies through single, broadband adjoint simulation when the objective function can be formulated as depending on a single dataset in the output `SimulationData` with frequency dependence only.
+- Convenience method `EMESimulation.subsection` to create a new EME simulation based on a subregion of an existing one.
 
 ### Changed
 - Error if field projection monitors found in 2D simulations, except `FieldProjectionAngleMonitor` with `far_field_approx = True`. Support for other monitors and for exact field projection will be coming in a subsequent Tidy3D version.
+- Mode solver now always operates on a reduced simulation copy.
 
 ### Fixed
 - Error when loading a previously run `Batch` or `ComponentModeler` containing custom data.

--- a/tests/test_components/test_custom.py
+++ b/tests/test_components/test_custom.py
@@ -604,6 +604,19 @@ def verify_custom_medium_methods(mat, reduced_fields):
     sim.subsection(subsection, remove_outside_custom_mediums=False)
     sim.subsection(subsection, remove_outside_custom_mediums=True)
 
+    # eme
+    eme_sim = td.EMESimulation(
+        axis=2,
+        freqs=[td.C_0],
+        size=(1, 1, 1),
+        grid_spec=td.GridSpec.auto(wavelength=1.0),
+        structures=(struct,),
+        eme_grid_spec=td.EMEUniformGrid(num_cells=1, mode_spec=td.EMEModeSpec()),
+    )
+    _ = eme_sim.grid
+    eme_sim.subsection(subsection, remove_outside_custom_mediums=False)
+    eme_sim.subsection(subsection, remove_outside_custom_mediums=True)
+
 
 def test_anisotropic_custom_medium():
     """Anisotropic CustomMedium."""

--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -1032,3 +1032,5 @@ def test_modes_eme_sim(mock_remote_api, local):
         with pytest.raises(SetupError):
             _ = msweb.run(solver)
         _ = msweb.run(solver.to_fdtd_mode_solver())
+
+    _ = solver.reduced_simulation_copy

--- a/tidy3d/components/eme/grid.py
+++ b/tidy3d/components/eme/grid.py
@@ -210,11 +210,12 @@ class EMEExplicitGrid(EMEGridSpec):
             raise ValidationError(
                 "There must be exactly one fewer item in 'boundaries' than " "in 'mode_specs'."
             )
-        rmin = boundaries[0]
-        for rmax in boundaries[1:]:
-            if rmax < rmin:
-                raise ValidationError("The 'boundaries' must be increasing.")
-            rmin = rmax
+        if len(boundaries) > 0:
+            rmin = boundaries[0]
+            for rmax in boundaries[1:]:
+                if rmax < rmin:
+                    raise ValidationError("The 'boundaries' must be increasing.")
+                rmin = rmax
         return val
 
     def make_grid(self, center: Coordinate, size: Size, axis: Axis) -> EMEGrid:
@@ -237,12 +238,15 @@ class EMEExplicitGrid(EMEGridSpec):
         """
         sim_rmin = center[axis] - size[axis] / 2
         sim_rmax = center[axis] + size[axis] / 2
-        if self.boundaries[0] < sim_rmin - fp_eps:
-            raise ValidationError(
-                "The first item in 'boundaries' is outside the simulation domain."
-            )
-        if self.boundaries[-1] > sim_rmax + fp_eps:
-            raise ValidationError("The last item in 'boundaries' is outside the simulation domain.")
+        if len(self.boundaries) > 0:
+            if self.boundaries[0] < sim_rmin - fp_eps:
+                raise ValidationError(
+                    "The first item in 'boundaries' is outside the simulation domain."
+                )
+            if self.boundaries[-1] > sim_rmax + fp_eps:
+                raise ValidationError(
+                    "The last item in 'boundaries' is outside the simulation domain."
+                )
 
         boundaries = [sim_rmin] + list(self.boundaries) + [sim_rmax]
         return EMEGrid(

--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -274,7 +274,7 @@ class CustomGridBoundaries(GridSpec1d):
 
     Example
     -------
-    >>> grid_1d = CustomGridCoords(boundaries=[-0.2, 0.0, 0.2, 0.4, 0.5, 0.6, 0.7])
+    >>> grid_1d = CustomGridBoundaries(coords=[-0.2, 0.0, 0.2, 0.4, 0.5, 0.6, 0.7])
     """
 
     coords: Coords1D = pd.Field(

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -1346,6 +1346,213 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
 
         return mesh_overrides
 
+    def subsection(
+        self,
+        region: Box,
+        boundary_spec: BoundarySpec = None,
+        grid_spec: Union[GridSpec, Literal["identical"]] = None,
+        symmetry: Tuple[Symmetry, Symmetry, Symmetry] = None,
+        sources: Tuple[SourceType, ...] = None,
+        monitors: Tuple[MonitorType, ...] = None,
+        remove_outside_structures: bool = True,
+        remove_outside_custom_mediums: bool = False,
+        include_pml_cells: bool = False,
+        **kwargs,
+    ) -> AbstractYeeGridSimulation:
+        """Generate a simulation instance containing only the ``region``.
+
+        Parameters
+        ----------
+        region : :class:.`Box`
+            New simulation domain.
+        boundary_spec : :class:.`BoundarySpec` = None
+            New boundary specification. If ``None``, then it is inherited from the original
+            simulation.
+        grid_spec : :class:.`GridSpec` = None
+            New grid specification. If ``None``, then it is inherited from the original
+            simulation. If ``identical``, then the original grid is transferred directly as a
+            :class:.`CustomGrid`. Note that in the latter case the region of the new simulation is
+            snapped to the original grid lines.
+        symmetry : Tuple[Literal[0, -1, 1], Literal[0, -1, 1], Literal[0, -1, 1]] = None
+            New simulation symmetry. If ``None``, then it is inherited from the original
+            simulation. Note that in this case the size and placement of new simulation domain
+            must be commensurate with the original symmetry.
+        sources : Tuple[SourceType, ...] = None
+            New list of sources. If ``None``, then the sources intersecting the new simulation
+            domain are inherited from the original simulation.
+        monitors : Tuple[MonitorType, ...] = None
+            New list of monitors. If ``None``, then the monitors intersecting the new simulation
+            domain are inherited from the original simulation.
+        remove_outside_structures : bool = True
+            Remove structures outside of the new simulation domain.
+        remove_outside_custom_mediums : bool = True
+            Remove custom medium data outside of the new simulation domain.
+        include_pml_cells : bool = False
+            Keep PML cells in simulation boundaries. Note that retained PML cells will be converted
+            to regular cells, and the simulation domain boundary will be moved accordingly.
+        **kwargs
+            Other arguments passed to new simulation instance.
+        """
+
+        # must intersect the original domain
+        if not self.intersects(region):
+            raise SetupError("Requested region does not intersect simulation domain")
+
+        # restrict to the original simulation domain
+        if include_pml_cells:
+            new_bounds = Box.bounds_intersection(self.simulation_bounds, region.bounds)
+        else:
+            new_bounds = Box.bounds_intersection(self.bounds, region.bounds)
+        new_bounds = [list(new_bounds[0]), list(new_bounds[1])]
+
+        # grid spec inheritace
+        if grid_spec is None:
+            grid_spec = self.grid_spec
+        elif isinstance(grid_spec, str) and grid_spec == "identical":
+            # create a custom grid from existing one
+            grids_1d = self.grid.boundaries.to_list
+            grid_spec = GridSpec.from_grid(self.grid)
+
+            # adjust region bounds to perfectly coincide with the grid
+            # note, sometimes (when a box already seems to perfrecty align with the grid)
+            # this causes the new region to expand one more pixel because of numerical roundoffs
+            # To help to avoid that we shrink new region by a small amount.
+            center = [(bmin + bmax) / 2 for bmin, bmax in zip(*new_bounds)]
+            size = [max(0.0, bmax - bmin - 2 * fp_eps) for bmin, bmax in zip(*new_bounds)]
+            aux_box = Box(center=center, size=size)
+            grid_inds = self.grid.discretize_inds(box=aux_box)
+
+            for dim in range(3):
+                # preserve zero size dimensions
+                if new_bounds[0][dim] != new_bounds[1][dim]:
+                    new_bounds[0][dim] = grids_1d[dim][grid_inds[dim][0]]
+                    new_bounds[1][dim] = grids_1d[dim][grid_inds[dim][1]]
+
+        # if symmetry is not overriden we inherit it from the original simulation where is needed
+        if symmetry is None:
+            # start with no symmetry
+            symmetry = [0, 0, 0]
+
+            # now check in each dimension whether we cross symmetry plane
+            for dim in range(3):
+                if self.symmetry[dim] != 0:
+                    crosses_symmetry = (
+                        new_bounds[0][dim] < self.center[dim]
+                        and new_bounds[1][dim] > self.center[dim]
+                    )
+
+                    # inherit symmetry only if we cross symmetry plane, otherwise we don't impose
+                    # symmetry even if the original simulation had symmetry
+                    if crosses_symmetry:
+                        symmetry[dim] = self.symmetry[dim]
+                        center = (new_bounds[0][dim] + new_bounds[1][dim]) / 2
+
+                        if not math.isclose(center, self.center[dim]):
+                            log.warning(
+                                f"The original simulation is symmetric along {'xyz'[dim]} direction. "
+                                "The requested new simulation region does cross the symmetry plane but is "
+                                "not symmetric with respect to it. To preserve correct symmetry, "
+                                "the requested simulation region is expanded symmetrically."
+                            )
+                            new_bounds[0][dim] = 2 * self.center[dim] - new_bounds[1][dim]
+
+        # symmetry and grid spec treatments could change new simulation bounds
+        # thus, recreate a box instance
+        new_box = Box.from_bounds(*new_bounds)
+
+        # inheritance of structures, sources, monitors, and boundary specs
+        if remove_outside_structures:
+            new_structures = [strc for strc in self.structures if new_box.intersects(strc.geometry)]
+        else:
+            new_structures = self.structures
+
+        if sources is None:
+            sources = [src for src in self.sources if new_box.intersects(src)]
+
+        if monitors is None:
+            monitors = [mnt for mnt in self.monitors if new_box.intersects(mnt)]
+
+        if boundary_spec is None:
+            boundary_spec = self.boundary_spec
+
+        # set boundary conditions in zero-size dimension to periodic
+        for dim in range(3):
+            if new_bounds[0][dim] == new_bounds[1][dim] and not isinstance(
+                boundary_spec.to_list[dim][0], Periodic
+            ):
+                axis_name = "xyz"[dim]
+                log.warning(
+                    f"The resulting simulation subsection has size zero along axis '{axis_name}'. "
+                    "Periodic boundary conditions are automatically set along this dimension."
+                )
+                boundary_spec = boundary_spec.updated_copy(**{"xyz"[dim]: Boundary.periodic()})
+
+        # reduction of custom medium data
+        new_sim_medium = self.medium
+        if remove_outside_custom_mediums:
+            # check for special treatment in case of PML
+            if any(
+                any(isinstance(edge, (PML, StablePML, Absorber)) for edge in boundary)
+                for boundary in boundary_spec.to_list
+            ):
+                # if we need to cut out outside custom medium we have to be careful about PML/Absorber
+                # we should include data in PML so that there is no artificial reflection at PML boundaries
+
+                # to do this, we first create an auxiliary simulation
+                aux_sim = self.updated_copy(
+                    center=new_box.center,
+                    size=new_box.size,
+                    grid_spec=grid_spec,
+                    boundary_spec=boundary_spec,
+                    monitors=[],
+                    sources=sources,  # need wavelength in case of auto grid
+                    symmetry=symmetry,
+                    structures=new_structures,
+                )
+
+                # then use its bounds as region for data cut off
+                new_bounds = aux_sim.simulation_bounds
+
+                # Note that this is not a full proof strategy. For example, if grid_spec is AutoGrid
+                # then after outside custom medium data is removed the grid sizes and, thus,
+                # pml extents can change as well
+
+            # now cut out custom medium data
+            new_structures_reduced_data = []
+
+            for structure in new_structures:
+                medium = structure.medium
+                if isinstance(medium, AbstractCustomMedium):
+                    new_structure_bounds = Box.bounds_intersection(
+                        new_bounds, structure.geometry.bounds
+                    )
+                    new_medium = medium.sel_inside(bounds=new_structure_bounds)
+                    new_structure = structure.updated_copy(medium=new_medium)
+                    new_structures_reduced_data.append(new_structure)
+                else:
+                    new_structures_reduced_data.append(structure)
+
+            new_structures = new_structures_reduced_data
+
+            if isinstance(self.medium, AbstractCustomMedium):
+                new_sim_medium = self.medium.sel_inside(bounds=new_bounds)
+
+        # finally, create an updated copy with all modifications
+        new_sim = self.updated_copy(
+            center=new_box.center,
+            size=new_box.size,
+            medium=new_sim_medium,
+            grid_spec=grid_spec,
+            boundary_spec=boundary_spec,
+            monitors=monitors,
+            sources=sources,
+            symmetry=symmetry,
+            structures=new_structures,
+            **kwargs,
+        )
+
+        return new_sim
+
 
 class Simulation(AbstractYeeGridSimulation):
     """
@@ -4285,210 +4492,3 @@ class Simulation(AbstractYeeGridSimulation):
             medium=scene.medium,
             **kwargs,
         )
-
-    def subsection(
-        self,
-        region: Box,
-        boundary_spec: BoundarySpec = None,
-        grid_spec: Union[GridSpec, Literal["identical"]] = None,
-        symmetry: Tuple[Symmetry, Symmetry, Symmetry] = None,
-        sources: Tuple[SourceType, ...] = None,
-        monitors: Tuple[MonitorType, ...] = None,
-        remove_outside_structures: bool = True,
-        remove_outside_custom_mediums: bool = False,
-        include_pml_cells: bool = False,
-        **kwargs,
-    ) -> Simulation:
-        """Generate a simulation instance containing only the ``region``.
-
-        Parameters
-        ----------
-        region : :class:.`Box`
-            New simulation domain.
-        boundary_spec : :class:.`BoundarySpec` = None
-            New boundary specification. If ``None``, then it is inherited from the original
-            simulation.
-        grid_spec : :class:.`GridSpec` = None
-            New grid specification. If ``None``, then it is inherited from the original
-            simulation. If ``identical``, then the original grid is transferred directly as a
-            :class:.`CustomGrid`. Note that in the latter case the region of the new simulation is
-            snapped to the original grid lines.
-        symmetry : Tuple[Literal[0, -1, 1], Literal[0, -1, 1], Literal[0, -1, 1]] = None
-            New simulation symmetry. If ``None``, then it is inherited from the original
-            simulation. Note that in this case the size and placement of new simulation domain
-            must be commensurate with the original symmetry.
-        sources : Tuple[SourceType, ...] = None
-            New list of sources. If ``None``, then the sources intersecting the new simulation
-            domain are inherited from the original simulation.
-        monitors : Tuple[MonitorType, ...] = None
-            New list of monitors. If ``None``, then the monitors intersecting the new simulation
-            domain are inherited from the original simulation.
-        remove_outside_structures : bool = True
-            Remove structures outside of the new simulation domain.
-        remove_outside_custom_mediums : bool = True
-            Remove custom medium data outside of the new simulation domain.
-        include_pml_cells : bool = False
-            Keep PML cells in simulation boundaries. Note that retained PML cells will be converted
-            to regular cells, and the simulation domain boundary will be moved accordingly.
-        **kwargs
-            Other arguments passed to new simulation instance.
-        """
-
-        # must intersect the original domain
-        if not self.intersects(region):
-            raise SetupError("Requested region does not intersect simulation domain")
-
-        # restrict to the original simulation domain
-        if include_pml_cells:
-            new_bounds = Box.bounds_intersection(self.simulation_bounds, region.bounds)
-        else:
-            new_bounds = Box.bounds_intersection(self.bounds, region.bounds)
-        new_bounds = [list(new_bounds[0]), list(new_bounds[1])]
-
-        # grid spec inheritace
-        if grid_spec is None:
-            grid_spec = self.grid_spec
-        elif isinstance(grid_spec, str) and grid_spec == "identical":
-            # create a custom grid from existing one
-            grids_1d = self.grid.boundaries.to_list
-            grid_spec = GridSpec.from_grid(self.grid)
-
-            # adjust region bounds to perfectly coincide with the grid
-            # note, sometimes (when a box already seems to perfrecty align with the grid)
-            # this causes the new region to expand one more pixel because of numerical roundoffs
-            # To help to avoid that we shrink new region by a small amount.
-            center = [(bmin + bmax) / 2 for bmin, bmax in zip(*new_bounds)]
-            size = [max(0.0, bmax - bmin - 2 * fp_eps) for bmin, bmax in zip(*new_bounds)]
-            aux_box = Box(center=center, size=size)
-            grid_inds = self.grid.discretize_inds(box=aux_box)
-
-            for dim in range(3):
-                # preserve zero size dimensions
-                if new_bounds[0][dim] != new_bounds[1][dim]:
-                    new_bounds[0][dim] = grids_1d[dim][grid_inds[dim][0]]
-                    new_bounds[1][dim] = grids_1d[dim][grid_inds[dim][1]]
-
-        # if symmetry is not overriden we inherit it from the original simulation where is needed
-        if symmetry is None:
-            # start with no symmetry
-            symmetry = [0, 0, 0]
-
-            # now check in each dimension whether we cross symmetry plane
-            for dim in range(3):
-                if self.symmetry[dim] != 0:
-                    crosses_symmetry = (
-                        new_bounds[0][dim] < self.center[dim]
-                        and new_bounds[1][dim] > self.center[dim]
-                    )
-
-                    # inherit symmetry only if we cross symmetry plane, otherwise we don't impose
-                    # symmetry even if the original simulation had symmetry
-                    if crosses_symmetry:
-                        symmetry[dim] = self.symmetry[dim]
-                        center = (new_bounds[0][dim] + new_bounds[1][dim]) / 2
-
-                        if not math.isclose(center, self.center[dim]):
-                            log.warning(
-                                f"The original simulation is symmetric along {'xyz'[dim]} direction. "
-                                "The requested new simulation region does cross the symmetry plane but is "
-                                "not symmetric with respect to it. To preserve correct symmetry, "
-                                "the requested simulation region is expanded symmetrically."
-                            )
-                            new_bounds[0][dim] = 2 * self.center[dim] - new_bounds[1][dim]
-
-        # symmetry and grid spec treatments could change new simulation bounds
-        # thus, recreate a box instance
-        new_box = Box.from_bounds(*new_bounds)
-
-        # inheritance of structures, sources, monitors, and boundary specs
-        if remove_outside_structures:
-            new_structures = [strc for strc in self.structures if new_box.intersects(strc.geometry)]
-        else:
-            new_structures = self.structures
-
-        if sources is None:
-            sources = [src for src in self.sources if new_box.intersects(src)]
-
-        if monitors is None:
-            monitors = [mnt for mnt in self.monitors if new_box.intersects(mnt)]
-
-        if boundary_spec is None:
-            boundary_spec = self.boundary_spec
-
-        # set boundary conditions in zero-size dimension to periodic
-        for dim in range(3):
-            if new_bounds[0][dim] == new_bounds[1][dim] and not isinstance(
-                boundary_spec.to_list[dim][0], Periodic
-            ):
-                axis_name = "xyz"[dim]
-                log.warning(
-                    f"The resulting simulation subsection has size zero along axis '{axis_name}'. "
-                    "Periodic boundary conditions are automatically set along this dimension."
-                )
-                boundary_spec = boundary_spec.updated_copy(**{"xyz"[dim]: Boundary.periodic()})
-
-        # reduction of custom medium data
-        new_sim_medium = self.medium
-        if remove_outside_custom_mediums:
-            # check for special treatment in case of PML
-            if any(
-                any(isinstance(edge, (PML, StablePML, Absorber)) for edge in boundary)
-                for boundary in boundary_spec.to_list
-            ):
-                # if we need to cut out outside custom medium we have to be careful about PML/Absorber
-                # we should include data in PML so that there is no artificial reflection at PML boundaries
-
-                # to do this, we first create an auxiliary simulation
-                aux_sim = self.updated_copy(
-                    center=new_box.center,
-                    size=new_box.size,
-                    grid_spec=grid_spec,
-                    boundary_spec=boundary_spec,
-                    monitors=[],
-                    sources=sources,  # need wavelength in case of auto grid
-                    symmetry=symmetry,
-                    structures=new_structures,
-                )
-
-                # then use its bounds as region for data cut off
-                new_bounds = aux_sim.simulation_bounds
-
-                # Note that this is not a full proof strategy. For example, if grid_spec is AutoGrid
-                # then after outside custom medium data is removed the grid sizes and, thus,
-                # pml extents can change as well
-
-            # now cut out custom medium data
-            new_structures_reduced_data = []
-
-            for structure in new_structures:
-                medium = structure.medium
-                if isinstance(medium, AbstractCustomMedium):
-                    new_structure_bounds = Box.bounds_intersection(
-                        new_bounds, structure.geometry.bounds
-                    )
-                    new_medium = medium.sel_inside(bounds=new_structure_bounds)
-                    new_structure = structure.updated_copy(medium=new_medium)
-                    new_structures_reduced_data.append(new_structure)
-                else:
-                    new_structures_reduced_data.append(structure)
-
-            new_structures = new_structures_reduced_data
-
-            if isinstance(self.medium, AbstractCustomMedium):
-                new_sim_medium = self.medium.sel_inside(bounds=new_bounds)
-
-        # finally, create an updated copy with all modifications
-        new_sim = self.updated_copy(
-            center=new_box.center,
-            size=new_box.size,
-            medium=new_sim_medium,
-            grid_spec=grid_spec,
-            boundary_spec=boundary_spec,
-            monitors=monitors,
-            sources=sources,
-            symmetry=symmetry,
-            structures=new_structures,
-            **kwargs,
-        )
-
-        return new_sim

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -336,56 +336,58 @@ class ModeSolver(Tidy3dBaseModel):
 
     def _data_on_yee_grid(self) -> ModeSolverData:
         """Solve for all modes, and construct data with fields on the Yee grid."""
-        _, _solver_coords = self.plane.pop_axis(
-            self._solver_grid.boundaries.to_list, axis=self.normal_axis
+        solver = self.reduced_simulation_copy
+
+        _, _solver_coords = solver.plane.pop_axis(
+            solver._solver_grid.boundaries.to_list, axis=solver.normal_axis
         )
 
         # Compute and store the modes at all frequencies
-        n_complex, fields, eps_spec = self._solve_all_freqs(
-            coords=_solver_coords, symmetry=self.solver_symmetry
+        n_complex, fields, eps_spec = solver._solve_all_freqs(
+            coords=_solver_coords, symmetry=solver.solver_symmetry
         )
 
         # start a dictionary storing the data arrays for the ModeSolverData
         index_data = ModeIndexDataArray(
             np.stack(n_complex, axis=0),
             coords=dict(
-                f=list(self.freqs),
-                mode_index=np.arange(self.mode_spec.num_modes),
+                f=list(solver.freqs),
+                mode_index=np.arange(solver.mode_spec.num_modes),
             ),
         )
         data_dict = {"n_complex": index_data}
 
         # Construct the field data on Yee grid
         for field_name in ("Ex", "Ey", "Ez", "Hx", "Hy", "Hz"):
-            xyz_coords = self.grid_snapped[field_name].to_list
+            xyz_coords = solver.grid_snapped[field_name].to_list
             scalar_field_data = ScalarModeFieldDataArray(
                 np.stack([field_freq[field_name] for field_freq in fields], axis=-2),
                 coords=dict(
                     x=xyz_coords[0],
                     y=xyz_coords[1],
                     z=xyz_coords[2],
-                    f=list(self.freqs),
-                    mode_index=np.arange(self.mode_spec.num_modes),
+                    f=list(solver.freqs),
+                    mode_index=np.arange(solver.mode_spec.num_modes),
                 ),
             )
             data_dict[field_name] = scalar_field_data
 
         # finite grid corrections
-        grid_factors = self._grid_correction(
-            simulation=self.simulation,
-            plane=self.plane,
-            mode_spec=self.mode_spec,
+        grid_factors = solver._grid_correction(
+            simulation=solver.simulation,
+            plane=solver.plane,
+            mode_spec=solver.mode_spec,
             n_complex=index_data,
-            direction=self.direction,
+            direction=solver.direction,
         )
 
         # make mode solver data on the Yee grid
-        mode_solver_monitor = self.to_mode_solver_monitor(name=MODE_MONITOR_NAME, colocate=False)
-        grid_expanded = self.simulation.discretize_monitor(mode_solver_monitor)
+        mode_solver_monitor = solver.to_mode_solver_monitor(name=MODE_MONITOR_NAME, colocate=False)
+        grid_expanded = solver.simulation.discretize_monitor(mode_solver_monitor)
         mode_solver_data = ModeSolverData(
             monitor=mode_solver_monitor,
-            symmetry=self.simulation.symmetry,
-            symmetry_center=self.simulation.center,
+            symmetry=solver.simulation.symmetry,
+            symmetry_center=solver.simulation.center,
             grid_expanded=grid_expanded,
             grid_primal_correction=grid_factors[0],
             grid_dual_correction=grid_factors[1],
@@ -1499,6 +1501,12 @@ class ModeSolver(Tidy3dBaseModel):
         """Strip objects not used by the mode solver from simulation object.
         This might significantly reduce upload time in the presence of custom mediums.
         """
+
+        # for now, we handle EME simulation by converting to FDTD simulation
+        # because we can't take planar subsection of an EME simulation.
+        # eventually, we will convert to ModeSimulation
+        if isinstance(self.simulation, EMESimulation):
+            return self.to_fdtd_mode_solver().reduced_simulation_copy
 
         # we preserve extra cells along the normal direction to ensure there is enough data for
         # subpixel


### PR DESCRIPTION
This PR:

1. Moves `subsection` from `Simulation` to `AbstractYeeGridSimulation`.
2. Extends `subsection` in `EMESimulation` to also allow inheriting the EME grid spec. The behavior when `eme_grid_spec == "identical"` is to extend the region to snap to EME cell boundaries.
3. Adds validator for EME simulation to be fully 3D
4. Makes `ModeSolver.reduced_simulation_copy` use `ModeSolver.to_fdtd_mode_solver()` when the `simulation` is an `EMESimulation`. This is needed for now because an `EMESimulation` must be fully 3D, while we need a 2D subsection in the mode solver. Eventually, instead of using `subsection` of `FDTDSimulation`, it might be nicer to convert to a `ModeSimulation` and use `subsection` of `ModeSimulation`. But that would be after the `ModeSimulation` PR is merged.
5. Makes `data_on_yee_grid` always use the `reduced_simulation_copy`.