### PR TITLE
Fixed invalid s-parameters from wave port.

### DIFF
--- a/tests/test_plugins/smatrix/terminal_component_modeler_def.py
+++ b/tests/test_plugins/smatrix/terminal_component_modeler_def.py
@@ -295,7 +295,7 @@ def make_coaxial_component_modeler(
                     radius=mean_radius,
                     num_points=41,
                     normal_axis=2,
-                    clockwise=False,
+                    clockwise=direction != "+",
                 ),
             )
         return port

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -32,6 +32,12 @@ def run_component_modeler(monkeypatch, modeler: TerminalComponentModeler):
         "_compute_F",
         lambda matrix: 1.0 / (2.0 * np.sqrt(np.abs(matrix) + 1e-4)),
     )
+    monkeypatch.setattr(
+        TerminalComponentModeler,
+        "_check_port_impedance_sign",
+        lambda self, Z_numpy: (),
+    )
+
     s_matrix = modeler._construct_smatrix()
     return s_matrix
 
@@ -547,3 +553,12 @@ def test_port_source_snapped_to_PML(tmp_path):
 
     with pytest.raises(SetupError):
         modeler._shift_value_signed(port)
+
+
+def test_wave_port_validate_current_integral(tmp_path):
+    """Checks that the current integral direction validator runs correctly."""
+    modeler = make_coaxial_component_modeler(
+        path_dir=str(tmp_path), port_types=(WavePort, WavePort)
+    )
+    with pytest.raises(pydantic.ValidationError):
+        _ = modeler.updated_copy(direction="-", path="ports/0/")

--- a/tidy3d/plugins/smatrix/ports/wave.py
+++ b/tidy3d/plugins/smatrix/ports/wave.py
@@ -15,7 +15,11 @@ from ....components.simulation import Simulation
 from ....components.source import GaussianPulse, ModeSource, ModeSpec
 from ....components.types import Bound, Direction, FreqArray
 from ....exceptions import ValidationError
-from ...microwave import CurrentIntegralTypes, ImpedanceCalculator, VoltageIntegralTypes
+from ...microwave import (
+    CurrentIntegralTypes,
+    ImpedanceCalculator,
+    VoltageIntegralTypes,
+)
 from ...mode import ModeSolver
 from .base_terminal import AbstractTerminalPort
 
@@ -183,5 +187,21 @@ class WavePort(AbstractTerminalPort, Box):
         if not values.get("voltage_integral") and not val:
             raise ValidationError(
                 "At least one of 'voltage_integral' or 'current_integral' must be provided."
+            )
+        return val
+
+    @pd.validator("current_integral", always=True)
+    def validate_current_integral_sign(cls, val, values):
+        """
+        Validate that the sign of ``current_integral`` matches the port direction.
+        """
+        if val is None:
+            return val
+
+        direction = values.get("direction")
+        name = values.get("name")
+        if val.sign != direction:
+            raise ValidationError(
+                f"'current_integral' sign must match the '{name}' direction '{direction}'."
             )
         return val


### PR DESCRIPTION
S-matrix is defined by:
![CodeCogsEqn](https://github.com/user-attachments/assets/bdb82253-02bb-48fe-94ea-aa10ddbb49e1)

where I is the current flows **into** the port, so I here introduced a invalidator to throw an error if the integral sign of `CurrentIntegralAxisAligned` doesn't match the port's direction.  In the subsequent S-matrix computation, if the voltage path is inversely chosen, it results in a negative Z_R, leading to invalid S-matrix. To address this, we now flip the sign where a negative Z_R occurs, which corresponds to where a negative voltage is given. This yields the correct S-matrix.