### PR TITLE
removed a redundant change log for 2d projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `flux` and `poynting` properties to `FieldProjectionCartesianData`.
 
 ### Changed
-- Error if field projection monitors found in 2D simulations, except `FieldProjectionAngleMonitor` with `far_field_approx = True`. Support for other monitors and for exact field projection will be coming in a subsequent Tidy3D version.
 - Mode solver now always operates on a reduced simulation copy.
 - Moved `EMESimulation` size limit validators to preupload.
 - Error if field projection monitors found in 2D simulations, except `FieldProjectionAngleMonitor` or `FieldProjectionCartesianMonitor` with `far_field_approx = True`. Support for other monitors and for exact field projection will be coming in a subsequent Tidy3D version.


### PR DESCRIPTION
There is one redundant change log regarding 2D projections by accident, I just deleted the first one.