### PR TITLE
Add LossyMetalMedium and subpixel options for lossy_metal including SIBC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new support functions for the Design plugin: automated batching of `Simulation` objects, and summary functions with `DesignSpace.estimate_cost` and `DesignSpace.summarize`.
 - Added validation and repair methods for `TriangleMesh` with inward-facing normals.
 - Added `from_admittance_coeffs` to `PoleResidue`, which allows for directly constructing a `PoleResidue` medium from an admittance function in the Laplace domain.
+- Added material type `LossyMetalMedium` that has high DC-conductivity. Its boundaries can be modeled by a surface impedance boundary condition (SIBC). This is treated as a subpixel method, which can be switched by setting `SubpixelSpec(lossy_metal=method)` where `method` can be `Staircasing()`, `VolumetricAveraging()`, or `SurfaceImpedance()`.
 
 ### Changed
 - Priority is given to `snapping_points` in `GridSpec` when close to structure boundaries, which reduces the chance of them being skipped.

--- a/docs/api/mediums.rst
+++ b/docs/api/mediums.rst
@@ -14,6 +14,7 @@ Spatially uniform
    :template: module.rst
 
    tidy3d.Medium
+   tidy3d.LossyMetalMedium
    tidy3d.PECMedium
    tidy3d.FullyAnisotropicMedium
 
@@ -24,6 +25,15 @@ Spatially varying
    :template: module.rst
 
    tidy3d.CustomMedium
+
+Fitting parameters
+^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: _autosummary/
+   :template: module.rst
+
+   tidy3d.SkinDepthFitterParam
 
 Dispersive Mediums
 ------------------

--- a/docs/api/subpixel_averaging.rst
+++ b/docs/api/subpixel_averaging.rst
@@ -21,3 +21,4 @@ Types of Subpixel Averaging Methods
    tidy3d.HeuristicPECStaircasing
    tidy3d.PolarizedAveraging
    tidy3d.PECConformal
+   tidy3d.SurfaceImpedance

--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -141,6 +141,27 @@ def test_PEC():
     _ = td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=td.PEC)
 
 
+def test_lossy_metal():
+    # frequency_range shouldn't be None
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.LossyMetalMedium()
+    # frequency_range shouldn't contain non-postive values
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.LossyMetalMedium(frequency_range=(0, 10))
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.LossyMetalMedium(frequency_range=(-10, 10))
+
+    # frequency_range should be finite
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.LossyMetalMedium(frequency_range=(10, np.inf))
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.LossyMetalMedium(frequency_range=(-np.inf, 10))
+
+    # default fitting
+    mat = td.LossyMetalMedium(conductivity=1.0, frequency_range=(1e14, 4e14))
+    model = mat.skin_depth_model
+
+
 def test_medium_dispersion():
     # construct media
     m_PR = td.PoleResidue(eps_inf=1.0, poles=[((-1 + 2j), (1 + 3j)), ((-2 + 4j), (1 + 5j))])

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -173,6 +173,7 @@ from .components.medium import (
     FullyAnisotropicMedium,
     KerrNonlinearity,
     Lorentz,
+    LossyMetalMedium,
     Medium,
     Medium2D,
     NonlinearModel,
@@ -183,6 +184,7 @@ from .components.medium import (
     PerturbationPoleResidue,
     PoleResidue,
     Sellmeier,
+    SkinDepthFitterParam,
     TwoPhotonAbsorption,
     medium_from_nk,
 )
@@ -255,6 +257,7 @@ from .components.subpixel_spec import (
     PolarizedAveraging,
     Staircasing,
     SubpixelSpec,
+    SurfaceImpedance,
     VolumetricAveraging,
 )
 
@@ -335,6 +338,8 @@ __all__ = [
     "CustomDrude",
     "CustomDebye",
     "CustomAnisotropicMedium",
+    "LossyMetalMedium",
+    "SkinDepthFitterParam",
     "RotationAroundAxis",
     "PerturbationMedium",
     "PerturbationPoleResidue",
@@ -507,6 +512,7 @@ __all__ = [
     "PolarizedAveraging",
     "HeuristicPECStaircasing",
     "PECConformal",
+    "SurfaceImpedance",
     "EMESimulation",
     "EMESimulationData",
     "EMEMonitor",

--- a/tidy3d/components/grid/mesher.py
+++ b/tidy3d/components/grid/mesher.py
@@ -17,7 +17,7 @@ from ...constants import C_0, fp_eps
 from ...exceptions import SetupError, ValidationError
 from ...log import log
 from ..base import Tidy3dBaseModel
-from ..medium import AnisotropicMedium, Medium2D, PECMedium
+from ..medium import AnisotropicMedium, LossyMetalMedium, Medium2D, PECMedium
 from ..structure import MeshOverrideStructure, Structure, StructureType
 from ..types import ArrayFloat1D, Axis, Bound, Coordinate
 
@@ -522,7 +522,7 @@ class GradedMesher(Mesher):
         min_steps = []
         for structure in structures:
             if isinstance(structure, Structure):
-                if isinstance(structure.medium, (PECMedium, Medium2D)) or (
+                if isinstance(structure.medium, (PECMedium, Medium2D, LossyMetalMedium)) or (
                     isinstance(structure.medium, AnisotropicMedium)
                     and structure.medium.is_comp_pec(axis)
                 ):

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -44,6 +44,7 @@ from .medium import (
     AbstractPerturbationMedium,
     AnisotropicMedium,
     FullyAnisotropicMedium,
+    LossyMetalMedium,
     Medium,
     Medium2D,
     MediumType,
@@ -4117,8 +4118,10 @@ class Simulation(AbstractYeeGridSimulation):
 
         mediums = self.scene.mediums
         contain_pec_structures = any(medium.is_pec for medium in mediums)
+        contain_sibc_structures = any(isinstance(medium, LossyMetalMedium) for medium in mediums)
         return self.courant * self._subpixel.courant_ratio(
-            contain_pec_structures=contain_pec_structures
+            contain_pec_structures=contain_pec_structures,
+            contain_sibc_structures=contain_sibc_structures,
         )
 
     @cached_property


### PR DESCRIPTION
## SIBC Applicable Medium

Theoretically we can use class composition to apply SIBC to all material types. However, in practice, it's almost only applied to DC-conductivity type material and `eps_inf` is ignored. To that regard, I subclass `LossyMetalMedium` from `Medium`, and  free parameters are conductivity, frequency_range, and fitting parameters.

Fitting is performed in its frequency_range, so frequency_range is a required field here. In fact, unlike other material types, frequency_range is a very important parameter here: the fitter results are sensitive to frequency range.

```
mat = td.LossyMetalMedium(conductivity=1e2, frequency_range=(2e14, 3e14))
mat.plot()
```
And the result:
![image](https://github.com/flexcompute/tidy3d/assets/92755338/4bacbc1a-cb17-4461-9425-38e5a29270ee)


## Subpixel Spec

`SubpixelSpec` now has four fields: dielectric, metal, PEC, and lossy_metal. When lossy_metal takes SIBC, solver will apply SIBC to structures made of `td.LossyMetalMedium`. We don't validate if the metal is lossy enough, as it heavily depends on the geometries.

