### PR TITLE
added validator to error out Bloch boundaries in along 0-dim in 2D simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `PolySlab` now raises error when differentiating and dilation causes damage to the polygon.
+- Validator `boundaries_for_zero_dims` to raise error when Bloch boundaries are used along 0-sized dims.
 
 ### Fixed
 - `DataArray` interpolation failure due to incorrect ordering of coordinates when interpolating with autograd tracers.


### PR DESCRIPTION
2D simulations now only support PEC, PMC, and periodic boundaries. We raise an error for Bloch boundaries as we don't yet have a solution for them.