### PR TITLE
Add aux field monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New subpixel averaging option `ContourPathAveraging` applied to dielectric material boundaries.
 - A property `interior_angle` in `PolySlab` that stores angles formed inside polygon by two adjacent edges.
 - `eps_component` argument in `td.Simulation.plot_eps()` to optionally select a specific permittivity component to plot (eg. `"xx"`).
+- Monitor `AuxFieldTimeMonitor` for aux fields like the free carrier density in `TwoPhotonAbsorption`.
 
 ### Fixed
 - Compatibility with `xarray>=2025.03`.

--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -797,6 +797,29 @@ def test_nonlinear_medium():
         )
         _ = sim.updated_copy(medium=med, path="structures/0")
 
+    grid_spec = td.GridSpec.auto(min_steps_per_wvl=10, wavelength=1)
+    sim = sim.updated_copy(grid_spec=grid_spec)
+    aux_fields = ("Nfz",)
+    with AssertLogLevel(None):
+        med = td.Medium(
+            nonlinear_spec=td.NonlinearSpec(models=[td.TwoPhotonAbsorption(beta=1, tau=1)])
+        )
+        monitor = td.AuxFieldTimeMonitor(
+            interval=1, size=(0, 0, 0), name="aux_field_time", fields=aux_fields
+        )
+        sim = sim.updated_copy(medium=med, path="structures/0")
+        sim = sim.updated_copy(monitors=[monitor])
+
+    with AssertLogLevel("WARNING", contains_str="stores field"):
+        med = td.Medium(
+            nonlinear_spec=td.NonlinearSpec(models=[td.TwoPhotonAbsorption(beta=1, tau=0)])
+        )
+        _ = sim.updated_copy(medium=med, path="structures/0")
+
+    with AssertLogLevel("WARNING", contains_str="stores field"):
+        med = td.Medium(nonlinear_spec=td.NonlinearSpec(models=[td.KerrNonlinearity(n2=1)]))
+        _ = sim.updated_copy(medium=med, path="structures/0")
+
 
 def test_custom_medium():
     Nx, Ny, Nz, Nf = 4, 3, 1, 1

--- a/tests/test_components/test_monitor.py
+++ b/tests/test_components/test_monitor.py
@@ -376,6 +376,7 @@ def test_monitor():
         name="directivity",
     )
     m10 = td.PermittivityMonitor(size=size, center=center, freqs=FREQS, name="perm")
+    m11 = td.AuxFieldTimeMonitor(size=size, center=center, name="aux_field_time", fields=("Nfx",))
 
     tmesh = np.linspace(0, 1, 10)
 

--- a/tests/test_data/test_data_arrays.py
+++ b/tests/test_data/test_data_arrays.py
@@ -30,6 +30,7 @@ SOURCES = [
     ),
 ]
 FIELDS = ("Ex", "Ey", "Ez", "Hx", "Hz")
+AUX_FIELDS = ("Nfz",)
 INTERVAL = 2
 ORDERS_X = list(range(-1, 2))
 ORDERS_Y = list(range(-2, 3))
