### PR TITLE
:memo: Basic example section introductions

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -29,6 +29,14 @@ iframe {width: 100%;border: unset}
 .toctree-wrapper li[class^=toctree-l3]>a {font-size: 0.9em; text-decoration: none}
 .toctree-wrapper li[class^=toctree-l4]>a {font-size: 0.9em; text-decoration: none}
 
+.toctree-wrapper.example-notebook-toc li[class^=toctree-l1] > a::before {
+    content: "📘 ";  /* Emoji before the link */
+}
+
+.toctree-wrapper.example-notebook-toc li[class^=toctree-l1] > a:hover::before {
+    content: "📖 ";  /* Change emoji on hover */
+}
+
 html[data-theme="light"] {
     --pst-color-primary: #b5445b;
     --pst-color-secondary: #4772ae;


### PR DESCRIPTION
(On a side note I'm the lucky Y2K winner)

Ok finally the branch name is correct and syncing to rtd:

- [X] Basic example section introductions
- [X] Improved notebook list styling

This is a live version before I fixed the notebook colors - it'd be handy to check this with multiple platforms and browsers.
https://docs.flexcompute.com/projects/tidy3d/en/demo-test-basic_section_intro/notebooks/docs/features/autograd.html

Turns out I had misinterpreted (closes https://github.com/flexcompute/autoflex/issues/10) where I thought we wanted descriptions for each notebooks, whereas we just wanted section descriptions. So this implements section descriptions. The good thing is I now also know how to implement like notebooks links with thumbnails and descriptions rather than this list so if we want to do that we can.


![image](https://github.com/user-attachments/assets/1912c24d-e6d3-442a-8b27-7d70445215f0)
