### PR TITLE
2nd round of autograd fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved passivity enforcement near high-Q poles in `FastDispersionFitter`. Failed passivity enforcement could lead to simulation divergences.
 - More helpful error and suggestion if users try to differentiate w.r.t. unsupported `FluxMonitor` output.
 - Removed positive warnings in Simulation validators for Bloch boundary conditions.
+- Improve accuracy in `Box` shifting boundary gradients.
+- Improve accuracy in `FieldData` operations involving H fields (like `.flux`).
+- Better error and warning handling in autograd pipeline.
 
 ## [2.7.2] - 2024-08-07
 

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -37,7 +37,7 @@ TEST_POLYSLAB_SPEED = False
 
 # whether to run numerical gradient tests, off by default because it runs real simulations
 RUN_NUMERICAL = False
-_NUMERICAL_COMBINATION = ("center_list", "mode")
+_NUMERICAL_COMBINATION = ("size_element", "mode")
 
 TEST_MODES = ("pipeline", "adjoint", "speed")
 TEST_MODE = "speed" if TEST_POLYSLAB_SPEED else "pipeline"
@@ -529,7 +529,7 @@ if TEST_POLYSLAB_SPEED:
     args = [("polyslab", "mode")]
 
 
-args = [("size_element", "mode")]
+# args = [("size_element", "mode")]
 
 
 def get_functions(structure_key: str, monitor_key: str) -> typing.Callable:

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -37,6 +37,7 @@ TEST_POLYSLAB_SPEED = False
 
 # whether to run numerical gradient tests, off by default because it runs real simulations
 RUN_NUMERICAL = False
+_NUMERICAL_COMBINATION = ("center_list", "mode")
 
 TEST_MODES = ("pipeline", "adjoint", "speed")
 TEST_MODE = "speed" if TEST_POLYSLAB_SPEED else "pipeline"
@@ -528,7 +529,7 @@ if TEST_POLYSLAB_SPEED:
     args = [("polyslab", "mode")]
 
 
-# args = [("custom_med", "mode")]
+args = [("size_element", "mode")]
 
 
 def get_functions(structure_key: str, monitor_key: str) -> typing.Callable:
@@ -598,7 +599,7 @@ def test_polyslab_axis_ops(axis):
 
 
 @pytest.mark.skipif(not RUN_NUMERICAL, reason="Numerical gradient tests runs through web API.")
-@pytest.mark.parametrize("structure_key, monitor_key", (("medium", "field_vol"),))
+@pytest.mark.parametrize("structure_key, monitor_key", (_NUMERICAL_COMBINATION,))
 def test_autograd_numerical(structure_key, monitor_key):
     """Test an objective function through tidy3d autograd."""
 
@@ -622,7 +623,7 @@ def test_autograd_numerical(structure_key, monitor_key):
     assert anp.all(grad != 0.0), "some gradients are 0"
 
     # numerical gradients
-    delta = 1e-2
+    delta = 1e-3
     sims_numerical = {}
 
     params_num = np.zeros((N_PARAMS, N_PARAMS))

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -1749,7 +1749,7 @@ class ModeData(ModeSolverDataset, ElectromagneticFieldData):
         for name in dataset_names:
             if name == "amps":
                 adjoint_sources += self.make_adjoint_sources_amps(fwidth=fwidth)
