### PR TITLE
size=0 adjoint montiors for single pixel dims in custom mediums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Autograd support for local field projections using `FieldProjectionKSpaceMonitor`.
 - Function `components.geometry.utils.flatten_groups` now also flattens transformed groups when requested.
 
+### Changed
+- `CustomMedium` design regions require far less data when performing inverse design by reducing adjoint field monitor size for dims with one pixel.
+
 ### Fixed
 - Regression in local field projection leading to incorrect results for `far_field_approx=True`.
 - Bug when differentiating with respect to `Cylinder.center`.

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -222,6 +222,20 @@ class Structure(AbstractStructure):
         if isinstance(self.geometry, PolySlab):
             size[self.geometry.axis] = 0
 
+        # custom medium only needs fields at center locations of unit cells.
+        if isinstance(self.medium, CustomMedium):
+            for axis, dim in enumerate("xyz"):
+                if self.medium.permittivity is not None:
+                    if len(self.medium.permittivity.coords[dim]) == 1:
+                        size[axis] = 0
+                if self.medium.eps_dataset is not None:
+                    zero_size = True
+                    for _, fld in self.medium.eps_dataset.field_components.items():
+                        if len(fld.coords[dim]) != 1:
+                            zero_size = False
+                    if zero_size:
+                        size[axis] = 0
+
         mnt_fld = FieldMonitor(
             size=size,
             center=center,


### PR DESCRIPTION
An optimization to reduce data usage for CustomMedium adjoint monitors. size=0 for any dims with just 1 pixel, since we only evaluate at centers.

Note; eventually would be realy nice to just have a point-cloud monitor and do these custom for each structure