### PR TITLE
More autograd improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validators using `TriangleMesh.intersections_plane` will fall back on bounding box in case the method fails for a non-watertight mesh.
 - Bug when running the same `ModeSolver` first locally then remotely, or vice versa, in which case the cached data from the first run is always returned.
 - Gradient monitors for `PolySlab` only store fields at the center location along axis, reducing data usage.
+- Validate the forward simulation on the client side even when using `local_gradient=False` for server-side gradient processing.
 
 ## [2.7.1] - 2024-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error when plotting mode plane PML and the simulation has symmetry.
 - Validators using `TriangleMesh.intersections_plane` will fall back on bounding box in case the method fails for a non-watertight mesh.
 - Bug when running the same `ModeSolver` first locally then remotely, or vice versa, in which case the cached data from the first run is always returned.
+- Gradient monitors for `PolySlab` only store fields at the center location along axis, reducing data usage.
 
 ## [2.7.1] - 2024-07-10
 

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -1074,6 +1074,14 @@ class SimulationData(AbstractYeeGridSimulationData):
             )
             sources_adj_all[mnt_data.monitor.name] = sources_adj
 
+        if not sources_adj_all:
+            raise ValueError(
+                "No adjoint sources created for this simulation. "
+                "This could indicate a bug in your setup, for example the objective function "
+                "output depending on a monitor that is not supported. If you encounter this error, "
+                "please examine your set up or contact customer support if you need more help."
+            )
+
         return sources_adj_all
 
     @property

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -388,12 +388,14 @@ def _run_primitive(
 
     td.log.info("running primitive '_run_primitive()'")
 
+    # compute the combined simulation for both local and remote, so we can validate it
+    sim_combined = setup_fwd(
+        sim_fields=sim_fields,
+        sim_original=sim_original,
+        local_gradient=local_gradient,
+    )
+
     if local_gradient:
-        sim_combined = setup_fwd(
-            sim_fields=sim_fields,
-            sim_original=sim_original,
-            local_gradient=local_gradient,
-        )
         sim_data_combined, _ = _run_tidy3d(sim_combined, task_name=task_name, **run_kwargs)
 
         field_map = postprocess_fwd(


### PR DESCRIPTION
Introduces a set of additional improvements to autograd plugin:
1. PolySlab grad monitor data is only stored on the plane where needed.
2. Validate FWD sim, even when it's a server-side run.
3. Properly handle error if no adjoint sources are present and add a more useful fix.

Let me know if you'd like this merged int https://github.com/flexcompute/tidy3d/pull/1891 for one PR? But would be good to include both in a 2.7.3