### PR TITLE
Support for adjoint simulations with no monitors (zero gradients)

### DIFF
--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -731,6 +731,32 @@ def test_autograd_async(use_emulated_run, structure_key, monitor_key):
     assert anp.all(grad != 0.0), "some gradients are 0"
 
 
+# @pytest.mark.parametrize("structure_key, monitor_key", args)
+# @pytest.mark.parametrize("structure_key, monitor_key", [args[3]])  # array
+@pytest.mark.parametrize("structure_key, monitor_key", [args[0]])
+def test_autograd_async_zero_grad(use_emulated_run, structure_key, monitor_key):
+    """Test an objective function that 'ignores' some simulations."""
+
+    fn_dict = get_functions(structure_key, monitor_key)
+    make_sim = fn_dict["sim"]
+    postprocess = fn_dict["postprocess"]
+
+    task_names = {"1", "2", "3", "4"}
+
+    def objective(*args):
+        """Objective function."""
+
+        sims = {task_name: make_sim(*args) for task_name in task_names}
+        batch_data = run_async(sims, verbose=False)
+        values = []
+        for _, sim_data in batch_data.items():
+            values.append(postprocess(sim_data))
+        return min(values)
+
+    val, grad = ag.value_and_grad(objective)(params0)
+    assert anp.all(grad != 0.0), "some gradients are 0"
+
+
 def test_autograd_speed_num_structures(use_emulated_run):
     """Test an objective function through tidy3d autograd."""
 

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -1033,8 +1033,10 @@ class SimulationData(AbstractYeeGridSimulationData):
         return sim_data_original, sim_data_fwd
 
     def make_adjoint_sim(
-        self, data_vjp_paths: set[tuple], adjoint_monitors: list[Monitor]
-    ) -> Simulation:
+        self,
+        data_vjp_paths: set[tuple],
+        adjoint_monitors: list[Monitor],
+    ) -> Simulation | None:
         """Make the adjoint simulation from the original simulation and the VJP-containing data."""
 
         sim_original = self.simulation
@@ -1044,6 +1046,9 @@ class SimulationData(AbstractYeeGridSimulationData):
         adj_srcs = []
         for src_list in sources_adj_dict.values():
             adj_srcs += list(src_list)
+
+        if not any(adj_srcs):
+            return None
 
         adjoint_source_info = self.process_adjoint_sources(adj_srcs=adj_srcs)
 
@@ -1086,14 +1091,6 @@ class SimulationData(AbstractYeeGridSimulationData):
                 dataset_names=dataset_names, fwidth=self.fwidth_adj
             )
             sources_adj_all[mnt_data.monitor.name] = sources_adj
-
-        if not any(src for _, src in sources_adj_all.items()):
-            raise ValueError(
-                "No adjoint sources created for this simulation. "
-                "This could indicate a bug in your setup, for example the objective function "
-                "output depending on a monitor that is not supported. If you encounter this error, "
-                "please examine your set up or contact customer support if you need more help."
-            )
 
         return sources_adj_all
 

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -13,7 +13,7 @@ from autograd.extend import defvjp, primitive
 import tidy3d as td
 from tidy3d.components.autograd import AutogradFieldMap, get_static
 from tidy3d.components.autograd.derivative_utils import DerivativeInfo
-from tidy3d.components.data.sim_data import AdjointSourceInfo
+from tidy3d.exceptions import AdjointError
 
 from ...core.s3utils import download_file, upload_file
 from ..asynchronous import DEFAULT_DATA_DIR
