### PR TITLE
Introducing AnalyticBeam components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `layer_refinement_specs` field in `GridSpec` that takes a list of `LayerRefinementSpec` for automatic mesh refinement and snapping in layered structures. Structure corners on the cross section perpendicular to layer thickness direction can be automatically identified. Mesh is automatically snapped and refined around those corners.
 - New field `drop_outside_sim` in `MeshOverrideStructure` to specify whether to drop an override structure if it is outside the simulation domain, but it overlaps with the simulation domain when projected to an axis.
 - Function `translated_copy` in `ElectromagneticFieldData` to facilitate computing overlaps between field data at different locations.
+- `PlaneWaveBeamProfile`, `GaussianBeamProfile` and `AstigmaticGaussianBeamProfile` components to compute field data associated to such beams based on their corresponding analytical expressions, and compute field overlaps with other data.
+- `num_freqs` argument to the `PlaneWave` source.
 
 ### Changed
 - The coordinate of snapping points in `GridSpec` can take value `None`, so that mesh can be selectively snapped only along certain dimensions.
 - Grid snapping for `MeshOverrideStructure` with `shadow=False` is only on if the structure refines the mesh.
 - Renamed `SkinDepthFitterParam` --> `SurfaceImpedanceFitterParam` used in `LossyMetalMedium`. `plot` in `LossyMetalMedium` now plots complex-valued surface impedance.
 - Changed plot_3d iframe url to tidy3d production environment.
+- `num_freqs` is now set to 3 by default for the `PlaneWave`, `GaussianBeam`, and `AnalyticGaussianBeam` sources, which makes the injection more accurate in broadband cases.
 
 ### Fixed
 - Make gauge selection for non-converged modes more robust.

--- a/docs/api/analytic_beams.rst
+++ b/docs/api/analytic_beams.rst
@@ -1,0 +1,12 @@
+.. currentmodule:: tidy3d
+
+Analytic Beams
+==============
+
+.. autosummary::
+   :toctree: _autosummary/
+   :template: module.rst
+
+    tidy3d.PlaneWaveAnalyticBeam
+    tidy3d.GaussianAnalyticBeam
+    tidy3d.AstigmaticGaussianAnalyticBeam

--- a/docs/api/analytic_beams.rst
+++ b/docs/api/analytic_beams.rst
@@ -7,6 +7,6 @@ Analytic Beams
    :toctree: _autosummary/
    :template: module.rst
 
-    tidy3d.PlaneWaveAnalyticBeam
-    tidy3d.GaussianAnalyticBeam
-    tidy3d.AstigmaticGaussianAnalyticBeam
+    tidy3d.PlaneWaveBeamProfile
+    tidy3d.GaussianBeamProfile
+    tidy3d.AstigmaticGaussianBeamProfile

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -13,6 +13,7 @@ API |:computer:|
     rf_material_library
     structures
     sources
+    analytic_beams
     monitors
     mode
     field_projector
@@ -38,6 +39,7 @@ API |:computer:|
 .. include:: /api/mediums.rst
 .. include:: /api/structures.rst
 .. include:: /api/sources.rst
+.. include:: /api/analytic_beams.rst
 .. include:: /api/monitors.rst
 .. include:: /api/mode.rst
 .. include:: /api/field_projector.rst

--- a/tests/test_components/test_beam.py
+++ b/tests/test_components/test_beam.py
@@ -1,12 +1,12 @@
-"""Tests for the various AnalyticBeam components."""
+"""Tests for the various BeamProfile components."""
 
 import numpy as np
 import pydantic.v1 as pd
 import pytest
 from tidy3d.components.beam import (
-    AstigmaticGaussianAnalyticBeam,
-    GaussianAnalyticBeam,
-    PlaneWaveAnalyticBeam,
+    AstigmaticGaussianBeamProfile,
+    GaussianBeamProfile,
+    PlaneWaveBeamProfile,
 )
 from tidy3d.components.data.monitor_data import FieldData
 
@@ -22,7 +22,7 @@ def test_gaussian_beam():
     resolution = 150
     waist_radius = 1.0
     waist_distance = 3.0
