### PR TITLE
Fix warning in arccos when the float number is slightly outside range

### DIFF
--- a/tidy3d/components/grid/corner_finder.py
+++ b/tidy3d/components/grid/corner_finder.py
@@ -132,6 +132,9 @@ class CornerFinderSpec(Tidy3dBaseModel):
         unit_next = normalize(vs_next - vs_orig)
         unit_previous = normalize(vs_previous - vs_orig)
         # angle
-        angle = np.arccos(np.sum(unit_next * unit_previous, axis=-1))
+        inner_product = np.sum(unit_next * unit_previous, axis=-1)
+        inner_product = np.where(inner_product > 1, 1, inner_product)
+        inner_product = np.where(inner_product < -1, -1, inner_product)
+        angle = np.arccos(inner_product)
         ind_filter = angle <= np.pi - self.angle_threshold
         return vs_orig[ind_filter]


### PR DESCRIPTION
Came across this warning in @lucas-flexcompute 's notebook because of machine precision in float number. The value is around -1.0000000000002.

`invalid value encountered in arccos ...`