### PR TITLE
Raising instead of warning if cost could not be estimated

### DIFF
--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -901,11 +901,8 @@ def estimate_cost(task_id: str, verbose: bool = True, solver_version: str = None
                 console.log(f"  {fc_post:1.3f} FlexCredit of the total cost from post-processing.")
         return task_info.estFlexUnit
 
-    log.warning(
-        "Could not get estimated cost! It will be reported during a simulation run in the "
-        "preprocessing step."
-    )
-    return None
+    # Something went wrong
+    raise WebError("Could not get estimated cost!")
 
 
 @wait_for_connection


### PR DESCRIPTION
This used to be a warning a long time ago because the web api was not backed by a pipeline. Now there should be no case in which the estimate cost call fails but the metadata is then correctly processed in a solver run.