### PR TITLE
QuasiUniformGrid and min_steps_per_sim_size`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - NumPy 2.1 compatibility issue where `numpy.float64` values passed to xarray interpolation would raise TypeError.
+- Support for quasi-uniform grid specifications via `QuasiUniformGrid` that subclasses from `GridSpec1d`. The grids are almost uniform, but can adjust locally to the edge of structure bounding boxes, and snapping points.
+- New field `min_steps_per_sim_size` in `AutoGrid` that sets minimal number of grid steps per longest edge length of simulation domain.
 
 ## [2.8.0rc1] - 2024-12-17
 

--- a/docs/api/discretization.rst
+++ b/docs/api/discretization.rst
@@ -10,6 +10,7 @@ Discretization
    tidy3d.GridSpec
    tidy3d.AutoGrid
    tidy3d.UniformGrid
+   tidy3d.QuasiUniformGrid
    tidy3d.CustomGrid
    tidy3d.CustomGridBoundaries
    tidy3d.Coords

--- a/tests/test_components/test_meshgenerate.py
+++ b/tests/test_components/test_meshgenerate.py
@@ -705,6 +705,7 @@ def test_shapely_strtree_warnings():
             wavelength=1.0,
             min_steps_per_wvl=6,
             dl_min=1.0,
+            dl_max=td.inf,
         )
 
 

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -128,6 +128,7 @@ from .components.grid.grid_spec import (
     CustomGrid,
     CustomGridBoundaries,
     GridSpec,
+    QuasiUniformGrid,
     UniformGrid,
 )
 from .components.heat_charge.boundary import (
@@ -324,6 +325,7 @@ __all__ = [
     "Coords",
     "GridSpec",
     "UniformGrid",
+    "QuasiUniformGrid",
     "CustomGrid",
     "AutoGrid",
     "CustomGridBoundaries",


### PR DESCRIPTION
Two main features:

- `QuasiUniformGrid`: grid is roughly uniform, but locally snapped. This makes it more useful than `UniformGrid` in many simulations.
-  In `AutoGrid`, adds a field `min_steps_per_sim_size`. Now the grid step size is constrained by both `min_steps_per_sim_size` and `min_steps_per_wvl`. In many RF simulations, the entire simulation domain is deep subwavelength. Previously, one needs to set a dramatically large value of `min_steps_per_wvl` so that the simulation domain has more than 1 grid point. `min_steps_per_sim_size` will be more useful in those simulations.