### PR TITLE
Adding reduced_simulation option to web functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `VisualizationSpec` that allows `Medium` instances to specify color and transparency plotting attributes that override default ones.
+- `reduce_simulation` argument added to all web functions to allow automatically reducing structures only to the simulation domain, including truncating data in custom media, thus reducing the simulation upload size. Currently only implemented for mode solver simulation types.
 
 ### Changed
 - `ModeMonitor` and `ModeSolverMonitor` now use the default `td.ModeSpec()` with `num_modes=1` when `mode_spec` is not provided.

--- a/tests/test_web/test_webapi_mode.py
+++ b/tests/test_web/test_webapi_mode.py
@@ -13,6 +13,7 @@ from tidy3d.web.api.webapi import (
     download_json,
     estimate_cost,
     get_info,
+    get_reduced_simulation,
     get_run_info,
     load_simulation,
     run,
@@ -257,8 +258,8 @@ def mock_webapi(
 @responses.activate
 def test_upload(monkeypatch, mock_upload, mock_get_info, mock_metadata):
     sim = make_mode_sim()
-    print(sim)
-    assert upload(sim, TASK_NAME, PROJECT_NAME)
+    assert sim != get_reduced_simulation(sim, reduce_simulation=True)
+    assert upload(sim, TASK_NAME, PROJECT_NAME, reduce_simulation=True)
 
 
 @responses.activate

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -13,6 +13,7 @@ from autograd.extend import defvjp, primitive
 import tidy3d as td
 from tidy3d.components.autograd import AutogradFieldMap, get_static
 from tidy3d.components.autograd.derivative_utils import DerivativeInfo
+from tidy3d.components.types import Literal
 
 from ...core.s3utils import download_file, upload_file
 from ..asynchronous import DEFAULT_DATA_DIR
@@ -90,6 +91,7 @@ def run(
     simulation_type: str = "tidy3d",
     parent_tasks: list[str] = None,
     local_gradient: bool = LOCAL_GRADIENT,
+    reduce_simulation: Literal["auto", True, False] = "auto",
 ) -> SimulationDataType:
     """
     Submits a :class:`.Simulation` to server, starts running, monitors progress, downloads,
@@ -123,6 +125,8 @@ def run(
     local_gradient: bool = False
         Whether to perform gradient calculation locally, requiring more downloads but potentially
         more stable with experimental features.
+    reduce_simulation: Literal["auto", True, False] = "auto"
+        Whether to reduce structures in the simulation to the simulation domain only. Note: currently only implemented for the mode solver.
 
     Returns
     -------
@@ -199,6 +203,7 @@ def run(
         worker_group=worker_group,
         simulation_type=simulation_type,
         parent_tasks=parent_tasks,
+        reduce_simulation=reduce_simulation,
     )
 
 
@@ -212,6 +217,7 @@ def run_async(
     simulation_type: str = "tidy3d",
     parent_tasks: dict[str, list[str]] = None,
     local_gradient: bool = LOCAL_GRADIENT,
+    reduce_simulation: Literal["auto", True, False] = "auto",
 ) -> BatchData:
     """Submits a set of Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`] objects to server,
     starts running, monitors progress, downloads, and loads results as a :class:`.BatchData` object.
@@ -236,6 +242,8 @@ def run_async(
     local_gradient: bool = False
         Whether to perform gradient calculations locally, requiring more downloads but potentially
         more stable with experimental features.
+    reduce_simulation: Literal["auto", True, False] = "auto"
+        Whether to reduce structures in the simulation to the simulation domain only. Note: currently only implemented for the mode solver.
 
     Returns
     ------
@@ -275,6 +283,7 @@ def run_async(
         verbose=verbose,
         simulation_type=simulation_type,
         parent_tasks=parent_tasks,
+        reduce_simulation=reduce_simulation,
     )
 
 


### PR DESCRIPTION
This is a missing piece from the special mode solver web functions which we want to deprecate.

Note that in our current web test mocking there's no good way for me to test if the simulation actually gets reduced since the upload and download are mocked...