### PR TITLE
maint[web]: Use default S3 TransferConfig for up/downloads

### DIFF
--- a/tidy3d/web/core/s3utils.py
+++ b/tidy3d/web/core/s3utils.py
@@ -173,12 +173,7 @@ def _get_progress(action: _S3Action):
     )
 
 
-_s3_config = TransferConfig(
-    multipart_threshold=1024 * 25,
-    max_concurrency=50,
-    multipart_chunksize=1024 * 25,
-    use_threads=True,
-)
+_s3_config = TransferConfig()
 
 _s3_sts_tokens: [str, _S3STSToken] = {}
 


### PR DESCRIPTION
The current `TransferConfig` limits chunking to 25kb and uses a pretty large no. of threads, which can become problematic in large batches. It's probably best to just use the S3 defaults ([see here](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/customizations/s3.html#boto3.s3.transfer.TransferConfig)).