### PR TITLE
feat[frontend]: add angle validator to specify expected angle in radians

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `ModeMonitor` and `ModeSolverMonitor` now use the default `td.ModeSpec()` with `num_modes=1` when `mode_spec` is not provided.
+- Update sidewall angle validator to clarify angle should be specified in radians.
 
 ### Fixed
 - NumPy 2.1 compatibility issue where `numpy.float64` values passed to xarray interpolation would raise TypeError.

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -1696,8 +1696,6 @@ class Planar(SimplePlaneIntersection, Geometry, ABC):
         "along the ``axis`` direction; "
         "and ``-np.pi/2<sidewall_angle<0`` specifies an expanding cross section "
         "along the ``axis`` direction.",
-        gt=-np.pi / 2,
-        lt=np.pi / 2,
         units=RADIAN,
     )
 
@@ -1711,6 +1709,16 @@ class Planar(SimplePlaneIntersection, Geometry, ABC):
         "E.g. if ``axis=1``, ``bottom`` refers to the negative side of the y-axis, and "
         "``top`` refers to the positive side of the y-axis.",
     )
+
+    @pydantic.validator("sidewall_angle", always=True)
+    def validate_angle(cls, value: float) -> float:
+        lower_bound = -np.pi / 2
+        upper_bound = np.pi / 2
+        if (value <= lower_bound) or (value >= upper_bound):
+            # u03C0 is unicode for pi
+            raise ValidationError(f"Sidewall angle ({value}) must be between -π/2 and π/2 rad.")
+
+        return value
 
     @property
     @abstractmethod


### PR DESCRIPTION
Provides a clearer validation message that the expected units for the `sidewall_angle` field are in radians to explain why the range is between +/- pi/2.