### PR TITLE
adjoint support for `TriangleMesh` geometries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Small inaccuracy when applying a mode solver `bend_radius` when the simulation grid is not symmetric w.r.t. the mode plane center. Previously, the radius was defined w.r.t. the middle grid coordinate, while now it is correctly applied w.r.t. the plane center.
 - Silence warning in graphene from checking fit quality at large frequencies.
 
+### Fixed
+- Gradient inaccuracy when a multi-frequency monitor is used but a single frequency is selected.
+
 ## [2.7.7] - 2024-11-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Gradient inaccuracy when a multi-frequency monitor is used but a single frequency is selected.
+- Revert single cell center approximation for custom medium gradient.
 
 ## [2.7.7] - 2024-11-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Small inaccuracy when applying a mode solver `bend_radius` when the simulation grid is not symmetric w.r.t. the mode plane center. Previously, the radius was defined w.r.t. the middle grid coordinate, while now it is correctly applied w.r.t. the plane center.
 - Silence warning in graphene from checking fit quality at large frequencies.
 
+### Changed
+- `BatchData` is now a mapping and can be accessed and iterated over like a Python dictionary (`.keys()`, `.values()`, `.items()`).
+
 ### Fixed
 - Gradient inaccuracy when a multi-frequency monitor is used but a single frequency is selected.
 - Revert single cell center approximation for custom medium gradient.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `@scalar_objective` decorator in `tidy3d.plugins.autograd` that wraps objective functions to ensure they return a scalar value and performs additional checks to ensure compatibility of objective functions with autograd. Used by default in `tidy3d.plugins.autograd.value_and_grad` as well as `tidy3d.plugins.autograd.grad`.
 - Autograd support for simulations without adjoint sources in `run` as well as `run_async`, which will not attempt to run the simulation but instead return zero gradients. This can sometimes occur if the objective function gradient does not depend on some simulations, for example when using `min` or `max` in the objective.
 
+- Support for differentiation with respect to `PolySlab.slab_bounds` and `PolySlab.dilation`.
+
 ### Changed
 - `CustomMedium` design regions require far less data when performing inverse design by reducing adjoint field monitor size for dims with one pixel.
 - Calling `.values` on `DataArray` no longer raises a `DeprecationWarning` during automatic differentiation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Autograd support for simulations without adjoint sources in `run` as well as `run_async`, which will not attempt to run the simulation but instead return zero gradients. This can sometimes occur if the objective function gradient does not depend on some simulations, for example when using `min` or `max` in the objective.
 
 - Support for differentiation with respect to `PolySlab.slab_bounds` and `PolySlab.dilation`.
+- Support for differentiation with respect to `PolySlab.slab_bounds`.
 
 ### Changed
 - `CustomMedium` design regions require far less data when performing inverse design by reducing adjoint field monitor size for dims with one pixel.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `BatchData` is now a mapping and can be accessed and iterated over like a Python dictionary (`.keys()`, `.values()`, `.items()`).
+### Added
+- Support for differentiation with respect to `PolySlab.slab_bounds`.
 
 ### Fixed
 - Gradient inaccuracy when a multi-frequency monitor is used but a single frequency is selected.
@@ -66,9 +68,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Differential operators `grad` and `value_and_grad` in `tidy3d.plugins.autograd` that behave similarly to the autograd operators but support auxiliary data via `aux_data=True` as well as differentiation w.r.t. `DataArray`.
 - `@scalar_objective` decorator in `tidy3d.plugins.autograd` that wraps objective functions to ensure they return a scalar value and performs additional checks to ensure compatibility of objective functions with autograd. Used by default in `tidy3d.plugins.autograd.value_and_grad` as well as `tidy3d.plugins.autograd.grad`.
 - Autograd support for simulations without adjoint sources in `run` as well as `run_async`, which will not attempt to run the simulation but instead return zero gradients. This can sometimes occur if the objective function gradient does not depend on some simulations, for example when using `min` or `max` in the objective.
-
-- Support for differentiation with respect to `PolySlab.slab_bounds` and `PolySlab.dilation`.
-- Support for differentiation with respect to `PolySlab.slab_bounds`.
 
 ### Changed
 - `CustomMedium` design regions require far less data when performing inverse design by reducing adjoint field monitor size for dims with one pixel.

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -55,7 +55,7 @@ params0 = np.random.random(N_PARAMS) - 0.5
 params0 /= np.linalg.norm(params0)
 
 # whether to plot the simulation within the objective function
-PLOT_SIM = False
+PLOT_SIM = True
 
 # whether to include a call to `objective(params)` in addition to gradient
 CALL_OBJECTIVE = False
@@ -70,7 +70,7 @@ FWIDTH = FREQ0 / 10
 # sim sizes
 LZ = 7.0 * WVL
 
-IS_3D = True
+IS_3D = False
 
 # TODO: test 2D and 3D parameterized
 
@@ -346,15 +346,16 @@ def make_structures(params: anp.ndarray) -> dict[str, td.Structure]:
     radii = 1.0 + 0.5 * params_01
 
     phis = 2 * anp.pi * anp.linspace(0, 1, NUM_VERTICES + 1)[:NUM_VERTICES]
-    xs = 1.5 * anp.cos(phis)
-    ys = 1.5 * anp.sin(phis)
+    xs = radii * anp.cos(phis)
+    ys = radii * anp.sin(phis)
     vertices = anp.stack((xs, ys), axis=-1)
-    slab_bounds = (-0.5 * params_01, 0.5 * params_01)
+    slab_bounds = (-0.5, 0.5)
+    # slab_bounds = (-0.5 * params_01, 0.5 * params_01)
     polyslab = td.Structure(
         geometry=td.PolySlab(
             vertices=vertices,
             slab_bounds=slab_bounds,
-            axis=2,
+            axis=0,
             sidewall_angle=0.00,
             dilation=0.00,
         ),

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -1333,6 +1333,7 @@ def test_pole_residue(monkeypatch):
         eps_out=1.0,
         frequency=freq,
         bounds=((-1, -1, -1), (1, 1, 1)),
+        bounds_intersect=((-1, -1, -1), (1, 1, 1)),
     )
 
     grads_computed = pr.compute_derivatives(derivative_info=info)
@@ -1412,6 +1413,7 @@ def test_custom_pole_residue(monkeypatch):
         eps_out=1.0,
         frequency=freq,
         bounds=((-1, -1, -1), (1, 1, 1)),
+        bounds_intersect=((-1, -1, -1), (1, 1, 1)),
     )
 
     grads_computed = pr.compute_derivatives(derivative_info=info)

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -569,7 +569,7 @@ if TEST_POLYSLAB_SPEED:
     args = [("polyslab", "mode")]
 
 
-# args = [("size_element", "mode")]
+args = [("polyslab", "mode")]
 
 
 def get_functions(structure_key: str, monitor_key: str) -> typing.Callable:

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -40,8 +40,8 @@ TEST_CUSTOM_MEDIUM_SPEED = False
 TEST_POLYSLAB_SPEED = False
 
 # whether to run numerical gradient tests, off by default because it runs real simulations
-RUN_NUMERICAL = False
-_NUMERICAL_COMBINATION = ("polyslab", "mode")
+RUN_NUMERICAL = True
+_NUMERICAL_COMBINATION = ("trimesh", "mode")
 
 TEST_MODES = ("pipeline", "adjoint", "speed")
 TEST_MODE = "speed" if TEST_POLYSLAB_SPEED else "pipeline"
@@ -55,7 +55,7 @@ params0 = np.random.random(N_PARAMS) - 0.5
 params0 /= np.linalg.norm(params0)
 
 # whether to plot the simulation within the objective function
-PLOT_SIM = False
+PLOT_SIM = True
 
 # whether to include a call to `objective(params)` in addition to gradient
 CALL_OBJECTIVE = False
@@ -455,6 +455,13 @@ def make_structures(params: anp.ndarray) -> dict[str, td.Structure]:
     )
     cylinder = td.Structure(geometry=cylinder_geo, medium=polyslab.medium)
 
+    vertices = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    faces = np.array([[1, 2, 3], [0, 3, 2], [0, 1, 3], [0, 2, 1]])
+    vertices = vertices + np.mean(params)
+    geo_tm = td.TriangleMesh.from_vertices_faces(vertices, faces)
+
+    triangle_mesh = td.Structure(geometry=geo_tm, medium=polyslab.medium)
+
     return dict(
         medium=medium,
         center_list=center_list,
@@ -467,6 +474,7 @@ def make_structures(params: anp.ndarray) -> dict[str, td.Structure]:
         pole_res=pole_res,
         custom_pole_res=custom_pole_res,
         cylinder=cylinder,
+        trimesh=triangle_mesh,
     )
 
 

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -70,8 +70,8 @@ FWIDTH = FREQ0 / 10
 # sim sizes
 LZ = 7.0 * WVL
 
-IS_3D = True
-POLYSLAB_AXIS = 0
+IS_3D = False
+POLYSLAB_AXIS = 2
 
 # TODO: test 2D and 3D parameterized
 

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -221,12 +221,23 @@ def use_emulated_run(monkeypatch):
                 batch_data_orig[task_name] = sim_data_orig
                 task_ids_fwd[task_name] = task_id_fwd
 
