### PR TITLE
fix polyslab edge gradient assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug when differentiating with respect to `Cylinder.center`.
 - `xarray` 2024.10.0 compatibility for autograd.
 - Some failing examples in the expressions plugin documentation.
-
+- Inaccuracy in transforming gradients from edge to `PolySlab.vertices`.
 
 ## [2.7.6] - 2024-10-30
 

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -1448,7 +1448,7 @@ class PolySlab(base.Planar):
 
         vjps_edges_in_plane = vjps_edges.values.reshape((num_vertices, 1)) * normal_vectors_in_plane
 
-        vjps_vertices = vjps_edges_in_plane + np.roll(vjps_edges_in_plane, axis=0, shift=-1)
+        vjps_vertices = vjps_edges_in_plane + np.roll(vjps_edges_in_plane, axis=0, shift=1)
         vjps_vertices /= 2.0  # each vertex is effected only 1/2 by each edge
 
         # sign change if counter clockwise, because normal direction is flipped


### PR DESCRIPTION
There was a bug in polyslab, when transforming edge gradients to vertex gradients. The vertex assignments were shifted incorrectly by 1. This wouldnt affect finely discretized polyslabs but becomes a major issue with more coarse grained polylsab discretizations.