### PR TITLE
Improve accuracy of normal E-field computation in mode solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed automatic creation of missing output directories.
 - Bug in handling of tuple-type gradients that could lead to empty tuples or failing gradient calculations when differentiating w.r.t. (for instance) `td.Box.center`.
 - Bug causing incorrect field projection results when multiple projection monitors with numerous sampling points were used.
+- Improved accuracy for normal E-field components in mode solver at microwave frequencies.
 
 ## [2.8.0] - 2025-03-04
 

--- a/tidy3d/components/mode/solver.py
+++ b/tidy3d/components/mode/solver.py
@@ -660,7 +660,12 @@ class EigSolver(Tidy3dBaseModel):
         Hx = h_field[:N, :] / (1j * neff - keff)
         Hy = h_field[N:, :] / (1j * neff - keff)
         Hz = inv_mu_zz.dot(dxf.dot(Ey) - dyf.dot(Ex))
-        Ez = inv_eps_zz.dot(dxb.dot(Hy) - dyb.dot(Hx))
+        # Ez = inv_eps_zz.dot(dxb.dot(Hy) - dyb.dot(Hx))
+
+        # Ez = -inv_eps_zz * div^H J H_xy, while Hxy = vals^-1 * qmat * Exy;
+        # Note that div^H J q_partial = 0, so Ez = -vals^-1 inv_eps_zz * div^H J q_ep Exy
+        h_partial_field = q_ep.dot(vecs) / (1j * neff - keff)
+        Ez = inv_eps_zz.dot(dxb.dot(h_partial_field[N:, :]) - dyb.dot(h_partial_field[:N, :]))
 
         # Bundle up
         E = np.stack((Ex, Ey, Ez), axis=0)


### PR DESCRIPTION
Consider a CPW at 1 GHz, previously the modal field profile is as follows (x is normal axis). Ex should be 0, but it's very noisy and large instead. `wg TE fraction` should be 1, but it's 0.407814.
![image](https://github.com/user-attachments/assets/a56b415a-20fd-4b0b-80f2-432334334dda)


This PR drops a term that is analytically 0, and now Ex is much smaller, and `wg TE fraction` is computed to 1.
![image](https://github.com/user-attachments/assets/66a0e123-ef62-4878-b3a4-f2009b6d117c)

