### PR TITLE
feat: add s3 config to download_file call.

### DIFF
--- a/tidy3d/web/core/s3utils.py
+++ b/tidy3d/web/core/s3utils.py
@@ -335,6 +335,7 @@ def download_file(
             Filename=str(to_file),
             Key=token.get_s3_key(),
             Callback=_callback,
+            Config=_s3_config,
         )
 
     if progress_callback is not None:


### PR DESCRIPTION
Adding `_s3_config` specified in s3utils into the `download_file` call, similar to `upload_fileobj`.