### PR TITLE
Array factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for running multiple adjoint simulations from a single forward simulation in adjoint pipeline depending on monitor configuration.
 - Ability to directly create `DirectivityData` from an `xarrray.Dataset` containing electromagnetic fields, where the flux is calculated by integrating the fields over the surface of a sphere.
 - Ability to the `TerminalComponentModeler` that enables the computation of antenna parameters and figures of merit, such as gain, radiation efficiency, and reflection efficiency. When there are multiple ports in the `TerminalComponentModeler`, these antenna parameters may be calculated with user-specified port excitation magnitudes and phases.
+- `RectangularAntennaArrayCalculator` class to compute the array factor and far-field radiation patterns for rectangular phased antenna arrays.
 
 ### Changed
 - The coordinate of snapping points in `GridSpec` can take value `None`, so that mesh can be selectively snapped only along certain dimensions.

--- a/tests/test_plugins/test_array_factor.py
+++ b/tests/test_plugins/test_array_factor.py
@@ -1,0 +1,721 @@
+"""Test the array factor functions."""
+
+import numpy as np
+import pydantic.v1 as pydantic
+import pytest
+import tidy3d as td
+import tidy3d.plugins.microwave as mw
+import tidy3d.plugins.smatrix as smatrix
+
+from ..utils import AssertLogLevel
+
+
+def analytical_array_factor(array_size, spacings, phase_shifts, theta, phi, freqs, medium):
+    """Analytical array factor for a rectangular array."""
+    n, k = medium.nk_model(freqs)
+    k = 2 * np.pi * freqs * n / td.C_0
+    n_x, n_y, n_z = array_size
+    d_x, d_y, d_z = spacings
+    phi_x, phi_y, phi_z = phase_shifts
+    psi_x = k[None, :] * d_x * np.sin(theta[:, None]) * np.cos(phi[:, None]) - phi_x
+    psi_y = k[None, :] * d_y * np.sin(theta[:, None]) * np.sin(phi[:, None]) - phi_y
+    psi_z = k[None, :] * d_z * np.cos(theta[:, None]) - phi_z
+    af_x = np.sin(n_x * psi_x / 2) / np.sin(psi_x / 2)
+    af_y = np.sin(n_y * psi_y / 2) / np.sin(psi_y / 2)
+    af_z = np.sin(n_z * psi_z / 2) / np.sin(psi_z / 2)
+    af_exact = af_x * af_y * af_z
+    return af_exact
+
+
+def test_rectangular_array_calculator_basic():
+    """Test the array factor for a rectangular array."""
+
+    n_x = 1
+    n_y = 2
+    n_z = 3
+
+    d_x = 0.4
+    d_y = 0.5
+    d_z = 0.6
+
+    phi_x = np.pi / 6
+    phi_y = np.pi / 4
+    phi_z = np.pi / 3
+
+    array_calculator = mw.RectangularAntennaArrayCalculator(
+        array_size=(n_x, n_y, n_z),
+        spacings=(d_x, d_y, d_z),
+        phase_shifts=(phi_x, phi_y, phi_z),
+    )
+
+    # test ._antenna_locations
+    assert np.allclose(
+        array_calculator._antenna_locations,
+        np.array(
+            [
+                [0.0, -d_y / 2, -d_z],
+                [0.0, -d_y / 2, 0.0],
+                [0.0, -d_y / 2, d_z],
+                [0.0, d_y / 2, -d_z],
+                [0.0, d_y / 2, 0.0],
+                [0.0, d_y / 2, d_z],
+            ]
+        ),
+    )
+
+    # test ._antenna_amps
+    assert np.allclose(array_calculator._antenna_amps, np.ones(n_x * n_y * n_z))
+
+    # test ._antenna_phases
+    assert np.allclose(
+        array_calculator._antenna_phases,
+        np.array(
+            [
+                0,
+                phi_z,
+                2 * phi_z,
+                phi_y + 0,
+                phi_y + phi_z,
+                phi_y + 2 * phi_z,
+            ]
+        ),
+    )
+
+    # test ._antenna_nominal_size
+    assert np.allclose(
+        array_calculator._antenna_nominal_size,
+        np.array([(n_x - 1) * d_x, (n_y - 1) * d_y, (n_z - 1) * d_z]),
+    )
+
+    # test ._antenna_nominal_center
+    assert np.allclose(array_calculator._antenna_nominal_center, np.array([0, 0, 0]))
+
+    # test ._extend_dims
+    assert array_calculator._extend_dims == [1, 2]
+
+    with pytest.raises(pydantic.ValidationError):
+        # Test invalid array size
+        mw.RectangularAntennaArrayCalculator(
+            array_size=(0, 4, 5), spacings=(0.5, 0.5, 0.5), phase_shifts=(0, 0, 0)
+        )
+
+    with pytest.raises(pydantic.ValidationError):
+        # Test invalid spacings
+        mw.RectangularAntennaArrayCalculator(
+            array_size=(3, 4, 5), spacings=(-0.5, 0.5, 0.5), phase_shifts=(0, 0, 0)
+        )
+
+    with pytest.raises(pydantic.ValidationError):
+        # Test wrong length of amp_multipliers
+        mw.RectangularAntennaArrayCalculator(
+            array_size=(3, 4, 5),
+            spacings=(0.5, 0.5, 0.5),
+            phase_shifts=(0, 0, 0),
+            amp_multipliers=(0.5, 0.5),
+        )
+
+    for i in range(3):
+        with pytest.raises(pydantic.ValidationError):
+            # Test wrong length of amp_multipliers components
+            amps = [np.ones(3), np.ones(4), np.ones(5)]
+            amps[i] = np.ones(10)
+            mw.RectangularAntennaArrayCalculator(
+                array_size=(3, 4, 5),
+                spacings=(0.5, 0.5, 0.5),
+                phase_shifts=(0, 0, 0),
+                amp_multipliers=amps,
+            )
+
+
+def test_rectangular_array_calculator_array_factor():
+    """Test the array factor for a rectangular array."""
+
+    n_x = 1
+    n_y = 2
+    n_z = 3
+
+    d_x = 0.4
+    d_y = 0.5
+    d_z = 0.6
+
+    phi_x = np.pi / 6
+    phi_y = np.pi / 4
+    phi_z = np.pi / 3
+
+    array_calculator = mw.RectangularAntennaArrayCalculator(
+        array_size=(n_x, n_y, n_z),
+        spacings=(d_x, d_y, d_z),
+        phase_shifts=(phi_x, phi_y, phi_z),
+    )
+
+    # Test basic array factor calculation
+    theta = np.linspace(0, np.pi, 10)
+    phi = np.linspace(0, 2 * np.pi, 10)
+    theta_grid, phi_grid = np.meshgrid(theta, phi)
+    theta_grid = theta_grid.flatten()
+    phi_grid = phi_grid.flatten()
+    medium = td.Medium(permittivity=1)
+    freqs = np.array([1e9, 2e9, 3e9])
+
+    af = array_calculator.array_factor(theta_grid, phi_grid, freqs, medium)
+    assert af.shape == (100, 3)
+
+    af_exact = analytical_array_factor(
+        (n_x, n_y, n_z), (d_x, d_y, d_z), (phi_x, phi_y, phi_z), theta_grid, phi_grid, freqs, medium
+    )
+
+    assert np.allclose(np.abs(af), np.abs(af_exact))
+
+    # Test array factor with amplitude multipliers
+    array_calculator_amps = mw.RectangularAntennaArrayCalculator(
+        array_size=(n_x, n_y, n_z),
+        spacings=(d_x, d_y, d_z),
+        phase_shifts=(phi_x, phi_y, phi_z),
+        amp_multipliers=(0.5 * np.ones(n_x), 0.4 * np.ones(n_y), 0.3 * np.ones(n_z)),
+    )
+    af_amps = array_calculator_amps.array_factor(theta_grid, phi_grid, freqs, medium)
+    assert af_amps.shape == (100, 3)
+    assert np.allclose(np.abs(af_amps), np.abs(af_exact) * 0.5 * 0.4 * 0.3)
+
+    # Test array factor with non-uniform amplitude multipliers
+    # we will use amplitude multipliers that make the array effective size different from nominal size
+    n_x = 5
+    n_y = 8
+    n_z = 9
+    array_calculator_amps_nonuniform = mw.RectangularAntennaArrayCalculator(
+        array_size=(n_x, n_y, n_z),
+        spacings=(d_x, d_y, d_z),
+        phase_shifts=(phi_x, phi_y, phi_z),
+        amp_multipliers=(
+            np.int64(np.arange(n_x) % 2 == 0),
+            np.int64(np.arange(n_y) % 2 == 0),
+            np.int64(np.arange(n_z) % 2 == 0),
+        ),
+    )
+
+    af_amps_nonuniform = array_calculator_amps_nonuniform.array_factor(
+        theta_grid, phi_grid, freqs, medium
+    )
+    af_amps_nonuniform_exact = analytical_array_factor(
+        (3, 4, 5),
+        (2 * d_x, 2 * d_y, 2 * d_z),
+        (2 * phi_x, 2 * phi_y, 2 * phi_z),
+        theta_grid,
+        phi_grid,
+        freqs,
+        medium,
+    )
+    assert af_amps_nonuniform.shape == (100, 3)
+    assert np.allclose(np.abs(af_amps_nonuniform), np.abs(af_amps_nonuniform_exact))
+
+    # Test validation
+    with pytest.raises(ValueError):
+        # Test mismatched theta/phi lengths
+        array_calculator.array_factor(theta, phi[:5], freqs, medium)
+
+
+def make_antenna_sim():
+    # Scaling used for millimeters
+    mm = 1e3
+
+    # Frequency range
+    freq_start = 5e9
+    freq_stop = 15e9
+
+    freq0 = (freq_start + freq_stop) / 2  # Centeral frequency
+    freqs_target = np.linspace(freq_start, freq_stop, 5)
+    fwidth = freq_stop - freq_start  # Bandwidth
+
+    # Wavelength of centeral frequency in Vaccum
+    wavelength0 = td.C_0 / freq0
+
+    # Frequency sweep for S-parameters
+    freqs = np.linspace(freq_start, freq_stop, 201)
+
+    # Dipole parameters
+    dipole_length = 0.47 * wavelength0
+    dipole_radius = wavelength0 / 150
+
+    dipole_width = dipole_radius * 4
+    dipole_gap = dipole_width
+    arm_length = 0.5 * (dipole_length - dipole_gap)
+    arm_center = 0.5 * arm_length + 0.5 * dipole_gap
+
+    pml_buffer = 0.25 * wavelength0
+
+    sim_x = dipole_length + 2 * pml_buffer
+    sim_y = dipole_width + 2 * pml_buffer
+    sim_z = dipole_width + 2 * pml_buffer
+
+    # Material present
+    background_medium = td.Medium(permittivity=2)
+    PEC = td.PEC2D  # Thickness-free PEC medium
+
+    arm_a = td.Structure(
+        geometry=td.Box(center=[-arm_center, 0, 0], size=[arm_length, dipole_width, 0]),
+        medium=PEC,
+    )
+
+    arm_b = td.Structure(
+        geometry=td.Box(center=[arm_center, 0, 0], size=[arm_length, dipole_width, 0]),
+        medium=PEC,
+    )
+
+    background = td.Structure(
+        geometry=td.Box(center=[0, 0, 0], size=[td.inf, td.inf, td.inf]),
+        medium=background_medium,
+    )
+
+    background_finite = td.Structure(
+        geometry=td.Box(
+            center=[0.1 * wavelength0, 0.2 * wavelength0, 0.3 * wavelength0],
+            size=[3 * wavelength0, 4 * wavelength0, 5 * wavelength0],
+        ),
+        medium=background_medium,
+    )
+
+    # Define observation parameters used for projection monitors
+    theta = np.linspace(0, np.pi, 101)
+    phi = np.linspace(0, 2 * np.pi, 101)
+
+    # Field monitor to view the electromagnetic fields in the dipole plane
+    monitor_field = td.FieldMonitor(
+        center=(0, 0, 0),
+        size=(td.inf, td.inf, 0),
+        freqs=[freq0],
+        name="field",
+    )
+
+    # Angular projection monitor to view radiation intensity
+    monitor_projection = td.FieldProjectionAngleMonitor(
+        center=[0, 0, 0],
+        size=(dipole_length + pml_buffer, dipole_width + pml_buffer, dipole_width + pml_buffer),
+        freqs=freqs_target,
+        name="radiation",
+        phi=list(phi),
+        theta=list(theta),
+        far_field_approx=False,
+    )
+
+    # We define a DirectivityMonitor to obatin radiation characteritics such as directivity, axial ratio and polarized far fields.
+    monitor_directivity = td.DirectivityMonitor(
+        center=[0, 0, 0],
+        size=monitor_projection.size,
+        freqs=freqs_target,
+        name="directivity",
+        phi=list(phi),
+        theta=list(theta),
+        far_field_approx=False,
+    )
+
+    # Create the simulation object
+    sim = td.Simulation(
+        center=(1 * mm, 2 * mm, 1 * mm),
+        medium=td.Medium(permittivity=4),
+        size=[sim_x, sim_y, sim_z],
+        grid_spec=td.GridSpec.auto(
+            min_steps_per_wvl=20,  # The largest cell size is set to 20 cells per smallest wavelength.
+            wavelength=td.C_0 / freq_stop,  # Smallest wavelength to resolve
+            layer_refinement_specs=[
+                td.LayerRefinementSpec(axis=2, size=[0.3 * wavelength0, 0.3 * wavelength0, 0])
+            ],
+            snapping_points=[(0, 0, 0), (0.25 * wavelength0, 0.3 * wavelength0, None)],
+            override_structures=[
+                td.MeshOverrideStructure(
+                    geometry=td.Box(
+                        size=[0.25 * wavelength0, 0.25 * wavelength0, 0.25 * wavelength0]
+                    ),
+                    dl=[1 * mm, 1 * mm, 1 * mm],
+                ),
+                td.Structure(
+                    geometry=td.Box(
+                        size=[0.5 * wavelength0, td.inf, 20 * wavelength0], center=[0, 0, 0]
+                    ),
+                    medium=td.Medium(permittivity=2),
+                ),
+            ],
+        ),
+        structures=[background, background_finite, arm_a, arm_b],
+        monitors=[monitor_projection, monitor_field, monitor_directivity],
+        run_time=100 * (wavelength0 / td.C_0),
+        plot_length_units="mm",  # This option will make plots default to units of millimeters.
+    )
+
+    # Define the port impedance
+    port_impedance = 50
+
+    # Setup a LumpedPort for the TerminalComponentModeler
+    port = smatrix.LumpedPort(
+        center=[0, 0, 0],
+        size=[dipole_gap, dipole_width, 0],
+        voltage_axis=0,
+        name="lumped_port",
+        impedance=port_impedance,
+    )
+
+    # We integrate the base simulation with the LumpedPort using the TerminalComponentModeler.
+    modeler = smatrix.TerminalComponentModeler(
+        simulation=sim,
+        ports=[port],
+        freqs=freqs,
+        verbose=True,
+        remove_dc_component=False,  # Include DC component for more accuracy at low frequencies
+    )
+
+    sim_unit = list(modeler.sim_dict.values())[0]
+
+    return sim_unit
+
+
+def test_rectangular_array_calculator_array_make_antenna_array():
+    """Test automatic antenna array creation."""
+    freq0 = 10e9
+    wavelength0 = td.C_0 / 10e9
+    sim_unit = make_antenna_sim()
+    array_calculator = mw.RectangularAntennaArrayCalculator(
+        array_size=(1, 2, 3),
+        spacings=(0.5 * wavelength0, 0.6 * wavelength0, 0.4 * wavelength0),
+        phase_shifts=(np.pi / 3, np.pi / 4, np.pi / 5),
+    )
+
+    # check correctness of the antenna bounds detection
+    antenna_bounds = array_calculator._detect_antenna_bounds(sim_unit)
+    # we don't extend along x-axis here, so the bounds should be the same as in the original simulation
+    # in z-direction antenna has size zero
+    assert np.allclose(
+        antenna_bounds[0], [sim_unit.bounds[0][0], sim_unit.sources[-1].geometry.bounds[0][1], 0]
+    )
+    assert np.allclose(
+        antenna_bounds[1], [sim_unit.bounds[1][0], sim_unit.sources[-1].geometry.bounds[1][1], 0]
+    )
+
+    sim_array = array_calculator.make_antenna_array(sim_unit)
+
+    # check that it generated the right number of structures (2 arms * 6 + 2 boxes extending beoynd the simulation domain, that are automatically extended instead of duplicated)
+    assert len(sim_array.structures) == 14
+
+    # check that infinite box is automatically extended
+    assert sim_array.structures[0].geometry.center == (0, 0, 0)
+    assert sim_array.structures[0].geometry.size == (td.inf, td.inf, td.inf)
+
+    # check that large finite box is automatically extended as well
+    # it should go beyond the simulation domain by the same amount as in the original simulation
+    old_box_bounds = np.array(sim_unit.structures[1].geometry.bounds)
+    new_box_bounds = np.array(sim_array.structures[1].geometry.bounds)
+    old_sim_bounds = np.array(sim_unit.bounds)
+    new_sim_bounds = np.array(sim_array.bounds)
+    assert np.allclose(new_box_bounds[0] - new_sim_bounds[0], old_box_bounds[0] - old_sim_bounds[0])
+    assert np.allclose(new_box_bounds[1] - new_sim_bounds[1], old_box_bounds[1] - old_sim_bounds[1])
+
+    # check that we did not duplicate any near-field monitors
+    assert len(sim_array.monitors) == 2
+
+    # check that monitors are expanded correctly
+    # that is, bounds are located the same distance from simulation domain bounds
+    old_monitors = [
+        mnt
+        for mnt in sim_unit.monitors
+        if isinstance(mnt, (td.FieldProjectionAngleMonitor, td.DirectivityMonitor))
+    ]
+    new_monitors = [
+        mnt
+        for mnt in sim_array.monitors
+        if isinstance(mnt, (td.FieldProjectionAngleMonitor, td.DirectivityMonitor))
+    ]
+    for old_mnt, new_mnt in zip(old_monitors, new_monitors):
+        assert np.allclose(
+            np.array(old_mnt.bounds[0]) - np.array(old_sim_bounds[0]),
+            np.array(new_mnt.bounds[0]) - np.array(new_sim_bounds[0]),
+        )
+        assert np.allclose(
+            np.array(old_mnt.bounds[1]) - np.array(old_sim_bounds[1]),
+            np.array(new_mnt.bounds[1]) - np.array(new_sim_bounds[1]),
+        )
+
+    # check sources are duplicated
+    assert len(sim_array.sources) == 6
+
+    # check that override_structures are duplicated
+    assert len(sim_unit.grid_spec.override_structures) == 2
+    assert len(sim_array.grid_spec.override_structures) == 7
+
+    # check that phase shifts are applied correctly
+    phases_expected = array_calculator._antenna_phases
+    phases_actual = np.array([s.source_time.phase for s in sim_array.sources])
+    assert np.allclose(phases_actual, phases_expected)
+
+    # check centers of the sources
+    centers_expected = np.array(sim_unit.sources[0].center) + array_calculator._antenna_locations
+    centers_actual = np.array([s.center for s in sim_array.sources])
+    assert np.allclose(centers_actual, centers_expected)
+
+    # check that lumped elements are duplicated
+    assert len(sim_array.lumped_elements) == 6
+
+    # test a case when we have a non-box object extending beyond the simulation domain
+    # in this case we will duplicate the object
+    background_sphere = td.Structure(
+        geometry=td.Sphere(
+            center=[0.1 * wavelength0, 0.2 * wavelength0, 0.3 * wavelength0], radius=3 * wavelength0
+        ),
+        medium=td.Medium(permittivity=2),
+    )
+
+    sim_unit_with_sphere = sim_unit.updated_copy(
+        structures=[background_sphere] + list(sim_unit.structures)
+    )
+    # check correctness of the antenna bounds detection
+    antenna_bounds_with_sphere = array_calculator._detect_antenna_bounds(sim_unit_with_sphere)
+    assert np.allclose(antenna_bounds_with_sphere[0], sim_unit_with_sphere.bounds[0])
+    assert np.allclose(antenna_bounds_with_sphere[1], sim_unit_with_sphere.bounds[1])
+
+    sim_array_with_sphere = array_calculator.make_antenna_array(sim_unit_with_sphere)
+    assert len(sim_array_with_sphere.structures) == 20
+
+    # check that projection monitors with zero size are not duplicated
+    monitor_projection_flat = td.FieldProjectionAngleMonitor(
+        center=[0, 0, 0.1 * wavelength0],
+        size=(td.inf, td.inf, 0),
+        freqs=[freq0],
+        name="radiation",
+        phi=[0],
+        theta=[0],
+        far_field_approx=False,
+    )
+
+    sim_unit_with_flat_monitor = sim_unit.updated_copy(monitors=[monitor_projection_flat])
+
+    with AssertLogLevel("WARNING"):
+        sim_array_with_flat_monitor = array_calculator.make_antenna_array(
+            sim_unit_with_flat_monitor
+        )
+    assert len(sim_array_with_flat_monitor.monitors) == 0
+
+    sim_unit_with_layer_refinement = sim_unit.updated_copy(
+        grid_spec=td.GridSpec.auto(
+            min_steps_per_wvl=20,
+            wavelength=td.C_0 / freq0,
+            layer_refinement_specs=[
+                td.LayerRefinementSpec(axis=2, size=[0.3 * wavelength0, 0.3 * wavelength0, 0]),
+                td.LayerRefinementSpec(axis=0, size=[0.1 * wavelength0, td.inf, 3 * wavelength0]),
+            ],
+            snapping_points=[(0, 0, 0), (0.25 * wavelength0, 0.3 * wavelength0, None)],
+        )
+    )
+
+    sim_array_with_layer_refinement = array_calculator.make_antenna_array(
+        sim_unit_with_layer_refinement
+    )
+    assert len(sim_array_with_layer_refinement.grid_spec.layer_refinement_specs) == 7
+    assert len(sim_array_with_layer_refinement.grid_spec.snapping_points) == 12
+
+
+def test_rectangular_array_calculator_monitor_data_from_array_factor():
+    """Test that we can get monitor data from array factor."""
+    freq0 = 10e9
+    wavelength0 = td.C_0 / freq0
+    array_calculator = mw.RectangularAntennaArrayCalculator(
+        array_size=(1, 2, 3),
+        spacings=(0.5 * wavelength0, 0.6 * wavelength0, 0.4 * wavelength0),
+        phase_shifts=(np.pi / 3, np.pi / 4, np.pi / 5),
+    )
+
+    monitor = td.FieldProjectionAngleMonitor(
+        center=[0, 0, 0],
+        size=(wavelength0, wavelength0, wavelength0),
+        freqs=[freq0, 1.1 * freq0],
+        name="radiation",
+        phi=list(np.linspace(0, 2 * np.pi, 20)),
+        theta=list(np.linspace(0, np.pi, 10)),
+        far_field_approx=False,
+    )
+
+    new_monitor = td.FieldProjectionAngleMonitor(
+        center=[0, 0, 0],
+        size=(wavelength0, 2 * wavelength0, 3 * wavelength0),
+        freqs=[freq0, 1.1 * freq0],
+        name="radiation",
+        phi=list(np.linspace(0, 2 * np.pi, 20)),
+        theta=list(np.linspace(0, np.pi, 10)),
+        far_field_approx=False,
+    )
+
+    coords = dict(
+        r=[monitor.proj_distance],
+        theta=list(monitor.theta),
+        phi=list(monitor.phi),
+        f=list(monitor.freqs),
+    )
+    values = (1 + 1j) * np.ones(
+        (len(coords["r"]), len(coords["theta"]), len(coords["phi"]), len(coords["f"]))
+    )
+    data = td.FieldProjectionAngleDataArray(values, coords=coords)
+
+    monitor_data = td.FieldProjectionAngleData(
+        monitor=monitor,
+        Er=data,
+        Etheta=data,
+        Ephi=data,
+        Hr=data,
+        Htheta=data,
+        Hphi=data,
+        projection_surfaces=monitor.projection_surfaces,
+    )
+
+    new_monitor_data = array_calculator.monitor_data_from_array_factor(monitor_data)
+    assert new_monitor_data.monitor == monitor
+    new_monitor_data = array_calculator.monitor_data_from_array_factor(monitor_data, new_monitor)
+    assert new_monitor_data.monitor == new_monitor
+
+    # check that array factor is applied to fields
+    theta_grid, phi_grid = np.meshgrid(monitor.theta, monitor.phi, indexing="ij")
+    array_factor = array_calculator.array_factor(
+        theta=theta_grid.ravel(), phi=phi_grid.ravel(), frequency=np.array(monitor.freqs)
+    )
+    array_factor = np.reshape(
+        array_factor, (len(monitor.theta), len(monitor.phi), len(monitor.freqs))
+    )
+    for _, field in new_monitor_data.field_components.items():
+        # print(field.data[0])
+        # print(array_factor * (1 + 1j))
+        assert np.allclose(field.data[0], array_factor * (1 + 1j))
+
+    # create a directivity monitor and data
+    monitor_directivity = td.DirectivityMonitor(
+        center=[0, 0, 0],
+        size=monitor.size,
+        freqs=monitor.freqs,
+        name="directivity",
+        phi=monitor.phi,
+        theta=monitor.theta,
+    )
+
+    new_monitor_directivity = td.DirectivityMonitor(
+        center=[0, 0, 0],
+        size=new_monitor.size,
+        freqs=new_monitor.freqs,
+        name="directivity",
+        phi=new_monitor.phi,
+        theta=new_monitor.theta,
+    )
+
+    directivity_data = td.DirectivityData(
+        monitor=monitor_directivity,
+        flux=monitor_data.flux_from_projected_fields(),
+        projection_surfaces=monitor_directivity.projection_surfaces,
+        Er=data,
+        Etheta=data,
+        Ephi=data,
+        Hr=data,
+        Htheta=data,
+        Hphi=data,
+    )
+
+    new_monitor_data = array_calculator.monitor_data_from_array_factor(directivity_data)
+    assert new_monitor_data.monitor == monitor_directivity
+    new_monitor_data = array_calculator.monitor_data_from_array_factor(
+        directivity_data, new_monitor_directivity
+    )
+    assert new_monitor_data.monitor == new_monitor_directivity
+
+    # check the case when we don't have enough points in theta and/or phi
+    monitor_directivity_under_sampled = td.DirectivityMonitor(
+        center=[0, 0, 0],
+        size=(wavelength0, wavelength0, wavelength0),
+        freqs=[freq0, 1.1 * freq0],
+        name="radiation",
+        phi=list(np.linspace(0, 2 * np.pi, 10)),
+        theta=list(np.linspace(0, np.pi, 10)),
+        far_field_approx=False,
+    )
+    coords_under_sampled = dict(
+        r=[monitor_directivity_under_sampled.proj_distance],
+        theta=list(monitor_directivity_under_sampled.theta),
+        phi=list(monitor_directivity_under_sampled.phi),
+        f=list(monitor_directivity_under_sampled.freqs),
+    )
+    values_under_sampled = (1 + 1j) * np.random.random(
+        (
+            len(coords_under_sampled["r"]),
+            len(coords_under_sampled["theta"]),
+            len(coords_under_sampled["phi"]),
+            len(coords_under_sampled["f"]),
+        )
+    )
+    data_under_sampled = td.FieldProjectionAngleDataArray(
+        values_under_sampled, coords=coords_under_sampled
+    )
+
+    directivity_data_under_sampled = td.DirectivityData(
+        monitor=monitor_directivity_under_sampled,
+        flux=monitor_data.flux_from_projected_fields(),
+        projection_surfaces=monitor_directivity_under_sampled.projection_surfaces,
+        Er=data_under_sampled,
+        Etheta=data_under_sampled,
+        Ephi=data_under_sampled,
+        Hr=data_under_sampled,
+        Htheta=data_under_sampled,
+        Hphi=data_under_sampled,
+    )
+    with AssertLogLevel("WARNING"):
+        new_monitor_data_under_sampled = array_calculator.monitor_data_from_array_factor(
+            directivity_data_under_sampled
+        )
+    assert new_monitor_data_under_sampled is None
+
+
+def test_rectangular_array_calculator_simulation_data_from_array_factor():
+    """Test that we can get simulation data from array factor."""
+    freq0 = 10e9
+    wavelength0 = td.C_0 / freq0
+    array_calculator = mw.RectangularAntennaArrayCalculator(
+        array_size=(1, 2, 3),
+        spacings=(0.5 * wavelength0, 0.6 * wavelength0, 0.4 * wavelength0),
+        phase_shifts=(np.pi / 3, np.pi / 4, np.pi / 5),
+    )
+
+    sim_unit = make_antenna_sim()
+
+    monitor = sim_unit.monitors[0]
+    monitor_directivity = sim_unit.monitors[2]
+    coords = dict(
+        r=[monitor.proj_distance],
+        theta=list(monitor.theta),
+        phi=list(monitor.phi),
+        f=list(monitor.freqs),
+    )
+    values = (1 + 1j) * np.ones(
+        (len(coords["r"]), len(coords["theta"]), len(coords["phi"]), len(coords["f"]))
+    )
+    data = td.FieldProjectionAngleDataArray(values, coords=coords)
+
+    monitor_data = td.FieldProjectionAngleData(
+        monitor=monitor,
+        Er=data,
+        Etheta=data,
+        Ephi=data,
+        Hr=data,
+        Htheta=data,
+        Hphi=data,
+        projection_surfaces=monitor.projection_surfaces,
+    )
+
+    directivity_data = td.DirectivityData(
+        monitor=monitor_directivity,
+        flux=monitor_data.flux_from_projected_fields(),
+        projection_surfaces=monitor_directivity.projection_surfaces,
+        Er=data,
+        Etheta=data,
+        Ephi=data,
+        Hr=data,
+        Htheta=data,
+        Hphi=data,
+    )
+
+    sim_data = td.SimulationData(
+        simulation=sim_unit.updated_copy(monitors=[monitor, monitor_directivity]),
+        data=[monitor_data, directivity_data],
+    )
+
+    sim_data_from_array_factor = array_calculator.simulation_data_from_array_factor(sim_data)
+    assert len(sim_data_from_array_factor.data) == 2

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -67,6 +67,7 @@ from .monitor import (
     AbstractFieldProjectionMonitor,
     AbstractModeMonitor,
     DiffractionMonitor,
+    DirectivityMonitor,
     FieldMonitor,
     FieldProjectionAngleMonitor,
     FieldProjectionCartesianMonitor,
@@ -3326,13 +3327,13 @@ class Simulation(AbstractYeeGridSimulation):
 
     @pydantic.validator("monitors", always=True)
     @skip_if_fields_missing(["medium", "structures"])
-    def diffraction_monitor_medium(cls, val, values):
-        """If any :class:`.DiffractionMonitor` exists, ensure is does not lie in a lossy medium."""
+    def diffraction_and_directivity_monitor_medium(cls, val, values):
+        """If any :class:`.DiffractionMonitor` or  :class:`.DirectivityMonitor` exists, ensure it does not lie in a lossy medium."""
         monitors = val
         structures = values.get("structures")
         medium = values.get("medium")
         for monitor in monitors:
-            if isinstance(monitor, DiffractionMonitor):
+            if isinstance(monitor, (DiffractionMonitor, DirectivityMonitor)):
                 medium_set = Scene.intersecting_media(monitor, structures)
                 medium = medium_set.pop() if medium_set else medium
                 freqs = np.array(monitor.freqs)
@@ -3340,7 +3341,7 @@ class Simulation(AbstractYeeGridSimulation):
                     freqs = 0.5 * (np.min(freqs) + np.max(freqs))
                 _, index_k = medium.nk_model(frequency=freqs)
                 if not np.all(index_k == 0):
-                    raise SetupError("Diffraction monitors must not lie in a lossy medium.")
+                    raise SetupError(f"'{monitor.type}' must not lie in a lossy medium.")
         return val
 
     @pydantic.validator("grid_spec", always=True)

--- a/tidy3d/plugins/microwave/__init__.py
+++ b/tidy3d/plugins/microwave/__init__.py
@@ -1,6 +1,9 @@
 """Imports from microwave plugin."""
 
 from . import models
+from .array_factor import (
+    RectangularAntennaArrayCalculator,
+)
 from .auto_path_integrals import path_integrals_from_lumped_element
 from .custom_path_integrals import (
     CustomCurrentIntegral2D,
@@ -28,4 +31,5 @@ __all__ = [
     "models",
     "path_integrals_from_lumped_element",
     "rf_material_library",
+    "RectangularAntennaArrayCalculator",
 ]

--- a/tidy3d/plugins/microwave/array_factor.py
+++ b/tidy3d/plugins/microwave/array_factor.py
@@ -1,0 +1,776 @@
+"""Convenience functions for estimating antenna radiation by applying array factor."""
+
+from abc import ABC, abstractmethod
+from typing import Optional, Tuple, Union
+
+import numpy as np
+import pydantic.v1 as pd
+from pydantic.v1 import NonNegativeFloat, PositiveInt
+
+from ...components.base import Tidy3dBaseModel, skip_if_fields_missing
+from ...components.data.monitor_data import AbstractFieldProjectionData, DirectivityData
+from ...components.data.sim_data import SimulationData
+from ...components.geometry.base import Box, Geometry
+from ...components.grid.grid_spec import GridSpec, LayerRefinementSpec
+from ...components.lumped_element import LumpedElement
+from ...components.medium import Medium, MediumType3D
+from ...components.monitor import AbstractFieldProjectionMonitor, MonitorType
+from ...components.simulation import Simulation
+from ...components.source.utils import SourceType
+from ...components.structure import MeshOverrideStructure, Structure
+from ...components.types import ArrayLike, Axis, Bound
+from ...constants import C_0, inf
+from ...log import log
+
+
+class AbstractAntennaArrayCalculator(Tidy3dBaseModel, ABC):
+    """Abstract base for phased array calculators."""
+
+    @property
+    @abstractmethod
+    def _antenna_locations(self) -> ArrayLike:
+        """Locations of antennas' centers in an array."""
+
+    @property
+    @abstractmethod
+    def _antenna_amps(self) -> ArrayLike:
+        """Amplitude multipliers of antennas in an array."""
+
+    @property
+    @abstractmethod
+    def _antenna_phases(self) -> ArrayLike:
+        """Phase shifts of antennas in an array."""
+
+    @property
+    @abstractmethod
+    def _extend_dims(self):
+        """Dimensions along which antennas will be duplicated."""
+
+    @property
+    def _antenna_nominal_size(self) -> ArrayLike:
+        """Size of the antenna array without taking into account size of a single antenna."""
+        rmin = np.min(self._antenna_locations, axis=0)
+        rmax = np.max(self._antenna_locations, axis=0)
+
+        return rmax - rmin
+
+    @property
+    def _antenna_nominal_center(self) -> ArrayLike:
+        """Center of the antenna array without taking into account size of a single antenna."""
+        rmin = np.min(self._antenna_locations, axis=0)
+        rmax = np.max(self._antenna_locations, axis=0)
+
+        return 0.5 * (rmax + rmin)
+
+    def _detect_antenna_bounds(self, simulation: Simulation):
+        """Detect the bounds of the antenna in the simulation."""
+        # directions in which we will need to tile simulation
+        extend_dims = self._extend_dims
+
+        # detect bounding box of all structures, sources, and lumped elements in the simulation
+        sim_bounds = np.array(simulation.bounds)
+        antenna_bounds = sim_bounds.copy()
+        for dim in extend_dims:
+            antenna_bounds[0][dim] = inf
+            antenna_bounds[1][dim] = -inf
+
+        all_objects = list(simulation.structures)
+        all_objects += list(simulation.sources)
+        all_objects += list(simulation.lumped_elements)
+
+        for obj in all_objects:
+            # get bounding box of the object
+            if isinstance(obj, Structure):
+                obj_bounds = np.array(obj.geometry.bounds)
+            else:
+                obj_bounds = np.array(obj.bounds)
+
+            for dim in extend_dims:
+                # update minimum and maximum bounds in each dimension
+                # check if object extends beyond the simulation bounds on both sides
+                extends_beyond_min = obj_bounds[0][dim] < sim_bounds[0][dim]
+                extends_beyond_max = obj_bounds[1][dim] > sim_bounds[1][dim]
+                if extends_beyond_min or extends_beyond_max:
+                    # in case of a box, we just ignore it, since we will be able to extend it later
+                    if (
+                        isinstance(obj, Structure)
+                        and isinstance(obj.geometry, Box)
+                        and extends_beyond_min
+                        and extends_beyond_max
+                    ):
+                        continue
+                    # otherwise shrink the object bounds to simulation bounds
+                    obj_bounds[0][dim] = max(obj_bounds[0][dim], sim_bounds[0][dim])
+                    obj_bounds[1][dim] = min(obj_bounds[1][dim], sim_bounds[1][dim])
+                    # and show a warning
+                    log.warning(
+                        f"Object {obj.name} (type: {obj.type}) extends beyond simulation bounds along"
+                        f" '{'xyz'[dim]}' axis. Please check your antenna setup for correctness."
+                    )
+                # update minimum and maximum bounds in each dimension
+                antenna_bounds[0][dim] = min(antenna_bounds[0][dim], obj_bounds[0][dim])
+                antenna_bounds[1][dim] = max(antenna_bounds[1][dim], obj_bounds[1][dim])
+
+        return antenna_bounds
+
+    def _try_to_expand_geometry(
+        self, geometry: Geometry, old_sim_bounds: Bound, new_sim_bounds: Bound
+    ):
+        """Try to expand geometry to cover the entire simulation domain."""
+
+        can_expand = isinstance(geometry, Box) and all(
+            geometry.bounds[0][dim] < old_sim_bounds[0][dim]
+            or geometry.bounds[1][dim] > old_sim_bounds[1][dim]
+            for dim in self._extend_dims
+        )
+
+        if not can_expand:
+            return None  # could not expand geometry, so we will duplicate
+
+        # get original structure bounds
+        box_bounds = np.array(geometry.bounds)
+        box_size = np.array(geometry.size)
+        box_center = np.array(geometry.center)
+
+        for dim in self._extend_dims:
+            # if it extends beyond simulation bounds, but size is not inf
+            # we will adjust it so that it goes out of bounds by the same amount as in the initial simulation.
+            # No need to do anything if size is inf.
+            if box_size[dim] != np.inf:
+                # shift min bounds to new location
+                box_bounds[0][dim] = new_sim_bounds[0][dim] + (
+                    box_bounds[0][dim] - old_sim_bounds[0][dim]
+                )
+
+                # shift max bounds to new location
+                box_bounds[1][dim] = new_sim_bounds[1][dim] - (
+                    old_sim_bounds[1][dim] - box_bounds[1][dim]
+                )
+
+                # calculate new structure size and center
+                box_size[dim] = box_bounds[1][dim] - box_bounds[0][dim]
+                box_center[dim] = 0.5 * (box_bounds[0][dim] + box_bounds[1][dim])
+
+        return geometry.updated_copy(
+            center=tuple(box_center),
+            size=tuple(box_size),
+        )
+
+    def _duplicate_or_expand_list_of_objects(
+        self,
+        objects: Tuple[
+            Union[Structure, MeshOverrideStructure, LayerRefinementSpec, LumpedElement], ...
+        ],
+        old_sim_bounds: Bound,
+        new_sim_bounds: Bound,
+    ):
+        """Duplicate or expand a list of objects."""
+
+        locations = self._antenna_locations
+
+        array_objects = []
+        for obj in objects:
+            if isinstance(obj, (Structure, MeshOverrideStructure)):
+                geometry = obj.geometry
+                if isinstance(obj, Structure) and obj.medium.is_custom:
+                    log.warning(
+                        f"Object '{obj.name}' contains a custom medium which has limited support "
+                        "in automatic antenna array generation. The custom medium's spatial distribution "
+                        "will remain fixed and will not be translated along with the structure geometry."
+                    )
+            elif isinstance(obj, (LayerRefinementSpec, LumpedElement)):
+                geometry = obj
+            else:
+                raise ValueError(f"Object of type {type(obj)} is not supported.")
+
+            # check if it is a box and extends beyond simulation bounds
+            expanded_geometry = self._try_to_expand_geometry(
+                geometry=geometry, old_sim_bounds=old_sim_bounds, new_sim_bounds=new_sim_bounds
+            )
+
+            if expanded_geometry is None:
+                # could not expand geometry, so we duplicate
+                for ind, translation_vector in enumerate(locations):
+                    if isinstance(obj, Structure):
+                        new_obj = obj.updated_copy(
+                            geometry=obj.geometry.translated(*translation_vector),
+                            name=None if obj.name is None else f"{obj.name}_{ind}",
+                        )
+                    elif isinstance(obj, MeshOverrideStructure):
+                        new_obj = obj.updated_copy(
+                            geometry=obj.geometry.translated(*translation_vector).bounding_box,
+                            name=None if obj.name is None else f"{obj.name}_{ind}",
+                        )
+                    elif isinstance(obj, LayerRefinementSpec):
+                        new_obj = obj.updated_copy(
+                            center=tuple(obj.center + translation_vector),
+                        )
+                    elif isinstance(obj, LumpedElement):
+                        new_obj = obj.updated_copy(
+                            center=tuple(obj.center + translation_vector),
+                            name=None if obj.name is None else f"{obj.name}_{ind}",
+                        )
+                    array_objects.append(new_obj)
+            else:
+                # could expand geometry, so we create a copy of the original object with updated size and center
+                if isinstance(obj, (Structure, MeshOverrideStructure)):
+                    new_obj = obj.updated_copy(
+                        geometry=expanded_geometry,
+                    )
+                elif isinstance(obj, (LayerRefinementSpec, LumpedElement)):
+                    new_obj = expanded_geometry
+
+                # add the new object to the list of objects
+                array_objects.append(new_obj)
+
+        return array_objects
+
+    def _expand_monitors(
+        self,
+        monitors: Tuple[MonitorType, ...],
+        antenna_bounds: Bound,
+        new_sim_bounds: Bound,
+        old_sim_bounds: Bound,
+    ):
+        """Expand monitors."""
+
+        extend_dims = self._extend_dims
+
+        # expand far-field monitors
+        array_monitors = []
+        for monitor in monitors:
+            # we only expand field projection monitors
+            if isinstance(monitor, AbstractFieldProjectionMonitor):
+                # get original monitor bounds
+                mnt_bounds = np.array(monitor.bounds)
+                mnt_size = np.array(monitor.size)
+                mnt_center = np.array(monitor.center)
+
+                if any(mnt_size[dim] == 0 for dim in extend_dims):
+                    log.warning(
+                        f"Monitor '{monitor.name}' (type: '{monitor.type}') has zero size along "
+                        f"one of the axes. It will not be included in the resulting simulation."
+                    )
+                    continue
+
+                for dim in extend_dims:
+                    if mnt_size[dim] != np.inf:
+                        # check that monitor covers the estimated antenna box
+                        if (
+                            mnt_bounds[0][dim] > antenna_bounds[0][dim]
+                            or mnt_bounds[1][dim] < antenna_bounds[1][dim]
+                        ):
+                            log.warning(
+                                f"Monitor '{monitor.name}' (type: '{monitor.type}') does not cover "
+                                f"the estimated antenna box along '{'xyz'[dim]}' axis. "
+                                "The automatically extended monitor will likely be wrong. "
+                                "Please double check the resulting simulation."
+                            )
+                        # shift min bounds to new location
+                        mnt_bounds[0][dim] = new_sim_bounds[0][dim] + (
+                            mnt_bounds[0][dim] - old_sim_bounds[0][dim]
+                        )
+
+                        # shift max bounds to new location
+                        mnt_bounds[1][dim] = new_sim_bounds[1][dim] - (
+                            old_sim_bounds[1][dim] - mnt_bounds[1][dim]
+                        )
+
+                        # calculate new monitor size and center
+                        mnt_size[dim] = mnt_bounds[1][dim] - mnt_bounds[0][dim]
+                        mnt_center[dim] = 0.5 * (mnt_bounds[0][dim] + mnt_bounds[1][dim])
+
+                # create a copy of the original monitor with updated size and center
+                new_mnt = monitor.updated_copy(
+                    center=tuple(mnt_center),
+                    size=tuple(mnt_size),
+                )
+
+                # add the new monitor to the list of monitors
+                array_monitors.append(new_mnt)
+
+            # otherwise we ignore and warn the user
+            else:
+                log.warning(
+                    f"Monitor '{monitor.name}' (type: '{monitor.type}') will not be automatically "
+                    "transferred into the resulting antenna array simulation."
+                )
+
+        return array_monitors
+
+    def _duplicate_structures(
+        self, structures: Tuple[Structure, ...], new_sim_bounds: Bound, old_sim_bounds: Bound
+    ):
+        """Duplicate structures."""
+
+        return self._duplicate_or_expand_list_of_objects(
+            objects=structures, old_sim_bounds=old_sim_bounds, new_sim_bounds=new_sim_bounds
+        )
+
+    def _duplicate_sources(
+        self,
+        sources: Tuple[SourceType, ...],
+        lumped_elements: Tuple[LumpedElement, ...],
+        old_sim_bounds: Bound,
+        new_sim_bounds: Bound,
+    ):
+        """Duplicate sources and lumped elements."""
+        array_lumped_elements = self._duplicate_or_expand_list_of_objects(
+            objects=lumped_elements, old_sim_bounds=old_sim_bounds, new_sim_bounds=new_sim_bounds
+        )
+
+        array_sources = []
+        for ind, (translation_vector, phase_shift, amp_multiplier) in enumerate(
+            zip(self._antenna_locations, self._antenna_phases, self._antenna_amps)
+        ):
+            if amp_multiplier != 0.0:
+                for source in sources:
+                    new_source = source.updated_copy(
+                        center=tuple(source.center + translation_vector),
+                        name=f"{source.name}_{ind}",
+                        source_time=source.source_time.updated_copy(
+                            phase=source.source_time.phase + phase_shift,
+                            amplitude=source.source_time.amplitude * amp_multiplier,
+                        ),
+                    )
+                    array_sources.append(new_source)
+
+        return array_sources, array_lumped_elements
+
+    def _duplicate_grid_specs(
+        self, grid_spec: GridSpec, old_sim_bounds: Bound, new_sim_bounds: Bound
+    ):
+        """Duplicate grid specs."""
+
+        array_overrides = self._duplicate_or_expand_list_of_objects(
+            objects=grid_spec.override_structures,
+            old_sim_bounds=old_sim_bounds,
+            new_sim_bounds=new_sim_bounds,
+        )
+        array_layer_refinement_specs = self._duplicate_or_expand_list_of_objects(
+            objects=grid_spec.layer_refinement_specs,
+            old_sim_bounds=old_sim_bounds,
+            new_sim_bounds=new_sim_bounds,
+        )
+
+        array_snapping_points = []
+        for translation_vector in self._antenna_locations:
+            for snapping_point in grid_spec.snapping_points:
+                new_snapping_point = [
+                    snapping_point[dim] + translation_vector[dim]
+                    if snapping_point[dim] is not None
+                    else None
+                    for dim in range(3)
+                ]
+                array_snapping_points.append(new_snapping_point)
+
+        return grid_spec.updated_copy(
+            override_structures=array_overrides,
+            layer_refinement_specs=array_layer_refinement_specs,
+            snapping_points=array_snapping_points,
+        )
+
+    def make_antenna_array(self, simulation: Simulation) -> Simulation:
+        """
+        Converts a single antenna simulation into an antenna array simulation.
+        This function identifies the size and position of the single antenna
+        in the input simulation and uses this information to compute the dimensions
+        of the resulting antenna array simulation. All structures, sources, lumped elements,
+        and mesh override structures are duplicated, while monitors are extended in size.
+        Only projection monitors are transferred into the resulting simulation.
+
+        For best results, the antenna assembly should be contained within the simulation bounds.
+
+        Parameters:
+        ----------
+        simulation : Simulation
+            The simulation specification describing a single antenna setup.
+
+        Returns:
+        --------
+        Simulation
+            The simulation specification describing the antenna array.
+        """
+
+        # detect bounding box of all structures, sources, and lumped elements in the simulation
+        sim_bounds = np.array(simulation.bounds)
+        antenna_bounds = self._detect_antenna_bounds(simulation)
+
+        # compute the center and size of the antenna
+        antenna_size = antenna_bounds[1] - antenna_bounds[0]
+        antenna_center = 0.5 * (antenna_bounds[0] + antenna_bounds[1])
+
+        # compute buffer between the antenna and simulation bounds on each side
+        buffer_min = antenna_bounds[0] - sim_bounds[0]
+        buffer_max = sim_bounds[1] - antenna_bounds[1]
+
+        # compute total size of the antenna array in x, y, and z directions
+        antenna_array_size = self._antenna_nominal_size + antenna_size
+
+        new_sim_bounds = [
+            antenna_center + self._antenna_nominal_center - antenna_array_size / 2 - buffer_min,
+            antenna_center + self._antenna_nominal_center + antenna_array_size / 2 + buffer_max,
+        ]
+
+        # compute the total size of the simulation domain
+        new_sim_size = new_sim_bounds[1] - new_sim_bounds[0]
+        new_sim_center = 0.5 * (new_sim_bounds[0] + new_sim_bounds[1])
+
+        # duplicate structures, sources, lumped elements, and override structures
+        array_structures = self._duplicate_structures(
+            structures=simulation.structures,
+            new_sim_bounds=new_sim_bounds,
+            old_sim_bounds=sim_bounds,
+        )
+        array_sources, array_lumped_elements = self._duplicate_sources(
+            sources=simulation.sources,
+            lumped_elements=simulation.lumped_elements,
+            old_sim_bounds=sim_bounds,
+            new_sim_bounds=new_sim_bounds,
+        )
+        array_monitors = self._expand_monitors(
+            monitors=simulation.monitors,
+            antenna_bounds=antenna_bounds,
+            new_sim_bounds=new_sim_bounds,
+            old_sim_bounds=sim_bounds,
+        )
+        array_grid_spec = self._duplicate_grid_specs(
+            grid_spec=simulation.grid_spec, old_sim_bounds=sim_bounds, new_sim_bounds=new_sim_bounds
+        )
+
+        new_sim = simulation.updated_copy(
+            center=tuple(new_sim_center),
+            size=tuple(new_sim_size),
+            structures=array_structures,
+            monitors=array_monitors,
+            sources=array_sources,
+            lumped_elements=array_lumped_elements,
+            grid_spec=array_grid_spec,
+        )
+
+        return new_sim
+
+    @abstractmethod
+    def array_factor(
+        self,
+        theta: Union[float, ArrayLike],
+        phi: Union[float, ArrayLike],
+        frequency: Union[NonNegativeFloat, ArrayLike],
+    ) -> ArrayLike:
+        """
+        Compute the array factor for an antenna array.
+
+        Parameters:
+        -----------
+        theta : Union[float, ArrayLike]
+            Observation angles in the elevation plane (in radians).
+        phi : Union[float, ArrayLike]
+            Observation angles in the azimuth plane (in radians).
+        frequency : Union[NonNegativeFloat, ArrayLike]
+            Signal frequency (in Hz).
+
+        Returns:
+        --------
+        ArrayLike
+            Array factor values for each combination of theta and phi.
+        """
+
+    def monitor_data_from_array_factor(
+        self,
+        monitor_data: AbstractFieldProjectionData,
+        new_monitor: AbstractFieldProjectionMonitor = None,
+    ) -> AbstractFieldProjectionData:
+        """Apply the array factor to the monitor data of a single antenna.
+
+        Parameters:
+        ----------
+        monitor_data : AbstractFieldProjectionData
+            The monitor data of a single antenna.
+        new_monitor : AbstractFieldProjectionMonitor = None
+            The new monitor to be used in the resulting data.
+
+        Returns:
+        --------
+        AbstractFieldProjectionData
+            The monitor data of the antenna array.
+        """
+
+        # Get spherical coordinates
+        r, theta, phi = list(monitor_data.coords_spherical.values())
+        freqs = monitor_data.f
+        coords_shape = list(np.shape(r))
+        coords_shape.append(len(freqs))
+
+        # Compute the array factor
+        af = self.array_factor(theta.ravel(), phi.ravel(), freqs, monitor_data.medium)
+        af = np.reshape(af, coords_shape)
+
+        update_dict = {}
+
+        # Apply the array factor to the monitor data
+        for key, field in monitor_data.field_components.items():
+            update_dict[key] = field.copy() * af
+
+        if new_monitor is not None:
+            monitor = new_monitor
+        else:
+            monitor = monitor_data.monitor
+
+        update_dict["monitor"] = monitor
+        update_dict["projection_surfaces"] = monitor.projection_surfaces
+
+        if isinstance(monitor_data, DirectivityData):
+            # Attempt to recompute flux
+            try:
+                update_dict["flux"] = monitor_data.flux_from_projected_fields()
+            except ValueError as e:
+                log.warning(
+                    "Could not recalculate flux for a 'DirectivityData' due to the following "
+                    f"reason: {e} This monitor will not be included in the resulting data."
+                )
+                return None
+
+        # Create a new monitor data with the updated fields
+        new_mnt_data = monitor_data.updated_copy(
+            **update_dict,
+        )
+
+        return new_mnt_data
+
+    def simulation_data_from_array_factor(
+        self,
+        antenna_data: SimulationData,
+    ) -> SimulationData:
+        """
+        Computes the far-field data of a rectangular antenna array based on the far-field data of
+        a single antenna. Additionaly, it automatically converts a single antenna simulation setup
+        into the corresponding antenna array simulation setup.
+
+        Note that any near-field monitor data will be ignored.
+
+        Parameters:
+        ----------
+        antenna_data : SimulationData
+            The far-field data of a single antenna.
+
+        Returns:
+        --------
+        SimulationData
+            The far-field data of the antenna array.
+        """
+
+        # create an expanded simulation for reference
+        sim_array = self.make_antenna_array(antenna_data.simulation)
+
+        # names of transferred monitors
+        mnt_dict = {mnt.name: mnt for mnt in sim_array.monitors}
+
+        # process far field data
+        data_array = []
+        good_monitors = []
+        for mnt_data in antenna_data.data:
+            mnt_name = mnt_data.monitor.name
+            if mnt_name in mnt_dict:
+                array_mnt_data = self.monitor_data_from_array_factor(
+                    monitor_data=mnt_data,
+                    new_monitor=mnt_dict[mnt_name],
+                )
+                if array_mnt_data is not None:
+                    good_monitors.append(mnt_dict[mnt_name])
+                    data_array.append(array_mnt_data)
+
+        return SimulationData(
+            simulation=sim_array.updated_copy(monitors=good_monitors), data=data_array
+        )
+
+
+class RectangularAntennaArrayCalculator(AbstractAntennaArrayCalculator):
+    """This class provides methods to calculate the array factor and far-field radiation patterns
+    for rectangular phased antenna arrays. It handles arrays with arbitrary size, spacing,
+    phase shifts, and amplitude tapering in x, y, and z directions.
+
+    The array factor is calculated using the standard array factor formula for rectangular arrays,
+    which accounts for the spatial distribution of antennas and their relative phases and amplitudes.
+    This can be used to analyze beam steering, sidelobe levels, and other array characteristics.
+
+    In addition, this class provides a convenience method to create an antenna array simulation
+    from a single antenna simulation. This can be used to compute the behavior (near-field and/or
+    far-field) of the full antenna array directly without any approximations. Such a simulation setup
+    can be obtained:
+    - by directly calling the `make_antenna_array` function, or
+    - by accessing the field `.simulation` of the `SimulationData` object returned by the
+      `simulation_data_from_array_factor` method.
+
+    Example:
+    --------
+    >>> array_calculator = RectangularAntennaArrayCalculator(
+    ...    array_size=(3, 4, 5),
+    ...    spacings=(0.5, 0.5, 0.5),
+    ...    phase_shifts=(0, 0, 0),
+    ... )
+    """
+
+    array_size: Tuple[PositiveInt, PositiveInt, PositiveInt] = pd.Field(
+        title="Array Size",
+        description="Number of antennas along x, y, and z directions.",
+    )
+
+    spacings: Tuple[NonNegativeFloat, NonNegativeFloat, NonNegativeFloat] = pd.Field(
+        title="Antenna Spacings",
+        description="Center-to-center spacings between antennas along x, y, and z directions.",
+    )
+
+    phase_shifts: Tuple[float, float, float] = pd.Field(
+        (0, 0, 0),
+        title="Phase Shifts",
+        description="Phase-shifts between antennas along x, y, and z directions.",
+    )
+
+    amp_multipliers: Tuple[Optional[ArrayLike], Optional[ArrayLike], Optional[ArrayLike]] = (
+        pd.Field(
+            (None, None, None),
+            title="Amplitude Multipliers",
+            description="Amplitude multipliers spatially distributed along x, y, and z directions.",
+        )
+    )
+
+    @pd.validator("amp_multipliers", pre=True, always=True)
+    @skip_if_fields_missing(["array_size"])
+    def _check_amp_multipliers(cls, val, values):
+        """Check that the length of the amplitude multipliers is equal to the array size along each dimension."""
+        array_size = values.get("array_size")
+        if len(val) != 3:
+            raise ValueError("'amp_multipliers' must have 3 elements.")
+        if val[0] is not None and len(val[0]) != array_size[0]:
+            raise ValueError(
+                f"'amp_multipliers' has length of {len(val[0])} along the x direction, but the array size is {array_size[0]}."
+            )
+        if val[1] is not None and len(val[1]) != array_size[1]:
+            raise ValueError(
+                f"'amp_multipliers' has length of {len(val[1])} along the y direction, but the array size is {array_size[1]}."
+            )
+        if val[2] is not None and len(val[2]) != array_size[2]:
+            raise ValueError(
+                f"'amp_multipliers' has length of {len(val[2])} along the z direction, but the array size is {array_size[2]}."
+            )
+        return val
+
+    @property
+    def _antenna_locations(self) -> ArrayLike:
+        """Locations of antennas' centers in an array."""
+
+        x = (np.arange(self.array_size[0]) - (self.array_size[0] - 1) / 2) * self.spacings[0]
+        y = (np.arange(self.array_size[1]) - (self.array_size[1] - 1) / 2) * self.spacings[1]
+        z = (np.arange(self.array_size[2]) - (self.array_size[2] - 1) / 2) * self.spacings[2]
+
+        X, Y, Z = np.meshgrid(x, y, z)
+
+        return np.transpose([X.ravel(), Y.ravel(), Z.ravel()])
+
+    @property
+    def _antenna_amps(self) -> ArrayLike:
+        """Amplitude multipliers of antennas in an array."""
+
+        amps_per_dim = [
+            np.ones(size) if multiplier is None else multiplier
+            for multiplier, size in zip(self.amp_multipliers, self.array_size)
+        ]
+
+        amps_grid = np.meshgrid(*amps_per_dim)
+
+        return np.ravel(amps_grid[0] * amps_grid[1] * amps_grid[2])
+
+    @property
+    def _antenna_phases(self) -> ArrayLike:
+        """Phase shifts of antennas in an array."""
+
+        phase_shifts_per_dim = [
+            np.arange(self.array_size[dim]) * self.phase_shifts[dim] for dim in range(3)
+        ]
+
+        phase_shifts_grid = np.meshgrid(*phase_shifts_per_dim)
+
+        return np.ravel(sum(p for p in phase_shifts_grid))
+
+    @property
+    def _extend_dims(self) -> Tuple[Axis, ...]:
+        """Dimensions along which antennas will be duplicated."""
+        return [ind for ind, size in enumerate(self.array_size) if size > 1]
+
+    def array_factor(
+        self,
+        theta: Union[float, ArrayLike],
+        phi: Union[float, ArrayLike],
+        frequency: Union[NonNegativeFloat, ArrayLike],
+        medium: MediumType3D = Medium(),
+    ) -> ArrayLike:
+        """
+        Compute the array factor for a 3D antenna array.
+
+        Parameters:
+        -----------
+        theta : Union[float, ArrayLike]
+            Observation angles in the elevation plane (in radians).
+        phi : Union[float, ArrayLike]
+            Observation angles in the azimuth plane (in radians).
+        frequency : Union[NonNegativeFloat, ArrayLike]
+            Signal frequency (in Hz).
+
+        Returns:
+        --------
+        ArrayLike
+            Array factor values for each combination of theta and phi.
+        """
+
+        # Convert all inputs to numpy arrays
+        theta_array = np.atleast_1d(theta)
+        phi_array = np.atleast_1d(phi)
+
+        # ensure that theta and phi have the same length
+        if len(theta_array) != len(phi_array):
+            raise ValueError("'theta' and 'phi' must have the same length")
+
+        # reshape inputs for easier broadcasting
+        theta_array = np.reshape(theta_array, (len(theta_array), 1))
+        phi_array = np.reshape(phi_array, (len(phi_array), 1))
+        f_array = np.reshape(frequency, (1, len(np.atleast_1d(frequency))))
+
+        eps_complex = np.array(medium.eps_model(f_array))
+
+        wavelength = C_0 / f_array / np.sqrt(eps_complex)
+        k = 2 * np.pi / wavelength  # Wavenumber
+
+        # Calculate the phase shift in the x, y, and z directions
+        psi_x = (
+            k * self.spacings[0] * np.sin(theta_array) * np.cos(phi_array) - self.phase_shifts[0]
+        )
+        psi_y = (
+            k * self.spacings[1] * np.sin(theta_array) * np.sin(phi_array) - self.phase_shifts[1]
+        )
+        psi_z = k * self.spacings[2] * np.cos(theta_array) - self.phase_shifts[2]
+
+        amp_x = 1.0 if self.amp_multipliers[0] is None else self.amp_multipliers[0][:, None, None]
+        amp_y = 1.0 if self.amp_multipliers[1] is None else self.amp_multipliers[1][:, None, None]
+        amp_z = 1.0 if self.amp_multipliers[2] is None else self.amp_multipliers[2][:, None, None]
+
+        # Calculate the array factor in the x, y, and z directions
+        af_x = np.sum(
+            amp_x
+            * np.exp(-1j * np.arange(self.array_size[0])[:, None, None] * psi_x[np.newaxis, :]),
+            axis=0,
+        )
+        af_y = np.sum(
+            amp_y
+            * np.exp(-1j * np.arange(self.array_size[1])[:, None, None] * psi_y[np.newaxis, :]),
+            axis=0,
+        )
+        af_z = np.sum(
+            amp_z
+            * np.exp(-1j * np.arange(self.array_size[2])[:, None, None] * psi_z[np.newaxis, :]),
+            axis=0,
+        )
+
+        # Calculate the overall array factor
+        array_factor = af_x * af_y * af_z
+
+        return array_factor


### PR DESCRIPTION
Currently I implemented this functionality as stand-alone functions in the `microwave` plugin. Specifically, it includes:
- `make_antenna_array`: converts a single antenna simulation into an array simulation
- `rectangular_antenna_array_factor`: comptutes array factor for 1D/2D/3D rectangular arrays
- `monitor_data_from_array_factor`: converts a single antenna field projection monitor data into one for an antenna array
- `simulation_data_from_array_factor`: coverts an entire simulation data for a single antenna into simulation data of an antenna array

Example of usage here:
https://github.com/flexcompute/tidy3d-notebooks/blob/daniil/array-factor/DipoleAntenna.ipynb

This lacks tests, but I wanted to first confirm if this organization/naming looks good. I guess, an alternative is to wrap these functions into a class, for example, `RectangularAntennaArrayCalculator`:
```
array_calculator = RectangularAntennaArrayCalculator(array_size=array_size, spacings=spacings, phase_shifts=phase_shifts)

array_factor = array_calculator.array_factor(theta=theta, phi=phi, f=freqs)
sim_array = array_calculator.make_array_simulation(sim_unit)
sim_array_data = array_calculator.simulation_data_from_array_factor(sim_unit_data)
```
this would be easier to generalize to `HexagonalAntennaArrayCalculator`, `CircularAntennaArrayCalculator`, etc

