### PR TITLE
fix bug in the resistor and coax resistor variants of lumped elements

### DIFF
--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -98,9 +98,12 @@ def test_plot_sim_eps(tmp_path):
 
 @pytest.mark.parametrize("port_refinement", [False, True])
 def test_make_component_modeler(tmp_path, port_refinement):
-    _ = make_component_modeler(
+    modeler = make_component_modeler(
         planar_pec=False, path_dir=str(tmp_path), port_refinement=port_refinement
     )
+    if port_refinement:
+        for sim in modeler.sim_dict.values():
+            _ = sim.volumetric_structures
 
 
 def test_run(monkeypatch, tmp_path):
@@ -235,7 +238,12 @@ def test_converting_port_to_simulation_objects(snap_center):
 
 @pytest.mark.parametrize("port_refinement", [False, True])
 def test_make_coaxial_component_modeler(tmp_path, port_refinement):
-    _ = make_coaxial_component_modeler(path_dir=str(tmp_path), port_refinement=port_refinement)
+    modeler = make_coaxial_component_modeler(
+        path_dir=str(tmp_path), port_refinement=port_refinement
+    )
+    if port_refinement:
+        for sim in modeler.sim_dict.values():
+            _ = sim.volumetric_structures
 
 
 def test_run_coaxial_component_modeler(monkeypatch, tmp_path):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -849,7 +849,22 @@ SIM_FULL = td.Simulation(
     lumped_elements=[
         td.LumpedResistor(
             center=(2, 2, 0), size=(0.2, 0.2, 0), name="Resistor", resistance=42, voltage_axis=0
-        )
+        ),
+        td.CoaxialLumpedResistor(
+            center=(3, 2, 0),
+            outer_diameter=2.0,
+            inner_diameter=0.2,
+            name="Coax Resistor",
+            resistance=42,
+            normal_axis=0,
+        ),
+        td.LinearLumpedElement(
+            center=(1, 2, 0),
+            size=(0.2, 0.2, 0),
+            name="LCParallel",
+            network=td.RLCNetwork(inductance=1e-9, capacitance=10e-12, network_topology="parallel"),
+            voltage_axis=0,
+        ),
     ],
     symmetry=(0, 0, 0),
     boundary_spec=td.BoundarySpec(

--- a/tidy3d/components/lumped_element.py
+++ b/tidy3d/components/lumped_element.py
@@ -83,14 +83,14 @@ class LumpedElement(Tidy3dBaseModel, ABC):
         """Converts the :class:`.LumpedElement` object to a :class:`.Geometry`."""
 
     @abstractmethod
-    def to_structure(self) -> Structure:
+    def to_structure(self, grid: Grid = None) -> Structure:
         """Converts the network portion of the :class:`.LumpedElement` object to a
         :class:`.Structure`."""
 
     def to_structures(self, grid: Grid = None) -> list[Structure]:
         """Converts the :class:`.LumpedElement` object to a list of :class:`.Structure`
         which are ready to be added to the :class:`.Simulation`"""
-        return [self.to_structure]
+        return [self.to_structure(grid)]
 
 
 class RectangularLumpedElement(LumpedElement, Box):


### PR DESCRIPTION
Recent PR merge broke the existing implementations of `LumpedResistor` and `CoaxialLumpedResistor`. Fixed and also expanded unit tests.

I didn't add CHANGELOG entry because it was introduced by previous merge.