### PR TITLE
Suggest a better f_width for TerminalComponentModeler

### DIFF
--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -23,7 +23,7 @@ from ..ports.base_terminal import AbstractTerminalPort, TerminalPortDataArray
 from ..ports.coaxial_lumped import CoaxialLumpedPort
 from ..ports.rectangular_lumped import LumpedPort
 from ..ports.wave import WavePort
-from .base import FWIDTH_FRAC, AbstractComponentModeler, TerminalPortType
+from .base import AbstractComponentModeler, TerminalPortType
 
 
 class PortDataArray(DataArray):
@@ -177,9 +177,9 @@ class TerminalComponentModeler(AbstractComponentModeler):
     @cached_property
     def _source_time(self):
         """Helper to create a time domain pulse for the frequency range of interest."""
-        freq0 = np.mean(self.freqs)
-        fdiff = max(self.freqs) - min(self.freqs)
-        fwidth = max(fdiff, freq0 * FWIDTH_FRAC)
+        freq0 = (min(self.freqs) + max(self.freqs)) / 2
+        # This ensures the amplitude at the maximum frequency is around 0.1 of the amplitude at the central frequency
+        fwidth = freq0 * np.sqrt(2) / np.pi
         return GaussianPulse(
             freq0=freq0, fwidth=fwidth, remove_dc_component=self.remove_dc_component
         )


### PR DESCRIPTION
Previous parameters result a central frequency out of the frequency range as shown, which uses f_min=0 and f_max = 50GHz. I took f_width=0.5*freq_0, which might not be optimal but helps centre the frequency at around 25GHz and improved S-parameters a bit.
![image](https://github.com/user-attachments/assets/3a42b384-a3af-47cc-9b47-e60d28e23889)
![Screenshot from 2024-11-21 16-58-17](https://github.com/user-attachments/assets/6835e7d3-e032-4c4e-9e05-44ff9bbbdd00)
