### PR TITLE
Silence graphene warning from checking fit at high freq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug when adding 2D structures to the `Simulation` that are composed of multiple overlapping polygons.
 - Fields stored in `ModeMonitor` objects were computed colocated to the grid boundaries, but the built-in `ModeMonitor.colocate=False` was resulting in wrong results in some cases, most notably if symmetries are also involved.
 - Small inaccuracy when applying a mode solver `bend_radius` when the simulation grid is not symmetric w.r.t. the mode plane center. Previously, the radius was defined w.r.t. the middle grid coordinate, while now it is correctly applied w.r.t. the plane center.
+- Silence warning in graphene from checking fit quality at large frequencies.
 
 ## [2.7.2] - 2024-08-07
 

--- a/tests/test_package/test_parametric_variants.py
+++ b/tests/test_package/test_parametric_variants.py
@@ -9,6 +9,8 @@ from tidy3d.material_library.parametric_materials import (
     Graphene,
 )
 
+from ..utils import AssertLogLevel
+
 # bounds for MU_C
 GRAPHENE_MU_C_MIN = 0
 GRAPHENE_MU_C_MAX = 3
@@ -56,3 +58,10 @@ def test_graphene(rng_seed, log_capture):
     sigma1 = graphene.medium.sigma_model(freqs)
     sigma2 = graphene.intraband_drude.sigma_model(freqs)
     assert np.allclose(sigma1, sigma2, rtol=0, atol=GRAPHENE_FIT_ATOL)
+
+    gamma = 10 / 8065.54429
+    temp = 300
+    mu_c = 0.55
+
+    with AssertLogLevel(log_capture, None):
+        _ = Graphene(gamma=gamma, mu_c=mu_c, temp=temp).medium

--- a/tidy3d/material_library/parametric_materials.py
+++ b/tidy3d/material_library/parametric_materials.py
@@ -191,7 +191,8 @@ class Graphene(ParametricVariantItem2D):
 
         pole_residue = self._fit_interband_conductivity(flattened_freqs, sigma_inds, inds)
         pole_residue_filtered = self._filter_poles(pole_residue)
-        sigma_fit = pole_residue_filtered.sigma_model(freqs)
+        # silence warnings associated with frequency range just for checking fit
+        sigma_fit = pole_residue_filtered.updated_copy(frequency_range=None).sigma_model(freqs)
         if not np.allclose(sigma, sigma_fit, rtol=0, atol=GRAPHENE_FIT_ATOL):
             log.warning(
                 "Graphene fit may not be good. Try changing the physical or fitting parameters."


### PR DESCRIPTION
Graphene gave a warning sometimes because it was fitting and checking the fit at high frequencies (higher than supported in the `PoleResidue.frequency_range`). This PR just overrides the frequency range temporarily for fit quality checking purposes, without changing the returned medium.