### PR TITLE
Structure priority option in structure overlapping region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `eps_lim` keyword argument to `Simulation.plot_eps()` for manual control over the permittivity color limits.
 - Added `thickness` parameter to `LossyMetalMedium` for computing surface impedance of a thin conductor.
+- `priority` field in `Structure` and `MeshOverrideStructure` for setting the behavior in structure overlapping region. When its value is `None`, the priority is automatically determined based on the material property and simulation's `structure_priority_mode`.
 
 ### Changed
 - Relaxed bounds checking of path integrals during `WavePort` validation.

--- a/tests/test_components/test_scene.py
+++ b/tests/test_components/test_scene.py
@@ -307,3 +307,48 @@ def test_max_geometry_validation():
     ]
     with pytest.raises(pd.ValidationError, match=f" {MAX_GEOMETRY_COUNT + 2} "):
         _ = td.Scene(structures=not_fine)
+
+
+def test_structure_manual_priority():
+    """make sure structure is properly orderd based on the priority settings."""
+
+    box = td.Structure(
+        geometry=td.Box(size=(1, 1, 1), center=(0, 0, 0)),
+        medium=td.Medium(permittivity=2.0),
+    )
+    structures = []
+    priorities = [2, 4, -1, -4, 0]
+    for priority in priorities:
+        structures.append(box.updated_copy(priority=priority))
+    scene = td.Scene(
+        structures=structures,
+    )
+
+    sorted_priorities = [s.priority for s in scene.sorted_structures]
+    assert all(np.diff(sorted_priorities) >= 0)
+
+
+def test_structure_automatic_priority():
+    """make sure metallic structure has the highest priority in `conductor` mode."""
+
+    box = td.Structure(
+        geometry=td.Box(size=(1, 1, 1), center=(0, 0, 0)),
+        medium=td.Medium(permittivity=2.0),
+    )
+    box_pec = box.updated_copy(medium=td.PEC)
+    box_lossymetal = box.updated_copy(
+        medium=td.LossyMetalMedium(conductivity=1.0, frequency_range=(1e14, 2e14))
+    )
+    structures = [box_pec, box_lossymetal, box]
+    scene = td.Scene(
+        structures=structures,
+        structure_priority_mode="equal",
+    )
+
+    # in equal mode, the order is preserved
+    scene.sorted_structures == structures
+
+    # conductor mode
+    scene = scene.updated_copy(structure_priority_mode="conductor")
+    assert scene.sorted_structures[-1].medium == td.PEC
+    assert isinstance(scene.sorted_structures[-2].medium, td.LossyMetalMedium)

--- a/tidy3d/components/base_sim/simulation.py
+++ b/tidy3d/components/base_sim/simulation.py
@@ -16,7 +16,7 @@ from ..geometry.base import Box
 from ..medium import Medium, MediumType3D
 from ..scene import Scene
 from ..structure import Structure
-from ..types import TYPE_TAG_STR, Ax, Axis, Bound, LengthUnit, Symmetry
+from ..types import TYPE_TAG_STR, Ax, Axis, Bound, LengthUnit, PriorityMode, Symmetry
 from ..validators import (
     _warn_unsupported_traced_argument,
     assert_objects_in_sim_bounds,
@@ -119,6 +119,15 @@ class AbstractSimulation(Box, ABC):
         "include the desired unit specifier in labels.",
     )
 
+    structure_priority_mode: PriorityMode = pd.Field(
+        "equal",
+        title="Structure Priority Setting",
+        description="This field only affects structures of `priority=None`. "
+        "If `equal`, the priority of those structures is set to 0; if `conductor`, "
+        "the priority of structures made of `LossyMetalMedium` is set to 90, "
+        "`PECMedium` to 100, and others to 0.",
+    )
+
     """ Validating setup """
 
     @pd.root_validator(pre=True)
@@ -191,7 +200,10 @@ class AbstractSimulation(Box, ABC):
         """Scene instance associated with the simulation."""
 
         return Scene(
-            medium=self.medium, structures=self.structures, plot_length_units=self.plot_length_units
+            medium=self.medium,
+            structures=self.structures,
+            plot_length_units=self.plot_length_units,
+            structure_priority_mode=self.structure_priority_mode,
         )
 
     def get_monitor_by_name(self, name: str) -> AbstractMonitor:

