### PR TITLE
Add permittivity monitor to mode simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ability to select payment option when submitting jobs from the Python client.
 - Periodic repetition of EME subgrids via `num_reps` or `EMEPeriodicitySweep`.
 - Methods `EMEExplicitGrid.from_structures` and `EMECompositeGrid.from_structure_groups` to place EME cell boundaries at structure bounds.
+- 'ModeSimulation' now supports 'PermittivityMonitor'.
 
 ### Changed
 - Performance enhancement for adjoint gradient calculations by optimizing field interpolation.

--- a/tests/test_components/test_mode.py
+++ b/tests/test_components/test_mode.py
@@ -77,11 +77,15 @@ def test_angle_rotation_with_phi():
 
 def get_mode_sim():
     mode_spec = MODE_SPEC.updated_copy(filter_pol="tm")
+    permittivity_monitor = td.PermittivityMonitor(
+        size=(1, 1, 0), center=(0, 0, 0), name="eps", freqs=FS
+    )
     sim = td.ModeSimulation(
         size=SIZE_2D,
         freqs=FS,
         mode_spec=mode_spec,
         grid_spec=td.GridSpec.auto(wavelength=td.C_0 / FS[0]),
+        monitors=[permittivity_monitor],
     )
     return sim
 
@@ -153,7 +157,7 @@ def test_mode_sim():
     )
 
     assert td.ModeSimulation.from_simulation(sim) == sim
-    assert td.ModeSimulation.from_mode_solver(sim._mode_solver) == sim
+    assert td.ModeSimulation.from_mode_solver(sim._mode_solver) == sim.updated_copy(monitors=[])
     _ = td.ModeSimulation.from_simulation(
         simulation=fdtd_sim,
         plane=td.Box(size=(4, 4, 0)),

--- a/tidy3d/components/mode/data/sim_data.py
+++ b/tidy3d/components/mode/data/sim_data.py
@@ -7,13 +7,15 @@ from typing import Literal, Tuple
 import pydantic.v1 as pd
 
 from ...base import cached_property
-from ...data.monitor_data import ModeSolverData
+from ...data.monitor_data import ModeSolverData, PermittivityData
 from ...data.sim_data import AbstractYeeGridSimulationData
 from ...types import (
     Ax,
     PlotScale,
 )
 from ..simulation import ModeSimulation
+
+ModeSimulationMonitorDataType = PermittivityData
 
 
 class ModeSimulationData(AbstractYeeGridSimulationData):
@@ -29,7 +31,7 @@ class ModeSimulationData(AbstractYeeGridSimulationData):
         description=":class:`.ModeSolverData` containing the field and effective index on unexpanded grid.",
     )
 
-    data: Tuple[None, ...] = pd.Field(
+    data: Tuple[ModeSimulationMonitorDataType, ...] = pd.Field(
         (),
         title="Monitor Data",
         description="List of monitor data "

--- a/tidy3d/components/mode/simulation.py
+++ b/tidy3d/components/mode/simulation.py
@@ -16,7 +16,7 @@ from ..geometry.base import Box
 from ..grid.grid import Grid
 from ..grid.grid_spec import GridSpec
 from ..mode_spec import ModeSpec
-from ..monitor import ModeMonitor, ModeSolverMonitor
+from ..monitor import ModeMonitor, ModeSolverMonitor, PermittivityMonitor
 from ..simulation import AbstractYeeGridSimulation, Simulation
 from ..source.field import ModeSource
 from ..types import (
@@ -28,6 +28,8 @@ from ..types import (
 )
 from ..validators import validate_mode_plane_radius
 from .mode_solver import ModeSolver
+
+ModeSimulationMonitorType = PermittivityMonitor
 
 # dummy run time for conversion to FDTD sim
 # should be very small -- otherwise, generating tmesh will fail or take a long time
@@ -148,7 +150,7 @@ class ModeSimulation(AbstractYeeGridSimulation):
         "apply PML layers in the mode solver.",
     )
 
-    monitors: Tuple[()] = pd.Field(
+    monitors: Tuple[ModeSimulationMonitorType, ...] = pd.Field(
         (),
         title="Monitors",
         description="Tuple of monitors in the simulation. "


### PR DESCRIPTION
This PR simply adds `PermittivityMonitor` as a possible monitor type to `ModeSimulation`, which is quite useful for obtaining subpixel-averaged permittivity without running a full FDTD simulation.