### PR TITLE
add internal construct smatrix

### DIFF
--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -121,19 +121,19 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
 
     @cached_property
     def sim_dict(self) -> Dict[str, Simulation]:
-        """Generate all the :class:`Simulation` objects for the S matrix calculation."""
+        """Generate all the :class:`.Simulation` objects for the S matrix calculation."""
 
     def to_file(self, fname: str) -> None:
-        """Exports :class:`Tidy3dBaseModel` instance to .yaml, .json, or .hdf5 file
+        """Exports :class:`AbstractComponentModeler` instance to .yaml, .json, or .hdf5 file
 
         Parameters
         ----------
         fname : str
-            Full path to the .yaml or .json file to save the :class:`Tidy3dBaseModel` to.
+            Full path to the .yaml or .json file to save the :class:`AbstractComponentModeler` to.
 
         Example
         -------
-        >>> simulation.to_file(fname='folder/sim.json') # doctest: +SKIP
+        >>> modeler.to_file(fname='folder/sim.json') # doctest: +SKIP
         """
 
         batch_cached = self._cached_properties.get("batch")
@@ -149,7 +149,7 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
 
     @cached_property
     def batch(self) -> Batch:
-        """Batch associated with this component modeler."""
+        """:class:`.Batch` associated with this component modeler."""
 
         if self.batch_cached is not None:
             return self.batch_cached
@@ -175,7 +175,7 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
 
     @cached_property
     def batch_data(self) -> BatchData:
-        """The ``BatchData`` associated with the simulations run for this component modeler."""
+        """The :class:`.BatchData` associated with the simulations run for this component modeler."""
         return self.batch.run(path_dir=self.path_dir)
 
     def get_path_dir(self, path_dir: str) -> None:
@@ -193,11 +193,11 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
 
     @cached_property
     def _batch_path(self) -> str:
-        """Where we store the batch for this ComponentModeler instance after the run."""
+        """Where we store the batch for this :class:`AbstractComponentModeler` instance after the run."""
         return os.path.join(self.path_dir, "batch" + str(hash(self)) + ".hdf5")
 
     def _run_sims(self, path_dir: str = DEFAULT_DATA_DIR) -> BatchData:
-        """Run :class:`Simulations` for each port and return the batch after saving."""
+        """Run :class:`.Simulation` for each port and return the batch after saving."""
         _ = self.get_path_dir(path_dir)
         self.batch.to_file(self._batch_path)
         batch_data = self.batch_data
@@ -212,7 +212,11 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
 
     @abstractmethod
     def _construct_smatrix(self, batch_data: BatchData) -> DataArray:
-        """Post process :class:`BatchData` to generate scattering matrix."""
+        """Post process :class:`.BatchData` to generate scattering matrix."""
+
+    @abstractmethod
+    def _internal_construct_smatrix(self, batch_data: BatchData) -> DataArray:
+        """Post process :class:`.BatchData` to generate scattering matrix, for internal use only."""
 
     def run(self, path_dir: str = DEFAULT_DATA_DIR) -> DataArray:
         """Solves for the scattering matrix of the system."""
@@ -220,7 +224,7 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
         return self._construct_smatrix()
 
     def load(self, path_dir: str = DEFAULT_DATA_DIR) -> DataArray:
-        """Load a scattering matrix from saved :class:`BatchData` object."""
+        """Load a scattering matrix from saved :class:`.BatchData` object."""
         return self.run(path_dir=path_dir)
 
     @staticmethod

--- a/tidy3d/plugins/smatrix/component_modelers/modal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/modal.py
@@ -17,6 +17,7 @@ from ....components.source import GaussianPulse, ModeSource
 from ....components.types import Ax, Complex
 from ....components.viz import add_ax_if_none, equal_aspect
 from ....exceptions import SetupError
+from ....web.api.container import BatchData
 from ..ports.modal import ModalPortDataArray, Port
 from .base import FWIDTH_FRAC, AbstractComponentModeler
 
@@ -92,7 +93,7 @@ class ComponentModeler(AbstractComponentModeler):
 
     @cached_property
     def sim_dict(self) -> Dict[str, Simulation]:
-        """Generate all the :class:`Simulation` objects for the S matrix calculation."""
+        """Generate all the :class:`.Simulation` objects for the S matrix calculation."""
 
         sim_dict = {}
         mode_monitors = [self.to_monitor(port=port) for port in self.ports]
@@ -205,7 +206,7 @@ class ComponentModeler(AbstractComponentModeler):
     @equal_aspect
     @add_ax_if_none
     def plot_sim(self, x: float = None, y: float = None, z: float = None, ax: Ax = None) -> Ax:
-        """Plot a :class:`Simulation` with all sources added for each port, for troubleshooting."""
+        """Plot a :class:`.Simulation` with all sources added for each port, for troubleshooting."""
 
         plot_sources = []
         for port_source in self.ports:
@@ -219,7 +220,7 @@ class ComponentModeler(AbstractComponentModeler):
     def plot_sim_eps(
         self, x: float = None, y: float = None, z: float = None, ax: Ax = None, **kwargs
     ) -> Ax:
-        """Plot permittivity of the :class:`Simulation` with all sources added for each port."""
+        """Plot permittivity of the :class:`.Simulation` with all sources added for each port."""
 
         plot_sources = []
         for port_source in self.ports:
@@ -256,7 +257,11 @@ class ComponentModeler(AbstractComponentModeler):
         return max_mode_index_out, max_mode_index_in
 
     def _construct_smatrix(self) -> ModalPortDataArray:
-        """Post process `BatchData` to generate scattering matrix."""
+        """Post process :class:`.BatchData` to generate scattering matrix."""
+        return self._internal_construct_smatrix(batch_data=self.batch_data)
+
+    def _internal_construct_smatrix(self, batch_data: BatchData) -> ModalPortDataArray:
+        """Post process :class:`.BatchData` to generate scattering matrix, for internal use only."""
 
         batch_data = self.batch_data
 

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -183,9 +183,11 @@ class TerminalComponentModeler(AbstractComponentModeler):
         )
 
     def _construct_smatrix(self) -> TerminalPortDataArray:
-        """Post process ``BatchData`` to generate scattering matrix."""
+        """Post process :class:`.BatchData` to generate scattering matrix."""
+        return self._internal_construct_smatrix(batch_data=self.batch_data)
 
-        batch_data = self.batch_data
+    def _internal_construct_smatrix(self, batch_data: BatchData) -> TerminalPortDataArray:
+        """Post process :class:`.BatchData` to generate scattering matrix, for internal use only."""
 
         port_names = [port.name for port in self.ports]
 


### PR DESCRIPTION
I find for development work it is handy to have a `_construct_smatrix` version that accepts an arbitrary `batch_data`. This allows us to run the simulations once and save/load the `batch_data` to/from file. I also fixed some docstring links that were broken.

Additional question, @tylerflex is there a simple way to change how the `BatchData` is created and read from so that it is easier to switch between:

1. Web version that uses `Batch.run`
2. local backend solver using `run_sim` 
3. loading from file

I find when I am developing I always have some code that is needed to change between these methods for generating `BatchData`.