### PR TITLE
feature[design]: allow design plugin to interface with pytorch via Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mobility models for `SemiconductorMedium`: `ConstantMobilityModel`, `CaugheyThomasMobility`
 - Bandgap narrowing models for `SemiconductorMedium`: `SlotboomBandGapNarrowing`
 - Generation-recombination models for `SemiconductorMedium`: `ShockleyReedHallRecombination`, `RadiativeRecombination`, `AugerRecombination`
+- Accessors and length functions implemented for `Result` class in design plugin.
 
 ### Changed
 - `ModeMonitor` and `ModeSolverMonitor` now use the default `td.ModeSpec()` with `num_modes=1` when `mode_spec` is not provided.
@@ -34,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validation error in inverse design plugin when simulation has no sources by adding a source existence check before validating pixel size.
 - System-dependent floating-point precision issue in EMEGrid validation.
 - Fixed magnitude of gradient computation in `CustomMedium` by accounting properly for full volume element when permittivity data is defined over less dimensions than the medium.
+- Fixed key ordering in design plugin when returning `Result` from an optimization method run.
 
 ## [2.8.0rc1] - 2024-12-17
 

--- a/tidy3d/plugins/design/design.py
+++ b/tidy3d/plugins/design/design.py
@@ -124,7 +124,7 @@ class DesignSpace(Tidy3dBaseModel):
         fn_args_coords_T = list(map(list, zip(*fn_args_coords)))
 
         return Result(
-            dims=self.dims,
+            dims=tuple(fn_args[0].keys()),
             values=fn_values,
             coords=fn_args_coords_T,
             fn_source=fn_source,

--- a/tidy3d/plugins/design/result.py
+++ b/tidy3d/plugins/design/result.py
@@ -427,3 +427,16 @@ class Result(Tidy3dBaseModel):
             return new_result
 
         return self.updated_copy(values=new_values, coords=new_coords)
+
+    def __len__(self):
+        """Implement len function to return the number of items in the result."""
+
+        return len(self.coords)
+
+    def __getitem__(self, data_index):
+        """Implement the accessor function to index into the coordinates and values of the result."""
+
+        features = self.coords[data_index]
+        labels = self.values[data_index]
+
+        return np.array(features), np.array(labels)


### PR DESCRIPTION
This PR fixes a small bug in the design plugin wherein the optimization method returns the dimensions in a different order and so labeling with the `self.dims` parameter can end up being incorrect.

It also implements accessor and length functions for the Result class so that it can be used directly as a Dataset in PyTorch. This also may be useful generally.

Marking this as a draft for now to discuss if we want to make these changes to the plugin. The changes are currently needed for the surrogate notebooks draft PR. (https://github.com/flexcompute/tidy3d-notebooks/pull/228)