### PR TITLE
more polyslab gradient bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+### Fixed
+- Minor gradient bugfix for `PolySlab` involving the gradient norm and displacement field contribution.
+
 ## [2.7.5] - 2024-10-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Fixed
-- Minor gradient bugfix for `PolySlab` involving the gradient norm and displacement field contribution.
+- Minor gradient direction and normalization fixes for polyslab, field monitors, and diffraction monitors in autograd.
 
 ## [2.7.5] - 2024-10-16
 

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -35,8 +35,8 @@ TEST_CUSTOM_MEDIUM_SPEED = False
 TEST_POLYSLAB_SPEED = False
 
 # whether to run numerical gradient tests, off by default because it runs real simulations
-RUN_NUMERICAL = False
-_NUMERICAL_COMBINATION = ("size_element", "mode")
+RUN_NUMERICAL = True
+_NUMERICAL_COMBINATION = ("polyslab", "diff")
 
 TEST_MODES = ("pipeline", "adjoint", "speed")
 TEST_MODE = "speed" if TEST_POLYSLAB_SPEED else "pipeline"
@@ -78,7 +78,7 @@ DA_SHAPE_X = 1 if IS_3D else 1
 DA_SHAPE = (DA_SHAPE_X, 1_000, 1_000) if TEST_CUSTOM_MEDIUM_SPEED else (DA_SHAPE_X, 12, 12)
 
 # number of vertices in the polyslab
-NUM_VERTICES = 100_000 if TEST_POLYSLAB_SPEED else 110
+NUM_VERTICES = 100_000 if TEST_POLYSLAB_SPEED else 210
 
 PNT_DIPOLE = td.PointDipole(
     center=(0, 0, -LZ / 2 + WVL),
@@ -99,6 +99,7 @@ PLANE_WAVE = td.PlaneWave(
         fwidth=FWIDTH,
         amplitude=1.0,
     ),
+    pol_angle=0 * np.pi / 2.0,
 )
 
 # sim that we add traced structures and monitors to
@@ -329,16 +330,17 @@ def make_structures(params: anp.ndarray) -> dict[str, td.Structure]:
     radii = 1.0 + 0.5 * params_01
 
     phis = 2 * anp.pi * anp.linspace(0, 1, NUM_VERTICES + 1)[:NUM_VERTICES]
+    phis = phis[::-1]
     xs = radii * anp.cos(phis)
     ys = radii * anp.sin(phis)
     vertices = anp.stack((xs, ys), axis=-1)
     polyslab = td.Structure(
         geometry=td.PolySlab(
             vertices=vertices,
-            slab_bounds=(-0.5, 0.5),
+            slab_bounds=(-td.inf, td.inf),
             axis=0,
-            sidewall_angle=0.01,
-            dilation=0.01,
+            sidewall_angle=0.00,
+            dilation=0.0,
         ),
         medium=med,
     )
