### PR TITLE
implementing interpolation option for `plot_field` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Users can pass the `shading` argument in the `SimulationData.plot_field` to `Xarray.plot` method. When `shading='gouraud'`, the image is interpolated, producing a smoother visualization.
 - Users can manually specify the background medium for a structure to be used for geometry gradient calculations by supplying `Structure.background_permittivity`. This is useful when there are overlapping structures or structures embedded in other mediums.
 - Autograd functions can now be called directly on `DataArray` (e.g., `np.sum(data_array)`) in objective functions.
 

--- a/tests/test_data/test_sim_data.py
+++ b/tests/test_data/test_sim_data.py
@@ -140,6 +140,10 @@ def test_plot(phase):
                 "field", field_cmp, val="imag", f=1e14, phase=phase, **xyz_kwargs
             )
             plt.close()
+    for shading in ["gouraud", "nearest", "auto"]:
+        _ = sim_data.plot_field(
+            "field", field_cmp, val="imag", f=1e14, phase=phase, shading=shading, **xyz_kwargs
+        )
     for axis_name in "xyz":
         xyz_kwargs = {axis_name: 0}
         _ = sim_data.plot_field("field", "int", f=1e14, phase=phase, **xyz_kwargs)

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -447,6 +447,7 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
         vmin: float = None,
         vmax: float = None,
         ax: Ax = None,
+        shading: str = "flat",
         **sel_kwargs,
     ) -> Ax:
         """Plot the field data for a monitor with simulation plot overlaid.
@@ -481,6 +482,8 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
             inferred from the data and other keyword arguments.
         ax : matplotlib.axes._subplots.Axes = None
             matplotlib axes to plot on, if not specified, one is created.
+        shading: str = 'flat'
+            Shading argument for Xarray plot method ('flat','nearest','goraud')
         sel_kwargs : keyword arguments used to perform ``.sel()`` selection in the monitor data.
             These kwargs can select over the spatial dimensions (``x``, ``y``, ``z``),
             frequency or time dimensions (``f``, ``t``) or ``mode_index``, if applicable.
@@ -493,7 +496,6 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
         matplotlib.axes._subplots.Axes
             The supplied or created matplotlib axes.
         """
-
         # get the DataArray corresponding to the monitor_name and field_name
         # deprecated intensity
         if field_name == "int":
@@ -640,6 +642,8 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
             vmax=vmax,
             cmap_type=cmap_type,
             ax=ax,
+            shading=shading,
+            infer_intervals=True if shading == "flat" else False,
         )
 
     def plot_field(
@@ -654,6 +658,7 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
         vmin: float = None,
         vmax: float = None,
         ax: Ax = None,
+        shading: str = "flat",
         **sel_kwargs,
     ) -> Ax:
         """Plot the field data for a monitor with simulation plot overlaid.
@@ -689,6 +694,8 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
             inferred from the data and other keyword arguments.
         ax : matplotlib.axes._subplots.Axes = None
             matplotlib axes to plot on, if not specified, one is created.
+        shading: str = 'flat'
+            Shading argument for Xarray plot method ('flat','nearest','goraud')
         sel_kwargs : keyword arguments used to perform ``.sel()`` selection in the monitor data.
             These kwargs can select over the spatial dimensions (``x``, ``y``, ``z``),
             frequency or time dimensions (``f``, ``t``) or ``mode_index``, if applicable.
@@ -703,6 +710,7 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
         """
 
         field_monitor_data = self.load_field_monitor(field_monitor_name)
+
         return self.plot_field_monitor_data(
             field_monitor_data=field_monitor_data,
             field_name=field_name,
@@ -714,6 +722,7 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
             vmin=vmin,
             vmax=vmax,
             ax=ax,
+            shading=shading,
             **sel_kwargs,
         )
 
@@ -731,6 +740,7 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
         vmax: float = None,
         cmap_type: ColormapType = "divergent",
         ax: Ax = None,
+        **kwargs,
     ) -> Ax:
         """Plot the field data for a monitor with simulation plot overlaid.
 
@@ -763,6 +773,7 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
             Type of color map to use for plotting.
         ax : matplotlib.axes._subplots.Axes = None
             matplotlib axes to plot on, if not specified, one is created.
+        **kwargs : Extra arguments to ``DataArray.plot``.
 
         Returns
         -------
@@ -802,6 +813,7 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
             robust=robust,
             center=center,
             cbar_kwargs={"label": field_data.name},
+            **kwargs,
         )
 
         # plot the simulation epsilon


### PR DESCRIPTION
Hi @tylerflex,

I’ve implemented the interpolation option. Here's how I approached it:

The default is set to False, so it generates a regular plot.
If set to `True`, it interpolates with 200 x 200 points.
If a `tuple (a, b)` is provided, it interpolates with a x b points.
If an `int a` is provided, it interpolates with a x a points.
I added an assertion to prevent users from interpolating more than 1000 points in any dimension to avoid potential notebook crashes due to memory limitations.

Let me know if this approach is too complex; I can simplify it if needed, like just True or False.

Fixes #1952