### PR TITLE
:zap: Fix normal axis in doping

### DIFF
--- a/tidy3d/components/tcad/doping.py
+++ b/tidy3d/components/tcad/doping.py
@@ -46,7 +46,8 @@ class AbstractDopingBox(Box):
                 # normal_position = coords[var_name][0]
 
         # if provided coordinates are 3D, check if box is 2D
-        normal_axis = self._normal_dim()
+        if normal_axis is None:
+            normal_axis = self._normal_dim()
 
         if meshgrid:
             X, Y, Z = np.meshgrid(coords["x"], coords["y"], coords["z"], indexing="ij")


### PR DESCRIPTION
This PR fixes an issue with plotting where the doping box is not 3D but the structure is.

fyi @alec-flexcompute 