### PR TITLE
Add more robust gauge choice for high-order modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Disallow very small polygons when subdividing 2D structures.
 - For efficiency, `translated`, `scaled`, and `rotated` `PolySlab`-s now return updated `PolySlab` objects rather than a `Transformed` object, except when the rotation axis is not the same as the slab axis, in which case `Transformed` is still returned.
 - Default choice of frequency in `Simulation.plot_eps` and `Simulation.plot_structures_eps` is now the central frequency of all sources in the simulation. If the central frequencies differ, the permittivity is evaluated at infinite frequency, and a warning is emitted. 
+- Mode solver fields are more consistently normalized with respect to grid-dependent sign inversions in high order modes.
 
 ### Fixed
 - Significant speedup for field projection computations.

--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -1098,3 +1098,63 @@ def test_mode_small_bend_radius_fail():
             freqs=np.linspace(1e14, 2e14, 100),
             mode_spec=td.ModeSpec(num_modes=1, bend_radius=1, bend_axis=0),
         )
+
+
+def make_high_order_mode_solver(sign, dim=3):
+    waveguide = td.Structure(
+        geometry=td.Box(size=(td.inf, 0.6, 0.2)),
+        medium=td.Medium(permittivity=3.47**2),
+    )
+
+    refine_box = td.MeshOverrideStructure(
+        geometry=td.Box(center=(0, sign * 0.3, 0), size=(td.inf, 0.1, 0.3)),
+        dl=[None, 0.02, 0.02],
+    )
+
+    pml = td.Boundary(plus=td.PML(), minus=td.PML())
+    periodic = td.Boundary(plus=td.Periodic(), minus=td.Periodic())
+
+    sim = td.Simulation(
+        size=(10, 2.5, 1.5 if dim == 3 else 0),
+        grid_spec=td.GridSpec.auto(
+            min_steps_per_wvl=20, wavelength=1.55, override_structures=[refine_box]
+        ),
+        structures=[waveguide],
+        medium=td.Medium(permittivity=1.44**2),
+        boundary_spec=td.BoundarySpec(x=pml, y=pml, z=pml if dim == 3 else periodic),
+        run_time=1e-12,
+    )
+
+    plane = td.Box(center=(0, 0, 0), size=(0, 2.5, 1.5))
+    freq0 = td.C_0 / 1.55
+    num_modes = 3
+
+    mode_spec = td.ModeSpec(
+        num_modes=num_modes,
+        target_neff=3.47,
+        group_index_step=False,
+    )
+
+    return ModeSolver(
+        simulation=sim,
+        plane=plane,
+        mode_spec=mode_spec,
+        freqs=[freq0],
+    )
+
+
+def test_high_order_mode_normalization():
+    # 3D simulation
+    ms1 = make_high_order_mode_solver(1)
+    ms2 = make_high_order_mode_solver(-1)
+    overlap = ms1.data.outer_dot(ms2.data).isel(mode_index_0=2, mode_index_1=2).values.item()
+    assert abs(1 - overlap) < 1e-3
+
+    # 2D simulation
+    ms1 = make_high_order_mode_solver(1, 2)
+    values = ms1.data.Ez.isel(mode_index=2).values.squeeze().real
+    assert (values[: values.size // 3] > 0).all()
+
+    ms2 = make_high_order_mode_solver(-1, 2)
+    values = ms2.data.Ez.isel(mode_index=2).values.squeeze().real
+    assert (values[: values.size // 3] > 0).all()

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -41,6 +41,7 @@ from ...components.types import (
     ArrayComplex3D,
     ArrayComplex4D,
     ArrayFloat1D,
+    ArrayFloat2D,
     Ax,
     Axis,
     Axis2D,
@@ -1150,13 +1151,15 @@ class ModeSolver(Tidy3dBaseModel):
         return n_complex, fields, eps_spec
 
     @staticmethod
-    def _postprocess_solver_fields(solver_fields, normal_axis, plane, mode_spec):
+    def _postprocess_solver_fields(solver_fields, normal_axis, plane, mode_spec, coords):
         """Postprocess `solver_fields` from `compute_modes` to proper coordinate"""
         fields = {key: [] for key in ("Ex", "Ey", "Ez", "Hx", "Hy", "Hz")}
+        diff_coords = (np.diff(coords[0]), np.diff(coords[1]))
+
         for mode_index in range(mode_spec.num_modes):
             # Get E and H fields at the current mode_index
             ((Ex, Ey, Ez), (Hx, Hy, Hz)) = ModeSolver._process_fields(
-                solver_fields, mode_index, normal_axis, plane
+                solver_fields, mode_index, normal_axis, plane, diff_coords
             )
 
             # Note: back in original coordinates
@@ -1194,7 +1197,7 @@ class ModeSolver(Tidy3dBaseModel):
         )
 
         fields = self._postprocess_solver_fields(
-            solver_fields, self.normal_axis, self.plane, self.mode_spec
+            solver_fields, self.normal_axis, self.plane, self.mode_spec, coords
         )
         return n_complex, fields, eps_spec
 
@@ -1250,7 +1253,7 @@ class ModeSolver(Tidy3dBaseModel):
         )
 
         fields = self._postprocess_solver_fields(
-            solver_fields, self.normal_axis, self.plane, self.mode_spec
+            solver_fields, self.normal_axis, self.plane, self.mode_spec, coords
         )
         return n_complex, fields, eps_spec
 
@@ -1261,11 +1264,53 @@ class ModeSolver(Tidy3dBaseModel):
         return np.stack(plane.unpop_axis(f_z, (f_x, f_y), axis=normal_axis), axis=0)
 
     @staticmethod
+    def _weighted_coord_max(
+        array: ArrayFloat2D, u: ArrayFloat1D, v: ArrayFloat1D
+    ) -> Tuple[int, int]:
+        """2D argmax for an array weighted in both directions."""
+        m = array * u.reshape(-1, 1)
+        i = np.arange(array.shape[0])
+        i = int(0.5 + (m * i.reshape(-1, 1)).sum() / m.sum())
+        m = array * v
+        j = np.arange(array.shape[1])
+        j = int(0.5 + (m * j).sum() / m.sum())
+        return i, j
+
+    @staticmethod
+    def _inverted_gauge(e_field: FIELD, diff_coords: Tuple[ArrayFloat1D, ArrayFloat1D]) -> bool:
+        """Check if the lower xy region of the mode has a negative sign."""
+        dx, dy = diff_coords
+        e_x, e_y = e_field[:2, :, :, 0]
+        e_x = e_x.real
+        e_y = e_y.real
+        e = e_x if np.abs(e_x).max() > np.abs(e_y).max() else e_y
+        abs_e = np.abs(e)
+        e_2 = abs_e**2
+        i, j = e.shape
+        while i > 0 and j > 0:
+            if (e[:i, :j] > 0).all():
+                return False
+            elif (e[:i, :j] < 0).all():
+                return True
+            else:
+                threshold = abs_e[:i, :j].max() * 0.5
+                i, j = ModeSolver._weighted_coord_max(e_2[:i, :j], dx[:i], dy[:j])
+                if abs(e[i, j]) >= threshold:
+                    return e[i, j] < 0
+                # Do not close the window for 1D mode solvers
+                if e.shape[0] == 1:
+                    i = 1
+                elif e.shape[1] == 1:
+                    j = 1
+        return False
+
+    @staticmethod
     def _process_fields(
         mode_fields: ArrayComplex4D,
         mode_index: pydantic.NonNegativeInt,
         normal_axis: Axis,
         plane: MODE_PLANE_TYPE,
+        diff_coords: Tuple[ArrayFloat1D, ArrayFloat1D],
     ) -> Tuple[FIELD, FIELD]:
         """Transform solver fields to simulation axes and set gauge."""
 
@@ -1277,6 +1322,13 @@ class ModeSolver(Tidy3dBaseModel):
         phi = np.angle(E[:2].ravel()[ind_max])
         E *= np.exp(-1j * phi)
         H *= np.exp(-1j * phi)
+
+        # High-order modes with opposite-sign lobes will show inconsistent sign, heavily dependent
+        # on the exact local grid to choose the previous gauge. This method flips the gauge sign
+        # when necessary to make it more consistent.
+        if ModeSolver._inverted_gauge(E, diff_coords):
+            E *= -1
+            H *= -1
 
         # Rotate back to original coordinates
         (Ex, Ey, Ez) = ModeSolver._rotate_field_coords(E, normal_axis, plane)


### PR DESCRIPTION
I'm porting this gauge fix from PhotonForge, where it's been working for a while now. It works for 2D and 1D mode domains and should not change the current gauge used for fundamental modes.

I'm attaching a notebook that more easily illustrates the problem. Just compare the results with and without this fix:
[gauge_test.zip](https://github.com/user-attachments/files/17365524/gauge_test.zip)