### PR TITLE
fix[tests]: clear log capture at start of local mode solver test

### DIFF
--- a/tests/_test_data/_test_datasets_no_vtk.py
+++ b/tests/_test_data/_test_datasets_no_vtk.py
@@ -21,10 +21,10 @@ def hide_vtk(monkeypatch, request):
 
 
 @pytest.mark.usefixtures("hide_vtk")
-def test_triangular_dataset_no_vtk(tmp_path, log_capture):
-    _test_triangular_dataset(log_capture, tmp_path, "test_name", no_vtk=True)
+def test_triangular_dataset_no_vtk(tmp_path):
+    _test_triangular_dataset(tmp_path, "test_name", no_vtk=True)
 
 
 @pytest.mark.usefixtures("hide_vtk")
-def test_tetrahedral_dataset_no_vtk(tmp_path, log_capture):
-    _test_tetrahedral_dataset(log_capture, tmp_path, "test_name", no_vtk=True)
+def test_tetrahedral_dataset_no_vtk(tmp_path):
+    _test_tetrahedral_dataset(tmp_path, "test_name", no_vtk=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,27 +1,5 @@
 import numpy as np
 import pytest
-import tidy3d as td
-
-
-class CaptureHandler:
-    """Log handler used to store log records during tests."""
-
-    def __init__(self):
-        self.level = 0
-        self.records = []
-
-    def handle(self, level, level_name, message):
-        self.records.append((level, message))
-
-
-@pytest.fixture
-def log_capture(monkeypatch):
-    """Captures log records and makes them available as a list of tuples with
-    the log level and message.
-    """
-    log_capture = CaptureHandler()
-    monkeypatch.setitem(td.log.handlers, "pytest_capture", log_capture)
-    return log_capture.records
 
 
 @pytest.fixture

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -733,7 +733,7 @@ def test_autograd_numerical(structure_key, monitor_key):
     print(f"avg(diff(objectives)) = {diff_objectives_num:.4f}")
 
 
-def test_run_zero_grad(use_emulated_run, log_capture):
+def test_run_zero_grad(use_emulated_run):
     """Test warning if no adjoint sim is run (no adjoint sources).
 
     This checks the case where a simulation is still part of the computational
@@ -752,7 +752,7 @@ def test_run_zero_grad(use_emulated_run, log_capture):
         sim_data = run(sim, task_name="adjoint_test", verbose=False)
         return 0 * postprocess(sim_data)
 
-    with AssertLogLevel(log_capture, "WARNING", contains_str="no sources"):
+    with AssertLogLevel("WARNING", contains_str="no sources"):
         grad = ag.grad(objective)(params0)
 
 
@@ -813,7 +813,7 @@ def test_autograd_async(use_emulated_run, structure_key, monitor_key):
 
 
 @pytest.mark.parametrize("structure_key, monitor_key", args)
-def test_autograd_async_some_zero_grad(use_emulated_run, log_capture, structure_key, monitor_key):
+def test_autograd_async_some_zero_grad(use_emulated_run, structure_key, monitor_key):
     """Test objective where only some simulations in batch have adjoint sources."""
 
     fn_dict = get_functions(structure_key, monitor_key)
@@ -830,13 +830,12 @@ def test_autograd_async_some_zero_grad(use_emulated_run, log_capture, structure_
             values.append(postprocess(sim_data))
         return min(values)
 
-    # with AssertLogLevel(log_capture, "DEBUG", contains_str="no sources"):
     val, grad = ag.value_and_grad(objective)(params0)
 
     assert anp.all(grad != 0.0), "some gradients are 0"
 
 
-def test_autograd_async_all_zero_grad(use_emulated_run, log_capture):
+def test_autograd_async_all_zero_grad(use_emulated_run):
     """Test objective where no simulation in batch has adjoint sources."""
 
     fn_dict = get_functions(args[0][0], args[0][1])
@@ -853,7 +852,7 @@ def test_autograd_async_all_zero_grad(use_emulated_run, log_capture):
             values.append(postprocess(sim_data))
         return 0 * sum(values)
 
-    with AssertLogLevel(log_capture, "WARNING", contains_str="contains adjoint sources"):
+    with AssertLogLevel("WARNING", contains_str="contains adjoint sources"):
         grad = ag.grad(objective)(params0)
 
 
@@ -1030,7 +1029,7 @@ def test_sim_full_ops(structure_key):
     ag.grad(objective)(params0)
 
 
-def test_sim_traced_override_structures(log_capture):
+def test_sim_traced_override_structures():
     """Make sure that sims with traced override structures are handled properly."""
 
     def f(x):
@@ -1041,7 +1040,7 @@ def test_sim_traced_override_structures(log_capture):
         sim = SIM_FULL.updated_copy(override_structures=[override_structure], path="grid_spec")
         return sim.grid_spec.override_structures[0].geometry.size[2]
 
-    with AssertLogLevel(log_capture, "WARNING", contains_str="override structures"):
+    with AssertLogLevel("WARNING", contains_str="override structures"):
         ag.grad(f)(1.0)
 
 
@@ -1062,7 +1061,7 @@ def test_sim_fields_io(structure_key, tmp_path):
         assert np.all(data == autograd_field_map[path])
 
 
-def test_web_incompatible_inputs(log_capture, monkeypatch):
+def test_web_incompatible_inputs(monkeypatch):
     """Test what happens when bad inputs passed to web.run()."""
 
     def catch(*args, **kwargs):
@@ -1097,7 +1096,7 @@ def test_web_incompatible_inputs(log_capture, monkeypatch):
         td.web.run_async([SIM_BASE])
 
 
-def test_too_many_traced_structures(monkeypatch, log_capture, use_emulated_run):
+def test_too_many_traced_structures(monkeypatch, use_emulated_run):
     """More traced structures than allowed."""
 
     from tidy3d.web.api.autograd.autograd import MAX_NUM_TRACED_STRUCTURES
@@ -1568,7 +1567,7 @@ def compute_grad(postprocess_fn: typing.Callable, structure_key: str) -> typing.
     return ag.grad(objective)(params)
 
 
-def check_1_src_single(log_capture, structure_key):
+def check_1_src_single(structure_key):
     def postprocess(sim_data: td.SimulationData) -> float:
         """Postprocess function that should return 1 adjoint sources."""
         amps = get_amps(sim_data, "single").sel(mode_index=0, direction="+")
@@ -1577,7 +1576,7 @@ def check_1_src_single(log_capture, structure_key):
     return postprocess
 
 
-def check_2_src_single(log_capture, structure_key):
+def check_2_src_single(structure_key):
     def postprocess(sim_data: td.SimulationData) -> float:
         """Postprocess function that should return 2 different adjoint sources."""
         amps = get_amps(sim_data, "single").sel(mode_index=0)
@@ -1586,7 +1585,7 @@ def check_2_src_single(log_capture, structure_key):
     return postprocess
 
 
-def check_1_src_multi(log_capture, structure_key):
+def check_1_src_multi(structure_key):
     def postprocess(sim_data: td.SimulationData) -> float:
         """Postprocess function that should return 1 adjoint sources."""
         amps = get_amps(sim_data, "multi").sel(mode_index=0, direction="+", f=FREQ0)
@@ -1595,7 +1594,7 @@ def check_1_src_multi(log_capture, structure_key):
     return postprocess
 
 
-def check_2_src_multi(log_capture, structure_key):
+def check_2_src_multi(structure_key):
     def postprocess(sim_data: td.SimulationData) -> float:
         """Postprocess function that should return 2 different adjoint sources."""
         amps = get_amps(sim_data, "multi").sel(mode_index=0, f=FREQ1)
@@ -1604,7 +1603,7 @@ def check_2_src_multi(log_capture, structure_key):
     return postprocess
 
 
-def check_2_src_both(log_capture, structure_key):
+def check_2_src_both(structure_key):
     def postprocess(sim_data: td.SimulationData) -> float:
         """Postprocess function that should return 2 different adjoint sources."""
         amps_single = get_amps(sim_data, "single").sel(mode_index=0, direction="+")
@@ -1614,7 +1613,7 @@ def check_2_src_both(log_capture, structure_key):
     return postprocess
 
 
-def check_1_multisrc(log_capture, structure_key):
+def check_1_multisrc(structure_key):
     def postprocess(sim_data: td.SimulationData) -> float:
         """Postprocess function that should raise ValueError because diff sources, diff freqs."""
         amps_single = get_amps(sim_data, "single").sel(mode_index=0, direction="+")
@@ -1624,7 +1623,7 @@ def check_1_multisrc(log_capture, structure_key):
     return postprocess
 
 
-def check_2_multisrc(log_capture, structure_key):
+def check_2_multisrc(structure_key):
     def postprocess(sim_data: td.SimulationData) -> float:
         """Postprocess function that should raise ValueError because diff sources, diff freqs."""
         amps_single = get_amps(sim_data, "single").sel(mode_index=0, direction="+")
@@ -1634,7 +1633,7 @@ def check_2_multisrc(log_capture, structure_key):
     return postprocess
 
 
-def check_1_src_broadband(log_capture, structure_key):
+def check_1_src_broadband(structure_key):
     def postprocess(sim_data: td.SimulationData) -> float:
         """Postprocess function that should return 1 broadband adjoint sources with many freqs."""
         amps = get_amps(sim_data, "multi").sel(mode_index=0, direction="+")
@@ -1659,9 +1658,7 @@ checks = list(MULT_FREQ_TEST_CASES.items())
 
 @pytest.mark.parametrize("label, check_fn", checks)
 @pytest.mark.parametrize("structure_key", ("custom_med",))
-def test_multi_freq_edge_cases(
-    log_capture, use_emulated_run, structure_key, label, check_fn, monkeypatch
-):
+def test_multi_freq_edge_cases(use_emulated_run, structure_key, label, check_fn, monkeypatch):
     # test multi-frequency adjoint handling
 
     import tidy3d.components.data.sim_data as sd
@@ -1669,7 +1666,7 @@ def test_multi_freq_edge_cases(
     monkeypatch.setattr(sd, "RESIDUAL_CUTOFF_ADJOINT", 1)
     reload(td)
 
-    postprocess_fn = check_fn(structure_key=structure_key, log_capture=log_capture)
+    postprocess_fn = check_fn(structure_key=structure_key)
 
     def objective(params):
         structure_traced = make_structures(params)[structure_key]
@@ -1733,7 +1730,7 @@ def test_multi_frequency_equivalence(use_emulated_run, structure_key):
     assert not np.any(np.isclose(grad_multi, 0))
 
 
-def test_error_flux(use_emulated_run, log_capture):
+def test_error_flux(use_emulated_run):
     """Make sure proper error raised if differentiating w.r.t. FluxData."""
 
     def objective(params):
@@ -1751,7 +1748,7 @@ def test_error_flux(use_emulated_run, log_capture):
         g = ag.grad(objective)(params0)
 
 
-def test_extraneous_field(use_emulated_run, log_capture):
+def test_extraneous_field(use_emulated_run):
     """Make sure this doesnt fail."""
 
     def objective(params):
@@ -1776,7 +1773,7 @@ def test_extraneous_field(use_emulated_run, log_capture):
     g = ag.grad(objective)(params0)
 
 
-def test_background_medium(log_capture):
+def test_background_medium():
     geo = td.Box(size=(1, 1, 1), center=(0, 0, 0))
     med = td.Medium(permittivity=2.0)
 
@@ -1814,7 +1811,7 @@ def test_background_medium(log_capture):
     )
 
     # background permittivity (deprecated)
-    with AssertLogLevel(log_capture, "WARNING", contains_str="deprecated"):
+    with AssertLogLevel("WARNING", contains_str="deprecated"):
         s_warn = td.Structure(
             geometry=geo,
             medium=med,

--- a/tests/test_components/test_boundaries.py
+++ b/tests/test_components/test_boundaries.py
@@ -19,7 +19,7 @@ from tidy3d.components.source.field import PlaneWave
 from tidy3d.components.source.time import GaussianPulse
 from tidy3d.exceptions import DataError, SetupError
 
-from ..utils import assert_log_level
+from ..utils import AssertLogLevel
 
 
 def test_bloch_phase():
@@ -87,17 +87,17 @@ def test_boundary_validators():
 
 
 @pytest.mark.parametrize("boundary, log_level", [(PMCBoundary(), None), (Periodic(), "WARNING")])
-def test_boundary_validator_warnings(log_capture, boundary, log_level):
+def test_boundary_validator_warnings(boundary, log_level):
     """Test the validators in class `Boundary` which should show a warning but not an error"""
-    boundary = Boundary(plus=PECBoundary(), minus=boundary)
-    assert_log_level(log_capture, log_level)
+    with AssertLogLevel(log_level):
+        _ = Boundary(plus=PECBoundary(), minus=boundary)
 
 
 @pytest.mark.parametrize("boundary, log_level", [(PMCBoundary(), None), (Periodic(), "WARNING")])
-def test_boundary_validator_warnings_switched(log_capture, boundary, log_level):
+def test_boundary_validator_warnings_switched(boundary, log_level):
     """Test the validators in class `Boundary` which should show a warning but not an error"""
-    boundary = Boundary(minus=PECBoundary(), plus=boundary)
-    assert_log_level(log_capture, log_level)
+    with AssertLogLevel(log_level):
+        _ = Boundary(minus=PECBoundary(), plus=boundary)
 
 
 def test_boundary():

--- a/tests/test_components/test_custom.py
+++ b/tests/test_components/test_custom.py
@@ -24,7 +24,7 @@ from tidy3d.components.medium import (
     CustomSellmeier,
 )
 
-from ..utils import assert_log_level, cartesian_to_unstructured
+from ..utils import AssertLogLevel, cartesian_to_unstructured
 
 np.random.seed(4)
 
@@ -160,13 +160,13 @@ def test_io_hdf5(tmp_path):
     assert FIELD_SRC == FIELD_SRC2
 
 
-def test_io_json(tmp_path, log_capture):
+def test_io_json(tmp_path):
     """to json warns and then from json errors."""
     path = str(tmp_path / "custom_source.json")
-    FIELD_SRC.to_file(path)
-    assert_log_level(log_capture, "WARNING")
-    FIELD_SRC2 = FIELD_SRC.from_file(path)
-    assert_log_level(log_capture, "WARNING")
+    with AssertLogLevel("WARNING"):
+        FIELD_SRC.to_file(path)
+    with AssertLogLevel("WARNING"):
+        FIELD_SRC2 = FIELD_SRC.from_file(path)
     assert FIELD_SRC2.field_dataset is None
 
 
@@ -978,7 +978,7 @@ def test_custom_debye(unstructured):
 
 
 @pytest.mark.parametrize("unstructured", [True])
-def test_custom_anisotropic_medium(log_capture, unstructured):
+def test_custom_anisotropic_medium(unstructured):
     """Custom anisotropic medium."""
     seed = 43243
 
@@ -1008,8 +1008,8 @@ def test_custom_anisotropic_medium(log_capture, unstructured):
     verify_custom_medium_methods(mat, [])
     assert not mat.is_spatially_uniform
 
-    mat = CustomAnisotropicMedium(xx=mat_xx, yy=mat_yy, zz=mat_zz, subpixel=True)
-    assert_log_level(log_capture, "WARNING")
+    with AssertLogLevel("WARNING"):
+        mat = CustomAnisotropicMedium(xx=mat_xx, yy=mat_yy, zz=mat_zz, subpixel=True)
 
     ## interpolation method verification for "xx" component
     # 1) xx-component is using `interp_method = nearest`, and mat using `None`;
@@ -1127,7 +1127,7 @@ def test_io_dispersive(tmp_path, unstructured, z_custom):
     assert sim_load == sim
 
 
-def test_warn_planewave_intersection(log_capture):
+def test_warn_planewave_intersection():
     """Warn that if a nonuniform custom medium is intersecting PlaneWave source."""
     src = td.PlaneWave(
         source_time=td.GaussianPulse(freq0=3e14, fwidth=1e13),
@@ -1144,15 +1144,15 @@ def test_warn_planewave_intersection(log_capture):
         medium=mat,
     )
 
-    sim = td.Simulation(
-        size=(1, 1, 2),
-        structures=[box],
-        grid_spec=td.GridSpec.auto(wavelength=1),
-        sources=[src],
-        run_time=1e-12,
-        boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
-    )
-    assert_log_level(log_capture, None)
+    with AssertLogLevel(None):
+        sim = td.Simulation(
+            size=(1, 1, 2),
+            structures=[box],
+            grid_spec=td.GridSpec.auto(wavelength=1),
+            sources=[src],
+            run_time=1e-12,
+            boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
+        )
 
     # nonuniform custom medium
     permittivity = make_spatial_data(value=1, unstructured=False, seed=0, uniform=False)
@@ -1161,11 +1161,11 @@ def test_warn_planewave_intersection(log_capture):
         geometry=td.Box(size=(td.inf, td.inf, 1)),
         medium=mat,
     )
-    sim.updated_copy(structures=[box])
-    assert_log_level(log_capture, "WARNING")
+    with AssertLogLevel("WARNING"):
+        sim.updated_copy(structures=[box])
 
 
-def test_warn_diffraction_monitor_intersection(log_capture):
+def test_warn_diffraction_monitor_intersection():
     """Warn that if a nonuniform custom medium is intersecting Diffraction Monitor."""
     src = td.PointDipole(
         source_time=td.GaussianPulse(freq0=2.5e14, fwidth=1e13),
@@ -1188,16 +1188,16 @@ def test_warn_diffraction_monitor_intersection(log_capture):
         medium=mat,
     )
 
-    sim = td.Simulation(
-        size=(1, 1, 2),
-        structures=[box],
-        grid_spec=td.GridSpec.auto(wavelength=1),
-        monitors=[monitor],
-        sources=[src],
-        run_time=1e-12,
-        boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
-    )
-    assert_log_level(log_capture, None)
+    with AssertLogLevel(None):
+        sim = td.Simulation(
+            size=(1, 1, 2),
+            structures=[box],
+            grid_spec=td.GridSpec.auto(wavelength=1),
+            monitors=[monitor],
+            sources=[src],
+            run_time=1e-12,
+            boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
+        )
 
     # nonuniform custom medium
     permittivity = make_spatial_data(value=1, unstructured=False, seed=0, uniform=False)
@@ -1206,8 +1206,8 @@ def test_warn_diffraction_monitor_intersection(log_capture):
         geometry=td.Box(size=(td.inf, td.inf, 1)),
         medium=mat,
     )
-    sim.updated_copy(structures=[box])
-    assert_log_level(log_capture, "WARNING")
+    with AssertLogLevel("WARNING"):
+        sim.updated_copy(structures=[box])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_components/test_eme.py
+++ b/tests/test_components/test_eme.py
@@ -86,12 +86,12 @@ def make_eme_sim():
     return sim
 
 
-def test_sim_version_update(log_capture):
+def test_sim_version_update():
     sim = make_eme_sim()
     sim_dict = sim.dict()
     sim_dict["version"] = "ancient_version"
 
-    with AssertLogLevel(log_capture, "WARNING"):
+    with AssertLogLevel("WARNING"):
         sim_new = td.EMESimulation.parse_obj(sim_dict)
 
     assert sim_new.version == td.__version__
@@ -280,7 +280,7 @@ def test_eme_monitor():
     )
 
 
-def test_eme_simulation(log_capture):
+def test_eme_simulation():
     sim = make_eme_sim()
     _ = sim.plot(x=0, ax=AX)
     _ = sim.plot(y=0, ax=AX)
@@ -324,7 +324,7 @@ def test_eme_simulation(log_capture):
 
     # test warning for not providing wavelength in autogrid
     grid_spec = td.GridSpec.auto(min_steps_per_wvl=20)
-    with AssertLogLevel(log_capture, "INFO"):
+    with AssertLogLevel("INFO"):
         sim = sim.updated_copy(grid_spec=grid_spec)
     # multiple freqs are ok, but not for autogrid
     _ = sim.updated_copy(grid_spec=td.GridSpec.uniform(dl=0.2), freqs=[1e10] + list(sim.freqs))
@@ -373,7 +373,7 @@ def test_eme_simulation(log_capture):
     modulation_spec = MODULATION_SPEC.updated_copy(permittivity=ST)
     modulated = td.Medium(permittivity=2, modulation_spec=modulation_spec)
     struct = sim.structures[0].updated_copy(medium=modulated)
-    with AssertLogLevel(log_capture, "WARNING"):
+    with AssertLogLevel("WARNING"):
         _ = td.EMESimulation(
             size=sim.size,
             monitors=sim.monitors,
@@ -388,7 +388,7 @@ def test_eme_simulation(log_capture):
         permittivity=2, nonlinear_spec=td.NonlinearSpec(models=[td.KerrNonlinearity(n2=1)])
     )
     struct = sim.structures[0].updated_copy(medium=nonlinear)
-    with AssertLogLevel(log_capture, "WARNING"):
+    with AssertLogLevel("WARNING"):
         _ = td.EMESimulation(
             size=sim.size,
             monitors=sim.monitors,
@@ -442,7 +442,7 @@ def test_eme_simulation(log_capture):
     with pytest.raises(SetupError):
         sim_bad.validate_pre_upload()
     sim_bad = sim.updated_copy(size=(500, 500, 3), monitors=[])
-    with AssertLogLevel(log_capture, "WARNING", "slow-down"):
+    with AssertLogLevel("WARNING", "slow-down"):
         sim_bad.validate_pre_upload()
 
     sim_bad = sim.updated_copy(
@@ -464,7 +464,7 @@ def test_eme_simulation(log_capture):
         freqs=list(1e14 * np.linspace(1, 2, 5)),
         grid_spec=sim.grid_spec.updated_copy(wavelength=1),
     )
-    with AssertLogLevel(log_capture, "WARNING", contains_str="estimated storage"):
+    with AssertLogLevel("WARNING", contains_str="estimated storage"):
         sim_bad.validate_pre_upload()
     sim_bad = sim.updated_copy(
         size=(10, 10, 10),
@@ -550,7 +550,7 @@ def test_eme_simulation(log_capture):
         _ = sim.updated_copy(sweep_spec=td.EMEModeSweep(num_modes=list(np.arange(150, 200))))
 
     # don't warn in these two cases
-    with AssertLogLevel(log_capture, None):
+    with AssertLogLevel(None):
         sim_good = sim.updated_copy(
             constraint="passive",
             eme_grid_spec=td.EMEUniformGrid(num_cells=1, mode_spec=td.EMEModeSpec(num_modes=40)),
@@ -568,7 +568,7 @@ def test_eme_simulation(log_capture):
         constraint="passive",
         eme_grid_spec=td.EMEUniformGrid(num_cells=1, mode_spec=td.EMEModeSpec(num_modes=60)),
     )
-    with AssertLogLevel(log_capture, "WARNING", contains_str="constraint"):
+    with AssertLogLevel("WARNING", contains_str="constraint"):
         sim_bad.validate_pre_upload()
 
     _ = sim.port_modes_monitor

--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -866,7 +866,7 @@ def test_to_gds(geometry, tmp_path):
     assert len(cell.polygons) == 0
 
 
-def test_custom_surface_geometry(tmp_path, log_capture):
+def test_custom_surface_geometry(tmp_path):
     # create tetrahedron STL
     vertices = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
     faces = np.array([[1, 2, 3], [0, 3, 2], [0, 1, 3], [0, 2, 1]])
@@ -917,34 +917,34 @@ def test_custom_surface_geometry(tmp_path, log_capture):
     vertices = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
     faces = np.array([[2, 3, 1], [0, 2, 3], [0, 3, 1], [0, 1, 2]])
     tetrahedron = trimesh.Trimesh(vertices, faces)
-    with AssertLogLevel(log_capture, "WARNING", contains_str="face orientations"):
+    with AssertLogLevel("WARNING", contains_str="face orientations"):
         geom = td.TriangleMesh.from_trimesh(tetrahedron)
-    with AssertLogLevel(log_capture, None):
+    with AssertLogLevel(None):
         geom = geom.fix_winding()
 
     # test non-watertight mesh
     vertices = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
     faces = np.array([[0, 3, 2], [0, 1, 3], [0, 2, 1]])
     tetrahedron = trimesh.Trimesh(vertices, faces)
-    with AssertLogLevel(log_capture, "WARNING", contains_str="watertight"):
+    with AssertLogLevel("WARNING", contains_str="watertight"):
         geom = td.TriangleMesh.from_trimesh(tetrahedron)
-    with AssertLogLevel(log_capture, None):
+    with AssertLogLevel(None):
         geom = geom.fill_holes()
 
     # test inward normals
     vertices = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
     faces = np.array([[2, 1, 3], [0, 3, 2], [0, 1, 3], [0, 2, 1]])
     tetrahedron = trimesh.Trimesh(vertices, faces)
-    with AssertLogLevel(log_capture, "WARNING", contains_str="outward"):
+    with AssertLogLevel("WARNING", contains_str="outward"):
         geom = td.TriangleMesh.from_trimesh(tetrahedron)
-    with AssertLogLevel(log_capture, None):
+    with AssertLogLevel(None):
         geom = geom.fix_normals()
 
     # test zero area triangles
     vertices = np.array([[1, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
     faces = np.array([[1, 2, 3], [0, 3, 2], [0, 1, 3], [0, 2, 1]])
     tetrahedron = trimesh.Trimesh(vertices, faces)
-    with AssertLogLevel(log_capture, "WARNING"):
+    with AssertLogLevel("WARNING"):
         geom = td.TriangleMesh.from_trimesh(tetrahedron)
     assert all(np.array(geom.trimesh.area_faces) > AREA_SIZE_THRESHOLD)
 

--- a/tests/test_components/test_heat_charge.py
+++ b/tests/test_components/test_heat_charge.py
@@ -7,7 +7,7 @@ import tidy3d as td
 from matplotlib import pyplot as plt
 from tidy3d.exceptions import DataError
 
-from ..utils import assert_log_level
+from ..utils import AssertLogLevel
 
 
 def make_heat_charge_mediums():
@@ -401,19 +401,19 @@ def test_grid_spec():
         grid_spec.updated_copy(distance_interface=2, distance_bulk=1)
 
 
-def test_heat_charge_sources(log_capture):  # noqa: F811
+def test_heat_charge_sources():  # noqa: F811
     """ "Tests whether heat-charge sources can be created and associated warnings"""
     # this shouldn't issue warning
-    _ = td.HeatSource(structures=["solid_structure"], rate=100)
-    assert len(log_capture) == 0
+    with AssertLogLevel(None):
+        _ = td.HeatSource(structures=["solid_structure"], rate=100)
 
     # this should issue warning
-    _ = td.UniformHeatSource(structures=["solid_structure"], rate=100)
-    assert_log_level(log_capture, "WARNING")
+    with AssertLogLevel("WARNING"):
+        _ = td.UniformHeatSource(structures=["solid_structure"], rate=100)
 
     # this shouldn't issue warning
-    _ = td.HeatSource(structures=["solid_structure"], rate="100")
-    assert len(log_capture) == 1
+    with AssertLogLevel(None):
+        _ = td.HeatSource(structures=["solid_structure"], rate="100")
 
 
 def make_heat_charge_heat_sim():
@@ -483,7 +483,7 @@ def make_heat_charge_cond_sim():
     return cond_sim
 
 
-def test_heat_charge_sim(log_capture):  # noqa: F811
+def test_heat_charge_sim():  # noqa: F811
     """Creates heat-charge simulations and performs a bunch of
     checks for different conditions"""
     bc_temp, bc_flux, bc_conv, bc_volt, bc_current = make_heat_charge_bcs()
@@ -592,7 +592,7 @@ def test_heat_charge_sim(log_capture):  # noqa: F811
 
 
 @pytest.mark.parametrize("shift_amount, log_level", ((1, None), (2, "WARNING")))
-def test_heat_charge_sim_bounds(shift_amount, log_level, log_capture):  # noqa: F811
+def test_heat_charge_sim_bounds(shift_amount, log_level):  # noqa: F811
     """make sure bounds are working correctly"""
 
     # make sure all things are shifted to this central location
@@ -630,8 +630,8 @@ def test_heat_charge_sim_bounds(shift_amount, log_level, log_capture):  # noqa: 
             center = shift_amount * amp * sign
             if np.sum(center) < 1e-12:
                 continue
-            place_box(tuple(center))
-    assert_log_level(log_capture, log_level)
+            with AssertLogLevel(log_level):
+                place_box(tuple(center))
 
 
 @pytest.mark.parametrize(
@@ -642,23 +642,23 @@ def test_heat_charge_sim_bounds(shift_amount, log_level, log_capture):  # noqa: 
         ((0.1, 0.1, 1), "WARNING"),
     ],
 )
