### PR TITLE
Fixed angle simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added mode solver option `precision='auto'` to automatically select single or double precision for optimizing performance and accuracy.
 - Added `LinearLumpedElement` as a new supported `LumpedElement` type. This enhancement allows for the modeling of two-terminal passive networks, which can include any configuration of resistors, inductors, and capacitors, within the `Simulation`. Simple RLC networks are described using `RLCNetwork`, while more complex networks can be represented by their admittance transfer function through `AdmittanceNetwork`.
 - Option for the `ModeSolver` and `ModeSolverMonitor` to store only a subset of field components.
+- Added an option to simulate plane wave propagation at fixed angles by setting parameter `angular_spec=FixedAngleSpec()` when defining a `PlaneWave` source.
 
 ### Changed
 - Priority is given to `snapping_points` in `GridSpec` when close to structure boundaries, which reduces the chance of them being skipped.

--- a/docs/api/sources.rst
+++ b/docs/api/sources.rst
@@ -32,3 +32,14 @@ Source Time Dependence
    tidy3d.GaussianPulse
    tidy3d.ContinuousWave
    tidy3d.CustomSourceTime
+
+
+Angled Plane Wave Specifications
+--------------------------------
+
+.. autosummary::
+   :toctree: _autosummary/
+   :template: module.rst
+
+   tidy3d.FixedInPlaneK
+   tidy3d.FixedAngle

--- a/tests/_test_local/_test_data_performance.py
+++ b/tests/_test_local/_test_data_performance.py
@@ -10,7 +10,8 @@ from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.grid.grid_spec import GridSpec
 from tidy3d.components.monitor import FieldMonitor
 from tidy3d.components.simulation import Simulation
-from tidy3d.components.source import GaussianPulse, PointDipole
+from tidy3d.components.source.current import PointDipole
+from tidy3d.components.source.time import GaussianPulse
 
 sys.path.append("/users/twhughes/Documents/Flexcompute/tidy3d-core")
 from tidy3d_backend.utils import Profile

--- a/tests/test_components/test_boundaries.py
+++ b/tests/test_components/test_boundaries.py
@@ -14,7 +14,9 @@ from tidy3d.components.boundary import (
     PMCBoundary,
     StablePML,
 )
-from tidy3d.components.source import GaussianPulse, PlaneWave, PointDipole
+from tidy3d.components.source.current import PointDipole
+from tidy3d.components.source.field import PlaneWave
+from tidy3d.components.source.time import GaussianPulse
 from tidy3d.exceptions import DataError, SetupError
 
 from ..utils import assert_log_level

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -814,6 +814,7 @@ def test_nyquist():
         frequency_range = (-2, -1)
         monitors = ()
         _cached_properties = {}
+        _fixed_angle_sources = ()
 
     m = MockSim()
     assert td.Simulation.nyquist_step.fget(m) == 1
@@ -3027,3 +3028,96 @@ def test_validate_sources_monitors_in_bounds():
             grid_spec=td.GridSpec(wavelength=1.0),
             monitors=[mode_monitor],
         )
+
+
+def test_fixed_angle_sim():
+    wvl_um = 1.0
+    freq0 = td.C_0 / wvl_um
+    fwidth = freq0 / 5
+
+    freqs = freq0 + 0.5 * fwidth * np.linspace(-1, 1, 11)
+    med = td.Medium(permittivity=5)
+    sphere = td.Structure(
+        geometry=td.Sphere(radius=0.5),
+        medium=med,
+    )
+    flux_r_mnt = td.FluxMonitor(
+        center=(-1, 0, 0), size=(0, td.inf, td.inf), freqs=freqs, name="flux_r"
+    )
+    source = td.PlaneWave(
+        angle_phi=np.pi / 6,
+        angle_theta=np.pi / 5,
+        angular_spec=td.FixedAngleSpec(),
+        direction="+",
+        center=(-0.9, 0, 0),
+        size=(0, td.inf, td.inf),
+        pol_angle=np.pi / 4,
+        source_time=td.GaussianPulse(freq0=freq0, fwidth=fwidth),
+    )
+    sim_size = (2.2, 2.2, 2.2)
+    sim = td.Simulation(
+        structures=[sphere],
+        sources=[source],
+        monitors=[flux_r_mnt],
+        size=sim_size,
+        grid_spec=td.GridSpec.auto(min_steps_per_wvl=15),
+        boundary_spec=td.BoundarySpec(
+            x=td.Boundary.absorber(), y=td.Boundary.periodic(), z=td.Boundary.periodic()
+        ),
+        run_time=10 / fwidth,
+    )
+
+    assert sim._is_fixed_angle
+
+    with pytest.raises(pydantic.ValidationError):
+        _ = sim.updated_copy(
+            boundary_spec=td.BoundarySpec(
+                x=td.Boundary.pml(),
+                y=td.Boundary.bloch_from_source(source=source, axis=1, domain_size=2.2),
+                z=td.Boundary.bloch_from_source(source=source, axis=2, domain_size=2.2),
+            )
+        )
+
+    with pytest.raises(pydantic.ValidationError):
+        _ = sim.updated_copy(med=td.Medium(conductivity=0.001))
+
+    anisotropic_med = td.FullyAnisotropicMedium(permittivity=[[2, 0, 0], [0, 1, 0], [0, 0, 3]])
+    with pytest.raises(pydantic.ValidationError):
+        _ = sim.updated_copy(structures=[sphere.updated_copy(medium=anisotropic_med)])
+
+    with pytest.raises(pydantic.ValidationError):
+        _ = sim.updated_copy(sources=[source, source])
+
+    with pytest.raises(pydantic.ValidationError):
+        _ = sim.updated_copy(
+            structures=[sphere.updated_copy(medium=td.Medium(conductivity=-0.1, allow_gain=True))]
+        )
+
+    with pytest.raises(pydantic.ValidationError):
+        _ = sim.updated_copy(monitors=[td.FieldTimeMonitor(size=[td.inf, td.inf, 0], name="time")])
+
+    with pytest.raises(pydantic.ValidationError):
+        _ = sim.updated_copy(monitors=[td.FluxTimeMonitor(size=[td.inf, td.inf, 0], name="time")])
+
+    nonlinear_med = td.Medium(
+        permittivity=3,
+        nonlinear_spec=td.NonlinearSpec(
+            models=[
+                td.KerrNonlinearity(n2=-1 + 1j, n0=1),
+            ],
+            num_iters=20,
+        ),
+    )
+    with pytest.raises(pydantic.ValidationError):
+        _ = sim.updated_copy(structures=[sphere.updated_copy(medium=nonlinear_med)])
+
+    time_modulated_med = td.Medium(
+        permittivity=2,
+        modulation_spec=td.ModulationSpec(
+            permittivity=td.SpaceTimeModulation(
+                time_modulation=td.ContinuousWaveTimeModulation(freq0=td.C_0, amplitude=1, phase=0),
+            )
+        ),
+    )
+    with pytest.raises(pydantic.ValidationError):
+        _ = sim.updated_copy(structures=[sphere.updated_copy(medium=time_modulated_med)])

--- a/tests/test_components/test_source.py
+++ b/tests/test_components/test_source.py
@@ -5,7 +5,7 @@ import numpy as np
 import pydantic.v1 as pydantic
 import pytest
 import tidy3d as td
-from tidy3d.components.source import CHEB_GRID_WIDTH, DirectionalSource
+from tidy3d.components.source.field import CHEB_GRID_WIDTH, DirectionalSource
 from tidy3d.exceptions import SetupError
 
 from ..utils import AssertLogLevel, assert_log_level
@@ -79,7 +79,7 @@ def test_source_times():
     # plt.close()
 
     # test we can make cw pulse
