### PR TITLE
Replace infinite coordinates for shapely operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
 ## [2.7.5] - 2024-10-10
 
 ### Added
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix to batch mode solver run that could create multiple copies of the same folder.
 - Fixed ``ModeSolver.plot`` method when the simulation is not at the origin.
 - Gradient calculation is orders of magnitude faster for large datasets and many structures by applying more efficient handling of field interpolation and passing to structures.
+- Bug with infinite coordinates in `ClipOperation` not working with shapely.
 
 ## [2.7.4] - 2024-09-25
 

--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -189,6 +189,17 @@ def test_intersections_plane(component):
     assert len(component.intersections_plane(x=10000)) == 0
 
 
+def test_intersections_plane_inf():
+    a = (
+        td.Cylinder(radius=3.2, center=(0.45, 9, 0), length=td.inf)
+        + td.Box(center=(0, 0, 0), size=(0.9, 24, td.inf))
+        + td.Box(center=(0, 0, 0), size=(7.3, 18, td.inf))
+    )
+    b = td.Cylinder(radius=2.9, center=(-0.45, 9, 0), length=td.inf)
+    c = a - b
+    assert len(c.intersections_plane(y=0)) == 1
+
+
 def test_bounds_base():
     assert all(a == b for a, b in zip(Planar.bounds.fget(POLYSLAB), POLYSLAB.bounds))
 

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -2857,12 +2857,10 @@ class ClipOperation(Geometry):
             For more details refer to
             `Shapely's Documentation <https://shapely.readthedocs.io/en/stable/project.html>`_.
         """
-        geom_a = Geometry.evaluate_inf_shape(
-            shapely.unary_union(self.geometry_a.intersections_tilted_plane(normal, origin, to_2D))
-        )
-        geom_b = Geometry.evaluate_inf_shape(
-            shapely.unary_union(self.geometry_b.intersections_tilted_plane(normal, origin, to_2D))
-        )
+        a = self.geometry_a.intersections_tilted_plane(normal, origin, to_2D)
+        b = self.geometry_b.intersections_tilted_plane(normal, origin, to_2D)
+        geom_a = shapely.unary_union([Geometry.evaluate_inf_shape(g) for g in a])
+        geom_b = shapely.unary_union([Geometry.evaluate_inf_shape(g) for g in b])
         return ClipOperation.to_polygon_list(self._shapely_operation(geom_a, geom_b))
 
     def intersections_plane(
@@ -2886,12 +2884,10 @@ class ClipOperation(Geometry):
             For more details refer to
             `Shapely's Documentaton <https://shapely.readthedocs.io/en/stable/project.html>`_.
         """
-        geom_a = Geometry.evaluate_inf_shape(
-            shapely.unary_union(self.geometry_a.intersections_plane(x, y, z))
-        )
-        geom_b = Geometry.evaluate_inf_shape(
-            shapely.unary_union(self.geometry_b.intersections_plane(x, y, z))
-        )
+        a = self.geometry_a.intersections_plane(x, y, z)
+        b = self.geometry_b.intersections_plane(x, y, z)
+        geom_a = shapely.unary_union([Geometry.evaluate_inf_shape(g) for g in a])
+        geom_b = shapely.unary_union([Geometry.evaluate_inf_shape(g) for g in b])
         return ClipOperation.to_polygon_list(self._shapely_operation(geom_a, geom_b))
 
     @cached_property

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -1745,7 +1745,7 @@ class ComplexPolySlabBase(PolySlab):
         return [
             shapely.unary_union(
                 [
-                    shape
+                    base.Geometry.evaluate_inf_shape(shape)
                     for polyslab in self.sub_polyslabs
                     for shape in polyslab.intersections_tilted_plane(normal, origin, to_2D)
                 ]


### PR DESCRIPTION
This fixes the bug described in https://github.com/flexcompute/tidy3d-core/issues/726

The added test is the minimal failure case I could find, but to be honest, I'm not 100% sure why it fails in this instance when other shapes with infinite coordinates worked fine in shapely.