### PR TITLE
Convenience function to add charge perturbations with Nedeljkovic Soref Mashanovich model

### DIFF
--- a/tests/test_components/test_parameter_perturbation.py
+++ b/tests/test_components/test_parameter_perturbation.py
@@ -653,3 +653,24 @@ def test_index_perturbation():
             ),
             freq=freq0,
         )
+
+
+def test_delta_model():
+    """Test delta models."""
+
+    # let's first define a frequency
+    wvl = (3.5 + 4) / 2
+    freq = td.C_0 / wvl
+    delta_model = td.NedeljkovicSorefMashanovich(ref_freq=freq)
+
+    # make sure it's interpolating correctly
+    coeffs_3_5 = np.array([3.10e-21, 1.210, 6.05e-20, 1.145, 6.95e-21, 0.986, 9.28e-18, 0.834])
+    coeffs_4 = np.array([7.4e-22, 1.245, 5.43e-20, 1.153, 7.25e-21, 0.991, 9.99e-18, 0.839])
+
+    averaged_vals = (coeffs_3_5 + coeffs_4) / 2
+    interpolated_results = [
+        value.item() for _, value in delta_model._coeffs_at_ref_freq.data_vars.items()
+    ]
+    error = np.abs(np.mean(averaged_vals - np.array(interpolated_results)))
+
+    assert error < 1e-16

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -290,6 +290,7 @@ from .components.parameter_perturbation import (
     IndexPerturbation,
     LinearChargePerturbation,
     LinearHeatPerturbation,
+    NedeljkovicSorefMashanovich,
     ParameterPerturbation,
     PermittivityPerturbation,
 )
