### PR TITLE
Fix:Error message for invalid task ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Supplying autograd-traced values to geometric fields (`center`, `size`) of simulations, monitors, and sources now logs a warning and falls back to the static value instead of erroring.
 - Attempting to differentiate server-side field projections now raises a clear error instead of silently failing.
+- Improved error message and handling when attempting to load a non-existent task ID.
 
 ## [2.8.3] - 2025-04-24
 

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -39,6 +39,7 @@ from tidy3d.web.api.webapi import (
     upload,
 )
 from tidy3d.web.core.environment import Env
+from tidy3d.web.core.exceptions import WebNotFoundError
 from tidy3d.web.core.types import PayType, TaskType
 
 TASK_NAME = "task_name_test"
@@ -723,3 +724,18 @@ def test_main(mock_webapi, monkeypatch, mock_job_status, tmp_path):
                 "--inspect_sim",
             ]
         )
+
+
+@responses.activate
+def test_load_invalid_task_raises(mock_webapi):
+    """Ensure that load() raises TaskNotFoundError for a non-existent task ID."""
+    fake_id = "INVALID_TASK_ID"
+
+    responses.add(
+        responses.GET,
+        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{fake_id}/detail",
+        json={"error": "Task not found"},
+        status=404,
+    )
+    with pytest.raises(WebNotFoundError, match="Resource not found"):
+        load(fake_id)

--- a/tidy3d/web/core/exceptions.py
+++ b/tidy3d/web/core/exceptions.py
@@ -11,3 +11,9 @@ class WebError(Exception):
         log = get_logger()
         super().__init__(message)
         log.error(message)
+
+
+class WebNotFoundError(WebError):
+    """A generic error indicating an HTTP 404 (resource not found)."""
+
+    pass

--- a/tidy3d/web/core/http_util.py
+++ b/tidy3d/web/core/http_util.py
@@ -25,7 +25,7 @@ from .constants import (
 )
 from .core_config import get_logger
 from .environment import Env
-from .exceptions import WebError
+from .exceptions import WebError, WebNotFoundError
 
 REINITIALIZED = False
 
@@ -131,7 +131,7 @@ def http_interceptor(func):
 
         if resp.status_code != ResponseCodes.OK.value:
             if resp.status_code == ResponseCodes.NOT_FOUND.value:
-                return None
+                raise WebNotFoundError("Resource not found (HTTP 404).")
             json_resp = resp.json()
             if "error" in json_resp.keys():
                 raise WebError(json_resp["error"])

--- a/tidy3d/web/core/task_core.py
+++ b/tidy3d/web/core/task_core.py
@@ -12,12 +12,14 @@ import pydantic.v1 as pd
 from botocore.exceptions import ClientError
 from pydantic.v1 import Extra, Field, parse_obj_as
 
+import tidy3d as td
+
 from . import http_util
 from .cache import FOLDER_CACHE
 from .constants import SIM_ERROR_FILE, SIM_FILE_HDF5_GZ, SIM_LOG_FILE, SIMULATION_DATA_HDF5_GZ
 from .core_config import get_logger_console
 from .environment import Env
-from .exceptions import WebError
+from .exceptions import WebError, WebNotFoundError
 from .file_util import read_simulation_from_hdf5
 from .http_util import http
 from .s3utils import download_file, download_gz_file, upload_file
@@ -261,7 +263,12 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
             :class:`.SimulationTask` object containing info about status,
              size, credits of task and others.
         """
-        resp = http.get(f"tidy3d/tasks/{task_id}/detail")
+        try:
+            resp = http.get(f"tidy3d/tasks/{task_id}/detail")
+        except WebNotFoundError as e:
+            td.log.error(f"The requested task ID '{task_id}' does not exist.")
+            raise e
+
         task = SimulationTask(**resp) if resp else None
         return task
 


### PR DESCRIPTION
Previously, when web.load received a 404 response for an invalid or non-existent task ID, the client would return None and produce unhelpful error messages. This commit changes that behavior: it now raises a TaskNotFoundError with a clear, user-friendly explanation.
<img width="661" alt="Screenshot 2025-03-31 at 11 22 56 PM" src="https://github.com/user-attachments/assets/996af424-6806-4d0c-8080-75672502007d" />
