### PR TITLE
`Structure.from_permittivity_array`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Convenience method `Structure.from_permittivity_array(geometry, eps_data)`, which creates structure containing `CustomMedium` with `eps_data` array sampled within `geometry.bounds`.
+
 ### Fixed
 - Ensure `path` argument in `run()` function is respected when running under autograd or the adjoint plugin.
 


### PR DESCRIPTION
Fixes #1971 

Open to changing the name `Structure.from_custom_data` since it technically just creates structure from custom permittivity data? maybe it could be generalized?

But basically I think this will simplify some adjoint demos so would be good to have in 2.7.4