### PR TITLE
fix `attrs` bug with `inf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Silence warning in graphene from checking fit quality at large frequencies.
 - `CustomCurrentSource` now correctly validates its current dataset.
 - Better plotting of grids, respecting 2D and 1D simulation edge cases.
+- Bug when `td.inf` are in `attrs` and files saved and loaded to .json twice.
 
 ## [2.7.7] - 2024-11-15
 

--- a/tests/test_components/test_IO.py
+++ b/tests/test_components/test_IO.py
@@ -335,3 +335,14 @@ def test_data_array_to_hdf5(tmp_path):
 
     # pass a file name
     flux.to_hdf5(fname=path, group_path="test")
+
+
+def test_inf_attrs(tmp_path):
+    """But if infinity added to attrs."""
+
+    path = str(tmp_path / "test.json")
+    m = td.Medium(attrs={"a": td.inf})
+    m.to_file(path)
+    m2 = m.from_file(path)
+    m2.to_file(path)
+    m.from_file(path)

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -935,7 +935,9 @@ class Tidy3dBaseModel(pydantic.BaseModel):
 
             tmp_string = "<<TEMPORARY_INFINITY_STRING>>"
             json_string = json_string.replace("-Infinity", tmp_string)
+            json_string = json_string.replace('""-Infinity""', tmp_string)
             json_string = json_string.replace("Infinity", '"Infinity"')
+            json_string = json_string.replace('""Infinity""', '"Infinity"')
             return json_string.replace(tmp_string, '"-Infinity"')
 
         json_string = self.json(indent=indent, exclude_unset=exclude_unset, **kwargs)


### PR DESCRIPTION
Solution:
* make sure `Tidy3dBaseModel._json()` looks at / doesn't ignore `attrs` (?)
* [better] write custom encoder to properly handle infinity in the `json()` logic