### PR TITLE
Support for automatically running multiple adjoint simulations from single fwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Function `translated_copy` in `ElectromagneticFieldData` to facilitate computing overlaps between field data at different locations.
 - `PlaneWaveBeamProfile`, `GaussianBeamProfile` and `AstigmaticGaussianBeamProfile` components to compute field data associated to such beams based on their corresponding analytical expressions, and compute field overlaps with other data.
 - `num_freqs` argument to the `PlaneWave` source.
+- Support for running multiple adjoint simulations from a single forward simulation in adjoint pipeline depending on monitor configuration.
 
 ### Changed
 - The coordinate of snapping points in `GridSpec` can take value `None`, so that mesh can be selectively snapped only along certain dimensions.

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -151,7 +151,7 @@ def use_emulated_run(monkeypatch):
     import tidy3d
 
     if TEST_MODE in ("pipeline", "speed"):
-        task_id_fwd = "task_fwd"
+        task_name_fwd = "task_fwd"
         AUX_KEY_SIM_FIELDS_KEYS = "sim_fields_keys"
 
         cache = {}
@@ -168,7 +168,7 @@ def use_emulated_run(monkeypatch):
 
         def emulated_run_fwd(simulation, task_name, **run_kwargs) -> td.SimulationData:
             """What gets called instead of ``web/api/autograd/autograd.py::_run_tidy3d``."""
-            task_id_fwd = task_name
+            task_name_fwd = task_name
             if run_kwargs.get("simulation_type") == "autograd_fwd":
                 sim_original = simulation
                 sim_fields_keys = run_kwargs["sim_fields_keys"]
@@ -186,28 +186,28 @@ def use_emulated_run(monkeypatch):
                 )
 
                 # cache original and fwd data locally for test
-                cache[task_id_fwd] = copy.copy(aux_data)
-                cache[task_id_fwd][AUX_KEY_SIM_FIELDS_KEYS] = sim_fields_keys
+                cache[task_name_fwd] = copy.copy(aux_data)
+                cache[task_name_fwd][AUX_KEY_SIM_FIELDS_KEYS] = sim_fields_keys
                 # return original data only
-                return aux_data[AUX_KEY_SIM_DATA_ORIGINAL], task_id_fwd
+                return aux_data[AUX_KEY_SIM_DATA_ORIGINAL], task_name_fwd
             else:
-                return run_emulated(simulation, task_name=task_name), task_id_fwd
+                return run_emulated(simulation, task_name=task_name), task_name_fwd
 
         def emulated_run_bwd(simulation, task_name, **run_kwargs) -> td.SimulationData:
             """What gets called instead of ``web/api/autograd/autograd.py::_run_tidy3d_bwd``."""
 
-            task_id_fwd = task_name[:-8]
+            task_name_fwd = "".join(task_name.partition("_adjoint")[:-2])
 
             # run the adjoint sim
             sim_data_adj = run_emulated(simulation, task_name="task_name")
 
             # grab the fwd and original data from the cache
-            aux_data_fwd = cache[task_id_fwd]
+            aux_data_fwd = cache[task_name_fwd]
             sim_data_orig = aux_data_fwd[AUX_KEY_SIM_DATA_ORIGINAL]
             sim_data_fwd = aux_data_fwd[AUX_KEY_SIM_DATA_FWD]
 
             # get the original traced fields
