### PR TITLE
Allow MeshOverrideStructure to unshadow structures in overlapping region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `VisualizationSpec` that allows `Medium` instances to specify color and transparency plotting attributes that override default ones.
 - `reduce_simulation` argument added to all web functions to allow automatically reducing structures only to the simulation domain, including truncating data in custom media, thus reducing the simulation upload size. Currently only implemented for mode solver simulation types.
+- Support for quasi-uniform grid specifications via `QuasiUniformGrid` that subclasses from `GridSpec1d`. The grids are almost uniform, but can adjust locally to the edge of structure bounding boxes, and snapping points.
+- New field `min_steps_per_sim_size` in `AutoGrid` that sets minimal number of grid steps per longest edge length of simulation domain.
+- New field `shadow` in `MeshOverrideStructure` that sets grid size in overlapping region according to structure list or minimal grid size.
 
 ### Changed
 - `ModeMonitor` and `ModeSolverMonitor` now use the default `td.ModeSpec()` with `num_modes=1` when `mode_spec` is not provided.
@@ -17,8 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - NumPy 2.1 compatibility issue where `numpy.float64` values passed to xarray interpolation would raise TypeError.
-- Support for quasi-uniform grid specifications via `QuasiUniformGrid` that subclasses from `GridSpec1d`. The grids are almost uniform, but can adjust locally to the edge of structure bounding boxes, and snapping points.
-- New field `min_steps_per_sim_size` in `AutoGrid` that sets minimal number of grid steps per longest edge length of simulation domain.
 - Validation error in inverse design plugin when simulation has no sources by adding a source existence check before validating pixel size.
 - System-dependent floating-point precision issue in EMEGrid validation.
 - Fixed magnitude of gradient computation in `CustomMedium` by accounting properly for full volume element when permittivity data is defined over less dimensions than the medium.

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -665,11 +665,19 @@ class MeshOverrideStructure(AbstractStructure):
 
     enforce: bool = pydantic.Field(
         False,
-        title="Enforce grid size",
+        title="Enforce Grid Size",
         description="If ``True``, enforce the grid size setup inside the structure "
         "even if the structure is inside a structure of smaller grid size. In the intersection "
         "region of multiple structures of ``enforce=True``, grid size is decided by "
         "the last added structure of ``enforce=True``.",
+    )
+
+    shadow: bool = pydantic.Field(
+        True,
+        title="Grid Size Choice In Structure Overlapping Region",
+        description="In structure intersection region, grid size is decided by the latter added "
+        "structure in the structure list when ``shadow=True``; or the structure of smaller grid size "
+        "when ``shadow=False``.",
     )
 
     @pydantic.validator("geometry")
@@ -682,6 +690,13 @@ class MeshOverrideStructure(AbstractStructure):
                     f"Given type of '{type(val)}, using '{type(val)}.bounding_box' instead."
                 )
                 return val.bounding_box
+        return val
+
+    @pydantic.validator("shadow")
+    def _unshadowed_cannot_be_enforced(cls, val, values):
+        """Unshadowed structure cannot be enforced."""
+        if not val and values["enforce"]:
+            raise SetupError("A structure cannot be simultaneously enforced and unshadowed.")
         return val
 
 


### PR DESCRIPTION
Related to @lucas-flexcompute 's comment on https://github.com/flexcompute/tidy3d/pull/2113

When we automatically add mesh override structure that has the same geometry as regular structure, we don't want it to shadow physical structures if the physical structure sets a smaller grid size. 

With `shadow=False`, we drop the logic for checking if the override structure is covered or covering other structures.