### PR TITLE
Reduce complex tolerance in mode solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `ModeMonitor` and `ModeSolverMonitor` now use the default `td.ModeSpec()` with `num_modes=1` when `mode_spec` is not provided.
 - Update sidewall angle validator to clarify angle should be specified in radians.
+- Reduced the complex tolerance in the mode solver below which permittivity is considered lossless, in order to correctly compute very low-loss modes.
 
 ### Fixed
 - NumPy 2.1 compatibility issue where `numpy.float64` values passed to xarray interpolation would raise TypeError.

--- a/tidy3d/plugins/mode/solver.py
+++ b/tidy3d/plugins/mode/solver.py
@@ -15,7 +15,7 @@ from .derivatives import create_s_matrices as s_mats
 from .transforms import angled_transform, radial_transform
 
 # Consider vec to be complex if norm(vec.imag)/norm(vec) > TOL_COMPLEX
-TOL_COMPLEX = fp_eps
+TOL_COMPLEX = 1e-10
 # Tolerance for eigs
 TOL_EIGS = fp_eps
 # Tolerance for deciding on the matrix to be diagonal or tensorial


### PR DESCRIPTION
Currently, for a waveguide with conductivity than about 1e-8, our mode solver returns `k_eff=0`. This is due to the complex tolerance set to `fp_eps` regardless of requested precision.

I propose we reduce the complex tolerance to 1e-10 for both precisions. This is what I get then:

![image](https://github.com/user-attachments/assets/ee135b20-fcaa-4c5c-8c30-5c2c43a45081)

Alternative is to set it based on precision. However, first of all this requires some refactor as it is currently a unique constant, and the `ModeSpec.precision` will need to be passed around. Second, as shown above, keeping it lower than `fp_eps` even for single precision makes even single-precision simulations accurate for some of the scanned range.