### PR TITLE
Added a fix to ensure remote folder is created before running batch o…

### DIFF
--- a/tidy3d/web/api/mode.py
+++ b/tidy3d/web/api/mode.py
@@ -231,6 +231,10 @@ def run_batch(
 
     if verbose:
         console.log(f"[cyan]Running a batch of [deep_pink4]{num_mode_solvers} mode solvers.\n")
+
+        # Create the common folder before running the parallel computation
+        _ = Folder.create(folder_name=folder_name)
+
         with Progress(console=console) as progress:
             pbar = progress.add_task("Status:", total=num_mode_solvers)
             results = Parallel(n_jobs=max_workers, backend="threading")(


### PR DESCRIPTION
…f mode solver simulations.

One user reported that running batch solver for mode solver created multiple folders with the same name on our web platform. We figured out a way to fix this by creating the folder explicitly first before running the async call for batch solver.  Last time I had asked the user to just implement in their frontend code and it works so we just need to include this before the next release. Thank you!