### PR TITLE
auto grab permittivity inside and outside `PolySlab` and `Cylinder`

### DIFF
--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -1309,6 +1309,8 @@ def test_pole_residue(monkeypatch):
         eps_out=1.0,
         frequency=freq,
         bounds=((-1, -1, -1), (1, 1, 1)),
+        eps_no_structure=td.SpatialDataArray([[[1.0]]], coords=dict(x=[0], y=[0], z=[0])),
+        eps_inf_structure=td.SpatialDataArray([[[2.0]]], coords=dict(x=[0], y=[0], z=[0])),
     )
 
     grads_computed = pr.compute_derivatives(derivative_info=info)
@@ -1388,6 +1390,8 @@ def test_custom_pole_residue(monkeypatch):
         eps_out=1.0,
         frequency=freq,
         bounds=((-1, -1, -1), (1, 1, 1)),
+        eps_no_structure=td.SpatialDataArray([[[1.0]]], coords=dict(x=[0], y=[0], z=[0])),
+        eps_inf_structure=td.SpatialDataArray([[[2.0]]], coords=dict(x=[0], y=[0], z=[0])),
     )
 
     grads_computed = pr.compute_derivatives(derivative_info=info)

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -6,7 +6,7 @@ import pydantic.v1 as pd
 import xarray as xr
 
 from ..base import Tidy3dBaseModel
-from ..data.data_array import ScalarFieldDataArray
+from ..data.data_array import ScalarFieldDataArray, SpatialDataArray
 from ..types import Bound, tidycomplex
 from .types import PathType
 from .utils import get_static
@@ -92,6 +92,13 @@ class DerivativeInfo(Tidy3dBaseModel):
         "Used when it can not be computed from ``eps_data`` or when ``eps_approx==True``.",
     )
 
+    eps_background: tidycomplex = pd.Field(
+        None,
+        title="Permittivity in Background",
+        description="Permittivity outside of the ``Structure`` as manually specified by. "
+        "``Structure.background_medium``. ",
+    )
+
     bounds: Bound = pd.Field(
         ...,
         title="Geometry Bounds",
@@ -102,6 +109,22 @@ class DerivativeInfo(Tidy3dBaseModel):
         ...,
         title="Frequency of adjoint simulation",
         description="Frequency at which the adjoint gradient is computed.",
+    )
+
+    eps_no_structure: SpatialDataArray = pd.Field(
+        None,
+        title="Permittivity Without Structure",
+        description="The permittivity of the original simulation without the structure that is "
+        "being differentiated with respect to. Used to approximate permittivity outside of the "
+        "structure for shape optimization.",
+    )
+
+    eps_inf_structure: SpatialDataArray = pd.Field(
+        None,
+        title="Permittivity With Infinite Structure",
+        description="The permittivity of the original simulation where the structure being "
+        " differentiated with respect to is inifinitely large. Used to approximate permittivity "
+        "inside of the structure for shape optimization.",
     )
 
     eps_approx: bool = pd.Field(
@@ -149,6 +172,25 @@ class DerivativeInfo(Tidy3dBaseModel):
 
         return dict(D_norm=D_der_norm, E_perp1=E_der_perp1, E_perp2=E_der_perp2)
 
+    def evaluate_eps(
+        self,
+        spatial_coords: np.ndarray,  # (N, 3)
+        is_inside: bool,
+    ) -> SpatialDataArray:
+        """Evaluate permittivity without the structure at a set of points."""
+
+        permittivity_array = self.eps_inf_structure if is_inside else self.eps_no_structure
+
+        if permittivity_array is None:
+            raise ValueError("Can't evaluate eps because the permittivity array is missing.")
+
+        key = "key"
+        eps_out = self.evaluate_flds_at(
+            fld_dataset={key: permittivity_array},
+            spatial_coords=spatial_coords,
+        )[key]
+        return eps_out.values
+
     @staticmethod
     def evaluate_flds_at(
         fld_dataset: dict[str, ScalarFieldDataArray],
@@ -167,7 +209,14 @@ class DerivativeInfo(Tidy3dBaseModel):
 
         components = {}
         for fld_name, arr in fld_dataset.items():
-            components[fld_name] = arr.interp(**interp_kwargs, assume_sorted=True).sum("f")
+            arr_interp = arr.interp(
+                **interp_kwargs,
+                assume_sorted=True,
+                kwargs={"bounds_error": False, "fill_value": None},
+            )
+            if "f" in arr_interp.coords:
+                arr_interp = arr_interp.sum("f")
+            components[fld_name] = arr_interp
 
         return components
 

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -1420,9 +1420,24 @@ class PolySlab(base.Planar):
         E_der_edge = grad_bases["E_perp1"]
         E_der_slab = grad_bases["E_perp2"]
 
+        # determine background medium
+        if derivative_info.eps_background is not None:
+            eps_out = derivative_info.eps_background
+        else:
+            if derivative_info.eps_no_structure is not None:
+                eps_out = derivative_info.evaluate_eps(edge_centers_xyz, is_inside=False)
+            else:
+                eps_out = derivative_info.eps_out
+
+        # determine inside medium
+        if derivative_info.eps_inf_structure is not None:
+            eps_in = derivative_info.evaluate_eps(edge_centers_xyz, is_inside=True)
+        else:
+            eps_in = derivative_info.eps_in
+
         # approximate permittivity in and out
-        delta_eps_inv = 1.0 / derivative_info.eps_in - 1.0 / derivative_info.eps_out
-        delta_eps = derivative_info.eps_in - derivative_info.eps_out
+        delta_eps_inv = 1.0 / eps_in - 1.0 / eps_out
+        delta_eps = eps_in - eps_out
 
         # put together VJP using D_normal and E_perp integration
         vjps_edges = 0.0

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -19,6 +19,7 @@ from .autograd.utils import get_static
 from .base import Tidy3dBaseModel, skip_if_fields_missing
 from .data.data_array import ScalarFieldDataArray
 from .geometry.polyslab import PolySlab
+from .geometry.primitives import Cylinder
 from .geometry.utils import GeometryType, validate_no_transformed_polyslabs
 from .grid.grid import Coords
 from .medium import AbstractCustomMedium, CustomMedium, Medium, Medium2D, MediumType
@@ -257,7 +258,7 @@ class Structure(AbstractStructure):
         center = [get_static(x) for x in box.center]
 
         # polyslab only needs fields at the midpoint along axis
-        if isinstance(self.geometry, PolySlab):
+        if isinstance(self.geometry, (PolySlab, Cylinder)):
             size[self.geometry.axis] = 0
 
         # custom medium only needs fields at center locations of unit cells.


### PR DESCRIPTION
Fixes https://github.com/flexcompute/tidy3d/issues/1121

Approach is to call `Simulation.epsilon` without the structure present and then store this information in the `DerivativeInfo`. Then the gradient calculation can interpolate this data where it's needed, which gives a pretty good prox y to the permittivity outside the structture at that location.

Permittivity inside can still just use the `Structure.medium.eps_model`

Implemented for `PolySlab` but not yet for `Box`.