### PR TITLE
Minor docs change for FluidMedium and SolidMedium

### DIFF
--- a/docs/api/heat/mediums.rst
+++ b/docs/api/heat/mediums.rst
@@ -7,6 +7,9 @@ Material Thermal
    :toctree: ../_autosummary/
    :template: module.rst
 
+   tidy3d.FluidMedium
+   tidy3d.SolidMedium
+
    tidy3d.FluidSpec
    tidy3d.SolidSpec
 

--- a/tidy3d/components/material/tcad/heat.py
+++ b/tidy3d/components/material/tcad/heat.py
@@ -49,7 +49,7 @@ class FluidMedium(AbstractHeatMedium):
 
     Example
     -------
-    >>> solid = FluidSpec()
+    >>> solid = FluidMedium()
     """
 
 
@@ -62,7 +62,7 @@ class SolidMedium(AbstractHeatMedium):
 
     Example
     -------
-    >>> solid = SolidSpec(
+    >>> solid = SolidMedium(
     ...     capacity=2,
     ...     conductivity=3,
     ... )


### PR DESCRIPTION
I just realized we haven't `SolidMedium` and `FluidMedium` in the docs