### PR TITLE
display task_id in download log error message

### DIFF
--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -328,7 +328,7 @@ def get_status(task_id) -> str:
         return "success"
     if status == "error":
         raise WebError(
-            f"Error running task {task_id}! Use 'web.download_log(task_id)' to "
+            f"Error running task {task_id}! Use 'web.download_log('{task_id}')' to "
             "download and examine the solver log, and/or contact customer support for help."
         )
     return status


### PR DESCRIPTION
Just a minor suggestion:

If web api errors,  you will get this message

```
WebError: Error running task fdve-054f3bb4-df18-49cb-8898-af0a439bb639! 
Use 'web.download_log(task_id)' to download and examine the solver log, or contact customer support for help.
```

was always a bit frustrating because I needed to construct the log call using the task id, now it prints
```
WebError: Error running task fdve-054f3bb4-df18-49cb-8898-af0a439bb639! 
Use 'web.download_log('fdve-054f3bb4-df18-49cb-8898-af0a439bb639')' to download and examine the solver log, and/or contact customer support for help.
```