-            return batch_data_orig, task_ids_fwd
+            class EmulatedBatchData(web.BatchData):
+                def load_sim_data(self, task_name):
+                    return batch_data_orig[task_name]
+
+            task_paths = {task_name: "" for task_name in simulations.keys()}
+
+            batch_data = EmulatedBatchData(
+                task_paths=task_paths,
+                task_ids=task_ids_fwd,
+                verbose=False,
+            )
+
+            return batch_data, task_ids_fwd
 
         def emulated_run_async_bwd(simulations, **run_kwargs) -> td.SimulationData:
             vjp_dict = {}
             for task_name, simulation in simulations.items():
-                task_id_fwd = task_name[:-8]
                 vjp_dict[task_name] = emulated_run_bwd(simulation, task_name, **run_kwargs)
             return vjp_dict
 

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -876,22 +876,22 @@ def test_autograd_speed_num_structures(use_emulated_run):
 def test_autograd_polyslab_cylinder(use_emulated_run, monitor_key):
     """Test an objective function through tidy3d autograd."""
 
-    t = 1.0
+    t0 = 1.0
     axis = 0
 
-    num_pts = 89
+    num_pts = 819
 
     monitor, postprocess = make_monitors()[monitor_key]
 
-    def make_cylinder(radius, x0, y0):
+    def make_cylinder(radius, x0, y0, t):
         return td.Cylinder(
             center=td.Cylinder.unpop_axis(0.0, (x0, y0), axis=axis),
             radius=radius,
             length=t,
             axis=axis,
-        )  # .to_polyslab(num_pts)
+        ).to_polyslab(num_pts)
 
-    def make_polyslab(radius, x0, y0):
+    def make_polyslab(radius, x0, y0, t):
         phis = anp.linspace(0, 2 * np.pi, num_pts + 1)[:-1]
 
         xs = radius * anp.cos(phis) + x0
@@ -911,7 +911,7 @@ def test_autograd_polyslab_cylinder(use_emulated_run, monitor_key):
 
         return SIM_BASE.updated_copy(structures=[structure], monitors=[monitor])
 
-    p0 = [1.0, 0.0, 0.0]
+    p0 = [1.0, 0.0, 0.0, t0]
 
     def objective_polyslab(params):
         """Objective function."""

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -41,7 +41,7 @@ TEST_POLYSLAB_SPEED = False
 
 # whether to run numerical gradient tests, off by default because it runs real simulations
 RUN_NUMERICAL = False
-_NUMERICAL_COMBINATION = ("size_element", "mode")
+_NUMERICAL_COMBINATION = ("polyslab", "mode")
 
 TEST_MODES = ("pipeline", "adjoint", "speed")
 TEST_MODE = "speed" if TEST_POLYSLAB_SPEED else "pipeline"
@@ -349,10 +349,11 @@ def make_structures(params: anp.ndarray) -> dict[str, td.Structure]:
     xs = radii * anp.cos(phis)
     ys = radii * anp.sin(phis)
     vertices = anp.stack((xs, ys), axis=-1)
