### PR TITLE
chore: add dependency group for `design` plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Dependencies for the `design` plugin can now be installed via `pip install tidy3d[design]`.
+
 ### Fixed
 - Bug in `LayerRefinementSpec` that refines grids outside the layer region when one in-plane dimension is of size infinity.
 - Querying tasks was sometimes erroring unexpectedly.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -171,6 +171,63 @@ Some users or systems may require a more specialized installation, which we will
 
         See the development installation `instructions <../development/index.html>`_. You can install ``tidy3d`` within reproducible environment guaranteed by the developers using the ``poetry.lock`` installation and the ``poetry`` toolchain.
 
+Optional Dependencies
+=====================
+
+Tidy3D provides several optional dependency groups that you can install based on your specific needs.
+
+Installing Optional Core Dependencies
+-------------------------------------
+
+Tidy3D has several optional dependencies that provide additional functionality. You can install these using the following syntax:
+
+.. code-block:: bash
+
+    pip install "tidy3d[dependency_group]"
+
+Where ``dependency_group`` is one of the following:
+
+- ``gdspy``: Adds support for GDS export using `gdspy <https://github.com/heitzmann/gdspy>`_.
+- ``gdstk``: Adds support for GDS export using `gdstk <https://github.com/heitzmann/gdstk>`_.
+- ``trimesh``: Support for more complex mesh handling and manipulation.
+- ``vtk``: Support for working with unstructured data.
+- ``heatcharge``: Additional dependencies for heat & charge solvers.
+
+For example, to install Tidy3D with trimesh support:
+
+.. code-block:: bash
+
+    pip install "tidy3d[trimesh]"
+
+Installing Plugin Dependencies
+------------------------------
+
+Tidy3D also offers plugins that require additional dependencies:
+
+- ``design``: Design space exploration and optimization.
+- ``pytorch``: A PyTorch wrapper for objective functions defined using autograd.
+- ``adjoint``: Adjoint optimization using JAX (deprecated in favor of native autorad support in Tidy3D)
+
+For example, to install the design plugin dependencies:
+
+.. code-block:: bash
+
+    pip install "tidy3d[design]"
+
+Multiple dependency groups can be installed simultaneously:
+
+.. code-block:: bash
+
+    pip install "tidy3d[design,trimesh]"
+
+Developer Installation
+----------------------
+
+For developers and those who want to install all optional dependencies:
+
+.. code-block:: bash
+
+    pip install "tidy3d[dev]"
 
 Next Steps
 ==========

