### PR TITLE
add the num_freqs arg to .to_source methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve accuracy in `Box` shifting boundary gradients.
 - Improve accuracy in `FieldData` operations involving H fields (like `.flux`).
 - Better error and warning handling in autograd pipeline.
+- Added the option to specify the `num_freqs` argument and `kwargs` to the `.to_source` method for both `ModeSolver` and `ComponentModeler`. 
 
 ## [2.7.2] - 2024-08-07
 

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -936,6 +936,8 @@ class ModeSolver(Tidy3dBaseModel):
         source_time: SourceTime,
         direction: Direction = None,
         mode_index: pydantic.NonNegativeInt = 0,
+        num_freqs: pydantic.PositiveInt = 1,
+        **kwargs,
     ) -> ModeSource:
         """Creates :class:`.ModeSource` from a :class:`ModeSolver` instance plus additional
         specifications.
@@ -967,6 +969,8 @@ class ModeSolver(Tidy3dBaseModel):
             mode_spec=self.mode_spec,
             mode_index=mode_index,
             direction=direction,
+            num_freqs=num_freqs,
+            **kwargs,
         )
 
     def to_monitor(self, freqs: List[float] = None, name: str = None) -> ModeMonitor:

--- a/tidy3d/plugins/smatrix/component_modelers/modal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/modal.py
@@ -179,7 +179,9 @@ class ComponentModeler(AbstractComponentModeler):
             name=port.name,
         )
 
-    def to_source(self, port: Port, mode_index: int) -> List[ModeSource]:
+    def to_source(
+        self, port: Port, mode_index: int, num_freqs: int = 1, **kwargs
+    ) -> List[ModeSource]:
         """Creates a list of mode sources from a given port."""
         freq0 = np.mean(self.freqs)
         fdiff = max(self.freqs) - min(self.freqs)
@@ -192,6 +194,8 @@ class ComponentModeler(AbstractComponentModeler):
             mode_index=mode_index,
             direction=port.direction,
             name=port.name,
+            num_freqs=num_freqs,
+            **kwargs,
         )
 
     def _shift_value_signed(self, port: Port) -> float:


### PR DESCRIPTION
Hi @tylerflex.
I am opening the PR to fix #1926.

I just added the `num_freqs` argument to the `.to_source` method for the `ModeSolve` and `ComponentModeler`.
I added it with the default value of 1.

I added only you as a reviewer only because it seems quite simple.

Thank you