### PR TITLE
Add adaptive scientific notation for frequency range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for quasi-uniform grid specifications via `QuasiUniformGrid` that subclasses from `GridSpec1d`. The grids are almost uniform, but can adjust locally to the edge of structure bounding boxes, and snapping points.
 - New field `min_steps_per_sim_size` in `AutoGrid` that sets minimal number of grid steps per longest edge length of simulation domain.
 - New field `shadow` in `MeshOverrideStructure` that sets grid size in overlapping region according to structure list or minimal grid size.
+- Scientific notation for frequency range warnings.
+
 
 ### Changed
 - `ModeMonitor` and `ModeSolverMonitor` now use the default `td.ModeSpec()` with `num_modes=1` when `mode_spec` is not provided.

--- a/tests/test_components/test_base.py
+++ b/tests/test_components/test_base.py
@@ -232,3 +232,28 @@ def test_attrs(tmp_path):
     obj.attrs["not_serializable"] = type
     with pytest.raises(TypeError):
         obj.json()
+
+
+@pytest.mark.parametrize(
+    "min_val, max_val, min_digits, expected",
+    [
+        (1234567, 1234577, 4, ("1.23457e6", "1.23458e6")),
+        (1234567, 1234577, 6, ("1.234567e6", "1.234577e6")),
+        (1.23e-3, 1.28e-3, 4, ("1.2300e-3", "1.2800e-3")),
+        (123456789012345, 123456789012346, 4, ("1.23456789012345e14", "1.23456789012346e14")),
+        (123656789012345, 123756789012346, 4, ("1.2366e14", "1.2376e14")),
+        (123, 123, 4, ("1.2300e2", "1.2300e2")),
+    ],
+    ids=[
+        "default_min_digits",
+        "increased_min_digits",
+        "small_numbers",
+        "large_numbers_precise",
+        "large_numbers_rounded",
+        "identical_numbers",
+    ],
+)
+def test_scientific_notation(min_val, max_val, min_digits, expected):
+    """Test the _scientific_notation method with various inputs."""
+    result = Tidy3dBaseModel._scientific_notation(min_val, max_val, min_digits=min_digits)
+    assert result == expected

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -2833,6 +2833,8 @@ class Simulation(AbstractYeeGridSimulation):
 
                     # make sure medium frequency range includes all monitor frequencies
                     fmin_med, fmax_med = medium.frequency_range
+                    sci_fmin_med, sci_fmax_med = cls._scientific_notation(fmin_med, fmax_med)
+
                     if fmin_mon < fmin_med or fmax_mon > fmax_med:
                         if medium_index == 0:
                             medium_str = "The simulation background medium"
@@ -2849,7 +2851,7 @@ class Simulation(AbstractYeeGridSimulation):
                             ]
 
                         consolidated_logger.warning(
-                            f"{medium_str} has a frequency range: ({fmin_med:2e}, {fmax_med:2e}) "
+                            f"{medium_str} has a frequency range: ({sci_fmin_med}, {sci_fmax_med}) "
                             "(Hz) that does not fully cover the frequencies contained in "
                             f"monitors[{monitor_index}]. "
                             "This can cause inaccuracies in the recorded results.",
@@ -2875,6 +2877,7 @@ class Simulation(AbstractYeeGridSimulation):
 
         freq_min = min((freq_range[0] for freq_range in source_ranges), default=0.0)
         freq_max = max((freq_range[1] for freq_range in source_ranges), default=0.0)
+        sci_fmin, sci_fmax = cls._scientific_notation(freq_min, freq_max)
 
         with log as consolidated_logger:
             for monitor_index, monitor in enumerate(val):
@@ -2885,7 +2888,7 @@ class Simulation(AbstractYeeGridSimulation):
                 if freqs.min() < freq_min or freqs.max() > freq_max:
                     consolidated_logger.warning(
                         f"monitors[{monitor_index}] contains frequencies "
-                        f"outside of the simulation frequency range ({freq_min:2e}, {freq_max:2e})"
+                        f"outside of the simulation frequency range ({sci_fmin}, {sci_fmax})"
                         "(Hz) as defined by the sources.",
                         custom_loc=["monitors", monitor_index, "freqs"],
                     )


### PR DESCRIPTION
As discussed with @tomflexcompute we want to include as many significant digits as possible, provided the two numbers (frequency range: fmin_med and fmax_med) remain identical up to that point.
Once a differing digit is encountered, the output rounds off subsequent digits. 
Also, the function returns the min and max values with same exponent.


Below are few test examples:
inputs are fmin_med and fmax_med


`Input: 1234567.56, 1234577.34
Output: 1.23457e6, 1.23458e6

Input: 1234567.56, 211234577.34
Output: 1e6, 211e6

Input: 1234567, 1934577
Output: 1e6, 2e6

Input: 1234567, 1284577
Output: 1.2e6, 1.3e6

Input: 123, 128
Output: 1.2e2, 1.3e2

Input: 0.00123, 0.00128
Output: 1.2e-3, 1.3e-3

Input: 0, 10
Output: 0e+00, 1e+01

Input: 123456789012345, 123456789012346
Output: 1.23456789012345e14, 1.23456789012346e14`