### PR TITLE
fix invalid geometry created in 'subdivide'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix numerical precision issue in `FieldProjectionCartesianMonitor`.
 - Bug where lumped elements in the `Simulation` were being overwritten by the `TerminalComponentModeler`.
 - Bug in `Simulation.subsection` where lumped elements were not being correctly removed.
+- Bug when adding 2D structures to the `Simulation` that are composed of multiple overlapping polygons.
 
 ## [2.7.2] - 2024-08-07
 

--- a/tidy3d/components/geometry/utils_2d.py
+++ b/tidy3d/components/geometry/utils_2d.py
@@ -122,15 +122,13 @@ def subdivide(
     plane = {coord: center}
 
     # Convert input geometry into MultiPolygon shapely geometry and track the original structure that references the media properties
-    geom_shapely = Geometry.evaluate_inf_shape(
-        shapely.MultiPolygon(geom.intersections_plane(**plane))
-    )
+    geom_shapely = Geometry.evaluate_inf_shape(shapely.union_all(geom.intersections_plane(**plane)))
 
     plane[coord] = center + check_delta[1]
     above_shapely = [
         (
             Geometry.evaluate_inf_shape(
-                shapely.MultiPolygon(structure.geometry.intersections_plane(**plane))
+                shapely.union_all(structure.geometry.intersections_plane(**plane))
             ),
             structure,
         )
@@ -141,7 +139,7 @@ def subdivide(
     below_shapely = [
         [
             Geometry.evaluate_inf_shape(
-                shapely.MultiPolygon(structure.geometry.intersections_plane(**plane))
+                shapely.union_all(structure.geometry.intersections_plane(**plane))
             ),
             structure,
         ]


### PR DESCRIPTION
Subdivide was creating MultiPolygon where polygons were overlapping. This caused an error later when performing set operations.