-            sim_fields_keys = cache[task_id_fwd][AUX_KEY_SIM_FIELDS_KEYS]
+            sim_fields_keys = cache[task_name_fwd][AUX_KEY_SIM_FIELDS_KEYS]
 
             # postprocess (compute adjoint gradients)
             traced_fields_vjp = postprocess_adj(
@@ -225,9 +225,9 @@ def use_emulated_run(monkeypatch):
             for task_name, simulation in simulations.items():
                 if sim_fields_keys_dict is not None:
                     run_kwargs["sim_fields_keys"] = sim_fields_keys_dict[task_name]
-                sim_data_orig, task_id_fwd = emulated_run_fwd(simulation, task_name, **run_kwargs)
+                sim_data_orig, task_name_fwd = emulated_run_fwd(simulation, task_name, **run_kwargs)
                 batch_data_orig[task_name] = sim_data_orig
-                task_ids_fwd[task_name] = task_id_fwd
+                task_ids_fwd[task_name] = task_name_fwd
 
             class EmulatedBatchData(web.BatchData):
                 def load_sim_data(self, task_name):
@@ -251,7 +251,6 @@ def use_emulated_run(monkeypatch):
 
         monkeypatch.setattr(webapi, "run", run_emulated)
         monkeypatch.setattr(tidy3d.web.api.autograd.autograd, "_run_tidy3d", emulated_run_fwd)
-        monkeypatch.setattr(tidy3d.web.api.autograd.autograd, "_run_tidy3d_bwd", emulated_run_bwd)
         monkeypatch.setattr(
             tidy3d.web.api.autograd.autograd, "_run_async_tidy3d", emulated_run_async_fwd
         )
@@ -752,7 +751,7 @@ def test_run_zero_grad(use_emulated_run):
         sim_data = run(sim, task_name="adjoint_test", verbose=False)
         return 0 * postprocess(sim_data)
 
-    with AssertLogLevel("WARNING", contains_str="no sources"):
+    with AssertLogLevel("WARNING", contains_str="fields are zero"):
         grad = ag.grad(objective)(params0)
 
 
@@ -1678,7 +1677,7 @@ def test_multi_freq_edge_cases(use_emulated_run, structure_key, label, check_fn,
         return postprocess_fn(data)
 
     if label == "src_2_freq_2_mon_2":
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(ValueError):
             g = ag.grad(objective)(params0)
     else:
         g = ag.grad(objective)(params0)

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -248,8 +248,7 @@ class DataArray(xr.DataArray):
         """Load an DataArray from an hdf5 file with a given path to the group."""
         if ".hdf5" not in fname:
             raise FileError(
-                "DataArray objects must be written to '.hdf5' format. "
-                f"Given filename of {fname}."
+                f"'DataArray' objects must be written to '.hdf5' format. Given filename of {fname}."
             )
         return cls.from_hdf5(fname=fname, group_path=group_path)
 

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -1033,48 +1033,67 @@ class SimulationData(AbstractYeeGridSimulationData):
 
         return sim_data_original, sim_data_fwd
 
-    def make_adjoint_sim(
+    def make_adjoint_sims(
         self,
         data_vjp_paths: set[tuple],
         adjoint_monitors: list[Monitor],
-    ) -> Simulation | None:
-        """Make the adjoint simulation from the original simulation and the VJP-containing data."""
+    ) -> list[Simulation]:
+        """Make the adjoint simulations from the original simulation and the VJP-containing data."""
+
+        if not data_vjp_paths:
+            return []
 
         sim_original = self.simulation
 
         # generate the adjoint sources {mnt_name : list[Source]}
         sources_adj_dict = self.make_adjoint_sources(data_vjp_paths=data_vjp_paths)
+        if not sources_adj_dict:
+            return []
+
         adj_srcs = []
         for src_list in sources_adj_dict.values():
             adj_srcs += list(src_list)
 
-        if not any(adj_srcs):
-            return None
+        adjoint_source_infos = self.process_adjoint_sources(adj_srcs=adj_srcs)
 
-        adjoint_source_info = self.process_adjoint_sources(adj_srcs=adj_srcs)
+        if not adjoint_source_infos:
+            return []
 
         # grab boundary conditions with flipped Bloch vectors (for adjoint)
         bc_adj = sim_original.boundary_spec.flipped_bloch_vecs
-
-        # fields to update the 'fwd' simulation with to make it 'adj'
-        sim_adj_update_dict = dict(
-            sources=adjoint_source_info.sources,
-            boundary_spec=bc_adj,
-            monitors=adjoint_monitors,
-            post_norm=adjoint_source_info.post_norm,
-        )
-
-        if not adjoint_source_info.normalize_sim:
-            sim_adj_update_dict["normalize_index"] = None
 
         # set the ADJ grid spec wavelength to the original wavelength (for same meshing)
         grid_spec_original = sim_original.grid_spec
         if sim_original.sources and grid_spec_original.wavelength is None:
             wavelength_original = grid_spec_original.wavelength_from_sources(sim_original.sources)
             grid_spec_adj = grid_spec_original.updated_copy(wavelength=wavelength_original)
-            sim_adj_update_dict["grid_spec"] = grid_spec_adj
 
-        return sim_original.updated_copy(**sim_adj_update_dict)
+        adj_sims = []
+        for adjoint_source_info in adjoint_source_infos:
+            # only include monitors with the same freqs as the adjoint sources
+            monitors = [
+                m.updated_copy(freqs=adjoint_source_info.post_norm.f) for m in adjoint_monitors
+            ]
+
+            # fields to update the 'fwd' simulation with to make it 'adj'
+            sim_adj_update_dict = dict(
+                sources=adjoint_source_info.sources,
+                boundary_spec=bc_adj,
+                monitors=monitors,
+                post_norm=adjoint_source_info.post_norm,
+            )
+
+            if not adjoint_source_info.normalize_sim:
+                sim_adj_update_dict["normalize_index"] = None
+
+            if sim_original.sources and grid_spec_original.wavelength is None:
+                sim_adj_update_dict["grid_spec"] = grid_spec_adj
+
+            adj_sims.append(sim_original.updated_copy(**sim_adj_update_dict))
+
+        log.info(f"Created {len(adj_sims)} adjoint simulations.")
+
+        return adj_sims
 
     def make_adjoint_sources(self, data_vjp_paths: set[tuple]) -> dict[str, SourceType]:
         """Generate all of the non-zero sources for the adjoint simulation given the VJP data."""
@@ -1092,6 +1111,9 @@ class SimulationData(AbstractYeeGridSimulationData):
                 dataset_names=dataset_names, fwidth=self.fwidth_adj
             )
             sources_adj_all[mnt_data.monitor.name] = sources_adj
+            log.info(
+                f"Created {len(sources_adj)} adjoint sources for monitor '{mnt_data.monitor.name}'."
+            )
 
         return sources_adj_all
 
@@ -1101,9 +1123,8 @@ class SimulationData(AbstractYeeGridSimulationData):
         normalize_index_fwd = self.simulation.normalize_index or 0
         return self.simulation.sources[normalize_index_fwd].source_time.fwidth
 
-    def process_adjoint_sources(self, adj_srcs: list[SourceType]) -> AdjointSourceInfo:
+    def process_adjoint_sources(self, adj_srcs: list[SourceType]) -> list[AdjointSourceInfo]:
         """Compute list of final sources along with a post run normalization for adj fields."""
-
         # dictionary mapping hash of sources with same freq dependence to list of time-dependencies
         hashes_to_sources = defaultdict(None)
         hashes_to_src_times = defaultdict(list)
@@ -1115,39 +1136,36 @@ class SimulationData(AbstractYeeGridSimulationData):
             hashes_to_sources[tmp_src_hash] = src
             hashes_to_src_times[tmp_src_hash].append(src.source_time)
 
+        # Group sources by frequency or port, whichever gives fewer groups
         num_ports = len(hashes_to_src_times)
-        unique_freqs = {src.source_time.freq0 for src in adj_srcs}
-        num_unique_freqs = len(unique_freqs)
+        num_unique_freqs = len({src.source_time.freq0 for src in adj_srcs})
 
-        # next, figure out which treatment / normalization to apply
-        if num_unique_freqs == 1:
-            log.info("Adjoint source creation: one unique frequency, no normalization.")
-            freqs_adj = self.simulation.freqs_adjoint
+        log.info(f"Found {num_ports} spatial ports and {num_unique_freqs} unique frequencies.")
 
-            # if many adjoint freqs, but only 1 unique, need to mask out the non-contributors
-            if len(freqs_adj) > 1:
-                coords = dict(f=freqs_adj)
-                data = [1 if f == tuple(unique_freqs)[0] else 0 for f in freqs_adj]
-                post_norm = xr.DataArray(data, coords=coords)
-                return AdjointSourceInfo(sources=adj_srcs, post_norm=post_norm, normalize_sim=True)
+        adjoint_infos = []
+        if num_unique_freqs <= num_ports:
+            log.info("Grouping adjoint sources by frequency.")
+            unique_freqs = {src.source_time.freq0 for src in adj_srcs}
+            for freq0 in unique_freqs:
+                group = [src for src in adj_srcs if src.source_time.freq0 == freq0]
+                post_norm = xr.DataArray(data=np.array([1 + 0j]), coords={"f": [freq0]})
+                adjoint_infos.append(
+                    AdjointSourceInfo(sources=group, post_norm=post_norm, normalize_sim=True)
+                )
+        else:
+            log.info("Grouping adjoint sources by port.")
+            for src_hash, src_times in hashes_to_src_times.items():
+                base_src = hashes_to_sources[src_hash]
+                group = [base_src.updated_copy(source_time=src_time) for src_time in src_times]
+                processed_srcs, post_norm = self.process_adjoint_sources_broadband(group)
+                adjoint_infos.append(
+                    AdjointSourceInfo(
+                        sources=processed_srcs, post_norm=post_norm, normalize_sim=True
+                    )
+                )
 
-            return AdjointSourceInfo(sources=adj_srcs, post_norm=1.0, normalize_sim=True)
-
-        if num_ports == 1 and len(adj_srcs) == num_unique_freqs:
-            log.info("Adjoint source creation: one spatial port detected.")
-            adj_srcs, post_norm = self.process_adjoint_sources_broadband(adj_srcs)
-            return AdjointSourceInfo(sources=adj_srcs, post_norm=post_norm, normalize_sim=True)
-
-        # if several spatial ports and several frequencies, try to fit
-        log.info("Adjoint source creation: trying multifrequency fit.")
-        adj_srcs, post_norm = self.process_adjoint_sources_fit(
-            adj_srcs=adj_srcs,
-            hashes_to_src_times=hashes_to_src_times,
-            hashes_to_sources=hashes_to_sources,
-        )
-        return AdjointSourceInfo(sources=adj_srcs, post_norm=post_norm, normalize_sim=False)
-
-    """ SIMPLE APPROACH """
+        log.info(f"Created {len(adjoint_infos)} adjoint source groups.")
+        return adjoint_infos
 
     def process_adjoint_sources_broadband(
         self, adj_srcs: list[SourceType]
@@ -1190,115 +1208,6 @@ class SimulationData(AbstractYeeGridSimulationData):
         coords = dict(f=freqs)
         amps_complex = np.array(amps_complex)
         return xr.DataArray(amps_complex, coords=coords)
-
-    """ FITTING APPROACH """
-
-    def process_adjoint_sources_fit(
-        self,
-        adj_srcs: list[SourceType],
-        hashes_to_src_times: dict[str, GaussianPulse],
-        hashes_to_sources: dict[str, list[SourceType]],
-    ) -> tuple[list[SourceType], float]:
-        """Process the adjoint sources using a least squared fit to the derivative data."""
-
-        raise NotImplementedError(
-            "Can't perform multi-frequency autograd with several adjoint sources yet. "
-            "In the meantime, please construct a single 'Simulation' per output data "
-            "(can be multi-frequency) and run in parallel using 'web.run_async'. For example, "
-            "if your problem has 'P' outuput ports, e.g. waveguides, please make a 'Simulation' "
-            "corresponding to the objective function contribution at each port."
-        )
-
-        # new adjoint sources
-        new_adj_srcs = []
-        for src_hash, source_times in hashes_to_src_times.items():
-            src = hashes_to_sources[src_hash]
-            new_sources = self.correct_adjoint_sources(
-                src=src, fwidth=self.fwidth_adj, source_times=source_times
-            )
-            new_adj_srcs += new_sources
-
-        # compute amplitudes of each adjoint source, and the norm
-        adj_src_amps = []
-        for src in new_adj_srcs:
-            amp = src.source_time.amp_complex
-            adj_src_amps.append(amp)
-        norm_amps = np.linalg.norm(adj_src_amps)
-
-        # normalize all of the adjoint sources by this and return the normalization term used
-        adj_srcs_norm = []
-        for src in new_adj_srcs:
-            src_time = src.source_time
-            amp = src_time.amp_complex
-            src_time_norm = src_time.from_amp_complex(amp=amp / norm_amps)
-            src_nrm = src.updated_copy(source_time=src_time_norm)
-            adj_srcs_norm.append(src_nrm)
-
-        return adj_srcs_norm, norm_amps
-
-    def correct_adjoint_sources(
-        self, src: SourceType, fwidth: float, source_times: list[GaussianPulse]
-    ) -> [SourceType]:
-        """Corret a set of spectrally overlapping adjoint sources to give correct E_adj."""
-
-        freqs = [st.freq0 for st in source_times]
-        times = self.simulation.tmesh
-        dt = self.simulation.dt
-
-        def get_spectrum(source_time: GaussianPulse, freqs: list[float]) -> complex:
-            """Get the spectrum of a source time at a given frequency."""
-            return source_time.spectrum(times=times, freqs=freqs, dt=dt)
-
-        # compute matrix coupling the spectra of Gaussian pulses centered at each adjoint freq
-        def get_coupling_matrix(fwidth: float) -> np.ndarray:
-            """Matrix coupling the spectra of Gaussian pulses centered at each adjoint freq."""
-
-            return np.array(
-                [
-                    get_spectrum(
-                        source_time=GaussianPulse(freq0=source_time.freq0, fwidth=fwidth),
-                        freqs=freqs,
-                    )
-                    for source_time in source_times
-                ]
-            ).T
-
-        amps_adj = np.array([src_time.amp_complex for src_time in source_times])
-
-        # compute the corrected set of amps to inject at each freq to take coupling into account
-        def get_amps_corrected(fwidth: float) -> tuple[np.ndarray, float]:
-            """New set of new adjoint source amps that generate the desired response at each f."""
-            J_coupling = get_coupling_matrix(fwidth=fwidth)
-
-            amps_adj_new, *info = np.linalg.lstsq(J_coupling, amps_adj, rcond=None)
-            # amps_adj_new = np.linalg.solve(J_coupling, amps_adj)
-            residual = J_coupling @ amps_adj_new - amps_adj
-            residual_norm = np.linalg.norm(residual) / np.linalg.norm(amps_adj)
-            return amps_adj_new, residual_norm
-
-        # get the corrected amplitudes
-        amps_corrected, res_norm = get_amps_corrected(self.fwidth_adj)
-
-        if res_norm > RESIDUAL_CUTOFF_ADJOINT:
-            raise ValueError(
-                f"Residual of {res_norm:.5e} found when trying to fit adjoint source spectrum. "
-                f"This is above our accuracy cutoff of {RESIDUAL_CUTOFF_ADJOINT:.5e} and therefore "
-                "we are not able to process this adjoint simulation in a broadband way. "
-                "To fix, split your simulation into a set of simulations, one for each port, and "
-                "run parallel, broadband simulations using 'web.run_async'. "
-            )
-
-        # construct the new adjoint sources with the corrected amplitudes
-        src_times_corrected = [
-            src_time.from_amp_complex(amp=amp, fwidth=self.fwidth_adj)
-            for src_time, amp in zip(source_times, amps_corrected)
-        ]
-        srcs_corrected = []
-        for src_time in src_times_corrected:
-            src_new = src.updated_copy(source_time=src_time)
-            srcs_corrected.append(src_new)
-
-        return srcs_corrected
 
     def get_adjoint_data(self, structure_index: int, data_type: str) -> MonitorDataType:
         """Grab the field or permittivity data for a given structure index."""

--- a/tidy3d/plugins/autograd/README.md
+++ b/tidy3d/plugins/autograd/README.md
@@ -210,11 +210,13 @@ The following components are traceable as outputs of the `td.SimulationData`
 We also support the following high-level features:
 
 - To manually set the background permittivity of a structure for purposes of shape optimization, one can set `Structure.background_medium`.
-  This is useful when there is a substrate or multiple overlapping structures as some geometries, such as `PolySlab`, do not automatically detect background permittivity and instead use the `Simulation.medium` by default.
-- Compute gradients for objective functions that rely on multi-frequency data using a single broadband adjoint source.
-- Enable server-side gradient processing by setting `local_gradient=False` in the web functions.
-  This can significantly reduce data storage time.
-  However, exercise caution when using this feature with multi-frequency monitors and large design regions, as it may result in substantial data storage on our servers.
+- Compute gradients for objective functions that rely on multi-frequency data using a single broadband adjoint source. Note that this only works for mode monitors.
+- Enable local gradient processing by setting `local_gradient=True` in the web run functions.
+  This will cause the forward and adjoint field monitor data to be downloaded locally.
+  Can be useful for inspecting these fields, but will cause significantly more data/bandwidth usage.
+- We automatically determine the number of adjoint simulations to run from a given forward simulation to maintain gradient accuracy.
+  Adjoint sources are automatically grouped by either frequency or spatial port (whichever yields fewer adjoint simulations), and all adjoint simulations are run in a single batch (applies to both `run` and `run_async`).
+  The parameter `max_num_adjoint_per_fwd` (default `10`) prevents launching unexpectedly large numbers of adjoint simulations automatically.
 
 We currently have the following restrictions:
 
@@ -222,14 +224,14 @@ We currently have the following restrictions:
   To bypass this restriction, use `GeometryGroup` to group structures with the same medium.
 - `web.run_async` for simulations with tracers does not return a `BatchData` but rather a `dict` mapping task name to `SimulationData`.
   There may be high memory usage with many simulations or a lot of data for each.
-- Tidy3D can handle objective functions over a single simulation under any of the following conditions for the monitors that the objective function output depends on:
-  - Several monitors, all with the same frequency.
-  - One monitor with many frequencies where the data is being extracted out of a single coordinate (e.g., single mode_index or direction will work, multiple will not).
-  If your optimization does not fall into one of these categories, you must split it into separate simulations and run them with `web.run_async`. In all cases, the adjoint simulation bandwidth will be the same as the forward simulation. These limitations allow us to avoid the need to use methods that combine all adjoint sources into one simulation, which have the potential to degrade accuracy and increase the run time and cost significantly. That being said, we plan to offer support for more flexible and general broadband adjoint in the future.
+- Differentiating w.r.t. field monitors will lead to one adjoint simulation _per frequency_ in the monitor, which can cause significant data usage for large monitors.
+- The forward simulation records fields and permittivities within the bounding box of any traced object (e.g., design region) at each unique frequency in the simulation (defined by the monitors).
+  This can cause unnecessary data usage during the forward pass, especially if the monitors contain many frequencies that are not relevant for the objective function (i.e., they are not being differentiated w.r.t.).
+  To avoid this, restrict the frequencies in the monitors only to the ones that are relevant for differentiation during optimization.
 
 ### To be supported soon
 
-Next on our roadmap (targeting 2.8 and 2.9, fall 2024) is to support:
+Next on our roadmap (targeting 2.8 and 2.9, 2025) is to support:
 
 - `TriangleMesh`.
 - `GUI` integration of invdes plugin.

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -5,6 +5,7 @@ import tempfile
 import typing
 from collections import defaultdict
 from os.path import basename, dirname, join
+from pathlib import Path
 
 import numpy as np
 from autograd.builtins import dict as dict_ag
@@ -33,9 +34,13 @@ SIM_VJP_FILE = "output/autograd_sim_vjp.hdf5"
 SIM_FIELDS_KEYS_FILE = "autograd_sim_fields_keys.hdf5"
 
 MAX_NUM_TRACED_STRUCTURES = 500
+MAX_NUM_ADJOINT_PER_FWD = 10
 
 # default value for whether to do local gradient calculation (True) or server side (False)
 LOCAL_GRADIENT = False
+
+# directory to store adjoint data for local gradient calculation relative to run path
+LOCAL_ADJOINT_DIR = "adjoint_data"
 
 # if True, will plot the adjoint fields on the plane provided. used for debugging only
 _INSPECT_ADJOINT_FIELDS = False
@@ -60,10 +65,12 @@ def is_valid_for_autograd(simulation: td.Simulation) -> bool:
     structure_indices = {i for key, i, *_ in traced_fields.keys() if key == "structures"}
     num_traced_structures = len(structure_indices)
     if num_traced_structures > MAX_NUM_TRACED_STRUCTURES:
-        raise ValueError(
+        msg = (
             f"Autograd support is currently limited to {MAX_NUM_TRACED_STRUCTURES} structures with "
             f"traced fields. Found {num_traced_structures} structures with traced fields."
         )
+        td.log.error(msg)
+        raise ValueError(msg)
 
     return True
 
@@ -91,6 +98,7 @@ def run(
     simulation_type: str = "tidy3d",
     parent_tasks: list[str] = None,
     local_gradient: bool = LOCAL_GRADIENT,
+    max_num_adjoint_per_fwd: int = MAX_NUM_ADJOINT_PER_FWD,
     reduce_simulation: Literal["auto", True, False] = "auto",
 ) -> SimulationDataType:
     """
@@ -125,6 +133,8 @@ def run(
     local_gradient: bool = False
         Whether to perform gradient calculation locally, requiring more downloads but potentially
         more stable with experimental features.
+    max_num_adjoint_per_fwd: int = 10
+        Maximum number of adjoint simulations allowed to run automatically.
     reduce_simulation: Literal["auto", True, False] = "auto"
         Whether to reduce structures in the simulation to the simulation domain only. Note: currently only implemented for the mode solver.
 
@@ -188,6 +198,7 @@ def run(
             simulation_type="tidy3d_autograd",
             parent_tasks=parent_tasks,
             local_gradient=local_gradient,
+            max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
         )
 
     return run_webapi(
@@ -217,6 +228,7 @@ def run_async(
     simulation_type: str = "tidy3d",
     parent_tasks: dict[str, list[str]] = None,
     local_gradient: bool = LOCAL_GRADIENT,
+    max_num_adjoint_per_fwd: int = MAX_NUM_ADJOINT_PER_FWD,
     reduce_simulation: Literal["auto", True, False] = "auto",
 ) -> BatchData:
     """Submits a set of Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`] objects to server,
@@ -242,6 +254,8 @@ def run_async(
     local_gradient: bool = False
         Whether to perform gradient calculations locally, requiring more downloads but potentially
         more stable with experimental features.
+    max_num_adjoint_per_fwd: int = 10
+        Maximum number of adjoint simulations allowed to run automatically.
     reduce_simulation: Literal["auto", True, False] = "auto"
         Whether to reduce structures in the simulation to the simulation domain only. Note: currently only implemented for the mode solver.
 
@@ -272,6 +286,7 @@ def run_async(
             simulation_type="tidy3d_autograd_async",
             parent_tasks=parent_tasks,
             local_gradient=local_gradient,
+            max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
         )
 
     return run_async_webapi(
@@ -294,6 +309,7 @@ def _run(
     simulation: td.Simulation,
     task_name: str,
     local_gradient: bool = LOCAL_GRADIENT,
+    max_num_adjoint_per_fwd: int = MAX_NUM_ADJOINT_PER_FWD,
     **run_kwargs,
 ) -> td.SimulationData:
     """User-facing ``web.run`` function, compatible with ``autograd`` differentiation."""
@@ -321,6 +337,7 @@ def _run(
         task_name=task_name,
         aux_data=aux_data,
         local_gradient=local_gradient,
+        max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
         **run_kwargs,
     )
 
@@ -330,6 +347,7 @@ def _run(
 def _run_async(
     simulations: dict[str, td.Simulation],
     local_gradient: bool = LOCAL_GRADIENT,
+    max_num_adjoint_per_fwd: int = MAX_NUM_ADJOINT_PER_FWD,
     **run_async_kwargs,
 ) -> dict[str, td.SimulationData]:
     """User-facing ``web.run_async`` function, compatible with ``autograd`` differentiation."""
@@ -352,6 +370,7 @@ def _run_async(
         sims_original=sims_original,
         aux_data_dict=aux_data_dict,
         local_gradient=local_gradient,
+        max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
         **run_async_kwargs,
     )
 
@@ -394,6 +413,7 @@ def _run_primitive(
     task_name: str,
     aux_data: dict,
     local_gradient: bool,
+    max_num_adjoint_per_fwd: int,
     **run_kwargs,
 ) -> AutogradFieldMap:
     """Autograd-traced 'run()' function: runs simulation, strips tracer data, caches fwd data."""
@@ -444,6 +464,7 @@ def _run_async_primitive(
     sims_original: dict[str, td.Simulation],
     aux_data_dict: dict[dict[str, typing.Any]],
     local_gradient: bool,
+    max_num_adjoint_per_fwd: int,
     **run_async_kwargs,
 ) -> dict[str, AutogradFieldMap]:
     task_names = sim_fields_dict.keys()
@@ -453,7 +474,11 @@ def _run_async_primitive(
         for task_name in task_names:
             sim_fields = sim_fields_dict[task_name]
             sim_original = sims_original[task_name]
-            sims_combined[task_name] = setup_fwd(sim_fields=sim_fields, sim_original=sim_original)
+            sims_combined[task_name] = setup_fwd(
+                sim_fields=sim_fields,
+                sim_original=sim_original,
+                local_gradient=local_gradient,
+            )
 
         batch_data_combined, _ = _run_async_tidy3d(sims_combined, **run_async_kwargs)
 
@@ -467,7 +492,6 @@ def _run_async_primitive(
                 sim_original=sim_original,
                 aux_data=aux_data,
             )
-
     else:
         run_async_kwargs["simulation_type"] = "autograd_fwd"
         run_async_kwargs["sim_fields_keys_dict"] = {}
@@ -580,30 +604,43 @@ def _run_bwd(
     task_name: str,
     aux_data: dict,
     local_gradient: bool,
+    max_num_adjoint_per_fwd: int,
     **run_kwargs,
 ) -> typing.Callable[[AutogradFieldMap], AutogradFieldMap]:
-    """VJP-maker for ``_run_primitive()``. Constructs and runs adjoint simulation, computes grad."""
+    """VJP-maker for ``_run_primitive()``. Constructs and runs adjoint simulations, computes grad."""
 
     # get the fwd epsilon and field data from the cached aux_data
     sim_data_orig = aux_data[AUX_KEY_SIM_DATA_ORIGINAL]
-    # strip the sim fields keys
     sim_fields_keys = list(sim_fields_original.keys())
+
+    td.log.info(f"Number of fields to compute gradients for: {len(sim_fields_keys)}")
 
     if local_gradient:
         sim_data_fwd = aux_data[AUX_KEY_SIM_DATA_FWD]
+        td.log.info("Using local gradient computation mode")
+    else:
+        td.log.info("Using server-side gradient computation mode")
 
-    td.log.info("constructing custom vjp function for backwards pass.")
+    td.log.info("Constructing custom VJP function for backwards pass.")
 
     def vjp(data_fields_vjp: AutogradFieldMap) -> AutogradFieldMap:
         """dJ/d{sim.traced_fields()} as a function of Function of dJ/d{data.traced_fields()}"""
 
-        sim_adj = setup_adj(
+        # filter out any data_fields_vjp with all 0's and skip the corresponding adjoint simulation
+        data_fields_vjp = {k: v for k, v in data_fields_vjp.items() if not np.allclose(v, 0)}
+        if not data_fields_vjp:
+            td.log.warning("All VJP fields are zero, skipping adjoint simulation")
+            return {k: 0 * v for k, v in sim_fields_original.items()}
+
+        # build the (possibly multiple) adjoint simulations
+        sims_adj = setup_adj(
             data_fields_vjp=data_fields_vjp,
             sim_data_orig=sim_data_orig,
             sim_fields_keys=sim_fields_keys,
+            max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
         )
 
-        if sim_adj is None:
+        if not sims_adj:
             td.log.warning(
                 f"Adjoint simulation for task '{task_name}' contains no sources. "
                 "This can occur if the objective function does not depend on the "
@@ -612,31 +649,66 @@ def _run_bwd(
             )
             return {k: 0 * v for k, v in sim_fields_original.items()}
 
-        # run adjoint simulation
-        task_name_adj = str(task_name) + "_adjoint"
+        # Run adjoint simulations in batch
+        task_names_adj = [f"{task_name}_adjoint_{i}" for i in range(len(sims_adj))]
+        sims_adj_dict = dict(zip(task_names_adj, sims_adj))
+
+        td.log.info(f"Running {len(sims_adj)} adjoint simulations")
+
+        vjp_traced_fields = {}
 
         if local_gradient:
-            sim_data_adj, _ = _run_tidy3d(sim_adj, task_name=task_name_adj, **run_kwargs)
+            # Run all adjoint sims in batch
+            td.log.info("Starting local batch adjoint simulations")
+            path = Path(run_kwargs.pop("path"))
+            path_dir_adj = path.parent / LOCAL_ADJOINT_DIR
+            path_dir_adj.mkdir(exist_ok=True)
 
-            vjp_traced_fields = postprocess_adj(
-                sim_data_adj=sim_data_adj,
-                sim_data_orig=sim_data_orig,
-                sim_data_fwd=sim_data_fwd,
-                sim_fields_keys=sim_fields_keys,
+            batch_data_adj, _ = _run_async_tidy3d(
+                sims_adj_dict, path_dir=str(path_dir_adj), **run_kwargs
             )
+            td.log.info("Completed local batch adjoint simulations")
 
+            # sum partial derivatives from each adjoint simulation
+            for task_name_adj, sim_data_adj in batch_data_adj.items():
+                td.log.info(f"Processing VJP contribution from {task_name_adj}")
+                vjp_fields = postprocess_adj(
+                    sim_data_adj=sim_data_adj,
+                    sim_data_orig=sim_data_orig,
+                    sim_data_fwd=sim_data_fwd,
+                    sim_fields_keys=sim_fields_keys,
+                )
+                for k, v in vjp_fields.items():
+                    vjp_traced_fields[k] = vjp_traced_fields.get(k, 0) + v
         else:
-            task_id_fwd = aux_data[AUX_KEY_FWD_TASK_ID]
-            run_kwargs["parent_tasks"] = [task_id_fwd]
-            run_kwargs["simulation_type"] = "autograd_bwd"
-            sim_adj = sim_adj.updated_copy(simulation_type="autograd_bwd", deep=False)
+            td.log.info("Starting server-side batch of adjoint simulations ...")
 
-            vjp_traced_fields = _run_tidy3d_bwd(
-                sim_adj,
-                task_name=task_name_adj,
+            # Link each adjoint sim to the forward task it depends on
+            task_id_fwd = aux_data[AUX_KEY_FWD_TASK_ID]
+            run_kwargs["simulation_type"] = "autograd_bwd"
+
+            # Build a per-task parent_tasks mapping
+            parent_tasks = {}
+            for tname_adj in sims_adj_dict.keys():
+                parent_tasks[tname_adj] = [task_id_fwd]
+            run_kwargs["parent_tasks"] = parent_tasks
+
+            # Update each simulation's type, then run them in batch
+            sims_adj_dict = {
+                tname_adj: sim.updated_copy(simulation_type="autograd_bwd", deep=False)
+                for tname_adj, sim in sims_adj_dict.items()
+            }
+            vjp_traced_fields_dict = _run_async_tidy3d_bwd(
+                simulations=sims_adj_dict,
                 **run_kwargs,
             )
+            td.log.info("Completed server-side batch of adjoint simulations.")
 
+            for fields in vjp_traced_fields_dict.values():
+                for k, v in fields.items():
+                    vjp_traced_fields[k] = vjp_traced_fields.get(k, 0) + v
+
+        td.log.debug(f"Computed gradients for {len(vjp_traced_fields)} fields")
         return vjp_traced_fields
 
     return vjp
@@ -648,6 +720,7 @@ def _run_async_bwd(
     sims_original: dict[str, td.Simulation],
     aux_data_dict: dict[str, dict[str, typing.Any]],
     local_gradient: bool,
+    max_num_adjoint_per_fwd: int,
     **run_async_kwargs,
 ) -> typing.Callable[[dict[str, AutogradFieldMap]], dict[str, AutogradFieldMap]]:
     """VJP-maker for ``_run_primitive()``. Constructs and runs adjoint simulation, computes grad."""
@@ -661,7 +734,6 @@ def _run_async_bwd(
     for task_name in task_names:
         aux_data = aux_data_dict[task_name]
         sim_data_orig_dict[task_name] = aux_data[AUX_KEY_SIM_DATA_ORIGINAL]
-        # strip the sim fields keys
         sim_fields_keys_dict[task_name] = list(sim_fields_original_dict[task_name].keys())
 
         if local_gradient:
@@ -672,51 +744,60 @@ def _run_async_bwd(
     def vjp(data_fields_dict_vjp: dict[str, AutogradFieldMap]) -> dict[str, AutogradFieldMap]:
         """dJ/d{sim.traced_fields()} as a function of Function of dJ/d{data.traced_fields()}"""
 
-        task_names_adj = [task_name + "_adjoint" for task_name in task_names]
-
-        sims_adj = {}
+        # Collect all adjoint simulations across all forward tasks
+        all_sims_adj = {}
         sim_fields_vjp_dict = {}
-        for task_name, task_name_adj in zip(task_names, task_names_adj):
+        task_name_mapping = {}  # Maps adjoint task names to original task names
+
+        for task_name in task_names:
             data_fields_vjp = data_fields_dict_vjp[task_name]
             sim_data_orig = sim_data_orig_dict[task_name]
             sim_fields_keys = sim_fields_keys_dict[task_name]
 
-            sim_adj = setup_adj(
+            sims_adj = setup_adj(
                 data_fields_vjp=data_fields_vjp,
                 sim_data_orig=sim_data_orig,
                 sim_fields_keys=sim_fields_keys,
+                max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
             )
 
-            if sim_adj is None:
-                td.log.debug(f"Adjoint simulation for task '{task_name}' contains no sources. ")
+            if not sims_adj:
+                td.log.debug(f"Adjoint simulation for task '{task_name}' contains no sources.")
                 sim_fields_vjp_dict[task_name] = {
                     k: 0 * v for k, v in sim_fields_original_dict[task_name].items()
                 }
-            sims_adj[task_name_adj] = sim_adj
+                continue
 
-        sims_to_run = {k: v for k, v in sims_adj.items() if v is not None}
+            # Add each adjoint simulation to the combined batch with unique task names
+            for i, sim_adj in enumerate(sims_adj):
+                adj_task_name = f"{task_name}_adjoint_{i}"
+                all_sims_adj[adj_task_name] = sim_adj
+                task_name_mapping[adj_task_name] = task_name
 
-        if not sims_to_run:
+        if not all_sims_adj:
             td.log.warning(
-                "No simulation in batch contains adjoint sources and thus all gradients are zero. "
-                "This likely indicates an issue with your setup, consider double-checking or contact support."
+                "No simulation in batch contains adjoint sources and thus all gradients are zero."
             )
             return sim_fields_vjp_dict
 
-        task_names_adj = list(sims_to_run.keys())
-        task_names_fwd = [name.removesuffix("_adjoint") for name in task_names_adj]
-
         if local_gradient:
-            # run adjoint simulation
-            batch_data_adj, _ = _run_async_tidy3d(sims_to_run, **run_async_kwargs)
+            # Run all adjoint simulations in a single batch
+            path_dir = Path(run_async_kwargs.pop("path_dir"))
+            path_dir_adj = path_dir / LOCAL_ADJOINT_DIR
+            path_dir_adj.mkdir(exist_ok=True)
 
-            for task_name, task_name_adj in zip(task_names_fwd, task_names_adj):
+            batch_data_adj, _ = _run_async_tidy3d(
+                all_sims_adj, path_dir=str(path_dir_adj), **run_async_kwargs
+            )
+
+            # Process results for each original task
+            for adj_task_name, sim_data_adj in batch_data_adj.items():
+                task_name = task_name_mapping[adj_task_name]
                 sim_data_orig = sim_data_orig_dict[task_name]
                 sim_data_fwd = sim_data_fwd_dict[task_name]
                 sim_fields_keys = sim_fields_keys_dict[task_name]
 
-                sim_data_adj = batch_data_adj[task_name_adj]
-
+                # Compute VJP contribution
                 sim_fields_vjp = postprocess_adj(
                     sim_data_adj=sim_data_adj,
                     sim_data_orig=sim_data_orig,
@@ -724,27 +805,43 @@ def _run_async_bwd(
                     sim_fields_keys=sim_fields_keys,
                 )
 
-                sim_fields_vjp_dict[task_name] = sim_fields_vjp
+                # Sum contributions for each original task
+                if task_name in sim_fields_vjp_dict:
+                    for k, v in sim_fields_vjp.items():
+                        sim_fields_vjp_dict[task_name][k] += v
+                else:
+                    sim_fields_vjp_dict[task_name] = sim_fields_vjp
+
         else:
+            # Set up parent tasks mapping for all adjoint simulations
             parent_tasks = {}
-            for task_name_fwd, task_name_adj in zip(task_names_fwd, task_names_adj):
-                task_id_fwd = aux_data_dict[task_name_fwd][AUX_KEY_FWD_TASK_ID]
-                parent_tasks[task_name_adj] = [task_id_fwd]
+            for adj_task_name, task_name in task_name_mapping.items():
+                task_id_fwd = aux_data_dict[task_name][AUX_KEY_FWD_TASK_ID]
+                parent_tasks[adj_task_name] = [task_id_fwd]
 
             run_async_kwargs["parent_tasks"] = parent_tasks
             run_async_kwargs["simulation_type"] = "autograd_bwd"
-            simulations = {
+
+            # Update simulation types
+            all_sims_adj = {
                 task_name: sim.updated_copy(simulation_type="autograd_bwd", deep=False)
-                for task_name, sim in sims_to_run.items()
+                for task_name, sim in all_sims_adj.items()
             }
-            sim_fields_vjp_dict_adj_keys = _run_async_tidy3d_bwd(
-                simulations=simulations,
+
+            # Run all adjoint simulations in a single batch
+            sim_fields_vjp_dict_adj = _run_async_tidy3d_bwd(
+                simulations=all_sims_adj,
                 **run_async_kwargs,
             )
 
-            # swap adjoint task_names for original task_names
-            for task_name_fwd, task_name_adj in zip(task_names_fwd, task_names_adj):
-                sim_fields_vjp_dict[task_name_fwd] = sim_fields_vjp_dict_adj_keys[task_name_adj]
+            # Combine results for each original task
+            for adj_task_name, fields in sim_fields_vjp_dict_adj.items():
+                task_name = task_name_mapping[adj_task_name]
+                if task_name in sim_fields_vjp_dict:
+                    for k, v in fields.items():
+                        sim_fields_vjp_dict[task_name][k] += v
+                else:
+                    sim_fields_vjp_dict[task_name] = fields
 
         return sim_fields_vjp_dict
 
@@ -755,7 +852,8 @@ def setup_adj(
     data_fields_vjp: AutogradFieldMap,
     sim_data_orig: td.SimulationData,
     sim_fields_keys: list[tuple],
-) -> typing.Optional[td.Simulation]:
+    max_num_adjoint_per_fwd: int,
+) -> list[td.Simulation]:
     """Construct an adjoint simulation from a set of data_fields for the VJP."""
 
     td.log.info("Running custom vjp (adjoint) pipeline.")
@@ -774,14 +872,12 @@ def setup_adj(
         num_monitors:
     ]
 
-    sim_adj = sim_data_vjp.make_adjoint_sim(
+    sims_adj = sim_data_vjp.make_adjoint_sims(
         data_vjp_paths=data_vjp_paths,
         adjoint_monitors=adjoint_monitors,
     )
-    if sim_adj is None:
-        return sim_adj
 
-    if _INSPECT_ADJOINT_FIELDS:
+    if _INSPECT_ADJOINT_FIELDS and sims_adj:
         adj_fld_mnt = td.FieldMonitor(
             center=_INSPECT_ADJOINT_PLANE.center,
             size=_INSPECT_ADJOINT_PLANE.size,
@@ -794,7 +890,7 @@ def setup_adj(
         import tidy3d.web as web
 
         sim_data_new = web.run(
-            sim_adj.updated_copy(monitors=[adj_fld_mnt]),
+            sims_adj[0].updated_copy(monitors=[adj_fld_mnt]),
             task_name="adjoint_field_viz",
             verbose=False,
         )
@@ -804,9 +900,18 @@ def setup_adj(
         sim_data_new.plot_field("adjoint_fields", "Ez", "re", ax=ax3)
         plt.show()
 
-    td.log.info(f"Adjoint simulation created with {len(sim_adj.sources)} sources.")
+    if len(sims_adj) > max_num_adjoint_per_fwd:
+        msg = (
+            f"Number of adjoint simulations ({len(sims_adj)}) exceeds the maximum allowed "
+            f"({max_num_adjoint_per_fwd}) per forward simulation. This typically means that "
+            "there are many frequencies and monitors in the simulation that are being differentiated "
+            "w.r.t. in the objective function. To proceed, please double-check the simulation "
+            "setup, increase the 'max_num_adjoint_per_fwd' parameter in the run function, and re-run."
+        )
+        td.log.error(msg)
+        raise ValueError(msg)
 
-    return sim_adj
+    return sims_adj
 
 
 def postprocess_adj(
@@ -833,7 +938,6 @@ def postprocess_adj(
         eps_adj = sim_data_adj.get_adjoint_data(structure_index, data_type="eps")
 
         # post normalize the adjoint fields if a single, broadband source
-
         fwd_flds_normed = {}
         for key, val in E_adj.field_components.items():
             fwd_flds_normed[key] = val * sim_data_adj.simulation.post_norm
@@ -959,20 +1063,10 @@ def _run_tidy3d(
     return data, job.task_id
 
 
-def _run_tidy3d_bwd(simulation: td.Simulation, task_name: str, **run_kwargs) -> AutogradFieldMap:
-    """Run a simulation without any tracers using regular web.run()."""
-    job_init_kwargs = parse_run_kwargs(**run_kwargs)
-    job = Job(simulation=simulation, task_name=task_name, **job_init_kwargs)
-    td.log.info(f"running {job.simulation_type} simulation with '_run_tidy3d_bwd()'")
-    job.start()
-    job.monitor()
-    return get_vjp_traced_fields(task_id_adj=job.task_id, verbose=job.verbose)
-
-
 def _run_async_tidy3d(
     simulations: dict[str, td.Simulation], **run_kwargs
 ) -> tuple[BatchData, dict[str, str]]:
-    """Run a simulation without any tracers using regular web.run()."""
+    """Run a batch of simulations using regular web.run()."""
     batch_init_kwargs = parse_run_kwargs(**run_kwargs)
     path_dir = run_kwargs.pop("path_dir", None)
     batch = Batch(simulations=simulations, **batch_init_kwargs)
@@ -1006,12 +1100,12 @@ def _run_async_tidy3d_bwd(
     simulations: dict[str, td.Simulation],
     **run_kwargs,
 ) -> dict[str, AutogradFieldMap]:
-    """Run a simulation without any tracers using regular web.run()."""
+    """Run a batch of adjoint simulations using regular web.run()."""
 
     batch_init_kwargs = parse_run_kwargs(**run_kwargs)
-    _ = run_kwargs.pop("path_dir")
+    _ = run_kwargs.pop("path_dir", None)
     batch = Batch(simulations=simulations, **batch_init_kwargs)
-    td.log.info(f"running {batch.simulation_type} simulation with '_run_tidy3d_bwd()'")
+    td.log.info(f"running {batch.simulation_type} batch with '_run_async_tidy3d_bwd()'")
 
     batch.start()
     batch.monitor()


### PR DESCRIPTION
**Summary of Changes**:

- **Multiple Adjoint Simulations**: Each forward simulation can now spawn multiple adjoint simulations, grouped by either port or frequency (whichever yields fewer adjoint simulations).  
- **Batch Execution**: All adjoint simulations are now combined and run in a single batch—this applies to both `run` (1 forward → N adjoint) and `run_async` (N forward → M adjoint).  
- **`max_num_adjoint_sims`**: Introduced a limit on the maximum number of adjoint simulations to run automatically (defaults to `10`) to prevent unexpectedly large batched runs.  
- **Testing**: Verified on the `AutogradWDM` notebook and various numerical test scenarios.  
- **Known Edge Case**: When grouping by port for broadband sources, some setups with overlapping frequencies in the adjoint sources still don't work. This needs some modified handling in the post-normalization amplitudes that I'll implement in a separate PR, but this is not a regression so I think it's ok to not include here.

I also removed the stale broadband fitting code for now, until we can explore that implementation again.