### PR TITLE
Add component selection to plot_eps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fill` and `fill_structures` argument in `td.Simulation.plot_structures()` and `td.Simulation.plot()` respectively to disable fill and plot outlines of structures only.
 - New subpixel averaging option `ContourPathAveraging` applied to dielectric material boundaries.
 - A property `interior_angle` in `PolySlab` that stores angles formed inside polygon by two adjacent edges.
+- `eps_component` argument in `td.Simulation.plot_eps()` to optionally select a specific permittivity component to plot (eg. `"xx"`).
 
 ### Fixed
 - Compatibility with `xarray>=2025.03`.

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -1,11 +1,15 @@
 """Tests the simulation and its validators."""
 
+import shutil
+from pathlib import Path
+
 import gdstk
 import matplotlib.pyplot as plt
 import numpy as np
 import pydantic.v1 as pydantic
 import pytest
 import tidy3d as td
+from matplotlib.testing.decorators import check_figures_equal
 from tidy3d.components import simulation
 from tidy3d.components.scene import MAX_GEOMETRY_COUNT, MAX_NUM_MEDIUMS
 from tidy3d.components.simulation import MAX_NUM_SOURCES
@@ -691,6 +695,208 @@ def test_plot_eps_bounds():
     plt.close()
     _ = SIM_FULL.plot_eps(x=0, hlim=[-0.45, 0.45], vlim=[-0.45, 0.45])
     plt.close()
+
+
+class TestAnisotropicPlotting:
+    """Tests for plotting anisotropic media"""
+
+    diag_comps = ["xx", "yy", "zz"]
+    offdiag_comps = ["xy", "yx", "xz", "zx", "yz", "zy"]
+    allcomps = diag_comps + offdiag_comps
+
+    medium_diag = td.AnisotropicMedium(
+        xx=td.Medium(permittivity=5), yy=td.Medium(permittivity=10), zz=td.Medium(permittivity=15)
+    )
+
+    medium_fullyani = td.FullyAnisotropicMedium(permittivity=[[6, 2, 3], [2, 7, 4], [3, 4, 8]])
+
+    @pytest.fixture(scope="class")
+    def medium_customani(self):
+        """based this custom medium on
+        https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.CustomAnisotropicMedium.html
+        """
+        Nx, Ny, Nz = 100, 100, 100
+        x = np.linspace(-1, 1, Nx)
+        y = np.linspace(-1, 1, Ny)
+        z = np.linspace(-1, 1, Nz)
+        coords = dict(x=x, y=y, z=z)
+        permittivity = td.SpatialDataArray(2 * np.ones((Nx, Ny, Nz)), coords=coords)
+        conductivity = td.SpatialDataArray(np.ones((Nx, Ny, Nz)), coords=coords)
+        medium_xx = td.CustomMedium(permittivity=permittivity, conductivity=conductivity)
+        medium_yy = td.CustomMedium(permittivity=2 * permittivity, conductivity=conductivity)
+
+        # make the zz component a spatially varying medium
+        # define coordinate array
+        x_mesh, y_mesh, _ = np.meshgrid(x, y, z, indexing="ij")
+        r_mesh = np.sqrt(x_mesh**2 + y_mesh**2)  # radial distance
+
+        # index of refraction array
+        # assign the refractive index value to the array according to the desired profile
+        n_data = np.ones((Nx, Ny, Nz))
+        n0 = 2
+        A = 0.5
+        r = 1
+        n_data[r_mesh <= r] = n0 * (1 - A * r_mesh[r_mesh <= r] ** 2)
+        # convert to dataset array
+        n_dataset = td.SpatialDataArray(n_data, coords=dict(x=x, y=y, z=z))
+        medium_zz = td.CustomMedium.from_nk(n_dataset, interp_method="nearest")
+
+        return td.CustomAnisotropicMedium(xx=medium_xx, yy=medium_yy, zz=medium_zz)
+
+    @pytest.fixture(scope="module", autouse=True)
+    def cleanup_figures(self):
+        yield  # Run tests first
+        fig_dir = Path().resolve() / "result_images"
+        shutil.rmtree(fig_dir, ignore_errors=False)
+
+    def make_sim(self, medium):
+        L = 5
+
+        source = td.UniformCurrentSource(
+            center=(0, 0, -L / 3),
+            size=(L, L / 2, 0),
+            polarization="Ex",
+            source_time=td.GaussianPulse(
+                freq0=td.C_0,
+                fwidth=10e14,
+            ),
+        )
+        structures = (td.Structure(geometry=td.Sphere(center=(0, 0, 0), radius=1), medium=medium),)
+
+        return td.Simulation(
+            size=(L, L, L),
+            grid_spec=td.GridSpec.uniform(dl=0.01),
+            structures=structures,
+            sources=[source],
+            run_time=1e-12,
+        )
+
+    @pytest.mark.parametrize("eps_comp", ("xyz", "123", "", 5))
+    def test_bad_eps_arg(self, eps_comp):
+        """Tests that an incorrect component raises the proper exception."""
+        with pytest.raises(ValueError, match=f"eps_component '{eps_comp}' is not supported. "):
+            self.make_sim(self.medium_diag).plot_eps(x=0, eps_component=eps_comp)
+
+    @pytest.mark.parametrize(
+        "eps_comp",
+        [
+            None,
+        ]
+        + diag_comps,
+    )
+    def test_plot_anisotropic_medium(self, eps_comp):
+        """Test plotting diagonal components of a diagonally anisotropic medium succeeds or not.
+        diagonal components and ``None`` should succeed.
+        """
+        self.make_sim(self.medium_diag).plot_eps(x=0, eps_component=eps_comp)
+
+    @pytest.mark.parametrize("eps_comp", offdiag_comps)
+    def test_plot_anisotropic_medium_offdiagfail(self, eps_comp):
+        """Tests that plotting off-diagonal components of a diagonally anisotropic medium raises an exception."""
+        with pytest.raises(
+            ValueError,
+            match=f"Plotting component '{eps_comp}' of a diagonally-anisotropic permittivity tensor is not supported",
+        ):
+            self.make_sim(self.medium_diag).plot_eps(x=0, eps_component=eps_comp)
+
+    @pytest.mark.parametrize(
+        "eps_comp1,eps_comp2",
+        (
+            pytest.param("xx", "yy", marks=pytest.mark.xfail),
+            pytest.param("xx", "zz", marks=pytest.mark.xfail),
+            pytest.param("yy", "zz", marks=pytest.mark.xfail),
+        ),
+    )
+    @check_figures_equal(extensions=("png",))
+    def test_plot_anisotropic_medium_diff(self, fig_test, fig_ref, eps_comp1, eps_comp2):
+        """Tests that the plots of different components of an AnisotropicMedium are actually different."""
+        sim = self.make_sim(self.medium_diag)
+
+        ax1 = fig_test.add_subplot()
+        sim.plot_eps(x=0, eps_component=eps_comp1, ax=ax1)
+        ax2 = fig_ref.add_subplot()
+        sim.plot_eps(x=0, eps_component=eps_comp2, ax=ax2)
+
+    @pytest.mark.parametrize(
+        "eps_comp",
+        [
+            None,
+        ]
+        + diag_comps
+        + offdiag_comps,
+    )
+    def test_plot_fully_anisotropic_medium(self, eps_comp):
+        """Test plotting all components of a fully anisotropic medium.
+        All plots should succeed.
+        """
+        sim = self.make_sim(self.medium_fullyani)
+        sim.plot_eps(x=0, eps_component=eps_comp)
+
+    # Test parameters for comparing plots of a FullyAnisotropicMedium
+    fullyani_testplot_diff_params = []
+    for eps_comp1 in allcomps:
+        for eps_comp2 in allcomps:
+            if eps_comp1 == eps_comp2 or eps_comp1[::-1] == eps_comp2:
+                # Same components, or transposed components (eg. xy and yx) should plot the same
+                fullyani_testplot_diff_params.append((eps_comp1, eps_comp2))
+            else:
+                # All other component pairs should plot differently
+                fullyani_testplot_diff_params.append(
+                    pytest.param(eps_comp1, eps_comp2, marks=pytest.mark.xfail)
+                )
+
+    @pytest.mark.parametrize("eps_comp1,eps_comp2", fullyani_testplot_diff_params)
+    @check_figures_equal(extensions=("png",))
+    def test_plot_fully_anisotropic_medium_diff(self, fig_test, fig_ref, eps_comp1, eps_comp2):
+        """Tests that the plots of different components of a FullyAnisotropicMedium are actually different."""
+        sim = self.make_sim(self.medium_fullyani)
+
+        ax1 = fig_test.add_subplot()
+        sim.plot_eps(x=0, eps_component=eps_comp1, ax=ax1)
+        ax2 = fig_ref.add_subplot()
+        sim.plot_eps(x=0, eps_component=eps_comp2, ax=ax2)
+
+    @pytest.mark.parametrize(
+        "eps_comp",
+        [
+            None,
+        ]
+        + diag_comps,
+    )
+    def test_plot_customanisotropic_medium(self, eps_comp, medium_customani):
+        """Test plotting diagonal components of a diagonally anisotropic custom medium.
+        diagonal components and ``None`` should succeed.
+        """
+        self.make_sim(medium_customani).plot_eps(x=0, eps_component=eps_comp)
+
+    @pytest.mark.parametrize("eps_comp", offdiag_comps)
+    def test_plot_customanisotropic_medium_offdiagfail(self, eps_comp, medium_customani):
+        """Tests that plotting off-diagonal components of a diagonally anisotropic custom medium raises an exception."""
+        with pytest.raises(
+            ValueError,
+            match=f"Plotting component '{eps_comp}' of a diagonally-anisotropic permittivity tensor is not supported.",
+        ):
+            self.make_sim(medium_customani).plot_eps(x=0, eps_component=eps_comp)
+
+    @pytest.mark.parametrize(
+        "eps_comp1,eps_comp2",
+        (
+            pytest.param("xx", "yy", marks=pytest.mark.xfail),
+            pytest.param("xx", "zz", marks=pytest.mark.xfail),
+            pytest.param("yy", "zz", marks=pytest.mark.xfail),
+        ),
+    )
+    @check_figures_equal(extensions=("png",))
+    def test_plot_customanisotropic_medium_diff(
+        self, fig_test, fig_ref, eps_comp1, eps_comp2, medium_customani
+    ):
+        """Tests that the plots of different components of an AnisotropicMedium are actually different."""
+        sim = self.make_sim(medium_customani)
+
+        ax1 = fig_test.add_subplot()
+        sim.plot_eps(x=0, eps_component=eps_comp1, ax=ax1)
+        ax2 = fig_ref.add_subplot()
+        sim.plot_eps(x=0, eps_component=eps_comp2, ax=ax2)
 
 
 def test_plot():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -398,6 +398,7 @@ start_node = VJPNode.new_root()
 tracer = new_box(1.0, 0, start_node)
 tracer_arr = new_box(np.array([[[1.0]]]), 0, start_node)
 
+
 SIM_FULL = td.Simulation(
     size=(8.0, 8.0, 8.0),
     run_time=1e-12,
@@ -469,6 +470,12 @@ SIM_FULL = td.Simulation(
         td.Structure(
             geometry=td.Box(size=(1, 1, 1), center=(-1, 0, 0)),
             medium=td.AnisotropicMedium(xx=td.PEC, yy=td.Medium(), zz=td.Medium()),
+        ),
+        # Test a fully anistropic medium
+        td.Structure(
+            geometry=td.Box(size=(1, 1, 1), center=(-1, 0, 0)),
+            medium=td.FullyAnisotropicMedium(permittivity=[[6, 2, 3], [2, 7, 4], [3, 4, 9]]),
+            name="fully_anisotropic_box",
         ),
         td.Structure(
             geometry=td.GeometryGroup(geometries=[td.Box(size=(1, 1, 1), center=(-1, 0, 0))]),

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -84,6 +84,7 @@ from .types import (
     FreqBound,
     InterpMethod,
     Literal,
+    PermittivityComponent,
     PoleAndResidue,
     TensorReal,
 )
@@ -1053,6 +1054,30 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
             return self.eps_model(frequency)
         return 0j
 
+    def _eps_plot(
+        self, frequency: float, eps_component: Optional[PermittivityComponent] = None
+    ) -> float:
+        """Returns real part of epsilon for plotting. A specific component of the epsilon tensor can
+        be selected for anisotropic medium.
+
+        Parameters
+        ----------
+        frequency : float
+            Frequency to evaluate permittivity at.
+        eps_component : PermittivityComponent
+            Component of the permittivity tensor to plot
+            e.g. ``"xx"``, ``"yy"``, ``"zz"``, ``"xy"``, ``"yz"``, ...
+            Defaults to ``None``, which returns the average of the diagonal values.
+
+        Returns
+        -------
+        float
+            Element ``eps_component`` of the relative permittivity tensor evaluated at ``frequency``.
+        """
+        # Assumes the material is isotropic
+        # Will need to be overridden for anisotropic materials
+        return self.eps_model(frequency).real
+
     @cached_property
     @abstractmethod
     def n_cfl(self):
@@ -1529,6 +1554,36 @@ class AbstractCustomMedium(AbstractMedium, ABC):
             return (eps, eps, eps)
         eps_spatial_array = (_get_numpy_array(eps_comp).ravel() for eps_comp in eps_spatial)
         return tuple(eps_comp[np.argmax(np.abs(eps_comp))] for eps_comp in eps_spatial_array)
+
+    def _get_real_vals(self, x: np.ndarray) -> np.ndarray:
+        """Grab the real part of the values in array.
+        Used for _eps_bounds()
+        """
+        return _get_numpy_array(np.real(x)).ravel()
+
+    def _eps_bounds(
+        self, frequency: float = None, eps_component: Optional[PermittivityComponent] = None
+    ) -> Tuple[float, float]:
+        """Returns permittivity bounds for setting the color bounds when plotting.
+
+        Parameters
+        ----------
+        frequency : float = None
+            Frequency to evaluate the relative permittivity of all mediums.
+            If not specified, evaluates at infinite frequency.
+        eps_component : Optional[PermittivityComponent] = None
+            Component of the permittivity tensor to plot for anisotropic materials,
+            e.g. ``"xx"``, ``"yy"``, ``"zz"``, ``"xy"``, ``"yz"``, ...
+            Defaults to ``None``, which returns the average of the diagonal values.
+
+        Returns
+        -------
+        Tuple[float, float]
+            The min and max values of the permittivity for the selected component and evaluated at ``frequency``.
+        """
+        eps_dataarray = self.eps_dataarray_freq(frequency)
+        all_eps = np.concatenate(self._get_real_vals(eps_comp) for eps_comp in eps_dataarray)
+        return (np.min(all_eps), np.max(all_eps))
 
     @staticmethod
     def _validate_isreal_dataarray(dataarray: CustomSpatialDataType) -> bool:
@@ -5728,6 +5783,38 @@ class AnisotropicMedium(AbstractMedium):
         field_name = cmp + cmp
         return self.components[field_name].eps_model(frequency)
 
+    def _eps_plot(
+        self, frequency: float, eps_component: Optional[PermittivityComponent] = None
+    ) -> float:
+        """Returns real part of epsilon for plotting. A specific component of the epsilon tensor can
+        be selected for anisotropic medium.
+
+        Parameters
+        ----------
+        frequency : float
+        eps_component : PermittivityComponent
+
+        Returns
+        -------
+        float
+            Element ``eps_component`` of the relative permittivity tensor evaluated at ``frequency``.
+        """
+        if eps_component is None:
+            # return the average of the diag
+            return self.eps_model(frequency).real
+        elif eps_component in ["xx", "yy", "zz"]:
+            # return the requested diagonal component
+            comp2indx = {"x": 0, "y": 1, "z": 2}
+            return self.eps_comp(
+                row=comp2indx[eps_component[0]],
+                col=comp2indx[eps_component[1]],
+                frequency=frequency,
+            ).real
+        else:
+            raise ValueError(
+                f"Plotting component '{eps_component}' of a diagonally-anisotropic permittivity tensor is not supported."
+            )
+
     @add_ax_if_none
     def plot(self, freqs: float, ax: Ax = None) -> Ax:
         """Plot n, k of a :class:`.Medium` as a function of frequency."""
@@ -6017,6 +6104,32 @@ class FullyAnisotropicMedium(AbstractMedium):
         sig = self.conductivity[row][col]
         return AbstractMedium.eps_sigma_to_eps_complex(eps, sig, frequency)
 
+    def _eps_plot(
+        self, frequency: float, eps_component: Optional[PermittivityComponent] = None
+    ) -> float:
+        """Returns real part of epsilon for plotting. A specific component of the epsilon tensor can
+        be selected for anisotropic medium.
+
+        Parameters
+        ----------
+        frequency : float
+        eps_component : PermittivityComponent
+
+        Returns
+        -------
+        float
+            Element ``eps_component`` of the relative permittivity tensor evaluated at ``frequency``.
+        """
+        if eps_component is None:
+            # return the average of the diag
+            return self.eps_model(frequency).real
+
+        # return the requested component
+        comp2indx = {"x": 0, "y": 1, "z": 2}
+        return self.eps_comp(
+            row=comp2indx[eps_component[0]], col=comp2indx[eps_component[1]], frequency=frequency
+        ).real
+
     @cached_property
     def n_cfl(self):
         """This property computes the index of refraction related to CFL condition, so that
@@ -6226,6 +6339,40 @@ class CustomAnisotropicMedium(AbstractCustomMedium, AnisotropicMedium):
             mat_component.eps_dataarray_freq(frequency)[ind]
             for ind, mat_component in enumerate(self.components.values())
         )
+
+    def _eps_bounds(
+        self, frequency: float = None, eps_component: Optional[PermittivityComponent] = None
+    ) -> Tuple[float, float]:
+        """Returns permittivity bounds for setting the color bounds when plotting.
+
+        Parameters
+        ----------
+        frequency : float = None
+            Frequency to evaluate the relative permittivity of all mediums.
+            If not specified, evaluates at infinite frequency.
+        eps_component : Optional[PermittivityComponent] = None
+            Component of the permittivity tensor to plot for anisotropic materials,
+            e.g. ``"xx"``, ``"yy"``, ``"zz"``, ``"xy"``, ``"yz"``, ...
+            Defaults to ``None``, which returns the average of the diagonal values.
+
+        Returns
+        -------
+        Tuple[float, float]
+            The min and max values of the permittivity for the selected component and evaluated at ``frequency``.
+        """
+        comps = ["xx", "yy", "zz"]
+        if eps_component in comps:
+            # Return the bounds of a specific component
+            eps_dataarray = self.eps_dataarray_freq(frequency)
+            eps = self._get_real_vals(eps_dataarray[comps.index(eps_component)])
+            return (np.min(eps), np.max(eps))
+        elif eps_component is None:
+            # Returns the bounds across all components
+            return super()._eps_bounds(frequency=frequency)
+        else:
+            raise ValueError(
+                f"Plotting component '{eps_component}' of a diagonally-anisotropic permittivity tensor is not supported."
+            )
 
     def _sel_custom_data_inside(self, bounds: Bound):
         return self

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -35,7 +35,6 @@ from .data.utils import (
     TetrahedralGridDataset,
     TriangularGridDataset,
     UnstructuredGridDataset,
-    _get_numpy_array,
 )
 from .geometry.base import Box, ClipOperation, GeometryGroup
 from .geometry.utils import flatten_groups, merging_geometries_on_plane, traverse_geometries
@@ -56,6 +55,7 @@ from .types import (
     Coordinate,
     InterpMethod,
     LengthUnit,
+    PermittivityComponent,
     Shapely,
     Size,
 )
@@ -767,6 +767,7 @@ class Scene(Tidy3dBaseModel):
         hlim: Tuple[float, float] = None,
         vlim: Tuple[float, float] = None,
         grid: Grid = None,
+        eps_component: Optional[PermittivityComponent] = None,
     ) -> Ax:
         """Plot each of scene's structures on a plane defined by one nonzero x,y,z coordinate.
         The permittivity is plotted in grayscale based on its value at the specified frequency.
@@ -798,6 +799,10 @@ class Scene(Tidy3dBaseModel):
             The x range if plotting on xy or xz planes, y range if plotting on yz plane.
         vlim : Tuple[float, float] = None
             The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
+        eps_component : Optional[PermittivityComponent] = None
+            Component of the permittivity tensor to plot for anisotropic materials,
+            e.g. ``"xx"``, ``"yy"``, ``"zz"``, ``"xy"``, ``"yz"``, ...
+            Defaults to ``None``, which returns the average of the diagonal values.
 
         Returns
         -------
@@ -819,6 +824,7 @@ class Scene(Tidy3dBaseModel):
             vlim=vlim,
             grid=grid,
             property="eps",
+            eps_component=eps_component,
         )
 
     @equal_aspect
@@ -838,6 +844,7 @@ class Scene(Tidy3dBaseModel):
         vlim: Tuple[float, float] = None,
         grid: Grid = None,
         property: Literal["eps", "doping", "N_a", "N_d"] = "eps",
+        eps_component: Optional[PermittivityComponent] = None,
     ) -> Ax:
         """Plot each of scene's structures on a plane defined by one nonzero x,y,z coordinate.
         The permittivity is plotted in grayscale based on its value at the specified frequency.
@@ -872,6 +879,10 @@ class Scene(Tidy3dBaseModel):
         property: Literal["eps", "doping", "N_a", "N_d"] = "eps"
             Indicates the property to plot for the structures. Currently supported properties
             are ["eps", "doping", "N_a", "N_d"]
+        eps_component : Optional[PermittivityComponent] = None
+            Component of the permittivity tensor to plot for anisotropic materials,
+            e.g. ``"xx"``, ``"yy"``, ``"zz"``, ``"xy"``, ``"yz"``, ...
+            Defaults to ``None``, which returns the average of the diagonal values.
 
         Returns
         -------
@@ -914,7 +925,7 @@ class Scene(Tidy3dBaseModel):
 
         if property_min is None or property_max is None:
             if property == "eps":
-                eps_min_sim, eps_max_sim = self.eps_bounds(freq=freq)
+                eps_min_sim, eps_max_sim = self.eps_bounds(freq=freq, eps_component=eps_component)
                 if property_min is None:
                     property_min = eps_min_sim
 
@@ -965,6 +976,7 @@ class Scene(Tidy3dBaseModel):
                         reverse=reverse,
                         shape=shape,
                         ax=ax,
+                        eps_component=eps_component,
                     )
                 else:
                     # For custom medium, apply pcolormesh clipped by the shape.
@@ -981,6 +993,7 @@ class Scene(Tidy3dBaseModel):
                         shape,
                         ax,
                         grid,
+                        eps_component=eps_component,
                     )
 
         if cbar:
@@ -1013,38 +1026,26 @@ class Scene(Tidy3dBaseModel):
         )
 
     @staticmethod
-    def _eps_bounds(medium_list: list[Medium], freq: float = None) -> Tuple[float, float]:
+    def _eps_bounds(
+        medium_list: list[Medium],
+        freq: float = None,
+        eps_component: Optional[PermittivityComponent] = None,
+    ) -> Tuple[float, float]:
         """Compute range of (real) permittivity present in the mediums at frequency "freq"."""
         medium_list = [medium for medium in medium_list if not medium.is_pec]
-        # regular medium
-        eps_list = [
-            np.real(medium.eps_model(freq))
-            for medium in medium_list
-            if not isinstance(medium, AbstractCustomMedium) and not isinstance(medium, Medium2D)
-        ]
+        eps_list = [medium._eps_plot(freq, eps_component) for medium in medium_list]
+        eps_list = [eps for eps in eps_list if eps is not None]
         eps_min = min(eps_list, default=1)
         eps_max = max(eps_list, default=1)
         # custom medium, the min and max in the supplied dataset over all components and
         # spatial locations.
         for mat in [medium for medium in medium_list if isinstance(medium, AbstractCustomMedium)]:
-            eps_dataarray = mat.eps_dataarray_freq(freq)
-            eps_min = min(
-                eps_min,
-                min(
-                    np.min(_get_numpy_array(np.real(eps_comp)).ravel())
-                    for eps_comp in eps_dataarray
-                ),
-            )
-            eps_max = max(
-                eps_max,
-                max(
-                    np.max(_get_numpy_array(np.real(eps_comp)).ravel())
-                    for eps_comp in eps_dataarray
-                ),
-            )
+            mat_epsmin, mat_epsmax = mat._eps_bounds(frequency=freq, eps_component=eps_component)
+            eps_min = min(eps_min, mat_epsmin)
+            eps_max = max(eps_max, mat_epsmax)
         return eps_min, eps_max
 
-    def eps_bounds(self, freq: float = None) -> Tuple[float, float]:
+    def eps_bounds(self, freq: float = None, eps_component: str = None) -> Tuple[float, float]:
         """Compute range of (real) permittivity present in the scene at frequency "freq".
 
         Parameters
@@ -1052,6 +1053,10 @@ class Scene(Tidy3dBaseModel):
         freq : float = None
             Frequency to evaluate the relative permittivity of all mediums.
             If not specified, evaluates at infinite frequency.
+        eps_component : Optional[PermittivityComponent] = None
+            Component of the permittivity tensor to plot for anisotropic materials,
+            e.g. ``"xx"``, ``"yy"``, ``"zz"``, ``"xy"``, ``"yz"``, ...
+            Defaults to ``None``, which returns the average of the diagonal values.
 
         Returns
         -------
@@ -1060,7 +1065,7 @@ class Scene(Tidy3dBaseModel):
         """
 
         medium_list = [self.medium] + list(self.mediums)
-        return self._eps_bounds(medium_list=medium_list, freq=freq)
+        return self._eps_bounds(medium_list=medium_list, freq=freq, eps_component=eps_component)
 
     def _pcolormesh_shape_custom_medium_structure_eps(
         self,
@@ -1076,6 +1081,7 @@ class Scene(Tidy3dBaseModel):
         shape: Shapely,
         ax: Ax,
         grid: Grid,
+        eps_component: Optional[PermittivityComponent] = None,
     ):
         """
         Plot shape made of custom medium with ``pcolormesh``.
@@ -1083,6 +1089,8 @@ class Scene(Tidy3dBaseModel):
         coords = "xyz"
         normal_axis_ind, normal_position = Box.parse_xyz_kwargs(x=x, y=y, z=z)
         normal_axis, plane_axes = Box.pop_axis(coords, normal_axis_ind)
+
+        comp2ind = {dim + dim: index for dim, index in zip("xyz", range(3))}
 
         # make grid for eps interpolation
         # we will do this by combining shape bounds and points where custom eps is provided
@@ -1112,18 +1120,23 @@ class Scene(Tidy3dBaseModel):
                             axis=normal_axis_ind, pos=normal_position
                         )
                 else:
-                    eps_mean = (eps_diag[0] + eps_diag[1] + eps_diag[2]) / 3
+                    # Select the permittivity component to plot
+                    if eps_component in comp2ind:
+                        eps = eps_diag[comp2ind[eps_component]]
+                    else:
+                        # default to plotting the mean of the diagonal elements
+                        eps = (eps_diag[0] + eps_diag[1] + eps_diag[2]) / 3
 
-                    if isinstance(eps_mean, TetrahedralGridDataset):
+                    if isinstance(eps, TetrahedralGridDataset):
                         # extract slice if volumetric unstructured data
-                        eps_mean = eps_mean.plane_slice(axis=normal_axis_ind, pos=normal_position)
+                        eps = eps.plane_slice(axis=normal_axis_ind, pos=normal_position)
 
                     if reverse:
-                        eps_mean = eps_min + eps_max - eps_mean
+                        eps = eps_min + eps_max - eps
 
                     # at this point eps_mean is TriangularGridDataset and we just plot it directly
                     # with applying shape mask
-                    eps_mean.plot(
+                    eps.plot(
                         grid=False,
                         ax=ax,
                         cbar=False,
@@ -1189,8 +1202,14 @@ class Scene(Tidy3dBaseModel):
             normal_axis: [normal_position],
         }
         coord_shape = Coords(**coord_dict)
-        # interpolate permittivity and take the average over components
-        eps_shape = np.mean(medium.eps_diagonal_on_grid(frequency=freq, coords=coord_shape), axis=0)
+
+        # interpolate permittivity and pick the component to plot
+        eps_shape = medium.eps_diagonal_on_grid(frequency=freq, coords=coord_shape)
+        if eps_component in comp2ind:
+            eps_shape = eps_shape[comp2ind[eps_component]]
+        else:
+            eps_shape = np.mean(eps_shape, axis=0)
+
         # remove the normal_axis and take real part
         eps_shape = eps_shape.real.mean(axis=normal_axis_ind)
         # reverse
@@ -1219,6 +1238,7 @@ class Scene(Tidy3dBaseModel):
         eps_max: float,
         reverse: bool = False,
         alpha: float = None,
+        eps_component: Optional[PermittivityComponent] = None,
     ) -> PlotParams:
         """Constructs the plot parameters for a given medium in scene.plot_eps()."""
 
@@ -1238,8 +1258,7 @@ class Scene(Tidy3dBaseModel):
             # 2d material
             plot_params = plot_params.copy(update={"edgecolor": "k", "linewidth": 1})
         else:
-            # regular medium
-            eps_medium = medium.eps_model(frequency=freq).real
+            eps_medium = medium._eps_plot(frequency=freq, eps_component=eps_component)
             delta_eps = eps_medium - eps_min
             delta_eps_max = eps_max - eps_min + 1e-5
             eps_fraction = delta_eps / delta_eps_max
@@ -1259,10 +1278,17 @@ class Scene(Tidy3dBaseModel):
         ax: Ax,
         reverse: bool = False,
         alpha: float = None,
+        eps_component: Optional[PermittivityComponent] = None,
     ) -> Ax:
         """Plot a structure's cross section shape for a given medium, grayscale for permittivity."""
         plot_params = self._get_structure_eps_plot_params(
-            medium=medium, freq=freq, eps_min=eps_min, eps_max=eps_max, alpha=alpha, reverse=reverse
+            medium=medium,
+            freq=freq,
+            eps_min=eps_min,
+            eps_max=eps_max,
+            alpha=alpha,
+            reverse=reverse,
+            eps_component=eps_component,
         )
         ax = self.box.plot_shape(shape=shape, plot_params=plot_params, ax=ax)
         return ax

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -6,7 +6,7 @@ import math
 import pathlib
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union, get_args
 
 import autograd.numpy as np
 
@@ -107,6 +107,7 @@ from .types import (
     FreqBound,
     InterpMethod,
     Literal,
+    PermittivityComponent,
     Symmetry,
     annotate_type,
 )
@@ -468,6 +469,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         hlim: Tuple[float, float] = None,
         vlim: Tuple[float, float] = None,
         ax: Ax = None,
+        eps_component: Optional[PermittivityComponent] = None,
     ) -> Ax:
         """Plot each of simulation's components on a plane defined by one nonzero x,y,z coordinate.
         The permittivity is plotted in grayscale based on its value at the specified frequency.
@@ -500,6 +502,10 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
             The x range if plotting on xy or xz planes, y range if plotting on yz plane.
         vlim : Tuple[float, float] = None
             The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
+        eps_component : Optional[PermittivityComponent] = None
+            Component of the permittivity tensor to plot for anisotropic materials,
+            e.g. ``"xx"``, ``"yy"``, ``"zz"``, ``"xy"``, ``"yz"``, ...
+            Defaults to ``None``, which returns the average of the diagonal values.
 
         Returns
         -------
@@ -512,6 +518,15 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         **Notebooks**
             * `Visualizing geometries in Tidy3D: Plotting Permittivity <../../notebooks/VizSimulation.html#Plotting-Permittivity>`_
         """
+
+        # check that eps_component is one of the allowed values, otherwise raise an error
+        if eps_component is not None:
+            if eps_component not in get_args(PermittivityComponent):
+                raise ValueError(
+                    f"eps_component '{eps_component}' is not supported. "
+                    "eps_component must be one of the following values:"
+                    "'xx', 'yy', 'zz', 'xy', 'yx', 'xz', 'zx', 'yz', 'zy', or 'None'"
+                )
 
         hlim, vlim = Scene._get_plot_lims(
             bounds=self.simulation_bounds, x=x, y=y, z=z, hlim=hlim, vlim=vlim
@@ -527,6 +542,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
             z=z,
             hlim=hlim,
             vlim=vlim,
+            eps_component=eps_component,
         )
         ax = self.plot_sources(ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim, alpha=source_alpha)
         ax = self.plot_monitors(ax=ax, x=x, y=y, z=z, hlim=hlim, vlim=vlim, alpha=monitor_alpha)
@@ -555,6 +571,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         ax: Ax = None,
         hlim: Tuple[float, float] = None,
         vlim: Tuple[float, float] = None,
+        eps_component: Optional[PermittivityComponent] = None,
     ) -> Ax:
         """Plot each of simulation's structures on a plane defined by one nonzero x,y,z coordinate.
         The permittivity is plotted in grayscale based on its value at the specified frequency.
