### PR TITLE
fix link

### DIFF
--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -223,7 +223,7 @@ class UniformGrid(GridSpec1d):
         Specification for non-uniform grid along a given dimension.
 
     **Notebooks:**
-        * `Photonic crystal waveguide polarization filter <../../../notebooks/PhotonicCrystalWaveguidePolarizationFilter.html>`_
+        * `Photonic crystal waveguide polarization filter <../../notebooks/PhotonicCrystalWaveguidePolarizationFilter.html>`_
         * `Using automatic nonuniform meshing <../../notebooks/AutoGrid.html>`_
     """
 


### PR DESCRIPTION
The this [link](https://docs.flexcompute.com/projects/tidy3d/en/notebooks/PhotonicCrystalWaveguidePolarizationFilter/) is broke in [this page.](https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.UniformGrid.html)

It seems that is just on extra '..', but I am not 100% sure. Is it correct @daquinteroflex?

