### PR TITLE
fix: bug in local field projection for `far_field_approx=True`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Regression in local field projection leading to incorrect results for `far_field_approx=True`.
+
 ## [2.7.6] - 2024-10-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Autograd support for local field projections using `FieldProjectionKSpaceMonitor`.
+
 ### Fixed
 - Regression in local field projection leading to incorrect results for `far_field_approx=True`.
 

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -1003,7 +1003,7 @@ def test_interp_objectives(use_emulated_run, colocate, objtype):
 
 
 @pytest.mark.parametrize("far_field_approx", [True, False])
-@pytest.mark.parametrize("projection_type", ["angular", "cartesian"])
+@pytest.mark.parametrize("projection_type", ["angular", "cartesian", "kspace"])
 @pytest.mark.parametrize("sim_2d", [True, False])
 class TestFieldProjection:
     @staticmethod
@@ -1042,6 +1042,20 @@ class TestFieldProjection:
                 freqs=monitor.freqs,
                 x=x_proj,
                 y=y_proj,
+                proj_axis=1,
+                proj_distance=r_proj,
+                far_field_approx=far_field_approx,
+                name="far_field",
+            )
+        elif projection_type == "kspace":
+            ux = np.linspace(-0.7, 0.7, 2)
+            uy = np.linspace(-0.7, 0.7, 3)
+            monitor_far = td.FieldProjectionKSpaceMonitor(
+                center=monitor.center,
+                size=monitor.size,
+                freqs=monitor.freqs,
+                ux=ux,
+                uy=uy,
                 proj_axis=1,
                 proj_distance=r_proj,
                 far_field_approx=far_field_approx,

--- a/tidy3d/components/field_projection.py
+++ b/tidy3d/components/field_projection.py
@@ -482,8 +482,11 @@ class FieldProjector(Tidy3dBaseModel):
 
         order = [idx_u, idx_v, idx_w]
         zeros = np.zeros(jm[0].shape)
-        J = anp.array([*jm[:2], zeros])[order]
-        M = anp.array([*jm[2:], zeros])[order]
+
+        # for each index (0, 1, 2), if it’s in the first two elements of order,
+        # select the corresponding jm element for J or the offset element (+2) for M
+        J = anp.array([jm[order.index(i)] if i in order[:2] else zeros for i in range(3)])
+        M = anp.array([jm[order.index(i) + 2] if i in order[:2] else zeros for i in range(3)])
 
         cos_theta_cos_phi = cos_theta[:, None] * cos_phi[None, :]
         cos_theta_sin_phi = cos_theta[:, None] * sin_phi[None, :]


### PR DESCRIPTION
Fixes a bug in the local field projection that was introduced in #1822. The bug occurred because autograd-compatible indexing of `J` and `M` was incorrect and a bit more involved than I thought...

The good news is that this PR also introduces autograd support for the kspace field projection.