### PR TITLE
Limit max data size to 100 * simulation.num_cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Behavior of `FieldProjector` now matches the server-side computation, which does not truncate the integration surface when it extends into PML regions.
 - Enabled the user to set the `ModeMonitor.colocate` field and changed to `True` by default (fields were actually already returned colocated even though this field was `False` previously).
 - More robust mode solver at radio frequencies.
-
+- Maximum simulation data size (in bytes) was capped to `100` times the number of cells in the simulation. The old cap of `50GB` total also still applies.
+ 
 ### Fixed
 - Significant speedup for field projection computations.
 - Fix numerical precision issue in `FieldProjectionCartesianMonitor`.

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -551,6 +551,14 @@ def test_validate_mnt_size(monkeypatch, log_capture):
         )
         s._validate_monitor_size()
 
+    # error for simulation size in units of number of grid cells
+    monkeypatch.setattr(simulation, "MAX_SIMULATION_DATA_SIZE_NUM_CELLS", 0.5 / s.num_cells)
+    with pytest.raises(SetupError):
+        s = SIM.copy(
+            update=dict(monitors=(td.FieldMonitor(name="f", freqs=[1e12], size=(1, 1, 1)),))
+        )
+        s._validate_monitor_size()
+
 
 def test_max_geometry_validation():
     gs = td.GridSpec(wavelength=1.0)

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -126,7 +126,10 @@ MAX_CELLS_TIMES_STEPS = 1e16
 MAX_TIME_MONITOR_STEPS = 5000  # does not apply to 0D monitors
 WARN_MONITOR_DATA_SIZE_GB = 10
 MAX_MONITOR_INTERNAL_DATA_SIZE_GB = 50
-MAX_SIMULATION_DATA_SIZE_GB = 50
+MAX_SIMULATION_DATA_SIZE_GB = 50  # absolute maximum of simulation data size
+MAX_SIMULATION_DATA_SIZE_NUM_CELLS = (
+    100  # max data size (bytes) relative to number of points in simulation
+)
 WARN_MODE_NUM_CELLS = 1e5
 
 # number of grid cells at which we warn about slow Simulation.epsilon()
@@ -3388,10 +3391,12 @@ class Simulation(AbstractYeeGridSimulation):
 
                 total_size_gb += monitor_size_gb
 
-        if total_size_gb > MAX_SIMULATION_DATA_SIZE_GB:
+        max_data_size_gb = MAX_SIMULATION_DATA_SIZE_NUM_CELLS * self.num_cells / 1e9
+        max_data_size_gb = min([MAX_SIMULATION_DATA_SIZE_GB, max_data_size_gb])
+        if total_size_gb > max_data_size_gb:
             raise SetupError(
                 f"Simulation's monitors have {total_size_gb:.2f}GB of estimated storage, "
-                f"a maximum of {MAX_SIMULATION_DATA_SIZE_GB:.2f}GB are allowed."
+                f"a maximum of {max_data_size_gb:.2f}GB are allowed."
             )
 
         # Some monitors store much less data than what is needed internally. Make sure that the


### PR DESCRIPTION
At some point we had a user submit many small simulations that each needed to upload GBs of data, which overloaded our servers. I discussed with Zongfu at the time that one solution would be to allow at most `100 * simulation.num_cells` bytes of data to be produced by a given simulation. So a simulation with 1M points can only have 100MB output, but a simulation with 500M points reaches our other hard limit of 50GB data total.

I am not sure if this will interfere with e.g. some of the adjoint examples, but I'm PR-ing this into pre/2.8, so we can see what happens during a notebook rerun.

Now that I think about it, this limit would mean recording all the fields in the entire simulation over 4 freqs only. It could be an issue in broadband 2D optimizations for example. But not sure how to both protect our infrastructure and not restrict users too much. In the particular problematic case the issue was due to a time monitor, which I'm more OK restricting.