### PR TITLE
fix field projection discrepancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BatchData` is now a mapping and can be accessed and iterated over like a Python dictionary (`.keys()`, `.values()`, `.items()`).
 - `MethodRandom` and `MethodRandomCustom` have been removed from the Design plugin, and `DesignSpace.run_batch` has been superseded by `.run`.
 - Design plugin has been significantly reworked to improve ease of use and allow for new optimization methods.
+- Behavior of `FieldProjector` now matches the server-side computation, which does not truncate the integration surface when it extends into PML regions.
 
 ### Fixed
 - Significant speedup for field projection computations.

--- a/tidy3d/components/field_projection.py
+++ b/tidy3d/components/field_projection.py
@@ -318,18 +318,18 @@ class FieldProjector(Tidy3dBaseModel):
         wavelength = C_0 / frequency / index_n
 
         _, idx_uv = surface.monitor.pop_axis((0, 1, 2), axis=surface.axis)
-
+        coord_list = sim_data.simulation.grid.boundaries.to_list
         for idx in idx_uv:
             # pick sample points on the monitor and handle the possibility of an "infinite" monitor
+            # Fields within PML regions are included, to match the server-side computation.
             start = np.maximum(
                 surface.monitor.center[idx] - surface.monitor.size[idx] / 2.0,
-                sim_data.simulation.center[idx] - sim_data.simulation.size[idx] / 2.0,
+                coord_list[idx][0],
             )
             stop = np.minimum(
                 surface.monitor.center[idx] + surface.monitor.size[idx] / 2.0,
-                sim_data.simulation.center[idx] + sim_data.simulation.size[idx] / 2.0,
+                coord_list[idx][-1],
             )
-
             if pts_per_wavelength is None:
                 points = sim_data.simulation.grid.boundaries.to_list[idx]
                 points[np.argwhere(points < start)] = start


### PR DESCRIPTION
Small change to behavior when integration surface extends into PML region. We changed the behavior to closer match the server-side computations. Users should probably not be setting up simulations like this anyways, since field projection is only accurate when the field goes to 0 at the boundaries of the integration surface.

Backend [PR](https://github.com/flexcompute/tidy3d-core/pull/729) and related [issue](https://github.com/flexcompute/tidy3d-core/issues/679)
