### PR TITLE
fix[invdes]: handle pixel size validation for simulations without sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - NumPy 2.1 compatibility issue where `numpy.float64` values passed to xarray interpolation would raise TypeError.
 - Support for quasi-uniform grid specifications via `QuasiUniformGrid` that subclasses from `GridSpec1d`. The grids are almost uniform, but can adjust locally to the edge of structure bounding boxes, and snapping points.
 - New field `min_steps_per_sim_size` in `AutoGrid` that sets minimal number of grid steps per longest edge length of simulation domain.
+- Validation error in inverse design plugin when simulation has no sources by adding a source existence check before validating pixel size.
 
 ## [2.8.0rc1] - 2024-12-17
 

--- a/tests/test_plugins/test_invdes.py
+++ b/tests/test_plugins/test_invdes.py
@@ -625,3 +625,23 @@ def test_validate_invdes_metric():
     invdes = invdes.updated_copy(simulation=simulation.updated_copy(monitors=[monitor]))
     with pytest.raises(ValueError, match="must return a real"):
         invdes.updated_copy(metric=metric)
+
+
+def test_pixel_size_warn_validator_no_sources(log_capture):
+    """Test that pixel size validator handles simulations without sources."""
+
+    sourceless_sim = simulation.updated_copy(sources=[])
+
+    invdes = make_invdes()
+    invdes = invdes.updated_copy(simulation=sourceless_sim)
+
+    with AssertLogLevel(log_capture, "WARNING", contains_str="Cannot validate pixel size"):
+        region_coarse = invdes.design_region.updated_copy(pixel_size=1.0)
+        invdes = invdes.updated_copy(design_region=region_coarse)
+
+    invdes_multi = make_invdes_multi()
+    sourceless_sims = [sourceless_sim for _ in invdes_multi.simulations]
+    invdes_multi = invdes_multi.updated_copy(simulations=sourceless_sims)
+
+    with AssertLogLevel(log_capture, "WARNING", contains_str="Cannot validate pixel size"):
+        invdes_multi = invdes_multi.updated_copy(design_region=region_coarse)

--- a/tidy3d/plugins/invdes/validators.py
+++ b/tidy3d/plugins/invdes/validators.py
@@ -33,6 +33,13 @@ def check_pixel_size(sim_field_name: str):
 
     def check_pixel_size_sim(sim: td.Simulation, pixel_size: float, index: int = None) -> None:
         """Check a pixel size compared to the simulation min wvl in material."""
+        if not sim.sources:
+            td.log.warning(
+                "Cannot validate pixel size in design region: simulation has no sources. "
+                "Please ensure the pixel size is appropriate for your target wavelength."
+            )
+            return
+
         if pixel_size > PIXEL_SIZE_WARNING_THRESHOLD * sim.wvl_mat_min:
             sim_string = f"simulations[{index}]" if index else "the simulation"
 


### PR DESCRIPTION
Currently `InverseDesign` validation will error if the simulation contains no sources due to the `_check_pixel_size` validator trying to access `sim.wvl_mat_min`, which depends on the sources being present.
This PR skips the validator if the simulation contains no sources and instead warns the user about checking the pixel size. The reason for not erroring is that we probably still want to allow the construction of simulations without sources in the plugin since we also allow it in `td.Simulation` (and it can be useful in some cases).