### PR TITLE
Minimum install for tidy3d

### DIFF
--- a/tidy3d/components/autograd/functions.py
+++ b/tidy3d/components/autograd/functions.py
@@ -6,7 +6,6 @@ from autograd.extend import defjvp, defvjp, primitive
 from autograd.numpy.numpy_jvps import broadcast
 from autograd.numpy.numpy_vjps import unbroadcast_f
 from numpy.typing import NDArray
-from scipy.interpolate import RegularGridInterpolator
 
 from .types import InterpolationType
 
@@ -127,6 +126,8 @@ def interpn(
     --------
     `scipy.interpolate.interpn <https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interpn.html>`_
     """
+    from scipy.interpolate import RegularGridInterpolator
+
     if method == "nearest":
         interp_fn = _evaluate_nearest
     elif method == "linear":

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -6,7 +6,6 @@ from abc import ABC
 from typing import Any, Dict, List, Mapping, Union
 
 import autograd.numpy as anp
-import dask
 import h5py
 import numpy as np
 import xarray as xr
@@ -256,6 +255,8 @@ class DataArray(xr.DataArray):
 
     def __hash__(self) -> int:
         """Generate hash value for a :class:.`DataArray` instance, needed for custom components."""
+        import dask
+
         token_str = dask.base.tokenize(self)
         return hash(token_str)
 

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -9,8 +9,12 @@ from typing import Any, Callable, Dict, Tuple, Union
 import numpy as np
 import pydantic.v1 as pd
 import xarray as xr
-from matplotlib import pyplot as plt
-from matplotlib.tri import Triangulation
+
+try:
+    from matplotlib import pyplot as plt
+    from matplotlib.tri import Triangulation
+except ImportError:
+    pass
 
 from ...constants import PICOSECOND_PER_NANOMETER_PER_KILOMETER, inf
 from ...exceptions import DataError, Tidy3dNotImplementedError, ValidationError

--- a/tidy3d/components/eme/simulation.py
+++ b/tidy3d/components/eme/simulation.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from typing import Dict, List, Literal, Optional, Tuple, Union
 
-import matplotlib as mpl
+try:
+    import matplotlib as mpl
+except ImportError:
+    pass
 import numpy as np
 import pydantic.v1 as pd
 

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -11,7 +11,11 @@ import autograd.numpy as np
 import pydantic.v1 as pydantic
 import shapely
 import xarray as xr
-from matplotlib import patches
+
+try:
+    from matplotlib import patches
+except ImportError:
+    pass
 
 from ...constants import LARGE_NUMBER, MICROMETER, RADIAN, fp_eps, inf
 from ...exceptions import (

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -10,7 +10,6 @@ import autograd.numpy as np
 import pydantic.v1 as pydantic
 import shapely
 from autograd.tracer import getval, isbox
-from matplotlib import path
 
 from ...constants import LARGE_NUMBER, MICROMETER, fp_eps
 from ...exceptions import SetupError, ValidationError
@@ -478,6 +477,11 @@ class PolySlab(base.Planar):
         with the same shape which is ``True`` for every point in zip(x, y, z) that is inside the
         volume of the :class:`Geometry`, and ``False`` otherwise.
 
+        Note
+        ----
+        For slanted sidewalls, this function only works if x, y, and z are arrays produced by a
+        ``meshgrid call``, i.e. 3D arrays and each is constant along one axis.
+
         Parameters
         ----------
         x : np.ndarray[float]
@@ -523,13 +527,9 @@ class PolySlab(base.Planar):
 
             # vertical sidewall
             if math.isclose(self.sidewall_angle, 0):
-                # face_polygon = self.make_shapely_polygon(self.reference_polygon)
-                # fun_contain = contains_pointwise(face_polygon)
-                # contains_vectorized = np.vectorize(fun_contain, signature="(n)->()")
-                poly_path = path.Path(self.reference_polygon)
-                contains_vectorized = poly_path.contains_points
-                points_stacked = np.stack((xs_slab, ys_slab), axis=1)
-                inside_polygon_slab = contains_vectorized(points_stacked)
+                face_polygon = shapely.Polygon(self.reference_polygon)
+                shapely.prepare(face_polygon)
+                inside_polygon_slab = shapely.contains_xy(face_polygon, x=xs_slab, y=ys_slab)
                 inside_polygon[inside_height] = inside_polygon_slab
             # slanted sidewall, offsetting vertices at each z
             else:
@@ -550,15 +550,11 @@ class PolySlab(base.Planar):
                     vertices_z = self._shift_vertices(
                         self.middle_polygon, _move_axis(dist)[0, 0, z_i]
                     )[0]
-                    # face_polygon = self.make_shapely_polygon(vertices_z)
-                    # fun_contain = contains_pointwise(face_polygon)
-                    # contains_vectorized = np.vectorize(fun_contain, signature="(n)->()")
-                    poly_path = path.Path(vertices_z)
-                    contains_vectorized = poly_path.contains_points
-                    points_stacked = np.stack(
-                        (x_axis[:, :, 0].flatten(), y_axis[:, :, 0].flatten()), axis=1
-                    )
-                    inside_polygon_slab = contains_vectorized(points_stacked)
+                    face_polygon = shapely.Polygon(vertices_z)
+                    shapely.prepare(face_polygon)
+                    xs = x_axis[:, :, 0].flatten()
+                    ys = y_axis[:, :, 0].flatten()
+                    inside_polygon_slab = shapely.contains_xy(face_polygon, x=xs, y=ys)
                     inside_polygon_axis[:, :, z_i] = inside_polygon_slab.reshape(x_axis.shape[:2])
                 inside_polygon = _move_axis_reverse(inside_polygon_axis)
         else:

--- a/tidy3d/components/heat_charge/simulation.py
+++ b/tidy3d/components/heat_charge/simulation.py
@@ -7,7 +7,11 @@ from typing import Dict, List, Tuple, Union
 
 import numpy as np
 import pydantic.v1 as pd
-from matplotlib import colormaps
+
+try:
+    from matplotlib import colormaps
+except ImportError:
+    pass
 
 from ...constants import VOLUMETRIC_HEAT_RATE, inf
 from ...exceptions import SetupError

--- a/tidy3d/components/parameter_perturbation.py
+++ b/tidy3d/components/parameter_perturbation.py
@@ -6,7 +6,10 @@ import functools
 from abc import ABC, abstractmethod
 from typing import Callable, List, Optional, Tuple, Union
 
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    pass
 import numpy as np
 import pydantic.v1 as pd
 

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 import autograd.numpy as np
-import matplotlib as mpl
-import matplotlib.pylab as plt
+
+try:
+    import matplotlib as mpl
+    import matplotlib.pylab as plt
+    from mpl_toolkits.axes_grid1 import make_axes_locatable
+except ImportError:
+    pass
 import pydantic.v1 as pd
-from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from ..constants import CONDUCTIVITY, THERMAL_CONDUCTIVITY, inf
 from ..exceptions import SetupError, Tidy3dError

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -9,7 +9,12 @@ from collections import defaultdict
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 import autograd.numpy as np
-import matplotlib as mpl
+
+try:
+    import matplotlib as mpl
+except ImportError:
+    pass
+
 import pydantic.v1 as pydantic
 import xarray as xr
 

--- a/tidy3d/components/types.py
+++ b/tidy3d/components/types.py
@@ -9,7 +9,11 @@ except ImportError:
     from typing_extensions import Literal
 import autograd.numpy as np
 import pydantic.v1 as pydantic
-from matplotlib.axes import Axes
+
+try:
+    from matplotlib.axes import Axes
+except ImportError:
+    Axes = None
 from shapely.geometry.base import BaseGeometry
 from typing_extensions import Annotated
 

--- a/tidy3d/components/viz.py
+++ b/tidy3d/components/viz.py
@@ -6,11 +6,18 @@ from functools import wraps
 from html import escape
 from typing import Any
 
-import matplotlib.pyplot as plt
-import matplotlib.ticker as ticker
 import pydantic.v1 as pd
-from matplotlib.patches import ArrowStyle, PathPatch
-from matplotlib.path import Path
+
+try:
+    import matplotlib.pyplot as plt
+    import matplotlib.ticker as ticker
+    from matplotlib.patches import ArrowStyle, PathPatch
+    from matplotlib.path import Path
+
+    # default arrow style
+    arrow_style = ArrowStyle.Simple(head_length=12, head_width=9, tail_width=4)
+except ImportError:
+    arrow_style = None
 from numpy import array, concatenate, inf, ones
 
 from ..constants import UnitScaling
@@ -160,10 +167,6 @@ MEDIUM_CMAP = [
 # colormap for structure's permittivity in plot_eps
 STRUCTURE_EPS_CMAP = "gist_yarg"
 STRUCTURE_HEAT_COND_CMAP = "gist_yarg"
-
-# default arrow style
-arrow_style = ArrowStyle.Simple(head_length=12, head_width=9, tail_width=4)
-
 
 """=================================================================================================
 Descartes modified from https://pypi.org/project/descartes/ for Shapely >= 1.8.0


### PR DESCRIPTION
Shifting some things around to identify minimal set of packages needed to be able to validate a sample simulation file.

Currently requires:
```text
annotated-types   0.7.0
autograd          1.7.0
cycler            0.12.1
h5py              3.12.1
kiwisolver        1.4.7
matplotlib        3.9.2
numpy             2.1.3
packaging         24.2
pandas            2.2.3
pillow            11.0.0
pydantic          2.10.1
pydantic-core     2.27.1
pyparsing         3.2.0
pyroots           0.5.0
python-dateutil   2.9.0.post0
pytz              2024.2
pyyaml            6.0.2
rich              13.9.4
shapely           2.0.6
six               1.16.0
typing-extensions 4.12.2
xarray            2024.10.0
```