--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -22,6 +22,7 @@ from ..types import (
     Axis,
     Coordinate,
     CoordinateOptional,
+    PriorityMode,
     Symmetry,
     annotate_type,
 )
@@ -959,6 +960,7 @@ class GridRefinement(Tidy3dBaseModel):
             dl=dl_list,
             shadow=False,
             drop_outside_sim=drop_outside_sim,
+            priority=-1,
         )
 
 
@@ -1518,6 +1520,7 @@ class LayerRefinementSpec(Box):
                     dl=self._unpop_axis(ax_coord=dl, plane_coord=None),
                     shadow=False,
                     drop_outside_sim=self.refinement_inside_sim_only,
+                    priority=-1,
                 )
             )
 
@@ -2293,10 +2296,11 @@ class GridSpec(Tidy3dBaseModel):
         wavelength: pd.PositiveFloat,
         sim_size: Tuple[float, 3],
         lumped_elements: List[LumpedElementType],
+        structure_priority_mode: PriorityMode = "equal",
         internal_override_structures: List[MeshOverrideStructure] = None,
     ) -> List[StructureType]:
-        """Internal and external mesh override structures. External override structures take higher priority.
-        So far, internal override structures all come from `layer_refinement_specs`.
+        """Internal and external mesh override structures sorted based on their priority. By default,
+        the priority of internal override structures is -1, and 0 for external ones.
 
         Parameters
         ----------
@@ -2308,22 +2312,23 @@ class GridSpec(Tidy3dBaseModel):
             Simulation domain size.
         lumped_elements : List[LumpedElementType]
             List of lumped elements.
+        structure_priority_mode : PriorityMode
+            Structure priority setting.
         internal_override_structures : List[MeshOverrideStructure]
             If `None`, recomputes internal override structures.
 
         Returns
         -------
         List[StructureType]
-            List of override structures.
+            List of sorted override structures.
         """
 
         if internal_override_structures is None:
-            return (
-                self.internal_override_structures(structures, wavelength, sim_size, lumped_elements)
-                + self.external_override_structures
+            internal_override_structures = self.internal_override_structures(
+                structures, wavelength, sim_size, lumped_elements
             )
-
-        return internal_override_structures + self.external_override_structures
+        all_structures = internal_override_structures + self.external_override_structures
+        return Structure._sort_structures(all_structures, structure_priority_mode)
 
     def _min_vacuum_dl_in_autogrid(self, wavelength: float, sim_size: Tuple[float, 3]) -> float:
         """Compute grid step size in vacuum for Autogrd. If AutoGrid is applied along more than 1 dimension,
@@ -2398,6 +2403,7 @@ class GridSpec(Tidy3dBaseModel):
             [None, None],
             [None, None],
         ],
+        structure_priority_mode: PriorityMode = "equal",
     ) -> Grid:
         """Make the entire simulation grid based on some simulation parameters.
 
@@ -2425,6 +2431,8 @@ class GridSpec(Tidy3dBaseModel):
         boundary_types : Tuple[Tuple[str, str], Tuple[str, str], Tuple[str, str]] = [[None, None], [None, None], [None, None]]
             Type of boundary conditions along each dimension: "pec/pmc", "periodic", or
             None for any other. This is relevant only for gap meshing.
+        structure_priority_mode : PriorityMode
+            Structure priority setting.
 
         Returns
         -------
@@ -2441,6 +2449,7 @@ class GridSpec(Tidy3dBaseModel):
             lumped_elements=lumped_elements,
             internal_override_structures=internal_override_structures,
             internal_snapping_points=internal_snapping_points,
+            structure_priority_mode=structure_priority_mode,
         )
 
         return grid
@@ -2460,6 +2469,7 @@ class GridSpec(Tidy3dBaseModel):
             [None, None],
             [None, None],
         ],
+        structure_priority_mode: PriorityMode = "equal",
     ) -> Tuple[Grid, List[CoordinateOptional]]:
         """Make the entire simulation grid based on some simulation parameters.
         Also return snappiung point resulted from iterative gap meshing.
