### PR TITLE
Set angle_phi to multiple of np.pi / 2 if angle_rotation is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `num_freqs` in Gaussian beam type sources limited to 20, which should besufficient for all cases.
+- The `angle_phi` parameter of `ModeSpec` is only limited to multiples of `np.pi / 2` if `angle_rotation` is set to `True`, as other values would currently not work correctly.
 
 ## [2.8.1] - 2025-03-20
 

--- a/tests/test_components/test_mode.py
+++ b/tests/test_components/test_mode.py
@@ -72,7 +72,7 @@ def test_angle_rotation_with_phi():
 
     # Case where angle_phi is not a multiple of np.pi and angle_rotation is True
     with pytest.raises(pydantic.ValidationError):
-        td.ModeSpec(angle_phi=np.pi / 2, angle_rotation=True)
+        td.ModeSpec(angle_phi=np.pi / 3, angle_rotation=True)
 
 
 def get_mode_sim():

--- a/tidy3d/components/mode_spec.py
+++ b/tidy3d/components/mode_spec.py
@@ -225,10 +225,10 @@ class ModeSpec(Tidy3dBaseModel):
 
     @pd.validator("angle_rotation")
     def angle_rotation_with_phi(cls, val, values):
-        """Currently ``angle_rotation`` is only supported with ``angle_phi % np.pi == 0``."""
-        if val and not isclose(values["angle_phi"] % np.pi, 0):
+        """Currently ``angle_rotation`` is only supported with ``angle_phi % (np.pi / 2) == 0``."""
+        if val and not isclose(values["angle_phi"] % (np.pi / 2), 0):
             raise ValidationError(
-                "Parameter 'angle_phi' must be a multiple of 'np.pi' when 'angle_rotation' is "
+                "Parameter 'angle_phi' must be a multiple of 'np.pi / 2' when 'angle_rotation' is "
                 "enabled."
             )
         return val


### PR DESCRIPTION
I saw that we actually do test `np.pi / 2` on the backend and I also tested myself. I also tested that indeed values in between produce quite wrong results for now. Finally, I had not put a changelog the previous time, so adding this here too.