### PR TITLE
fix bug when setting 'path_dir' in ComponentModeler

### DIFF
--- a/tests/test_plugins/smatrix/test_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_component_modeler.py
@@ -395,3 +395,12 @@ def test_to_from_file_batch(tmp_path, monkeypatch):
     modeler2 = modeler.from_file(fname)
 
     assert modeler2.batch_cached == modeler2.batch == batch
+
+
+def test_non_default_path_dir(monkeypatch):
+    modeler = make_component_modeler(path_dir="not_default")
+    monkeypatch.setattr(ComponentModeler, "_construct_smatrix", lambda self: None)
+    modeler.run()
+    modeler.run(path_dir="not_default")
+    with pytest.raises(ValueError):
+        modeler.run(path_dir="a_new_path")

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -181,7 +181,7 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
     def get_path_dir(self, path_dir: str) -> None:
         """Check whether the supplied 'path_dir' matches the internal field value."""
 
-        if path_dir != self.path_dir:
+        if path_dir != self.path_dir and path_dir != DEFAULT_DATA_DIR:
             raise ValueError(
                 f"'path_dir' of '{path_dir}' passed, but 'ComponentModeler.path_dir' is "
                 f"{self.path_dir}. Moving forward, only the 'ComponentModeler.path_dir' will be "


### PR DESCRIPTION
Fixed a small bug that doesn't allow you to change the `path_dir` in the `ComponentModeler`. It is from a recent PR, so no changelog required.