### PR TITLE
Bump to xarray>=2023.08.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2708,8 +2708,8 @@ files = [
 numpy = [
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
     {version = ">=1.23.3", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
-    {version = ">1.20", markers = "python_version < \"3.10\""},
     {version = ">=1.21.2", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
+    {version = ">1.20", markers = "python_version < \"3.10\""},
 ]
 
 [package.extras]
@@ -5648,4 +5648,4 @@ vtk = ["vtk"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0.0"
-content-hash = "76d051e2e954bfa37a76c515fb60f38bf8a85605aed6bfd6288b1d1e30138ec2"
+content-hash = "d1e2bc786fd54b77adb7536b3ef62341ed299eab8afb765a23eacb10ebbea707"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ documentation = "https://docs.flexcompute.com/projects/tidy3d/en/latest/"
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0.0"
 pyroots = ">=0.5.0"
-xarray = ">=0.16.2"
+xarray = ">=2023.08.0"
 importlib-metadata = ">=6.0.0"
 h5netcdf = "1.0.2"
 h5py = "^3.0.0"


### PR DESCRIPTION
Need to bump xarray because we depend on `xr.DataArray.coords.copy()` quite a bit, which is not implemented for `xarray<2023.08.0`. A user encountered this error because they were using an older xarray version.

This technically is a bug that exists across most previous releases, not sure how this would be handled (i.e., where is this supposed to get merged into?).