@@ -422,7 +424,7 @@ def make_monitors() -> dict[str, tuple[td.Monitor, typing.Callable[[td.Simulatio
     mode_mnt = td.ModeMonitor(
         size=(2, 2, 0),
         center=(0, 0, +LZ / 2 - X * WVL),
-        mode_spec=td.ModeSpec(),
+        mode_spec=td.ModeSpec(num_modes=2),
         freqs=[FREQ0],
         name="mode",
     )
@@ -450,10 +452,10 @@ def make_monitors() -> dict[str, tuple[td.Monitor, typing.Callable[[td.Simulatio
 
     def field_vol_postprocess_fn(sim_data, mnt_data):
         value = 0.0
-        for _, val in mnt_data.field_components.items():
-            value = value + abs(anp.sum(val.values))
-        intensity = anp.nan_to_num(anp.sum(sim_data.get_intensity(mnt_data.monitor.name).values))
-        value += intensity
+        # for _, val in mnt_data.field_components.items():
+        #     value = value + abs(anp.sum(val.values))
+        # intensity = anp.nan_to_num(anp.sum(sim_data.get_intensity(mnt_data.monitor.name).values))
+        # value += intensity
         value += anp.sum(mnt_data.flux.values)
         return value
 
@@ -619,7 +621,7 @@ def test_autograd_numerical(structure_key, monitor_key):
     assert anp.all(grad != 0.0), "some gradients are 0"
 
     # numerical gradients
-    delta = 1e-3
+    delta = 1e-1
     sims_numerical = {}
 
     params_num = np.zeros((N_PARAMS, N_PARAMS))
@@ -1210,6 +1212,7 @@ def _test_many_structures():
                 center=(0, 0, -1),
                 size=(td.inf, td.inf, 0),
                 direction="+",
+                pol_angle=np.pi / 2,
             )
 
             sim = td.Simulation(

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -35,8 +35,8 @@ TEST_CUSTOM_MEDIUM_SPEED = False
 TEST_POLYSLAB_SPEED = False
 
 # whether to run numerical gradient tests, off by default because it runs real simulations
-RUN_NUMERICAL = True
-_NUMERICAL_COMBINATION = ("polyslab", "diff")
+RUN_NUMERICAL = False
+_NUMERICAL_COMBINATION = ("size_element", "mode")
 
 TEST_MODES = ("pipeline", "adjoint", "speed")
 TEST_MODE = "speed" if TEST_POLYSLAB_SPEED else "pipeline"
@@ -78,7 +78,7 @@ DA_SHAPE_X = 1 if IS_3D else 1
 DA_SHAPE = (DA_SHAPE_X, 1_000, 1_000) if TEST_CUSTOM_MEDIUM_SPEED else (DA_SHAPE_X, 12, 12)
 
 # number of vertices in the polyslab
-NUM_VERTICES = 100_000 if TEST_POLYSLAB_SPEED else 210
+NUM_VERTICES = 100_000 if TEST_POLYSLAB_SPEED else 110
 
 PNT_DIPOLE = td.PointDipole(
     center=(0, 0, -LZ / 2 + WVL),
@@ -99,7 +99,6 @@ PLANE_WAVE = td.PlaneWave(
         fwidth=FWIDTH,
         amplitude=1.0,
     ),
-    pol_angle=0 * np.pi / 2.0,
 )
 
 # sim that we add traced structures and monitors to
@@ -330,17 +329,16 @@ def make_structures(params: anp.ndarray) -> dict[str, td.Structure]:
     radii = 1.0 + 0.5 * params_01
 
     phis = 2 * anp.pi * anp.linspace(0, 1, NUM_VERTICES + 1)[:NUM_VERTICES]
-    phis = phis[::-1]
     xs = radii * anp.cos(phis)
     ys = radii * anp.sin(phis)
     vertices = anp.stack((xs, ys), axis=-1)
     polyslab = td.Structure(
         geometry=td.PolySlab(
             vertices=vertices,
-            slab_bounds=(-td.inf, td.inf),
+            slab_bounds=(-0.5, 0.5),
             axis=0,
-            sidewall_angle=0.00,
-            dilation=0.0,
+            sidewall_angle=0.01,
+            dilation=0.01,
         ),
         medium=med,
     )
@@ -424,7 +422,7 @@ def make_monitors() -> dict[str, tuple[td.Monitor, typing.Callable[[td.Simulatio
     mode_mnt = td.ModeMonitor(
         size=(2, 2, 0),
         center=(0, 0, +LZ / 2 - X * WVL),
-        mode_spec=td.ModeSpec(num_modes=2),
+        mode_spec=td.ModeSpec(),
         freqs=[FREQ0],
         name="mode",
     )
@@ -452,10 +450,10 @@ def make_monitors() -> dict[str, tuple[td.Monitor, typing.Callable[[td.Simulatio
 
     def field_vol_postprocess_fn(sim_data, mnt_data):
         value = 0.0
-        # for _, val in mnt_data.field_components.items():
-        #     value = value + abs(anp.sum(val.values))
-        # intensity = anp.nan_to_num(anp.sum(sim_data.get_intensity(mnt_data.monitor.name).values))
-        # value += intensity
+        for _, val in mnt_data.field_components.items():
+            value = value + abs(anp.sum(val.values))
+        intensity = anp.nan_to_num(anp.sum(sim_data.get_intensity(mnt_data.monitor.name).values))
+        value += intensity
         value += anp.sum(mnt_data.flux.values)
         return value
 
@@ -621,7 +619,7 @@ def test_autograd_numerical(structure_key, monitor_key):
     assert anp.all(grad != 0.0), "some gradients are 0"
 
     # numerical gradients
-    delta = 1e-1
+    delta = 1e-3
     sims_numerical = {}
 
     params_num = np.zeros((N_PARAMS, N_PARAMS))
@@ -1212,7 +1210,6 @@ def _test_many_structures():
                 center=(0, 0, -1),
                 size=(td.inf, td.inf, 0),
                 direction="+",
-                pol_angle=np.pi / 2,
             )
 
             sim = td.Simulation(

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -2974,7 +2974,7 @@ class DiffractionData(AbstractFieldProjectionData):
         theta_data, phi_data = self.angles
         angle_sel_kwargs = dict(orders_x=int(order_x), orders_y=int(order_y), f=float(freq0))
         angle_theta = float(theta_data.sel(**angle_sel_kwargs))
-        angle_phi = 0 * np.pi + float(phi_data.sel(**angle_sel_kwargs))
+        angle_phi = float(phi_data.sel(**angle_sel_kwargs))
 
         # if the angle is nan, this amplitude is set to 0 in the fwd pass, so should skip adj
         if np.isnan(angle_theta):

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -1037,7 +1037,7 @@ class FieldData(FieldDataset, ElectromagneticFieldData):
 
             for freq0 in field_component.coords["f"]:
                 omega0 = 2 * np.pi * freq0
-                scaling_factor = 1 / (MU_0 * omega0)
+                scaling_factor = 33 / (MU_0 * omega0)
 
                 forward_amp = self.get_amplitude(field_component.sel(f=freq0))
 
@@ -1076,7 +1076,7 @@ class FieldData(FieldDataset, ElectromagneticFieldData):
             for name, field_component in self.field_components.items():
                 # get the VJP values at frequency and apply adjoint phase
                 field_component = field_component.sel(f=freq0)
-                values = -1j * field_component.values
+                values = 2 * -1j * field_component.values
 
                 # make source go backwards
                 if "H" in name:
@@ -2974,7 +2974,7 @@ class DiffractionData(AbstractFieldProjectionData):
         theta_data, phi_data = self.angles
         angle_sel_kwargs = dict(orders_x=int(order_x), orders_y=int(order_y), f=float(freq0))
         angle_theta = float(theta_data.sel(**angle_sel_kwargs))
-        angle_phi = np.pi + float(phi_data.sel(**angle_sel_kwargs))
+        angle_phi = 0 * np.pi + float(phi_data.sel(**angle_sel_kwargs))
 
         # if the angle is nan, this amplitude is set to 0 in the fwd pass, so should skip adj
         if np.isnan(angle_theta):
@@ -3000,7 +3000,7 @@ class DiffractionData(AbstractFieldProjectionData):
             center=self.monitor.center,
             source_time=GaussianPulse(
                 amplitude=abs(src_amp),
-                phase=np.pi + np.angle(src_amp),
+                phase=np.angle(src_amp),
                 freq0=freq0,
                 fwidth=fwidth,
             ),

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -2433,7 +2433,7 @@ class Box(SimplePlaneIntersection, Centered):
         eps_xyz = [derivative_info.eps_data[f"eps_{dim}{dim}"] for dim in "xyz"]
 
         # number of cells from the edge of data to register "inside" (index = num_cells_in - 1)
-        num_cells_in = 3
+        num_cells_in = 4
 
         # if not enough data, just use best guess using eps in medium and simulation
         needs_eps_approx = any(len(eps.coords[dim_normal]) <= num_cells_in for eps in eps_xyz)

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -1425,7 +1425,7 @@ class PolySlab(base.Planar):
         vjps_edges = 0.0
 
         # perform D-normal integral
-        contrib_D = delta_eps_inv * D_der_norm
+        contrib_D = -delta_eps_inv * D_der_norm
         vjps_edges += contrib_D
 
         # perform E-perpendicular integrals
@@ -1438,12 +1438,9 @@ class PolySlab(base.Planar):
         edge_areas = edge_lengths
 
         # correction to edge area based on sidewall distance along slab axis
-        dim_axis = "xyz"[self.axis]
-        field_coords_axis = derivative_info.E_der_map[f"E{dim_axis}"].coords[dim_axis]
-        if len(field_coords_axis) > 1:
-            slab_height = abs(float(np.squeeze(np.diff(self.slab_bounds))))
-            if not np.isinf(slab_height):
-                edge_areas *= slab_height
+        slab_height = abs(float(np.squeeze(np.diff(self.slab_bounds))))
+        if not np.isinf(slab_height):
+            edge_areas *= slab_height
 
         vjps_edges *= edge_areas
 
@@ -1452,6 +1449,7 @@ class PolySlab(base.Planar):
         vjps_edges_in_plane = vjps_edges.values.reshape((num_vertices, 1)) * normal_vectors_in_plane
 
         vjps_vertices = vjps_edges_in_plane + np.roll(vjps_edges_in_plane, axis=0, shift=-1)
+        vjps_vertices /= 2.0  # each vertex is effected only 1/2 by each edge
 
         # sign change if counter clockwise, because normal direction is flipped
         if self.is_ccw:

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -870,9 +870,6 @@ def _run_tidy3d(
     return data, job.task_id
 
 
-defvjp(_run_tidy3d, _run_bwd, argnums=[0])
-
-
 def _run_tidy3d_bwd(simulation: td.Simulation, task_name: str, **run_kwargs) -> AutogradFieldMap:
     """Run a simulation without any tracers using regular web.run()."""
     job_init_kwargs = parse_run_kwargs(**run_kwargs)

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -870,6 +870,9 @@ def _run_tidy3d(
     return data, job.task_id
 
 
+defvjp(_run_tidy3d, _run_bwd, argnums=[0])
+
+
 def _run_tidy3d_bwd(simulation: td.Simulation, task_name: str, **run_kwargs) -> AutogradFieldMap:
     """Run a simulation without any tracers using regular web.run()."""
     job_init_kwargs = parse_run_kwargs(**run_kwargs)


### PR DESCRIPTION
Some minor but important polyslab gradient fixes. Surprised I missed this but glad I ended up catching it after all. Goes to show how tricky these things can be.

1. Found a sign error in the gradient contribution. This was not really affecting anything except in certain polarizations, it turned out to improve a customers' taper gradient accuracy, and fixed one of my numerical tests under certain conditions.

2. Also realized some condition for incorporating the slab_bounds into the area calculation was not being included as it was out of date with another PR. So after this fix + another tweak to the gradient norm, I am seeing POlySlab gradients matching numerical not only better than before but with the right magnitude.