### PR TITLE
Fix potential self-intersection polygon in Scene._filter_structures_plane

### DIFF
--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -637,7 +637,7 @@ class Scene(Tidy3dBaseModel):
                 if _shape.is_empty or not shape.intersects(_shape):
                     continue
 
-                diff_shape = _shape - shape
+                diff_shape = (_shape - shape).buffer(0)
 
                 # different prop, remove intersection from background shape
                 if prop != _prop and len(diff_shape.bounds) > 0:


### PR DESCRIPTION
This fixes the shapely/GEOS error in mode solver metadata pipeline when trying to find materials on the modal plane.

Hard to fabricate a test myself so I'll leave it out.