### PR TITLE
Fix arrow curvature in bent sources/monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed scaling for adjoint sources when differentiating with respect to `FieldData` to account for the mesh size of the monitor and thus the created source. This aligns adjoint gradient magnitudes with numerical finite difference gradients for field data.
 - Warn when mode solver pml covers a significant portion of the mode plane.
 - TFSF server errors related to the auxiliary plane wave source that would previously happen on the server are now caught upon simulation creation.
+- Opposite arrow curvature for mode sources and monitors with non-zero bendind radius when plotted in the figure's Y axis.
 
 ### Changed
 - `num_freqs` in Gaussian beam type sources limited to 20, which should besufficient for all cases.

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -364,6 +364,11 @@ class AbstractModeMonitor(PlanarMonitor, FreqMonitor):
         kwargs_alpha = patch_kwargs.get("alpha")
         arrow_alpha = ARROW_ALPHA if kwargs_alpha is None else kwargs_alpha
 
+        bend_radius = self.mode_spec.bend_radius
+        # Curvature has to be reversed because of ploting coordinates
+        if (self.normal_axis, self._bend_axis) in [(1, 2), (2, 0), (2, 1)]:
+            bend_radius = -bend_radius
+
         # and then add an arrow using the direction comuputed from `_dir_arrow`.
         ax = self._plot_arrow(
             x=x,
@@ -371,7 +376,7 @@ class AbstractModeMonitor(PlanarMonitor, FreqMonitor):
             z=z,
             ax=ax,
             direction=self._dir_arrow,
-            bend_radius=self.mode_spec.bend_radius,
+            bend_radius=bend_radius,
             bend_axis=self._bend_axis,
             color=ARROW_COLOR_MONITOR,
             alpha=arrow_alpha,

--- a/tidy3d/components/source/base.py
+++ b/tidy3d/components/source/base.py
@@ -86,9 +86,15 @@ class Source(Box, AbstractSource, ABC):
         if self._dir_vector is not None:
             bend_radius = None
             bend_axis = None
-            if hasattr(self, "mode_spec"):
+            if hasattr(self, "mode_spec") and self.mode_spec.bend_radius is not None:
                 bend_radius = self.mode_spec.bend_radius
                 bend_axis = self._bend_axis
+                sign = 1 if self.direction == "+" else -1
+                # Curvature has to be reversed because of ploting coordinates
+                if (self.size.index(0), bend_axis) in [(1, 2), (2, 0), (2, 1)]:
+                    bend_radius *= -sign
+                else:
+                    bend_radius *= sign
 
             ax = self._plot_arrow(
                 x=x,


### PR DESCRIPTION
Fix for #2374

This should cover all test cases: [test.zip](https://github.com/user-attachments/files/19690624/test.zip)

Here's the result:
![image](https://github.com/user-attachments/assets/3c9d6350-bf14-448a-b911-9080cd73c318)