### PR TITLE
fix: deletion of tasks using `web.delete(task_id)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug in handling of tuple-type gradients that could lead to empty tuples or failing gradient calculations when differentiating w.r.t. (for instance) `td.Box.center`.
 - Bug causing incorrect field projection results when multiple projection monitors with numerous sampling points were used.
 - Improved accuracy for normal E-field components in mode solver at microwave frequencies.
+- Deleting tasks using `web.delete(task_id)` would error when deleting tasks in the tidy3d root folder and others would not get completely removed in the Web GUI.
 
 ## [2.8.0] - 2025-03-04
 

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -343,6 +343,39 @@ def _test_load(mock_load, mock_get_info, tmp_path):
 @responses.activate
 def test_delete(set_api_key, mock_get_info):
     responses.add(
+        responses.GET,
+        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}",
+        json={
+            "data": {
+                "taskId": TASK_ID,
+                "groupId": "group123",
+                "version": "v1",
+                "createdAt": CREATED_AT,
+            }
+        },
+        status=200,
+    )
+
+    responses.add(
+        responses.DELETE,
+        f"{Env.current.web_api_endpoint}/tidy3d/group/group123/versions",
+        match=[
+            matchers.json_params_matcher(
+                {
+                    "versions": ["v1"],
+                }
+            )
+        ],
+        json={
+            "data": {
+                "taskId": TASK_ID,
+                "createdAt": CREATED_AT,
+            }
+        },
+        status=200,
+    )
+
+    responses.add(
         responses.DELETE,
         f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}",
         json={
@@ -413,10 +446,44 @@ def test_delete_old(set_api_key):
         json={"data": {"projectId": TASK_ID, "projectName": PROJECT_NAME}},
         status=200,
     )
+
     responses.add(
         responses.GET,
         f"{Env.current.web_api_endpoint}/tidy3d/projects/{TASK_ID}/tasks",
         json={"data": [{"taskId": TASK_ID, "createdAt": CREATED_AT}]},
+        status=200,
+    )
+
+    responses.add(
+        responses.GET,
+        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{TASK_ID}",
+        json={
+            "data": {
+                "taskId": TASK_ID,
+                "groupId": "group123",
+                "version": "v1",
+                "createdAt": CREATED_AT,
+            }
+        },
+        status=200,
+    )
+
+    responses.add(
+        responses.DELETE,
+        f"{Env.current.web_api_endpoint}/tidy3d/group/group123/versions",
+        match=[
+            matchers.json_params_matcher(
+                {
+                    "versions": ["v1"],
+                }
+            )
+        ],
+        json={
+            "data": {
+                "taskId": TASK_ID,
+                "createdAt": CREATED_AT,
+            }
+        },
         status=200,
     )
 

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -815,23 +815,23 @@ def load(
 
 
 @wait_for_connection
-def delete(task_id: TaskId) -> TaskInfo:
+def delete(task_id: TaskId, versions: bool = False) -> TaskInfo:
     """Delete server-side data associated with task.
 
     Parameters
     ----------
     task_id : str
         Unique identifier of task on server.  Returned by :meth:`upload`.
+    versions : bool = False
+        If ``True``, delete all versions of the task in the task group. Otherwise, delete only the version associated with the task ID.
 
     Returns
     -------
     TaskInfo
         Object containing information about status, size, credits of task.
     """
-
-    # task = SimulationTask.get(task_id)
     task = SimulationTask(taskId=task_id)
-    task.delete()
+    task.delete(versions=versions)
     return TaskInfo(**{"taskId": task.task_id, **task.dict()})
 
 

--- a/tidy3d/web/core/http_util.py
+++ b/tidy3d/web/core/http_util.py
@@ -178,10 +178,12 @@ class HttpSessionManager:
             REINITIALIZED = True
 
     @http_interceptor
-    def get(self, path: str, json=None):
+    def get(self, path: str, json=None, params=None):
         """Get the resource."""
         self.reinit()
-        return self.session.get(url=Env.current.get_real_url(path), auth=api_key_auth, json=json)
+        return self.session.get(
+            url=Env.current.get_real_url(path), auth=api_key_auth, json=json, params=params
+        )
 
     @http_interceptor
     def post(self, path: str, json=None):
@@ -198,10 +200,12 @@ class HttpSessionManager:
         )
 
     @http_interceptor
-    def delete(self, path: str):
+    def delete(self, path: str, json=None, params=None):
         """Delete the resource."""
         self.reinit()
-        return self.session.delete(Env.current.get_real_url(path), auth=api_key_auth)
+        return self.session.delete(
+            Env.current.get_real_url(path), auth=api_key_auth, json=json, params=params
+        )
 
 
 http = HttpSessionManager(requests.Session())

--- a/tidy3d/web/core/task_core.py
+++ b/tidy3d/web/core/task_core.py
@@ -69,7 +69,7 @@ class Folder(Tidy3DResource, Queryable, extra=Extra.allow):
         """
         folder = FOLDER_CACHE.get(folder_name)
         if not folder:
-            resp = http.get(f"tidy3d/project?projectName={folder_name}")
+            resp = http.get("tidy3d/project", params={"projectName": folder_name})
             if resp:
                 folder = Folder(**resp)
         if create and not folder:
@@ -280,11 +280,28 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
             return []
         return parse_obj_as(List[SimulationTask], resp)
 
-    def delete(self):
-        """Delete current task from server."""
+    def delete(self, versions: bool = False):
+        """Delete current task from server.
+
+        Parameters
+        ----------
+        versions : bool = False
+            If ``True``, delete all versions of the task in the task group. Otherwise, delete only the version associated with the current task ID.
+        """
         if not self.task_id:
             raise ValueError("Task id not found.")
-        http.delete(f"tidy3d/tasks/{self.task_id}")
+
+        task_details = http.get(f"tidy3d/tasks/{self.task_id}")
+
+        if task_details and "groupId" in task_details and "version" in task_details:
+            group_id = task_details["groupId"]
+            version = task_details["version"]
+            if versions:
+                http.delete("tidy3d/group", json={"groupIds": [group_id]})
+            else:
+                http.delete(f"tidy3d/group/{group_id}/versions", json={"versions": [version]})
+        else:  # Fallback to old method if we can't get the groupId and version
+            http.delete(f"tidy3d/tasks/{self.task_id}")
 
     def get_simulation_json(self, to_file: str, verbose: bool = True) -> pathlib.Path:
         """Get json file for a :class:`.Simulation` from server.


### PR DESCRIPTION
Fixes task deletion not working properly in 2.8.0.
I added an optional argument `versions: bool` to either delete only the version associated with a specific task ID or to delete all versions in the task's group.

```py
import tidy3d.web as web
task_id = "fdve-a124a6f9-33ce-4eac-9189-85fe2ba81dac"
web.delete(task_id)
# web.delete(task_id, versions=True)  # will delete all versions
```

<img width="1836" alt="image" src="https://github.com/user-attachments/assets/d8b01484-f1ac-4ac6-8e0c-f61fab0a3740" />

-->

<img width="1836" alt="image" src="https://github.com/user-attachments/assets/82fdbc83-6550-445a-a4c5-5ff61cf41429" />