### PR TITLE
refactor gradient calculations to use `DerivativeSurfaceMesh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Option for the `ModeSolver` and `ModeSolverMonitor` to store only a subset of field components.
 - Added an option to simulate plane wave propagation at fixed angles by setting parameter `angular_spec=FixedAngleSpec()` when defining a `PlaneWave` source.
 - The universal `tidy3d.web` can now also be used to handle `ModeSolver` simulations.
+- Support for differentiation with respect to `PolySlab.slab_bounds`.
 
 ### Changed
 - Priority is given to `snapping_points` in `GridSpec` when close to structure boundaries, which reduces the chance of them being skipped.
@@ -48,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MeshOverrideStructure` accepts `Box` as geometry. Other geometry types will raise a warning and convert to bounding box.
 - Double precision mode solver is now supported in EME.
 - `estimate_cost` is now called at the end of every `web.upload` call.
+- Internal refactor of adjoint shape gradients using `GradientSurfaceMesh`.
 
 ### Fixed
 - Significant speedup for field projection computations.
@@ -73,8 +75,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `@scalar_objective` decorator in `tidy3d.plugins.autograd` that wraps objective functions to ensure they return a scalar value and performs additional checks to ensure compatibility of objective functions with autograd. Used by default in `tidy3d.plugins.autograd.value_and_grad` as well as `tidy3d.plugins.autograd.grad`.
 - Autograd support for simulations without adjoint sources in `run` as well as `run_async`, which will not attempt to run the simulation but instead return zero gradients. This can sometimes occur if the objective function gradient does not depend on some simulations, for example when using `min` or `max` in the objective.
 - `bend_angle_rotation` in `ModeSpec` to improve accuracy in some cases when both `bend_radius` and `angle_theta` are defined. This option is disabled by default but it can be tried when very high accuracy is required in `ModeSource` and `ModeMonitor` objects that are placed in bend and angled waveguides.
-
-- Support for differentiation with respect to `PolySlab.slab_bounds` and `PolySlab.dilation`.
 
 ### Changed
 - `CustomMedium` design regions require far less data when performing inverse design by reducing adjoint field monitor size for dims with one pixel.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Autograd support for simulations without adjoint sources in `run` as well as `run_async`, which will not attempt to run the simulation but instead return zero gradients. This can sometimes occur if the objective function gradient does not depend on some simulations, for example when using `min` or `max` in the objective.
 - `bend_angle_rotation` in `ModeSpec` to improve accuracy in some cases when both `bend_radius` and `angle_theta` are defined. This option is disabled by default but it can be tried when very high accuracy is required in `ModeSource` and `ModeMonitor` objects that are placed in bend and angled waveguides.
 
+- Support for differentiation with respect to `PolySlab.slab_bounds` and `PolySlab.dilation`.
+
 ### Changed
 - `CustomMedium` design regions require far less data when performing inverse design by reducing adjoint field monitor size for dims with one pixel.
 - Calling `.values` on `DataArray` no longer raises a `DeprecationWarning` during automatic differentiation.

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -558,7 +558,7 @@ if TEST_POLYSLAB_SPEED:
     args = [("polyslab", "mode")]
 
 
-# args = [("size_element", "mode")]
+args = [("polyslab", "mode")]
 
 
 def get_functions(structure_key: str, monitor_key: str) -> typing.Callable:

--- a/tidy3d/plugins/autograd/README.md
+++ b/tidy3d/plugins/autograd/README.md
@@ -189,7 +189,7 @@ The following components are traceable as inputs to the `td.Simulation`
 | Component Type                                                    | Traceable Attributes                                    |
 | ----------------------------------------------------------------- | ------------------------------------------------------- |
 | rectangular prisms                                                | `Box.center`, `Box.size`                                |
-| polyslab (including those with dilation or slanted sidewalls)     | `PolySlab.vertices`                                     |
+| polyslab (including those with dilation or slanted sidewalls)     | `PolySlab.vertices`, `PolySlab.slab_bounds`                          |
 | regular mediums                                                   | `Medium.permittivity`, `Medium.conductivity`            |
 | spatially varying mediums (for topology optimization mainly)      | `CustomMedium.permittivity`, `CustomMedium.eps_dataset` |
 | groups of geometries with the same medium (for faster processing) | `GeometryGroup.geometries`                              |

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -886,6 +886,13 @@ def postprocess_adj(
         else:
             eps_no_structure = eps_inf_structure = None
 
+        # get minimum intersection of bounds with structure and sim
+        struct_bounds = rmin_struct, rmax_struct = structure.geometry.bounds
+        rmin_sim, rmax_sim = sim_data_orig.simulation.bounds
+        rmin_intersect = tuple([max(a, b) for a, b in zip(rmin_sim, rmin_struct)])
+        rmax_intersect = tuple([min(a, b) for a, b in zip(rmax_sim, rmax_struct)])
+        bounds_intersect = (rmin_intersect, rmax_intersect)
+
         derivative_info = DerivativeInfo(
             paths=structure_paths,
             E_der_map=E_der_map.field_components,
@@ -899,9 +906,10 @@ def postprocess_adj(
             eps_out=eps_out,
             eps_background=eps_background,
             frequency=freq_adj,
-            bounds=structure.geometry.bounds,  # TODO: pass intersecting bounds with sim?
             eps_no_structure=eps_no_structure,
             eps_inf_structure=eps_inf_structure,
+            bounds=struct_bounds,
+            bounds_intersect=bounds_intersect,
         )
 
         vjp_value_map = structure.compute_derivatives(derivative_info)


### PR DESCRIPTION
Part 1 of an effort to generalize the VJP calculations so the Geometry and Medium just need to construct a single `DerivativeSurfaceMesh` for every field. The `DerivativeInfo` then has a method that computes derivatives given a `DerivativeSurfaceMesh`.