-    from tidy3d.components.source import ContinuousWave
+    from tidy3d.components.source.time import ContinuousWave
 
     c = ContinuousWave(freq0=1e12, fwidth=0.1e12)
     c.amp_time(ts)

--- a/tests/test_components/test_source.py
+++ b/tests/test_components/test_source.py
@@ -379,3 +379,41 @@ def test_custom_field_source(log_capture):
         n_dataset2 = td.ScalarFieldDataArray(n_data2, coords=dict(x=X2, y=Y, z=Z, f=freqs))
         field_dataset = td.FieldDataset(Ex=n_dataset, Hy=n_dataset2)
         make_custom_field_source(field_dataset)
+
+
+def test_fixed_angle_source():
+    plane_wave = td.PlaneWave(
+        size=(0, td.inf, td.inf),
+        direction="+",
+        angle_theta=np.pi / 6,
+        angle_phi=np.pi / 4,
+        pol_angle=np.pi / 5,
+        source_time=td.GaussianPulse(freq0=td.C_0, fwidth=0.2 * td.C_0),
+        angular_spec=td.FixedInPlaneKSpec(),
+    )
+
+    assert not plane_wave._is_fixed_angle
+
+    plane_wave = td.PlaneWave(
+        size=(0, td.inf, td.inf),
+        direction="+",
+        angle_theta=np.pi / 6,
+        angle_phi=np.pi / 4,
+        pol_angle=np.pi / 5,
+        source_time=td.GaussianPulse(freq0=td.C_0, fwidth=0.2 * td.C_0),
+        angular_spec=td.FixedAngleSpec(),
+    )
+
+    assert plane_wave._is_fixed_angle
+
+    plane_wave = td.PlaneWave(
+        size=(0, td.inf, td.inf),
+        direction="+",
+        angle_theta=0,
+        angle_phi=np.pi / 4,
+        pol_angle=np.pi / 5,
+        source_time=td.GaussianPulse(freq0=td.C_0, fwidth=0.2 * td.C_0),
+        angular_spec=td.FixedAngleSpec(),
+    )
+
+    assert not plane_wave._is_fixed_angle

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -13,7 +13,8 @@ from tidy3d.components.data.monitor_data import FieldData
 from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.grid.grid_spec import GridSpec
 from tidy3d.components.monitor import FieldMonitor
