### PR TITLE
:wrench: :robot: Fix release actions deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
       if: contains(github.ref, 'rc') == false
       uses: everlytic/branch-merge@1.1.2
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.GH_PAT }}
         source_ref: ${{ github.ref }}
         target_branch: "latest"
         commit_message_template: ':tada: RELEASE: Merged {source_ref} into target {target_branch}'
@@ -90,7 +90,7 @@ jobs:
       with:
         generate_release_notes: true      
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GH_PAT }}
   pypi-release:
     runs-on: ubuntu-latest
     steps:
@@ -119,7 +119,7 @@ jobs:
       if: contains(github.ref, 'rc') == false
       uses: everlytic/branch-merge@1.1.2
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.GH_PAT }}
         source_ref: "latest"
         target_branch: "develop"
         commit_message_template: ':tada: RELEASE: Synced latest into develop'

--- a/.github/workflows/sync-to-readthedocs-repo.yaml
+++ b/.github/workflows/sync-to-readthedocs-repo.yaml
@@ -50,7 +50,7 @@ jobs:
           git remote add mirror https://github.com/flexcompute-readthedocs/tidy3d-docs.git
           git push mirror ${{ needs.extract_branch_or_tag.outputs.ref_name }} --force # overwrites always
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 
       # Conditional Checkout for Tag
       - name: Checkout Tag if tag-triggered-sync
@@ -69,4 +69,4 @@ jobs:
           git remote add mirror https://github.com/flexcompute-readthedocs/tidy3d-docs.git
           git push mirror ${{ needs.extract_branch_or_tag.outputs.ref_name }} --force # overwrites always
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
Turns out I needed to make sure the release and sync workflows were associated to a non-robot github action secret in order for the full connected workflow to work. 

Should fix the release and sync action bugs we ran into earlier.