### PR TITLE
fix: xarray 2023.08.0 compatibility

### DIFF
--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -1527,7 +1527,7 @@ class TestDataArrayGrads:
         """Test grads of TidyArrayBox methods implemented in autograd/boxes.py"""
 
         def objective(x, attr):
-            da = DataArray(x, dims=map(str, range(x.ndim)))
+            da = DataArray(x)
             attr_value = getattr(da, attr)
             val = attr_value() if callable(attr_value) else attr_value
             return val.item()
@@ -1540,11 +1540,11 @@ class TestDataArrayGrads:
 
         def objective(a, b):
             coords = {str(i): np.arange(a.shape[i]) for i in range(a.ndim)}
-            da = DataArray(a, coords=coords, dims=map(str, range(a.ndim)))
+            da = DataArray(a, coords=coords)
             da_mult = da.multiply_at(b, "0", [0, 1]) ** 2
             return np.sum(da_mult).item()
 
         a = rng.uniform(-1, 1, (3, 3))
         b = 1.0
-        check_grads(lambda x: objective(x, b), modes=["fwd", "rev"], order=1)(a)
-        check_grads(lambda x: objective(a, x), modes=["fwd", "rev"], order=1)(b)
+        check_grads(lambda x: objective(x, b), modes=["fwd", "rev"], order=2)(a)
+        check_grads(lambda x: objective(a, x), modes=["fwd", "rev"], order=2)(b)

--- a/tidy3d/components/autograd/boxes.py
+++ b/tidy3d/components/autograd/boxes.py
@@ -5,11 +5,20 @@ import importlib
 from typing import Any, Callable, Dict, List, Tuple
 
 import autograd.numpy as anp
+from autograd.extend import defjvp
 from autograd.numpy.numpy_boxes import ArrayBox
+from autograd.numpy.numpy_wrapper import _astype
 
 TidyArrayBox = ArrayBox  # NOT a subclass
 
 _autograd_module_cache = {}  # cache for imported autograd modules
+
+defjvp(
+    _astype,
+    lambda g, ans, A, dtype, order="K", casting="unsafe", subok=True, copy=True: _astype(g, dtype),
+)
+
+anp.astype = _astype
 
 
 @classmethod


### PR DESCRIPTION
fixes xarray compatibility issues caused by latest Dataarray changes

short explanation: older xarray has a check when assigning to values, which calls `astype` if `__array_namespace__` exists. since our new arraybox has that now, we need to put `astype` into the `autograd.numpy` namespace, otherwise it fails.