@@ -2488,6 +2498,8 @@ class GridSpec(Tidy3dBaseModel):
         boundary_types : Tuple[Tuple[str, str], Tuple[str, str], Tuple[str, str]] = [[None, None], [None, None], [None, None]]
             Type of boundary conditions along each dimension: "pec/pmc", "periodic", or
             None for any other. This is relevant only for gap meshing.
+        structure_priority_mode : PriorityMode
+            Structure priority setting.
 
         Returns
         -------
@@ -2504,6 +2516,7 @@ class GridSpec(Tidy3dBaseModel):
             lumped_elements=lumped_elements,
             internal_override_structures=internal_override_structures,
             internal_snapping_points=internal_snapping_points,
+            structure_priority_mode=structure_priority_mode,
         )
 
         sim_geometry = structures[0].geometry
@@ -2549,6 +2562,7 @@ class GridSpec(Tidy3dBaseModel):
                     internal_override_structures=internal_override_structures,
                     internal_snapping_points=snapping_lines + internal_snapping_points,
                     dl_min_from_gaps=0.45 * min_gap_width,
+                    structure_priority_mode=structure_priority_mode,
                 )
 
                 same = old_grid == new_grid
@@ -2575,6 +2589,7 @@ class GridSpec(Tidy3dBaseModel):
         internal_override_structures: List[MeshOverrideStructure] = None,
         internal_snapping_points: List[CoordinateOptional] = None,
         dl_min_from_gaps: pd.PositiveFloat = inf,
+        structure_priority_mode: PriorityMode = "equal",
     ) -> Grid:
         """Make the entire simulation grid based on some simulation parameters.
 
@@ -2601,7 +2616,8 @@ class GridSpec(Tidy3dBaseModel):
             If `None`, recomputes internal snapping points.
         dl_min_from_gaps : pd.PositiveFloat
             Minimal grid size computed based on autodetected gaps.
-
+        structure_priority_mode : PriorityMode
+            Structure priority setting.
 
         Returns
         -------
@@ -2664,6 +2680,7 @@ class GridSpec(Tidy3dBaseModel):
             wavelength,
             sim_size,
             lumped_elements,
+            structure_priority_mode,
             internal_override_structures,
         )
 

--- a/tidy3d/components/lumped_element.py
+++ b/tidy3d/components/lumped_element.py
@@ -203,6 +203,7 @@ class RectangularLumpedElement(LumpedElement, Box):
                 geometry=Box(center=self.center, size=override_size),
                 dl=(dl, dl, dl),
                 shadow=False,
+                priority=-1,
             )
         ]
 
@@ -408,6 +409,7 @@ class CoaxialLumpedResistor(LumpedElement):
                 geometry=Box(center=self.center, size=override_size),
                 dl=override_dl,
                 shadow=False,
+                priority=-1,
             )
         ]
 

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -54,6 +54,7 @@ from .types import (
     InterpMethod,
     LengthUnit,
     PermittivityComponent,
+    PriorityMode,
     Shapely,
     Size,
 )
@@ -106,8 +107,20 @@ class Scene(Tidy3dBaseModel):
         (),
         title="Structures",
         description="Tuple of structures present in scene. "
-        "Note: Structures defined later in this list override the "
-        "simulation material properties in regions of spatial overlap.",
+        "Note: In regions of spatial overlap between structures, "
+        "material properties are dictated by structure of higher priority. "
+        "The priority for structure of `priority=None` is set automatically "
+        "based on `structure_priority_mode`. For structures of equal priority, "
+        "the structure added later to the structure list takes precedence.",
+    )
+
+    structure_priority_mode: PriorityMode = pd.Field(
+        "equal",
+        title="Structure Priority Setting",
+        description="This field only affects structures of `priority=None`. "
+        "If `equal`, the priority of those structures is set to 0; if `conductor`, "
+        "the priority of structures made of `LossyMetalMedium` is set to 90, "
+        "`PECMedium` to 100, and others to 0.",
     )
 
     plot_length_units: Optional[LengthUnit] = pd.Field(
@@ -246,6 +259,17 @@ class Scene(Tidy3dBaseModel):
         return {medium: index for index, medium in enumerate(self.mediums)}
 
     @cached_property
+    def sorted_structures(self) -> List[Structure]:
+        """Returns a list of sorted structures based on their priority.In the sorted list,
+        latter added structures take higher priority.
+
+        Returns
+        -------
+        List[:class:`.Structure`]
+        """
+        return Structure._sort_structures(self.structures, self.structure_priority_mode)
+
+    @cached_property
     def background_structure(self) -> Structure:
         """Returns structure representing the background of the :class:`.Scene`."""
         geometry = Box(size=(inf, inf, inf))
@@ -254,7 +278,7 @@ class Scene(Tidy3dBaseModel):
     @cached_property
     def all_structures(self) -> List[Structure]:
         """List of all structures in the simulation including the background."""
-        return [self.background_structure] + list(self.structures)
+        return [self.background_structure] + self.sorted_structures
 
     @staticmethod
     def intersecting_media(
@@ -443,7 +467,7 @@ class Scene(Tidy3dBaseModel):
         """
 
         medium_shapes = self._get_structures_2dbox(
-            structures=self.to_static().structures, x=x, y=y, z=z, hlim=hlim, vlim=vlim
+            structures=self.to_static().sorted_structures, x=x, y=y, z=z, hlim=hlim, vlim=vlim
         )
         medium_map = self.medium_map
         for medium, shape in medium_shapes:
@@ -889,7 +913,7 @@ class Scene(Tidy3dBaseModel):
             The supplied or created matplotlib axes.
         """
 
-        structures = self.structures
+        structures = self.sorted_structures
 
         # alpha is None just means plot without any transparency
         if alpha is None:
@@ -1466,7 +1490,7 @@ class Scene(Tidy3dBaseModel):
             The supplied or created matplotlib axes.
         """
 
-        structures = self.structures
+        structures = self.sorted_structures
 
         # alpha is None just means plot without any transparency
         if alpha is None:
@@ -1744,7 +1768,7 @@ class Scene(Tidy3dBaseModel):
         """
 
         scene_dict = self.dict()
-        structures = self.structures
+        structures = self.sorted_structures
         array_dict = {
             "temperature": temperature,
             "electron_density": electron_density,
@@ -1795,7 +1819,7 @@ class Scene(Tidy3dBaseModel):
         acceptors_lims = [1e50, -1e50]
         donors_lims = [1e50, -1e50]
 
-        for struct in [self.background_structure] + list(self.structures):
+        for struct in self.all_structures:
             if isinstance(struct.medium.charge, SemiconductorMedium):
                 electric_spec = struct.medium.charge
                 for doping, limits in zip(

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -994,10 +994,16 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         plot_params[0] = plot_params[0].include_kwargs(edgecolor=kwargs["colors_internal"])
 
         if self.grid_spec.auto_grid_used:
+            # Internal and external override structures are visualized with different colors,
+            # so let's not sort them together.
             all_override_structures = [
-                self.internal_override_structures,
-                self.grid_spec.external_override_structures,
+                Structure._sort_structures(structures, self.scene.structure_priority_mode)
+                for structures in [
+                    self.internal_override_structures,
+                    self.grid_spec.external_override_structures,
+                ]
             ]
+
             for structures, plot_param in zip(all_override_structures, plot_params):
                 for structure in structures:
                     bounds = list(zip(*structure.geometry.bounds))
@@ -1229,6 +1235,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
             internal_snapping_points=self.internal_snapping_points,
             internal_override_structures=self.internal_override_structures,
             boundary_types=boundary_types,
+            structure_priority_mode=self.scene.structure_priority_mode,
         )
 
         # This would AutoGrid the in-plane directions of the 2D materials
@@ -1268,7 +1275,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
     @cached_property
     def static_structures(self) -> list[Structure]:
         """Structures in simulation with all autograd tracers removed."""
-        return [structure.to_static() for structure in self.structures]
+        return [structure.to_static() for structure in self.scene.sorted_structures]
 
     @cached_property
     def num_cells(self) -> int:
@@ -1569,7 +1576,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
             not any(isinstance(medium, Medium2D) for medium in self.scene.mediums)
             and not self.lumped_elements
         ):
-            return self.structures
+            return self.scene.sorted_structures
 
         def get_dls(geom: Geometry, axis: Axis, num_dls: int) -> List[float]:
             """Get grid size around the 2D material."""
@@ -4538,7 +4545,7 @@ class Simulation(AbstractYeeGridSimulation):
         clip = gdstk.rectangle(bmin, bmax)
 
         polygons = []
-        for structure in self.structures:
+        for structure in self.scene.sorted_structures:
             gds_layer, gds_dtype = gds_layer_dtype_map.get(structure.medium, (0, 0))
             for polygon in structure.to_gdstk(
                 x=x,
@@ -5009,7 +5016,7 @@ class Simulation(AbstractYeeGridSimulation):
         ]
         datasets_geometry = []
 
-        for struct in self.structures:
+        for struct in self.scene.sorted_structures:
             for geometry in traverse_geometries(struct.geometry):
                 if isinstance(geometry, TriangleMesh):
                     datasets_geometry += [geometry.mesh_dataset]

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import pathlib
 from collections import defaultdict
-from typing import Optional, Tuple, Union
+from functools import cmp_to_key
+from typing import List, Optional, Tuple, Union
 
 import autograd.numpy as anp
 import numpy as np
@@ -24,9 +25,9 @@ from .geometry.polyslab import PolySlab
 from .geometry.utils import GeometryType, validate_no_transformed_polyslabs
 from .grid.grid import Coords
 from .material.types import StructureMediumType
-from .medium import AbstractCustomMedium, CustomMedium, Medium, Medium2D
+from .medium import AbstractCustomMedium, CustomMedium, LossyMetalMedium, Medium, Medium2D
 from .monitor import FieldMonitor, PermittivityMonitor
-from .types import TYPE_TAG_STR, Ax, Axis
+from .types import TYPE_TAG_STR, Ax, Axis, PriorityMode
 from .validators import validate_name_str
 from .viz import add_ax_if_none, equal_aspect
 
@@ -69,6 +70,16 @@ class AbstractStructure(Tidy3dBaseModel):
         "``Simulation`` by default to compute the shape derivatives.",
     )
 
+    priority: int = pydantic.Field(
+        None,
+        title="Priority",
+        description="Priority of the structure applied in structure overlapping region. "
+        "The material property in the overlapping region is dictated by the structure "
+        "of higher priority. For structures of equal priority, "
+        "the structure added later to the structure list takes precedence. When `priority` is None, "
+        "the value is automatically assigned based on `structure_priority_mode` in the `Simulation`.",
+    )
+
     @pydantic.root_validator(skip_on_failure=True)
     def _handle_background_mediums(cls, values):
         """Handle background medium combinations, including deprecation."""
@@ -103,6 +114,27 @@ class AbstractStructure(Tidy3dBaseModel):
         """Prevents the creation of slanted polyslabs rotated out of plane."""
         validate_no_transformed_polyslabs(val)
         return val
+
+    def _priority(self, priority_mode: PriorityMode) -> int:
+        """Priority of this structure. The priority value is set automatically based on `priority_modes,
+        if its original value is `None`.
+        """
+        if self.priority is not None:
+            return self.priority
+        return 0
+
+    @staticmethod
+    def _sort_structures(
+        structures: List[StructureType], structure_priority_mode: PriorityMode
+    ) -> List[StructureType]:
+        """Sort structure lists based on their priority values in ascending order."""
+
+        def structure_comparator(struct1, struct2):
+            return struct1._priority(structure_priority_mode) - struct2._priority(
+                structure_priority_mode
+            )
+
+        return sorted(structures, key=cmp_to_key(structure_comparator))
 
     @property
     def viz_spec(self):
@@ -182,6 +214,20 @@ class Structure(AbstractStructure):
         description="Defines the electromagnetic properties of the structure's medium.",
         discriminator=TYPE_TAG_STR,
     )
+
+    def _priority(self, priority_mode: PriorityMode) -> int:
+        """Priority of this structure. The priority value is set automatically based on `priority_modes,
+        if its original value is `None`.
+        """
+        if self.priority is not None:
+            return self.priority
+
+        if priority_mode == "conductor":
+            if self.medium.is_pec:
+                return 100
+            if isinstance(self.medium, LossyMetalMedium):
+                return 90
+        return 0
 
     @property
     def viz_spec(self):
@@ -613,6 +659,13 @@ class MeshOverrideStructure(AbstractStructure):
         title="Grid Size",
         description="Grid size along x, y, z directions.",
         units=MICROMETER,
+    )
+
+    priority: int = pydantic.Field(
+        0,
+        title="Priority",
+        description="Priority of the structure applied in mesh override structure overlapping region. "
+        "The priority of internal override structures is ``-1``.",
     )
 
     enforce: bool = pydantic.Field(

--- a/tidy3d/components/tcad/simulation/heat_charge.py
+++ b/tidy3d/components/tcad/simulation/heat_charge.py
@@ -1043,7 +1043,7 @@ class HeatChargeSimulation(AbstractSimulation):
 
         # get structure list
         structures = [self.simulation_structure]
-        structures += list(self.structures)
+        structures += list(self.scene.sorted_structures)
 
         # construct slicing plane
         axis, position = Box.parse_xyz_kwargs(x=x, y=y, z=z)
@@ -1433,7 +1433,7 @@ class HeatChargeSimulation(AbstractSimulation):
         """
 
         # background can't have source, so no need to add background structure
