### PR TITLE
Remove flux monitor frequencies from adjoint frequencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduced the complex tolerance in the mode solver below which permittivity is considered lossless, in order to correctly compute very low-loss modes.
 -`HeatChargeSimulation` supersedes `HeatSimulation`. Though both of the can be used for Heat simulation interchangeably, the latter has been deprecated and will disappear in the future. 
 - `FluidSpec` and `SolidSpec` are now deprecated in favor of `FluidMedium` and `SolidMedium`. Both can still be used interchangeably.
+- Exclude `FluxMonitor` frequencies from adjoint design region gradient monitors since we do not differentiate through `FluxData`
 
 ### Fixed
 - NumPy 2.1 compatibility issue where `numpy.float64` values passed to xarray interpolation would raise TypeError.

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -74,6 +74,7 @@ from .monitor import (
     FieldProjectionCartesianMonitor,
     FieldProjectionKSpaceMonitor,
     FieldTimeMonitor,
+    FluxMonitor,
     FreqMonitor,
     ModeMonitor,
     Monitor,
@@ -3893,7 +3894,9 @@ class Simulation(AbstractYeeGridSimulation):
 
         freqs = set()
         for mnt in self.monitors:
-            if isinstance(mnt, FreqMonitor):
+            # since we cannot differentiate through the FluxMonitor, we can ignore
+            # the frequencies it is tracking
+            if isinstance(mnt, FreqMonitor) and not isinstance(mnt, FluxMonitor):
                 freqs.update(mnt.freqs)
         freqs = sorted(freqs)
         return freqs


### PR DESCRIPTION
Since we are not differentiating through flux data, this removes frequencies in FluxMonitors from the adjoint frequencies

A replacement for the time being for this closed PR: https://github.com/flexcompute/tidy3d/pull/2201