-            else:
+            elif not np.all(self.n_complex.values == 0.0):
                 log.warning(
                     f"Can't create adjoint source for 'ModeData.{type(self)}.{name}'. "
                     f"for monitor '{self.monitor.name}'. "

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -46,7 +46,7 @@ RESIDUAL_CUTOFF_ADJOINT = 1e-6
 class AdjointSourceInfo(Tidy3dBaseModel):
     """Stores information about the adjoint sources to pass to autograd pipeline."""
 
-    sources: tuple[SourceType, ...] = pd.Field(
+    sources: Tuple[annotate_type(SourceType), ...] = pd.Field(
         ...,
         title="Adjoint Sources",
         description="Set of processed sources to include in the adjoint simulation.",
@@ -1117,6 +1117,9 @@ class SimulationData(AbstractYeeGridSimulationData):
             adj_srcs, post_norm = self.process_adjoint_sources_broadband(adj_srcs)
             return AdjointSourceInfo(sources=adj_srcs, post_norm=post_norm, normalize_sim=True)
 
+        import pdb
+
+        pdb.set_trace()
         # if several spatial ports and several frequencies, try to fit
         log.info("Adjoint source creation: trying multifrequency fit.")
         adj_srcs, post_norm = self.process_adjoint_sources_fit(

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -1074,7 +1074,7 @@ class SimulationData(AbstractYeeGridSimulationData):
             )
             sources_adj_all[mnt_data.monitor.name] = sources_adj
 
-        if not sources_adj_all:
+        if not any(src for _, src in sources_adj_all.items()):
             raise ValueError(
                 "No adjoint sources created for this simulation. "
                 "This could indicate a bug in your setup, for example the objective function "
@@ -1117,9 +1117,6 @@ class SimulationData(AbstractYeeGridSimulationData):
             adj_srcs, post_norm = self.process_adjoint_sources_broadband(adj_srcs)
             return AdjointSourceInfo(sources=adj_srcs, post_norm=post_norm, normalize_sim=True)
 
-        import pdb
-
-        pdb.set_trace()
         # if several spatial ports and several frequencies, try to fit
         log.info("Adjoint source creation: trying multifrequency fit.")
         adj_srcs, post_norm = self.process_adjoint_sources_fit(

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -2433,7 +2433,7 @@ class Box(SimplePlaneIntersection, Centered):
         eps_xyz = [derivative_info.eps_data[f"eps_{dim}{dim}"] for dim in "xyz"]
 
         # number of cells from the edge of data to register "inside" (index = num_cells_in - 1)
-        num_cells_in = 4
+        num_cells_in = 3
 
         # if not enough data, just use best guess using eps in medium and simulation
         needs_eps_approx = any(len(eps.coords[dim_normal]) <= num_cells_in for eps in eps_xyz)

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -2437,6 +2437,7 @@ class Box(SimplePlaneIntersection, Centered):
 
         # if not enough data, just use best guess using eps in medium and simulation
         needs_eps_approx = any(len(eps.coords[dim_normal]) <= num_cells_in for eps in eps_xyz)
+
         if derivative_info.eps_approx or needs_eps_approx:
             eps_xyz_inside = 3 * [derivative_info.eps_in]
             eps_xyz_outside = 3 * [derivative_info.eps_out]
@@ -2447,7 +2448,7 @@ class Box(SimplePlaneIntersection, Centered):
             if min_max_index == 0:
                 index_out, index_in = (0, num_cells_in - 1)
             else:
-                index_out, index_in = (-1, -num_cells_in - 1)
+                index_out, index_in = (-1, -num_cells_in)
             eps_xyz_inside = [eps.isel(**{dim_normal: index_in}) for eps in eps_xyz]
             eps_xyz_outside = [eps.isel(**{dim_normal: index_out}) for eps in eps_xyz]
 

--- a/tidy3d/plugins/autograd/README.md
+++ b/tidy3d/plugins/autograd/README.md
@@ -127,37 +127,35 @@ The following components are traceable as inputs to the `td.Simulation`
 - `CustomPoleResidue.eps_inf`
 - `CustomPoleResidue.poles`
 
+- `Cylinder.radius`
+- `Cylinder.center` (along non-axis dimensions)
+
+- `ComplexPolySlab.sub_polyslabs`
+
 The following components are traceable as outputs of the `td.SimulationData`
 
 - `ModeData.amps`
+
 - `DiffractionData.amps`
+
 - `FieldData.field_components`
-
-We currently have the following restrictions:
-
-- All monitors in the `Simulation` must be single frequency only.
-- Only 500 max structures containing tracers can be added to the `Simulation` to cut down on processing time. In the future, `GeometryGroup` support will allow us to relax this restriction.
-- `web.run_async` for simulations with tracers does not return a `BatchData` but rather a `dict` mapping task name to `SimulationData`. There may be high memory usage with many simulations or a lot of data for each.
-- Gradient calculations are done client-side, meaning the field data in the traced structure regions must be downloaded. This can be a large amount of data for large, 3D structures.
-
-### To be supported soon
-
-Next on our roadmap (targeting 2.8 and 2.9, summer 2024) is to support:
-
-- support for multi-frequency monitors in certain situations (single adjoint source).
-- server-side gradient processing.
-
 - `FieldData` operations:
   - `FieldData.flux`
   - `SimulationData.get_intensity`
   - `SimulationData.get_poynting`
 
-- `PoleResidue` and other dispersive models.
-- custom (spatially-dependent) dispersive models, allowing topology optimization with metals.
+Other features
+- support for multi-frequency monitors in certain situations (single adjoint source).
+- server-side gradient processing by passing `local_gradient=False` to the `web` functions. This can dramatically cut down on data storage time, just be careful about using this with multi-frequency monitors and large design regions as it can lead to large data storage on our servers.
 
-- `ComplexPolySlab`
+We currently have the following restrictions:
 
-Later this year (2024), we plan to support:
+- Only 500 max structures containing tracers can be added to the `Simulation` to cut down on processing time. To bypass this restriction, use `GeometryGroup` to group structures with the same medium.
+- `web.run_async` for simulations with tracers does not return a `BatchData` but rather a `dict` mapping task name to `SimulationData`. There may be high memory usage with many simulations or a lot of data for each.
+
+### To be supported soon
+
+Next on our roadmap (targeting 2.8 and 2.9, fall 2024) is to support:
 
 - `TriangleMesh`.
 - `GUI` integration of invdes plugin.

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -738,6 +738,8 @@ def setup_adj(
     # immediately filter out any data_vjps with all 0's in the data
     data_fields_vjp = {key: get_static(value) for key, value in data_fields_vjp.items()}
 
+    # import pdb; pdb.set_trace()
+
     # insert the raw VJP data into the .data of the original SimulationData
     sim_data_vjp = sim_data_orig.insert_traced_fields(field_mapping=data_fields_vjp)
 

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -738,8 +738,6 @@ def setup_adj(
     # immediately filter out any data_vjps with all 0's in the data
     data_fields_vjp = {key: get_static(value) for key, value in data_fields_vjp.items()}
 
-    # import pdb; pdb.set_trace()
-
     # insert the raw VJP data into the .data of the original SimulationData
     sim_data_vjp = sim_data_orig.insert_traced_fields(field_mapping=data_fields_vjp)
 


### PR DESCRIPTION
* some adjoint source fixes for FieldData involving H fields.
* better gradients for Box shifting boundaries based on permittivity.
* re-introduce automatic permittivity grabbing for geometry group shifting boundaries.
* better error and warning handling across the board.
* adds a way to visualize adjoint fields (only for development purposes currently, no public API).