### PR TITLE
Automatical mesh refinement in layered structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Advanced option `dist_type` that allows `LinearLumpedElement` to be distributed across grid cells in different ways. For example, restricting the network portion to a single cell and using PEC wires to connect to the desired location of the terminals. 
+- New `layer_refinement_specs` field in `GridSpec` that takes a list of `LayerRefinementSpec` for automatic mesh refinement and snapping in layered structures. Structure corners on the cross section perpendicular to layer thickness direction can be automatically identified. Mesh is automatically snapped and refined around those corners.
+
+### Changed
+- The coordinate of snapping points in `GridSpec` can take value `None`, so that mesh can be selectively snapped only along certain dimensions.
 
 ## [2.8.0rc2] - 2025-01-28
 

--- a/docs/api/discretization.rst
+++ b/docs/api/discretization.rst
@@ -17,3 +17,6 @@ Discretization
    tidy3d.FieldGrid
    tidy3d.YeeGrid
    tidy3d.Grid
+   tidy3d.LayerRefinementSpec
+   tidy3d.GridRefinement
+   tidy3d.CornerFinderSpec

--- a/tests/test_components/test_layerrefinement.py
+++ b/tests/test_components/test_layerrefinement.py
@@ -1,0 +1,268 @@
+"""Tests 2d corner finder."""
+
+import numpy as np
+import pydantic.v1 as pydantic
+import pytest
+import tidy3d as td
+from tidy3d.components.grid.corner_finder import CornerFinderSpec
+from tidy3d.components.grid.grid_spec import GridRefinement, LayerRefinementSpec
+
+CORNER_FINDER = CornerFinderSpec()
+GRID_REFINEMENT = GridRefinement()
+LAYER_REFINEMENT = LayerRefinementSpec(axis=2, size=(td.inf, td.inf, 2))
+LAYER2D_REFINEMENT = LayerRefinementSpec(axis=2, size=(td.inf, td.inf, 0))
+
+
+def test_2dcorner_finder_filter_collinear_vertex():
+    """In corner finder, test that collinear vertices are filtered"""
+    # 2nd and 3rd vertices are on a collinear line
+    vertices = ((0, 0), (0.1, 0), (0.5, 0), (1, 0), (1, 1))
+    polyslab = td.PolySlab(vertices=vertices, axis=2, slab_bounds=[-1, 1])
+    structures = [td.Structure(geometry=polyslab, medium=td.PEC)]
+    corners = CORNER_FINDER.corners(normal_axis=2, coord=0, structure_list=structures)
+    assert len(corners) == 3
+
+    # if angle threshold is 0, collinear vertex will not be filtered
+    corner_finder = CORNER_FINDER.updated_copy(angle_threshold=0)
+    corners = corner_finder.corners(normal_axis=2, coord=0, structure_list=structures)
+    assert len(corners) == 5
+
+
+def test_2dcorner_finder_filter_nearby_vertex():
+    """In corner finder, test that vertices that are very close are filtered"""
+    # filter duplicate vertices
+    vertices = ((0, 0), (0, 0), (1e-4, -1e-4), (1, 0), (1, 1))
+    polyslab = td.PolySlab(vertices=vertices, axis=2, slab_bounds=[-1, 1])
+    structures = [td.Structure(geometry=polyslab, medium=td.PEC)]
+    corners = CORNER_FINDER.corners(normal_axis=2, coord=0, structure_list=structures)
+    assert len(corners) == 4
+
+    # filter very close vertices
+    corner_finder = CORNER_FINDER.updated_copy(distance_threshold=2e-4)
+    corners = corner_finder.corners(normal_axis=2, coord=0, structure_list=structures)
+    assert len(corners) == 3
+
+
+def test_2dcorner_finder_medium():
+    """No corner found if the medium is dielectric while asking to search for corner of metal."""
+    structures = [td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=td.Medium())]
+    corners = CORNER_FINDER.corners(normal_axis=2, coord=0, structure_list=structures)
+    assert len(corners) == 0
+
+
+def test_2dcorner_finder_polygon_with_hole():
+    """Find corners related to interior holes of a polygon."""
+    structures = [
+        td.Structure(geometry=td.Box(size=(2, 2, 2)), medium=td.PEC),
+        td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=td.Medium()),
+    ]
+    corners = CORNER_FINDER.corners(normal_axis=2, coord=0, structure_list=structures)
+    # 4 interior, 4 exterior
+    assert len(corners) == 8
+
+
+def test_gridrefinement():
+    """Test GradRefinement is working as expected."""
+
+    # generate override structures for z-axis
+    center = [None, None, 0]
+    grid_size_in_vaccum = 1
+    structure = GRID_REFINEMENT.override_structure(center, grid_size_in_vaccum)
+    assert not structure.shadow
+    for axis in range(2):
+        assert structure.dl[axis] is None
+        assert structure.geometry.size[axis] == td.inf
+    dl = grid_size_in_vaccum / GRID_REFINEMENT._refinement_factor
+    assert np.isclose(structure.dl[2], dl)
+    assert np.isclose(structure.geometry.size[2], dl * GRID_REFINEMENT.num_cells)
+
+    # explicitly define step size in refinement region that is smaller than that of refinement_factor
+    dl = 1
+    grid_refinement = GRID_REFINEMENT.updated_copy(dl=dl)
+    structure = grid_refinement.override_structure(center, grid_size_in_vaccum)
+    for axis in range(2):
+        assert structure.dl[axis] is None
+        assert structure.geometry.size[axis] == td.inf
+    assert np.isclose(structure.dl[2], dl)
+    assert np.isclose(structure.geometry.size[2], dl * GRID_REFINEMENT.num_cells)
+
+
+def test_layerrefinement():
+    """Test LayerRefinementSpec is working as expected."""
+
+    # size along axis must be inf
+    with pytest.raises(pydantic.ValidationError):
+        _ = LayerRefinementSpec(axis=0, size=(td.inf, 0, 0))
+
+    # classmethod
+    for axis in range(3):
+        layer = LayerRefinementSpec.from_layer_bounds(axis=axis, bounds=(0, 1))
+        assert layer.center[axis] == 0.5
+        assert layer.size[axis] == 1
+        assert layer.size[(axis + 1) % 3] == td.inf
+        assert layer.size[(axis + 2) % 3] == td.inf
+        assert layer._is_inplane_unbounded
+
+    layer = LayerRefinementSpec.from_bounds(axis=axis, rmin=(0, 0, 0), rmax=(1, 2, 3))
+    layer = LayerRefinementSpec.from_bounds(rmin=(0, 0, 0), rmax=(1, 2, 3))
+    assert layer.axis == 0
+    assert np.isclose(layer.length_axis, 1)
+    assert np.isclose(layer.center_axis, 0.5)
+    assert not layer._is_inplane_unbounded
+
+    # from structures
+    structures = [td.Structure(geometry=td.Box(size=(td.inf, 2, 3)), medium=td.Medium())]
+    layer = LayerRefinementSpec.from_structures(structures)
+    assert layer.axis == 1
+
+    with pytest.raises(pydantic.ValidationError):
+        structures = [
+            td.Structure(geometry=td.Box(size=(td.inf, td.inf, td.inf)), medium=td.Medium())
+        ]
+        layer = LayerRefinementSpec.from_structures(structures)
+
+    with pytest.raises(pydantic.ValidationError):
+        _ = LayerRefinementSpec.from_layer_bounds(axis=axis, bounds=(0, td.inf))
+    with pytest.raises(pydantic.ValidationError):
+        _ = LayerRefinementSpec.from_layer_bounds(axis=axis, bounds=(td.inf, 0))
+    with pytest.raises(pydantic.ValidationError):
+        _ = LayerRefinementSpec.from_layer_bounds(axis=axis, bounds=(-td.inf, 0))
+    with pytest.raises(pydantic.ValidationError):
+        _ = LayerRefinementSpec.from_layer_bounds(axis=axis, bounds=(1, -1))
+
+
+def test_layerrefinement_inplane_inside():
+    # inplane inside
+    layer = LayerRefinementSpec.from_layer_bounds(axis=2, bounds=(0, 1))
+    assert layer._inplane_inside([3e3, 4e4])
+    layer = LayerRefinementSpec(axis=1, size=(1, 0, 1))
+    assert layer._inplane_inside([0, 0])
+    assert not layer._inplane_inside([2, 0])
+
+
+def test_layerrefinement_snapping_points():
+    """Test snapping points for LayerRefinementSpec is working as expected."""
+
+    # snapping points for layer bounds
+    points = LAYER2D_REFINEMENT._snapping_points_along_axis
+    assert len(points) == 1
+    assert points[0] == (None, None, 0)
+
+    points = LAYER_REFINEMENT._snapping_points_along_axis
+    assert len(points) == 1
+    assert points[0] == (None, None, -1)
+
+
+def test_grid_spec_with_layers():
+    """Test the application of layer_specs to GridSpec."""
+
+    thickness = 1e-3
+    # a PEC thin layer structure
+    box1 = td.Box(size=(thickness, 2, 2))
+    box2 = td.Box(center=(0, -1, 0), size=(thickness, 1, 1))
+    pec_str = td.Structure(geometry=box1 - box2, medium=td.PEC)
+    # a pin
+    pin_str = td.Structure(
+        geometry=td.Cylinder(axis=0, radius=0.1, length=1.1, center=(-0.5, 0, 0)), medium=td.PEC
+    )
+    layer = LayerRefinementSpec.from_structures(
+        [
+            pec_str,
+        ]
+    )
+    assert layer.axis == 0
+
+    sim = td.Simulation(
+        size=(4, 4, 4),
+        grid_spec=td.GridSpec.auto(
+            min_steps_per_wvl=11, wavelength=1, layer_refinement_specs=[layer]
+        ),
+        boundary_spec=td.BoundarySpec.pml(),
+        structures=[pec_str, pin_str],
+        run_time=1e-12,
+    )
+    # lower bound is snapped
+    assert any(np.isclose(sim.grid.boundaries.x, -thickness / 2))
+    # corner snapped
+    assert any(np.isclose(sim.grid.boundaries.y, -0.5))
+    assert any(np.isclose(sim.grid.boundaries.z, -0.5))
+    assert any(np.isclose(sim.grid.boundaries.z, 0.5))
+
+    # differnt laye parameters
+    def update_sim_with_newlayer(layer):
+        return sim.updated_copy(
+            grid_spec=td.GridSpec.auto(
+                min_steps_per_wvl=11, wavelength=1, layer_refinement_specs=[layer]
+            )
+        )
+
+    # bounds snapping
+    layer = LayerRefinementSpec.from_structures(
+        [
+            pec_str,
+        ],
+        bounds_snapping="bounds",
+    )
+    sim2 = update_sim_with_newlayer(layer)
+    assert any(np.isclose(sim2.grid.boundaries.x, -thickness / 2))
+    assert any(np.isclose(sim2.grid.boundaries.x, thickness / 2))
+
+    # layer thickness refinement
+    def count_grids_within_layer(sim_t):
+        float_relax = 1.001
+        x = sim_t.grid.boundaries.x
+        x = x[x >= -thickness / 2 * float_relax]
+        x = x[x <= thickness / 2 * float_relax]
+        return len(x)
+
+    layer = LayerRefinementSpec.from_structures(
+        [
+            pec_str,
+        ],
+        min_steps_along_axis=3,
+    )
+    sim2 = update_sim_with_newlayer(layer)
+    assert count_grids_within_layer(sim2) == 4
+
+    # layer thickness refinement + bounds refinement, but the latter is too coarse so that it's abandoned
+    layer = LayerRefinementSpec.from_structures(
+        [
+            pec_str,
+        ],
+        min_steps_along_axis=3,
+        bounds_refinement=td.GridRefinement(),
+    )
+    sim2 = update_sim_with_newlayer(layer)
+    assert count_grids_within_layer(sim2) == 4
+    # much finer refinement to be included
+    layer = LayerRefinementSpec.from_structures(
+        [
+            pec_str,
+        ],
+        min_steps_along_axis=3,
+        bounds_refinement=td.GridRefinement(dl=thickness / 10),
+    )
+    sim2 = update_sim_with_newlayer(layer)
+    assert count_grids_within_layer(sim2) > 10
+
+    # layer bounds refinement: combined into one structure when they overlap
+    layer = LayerRefinementSpec.from_structures(
+        [
+            pec_str,
+        ],
+        bounds_refinement=td.GridRefinement(dl=thickness * 1.1, num_cells=1),
+        corner_finder=None,
+    )
+    sim2 = update_sim_with_newlayer(layer)
+    assert len(sim2.grid_spec.all_override_structures(list(sim2.structures), 1.0, sim2.size)) == 1
+
+    # separate when they don't overlap
+    layer = LayerRefinementSpec.from_structures(
+        [
+            pec_str,
+        ],
+        bounds_refinement=td.GridRefinement(dl=thickness * 0.9, num_cells=1),
+        corner_finder=None,
+    )
+    sim2 = update_sim_with_newlayer(layer)
+    assert len(sim2.grid_spec.all_override_structures(list(sim2.structures), 1.0, sim2.size)) == 2

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -188,12 +188,15 @@ from .components.geometry.base import Box, ClipOperation, Geometry, GeometryGrou
 from .components.geometry.mesh import TriangleMesh
 from .components.geometry.polyslab import PolySlab
 from .components.geometry.primitives import Cylinder, Sphere
