### PR TITLE
fixed bug that replaced all lumped elements in simulations, when using TerminalComponentModeler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Significant speedup for field projection computations.
 - Fix numerical precision issue in `FieldProjectionCartesianMonitor`.
+- Bug where lumped elements in the `Simulation` were being overwritten by the `TerminalComponentModeler`.
 
 ## [2.7.2] - 2024-08-07
 

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -132,13 +132,13 @@ class TerminalComponentModeler(AbstractComponentModeler):
 
         new_mnts = list(self.simulation.monitors) + field_monitors
 
-        lumped_resistors = [
+        new_lumped_elements = list(self.simulation.lumped_elements) + [
             port.to_load(snap_center=snap_centers[port.name]) for port in self._lumped_ports
         ]
 
         update_dict = dict(
             monitors=new_mnts,
-            lumped_elements=lumped_resistors,
+            lumped_elements=new_lumped_elements,
         )
 
         # This is the new default simulation will all shared components added


### PR DESCRIPTION
Just had to copy any existing lumped elements before adding loads from the ports.