-    beam = GaussianAnalyticBeam(
+    beam = GaussianBeamProfile(
         center=center,
         size=size,
         resolution=resolution,
@@ -30,7 +30,6 @@ def test_gaussian_beam():
         waist_radius=waist_radius,
         waist_distance=waist_distance,
     )
-    print(beam)
     field_data = beam.field_data
     assert isinstance(field_data, FieldData)
     assert np.allclose(field_data.flux, 1)
@@ -43,7 +42,7 @@ def test_plane_wave():
     center = (0, 0, 0)
     size = (10, 0, 10)
     resolution = 100
-    beam = PlaneWaveAnalyticBeam(center=center, size=size, resolution=resolution, freqs=FREQS)
+    beam = PlaneWaveBeamProfile(center=center, size=size, resolution=resolution, freqs=FREQS)
     field_data = beam.field_data
     assert isinstance(field_data, FieldData)
     assert np.allclose(field_data.flux, 1)
@@ -57,7 +56,7 @@ def test_astigmatic_gaussian_beam():
     size = (0, 20, 20)
     waist_sizes = (4.0, 2.0)
     waist_distances = (1.0, 2.0)
-    beam = AstigmaticGaussianAnalyticBeam(
+    beam = AstigmaticGaussianBeamProfile(
         center=center,
         size=size,
         freqs=FREQS,
@@ -96,7 +95,7 @@ def test_invalid_beam_size():
     size = (10, 10, 10)
     resolution = 100
     with pytest.raises(pd.ValidationError):
-        GaussianAnalyticBeam(center=center, size=size, resolution=resolution, freqs=FREQS)
+        GaussianBeamProfile(center=center, size=size, resolution=resolution, freqs=FREQS)
 
 
 def test_gaussian_beam_ex_spread_waist_distance():
@@ -109,7 +108,7 @@ def test_gaussian_beam_ex_spread_waist_distance():
     waist_radius = 1.0
     waist_distance_1 = 3.0
     waist_distance_2 = 1.0
-    beam_data_1 = GaussianAnalyticBeam(
+    beam_data_1 = GaussianBeamProfile(
         center=center,
         size=size,
         resolution=resolution,
@@ -117,7 +116,7 @@ def test_gaussian_beam_ex_spread_waist_distance():
         waist_radius=waist_radius,
         waist_distance=waist_distance_1,
     )
-    beam_data_2 = GaussianAnalyticBeam(
+    beam_data_2 = GaussianBeamProfile(
         center=center,
         size=size,
         resolution=resolution,
@@ -141,7 +140,7 @@ def test_gaussian_beam_center():
     waist_radius = 1.0
 
     # Normal beam data should be centered at x=0, y=0
-    beam = GaussianAnalyticBeam(
+    beam = GaussianBeamProfile(
         center=center,
         size=size,
         resolution=resolution,
@@ -192,7 +191,7 @@ def test_beam_overlap():
     resolution2 = 200
     waist_radius = 1.0
     waist_distance = 3.0
-    beam1 = GaussianAnalyticBeam(
+    beam1 = GaussianBeamProfile(
         center=center,
         size=size,
         resolution=resolution1,
@@ -200,7 +199,7 @@ def test_beam_overlap():
         waist_radius=waist_radius,
         waist_distance=waist_distance,
     )
-    beam2 = AstigmaticGaussianAnalyticBeam(
+    beam2 = AstigmaticGaussianBeamProfile(
         center=center,
         size=size,
         resolution=resolution2,

--- a/tests/test_components/test_beam.py
+++ b/tests/test_components/test_beam.py
@@ -1,0 +1,222 @@
+"""Tests for the various AnalyticBeam components."""
+
+import numpy as np
+import pydantic.v1 as pd
+import pytest
+from tidy3d.components.beam import (
+    AstigmaticGaussianAnalyticBeam,
+    GaussianAnalyticBeam,
+    PlaneWaveAnalyticBeam,
+)
+from tidy3d.components.data.monitor_data import FieldData
+
+FREQS = np.linspace(1e14, 2e14, 10).tolist()
+
+
+def test_gaussian_beam():
+    """
+    Test Gaussian beam creation and field data validation.
+    """
+    center = (0, 0, 0)
+    size = (10, 10, 0)
+    resolution = 150
+    waist_radius = 1.0
+    waist_distance = 3.0
+    beam = GaussianAnalyticBeam(
+        center=center,
+        size=size,
+        resolution=resolution,
+        freqs=FREQS,
+        waist_radius=waist_radius,
+        waist_distance=waist_distance,
+    )
+    print(beam)
+    field_data = beam.field_data
+    assert isinstance(field_data, FieldData)
+    assert np.allclose(field_data.flux, 1)
+
+
+def test_plane_wave():
+    """
+    Test plane wave creation and field data validation.
+    """
+    center = (0, 0, 0)
+    size = (10, 0, 10)
+    resolution = 100
+    beam = PlaneWaveAnalyticBeam(center=center, size=size, resolution=resolution, freqs=FREQS)
+    field_data = beam.field_data
+    assert isinstance(field_data, FieldData)
+    assert np.allclose(field_data.flux, 1)
+
+
+def test_astigmatic_gaussian_beam():
+    """
+    Test astigmatic Gaussian beam creation, field data validatio variation along y and z axes.
+    """
+    center = (0, 0, 0)
+    size = (0, 20, 20)
+    waist_sizes = (4.0, 2.0)
+    waist_distances = (1.0, 2.0)
+    beam = AstigmaticGaussianAnalyticBeam(
+        center=center,
+        size=size,
+        freqs=FREQS,
+        waist_sizes=waist_sizes,
+        waist_distances=waist_distances,
+    )
+    field_data = beam.field_data
+    assert isinstance(field_data, FieldData)
+    assert np.allclose(field_data.flux, 1)
+
+    # Test that the spread is larger in the dimension in which the waist size is larger
+    ey_variation_y = np.std(field_data.Ey.isel(f=0).sel(z=0, method="nearest").values)
+    ey_variation_z = np.std(field_data.Ey.isel(f=0).sel(y=0, method="nearest").values)
+    assert ey_variation_y > ey_variation_z
+
+    # Test that the opposite direction field data has opposite flux
+    field_data_bwd = beam.updated_copy(direction="-").field_data
+
+    # import matplotlib.pyplot as plt
+    # fig, ax = plt.subplots(3, 2)
+    # field_data.Ex.abs.isel(f=0).plot(ax=ax[0, 0])
+    # field_data_bwd.Ex.abs.isel(f=0).plot(ax=ax[0, 1])
+    # field_data.Ey.abs.isel(f=0).plot(ax=ax[1, 0])
+    # field_data_bwd.Ey.abs.isel(f=0).plot(ax=ax[1, 1])
+    # field_data.Ez.abs.isel(f=0).plot(ax=ax[2, 0])
+    # field_data_bwd.Ez.abs.isel(f=0).plot(ax=ax[2, 1])
+    # plt.show()
+    assert field_data.flux == -field_data_bwd.flux
+
+
+def test_invalid_beam_size():
+    """
+    Test that a beam with three nonzero size values raises a validation error.
+    """
+    center = (0, 0, 0)
+    size = (10, 10, 10)
+    resolution = 100
+    with pytest.raises(pd.ValidationError):
+        GaussianAnalyticBeam(center=center, size=size, resolution=resolution, freqs=FREQS)
+
+
+def test_gaussian_beam_ex_spread_waist_distance():
+    """
+    Test that the Gaussian beam has a larger spread when the waist distance is decreased.
+    """
+    center = (0, 0, 0)
+    size = (10, 10, 0)
+    resolution = 150
+    waist_radius = 1.0
+    waist_distance_1 = 3.0
+    waist_distance_2 = 1.0
+    beam_data_1 = GaussianAnalyticBeam(
+        center=center,
+        size=size,
+        resolution=resolution,
+        freqs=FREQS,
+        waist_radius=waist_radius,
+        waist_distance=waist_distance_1,
+    )
+    beam_data_2 = GaussianAnalyticBeam(
+        center=center,
+        size=size,
+        resolution=resolution,
+        freqs=FREQS,
+        waist_radius=waist_radius,
+        waist_distance=waist_distance_2,
+    )
+    ex_spread_1 = np.std(beam_data_1.field_data.Ex.isel(f=0).values)
+    ex_spread_2 = np.std(beam_data_2.field_data.Ex.isel(f=0).values)
+    assert ex_spread_2 > ex_spread_1
+
+
+def test_gaussian_beam_center():
+    """
+    Test that a Gaussian beam with a nonzero
+    angle_theta and a nonzero waist_distance is centered away from x=0, y=0.
+    """
+    center = (0, 0, 0)
+    size = (10, 10, 0)
+    resolution = 151
+    waist_radius = 1.0
+
+    # Normal beam data should be centered at x=0, y=0
+    beam = GaussianAnalyticBeam(
+        center=center,
+        size=size,
+        resolution=resolution,
+        freqs=FREQS,
+        waist_radius=waist_radius,
+    )
+
+    # Angled beam data without waist_distance should also be centered at x=0, y=0
+    beam_data_angled = beam.updated_copy(angle_theta=np.pi / 4, angle_phi=np.pi / 4)
+
+    # Angled beam data with waist_distance should be centered away from the center plane
+    beam_data_angled_distance = beam_data_angled.updated_copy(waist_distance=5)
+
+    field_data = beam.field_data
+    field_data_angled = beam_data_angled.field_data
+    field_data_angled_distance = beam_data_angled_distance.field_data
+
+    def get_center(data):
+        ex_field = data.Ex.isel(f=0).abs
+        x, y = ex_field.coords["x"].values, ex_field.coords["y"].values
+        max_ex_index = np.unravel_index(np.argmax(ex_field.values), ex_field.shape)
+        return x[max_ex_index[0]], y[max_ex_index[1]]
+
+    print(get_center(field_data))
+    print(get_center(field_data_angled))
+    print(get_center(field_data_angled_distance))
+
+    # import matplotlib.pyplot as plt
+    # fig, ax = plt.subplots(3, 2)
+    # field_data.Ex.abs.isel(f=0).plot(ax=ax[0, 0])
+    # field_data.Ey.abs.isel(f=0).plot(ax=ax[1, 0])
+    # field_data.Ez.abs.isel(f=0).plot(ax=ax[2, 0])
+    # field_data_angled_distance.Ex.abs.isel(f=0).plot(ax=ax[0, 1])
+    # field_data_angled_distance.Ey.abs.isel(f=0).plot(ax=ax[1, 1])
+    # field_data_angled_distance.Ez.abs.isel(f=0).plot(ax=ax[2, 1])
+    # plt.show()
+
+    assert np.allclose(get_center(field_data), (0, 0))
+    assert np.allclose(get_center(field_data_angled), (0, 0))
+    assert np.all(np.abs(get_center(field_data_angled_distance)) > 1)
+
+
+def test_beam_overlap():
+    """Test that an outer dot can be computed between two beams."""
+    center = (0, 0, 0)
+    size = (10, 10, 0)
+    resolution1 = 150
+    resolution2 = 200
+    waist_radius = 1.0
+    waist_distance = 3.0
+    beam1 = GaussianAnalyticBeam(
+        center=center,
+        size=size,
+        resolution=resolution1,
+        freqs=FREQS,
+        waist_radius=waist_radius,
+        waist_distance=waist_distance,
+    )
+    beam2 = AstigmaticGaussianAnalyticBeam(
+        center=center,
+        size=size,
+        resolution=resolution2,
+        freqs=FREQS,
+        waist_sizes=[waist_radius, waist_radius],
+        waist_distances=[waist_distance, waist_distance],
+    )
+    outer_dot = beam1.field_data.outer_dot(beam2.field_data)
+    # Equivalent beam definition apart from different discretization, leading to a small mismatch
+    assert np.allclose(outer_dot, 1.0, rtol=1e-3)
+
+
+if __name__ == "__main__":
+    # test_gaussian_beam()
+    # test_plane_wave()
+    # test_astigmatic_gaussian_beam()
+    # test_invalid_beam_size()
+    test_gaussian_beam_ex_spread_waist_distance()
+    # test_gaussian_beam_center()

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -76,6 +76,13 @@ from .components.bc_placement import (
     StructureStructureInterface,
 )
 
+# analytic beams
+from .components.beam import (
+    AstigmaticGaussianAnalyticBeam,
+    GaussianAnalyticBeam,
+    PlaneWaveAnalyticBeam,
+)
+
 # boundary
 from .components.boundary import (
     PML,
@@ -445,6 +452,9 @@ __all__ = [
     "CustomFieldSource",
     "TFSF",
     "CustomCurrentSource",
+    "GaussianAnalyticBeam",
+    "AstigmaticGaussianAnalyticBeam",
+    "PlaneWaveAnalyticBeam",
     "FieldMonitor",
     "FieldTimeMonitor",
     "FluxMonitor",

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -78,9 +78,9 @@ from .components.bc_placement import (
 
 # analytic beams
 from .components.beam import (
-    AstigmaticGaussianAnalyticBeam,
-    GaussianAnalyticBeam,
-    PlaneWaveAnalyticBeam,
+    AstigmaticGaussianBeamProfile,
+    GaussianBeamProfile,
+    PlaneWaveBeamProfile,
 )
 
 # boundary
@@ -452,9 +452,9 @@ __all__ = [
     "CustomFieldSource",
     "TFSF",
     "CustomCurrentSource",
-    "GaussianAnalyticBeam",
-    "AstigmaticGaussianAnalyticBeam",
-    "PlaneWaveAnalyticBeam",
+    "GaussianBeamProfile",
+    "AstigmaticGaussianBeamProfile",
+    "PlaneWaveBeamProfile",
     "FieldMonitor",
     "FieldTimeMonitor",
     "FluxMonitor",

--- a/tidy3d/components/beam.py
+++ b/tidy3d/components/beam.py
@@ -2,7 +2,7 @@
 astigmatic Gaussian beam."""
 
 from abc import abstractmethod
-from typing import Tuple
+from typing import Optional, Tuple, Union
 
 import autograd.numpy as np
 import pydantic.v1 as pd
@@ -15,13 +15,14 @@ from .geometry.base import Box
 from .grid.grid import Coords, Grid
 from .medium import Medium, MediumType
 from .monitor import FieldMonitor
-from .types import Direction, FreqArray, Literal, Numpy
+from .source.field import FixedAngleSpec, FixedInPlaneKSpec
+from .types import TYPE_TAG_STR, Direction, FreqArray, Literal, Numpy
 from .validators import assert_plane
 
 DEFAULT_RESOLUTION = 200
 
 
-class AnalyticBeam(Box):
+class BeamProfile(Box):
     """Base class for handling analytic beams."""
 
     resolution: float = pd.Field(
@@ -79,12 +80,6 @@ class AnalyticBeam(Box):
         title="Direction",
         description="Specifies propagation in the positive or negative direction of the normal "
         "axis.",
-    )
-
-    fixed_angle: Literal[False] = pd.Field(
-        False,
-        title="Fixed Angle Flag",
-        description="Fixed angle flag. Only used internally when computing source beams.",
     )
 
     _plane_validator = assert_plane()
@@ -178,15 +173,9 @@ class AnalyticBeam(Box):
         self, points: Numpy, background_n: float, field: Literal["E", "H"]
     ) -> Numpy:
         """Analytic beam with all the beam parameters but assuming ``z`` as the normal axis."""
-        angle_theta = self.angle_theta
-        angle_phi = self.angle_phi
 
         # Rotate points to axes where propagation is along z
-        if self.fixed_angle:
-            points_prop_z = points
-        else:
-            points_prop_z = self.rotate_points(points, [0, 0, 1], -angle_phi)
-            points_prop_z = self.rotate_points(points_prop_z, [0, 1, 0], -angle_theta)
+        points_prop_z = self._rotate_points_z(points)
 
         # Reflection at the z = 0 plane for negative direction
         if self.direction == "-":
@@ -214,8 +203,7 @@ class AnalyticBeam(Box):
                 field_vals[:2, :] *= -1
 
         # Rotate the fields back to the original propagation axes
-        field_vals = self.rotate_points(field_vals, [0, 1, 0], angle_theta)
-        field_vals = self.rotate_points(field_vals, [0, 0, 1], angle_phi)
+        field_vals = self._inverse_rotate_field_vals_z(field_vals, background_n)
 
         return field_vals
 
@@ -250,34 +238,115 @@ class AnalyticBeam(Box):
         # Reshape to (3, Nx, Ny, Nz, num_freqs)
         return np.reshape(field_vals, (3, Nx, Ny, Nz, len(self.freqs)))
 
+    def _rotate_points_z(self, points: Numpy) -> Numpy:
+        """Rotate points to new coordinates where z is the propagation axis."""
+        points_prop_z = self.rotate_points(points, [0, 0, 1], -self.angle_phi)
+        points_prop_z = self.rotate_points(points_prop_z, [0, 1, 0], -self.angle_theta)
+        return points_prop_z
 
-class PlaneWaveAnalyticBeam(AnalyticBeam):
+    def _inverse_rotate_field_vals_z(self, field_vals: Numpy, background_n: Numpy) -> Numpy:
+        """Rotate field values from coordinates where z is the propagation axis to angled
+        coordinates."""
+        field_vals = self.rotate_points(field_vals, [0, 1, 0], self.angle_theta)
+        field_vals = self.rotate_points(field_vals, [0, 0, 1], self.angle_phi)
+        return field_vals
+
+
+class PlaneWaveBeamProfile(BeamProfile):
     """Component for constructing plane wave beam data. The normal direction is implicitly
     defined by the ``size`` parameter.
 
     See also :class:`.PlaneWave`.
     """
 
-    fixed_angle: bool = pd.Field(
+    angular_spec: Union[FixedInPlaneKSpec, FixedAngleSpec] = pd.Field(
+        FixedAngleSpec(),
+        title="Angular Dependence Specification",
+        description="Specification of plane wave propagation direction dependence on wavelength.",
+        discriminator=TYPE_TAG_STR,
+    )
+
+    as_fixed_angle_source: bool = pd.Field(
         False,
         title="Fixed Angle Flag",
-        description="Fixed angle flag. Only used internally when computing source beams.",
+        description="Fixed angle flag. Only used internally when computing source beams for "
+        "injection in an FDTD simulation with fixed angle boudnaries. Use ``angular_spec`` to "
+        "switch between waves with fixed angle and fixed in-plane k.",
     )
+
+    angle_theta_frequency: Optional[float] = pd.Field(
+        None,
+        title="Frequency at Which Angle Theta is Defined",
+        description="Frequency for which ``angle_theta`` is set. This only has an effect for "
+        "fixed in-plane wave-vector beams. If not supplied, the average of the beam ``freqs`` is "
+        "used.",
+    )
+
+    @property
+    def _angle_theta_frequency(self):
+        if not self.angle_theta_frequency:
+            return np.mean(self.freqs)
+        return self.angle_theta_frequency
+
+    def in_plane_k(self, background_n: float):
+        """In-plane wave vector. Only the real part is taken so the beam has no in-plane decay."""
+        k0 = 2 * np.pi * self._angle_theta_frequency / C_0 * background_n
+        k_in_plane = k0.real * np.sin(self.angle_theta)
+        return [k_in_plane * np.cos(self.angle_phi), k_in_plane * np.sin(self.angle_phi)]
 
     def scalar_field(self, points: Numpy, background_n: float) -> Numpy:
         """Scalar field for plane wave.
         Scalar field corresponding to the analytic beam in coordinate system such that the
         propagation direction is z and the ``E``-field is entirely ``x``-polarized. The field is
         computed on an unstructured array ``points`` of shape ``(3, ...)``.
+        For the special case of fixed in-plane k, the propagation axis is not actually z. In fact
+        the propagation axis is frequency dependent and the only thing that is constant is the
+        in-plane k, which is why we do not rotate the points in ``self._rotate_points_z``.
         """
+        # Get the z-direction wave-vector magnitude depending on whether we're dealing with a
+        # Bloch boundary or fixed angle plane wave
+        kx, ky = 0, 0
         k0 = 2 * np.pi * np.array(self.freqs) / C_0 * background_n
-        if self.fixed_angle:
-            k0 *= np.cos(self.angle_theta)
-        field = np.exp(1j * np.outer(points[2], k0))
+        if self.as_fixed_angle_source:
+            kz = k0 * np.cos(self.angle_theta)
+        elif isinstance(self.angular_spec, FixedAngleSpec):
+            kz = k0
+        elif isinstance(self.angular_spec, FixedInPlaneKSpec):
+            kx, ky = self.in_plane_k(background_n)
+            kz = np.sqrt(k0**2 - kx**2 - ky**2)
+        field = np.exp(
+            1j * (np.outer(points[2], kz) + np.outer(points[0], kx) + np.outer(points[1], ky))
+        )
         return field
 
+    def _rotate_points_z(self, points: Numpy) -> Numpy:
+        """Rotate points to new coordinates where z is the propagation axis.
+        If we're computing numerical fixed angle or fixed in-plane k, we don't rotate the
+        points, which combines with handling in ``scalar_field`` and"
+        ``_inverse_rotate_field_vals_z."""
+        if self.as_fixed_angle_source or isinstance(self.angular_spec, FixedInPlaneKSpec):
+            return points
+        return super()._rotate_points_z(points)
 
-class GaussianAnalyticBeam(AnalyticBeam):
+    def _inverse_rotate_field_vals_z(self, field_vals: Numpy, background_n: Numpy) -> Numpy:
+        """Rotate field values from coordinates where z is the propagation axis to angled
+        coordinates. Special handling is needed if fixed in-plane k wave."""
+        if isinstance(self.angular_spec, FixedInPlaneKSpec):
+            # in case of bloch bcs, wave angle is frequency dependent
+            k0 = 2 * np.pi * np.array(self.freqs) / C_0 * background_n
+            kx, ky = self.in_plane_k(background_n)
+            k_perp = np.sqrt(kx**2 + ky**2)
+            angle_theta_actual = np.real(np.arcsin(k_perp / k0))
+            for ind in range(len(self.freqs)):
+                field_vals[:, :, ind] = self.rotate_points(
+                    field_vals[:, :, ind], [0, 1, 0], angle_theta_actual[ind]
+                )
+            field_vals = self.rotate_points(field_vals, [0, 0, 1], self.angle_phi)
+            return field_vals
+        return super()._inverse_rotate_field_vals_z(field_vals, background_n)
+
+
+class GaussianBeamProfile(BeamProfile):
     """Component for constructing Gaussian beam data. The normal direction is implicitly
     defined by the ``size`` parameter.
 
@@ -343,7 +412,7 @@ class GaussianAnalyticBeam(AnalyticBeam):
         return scalar_gaussian
 
 
-class AstigmaticGaussianAnalyticBeam(AnalyticBeam):
+class AstigmaticGaussianBeamProfile(BeamProfile):
     """Component for constructing astigmatic Gaussian beam data. The normal direction is implicitly
     defined by the ``size`` parameter.
 

--- a/tidy3d/components/beam.py
+++ b/tidy3d/components/beam.py
@@ -1,0 +1,418 @@
+"""Classes for creating data based on analytic beams like plane wave, Gaussian beam, and
+astigmatic Gaussian beam."""
+
+from abc import abstractmethod
+from typing import Tuple
+
+import autograd.numpy as np
+import pydantic.v1 as pd
+
+from ..constants import C_0, ETA_0, HERTZ, MICROMETER, RADIAN
+from .base import cached_property
+from .data.data_array import ScalarFieldDataArray
+from .data.monitor_data import FieldData
+from .geometry.base import Box
+from .grid.grid import Coords, Grid
+from .medium import Medium, MediumType
+from .monitor import FieldMonitor
+from .types import Direction, FreqArray, Literal, Numpy
+from .validators import assert_plane
+
+DEFAULT_RESOLUTION = 200
+
+
+class AnalyticBeam(Box):
+    """Base class for handling analytic beams."""
+
+    resolution: float = pd.Field(
+        DEFAULT_RESOLUTION,
+        title="Sampling resolution",
+        description="Sampling resolution in the tangential directions of the beam (defines a "
+        "number of equally spaced points).",
+        units=MICROMETER,
+    )
+
+    freqs: FreqArray = pd.Field(
+        ...,
+        title="Frequencies",
+        description="List of frequencies at which the beam is sampled.",
+        units=HERTZ,
+    )
+
+    background_medium: MediumType = pd.Field(
+        Medium(),
+        title="Background Medium",
+        description="Background medium in which the beam is embedded.",
+    )
+
+    angle_theta: float = pd.Field(
+        0.0,
+        title="Polar Angle",
+        description="Polar angle of the propagation axis from the normal axis.",
+        units=RADIAN,
+    )
+
+    angle_phi: float = pd.Field(
+        0.0,
+        title="Azimuth Angle",
+        description="Azimuth angle of the propagation axis in the plane orthogonal to the "
+        "normal axis.",
+        units=RADIAN,
+    )
+
+    pol_angle: float = pd.Field(
+        0.0,
+        title="Polarization Angle",
+        description="Specifies the angle between the electric field polarization of the "
+        "beam and the plane defined by the normal axis and the propagation axis (rad). "
+        "``pol_angle=0`` (default) specifies P polarization, "
+        "while ``pol_angle=np.pi/2`` specifies S polarization. "
+        "At normal incidence when S and P are undefined, ``pol_angle=0`` defines: "
+        "- ``Ey`` polarization for propagation along ``x``."
+        "- ``Ex`` polarization for propagation along ``y``."
+        "- ``Ex`` polarization for propagation along ``z``.",
+        units=RADIAN,
+    )
+
+    direction: Direction = pd.Field(
+        "+",
+        title="Direction",
+        description="Specifies propagation in the positive or negative direction of the normal "
+        "axis.",
+    )
+
+    fixed_angle: Literal[False] = pd.Field(
+        False,
+        title="Fixed Angle Flag",
+        description="Fixed angle flag. Only used internally when computing source beams.",
+    )
+
+    _plane_validator = assert_plane()
+
+    @property
+    def grid(self) -> Grid:
+        """Return a Grid object on which the beam will be sampled."""
+        dim_n, dim_tan = self.pop_axis("xyz", self.size.index(0.0))
+        bounds_n, bounds_tan = self.pop_axis(np.array(self.bounds).T, self.size.index(0.0))
+        boundaries = {
+            dim_n: bounds_n,
+            dim_tan[0]: np.linspace(bounds_tan[0][0], bounds_tan[0][1], int(self.resolution)),
+            dim_tan[1]: np.linspace(bounds_tan[1][0], bounds_tan[1][1], int(self.resolution)),
+        }
+        return Grid(boundaries=boundaries)
+
+    @property
+    def monitor(self) -> FieldMonitor:
+        """``FieldMonitor`` with the same center, size, and frequencies as the beam, to be used
+        in the ``FieldData`` created by the ``field_data`` method."""
+        return FieldMonitor(
+            size=self.size,
+            center=self.center,
+            freqs=self.freqs,
+            name="<<BEAM_DATA>>",
+        )
+
+    @cached_property
+    def field_data(self) -> FieldData:
+        """Compute a FieldData for the spatial E and H field amplitudes of an analytically defined
+        beam."""
+
+        background_n = np.zeros(len(self.freqs), dtype=complex)
+        for freq_id, freq in enumerate(self.freqs):
+            eps = self.background_medium.eps_model(freq)
+            nk_medium = self.background_medium.eps_complex_to_nk(eps)
+            background_n[freq_id] = np.squeeze(nk_medium[0]) + 1j * np.squeeze(nk_medium[1])
+
+        data_dict = self._field_data_on_grid(grid=self.grid, background_n=background_n)
+        data_raw = FieldData(monitor=self.monitor, grid_expanded=self.grid, **data_dict)
+
+        # Normalize by the flux
+        fields_norm = {}
+        flux = np.abs(data_raw.flux)
+        for field_name, field_data in data_raw.field_components.items():
+            fields_norm[field_name] = (field_data / np.sqrt(flux)).astype(field_data.dtype)
+
+        return data_raw.updated_copy(**fields_norm)
+
+    def _field_data_on_grid(self, grid: Grid, background_n: Numpy, colocate=True) -> dict:
+        """Compute the field data for each field component on a grid for the beam.
+        A dictionary of the scalar field data arrays is returned, not yet packaged as ``FieldData``.
+        """
+
+        field_components = ["Ex", "Ey", "Ez", "Hx", "Hy", "Hz"]
+        if colocate:
+            # Just sample at the grid boundaries for each field component
+            # We skip the last boundary because that's how things also work in the solver (no
+            # field defined at the last boundary)
+            coords_dict = {key: val[:-1] for key, val in grid.boundaries.to_dict.items()}
+            grid_dict = {component: Coords(**coords_dict) for component in field_components}
+        else:
+            # Yee grid for each field component
+            grid_dict = grid.yee.grid_dict
+
+        # Compute each field component over the beam grid
+        scalar_fields = {}
+        for comp, field in enumerate(field_components):
+            x, y, z = grid_dict[field].to_list
+            # Center component grid at beam center
+            x_c, y_c, z_c = (coords - cent for coords, cent in zip((x, y, z), self.center))
+            # Stack E and H fields
+            field_vals = self.analytic_beam(x_c, y_c, z_c, background_n, field=field[0])
+            # Get the current field component
+            field_vals = field_vals[comp % 3]
+            # Make the ScalarFieldDataArray for the current component
+            coords = dict(x=x, y=y, z=z, f=np.array(self.freqs))
+            field_data = ScalarFieldDataArray(field_vals, coords=coords)
+            scalar_fields[field] = field_data
+
+        return scalar_fields
+
+    @abstractmethod
+    def scalar_field(self, points: Numpy, background_n: float) -> Numpy:
+        """Scalar field corresponding to the analytic beam in coordinate system such that the
+        propagation direction is z and the ``E``-field is entirely ``x``-polarized. The field is
+        computed on an unstructured array ``points`` of shape ``(3, ...)``."""
+        pass
+
+    def analytic_beam_z_normal(
+        self, points: Numpy, background_n: float, field: Literal["E", "H"]
+    ) -> Numpy:
+        """Analytic beam with all the beam parameters but assuming ``z`` as the normal axis."""
+        angle_theta = self.angle_theta
+        angle_phi = self.angle_phi
+
+        # Rotate points to axes where propagation is along z
+        if self.fixed_angle:
+            points_prop_z = points
+        else:
+            points_prop_z = self.rotate_points(points, [0, 0, 1], -angle_phi)
+            points_prop_z = self.rotate_points(points_prop_z, [0, 1, 0], -angle_theta)
+
+        # Reflection at the z = 0 plane for negative direction
+        if self.direction == "-":
+            points_prop_z[2, :] *= -1
+
+        # Get fields polarized along x and propagating along z
+        scalar_field = self.scalar_field(points_prop_z, background_n)
+
+        # Set the correct field component based on the scalar field values
+        field_shape = tuple(list(points.shape) + [len(self.freqs)])
+        field_vals = np.zeros(field_shape, dtype=np.complex128)
+        if field == "E":
+            field_vals[0, ...] = scalar_field
+        else:
+            field_vals[1, ...] = scalar_field / ETA_0 * background_n
+
+        # Rotate polarization
+        field_vals = self.rotate_points(field_vals, [0, 0, 1], self.pol_angle)
+
+        # Reflection of the field components at the z = 0 plane for negative direction
+        if self.direction == "-":
+            if field == "E":
+                field_vals[2, :] *= -1
+            else:
+                field_vals[:2, :] *= -1
+
+        # Rotate the fields back to the original propagation axes
+        field_vals = self.rotate_points(field_vals, [0, 1, 0], angle_theta)
+        field_vals = self.rotate_points(field_vals, [0, 0, 1], angle_phi)
+
+        return field_vals
+
+    def analytic_beam(
+        self,
+        x: Numpy,
+        y: Numpy,
+        z: Numpy,
+        background_n: float,
+        field: Literal["E", "H"],
+    ) -> Numpy:
+        """Sample the analytic beam fields on a cartesian grid of points in x, y, z."""
+
+        # Make a meshgrid
+        (x_mesh, y_mesh, z_mesh) = np.meshgrid(x, y, z, indexing="ij")
+        (Nx, Ny, Nz) = x_mesh.shape
+
+        # Move to coordinates where the normal axis is z
+        (z_new, (x_new, y_new)) = self.pop_axis((x_mesh, y_mesh, z_mesh), axis=self.size.index(0.0))
+        points = np.stack([coords.ravel() for coords in (x_new, y_new, z_new)], axis=0)
+
+        # Sample the plane wave fields
+        f_x, f_y, f_z = self.analytic_beam_z_normal(points, background_n, field)
+
+        # Move back to original coordinates
+        field_vals = np.stack(self.unpop_axis(f_z, (f_x, f_y), axis=self.size.index(0.0)), axis=0)
+
+        # H field gets a -1 factor if a reflection was involved
+        if self.size.index(0.0) == 1 and field == "H":
+            field_vals *= -1
+
+        # Reshape to (3, Nx, Ny, Nz, num_freqs)
+        return np.reshape(field_vals, (3, Nx, Ny, Nz, len(self.freqs)))
+
+
+class PlaneWaveAnalyticBeam(AnalyticBeam):
+    """Component for constructing plane wave beam data. The normal direction is implicitly
+    defined by the ``size`` parameter.
+
+    See also :class:`.PlaneWave`.
+    """
+
+    fixed_angle: bool = pd.Field(
+        False,
+        title="Fixed Angle Flag",
+        description="Fixed angle flag. Only used internally when computing source beams.",
+    )
+
+    def scalar_field(self, points: Numpy, background_n: float) -> Numpy:
+        """Scalar field for plane wave.
+        Scalar field corresponding to the analytic beam in coordinate system such that the
+        propagation direction is z and the ``E``-field is entirely ``x``-polarized. The field is
+        computed on an unstructured array ``points`` of shape ``(3, ...)``.
+        """
+        k0 = 2 * np.pi * np.array(self.freqs) / C_0 * background_n
+        if self.fixed_angle:
+            k0 *= np.cos(self.angle_theta)
+        field = np.exp(1j * np.outer(points[2], k0))
+        return field
+
+
+class GaussianAnalyticBeam(AnalyticBeam):
+    """Component for constructing Gaussian beam data. The normal direction is implicitly
+    defined by the ``size`` parameter.
+
+    See also :class:`.GaussianBeam`.
+    """
+
+    waist_radius: pd.PositiveFloat = pd.Field(
+        1.0,
+        title="Waist Radius",
+        description="Radius of the beam at the waist.",
+        units=MICROMETER,
+    )
+
+    waist_distance: float = pd.Field(
+        0.0,
+        title="Waist Distance",
+        description="Distance from the beam waist along the propagation direction. "
+        "A positive value means the waist is positioned behind the beam, considering the propagation direction. "
+        "For example, for a beam propagating in the ``+`` direction, a positive value of ``beam_distance`` "
+        "means the beam waist is positioned in the ``-`` direction (behind the beam). "
+        "A negative value means the beam waist is in the ``+`` direction (in front of the beam). "
+        "For an angled beam, the distance is defined along the rotated propagation direction.",
+        units=MICROMETER,
+    )
+
+    def beam_params(self, z: Numpy, k0: Numpy) -> Tuple[Numpy, Numpy, Numpy]:
+        """Compute the parameters needed to evaluate a Gaussian beam at z.
+
+        Parameters
+        ----------
+        z : Numpy
+            Axial distance from the beam center.
+        k0 : Numpy
+            Wave vector magnitude.
+        """
+
+        w_0, z_0 = self.waist_radius, self.waist_distance
+        z_r = w_0**2 * k0 / 2  # shape k0
+        w_z = w_0 * np.sqrt(1 + np.outer(z + z_0, 1 / z_r) ** 2)  # shape (Np, Nk0)
+        # inv_r_z shape (Np, Nk0)
+        inv_r_z = (z + z_0)[:, None] / ((z + z_0)[:, None] ** 2 + z_r[None, :] ** 2)
+        # we choose gauge such that psi_g = 0 at z = 0 (beam plane)
+        # this is needed for a proper interpolation between different frequencies
+        # psi_g shape (Np, Nk0)
+        psi_g = np.arctan(np.outer(z + z_0, 1 / z_r)) - np.arctan(np.outer(z_0, 1 / z_r))
+        return w_z, inv_r_z, psi_g
+
+    def scalar_field(self, points: Numpy, background_n: float) -> Numpy:
+        """Scalar field for Gaussian beam.
+        Scalar field corresponding to the analytic beam in coordinate system such that the
+        propagation direction is z and the ``E``-field is entirely ``x``-polarized. The field is
+        computed on an unstructured array ``points`` of shape ``(3, ...)``.
+        """
+        k0 = 2 * np.pi * np.array(self.freqs) / C_0 * background_n
+        x, y, z = points
+        w_0 = self.waist_radius
+        w_z, inv_r_z, psi_g = self.beam_params(z, k0)
+        r_2 = x**2 + y**2
+        scalar_gaussian = w_0 / w_z
+        scalar_gaussian *= np.exp(-r_2[:, None] / w_z**2)
+        scalar_gaussian *= np.exp(1j * (np.outer(z, k0) + np.outer(r_2, k0) / 2 * inv_r_z - psi_g))
+
+        return scalar_gaussian
+
+
+class AstigmaticGaussianAnalyticBeam(AnalyticBeam):
+    """Component for constructing astigmatic Gaussian beam data. The normal direction is implicitly
+    defined by the ``size`` parameter.
+
+    See also :class:`.AstigmaticGaussianBeam`.
+    """
+
+    waist_sizes: Tuple[pd.PositiveFloat, pd.PositiveFloat] = pd.Field(
+        (1.0, 1.0),
+        title="Waist sizes",
+        description="Size of the beam at the waist in the local x and y directions.",
+        units=MICROMETER,
+    )
+
+    waist_distances: Tuple[float, float] = pd.Field(
+        (0.0, 0.0),
+        title="Waist distances",
+        description="Distance to the beam waist along the propagation direction "
+        "for the waist sizes in the local x and y directions. "
+        "When ``direction`` is ``+`` and ``waist_distances`` are positive, the waist "
+        "is on the ``-`` side (behind) the beam plane. When ``direction`` is ``+`` and "
+        "``waist_distances`` are negative, the waist is on the ``+`` side (in front) of "
+        "the beam plane.",
+        units=MICROMETER,
+    )
+
+    def beam_params(self, z: Numpy, k0: Numpy) -> Tuple[Numpy, Numpy, Numpy, Numpy]:
+        """Compute the parameters needed to evaluate an astigmatic Gaussian beam at z.
+
+        Parameters
+        ----------
+        z : Numpy
+            Axial distance from the beam center.
+        k0 : Numpy
+            Wave vector magnitude.
+        """
+
+        w_xy, z_xy = self.waist_sizes, self.waist_distances  # shape (2, )
+        z_r = [w**2 * k0 / 2 for w in w_xy]  # shape (2, Nk0)
+        w_z, w_0, inv_r_z, psi_g = [], [], [], []  # final shape (2, Np, Nk0) after loop below
+        for w, z_i, z_ri in zip(w_xy, z_xy, z_r):
+            w_z.append(w * np.sqrt(1 + np.outer(z + z_i, 1 / z_ri) ** 2))
+            w_0.append(w * np.sqrt(1 + np.outer(z_i, 1 / z_ri) ** 2))
+            inv_r_z.append((z + z_i)[:, None] / ((z + z_i)[:, None] ** 2 + z_ri[None, :] ** 2))
+            # we choose gauge such that psi_g = 0 at z = 0 (beam plane)
+            # this is needed for a proper interpolation between different frequencies
+            # psi_g shape (Np, Nk0)
+            psi_g_1 = np.arctan(np.outer((z + z_i), 1 / z_ri)) / 2
+            psi_g_2 = np.arctan(np.outer((z_i), 1 / z_ri)) / 2
+            psi_g.append(psi_g_1 - psi_g_2)
+
+        return w_0, w_z, inv_r_z, psi_g
+
+    def scalar_field(self, points: Numpy, background_n: float) -> Numpy:
+        """
+        Scalar field for astigmatic Gaussian beam.
+        Scalar field corresponding to the analytic beam in coordinate system such that the
+        propagation direction is z and the ``E``-field is entirely ``x``-polarized. The field is
+        computed on an unstructured array ``points`` of shape ``(3, ...)``.
+        """
+        k0 = 2 * np.pi * np.array(self.freqs) / C_0 * background_n
+        x, y, z = points
+        w_0, w_z, inv_r_z, psi_g = self.beam_params(z, k0)
+        x_2 = x**2
+        y_2 = y**2
+
+        q_term1_inv = 1j * np.outer(x_2, k0) / 2 * inv_r_z[0] - x_2[:, None] / w_z[0] ** 2
+        q_term2_inv = 1j * np.outer(y_2, k0) / 2 * inv_r_z[1] - y_2[:, None] / w_z[1] ** 2
+        angle_term = q_term1_inv + q_term2_inv + 1j * (np.outer(z, k0) - psi_g[0] - psi_g[1])
+        scalar_gaussian = np.exp(angle_term)
+
+        ampl = np.sqrt(w_0[0] * w_0[1] / w_z[0] / w_z[1])
+        return scalar_gaussian * ampl

--- a/tidy3d/components/source/field.py
+++ b/tidy3d/components/source/field.py
@@ -34,6 +34,10 @@ from .base import Source
 CHEB_GRID_WIDTH = 1.5
 # Number of frequencies in a broadband source above which to issue a warning
 WARN_NUM_FREQS = 20
+# For broadband plane waves with constan in-plane k, the Chebyshev grid is truncated at
+# ``CRITICAL_FREQUENCY_FACTOR * f_crit``, where ``f_crit`` is the critical frequency
+# (oblique propagation).
+CRITICAL_FREQUENCY_FACTOR = 1.15
 
 
 class FieldSource(Source, ABC):
@@ -105,6 +109,10 @@ class BroadbandSource(Source, ABC):
     def frequency_grid(self) -> np.ndarray:
         """A Chebyshev grid used to approximate frequency dependence."""
         freq_min, freq_max = self.source_time.frequency_range(num_fwidth=CHEB_GRID_WIDTH)
+        return self._chebyshev_freq_grid(freq_min, freq_max)
+
+    def _chebyshev_freq_grid(self, freq_min, freq_max):
+        """A Chebyshev grid based on a minimum and maximum frequency."""
         freq_avg = 0.5 * (freq_min + freq_max)
         freq_diff = 0.5 * (freq_max - freq_min)
         uni_points = (2 * np.arange(self.num_freqs) + 1) / (2 * self.num_freqs)
@@ -466,7 +474,7 @@ class FixedAngleSpec(AbstractAngularSpec):
     """
 
 
-class PlaneWave(AngledFieldSource, PlanarSource):
+class PlaneWave(AngledFieldSource, PlanarSource, BroadbandSource):
     """Uniform current distribution on an infinite extent plane. One element of size must be zero.
 
     Example
@@ -492,10 +500,46 @@ class PlaneWave(AngledFieldSource, PlanarSource):
         discriminator=TYPE_TAG_STR,
     )
 
+    num_freqs: int = pydantic.Field(
+        3,
+        title="Number of Frequency Points",
+        description="Number of points used to approximate the frequency dependence of the injected "
+        "field. Default is 3, which should cover even very broadband sources. For simulations "
+        "which are not very broadband and the source is very large (e.g. metalens simulations), "
+        "decreasing the value to 1 may lead to a speed up in the preprocessing.",
+        ge=1,
+        le=10,
+    )
+
     @cached_property
     def _is_fixed_angle(self) -> bool:
         """Whether the plane wave is at a fixed non-zero angle."""
         return isinstance(self.angular_spec, FixedAngleSpec) and self.angle_theta != 0.0
+
+    @cached_property
+    def frequency_grid(self) -> np.ndarray:
+        """A Chebyshev grid used to approximate frequency dependence."""
+        freq_min, freq_max = self.source_time.frequency_range(num_fwidth=CHEB_GRID_WIDTH)
+        if not self._is_fixed_angle:
+            # For frequency-dependent angles (constat in-plane k), truncate minimum frequency at
+            # the critical frequency of glancing incidence
+            f_crit = self.source_time.freq0 * np.sin(self.angle_theta)
+            freq_min = max(freq_min, f_crit * CRITICAL_FREQUENCY_FACTOR)
+        return self._chebyshev_freq_grid(freq_min, freq_max)
+
+    def _post_init_validators(self) -> None:
+        """Error if a broadband plane wave with constant in-plane k is defined such that
+        the source frequency range is entirely below ``f_crit * CRITICAL_FREQUENCY_FACTOR."""
+        if self._is_fixed_angle or self.num_freqs == 1:
+            return
+        freq_min, freq_max = self.source_time.frequency_range(num_fwidth=CHEB_GRID_WIDTH)
+        f_crit = self.source_time.freq0 * np.sin(self.angle_theta)
+        if f_crit * CRITICAL_FREQUENCY_FACTOR > freq_max:
+            raise SetupError(
+                "Broadband plane wave source defined with a bandwidth too close to the critical "
+                "frequency of oblique incidence. Increase the source bandwidth, or disable the "
+                "broadband handling by setting 'num_freqs' to 1."
+            )
 
 
 class GaussianBeam(AngledFieldSource, PlanarSource, BroadbandSource):
@@ -546,6 +590,16 @@ class GaussianBeam(AngledFieldSource, PlanarSource, BroadbandSource):
         units=MICROMETER,
     )
 
+    num_freqs: int = pydantic.Field(
+        3,
+        title="Number of Frequency Points",
+        description="Number of points used to approximate the frequency dependence of injected "
+        "field. A Chebyshev interpolation is used, thus, only a small number of points, i.e., less "
+        "than 20, is typically sufficient to obtain converged results.",
+        ge=1,
+        le=99,
+    )
+
 
 class AstigmaticGaussianBeam(AngledFieldSource, PlanarSource, BroadbandSource):
     """The simple astigmatic Gaussian distribution allows
@@ -592,6 +646,16 @@ class AstigmaticGaussianBeam(AngledFieldSource, PlanarSource, BroadbandSource):
         "``waist_distances`` are negative, the waist is on the ``+`` side (in front) of "
         "the source plane.",
         units=MICROMETER,
+    )
+
+    num_freqs: int = pydantic.Field(
+        3,
+        title="Number of Frequency Points",
+        description="Number of points used to approximate the frequency dependence of injected "
+        "field. A Chebyshev interpolation is used, thus, only a small number of points, i.e., less "
+        "than 20, is typically sufficient to obtain converged results.",
+        ge=1,
+        le=99,
     )
 
 


### PR DESCRIPTION
This introduces `PlaneWaveAnalyticBeam`, `GaussianAnalyticBeam`, and `AstigmaticGaussianAnalyticBeam` components, which can be used to generate the fields that correspond to such beams in a given cross-section. The main use case for this is to compute overlap integrals with recorded field data.

I'm not a fan of the `Analytic` part in the name, but simply `GaussianBeam` is already the name of our source. Ideas for other names are welcome!

@tomflexcompute could you check if this works in your example, and maybe share it with me so we can add something related to it as a test?