### PR TITLE
Allow double precision mode solver in EME.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default choice of frequency in `Simulation.plot_eps` and `Simulation.plot_structures_eps` is now the central frequency of all sources in the simulation. If the central frequencies differ, the permittivity is evaluated at infinite frequency, and a warning is emitted. 
 - Mode solver fields are more consistently normalized with respect to grid-dependent sign inversions in high order modes.
 - `MeshOverrideStructure` accepts `Box` as geometry. Other geometry types will raise a warning and convert to bounding box.
+- Double precision mode solver is now supported in EME.
 
 ### Fixed
 - Significant speedup for field projection computations.

--- a/tidy3d/components/eme/grid.py
+++ b/tidy3d/components/eme/grid.py
@@ -52,14 +52,6 @@ class EMEModeSpec(ModeSpec):
         units=RADIAN,
     )
 
-    precision: Literal["single"] = pd.Field(
-        "single",
-        title="single or double precision in mode solver",
-        description="The solver will be faster and using less memory under "
-        "single precision, but more accurate under double precision. Only single precision is "
-        "currently supported in EME.",
-    )
-
     # this method is not supported because not all ModeSpec features are supported
     # @classmethod
     # def _from_mode_spec(cls, mode_spec: ModeSpec) -> EMEModeSpec:


### PR DESCRIPTION
Previously we restricted EME to use the single-precision mode solver (not completely sure why), but Filipe's recent testing makes it clear that the double-precision solver is needed to resolve the attenuation constant in low-loss waveguides (such as bends with large radius).

I did quickly check that the metadata calculation in this case looks correct.