### PR TITLE
Moving nonlinear warnings to simulation and consolidating

### DIFF
--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -561,17 +561,6 @@ def test_nonlinear_medium(log_capture):
         )
     )
 
-    # complex parameters
-    with AssertLogLevel(log_capture, "WARNING", contains_str="preferred"):
-        med = td.Medium(
-            nonlinear_spec=td.NonlinearSpec(
-                models=[
-                    td.KerrNonlinearity(n2=-1 + 1j, n0=1),
-                ],
-                num_iters=20,
-            )
-        )
-
     # warn about deprecated api
     med = td.Medium(nonlinear_spec=td.NonlinearSusceptibility(chi3=1.5))
     assert_log_level(log_capture, "WARNING")
@@ -621,12 +610,6 @@ def test_nonlinear_medium(log_capture):
     with pytest.raises(ValidationError):
         med = td.Medium(nonlinear_spec=td.NonlinearSpec(models=[td.KerrNonlinearity(n2=-1j, n0=1)]))
 
-    with AssertLogLevel(log_capture, "WARNING", contains_str="phenomenological"):
-        med = td.Medium(
-            nonlinear_spec=td.NonlinearSpec(models=[td.TwoPhotonAbsorption(beta=-1, n0=1)]),
-            allow_gain=True,
-        )
-
     # automatic detection of n0 and freq0
     n0 = 2
     freq0 = td.C_0 / 1
@@ -648,6 +631,26 @@ def test_nonlinear_medium(log_capture):
     )
     assert n0 == nonlinear_spec.models[0]._get_n0(n0=None, medium=medium, freqs=[freq0])
     assert freq0 == nonlinear_spec.models[0]._get_freq0(freq0=None, freqs=[freq0])
+
+    # two photon absorption is phenomenological
+    with AssertLogLevel(log_capture, "WARNING", contains_str="phenomenological"):
+        med = td.Medium(
+            nonlinear_spec=td.NonlinearSpec(models=[td.TwoPhotonAbsorption(beta=-1, n0=1)]),
+            allow_gain=True,
+        )
+        sim.updated_copy(medium=med, path="structures/0")
+
+    # complex parameters
+    with AssertLogLevel(log_capture, "WARNING", contains_str="preferred"):
+        med = td.Medium(
+            nonlinear_spec=td.NonlinearSpec(
+                models=[
+                    td.KerrNonlinearity(n2=-1 + 1j, n0=1),
+                ],
+                num_iters=20,
+            )
+        )
+        sim.updated_copy(medium=med, path="structures/0")
 
     # subsection with nonlinear materials needs to hardcode source info
     sim2 = sim.updated_copy(center=(-4, -4, -4), path="sources/0")

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -442,14 +442,6 @@ class TwoPhotonAbsorption(NonlinearModel):
 
     def _validate_medium(self, medium: AbstractMedium):
         """Check that the model is compatible with the medium."""
-        log.warning(
-            "Found a medium with a 'TwoPhotonAbsorption' nonlinearity. "
-            "This uses a phenomenological model based on complex fields, "
-            "so care should be taken in interpreting the results. For more "
-            "information on the model, see the documentation at "
-            "'https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.TwoPhotonAbsorption.html' or the following reference: "
-            "'N. Suzuki, \"FDTD Analysis of Two-Photon Absorption and Free-Carrier Absorption in Si High-Index-Contrast Waveguides,\" J. Light. Technol. 25, 9 (2007).'."
-        )
         # if n0 is specified, we can go ahead and validate passivity
         if self.n0 is not None:
             self._validate_medium_freqs(medium, [])
@@ -458,19 +450,6 @@ class TwoPhotonAbsorption(NonlinearModel):
     def complex_fields(self) -> bool:
         """Whether the model uses complex fields."""
         return True
