### PR TITLE
Validate that bend radius is not smaller than half the mode plane size

### DIFF
--- a/tests/test_components/test_monitor.py
+++ b/tests/test_components/test_monitor.py
@@ -296,6 +296,24 @@ def test_monitor_num_modes(log_capture, num_modes, log_level):
     assert_log_level(log_capture, log_level)
 
 
+def test_mode_bend_radius():
+    """Test that small bend radius fails."""
+
+    with pytest.raises(ValueError):
+        mnt = td.ModeMonitor(
+            size=(5, 0, 1),
+            freqs=np.linspace(1e14, 2e14, 100),
+            name="test",
+            mode_spec=td.ModeSpec(num_modes=1, bend_radius=1, bend_axis=1),
+        )
+        _ = td.Simulation(
+            size=(2, 2, 2),
+            run_time=1e-12,
+            monitors=[mnt],
+            grid_spec=td.GridSpec.uniform(dl=0.1),
+        )
+
+
 def test_diffraction_validators():
     # ensure error if boundaries are not periodic
     boundary_spec = td.BoundarySpec(

--- a/tests/test_components/test_source.py
+++ b/tests/test_components/test_source.py
@@ -46,6 +46,22 @@ def test_dir_vector():
     assert DirectionalSource._dir_vector.fget(S) is None
 
 
+def test_mode_bend_radius():
+    """Test that small bend radius fails."""
+
+    with pytest.raises(ValueError):
+        src = td.ModeSource(
+            size=(1, 0, 5),
+            source_time=ST,
+            mode_spec=td.ModeSpec(num_modes=1, bend_radius=1, bend_axis=0),
+        )
+        _ = td.Simulation(
+            size=(2, 2, 2),
+            run_time=1e-12,
+            sources=[src],
+        )
+
+
 def test_UniformCurrentSource():
     g = td.GaussianPulse(freq0=1e12, fwidth=0.1e12)
 

--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -1034,3 +1034,14 @@ def test_modes_eme_sim(mock_remote_api, local):
         _ = msweb.run(solver.to_fdtd_mode_solver())
 
     _ = solver.reduced_simulation_copy
+
+
+def test_mode_bend_radius():
+    """Test that small bend radius fails."""
+
+    with pytest.raises(ValueError):
+        ms = ModeSolver(
+            plane=PLANE,
+            freqs=np.linspace(1e14, 2e14, 100),
+            mode_spec=td.ModeSpec(num_modes=1, bend_radius=1, bend_axis=0),
+        )

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -85,7 +85,11 @@ from .source import (
 from .structure import MeshOverrideStructure, Structure
 from .subpixel_spec import SubpixelSpec
 from .types import TYPE_TAG_STR, Ax, Axis, FreqBound, InterpMethod, Literal, Symmetry, annotate_type
-from .validators import assert_objects_in_sim_bounds, validate_mode_objects_symmetry
+from .validators import (
+    assert_objects_in_sim_bounds,
+    validate_mode_objects_symmetry,
+    validate_mode_plane_radius,
+)
 from .viz import (
     PlotParams,
     add_ax_if_none,
@@ -3245,6 +3249,24 @@ class Simulation(AbstractYeeGridSimulation):
         self._validate_tfsf_nonuniform_grid()
         self._validate_nonlinear_specs()
         self._validate_custom_source_time()
+        self._validate_mode_object_bends()
+
+    def _validate_mode_object_bends(self) -> None:
+        """Error if any mode sources or monitors with bends have a radius that is too small."""
+        for imnt, monitor in enumerate(self.monitors):
+            if isinstance(monitor, AbstractModeMonitor):
+                validate_mode_plane_radius(
+                    mode_spec=monitor.mode_spec,
+                    plane=monitor.geometry,
+                    msg_prefix=f"Monitor at 'monitors[{imnt}]' ",
+                )
+        for isrc, source in enumerate(self.sources):
+            if isinstance(source, ModeSource):
+                validate_mode_plane_radius(
+                    mode_spec=source.mode_spec,
+                    plane=source.geometry,
+                    msg_prefix=f"Source at 'sources[{isrc}]' ",
+                )
 
     def _validate_custom_source_time(self):
         """Warn if all simulation times are outside CustomSourceTime definition range."""

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -46,7 +46,11 @@ from ...components.types import (
     PlotScale,
     Symmetry,
 )
-from ...components.validators import validate_freqs_min, validate_freqs_not_empty
+from ...components.validators import (
+    validate_freqs_min,
+    validate_freqs_not_empty,
+    validate_mode_plane_radius,
+)
 from ...components.viz import make_ax, plot_params_pml
 from ...constants import C_0
 from ...exceptions import SetupError, ValidationError
@@ -172,6 +176,11 @@ class ModeSolver(Tidy3dBaseModel):
         if not sim_box.intersects(val):
             raise SetupError("'ModeSolver.plane' must intersect 'ModeSolver.simulation'.")
         return val
+
+    def _post_init_validators(self) -> None:
+        validate_mode_plane_radius(
+            mode_spec=self.mode_spec, plane=self.plane, msg_prefix="Mode solver"
+        )
 
     @cached_property
     def normal_axis(self) -> Axis:
@@ -1511,6 +1520,7 @@ class ModeSolver(Tidy3dBaseModel):
             )
 
     def validate_pre_upload(self, source_required: bool = True):
+        """Validate the fully initialized mode solver is ok for upload to our servers."""
         self._validate_modes_size()
 
     @cached_property


### PR DESCRIPTION
This was a bit annoying because I need to validate both mode sources/monitors and mode solver init, which have different fields needed for the validation ("size" for mode sources and monitors, "plane" for mode solver). So I couldn't write a native pydantic validator but made it a post-init instead. I also decided to put the validation in Simulation so I could point to the exact monitor/source index, but on the other hand maybe it's nicer to validate as soon as the object is created? Let me know what you think. Fixes #1299 