### PR TITLE
Validating that bend_radius is strictly larger than half the mode plane size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The `bend_radius` for a mode solve must be strictly larger than half the mode plane size (previously it could be equal).
+
 ## [2.8.2] - 2025-04-09
 
 ### Added

--- a/tidy3d/components/validators.py
+++ b/tidy3d/components/validators.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pydantic.v1 as pydantic
 
+from ..constants import fp_eps
 from ..exceptions import SetupError, ValidationError
 from ..log import log
 from .base import DATA_ARRAY_MAP, skip_if_fields_missing
@@ -459,8 +460,8 @@ def validate_mode_plane_radius(mode_spec: ModeSpec, plane: Box, msg_prefix: str 
     _, plane_axs = plane.pop_axis([0, 1, 2], plane.size.index(0.0))
     radial_ax = plane_axs[(mode_spec.bend_axis + 1) % 2]
 
-    if np.abs(mode_spec.bend_radius) < plane.size[radial_ax] / 2:
+    if not (np.abs(mode_spec.bend_radius) > plane.size[radial_ax] / 2 + fp_eps):
         raise ValueError(
-            f"{msg_prefix} bend radius is smaller than half the mode plane size "
-            "along the radial axis, which can produce wrong results."
+            f"{msg_prefix} bend radius must be larger than half the mode plane size "
+            "along the radial axis to avoid wrong results."
         )


### PR DESCRIPTION
The case when the two are equal could actually be particularly problematic as the bend center lies on a grid point, which is a singularity in our coordinate transformation.

So maybe I should even leave a bit of buffer extra?