### PR TITLE
Fix duplicate CI runs on non-develop branches

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -8,7 +8,7 @@ on:
         type: boolean
         default: false
   push:
-    branches: [ develop, latest , 'pre/*']
+    branches: [ develop, latest ]
   pull_request:
     branches:
       - latest


### PR DESCRIPTION
Currently the test workflow is triggered twice on `pre/*` because merging a PR is both a `push` as well as a `pull_request` event. Was confused why this doesn't happen on `develop` but apparently github automatically optimizes this away on default branches (but not on others). The more you know...