### PR TITLE
fix[autograd]: ensure consistent task name mapping for batch autograd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Gradient inaccuracy when a multi-frequency monitor is used but a single frequency is selected.
 - Revert single cell center approximation for custom medium gradient.
+- Potential task name mismatches between forward and adjoint simulations in batch tasks.
 
 ## [2.7.7] - 2024-11-15
 

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -755,7 +755,7 @@ def test_autograd_async(use_emulated_run, structure_key, monitor_key):
     make_sim = fn_dict["sim"]
     postprocess = fn_dict["postprocess"]
 
-    task_names = {"1", "2", "3", "4"}
+    task_names = {"test_a", "adjoint", "task1", "_test"}
 
     def objective(*args):
         sims = {task_name: make_sim(*args) for task_name in task_names}

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -695,7 +695,7 @@ def _run_async_bwd(
             return sim_fields_vjp_dict
 
         task_names_adj = list(sims_to_run.keys())
-        task_names_fwd = [name.rstrip("_adjoint") for name in task_names_adj]
+        task_names_fwd = [name.removesuffix("_adjoint") for name in task_names_adj]
 
         if local_gradient:
             # run adjoint simulation


### PR DESCRIPTION
https://github.com/flexcompute/tidy3d/pull/2061 introduced a bug that causes a mismatch between forward and adjoint simulation task names in `run_async` due to incorrect use of [rstrip](https://docs.python.org/3/library/stdtypes.html#str.rstrip). So whenever the forward task name ends with any character in `_adjoint`, `run_async` would break during autodiff. This PR fixes that and updates the autograd `run_async` test to check for this.