### PR TITLE
:wrench: Propagate pre/2.8 sync fix to develop

### DIFF
--- a/.github/workflows/sync-to-readthedocs-repo.yaml
+++ b/.github/workflows/sync-to-readthedocs-repo.yaml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Push corresponding reference to mirror repo
         run: |
+          git fetch --unshallow origin ${{ needs.extract_branch_or_tag.outputs.ref_name }}
+          git pull origin ${{ needs.extract_branch_or_tag.outputs.ref_name }}
           git remote add mirror https://github.com/flexcompute-readthedocs/tidy3d-docs.git
           git push mirror ${{ needs.extract_branch_or_tag.outputs.ref_name }} --force # overwrites always
         env:


### PR DESCRIPTION
Propagates the fixes already in `pre/2.8` into `develop` without the need of a full merge. Might cause minor conflicts but not too much I believe.

https://github.com/flexcompute/tidy3d/pull/1853

Related to the failed actions with the same issue as in pre/2.8
https://github.com/flexcompute/tidy3d/actions/runs/10246045167
https://github.com/flexcompute/tidy3d/actions/runs/10246041961