+from .components.grid.corner_finder import CornerFinderSpec
 from .components.grid.grid import Coords, Coords1D, FieldGrid, Grid, YeeGrid
 from .components.grid.grid_spec import (
     AutoGrid,
     CustomGrid,
     CustomGridBoundaries,
+    GridRefinement,
     GridSpec,
+    LayerRefinementSpec,
     QuasiUniformGrid,
     UniformGrid,
 )
@@ -374,6 +377,9 @@ __all__ = [
     "CustomGrid",
     "AutoGrid",
     "CustomGridBoundaries",
+    "LayerRefinementSpec",
+    "GridRefinement",
+    "CornerFinderSpec",
     "Box",
     "Sphere",
     "Cylinder",

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -375,6 +375,15 @@ class Geometry(Tidy3dBaseModel, ABC):
         rmax = tuple(min(v1, v2) for v1, v2 in zip(rmax1, rmax2))
         return (rmin, rmax)
 
+    @staticmethod
+    def bounds_union(bounds1: Bound, bounds2: Bound) -> Bound:
+        """Return the bounds that are the union of two bounds."""
+        rmin1, rmax1 = bounds1
+        rmin2, rmax2 = bounds2
+        rmin = tuple(min(v1, v2) for v1, v2 in zip(rmin1, rmin2))
+        rmax = tuple(max(v1, v2) for v1, v2 in zip(rmax1, rmax2))
+        return (rmin, rmax)
+
     @cached_property
     def bounding_box(self):
         """Returns :class:`Box` representation of the bounding box of a :class:`Geometry`.

--- a/tidy3d/components/grid/corner_finder.py
+++ b/tidy3d/components/grid/corner_finder.py
@@ -1,0 +1,137 @@
+"""Find corners of structures on a 2D plane."""
+
+from typing import List, Literal, Optional
+
+import numpy as np
+import pydantic.v1 as pd
+
+from ...constants import inf
+from ..base import Tidy3dBaseModel
+from ..geometry.base import Box, ClipOperation
+from ..geometry.utils import merging_geometries_on_plane
+from ..medium import PEC, LossyMetalMedium
+from ..structure import Structure
+from ..types import ArrayFloat2D, Axis
+
+CORNER_ANGLE_THRESOLD = 0.1 * np.pi
+
+
+class CornerFinderSpec(Tidy3dBaseModel):
+    """Specification for corner detection on a 2D plane."""
+
+    medium: Literal["metal", "dielectric", "all"] = pd.Field(
+        "metal",
+        title="Material Type For Corner Identification",
+        description="Find corners of structures made of ``medium``, "
+        "which can take value ``metal`` for PEC and lossy metal, ``dielectric`` "
+        "for non-metallic materials, and ``all`` for all materials.",
+    )
+
+    angle_threshold: float = pd.Field(
+        CORNER_ANGLE_THRESOLD,
+        title="Angle Threshold In Corner Identification",
+        description="A vertex is qualified as a corner if the angle spanned by its two edges "
+        "is larger than the supplementary angle of "
+        "this threshold value.",
+        ge=0,
+        lt=np.pi,
+    )
+
+    distance_threshold: Optional[pd.PositiveFloat] = pd.Field(
+        None,
+        title="Distance Threshold In Corner Identification",
+        description="If not ``None`` and the distance of the vertex to its neighboring vertices "
+        "is below the threshold value based on Douglas-Peucker algorithm, the vertex is disqualified as a corner.",
+    )
+
+    def corners(
+        self,
+        normal_axis: Axis,
+        coord: float,
+        structure_list: List[Structure],
+    ) -> ArrayFloat2D:
+        """On a 2D plane specified by axis = `normal_axis` and coordinate `coord`, find out corners of merged
+        geometries made of `medium`.
+
+
+        Parameters
+        ----------
+        normal_axis : Axis
+            Axis normal to the 2D plane.
+        coord : float
+            Position of plane along the normal axis.
+        structure_list : List[Structure]
+            List of structures present in simulation.
+
+        Returns
+        -------
+        ArrayFloat2D
+            Corner coordinates.
+        """
+
+        # Construct plane
+        center = [0, 0, 0]
+        size = [inf, inf, inf]
+        center[normal_axis] = coord
+        size[normal_axis] = 0
+        plane = Box(center=center, size=size)
+
+        # prepare geometry and medium list
+        geometry_list = [structure.geometry for structure in structure_list]
+        # For metal, we don't distinguish between LossyMetal and PEC,
+        # so they'll be merged to PEC. Other materials are considered as dielectric.
+        medium_list = (structure.medium for structure in structure_list)
+        medium_list = [
+            PEC if (mat.is_pec or isinstance(mat, LossyMetalMedium)) else mat for mat in medium_list
+        ]
+        # merge geometries
+        merged_geos = merging_geometries_on_plane(geometry_list, plane, medium_list)
+
+        # corner finder
+        corner_list = []
+        for mat, shapes in merged_geos:
+            if self.medium != "all" and mat.is_pec != (self.medium == "metal"):
+                continue
+            polygon_list = ClipOperation.to_polygon_list(shapes)
+            for poly in polygon_list:
+                poly = poly.normalize().buffer(0)
+                if self.distance_threshold is not None:
+                    poly = poly.simplify(self.distance_threshold, preserve_topology=True)
+                corner_list.append(self._filter_collinear_vertices(list(poly.exterior.coords)))
+                # in case the polygon has holes
+                for poly_inner in poly.interiors:
+                    corner_list.append(self._filter_collinear_vertices(list(poly_inner.coords)))
+
+        if len(corner_list) > 0:
+            corner_list = np.concatenate(corner_list)
+        return corner_list
+
+    def _filter_collinear_vertices(self, vertices: ArrayFloat2D) -> ArrayFloat2D:
+        """Filter collinear vertices of a polygon, and return corners.
+
+        Parameters
+        ----------
+        vertices : ArrayFloat2D
+            Polygon vertices from shapely.Polygon. The last vertex is identical to the 1st
+            vertex to make a valid polygon.
+
+        Returns
+        -------
+        ArrayFloat2D
+            Corner coordinates.
+        """
+
+        def normalize(v):
+            return v / np.linalg.norm(v, axis=-1)[:, np.newaxis]
+
+        # drop the last vertex, which is identical to the 1st one.
+        vs_orig = np.array(vertices[:-1])
+        # compute unit vector to next and previous vertex
+        vs_next = np.roll(vs_orig, axis=0, shift=-1)
+        vs_previous = np.roll(vs_orig, axis=0, shift=+1)
+        unit_next = normalize(vs_next - vs_orig)
+        unit_previous = normalize(vs_previous - vs_orig)
+        # angle
+        angle = np.arccos(np.sum(unit_next * unit_previous, axis=-1))
+        ind_filter = angle <= np.pi - self.angle_threshold
+        return vs_orig[ind_filter]

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -38,7 +38,7 @@ from .data.utils import (
     _get_numpy_array,
 )
 from .geometry.base import Box, ClipOperation, GeometryGroup
-from .geometry.utils import flatten_groups, traverse_geometries
+from .geometry.utils import flatten_groups, merging_geometries_on_plane, traverse_geometries
 from .grid.grid import Coords, Grid
 from .material.multi_physics import MultiPhysicsMedium
 from .medium import (
@@ -251,6 +251,11 @@ class Scene(Tidy3dBaseModel):
         """Returns structure representing the background of the :class:`.Scene`."""
         geometry = Box(size=(inf, inf, inf))
         return Structure(geometry=geometry, medium=self.medium)
+
+    @cached_property
+    def all_structures(self) -> List[Structure]:
+        """List of all structures in the simulation including the background."""
+        return [self.background_structure] + list(self.structures)
 
     @staticmethod
     def intersecting_media(
@@ -660,57 +665,9 @@ class Scene(Tidy3dBaseModel):
         List[Tuple[:class:`.AbstractMedium`, shapely.geometry.base.BaseGeometry]]
             List of shapes and their property value on the plane after merging.
         """
-
-        if len(structures) != len(property_list):
-            raise SetupError(
-                "Number of provided property values is not equal to the number of structures."
-            )
-
-        shapes = []
-        for structure, prop in zip(structures, property_list):
-            # get list of Shapely shapes that intersect at the plane
-            shapes_plane = plane.intersections_with(structure.geometry)
-
-            # Append each of them and their property information to the list of shapes
-            for shape in shapes_plane:
-                shapes.append((prop, shape, shape.bounds))
-
-        background_shapes = []
-        for prop, shape, bounds in shapes:
-            minx, miny, maxx, maxy = bounds
-
-            # loop through background_shapes (note: all background are non-intersecting or merged)
-            for index, (_prop, _shape, _bounds) in enumerate(background_shapes):
-                _minx, _miny, _maxx, _maxy = _bounds
-
-                # do a bounding box check to see if any intersection to do anything about
-                if minx > _maxx or _minx > maxx or miny > _maxy or _miny > maxy:
-                    continue
-
-                # look more closely to see if intersected.
-                if shape.disjoint(_shape):
-                    continue
-
-                # different prop, remove intersection from background shape
-                if prop != _prop:
-                    diff_shape = (_shape - shape).buffer(0).normalize()
-                    # mark background shape for removal if nothing left
-                    if diff_shape.is_empty or len(diff_shape.bounds) == 0:
-                        background_shapes[index] = None
-                    background_shapes[index] = (_prop, diff_shape, diff_shape.bounds)
-                # same prop, unionize shapes and mark background shape for removal
-                else:
-                    shape = (shape | _shape).buffer(0).normalize()
-                    background_shapes[index] = None
-
-            # after doing this with all background shapes, add this shape to the background
-            background_shapes.append((prop, shape, shape.bounds))
-
-            # remove any existing background shapes that have been marked as 'None'
-            background_shapes = [b for b in background_shapes if b is not None]
-
-        # filter out any remaining None or empty shapes (shapes with area completely removed)
-        return [(prop, shape) for (prop, shape, _) in background_shapes if shape]
+        return merging_geometries_on_plane(
+            [structure.geometry for structure in structures], plane, property_list
+        )
 
     """ Plotting Optical """
 

--- a/tidy3d/components/types.py
+++ b/tidy3d/components/types.py
@@ -2,6 +2,7 @@
 
 from typing import (
     Literal,  # We support py3.9+, so direct typing import is fine.
+    Optional,
     Tuple,
     Union,
 )
@@ -188,6 +189,7 @@ ScalarSymmetry = Literal[0, 1]
 Size1D = pydantic.NonNegativeFloat
 Size = Tuple[Size1D, Size1D, Size1D]
 Coordinate = Tuple[float, float, float]
+CoordinateOptional = Tuple[Optional[float], Optional[float], Optional[float]]
 Coordinate2D = Tuple[float, float]
 Bound = Tuple[Coordinate, Coordinate]
 GridSize = Union[pydantic.PositiveFloat, Tuple[pydantic.PositiveFloat, ...]]


### PR DESCRIPTION
(associated with https://github.com/flexcompute/tidy3d-core/issues/509)

## Background

In many applications, structures are built layer by layer. Materials can be considered uniform along the normal axis. 
- When there are metals (including PEC and lossy metal) present in the layer, it's important to snap and refine grid to the metal corners. We also want to refine around the corners/edges.
- Sometimes we want to resolve layer thickness. In most cases, we want lower or upper bound of the layer (or both) to be at grid.

In 2D, we can simply use shapely to find out corners. With corners, we can have boundaries (or edges). With the two, we can automatically generate snapping points and refinement mesh override structures.

## Features
- A dedicated [file](https://github.com/flexcompute/tidy3d/blob/9b3cd40ab34716f372848490dbd2a33589c9af2f/tidy3d/components/grid/corner_finder.py) for 2d corner finder;
- A `GridRefinement` class [here](https://github.com/flexcompute/tidy3d/blob/9b3cd40ab34716f372848490dbd2a33589c9af2f/tidy3d/components/grid/grid_spec.py#L834-L836) for local mesh refinement. It is to make it easier to generate mesh override structures based on the number of grid cells and refined grid size. The refined grid size can be defined by either the refinement factor w.r.t. vacuum grid size, or grid size directly.
- `LayerRefinementSpec` that defines the layer (it can be bounded on the inplane dimensions so that corners outside the bound are discarded) and various mesh generation specs.
- Added `layer_refinement_specs` field to `GridSpec`. The final snapping points and override structures will be internal ones + user supplied ones. The internal ones are generated by `LayerRefinementSpec`.
- When `dl_min` is not set by the user, we'll automatically generate a value based on the structures, simulation domain size, and layer_specs. 

## Examples

If we are fine with default meshing specs, `layer_refinement_spec` can be easily defined. First, let's defined a layer that is unbounded perpendicular to the normal axis:
```
layer = td.LayerRefinementSpec.from_unbounded(
    axis=2,
    bounds=(-patch_thickness/2, patch_thickness/2),
)
```
and grid_spec,
`grid_spec = td.GridSpec.auto(wavelength=wavelength, layer_refinement_specs=[layer])`

Consider a patch antenna but we drill a big hole on the left, with the above grid_spec, we get
![image](https://github.com/user-attachments/assets/67f80919-f487-43e6-b306-8c50813b7bb6)

As you can see, metal corners are all identified, and snapping points are applied at those corners. Small mesh refinement structures are placed at corners, too, so that the mesh is denser near those singularities.

Sometimes, you only want refine a portion of the layer, as the other portion is not affecting the simulation as much. E.g., we only want to refine the feeding region,
```
layer = td.LayerRefinementSpec(
    axis=2,
    center=(0, -10e3, 0),
    size=(10e3,10e3, patch_thickness),
)
```
![image](https://github.com/user-attachments/assets/b30148ee-f6dd-4340-a398-5bd9146926f7)

## Tasks

### Major
- [x] Layer refinement specification class to define layer position and refinement parameters: defined [here](https://github.com/flexcompute/tidy3d/blob/ba8cd2e1ae03b27253f12e0e6b456af352abb027/tidy3d/components/grid/grid_spec.py#L535-L538)
- [x] Corner finder in 2d with shapely
- [x] Automatic snapping points generation
- [x] Automatically sets `dl_min` if not set yet:
  - [x] Compute dl_min from layers
  - [x] Compute dl_min from all structures
- [x] Automatic mesh refinement structures generation

### Minor
- [x] Allow snapping points to take `None` as coordinate, so that it's not snapped along that axis. Now snapping point is of type [CoordinateOptional](https://github.com/flexcompute/tidy3d/blob/ba8cd2e1ae03b27253f12e0e6b456af352abb027/tidy3d/components/types.py#L188). In visualization, snapping points will be `snapping line` if one of the inplane coordinate is `None`.
- [x] Shift `_filter_structures_plane` to geometry/utils.py, as it'll be used in 2d corner finder.

### Miscellaneous
- [x] Rebase once https://github.com/flexcompute/tidy3d/pull/2130 is merged. Many conflicts expected.
- [x] Add tests
- [x] Add CHANGELOG
- [x] Better visualization of snapping points that contain `None`