### PR TITLE
Fix gradient magnitude custom medium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New field `min_steps_per_sim_size` in `AutoGrid` that sets minimal number of grid steps per longest edge length of simulation domain.
 - Validation error in inverse design plugin when simulation has no sources by adding a source existence check before validating pixel size.
 - System-dependent floating-point precision issue in EMEGrid validation.
+- Fixed magnitude of gradient computation in `CustomMedium` by accounting properly for full volume element when permittivity data is defined over less dimensions than the medium.
 
 ## [2.8.0rc1] - 2024-12-17
 


### PR DESCRIPTION
Found while debugging the autograd level set notebook that the gradient magnitudes when using the autograd version vs. the Jax version were off by a couple orders of magnitude (the direction was the same). `CustomMedium` is implemented differently than `JaxCustomMedium` for the case where the gradient is computed with the coordinate array for one of the dimensions fixed. In `CustomMedium`, the volume normalization was not taking into account the thickness of the dimension and summing so that each slice in the gradient array were all effectively weighted by 1. The change here is to use `mean` instead of `sum` and multiply by missing volume factors.