### PR TITLE
Use `bayes_opt<2`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6142,4 +6142,4 @@ vtk = ["vtk"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0.0"
-content-hash = "0a16ce7a60e84d86f622bd9d40bfd8093018c20507c7c914b733d3e7081da956"
+content-hash = "4b61d8fc5d68d0b8b997c8a3c181b31d00bf59086527f185be3480ea3a622bba"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ jax = { version = ">=0.4.26", extras = [
 ], source = "jaxsource", optional = true }
 
 # design
-bayesian-optimization = { version = "*", optional = true }
+bayesian-optimization = { version = "<2", optional = true }
 pygad = { version = "3.3.1", optional = true }
 pyswarms = { version = "*", optional = true }
 


### PR DESCRIPTION
The Bayesian optimization package that we use in the design plugin introduces breaking API changes in 2.0, so setting the version to `<2` for now. I played around a bit with updating to 2.0 but the interface changes are significant, so holding off for now.