### PR TITLE
:books: Improving default type linking on parameters list

### DIFF
--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -1089,8 +1089,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
             default_val = field.get_default()
             if "=" in str(default_val):
                 # handle cases where default values are pydantic models
-                default_val = f"{default_val.__class__.__name__}({default_val})"
-                default_val = (", ").join(default_val.split(" "))
+                default_val = f"{default_val.__class__.__name__}"
 
             # make first line: name : type = default
             default_str = "" if field.required else f" = {default_val}"


### PR DESCRIPTION
- When the field is a non-uion type, e.g. grid_spec, and boundary_spec, the hyperlink is not generated in the page
-  I wonder if for default values, we should not display optional fields like GridSpec(attrs={} , …) just becomes GridSpec()?