### PR TITLE
Skip geometry validation in simulation subsection and mode solver reduction

### DIFF
--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -1564,9 +1564,21 @@ class ModeSolver(Tidy3dBaseModel):
             remove_outside_custom_mediums=True,
             remove_outside_structures=True,
             include_pml_cells=True,
+            validate_geometries=False,
+            deep_copy=False,
         )
-
-        return self.updated_copy(simulation=new_sim)
+        # Let's only validate mode solver where geometry validation is skipped: geometry replaced by its bounding
+        # box
+        structures = [
+            strc.updated_copy(geometry=strc.geometry.bounding_box, deep=False)
+            for strc in new_sim.structures
+        ]
+        # skip validation as it's validated already in subsection
+        aux_new_sim = new_sim.updated_copy(structures=structures, deep=False, validate=False)
+        # validate mode solver here where geometry is replaced by its bounding box
+        new_mode = self.updated_copy(simulation=aux_new_sim, deep=False)
+        # return full mode solver and skip validation
+        return new_mode.updated_copy(simulation=new_sim, deep=False, validate=False)
 
     def to_fdtd_mode_solver(self) -> ModeSolver:
         """Construct a new :class:`.ModeSolver` by converting ``simulation``


### PR DESCRIPTION
This is part of efforts in speeding up mode solver when a geometry group contains large number of geometries. (Last piece in resolving https://github.com/flexcompute/tidy3d-core/issues/692)

- Add options in `updated_copy` to skip valiation.
- The geometry is validated when the simulation object is initialized, and they are not modified in subsection. Thus we can skip validators that are directly associated with geometry.
- For validators of other simulation fields associated with geometry, only the bounding box of the geometry matters. So to validate other simulation fields, we use an auxiliary simulation object whose geometry is replaced by its bounding box.

