### PR TITLE
Correct scaling for adjoint sources created from field monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Compatibility with `xarray>=2025.03`.
 - Inaccurate gradient when auto-grabbing permittivities for structures using `td.PolySlab` when using dispersive material models.
+- Fixed scaling for adjoint sources when differentiating with respect to `FieldData` to account for the mesh size of the monitor and thus the created source. This aligns adjoint gradient magnitudes with numerical finite difference gradients for field data.
 
 ## [2.8.1] - 2025-03-20
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,7 +275,10 @@ ignore = [
 
 [tool.pytest.ini_options]
 # TODO: remove --assert=plain when https://github.com/scipy/scipy/issues/22236 is resolved
-addopts = "--cov=tidy3d --doctest-modules -n auto --dist worksteal --assert=plain"
+addopts = "--cov=tidy3d --doctest-modules -n auto --dist worksteal --assert=plain -m 'not numerical' "
+markers = [
+    "numerical: marks numerical tests for adjoint gradients that require running simulations (deselect with '-m \"not numerical\"')",
+]
 env = ["MPLBACKEND=Agg", "OMP_NUM_THREADS=1"]
 doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"
 norecursedirs = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import os
+from pathlib import Path
 
 import autograd
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import psutil
@@ -68,3 +70,33 @@ def pytest_xdist_auto_num_workers(config):
     if os.getenv("GITHUB_ACTIONS"):
         return cores
     return max(1, cores - 1)
+
+
+@pytest.fixture
+def mpl_config_noninteractive():
+    """Configure matplotlib non-interactive backend for all tests in this module."""
+    original_backend = mpl.get_backend()
+    mpl.use("Agg")
+    yield
+    plt.close("all")
+    mpl.use(original_backend)
+
+
+@pytest.fixture
+def mpl_config_interactive():
+    """Configure matplotlib interactive backend for all tests in this module."""
+    original_backend = mpl.get_backend()
+    mpl.use("TkAgg")
+    yield
+    mpl.use(original_backend)
+
+
+@pytest.fixture
+def dir_name(request):
+    return request.param
+
+
+@pytest.fixture
+def create_directory(dir_name):
+    if dir_name is not None:
+        directory = Path(dir_name).mkdir(parents=True, exist_ok=True)

--- a/tests/test_components/test_autograd_numerical.py
+++ b/tests/test_components/test_autograd_numerical.py
@@ -1,0 +1,370 @@
+# test autograd and compares to numerically computed finite difference gradients
+
+import operator
+import sys
+
+import autograd as ag
+import matplotlib.pylab as plt
+import numpy as np
+import pytest
+import tidy3d as td
+import tidy3d.web as web
+from scipy.ndimage import gaussian_filter
+
+PLOT_FD_ADJ_COMPARISON = False
+NUM_FINITE_DIFFERENCE = 10
+SAVE_FD_ADJ_DATA = False
+SAVE_FD_LOC = 0
+SAVE_ADJ_LOC = 1
+LOCAL_GRADIENT = False
+VERBOSE = False
+NUMERICAL_RESULTS_DATA_DIR = "./numerical_field_test/"
+SHOW_PRINT_STATEMENTS = False
+
+RMS_THRESHOLD = 0.25
+
+if PLOT_FD_ADJ_COMPARISON:
+    pytestmark = pytest.mark.usefixtures("mpl_config_interactive")
+else:
+    pytestmark = pytest.mark.usefixtures("mpl_config_noninteractive")
+
+if SHOW_PRINT_STATEMENTS:
+    sys.stdout = sys.stderr
+
+FINITE_DIFF_PERM_SEED = 1.5**2
+MESH_FACTOR_DESIGN = 30.0
+
+
+def get_sim_geometry(mesh_wvl_um):
+    return td.Box(size=(5 * mesh_wvl_um, 5 * mesh_wvl_um, 7 * mesh_wvl_um), center=(0, 0, 0))
+
+
+def make_base_sim(
+    mesh_wvl_um,
+    adj_wvl_um,
+    monitor_size_wvl,
+    box_for_override,
+    monitor_bg_index=1.0,
+    run_time=1e-11,
+):
+    sim_geometry = get_sim_geometry(mesh_wvl_um)
+    sim_size_um = sim_geometry.size
+    sim_center_um = sim_geometry.center
+
+    boundary_spec = td.BoundarySpec(
+        x=td.Boundary.pml(),
+        y=td.Boundary.pml(),
+        z=td.Boundary.pml(),
+    )
+
+    dl_design = mesh_wvl_um / MESH_FACTOR_DESIGN
+
+    mesh_overrides = []
+    mesh_overrides.extend(
+        [
+            td.MeshOverrideStructure(
+                geometry=box_for_override,
+                dl=[dl_design, dl_design, dl_design],
+            ),
+        ]
+    )
+
+    src_size = sim_size_um[0:2] + (0,)
+
+    wl_min_src_um = 0.9 * adj_wvl_um
+    wl_max_src_um = 1.1 * adj_wvl_um
+
+    fwidth_src = td.C_0 * ((1.0 / wl_min_src_um) - (1.0 / wl_max_src_um))
+    freq0 = td.C_0 / adj_wvl_um
+
+    pulse = td.GaussianPulse(freq0=freq0, fwidth=fwidth_src)
+    src = td.PlaneWave(
+        center=(0, 0, -2 * mesh_wvl_um),
+        size=src_size,
+        source_time=pulse,
+        direction="+",
+    )
+
+    field_monitor = td.FieldMonitor(
+        center=(0, 0, 0.25 * sim_size_um[2]),
+        size=tuple(dim * mesh_wvl_um for dim in monitor_size_wvl),
+        name="monitor_fields",
+        freqs=[freq0],
+    )
+
+    monitor_index_block = td.Box(
+        center=(0, 0, 0.25 * sim_size_um[2] + mesh_wvl_um),
+        size=tuple(2 * size for size in sim_size_um[0:2]) + (mesh_wvl_um + 0.5 * sim_size_um[2],),
+    )
+    monitor_index_block_structure = td.Structure(
+        geometry=monitor_index_block, medium=td.Medium(permittivity=monitor_bg_index**2)
+    )
+
+    sim_base = td.Simulation(
+        center=sim_center_um,
+        size=sim_size_um,
+        grid_spec=td.GridSpec.auto(
+            min_steps_per_wvl=30,
+            wavelength=mesh_wvl_um,
+            override_structures=mesh_overrides,
+        ),
+        structures=[monitor_index_block_structure],
+        sources=[src],
+        monitors=[field_monitor],
+        run_time=run_time,
+        boundary_spec=boundary_spec,
+        subpixel=True,
+    )
+
+    return sim_base
+
+
+def create_objective_function(geometry, create_sim_base, eval_fn, sim_path_dir):
+    def objective(perm_arrays):
+        sim_base = create_sim_base()
+
+        simulation_dict = {}
+        for idx in range(0, len(perm_arrays)):
+            block_structure = td.Structure.from_permittivity_array(
+                eps_data=perm_arrays[idx],
+                geometry=geometry,
+            )
+
+            sim_with_block = sim_base.updated_copy(
+                structures=sim_base.structures + (block_structure,)
+            )
+
+            simulation_dict[f"numerical_field_testing_{idx}"] = sim_with_block.copy()
+
+        sim_data = web.run_async(
+            simulation_dict, path_dir=sim_path_dir, local_gradient=LOCAL_GRADIENT, verbose=VERBOSE
+        )
+
+        objective_vals = []
+        for idx in range(0, len(perm_arrays)):
+            objective_vals.append(eval_fn(sim_data[f"numerical_field_testing_{idx}"]))
+
+        if len(perm_arrays) == 1:
+            return objective_vals[0]
+
+        return objective_vals
+
+    return objective
+
+
+def make_eval_fns(monitor_size_wvl):
+    num_nonzero_spatial_dims = 3 - np.sum(np.isclose(monitor_size_wvl, 0))
+
+    def intensity(sim_data):
+        field_data = sim_data["monitor_fields"]
+        shape_x, shape_y, shape_z, *_ = field_data.Ex.values.shape
+
+        total = 0.0
+        return np.sum(
+            np.abs(field_data.Ex.values[shape_x // 2, shape_y // 2, shape_z // 2]) ** 2
+            + np.abs(field_data.Ey.values[shape_x // 2, shape_y // 2, shape_z // 2]) ** 2
+            + np.abs(field_data.Ez.values[shape_x // 2, shape_y // 2, shape_z // 2]) ** 2
+        )
+
+    eval_fns = [intensity]
+    eval_fn_names = ["intensity"]
+
+    if num_nonzero_spatial_dims == 2:
+
+        def flux(sim_data):
+            field_data = sim_data["monitor_fields"]
+
+            return np.sum(field_data.flux.values)
+
+        eval_fns.append(flux)
+        eval_fn_names.append("flux")
+
+    return eval_fns, eval_fn_names
+
+
+background_indices = [1.0, 1.5]
+mesh_wvls_um = [1.55, 1.55, 10 * 1.55, 10 * 1.55]
+adj_wvls_um = [1.55, 2.2, 10 * 1.55, 10 * 2.2]
+monitor_sizes_3d_wvl = [(0.5, 0.5, 0), (0.5, 0.5, 0.5), (0.5, 0, 0), (0, 0.5, 0), (0, 0, 0)]
+
+field_data_test_parameters = []
+
+test_number = 0
+for idx in range(0, len(mesh_wvls_um)):
+    mesh_wvl_um = mesh_wvls_um[idx]
+    adj_wvl_um = adj_wvls_um[idx]
+
+    for monitor_size_wvl in monitor_sizes_3d_wvl:
+        eval_fns, eval_fn_names = make_eval_fns(monitor_size_wvl)
+
+        for monitor_bg_index in background_indices:
+            for eval_fn_idx, eval_fn in enumerate(eval_fns):
+                field_data_test_parameters.append(
+                    {
+                        "mesh_wvl_um": mesh_wvl_um,
+                        "adj_wvl_um": adj_wvl_um,
+                        "monitor_size_wvl": monitor_size_wvl,
+                        "monitor_bg_index": monitor_bg_index,
+                        "eval_fn": eval_fn,
+                        "eval_fn_name": eval_fn_names[eval_fn_idx],
+                        "test_number": test_number,
+                    }
+                )
+
+                test_number += 1
+
+
+@pytest.mark.numerical
+@pytest.mark.parametrize(
+    "field_data_test_parameters, dir_name",
+    zip(
+        field_data_test_parameters,
+        ([NUMERICAL_RESULTS_DATA_DIR] if SAVE_FD_ADJ_DATA else [None])
+        * len(field_data_test_parameters),
+    ),
+    indirect=["dir_name"],
+)
+def test_finite_difference_field_data(field_data_test_parameters, rng, tmp_path, create_directory):
+    """Test a variety of autograd permittivity gradients for FieldData by"""
+    """comparing them to numerical finite difference."""
+
+    num_tests = 0
+    for monitor_size_wvl in monitor_sizes_3d_wvl:
+        eval_fns, _ = make_eval_fns(monitor_size_wvl)
+        num_tests += len(eval_fns) * len(background_indices) * len(mesh_wvls_um)
+
+    test_results = np.zeros((2, NUM_FINITE_DIFFERENCE))
+
+    test_number = field_data_test_parameters["test_number"]
+
+    (
+        mesh_wvl_um,
+        adj_wvl_um,
+        monitor_size_wvl,
+        monitor_bg_index,
+        eval_fn,
+        eval_fn_name,
+        test_number,
+    ) = operator.itemgetter(
+        "mesh_wvl_um",
+        "adj_wvl_um",
+        "monitor_size_wvl",
+        "monitor_bg_index",
+        "eval_fn",
+        "eval_fn_name",
+        "test_number",
+    )(field_data_test_parameters)
+
+    mesh_wvl_um = mesh_wvls_um[idx]
+    adj_wvl_um = adj_wvls_um[idx]
+
+    dim_um = mesh_wvl_um
+    dim_um = mesh_wvl_um
+    thickness_um = 0.5 * mesh_wvl_um
+    block = td.Box(center=(0, 0, 0), size=(dim_um, dim_um, thickness_um))
+
+    dim = 1 + int(dim_um / (mesh_wvl_um / MESH_FACTOR_DESIGN))
+    Nz = 1 + int(thickness_um / (mesh_wvl_um / MESH_FACTOR_DESIGN))
+
+    sim_geometry = get_sim_geometry(mesh_wvl_um)
+
+    box_for_override = td.Box(
+        center=(0, 0, 0), size=sim_geometry.size[0:2] + (thickness_um + mesh_wvl_um,)
+    )
+
+    eval_fns, eval_fn_names = make_eval_fns(monitor_size_wvl)
+
+    sim_path_dir = tmp_path / f"test{test_number}"
+    sim_path_dir.mkdir()
+
+    objective = create_objective_function(
+        block,
+        lambda mesh_wvl_um=mesh_wvl_um,
+        adj_wvl_um=adj_wvl_um,
+        monitor_size_wvl=monitor_size_wvl,
+        box_for_override=box_for_override,
+        monitor_bg_index=monitor_bg_index: make_base_sim(
+            mesh_wvl_um=mesh_wvl_um,
+            adj_wvl_um=adj_wvl_um,
+            monitor_size_wvl=monitor_size_wvl,
+            box_for_override=box_for_override,
+            monitor_bg_index=monitor_bg_index,
+        ),
+        eval_fn,
+        sim_path_dir=str(sim_path_dir),
+    )
+
+    obj_val_and_grad = ag.value_and_grad(objective)
+
+    perm_init = FINITE_DIFF_PERM_SEED**2 * np.ones((dim, dim, Nz))
+
+    obj, adj_grad = obj_val_and_grad([perm_init])
+
+    # empirical step size from running other finite difference tests for field
+    # cases with permittivity
+    fd_step = 0.1
+
+    all_perm = []
+    pattern_dot_adj_gradient = np.zeros(NUM_FINITE_DIFFERENCE)
+
+    for fd_idx in range(0, NUM_FINITE_DIFFERENCE):
+        random_pattern = rng.random((dim, dim, Nz)) - 0.5
+        random_pattern = gaussian_filter(random_pattern, sigma=3)
+        random_pattern /= np.linalg.norm(random_pattern)
+
+        pattern_dot_adj_gradient[fd_idx] = np.sum(random_pattern * adj_grad)
+
+        perm_up = perm_init.copy() + fd_step * random_pattern
+        perm_down = perm_init.copy() - fd_step * random_pattern
+
+        all_perm.append(perm_up)
+        all_perm.append(perm_down)
+
+    all_obj = objective(all_perm)
+
+    fd_grad = np.zeros(NUM_FINITE_DIFFERENCE)
+    for fd_idx in range(0, NUM_FINITE_DIFFERENCE):
+        obj_up_location = 2 * fd_idx
+        obj_down_location = 2 * fd_idx + 1
+
+        fd_grad[fd_idx] = (all_obj[obj_up_location] - all_obj[obj_down_location]) / (2 * fd_step)
+
+    rms_error = np.linalg.norm(fd_grad - pattern_dot_adj_gradient)
+    fd_mag = np.linalg.norm(fd_grad)
+    adj_mag = np.linalg.norm(pattern_dot_adj_gradient)
+    percentage_error = 100.0 * np.mean(
+        (fd_grad - pattern_dot_adj_gradient) / (fd_grad + np.finfo(np.float64).eps)
+    )
+
+    print("\n" * 3)
+    print("-" * 20)
+    print(f"Numerical test #{test_number}")
+    print(f"Mesh and adjoint wavelengths: {mesh_wvl_um}, {adj_wvl_um}")
+    print(f"Monitor size: {monitor_size_wvl}")
+    print(f"Background index for monitor: {monitor_bg_index}")
+    print(f"Eval function: {eval_fn_name}")
+    print(f"RMS Error: {rms_error}")
+    print(f"FD, Adj magnitudes: {fd_mag}, {adj_mag}")
+    print(f"Percentage Error: {percentage_error}")
+    print("-" * 20)
+    print("\n" * 3)
+
+    assert rms_error < RMS_THRESHOLD * fd_mag, "RMS error magnitude too large"
+
+    test_results[SAVE_FD_LOC, :] = fd_grad
+    test_results[SAVE_ADJ_LOC, :] = pattern_dot_adj_gradient
+
+    test_number += 1
+
+    if PLOT_FD_ADJ_COMPARISON:
+        plt.plot(pattern_dot_adj_gradient, color="g", linewidth=2.0)
+        plt.plot(fd_grad, color="b", linewidth=1.5, linestyle="--")
+        plt.title(f"Gradient for objective: {eval_fn_name}")
+        plt.legend(["Finite difference", "Adjoint"])
+        plt.xlabel("Sample number")
+        plt.ylabel("Gradient value")
+        plt.legend()
+        plt.show()
+
+    if SAVE_FD_ADJ_DATA:
+        np.save(f"{NUMERICAL_RESULTS_DATA_DIR}/results_{test_number}.npy", test_results)

--- a/tests/test_components/test_viz.py
+++ b/tests/test_components/test_viz.py
@@ -10,15 +10,7 @@ from tidy3d.components.viz import Polygon, set_default_labels_and_title
 from tidy3d.constants import inf
 from tidy3d.exceptions import Tidy3dKeyError
 
-
-@pytest.fixture(scope="module", autouse=True)
-def mpl_config():
-    """Configure matplotlib non-interactive backend for all tests in this module."""
-    original_backend = mpl.get_backend()
-    mpl.use("Agg")
-    yield
-    plt.close("all")
-    mpl.use(original_backend)
+pytestmark = pytest.mark.usefixtures("mpl_config_noninteractive")
 
 
 def test_make_polygon_dict():

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -13,7 +13,7 @@ import xarray as xr
 from pandas import DataFrame
 from xarray.core.types import Self
 
-from ...constants import C_0, ETA_0, MICROMETER, MU_0
+from ...constants import C_0, EPSILON_0, ETA_0, MICROMETER
 from ...exceptions import DataError, SetupError, Tidy3dNotImplementedError, ValidationError
 from ...log import log
 from ..base import TYPE_TAG_STR, cached_property, skip_if_fields_missing
@@ -1158,53 +1158,8 @@ class FieldData(FieldDataset, ElectromagneticFieldData):
 
     def make_adjoint_sources(
         self, dataset_names: list[str], fwidth: float
-    ) -> List[Union[CustomCurrentSource, PointDipole]]:
+    ) -> List[CustomCurrentSource]:
         """Converts a :class:`.FieldData` to a list of adjoint current or point sources."""
-
-        if np.allclose(self.monitor.size, 0):
-            return self.to_adjoint_point_sources(fwidth=fwidth)
-
-        return self.to_adjoint_field_sources(fwidth=fwidth)
-
-    def to_adjoint_point_sources(self, fwidth: float) -> List[PointDipole]:
-        """Create adjoint point dipole source if this field data contains one item."""
-
-        sources = []
-
-        for polarization, field_component in self.field_components.items():
-            if field_component is None:
-                continue
-
-            for freq0 in field_component.coords["f"]:
-                omega0 = 2 * np.pi * freq0
-                scaling_factor = 33 / (MU_0 * omega0)
-
-                forward_amp = self.get_amplitude(field_component.sel(f=freq0))
-
-                if forward_amp == 0.0:
-                    continue
-
-                adj_phase = np.pi + np.angle(forward_amp)
-                adj_amp = scaling_factor * forward_amp
-
-                src_adj = PointDipole(
-                    center=self.monitor.center,
-                    polarization=polarization,
-                    source_time=GaussianPulse(
-                        freq0=freq0,
-                        fwidth=fwidth,
-                        amplitude=abs(adj_amp),
-                        phase=adj_phase,
-                    ),
-                    interpolate=True,
-                )
-
-                sources.append(src_adj)
-
-        return sources
-
-    def to_adjoint_field_sources(self, fwidth: float) -> List[CustomCurrentSource]:
-        """Create adjoint custom field sources if this field data has some dimensionality."""
 
         sources = []
         source_geo = self.monitor.geometry
@@ -1221,12 +1176,24 @@ class FieldData(FieldDataset, ElectromagneticFieldData):
                 if "H" in name:
                     values *= -1
 
-                # make coords that are shifted relative to geometry (0,0,0) = geometry.center
                 coords = dict(field_component.coords.copy())
+                grid_coords = Coords(**{key: coords[key] for key in "xyz"})
+
+                size_element = grid_coords.cell_size_meshgrid
+
+                # make coords that are shifted relative to geometry (0,0,0) = geometry.center
                 for dim, key in enumerate("xyz"):
                     coords[key] = np.array(coords[key]) - source_geo.center[dim]
+
                 coords["f"] = np.array([freq0])
                 values = np.expand_dims(values, axis=-1)
+
+                size_element = np.reshape(size_element, values.shape)
+
+                omega0 = 2 * np.pi * freq0
+                scaling_factor = 0.5 * omega0 * EPSILON_0 / size_element
+
+                values *= scaling_factor
 
                 # ignore zero components
                 if not np.all(values == 0):

--- a/tidy3d/components/grid/grid.py
+++ b/tidy3d/components/grid/grid.py
@@ -8,7 +8,7 @@ import numpy as np
 import pydantic.v1 as pd
 
 from ...exceptions import SetupError
-from ..base import Tidy3dBaseModel
+from ..base import Tidy3dBaseModel, cached_property
 from ..data.data_array import DataArray, ScalarFieldDataArray, SpatialDataArray
 from ..data.utils import UnstructuredGridDataset, UnstructuredGridDatasetType
 from ..geometry.base import Box
@@ -50,6 +50,46 @@ class Coords(Tidy3dBaseModel):
     def to_list(self):
         """Return a list of the three Coord1D objects as numpy arrays."""
         return list(self.to_dict.values())
+
+    @cached_property
+    def cell_sizes(self) -> SpatialDataArray:
+        """Returns the sizes of the cells in each coordinate array as a dictionary."""
+        cell_sizes = {}
+
+        coord_dict = self.to_dict
+        for dim in "xyz":
+            if len(coord_dict[dim]) > 1:
+                diff = coord_dict[dim][1:] - coord_dict[dim][0:-1]
+
+                diff_left = np.pad(diff, ((1, 0)), mode="edge")
+                diff_right = np.pad(diff, ((0, 1)), mode="edge")
+
+                diff_avg = 0.5 * (diff_left + diff_right)
+                cell_sizes[dim] = diff_avg
+            else:
+                cell_sizes[dim] = 1
+
+        return cell_sizes
+
+    @cached_property
+    def cell_size_meshgrid(self):
+        """Returns an N-dimensional grid where N is the number of coordinate arrays that have more than one
+        element. Each grid element corresponds to the size of the mesh cell in N-dimensions and 1 for N=0."""
+        coord_dict = self.to_dict
+
+        cell_size_meshgrid = np.squeeze(np.ones(tuple(len(coord_dict[dim]) for dim in "xyz")))
+        meshgrid_elements = [
+            size for dim, size in self.cell_sizes.items() if len(coord_dict[dim]) > 1
+        ]
+
+        if len(meshgrid_elements) > 1:
+            meshgrid = np.meshgrid(*meshgrid_elements, indexing="ij")
+            for idx in range(0, len(meshgrid)):
+                cell_size_meshgrid *= np.reshape(meshgrid[idx], cell_size_meshgrid.shape)
+        elif len(meshgrid_elements) == 1:
+            cell_size_meshgrid = meshgrid_elements[0]
+
+        return cell_size_meshgrid
 
     def _interp_from_xarray(
         self,


### PR DESCRIPTION
Corrects the normalization for field sources created when differentiating through field monitors. Here, depending on the size of the source, we normalize by the volume, area, or linear element associated with the mesh the source is created on. Originally, I thought we would have to pass in more information about the mesh surrounding the monitor, but we can use the coordinates already inside of the monitor data for the normalization.

An associated numerical test is also added that does not get run unless the --run-numerical-adjoint flag is passed into pytest.

I'm verifying this one more time and will post a plot of the finite difference vs. adjoint gradient with this change after that runs!