### PR TITLE
add tool for calculating antenna lobe measures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- New `LobeMeasurer` tool in the `microwave` plugin that locates lobes in antenna patterns and calculates lobe measures like half-power beamwidth and sidelobe level.
 
 ### Changed
 

--- a/docs/api/plugins/microwave.rst
+++ b/docs/api/plugins/microwave.rst
@@ -15,3 +15,4 @@ Microwave
    tidy3d.plugins.microwave.CustomCurrentIntegral2D
    tidy3d.plugins.microwave.ImpedanceCalculator
    tidy3d.plugins.microwave.RectangularAntennaArrayCalculator
+   tidy3d.plugins.microwave.LobeMeasurer

--- a/tests/test_plugins/test_microwave.py
+++ b/tests/test_plugins/test_microwave.py
@@ -1,8 +1,10 @@
 """Test the microwave plugin."""
 
+from math import isclose
+
 import matplotlib.pyplot as plt
 import numpy as np
-import pydantic.v1 as pydantic
+import pydantic.v1 as pd
 import pytest
 import tidy3d as td
 import tidy3d.plugins.microwave as mw
@@ -318,7 +320,7 @@ def test_tiny_voltage_path():
 
 def test_impedance_calculator():
     """Check validation of ImpedanceCalculator when integrals are missing."""
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(pd.ValidationError):
         _ = mw.ImpedanceCalculator(voltage_integral=None, current_integral=None)
 
 
@@ -459,12 +461,12 @@ def test_vertices_validator_custom_current_integral():
     # Make wrong box
     vertices = [(0.2, -0.2, 0.5), (0.2, 0.2), (-0.2, 0.2), (-0.2, -0.2), (0.2, -0.2)]
 
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(pd.ValidationError):
         _ = mw.CustomCurrentIntegral2D(axis=2, position=0, vertices=vertices)
 
     # Make wrong box shape
     vertices = [(0.2, 0.2, -0.2, -0.2, 0.2), (-0.2, 0.2, 0.2, -0.2, 0.2)]
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(pd.ValidationError):
         _ = mw.CustomCurrentIntegral2D(axis=2, position=0, vertices=vertices)
 
 
@@ -646,3 +648,147 @@ def test_auto_path_integrals_for_lumped_element():
     SIM_Z_with_element = SIM_Z.updated_copy(lumped_elements=[linear_element])
 
     _, _ = mw.path_integrals_from_lumped_element(linear_element, SIM_Z_with_element.grid, "+")