-        structures = self.structures
+        structures = self.scene.sorted_structures
 
         # alpha is None just means plot without any transparency
         if alpha is None:

--- a/tidy3d/components/types.py
+++ b/tidy3d/components/types.py
@@ -200,6 +200,7 @@ PlanePosition = Literal["bottom", "middle", "top"]
 ClipOperationType = Literal["union", "intersection", "difference", "symmetric_difference"]
 BoxSurface = Literal["x-", "x+", "y-", "y+", "z-", "z+"]
 LengthUnit = Literal["nm", "μm", "um", "mm", "cm", "m"]
+PriorityMode = Literal["equal", "conductor"]
 
 """ medium """
 

--- a/tidy3d/plugins/adjoint/components/simulation.py
+++ b/tidy3d/plugins/adjoint/components/simulation.py
@@ -419,7 +419,9 @@ class JaxSimulation(Simulation, JaxObject):
         sim = Simulation.parse_obj(sim_dict)
 
         # put all structures and monitors in one list
-        all_structures = list(self.structures) + [js.to_structure() for js in self.input_structures]
+        all_structures = list(self.scene.sorted_structures) + [
+            js.to_structure() for js in self.input_structures
+        ]
         all_monitors = (
             list(self.monitors)
             + list(self.output_monitors)


### PR DESCRIPTION
In many RF smulations, metallic structures are usually very thin: thickness much smaller than grid size. We can still accurately simulate them by applying PEC conformal meshing and SIBC techniques. However, since we slightly expand the structures in the solver (not really now, but a similar strategy), when the metallic structures are not added later compared to the touching dielectric structures in the structure list, those metallic structures will be completely missing in Yee-grid representation. It is a very common issues when people setup an RF simulation, even among our internal developers.

As discussed [here](https://github.com/flexcompute/tidy3d-core/issues/943), the scope of this PR:

- [x] Add a priority field to `AbstractStructure`. The default value is `None`.
- [x] Add a field `structure_priority_mode` to `Scene`. It sets priority of structures that have `priority=None`. Right now, there are two modes:
  - [x] `equal` that sets `priority=0`;
  - [x] `conductor` that sets `priority=90` for lossyMetaMedium, and 100 for PEC, and 0 for others
- [x] A cached_property `sorted_structures` in Scene to be applied in places where `sim.structures` was used
- [x] MeshOverideStructures will have default priority=0, regardless of the value of  `structure_priority_mode`.
- [x] In meshing, `structures = sorted_structure + sorted_mesh_override_structures`; internal mesh override structures have priority=-1
- [x] Priority of 2d medium: no different from the bulk.
- [x] Add tests