### PR TITLE
more autograd fixes for 2.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Gradient inaccuracy when a multi-frequency monitor is used but a single frequency is selected.
+- Revert single cell center approximation for custom medium gradient.
 
 ## [2.7.7] - 2024-11-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `BatchData` is now a mapping and can be accessed and iterated over like a Python dictionary (`.keys()`, `.values()`, `.items()`).
+
 ### Fixed
 - Gradient inaccuracy when a multi-frequency monitor is used but a single frequency is selected.
 - Revert single cell center approximation for custom medium gradient.

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -220,12 +220,23 @@ def use_emulated_run(monkeypatch):
                 batch_data_orig[task_name] = sim_data_orig
                 task_ids_fwd[task_name] = task_id_fwd
 
-            return batch_data_orig, task_ids_fwd
+            class EmulatedBatchData(web.BatchData):
+                def load_sim_data(self, task_name):
+                    return batch_data_orig[task_name]
+
+            task_paths = {task_name: "" for task_name in simulations.keys()}
+
+            batch_data = EmulatedBatchData(
+                task_paths=task_paths,
+                task_ids=task_ids_fwd,
+                verbose=False,
+            )
+
+            return batch_data, task_ids_fwd
 
         def emulated_run_async_bwd(simulations, **run_kwargs) -> td.SimulationData:
             vjp_dict = {}
             for task_name, simulation in simulations.items():
-                task_id_fwd = task_name[:-8]
                 vjp_dict[task_name] = emulated_run_bwd(simulation, task_name, **run_kwargs)
             return vjp_dict
 

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -260,20 +260,6 @@ class Structure(AbstractStructure):
         if isinstance(self.geometry, PolySlab):
             size[self.geometry.axis] = 0
 
-        # custom medium only needs fields at center locations of unit cells.
-        if isinstance(self.medium, CustomMedium):
-            for axis, dim in enumerate("xyz"):
-                if self.medium.permittivity is not None:
-                    if len(self.medium.permittivity.coords[dim]) == 1:
-                        size[axis] = 0
-                if self.medium.eps_dataset is not None:
-                    zero_size = True
-                    for _, fld in self.medium.eps_dataset.field_components.items():
-                        if len(fld.coords[dim]) != 1:
-                            zero_size = False
-                    if zero_size:
-                        size[axis] = 0
-
         mnt_fld = FieldMonitor(
             size=size,
             center=center,

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -249,7 +249,8 @@ class Structure(AbstractStructure):
     ) -> (FieldMonitor, PermittivityMonitor):
         """Generate the field and permittivity monitor for this structure."""
 
-        box = self.geometry.bounding_box
+        geometry = self.geometry
+        box = geometry.bounding_box
 
         # we dont want these fields getting traced by autograd, otherwise it messes stuff up
 
@@ -257,8 +258,8 @@ class Structure(AbstractStructure):
         center = [get_static(x) for x in box.center]
 
         # polyslab only needs fields at the midpoint along axis
-        if isinstance(self.geometry, PolySlab):
-            size[self.geometry.axis] = 0
+        if isinstance(geometry, PolySlab) and not isinstance(self.medium, AbstractCustomMedium):
+            size[geometry.axis] = 0
 
         mnt_fld = FieldMonitor(
             size=size,

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -712,7 +712,7 @@ def _run_async_bwd(
                 sim_data_fwd = sim_data_fwd_dict[task_name]
                 sim_fields_keys = sim_fields_keys_dict[task_name]
 
-                sim_data_adj = batch_data_adj.get(task_name_adj)
+                sim_data_adj = batch_data_adj[task_name_adj]
 
                 sim_fields_vjp = postprocess_adj(
                     sim_data_adj=sim_data_adj,

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -6,6 +6,7 @@ import concurrent
 import os
 import time
 from abc import ABC
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from typing import Dict, Optional, Tuple
 
@@ -339,7 +340,7 @@ class Job(WebContainer):
         return web.estimate_cost(self.task_id, verbose=verbose, solver_version=self.solver_version)
 
 
-class BatchData(Tidy3dBaseModel):
+class BatchData(Tidy3dBaseModel, Mapping):
     """
     Holds a collection of :class:`.SimulationData` returned by :class:`Batch`.
 
@@ -391,15 +392,17 @@ class BatchData(Tidy3dBaseModel):
             verbose=False,
         )
 
-    def items(self) -> Tuple[TaskName, SimulationDataType]:
-        """Iterate through the simulations for each task_name."""
-
-        for task_name in self.task_paths.keys():
-            yield task_name, self.load_sim_data(task_name)
-
     def __getitem__(self, task_name: TaskName) -> SimulationDataType:
         """Get the simulation data object for a given ``task_name``."""
         return self.load_sim_data(task_name)
+
+    def __iter__(self):
+        """Iterate over the task names."""
+        return iter(self.task_paths)
+
+    def __len__(self):
+        """Return the number of tasks in the batch."""
+        return len(self.task_paths)
 
     @classmethod
     def load(cls, path_dir: str = DEFAULT_DATA_DIR) -> BatchData:


### PR DESCRIPTION
1. single cell approximation for CustomMedium was giving inaccurate gradients. Revert to old approach that sums over single cell dims at expense of more data.
2. cherry pick this commit from 2.8 that fixes run_async for local gradients. https://github.com/flexcompute/tidy3d/commit/d12ace8b9a454f90134b2c6ca4114f58e69dbdb7