### PR TITLE
User friendly error for wvl_mat_min when no sources present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -`HeatChargeSimulation` supersedes `HeatSimulation`. Though both of the can be used for Heat simulation interchangeably, the latter has been deprecated and will disappear in the future. 
 - `FluidSpec` and `SolidSpec` are now deprecated in favor of `FluidMedium` and `SolidMedium`. Both can still be used interchangeably.
 - Exclude `FluxMonitor` frequencies from adjoint design region gradient monitors since we do not differentiate through `FluxData`
+- Check for empty source list in `wvl_mat_min` in `Simulation` and raise user friendly error if no sources exist in the simulation.
 
 ### Fixed
 - NumPy 2.1 compatibility issue where `numpy.float64` values passed to xarray interpolation would raise TypeError.

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -9,7 +9,7 @@ import tidy3d as td
 from tidy3d.components import simulation
 from tidy3d.components.scene import MAX_GEOMETRY_COUNT, MAX_NUM_MEDIUMS
 from tidy3d.components.simulation import MAX_NUM_SOURCES
-from tidy3d.exceptions import SetupError, Tidy3dKeyError
+from tidy3d.exceptions import SetupError, Tidy3dError, Tidy3dKeyError
 
 from ..utils import (
     SIM_FULL,
@@ -619,6 +619,14 @@ def test_max_geometry_validation():
 def test_no_monitor():
     with pytest.raises(Tidy3dKeyError):
         SIM.get_monitor_by_name("NOPE")
+
+
+def test_wvl_mat_min_error():
+    """Make sure we get an error when there are no sources in the simulation but
+    we ask for the minimum wavelength in material."""
+
+    with pytest.raises(Tidy3dError):
+        SIM.wvl_mat_min()
 
 
 def test_plot_structure():

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -4642,6 +4642,12 @@ class Simulation(AbstractYeeGridSimulation):
         float
             Minimum wavelength in the material (microns).
         """
+        if len(self.sources) == 0:
+            raise Tidy3dError(
+                "There are no sources present in the simulation. Please "
+                "add sources before querying for the minimum material "
+                "wavelength."
+            )
         freq_max = max(source.source_time.freq0 for source in self.sources)
         wvl_min = C_0 / freq_max
 


### PR DESCRIPTION
Raise an error when the user tries to get the minimum wavelength in material, but there are no sources present in the simulation.

Added associated test to make sure we are catching this condition.