-
-    @pd.validator("beta", always=True)
-    def _warn_for_complex_beta(cls, val):
-        if val is None:
-            return val
-        if np.iscomplex(val):
-            log.warning(
-                "Complex values of 'beta' in 'TwoPhotonAbsorption' are deprecated "
-                "and may be removed in a future version. The implementation with "
-                "complex 'beta' is as described in the 'TwoPhotonAbsorption' docstring, "
-                "but the physical interpretation of 'beta' may not be correct if it is complex."
-            )
-        return val
 
 
 class KerrNonlinearity(NonlinearModel):
@@ -546,13 +525,6 @@ class KerrNonlinearity(NonlinearModel):
 
     def _validate_medium(self, medium: AbstractMedium):
         """Check that the model is compatible with the medium."""
-        log.warning(
-            "Found a medium with a 'KerrNonlinearity'. Usually, "
-            "'NonlinearSusceptibility' is preferred, as it captures "
-            "additional physical effects by acting on the underlying real fields. "
-            "The relation between the parameters is "
-            "'chi3 = (4/3) * eps_0 * c_0 * n0 * Re(n0) * n2'."
-        )
         # if n0 is specified, we can go ahead and validate passivity
         if self.n0 is not None:
             self._validate_medium_freqs(medium, [])

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -45,10 +45,12 @@ from .medium import (
     AbstractPerturbationMedium,
     AnisotropicMedium,
     FullyAnisotropicMedium,
+    KerrNonlinearity,
     Medium,
     Medium2D,
     MediumType,
     MediumType3D,
+    TwoPhotonAbsorption,
 )
 from .monitor import (
     AbstractFieldProjectionMonitor,
@@ -3360,12 +3362,38 @@ class Simulation(AbstractYeeGridSimulation):
 
     def _validate_nonlinear_specs(self) -> None:
         """Run :class:`.NonlinearSpec` validators that depend on knowing the central
-        frequencies of the sources."""
+        frequencies of the sources. Also print some warnings only once per unique medium."""
         freqs = np.array([source.source_time.freq0 for source in self.sources])
         for medium in self.scene.mediums:
             if medium.nonlinear_spec is not None:
                 for model in medium._nonlinear_models:
                     model._validate_medium_freqs(medium, freqs)
+
+                    if isinstance(model, TwoPhotonAbsorption):
+                        if np.iscomplex(model.beta):
+                            log.warning(
+                                "Complex values of 'beta' in 'TwoPhotonAbsorption' are deprecated "
+                                "and may be removed in a future version. The implementation with "
+                                "complex 'beta' is as described in the 'TwoPhotonAbsorption' docstring, "
+                                "but the physical interpretation of 'beta' may not be correct if it is complex."
+                            )
+                        log.warning(
+                            "Found a medium with a 'TwoPhotonAbsorption' nonlinearity. "
+                            "This uses a phenomenological model based on complex fields, "
+                            "so care should be taken in interpreting the results. For more "
+                            "information on the model, see the documentation at "
+                            "'https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.TwoPhotonAbsorption.html' or the following reference: "
+                            "'N. Suzuki, \"FDTD Analysis of Two-Photon Absorption and Free-Carrier Absorption in Si High-Index-Contrast Waveguides,\" J. Light. Technol. 25, 9 (2007).'."
+                        )
+
+                    if isinstance(model, KerrNonlinearity):
+                        log.warning(
+                            "Found a medium with a 'KerrNonlinearity'. Usually, "
+                            "'NonlinearSusceptibility' is preferred, as it captures "
+                            "additional physical effects by acting on the underlying real fields. "
+                            "The relation between the parameters is "
+                            "'chi3 = (4/3) * eps_0 * c_0 * n0 * Re(n0) * n2'."
+                        )
 
     """ Pre submit validation (before web.upload()) """
 


### PR DESCRIPTION
A user had 2000 structures each with the same nonlinear medium, which was producing a giant output of warnings.

Moving the warnings to `Simulation` ensures that they would only get printed once per unique medium. Any objections to this? Main difference seems to be that the warning will be shown a bit later (not immediately when constructing the medium), but still well in time to act on?