### PR TITLE
Add periodic repetition in EME simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Ability to select payment option when submitting jobs from the Python client.
+- Periodic repetition of EME subgrids via `num_reps` or `EMEPeriodicitySweep`.
+- Methods `EMEExplicitGrid.from_structures` and `EMECompositeGrid.from_structure_groups` to place EME cell boundaries at structure bounds.
 
 ### Changed
 - Performance enhancement for adjoint gradient calculations by optimizing field interpolation.
+- Auto grid in EME simulations with multiple `freqs` provided uses the largest instead of raising an error.
 
 ### Fixed
 - Fixed `reverse` property of `td.Scene.plot_structures_property()` to also reverse the colorbar.

--- a/tests/test_components/test_eme.py
+++ b/tests/test_components/test_eme.py
@@ -324,19 +324,14 @@ def test_eme_simulation():
 
     # test warning for not providing wavelength in autogrid
     grid_spec = td.GridSpec.auto(min_steps_per_wvl=20)
-    with AssertLogLevel("INFO"):
+    with AssertLogLevel("INFO", contains_str="wavelength"):
         sim = sim.updated_copy(grid_spec=grid_spec)
     # multiple freqs are ok, but not for autogrid
     _ = sim.updated_copy(grid_spec=td.GridSpec.uniform(dl=0.2), freqs=[1e10] + list(sim.freqs))
-    with pytest.raises(SetupError):
-        _ = td.EMESimulation(
-            size=sim.size,
+    with AssertLogLevel("INFO", contains_str="wavelength"):
+        _ = sim.updated_copy(
             freqs=list(sim.freqs) + [1e10],
-            monitors=sim.monitors,
-            structures=sim.structures,
             grid_spec=grid_spec,
-            axis=sim.axis,
-            eme_grid_spec=sim.eme_grid_spec,
         )
 
     # test port offsets
@@ -385,7 +380,7 @@ def test_eme_simulation():
         )
     # warn for nonlinear
     nonlinear = td.Medium(
-        permittivity=2, nonlinear_spec=td.NonlinearSpec(models=[td.KerrNonlinearity(n2=1)])
+        permittivity=2, nonlinear_spec=td.NonlinearSpec(models=[td.NonlinearSusceptibility(chi3=1)])
     )
     struct = sim.structures[0].updated_copy(medium=nonlinear)
     with AssertLogLevel("WARNING"):
@@ -450,6 +445,11 @@ def test_eme_simulation():
         grid_spec=sim.grid_spec.updated_copy(wavelength=1),
     )
     with pytest.raises(SetupError):