@@ -97,6 +97,7 @@ def run(
     simulation_type: str = "tidy3d",
     parent_tasks: list[str] = None,
     local_gradient: bool = LOCAL_GRADIENT,
+    allow_zero_gradient: bool = False,
 ) -> SimulationDataType:
     """
     Submits a :class:`.Simulation` to server, starts running, monitors progress, downloads,
@@ -191,6 +192,7 @@ def run(
             simulation_type="tidy3d_autograd",
             parent_tasks=parent_tasks,
             local_gradient=local_gradient,
+            allow_zero_gradient=allow_zero_gradient,
         )
 
     return run_webapi(
@@ -219,6 +221,7 @@ def run_async(
     simulation_type: str = "tidy3d",
     parent_tasks: dict[str, list[str]] = None,
     local_gradient: bool = LOCAL_GRADIENT,
+    allow_zero_gradient: bool = True,
 ) -> BatchData:
     """Submits a set of Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`] objects to server,
     starts running, monitors progress, downloads, and loads results as a :class:`.BatchData` object.
@@ -271,6 +274,7 @@ def run_async(
             simulation_type="tidy3d_autograd_async",
             parent_tasks=parent_tasks,
             local_gradient=local_gradient,
+            allow_zero_gradient=allow_zero_gradient,
         )
 
     return run_async_webapi(
@@ -289,7 +293,11 @@ def run_async(
 
 
 def _run(
-    simulation: td.Simulation, task_name: str, local_gradient: bool = LOCAL_GRADIENT, **run_kwargs
+    simulation: td.Simulation,
+    task_name: str,
+    local_gradient: bool = LOCAL_GRADIENT,
+    allow_zero_gradient: bool = False,
+    **run_kwargs,
 ) -> td.SimulationData:
     """User-facing ``web.run`` function, compatible with ``autograd`` differentiation."""
 
@@ -316,6 +324,7 @@ def _run(
         task_name=task_name,
         aux_data=aux_data,
         local_gradient=local_gradient,
+        allow_zero_gradient=allow_zero_gradient,
         **run_kwargs,
     )
 
@@ -323,7 +332,10 @@ def _run(
 
 
 def _run_async(
-    simulations: dict[str, td.Simulation], local_gradient: bool = LOCAL_GRADIENT, **run_async_kwargs
+    simulations: dict[str, td.Simulation],
+    local_gradient: bool = LOCAL_GRADIENT,
+    allow_zero_gradient: bool = True,
+    **run_async_kwargs,
 ) -> dict[str, td.SimulationData]:
     """User-facing ``web.run_async`` function, compatible with ``autograd`` differentiation."""
 
@@ -345,6 +357,7 @@ def _run_async(
         sims_original=sims_original,
         aux_data_dict=aux_data_dict,
         local_gradient=local_gradient,
+        allow_zero_gradient=allow_zero_gradient,
         **run_async_kwargs,
     )
 
@@ -387,6 +400,7 @@ def _run_primitive(
     task_name: str,
     aux_data: dict,
     local_gradient: bool,
+    allow_zero_gradient: bool,
     **run_kwargs,
 ) -> AutogradFieldMap:
     """Autograd-traced 'run()' function: runs simulation, strips tracer data, caches fwd data."""
@@ -437,6 +451,7 @@ def _run_async_primitive(
     sims_original: dict[str, td.Simulation],
     aux_data_dict: dict[dict[str, typing.Any]],
     local_gradient: bool,
+    allow_zero_gradient: bool,
     **run_async_kwargs,
 ) -> dict[str, AutogradFieldMap]:
     task_names = sim_fields_dict.keys()
@@ -573,6 +588,7 @@ def _run_bwd(
     task_name: str,
     aux_data: dict,
     local_gradient: bool,
+    allow_zero_gradient: bool,
     **run_kwargs,
 ) -> typing.Callable[[AutogradFieldMap], AutogradFieldMap]:
     """VJP-maker for ``_run_primitive()``. Constructs and runs adjoint simulation, computes grad."""
@@ -594,7 +610,17 @@ def _run_bwd(
             data_fields_vjp=data_fields_vjp,
             sim_data_orig=sim_data_orig,
             sim_fields_keys=sim_fields_keys,
+            allow_zero_gradient=allow_zero_gradient,
         )
+
+        if sim_adj is None:
+            td.log.warning(
+                f"Adjoint simulation for task {task_name} contains no sources. "
+                "This can occur if the objective function depends on an unsupported monitor "
+                "or uses a function like `min` or `max`. If this is unexpected, please review "
+                "your setup or contact customer support for assistance."
+            )
+            return {k: 0 * v for k, v in sim_fields_original.items()}
 
         # run adjoint simulation
         task_name_adj = str(task_name) + "_adjoint"
@@ -632,6 +658,7 @@ def _run_async_bwd(
     sims_original: dict[str, td.Simulation],
     aux_data_dict: dict[str, dict[str, typing.Any]],
     local_gradient: bool,
+    allow_zero_gradient: bool,
     **run_async_kwargs,
 ) -> typing.Callable[[dict[str, AutogradFieldMap]], dict[str, AutogradFieldMap]]:
     """VJP-maker for ``_run_primitive()``. Constructs and runs adjoint simulation, computes grad."""
@@ -659,6 +686,7 @@ def _run_async_bwd(
         task_names_adj = {task_name + "_adjoint" for task_name in task_names}
 
         sims_adj = {}
+        sim_fields_vjp_dict = {}
         for task_name, task_name_adj in zip(task_names, task_names_adj):
             data_fields_vjp = data_fields_dict_vjp[task_name]
             sim_data_orig = sim_data_orig_dict[task_name]
@@ -668,20 +696,39 @@ def _run_async_bwd(
                 data_fields_vjp=data_fields_vjp,
                 sim_data_orig=sim_data_orig,
                 sim_fields_keys=sim_fields_keys,
+                allow_zero_gradient=allow_zero_gradient,
             )
+
+            if sim_adj is None:
+                td.log.warning(
+                    f"Adjoint simulation for task {task_name} contains no sources. "
+                    "This can occur if the objective function depends on an unsupported monitor "
+                    "or uses a function like `min` or `max`. If this is unexpected, please review "
+                    "your setup or contact customer support for assistance."
+                )
+                sim_fields_vjp_dict[task_name] = {
+                    k: 0 * v for k, v in sim_fields_original_dict[task_name].items()
+                }
+
             sims_adj[task_name_adj] = sim_adj
-            # TODO: handle case where no adjoint sources?
+
+        sims_to_run = {k: v for k, v in sims_adj.items() if v is not None}
+        task_names_adj = set(sims_to_run.keys())
+        task_names_fwd = {task_name.replace("_adjoint", "") for task_name in task_names_adj}
+
+        if not sims_to_run:
+            return sim_fields_vjp_dict
 
         if local_gradient:
             # run adjoint simulation
-            batch_data_adj, _ = _run_async_tidy3d(sims_adj, **run_async_kwargs)
+            batch_data_adj, _ = _run_async_tidy3d(sims_to_run, **run_async_kwargs)
 
-            sim_fields_vjp_dict = {}
-            for task_name, task_name_adj in zip(task_names, task_names_adj):
-                sim_data_adj = batch_data_adj[task_name_adj]
+            for task_name, task_name_adj in zip(task_names_fwd, task_names_adj):
                 sim_data_orig = sim_data_orig_dict[task_name]
                 sim_data_fwd = sim_data_fwd_dict[task_name]
                 sim_fields_keys = sim_fields_keys_dict[task_name]
+
+                sim_data_adj = batch_data_adj.get(task_name_adj)
 
                 sim_fields_vjp = postprocess_adj(
                     sim_data_adj=sim_data_adj,
@@ -689,28 +736,27 @@ def _run_async_bwd(
                     sim_data_fwd=sim_data_fwd,
                     sim_fields_keys=sim_fields_keys,
                 )
-                sim_fields_vjp_dict[task_name] = sim_fields_vjp
 
+                sim_fields_vjp_dict[task_name] = sim_fields_vjp
         else:
             parent_tasks = {}
-            for task_name_fwd, task_name_adj in zip(task_names, task_names_adj):
+            for task_name_fwd, task_name_adj in zip(task_names_fwd, task_names_adj):
                 task_id_fwd = aux_data_dict[task_name_fwd][AUX_KEY_FWD_TASK_ID]
                 parent_tasks[task_name_adj] = [task_id_fwd]
 
             run_async_kwargs["parent_tasks"] = parent_tasks
             run_async_kwargs["simulation_type"] = "autograd_bwd"
-            sims_adj = {
+            sims_to_run = {
                 task_name: sim.updated_copy(simulation_type="autograd_bwd", deep=False)
-                for task_name, sim in sims_adj.items()
+                for task_name, sim in sims_to_run.items()
             }
             sim_fields_vjp_dict_adj_keys = _run_async_tidy3d_bwd(
-                simulations=sims_adj,
+                simulations=sims_to_run,
                 **run_async_kwargs,
             )
 
             # swap adjoint task_names for original task_names
-            sim_fields_vjp_dict = {}
-            for task_name_fwd, task_name_adj in zip(task_names, task_names_adj):
+            for task_name_fwd, task_name_adj in zip(task_names_fwd, task_names_adj):
                 sim_fields_vjp_dict[task_name_fwd] = sim_fields_vjp_dict_adj_keys[task_name_adj]
 
         return sim_fields_vjp_dict
@@ -722,7 +768,8 @@ def setup_adj(
     data_fields_vjp: AutogradFieldMap,
     sim_data_orig: td.SimulationData,
     sim_fields_keys: list[tuple],
-) -> tuple[td.Simulation, AdjointSourceInfo]:
+    allow_zero_gradient: bool,
+) -> td.Simulation | None:
     """Construct an adjoint simulation from a set of data_fields for the VJP."""
 
     td.log.info("Running custom vjp (adjoint) pipeline.")
@@ -742,8 +789,17 @@ def setup_adj(
     ]
 
     sim_adj = sim_data_vjp.make_adjoint_sim(
-        data_vjp_paths=data_vjp_paths, adjoint_monitors=adjoint_monitors
+        data_vjp_paths=data_vjp_paths,
+        adjoint_monitors=adjoint_monitors,
     )
+    if sim_adj is None:
+        if allow_zero_gradient:
+            return sim_adj
+        raise AdjointError(
+            "Adjoint simulation creation failed and `allow_zero_gradient` is set to False. "
+            "Ensure that your objective function is correctly set up and that all necessary monitors are supported. "
+            "If this issue persists, please review your setup or contact customer support for assistance."
+        )
 
     if _INSPECT_ADJOINT_FIELDS:
         adj_fld_mnt = td.FieldMonitor(


### PR DESCRIPTION
Idea is to allow functions like `min()` and `max()` in an objective function where some simulations (for example in an adjoint batch) might not get adjoint sources.

Approach:
 - Generally allow `make_adjoint_sim` to return `None` instead of erroring.
 - Handle whether or not we error if there are no adjoint sources in `run` and `run_async`, where by default we error in `run` and only warn in `run_async`:
   - In `run`, the user is probably running only a single simulation. If that gets no adjoint sources, then there is a problem with the setup. However, it is possible that a user might be running multiple simulations serially, in which case we do offer the option to allow "empty" adjoint sims.
   - In `run_async`, the user is expected to run a batch of multiple simulations, so it should generally be fine if some of those do not receive adjoint sources. We should probably error though if _all_ simulations in a batch have no adjoint sources.