### PR TITLE
In LossyMetal rename SkinDepthFitterParam to SurfaceImpedanceFitterParam and plot impedance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The coordinate of snapping points in `GridSpec` can take value `None`, so that mesh can be selectively snapped only along certain dimensions.
 - Grid snapping for `MeshOverrideStructure` with `shadow=False` is only on if the structure refines the mesh.
+- Renamed `SkinDepthFitterParam` --> `SurfaceImpedanceFitterParam` used in `LossyMetalMedium`. `plot` in `LossyMetalMedium` now plots complex-valued surface impedance.
+
 ### Fixed
 - Make gauge selection for non-converged modes more robust.
 

--- a/docs/api/mediums.rst
+++ b/docs/api/mediums.rst
@@ -33,7 +33,7 @@ Fitting parameters
    :toctree: _autosummary/
    :template: module.rst
 
-   tidy3d.SkinDepthFitterParam
+   tidy3d.SurfaceImpedanceFitterParam
 
 Dispersive Mediums
 ------------------

--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -144,22 +144,35 @@ def test_PEC():
 def test_lossy_metal():
     # frequency_range shouldn't be None
     with pytest.raises(pydantic.ValidationError):
-        _ = td.LossyMetalMedium()
+        _ = td.LossyMetalMedium(conductivity=1)
     # frequency_range shouldn't contain non-postive values
     with pytest.raises(pydantic.ValidationError):
-        _ = td.LossyMetalMedium(frequency_range=(0, 10))
+        _ = td.LossyMetalMedium(conductivity=1, frequency_range=(0, 10))
     with pytest.raises(pydantic.ValidationError):
-        _ = td.LossyMetalMedium(frequency_range=(-10, 10))
+        _ = td.LossyMetalMedium(conductivity=1, frequency_range=(-10, 10))
 
     # frequency_range should be finite
     with pytest.raises(pydantic.ValidationError):
-        _ = td.LossyMetalMedium(frequency_range=(10, np.inf))
+        _ = td.LossyMetalMedium(conductivity=1, frequency_range=(10, np.inf))
     with pytest.raises(pydantic.ValidationError):
-        _ = td.LossyMetalMedium(frequency_range=(-np.inf, 10))
+        _ = td.LossyMetalMedium(conductivity=1, frequency_range=(-np.inf, 10))
+
+    # allow_gain cannot be true
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.LossyMetalMedium(allow_gain=True, conductivity=1, frequency_range=(10, 20))
+
+    # conductivity cannot be negative
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.LossyMetalMedium(conductivity=-1, frequency_range=(10, 20))
+
+    # conductivity cannot be 0
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.LossyMetalMedium(conductivity=0, frequency_range=(10, 20))
 
     # default fitting
     mat = td.LossyMetalMedium(conductivity=1.0, frequency_range=(1e14, 4e14))
-    model = mat.skin_depth_model
+    model = mat.scaled_surface_impedance_model
+    num_poles = mat.num_poles
 
 
 def test_medium_dispersion():

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -242,7 +242,7 @@ from .components.medium import (
     PerturbationPoleResidue,
     PoleResidue,
     Sellmeier,
-    SkinDepthFitterParam,
+    SurfaceImpedanceFitterParam,
     TwoPhotonAbsorption,
     medium_from_nk,
 )
@@ -408,7 +408,7 @@ __all__ = [
     "CustomDebye",
     "CustomAnisotropicMedium",
     "LossyMetalMedium",
-    "SkinDepthFitterParam",
+    "SurfaceImpedanceFitterParam",
     "RotationAroundAxis",
     "PerturbationMedium",
     "PerturbationPoleResidue",


### PR DESCRIPTION
The original term `SkinDepthFitterParam` is very nonstandard, and people might get more confused in the future when we extend it to more complicated imperfect metals, e.g. including surface roughness. Luckily, it was rolled out in the pre-release, so let's fix that before it's going formal.

Even though internally we are fitting `Z/(-j omega)` where `Z` is the surface impedance, we plot surface impedance as it's more relevant to users. 