@@ -586,6 +603,10 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
             The x range if plotting on xy or xz planes, y range if plotting on yz plane.
         vlim : Tuple[float, float] = None
             The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
+        eps_component : Optional[PermittivityComponent] = None
+            Component of the permittivity tensor to plot for anisotropic materials,
+            e.g. ``"xx"``, ``"yy"``, ``"zz"``, ``"xy"``, ``"yz"``, ...
+            Defaults to ``None``, which returns the average of the diagonal values.
 
         Returns
         -------
@@ -620,6 +641,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
             vlim=vlim,
             grid=self.grid,
             reverse=reverse,
+            eps_component=eps_component,
         )
 
     @equal_aspect

--- a/tidy3d/components/types.py
+++ b/tidy3d/components/types.py
@@ -215,6 +215,8 @@ FreqBoundMax = float
 FreqBoundMin = float
 FreqBound = Tuple[FreqBoundMin, FreqBoundMax]
 
+PermittivityComponent = Literal["xx", "xy", "xz", "yx", "yy", "yz", "zx", "zy", "zz"]
+
 """ sources """
 
 Polarization = Literal["Ex", "Ey", "Ez", "Hx", "Hy", "Hz"]


### PR DESCRIPTION
Closes https://github.com/flexcompute/tidy3d/issues/2085

Adds "component" argument to simulation.plot_eps(), where component = "xx", "yy", "zz", "xy", "yz", "xz". Affects plotting of AnisotropicMedium, FullyAnisotropicMedium and CustomAnisotropicMedium.

my first PR :')