### PR TITLE
automatic mode rotation for bent waveguide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Differential operators `grad` and `value_and_grad` in `tidy3d.plugins.autograd` that behave similarly to the autograd operators but support auxiliary data via `aux_data=True` as well as differentiation w.r.t. `DataArray`.
 - `@scalar_objective` decorator in `tidy3d.plugins.autograd` that wraps objective functions to ensure they return a scalar value and performs additional checks to ensure compatibility of objective functions with autograd. Used by default in `tidy3d.plugins.autograd.value_and_grad` as well as `tidy3d.plugins.autograd.grad`.
 - Autograd support for simulations without adjoint sources in `run` as well as `run_async`, which will not attempt to run the simulation but instead return zero gradients. This can sometimes occur if the objective function gradient does not depend on some simulations, for example when using `min` or `max` in the objective.
+- `bend_angle_rotation` in `ModeSpec` to improve accuracy in some cases when both `bend_radius` and `angle_theta` are defined. This option is disabled by default but it can be tried when very high accuracy is required in `ModeSource` and `ModeMonitor` objects that are placed in bend and angled waveguides.
 
 ### Changed
 - `CustomMedium` design regions require far less data when performing inverse design by reducing adjoint field monitor size for dims with one pixel.

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -59,6 +59,7 @@ from .components.data.data_array import (
     PointDataArray,
     ScalarFieldDataArray,
     ScalarFieldTimeDataArray,
+    ScalarModeFieldCylindricalDataArray,
     ScalarModeFieldDataArray,
     SpatialDataArray,
 )
@@ -399,6 +400,7 @@ __all__ = [
     "FieldProjector",
     "ScalarFieldDataArray",
     "ScalarModeFieldDataArray",
+    "ScalarModeFieldCylindricalDataArray",
     "ScalarFieldTimeDataArray",
     "SpatialDataArray",
     "ModeAmpsDataArray",

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -813,6 +813,24 @@ class ScalarModeFieldDataArray(AbstractSpatialDataArray):
     _dims = ("x", "y", "z", "f", "mode_index")
 
 
+class ScalarModeFieldCylindricalDataArray(AbstractSpatialDataArray):
+    """Spatial distribution of a mode in frequency-domain as a function of mode index.
+
+    Example
+    -------
+    >>> rho = [1,2]
+    >>> theta = [2,3,4]
+    >>> axial = [3,4,5,6]
+    >>> f = [2e14, 3e14]
+    >>> mode_index = np.arange(5)
+    >>> coords = dict(rho=rho, theta=theta, axial=axial, f=f, mode_index=mode_index)
+    >>> fd = ScalarModeFieldCylindricalDataArray((1+1j) * np.random.random((2,3,4,2,5)), coords=coords)
+    """
+
+    __slots__ = ()
+    _dims = ("rho", "theta", "axial", "f", "mode_index")
+
+
 class FluxDataArray(DataArray):
     """Flux through a surface in the frequency-domain.
 

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -32,6 +32,7 @@ from .data_array import (
     PointDataArray,
     ScalarFieldDataArray,
     ScalarFieldTimeDataArray,
+    ScalarModeFieldCylindricalDataArray,
     ScalarModeFieldDataArray,
     SpatialDataArray,
     TimeDataArray,
@@ -149,6 +150,7 @@ EMScalarFieldType = Union[
     ScalarFieldDataArray,
     ScalarFieldTimeDataArray,
     ScalarModeFieldDataArray,
+    ScalarModeFieldCylindricalDataArray,
     EMEScalarModeFieldDataArray,
     EMEScalarFieldDataArray,
 ]

--- a/tidy3d/components/mode.py
+++ b/tidy3d/components/mode.py
@@ -129,6 +129,18 @@ class ModeSpec(Tidy3dBaseModel):
         "yz plane, the ``bend_axis`` is always 1 (the global z axis).",
     )
 
+    bend_angle_rotation: bool = pd.Field(
+        False,
+        title="Use fields rotation when both bend and angle are defined",
+        description="Defines how modes are computed when both a bend and an angle are defined. "
+        "If `False`, the two coordinate transformations are directly composed. "
+        "If `True`, the structures in the simulation are first rotated to compute a mode solution at "
+        "a reference plane normal to the bend's azimuthal direction. Then, the fields are rotated to align with "
+        "the mode plane, using the `n_eff` calculated at the reference plane. The second option can "
+        "produce more accurate results, but more care must be taken, for example, in ensuring that the "
+        "original mode plane intersects the correct geometries in the simulation with rotated structures.",
+    )
+
     track_freq: Union[TrackFreq, None] = pd.Field(
         "central",
         title="Mode Tracking Frequency",


### PR DESCRIPTION
@momchil-flex This is a very initial draft and not ready for review yet, but could you take a quick look at the code structure to see if there are any major mistakes so I can address them early on? I added a field `bend_correction` in mode_spec, and the process for mode rotation is mostly in `data_raw` in `ModeSolver`.