+
+
+def test_lobe_measurer_validation():
+    """ "Make sure the lobe measurer validates inputs correctly."""
+    theta = np.linspace(0, 2 * np.pi, 101, endpoint=False)
+    Urad = np.cos(theta)
+
+    # Raise error when radiation pattern is negative
+    with pytest.raises(pd.ValidationError):
+        mw.LobeMeasurer(
+            angle=theta,
+            radiation_pattern=Urad,
+        )
+
+    Urad = np.cos(theta) + 1j * np.sin(theta)
+    # Raise error when radiation pattern is complex
+    with pytest.raises(pd.ValidationError):
+        mw.LobeMeasurer(
+            angle=theta,
+            radiation_pattern=Urad,
+        )
+
+    theta = np.linspace(-np.pi, np.pi, 101, endpoint=False)
+    Urad = np.cos(theta) ** 2
+    # No error when cyclic extension is disabled
+    mw.LobeMeasurer(angle=theta, radiation_pattern=Urad, apply_cyclic_extension=False)
+
+    # Raise error when cyclic extension is enabled and angle array is not in [0, 2π)
+    with pytest.raises(pd.ValidationError):
+        mw.LobeMeasurer(
+            angle=theta,
+            radiation_pattern=Urad,
+        )
+
+    theta = np.linspace(-np.pi, np.pi, 101, endpoint=False)
+    theta[10] = theta[75]
+    Urad = np.cos(theta) ** 2
+    # Make sure array is sorted
+    with pytest.raises(pd.ValidationError):
+        mw.LobeMeasurer(angle=theta, radiation_pattern=Urad, apply_cyclic_extension=False)
+
+
+@pytest.mark.parametrize("apply_cyclic_extension", [True, False])
+@pytest.mark.parametrize("include_endpoint", [True, False])
+def test_lobe_measurements(apply_cyclic_extension, include_endpoint):
+    """Run the lobe measurer on some test data and check the results."""
+
+    # Example 2.4 from Antenna Theory by Balanis
+    theta = np.linspace(0, 2 * np.pi, 301, endpoint=include_endpoint)
+    Urad_raw = np.cos(theta) ** 2 * np.cos(3 * theta) ** 2
+
+    angular_tol = 2 * np.pi / len(theta)
+
+    # Smooth out small variations using vectorized operations
+    # This will help check if the lobe measurer correctly places peaks
+    # at the center of any plateau regions
+    tolerance = 1e-7
+    diffs = np.abs(np.diff(Urad_raw))
+    mask = np.append(False, diffs < tolerance)  # False for first element to maintain array size
+    Urad = np.where(mask, np.roll(Urad_raw, 1), Urad_raw)  # Replace small variations
+
+    # Check against easy numpy peak finding
+    if apply_cyclic_extension:
+        max_lobe_loc = np.argmax(Urad)
+        max_lobe_level = Urad[max_lobe_loc]
+    else:
+        # When the signal is not cyclically extended, the peak finding
+        # will not find the first peak near the boundary
+        max_lobe_loc = np.argmax(Urad[1:]) + 1
+        max_lobe_level = Urad[max_lobe_loc]
+
+    lobe_measurer = mw.LobeMeasurer(
+        angle=theta,
+        radiation_pattern=Urad,
+        width_measure=0.5,
+        apply_cyclic_extension=apply_cyclic_extension,
+    )
+    lobe_measures = lobe_measurer.lobe_measures
+    num_rows, num_cols = lobe_measures.shape
+    assert num_cols == 7
+    # Check the number of lobes found
+    if apply_cyclic_extension:
+        assert num_rows == 6
+    else:
+        assert num_rows == 5
+
+    assert isclose(lobe_measurer.main_lobe["magnitude"], max_lobe_level)
+    assert isclose(lobe_measurer.main_lobe["direction"], theta[max_lobe_loc], abs_tol=angular_tol)
+    assert isclose(lobe_measurer.main_lobe["beamwidth"], 0.5, abs_tol=angular_tol)
+    assert isclose(lobe_measurer.main_lobe["FNBW"], np.pi / 3, abs_tol=angular_tol)
+
+    sidelobe_level = lobe_measurer.sidelobe_level
+
+    # The side lobe level will not be accurate for this pattern
+    # when using cyclic extension, since there are two main lobes with similar magnitude
+    if not apply_cyclic_extension:
+        assert isclose(sidelobe_level, 0.3167, rel_tol=1e-2)
+
+    # Plot the radiation pattern and the lobe measures
+    # for debugging purposes
+    # These additional lobe measures are useful for plotting
+    # the calculated beamwidths.
+    # x_start = lobe_measures["beamwidth bounds"][0]
+    # x_end = lobe_measures["beamwidth bounds"]
+    # width_heights = lobe_measures["beamwidth magnitude"]
+    # import matplotlib.pyplot as plt
+    # from matplotlib import use
+    # use("TkAgg")
+    # _, ax = plt.subplots(1, 1, tight_layout=True)
+    # ax.plot(theta, Urad)
+    # ax.plot(lobe_measures["direction"], lobe_measures["magnitude"], "x")
+    # for index, _ in lobe_measures.iterrows():
+    #     x = [x_start[index], x_end[index]]
+    #     y = [width_heights[index], width_heights[index]]
+    #     ax.plot(x, y, "-r")
+    # plt.show()
+
+    # Now test when no lobes are found
+    lobe_measurer = mw.LobeMeasurer(
+        angle=theta,
+        radiation_pattern=np.zeros_like(Urad),
+        width_measure=0.5,
+        apply_cyclic_extension=apply_cyclic_extension,
+    )
+    assert lobe_measurer.main_lobe.empty
+    lobe_measures = lobe_measurer.lobe_measures
+    assert lobe_measures.empty
+    sidelobe_level = lobe_measurer.sidelobe_level
+    assert sidelobe_level is None
+
+
+@pytest.mark.parametrize("min_value", [0.0, 1.0])
+def test_lobe_plots(min_value):
+    """Run the lobe measurer on some test data and plot the results."""
+    # Interative plotting for debugging
+    # from matplotlib import use
+    # use("TkAgg")
+    theta = np.linspace(0, 2 * np.pi, 301)
+    Urad = np.cos(theta) ** 2 * np.cos(3 * theta) ** 2 + min_value
+    lobe_measurer = mw.LobeMeasurer(angle=theta, radiation_pattern=Urad)
+    _, ax = plt.subplots(1, 1, subplot_kw={"projection": "polar"})
+    ax.plot(theta, Urad, "k")
+    lobe_measurer.plot(0, ax)
+    plt.show()