@@ -432,6 +433,7 @@ __all__ = [
     "RotationAroundAxis",
     "PerturbationMedium",
     "PerturbationPoleResidue",
+    "NedeljkovicSorefMashanovich",
     "ParameterPerturbation",
     "LinearHeatPerturbation",
     "CustomHeatPerturbation",

--- a/tidy3d/components/parameter_perturbation.py
+++ b/tidy3d/components/parameter_perturbation.py
@@ -12,11 +12,12 @@ except ImportError:
     pass
 import numpy as np
 import pydantic.v1 as pd
+import xarray as xr
 
 from ..components.data.validators import validate_no_nans
 from ..components.types import TYPE_TAG_STR, ArrayLike, Ax, Complex, FieldVal, InterpMethod
 from ..components.viz import add_ax_if_none
-from ..constants import CMCUBE, EPSILON_0, HERTZ, KELVIN, PERCMCUBE, inf
+from ..constants import C_0, CMCUBE, EPSILON_0, HERTZ, KELVIN, PERCMCUBE, inf
 from ..exceptions import DataError
 from ..log import log
 from .base import Tidy3dBaseModel, cached_property
@@ -1227,6 +1228,411 @@ class PermittivityPerturbation(Tidy3dBaseModel):
         return delta_eps_sampled, delta_sigma_sampled
 
 
+class AbstractDeltaModel(Tidy3dBaseModel):
+    """Abstract class for the definition of delta models"""
+
+    @abstractmethod
+    def delta_k(self) -> ChargePerturbationType:
+        """Return the perturbation range of the model."""
+
+    @abstractmethod
+    def delta_n(self) -> HeatPerturbationType:
+        """Return the perturbation range of the model."""
+
+
+class NedeljkovicSorefMashanovich(AbstractDeltaModel):
+    """Nedeljkovic-Soref-Mashanovich model for the perturbation of the refractive index and
+    extinction coefficient due to free carriers.
+
+    M. Nedeljkovic, R. Soref and G. Z. Mashanovich, "Free-Carrier Electrorefraction and Electroabsorption
+    Modulation Predictions for Silicon Over the 1–14- μm Infrared Wavelength Range," in IEEE Photonics
+    Journal, vol. 3, no. 6, pp. 1171-1180, Dec. 2011, doi: 10.1109/JPHOT.2011.2171930
+
+    Example
+    -------
+    """
+
+    perturb_coeffs = xr.Dataset(
+        {
+            "a": (
+                "wvl",
+                [
+                    3.48e-22,
+                    8.88e-21,
+                    3.22e-20,
+                    1.67e-20,
+                    6.29e-21,
+                    3.10e-21,
+                    7.45e-22,
+                    2.16e-22,
+                    9.28e-23,
+                    4.58e-23,
+                    3.26e-23,
+                    2.70e-23,
+                    2.25e-23,
+                    1.36e-23,
+                    1.85e-23,
+                    3.05e-23,
+                    4.08e-23,
+                    4.14e-23,
+                    3.81e-23,
+                    4.23e-23,
+                    5.81e-23,
+                    8.20e-23,
+                    1.13e-22,
+                    1.22e-22,
+                    1.09e-22,
+                    1.20e-22,
+                    1.62e-22,
+                ],
+            ),
+            "b": (
+                "wvl",
+                [
+                    1.229,
+                    1.167,
+                    1.149,
+                    1.169,
+                    1.193,
+                    1.210,
+                    1.245,
+                    1.277,
+                    1.299,
+                    1.319,
+                    1.330,
+                    1.338,
+                    1.345,
+                    1.359,
+                    1.354,
+                    1.345,
+                    1.340,
+                    1.341,
+                    1.344,
+                    1.344,
+                    1.338,
+                    1.331,
+                    1.325,
+                    1.324,
+                    1.328,
+                    1.327,
+                    1.321,
+                ],
+            ),
+            "c": (
+                "wvl",
+                [
+                    1.02e-19,
+                    5.84e-20,
+                    6.21e-20,
+                    8.08e-20,
+                    3.40e-20,
+                    6.05e-20,
+                    5.43e-20,
+                    5.58e-20,
+                    6.65e-20,
+                    8.53e-20,
+                    1.53e-19,
+                    1.22e-19,
+                    1.29e-19,
+                    9.99e-20,
+                    1.32e-19,
+                    1.57e-18,
+                    1.45e-18,
+                    1.70e-18,
+                    1.25e-18,
+                    8.14e-19,
+                    1.55e-18,
+                    4.81e-18,
+                    4.72e-18,
+                    2.09e-18,
+                    1.16e-18,
+                    2.01e-18,
+                    7.52e-18,
+                ],
+            ),
+            "d": (
+                "wvl",
+                [
+                    1.089,
+                    1.109,
+                    1.119,
+                    1.123,
+                    1.151,
+                    1.145,
+                    1.153,
+                    1.158,
+                    1.160,
+                    1.159,
+                    1.149,
+                    1.158,
+                    1.160,
+                    1.170,
+                    1.167,
+                    1.111,
+                    1.115,
+                    1.115,
+                    1.125,
+                    1.137,
+                    1.124,
+                    1.100,
+                    1.102,
+                    1.124,
+                    1.140,
+                    1.130,
+                    1.101,
+                ],
+            ),
+            "p": (
+                "wvl",
+                [
+                    2.98e-22,
+                    5.40e-22,
+                    1.91e-21,
+                    5.70e-21,
+                    6.57e-21,
+                    6.95e-21,
+                    7.25e-21,
+                    1.19e-20,
+                    2.46e-20,
+                    3.64e-20,
+                    4.96e-20,
+                    5.91e-20,
+                    5.52e-20,
+                    3.19e-20,
+                    3.56e-20,
+                    8.65e-20,
+                    2.09e-19,
+                    2.07e-19,
+                    3.01e-19,
+                    5.07e-19,
+                    1.51e-19,
+                    2.19e-19,
+                    3.04e-19,
+                    4.44e-19,
+                    6.96e-19,
+                    1.05e-18,
+                    1.45e-18,
+                ],
+            ),
+            "q": (
+                "wvl",
+                [
+                    1.016,
+                    1.011,
+                    0.992,
+                    0.976,
+                    0.981,
+                    0.986,
+                    0.991,
+                    0.985,
+                    0.973,
+                    0.968,
+                    0.965,
+                    0.964,
+                    0.969,
+                    0.984,
+                    0.984,
+                    0.966,
+                    0.948,
+                    0.951,
+                    0.944,
+                    0.934,
+                    0.965,
+                    0.958,
+                    0.953,
+                    0.945,
+                    0.936,
+                    0.928,
+                    0.922,
+                ],
+            ),
+            "r": (
+                "wvl",
+                [
+                    1.25e-18,
+                    1.53e-18,
+                    2.28e-18,
+                    5.19e-18,
+                    3.62e-18,
+                    9.28e-18,
+                    9.99e-18,
+                    1.29e-17,
+                    2.03e-17,
+                    3.31e-17,
+                    6.92e-17,
+                    8.23e-17,
+                    1.15e-16,
+                    4.81e-16,
+                    7.44e-16,
+                    7.11e-16,
+                    5.29e-16,
+                    9.72e-16,
+                    1.22e-15,
+                    1.16e-15,
+                    3.16e-15,
+                    1.51e-14,
+                    2.71e-14,
+                    2.65e-14,
+                    2.94e-14,
+                    6.85e-14,
+                    2.60e-13,
+                ],
+            ),
+            "s": (
+                "wvl",
+                [
+                    0.835,
+                    0.838,
+                    0.841,
+                    0.832,
+                    0.849,
+                    0.834,
+                    0.839,
+                    0.838,
+                    0.833,
+                    0.826,
+                    0.812,
+                    0.812,
+                    0.807,
+                    0.776,
+                    0.769,
+                    0.774,
+                    0.783,
+                    0.772,
+                    0.769,
+                    0.772,
+                    0.750,
+                    0.716,
+                    0.704,
+                    0.706,
+                    0.705,
+                    0.686,
+                    0.656,
+                ],
+            ),
+        },
+        coords={"wvl": np.array([1.3, 1.55] + list(np.arange(2, 14.5, 0.5)))},
+    )
+
+    ref_freq: pd.NonNegativeFloat = pd.Field(
+        ...,
+        title="Reference Frequency",
+        description="Reference frequency to evaluate perturbation at (Hz).",
+        units=HERTZ,
+    )
+
+    electrons_grid: np.ndarray = pd.Field(
+        np.concatenate(([0], np.logspace(-6, 22, num=200))),
+        title="Electron concentration grid.",
+        descriptio="The model will be evaluated at these concentration values. Since "
+        "the data at these locations will later be interpolated to determine perturbations "
+        "one should provide representative values. Usually, it is convenient to provide "
+        "evenly spaced values in logarithmic scale to cover the whole range of concentrations, "
+        "i.e., `np.concatenate(([0], np.logspace(-6, 22, num=200)))`.",
+    )
+
+    holes_grid: np.ndarray = pd.Field(
+        np.concatenate(([0], np.logspace(-6, 22, num=200))),
+        title="Hole concentration grid.",
+        descriptio="The model will be evaluated at these concentration values. Since "
+        "the data at these locations will later be interpolated to determine perturbations "
+        "one should provide representative values. Usually, it is convenient to provide "
+        "evenly spaced values in logarithmic scale to cover the whole range of concentrations, "
+        "i.e., `np.concatenate(([0], np.logspace(-6, 22, num=200)))`.",
+    )
+
+    @pd.root_validator(skip_on_failure=True)
+    def _check_freq_in_range(cls, values):
+        """Check that the given frequency is within validity range.
+        If not, issue a warning.
+        """
+
+        freq = values.get("ref_freq")
+        wavelengths = list(values.get("perturb_coeffs").coords["wvl"])
+
+        freq_range = (C_0 / np.max(wavelengths), C_0 / np.min(wavelengths))
+
+        if freq < freq_range[0] or freq > freq_range[1]:
+            log.warning(
+                f"Given frequency {freq} Hz is outside of the validity range ({freq_range[0]} - "
+                f"{freq_range[1]} Hz) of the Nedeljkovic-Soref-Mashanovich model."
+            )
+
+        return values
+
+    @cached_property
+    def ref_wavelength(self) -> float:
+        """Reference wavelength (um) to evaluate perturbation at."""
+        return C_0 / self.ref_freq
+
+    @cached_property
+    def _coeffs_at_ref_freq(self) -> xr.Dataset:
+        """Coefficients at reference frequency."""
+        return self.perturb_coeffs.interp(wvl=self.ref_wavelength)
+
+    def delta_k(self) -> ChargePerturbationType:
+        """Return the perturbation range of the model."""
+
+        # create free-carrier mesh
+        # NOTE: this range (0, 1e22) should work in most cases. If need be we can add a new field
+        # to the model to allow for custom ranges.
+        Ne_range = self.electrons_grid
+        Nh_range = self.holes_grid
+
+        Ne_mesh, Nh_mesh = np.meshgrid(Ne_range, Nh_range, indexing="ij")
+
+        # get parameters a, b, c, d
+        ke_coeff = self._coeffs_at_ref_freq["a"].item()
+        ke_pow = self._coeffs_at_ref_freq["b"].item()
+
+        kh_coeff = self._coeffs_at_ref_freq["c"].item()
+        kh_pow = self._coeffs_at_ref_freq["d"].item()
+
+        dk_mesh = ke_coeff * Ne_mesh**ke_pow + kh_coeff * Nh_mesh**kh_pow
+
+        # NOTE: since the formula gives us the absorption coefficient, we need to multiply by a factor
+        # to get the extinction coefficient (k)
+        # additionally, this dk is in cm^-1, so we need toconvert to um^-1
+        k_factor = self.ref_wavelength * 1e-4 / 4 / np.pi
+        dk_mesh = dk_mesh * k_factor
+
+        # convert t ChargeDataArray
+        dk_data = ChargeDataArray(dk_mesh, coords=dict(n=Ne_range, p=Nh_range))
+
+        # create CustomChargePerturbation
+        k_si_charge = CustomChargePerturbation(perturbation_values=dk_data)
+
+        return ParameterPerturbation(charge=k_si_charge)
+
+    def delta_n(self) -> ChargePerturbationType:
+        """Return the perturbation range of the model."""
+
+        # create free-carrier mesh
+        # NOTE: this range (0, 1e22) should work in most cases. If need be we can add a new field
+        # to the model to allow for custom ranges.
+        Ne_range = self.electrons_grid
+        Nh_range = self.holes_grid
+
+        Ne_mesh, Nh_mesh = np.meshgrid(Ne_range, Nh_range, indexing="ij")
+
+        # get parameters p, q, r, s
+        ne_coeff = self._coeffs_at_ref_freq["p"].item()
+        ne_pow = self._coeffs_at_ref_freq["q"].item()
+
+        nh_coeff = self._coeffs_at_ref_freq["r"].item()
+        nh_pow = self._coeffs_at_ref_freq["s"].item()
+
+        dn_mesh = -ne_coeff * Ne_mesh**ne_pow - nh_coeff * Nh_mesh**nh_pow
+
+        # create ChargeDataArray
+        dn_data = ChargeDataArray(dn_mesh, coords=dict(n=Ne_range, p=Nh_range))
+
+        # create CustomChargePerturbation
+        n_si_charge = CustomChargePerturbation(perturbation_values=dn_data)
+
+        return ParameterPerturbation(charge=n_si_charge)
+
+
 class IndexPerturbation(Tidy3dBaseModel):
     """A general medium perturbation model which is defined through perturbation to
     refractive index, n and k.
@@ -1380,3 +1786,7 @@ class IndexPerturbation(Tidy3dBaseModel):
             delta_sigma = delta_sigma * EPSILON_0
 
         return delta_eps, delta_sigma
+
+    def from_perturbation_delta_model(cls, deltas_model: AbstractDeltaModel) -> IndexPerturbation:
+        """Create an IndexPerturbation from a DeltaPerturbationModel."""
+        return IndexPerturbation(delta_n=deltas_model.delta_n, delta_k=deltas_model.delta_k)


### PR DESCRIPTION
This PR adds a convenience class that allows to easily specify medium perturbation using the model in [here](https://ieeexplore.ieee.org/document/6051462). It addresses issue https://github.com/flexcompute/tidy3d-core/issues/846

For instance, in the Charge notebook one can now define the perturbation medium like this
```python
perturbation_model = td.NedeljkovicSorefMashanovich(ref_freq=freq0)

si_perturb = td.PerturbationMedium.from_unperturbed(
    medium=si_non_perturb,
    perturbation_spec=td.IndexPerturbation(
        delta_n=perturbation_model.delta_n(),
        delta_k=perturbation_model.delta_k(),
        freq=freq0,
    )
)
```
The class `NedeljkovicSorefMashanovich` derives from a new class `AbstractDeltaModel` so potentially more perturbation models could be implemented following this approach (or used as template).