### PR TITLE
Enabled kspace projection for 2D simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `PolySlab` now raises error when differentiating and dilation causes damage to the polygon.
 - Validator `boundaries_for_zero_dims` to raise error when Bloch boundaries are used along 0-sized dims.
+- `FieldProjectionKSpaceMonitor` support for 2D simulations with `far_field_approx = True`. 
 
 ### Fixed
 - `DataArray` interpolation failure due to incorrect ordering of coordinates when interpolating with autograd tracers.

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -986,11 +986,11 @@ class Geometry(Tidy3dBaseModel, ABC):
             return theta_local, phi_local
 
         x = np.cos(theta_local)
-        y = np.sin(theta_local) * np.sin(phi_local)
-        z = -np.sin(theta_local) * np.cos(phi_local)
+        y = np.sin(theta_local) * np.cos(phi_local)
+        z = np.sin(theta_local) * np.sin(phi_local)
 
         if axis == 1:
-            x, y, z = -z, x, -y
+            x, y, z = y, x, z
 
         theta = np.arccos(z)
         phi = np.arctan2(y, x)


### PR DESCRIPTION
Updated the frontend validator ` _projection_mnts_2d` to enable k-space projection in 2D simulations. Also corrected `kspace_2_sph`.