--- a/tidy3d/plugins/microwave/__init__.py
+++ b/tidy3d/plugins/microwave/__init__.py
@@ -11,6 +11,7 @@ from .custom_path_integrals import (
     CustomVoltageIntegral2D,
 )
 from .impedance_calculator import CurrentIntegralTypes, ImpedanceCalculator, VoltageIntegralTypes
+from .lobe_measurer import LobeMeasurer
 from .path_integrals import (
     AxisAlignedPathIntegral,
     CurrentIntegralAxisAligned,
@@ -32,4 +33,5 @@ __all__ = [
     "path_integrals_from_lumped_element",
     "rf_material_library",
     "RectangularAntennaArrayCalculator",
+    "LobeMeasurer",
 ]

--- a/tidy3d/plugins/microwave/lobe_measurer.py
+++ b/tidy3d/plugins/microwave/lobe_measurer.py
@@ -1,0 +1,344 @@
+"""Tool for finding and characterizing lobes in antenna radiation patterns."""
+
+from math import isclose, isnan
+from typing import Optional
+
+import numpy as np
+import pydantic.v1 as pd
+from pandas import DataFrame
+from scipy.signal import find_peaks, peak_widths
+
+from ...components.base import Tidy3dBaseModel, cached_property, skip_if_fields_missing
+from ...components.types import ArrayFloat1D, ArrayLike, Ax
+from ...constants import fp_eps
+from ...exceptions import ValidationError
+from .viz import plot_params_lobe_FNBW, plot_params_lobe_peak, plot_params_lobe_width
+
+# The minimum plateau size for peak finding, which is set to 0 to ensure that all peaks are found.
+# A value must be provided to retrieve additional information from `find_peaks`.
+MIN_PLATEAU_SIZE = 0
+DEFAULT_MIN_LOBE_REL_HEIGHT = 1e-3
+DEFAULT_NULL_THRESHOLD = 1e-3
+
+
+class LobeMeasurer(Tidy3dBaseModel):
+    """
+    Tool for detecting and analyzing lobes in antenna radiation patterns,
+    along with their characteristics such as direction and beamwidth.
+
+    Example
+    -------
+    >>> theta = np.linspace(0, 2 * np.pi, 301, endpoint=False)
+    >>> Urad = np.cos(theta) ** 2 * np.cos(3 * theta) ** 2
+    >>> lobe_measurer = LobeMeasurer(
+    ...     angle=theta,
+    ...     radiation_pattern=Urad)
+    >>> lobe_measures = lobe_measurer.lobe_measures
+    """
+
+    angle: ArrayFloat1D = pd.Field(
+        ...,
+        title="Angle",
+        description="A 1-dimensional array of angles in radians. The angles should be "
+        "in the range [0, 2π] and should be sorted in ascending order.",
+    )
+
+    radiation_pattern: ArrayFloat1D = pd.Field(
+        ...,
+        title="Radiation Pattern",
+        description="A 1-dimensional array of real values representing the radiation pattern "
+        "of the antenna measured on a linear scale.",
+    )
+
+    apply_cyclic_extension: bool = pd.Field(
+        True,
+        title="Apply Cyclic Extension",
+        description="To enable accurate peak finding near boundaries of the ``angle`` array, "
+        "we need to extend the signal using its periodicity. If lobes near the boundaries are not "
+        "of interest, this can be set to ``False``.",
+    )
+
+    width_measure: float = pd.Field(
+        0.5,
+        gt=0.0,
+        le=1.0,
+        title="Beamwidth Measure",
+        description="Relative magnitude of the lobes at which the beamwidth is measured. "
+        "Default value of ``0.5`` corresponds with the half-power beamwidth.",
+    )
+
+    min_lobe_height: float = pd.Field(
+        DEFAULT_MIN_LOBE_REL_HEIGHT,
+        gt=0.0,
+        le=1.0,
+        title="Minimum Lobe Height",
+        description="Only lobes in the radiation pattern with heights above this value are found. "
+        "Lobe heights are measured relative to the maximum value in ``radiation_pattern``.",
+    )
+
+    null_threshold: float = pd.Field(
+        DEFAULT_NULL_THRESHOLD,
+        gt=0.0,
+        le=1.0,
+        title="Null Threshold",
+        description="The threshold for detecting nulls, "
+        "which is relative to the maximum value in the ``radiation_pattern``.",
+    )
+
+    @pd.validator("angle", always=True)
+    def _sorted_angle(cls, val):
+        """Ensure the angle array is sorted."""
+        if not np.all(np.diff(val) >= 0):
+            raise ValidationError("The angle array must be sorted in ascending order.")
+        return val
+
+    @pd.validator("radiation_pattern", always=True)
+    def _nonnegative_radiation_pattern(cls, val):
+        """Ensure the radiation pattern is nonnegative."""
+        if not np.all(val >= 0):
+            raise ValidationError("Radiation pattern must be nonnegative.")
+        return val
+
+    @pd.validator("apply_cyclic_extension", always=True)
+    @skip_if_fields_missing(["angle"])
+    def _cyclic_extension_valid(cls, val, values):
+        if val:
+            angle = values.get("angle")
+            if np.any(angle < 0) or np.any(angle > 2 * np.pi):
+                raise ValidationError(
+                    "When using cyclic extension, the angle array must be in the range [0, 2π]."
+                )
+        return val
+
+    @cached_property
+    def lobe_measures(self) -> DataFrame:
+        """
+        The lobe measures as a pandas ``pandas.DataFrame`` with the following columns:
+
+        - ``direction``: The angular position of the lobe peak.
+        - ``magnitude``: The height of the lobe peak.
+        - ``beamwidth``: The width of the lobe at the specified beamwidth measure.
+        - ``beamwidth magnitude``: The magnitude at which the beamwidth is measured.
+        - ``beamwidth bounds``: The bounds of the lobe at the the beamwidth measure.
+        - ``FNBW``: The first null beam width (FNBW) of the lobe.
+        - ``FNBW bounds``: The locations of the nulls on either side of the lobe.
+
+        Returns
+        -------
+        DataFrame
+            A DataFrame containing all lobe measures, where rows indicate the lobe index.
+        """
+        if self.apply_cyclic_extension:
+            angle, signal = self.cyclic_extension(self.angle, self.radiation_pattern)
+        else:
+            angle, signal = self.angle, self.radiation_pattern
+
+        peaks, peak_props = find_peaks(
+            signal,
+            plateau_size=MIN_PLATEAU_SIZE,
+            height=self.min_lobe_height,
+        )
+        if len(peaks) == 0:
+            return DataFrame()
+        # Find the locations of nulls in the signal
+        max_mag = np.max(signal)
+        null_height = self.null_threshold * max_mag
+        _, null_peak_props = find_peaks(
+            -signal,
+            plateau_size=MIN_PLATEAU_SIZE,
+            height=-null_height,
+        )
+
+        # Extract and post process the peak properties from Scipy
+        peak_locations = self._extract_peak_locations(angle, peak_props)
+        peak_heights = self._extract_peak_heights(peak_props)
+        widths, beamwidth_height, beamwidth_min, beamwidth_max = self._calc_peak_widths(
+            angle, signal, peaks
+        )
+        null_locations = self._extract_peak_locations(angle, null_peak_props)
+        FNBWs, FNBW_min, FNBW_max = self._first_null_beam_widths(peak_locations, null_locations)
+
+        width_bounds = list(zip(beamwidth_min, beamwidth_max))
+        FNBW_bounds = list(zip(FNBW_min, FNBW_max))
+        data = {
+            "direction": peak_locations,
+            "magnitude": peak_heights,
+            "beamwidth": widths,
+            "beamwidth magnitude": beamwidth_height,
+            "beamwidth bounds": width_bounds,
+            "FNBW": FNBWs,
+            "FNBW bounds": FNBW_bounds,
+        }
+
+        dataframe = DataFrame(data)
+        if self.apply_cyclic_extension:
+            dataframe = self._filter_out_of_bounds_lobes(dataframe)
+        return dataframe
+
+    @staticmethod
+    def cyclic_extension(angle: ArrayLike, signal: ArrayLike) -> tuple[ArrayLike, ArrayLike]:
+        """
+        This helper function extends the given `signal` array by leveraging its periodic nature.
+        It ensures that the peak finding algorithm in Scipy can reliably detect peaks near the
+        minimum and maximum values of the ``angle`` array. The returned arrays are extended to
+        the range [-π, 3π).
+
+        Parameters
+        ----------
+        angle : ArrayLike
+            The array of angles, expected to be in the range [0, 2π].
+        signal : ArrayLike
+            The array of signal values corresponding to the angle array.
+
+        Returns
+        -------
+        tuple[ArrayLike, ArrayLike]
+            A tuple containing the extended `angle` and `signal` arrays.
+        """
+        # Ensure the last sample is not duplicated if it is at 2π
+        if isclose(angle[-1], 2 * np.pi, rel_tol=fp_eps):
+            angle = angle[:-1]
+            signal = signal[:-1]
+
+        first_locs = np.array(np.logical_and(angle >= 0, angle < np.pi)).nonzero()
+        second_locs = np.array(np.logical_and(angle >= np.pi, angle < 2 * np.pi)).nonzero()
+        angle = np.concatenate(
+            [angle[second_locs] - 2 * np.pi, angle, angle[first_locs] + 2 * np.pi]
+        )
+        signal = np.concatenate([signal[second_locs], signal, signal[first_locs]])
+        return angle, signal
+
+    @staticmethod
+    def _extract_peak_locations(angle: ArrayLike, peak_props: dict) -> ArrayLike:
+        """Get the peak positions in terms of the angular coordinates."""
+        left_locs = peak_props["left_edges"]
+        right_locs = peak_props["right_edges"]
+        left_x = angle[left_locs]
+        right_x = angle[right_locs]
+        peaks = (left_x + right_x) / 2
+        return peaks
+
+    @staticmethod
+    def _extract_peak_heights(peak_props: dict) -> ArrayLike:
+        """Get the peak heights."""
+        return peak_props["peak_heights"]
+
+    def _calc_peak_widths(
+        self, angle: ArrayLike, signal: ArrayLike, peaks: ArrayLike
+    ) -> tuple[ArrayLike, ArrayLike, ArrayLike, ArrayLike]:
+        """Get the peak widths in terms of the angular coordinates."""
+        rel_height = 1.0 - self.width_measure
+        last_element = len(signal) - 1
+        left_ips = np.zeros_like(peaks)
+        right_ips = last_element * np.ones_like(peaks)
+        dummy_prominence_data = (signal[peaks], left_ips, right_ips)
+        widths, width_heights, left_ips, right_ips = peak_widths(
+            signal, peaks, rel_height, dummy_prominence_data
+        )
+        left_x = np.interp(left_ips, np.arange(len(angle)), angle)
+        right_x = np.interp(right_ips, np.arange(len(angle)), angle)
+        widths = right_x - left_x
+        # Check that widths were properly found and are not simply the bounds
+        improper_width_mask = np.logical_or(left_ips == 0, right_ips == last_element)
+        widths[improper_width_mask] = np.nan
+        width_heights[improper_width_mask] = np.nan
+        left_x[improper_width_mask] = np.nan
+        right_x[improper_width_mask] = np.nan
+        return widths, width_heights, left_x, right_x
+
+    @staticmethod
+    def _first_null_beam_widths(
+        peaks: ArrayLike, nulls: ArrayLike
+    ) -> tuple[ArrayLike, ArrayLike, ArrayLike]:
+        """Calculate the first null beam width for each lobe. If a beam null is not found,
+        the value for the width is set to ``nan``."""
+        insertion_indices = np.searchsorted(nulls, peaks)
+
+        left_nulls = np.full_like(peaks, np.nan)
+        right_nulls = np.full_like(peaks, np.nan)
+        left_mask = (insertion_indices > 0) & (insertion_indices < len(nulls))
+        right_mask = (insertion_indices >= 0) & (insertion_indices < len(nulls))
+        left_nulls[left_mask] = nulls[insertion_indices[left_mask] - 1]
+        right_nulls[right_mask] = nulls[insertion_indices[right_mask]]
+
+        peak_FNBW = right_nulls - left_nulls
+        return peak_FNBW, left_nulls, right_nulls
+
+    @staticmethod
+    def _filter_out_of_bounds_lobes(dataframe: DataFrame) -> DataFrame:
+        """Filter out lobes that are out of bounds of the original signal."""
+        filtered_dataframe = dataframe[
+            dataframe["direction"].between(0, 2 * np.pi, inclusive="left")
+        ]
+        return filtered_dataframe.reset_index(drop=True)
+
+    @property
+    def main_lobe(self) -> DataFrame:
+        """Properties of the main lobe."""
+        if self.lobe_measures.empty:
+            return DataFrame()
+        main_lobe_idx = self.lobe_measures["magnitude"].idxmax()
+        return self.lobe_measures.iloc[main_lobe_idx]
+
+    @property
+    def side_lobes(self) -> DataFrame:
+        """Properties of all side lobes."""
+        if self.lobe_measures.empty:
+            return DataFrame()
+        main_lobe_idx = self.lobe_measures["magnitude"].idxmax()
+        side_lobes = self.lobe_measures.drop(main_lobe_idx)
+        return side_lobes
+
+    @property
+    def sidelobe_level(self) -> Optional[float]:
+        """The sidelobe level returned on a linear scale."""
+        if self.side_lobes.empty:
+            return None
+        main_lobe_level = self.main_lobe["magnitude"]
+        side_lobes = self.side_lobes
+        max_side_lobe_idx = side_lobes["magnitude"].idxmax()
+        side_lobe_level = side_lobes.at[max_side_lobe_idx, "magnitude"]
+        return side_lobe_level / main_lobe_level
+
+    def plot(
+        self,
+        lobe_index: int,
+        ax: Ax,
+        include_beamwidth: bool = True,
+        include_FNWB: bool = True,
+    ) -> Ax:
+        """Annotate an existing ``matplotlib`` axis with lobe locations and widths.
+
+        Parameters
+        ----------
+        lobe_index : int
+            Index of the lobe to plot from the :attr:`lobe_measures`.
+        ax : Ax
+            ``matplotlib`` axis on which to plot the lobe measure.
+        include_beamwidth : bool, optional
+            If True, plot the beamwidth markers and fill the beamwidth region.
+        include_FNWB : bool, optional
+            If True, plot the First Null Beam Width markers and fill the FNBW region.
+
+        Returns
+        -------
+        Ax
+            The matplotlib axis with the plotted lobe measures.
+        """
+
+        lobe = self.lobe_measures.iloc[lobe_index]
+        direction = lobe["direction"]
+        ax.axvline(direction, **plot_params_lobe_peak.to_kwargs())
+
+        # Additional annotations of the plot
+        if include_beamwidth and not isnan(lobe["beamwidth magnitude"]):
+            width_bounds = lobe["beamwidth bounds"]
+            ax.axvline(width_bounds[0], **plot_params_lobe_width.to_kwargs())
+            ax.axvline(width_bounds[1], **plot_params_lobe_width.to_kwargs())
+
+        if include_FNWB and not isnan(lobe["FNBW"]):
+            FNBW_bounds = lobe["FNBW bounds"]
+            ax.axvline(FNBW_bounds[0], **plot_params_lobe_FNBW.to_kwargs())
+            ax.axvline(FNBW_bounds[1], **plot_params_lobe_FNBW.to_kwargs())
+
+        return ax

--- a/tidy3d/plugins/microwave/viz.py
+++ b/tidy3d/plugins/microwave/viz.py
@@ -7,6 +7,9 @@ from ...components.viz import PathPlotParams
 """ Constants """
 VOLTAGE_COLOR = "red"
 CURRENT_COLOR = "blue"
+LOBE_PEAK_COLOR = "tab:red"
+LOBE_WIDTH_COLOR = "tab:orange"
+LOBE_FNBW_COLOR = "tab:blue"
 PATH_LINEWIDTH = 2
 ARROW_CURRENT = dict(
     arrowstyle="-|>",
@@ -50,5 +53,32 @@ plot_params_current_path = PathPlotParams(
     color=CURRENT_COLOR,
     linestyle="--",
     linewidth=PATH_LINEWIDTH,
+    marker="",
+)
+
+plot_params_lobe_peak = PathPlotParams(
+    alpha=1.0,
+    zorder=inf,
+    color=LOBE_PEAK_COLOR,
+    linestyle="-",
+    linewidth=1,
+    marker="",
+)
+
+plot_params_lobe_width = PathPlotParams(
+    alpha=1.0,
+    zorder=inf,
+    color=LOBE_WIDTH_COLOR,
+    linestyle="--",
+    linewidth=1,
+    marker="",
+)
+
+plot_params_lobe_FNBW = PathPlotParams(
+    alpha=1.0,
+    zorder=inf,
+    color=LOBE_FNBW_COLOR,
+    linestyle=":",
+    linewidth=1,
     marker="",
 )


### PR DESCRIPTION
Uses `find_peaks` functionality in scipy.signal to locate lobes in antenna radiation patterns.

- [x] Basic functionality for finding main/side lobes, width measures like FWHM/FNBW, 
- [x] Improve input validation
- [x] More testing
- [x] improve docs