### PR TITLE
Create ParameterSpec

### DIFF
--- a/tests/test_plugins/test_invdes.py
+++ b/tests/test_plugins/test_invdes.py
@@ -2,10 +2,16 @@
 
 import autograd.numpy as anp
 import numpy as np
+import numpy.testing as npt
 import pytest
 import tidy3d as td
 import tidy3d.plugins.invdes as tdi
 from tidy3d.plugins.expressions import ModePower
+from tidy3d.plugins.invdes.initialization import (
+    CustomInitializationSpec,
+    RandomInitializationSpec,
+    UniformInitializationSpec,
+)
 
 # use single threading pipeline
 from ..test_components.test_autograd import use_emulated_run  # noqa: F401
@@ -280,17 +286,13 @@ def make_result(use_emulated_run):  # noqa: F811
 
     optimizer = make_optimizer()
 
-    PARAMS_0 = np.random.random(optimizer.design.design_region.params_shape)
-
-    return optimizer.run(params0=PARAMS_0, post_process_fn=post_process_fn)
+    return optimizer.run(post_process_fn=post_process_fn)
 
 
 def test_default_params(use_emulated_run):  # noqa: F811
     """Test default paramns running the optimization defined in the ``InverseDesign`` object."""
 
     optimizer = make_optimizer()
-
-    _ = np.random.random(optimizer.design.design_region.params_shape)
 
     optimizer.run(post_process_fn=post_process_fn)
 
@@ -313,9 +315,7 @@ def make_result_multi(use_emulated_run):  # noqa: F811
 
     optimizer = optimizer.updated_copy(design=design)
 
-    PARAMS_0 = np.random.random(optimizer.design.design_region.params_shape)
-
-    return optimizer.run(params0=PARAMS_0, post_process_fn=post_process_fn_multi)
+    return optimizer.run(post_process_fn=post_process_fn_multi)
 
 
 def test_result_store_full_results_is_false(use_emulated_run):  # noqa: F811
@@ -324,9 +324,7 @@ def test_result_store_full_results_is_false(use_emulated_run):  # noqa: F811
     optimizer = make_optimizer()
     optimizer = optimizer.updated_copy(store_full_results=False, num_steps=3)
 
-    PARAMS_0 = np.random.random(optimizer.design.design_region.params_shape)
-
-    result = optimizer.run(params0=PARAMS_0, post_process_fn=post_process_fn)
+    result = optimizer.run(post_process_fn=post_process_fn)
 
     # these store at the very beginning and at the end of every iteration
     # but when ``store_full_results == False``, they only store the last one
