### PR TITLE
Construct medium from a transfer function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added optimization methods to the Design plugin. The plugin has been expanded to include Bayesian optimization, genetic algorithms and particle swarm optimization. Explanations of these methods are available in new and updated notebooks.
 - Added new support functions for the Design plugin: automated batching of `Simulation` objects, and summary functions with `DesignSpace.estimate_cost` and `DesignSpace.summarize`.
 - Added validation and repair methods for `TriangleMesh` with inward-facing normals.
+- Added `from_admittance_coeffs` to `PoleResidue`, which allows for directly constructing a `PoleResidue` medium from an admittance function in the Laplace domain.
 
 ### Changed
 - Priority is given to `snapping_points` in `GridSpec` when close to structure boundaries, which reduces the chance of them being skipped.


### PR DESCRIPTION
Not sure if this is of interest to others, but when working on lumped elements I found that I needed to construct a `PoleResidue` medium given an admittance function in the Laplace domain, which is most commonly written as a rational expression. This might be useful in other cases where you would like to model a material that is not easily converted to `PoleResidue` format, but the differential equation governing the polarization current is available.

More precisely, given $\epsilon_\infty$ and an admittance relationship between electric field and a polarization current density

$$ J_p(s) = Y(s)E(s)$$

where

$$Y(s) = \frac{a_0 + a_1 s + \dots + a_M s^M}{b_0 + b_1 s + \dots + b_N s^N}$$

we can find an equivalent complex permittivity (assuming $Y(s)$ is causal, substitute $s = j \omega$) 

$$\epsilon(\omega) = \epsilon_\infty - \frac{1}{\\epsilon_0 j \omega}Y(j \omega).$$

Finally, we compute the poles and residues of $\frac{1}{\\epsilon_0 j \omega}Y(j \omega)$ to convert it into a `PoleResidue`  medium.

At this point I am just curious if this would be useful outside of lumped elements.