### PR TITLE
Only warn once per structure into PML to avoid duplicate warnings

### DIFF
--- a/tests/test_package/test_log.py
+++ b/tests/test_package/test_log.py
@@ -129,7 +129,7 @@ def test_logging_warning_capture():
         medium=td.Medium(permittivity=2, frequency_range=[0.5, 1]),
     )
 
-    # 2 warnings: inside pml
+    # 1 warning: inside pml
     box_in_pml = td.Structure(
         geometry=td.Box(center=(0, 0, 0), size=(domain_size * 1.001, 5, 5)),
         medium=td.Medium(permittivity=10),
@@ -216,7 +216,7 @@ def test_logging_warning_capture():
     sim.validate_pre_upload()
     warning_list = td.log.captured_warnings()
     print(json.dumps(warning_list, indent=4))
-    assert len(warning_list) == 32
+    assert len(warning_list) == 31
     td.log.set_capture(False)
 
     # check that capture doesn't change validation errors

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -3190,6 +3190,7 @@ class Simulation(AbstractYeeGridSimulation):
         with log as consolidated_logger:
             for i, structure in enumerate(self.structures):
                 geo_bounds = structure.geometry.bounds
+                warn = False  # will only warn once per structure
                 for sim_bound, geo_bound, pml_thick, bound_dim, pm_val in zip(
                     sim_bounds, geo_bounds, pml_thicks, bound_spec, (-1, 1)
                 ):
@@ -3200,14 +3201,16 @@ class Simulation(AbstractYeeGridSimulation):
                         in_pml_plus = (pm_val > 0) and (sim_pos < geo_pos <= sim_pos_pml)
                         in_pml_mnus = (pm_val < 0) and (sim_pos > geo_pos >= sim_pos_pml)
                         if not isinstance(bound_edge, Absorber) and (in_pml_plus or in_pml_mnus):
-                            consolidated_logger.warning(
-                                f"A bound of Simulation.structures[{i}] was detected as being "
-                                "within the simulation PML. We recommend extending structures to "
-                                "infinity or completely outside of the simulation PML to avoid "
-                                "unexpected effects when the structures are not translationally "
-                                "invariant within the PML.",
-                                custom_loc=["structures", i],
-                            )
+                            warn = True
+                if warn:
+                    consolidated_logger.warning(
+                        f"A bound of Simulation.structures[{i}] was detected as being "
+                        "within the simulation PML. We recommend extending structures to "
+                        "infinity or completely outside of the simulation PML to avoid "
+                        "unexpected effects when the structures are not translationally "
+                        "invariant within the PML.",
+                        custom_loc=["structures", i],
+                    )
 
     def _validate_tfsf_nonuniform_grid(self) -> None:
         """Warn if the grid is nonuniform along the directions tangential to the injection plane,


### PR DESCRIPTION
This was brought up by MC, a structure that touches the PML on multiple sides would raise multiple identical warnings. One option would be to include more information in the warning but to avoid verbosity I went the opposite way of just issuing one warning per structure.