+        sim_bad.validate_pre_upload()
+    sim_bad = sim.updated_copy(
+        freqs=list(sim.freqs) + list(1e14 * np.linspace(1, 2, 100)),
+    )
+    with AssertLogLevel("WARNING", contains_str="expensive"):
         sim_bad.validate_pre_upload()
     large_monitor = sim.monitors[2].updated_copy(size=(td.inf, td.inf, td.inf))
     _ = sim.updated_copy(
@@ -1248,3 +1248,120 @@ def test_eme_sim_subsection():
     region = td.Box(size=(2, 2, 0))
     with pytest.raises(pd.ValidationError):
         subsection = eme_sim.subsection(region=region)
+
+
+def test_eme_periodicity():
+    # give the middle subgrid a name
+    sim = make_eme_sim()
+    sim = sim.updated_copy(name="a", path="eme_grid_spec/subgrids/1")
+
+    # directly give it num_reps
+    # can't have field monitor
+    with pytest.raises(SetupError):
+        _ = sim.updated_copy(num_reps=2, path="eme_grid_spec/subgrids/1")
+
+    # EMEPeriodicitySweep validation
+    with pytest.raises(pd.ValidationError):
+        _ = td.EMEPeriodicitySweep(num_reps=[{"a": n} for n in range(150000, 150003)])
+    sweep_spec = td.EMEPeriodicitySweep(num_reps=[{"a": n} for n in range(1, 4)])
+    # still can't have field monitor
+    with pytest.raises(SetupError):
+        _ = sim.updated_copy(sweep_spec=sweep_spec)
+
+    # remove the field monitor, now it passes
+    desired_cell_index_pairs = set([(i, i + 1) for i in range(6)] + [(5, 1)])
+    with AssertLogLevel(None):
+        sim = sim.updated_copy(
+            monitors=[m for m in sim.monitors if not isinstance(m, td.EMEFieldMonitor)]
+        )
+        sim2 = sim.updated_copy(num_reps=2, path="eme_grid_spec/subgrids/1")
+        assert set(sim2._cell_index_pairs) == desired_cell_index_pairs
+    # sweep can't have coeff monitor
+    with pytest.raises(SetupError):
+        _ = sim.updated_copy(sweep_spec=sweep_spec)
+    # remove coeff monitor too, now it passes
+    with AssertLogLevel(None):
+        sim = sim.updated_copy(
+            monitors=[m for m in sim.monitors if not isinstance(m, td.EMECoefficientMonitor)]
+        )
+        sim2 = sim.updated_copy(sweep_spec=sweep_spec)
+        assert set(sim2._cell_index_pairs) == desired_cell_index_pairs
+
+
+def test_eme_grid_from_structures():
+    sim = make_eme_sim()
+    eme_grid_spec = td.EMEExplicitGrid.from_structures(
+        structures=sim.structures, axis=2, mode_spec=td.EMEModeSpec(num_modes=1)
+    )
+    sim = sim.updated_copy(eme_grid_spec=eme_grid_spec)
+    eme_grid_spec = td.EMECompositeGrid.from_structure_groups(
+        structure_groups=[[], [td.Box(center=(0, 0, 0), size=(1, 1, 1))], []],
+        axis=2,
+        mode_specs=[td.EMEModeSpec(num_modes=1)] * 3,
+        names=[None, "wg", None],
+        num_reps=[1, 2, 1],
+    )
+    sim = sim.updated_copy(eme_grid_spec=eme_grid_spec, monitors=[])
+    with pytest.raises(ValidationError):
+        _ = td.EMECompositeGrid.from_structure_groups(
+            structure_groups=[],
+            axis=2,
+            mode_specs=[],
+            names=[None, "wg", None],
+            num_reps=[1, 2, 1],
+        )
+    with pytest.raises(ValidationError):
+        _ = td.EMECompositeGrid.from_structure_groups(
+            structure_groups=[[], [td.Box(center=(0, 0, 0), size=(1, 1, 1))], []],
+            axis=2,
+            mode_specs=[td.EMEModeSpec(num_modes=1)] * 2,
+            names=[None, "wg", None],
+            num_reps=[1, 2, 1],
+        )
+    with pytest.raises(ValidationError):
+        _ = td.EMECompositeGrid.from_structure_groups(
+            structure_groups=[[], [td.Box(center=(0, 0, 0), size=(1, 1, 1))], []],
+            axis=2,
+            mode_specs=[td.EMEModeSpec(num_modes=1)] * 3,
+            names=[None, "wg"],
+            num_reps=[1, 2, 1],
+        )
+    with pytest.raises(ValidationError):
+        _ = td.EMECompositeGrid.from_structure_groups(
+            structure_groups=[[], [td.Box(center=(0, 0, 0), size=(1, 1, 1))], []],
+            axis=2,
+            mode_specs=[td.EMEModeSpec(num_modes=1)] * 3,
+            names=[None, "wg", None],
+            num_reps=[1, 2],
+        )
+    with pytest.raises(ValidationError):
+        _ = td.EMECompositeGrid.from_structure_groups(
+            structure_groups=[
+                [],
+                [td.Box(center=(0, 0, 0), size=(1, 1, 1))],
+                [td.Box(center=(0, 0, 3), size=(1, 1, 1))],
+            ],
+            axis=2,
+            mode_specs=[td.EMEModeSpec(num_modes=1)] * 3,
+            names=[None, "wg", None],
+            num_reps=[1, 2, 1],
+        )
+    _ = td.EMECompositeGrid.from_structure_groups(
+        structure_groups=[
+            [],
+            [td.Box(center=(0, 0, 0), size=(1, 1, 1))],
+            [td.Box(center=(0, 0, 1), size=(1, 1, 1))],
+        ],
+        axis=2,
+        mode_specs=[td.EMEModeSpec(num_modes=1)] * 3,
+        names=[None, "wg", None],
+        num_reps=[1, 2, 1],
+    )
+    with pytest.raises(ValidationError):
+        _ = td.EMECompositeGrid.from_structure_groups(
+            structure_groups=[[], [], [td.Box(center=(0, 0, 3), size=(1, 1, 1))]],
+            axis=2,
+            mode_specs=[td.EMEModeSpec(num_modes=1)] * 3,
+            names=[None, "wg", None],
+            num_reps=[1, 2, 1],
+        )

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -186,7 +186,7 @@ from .components.eme.monitor import (
 
 # EME
 from .components.eme.simulation import EMESimulation
-from .components.eme.sweep import EMEFreqSweep, EMELengthSweep, EMEModeSweep
+from .components.eme.sweep import EMEFreqSweep, EMELengthSweep, EMEModeSweep, EMEPeriodicitySweep
 
 # field projection
 from .components.field_projection import FieldProjector
@@ -665,6 +665,7 @@ __all__ = [
     "EMELengthSweep",
     "EMEModeSweep",
     "EMEFreqSweep",
+    "EMEPeriodicitySweep",
     "ModeSimulation",
     "ModeSimulationData",
     "FixedAngleSpec",

--- a/tidy3d/components/eme/grid.py
+++ b/tidy3d/components/eme/grid.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List, Literal, Tuple, Union
+from typing import Dict, List, Literal, Optional, Tuple, Union
 
 import numpy as np
 import pydantic.v1 as pd
@@ -14,11 +14,13 @@ from ..base import Tidy3dBaseModel, skip_if_fields_missing
 from ..geometry.base import Box
 from ..grid.grid import Coords1D
 from ..mode_spec import ModeSpec
+from ..structure import Structure
 from ..types import ArrayFloat1D, Axis, Coordinate, Size, TrackFreq
 
 # grid limits
 MAX_NUM_MODES = 100
 MAX_NUM_EME_CELLS = 100
+MAX_NUM_REPS = 100000
 
 
 class EMEModeSpec(ModeSpec):
@@ -96,6 +98,29 @@ class EMEGridSpec(Tidy3dBaseModel, ABC):
     in the simulation.
     """
 
+    num_reps: pd.PositiveInt = pd.Field(
+        1,
+        title="Number of Repetitions",
+        description="Number of periodic repetitions of this EME grid. Useful for "
+        "efficiently simulating long periodic structures like Bragg gratings. "
+        "Instead of explicitly repeating the cells, setting 'num_reps' allows "
+        "the EME solver to reuse the modes and cell interface scattering matrices.",
+    )
+
+    name: Optional[str] = pd.Field(
+        None, title="Name", description="Name of this 'EMEGridSpec'. Used in 'EMEPeriodicitySweep'."
+    )
+
+    @pd.validator("num_reps", always=True)
+    def _validate_num_reps(cls, val):
+        """Check num_reps is not too large."""
+        if val > MAX_NUM_REPS:
+            raise SetupError(
+                f"'EMEGridSpec' has 'num_reps={val:.2e}'; "
+                f"the largest value allowed is '{MAX_NUM_REPS}'."
+            )
+        return val
+
     @abstractmethod
     def make_grid(self, center: Coordinate, size: Size, axis: Axis) -> EMEGrid:
         """Generate EME grid from the EME grid spec.
@@ -115,6 +140,46 @@ class EMEGridSpec(Tidy3dBaseModel, ABC):
             An EME grid dividing the EME simulation into cells, as defined
             by the EME grid spec.
         """
+
+    @property
+    def real_cell_indices(self) -> int:
+        """The cell indices inside this EME grid, starting at 0,
+        not including periodic repetition of cells."""
+        return np.arange(self.num_real_cells)
+
+    @property
+    @abstractmethod
+    def num_real_cells(self) -> int:
+        """Number of real cells in this EME grid spec."""
+
+    @property
+    def virtual_cell_indices(self) -> int:
+        """The cell indices inside this EME grid, starting at 0
+        and including periodic repetition of cells with ``num_reps``."""
+        return list(self.real_cell_indices) * self.num_reps
+
+    @property
+    def num_virtual_cells(self) -> int:
+        """Number of virtual cells in this EME grid spec."""
+        return len(self.virtual_cell_indices)
+
+    def _updated_copy_num_reps(self, num_reps: Dict[str, pd.PositiveInt]) -> EMEGridSpec:
+        """Update ``num_reps`` of named subgrids."""
+        if self.name is not None:
+            new_num_reps = num_reps.get(self.name)
+            if new_num_reps is not None:
+                return self.updated_copy(num_reps=new_num_reps)
+        return self
+
+    @property
+    def _cell_index_pairs(self) -> List[pd.NonNegativeInt]:
+        """Pairs of adjacent cell indices."""
+        cell_indices = self.virtual_cell_indices
+        pairs = []
+        for i in range(len(cell_indices) - 1):
+            if (cell_indices[i], cell_indices[i + 1]) not in pairs:
+                pairs.append((cell_indices[i], cell_indices[i + 1]))
+        return pairs
 
 
 class EMEUniformGrid(EMEGridSpec):
@@ -160,6 +225,11 @@ class EMEUniformGrid(EMEGridSpec):
         return EMEGrid(
             boundaries=boundaries, mode_specs=mode_specs, center=center, size=size, axis=axis
         )
+
+    @property
+    def num_real_cells(self) -> int:
+        """Number of real cells in this EME grid spec."""
+        return self.num_cells
 
 
 class EMEExplicitGrid(EMEGridSpec):
@@ -248,6 +318,65 @@ class EMEExplicitGrid(EMEGridSpec):
             axis=axis,
             mode_specs=self.mode_specs,
         )
+
+    @classmethod
+    def from_structures(
+        cls, structures: List[Structure], axis: Axis, mode_spec: EMEModeSpec, **kwargs
+    ) -> EMEExplicitGrid:
+        """Create an explicit EME grid with boundaries aligned with
+        structure bounding boxes. Every cell in the resulting grid
+        has the same mode specification.
+
+        Parameters
+        ----------
+        structures : List[:class:`.Structure`]
+            A list of structures to define the :class:`.EMEExplicitGrid`.
+            The EME grid boundaries will be placed at the lower and upper bounds
+            of the bounding boxes of all the structures in the list.
+        axis : :class:`.Axis`
+            Propagation axis for the EME simulation.
+        mode_spec : :class:`.EMEModeSpec`
+            Mode specification for the EME grid. The same mode specification will
+            be used in every cell in the resulting :class:`.EMEExplicitGrid`.
+        **kwargs
+            Other arguments passed to the new :class:`.EMEExplicitGrid` instance.
+
+        Returns
+        -------
+        :class:`.EMEExplicitGrid`
+            Explicit EME grid with boundaries aligned with the structure bounding boxes.
+
+        Example
+        -------
+        >>> from tidy3d import EMEModeSpec, Structure, Box, Medium
+        >>> mode_spec = EMEModeSpec(num_modes=1)
+        >>> box = Structure(
+        ...     geometry=Box(center=(0, 0, 0), size=(1, 2, 3)),
+        ...     medium=Medium(permittivity=5),
+        ... )
+        >>> box2 = Structure(
+        ...     geometry=Box(center=(0, 0, 4), size=(1, 2, 3)),
+        ...     medium=Medium(permittivity=5),
+        ... )
+        >>> eme_grid_spec = EMEExplicitGrid.from_structures(
+        ...     structures=[box, box2],
+        ...     axis=2,
+        ...     mode_spec=mode_spec
+        ... )
+        """
+        rmins = [structure.geometry.bounds[0][axis] for structure in structures]
+        rmaxs = [structure.geometry.bounds[1][axis] for structure in structures]
+        boundaries = np.sort(np.unique(rmins + rmaxs))
+        if len(boundaries) > 1:
+            # first and last bounds are not needed
+            boundaries = boundaries[1:-1]
+        mode_specs = [mode_spec] * (len(boundaries) + 1)
+        return EMEExplicitGrid(boundaries=boundaries, mode_specs=mode_specs, **kwargs)
+
+    @property
+    def num_real_cells(self) -> int:
+        """Number of real cells in this EME grid spec."""
+        return len(self.mode_specs)
 
 
 EMESubgridType = Union[EMEUniformGrid, EMEExplicitGrid, "EMECompositeGrid"]
@@ -379,6 +508,159 @@ class EMECompositeGrid(EMEGridSpec):
             axis=axis,
             mode_specs=mode_specs,
         )
+
+    @property
+    def num_real_cells(self) -> int:
+        """Number of real cells in this EME grid spec."""
+        return np.sum([subgrid.num_real_cells for subgrid in self.subgrids])
+
+    @property
+    def virtual_cell_indices(self) -> int:
+        """The cell indices inside this EME grid, starting at 0
+        and including periodic repetition of cells with ``num_reps``."""
+        inds = []
+        for subgrid in self.subgrids:
+            start_ind = 0 if len(inds) == 0 else inds[-1] + 1
+            inds += [ind + start_ind for ind in subgrid.virtual_cell_indices]
+        return list(inds) * self.num_reps
+
+    def _updated_copy_num_reps(self, num_reps: Dict[str, pd.PositiveInt]) -> EMEGridSpec:
+        """Update ``num_reps`` of named subgrids."""
+        new_self = super()._updated_copy_num_reps(num_reps=num_reps)
+        new_subgrids = [
+            subgrid._updated_copy_num_reps(num_reps=num_reps) for subgrid in self.subgrids
+        ]
+        return new_self.updated_copy(subgrids=new_subgrids)
+
+    @classmethod
+    def from_structure_groups(
+        cls,
+        structure_groups: List[List[Structure]],
+        axis: Axis,
+        mode_specs: List[EMEModeSpec],
+        names: List[str] = None,
+        num_reps: List[pd.PositiveInt] = None,
+    ) -> EMECompositeGrid:
+        """Create a composite EME grid with boundaries aligned with
+        structure bounding boxes.
+
+        Parameters
+        ----------
+        structure_groups : List[List[:class:`.Structure`]]
+            A list of structure groups to define the :class:`.EMECompositeGrid`.
+            Each structure group will be used to generate an :class:`.EMEExplicitGrid`
+            with boundaries aligned with the bounding boxes of the structures
+            in that group. These will then be assembled as subgrids of an
+            :class:`.EMECompositeGrid`. Empty structure groups give rise to grids
+            containing a single cell. The boundary between adjacent subgrids
+            is determined from the structure groups; thus they must be consistent,
+            meaning that either the upper bound of one structure group must equal
+            the lower bound of the next, or one of the structure groups must be empty.
+            Two adjacent structure groups cannot be empty.
+        axis : :class:`.Axis`
+            Propagation axis for the EME simulation.
+        mode_specs : List[:class:`.EMEModeSpec`]
+            Mode specifications for each subgrid. Must be the same length as
+            ``structure_groups``.
+        names : List[str] = None
+            Names for each subgrid. Must be the same length as ``structure_groups``.
+            If ``None``, the subgrids do not recieve names.
+        num_reps : List[pd.PositiveInt] = None
+            Number of repetitions for each subgrid. Must be the same length as
+            ``structure_groups``. If ``None``, the subgrids are not repeated.
+
+        Returns
+        -------
+        :class:`.EMECompositeGrid`
+            Composite EME grid with subgrids defined by the structure groups.
+
+        Example
+        -------
+        >>> from tidy3d import EMEModeSpec, Structure, Box, Medium
+        >>> mode_spec = EMEModeSpec(num_modes=1)
+        >>> box = Structure(
+        ...     geometry=Box(center=(0, 0, 0), size=(1, 2, 3)),
+        ...     medium=Medium(permittivity=5),
+        ... )
+        >>> box2 = Structure(
+        ...     geometry=Box(center=(0, 0, 3), size=(1, 2, 3)),
+        ...     medium=Medium(permittivity=5),
+        ... )
+        >>> eme_grid_spec = EMECompositeGrid.from_structure_groups(
+        ...     structure_groups=[[box], [box2]],
+        ...     axis=2,
+        ...     mode_specs=[mode_spec]*2,
+        ...     names=["subgrid1", None],
+        ...     num_reps=[2, 1]
+        ... )
+        """
+        if len(structure_groups) == 0:
+            raise ValidationError("The list 'structure_groups' cannot be empty.")
+        if len(mode_specs) != len(structure_groups):
+            raise ValidationError(
+                "The lists 'mode_specs' and 'structure_groups' must " "have the same length."
+            )
+
+        subgrids = []
+        for structures, mode_spec in zip(structure_groups, mode_specs):
+            subgrids.append(
+                EMEExplicitGrid.from_structures(
+                    structures=structures, axis=axis, mode_spec=mode_spec
+                )
+            )
+
+        if names is not None:
+            if len(names) != len(structure_groups):
+                raise ValidationError(
+                    "The lists 'names' and 'structure_groups' must " "have the same length."
+                )
+            for i in range(len(subgrids)):
+                subgrids[i] = subgrids[i].updated_copy(name=names[i])
+
+        if num_reps is not None:
+            if len(num_reps) != len(structure_groups):
+                raise ValidationError(
+                    "The lists 'num_reps' and 'structure_groups' must " "have the same length."
+                )
+            for i in range(len(subgrids)):
+                subgrids[i] = subgrids[i].updated_copy(num_reps=num_reps[i])
+
+        # now try to determine subgrid_boundaries
+        # they need to be consistently determined by adjacent structure groups
+        subgrid_boundaries = [None] * (len(subgrids) - 1)
+        subgrid_rmins = [None] * len(subgrids)
+        subgrid_rmaxs = [None] * len(subgrids)
+
+        for i, structures in enumerate(structure_groups):
+            rmins = [structure.geometry.bounds[0][axis] for structure in structures]
+            rmaxs = [structure.geometry.bounds[1][axis] for structure in structures]
+            boundaries = np.sort(np.unique(rmins + rmaxs))
+            if len(boundaries) > 1:
+                subgrid_rmins[i] = boundaries[0]
+                subgrid_rmaxs[i] = boundaries[-1]
+
+        for i in range(len(subgrid_boundaries)):
+            rmax = subgrid_rmaxs[i]
+            rmin = subgrid_rmins[i + 1]
+            if rmax is not None:
+                if rmin is not None and rmax != rmin:
+                    raise ValidationError(
+                        f"The upper bound of 'structure_groups[{i}]', "
+                        f"'{rmax}', does not equal the lower bound of "
+                        f"'structure_groups[{i + 1}]', '{rmin}'."
+                    )
+                subgrid_boundaries[i] = rmax
+            elif rmin is not None:
+                subgrid_boundaries[i] = rmin
+            else:
+                raise ValidationError(
+                    "Not enough structures provided at "
+                    f"'structure_groups[{i}]' and "
+                    f"'structure_groups[{i + 1}]' to determine "
+                    "'subgrid_boundaries'."
+                )
+
+        return EMECompositeGrid(subgrids=subgrids, subgrid_boundaries=subgrid_boundaries)
 
 
 class EMEGrid(Box):

--- a/tidy3d/components/eme/simulation.py
+++ b/tidy3d/components/eme/simulation.py
@@ -11,6 +11,7 @@ except ImportError:
 import numpy as np
 import pydantic.v1 as pd
 
+from ...constants import C_0
 from ...exceptions import SetupError, ValidationError
 from ...log import log
 from ..base import cached_property
@@ -22,15 +23,18 @@ from ..medium import FullyAnisotropicMedium
 from ..monitor import AbstractModeMonitor, ModeSolverMonitor, Monitor, MonitorType
 from ..scene import Scene
 from ..simulation import AbstractYeeGridSimulation, Simulation
-from ..source.current import PointDipole
-from ..source.time import GaussianPulse
-from ..structure import Structure
 from ..types import Ax, Axis, FreqArray, Symmetry, annotate_type
 from ..validators import MIN_FREQUENCY, validate_freqs_min, validate_freqs_not_empty
 from ..viz import add_ax_if_none, equal_aspect
 from .grid import EMECompositeGrid, EMEExplicitGrid, EMEGrid, EMEGridSpec, EMEGridSpecType
-from .monitor import EMEFieldMonitor, EMEModeSolverMonitor, EMEMonitor, EMEMonitorType
-from .sweep import EMEFreqSweep, EMELengthSweep, EMEModeSweep, EMESweepSpecType
+from .monitor import (
+    EMECoefficientMonitor,
+    EMEFieldMonitor,
+    EMEModeSolverMonitor,
+    EMEMonitor,
+    EMEMonitorType,
+)
+from .sweep import EMEFreqSweep, EMELengthSweep, EMEModeSweep, EMEPeriodicitySweep, EMESweepSpecType
 
 # maximum numbers of simulation parameters
 MAX_GRID_CELLS = 20e9
@@ -41,7 +45,8 @@ WARN_MODE_NUM_CELLS = 1e5
 
 
 # eme specific simulation parameters
-MAX_NUM_FREQS = 20
+WARN_NUM_FREQS = 100
+MAX_NUM_FREQS = 500
 MAX_NUM_SWEEP = 100
 
 
@@ -51,6 +56,21 @@ WARN_CONSTRAINT_NUM_MODES = 50
 # dummy run time for conversion to FDTD sim
 # should be very small -- otherwise, generating tmesh will fail or take a long time
 RUN_TIME = 1e-30
+
+EME_SIM_YEE_SIM_SHARED_ATTRS = [
+    "center",
+    "size",
+    "medium",
+    "structures",
+    "symmetry",
+    "boundary_spec",
+    "version",
+    "plot_length_units",
+    "lumped_elements",
+    "subpixel",
+    "simulation_type",
+    "post_norm",
+]
 
 
 class EMESimulation(AbstractYeeGridSimulation):
@@ -562,6 +582,7 @@ class EMESimulation(AbstractYeeGridSimulation):
         _ = self.grid
         _ = self.eme_grid
         _ = self.mode_solver_monitors
+        _ = self._cell_index_pairs
         self._validate_too_close_to_edges()
         self._validate_sweep_spec()
         self._validate_symmetry()
@@ -699,10 +720,22 @@ class EMESimulation(AbstractYeeGridSimulation):
                         f"scaled frequencies {scaled_freqs}; the minimum allowed is "
                         f"{MIN_FREQUENCY:.0e} Hz."
                     )
+        elif isinstance(self.sweep_spec, EMEPeriodicitySweep):
+            for i, monitor in enumerate(self.monitors):
+                if isinstance(monitor, EMEFieldMonitor):
+                    raise SetupError(
+                        f"Monitor at 'monitors[{i}]' is an 'EMEFieldMonitor', "
+                        "which is not compatible with 'EMEPeriodicitySweep'."
+                    )
+                elif isinstance(monitor, EMECoefficientMonitor):
+                    raise SetupError(
+                        f"Monitor at 'monitors[{i}]' is an 'EMECoefficientMonitor', "
+                        "which is not compatible with 'EMEPeriodicitySweep'."
+                    )
 
     def _validate_monitor_setup(self):
         """Check monitor setup."""
-        for monitor in self.monitors:
+        for i, monitor in enumerate(self.monitors):
             if isinstance(monitor, EMEMonitor):
                 _ = self._monitor_eme_cell_indices(monitor=monitor)
             if (
@@ -752,6 +785,15 @@ class EMESimulation(AbstractYeeGridSimulation):
                     "max number of modes of the two EME ports, which is "
                     f"'mode_spec.num_modes={self.max_port_modes}'."
                 )
+            if isinstance(monitor, EMEFieldMonitor):
+                if not np.array_equal(
+                    self.eme_grid_spec.virtual_cell_indices, self.eme_grid_spec.real_cell_indices
+                ):
+                    raise SetupError(
+                        f"Monitor at 'monitors[{i}]' is an 'EMEFieldMonitor', "
+                        "which is not compatible with periodic repetition "
+                        "('num_reps != 1' in any 'EMEGridSpec'.)"
+                    )
 
     def _validate_sources_and_boundary(self):
         """Disallow sources and boundary."""
@@ -787,6 +829,13 @@ class EMESimulation(AbstractYeeGridSimulation):
             raise SetupError(
                 f"Simulation has {num_freqs:.2e} frequencies, "
                 f"a maximum of {MAX_NUM_FREQS:.2e} are allowed. Mode solving "
+                f"is repeated at each frequency, so EME simulations with too many frequencies "
+                f"can be slower and more expensive than FDTD simulations. "
+                f"Consider using an 'EMEFreqSweep' instead for a faster approximate solution."
+            )
+        if num_freqs > WARN_NUM_FREQS:
+            log.warning(
+                f"Simulation has {num_freqs:.2e} frequencies. Mode solving "
                 f"is repeated at each frequency, so EME simulations with too many frequencies "
                 f"can be slower and more expensive than FDTD simulations. "
                 f"Consider using an 'EMEFreqSweep' instead for a faster approximate solution."
@@ -1014,39 +1063,7 @@ class EMESimulation(AbstractYeeGridSimulation):
 
         # TODO: add option (true by default) to make Yee grid conformal to EME grid
 
-        # Add a simulation Box as the first structure
-        structures = [Structure(geometry=self.geometry, medium=self.medium)]
-        structures += self.structures
-
-        # make source for autogrid if needed
-        freqs = self.freqs
-        grid_spec = self.grid_spec
-        sources = []
-        if grid_spec.auto_grid_used and grid_spec.wavelength is None:
-            if not np.all(np.isclose(freqs, freqs[0])):
-                raise SetupError(
-                    "Multiple 'sim.freqs' are supplied. Please supply "
-                    "a 'wavelength' value for 'grid_spec' to control automatic "
-                    "grid generation."
-                )
-            plane = self.eme_grid.mode_planes[0]
-            sources.append(
-                PointDipole(
-                    center=plane.center,
-                    source_time=GaussianPulse(freq0=freqs[0], fwidth=0.1 * freqs[0]),
-                    polarization="Ez",
-                )
-            )
-
-        grid = self.grid_spec.make_grid(
-            structures=structures,
-            symmetry=self.symmetry,
-            periodic=self._periodic,
-            sources=sources,
-            num_pml_layers=self.num_pml_layers,
-        )
-
-        return grid
+        return self._as_fdtd_sim.grid
 
     def _monitor_num_transverse_cells(self, monitor: Monitor) -> int:
         """Total number of cells transverse to propagation axis
@@ -1064,35 +1081,37 @@ class EMESimulation(AbstractYeeGridSimulation):
 
         return num_transverse_cells_in_monitor(monitor)
 
+    @cached_property
+    def _as_fdtd_sim(self) -> Simulation:
+        """Convert :class:`.EMESimulation` to :class:`.Simulation`.
+        This should only be used to obtain the same material properties
+        for mode solving or related purposes; the sources and monitors of the
+        resulting simulation are not meaningful."""
+        return self._to_fdtd_sim()
+
     def _to_fdtd_sim(self) -> Simulation:
         """Convert :class:`.EMESimulation` to :class:`.Simulation`.
         This should only be used to obtain the same material properties
         for mode solving or related purposes; the sources and monitors of the
         resulting simulation are not meaningful."""
 
-        # source to silence warnings
-        plane = self.eme_grid.mode_planes[0]
-        freq0 = self.freqs[0]
-        source_time = GaussianPulse(freq0=freq0, fwidth=0.1 * freq0)
-        source = PointDipole(
-            center=plane.center,
-            source_time=source_time,
-            polarization="Ez",
-        )
+        grid_spec = self.grid_spec
+        if grid_spec.auto_grid_used and grid_spec.wavelength is None:
+            min_wvl = C_0 / np.max(self.freqs)
+            log.info(
+                f"Auto meshing using wavelength {min_wvl:1.4f} defined from "
+                "largest of 'EMESimulation.freqs'."
+            )
+            grid_spec = grid_spec.updated_copy(wavelength=min_wvl)
+
         # copy over all FDTD monitors too
         monitors = [monitor for monitor in self.monitors if not isinstance(monitor, EMEMonitor)]
+
+        kwargs = {key: getattr(self, key) for key in EME_SIM_YEE_SIM_SHARED_ATTRS}
         return Simulation(
-            center=self.center,
-            size=self.size,
-            medium=self.medium,
-            structures=self.structures,
-            symmetry=self.symmetry,
-            grid_spec=self.grid_spec,
-            boundary_spec=self.boundary_spec,
-            version=self.version,
-            subpixel=self.subpixel,
+            **kwargs,
             run_time=RUN_TIME,
-            sources=[source],
+            grid_spec=grid_spec,
             monitors=monitors,
         )
 
@@ -1175,3 +1194,15 @@ class EMESimulation(AbstractYeeGridSimulation):
         new_sim = new_sim.updated_copy(eme_grid_spec=eme_grid_spec)
 
         return new_sim
+
+    @property
+    def _cell_index_pairs(self) -> List[pd.NonNegativeInt]:
+        """All the pairs of adjacent EME cells needed, taken over all sweep indices."""
+        pairs = set()
+        if isinstance(self.sweep_spec, EMEPeriodicitySweep):
+            for num_reps in self.sweep_spec.num_reps:
+                eme_grid_spec = self.eme_grid_spec._updated_copy_num_reps(num_reps=num_reps)
+                pairs = pairs | set(eme_grid_spec._cell_index_pairs)
+        else:
+            pairs = set(self.eme_grid_spec._cell_index_pairs)
+        return list(pairs)

--- a/tidy3d/components/eme/sweep.py
+++ b/tidy3d/components/eme/sweep.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Union
+from typing import Dict, List, Union
 
 import pydantic.v1 as pd
 
+from ...exceptions import SetupError
 from ..base import Tidy3dBaseModel
 from ..types import ArrayFloat1D, ArrayInt1D, ArrayLike
+from .grid import MAX_NUM_REPS
 
 
 class EMESweepSpec(Tidy3dBaseModel, ABC):
@@ -81,4 +83,46 @@ class EMEFreqSweep(EMESweepSpec):
         return len(self.freq_scale_factors)
 
 
-EMESweepSpecType = Union[EMELengthSweep, EMEModeSweep, EMEFreqSweep]
+class EMEPeriodicitySweep(EMESweepSpec):
+    """Spec for sweeping number of repetitions of EME subgrids.
+    Useful for simulating long periodic structures like Bragg gratings,
+    as it allows the EME solver to reuse the modes and cell interface
+    scattering matrices.
+
+    Compared to setting ``num_reps`` directly in the ``eme_grid_spec``,
+    this sweep spec allows varying the number of repetitions,
+    effectively simulating multiple structures in a single EME simulation.
+
+    Example
+    -------
+    >>> n_list = [1, 50, 100]
+    >>> sweep_spec = EMEPeriodicitySweep(num_reps=[{"unit_cell": n} for n in n_list])
+    """
+
+    num_reps: List[Dict[str, pd.PositiveInt]] = pd.Field(
+        ...,
+        title="Number of Repetitions",
+        description="Number of periodic repetitions of named subgrids in this EME grid. "
+        "At each sweep index, contains a dict mapping the name of a subgrid to the "
+        "number of repetitions of that subgrid at that sweep index.",
+    )
+
+    @pd.validator("num_reps", always=True)
+    def _validate_num_reps(cls, val):
+        """Check num_reps is not too large."""
+        for num_reps_dict in val:
+            for value in num_reps_dict.values():
+                if value > MAX_NUM_REPS:
+                    raise SetupError(
+                        f"'EMEGridSpec' has 'num_reps={value:.2e}'; "
+                        f"the largest value allowed is '{MAX_NUM_REPS}'."
+                    )
+        return val
+
+    @property
+    def num_sweep(self) -> pd.PositiveInt:
+        """Number of sweep indices."""
+        return len(self.num_reps)
+
+
+EMESweepSpecType = Union[EMELengthSweep, EMEModeSweep, EMEFreqSweep, EMEPeriodicitySweep]

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -2419,7 +2419,7 @@ class ModeSolver(Tidy3dBaseModel):
         # because we can't take planar subsection of an EME simulation.
         # eventually, we will convert to ModeSimulation
         if isinstance(self.simulation, EMESimulation):
-            return self.to_fdtd_mode_solver().reduced_simulation_copy
+            return self.as_fdtd_mode_solver.reduced_simulation_copy
 
         # we preserve extra cells along the normal direction to ensure there is enough data for
         # subpixel
@@ -2489,8 +2489,16 @@ class ModeSolver(Tidy3dBaseModel):
                 "The method 'to_fdtd_mode_solver' is only needed "
                 "when the 'simulation' is an 'EMESimulation'."
             )
-        fdtd_sim = self.simulation._to_fdtd_sim()
+        fdtd_sim = self.simulation._as_fdtd_sim
         return self.updated_copy(simulation=fdtd_sim)
+
+    @cached_property
+    def as_fdtd_mode_solver(self) -> ModeSolver:
+        """Construct a new :class:`.ModeSolver` by converting ``simulation``
+        from a :class:`.EMESimulation` to an FDTD :class:`.Simulation`.
+        Only used as a workaround until :class:`.EMESimulation` is natively supported in the
+        :class:`.ModeSolver` webapi."""
+        return self.to_fdtd_mode_solver()
 
     def _patch_data(self, data: ModeSolverData):
         """

--- a/tidy3d/components/mode/simulation.py
+++ b/tidy3d/components/mode/simulation.py
@@ -268,7 +268,7 @@ class ModeSimulation(AbstractYeeGridSimulation):
         if grid_spec.auto_grid_used and grid_spec.wavelength is None:
             min_wvl = C_0 / np.max(self.freqs)
             log.info(
-                "Auto meshing using wavelength {min_wvl:1.4f} defined from "
+                f"Auto meshing using wavelength {min_wvl:1.4f} defined from "
                 "largest of 'ModeSimulation.freqs'."
             )
             grid_spec = grid_spec.updated_copy(wavelength=min_wvl)


### PR DESCRIPTION
Major changes:

- Adds a field `num_reps` to every `EMEGridSpec` class, which can be used to periodically repeat that subgrid while reusing mode solves, overlaps, and interface s-matrices
- Adds a class `EMEPeriodicitySweep` which allows sweeping the `num_reps` of every `EMEGridSpec` in the `EMESimulation.eme_grid_spec`. This is currently done by assigning names to `EMEGridSpec` objects, and then passing `num_reps` as a list of dictionaries, one for each sweep_index, and each of which is a mapping from the name of the subgrid which will be repeated to the desired number of repetitions of that subgrid.

Minor changes:

- When multiple freqs are provided, uses the largest for automeshing instead of raising an error.
- Adds methods `EMEExplicitGrid.from_structures` and `EMECompositeGrid.from_structure_groups` which place grid boundaries at structure bounds
- Increases `MAX_NUM_FREQS` to 100

Todo:

- [x] Check / extend test coverage