### PR TITLE
Fix adjoint source creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `ComponentModeler.to_file` when its batch is empty.
 - In web api, mode solver is patched with remote data so that certain methods like `plot_field` show remote data.
 - Added `viz_spec` property to `AbstractStructure` to fix error when plotting structures that have no `medium`.
+- Fixed invalid adjoint source creation by disallowing sources made from non-traced fields.
 
 ## [2.8.0rc2] - 2025-01-28
 

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -861,8 +861,19 @@ def setup_adj(
     # immediately filter out any data_vjps with all 0's in the data
     data_fields_vjp = {key: get_static(value) for key, value in data_fields_vjp.items()}
 
+    # start with the full simulation data structure and either zero out the fields
+    # that have no tracer data for them or insert the tracer data
+    full_sim_data_dict = sim_data_orig.strip_traced_fields(
+        include_untraced_data_arrays=True, starting_path=("data",)
+    )
+    for path in full_sim_data_dict.keys():
+        if path in data_fields_vjp:
+            full_sim_data_dict[path] = data_fields_vjp[path]
+        else:
+            full_sim_data_dict[path] *= 0
+
     # insert the raw VJP data into the .data of the original SimulationData
-    sim_data_vjp = sim_data_orig.insert_traced_fields(field_mapping=data_fields_vjp)
+    sim_data_vjp = sim_data_orig.insert_traced_fields(field_mapping=full_sim_data_dict)
 
     # make adjoint simulation from that SimulationData
     data_vjp_paths = set(data_fields_vjp.keys())


### PR DESCRIPTION
Currently, in `setup_adj`, the traced fields are inserted into the original simulation data. The fields in this simulation data control what adjoint sources are being created based on the monitor data functions `make_adjoint_sources`. Since the other fields are not zero'd, what is currently happening is that the traced field gradients replace the current simulation data and create correct adjoint sources, but the other simulation data that is not zero'd also is creating adjoint sources. 

The fix here is to zero out the simulation data when no traced field is present and to keep the insertion of the traced gradients the same so that we are only creating the adjoint sources we want.