### PR TITLE
fix[web]: fix task querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Bug in `LayerRefinementSpec` that refines grids outside the layer region when one in-plane dimension is of size infinity.
+- Querying tasks was sometimes erroring unexpectedly.
 
 ## [2.8.0] - 2025-03-04
 

--- a/tidy3d/web/core/http_util.py
+++ b/tidy3d/web/core/http_util.py
@@ -140,10 +140,12 @@ def http_interceptor(func):
         if not resp.text:
             return None
         result = resp.json()
-        warning = result.get("warning")
-        if warning:
-            log = get_logger()
-            log.warning(warning)
+
+        if isinstance(result, dict):
+            warning = result.get("warning")
+            if warning:
+                log = get_logger()
+                log.warning(warning)
 
         return result.get("data") if "data" in result else result
 


### PR DESCRIPTION
Fixes #2314 

Tasks are returned as a list so `dict.get()` for the warning was failing.