-from tidy3d.components.source import GaussianPulse, PointDipole
+from tidy3d.components.source.current import PointDipole
+from tidy3d.components.source.time import GaussianPulse
 from tidy3d.exceptions import SetupError
 from tidy3d.web.api.asynchronous import run_async
 from tidy3d.web.api.container import Batch, Job

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -248,6 +248,8 @@ from .components.source import (
     CustomCurrentSource,
     CustomFieldSource,
     CustomSourceTime,
+    FixedAngleSpec,
+    FixedInPlaneKSpec,
     GaussianBeam,
     GaussianPulse,
     ModeSource,
@@ -559,4 +561,6 @@ __all__ = [
     "EMELengthSweep",
     "EMEModeSweep",
     "EMEFreqSweep",
+    "FixedAngleSpec",
+    "FixedInPlaneKSpec",
 ]

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -239,25 +239,29 @@ from .components.scene import Scene
 
 # simulation
 from .components.simulation import Simulation
-
-# sources
-from .components.source import (
+from .components.source.base import Source
+from .components.source.current import (
+    CustomCurrentSource,
+    PointDipole,
+    UniformCurrentSource,
+)
+from .components.source.field import (
     TFSF,
     AstigmaticGaussianBeam,
-    ContinuousWave,
-    CustomCurrentSource,
     CustomFieldSource,
-    CustomSourceTime,
     FixedAngleSpec,
     FixedInPlaneKSpec,
     GaussianBeam,
-    GaussianPulse,
     ModeSource,
     PlaneWave,
-    PointDipole,
-    Source,
+)
+
+# sources
+from .components.source.time import (
+    ContinuousWave,
+    CustomSourceTime,
+    GaussianPulse,
     SourceTime,
-    UniformCurrentSource,
 )
 
 # structures

--- a/tidy3d/components/boundary.py
+++ b/tidy3d/components/boundary.py
@@ -13,7 +13,7 @@ from ..exceptions import DataError, SetupError
 from ..log import log
 from .base import Tidy3dBaseModel, cached_property
 from .medium import Medium
-from .source import TFSF, GaussianBeam, ModeSource, PlaneWave
+from .source.field import TFSF, GaussianBeam, ModeSource, PlaneWave
 from .types import TYPE_TAG_STR, Axis, Complex
 
 MIN_NUM_PML_LAYERS = 6

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -35,14 +35,18 @@ from ..monitor import (
     MonitorType,
     PermittivityMonitor,
 )
-from ..source import (
+from ..source.base import Source
+from ..source.current import (
     CustomCurrentSource,
+    PointDipole,
+)
+from ..source.field import (
     CustomFieldSource,
-    GaussianPulse,
     ModeSource,
     PlaneWave,
-    PointDipole,
-    Source,
+)
+from ..source.time import (
+    GaussianPulse,
     SourceTimeType,
 )
 from ..types import (

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -2797,7 +2797,7 @@ class DiffractionData(AbstractFieldProjectionData):
         units=MICROMETER,
     )
 
-    bloch_vecs: Tuple[float, float] = pd.Field(
+    bloch_vecs: Union[Tuple[float, float], Tuple[ArrayFloat1D, ArrayFloat1D]] = pd.Field(
         ...,
         title="Bloch vectors",
         description="Bloch vectors along the local x and y directions in units of "
@@ -2805,20 +2805,24 @@ class DiffractionData(AbstractFieldProjectionData):
     )
 
     @staticmethod
-    def shifted_orders(orders: Tuple[int, ...], bloch_vec: float) -> np.ndarray:
+    def shifted_orders(orders: Tuple[int, ...], bloch_vec: Union[float, np.ndarray]) -> np.ndarray:
         """Diffraction orders shifted by the Bloch vector."""
-        return bloch_vec + np.atleast_1d(orders)
+        return bloch_vec + np.atleast_2d(orders).T
 
     @staticmethod
     def reciprocal_coords(
-        orders: np.ndarray, size: float, bloch_vec: float, f: float, medium: MediumType
+        orders: np.ndarray,
+        size: float,
+        bloch_vec: Union[float, np.ndarray],
+        f: float,
+        medium: MediumType,
     ) -> np.ndarray:
         """Get the normalized "u" reciprocal coords for a vector of orders, size, and bloch vec."""
         if size == 0:
             return np.atleast_2d(0)
         epsilon = medium.eps_model(f)
         bloch_array = DiffractionData.shifted_orders(orders, bloch_vec)
-        return bloch_array[:, None] / size * C_0 / f / np.real(np.sqrt(epsilon))
+        return bloch_array / size * C_0 / f / np.real(np.sqrt(epsilon))
 
     @staticmethod
     def compute_angles(

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -22,7 +22,8 @@ from ..base_sim.data.sim_data import AbstractSimulationData
 from ..file_util import replace_values
 from ..monitor import Monitor
 from ..simulation import Simulation
-from ..source import GaussianPulse, SourceType
+from ..source.time import GaussianPulse
+from ..source.utils import SourceType
 from ..structure import Structure
 from ..types import Ax, Axis, ColormapType, FieldVal, PlotScale, annotate_type
 from ..viz import add_ax_if_none, equal_aspect

--- a/tidy3d/components/eme/simulation.py
+++ b/tidy3d/components/eme/simulation.py
@@ -19,7 +19,8 @@ from ..medium import FullyAnisotropicMedium
 from ..monitor import AbstractModeMonitor, ModeSolverMonitor, Monitor, MonitorType
 from ..scene import Scene
 from ..simulation import AbstractYeeGridSimulation, Simulation
-from ..source import GaussianPulse, PointDipole
+from ..source.current import PointDipole
+from ..source.time import GaussianPulse
 from ..structure import Structure
 from ..types import Ax, Axis, FreqArray, Symmetry, annotate_type
 from ..validators import MIN_FREQUENCY, validate_freqs_min, validate_freqs_not_empty

--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -13,7 +13,7 @@ from ...exceptions import SetupError
 from ...log import log
 from ..base import Tidy3dBaseModel
 from ..geometry.base import Box
-from ..source import SourceType
+from ..source.utils import SourceType
 from ..structure import Structure, StructureType
 from ..types import TYPE_TAG_STR, Axis, Coordinate, Symmetry, annotate_type
 from .grid import Coords, Coords1D, Grid

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -77,6 +77,7 @@ from .source import (
     CustomCurrentSource,
     CustomFieldSource,
     CustomSourceTime,
+    FixedAngleSpec,
     GaussianBeam,
     ModeSource,
     PlaneWave,
@@ -141,6 +142,9 @@ NUM_STRUCTURES_WARN_EPSILON = 10_000
 
 # height of the PML plotting boxes along any dimensions where sim.size[dim] == 0
 PML_HEIGHT_FOR_0_DIMS = inf
+
+# additional (safety) time step reduction factor for fixed angle simulations
+FIXED_ANGLE_DT_SAFETY_FACTOR = 0.9
 
 
 class AbstractYeeGridSimulation(AbstractSimulation, ABC):
@@ -2418,16 +2422,28 @@ class Simulation(AbstractYeeGridSimulation):
                     )
 
                 # check the Bloch boundary + angled plane wave case
-                num_bloch = sum(isinstance(bnd, (Periodic, BlochBoundary)) for bnd in boundary)
-                if num_bloch > 0:
-                    cls._check_bloch_vec(
-                        source=source,
-                        source_ind=source_ind,
-                        bloch_vec=boundary[0].bloch_vec,
-                        dim=tan_dir,
-                        medium=medium,
-                        domain_size=size[tan_dir],
-                    )
+                if isinstance(source.angular_spec, FixedAngleSpec):
+                    num_bloch = sum(isinstance(bnd, BlochBoundary) for bnd in boundary)
+                    if num_bloch > 0:
+                        raise SetupError(
+                            "Fixed angle plane wave sources ('FixedAngleSpec' and 'angle_theta' != 0) do "
+                            f"not require the Bloch boundary along dimension {tan_dir}. "
+                            "Either set the boundary conditions to 'Periodic' to proceed to simulate a plane "
+                            "wave with frequency-independent propagation direction, or switch to "
+                            "'FixedInPlaneKSpec' specification to simulate a plane wave with a fixed "
+                            "in-plane Bloch vector (frequency-dependent propagation direction)."
+                        )
+                else:
+                    num_bloch = sum(isinstance(bnd, (Periodic, BlochBoundary)) for bnd in boundary)
+                    if num_bloch > 0:
+                        cls._check_bloch_vec(
+                            source=source,
+                            source_ind=source_ind,
+                            bloch_vec=boundary[0].bloch_vec,
+                            dim=tan_dir,
+                            medium=medium,
+                            domain_size=size[tan_dir],
+                        )
         return val
 
     @pydantic.validator("monitors", always=True)
@@ -2553,6 +2569,58 @@ class Simulation(AbstractYeeGridSimulation):
             if isinstance(source, TFSF) and not all(sym == 0 for sym in symmetry):
                 raise SetupError("TFSF sources cannot be used with symmetries.")
         return val
+
+    @staticmethod
+    def _get_fixed_angle_sources(sources: Tuple[SourceType, ...]) -> Tuple[SourceType, ...]:
+        """Get list of plane wave sources with ``FixedAngleSpec``."""
+
+        return [
+            source for source in sources if isinstance(source, PlaneWave) and source._is_fixed_angle
+        ]
+
+    @pydantic.root_validator()
+    @skip_if_fields_missing(["sources", "structures", "medium", "monitors"], root=True)
+    def check_fixed_angle_components(cls, values):
+        """Error if a fixed-angle plane wave is combined with other sources
+        or fully anisotropic mediums or gain mediums."""
+
+        fixed_angle_sources = cls._get_fixed_angle_sources(values["sources"])
+
+        if len(fixed_angle_sources) > 0:
+            if len(fixed_angle_sources) > 1:
+                raise SetupError(
+                    "A fixed-angle plane wave source cannot be combined with other sources."
+                )
+
+            structures = values.get("structures")
+            structures = structures or []
+            medium_bg = values.get("medium")
+            mediums = [medium_bg] + [structure.medium for structure in structures]
+
+            if any(med.is_fully_anisotropic for med in mediums):
+                raise SetupError(
+                    "Fixed-angle plane wave sources cannot be used in the presence of 'FullyAnisotropicMedium'."
+                )
+
+            if any(med.is_nonlinear for med in mediums):
+                raise SetupError(
+                    "Fixed-angle plane wave sources cannot be used in the presence of nonlinear materials."
+                )
+
+            if any(med.is_time_modulated for med in mediums):
+                raise SetupError(
+                    "Fixed-angle plane wave sources cannot be used in the presence of time-modulated materials."
+                )
+
+            if any(med.allow_gain for med in mediums):
+                raise SetupError(
+                    "Fixed-angle plane wave sources cannot be used in the presence of gain materials."
+                )
+
+            if any(isinstance(mnt, TimeMonitor) for mnt in values["monitors"]):
+                raise SetupError("Time monitors cannot be used in fixed-angle simulations.")
+
+        return values
 
     @pydantic.validator("boundary_spec", always=True)
     @skip_if_fields_missing(["size", "symmetry"])
@@ -3253,7 +3321,8 @@ class Simulation(AbstractYeeGridSimulation):
                             "indicating an unexpected error. Please create a github issue so "
                             "that the problem can be investigated."
                         )
-                    if isinstance(list(mediums)[0], (AnisotropicMedium, FullyAnisotropicMedium)):
+                    src_medium = list(mediums)[0]
+                    if isinstance(src_medium, (AnisotropicMedium, FullyAnisotropicMedium)):
                         raise SetupError(
                             f"An anisotropic medium is detected on plane intersecting a {source.type} "
                             f"source. Injection of {source.type} into anisotropic media currently is "
@@ -3261,13 +3330,23 @@ class Simulation(AbstractYeeGridSimulation):
                         )
 
                     # check if the medium is spatially uniform
-                    if not list(mediums)[0].is_spatially_uniform:
+                    if not src_medium.is_spatially_uniform:
                         consolidated_logger.warning(
                             f"Nonuniform custom medium detected on plane intersecting a {source.type}. "
                             "Plane must be homogeneous. Make sure custom medium is uniform on the plane.",
                             custom_loc=["sources", source_id],
                         )
 
+                    if isinstance(source, PlaneWave) and source._is_fixed_angle:
+                        is_lossless_dieletric = (
+                            isinstance(src_medium, Medium) and src_medium.conductivity == 0
+                        )
+
+                        if not is_lossless_dieletric:
+                            raise SetupError(
+                                "A fixed angle plane wave can only be injected into a homogeneous isotropic"
+                                "dispersionless medium."
+                            )
         return val
 
     @pydantic.validator("normalize_index", always=True)
@@ -3858,6 +3937,16 @@ class Simulation(AbstractYeeGridSimulation):
         )
         return self.scene.background_structure
 
+    @cached_property
+    def _fixed_angle_sources(self) -> Tuple[SourceType, ...]:
+        """List of plane wave sources with ``FixedAngleSpec``."""
+        return self._get_fixed_angle_sources(self.sources)
+
+    @cached_property
+    def _is_fixed_angle(self) -> bool:
+        """Whether the simulation contains fixed angle sources."""
+        return len(self._fixed_angle_sources) > 0
+
     # candidate for removal in 3.0
     @staticmethod
     def intersecting_media(
@@ -4283,6 +4372,19 @@ class Simulation(AbstractYeeGridSimulation):
     """ Discretization """
 
     @cached_property
+    def _dt_fixed_angle_reduction_factor(self) -> float:
+        """Reduction in time step due to plane wave source with ``FixedAngleSpec``."""
+        if self._is_fixed_angle:
+            theta = self._fixed_angle_sources[0].angle_theta
+            return (
+                FIXED_ANGLE_DT_SAFETY_FACTOR
+                * np.sqrt(3)
+                * np.cos(theta) ** 2
+                / np.sqrt(2 + np.cos(theta) ** 2)
+            )
+        return 1
+
+    @cached_property
     def scaled_courant(self) -> float:
         """When conformal mesh is applied, courant number is scaled down depending on `conformal_mesh_spec`."""
 
@@ -4312,7 +4414,7 @@ class Simulation(AbstractYeeGridSimulation):
         dl_avg = 1 / np.sqrt(dl_sum_inv_sq)
         # material factor
         n_cfl = min(min(mat.n_cfl for mat in self.scene.mediums), 1)
-        return n_cfl * self.scaled_courant * dl_avg / C_0
+        return self._dt_fixed_angle_reduction_factor * n_cfl * self.scaled_courant * dl_avg / C_0
 
     @cached_property
     def tmesh(self) -> Coords1D:
@@ -4538,8 +4640,13 @@ class Simulation(AbstractYeeGridSimulation):
         # combined frequency upper bound
         freq_max = max(freq_source_max, freq_monitor_max)
 
+        # in fixed angle simulations both E and H are available at full and half steps
+        fixed_angle_factor = 1
+        if len(self._fixed_angle_sources) > 0:
+            fixed_angle_factor = 2
+
         if freq_max > 0:
-            nyquist_step = int(1 / (2 * freq_max) / self.dt) - 1
+            nyquist_step = int(1 / (2 * freq_max) / self.dt * fixed_angle_factor) - 1
             nyquist_step = max(1, nyquist_step)
         else:
             nyquist_step = 1

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -70,20 +70,19 @@ from .monitor import (
 )
 from .run_time_spec import RunTimeSpec
 from .scene import MAX_NUM_MEDIUMS, Scene
-from .source import (
+from .source.base import Source
+from .source.current import CustomCurrentSource
+from .source.field import (
     TFSF,
     AstigmaticGaussianBeam,
-    ContinuousWave,
-    CustomCurrentSource,
     CustomFieldSource,
-    CustomSourceTime,
     FixedAngleSpec,
     GaussianBeam,
     ModeSource,
     PlaneWave,
-    Source,
-    SourceType,
 )
+from .source.time import ContinuousWave, CustomSourceTime
+from .source.utils import SourceType
 from .structure import MeshOverrideStructure, Structure
 from .subpixel_spec import SubpixelSpec
 from .types import TYPE_TAG_STR, Ax, Axis, FreqBound, InterpMethod, Literal, Symmetry, annotate_type

--- a/tidy3d/components/source.py
+++ b/tidy3d/components/source.py
@@ -12,7 +12,7 @@ from typing_extensions import Literal
 from ..constants import GLANCING_CUTOFF, HERTZ, MICROMETER, RADIAN, inf
 from ..exceptions import SetupError, ValidationError
 from ..log import log
-from .base import cached_property, skip_if_fields_missing
+from .base import Tidy3dBaseModel, cached_property, skip_if_fields_missing
 from .base_sim.source import AbstractSource
 from .data.data_array import TimeDataArray
 from .data.dataset import FieldDataset, TimeDataset
@@ -1095,6 +1095,23 @@ class ModeSource(DirectionalSource, PlanarSource, BroadbandSource):
 """ Angled Field Sources one can use. """
 
 
+class AbstractAngularSpec(Tidy3dBaseModel, ABC):
+    """Abstract base for defining angular variability specifications for plane waves."""
+
+
+class FixedInPlaneKSpec(AbstractAngularSpec):
+    """Plane wave is injected such that its in-plane wavevector is constant. That is,
+    the injected field satisfies Bloch boundary conditions and its propagation direction is
+    frequency dependent.
+    """
+
+
+class FixedAngleSpec(AbstractAngularSpec):
+    """Plane wave is injected such that its propagation direction is frequency independent.
+    When using this option boundary conditions in tangential directions must be set to periodic.
+    """
+
+
 class PlaneWave(AngledFieldSource, PlanarSource):
     """Uniform current distribution on an infinite extent plane. One element of size must be zero.
 
@@ -1112,6 +1129,18 @@ class PlaneWave(AngledFieldSource, PlanarSource):
     **Lectures:**
         * `Using FDTD to Compute a Transmission Spectrum <https://www.flexcompute.com/fdtd101/Lecture-2-Using-FDTD-to-Compute-a-Transmission-Spectrum/>`__
     """
+
+    angular_spec: Union[FixedInPlaneKSpec, FixedAngleSpec] = pydantic.Field(
+        FixedInPlaneKSpec(),
+        title="Angular Dependence Specification",
+        description="Specification of plane wave propagation direction dependence on wavelength.",
+        discriminator=TYPE_TAG_STR,
+    )
+
+    @cached_property
+    def _is_fixed_angle(self) -> bool:
+        """Whether the plane wave is at a fixed non-zero angle."""
+        return isinstance(self.angular_spec, FixedAngleSpec) and self.angle_theta != 0.0
 
 
 class GaussianBeam(AngledFieldSource, PlanarSource, BroadbandSource):

--- a/tidy3d/components/source/base.py
+++ b/tidy3d/components/source/base.py
@@ -1,0 +1,120 @@
+"""Defines an abstract base for electromagnetic sources."""
+
+from __future__ import annotations
+
+from abc import ABC
+from typing import Tuple
+
+import pydantic.v1 as pydantic
+
+from ..base import cached_property
+from ..base_sim.source import AbstractSource
+from ..geometry.base import Box
+from ..types import TYPE_TAG_STR, Ax
+from ..validators import _assert_min_freq
+from ..viz import (
+    ARROW_ALPHA,
+    ARROW_COLOR_POLARIZATION,
+    ARROW_COLOR_SOURCE,
+    PlotParams,
+    plot_params_source,
+)
+from .time import SourceTimeType
+
+
+class Source(Box, AbstractSource, ABC):
+    """Abstract base class for all sources."""
+
+    source_time: SourceTimeType = pydantic.Field(
+        ...,
+        title="Source Time",
+        description="Specification of the source time-dependence.",
+        discriminator=TYPE_TAG_STR,
+    )
+
+    @cached_property
+    def plot_params(self) -> PlotParams:
+        """Default parameters for plotting a Source object."""
+        return plot_params_source
+
+    @cached_property
+    def geometry(self) -> Box:
+        """:class:`Box` representation of source."""
+
+        return Box(center=self.center, size=self.size)
+
+    @cached_property
+    def _injection_axis(self):
+        """Injection axis of the source."""
+        return None
+
+    @cached_property
+    def _dir_vector(self) -> Tuple[float, float, float]:
+        """Returns a vector indicating the source direction for arrow plotting, if not None."""
+        return None
+
+    @cached_property
+    def _pol_vector(self) -> Tuple[float, float, float]:
+        """Returns a vector indicating the source polarization for arrow plotting, if not None."""
+        return None
+
+    @pydantic.validator("source_time", always=True)
+    def _freqs_lower_bound(cls, val):
+        """Raise validation error if central frequency is too low."""
+        _assert_min_freq(val.freq0, msg_start="'source_time.freq0'")
+        return val
+
+    def plot(
+        self,
+        x: float = None,
+        y: float = None,
+        z: float = None,
+        ax: Ax = None,
+        **patch_kwargs,
+    ) -> Ax:
+        """Plot this source."""
+
+        kwargs_arrow_base = patch_kwargs.pop("arrow_base", None)
+
+        # call the `Source.plot()` function first.
+        ax = Box.plot(self, x=x, y=y, z=z, ax=ax, **patch_kwargs)
+
+        kwargs_alpha = patch_kwargs.get("alpha")
+        arrow_alpha = ARROW_ALPHA if kwargs_alpha is None else kwargs_alpha
+
+        # then add the arrow based on the propagation direction
+        if self._dir_vector is not None:
+            bend_radius = None
+            bend_axis = None
+            if hasattr(self, "mode_spec"):
+                bend_radius = self.mode_spec.bend_radius
+                bend_axis = self._bend_axis
+
+            ax = self._plot_arrow(
+                x=x,
+                y=y,
+                z=z,
+                ax=ax,
+                direction=self._dir_vector,
+                bend_radius=bend_radius,
+                bend_axis=bend_axis,
+                color=ARROW_COLOR_SOURCE,
+                alpha=arrow_alpha,
+                both_dirs=False,
+                arrow_base=kwargs_arrow_base,
+            )
+
+        if self._pol_vector is not None:
+            ax = self._plot_arrow(
+                x=x,
+                y=y,
+                z=z,
+                ax=ax,
+                direction=self._pol_vector,
+                color=ARROW_COLOR_POLARIZATION,
+                alpha=arrow_alpha,
+                both_dirs=False,
+                arrow_base=kwargs_arrow_base,
+            )
+
+        return ax

--- a/tidy3d/components/source/current.py
+++ b/tidy3d/components/source/current.py
@@ -1,0 +1,162 @@
+"""Defines electric current sources for injecting light into simulation."""
+
+from __future__ import annotations
+
+from abc import ABC
+from typing import Optional, Tuple
+
+import pydantic.v1 as pydantic
+from typing_extensions import Literal
+
+from ...constants import MICROMETER
+from ..base import cached_property
+from ..data.dataset import FieldDataset
+from ..data.validators import validate_can_interpolate, validate_no_nans
+from ..types import Polarization
+from ..validators import assert_single_freq_in_range, warn_if_dataset_none
+from .base import Source
+
+
+class CurrentSource(Source, ABC):
+    """Source implements a current distribution directly."""
+
+    polarization: Polarization = pydantic.Field(
+        ...,
+        title="Polarization",
+        description="Specifies the direction and type of current component.",
+    )
+
+    @cached_property
+    def _pol_vector(self) -> Tuple[float, float, float]:
+        """Returns a vector indicating the source polarization for arrow plotting, if not None."""
+        component = self.polarization[-1]  # 'x' 'y' or 'z'
+        pol_axis = "xyz".index(component)
+        pol_vec = [0, 0, 0]
+        pol_vec[pol_axis] = 1
+        return pol_vec
+
+
+class ReverseInterpolatedSource(Source):
+    """Abstract source that allows reverse-interpolation along zero-sized dimensions."""
+
+    interpolate: bool = pydantic.Field(
+        True,
+        title="Enable Interpolation",
+        description="Handles reverse-interpolation of zero-size dimensions of the source. "
+        "If ``False``, the source data is snapped to the nearest Yee grid point. If ``True``, "
+        "equivalent source data is applied on the surrounding Yee grid points to emulate "
+        "placement at the specified location using linear interpolation.",
+    )
+
+    confine_to_bounds: bool = pydantic.Field(
+        False,
+        title="Confine to Analytical Bounds",
+        description="If ``True``, any source amplitudes which, after discretization, fall beyond "
+        "the bounding box of the source are zeroed out, but only along directions where "
+        "the source has a non-zero extent. The bounding box is inclusive. Should be set ```True`` "
+        "when the current source is being used to excite a current in a conductive material.",
+    )
+
+
+class UniformCurrentSource(CurrentSource, ReverseInterpolatedSource):
+    """Source in a rectangular volume with uniform time dependence.
+
+    Notes
+    -----
+
+        Inputting the parameter ``size=(0,0,0)`` defines the equivalent of a point source.
+
+    Example
+    -------
+    >>> from tidy3d import GaussianPulse
+    >>> pulse = GaussianPulse(freq0=200e12, fwidth=20e12)
+    >>> pt_source = UniformCurrentSource(size=(0,0,0), source_time=pulse, polarization='Ex')
+    """
+
+
+class PointDipole(CurrentSource, ReverseInterpolatedSource):
+    """Uniform current source with a zero size. The source corresponds to an infinitesimal antenna
+    with a fixed current density, and is slightly different from a related definition that is used
+    in some contexts, namely an oscillating electric or magnetic dipole. The two are related through
+    a factor of ``omega ** 2`` in the power normalization, where ``omega`` is the angular frequency
+    of the oscillation. This is discussed further in our
+    `source normalization <../../faq/docs/faq/How-are-results-normalized.html>`_ FAQ page.
+
+    ..
+        TODO add image of how it looks like based on sim 1.
+
+    Example
+    -------
+    >>> from tidy3d import GaussianPulse
+    >>> pulse = GaussianPulse(freq0=200e12, fwidth=20e12)
+    >>> pt_dipole = PointDipole(center=(1,2,3), source_time=pulse, polarization='Ex')
+
+    See Also
+    --------
+
+    **Notebooks**
+        * `Particle swarm optimization of quantum emitter light extraction to free space <../../notebooks/BullseyeCavityPSO.html>`_
+        * `Adjoint optimization of quantum emitter light extraction to an integrated waveguide <../../notebooks/AdjointPlugin12LightExtractor.html>`_
+    """
+
+    size: Tuple[Literal[0], Literal[0], Literal[0]] = pydantic.Field(
+        (0, 0, 0),
+        title="Size",
+        description="Size in x, y, and z directions, constrained to ``(0, 0, 0)``.",
+        units=MICROMETER,
+    )
+
+
+class CustomCurrentSource(ReverseInterpolatedSource):
+    """Implements a source corresponding to an input dataset containing ``E`` and ``H`` fields.
+
+    Notes
+    -----
+
+        Injects the specified components of the ``E`` and ``H`` dataset directly as ``J`` and ``M`` current
+        distributions in the FDTD solver. The coordinates of all provided fields are assumed to be relative to the
+        source center.
+
+        The syntax is very similar to :class:`CustomFieldSource`, except instead of a ``field_dataset``, the source
+        accepts a :attr:`current_dataset`. This dataset still contains :math:`E_{x,y,z}` and :math:`H_{x,y,
+        z}` field components, which correspond to :math:`J` and :math:`M` components respectively. There are also
+        fewer constraints on the data requirements for :class:`CustomCurrentSource`. It can be volumetric or planar
+        without requiring tangential components. Finally, note that the dataset is still defined w.r.t. the source
+        center, just as in the case of the :class:`CustomFieldSource`, and can then be placed anywhere in the simulation.
+
+    Example
+    -------
+    >>> from tidy3d import ScalarFieldDataArray, GaussianPulse
+    >>> import numpy as np
+    >>> pulse = GaussianPulse(freq0=200e12, fwidth=20e12)
+    >>> x = np.linspace(-1, 1, 101)
+    >>> y = np.linspace(-1, 1, 101)
+    >>> z = np.array([0])
+    >>> f = [2e14]
+    >>> coords = dict(x=x, y=y, z=z, f=f)
+    >>> scalar_field = ScalarFieldDataArray(np.ones((101, 101, 1, 1)), coords=coords)
+    >>> dataset = FieldDataset(Ex=scalar_field)
+    >>> custom_source = CustomCurrentSource(
+    ...     center=(1, 1, 1),
+    ...     size=(2, 2, 0),
+    ...     source_time=pulse,
+    ...     current_dataset=dataset)
+
+    See Also
+    --------
+
+    **Notebooks**
+        * `Defining spatially-varying sources <../../notebooks/CustomFieldSource.html>`_
+    """
+
+    current_dataset: Optional[FieldDataset] = pydantic.Field(
+        ...,
+        title="Current Dataset",
+        description=":class:`.FieldDataset` containing the desired frequency-domain "
+        "electric and magnetic current patterns to inject.",
+    )
+
+    _no_nans_dataset = validate_no_nans("current_dataset")
+    _current_dataset_none_warning = warn_if_dataset_none("current_dataset")
+    _current_dataset_single_freq = assert_single_freq_in_range("current_dataset")
+    _can_interpolate = validate_can_interpolate("current_dataset")

--- a/tidy3d/components/source/time.py
+++ b/tidy3d/components/source/time.py
@@ -1,0 +1,407 @@
+"""Defines time dependencies of injected electromagnetic sources."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Optional, Union
+
+import numpy as np
+import pydantic.v1 as pydantic
+
+from ...constants import HERTZ
+from ...exceptions import ValidationError
+from ..data.data_array import TimeDataArray
+from ..data.dataset import TimeDataset
+from ..data.validators import validate_no_nans
+from ..time import AbstractTimeDependence
+from ..types import (
+    ArrayComplex1D,
+    ArrayFloat1D,
+    Ax,
+    FreqBound,
+    PlotVal,
+)
+from ..validators import warn_if_dataset_none
+from ..viz import add_ax_if_none
+
+# how many units of ``twidth`` from the ``offset`` until a gaussian pulse is considered "off"
+END_TIME_FACTOR_GAUSSIAN = 10
+
+
+class SourceTime(AbstractTimeDependence):
+    """Base class describing the time dependence of a source."""
+
+    @add_ax_if_none
+    def plot_spectrum(
+        self,
+        times: ArrayFloat1D,
+        num_freqs: int = 101,
+        val: PlotVal = "real",
+        ax: Ax = None,
+    ) -> Ax:
+        """Plot the complex-valued amplitude of the source time-dependence.
+        Note: Only the real part of the time signal is used.
+
+        Parameters
+        ----------
+        times : np.ndarray
+            Array of evenly-spaced times (seconds) to evaluate source time-dependence at.
+            The spectrum is computed from this value and the source time frequency content.
+            To see source spectrum for a specific :class:`Simulation`,
+            pass ``simulation.tmesh``.
+        num_freqs : int = 101
+            Number of frequencies to plot within the SourceTime.frequency_range.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+
+        fmin, fmax = self.frequency_range()
+        return self.plot_spectrum_in_frequency_range(
+            times, fmin, fmax, num_freqs=num_freqs, val=val, ax=ax
+        )
+
+    @abstractmethod
+    def frequency_range(self, num_fwidth: float = 4.0) -> FreqBound:
+        """Frequency range within plus/minus ``num_fwidth * fwidth`` of the central frequency."""
+
+    @abstractmethod
+    def end_time(self) -> Optional[float]:
+        """Time after which the source is effectively turned off / close to zero amplitude."""
+
+
+class Pulse(SourceTime, ABC):
+    """A source time that ramps up with some ``fwidth`` and oscillates at ``freq0``."""
+
+    freq0: pydantic.PositiveFloat = pydantic.Field(
+        ..., title="Central Frequency", description="Central frequency of the pulse.", units=HERTZ
+    )
+    fwidth: pydantic.PositiveFloat = pydantic.Field(
+        ...,
+        title="",
+        description="Standard deviation of the frequency content of the pulse.",
+        units=HERTZ,
+    )
+
+    offset: float = pydantic.Field(
+        5.0,
+        title="Offset",
+        description="Time delay of the maximum value of the "
+        "pulse in units of 1 / (``2pi * fwidth``).",
+        ge=2.5,
+    )
+
+    @property
+    def twidth(self) -> float:
+        """Width of pulse in seconds."""
+        return 1.0 / (2 * np.pi * self.fwidth)
+
+    def frequency_range(self, num_fwidth: float = 4.0) -> FreqBound:
+        """Frequency range within 5 standard deviations of the central frequency.
+
+        Parameters
+        ----------
+        num_fwidth : float = 4.
+            Frequency range defined as plus/minus ``num_fwidth * self.fwdith``.
+
+        Returns
+        -------
+        Tuple[float, float]
+            Minimum and maximum frequencies of the :class:`GaussianPulse` or :class:`ContinuousWave`
+            power.
+        """
+
+        freq_width_range = num_fwidth * self.fwidth
+        freq_min = max(0, self.freq0 - freq_width_range)
+        freq_max = self.freq0 + freq_width_range
+        return (freq_min, freq_max)
+
+
+class GaussianPulse(Pulse):
+    """Source time dependence that describes a Gaussian pulse.
+
+    Example
+    -------
+    >>> pulse = GaussianPulse(freq0=200e12, fwidth=20e12)
+    """
+
+    remove_dc_component: bool = pydantic.Field(
+        True,
+        title="Remove DC Component",
+        description="Whether to remove the DC component in the Gaussian pulse spectrum. "
+        "If ``True``, the Gaussian pulse is modified at low frequencies to zero out the "
+        "DC component, which is usually desirable so that the fields will decay. However, "
+        "for broadband simulations, it may be better to have non-vanishing source power "
+        "near zero frequency. Setting this to ``False`` results in an unmodified Gaussian "
+        "pulse spectrum which can have a nonzero DC component.",
+    )
+
+    def amp_time(self, time: float) -> complex:
+        """Complex-valued source amplitude as a function of time."""
+
+        omega0 = 2 * np.pi * self.freq0
+        time_shifted = time - self.offset * self.twidth
+
+        offset = np.exp(1j * self.phase)
+        oscillation = np.exp(-1j * omega0 * time)
+        amp = np.exp(-(time_shifted**2) / 2 / self.twidth**2) * self.amplitude
+
+        pulse_amp = offset * oscillation * amp
+
+        # subtract out DC component
+        if self.remove_dc_component:
+            pulse_amp = pulse_amp * (1j + time_shifted / self.twidth**2 / omega0)
+        else:
+            # 1j to make it agree in large omega0 limit
+            pulse_amp = pulse_amp * 1j
+
+        return pulse_amp
+
+    def end_time(self) -> Optional[float]:
+        """Time after which the source is effectively turned off / close to zero amplitude."""
+
+        # TODO: decide if we should continue to return an end_time if the DC component remains
+        # if not self.remove_dc_component:
+        #     return None
+
+        return self.offset * self.twidth + END_TIME_FACTOR_GAUSSIAN * self.twidth
+
+    @property
+    def amp_complex(self) -> complex:
+        """Grab the complex amplitude from a ``GaussianPulse``."""
+        phase = np.exp(1j * self.phase)
+        return self.amplitude * phase
+
+    @classmethod
+    def from_amp_complex(cls, amp: complex, **kwargs) -> GaussianPulse:
+        """Set the complex amplitude of a ``GaussianPulse``.
+
+        Parameters
+        ----------
+        amp : complex
+            Complex-valued amplitude to set in the returned ``GaussianPulse``.
+        kwargs : dict
+            Keyword arguments passed to ``GaussianPulse()``, excluding ``amplitude`` & ``phase``.
+        """
+        amplitude = abs(amp)
+        phase = np.angle(amp)
+        return cls(amplitude=amplitude, phase=phase, **kwargs)
+
+
+class ContinuousWave(Pulse):
+    """Source time dependence that ramps up to continuous oscillation
+    and holds until end of simulation.
+
+    Note
+    ----
+    Field decay will not occur, so the simulation will run for the full ``run_time``.
+    Also, source normalization of frequency-domain monitors is not meaningful.
+
+    Example
+    -------
+    >>> cw = ContinuousWave(freq0=200e12, fwidth=20e12)
+    """
+
+    def amp_time(self, time: float) -> complex:
+        """Complex-valued source amplitude as a function of time."""
+
+        twidth = 1.0 / (2 * np.pi * self.fwidth)
+        omega0 = 2 * np.pi * self.freq0
+        time_shifted = time - self.offset * twidth
+
+        const = 1.0
+        offset = np.exp(1j * self.phase)
+        oscillation = np.exp(-1j * omega0 * time)
+        amp = 1 / (1 + np.exp(-time_shifted / twidth)) * self.amplitude
+
+        return const * offset * oscillation * amp
+
+    def end_time(self) -> Optional[float]:
+        """Time after which the source is effectively turned off / close to zero amplitude."""
+        return None
+
+
+class CustomSourceTime(Pulse):
+    """Custom source time dependence consisting of a real or complex envelope
+    modulated at a central frequency, as shown below.
+
+    Note
+    ----
+    .. math::
+
+        amp\\_time(t) = amplitude \\cdot \\
+                e^{i \\cdot phase - 2 \\pi i \\cdot freq0 \\cdot t} \\cdot \\
+                envelope(t - offset / (2 \\pi \\cdot fwidth))
+
+    Note
+    ----
+    Depending on the envelope, field decay may not occur.
+    If field decay does not occur, then the simulation will run for the full ``run_time``.
+    Also, if field decay does not occur, then source normalization of frequency-domain
+    monitors is not meaningful.
+
+    Note
+    ----
+    The source time dependence is linearly interpolated to the simulation time steps.
+    The sampling rate should be sufficiently fast that this interpolation does not
+    introduce artifacts. The source time dependence should also start at zero and ramp up smoothly.
+    The first and last values of the envelope will be used for times that are out of range
+    of the provided data.
+
+    Example
+    -------
+    >>> cst = CustomSourceTime.from_values(freq0=1, fwidth=0.1,
+    ...     values=np.linspace(0, 9, 10), dt=0.1)
+
+    """
+
+    offset: float = pydantic.Field(
+        0.0,
+        title="Offset",
+        description="Time delay of the envelope in units of 1 / (``2pi * fwidth``).",
+    )
+
+    source_time_dataset: Optional[TimeDataset] = pydantic.Field(
+        ...,
+        title="Source time dataset",
+        description="Dataset for storing the envelope of the custom source time. "
+        "This envelope will be modulated by a complex exponential at frequency ``freq0``.",
+    )
+
+    _no_nans_dataset = validate_no_nans("source_time_dataset")
+    _source_time_dataset_none_warning = warn_if_dataset_none("source_time_dataset")
+
+    @pydantic.validator("source_time_dataset", always=True)
+    def _more_than_one_time(cls, val):
+        """Must have more than one time to interpolate."""
+        if val is None:
+            return val
+        if val.values.size <= 1:
+            raise ValidationError("'CustomSourceTime' must have more than one time coordinate.")
+        return val
+
+    @classmethod
+    def from_values(
+        cls, freq0: float, fwidth: float, values: ArrayComplex1D, dt: float
+    ) -> CustomSourceTime:
+        """Create a :class:`.CustomSourceTime` from a numpy array.
+
+        Parameters
+        ----------
+        freq0 : float
+            Central frequency of the source. The envelope provided will be modulated
+            by a complex exponential at this frequency.
+        fwidth : float
+            Estimated frequency width of the source.
+        values: ArrayComplex1D
+            Complex values of the source envelope.
+        dt: float
+            Time step for the ``values`` array. This value should be sufficiently small
+            that the interpolation to simulation time steps does not introduce artifacts.
+
+        Returns
+        -------
+        CustomSourceTime
+            :class:`.CustomSourceTime` with envelope given by ``values``, modulated by a complex
+            exponential at frequency ``freq0``. The time coordinates are evenly spaced
+            between ``0`` and ``dt * (N-1)`` with a step size of ``dt``, where ``N`` is the length of
+            the values array.
+        """
+
+        times = np.arange(len(values)) * dt
+        source_time_dataarray = TimeDataArray(values, coords=dict(t=times))
+        source_time_dataset = TimeDataset(values=source_time_dataarray)
+        return CustomSourceTime(
+            freq0=freq0,
+            fwidth=fwidth,
+            source_time_dataset=source_time_dataset,
+        )
+
+    @property
+    def data_times(self) -> ArrayFloat1D:
+        """Times of envelope definition."""
+        if self.source_time_dataset is None:
+            return []
+        data_times = self.source_time_dataset.values.coords["t"].values.squeeze()
+        return data_times
+
+    def _all_outside_range(self, run_time: float) -> bool:
+        """Whether all times are outside range of definition."""
+
+        # can't validate if data isn't loaded
+        if self.source_time_dataset is None:
+            return False
+
+        # make time a numpy array for uniform handling
+        data_times = self.data_times
+
+        # shift time
+        twidth = 1.0 / (2 * np.pi * self.fwidth)
+        max_time_shifted = run_time - self.offset * twidth
+        min_time_shifted = -self.offset * twidth
+
+        return (max_time_shifted < min(data_times)) | (min_time_shifted > max(data_times))
+
+    def amp_time(self, time: float) -> complex:
+        """Complex-valued source amplitude as a function of time.
+
+        Parameters
+        ----------
+        time : float
+            Time in seconds.
+
+        Returns
+        -------
+        complex
+            Complex-valued source amplitude at that time.
+        """
+
+        if self.source_time_dataset is None:
+            return None
+
+        # make time a numpy array for uniform handling
+        times = np.array([time] if isinstance(time, (int, float)) else time)
+        data_times = self.data_times
+
+        # shift time
+        twidth = 1.0 / (2 * np.pi * self.fwidth)
+        time_shifted = times - self.offset * twidth
+
+        # mask times that are out of range
+        mask = (time_shifted < min(data_times)) | (time_shifted > max(data_times))
+
+        # get envelope
+        envelope = np.zeros(len(time_shifted), dtype=complex)
+        values = self.source_time_dataset.values
+        envelope[mask] = values.sel(t=time_shifted[mask], method="nearest").to_numpy()
+        if not all(mask):
+            envelope[~mask] = values.interp(t=time_shifted[~mask]).to_numpy()
+
+        # modulation, phase, amplitude
+        omega0 = 2 * np.pi * self.freq0
+        offset = np.exp(1j * self.phase)
+        oscillation = np.exp(-1j * omega0 * times)
+        amp = self.amplitude
+
+        return offset * oscillation * amp * envelope
+
+    def end_time(self) -> Optional[float]:
+        """Time after which the source is effectively turned off / close to zero amplitude."""
+
+        if self.source_time_dataset is None:
+            return None
+
+        data_array = self.source_time_dataset.values
+
+        t_coords = data_array.coords["t"]
+        source_is_non_zero = ~np.isclose(abs(data_array), 0)
+        t_non_zero = t_coords[source_is_non_zero]
+
+        return np.max(t_non_zero)
+
+
+SourceTimeType = Union[GaussianPulse, ContinuousWave, CustomSourceTime]

--- a/tidy3d/components/source/utils.py
+++ b/tidy3d/components/source/utils.py
@@ -1,0 +1,28 @@
+"""Defines electric current sources for injecting light into simulation."""
+
+from __future__ import annotations
+
+from typing import Union
+
+from .current import CustomCurrentSource, PointDipole, UniformCurrentSource
+from .field import (
+    TFSF,
+    AstigmaticGaussianBeam,
+    CustomFieldSource,
+    GaussianBeam,
+    ModeSource,
+    PlaneWave,
+)
+
+# sources allowed in Simulation.sources
+SourceType = Union[
+    UniformCurrentSource,
+    PointDipole,
+    GaussianBeam,
+    AstigmaticGaussianBeam,
+    ModeSource,
+    PlaneWave,
+    CustomFieldSource,
+    CustomCurrentSource,
+    TFSF,
+]

--- a/tidy3d/plugins/adjoint/components/data/monitor_data.py
+++ b/tidy3d/plugins/adjoint/components/data/monitor_data.py
@@ -26,15 +26,10 @@ from .....components.data.monitor_data import (
     MonitorData,
 )
 from .....components.geometry.base import Box
-from .....components.source import (
-    CustomCurrentSource,
-    CustomFieldSource,
-    GaussianPulse,
-    ModeSource,
-    PlaneWave,
-    PointDipole,
-    Source,
-)
+from .....components.source.base import Source
+from .....components.source.current import CustomCurrentSource, PointDipole
+from .....components.source.field import CustomFieldSource, ModeSource, PlaneWave
+from .....components.source.time import GaussianPulse
 from .....constants import C_0, ETA_0, MU_0
 from .....exceptions import AdjointError
 from ..base import JaxObject

--- a/tidy3d/plugins/adjoint/components/data/sim_data.py
+++ b/tidy3d/plugins/adjoint/components/data/sim_data.py
@@ -11,7 +11,8 @@ from jax.tree_util import register_pytree_node_class
 
 from .....components.data.monitor_data import FieldData, MonitorDataType, PermittivityData
 from .....components.data.sim_data import SimulationData
-from .....components.source import GaussianPulse, PointDipole
+from .....components.source.current import PointDipole
+from .....components.source.time import GaussianPulse
 from .....log import log
 from ..base import JaxObject
 from ..simulation import JaxInfo, JaxSimulation

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -33,7 +33,8 @@ from ...components.mode import ModeSpec
 from ...components.monitor import ModeMonitor, ModeSolverMonitor
 from ...components.scene import Scene
 from ...components.simulation import Simulation
-from ...components.source import ModeSource, SourceTime
+from ...components.source.field import ModeSource
+from ...components.source.time import SourceTime
 from ...components.structure import Structure
 from ...components.subpixel_spec import SurfaceImpedance
 from ...components.types import (

--- a/tidy3d/plugins/smatrix/component_modelers/modal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/modal.py
@@ -13,7 +13,8 @@ from ....components.base import cached_property
 from ....components.data.sim_data import SimulationData
 from ....components.monitor import ModeMonitor
 from ....components.simulation import Simulation
-from ....components.source import GaussianPulse, ModeSource
+from ....components.source.field import ModeSource
+from ....components.source.time import GaussianPulse
 from ....components.types import Ax, Complex
 from ....components.viz import add_ax_if_none, equal_aspect
 from ....exceptions import SetupError

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -12,7 +12,7 @@ from ....components.data.data_array import DataArray, FreqDataArray
 from ....components.data.sim_data import SimulationData
 from ....components.geometry.utils_2d import snap_coordinate_to_grid
 from ....components.simulation import Simulation
-from ....components.source import GaussianPulse
+from ....components.source.time import GaussianPulse
 from ....components.types import Ax
 from ....components.viz import add_ax_if_none, equal_aspect
 from ....constants import C_0, OHM

--- a/tidy3d/plugins/smatrix/ports/base_terminal.py
+++ b/tidy3d/plugins/smatrix/ports/base_terminal.py
@@ -9,7 +9,8 @@ from ....components.data.data_array import DataArray, FreqDataArray
 from ....components.data.sim_data import SimulationData
 from ....components.grid.grid import Grid
 from ....components.monitor import FieldMonitor
-from ....components.source import GaussianPulse, Source
+from ....components.source.base import Source
+from ....components.source.time import GaussianPulse
 from ....components.types import FreqArray
 
 

--- a/tidy3d/plugins/smatrix/ports/coaxial_lumped.py
+++ b/tidy3d/plugins/smatrix/ports/coaxial_lumped.py
@@ -12,7 +12,8 @@ from ....components.geometry.utils_2d import increment_float
 from ....components.grid.grid import Grid, YeeGrid
 from ....components.lumped_element import CoaxialLumpedResistor
 from ....components.monitor import FieldMonitor
-from ....components.source import CustomCurrentSource, GaussianPulse
+from ....components.source.current import CustomCurrentSource
+from ....components.source.time import GaussianPulse
 from ....components.types import Axis, Coordinate, Direction, FreqArray, Size
 from ....components.validators import skip_if_fields_missing
 from ....constants import MICROMETER

--- a/tidy3d/plugins/smatrix/ports/rectangular_lumped.py
+++ b/tidy3d/plugins/smatrix/ports/rectangular_lumped.py
@@ -17,7 +17,8 @@ from ....components.geometry.utils_2d import increment_float
 from ....components.grid.grid import Grid, YeeGrid
 from ....components.lumped_element import LumpedResistor
 from ....components.monitor import FieldMonitor
-from ....components.source import GaussianPulse, UniformCurrentSource
+from ....components.source.current import UniformCurrentSource
+from ....components.source.time import GaussianPulse
 from ....components.types import Axis, FreqArray
 from ....components.validators import assert_plane
 from ....exceptions import SetupError, ValidationError

--- a/tidy3d/plugins/smatrix/ports/wave.py
+++ b/tidy3d/plugins/smatrix/ports/wave.py
@@ -13,7 +13,8 @@ from ....components.geometry.base import Box
 from ....components.grid.grid import Grid
 from ....components.monitor import FieldMonitor, ModeSolverMonitor
 from ....components.simulation import Simulation
-from ....components.source import GaussianPulse, ModeSource, ModeSpec
+from ....components.source.field import ModeSource, ModeSpec
+from ....components.source.time import GaussianPulse
 from ....components.types import Bound, Direction, FreqArray
 from ....exceptions import ValidationError
 from ...microwave import (

--- a/tidy3d/plugins/waveguide/rectangular_dielectric.py
+++ b/tidy3d/plugins/waveguide/rectangular_dielectric.py
@@ -16,7 +16,8 @@ from ...components.grid.grid_spec import GridSpec
 from ...components.medium import Medium, MediumType
 from ...components.mode import ModeSpec
 from ...components.simulation import Simulation
-from ...components.source import GaussianPulse, ModeSource
+from ...components.source.field import ModeSource
+from ...components.source.time import GaussianPulse
 from ...components.structure import Structure
 from ...components.types import TYPE_TAG_STR, ArrayFloat1D, Ax, Axis, Coordinate, Literal, Size1D
 from ...components.viz import add_ax_if_none


### PR DESCRIPTION
Summary of changes:
- introduced field `angular_spec` in `PlaneWave`, which can take values `FixedAngleSpec()` and `FixedInPlaneKSpec()`. Those are currently empty specs, but in future we could add parameters to them. 
- automatic time step reduction for `FixedAngleSpec()` due to a new stability criterion
- minor change in diffraction monitor data, so that results can be processed at multiple bloch vectors simultaneously
- btw, do you prefer `FixedAngleSpec()`/`FixedInPlaneKSpec()` or `ConstAngleSpec()`/`ConstInPlaneKSpec()`

example notebook https://github.com/flexcompute/tidy3d-notebooks/blob/daniil/fixed-angle/AngularFrequencyDependence.ipynb