@@ -384,7 +382,7 @@ def test_result(
 
     val_last1 = result.last["params"]
     val_last2 = result.get_last("params")
-    assert np.allclose(val_last1, val_last2)
+    npt.assert_allclose(val_last1, val_last2)
 
     result.plot_optimization()
     _ = result.sim_data_last(task_name="last")
@@ -500,5 +498,66 @@ def test_invdes_with_metric_objective(use_emulated_run, use_emulated_to_sim_data
         num_steps=1,
     )
 
-    params0 = np.random.random(invdes.design_region.params_shape)
-    optimizer.run(params0=params0)
+    optimizer.run()
+
+
+@pytest.mark.parametrize(
+    "spec_class, spec_kwargs, expected_shape",
+    [
+        (RandomInitializationSpec, {"min_value": 0.0, "max_value": 1.0}, (3, 3)),
+        (UniformInitializationSpec, {"value": 0.5}, (2, 2)),
+        (CustomInitializationSpec, {"params": np.array([[1, 2], [3, 4]])}, (2, 2)),
+    ],
+)
+def test_parameter_spec(spec_class, spec_kwargs, expected_shape):
+    """Test the creation of parameter arrays from different InitializationSpec classes."""
+    spec = spec_class(**spec_kwargs)
+    params = spec.create_parameters(expected_shape)
+    assert params.shape == expected_shape
+
+
+def test_parameter_spec_with_inverse_design(use_emulated_run, use_emulated_to_sim_data):  # noqa: F811
+    """Test InitializationSpec with InverseDesign class."""
+
+    metric = 2 * ModePower(monitor_name=MNT_NAME2, freqs=[FREQ0]) ** 2
+
+    initialization_spec = RandomInitializationSpec()
+    design_region = make_design_region()
+    design_region = design_region.updated_copy(initialization_spec=initialization_spec)
+
+    invdes = tdi.InverseDesign(
+        simulation=simulation,
+        design_region=design_region,
+        task_name="test_metric",
+        metric=metric,
+    )
+
+    optimizer = tdi.AdamOptimizer(
+        design=invdes,
+        learning_rate=0.2,
+        num_steps=1,
+    )
+
+    optimizer.run()
+
+
+def test_initial_simulation():
+    """Test the initial_simulation property for InverseDesign."""
+    invdes = make_invdes()
+    initial_sim = invdes.initial_simulation
+    assert isinstance(initial_sim, td.Simulation)
+    assert initial_sim.structures[-1] == invdes.design_region.to_structure(
+        invdes.design_region.initial_parameters
+    )
+
+
+def test_initial_simulation_multi():
+    """Test the initial_simulation property for InverseDesignMulti."""
+    invdes_multi = make_invdes_multi()
+    initial_sims = invdes_multi.initial_simulation
+    assert isinstance(initial_sims, dict)
+    for sim in initial_sims.values():
+        assert isinstance(sim, td.Simulation)
+        assert sim.structures[-1] == invdes_multi.design_region.to_structure(
+            invdes_multi.design_region.initial_parameters
+        )

--- a/tidy3d/plugins/invdes/__init__.py
+++ b/tidy3d/plugins/invdes/__init__.py
@@ -2,6 +2,11 @@
 
 from . import utils
 from .design import InverseDesign, InverseDesignMulti
+from .initialization import (
+    CustomInitializationSpec,
+    RandomInitializationSpec,
+    UniformInitializationSpec,
+)
 from .optimizer import AdamOptimizer
 from .penalty import ErosionDilationPenalty
 from .region import TopologyDesignRegion
@@ -16,5 +21,8 @@ __all__ = (
     "TopologyDesignRegion",
     "AdamOptimizer",
     "InverseDesignResult",
+    "RandomInitializationSpec",
+    "UniformInitializationSpec",
+    "CustomInitializationSpec",
     "utils",
 )

--- a/tidy3d/plugins/invdes/design.py
+++ b/tidy3d/plugins/invdes/design.py
@@ -85,6 +85,12 @@ class AbstractInverseDesign(InvdesBaseModel, abc.ABC):
 
         return objective_fn
 
+    @property
+    def initial_simulation(self) -> td.Simulation:
+        """Return a simulation with the initial design region parameters."""
+        initial_params = self.design_region.initial_parameters
+        return self.to_simulation(initial_params)
+
 
 class InverseDesign(AbstractInverseDesign):
     """Container for an inverse design problem."""

--- a/tidy3d/plugins/invdes/initialization.py
+++ b/tidy3d/plugins/invdes/initialization.py
@@ -1,0 +1,86 @@
+# module providing classes for initializing the parameters in an inverse design problem
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Optional, Union
+
+import numpy as np
+import pydantic.v1 as pd
+
+from tidy3d.components.base import Tidy3dBaseModel
+from tidy3d.components.types import ArrayLike
+
+
+class AbstractInitializationSpec(Tidy3dBaseModel, ABC):
+    """Abstract base class for initialization specifications."""
+
+    @abstractmethod
+    def create_parameters(self, shape: tuple[int, ...]) -> np.ndarray:
+        """Generate the parameter array based on the specification."""
+        pass
+
+
+class RandomInitializationSpec(AbstractInitializationSpec):
+    """Specification for random initial parameters.
+
+    When a seed is provided, a call to `create_parameters` will always return the same array.
+    """
+
+    min_value: float = pd.Field(
+        0.0,
+        title="Minimum Value",
+        description="Minimum value for the random parameters (inclusive).",
+    )
+    max_value: float = pd.Field(
+        1.0,
+        title="Minimum Value",
+        description="Maximum value for the random parameters (exclusive).",
+    )
+    seed: Optional[int] = pd.Field(None, description="Seed for the random number generator.")
+
+    def create_parameters(self, shape: tuple[int, ...]) -> np.ndarray:
+        """Generate the parameter array based on the specification."""
+        rng = np.random.default_rng(self.seed)
+        return rng.uniform(self.min_value, self.max_value, shape)
+
+
+class UniformInitializationSpec(AbstractInitializationSpec):
+    """Specification for uniform initial parameters."""
+
+    value: float = pd.Field(
+        0.5,
+        title="Value",
+        description="Value to use for all elements in the parameter array.",
+    )
+
+    def create_parameters(self, shape: tuple[int, ...]) -> np.ndarray:
+        """Generate the parameter array based on the specification."""
+        return np.full(shape, self.value)
+
+
+class CustomInitializationSpec(AbstractInitializationSpec):
+    """Specification for custom initial parameters provided by the user."""
+
+    params: ArrayLike = pd.Field(
+        ...,
+        title="Parameters",
+        description="Custom parameters provided by the user.",
+    )
+
+    def create_parameters(self, shape: tuple[int, ...]) -> np.ndarray:
+        """Return the custom parameters provided by the user."""
+        params = np.asarray(self.params)
+        if params.shape != shape:
+            raise ValueError(
+                f"Provided 'params.shape' ('{params.shape}') does not match "
+                f"the shape of the custom parameters ('{shape}')."
+            )
+        return params
+
+
+InitializationSpecType = Union[
+    RandomInitializationSpec,
+    UniformInitializationSpec,
+    CustomInitializationSpec,
+]


### PR DESCRIPTION
Adds `InitializationSpec` classes:
 - `UniformInitializationSpec(value=...)` -> uniform initialization with single value
 - `RandomInitializationSpec(min_value=..., max_value=..., seed=None)` -> random initialization between `min_value` and `max_value`, optional `seed`
 - `CustomInitializationSpec(params=...)`, where `params` is `ArrayLike` -> user-defined initial parameters

### Usage:

in `invdes.DesignRegion`:
```python
opt = DesignRegion(initialization_spec=UniformInitializationSpec())
```

more generally:
```python
spec = RandomInitializationSpec(min_value=0, max_value=1)
params = spec.create_parameters(shape=(x, y, ...))
```

The invdes optimizer calls `design_region.initial_parameters` to initialize the optimization.

@momchil-flex 