### PR TITLE
Improve passivity enforcement near high-Q poles in FastDispersionFitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added value_and_grad function to the autograd plugin, importable via `from tidy3d.plugins.autograd import value_and_grad`. Supports differentiating functions with auxiliary data (`value_and_grad(f, has_aux=True)`).
 
+### Fixed
+- Improved passivity enforcement near high-Q poles in `FastDispersionFitter`. Failed passivity enforcement could lead to simulation divergences.
+
 ## [2.7.2] - 2024-08-07
 
 ### Added

--- a/tests/test_plugins/test_dispersion_fitter.py
+++ b/tests/test_plugins/test_dispersion_fitter.py
@@ -272,3 +272,16 @@ def test_dispersion_guess(random_data):
     medium, rms = fitter.fit(num_tries=2)
 
     medium_new, rms_new = fitter.fit(num_tries=1, guess=medium)
+
+
+def test_dispersion_loss_samples():
+    wvls = np.array([275e-3, 260e-3, 255e-3])
+    n_nAlGaN = np.array([2.72, 2.68, 2.53])
+
+    nAlGaN_fitter = FastDispersionFitter(wvl_um=wvls, n_data=n_nAlGaN)
+    nAlGaN_mat, _ = nAlGaN_fitter.fit()
+
+    freq_list = nAlGaN_mat.angular_freq_to_Hz(nAlGaN_mat._imag_ep_extrema_with_samples())
+    ep = nAlGaN_mat.eps_model(freq_list)
+    for e in ep:
+        assert e.imag >= 0


### PR DESCRIPTION
The passivity enforcement including `imag_ep_extrema` and `omega_range` was not sufficient when the fit `PoleResidue` model contained high-Q poles. This PR adds extra samples around each pole in order to improve the passivity enforcement. Specifically, the samples are computed using an explicit formula for extrema around a single pole.

The fit for the example data in the issue remains poor -- this is to be expected, since the data exhibits dispersion but has no loss.