### PR TITLE
Support for adjoint simulations with no monitors (zero gradients)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Differentiable `smooth_min`, `smooth_max`, and `least_squares` functions in `tidy3d.plugins.autograd`.
 - Differential operators `grad` and `value_and_grad` in `tidy3d.plugins.autograd` that behave similarly to the autograd operators but support auxiliary data via `aux_data=True` as well as differentiation w.r.t. `DataArray`.
 - `@scalar_objective` decorator in `tidy3d.plugins.autograd` that wraps objective functions to ensure they return a scalar value and performs additional checks to ensure compatibility of objective functions with autograd. Used by default in `tidy3d.plugins.autograd.value_and_grad` as well as `tidy3d.plugins.autograd.grad`.
+- Autograd support for simulations without adjoint sources in `run` as well as `run_async`, which will not attempt to run the simulation but instead return zero gradients. This can sometimes occur if the objective function gradient does not depend on some simulations, for example when using `min` or `max` in the objective.
 
 
 ### Changed
@@ -25,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `xarray` 2024.10.0 compatibility for autograd.
 - Some failing examples in the expressions plugin documentation.
 - Inaccuracy in transforming gradients from edge to `PolySlab.vertices`.
+- Bug in `run_async` where an adjoint simulation would sometimes be assigned to the wrong forward simulation.
+
 
 ## [2.7.6] - 2024-10-30
 

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -1033,8 +1033,10 @@ class SimulationData(AbstractYeeGridSimulationData):
         return sim_data_original, sim_data_fwd
 
     def make_adjoint_sim(
-        self, data_vjp_paths: set[tuple], adjoint_monitors: list[Monitor]
-    ) -> Simulation:
+        self,
+        data_vjp_paths: set[tuple],
+        adjoint_monitors: list[Monitor],
+    ) -> Simulation | None:
         """Make the adjoint simulation from the original simulation and the VJP-containing data."""
 
         sim_original = self.simulation
@@ -1044,6 +1046,9 @@ class SimulationData(AbstractYeeGridSimulationData):
         adj_srcs = []
         for src_list in sources_adj_dict.values():
             adj_srcs += list(src_list)
+
+        if not any(adj_srcs):
+            return None
 
         adjoint_source_info = self.process_adjoint_sources(adj_srcs=adj_srcs)
 
@@ -1086,14 +1091,6 @@ class SimulationData(AbstractYeeGridSimulationData):
                 dataset_names=dataset_names, fwidth=self.fwidth_adj
             )
             sources_adj_all[mnt_data.monitor.name] = sources_adj
-
-        if not any(src for _, src in sources_adj_all.items()):
-            raise ValueError(
-                "No adjoint sources created for this simulation. "
-                "This could indicate a bug in your setup, for example the objective function "
-                "output depending on a monitor that is not supported. If you encounter this error, "
-                "please examine your set up or contact customer support if you need more help."
-            )
 
         return sources_adj_all
 

--- a/tidy3d/components/source.py
+++ b/tidy3d/components/source.py
@@ -101,7 +101,7 @@ class SourceTime(AbstractTimeDependence):
         """Frequency range within plus/minus ``num_fwidth * fwidth`` of the central frequency."""
 
     @abstractmethod
-    def end_time(self) -> float | None:
+    def end_time(self) -> Optional[float]:
         """Time after which the source is effectively turned off / close to zero amplitude."""
 
 
@@ -192,7 +192,7 @@ class GaussianPulse(Pulse):
 
         return pulse_amp
 
-    def end_time(self) -> float | None:
+    def end_time(self) -> Optional[float]:
         """Time after which the source is effectively turned off / close to zero amplitude."""
 
         # TODO: decide if we should continue to return an end_time if the DC component remains
@@ -251,7 +251,7 @@ class ContinuousWave(Pulse):
 
         return const * offset * oscillation * amp
 
-    def end_time(self) -> float | None:
+    def end_time(self) -> Optional[float]:
         """Time after which the source is effectively turned off / close to zero amplitude."""
         return None
 
@@ -420,7 +420,7 @@ class CustomSourceTime(Pulse):
 
         return offset * oscillation * amp * envelope
 
-    def end_time(self) -> float | None:
+    def end_time(self) -> Optional[float]:
         """Time after which the source is effectively turned off / close to zero amplitude."""
 
         if self.source_time_dataset is None:


### PR DESCRIPTION
Idea is to allow functions like `min()` and `max()` in an objective function where some simulations (for example in an adjoint batch) might not get adjoint sources.

Approach:
 - Generally allow `make_adjoint_sim` to return `None` instead of erroring.
 - We warn if:
   1. All simulations in `run_async` have no adjoint sources.
   2. The adjoint simulation in `run` has no adjoint sources.