@@ -50,6 +51,9 @@ PD = np.atleast_1d(4000)
 FIELD_MONITOR = td.FieldMonitor(size=SIZE_3D, fields=FIELDS, name="field", freqs=FREQS)
 FIELD_TIME_MONITOR = td.FieldTimeMonitor(
     size=SIZE_3D, fields=FIELDS, name="field_time", interval=INTERVAL
+)
+AUX_FIELD_TIME_MONITOR = td.AuxFieldTimeMonitor(
+    size=SIZE_3D, fields=AUX_FIELDS, name="aux_field_time", interval=INTERVAL
 )
 FIELD_MONITOR_2D = td.FieldMonitor(size=SIZE_2D, fields=FIELDS, name="field_2d", freqs=FREQS)
 FIELD_TIME_MONITOR_2D = td.FieldTimeMonitor(
@@ -80,6 +84,7 @@ DIRECTIVITY_MONITOR = td.DirectivityMonitor(
 MONITORS = [
     FIELD_MONITOR,
     FIELD_TIME_MONITOR,
+    AUX_FIELD_TIME_MONITOR,
     MODE_MONITOR_WITH_FIELDS,
     PERMITTIVITY_MONITOR,
     MODE_MONITOR,

--- a/tests/test_data/test_monitor_data.py
+++ b/tests/test_data/test_monitor_data.py
@@ -11,6 +11,7 @@ from tidy3d.components.data.data_array import (
     FreqModeDataArray,
 )
 from tidy3d.components.data.monitor_data import (
+    AuxFieldTimeData,
     DiffractionData,
     DirectivityData,
     FieldData,
@@ -24,6 +25,7 @@ from tidy3d.exceptions import DataError
 
 from ..utils import AssertLogLevel
 from .test_data_arrays import (
+    AUX_FIELD_TIME_MONITOR,
     DIFFRACTION_MONITOR,
     DIRECTIVITY_MONITOR,
     FIELD_MONITOR,
@@ -117,6 +119,17 @@ def make_field_time_data_2d(symmetry: bool = True):
         symmetry=sim.symmetry,
         symmetry_center=sim.center,
         grid_expanded=sim.discretize_monitor(FIELD_TIME_MONITOR_2D),
+    )
+
+
+def make_aux_field_time_data(symmetry: bool = True):
+    sim = SIM_SYM if symmetry else SIM
+    return AuxFieldTimeData(
+        monitor=AUX_FIELD_TIME_MONITOR,
+        Nfz=make_scalar_field_time_data_array("Ez", symmetry),
+        symmetry=sim.symmetry,
+        symmetry_center=sim.center,
+        grid_expanded=sim.discretize_monitor(AUX_FIELD_TIME_MONITOR),
     )
 
 

--- a/tests/test_data/test_sim_data.py
+++ b/tests/test_data/test_sim_data.py
@@ -15,6 +15,7 @@ from tidy3d.exceptions import DataError, Tidy3dKeyError
 from ..utils import get_nested_shape
 from .test_data_arrays import FIELD_MONITOR, SIM, SIM_SYM
 from .test_monitor_data import (
+    make_aux_field_time_data,
     make_diffraction_data,
     make_directivity_data,
     make_field_data,
@@ -32,6 +33,8 @@ FIELD_SYM = make_field_data()
 FIELD = make_field_data(symmetry=False)
 FIELD_TIME_SYM = make_field_time_data()
 FIELD_TIME = make_field_time_data(symmetry=False)
+AUX_FIELD_TIME_SYM = make_aux_field_time_data()
+AUX_FIELD_TIME = make_aux_field_time_data(symmetry=False)
 PERMITTIVITY_SYM = make_permittivity_data()
 PERMITTIVITY = make_permittivity_data(symmetry=False)
 MODE = make_mode_data()
@@ -45,6 +48,7 @@ DIRECTIVITY = make_directivity_data()
 MONITOR_DATA = (
     FIELD,
     FIELD_TIME,
+    AUX_FIELD_TIME,
     MODE_SOLVER,
     PERMITTIVITY,
     MODE,
@@ -56,6 +60,7 @@ MONITOR_DATA = (
 MONITOR_DATA_SYM = (
     FIELD_SYM,
     FIELD_TIME_SYM,
+    AUX_FIELD_TIME_SYM,
     MODE_SOLVER,
     PERMITTIVITY_SYM,
     MODE,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -787,6 +787,9 @@ SIM_FULL = td.Simulation(
             size=(0, 0, 0), center=(0, 0, 0), fields=["Ex"], freqs=[1.5e14, 2e14], name="field"
         ),
         td.FieldTimeMonitor(size=(0, 0, 0), center=(0, 0, 0), name="field_time", interval=100),
+        td.AuxFieldTimeMonitor(
+            size=(0, 0, 0), center=(0, 0, 0), fields=("Nfx",), name="aux_field_time", interval=100
+        ),
         td.FluxMonitor(size=(1, 1, 0), center=(0, 0, 0), freqs=[2e14, 2.5e14], name="flux"),
         td.FluxTimeMonitor(size=(1, 1, 0), center=(0, 0, 0), name="flux_time"),
         td.PermittivityMonitor(size=(1, 1, 0.1), name="eps", freqs=[1e14]),

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -269,6 +269,7 @@ from .components.mode_spec import ModeSpec
 
 # monitors
 from .components.monitor import (
+    AuxFieldTimeMonitor,
     DiffractionMonitor,
     DirectivityMonitor,
     FieldMonitor,
@@ -467,6 +468,7 @@ __all__ = [
     "PlaneWaveBeamProfile",
     "FieldMonitor",
     "FieldTimeMonitor",
+    "AuxFieldTimeMonitor",
     "FluxMonitor",
     "FluxTimeMonitor",
     "ModeMonitor",
@@ -503,6 +505,7 @@ __all__ = [
     "ModeSolverDataset",
     "FieldData",
     "FieldTimeData",
+    "AuxFieldTimeData",
     "PermittivityData",
     "FluxData",
     "FluxTimeData",

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 import numpy as np
 import pydantic.v1 as pd
@@ -149,32 +149,32 @@ EMScalarFieldType = Union[
 class ElectromagneticFieldDataset(AbstractFieldDataset, ABC):
     """Stores a collection of E and H fields with x, y, z components."""
 
-    Ex: EMScalarFieldType = pd.Field(
+    Ex: Optional[EMScalarFieldType] = pd.Field(
         None,
         title="Ex",
         description="Spatial distribution of the x-component of the electric field.",
     )
-    Ey: EMScalarFieldType = pd.Field(
+    Ey: Optional[EMScalarFieldType] = pd.Field(
         None,
         title="Ey",
         description="Spatial distribution of the y-component of the electric field.",
     )
-    Ez: EMScalarFieldType = pd.Field(
+    Ez: Optional[EMScalarFieldType] = pd.Field(
         None,
         title="Ez",
         description="Spatial distribution of the z-component of the electric field.",
     )
-    Hx: EMScalarFieldType = pd.Field(
+    Hx: Optional[EMScalarFieldType] = pd.Field(
         None,
         title="Hx",
         description="Spatial distribution of the x-component of the magnetic field.",
     )
-    Hy: EMScalarFieldType = pd.Field(
+    Hy: Optional[EMScalarFieldType] = pd.Field(
         None,
         title="Hy",
         description="Spatial distribution of the y-component of the magnetic field.",
     )
-    Hz: EMScalarFieldType = pd.Field(
+    Hz: Optional[EMScalarFieldType] = pd.Field(
         None,
         title="Hz",
         description="Spatial distribution of the z-component of the magnetic field.",
@@ -226,32 +226,32 @@ class FieldDataset(ElectromagneticFieldDataset):
     >>> data = FieldDataset(Ex=scalar_field, Hz=scalar_field)
     """
 
-    Ex: ScalarFieldDataArray = pd.Field(
+    Ex: Optional[ScalarFieldDataArray] = pd.Field(
         None,
         title="Ex",
         description="Spatial distribution of the x-component of the electric field.",
     )
-    Ey: ScalarFieldDataArray = pd.Field(
+    Ey: Optional[ScalarFieldDataArray] = pd.Field(
         None,
         title="Ey",
         description="Spatial distribution of the y-component of the electric field.",
     )
-    Ez: ScalarFieldDataArray = pd.Field(
+    Ez: Optional[ScalarFieldDataArray] = pd.Field(
         None,
         title="Ez",
         description="Spatial distribution of the z-component of the electric field.",
     )
-    Hx: ScalarFieldDataArray = pd.Field(
+    Hx: Optional[ScalarFieldDataArray] = pd.Field(
         None,
         title="Hx",
         description="Spatial distribution of the x-component of the magnetic field.",
     )
-    Hy: ScalarFieldDataArray = pd.Field(
+    Hy: Optional[ScalarFieldDataArray] = pd.Field(
         None,
         title="Hy",
         description="Spatial distribution of the y-component of the magnetic field.",
     )
-    Hz: ScalarFieldDataArray = pd.Field(
+    Hz: Optional[ScalarFieldDataArray] = pd.Field(
         None,
         title="Hz",
         description="Spatial distribution of the z-component of the magnetic field.",
@@ -272,32 +272,32 @@ class FieldTimeDataset(ElectromagneticFieldDataset):
     >>> data = FieldTimeDataset(Ex=scalar_field, Hz=scalar_field)
     """
 
-    Ex: ScalarFieldTimeDataArray = pd.Field(
+    Ex: Optional[ScalarFieldTimeDataArray] = pd.Field(
         None,
         title="Ex",
         description="Spatial distribution of the x-component of the electric field.",
     )
-    Ey: ScalarFieldTimeDataArray = pd.Field(
+    Ey: Optional[ScalarFieldTimeDataArray] = pd.Field(
         None,
         title="Ey",
         description="Spatial distribution of the y-component of the electric field.",
     )
-    Ez: ScalarFieldTimeDataArray = pd.Field(
+    Ez: Optional[ScalarFieldTimeDataArray] = pd.Field(
         None,
         title="Ez",
         description="Spatial distribution of the z-component of the electric field.",
     )
-    Hx: ScalarFieldTimeDataArray = pd.Field(
+    Hx: Optional[ScalarFieldTimeDataArray] = pd.Field(
         None,
         title="Hx",
         description="Spatial distribution of the x-component of the magnetic field.",
     )
-    Hy: ScalarFieldTimeDataArray = pd.Field(
+    Hy: Optional[ScalarFieldTimeDataArray] = pd.Field(
         None,
         title="Hy",
         description="Spatial distribution of the y-component of the magnetic field.",
     )
-    Hz: ScalarFieldTimeDataArray = pd.Field(
+    Hz: Optional[ScalarFieldTimeDataArray] = pd.Field(
         None,
         title="Hz",
         description="Spatial distribution of the z-component of the magnetic field.",
@@ -310,6 +310,88 @@ class FieldTimeDataset(ElectromagneticFieldDataset):
             raise ValueError("Can't apply phase to time-domain field data, which is real-valued.")
 
         return self
+
+
+class AuxFieldDataset(AbstractFieldDataset, ABC):
+    """Stores a collection of aux fields with x, y, z components."""
+
+    Nfx: Optional[EMScalarFieldType] = pd.Field(
+        None,
+        title="Nfx",
+        description="Spatial distribution of the free carrier density for "
+        "polarization in the x-direction.",
+    )
+    Nfy: Optional[EMScalarFieldType] = pd.Field(
+        None,
+        title="Nfy",
+        description="Spatial distribution of the free carrier density for "
+        "polarization in the y-direction.",
+    )
+    Nfz: Optional[EMScalarFieldType] = pd.Field(
+        None,
+        title="Nfz",
+        description="Spatial distribution of the free carrier density for "
+        "polarization in the z-direction.",
+    )
+
+    @property
+    def field_components(self) -> Dict[str, DataArray]:
+        """Maps the field components to their associated data."""
+        fields = {
+            "Nfx": self.Nfx,
+            "Nfy": self.Nfy,
+            "Nfz": self.Nfz,
+        }
+        return {field_name: field for field_name, field in fields.items() if field is not None}
+
+    @property
+    def grid_locations(self) -> Dict[str, str]:
+        """Maps field components to the string key of their grid locations on the yee lattice."""
+        return dict(Nfx="Ex", Nfy="Ey", Nfz="Ez")
+
+    @property
+    def symmetry_eigenvalues(self) -> Dict[str, Callable[[Axis], float]]:
+        """Maps field components to their (positive) symmetry eigenvalues."""
+
+        return dict(
+            Nfx=lambda dim: +1,
+            Nfy=lambda dim: +1,
+            Nfz=lambda dim: +1,
+        )
+
+
+class AuxFieldTimeDataset(AuxFieldDataset):
+    """Dataset storing a collection of the scalar components of aux fields in the time domain
+
+    Example
+    -------
+    >>> x = [-1,1]
+    >>> y = [-2,0,2]
+    >>> z = [-3,-1,1,3]
+    >>> t = [0, 1e-12, 2e-12]
+    >>> coords = dict(x=x, y=y, z=z, t=t)
+    >>> scalar_field = ScalarFieldTimeDataArray(np.random.random((2,3,4,3)), coords=coords)
+    >>> data = AuxFieldTimeDataset(Nfx=scalar_field)
+    """
+
+    Nfx: Optional[ScalarFieldTimeDataArray] = pd.Field(
+        None,
+        title="Nfx",
+        description="Spatial distribution of the free carrier density for polarization "
+        "in the x-direction.",
+    )
+    Nfy: Optional[ScalarFieldTimeDataArray] = pd.Field(
+        None,
+        title="Nfy",
+        description="Spatial distribution of the free carrier density for polarization "
+        "in the y-direction.",
+    )
+    Nfz: Optional[ScalarFieldTimeDataArray] = pd.Field(
+        None,
+        title="Nfz",
+        description="Spatial distribution of the free carrier density for polarization "
+        "in the z-direction.",
+    )
 
 
 class ModeSolverDataset(ElectromagneticFieldDataset):
@@ -338,32 +420,32 @@ class ModeSolverDataset(ElectromagneticFieldDataset):
     ... )
     """
 
-    Ex: ScalarModeFieldDataArray = pd.Field(
+    Ex: Optional[ScalarModeFieldDataArray] = pd.Field(
         None,
         title="Ex",
         description="Spatial distribution of the x-component of the electric field of the mode.",
     )
-    Ey: ScalarModeFieldDataArray = pd.Field(
+    Ey: Optional[ScalarModeFieldDataArray] = pd.Field(
         None,
         title="Ey",
         description="Spatial distribution of the y-component of the electric field of the mode.",
     )
-    Ez: ScalarModeFieldDataArray = pd.Field(
+    Ez: Optional[ScalarModeFieldDataArray] = pd.Field(
         None,
         title="Ez",
         description="Spatial distribution of the z-component of the electric field of the mode.",
     )
-    Hx: ScalarModeFieldDataArray = pd.Field(
+    Hx: Optional[ScalarModeFieldDataArray] = pd.Field(
         None,
         title="Hx",
         description="Spatial distribution of the x-component of the magnetic field of the mode.",
     )
-    Hy: ScalarModeFieldDataArray = pd.Field(
+    Hy: Optional[ScalarModeFieldDataArray] = pd.Field(
         None,
         title="Hy",
         description="Spatial distribution of the y-component of the magnetic field of the mode.",
     )
-    Hz: ScalarModeFieldDataArray = pd.Field(
+    Hz: Optional[ScalarModeFieldDataArray] = pd.Field(
         None,
         title="Hz",
         description="Spatial distribution of the z-component of the magnetic field of the mode.",
@@ -375,14 +457,14 @@ class ModeSolverDataset(ElectromagneticFieldDataset):
         description="Complex-valued effective propagation constants associated with the mode.",
     )
 
-    n_group_raw: GroupIndexDataArray = pd.Field(
+    n_group_raw: Optional[GroupIndexDataArray] = pd.Field(
         None,
         alias="n_group",  # This is for backwards compatibility only when loading old data
         title="Group Index",
         description="Index associated with group velocity of the mode.",
     )
 
-    dispersion_raw: ModeDispersionDataArray = pd.Field(
+    dispersion_raw: Optional[ModeDispersionDataArray] = pd.Field(
         None,
         title="Dispersion",
         description="Dispersion parameter for the mode.",

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -21,6 +21,7 @@ from ..base_sim.data.monitor_data import AbstractMonitorData
 from ..grid.grid import Coords, Grid
 from ..medium import Medium, MediumType
 from ..monitor import (
+    AuxFieldTimeMonitor,
     DiffractionMonitor,
     DirectivityMonitor,
     FieldMonitor,
@@ -85,6 +86,7 @@ from .data_array import (
 )
 from .dataset import (
     AbstractFieldDataset,
+    AuxFieldTimeDataset,
     Dataset,
     ElectromagneticFieldDataset,
     FieldDataset,
@@ -196,7 +198,9 @@ class MonitorData(AbstractMonitorData, ABC):
 class AbstractFieldData(MonitorData, AbstractFieldDataset, ABC):
     """Collection of scalar fields with some symmetry properties."""
 
-    monitor: Union[FieldMonitor, FieldTimeMonitor, PermittivityMonitor, ModeMonitor]
+    monitor: Union[
+        FieldMonitor, FieldTimeMonitor, AuxFieldTimeMonitor, PermittivityMonitor, ModeMonitor
+    ]
 
     symmetry: Tuple[Symmetry, Symmetry, Symmetry] = pd.Field(
         (0, 0, 0),
@@ -1293,6 +1297,41 @@ class FieldTimeData(FieldTimeDataset, ElectromagneticFieldData):
             # Reverse time coordinates
             new_data[comp] = new_data[comp].assign_coords({"t": field.t[::-1]}).sortby("t")
         return self.copy(update=new_data)
+
+
+class AuxFieldTimeData(AuxFieldTimeDataset, AbstractFieldData):
+    """
+    Data associated with a :class:`.AuxFieldTimeMonitor`: scalar components of aux fields.
+
+    Notes
+    -----
+
+        The data is stored as a `DataArray <https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html>`_
+        object using the `xarray <https://docs.xarray.dev/en/stable/index.html>`_ package.
+
+    Example
+    -------
+    >>> from tidy3d import ScalarFieldTimeDataArray
+    >>> x = [-1,1,3]
+    >>> y = [-2,0,2,4]
+    >>> z = [-3,-1,1,3,5]
+    >>> t = [0, 1e-12, 2e-12]
+    >>> coords = dict(x=x[:-1], y=y[:-1], z=z[:-1], t=t)
+    >>> grid = Grid(boundaries=Coords(x=x, y=y, z=z))
+    >>> scalar_field = ScalarFieldTimeDataArray(np.random.random((2,3,4,3)), coords=coords)
+    >>> monitor = AuxFieldTimeMonitor(
+    ...     size=(2,4,6), interval=100, name='field', fields=['Nfx'], colocate=True
+    ... )
+    >>> data = AuxFieldTimeData(monitor=monitor, Nfx=scalar_field, grid_expanded=grid)
+    """
+
+    monitor: AuxFieldTimeMonitor = pd.Field(
+        ...,
+        title="Monitor",
+        description="Time-domain auxiliary field monitor associated with the data.",
+    )
+
+    _contains_monitor_fields = enforce_monitor_fields_present()
 
 
 class PermittivityData(PermittivityDataset, AbstractFieldData):
@@ -3651,6 +3690,7 @@ MonitorDataTypes = (
     ModeData,
     FluxData,
     FluxTimeData,
+    AuxFieldTimeData,
     FieldProjectionKSpaceData,
     FieldProjectionCartesianData,
     FieldProjectionAngleData,

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -263,6 +263,11 @@ class NonlinearModel(ABC, Tidy3dBaseModel):
         """Whether the model uses complex fields."""
         return False
 
+    @property
+    def aux_fields(self) -> List[str]:
+        """List of available aux fields in this model."""
+        return []
+
 
 class NonlinearSusceptibility(NonlinearModel):
     """Model for an instantaneous nonlinear chi3 susceptibility.
@@ -499,6 +504,13 @@ class TwoPhotonAbsorption(NonlinearModel):
         """Whether the model uses complex fields."""
         return self.use_complex_fields
 
+    @property
+    def aux_fields(self) -> List[str]:
+        """List of available aux fields in this model."""
+        if self.tau == 0:
+            return []
+        return ["Nfx", "Nfy", "Nfz"]
+
 
 class KerrNonlinearity(NonlinearModel):
     """Model for Kerr nonlinearity which gives an intensity-dependent refractive index
@@ -715,6 +727,14 @@ class NonlinearSpec(ABC, Tidy3dBaseModel):
             new_model = model._hardcode_medium_freqs(medium=medium, freqs=freqs)
             new_models.append(new_model)
         return self.updated_copy(models=new_models)
+
+    @property
+    def aux_fields(self) -> List[str]:
+        """List of available aux fields in all present models."""
+        fields = []
+        for model in self.models:
+            fields += model.aux_fields
+        return fields
 
 
 class AbstractMedium(ABC, Tidy3dBaseModel):

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -16,6 +16,7 @@ from .medium import MediumType
 from .mode_spec import ModeSpec
 from .types import (
     ArrayFloat1D,
+    AuxField,
     Ax,
     Axis,
     Bound,
@@ -270,6 +271,51 @@ class AbstractFieldMonitor(Monitor, ABC):
         return solver_data_size
 
 
+class AbstractAuxFieldMonitor(Monitor, ABC):
+    """:class:`.Monitor` that records auxiliary fields as a function of x,y,z.
+
+    Auxiliary fields are used in certain nonlinear material models.
+    :class:`.TwoPhotonAbsorption` uses `Nfx`, `Nfy`, and `Nfz` for the
+    free-carrier density."""
+
+    fields: Tuple[AuxField, ...] = pydantic.Field(
+        (),
+        title="Aux Field Components",
+        description="Collection of auxiliary field components to store in the monitor. "
+        "Auxiliary fields which are not present in the simulation will be zero.",
+    )
+
+    interval_space: Tuple[pydantic.PositiveInt, pydantic.PositiveInt, pydantic.PositiveInt] = (
+        pydantic.Field(
+            (1, 1, 1),
+            title="Spatial Interval",
+            description="Number of grid step intervals between monitor recordings. If equal to 1, "
+            "there will be no downsampling. If greater than 1, the step will be applied, but the "
+            "first and last point of the monitor grid are always included.",
+        )
+    )
+
+    colocate: bool = pydantic.Field(
+        True,
+        title="Colocate Fields",
+        description="Toggle whether fields should be colocated to grid cell boundaries (i.e. "
+        "primal grid nodes).",
+    )
+
+    def _storage_size_solver(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
+        """Size of intermediate data recorded by the monitor during a solver run."""
+        final_data_size = self.storage_size(num_cells=num_cells, tmesh=tmesh)
+        if len(self.fields) == 0:
+            return 0
+
+        # internally solver stores all aux field components
+        field_components_factor = 3
+
+        # take out the stored field components factor and use the solver factor instead
+        solver_data_size = final_data_size / len(self.fields) * field_components_factor
+        return solver_data_size
+
+
 class PlanarMonitor(Monitor, ABC):
     """:class:`Monitor` that has a planar geometry."""
 
@@ -448,6 +494,33 @@ class FieldTimeMonitor(AbstractFieldMonitor, TimeMonitor):
         * `First walkthrough <../../notebooks/Simulation.html>`_: Usage in a basic simulation flow.
         * `Creating FDTD animations <../../notebooks/AnimationTutorial.html>`_.
 
+    """
+
+    def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
+        """Size of monitor storage given the number of points after discretization."""
+        # stores 1 real number per grid cell, per time step, per field
+        num_steps = self.num_steps(tmesh)
+        return BYTES_REAL * num_steps * num_cells * len(self.fields)
+
+
+class AuxFieldTimeMonitor(AbstractAuxFieldMonitor, TimeMonitor):
+    """:class:`.Monitor` that records auxiliary fields in the time domain.
+
+    Auxiliary fields are used in certain nonlinear material models.
+    :class:`.TwoPhotonAbsorption` uses `Nfx`, `Nfy`, and `Nfz` for the
+    free-carrier density.
+
+    Example
+    -------
+    >>> monitor = AuxFieldTimeMonitor(
+    ...     center=(1,2,3),
+    ...     size=(0,0,0),
+    ...     fields=['Nfx'],
+    ...     start=1e-13,
+    ...     stop=5e-13,
+    ...     interval=2,
+    ...     colocate=True,
+    ...     name='aux_monitor')
     """
 
     def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
@@ -1453,6 +1526,7 @@ class DiffractionMonitor(PlanarMonitor, FreqMonitor):
 MonitorType = Union[
     FieldMonitor,
     FieldTimeMonitor,
+    AuxFieldTimeMonitor,
     PermittivityMonitor,
     FluxMonitor,
     FluxTimeMonitor,

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -66,6 +66,7 @@ from .medium import (
 from .monitor import (
     AbstractFieldProjectionMonitor,
     AbstractModeMonitor,
+    AuxFieldTimeMonitor,
     DiffractionMonitor,
     DirectivityMonitor,
     FieldMonitor,
@@ -3723,6 +3724,26 @@ class Simulation(AbstractYeeGridSimulation):
                             "compatibility and may be removed in a future release."
                         )
 
+        for i, monitor in enumerate(self.monitors):
+            if isinstance(monitor, AuxFieldTimeMonitor):
+                for aux_field in monitor.fields:
+                    if aux_field not in self.aux_fields:
+                        log.warning(
+                            f"Monitor at 'monitors[{i}]' stores field '{aux_field}', "
+                            "which is not used by any of the nonlinear models present "
+                            "in the mediums in the simulation. The resulting data "
+                            "will be zero."
+                        )
+
+    @cached_property
+    def aux_fields(self) -> List[str]:
+        """All aux fields available in the simulation."""
+        fields = []
+        for medium in self.scene.mediums:
+            if medium.nonlinear_spec is not None:
+                fields += medium.nonlinear_spec.aux_fields
+        return fields
+
     """ Pre submit validation (before web.upload()) """
 
     def validate_pre_upload(self, source_required: bool = True) -> None:
@@ -3887,7 +3908,10 @@ class Simulation(AbstractYeeGridSimulation):
     def _validate_time_monitors_num_steps(self) -> None:
         """Raise an error if non-0D time monitors have too many time steps."""
         for monitor in self.monitors:
-            if not isinstance(monitor, FieldTimeMonitor) or len(monitor.zero_dims) == 3:
+            if (
+                not isinstance(monitor, (FieldTimeMonitor, AuxFieldTimeMonitor))
+                or len(monitor.zero_dims) == 3
+            ):
                 continue
             num_time_steps = monitor.num_steps(self.tmesh)
             if num_time_steps > MAX_TIME_MONITOR_STEPS:

--- a/tidy3d/components/types.py
+++ b/tidy3d/components/types.py
@@ -229,6 +229,7 @@ FieldType = Literal["Ex", "Ey", "Ez", "Hx", "Hy", "Hz"]
 FreqArray = Union[Tuple[float, ...], ArrayFloat1D]
 ObsGridArray = Union[Tuple[float, ...], ArrayFloat1D]
 PolarizationBasis = Literal["linear", "circular"]
+AuxField = Literal["Nfx", "Nfy", "Nfz"]
 
 """ plotting """
 


### PR DESCRIPTION
Adds monitor class `AuxFieldTimeMonitor` and corresponding data classes `AuxFieldTimeData` and `AuxFieldTimeDataset`. Currently it is modeled after `FieldTimeMonitor` -- you specify some aux field components to download, and it puts those in the corresponding data class. The default is no aux field components. Any field components which don't correspond to nonlinearities which are present in the region / material / simulation are just stored as 0.

Todo:

- [x] Add frontend unit tests
- [x] Finalize api
- [x] Maybe validate against requesting nonlinear aux field components for nonlinearities not present in the simulation. This was the purpose of the function `_aux_fields` in `Simulation`.