-def test_sim_structure_extent(log_capture, box_size, log_level):  # noqa: F811
+def test_sim_structure_extent(box_size, log_level):  # noqa: F811
     """Make sure we warn if structure extends exactly to simulation edges."""
 
     box = td.Structure(geometry=td.Box(size=box_size), medium=td.Medium(permittivity=2))
-    _ = td.HeatChargeSimulation(
-        size=(1, 1, 1),
-        structures=[box],
-        medium=td.Medium(electric_spec=td.ConductorSpec(conductivity=1)),
-        boundary_spec=[
-            td.HeatChargeBoundarySpec(
-                placement=td.SimulationBoundary(), condition=td.VoltageBC(voltage=1)
-            )
-        ],
-        grid_spec=td.UniformUnstructuredGrid(dl=0.1),
-    )
 
-    assert_log_level(log_capture, log_level)
+    with AssertLogLevel(log_level):
+        _ = td.HeatChargeSimulation(
+            size=(1, 1, 1),
+            structures=[box],
+            medium=td.Medium(electric_spec=td.ConductorSpec(conductivity=1)),
+            boundary_spec=[
+                td.HeatChargeBoundarySpec(
+                    placement=td.SimulationBoundary(), condition=td.VoltageBC(voltage=1)
+                )
+            ],
+            grid_spec=td.UniformUnstructuredGrid(dl=0.1),
+        )
 
 
 def make_heat_charge_sim_data():

