### PR TITLE
Pre-upload validating server autograd runs and optimizer

### DIFF
--- a/tests/test_plugins/test_invdes.py
+++ b/tests/test_plugins/test_invdes.py
@@ -297,6 +297,7 @@ def make_result(use_emulated_run):  # noqa: F811
     """Test running the optimization defined in the ``InverseDesign`` object."""
 
     optimizer = make_optimizer()
+    optimizer.validate_pre_upload()
 
     return optimizer.run(post_process_fn=post_process_fn)
 

--- a/tidy3d/plugins/invdes/optimizer.py
+++ b/tidy3d/plugins/invdes/optimizer.py
@@ -73,7 +73,7 @@ class AbstractOptimizer(InvdesBaseModel, abc.ABC):
 
     def validate_pre_upload(self) -> None:
         """Validate the fully initialized optimizer is ok for upload to our servers."""
-        pass
+        self.design.simulation.validate_pre_upload()
 
     def display_fn(self, result: InverseDesignResult, step_index: int) -> None:
         """Default display function while optimizing."""

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -410,6 +410,7 @@ def _run_primitive(
         )
 
     else:
+        sim_combined.validate_pre_upload()
         sim_original = sim_original.updated_copy(simulation_type="autograd_fwd", deep=False)
         run_kwargs["simulation_type"] = "autograd_fwd"
         run_kwargs["sim_fields_keys"] = list(sim_fields.keys())


### PR DESCRIPTION
- Add `validate_pre_upload()` call to the forward simulation *with monitors* when called in a server autograd run. The adjoint simulation includes the monitors already.
- Modify the optimizer `validate_pre_upload()` method to call the corresponding method for the embedded simulation.