### PR TITLE
Grid snapping off for unshadowed MeshOverrideStructure unless it refines mesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The coordinate of snapping points in `GridSpec` can take value `None`, so that mesh can be selectively snapped only along certain dimensions.
+- Grid snapping for `MeshOverrideStructure` with `shadow=False` is only on if the structure refines the mesh.
 
 ## [2.8.0rc2] - 2025-01-28
 

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -678,7 +678,8 @@ class MeshOverrideStructure(AbstractStructure):
         title="Grid Size Choice In Structure Overlapping Region",
         description="In structure intersection region, grid size is decided by the latter added "
         "structure in the structure list when ``shadow=True``; or the structure of smaller grid size "
-        "when ``shadow=False``.",
+        "when ``shadow=False``. If ``shadow=False``, and the structure doesn't refine the mesh, grid snapping to "
+        "the bounding box of the structure is disabled.",
     )
 
     @pydantic.validator("geometry")


### PR DESCRIPTION
Also fixed a bug.

The main motivation is that when the automatic mesh refinement structure is having a larger grid size, e.g. larger than the grid size from substrate material, we shouldn't snap its bounding box. This override structure should take no effect at all in meshing. To achieve that, now I shift all those unshadowed structures to the beginning of structure list (but after simulation structure) so that it won't affect intervals generated by other structures. The main logic for not inserting coordinates of bounding box is added to `insert_bbox`.

## Example

Consider a substrate of permittivity = 4.4, and default mesh refinement factor = 2, now the auto-generated override structures take no effect:
![image](https://github.com/user-attachments/assets/cdf33ae1-6f9a-40eb-be79-494c1eb19309)

If the refinement factor is 3, grids are snapped, and grid size refined:
![image](https://github.com/user-attachments/assets/e7d3c179-a929-43f6-977e-0cf0ecff16f7)

