### PR TITLE
Fix CustomSourceTime with times completely outside envelope range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `DataArray` interpolation failure due to incorrect ordering of coordinates when interpolating with autograd tracers.
+- Error in `CustomSourceTime` when evaluating at a list of times entirely outside of the range of the envelope definition times.
 
 ## [2.7.2] - 2024-08-07
 

--- a/tests/test_components/test_source.py
+++ b/tests/test_components/test_source.py
@@ -307,7 +307,19 @@ def test_custom_source_time(log_capture):
         atol=ATOL,
     )
 
+    # all times out of range
+    _ = cst.amp_time([-1])
+    _ = cst.amp_time(-1)
+    assert np.allclose(cst.amp_time([2]), np.exp(-1j * 2 * np.pi * 2 * freq0), rtol=0, atol=ATOL)
+
     assert_log_level(log_capture, None)
+
+    vals = td.components.data.data_array.TimeDataArray([1, 2], coords=dict(t=[-1, -0.5]))
+    dataset = td.components.data.dataset.TimeDataset(values=vals)
+    cst = td.CustomSourceTime(source_time_dataset=dataset, freq0=freq0, fwidth=0.1e12)
+    source = td.PointDipole(center=(0, 0, 0), source_time=cst, polarization="Ex")
+    with AssertLogLevel(log_capture, "WARNING", contains_str="defined over a time range"):
+        sim = sim.updated_copy(sources=[source])
 
     # test normalization warning
     with AssertLogLevel(log_capture, "WARNING"):

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -3161,6 +3161,24 @@ class Simulation(AbstractYeeGridSimulation):
         self._validate_no_structures_pml()
         self._validate_tfsf_nonuniform_grid()
         self._validate_nonlinear_specs()
+        self._validate_custom_source_time()
+
+    def _validate_custom_source_time(self):
+        """Warn if all simulation times are outside CustomSourceTime definition range."""
+        run_time = self._run_time
+        for idx, source in enumerate(self.sources):
+            if isinstance(source.source_time, CustomSourceTime):
+                if source.source_time._all_outside_range(run_time=run_time):
+                    data_times = source.source_time.data_times
+                    mint = np.min(data_times)
+                    maxt = np.max(data_times)
+                    log.warning(
+                        f"'CustomSourceTime' at 'sources[{idx}]' is defined over a time range "
+                        f"'({mint}, {maxt})' which does not include any of the 'Simulation' "
+                        f"times '({0, run_time})'. The envelope will be constant extrapolated "
+                        "from the first or last value in the 'CustomSourceTime', which may not "
+                        "be the desired outcome."
+                    )
 
     def _validate_no_structures_pml(self) -> None:
         """Ensure no structures terminate / have bounds inside of PML."""


### PR DESCRIPTION
Fixes this issue:
https://github.com/flexcompute/tidy3d/issues/1899

The behavior of CustomSourceTime is to interpolate for times within the envelope definition time range, and use nearest selection for times outside the envelope definition time range. When evaluating at a list of times which is completely outside the envelope definition time range, xarray.interp fails, because we pass it an empty list. This PR checks separately for this case, when no interpolation is needed.