### PR TITLE
Dilation support for `JaxPolySlab`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added value_and_grad function to the autograd plugin, importable via `from tidy3d.plugins.autograd import value_and_grad`. Supports differentiating functions with auxiliary data (`value_and_grad(f, has_aux=True)`).
 - `Simulation.num_computational_grid_points` property to examine the number of grid cells that compose the computational domain corresponding to the simulation. This can differ from `Simulation.num_cells` based on boundary conditions and symmetries.
- 
+- Support for `dilation` argument in `JaxPolySlab`.
+
 ### Fixed
 - `DataArray` interpolation failure due to incorrect ordering of coordinates when interpolating with autograd tracers.
 - Error in `CustomSourceTime` when evaluating at a list of times entirely outside of the range of the envelope definition times.
-
-### Fixed
 - Improved passivity enforcement near high-Q poles in `FastDispersionFitter`. Failed passivity enforcement could lead to simulation divergences.
 
 ## [2.7.2] - 2024-08-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Simulation.num_computational_grid_points` property to examine the number of grid cells that compose the computational domain corresponding to the simulation. This can differ from `Simulation.num_cells` based on boundary conditions and symmetries.
 - Support for `dilation` argument in `JaxPolySlab`.
 
+### Changed
+- `PolySlab` now raises error when differentiating and dilation causes damage to the polygon.
+
 ### Fixed
 - `DataArray` interpolation failure due to incorrect ordering of coordinates when interpolating with autograd tracers.
 - Error in `CustomSourceTime` when evaluating at a list of times entirely outside of the range of the envelope definition times.

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -10,6 +10,7 @@ import autograd.numpy as np
 import pydantic.v1 as pydantic
 import shapely
 import xarray as xr
+from autograd.tracer import isbox
 from matplotlib import path
 
 from ...constants import LARGE_NUMBER, MICROMETER, fp_eps
@@ -1316,6 +1317,13 @@ class PolySlab(base.Planar):
         shapely_poly = PolySlab.make_shapely_polygon(vertices)
         if shapely_poly.is_valid:
             return vertices
+        elif isbox(vertices):
+            raise NotImplementedError(
+                "The dilation caused damage to the polygon. "
+                "Automatically healing this is currently not supported when "
+                "differentiating w.r.t. the vertices. Try increasing the spacing "
+                "between vertices or reduce the amount of dilation."
+            )
         # perform healing
         poly_heal = shapely.make_valid(shapely_poly)
         return PolySlab._proper_vertices(list(poly_heal.exterior.coords))


### PR DESCRIPTION
Adds basic support for `dilation` argument in `JaxPolySlab`.

This also enables differentiation w.r.t. dilation, but note that this currently only works if no sidewall angle is present (see tests). Actually differentiating w.r.t. everything works (i.e., `dilation`, `sidewall_angle`, and `slab_bounds`) as long as there is no / very little sidewall angle.