### PR TITLE
Mode solver improvement for simulations at low-frequency containing metals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Design plugin has been significantly reworked to improve ease of use and allow for new optimization methods.
 - Behavior of `FieldProjector` now matches the server-side computation, which does not truncate the integration surface when it extends into PML regions.
 - Enabled the user to set the `ModeMonitor.colocate` field and changed to `True` by default (fields were actually already returned colocated even though this field was `False` previously).
+- More robust mode solver at radio frequencies.
 
 ### Fixed
 - Significant speedup for field projection computations.


### PR DESCRIPTION
Two main improvements:

- For the eigenvalue problem with the matrix `PQ` where `P = p_mu + p_partial` and `Q = q_ep + q_partial`, where `p_mu` denotes the matrix containing `mu_parallel`, and `q_ep` for `epsilon_parallel`, and the `partial` term for the remaining matrix components that contains `Grad*ep(mu)^-1*Grad`. One observation is that if you write out the block form, one can find that `p_partial @ q_partial=0`. Since `Grad` scales `1/(k0* dl)`, in low-frequency/high-resolution regime, `Grad` can be huge, not mention that `p(q)_partial` scales as `Grad**2`. So even though `p_partial @ q_partial` is strictly 0, machine error can generate nonzero terms that completely ruin the eigenvalues of matrix `PQ`. This is responsible for the oscillating phenomenon of effective n as a function of frequency in the low-frequency regime.

  In this PR, we don't compute `PQ` with the fully assembled matrix `P` and `Q`, but `PQ = p_mu @ Q + p_partial @ q_ep` so that `p_partial @ q_partial` is for sure dropped.

- Let's take matrix `P` as an illustration (the same applies to `Q`), `p_partial` scales as `1/(k0* dl)**2`. So in low-frequency/high-resolution regime, `p_partial` term might grow so huge that `p_mu` term becomes negligible. But for PEC, its permittivity value should still be significant. So our default permittivity value for PEC should be scaled by the factor  `1/(k0* dl)**2`.

(Tests to be added in the solver part in a separate PR.)