### PR TITLE
fix a colorbar reverse bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Performance enhancement for adjoint gradient calculations by optimizing field interpolation.
 
+### Fixed
+- Fixed `reverse` property of `td.Scene.plot_structures_property()` to also reverse the colorbar.
+
 ## [2.8.2] - 2025-04-09
 
 ### Added

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -61,6 +61,7 @@ from .validators import assert_unique_names
 from .viz import (
     MEDIUM_CMAP,
     STRUCTURE_EPS_CMAP,
+    STRUCTURE_EPS_CMAP_R,
     STRUCTURE_HEAT_COND_CMAP,
     PlotParams,
     add_ax_if_none,
@@ -1004,7 +1005,9 @@ class Scene(Tidy3dBaseModel):
                     ax=ax,
                 )
             else:
-                self._add_cbar_eps(eps_min=property_min, eps_max=property_max, ax=ax)
+                self._add_cbar_eps(
+                    eps_min=property_min, eps_max=property_max, ax=ax, reverse=reverse
+                )
 
         # clean up the axis display
         axis, _ = Box.parse_xyz_kwargs(x=x, y=y, z=z)
@@ -1017,10 +1020,14 @@ class Scene(Tidy3dBaseModel):
         return ax
 
     @staticmethod
-    def _add_cbar_eps(eps_min: float, eps_max: float, ax: Ax = None) -> None:
+    def _add_cbar_eps(eps_min: float, eps_max: float, ax: Ax = None, reverse: bool = False) -> None:
         """Add a permittivity colorbar to plot."""
         Scene._add_cbar(
-            vmin=eps_min, vmax=eps_max, label=r"$\epsilon_r$", cmap=STRUCTURE_EPS_CMAP, ax=ax
+            vmin=eps_min,
+            vmax=eps_max,
+            label=r"$\epsilon_r$",
+            cmap=STRUCTURE_EPS_CMAP if not reverse else STRUCTURE_EPS_CMAP_R,
+            ax=ax,
         )
 
     @staticmethod

--- a/tidy3d/components/viz.py
+++ b/tidy3d/components/viz.py
@@ -172,6 +172,7 @@ MEDIUM_CMAP = [
 
 # colormap for structure's permittivity in plot_eps
 STRUCTURE_EPS_CMAP = "gist_yarg"
+STRUCTURE_EPS_CMAP_R = "gist_yarg_r"
 STRUCTURE_HEAT_COND_CMAP = "gist_yarg"
 
 


### PR DESCRIPTION
It seems that the color bar is wrong when set reverse.

Before
![image](https://github.com/user-attachments/assets/d0a1bca5-06ed-4904-8cac-7a640eac6a8a)


After fixing


![image](https://github.com/user-attachments/assets/c00e50ae-365b-4a21-8704-c03e49b4ab18)
