### PR TITLE
Fix bug in subsection with nonlinear materials source detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Ensure `path` argument in `run()` function is respected when running under autograd or the adjoint plugin.
+- Bug in `Simulation.subsection` (used in the mode solver) when nonlinear materials rely on information about sources outside of the region.
 
 
 ## [2.7.3] - 2024-09-12

--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -616,6 +616,15 @@ def test_nonlinear_medium(log_capture):
     assert n0 == nonlinear_spec.models[0]._get_n0(n0=None, medium=medium, freqs=[freq0])
     assert freq0 == nonlinear_spec.models[0]._get_freq0(freq0=None, freqs=[freq0])
 
+    # subsection with nonlinear materials needs to hardcode source info
+    sim2 = sim.updated_copy(center=(-4, -4, -4), path="sources/0")
+    sim2 = sim2.updated_copy(
+        models=[td.TwoPhotonAbsorption(beta=1)], path="structures/0/medium/nonlinear_spec"
+    )
+    sim2 = sim2.subsection(region=td.Box(center=(0, 0, 0), size=(1, 1, 0)))
+    assert sim2.structures[0].medium.nonlinear_spec.models[0].n0 == n0
+    assert sim2.structures[0].medium.nonlinear_spec.models[0].freq0 == freq0
+
     # can't detect n0 with different source freqs
     source_time2 = source_time.updated_copy(freq0=2 * freq0)
     source2 = source.updated_copy(source_time=source_time2)

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -2452,7 +2452,10 @@ def test_sim_subsection(unstructured, nz):
     sim_red = SIM_FULL.subsection(region=region, monitors=[])
     assert len(sim_red.monitors) == 0
     sim_red = SIM_FULL.subsection(region=region, remove_outside_structures=False)
-    assert sim_red.structures == SIM_FULL.structures
+    assert len(sim_red.structures) == len(SIM_FULL.structures)
+    for strc_red, strc in zip(sim_red.structures, SIM_FULL.structures):
+        if strc.medium.nonlinear_spec is None:
+            assert strc == strc_red
     sim_red = SIM_FULL.subsection(region=region, remove_outside_custom_mediums=True)
 
     perm = td.SpatialDataArray(

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -341,7 +341,20 @@ class ModeSolver(Tidy3dBaseModel):
 
     def _data_on_yee_grid(self) -> ModeSolverData:
         """Solve for all modes, and construct data with fields on the Yee grid."""
-        solver = self.reduced_simulation_copy
+
+        # we try to do reduced simulation copy for efficiency
+        # it should never fail -- if it does, this is likely due to an oversight
+        # in the Simulation.subsection method. but falling back to non-reduced
+        # simulation prevents unneeded errors in this case
+        try:
+            solver = self.reduced_simulation_copy
+        except Exception as e:
+            solver = self
+            log.warning(
+                "Mode solver reduced_simulation_copy failed. "
+                "Falling back to non-reduced simulation, which may be slower. "
+                f"Exception: {str(e)}"
+            )
 
         _, _solver_coords = solver.plane.pop_axis(
             solver._solver_grid.boundaries.to_list, axis=solver.normal_axis


### PR DESCRIPTION
Subsection removes sources not intersecting the region, but some nonlinear materials rely on these sources to obtain n0 and freq0.

This PR updates all such nonlinear materials during subsection to obtain and hardcode n0 and freq0 so they no longer require the sources.