### PR TITLE
fix: make sure coordinates retain correct ordering after autograd interp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added value_and_grad function to the autograd plugin, importable via `from tidy3d.plugins.autograd import value_and_grad`. Supports differentiating functions with auxiliary data (`value_and_grad(f, has_aux=True)`).
 
+### Fixed
+- `DataArray` interpolation failure due to incorrect ordering of coordinates when interpolating with autograd tracers.
+
 ## [2.7.2] - 2024-08-07
 
 ### Added

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -330,11 +330,13 @@ class DataArray(xr.DataArray):
 
             obj = self if assume_sorted else self.sortby(list(coords.keys()))
 
+            out_coords = {k: coords.get(k, obj.coords[k]) for k in obj.dims}
             points = tuple(obj.coords[k] for k in obj.dims)
-            xi = tuple(coords.get(k, obj.coords[k]) for k in obj.dims)
+            xi = tuple(out_coords.values())
+
             vals = interpn(points, obj.tracers, xi, method=method)
 
-            da = DataArray(vals, dict(obj.coords) | coords)  # tracers go into .attrs
+            da = DataArray(vals, out_coords)  # tracers go into .attrs
             if isbox(self.values.flat[0]):  # if tracing .values instead of .attrs
                 da = da.copy(deep=False, data=vals)  # copy over tracers
 


### PR DESCRIPTION
Fixes autograd interpolation failures due to incorrect ordering of coordinates after interpolation.