### PR TITLE
Fix file contention issues in parallel tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -3,7 +3,7 @@ name: "tidy3d-frontend-tests"
 on:
   workflow_dispatch:
   push:
-    branches: [ develop, latest ]
+    branches: [ develop, latest, 'pre/*' ]
   pull_request:
     branches:
       - latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,7 +265,7 @@ ignore = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--doctest-modules -n auto"
+addopts = "--doctest-modules -n auto --dist worksteal"
 env = ["MPLBACKEND=Agg", "OMP_NUM_THREADS=1"]
 doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"
 norecursedirs = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,25 @@
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+import tidy3d as td
+from tidy3d.log import DEFAULT_LEVEL, set_logging_console, set_logging_level
 
 
 @pytest.fixture
 def rng():
     seed = 36523525
     return np.random.default_rng(seed)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def close_matplotlib():
+    plt.close()
+
+
+@pytest.fixture(autouse=True, scope="module")
+def reset_logger():
+    """Reset logger state at the beginning of each module."""
+    if "console" in td.log.handlers:
+        del td.log.handlers["console"]
+    set_logging_console()
+    set_logging_level(DEFAULT_LEVEL)

--- a/tests/test_package/test_config.py
+++ b/tests/test_package/test_config.py
@@ -12,7 +12,7 @@ def test_logging_level():
     # default level
     assert td.log.handlers["console"].level == _level_value[DEFAULT_LEVEL]
 
-    # check etting all levels
+    # check setting all levels
     for key, val in _level_value.items():
         td.config.logging_level = key
         assert td.log.handlers["console"].level == val

--- a/tests/test_plugins/autograd/conftest.py
+++ b/tests/test_plugins/autograd/conftest.py
@@ -1,8 +1,0 @@
-import pytest
-from numpy.random import Generator, default_rng
-
-
-@pytest.fixture(scope="module")
-def rng() -> Generator:
-    seed = 98276534394
-    return default_rng(seed)

--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -408,7 +408,7 @@ def test_mode_solver_simple(mock_remote_api, local):
 
 
 @responses.activate
-def test_mode_solver_remote_after_local(mock_remote_api):
+def test_mode_solver_remote_after_local(mock_remote_api, tmp_path):
     """Test that running a remote solver after a local one modifies the stored data. This is to
     catch a bug if ``_cached_properties["data"]`` is inadvertently used."""
 
@@ -436,7 +436,9 @@ def test_mode_solver_remote_after_local(mock_remote_api):
         direction="-",
     )
     data_local = ms.data
-    data_remote = msweb.run(ms)
+
+    data_remote = msweb.run(ms, results_file=tmp_path / "ms_remote.hdf5")
+
     assert np.all(data_local.n_eff != data_remote.n_eff)
 
 
@@ -482,7 +484,9 @@ def test_mode_solver_custom_medium(mock_remote_api, local, tmp_path):
             freqs=[freq0],
             direction="+",
         )
-        modes = ms.solve() if local else msweb.run(ms)
+        modes = (
+            ms.solve() if local else msweb.run(ms, results_file=tmp_path / "ms_custom_medium.hdf5")
+        )
         n_eff.append(modes.n_eff.values)
 
         if local:
@@ -796,7 +800,7 @@ def test_mode_solver_2D():
 
 @pytest.mark.parametrize("local", [True, False])
 @responses.activate
-def test_group_index(mock_remote_api, local):
+def test_group_index(mock_remote_api, local, tmp_path):
     """Test group index and dispersion calculation"""
 
     simulation = td.Simulation(
@@ -832,7 +836,9 @@ def test_group_index(mock_remote_api, local):
         freqs=freqs,
         direction="-",
     )
-    modes = ms.solve() if local else msweb.run(ms)
+
+    modes = ms.solve() if local else msweb.run(ms, results_file=tmp_path / "ms_remote.hdf5")
+
     if local:
         with AssertLogLevel("WARNING", contains_str="ModeSpec") as ctx:
             assert modes.n_group is None


### PR DESCRIPTION
This is a follow-up to https://github.com/flexcompute/tidy3d/pull/2165

Some test were sporadically failing due to I/O contention, so this fixes that. The PR also:
 - Introduces a `close_matplotlib` fixture that closes all matplotlib figures after testing a module so that these don't hang around for the whole test suite. Gets rid of a few warnings and reduces overall memory consumption.
 - Introduces a `reset_logger` that reset the logger for each test module, since most modules modify logger state.
 - Changes `pytest-xdist` distribution algorithm to "worksteal", which brings the time for the whole test suite further down from 160s to 50s (so ~8x improvement in total since https://github.com/flexcompute/tidy3d/pull/2165). This one should also be significant for CI. Let's see.
 - Removes the duplicate `rng` fixture in the autograd plugin.

This also includes the change to the test workflow we discussed @daquintero 