### PR TITLE
Fix for numpy deprecating cross product in 2D

### DIFF
--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -1250,7 +1250,7 @@ class PolySlab(base.Planar):
             return np.stack((-vys, vxs), axis=0)
 
         def cross(u, v):
-            return np.cross(u, v, axis=0)
+            return u[0] * v[1] - u[1] * v[0]
 
         def normalize(v):
             return v / np.linalg.norm(v, axis=0)


### PR DESCRIPTION
Ref: https://github.com/numpy/numpy/blob/d741eb282dd15acc1f49fa660519c99680435e75/numpy/_core/numeric.py#L1664

For some reason, the warning is not shown in normal tidy3d runs, but if we enable it around the function call with:

```python
import warnings
warnings.simplefilter("error")
```

it will show as an error. This affects PhotonForge because we don't differentiate warnings from errors through the python C API, so having this warning is preventing us from supporting numpy >= 2.