### PR TITLE
fix[tests]: increase overlap threshold in test_mode_solver_data_sort

### DIFF
--- a/tests/test_data/test_monitor_data.py
+++ b/tests/test_data/test_monitor_data.py
@@ -545,9 +545,10 @@ def test_mode_solver_data_sort():
     data_unsorted = data._reorder_modes(unsorting, phases, None)
 
     # sort back using all starting frequencies
-    data_first = data_unsorted.overlap_sort(track_freq="lowest")
-    data_last = data_unsorted.overlap_sort(track_freq="highest")
-    data_center = data_unsorted.overlap_sort(track_freq="central")
+    overlap_thresh = 0.95
+    data_first = data_unsorted.overlap_sort(track_freq="lowest", overlap_thresh=overlap_thresh)
+    data_last = data_unsorted.overlap_sort(track_freq="highest", overlap_thresh=overlap_thresh)
+    data_center = data_unsorted.overlap_sort(track_freq="central", overlap_thresh=overlap_thresh)
 
     # check that sorted data coincides with original
     for data_sorted in [data_first, data_last, data_center]:


### PR DESCRIPTION
This test has been failing sporadically. I was able to reproduce the issue locally when testing just this function instead of the whole test_monitor_data.py file. Changing the rng seed or state would then randomly cause the test to start working again. I traced this to the `unsorting` array that was getting generated (line 542 in the code change). When the random permutation was [3, 1, 2, 0] (i.e. - the first and last modes were swapped), they were not getting re-sorted properly. I was able to reproduce reliably by just hardcoding the permutation to this for all the frequencies.

It seems like the default `overlap_thresh` argument to the `overlap_sort` function is not high enough to properly sort these modes. Here, I've specified a higher `overlap_thresh` value in order for the test to pass assuming that the threshold being too low is mostly related to the test operating on generated data instead of actual mode solver runs. However, I'm wondering if this is an indication that the default should be made higher instead?