--- a/poetry.lock
+++ b/poetry.lock
@@ -390,8 +390,8 @@ files = [
 jmespath = ">=0.7.1,<2.0.0"
 python-dateutil = ">=2.1,<3.0.0"
 urllib3 = [
-    {version = ">=1.25.4,<1.27", markers = "python_version < \"3.10\""},
     {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""},
+    {version = ">=1.25.4,<1.27", markers = "python_version < \"3.10\""},
 ]
 
 [package.extras]
@@ -1072,7 +1072,7 @@ files = [
 [package.dependencies]
 fsspec = {version = "*", optional = true, markers = "extra == \"epath\""}
 importlib_resources = {version = "*", optional = true, markers = "extra == \"epath\""}
-typing_extensions = {version = "*", optional = true, markers = "extra == \"epy\""}
+typing_extensions = {version = "*", optional = true, markers = "extra == \"epath\" or extra == \"epy\""}
 zipp = {version = "*", optional = true, markers = "extra == \"epath\""}
 
 [package.extras]
@@ -1199,9 +1199,9 @@ files = [
 jax = ">=0.4.27"
 msgpack = "*"
 numpy = [
-    {version = ">=1.22", markers = "python_version < \"3.11\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
     {version = ">=1.23.2", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
+    {version = ">=1.22", markers = "python_version < \"3.11\""},
 ]
 optax = "*"
 orbax-checkpoint = "*"
@@ -1819,14 +1819,14 @@ importlib-metadata = {version = ">=4.6", markers = "python_version < \"3.10\""}
 jaxlib = ">=0.4.27,<=0.4.30"
 ml-dtypes = ">=0.2.0"
 numpy = [
-    {version = ">=1.22", markers = "python_version < \"3.11\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
     {version = ">=1.23.2", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
+    {version = ">=1.22", markers = "python_version < \"3.11\""},
 ]
 opt-einsum = "*"
 scipy = [
-    {version = ">=1.9", markers = "python_version < \"3.12\""},
     {version = ">=1.11.1", markers = "python_version >= \"3.12\""},
+    {version = ">=1.9", markers = "python_version < \"3.12\""},
 ]
 
 [package.extras]
@@ -1876,8 +1876,8 @@ files = [
 ml-dtypes = ">=0.2.0"
 numpy = ">=1.22"
 scipy = [
-    {version = ">=1.9", markers = "python_version < \"3.12\""},
     {version = ">=1.11.1", markers = "python_version >= \"3.12\""},
+    {version = ">=1.9", markers = "python_version < \"3.12\""},
 ]
 
 [package.source]
@@ -2788,10 +2788,10 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.21", markers = "python_version < \"3.10\""},
-    {version = ">=1.21.2", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\" and python_version < \"3.13\""},
     {version = ">=1.23.3", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
+    {version = ">=1.21.2", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
+    {version = ">=1.21", markers = "python_version < \"3.10\""},
 ]
 
 [package.extras]
@@ -3592,9 +3592,9 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
     {version = ">=1.23.2", markers = "python_version == \"3.11\""},
+    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -4193,9 +4193,9 @@ files = [
 astroid = ">=3.3.8,<=3.4.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = [
-    {version = ">=0.2", markers = "python_version < \"3.11\""},
     {version = ">=0.3.7", markers = "python_version >= \"3.12\""},
     {version = ">=0.3.6", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
+    {version = ">=0.2", markers = "python_version < \"3.11\""},
 ]
 isort = ">=4.2.5,<5.13.0 || >5.13.0,<7"
 mccabe = ">=0.6,<0.8"
@@ -6238,11 +6238,14 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 type = ["pytest-mypy"]
 
 [extras]
+adjoint = ["jax", "jaxlib"]
+design = ["bayesian-optimization", "pygad", "pyswarms"]
 dev = ["bayesian-optimization", "bump-my-version", "cma", "coverage", "devsim", "dill", "gdspy", "gdstk", "grcwa", "ipython", "ipython", "jax", "jaxlib", "jinja2", "jupyter", "memory_profiler", "myst-parser", "nbconvert", "nbdime", "nbsphinx", "networkx", "optax", "pre-commit", "psutil", "pydata-sphinx-theme", "pygad", "pylint", "pyswarms", "pytest", "pytest-cov", "pytest-env", "pytest-timeout", "pytest-xdist", "rtree", "ruff", "sax", "scikit-rf", "signac", "sphinx", "sphinx-book-theme", "sphinx-copybutton", "sphinx-favicon", "sphinx-notfound-page", "sphinx-sitemap", "sphinx-tabs", "sphinxemoji", "tmm", "torch", "torch", "tox", "trimesh", "vtk"]
 docs = ["cma", "devsim", "gdstk", "grcwa", "ipython", "jinja2", "jupyter", "myst-parser", "nbconvert", "nbdime", "nbsphinx", "optax", "pydata-sphinx-theme", "pylint", "sax", "signac", "sphinx", "sphinx-book-theme", "sphinx-copybutton", "sphinx-favicon", "sphinx-notfound-page", "sphinx-sitemap", "sphinx-tabs", "sphinxemoji", "tmm"]
 gdspy = ["gdspy"]
 gdstk = ["gdstk"]
-jax = ["jax", "jaxlib"]
+heatcharge = ["devsim", "trimesh", "vtk"]
+pytorch = ["torch", "torch"]
 ruff = ["ruff"]
 scikit-rf = ["scikit-rf"]
 trimesh = ["networkx", "rtree", "trimesh"]
@@ -6251,4 +6254,4 @@ vtk = ["vtk"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0.0"
-content-hash = "c3970d189d03c2096dd344ded8bf3fda706634943f771c32f274e9ed1dc9a71e"
+content-hash = "f674de7bbb51d492ef99839fa8198914aef2f8efd95bff8217067791705605f4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,11 +208,15 @@ docs = [
 ]
 gdspy = ["gdspy"]
 gdstk = ["gdstk"]
-jax = ["jaxlib", "jax"]
 scikit-rf = ["scikit-rf"]
 trimesh = ["trimesh", "networkx", "rtree"]
 vtk = ["vtk"]
 ruff = ["ruff"]
+heatcharge = ["trimesh", "vtk", "devsim"]
+# plugins with extra deps
+adjoint = ["jaxlib", "jax"]
+pytorch = ["torch"]
+design = ["bayesian-optimization", "pygad", "pyswarms"]
 
 [tool.poetry.scripts]
 tidy3d = "tidy3d.web.cli:tidy3d_cli"

--- a/tidy3d/plugins/design/method.py
+++ b/tidy3d/plugins/design/method.py
@@ -245,7 +245,8 @@ class MethodBayOpt(MethodOptimize, ABC):
             from bayes_opt import BayesianOptimization, UtilityFunction
         except ImportError:
             raise ImportError(
-                "Cannot run Bayesian optimization as 'bayes_opt' module not found. Please check installation or run 'pip install bayesian-optimization'."
+                "Cannot run Bayesian optimization as 'bayes_opt' module not found. "
+                "Please check installation or run 'pip install bayesian-optimization==1.5.1'."
             )
 
         # Identify non-numeric params and define boundaries for Bay-opt


### PR DESCRIPTION
Fixes #2322 by introducing a `design` plugin dependency group installable via `pip install tidy3d[design]` and updating the warning message if `bayesian-optimization` is not installed as suggested in https://github.com/flexcompute/tidy3d/issues/2322#issuecomment-2730640910.