### PR TITLE
Updated the medium intersection validator to handle 2D projection monitors without raising errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Stopped raising error when field projection monitor intersecting structures outside of the simulation domain.
+
 ## [2.7.3] - 2024-09-12
 
 ### Added

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -2977,3 +2977,35 @@ def test_validate_sources_monitors_in_bounds():
             grid_spec=td.GridSpec(wavelength=1.0),
             monitors=[mode_monitor],
         )
+
+
+def test_2d_projection_monitor_out_sim_domain():
+    # set up a structure interset with far field monitor outside the computational domain
+    cylinder = td.Structure(
+        geometry=td.Cylinder(axis=2, radius=0.5, length=2), medium=td.PECMedium()
+    )
+
+    num_phi = 100
+    theta = np.pi / 2
+    phis = np.linspace(0, np.pi, num_phi)
+    monitor_far = td.FieldProjectionAngleMonitor(
+        size=[2, 2, 0.5],
+        freqs=[1e12],
+        name="far_field",
+        theta=theta,
+        phi=phis,
+    )
+
+    sim2d = td.Simulation(
+        size=(4, 4, 0),
+        run_time=1e-12,
+        grid_spec=td.GridSpec.uniform(dl=0.025),
+        sources=[],
+        structures=[cylinder],
+        monitors=[monitor_far],
+        boundary_spec=td.BoundarySpec(
+            x=td.Boundary.pml(),
+            y=td.Boundary.pml(),
+            z=td.Boundary.periodic(),
+        ),
+    )


### PR DESCRIPTION
I updated the `_projection_monitors_homogeneous` validator to handle the error of medium intersections outside the computational domain in 2D simulations. The original validator checks if each face of a projection monitor intersects more than one medium. In 2D simulations, this was generating errors when faces normal to the 0-dim direction were included in the validation, which is not necessary. I removed those unnecessary faces accordingly for 2d simulations to avoid such errors.