### PR TITLE
add `background_permittivity` to `Structure` to manually override shape optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Users can manually specify the background medium for a structure to be used for geometry gradient calculations by supplying `Structure.background_permittivity`. This is useful when there are overlapping structures or structures embedded in other mediums.
 
 ## [2.7.5] - 2024-10-16
 

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -277,6 +277,7 @@ def make_structures(params: anp.ndarray) -> dict[str, td.Structure]:
     size_element = td.Structure(
         geometry=td.Box(center=(0, 0, 0), size=(1, size_y, 1)),
         medium=med,
+        background_permittivity=5.0,
     )
 
     # custom medium with variable permittivity data

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -53,6 +53,14 @@ class AbstractStructure(Tidy3dBaseModel):
 
     name: str = pydantic.Field(None, title="Name", description="Optional name for the structure.")
 
+    background_permittivity: float = pydantic.Field(
+        None,
+        ge=1.0,
+        title="Background Permittivity",
+        description="Relative permittivity used for the background of this structure "
+        "when performing shape optimization with autograd.",
+    )
+
     _name_validator = validate_name_str()
 
     @pydantic.validator("geometry")

--- a/tidy3d/plugins/autograd/README.md
+++ b/tidy3d/plugins/autograd/README.md
@@ -147,6 +147,7 @@ The following components are traceable as outputs of the `td.SimulationData`
 Other features
 - support for multi-frequency monitors in certain situations (single adjoint source).
 - server-side gradient processing by passing `local_gradient=False` to the `web` functions. This can dramatically cut down on data storage time, just be careful about using this with multi-frequency monitors and large design regions as it can lead to large data storage on our servers.
+- To manually set the background permittivity of a structure for purposes of shape optimization, one can set `Structure.background_permittivity`. This is useful when there is a substrate or multiple overlapping structures as some geometries, such as `PolySlab`, do not automatically detect background permittivity and instead use the `Simulation.medium` by default.
 
 We currently have the following restrictions:
 

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -811,6 +811,10 @@ def postprocess_adj(
         eps_in = np.mean(structure.medium.eps_model(freq_adj))
         eps_out = np.mean(sim_data_orig.simulation.medium.eps_model(freq_adj))
 
+        # manually override simulation medium as the background structure
+        if structure.background_permittivity is not None:
+            eps_out = structure.background_permittivity
+
         derivative_info = DerivativeInfo(
             paths=structure_paths,
             E_der_map=E_der_map.field_components,


### PR DESCRIPTION
Note, already done in #2030 but want in 2.7