+    slab_bounds = (-0.5 * params_01, 0.5 * params_01)
     polyslab = td.Structure(
         geometry=td.PolySlab(
             vertices=vertices,
-            slab_bounds=(-0.5, 0.5),
+            slab_bounds=slab_bounds,
             axis=0,
             sidewall_angle=0.01,
             dilation=0.01,

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -40,7 +40,7 @@ TEST_CUSTOM_MEDIUM_SPEED = False
 TEST_POLYSLAB_SPEED = False
 
 # whether to run numerical gradient tests, off by default because it runs real simulations
-RUN_NUMERICAL = False
+RUN_NUMERICAL = True
 _NUMERICAL_COMBINATION = ("polyslab", "mode")
 
 TEST_MODES = ("pipeline", "adjoint", "speed")
@@ -55,7 +55,7 @@ params0 = np.random.random(N_PARAMS) - 0.5
 params0 /= np.linalg.norm(params0)
 
 # whether to plot the simulation within the objective function
-PLOT_SIM = False
+PLOT_SIM = True
 
 # whether to include a call to `objective(params)` in addition to gradient
 CALL_OBJECTIVE = False
@@ -346,17 +346,17 @@ def make_structures(params: anp.ndarray) -> dict[str, td.Structure]:
     radii = 1.0 + 0.5 * params_01
 
     phis = 2 * anp.pi * anp.linspace(0, 1, NUM_VERTICES + 1)[:NUM_VERTICES]
-    xs = radii * anp.cos(phis)
-    ys = radii * anp.sin(phis)
+    xs = 1.5 * anp.cos(phis)
+    ys = 1.5 * anp.sin(phis)
     vertices = anp.stack((xs, ys), axis=-1)
     slab_bounds = (-0.5 * params_01, 0.5 * params_01)
     polyslab = td.Structure(
         geometry=td.PolySlab(
             vertices=vertices,
             slab_bounds=slab_bounds,
-            axis=0,
-            sidewall_angle=0.01,
-            dilation=0.01,
+            axis=2,
+            sidewall_angle=0.00,
+            dilation=0.00,
         ),
         medium=med,
     )

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -55,7 +55,7 @@ params0 = np.random.random(N_PARAMS) - 0.5
 params0 /= np.linalg.norm(params0)
 
 # whether to plot the simulation within the objective function
-PLOT_SIM = True
+PLOT_SIM = False
 
 # whether to include a call to `objective(params)` in addition to gradient
 CALL_OBJECTIVE = False
@@ -70,11 +70,11 @@ FWIDTH = FREQ0 / 10
 # sim sizes
 LZ = 7.0 * WVL
 
-IS_3D = False
+IS_3D = True
 
 # TODO: test 2D and 3D parameterized
 
-LX = 0.5 * WVL if IS_3D else 0.0
+LX = 3.5 * WVL if IS_3D else 0.0
 PML_X = True if IS_3D else False
 
 

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -226,12 +226,14 @@ class DerivativeInfo(Tidy3dBaseModel):
         interp_kwargs = {}
         for dim, locations_dim in zip("xyz", (xs, ys, zs)):
             # only include dims where the data has more than 1 coord, to avoid warnings and errors
-            if True or all(np.array(fld.coords).size > 1 for fld in fld_dataset.values()):
+            if True or any(np.array(fld.coords[dim]).size > 1 for fld in fld_dataset.values()):
                 interp_kwargs[dim] = xr.DataArray(locations_dim, dims=edge_index_dim)
 
         components = {}
         for fld_name, arr in fld_dataset.items():
-            components[fld_name] = arr.interp(**interp_kwargs, assume_sorted=True).sum("f")
+            components[fld_name] = arr.interp(
+                **interp_kwargs, assume_sorted=True, kwargs=dict(fill_value=None)
+            ).sum("f")
 
         return components
 

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -223,17 +223,22 @@ class DerivativeInfo(Tidy3dBaseModel):
         xs, ys, zs = spatial_coords.T
         edge_index_dim = "edge_index"
 
+        sum_dims = []
         interp_kwargs = {}
         for dim, locations_dim in zip("xyz", (xs, ys, zs)):
             # only include dims where the data has more than 1 coord, to avoid warnings and errors
-            if True or any(np.array(fld.coords[dim]).size > 1 for fld in fld_dataset.values()):
+            if any(np.array(fld.coords[dim]).size == 1 for fld in fld_dataset.values()):
+                sum_dims.append(dim)
+            else:
                 interp_kwargs[dim] = xr.DataArray(locations_dim, dims=edge_index_dim)
 
         components = {}
         for fld_name, arr in fld_dataset.items():
-            components[fld_name] = arr.interp(
-                **interp_kwargs, assume_sorted=True, kwargs=dict(fill_value=None)
-            ).sum("f")
+            components[fld_name] = (
+                arr.interp(**interp_kwargs, assume_sorted=True, kwargs=dict(fill_value=None))
+                .sum("f")
+                .sum(sum_dims)
+            )
 
         return components
 

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -236,8 +236,6 @@ class DerivativeInfo(Tidy3dBaseModel):
         contrib_D = -delta_eps_inv * D_der_norm
         vjps += contrib_D
 
-        # import pdb; pdb.set_trace()
-
         # perform E-perpendicular integrals
         for E_der in (E_der_perp1, E_der_perp2):
             contrib_E = E_der * delta_eps
@@ -255,24 +253,15 @@ class DerivativeInfo(Tidy3dBaseModel):
         xs, ys, zs = spatial_coords.T
         edge_index_dim = "edge_index"
 
-        sum_dims = []
         interp_kwargs = {}
         for dim, locations_dim in zip("xyz", (xs, ys, zs)):
-            # only include dims where the data has more than 1 coord, to avoid warnings and errors
-            if False and any(np.array(fld.coords[dim]).size == 1 for fld in fld_dataset.values()):
-                sum_dims.append(dim)
-            else:
-                interp_kwargs[dim] = xr.DataArray(locations_dim, dims=edge_index_dim)
+            interp_kwargs[dim] = xr.DataArray(locations_dim, dims=edge_index_dim)
 
         components = {}
         for fld_name, arr in fld_dataset.items():
-            components[fld_name] = (
-                arr.interp(**interp_kwargs, assume_sorted=True, kwargs=dict(fill_value=None))
-                .sum("f")
-                .sum(sum_dims)
-            )
-
-        # import pdb; pdb.set_trace()
+            components[fld_name] = arr.interp(
+                **interp_kwargs, assume_sorted=True, kwargs=dict(fill_value=None)
+            ).sum("f")
 
         return components
 

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -206,6 +206,8 @@ class DerivativeInfo(Tidy3dBaseModel):
         contrib_D = -delta_eps_inv * D_der_norm
         vjps += contrib_D
 
+        # import pdb; pdb.set_trace()
+
         # perform E-perpendicular integrals
         for E_der in (E_der_perp1, E_der_perp2):
             contrib_E = E_der * delta_eps
@@ -227,7 +229,7 @@ class DerivativeInfo(Tidy3dBaseModel):
         interp_kwargs = {}
         for dim, locations_dim in zip("xyz", (xs, ys, zs)):
             # only include dims where the data has more than 1 coord, to avoid warnings and errors
-            if any(np.array(fld.coords[dim]).size == 1 for fld in fld_dataset.values()):
+            if False and any(np.array(fld.coords[dim]).size == 1 for fld in fld_dataset.values()):
                 sum_dims.append(dim)
             else:
                 interp_kwargs[dim] = xr.DataArray(locations_dim, dims=edge_index_dim)
@@ -239,6 +241,8 @@ class DerivativeInfo(Tidy3dBaseModel):
                 .sum("f")
                 .sum(sum_dims)
             )
+
+        # import pdb; pdb.set_trace()
 
         return components
 

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -7,13 +7,47 @@ import xarray as xr
 
 from ..base import Tidy3dBaseModel
 from ..data.data_array import ScalarFieldDataArray
-from ..types import Bound, tidycomplex
+from ..types import ArrayLike, Bound, tidycomplex
 from .types import PathType
 from .utils import get_static
 
 # we do this because importing these creates circular imports
 FieldData = dict[str, ScalarFieldDataArray]
 PermittivityData = dict[str, ScalarFieldDataArray]
+
+
+class DerivativeSurfaceMesh(Tidy3dBaseModel):
+    """Stores information about the surfaces of an object to be used for derivative calculation."""
+
+    centers: ArrayLike = pd.Field(
+        ...,
+        title="Centers",
+        description="(N, 3) array storing the centers of each surface element.",
+    )
+
+    areas: ArrayLike = pd.Field(
+        ...,
+        title="Area Elements",
+        description="(N,) array storing the first perpendicular vectors of each surface element.",
+    )
+
+    normals: ArrayLike = pd.Field(
+        ...,
+        title="Normals",
+        description="(N, 3) array storing the normal vectors of each surface element.",
+    )
+
+    perps1: ArrayLike = pd.Field(
+        ...,
+        title="Perpendiculars 1",
+        description="(N, 3) array storing the first perpendicular vectors of each surface element.",
+    )
+
+    perps2: ArrayLike = pd.Field(
+        ...,
+        title="Perpendiculars 1",
+        description="(N, 3) array storing the first perpendicular vectors of each surface element.",
+    )
 
 
 class DerivativeInfo(Tidy3dBaseModel):
@@ -117,8 +151,22 @@ class DerivativeInfo(Tidy3dBaseModel):
         """Update this ``DerivativeInfo`` with new set of paths."""
         return self.updated_copy(paths=paths)
 
-    def grad_in_bases(self, spatial_coords: np.ndarray, basis_vectors: dict) -> dict:
-        """Get the ``D_norm``, ``E_edge`` ``E_slab`` components of the gradient contributions."""
+    @property
+    def delta_eps(self) -> complex:
+        return self.eps_in - self.eps_out
+
+    @property
+    def delta_eps_inv(self) -> complex:
+        return 1.0 / self.eps_in - 1.0 / self.eps_out
+
+    def grad_surfaces(self, surface_mesh: DerivativeSurfaceMesh) -> dict:
+        """Derivative with respect to the surface mesh elements, given the derivative fields."""
+
+        # strip out relevant info from `surface_mesh`
+        spatial_coords = surface_mesh.centers
+        normals = surface_mesh.normals
+        perps1 = surface_mesh.perps1
+        perps2 = surface_mesh.perps2
 
         # unpack electric and displacement fields
         E_fwd = self.E_fwd
@@ -133,21 +181,37 @@ class DerivativeInfo(Tidy3dBaseModel):
         D_adj_at_coords = self.evaluate_flds_at(fld_dataset=D_adj, spatial_coords=spatial_coords)
 
         # project the relevant field quantities into their respective basis for gradient calculation
-        D_fwd_norm = self.project_in_basis(D_fwd_at_coords, basis_vector=basis_vectors["norm"])
-        D_adj_norm = self.project_in_basis(D_adj_at_coords, basis_vector=basis_vectors["norm"])
+        D_fwd_norm = self.project_in_basis(D_fwd_at_coords, basis_vector=normals)
+        D_adj_norm = self.project_in_basis(D_adj_at_coords, basis_vector=normals)
 
-        E_fwd_perp1 = self.project_in_basis(E_fwd_at_coords, basis_vector=basis_vectors["perp1"])
-        E_adj_perp1 = self.project_in_basis(E_adj_at_coords, basis_vector=basis_vectors["perp1"])
+        E_fwd_perp1 = self.project_in_basis(E_fwd_at_coords, basis_vector=perps1)
+        E_adj_perp1 = self.project_in_basis(E_adj_at_coords, basis_vector=perps1)
 
-        E_fwd_perp2 = self.project_in_basis(E_fwd_at_coords, basis_vector=basis_vectors["perp2"])
-        E_adj_perp2 = self.project_in_basis(E_adj_at_coords, basis_vector=basis_vectors["perp2"])
+        E_fwd_perp2 = self.project_in_basis(E_fwd_at_coords, basis_vector=perps2)
+        E_adj_perp2 = self.project_in_basis(E_adj_at_coords, basis_vector=perps2)
 
         # multiply forward and adjoint
         D_der_norm = D_fwd_norm * D_adj_norm
         E_der_perp1 = E_fwd_perp1 * E_adj_perp1
         E_der_perp2 = E_fwd_perp2 * E_adj_perp2
 
-        return dict(D_norm=D_der_norm, E_perp1=E_der_perp1, E_perp2=E_der_perp2)
+        # approximate permittivity in and out
+        delta_eps_inv = self.delta_eps_inv
+        delta_eps = self.delta_eps
+
+        # put together VJP using D_normal and E_perp integration
+        vjps = 0.0
+
+        # perform D-normal integral
+        contrib_D = -delta_eps_inv * D_der_norm
+        vjps += contrib_D
+
+        # perform E-perpendicular integrals
+        for E_der in (E_der_perp1, E_der_perp2):
+            contrib_E = E_der * delta_eps
+            vjps += contrib_E
+
+        return surface_mesh.areas * vjps
 
     @staticmethod
     def evaluate_flds_at(

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -17,7 +17,29 @@ PermittivityData = dict[str, ScalarFieldDataArray]
 
 
 class DerivativeSurfaceMesh(Tidy3dBaseModel):
-    """Stores information about the surfaces of an object to be used for derivative calculation."""
+    """Stores information about the surfaces of an object to be used for derivative calculation.
+
+    user guide: this class is used to construct derivatives with respect to surface elements
+    given some forward and adjoint fields stored in a ``DerivativeInfo`` class. To use it,
+    you must specify the central locations of all the surface elements in ``centers``,
+    along with the area of each element in ``areas``. Then you need to specify three orthogonal
+    vectors (``normals``, ``perps1`` and ``perps2``). The derivative will be computed with
+    respect to a change in material along the ``normals`` direction. It is important to note
+    that the sign of these basis vectors is irrelevant since we end up multiplying the forward
+    and adjoint fields together in these bases.
+
+    After this ``DerivativeSurfaceMesh`` is constructed, given some ``DerivativeInfo`` in the
+    gradient calculation, a call to ``DerivativeInfo.grad_surfaces(x: DerivativeSurfaceMesh)``
+    will return the gradient with respect to a change in all of the provided surfaces.
+
+    The gradient is with respect to a change from the surface element permittivity from the
+    ``eps_in`` to ``eps_out`` field. So in principle it is always computing gradients with
+    respect to an infinitesimal outward shift in the normal direction. For example, for
+    ``PolySlab.vertices``, this means shifting each edge to the background.
+    For ``PolySlab.slab_bounds``, this means shifting the bound in either + or - direction if it
+    is index ``[1]`` or ``[0]`` respectively. This renders the sign of the normal vector
+    irrelevant.
+    """
 
     centers: ArrayLike = pd.Field(
         ...,

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -251,7 +251,7 @@ class DerivativeInfo(Tidy3dBaseModel):
         """Compute the value of an dict with keys Ex, Ey, Ez at a set of spatial locations."""
 
         xs, ys, zs = spatial_coords.T
-        edge_index_dim = "edge_index"
+        edge_index_dim = "i"
 
         interp_kwargs = {}
         for dim, locations_dim in zip("xyz", (xs, ys, zs)):

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -132,6 +132,14 @@ class DerivativeInfo(Tidy3dBaseModel):
         description="Bounds corresponding to the structure, used in ``Medium`` calculations.",
     )
 
+    bounds_intersect: Bound = pd.Field(
+        ...,
+        title="Geometry and Simulation Intersections Bounds",
+        description="Bounds corresponding to the minimum intersection between the "
+        "structure and the simulation it is contained in."
+        "",
+    )
+
     frequency: float = pd.Field(
         ...,
         title="Frequency of adjoint simulation",

--- a/tidy3d/components/base_sim/simulation.py
+++ b/tidy3d/components/base_sim/simulation.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Optional, Tuple
 
-import autograd.numpy as anp
 import pydantic.v1 as pd
 
 from ...exceptions import Tidy3dKeyError
@@ -135,35 +134,35 @@ class AbstractSimulation(Box, ABC):
     _unique_source_names = assert_unique_names("sources")
 
     _monitors_in_bounds = assert_objects_in_sim_bounds("monitors", strict_inequality=True)
-    _structures_in_bounds = assert_objects_in_sim_bounds("structures", error=False)
+    # _structures_in_bounds = assert_objects_in_sim_bounds("structures", error=False)
 
     @pd.validator("structures", always=True)
     @skip_if_fields_missing(["size", "center"])
     def _structures_not_at_edges(cls, val, values):
         """Warn if any structures lie at the simulation boundaries."""
 
-        if val is None:
-            return val
+        # if val is None:
+        #     return val
 
-        sim_box = Box(size=values.get("size"), center=values.get("center"))
-        sim_bound_min, sim_bound_max = sim_box.bounds
-        sim_bounds = list(sim_bound_min) + list(sim_bound_max)
+        # sim_box = Box(size=values.get("size"), center=values.get("center"))
+        # sim_bound_min, sim_bound_max = sim_box.bounds
+        # sim_bounds = list(sim_bound_min) + list(sim_bound_max)
 
-        with log as consolidated_logger:
-            for istruct, structure in enumerate(val):
-                struct_bound_min, struct_bound_max = structure.geometry.bounds
-                struct_bounds = list(struct_bound_min) + list(struct_bound_max)
+        # with log as consolidated_logger:
+        #     for istruct, structure in enumerate(val):
+        #         struct_bound_min, struct_bound_max = structure.geometry.bounds
+        #         struct_bounds = list(struct_bound_min) + list(struct_bound_max)
 
-                for sim_val, struct_val in zip(sim_bounds, struct_bounds):
-                    if anp.isclose(sim_val, struct_val):
-                        consolidated_logger.warning(
-                            f"Structure at 'structures[{istruct}]' has bounds that extend exactly "
-                            "to simulation edges. This can cause unexpected behavior. "
-                            "If intending to extend the structure to infinity along one dimension, "
-                            "use td.inf as a size variable instead to make this explicit.",
-                            custom_loc=["structures", istruct],
-                        )
-                        continue
+        #         for sim_val, struct_val in zip(sim_bounds, struct_bounds):
+        #             if anp.isclose(sim_val, struct_val):
+        #                 consolidated_logger.warning(
+        #                     f"Structure at 'structures[{istruct}]' has bounds that extend exactly "
+        #                     "to simulation edges. This can cause unexpected behavior. "
+        #                     "If intending to extend the structure to infinity along one dimension, "
+        #                     "use td.inf as a size variable instead to make this explicit.",
+        #                     custom_loc=["structures", istruct],
+        #                 )
+        #                 continue
 
         return val
 

--- a/tidy3d/components/base_sim/simulation.py
+++ b/tidy3d/components/base_sim/simulation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Optional, Tuple
 
+import autograd.numpy as anp
 import pydantic.v1 as pd
 
 from ...exceptions import Tidy3dKeyError
@@ -134,35 +135,35 @@ class AbstractSimulation(Box, ABC):
     _unique_source_names = assert_unique_names("sources")
 
     _monitors_in_bounds = assert_objects_in_sim_bounds("monitors", strict_inequality=True)
-    # _structures_in_bounds = assert_objects_in_sim_bounds("structures", error=False)
+    _structures_in_bounds = assert_objects_in_sim_bounds("structures", error=False)
 
     @pd.validator("structures", always=True)
     @skip_if_fields_missing(["size", "center"])
     def _structures_not_at_edges(cls, val, values):
         """Warn if any structures lie at the simulation boundaries."""
 
-        # if val is None:
-        #     return val
+        if val is None:
+            return val
 
-        # sim_box = Box(size=values.get("size"), center=values.get("center"))
-        # sim_bound_min, sim_bound_max = sim_box.bounds
-        # sim_bounds = list(sim_bound_min) + list(sim_bound_max)
+        sim_box = Box(size=values.get("size"), center=values.get("center"))
+        sim_bound_min, sim_bound_max = sim_box.bounds
+        sim_bounds = list(sim_bound_min) + list(sim_bound_max)
 
-        # with log as consolidated_logger:
-        #     for istruct, structure in enumerate(val):
-        #         struct_bound_min, struct_bound_max = structure.geometry.bounds
-        #         struct_bounds = list(struct_bound_min) + list(struct_bound_max)
+        with log as consolidated_logger:
+            for istruct, structure in enumerate(val):
+                struct_bound_min, struct_bound_max = structure.geometry.bounds
+                struct_bounds = list(struct_bound_min) + list(struct_bound_max)
 
-        #         for sim_val, struct_val in zip(sim_bounds, struct_bounds):
-        #             if anp.isclose(sim_val, struct_val):
-        #                 consolidated_logger.warning(
-        #                     f"Structure at 'structures[{istruct}]' has bounds that extend exactly "
-        #                     "to simulation edges. This can cause unexpected behavior. "
-        #                     "If intending to extend the structure to infinity along one dimension, "
-        #                     "use td.inf as a size variable instead to make this explicit.",
-        #                     custom_loc=["structures", istruct],
-        #                 )
-        #                 continue
+                for sim_val, struct_val in zip(sim_bounds, struct_bounds):
+                    if anp.isclose(sim_val, struct_val):
+                        consolidated_logger.warning(
+                            f"Structure at 'structures[{istruct}]' has bounds that extend exactly "
+                            "to simulation edges. This can cause unexpected behavior. "
+                            "If intending to extend the structure to infinity along one dimension, "
+                            "use td.inf as a size variable instead to make this explicit.",
+                            custom_loc=["structures", istruct],
+                        )
+                        continue
 
         return val
 

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -513,6 +513,12 @@ class DataArray(xr.DataArray):
                 result = result.transpose(*out_dims)
         return result
 
+    def to_static(self, **kwargs):
+        if kwargs:
+            raise ValueError("no kwargs can be passed to DataArray.to_static()")
+        data_static = get_static(self.data)
+        return self.copy(deep=True, data=data_static)
+
 
 class FreqDataArray(DataArray):
     """Frequency-domain array.

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -11,6 +11,7 @@ import autograd.numpy as np
 import pydantic.v1 as pydantic
 import shapely
 import xarray as xr
+from autograd.tracer import getval
 from matplotlib import patches
 
 from ...constants import LARGE_NUMBER, MICROMETER, RADIAN, fp_eps, inf
@@ -295,8 +296,8 @@ class Geometry(Tidy3dBaseModel, ABC):
             Whether the rectangular bounding boxes of the two geometries intersect.
         """
 
-        self_bmin, self_bmax = self.bounds
-        other_bmin, other_bmax = other.bounds
+        self_bmin, self_bmax = getval(self.bounds)
+        other_bmin, other_bmax = getval(other.bounds)
 
         for smin, omin, smax, omax, strict in zip(
             self_bmin, other_bmin, self_bmax, other_bmax, strict_inequality

--- a/tidy3d/components/geometry/mesh.py
+++ b/tidy3d/components/geometry/mesh.py
@@ -463,7 +463,7 @@ class TriangleMesh(base.Geometry, ABC):
         # "face_index", "vertex_index", "axis"
         vertices = self.triangles
 
-        perps1 = vertices[:, 0:2, :]
+        perps1 = vertices[:, 0:2, :].squeeze()
         perps1 /= np.linalg.norm(perps1)
 
         perps2 = np.cross(perps1, normals)

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -1421,10 +1421,10 @@ class PolySlab(base.Planar):
         ax_min, (r1_min, r2_min) = self.pop_axis(rmin, axis=self.axis)
         ax_max, (r1_max, r2_max) = self.pop_axis(rmax, axis=self.axis)
 
-        num_x = 1 if r1_min == r1_max else _NUM_PTS_DIM_SLAB_BOUNDS
-        num_y = 1 if r1_min == r2_max else _NUM_PTS_DIM_SLAB_BOUNDS
+        num_1 = 1 if r1_min == r1_max else _NUM_PTS_DIM_SLAB_BOUNDS
+        num_2 = 1 if r2_min == r2_max else _NUM_PTS_DIM_SLAB_BOUNDS
 
-        num_cells = num_x * num_y
+        num_cells = num_1 * num_2
         ones = np.ones(num_cells)
         zeros = np.zeros(num_cells)
 
@@ -1435,8 +1435,8 @@ class PolySlab(base.Planar):
             return np.stack(coords, axis=-1)
 
         # get center points and areas
-        r1_centers = np.linspace(r1_min, r1_max, 2 * num_x + 1)[1::2]
-        r2_centers = np.linspace(r2_min, r2_max, 2 * num_y + 1)[1::2]
+        r1_centers = np.linspace(r1_min, r1_max, 2 * num_1 + 1)[1::2]
+        r2_centers = np.linspace(r2_min, r2_max, 2 * num_2 + 1)[1::2]
         planar_centers = meshgrid_flatten_stack(r1_centers, r2_centers)
 
         area = 1.0
@@ -1444,7 +1444,7 @@ class PolySlab(base.Planar):
             if rmin != rmax:
                 area *= rmax - rmin
 
-        areas = area * np.ones(num_cells)
+        areas = area * np.ones(num_cells) / num_cells
 
         def get_grad(min_max_index: int) -> float:
             """Compute gradient for either min or max dimension."""

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -1474,6 +1474,10 @@ class PolySlab(base.Planar):
         vjp_min = np.real(np.sum(grads_min).item())
         vjp_max = np.real(np.sum(grads_max).item())
 
+        import pdb
+
+        pdb.set_trace()
+
         return [vjp_min, vjp_max]
 
     def compute_derivative_vertices(self, derivative_info: DerivativeInfo) -> TracedVertices:

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -17,7 +17,7 @@ from ...exceptions import SetupError, ValidationError
 from ...log import log
 from ...packaging import verify_packages_import
 from ..autograd import AutogradFieldMap, TracedVertices, get_static
-from ..autograd.derivative_utils import DerivativeInfo
+from ..autograd.derivative_utils import DerivativeInfo, DerivativeSurfaceMesh
 from ..base import cached_property, skip_if_fields_missing
 from ..types import (
     ArrayFloat2D,
@@ -1381,12 +1381,24 @@ class PolySlab(base.Planar):
     def compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
         """Compute the adjoint derivatives for this object."""
 
-        if derivative_info.paths != [("vertices",)]:
-            raise ValueError("only support derivative wrt 'PolySlab.vertices'.")
+        vjps = {}
 
-        vjp_vertices = self.compute_derivative_vertices(derivative_info=derivative_info)
+        for key in derivative_info.paths:
+            if key == ("vertices",):
+                vjp = self.compute_derivative_vertices(derivative_info=derivative_info)
+                vjps[key] = vjp
 
-        return {("vertices",): vjp_vertices}
+            elif key == ("slab_bounds",):
+                vjp = self.compute_derivative_slab_bounds(derivative_info=derivative_info)
+                vjps[key] = vjp
+
+            else:
+                raise ValueError(f"No derivative defined with respect to 'PolySlab' field '{key}'.")
+
+        return vjps
+
+    def compute_derivative_slab_bounds(self, derivative_info: DerivativeInfo) -> TracedVertices:
+        """Derivative with respect to slab_bounds."""
 
     def compute_derivative_vertices(self, derivative_info: DerivativeInfo) -> TracedVertices:
         # derivative w.r.t each edge
@@ -1410,31 +1422,6 @@ class PolySlab(base.Planar):
         # get basis vectors for every edge segment
         basis_vectors = self.edge_basis_vectors(edges=edges)
 
-        grad_bases = derivative_info.grad_in_bases(
-            spatial_coords=edge_centers_xyz, basis_vectors=basis_vectors
-        )
-
-        # unpack gradient contributions from different bases
-        D_der_norm = grad_bases["D_norm"]
-        E_der_edge = grad_bases["E_perp1"]
-        E_der_slab = grad_bases["E_perp2"]
-
-        # approximate permittivity in and out
-        delta_eps_inv = 1.0 / derivative_info.eps_in - 1.0 / derivative_info.eps_out
-        delta_eps = derivative_info.eps_in - derivative_info.eps_out
-
-        # put together VJP using D_normal and E_perp integration
-        vjps_edges = 0.0
-
-        # perform D-normal integral
-        contrib_D = -delta_eps_inv * D_der_norm
-        vjps_edges += contrib_D
-
-        # perform E-perpendicular integrals
-        for E_der in (E_der_edge, E_der_slab):
-            contrib_E = E_der * delta_eps
-            vjps_edges += contrib_E
-
         # scale by edge area
         edge_lengths = np.linalg.norm(edges, axis=-1)
         edge_areas = edge_lengths
@@ -1444,7 +1431,15 @@ class PolySlab(base.Planar):
         if not np.isinf(slab_height):
             edge_areas *= slab_height
 
-        vjps_edges *= edge_areas
+        surface_mesh = DerivativeSurfaceMesh(
+            centers=edge_centers_xyz,
+            areas=edge_areas,
+            normals=basis_vectors["norm"],
+            perps1=basis_vectors["perp1"],
+            perps2=basis_vectors["perp2"],
+        )
+
+        vjps_edges = derivative_info.grad_surfaces(surface_mesh=surface_mesh)
 
         _, normal_vectors_in_plane = self.pop_axis_vect(basis_vectors["norm"])
 

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -1412,11 +1412,13 @@ class PolySlab(base.Planar):
     ) -> TracedVertices:
         """Derivative with respect to slab_bounds."""
 
-        num_cells = _NUM_PTS_DIM_SLAB_BOUNDS * _NUM_PTS_DIM_SLAB_BOUNDS
+        num_x = _NUM_PTS_DIM_SLAB_BOUNDS
+        num_y = _NUM_PTS_DIM_SLAB_BOUNDS
+
+        num_cells = num_x * num_y
         ones = np.ones(num_cells)
         zeros = np.zeros(num_cells)
 
-        # get zmin, zmax
         rmin, rmax = self.bounds
         ax_min, (r1_min, r2_min) = self.pop_axis(rmin, axis=self.axis)
         ax_max, (r1_max, r2_max) = self.pop_axis(rmax, axis=self.axis)
@@ -1428,8 +1430,8 @@ class PolySlab(base.Planar):
             return np.stack(coords, axis=-1)
 
         # get center points and areas
-        r1_centers = np.linspace(r1_min, r1_max, 2 * _NUM_PTS_DIM_SLAB_BOUNDS + 1)[1::2]
-        r2_centers = np.linspace(r2_min, r2_max, 2 * _NUM_PTS_DIM_SLAB_BOUNDS + 1)[1::2]
+        r1_centers = np.linspace(r1_min, r1_max, 2 * num_x + 1)[1::2]
+        r2_centers = np.linspace(r2_min, r2_max, 2 * num_y + 1)[1::2]
         planar_centers = meshgrid_flatten_stack(r1_centers, r2_centers)
 
         area = (r1_max - r1_min) * (r2_max - r2_min) / num_cells

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -1389,8 +1389,6 @@ class PolySlab(base.Planar):
 
         vjps = {}
 
-        # TODO: pre-compute slab bounds vjps if we need them, to use below
-
         for key in derivative_info.paths:
             if key == ("vertices",):
                 vjp = self.compute_derivative_vertices(derivative_info=derivative_info)
@@ -1402,7 +1400,8 @@ class PolySlab(base.Planar):
                     derivative_info=derivative_info, min_max_index=min_max_index
                 )
 
-                # for - slab_bounds element, we need to reverse the face VJP since it points out (-)
+                # for ``slab_bounds[0]``, the ``VJP_face`` gives VJP for shifting face out.
+                # corresponds to a decrease ``slab_bounds[0]``. So we need -1 sign.
                 if min_max_index == 0:
                     vjp_face *= -1
 

--- a/tidy3d/components/geometry/primitives.py
+++ b/tidy3d/components/geometry/primitives.py
@@ -319,27 +319,13 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
 
             elif "center" in path:
                 _, center_index = path
-                if center_index == self.axis:
-                    raise NotImplementedError(
-                        "Currently cannot differentiate Cylinder with respect to its 'center' along"
-                        " the axis. If you would like this feature added, please feel free to raise"
-                        " an issue on the tidy3d front end repository."
-                    )
-
                 _, (index_x, index_y) = self.pop_axis((0, 1, 2), axis=self.axis)
                 if center_index == index_x:
                     vjps[path] = np.sum(vjps_vertices_xs)
                 elif center_index == index_y:
                     vjps[path] = np.sum(vjps_vertices_ys)
                 else:
-                    raise ValueError(
-                        "Something unexpected happened. Was asked to differentiate "
-                        f"with respect to 'Cylinder.center[{center_index}]', but this was not "
-                        "detected as being one of the parallel axis with "
-                        f"'Cylinder.axis' of '{self.axis}'. If you received this error, please raise "
-                        "an issue on the tidy3d front end repository with details about how you "
-                        "defined your 'Cylinder' in the objective function."
-                    )
+                    vjps[path] = vjp_top + vjp_bot
 
             else:
                 raise NotImplementedError(

--- a/tidy3d/components/geometry/primitives.py
+++ b/tidy3d/components/geometry/primitives.py
@@ -314,7 +314,7 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
             if path == ("length",):
                 vjps[path] = vjp_top - vjp_bot
 
-            if path == ("radius",):
+            elif path == ("radius",):
                 vjps[path] = vjp_xs + vjp_ys
 
             elif "center" in path:

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -451,14 +451,6 @@ class TwoPhotonAbsorption(NonlinearModel):
 
     def _validate_medium(self, medium: AbstractMedium):
         """Check that the model is compatible with the medium."""
-        log.warning(
-            "Found a medium with a 'TwoPhotonAbsorption' nonlinearity. "
-            "This uses a phenomenological model based on complex fields, "
-            "so care should be taken in interpreting the results. For more "
-            "information on the model, see the documentation at "
-            "'https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.TwoPhotonAbsorption.html' or the following reference: "
-            "'N. Suzuki, \"FDTD Analysis of Two-Photon Absorption and Free-Carrier Absorption in Si High-Index-Contrast Waveguides,\" J. Light. Technol. 25, 9 (2007).'."
-        )
         # if n0 is specified, we can go ahead and validate passivity
         if self.n0 is not None:
             self._validate_medium_freqs(medium, [])
@@ -467,19 +459,6 @@ class TwoPhotonAbsorption(NonlinearModel):
     def complex_fields(self) -> bool:
         """Whether the model uses complex fields."""
         return True
-
-    @pd.validator("beta", always=True)
-    def _warn_for_complex_beta(cls, val):
-        if val is None:
-            return val
-        if np.iscomplex(val):
-            log.warning(
-                "Complex values of 'beta' in 'TwoPhotonAbsorption' are deprecated "
-                "and may be removed in a future version. The implementation with "
-                "complex 'beta' is as described in the 'TwoPhotonAbsorption' docstring, "
-                "but the physical interpretation of 'beta' may not be correct if it is complex."
-            )
-        return val
 
 
 class KerrNonlinearity(NonlinearModel):
@@ -555,13 +534,6 @@ class KerrNonlinearity(NonlinearModel):
 
     def _validate_medium(self, medium: AbstractMedium):
         """Check that the model is compatible with the medium."""
-        log.warning(
-            "Found a medium with a 'KerrNonlinearity'. Usually, "
-            "'NonlinearSusceptibility' is preferred, as it captures "
-            "additional physical effects by acting on the underlying real fields. "
-            "The relation between the parameters is "
-            "'chi3 = (4/3) * eps_0 * c_0 * n0 * Re(n0) * n2'."
-        )
         # if n0 is specified, we can go ahead and validate passivity
         if self.n0 is not None:
             self._validate_medium_freqs(medium, [])

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -21,8 +21,7 @@ from .data.dataset import (
     UnstructuredGridDataset,
     _get_numpy_array,
 )
-from .geometry.base import Box, ClipOperation, GeometryGroup
-from .geometry.utils import flatten_groups, traverse_geometries
+from .geometry.base import Box
 from .grid.grid import Coords, Grid
 from .heat_charge_spec import ConductorSpec, SolidSpec
 from .medium import (
@@ -113,15 +112,15 @@ class Scene(Tidy3dBaseModel):
     def _validate_num_mediums(cls, val):
         """Error if too many mediums present."""
 
-        if val is None:
-            return val
+        # if val is None:
+        #     return val
 
-        mediums = {structure.medium for structure in val}
-        if len(mediums) > MAX_NUM_MEDIUMS:
-            raise SetupError(
-                f"Tidy3D only supports {MAX_NUM_MEDIUMS} distinct mediums."
-                f"{len(mediums)} were supplied."
-            )
+        # mediums = {structure.medium for structure in val}
+        # if len(mediums) > MAX_NUM_MEDIUMS:
+        #     raise SetupError(
+        #         f"Tidy3D only supports {MAX_NUM_MEDIUMS} distinct mediums."
+        #         f"{len(mediums)} were supplied."
+        #     )
 
         return val
 
@@ -129,22 +128,22 @@ class Scene(Tidy3dBaseModel):
     def _validate_num_geometries(cls, val):
         """Error if too many geometries in a single structure."""
 
-        if val is None:
-            return val
+        # if val is None:
+        #     return val
 
-        for i, structure in enumerate(val):
-            for geometry in flatten_groups(structure.geometry, flatten_transformed=True):
-                count = sum(
-                    1
-                    for g in traverse_geometries(geometry)
-                    if not isinstance(g, (GeometryGroup, ClipOperation))
-                )
-                if count > MAX_GEOMETRY_COUNT:
-                    raise SetupError(
-                        f"Structure at 'structures[{i}]' has {count} geometries that cannot be "
-                        f"flattened. A maximum of {MAX_GEOMETRY_COUNT} is supported due to "
-                        f"preprocessing performance."
-                    )
+        # for i, structure in enumerate(val):
+        #     for geometry in flatten_groups(structure.geometry, flatten_transformed=True):
+        #         count = sum(
+        #             1
+        #             for g in traverse_geometries(geometry)
+        #             if not isinstance(g, (GeometryGroup, ClipOperation))
+        #         )
+        #         if count > MAX_GEOMETRY_COUNT:
+        #             raise SetupError(
+        #                 f"Structure at 'structures[{i}]' has {count} geometries that cannot be "
+        #                 f"flattened. A maximum of {MAX_GEOMETRY_COUNT} is supported due to "
+        #                 f"preprocessing performance."
+        #             )
 
         return val
 

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -21,7 +21,8 @@ from .data.dataset import (
     UnstructuredGridDataset,
     _get_numpy_array,
 )
-from .geometry.base import Box
+from .geometry.base import Box, ClipOperation, GeometryGroup
+from .geometry.utils import flatten_groups, traverse_geometries
 from .grid.grid import Coords, Grid
 from .heat_charge_spec import ConductorSpec, SolidSpec
 from .medium import (
@@ -112,15 +113,15 @@ class Scene(Tidy3dBaseModel):
     def _validate_num_mediums(cls, val):
         """Error if too many mediums present."""
 
-        # if val is None:
-        #     return val
+        if val is None:
+            return val
 
-        # mediums = {structure.medium for structure in val}
-        # if len(mediums) > MAX_NUM_MEDIUMS:
-        #     raise SetupError(
-        #         f"Tidy3D only supports {MAX_NUM_MEDIUMS} distinct mediums."
-        #         f"{len(mediums)} were supplied."
-        #     )
+        mediums = {structure.medium for structure in val}
+        if len(mediums) > MAX_NUM_MEDIUMS:
+            raise SetupError(
+                f"Tidy3D only supports {MAX_NUM_MEDIUMS} distinct mediums."
+                f"{len(mediums)} were supplied."
+            )
 
         return val
 
@@ -128,22 +129,22 @@ class Scene(Tidy3dBaseModel):
     def _validate_num_geometries(cls, val):
         """Error if too many geometries in a single structure."""
 
-        # if val is None:
-        #     return val
+        if val is None:
+            return val
 
-        # for i, structure in enumerate(val):
-        #     for geometry in flatten_groups(structure.geometry, flatten_transformed=True):
-        #         count = sum(
-        #             1
-        #             for g in traverse_geometries(geometry)
-        #             if not isinstance(g, (GeometryGroup, ClipOperation))
-        #         )
-        #         if count > MAX_GEOMETRY_COUNT:
-        #             raise SetupError(
-        #                 f"Structure at 'structures[{i}]' has {count} geometries that cannot be "
-        #                 f"flattened. A maximum of {MAX_GEOMETRY_COUNT} is supported due to "
-        #                 f"preprocessing performance."
-        #             )
+        for i, structure in enumerate(val):
+            for geometry in flatten_groups(structure.geometry, flatten_transformed=True):
+                count = sum(
+                    1
+                    for g in traverse_geometries(geometry)
+                    if not isinstance(g, (GeometryGroup, ClipOperation))
+                )
+                if count > MAX_GEOMETRY_COUNT:
+                    raise SetupError(
+                        f"Structure at 'structures[{i}]' has {count} geometries that cannot be "
+                        f"flattened. A maximum of {MAX_GEOMETRY_COUNT} is supported due to "
+                        f"preprocessing performance."
+                    )
 
         return val
 

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -35,7 +35,7 @@ from .data.data_array import FreqDataArray
 from .data.dataset import CustomSpatialDataType, Dataset
 from .geometry.base import Box, Geometry
 from .geometry.mesh import TriangleMesh
-from .geometry.utils import flatten_groups, traverse_geometries
+from .geometry.utils import traverse_geometries
 from .geometry.utils_2d import get_bounds, get_thickened_geom, snap_coordinate_to_grid, subdivide
 from .grid.grid import Coords, Coords1D, Grid
 from .grid.grid_spec import AutoGrid, GridSpec, UniformGrid
@@ -46,8 +46,8 @@ from .medium import (
     AbstractPerturbationMedium,
     AnisotropicMedium,
     FullyAnisotropicMedium,
-    LossyMetalMedium,
     KerrNonlinearity,
+    LossyMetalMedium,
     Medium,
     Medium2D,
     MediumType,
@@ -2607,29 +2607,29 @@ class Simulation(AbstractYeeGridSimulation):
 
         return val
 
-    @pydantic.validator("structures", always=True)
-    def _validate_2d_geometry_has_2d_medium(cls, val, values):
-        """Warn if a geometry bounding box has zero size in a certain dimension."""
+    # @pydantic.validator("structures", always=True)
+    # def _validate_2d_geometry_has_2d_medium(cls, val, values):
+    #     """Warn if a geometry bounding box has zero size in a certain dimension."""
 
-        if val is None:
-            return val
+    #     if val is None:
+    #         return val
 
-        with log as consolidated_logger:
-            for i, structure in enumerate(val):
-                if isinstance(structure.medium, Medium2D):
-                    continue
-                for geom in flatten_groups(structure.geometry):
-                    zero_dims = geom.zero_dims
-                    if len(zero_dims) > 0:
-                        consolidated_logger.warning(
-                            f"Structure at 'structures[{i}]' has geometry with zero size along "
-                            f"dimensions {zero_dims}, and with a medium that is not a 'Medium2D'. "
-                            "This is probably not correct, since the resulting simulation will "
-                            "depend on the details of the numerical grid. Consider either "
-                            "giving the geometry a nonzero thickness or using a 'Medium2D'."
-                        )
+    #     with log as consolidated_logger:
+    #         for i, structure in enumerate(val):
+    #             if isinstance(structure.medium, Medium2D):
+    #                 continue
+    #             for geom in flatten_groups(structure.geometry):
+    #                 zero_dims = geom.zero_dims
+    #                 if len(zero_dims) > 0:
+    #                     consolidated_logger.warning(
+    #                         f"Structure at 'structures[{i}]' has geometry with zero size along "
+    #                         f"dimensions {zero_dims}, and with a medium that is not a 'Medium2D'. "
+    #                         "This is probably not correct, since the resulting simulation will "
+    #                         "depend on the details of the numerical grid. Consider either "
+    #                         "giving the geometry a nonzero thickness or using a 'Medium2D'."
+    #                     )
 
-        return val
+    #     return val
 
     @pydantic.validator("structures", always=True)
     def _validate_incompatible_material_intersections(cls, val, values):

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -46,10 +46,12 @@ from .medium import (
     AnisotropicMedium,
     FullyAnisotropicMedium,
     LossyMetalMedium,
+    KerrNonlinearity,
     Medium,
     Medium2D,
     MediumType,
     MediumType3D,
+    TwoPhotonAbsorption,
 )
 from .monitor import (
     AbstractFieldProjectionMonitor,
@@ -3416,12 +3418,38 @@ class Simulation(AbstractYeeGridSimulation):
 
     def _validate_nonlinear_specs(self) -> None:
         """Run :class:`.NonlinearSpec` validators that depend on knowing the central
-        frequencies of the sources."""
+        frequencies of the sources. Also print some warnings only once per unique medium."""
         freqs = np.array([source.source_time.freq0 for source in self.sources])
         for medium in self.scene.mediums:
             if medium.nonlinear_spec is not None:
                 for model in medium._nonlinear_models:
                     model._validate_medium_freqs(medium, freqs)
+
+                    if isinstance(model, TwoPhotonAbsorption):
+                        if np.iscomplex(model.beta):
+                            log.warning(
+                                "Complex values of 'beta' in 'TwoPhotonAbsorption' are deprecated "
+                                "and may be removed in a future version. The implementation with "
+                                "complex 'beta' is as described in the 'TwoPhotonAbsorption' docstring, "
+                                "but the physical interpretation of 'beta' may not be correct if it is complex."
+                            )
+                        log.warning(
+                            "Found a medium with a 'TwoPhotonAbsorption' nonlinearity. "
+                            "This uses a phenomenological model based on complex fields, "
+                            "so care should be taken in interpreting the results. For more "
+                            "information on the model, see the documentation at "
+                            "'https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.TwoPhotonAbsorption.html' or the following reference: "
+                            "'N. Suzuki, \"FDTD Analysis of Two-Photon Absorption and Free-Carrier Absorption in Si High-Index-Contrast Waveguides,\" J. Light. Technol. 25, 9 (2007).'."
+                        )
+
+                    if isinstance(model, KerrNonlinearity):
+                        log.warning(
+                            "Found a medium with a 'KerrNonlinearity'. Usually, "
+                            "'NonlinearSusceptibility' is preferred, as it captures "
+                            "additional physical effects by acting on the underlying real fields. "
+                            "The relation between the parameters is "
+                            "'chi3 = (4/3) * eps_0 * c_0 * n0 * Re(n0) * n2'."
+                        )
 
     """ Pre submit validation (before web.upload()) """
 

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 import pathlib
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 import autograd.numpy as np
@@ -34,7 +35,7 @@ from .data.data_array import FreqDataArray
 from .data.dataset import CustomSpatialDataType, Dataset
 from .geometry.base import Box, Geometry
 from .geometry.mesh import TriangleMesh
-from .geometry.utils import flatten_groups, traverse_geometries
+from .geometry.utils import traverse_geometries
 from .geometry.utils_2d import get_bounds, get_thickened_geom, snap_coordinate_to_grid, subdivide
 from .grid.grid import Coords, Coords1D, Grid
 from .grid.grid_spec import AutoGrid, GridSpec, UniformGrid
@@ -2610,23 +2611,23 @@ class Simulation(AbstractYeeGridSimulation):
     def _validate_2d_geometry_has_2d_medium(cls, val, values):
         """Warn if a geometry bounding box has zero size in a certain dimension."""
 
-        if val is None:
-            return val
+        # if val is None:
+        #     return val
 
-        with log as consolidated_logger:
-            for i, structure in enumerate(val):
-                if isinstance(structure.medium, Medium2D):
-                    continue
-                for geom in flatten_groups(structure.geometry):
-                    zero_dims = geom.zero_dims
-                    if len(zero_dims) > 0:
-                        consolidated_logger.warning(
-                            f"Structure at 'structures[{i}]' has geometry with zero size along "
-                            f"dimensions {zero_dims}, and with a medium that is not a 'Medium2D'. "
-                            "This is probably not correct, since the resulting simulation will "
-                            "depend on the details of the numerical grid. Consider either "
-                            "giving the geometry a nonzero thickness or using a 'Medium2D'."
-                        )
+        # with log as consolidated_logger:
+        #     for i, structure in enumerate(val):
+        #         if isinstance(structure.medium, Medium2D):
+        #             continue
+        #         for geom in flatten_groups(structure.geometry):
+        #             zero_dims = geom.zero_dims
+        #             if len(zero_dims) > 0:
+        #                 consolidated_logger.warning(
+        #                     f"Structure at 'structures[{i}]' has geometry with zero size along "
+        #                     f"dimensions {zero_dims}, and with a medium that is not a 'Medium2D'. "
+        #                     "This is probably not correct, since the resulting simulation will "
+        #                     "depend on the details of the numerical grid. Consider either "
+        #                     "giving the geometry a nonzero thickness or using a 'Medium2D'."
+        #                 )
 
         return val
 
@@ -2665,57 +2666,57 @@ class Simulation(AbstractYeeGridSimulation):
     def _structures_not_close_pml(cls, val, values):
         """Warn if any structures lie at the simulation boundaries."""
 
-        sim_box = Box(size=values.get("size"), center=values.get("center"))
-        sim_bound_min, sim_bound_max = sim_box.bounds
+        # sim_box = Box(size=values.get("size"), center=values.get("center"))
+        # sim_bound_min, sim_bound_max = sim_box.bounds
 
-        boundaries = val.to_list
-        structures = values.get("structures")
-        sources = values.get("sources")
+        # boundaries = val.to_list
+        # structures = values.get("structures")
+        # sources = values.get("sources")
 
-        if (not structures) or (not sources):
-            return val
+        # if (not structures) or (not sources):
+        #     return val
 
-        with log as consolidated_logger:
+        # with log as consolidated_logger:
 
-            def warn(istruct, side):
-                """Warning message for a structure too close to PML."""
-                consolidated_logger.warning(
-                    f"Structure at structures[{istruct}] was detected as being less "
-                    f"than half of a central wavelength from a PML on side {side}. "
-                    "To avoid inaccurate results or divergence, please increase gap between "
-                    "any structures and PML or fully extend structure through the pml.",
-                    custom_loc=["structures", istruct],
-                )
+        #     def warn(istruct, side):
+        #         """Warning message for a structure too close to PML."""
+        #         consolidated_logger.warning(
+        #             f"Structure at structures[{istruct}] was detected as being less "
+        #             f"than half of a central wavelength from a PML on side {side}. "
+        #             "To avoid inaccurate results or divergence, please increase gap between "
+        #             "any structures and PML or fully extend structure through the pml.",
+        #             custom_loc=["structures", istruct],
+        #         )
 
-            for istruct, structure in enumerate(structures):
-                struct_bound_min, struct_bound_max = structure.geometry.bounds
+        #     for istruct, structure in enumerate(structures):
+        #         struct_bound_min, struct_bound_max = structure.geometry.bounds
 
-                for source in sources:
-                    lambda0 = C_0 / source.source_time.freq0
+        #         for source in sources:
+        #             lambda0 = C_0 / source.source_time.freq0
 
-                    zipped = zip(["x", "y", "z"], sim_bound_min, struct_bound_min, boundaries)
-                    for axis, sim_val, struct_val, boundary in zipped:
-                        # The test is required only for PML and stable PML
-                        if not isinstance(boundary[0], (PML, StablePML)):
-                            continue
-                        if (
-                            boundary[0].num_layers > 0
-                            and struct_val > sim_val
-                            and abs(sim_val - struct_val) < lambda0 / 2
-                        ):
-                            warn(istruct, axis + "-min")
+        #             zipped = zip(["x", "y", "z"], sim_bound_min, struct_bound_min, boundaries)
+        #             for axis, sim_val, struct_val, boundary in zipped:
+        #                 # The test is required only for PML and stable PML
+        #                 if not isinstance(boundary[0], (PML, StablePML)):
+        #                     continue
+        #                 if (
+        #                     boundary[0].num_layers > 0
+        #                     and struct_val > sim_val
+        #                     and abs(sim_val - struct_val) < lambda0 / 2
+        #                 ):
+        #                     warn(istruct, axis + "-min")
 
-                    zipped = zip(["x", "y", "z"], sim_bound_max, struct_bound_max, boundaries)
-                    for axis, sim_val, struct_val, boundary in zipped:
-                        # The test is required only for PML and stable PML
-                        if not isinstance(boundary[1], (PML, StablePML)):
-                            continue
-                        if (
-                            boundary[1].num_layers > 0
-                            and struct_val < sim_val
-                            and abs(sim_val - struct_val) < lambda0 / 2
-                        ):
-                            warn(istruct, axis + "-max")
+        #             zipped = zip(["x", "y", "z"], sim_bound_max, struct_bound_max, boundaries)
+        #             for axis, sim_val, struct_val, boundary in zipped:
+        #                 # The test is required only for PML and stable PML
+        #                 if not isinstance(boundary[1], (PML, StablePML)):
+        #                     continue
+        #                 if (
+        #                     boundary[1].num_layers > 0
+        #                     and struct_val < sim_val
+        #                     and abs(sim_val - struct_val) < lambda0 / 2
+        #                 ):
+        #                     warn(istruct, axis + "-max")
 
         return val
 
@@ -3749,15 +3750,17 @@ class Simulation(AbstractYeeGridSimulation):
     def with_adjoint_monitors(self, sim_fields_keys: list) -> Simulation:
         """Copy of self with adjoint field and permittivity monitors for every traced structure."""
 
-        # set of indices in the structures needing adjoint monitors
-        structure_indices = {index for (_, index, *_) in sim_fields_keys}
-
-        mnts_fld, mnts_eps = self.make_adjoint_monitors(structure_indices=structure_indices)
+        mnts_fld, mnts_eps = self.make_adjoint_monitors(sim_fields_keys=sim_fields_keys)
         monitors = list(self.monitors) + list(mnts_fld) + list(mnts_eps)
         return self.copy(update=dict(monitors=monitors))
 
-    def make_adjoint_monitors(self, structure_indices: set[int]) -> tuple[list, list]:
+    def make_adjoint_monitors(self, sim_fields_keys: list) -> tuple[list, list]:
         """Get lists of field and permittivity monitors for this simulation."""
+
+        index_to_keys = defaultdict(list)
+
+        for _, index, *fields in sim_fields_keys:
+            index_to_keys[index].append(fields)
 
         freqs = self.freqs_adjoint
 
@@ -3765,10 +3768,12 @@ class Simulation(AbstractYeeGridSimulation):
         adjoint_monitors_eps = []
 
         # make a field and permittivity monitor for every structure needing one
-        for i in structure_indices:
+        for i, field_keys in index_to_keys.items():
             structure = self.structures[i]
 
-            mnt_fld, mnt_eps = structure.make_adjoint_monitors(freqs=freqs, index=i)
+            mnt_fld, mnt_eps = structure.make_adjoint_monitors(
+                freqs=freqs, index=i, field_keys=field_keys
+            )
 
             adjoint_monitors_fld.append(mnt_fld)
             adjoint_monitors_eps.append(mnt_eps)

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -245,7 +245,7 @@ class Structure(AbstractStructure):
         return monitor_name_map[data_type]
 
     def make_adjoint_monitors(
-        self, freqs: list[float], index: int
+        self, freqs: list[float], index: int, field_keys: list[str]
     ) -> (FieldMonitor, PermittivityMonitor):
         """Generate the field and permittivity monitor for this structure."""
 
@@ -258,7 +258,7 @@ class Structure(AbstractStructure):
         center = [get_static(x) for x in box.center]
 
         # polyslab only needs fields at the midpoint along axis
-        if isinstance(geometry, PolySlab) and not isinstance(self.medium, AbstractCustomMedium):
+        if isinstance(geometry, PolySlab) and not isinstance(self.medium, AbstractCustomMedium) and ["geometry", "slab_bounds"] not in field_keys:
             size[geometry.axis] = 0
 
         mnt_fld = FieldMonitor(

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -260,20 +260,6 @@ class Structure(AbstractStructure):
         if isinstance(self.geometry, PolySlab):
             size[self.geometry.axis] = 0
 
-        # custom medium only needs fields at center locations of unit cells.
-        if isinstance(self.medium, CustomMedium):
-            for axis, dim in enumerate("xyz"):
-                if self.medium.permittivity is not None:
-                    if len(self.medium.permittivity.coords[dim]) == 1:
-                        size[axis] = 0
-                if self.medium.eps_dataset is not None:
-                    zero_size = True
-                    for _, fld in self.medium.eps_dataset.field_components.items():
-                        if len(fld.coords[dim]) != 1:
-                            zero_size = False
-                    if zero_size:
-                        size[axis] = 0
-
         mnt_fld = FieldMonitor(
             size=size,
             center=center,

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -19,6 +19,7 @@ from .autograd.utils import get_static
 from .base import Tidy3dBaseModel, skip_if_fields_missing
 from .data.data_array import ScalarFieldDataArray
 from .geometry.polyslab import PolySlab
+from .geometry.primitives import Cylinder
 from .geometry.utils import GeometryType, validate_no_transformed_polyslabs
 from .grid.grid import Coords
 from .medium import AbstractCustomMedium, CustomMedium, Medium, Medium2D, MediumType
@@ -249,12 +250,12 @@ class Structure(AbstractStructure):
     ) -> (FieldMonitor, PermittivityMonitor):
         """Generate the field and permittivity monitor for this structure."""
 
-        geometry = self.geometry
-        box = geometry.bounding_box
+        geo = self.geometry
+        box = geo.bounding_box
 
         # we dont want these fields getting traced by autograd, otherwise it messes stuff up
 
-        size = [get_static(x) for x in box.size]  # TODO: expand slightly?
+        size = [get_static(x) for x in box.size]
         center = [get_static(x) for x in box.center]
 
         # polyslab only needs fields at the midpoint along axis

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -261,7 +261,7 @@ class Structure(AbstractStructure):
         if (
             isinstance(geo, PolySlab)
             and not isinstance(self.medium, AbstractCustomMedium)
-            and ["geometry", "slab_bounds"] not in field_keys
+            and field_keys == [("vertices",)]
         ):
             size[geo.axis] = 0
 

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -249,7 +249,8 @@ class Structure(AbstractStructure):
     ) -> (FieldMonitor, PermittivityMonitor):
         """Generate the field and permittivity monitor for this structure."""
 
-        box = self.geometry.bounding_box
+        geometry = self.geometry
+        box = geometry.bounding_box
 
         # we dont want these fields getting traced by autograd, otherwise it messes stuff up
 
@@ -257,8 +258,8 @@ class Structure(AbstractStructure):
         center = [get_static(x) for x in box.center]
 
         # polyslab only needs fields at the midpoint along axis
-        if isinstance(self.geometry, PolySlab):
-            size[self.geometry.axis] = 0
+        if isinstance(geometry, PolySlab) and not isinstance(self.medium, AbstractCustomMedium):
+            size[geometry.axis] = 0
 
         mnt_fld = FieldMonitor(
             size=size,

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -19,7 +19,6 @@ from .autograd.utils import get_static
 from .base import Tidy3dBaseModel, skip_if_fields_missing
 from .data.data_array import ScalarFieldDataArray
 from .geometry.polyslab import PolySlab
-from .geometry.primitives import Cylinder
 from .geometry.utils import GeometryType, validate_no_transformed_polyslabs
 from .grid.grid import Coords
 from .medium import AbstractCustomMedium, CustomMedium, Medium, Medium2D, MediumType
@@ -259,8 +258,12 @@ class Structure(AbstractStructure):
         center = [get_static(x) for x in box.center]
 
         # polyslab only needs fields at the midpoint along axis
-        if isinstance(geometry, PolySlab) and not isinstance(self.medium, AbstractCustomMedium) and ["geometry", "slab_bounds"] not in field_keys:
-            size[geometry.axis] = 0
+        if (
+            isinstance(geo, PolySlab)
+            and not isinstance(self.medium, AbstractCustomMedium)
+            and ["geometry", "slab_bounds"] not in field_keys
+        ):
+            size[geo.axis] = 0
 
         mnt_fld = FieldMonitor(
             size=size,

--- a/tidy3d/plugins/autograd/README.md
+++ b/tidy3d/plugins/autograd/README.md
@@ -189,7 +189,7 @@ The following components are traceable as inputs to the `td.Simulation`
 | Component Type                                                    | Traceable Attributes                                    |
 | ----------------------------------------------------------------- | ------------------------------------------------------- |
 | rectangular prisms                                                | `Box.center`, `Box.size`                                |
-| polyslab (including those with dilation or slanted sidewalls)     | `PolySlab.vertices`                                     |
+| polyslab (including those with dilation or slanted sidewalls)     | `PolySlab.vertices`, `PolySlab.slab_bounds`                          |
 | regular mediums                                                   | `Medium.permittivity`, `Medium.conductivity`            |
 | spatially varying mediums (for topology optimization mainly)      | `CustomMedium.permittivity`, `CustomMedium.eps_dataset` |
 | groups of geometries with the same medium (for faster processing) | `GeometryGroup.geometries`                              |

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -881,7 +881,7 @@ def postprocess_adj(
             eps_in=eps_in,
             eps_out=eps_out,
             frequency=freq_adj,
-            bounds=struct_bounds,  # TODO: pass intersecting bounds with sim?
+            bounds=struct_bounds,
             bounds_intersect=bounds_intersect,
         )
 

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -862,6 +862,13 @@ def postprocess_adj(
         if structure.background_medium is not None:
             eps_out = structure.background_medium.eps_model(freq_adj)
 
+        # get minimum intersection of bounds with structure and sim
+        struct_bounds = rmin_struct, rmax_struct = structure.geometry.bounds
+        rmin_sim, rmax_sim = sim_data_orig.simulation.bounds
+        rmin_intersect = tuple([max(a, b) for a, b in zip(rmin_sim, rmin_struct)])
+        rmax_intersect = tuple([min(a, b) for a, b in zip(rmax_sim, rmax_struct)])
+        bounds_intersect = (rmin_intersect, rmax_intersect)
+
         derivative_info = DerivativeInfo(
             paths=structure_paths,
             E_der_map=E_der_map.field_components,
@@ -874,7 +881,8 @@ def postprocess_adj(
             eps_in=eps_in,
             eps_out=eps_out,
             frequency=freq_adj,
-            bounds=structure.geometry.bounds,  # TODO: pass intersecting bounds with sim?
+            bounds=struct_bounds,  # TODO: pass intersecting bounds with sim?
+            bounds_intersect=bounds_intersect,
         )
 
         vjp_value_map = structure.compute_derivatives(derivative_info)

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -712,7 +712,7 @@ def _run_async_bwd(
                 sim_data_fwd = sim_data_fwd_dict[task_name]
                 sim_fields_keys = sim_fields_keys_dict[task_name]
 
-                sim_data_adj = batch_data_adj.get(task_name_adj)
+                sim_data_adj = batch_data_adj[task_name_adj]
 
                 sim_fields_vjp = postprocess_adj(
                     sim_data_adj=sim_data_adj,


### PR DESCRIPTION
currently fails with

```
td.TriangleMesh.from_vertices_faces(vertices, faces)
```

when `vertices` is traced