### PR TITLE
Fix system-dependent floating-point issue in EMEGrid validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for quasi-uniform grid specifications via `QuasiUniformGrid` that subclasses from `GridSpec1d`. The grids are almost uniform, but can adjust locally to the edge of structure bounding boxes, and snapping points.
 - New field `min_steps_per_sim_size` in `AutoGrid` that sets minimal number of grid steps per longest edge length of simulation domain.
 - Validation error in inverse design plugin when simulation has no sources by adding a source existence check before validating pixel size.
+- System-dependent floating-point precision issue in EMEGrid validation.
 
 ## [2.8.0rc1] - 2024-12-17
 

--- a/tidy3d/components/eme/grid.py
+++ b/tidy3d/components/eme/grid.py
@@ -231,11 +231,11 @@ class EMEExplicitGrid(EMEGridSpec):
         sim_rmin = center[axis] - size[axis] / 2
         sim_rmax = center[axis] + size[axis] / 2
         if len(self.boundaries) > 0:
-            if np.float32(sim_rmin) - np.float32(self.boundaries[0]) > fp_eps:
+            if sim_rmin - self.boundaries[0] > fp_eps:
                 raise ValidationError(
                     "The first item in 'boundaries' is outside the simulation domain."
                 )
-            if np.float32(self.boundaries[-1]) - np.float32(sim_rmax) > fp_eps:
+            if self.boundaries[-1] - sim_rmax > fp_eps:
                 raise ValidationError(
                     "The last item in 'boundaries' is outside the simulation domain."
                 )
@@ -324,11 +324,11 @@ class EMECompositeGrid(EMEGridSpec):
         bounds = []
         sim_rmin = center[axis] - size[axis] / 2
         sim_rmax = center[axis] + size[axis] / 2
-        if np.float32(sim_rmin) - np.float32(self.subgrid_boundaries[0]) > fp_eps:
+        if sim_rmin - self.subgrid_boundaries[0] > fp_eps:
             raise ValidationError(
                 "The first item in 'subgrid_boundaries' is outside the simulation domain."
             )
-        if np.float32(self.subgrid_boundaries[-1]) - np.float32(sim_rmax) > fp_eps:
+        if self.subgrid_boundaries[-1] - sim_rmax > fp_eps:
             raise ValidationError(
                 "The last item in 'subgrid_boundaries' is outside the simulation domain."
             )
@@ -438,7 +438,7 @@ class EMEGrid(Box):
                 "so that there is one mode spec per EME cell."
             )
         rmin = boundaries[0]
-        if np.float32(sim_rmin) - np.float32(rmin) > fp_eps:
+        if sim_rmin - rmin > fp_eps:
             raise ValidationError(
                 "The first item in 'boundaries' is outside the simulation domain."
             )
@@ -446,7 +446,7 @@ class EMEGrid(Box):
             if rmax < rmin:
                 raise ValidationError("The 'subgrid_boundaries' must be increasing.")
             rmin = rmax
-        if np.float32(rmax) - np.float32(sim_rmax) > fp_eps:
+        if rmax - sim_rmax > fp_eps:
             raise ValidationError("The last item in 'boundaries' is outside the simulation domain.")
         return val
 

--- a/tidy3d/components/eme/grid.py
+++ b/tidy3d/components/eme/grid.py
@@ -231,11 +231,11 @@ class EMEExplicitGrid(EMEGridSpec):
         sim_rmin = center[axis] - size[axis] / 2
         sim_rmax = center[axis] + size[axis] / 2
         if len(self.boundaries) > 0:
-            if self.boundaries[0] < sim_rmin - fp_eps:
+            if np.float32(sim_rmin) - np.float32(self.boundaries[0]) > fp_eps:
                 raise ValidationError(
                     "The first item in 'boundaries' is outside the simulation domain."
                 )
-            if self.boundaries[-1] > sim_rmax + fp_eps:
+            if np.float32(self.boundaries[-1]) - np.float32(sim_rmax) > fp_eps:
                 raise ValidationError(
                     "The last item in 'boundaries' is outside the simulation domain."
                 )
@@ -324,11 +324,11 @@ class EMECompositeGrid(EMEGridSpec):
         bounds = []
         sim_rmin = center[axis] - size[axis] / 2
         sim_rmax = center[axis] + size[axis] / 2
-        if self.subgrid_boundaries[0] < sim_rmin - fp_eps:
+        if np.float32(sim_rmin) - np.float32(self.subgrid_boundaries[0]) > fp_eps:
             raise ValidationError(
                 "The first item in 'subgrid_boundaries' is outside the simulation domain."
             )
-        if self.subgrid_boundaries[-1] > sim_rmax + fp_eps:
+        if np.float32(self.subgrid_boundaries[-1]) - np.float32(sim_rmax) > fp_eps:
             raise ValidationError(
                 "The last item in 'subgrid_boundaries' is outside the simulation domain."
             )
@@ -438,7 +438,7 @@ class EMEGrid(Box):
                 "so that there is one mode spec per EME cell."
             )
         rmin = boundaries[0]
-        if rmin < sim_rmin - fp_eps:
+        if np.float32(sim_rmin) - np.float32(rmin) > fp_eps:
             raise ValidationError(
                 "The first item in 'boundaries' is outside the simulation domain."
             )
@@ -446,7 +446,7 @@ class EMEGrid(Box):
             if rmax < rmin:
                 raise ValidationError("The 'subgrid_boundaries' must be increasing.")
             rmin = rmax
-        if rmax > sim_rmax + fp_eps:
+        if np.float32(rmax) - np.float32(sim_rmax) > fp_eps:
             raise ValidationError("The last item in 'boundaries' is outside the simulation domain.")
         return val
 


### PR DESCRIPTION
A validator was failing on certain systems because of the following comparison:
`if rmax > sim_rmax + fp_eps:`

`rmax` is a numpy float and `sim_rmax` is a python float. `fp_eps` is a numpy `float32`.

When `rmax` and `sim_rmax` are both 64-bit `6.45`, the comparison is False, as it should be.
When they are both cast to 32-bit, it is False.
When `sim_rmax` is 32-bit `6.44999980926513671875` and `rmax` is still 64-bit `6.45`, the comparison is True.

I fixed it by rewriting the comparison in the form
`np.float32(rmax) - np.float32(sim_rmax) > fp_eps`.
This ensures that everything is done using float32 datatype, and that the left-hand side is close to zero for safer comparison with fp_eps.

There may be other places in the code where `fp_eps` is used in an unsafe manner.


Thanks @e-g-melo and @tomflexcompute for finding this and helping pin down the issue. @e-g-melo can you see if this fixes your issue?


EDIT:
Instead of system-dependent, this seems to depend only on the numpy version and handling of promotions, see https://numpy.org/devdocs/numpy_2_0_migration_guide.html#changes-to-numpy-data-type-promotion