### PR TITLE
Fix simulation file overwriting caused by same file name of forward and adjoint simulations

### DIFF
--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -3,6 +3,7 @@
 import tempfile
 import typing
 from collections import defaultdict
+from os.path import basename, dirname, join
 
 import numpy as np
 from autograd.builtins import dict as dict_ag
@@ -886,6 +887,9 @@ def _run_tidy3d(
         verbose = run_kwargs.get("verbose", False)
         upload_sim_fields_keys(run_kwargs["sim_fields_keys"], task_id=job.task_id, verbose=verbose)
     path = run_kwargs.get("path", DEFAULT_DATA_PATH)
+    if task_name.endswith("_adjoint"):
+        path_parts = basename(path).split(".")
+        path = join(dirname(path), path_parts[0] + "_adjoint." + ".".join(path_parts[1:]))
     data = job.run(path)
     return data, job.task_id
 


### PR DESCRIPTION
Following the bug fix in 2.7.4 for autograd, whenever a adjoint simulation is ran, it would have the same file name as the forward simulation file, causing overwrite. This is because both the forward and adjoint simulation calls this function with the same arguments

In more detail, currently when this function is called, the if statement in line 886 is never called because for the forward and adjoint simulation, its types are always "'simulation_type': ‘tidy3d_autograd’’, and the only way to differentiate between them is by using the “_adjoint” postfix in task_name.

I propose this fix here to add the postfix to the file name as well, to avoid the overwriting while being as less invasive as possible.