--- a/tests/test_components/test_meshgenerate.py
+++ b/tests/test_components/test_meshgenerate.py
@@ -8,7 +8,7 @@ import tidy3d as td
 from tidy3d.components.grid.mesher import GradedMesher
 from tidy3d.constants import fp_eps
 
-from ..utils import AssertLogLevel, assert_log_level, cartesian_to_unstructured
+from ..utils import AssertLogLevel, cartesian_to_unstructured
 
 np.random.seed(4)
 
@@ -650,7 +650,7 @@ def test_mesher_timeout():
     _ = sim.grid
 
 
-def test_small_structure_size(log_capture):
+def test_small_structure_size():
     """Test that a warning is raised if a structure size is small during the auto meshing"""
     box_size = 0.03
     medium = td.Medium(permittivity=4)
@@ -660,40 +660,39 @@ def test_small_structure_size(log_capture):
         size=(0, 0, 0),
         polarization="Ex",
     )
-    sim = td.Simulation(
-        size=(10, 10, 10),
-        sources=[src],
-        structures=[box],
-        run_time=1e-12,
-        grid_spec=td.GridSpec.auto(wavelength=1),
-    )
 
     # Warning raised as structure is too thin
-    assert_log_level(log_capture, "WARNING")
+    with AssertLogLevel("WARNING"):
+        sim = td.Simulation(
+            size=(10, 10, 10),
+            sources=[src],
+            structures=[box],
+            run_time=1e-12,
+            grid_spec=td.GridSpec.auto(wavelength=1),
+        )
 
     # Warning not raised if structure is higher index
