### PR TITLE
A meshing bug that skips the domain coordinate

### DIFF
--- a/tests/test_components/test_grid_spec.py
+++ b/tests/test_components/test_grid_spec.py
@@ -424,3 +424,43 @@ def test_quasiuniform_grid():
         grid_spec=td.GridSpec.quasiuniform(dl=0.1, snapping_points=snapping_points)
     )
     assert any(np.isclose(sim.grid.boundaries.x, pos))
+
+
+def test_domain_mismatch():
+    """Test that generated grids match simulation domain. Previously it errors for z-axis."""
+    lam0 = 5
+
+    length = 5
+    width = 5
+    top_thickness = 0.2
+    bottom_thickness = 0.2
+
+    bottom = td.Structure(
+        geometry=td.Box(
+            center=[0, 0, 0],
+            size=[width, length, bottom_thickness],
+        ),
+        medium=td.Medium(permittivity=4),
+    )
+
+    top = td.Structure(
+        geometry=td.Box(
+            center=[0, 0, bottom_thickness / 2 + top_thickness / 2],
+            size=[width, length, top_thickness],
+        ),
+        medium=td.Medium(),
+    )
+
+    sim = td.Simulation(
+        center=[0, 0, 0],
+        size=[6, 6, 1],
+        grid_spec=td.GridSpec.auto(
+            min_steps_per_wvl=10,
+            wavelength=lam0,
+        ),
+        structures=[bottom, top],
+        sources=[],
+        run_time=1e-20,
+        boundary_spec=td.BoundarySpec.pml(),
+    )
+    z = sim.grid.boundaries.z

--- a/tidy3d/components/grid/mesher.py
+++ b/tidy3d/components/grid/mesher.py
@@ -673,7 +673,9 @@ class GradedMesher(Mesher):
         coords_filter = [interval_coords[0]]
         steps_filter = []
         for coord_ind, coord in enumerate(interval_coords[1:]):
-            if coord - coords_filter[-1] >= min_step:
+            if coord - coords_filter[-1] >= min_step or (
+                coord_ind == len(interval_coords) - 2 and not isclose(coord, coords_filter[-1])
+            ):
                 coords_filter.append(coord)
                 steps_filter.append(max_steps[coord_ind])
 


### PR DESCRIPTION
The added test previously would error:

> AutoGrid coordinates along axis 2 do not match the simulation domain, indicating an unexpected error in the meshing. Please create a github issue so that the problem can be investigated. In the meantime, switch to uniform or custom grid along 2.

Now in `filter_min_step`, make sure that the last coordinate is kept.