### PR TITLE
NumPy 2.1 compatibility for xarray interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+[Unreleased]
+
+### Fixed
+
+- NumPy 2.1 compatibility issue where `numpy.float64` values passed to xarray interpolation would raise TypeError.
+
 ## [2.8.0rc1] - 2024-12-17
 
 ### Added

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -2536,7 +2536,7 @@ class Box(SimplePlaneIntersection, Centered):
         def integrate_face(arr: xr.DataArray) -> complex:
             """Interpolate and integrate a scalar field data over the face using bounds."""
 
-            arr_at_face = arr.interp(**{dim_normal: coord_normal_face}, assume_sorted=True)
+            arr_at_face = arr.interp(**{dim_normal: float(coord_normal_face)}, assume_sorted=True)
 
             integral_result = integrate_within_bounds(
                 arr=arr_at_face,


### PR DESCRIPTION
Fix `TypeError` in `Box.derivative_face` when using NumPy 2.1+ by explicitly converting `coord_normal_face` from `numpy.float64` to Python `float` before passing to xarray's interpolation. This addresses stricter type checking in NumPy 2.1 while maintaining the same numerical behavior.

Previously this would error like:
```
...
  File "/Users/yannick/flexcompute/worktrees/surfacemesh_interp/tidy3d/components/geometry/base.py", line 2466, in integrate_face
    arr_at_face = arr.interp(**{dim_normal: coord_normal_face}, assume_sorted=True)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yannick/flexcompute/worktrees/surfacemesh_interp/tidy3d/components/data/data_array.py", line 343, in interp
    return super().interp(coords, method, assume_sorted, kwargs, **coords_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yannick/flexcompute/worktrees/surfacemesh_interp/.venv/lib/python3.12/site-packages/xarray/core/dataarray.py", line 2341, in interp
    ds = self._to_temp_dataset().interp(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yannick/flexcompute/worktrees/surfacemesh_interp/.venv/lib/python3.12/site-packages/xarray/core/dataset.py", line 4004, in interp
    indexers = dict(self._validate_interp_indexers(coords))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/yannick/flexcompute/worktrees/surfacemesh_interp/.venv/lib/python3.12/site-packages/xarray/core/dataset.py", line 2859, in _validate_interp_indexers
    raise TypeError(type(v))
TypeError: <class 'numpy.float64'>
```