-    log_capture.clear()
     box2 = box.updated_copy(medium=td.Medium(permittivity=300))
-    sim.updated_copy(structures=[box2])
-    assert len(log_capture) == 0
+    with AssertLogLevel(None):
+        sim.updated_copy(structures=[box2])
 
     # Warning not raised if structure is covered by an override structure
-    log_capture.clear()
     override = td.MeshOverrideStructure(geometry=box.geometry, dl=(box_size, td.inf, td.inf))
-    sim3 = sim.updated_copy(grid_spec=sim.grid_spec.updated_copy(override_structures=[override]))
-    assert len(log_capture) == 0
+    with AssertLogLevel(None):
+        sim3 = sim.updated_copy(
+            grid_spec=sim.grid_spec.updated_copy(override_structures=[override])
+        )
     # Also check that the structure boundaries are in the grid
     ind_mid_cell = int(sim3.grid.num_cells[0] // 2)
     bounds = [-box_size / 2, box_size / 2]
     assert np.allclose(bounds, sim3.grid.boundaries.x[ind_mid_cell : ind_mid_cell + 2])
 
     # Test that the error coming from two thin slabs on top of each other is resolved
-    log_capture.clear()
     box3 = td.Structure(
         geometry=td.Box(center=(box_size, 0, 0), size=(box_size, td.inf, td.inf)), medium=medium
     )
-    sim.updated_copy(structures=[box3, box])
-    assert_log_level(log_capture, "WARNING")
+    with AssertLogLevel("WARNING"):
+        sim.updated_copy(structures=[box3, box])
 
 
 def test_shapely_strtree_warnings():
@@ -802,14 +801,14 @@ def test_anisotropic_material_meshing(unstructured, z):
         assert np.allclose(sim_iso.grid.sizes.to_list[dim], sim_full.grid.sizes.to_list[dim])
 
 
-def test_override_are_box(log_capture):
-    with AssertLogLevel(log_capture, None):
+def test_override_are_box():
+    with AssertLogLevel(None):
         override_fine = td.MeshOverrideStructure(
             geometry=td.Box(size=(1, 1, 1)),
             dl=[1, 2, 3],
         )
 
-    with AssertLogLevel(log_capture, "WARNING", contains_str="Box"):
+    with AssertLogLevel("WARNING", contains_str="Box"):
         override_not_box = td.MeshOverrideStructure(
             geometry=td.Sphere(center=(0, 0, 0), radius=0.5),
             dl=[1, 2, 3],

--- a/tests/test_components/test_monitor.py
+++ b/tests/test_components/test_monitor.py
@@ -6,7 +6,7 @@ import pytest
 import tidy3d as td
 from tidy3d.exceptions import SetupError, ValidationError
 
-from ..utils import assert_log_level
+from ..utils import AssertLogLevel
 
 
 def test_stop_start():
@@ -25,11 +25,13 @@ time_sampling_tests = [
 
 
 @pytest.mark.parametrize("interval, start, stop, log_desired", time_sampling_tests)
-def test_monitor_interval_warn(log_capture, interval, start, stop, log_desired):
+def test_monitor_interval_warn(interval, start, stop, log_desired):
     """Assert time monitor interval warning handled as expected."""
 
-    mnt = td.FluxTimeMonitor(size=(1, 1, 0), name="f", interval=interval, stop=stop, start=start)
-    assert_log_level(log_capture, log_desired)
+    with AssertLogLevel(log_desired):
+        mnt = td.FluxTimeMonitor(
+            size=(1, 1, 0), name="f", interval=interval, stop=stop, start=start
+        )
 
     # make sure it got set to either 1 (undefined) or the specified value
     mnt_interval = interval if interval else 1
@@ -246,17 +248,17 @@ def test_monitor_freqs_empty():
         )
 
 
-def test_monitor_colocate(log_capture):
+def test_monitor_colocate():
     """test default colocate value, and warning if not set"""
 
-    monitor = td.FieldMonitor(
-        size=(td.inf, td.inf, td.inf),
-        freqs=np.linspace(1e12, 200e12, 1001),
-        name="test",
-        interval_space=(1, 2, 3),
-    )
-    assert monitor.colocate is True
-    assert_log_level(log_capture, None)
+    with AssertLogLevel(None):
+        monitor = td.FieldMonitor(
+            size=(td.inf, td.inf, td.inf),
+            freqs=np.linspace(1e12, 200e12, 1001),
+            name="test",
+            interval_space=(1, 2, 3),
+        )
+        assert monitor.colocate is True
 
     monitor = td.FieldMonitor(
         size=(td.inf, td.inf, td.inf),
@@ -271,29 +273,29 @@ def test_monitor_colocate(log_capture):
 @pytest.mark.parametrize(
     "freqs, log_level", [(np.arange(1, 2500), "WARNING"), (np.arange(1, 100), None)]
 )
-def test_monitor_num_freqs(log_capture, freqs, log_level):
+def test_monitor_num_freqs(freqs, log_level):
     """test default colocate value, and warning if not set"""
 
-    td.FieldMonitor(
-        size=(td.inf, td.inf, td.inf),
-        freqs=freqs * 1e12,
-        name="test",
-        colocate=True,
-    )
-    assert_log_level(log_capture, log_level)
+    with AssertLogLevel(log_level):
+        td.FieldMonitor(
+            size=(td.inf, td.inf, td.inf),
+            freqs=freqs * 1e12,
+            name="test",
+            colocate=True,
+        )
 
 
 @pytest.mark.parametrize("num_modes, log_level", [(101, "WARNING"), (100, None)])
-def test_monitor_num_modes(log_capture, num_modes, log_level):
+def test_monitor_num_modes(num_modes, log_level):
     """test default colocate value, and warning if not set"""
 
-    td.ModeMonitor(
-        size=(td.inf, 0, td.inf),
-        freqs=np.linspace(1e14, 2e14, 100),
-        name="test",
-        mode_spec=td.ModeSpec(num_modes=num_modes),
-    )
-    assert_log_level(log_capture, log_level)
+    with AssertLogLevel(log_level):
+        td.ModeMonitor(
+            size=(td.inf, 0, td.inf),
+            freqs=np.linspace(1e14, 2e14, 100),
+            name="test",
+            mode_spec=td.ModeSpec(num_modes=num_modes),
+        )
 
 
 def test_mode_bend_radius():

--- a/tests/test_components/test_parameter_perturbation.py
+++ b/tests/test_components/test_parameter_perturbation.py
@@ -16,7 +16,7 @@ sp_arr_2d_u = cartesian_to_unstructured(sp_arr_2d)
 sp_arrs = [sp_arr, sp_arr_u, sp_arr_2d, sp_arr_2d_u]
 
 
-def test_heat_perturbation(log_capture):
+def test_heat_perturbation():
     perturb = td.LinearHeatPerturbation(
         coeff=0.01,
         temperature_ref=300,
@@ -89,7 +89,7 @@ def test_heat_perturbation(log_capture):
         assert perturb.perturbation_range == (1j, 3 + 1j)
 
         # warning if trying to provide temperature range by hands
-        with AssertLogLevel(log_capture, "WARNING"):
+        with AssertLogLevel("WARNING"):
             _ = td.CustomHeatPerturbation(
                 perturbation_values=perturb_data,
                 interp_method=interp_method,
@@ -97,7 +97,7 @@ def test_heat_perturbation(log_capture):
             )
 
         # no warning if temperature range is correct
-        with AssertLogLevel(log_capture, None):
+        with AssertLogLevel(None):
             _ = td.CustomHeatPerturbation(
                 perturbation_values=perturb_data,
                 interp_method=interp_method,
@@ -143,7 +143,7 @@ def test_heat_perturbation(log_capture):
     plt.close("all")
 
 
-def test_charge_perturbation(log_capture):
+def test_charge_perturbation():
     perturb = td.LinearChargePerturbation(
         electron_coeff=1e-21,
         electron_ref=0,
@@ -274,7 +274,7 @@ def test_charge_perturbation(log_capture):
         assert perturb.is_complex
 
         # warning if trying to provide density ranges by hands
-        with AssertLogLevel(log_capture, "WARNING"):
+        with AssertLogLevel("WARNING"):
             _ = td.CustomChargePerturbation(
                 perturbation_values=perturb_data,
                 interp_method=interp_method,
@@ -282,7 +282,7 @@ def test_charge_perturbation(log_capture):
                 hole_range=(1e16, 1e18),
             )
 
-        with AssertLogLevel(log_capture, "WARNING"):
+        with AssertLogLevel("WARNING"):
             _ = td.CustomChargePerturbation(
                 perturbation_values=perturb_data,
                 interp_method=interp_method,
@@ -291,7 +291,7 @@ def test_charge_perturbation(log_capture):
             )
 
         # no warning if density ranges are correct
-        with AssertLogLevel(log_capture, None):
+        with AssertLogLevel(None):
             _ = td.CustomChargePerturbation(
                 perturbation_values=perturb_data,
                 interp_method=interp_method,

--- a/tests/test_components/test_perturbation_medium.py
+++ b/tests/test_components/test_perturbation_medium.py
@@ -9,7 +9,7 @@ from ..utils import AssertLogLevel, cartesian_to_unstructured
 
 
 @pytest.mark.parametrize("unstructured", [False, True])
-def test_perturbation_medium(unstructured, log_capture):
+def test_perturbation_medium(unstructured):
     # fields to sample at
     coords = dict(x=[1, 2], y=[3, 4], z=[5, 6])
     temperature = td.SpatialDataArray(300 * np.ones((2, 2, 2)), coords=coords)
@@ -48,7 +48,7 @@ def test_perturbation_medium(unstructured, log_capture):
 
     # different ways of defining
 
-    with AssertLogLevel(log_capture, None):
+    with AssertLogLevel(None):
         pmed_direct = td.PerturbationMedium(permittivity=10, permittivity_perturbation=pp_real)
         pmed_perm = td.PerturbationMedium(
             permittivity=10, perturbation_spec=td.PermittivityPerturbation(delta_eps=pp_real)
@@ -58,13 +58,13 @@ def test_perturbation_medium(unstructured, log_capture):
             perturbation_spec=td.IndexPerturbation(delta_n=pp_real, freq=td.C_0),
         )
 
-    with AssertLogLevel(log_capture, "WARNING"):
+    with AssertLogLevel("WARNING"):
         pmed_direct = td.PerturbationMedium(permittivity=1.21, permittivity_perturbation=pp_real)
-    with AssertLogLevel(log_capture, "WARNING"):
+    with AssertLogLevel("WARNING"):
         pmed_perm = td.PerturbationMedium(
             permittivity=1.21, perturbation_spec=td.PermittivityPerturbation(delta_eps=pp_real)
         )
-    with AssertLogLevel(log_capture, "WARNING"):
+    with AssertLogLevel("WARNING"):
         pmed_index = td.PerturbationMedium(
             permittivity=1.21,
             perturbation_spec=td.IndexPerturbation(delta_n=pp_real, freq=td.C_0),
@@ -107,7 +107,7 @@ def test_perturbation_medium(unstructured, log_capture):
             _ = pmed.perturbed_copy(1.1 * temperature)
 
     # conductivity validators
-    with AssertLogLevel(log_capture, None):
+    with AssertLogLevel(None):
         pmed_direct = td.PerturbationMedium(
             conductivity=3, conductivity_perturbation=pp_real, subpixel=False
         )
@@ -117,13 +117,13 @@ def test_perturbation_medium(unstructured, log_capture):
             subpixel=False,
         )
 
-    with AssertLogLevel(log_capture, "WARNING"):
+    with AssertLogLevel("WARNING"):
         pmed_direct = td.PerturbationMedium(conductivity_perturbation=pp_real, subpixel=False)
-    with AssertLogLevel(log_capture, "WARNING"):
+    with AssertLogLevel("WARNING"):
         pmed_perm = td.PerturbationMedium(
             perturbation_spec=td.PermittivityPerturbation(delta_sigma=pp_real), subpixel=False
         )
-    with AssertLogLevel(log_capture, "WARNING"):
+    with AssertLogLevel("WARNING"):
         pmed_index = td.PerturbationMedium(
             permittivity=2,
             perturbation_spec=td.IndexPerturbation(delta_k=pp_real, freq=td.C_0),
@@ -153,7 +153,7 @@ def test_perturbation_medium(unstructured, log_capture):
         )
 
     # Dispersive
-    with AssertLogLevel(log_capture, None):
+    with AssertLogLevel(None):
         pmed_direct = td.PerturbationPoleResidue(
             eps_inf=10,
             poles=[(1j, 3), (2j, 4)],
@@ -179,7 +179,7 @@ def test_perturbation_medium(unstructured, log_capture):
             allow_gain=True,
         )
 
-    with AssertLogLevel(log_capture, "WARNING"):
+    with AssertLogLevel("WARNING"):
         pmed_direct = td.PerturbationPoleResidue(
             eps_inf=0.2,
             poles=[(1j, 3), (2j, 4)],
@@ -189,7 +189,7 @@ def test_perturbation_medium(unstructured, log_capture):
             allow_gain=True,
         )
 
-    with AssertLogLevel(log_capture, "WARNING"):
+    with AssertLogLevel("WARNING"):
         pmed_perm = td.PerturbationPoleResidue(
             eps_inf=0.2,
             poles=[(1j, 3), (2j, 4)],
@@ -198,7 +198,7 @@ def test_perturbation_medium(unstructured, log_capture):
             allow_gain=True,
         )
 
-    with AssertLogLevel(log_capture, "WARNING"):
+    with AssertLogLevel("WARNING"):
         pmed_index = td.PerturbationPoleResidue(
             eps_inf=0.05,
             poles=[(0, 0.0001)],

--- a/tests/test_data/test_datasets.py
+++ b/tests/test_data/test_datasets.py
@@ -11,7 +11,7 @@ np.random.seed(4)
 
 
 @pytest.mark.parametrize("ds_name", ["test123", None])
-def test_triangular_dataset(log_capture, tmp_path, ds_name, no_vtk=False):
+def test_triangular_dataset(tmp_path, ds_name, no_vtk=False):
     import tidy3d as td
     from tidy3d.exceptions import DataError, Tidy3dImportError
 
@@ -64,7 +64,7 @@ def test_triangular_dataset(log_capture, tmp_path, ds_name, no_vtk=False):
         coords=dict(cell_index=np.arange(2), vertex_index=np.arange(3)),
     )
 
-    with AssertLogLevel(log_capture, "WARNING"):
+    with AssertLogLevel("WARNING"):
         tri_grid_with_degenerates = td.TriangularGridDataset(
             normal_axis=2,
             normal_pos=-3,
@@ -76,21 +76,21 @@ def test_triangular_dataset(log_capture, tmp_path, ds_name, no_vtk=False):
     # removal of degenerate cells
 
     # only removing degenerate cells will result in unsude points in this case
-    with AssertLogLevel(log_capture, "WARNING"):
+    with AssertLogLevel("WARNING"):
         tri_grid_with_fixed = tri_grid_with_degenerates.clean(
             remove_degenerate_cells=True, remove_unused_points=False
         )
     assert np.all(tri_grid_with_fixed.cells.values == [[1, 2, 3]])
 
     # once we remove those, no warning should occur
-    with AssertLogLevel(log_capture, None):
+    with AssertLogLevel(None):
         tri_grid_with_fixed = tri_grid_with_fixed.clean(
             remove_degenerate_cells=False, remove_unused_points=True
         )
     assert np.all(tri_grid_with_fixed.cells.values == [[0, 1, 2]])
 
     # doing both at the same time
-    with AssertLogLevel(log_capture, None):
+    with AssertLogLevel(None):
         tri_grid_with_fixed = tri_grid_with_degenerates.clean()
     assert np.all(tri_grid_with_fixed.cells.values == [[0, 1, 2]])
 
@@ -302,7 +302,7 @@ def test_triangular_dataset(log_capture, tmp_path, ds_name, no_vtk=False):
 
 
 @pytest.mark.parametrize("ds_name", ["test123", None])
-def test_tetrahedral_dataset(log_capture, tmp_path, ds_name, no_vtk=False):
+def test_tetrahedral_dataset(tmp_path, ds_name, no_vtk=False):
     import tidy3d as td
     from tidy3d.exceptions import DataError, Tidy3dImportError
 
@@ -356,7 +356,7 @@ def test_tetrahedral_dataset(log_capture, tmp_path, ds_name, no_vtk=False):
         coords=dict(cell_index=np.arange(6), vertex_index=np.arange(4)),
     )
 
-    with AssertLogLevel(log_capture, "WARNING"):
+    with AssertLogLevel("WARNING"):
         tet_grid_with_degenerates = td.TetrahedralGridDataset(
             points=tet_grid_points,
             cells=tet_grid_cells_bad,
@@ -366,21 +366,21 @@ def test_tetrahedral_dataset(log_capture, tmp_path, ds_name, no_vtk=False):
     # removal of degenerate cells
 
     # only removing degenerate cells will result in unsude points in this case
-    with AssertLogLevel(log_capture, "WARNING"):
+    with AssertLogLevel("WARNING"):
         tet_grid_with_fixed = tet_grid_with_degenerates.clean(
             remove_degenerate_cells=True, remove_unused_points=False
         )
     assert np.all(tet_grid_with_fixed.cells.values == [[0, 2, 3, 7], [0, 4, 6, 7], [0, 4, 5, 7]])
 
     # once we remove those, no warning should occur
-    with AssertLogLevel(log_capture, None):
+    with AssertLogLevel(None):
         tet_grid_with_fixed = tet_grid_with_fixed.clean(
             remove_degenerate_cells=False, remove_unused_points=True
         )
     assert np.all(tet_grid_with_fixed.cells.values == [[0, 1, 2, 6], [0, 3, 5, 6], [0, 3, 4, 6]])
 
     # doing both at the same time
-    with AssertLogLevel(log_capture, None):
+    with AssertLogLevel(None):
         tet_grid_with_fixed = tet_grid_with_degenerates.clean()
     assert np.all(tet_grid_with_fixed.cells.values == [[0, 1, 2, 6], [0, 3, 5, 6], [0, 3, 4, 6]])
 

--- a/tests/test_data/test_monitor_data.py
+++ b/tests/test_data/test_monitor_data.py
@@ -18,7 +18,7 @@ from tidy3d.components.data.monitor_data import (
 )
 from tidy3d.exceptions import DataError
 
-from ..utils import assert_log_level
+from ..utils import AssertLogLevel
 from .test_data_arrays import (
     DIFFRACTION_MONITOR,
     DIRECTIVITY_MONITOR,
@@ -502,16 +502,16 @@ def test_data_array_attrs():
     assert data.flux.f.attrs, "data coordinates have no attrs"
 
 
-def test_data_array_json_warns(log_capture, tmp_path):
+def test_data_array_json_warns(tmp_path):
     data = make_flux_data()
-    data.to_file(str(tmp_path / "flux.json"))
-    assert_log_level(log_capture, "WARNING")
+    with AssertLogLevel("WARNING"):
+        data.to_file(str(tmp_path / "flux.json"))
 
 
-def test_data_array_hdf5_no_warnings(log_capture, tmp_path):
+def test_data_array_hdf5_no_warnings(tmp_path):
     data = make_flux_data()
-    data.to_file(str(tmp_path / "flux.hdf5"))
-    assert_log_level(log_capture, None)
+    with AssertLogLevel(None):
+        data.to_file(str(tmp_path / "flux.hdf5"))
 
 
 def test_diffraction_data_use_medium():

--- a/tests/test_package/test_log.py
+++ b/tests/test_package/test_log.py
@@ -9,7 +9,7 @@ import tidy3d as td
 from tidy3d.exceptions import Tidy3dError
 from tidy3d.log import DEFAULT_LEVEL, _get_level_int, set_logging_level
 
-from ..utils import AssertLogLevel, assert_log_level
+from ..utils import AssertLogLevel
 
 
 def test_log():
@@ -272,27 +272,21 @@ def test_log_suppression():
     td.config.log_suppression = True
 
 
-def test_assert_log_level(log_capture):
+def test_assert_log_level():
     """Test features of the assert_log_level"""
 
     # log was captured
-    with AssertLogLevel(log_capture, "WARNING", contains_str="ABC"):
+    with AssertLogLevel("WARNING", contains_str="ABC"):
         td.log.warning("ABC")
 
-    # string was not matched (manually clear because not sure any other way using context manager)
-    td.log.warning("ABC")
-    with pytest.raises(AssertionError):
-        assert_log_level(log_capture, "WARNING", contains_str="DEF")
-    log_capture.clear()
+    # Test when log message doesn't contain expected string
+    with pytest.raises(AssertionError), AssertLogLevel("WARNING", contains_str="DEF"):
+        td.log.warning("ABC")
 
-    # string was matched at the wrong level
-    td.log.info("ABC")
-    with pytest.raises(AssertionError):
-        assert_log_level(log_capture, "WARNING", contains_str="ABC")
-    log_capture.clear()
+    # Test when log message is at incorrect level
+    with pytest.raises(AssertionError), AssertLogLevel("WARNING", contains_str="ABC"):
+        td.log.info("ABC")  # Should fail since INFO < WARNING
 
-    # log exceeds expected level
-    td.log.warning("ABC")
-    with pytest.raises(AssertionError):
-        assert_log_level(log_capture, "INFO")
-    log_capture.clear()
+    # Test when log level is higher than expected
+    with pytest.raises(AssertionError), AssertLogLevel("INFO"):
+        td.log.warning("ABC")  # Should fail since WARNING > INFO

--- a/tests/test_package/test_material_library.py
+++ b/tests/test_package/test_material_library.py
@@ -12,19 +12,19 @@ from tidy3d.material_library.material_library import (
     material_library,
 )
 
-from ..utils import assert_log_level
+from ..utils import AssertLogLevel
 
 
-def test_warning_default_variant_switching(log_capture):
+def test_warning_default_variant_switching():
     """Issue warning for switching default medium variant."""
 
     # no warning for most materials with no default change
-    _ = td.material_library["cSi"].medium
-    assert_log_level(log_capture, None)
+    with AssertLogLevel(None):
+        _ = td.material_library["cSi"].medium
 
     # issue warning for SiO2
-    _ = td.material_library["SiO2"].medium
-    assert_log_level(log_capture, "WARNING")
+    with AssertLogLevel("WARNING"):
+        _ = td.material_library["SiO2"].medium
 
 
 def test_VariantItem():

--- a/tests/test_package/test_parametric_variants.py
+++ b/tests/test_package/test_parametric_variants.py
@@ -30,7 +30,7 @@ def test_graphene_defaults():
 
 
 @pytest.mark.parametrize("rng_seed", np.arange(0, 15))
-def test_graphene(rng_seed, log_capture):
+def test_graphene(rng_seed):
     """test graphene for range of physical parameters"""
     rng = default_rng(rng_seed)
     gamma_min = GRAPHENE_GAMMA_MIN
@@ -63,5 +63,5 @@ def test_graphene(rng_seed, log_capture):
     temp = 300
     mu_c = 0.55
 
-    with AssertLogLevel(log_capture, None):
+    with AssertLogLevel(None):
         _ = Graphene(gamma=gamma, mu_c=mu_c, temp=temp).medium

--- a/tests/test_plugins/test_invdes.py
+++ b/tests/test_plugins/test_invdes.py
@@ -310,14 +310,12 @@ def test_default_params(use_emulated_run):  # noqa: F811
     optimizer.run(post_process_fn=post_process_fn)
 
 
-def test_warn_zero_grad(log_capture, use_emulated_run):  # noqa: F811
+def test_warn_zero_grad(use_emulated_run):  # noqa: F811
     """Test default paramns running the optimization defined in the ``InverseDesign`` object."""
 
     optimizer = make_optimizer()
-    with AssertLogLevel(
-        log_capture, "WARNING", contains_str="All elements of the gradient are almost zero"
-    ):
-        _ = optimizer.run(post_process_fn=post_process_fn_untraced)
+    with AssertLogLevel("WARNING", contains_str="All elements of the gradient are almost zero"):
+        optimizer.run(post_process_fn=post_process_fn_untraced)
 
 
 def make_result_multi(use_emulated_run):  # noqa: F811
@@ -437,7 +435,7 @@ def test_result_empty():
         result_empty.get_last("params")
 
 
-def test_invdes_io(tmp_path, log_capture, use_emulated_run):  # noqa: F811
+def test_invdes_io(tmp_path, use_emulated_run):  # noqa: F811
     """Test saving a loading ``invdes`` components to file."""
 
     result = make_result(use_emulated_run)
@@ -485,21 +483,21 @@ def test_objective_utilities(use_emulated_run):  # noqa: F811
         utils.get_amps(sim_data, MNT_NAME1)
 
 
-def test_pixel_size_warn_validator(log_capture):
+def test_pixel_size_warn_validator():
     """test that pixel size validator warning is raised if too large."""
 
-    with AssertLogLevel(log_capture, None):
+    with AssertLogLevel(None):
         invdes = make_invdes()
 
     wvl_mat_min = invdes.simulation.wvl_mat_min
     region_too_coarse = invdes.design_region.updated_copy(pixel_size=wvl_mat_min)
-    with AssertLogLevel(log_capture, "WARNING", contains_str="pixel_size"):
+    with AssertLogLevel("WARNING", contains_str="pixel_size"):
         invdes = invdes.updated_copy(design_region=region_too_coarse)
 
-    with AssertLogLevel(log_capture, None):
+    with AssertLogLevel(None):
         invdes_multi = make_invdes_multi()
 
-    with AssertLogLevel(log_capture, "WARNING", contains_str="pixel_size"):
+    with AssertLogLevel("WARNING", contains_str="pixel_size"):
         invdes_multi = invdes_multi.updated_copy(design_region=region_too_coarse)
 
 
@@ -627,7 +625,7 @@ def test_validate_invdes_metric():
         invdes.updated_copy(metric=metric)
 
 
-def test_pixel_size_warn_validator_no_sources(log_capture):
+def test_pixel_size_warn_validator_no_sources():
     """Test that pixel size validator handles simulations without sources."""
 
     sourceless_sim = simulation.updated_copy(sources=[])
@@ -635,7 +633,7 @@ def test_pixel_size_warn_validator_no_sources(log_capture):
     invdes = make_invdes()
     invdes = invdes.updated_copy(simulation=sourceless_sim)
 
-    with AssertLogLevel(log_capture, "WARNING", contains_str="Cannot validate pixel size"):
+    with AssertLogLevel("WARNING", contains_str="Cannot validate pixel size"):
         region_coarse = invdes.design_region.updated_copy(pixel_size=1.0)
         invdes = invdes.updated_copy(design_region=region_coarse)
 
@@ -643,5 +641,5 @@ def test_pixel_size_warn_validator_no_sources(log_capture):
     sourceless_sims = [sourceless_sim for _ in invdes_multi.simulations]
     invdes_multi = invdes_multi.updated_copy(simulations=sourceless_sims)
 
-    with AssertLogLevel(log_capture, "WARNING", contains_str="Cannot validate pixel size"):
+    with AssertLogLevel("WARNING", contains_str="Cannot validate pixel size"):
         invdes_multi = invdes_multi.updated_copy(design_region=region_coarse)

--- a/tests/test_plugins/test_polyslab.py
+++ b/tests/test_plugins/test_polyslab.py
@@ -3,7 +3,7 @@ import numpy as np
 import tidy3d as td
 from tidy3d.plugins.polyslab import ComplexPolySlab
 
-from ..utils import assert_log_level
+from ..utils import AssertLogLevel
 
 
 def test_divide_simple_events():
@@ -29,7 +29,7 @@ def test_divide_simple_events():
                 _ = s.geometry_group
 
 
-def test_many_sub_polyslabs(log_capture):
+def test_many_sub_polyslabs():
     """warn when too many subpolyslabs are generated."""
 
     # generate vertices that can generate at least this number
@@ -46,11 +46,12 @@ def test_many_sub_polyslabs(log_capture):
         sidewall_angle=np.pi / 4,
         reference_plane="bottom",
     )
-    _ = td.Structure(
-        geometry=s.geometry_group,
-        medium=td.Medium(permittivity=2),
-    )
-    assert_log_level(log_capture, "WARNING")
+
+    with AssertLogLevel("WARNING"):
+        _ = td.Structure(
+            geometry=s.geometry_group,
+            medium=td.Medium(permittivity=2),
+        )
 
 
 def test_divide_simulation():

--- a/tests/test_plugins/test_resonance_finder.py
+++ b/tests/test_plugins/test_resonance_finder.py
@@ -27,7 +27,7 @@ def check_resonances(freqs, decays, amplitudes, phases, resonances):
     decays = decays[inds]
     amplitudes = amplitudes[inds]
     phases = phases[inds]
-    assert len(freqs) == resonances.dims["freq"]
+    assert len(freqs) == resonances.sizes["freq"]
 
     complex_amplitudes = amplitudes * np.exp(1j * phases)
 


### PR DESCRIPTION
This is a band-aid fix for the test coupling. Works for this specific case, but we'll need to do more robust warning capturing if we want to avoid dealing with this in the future.