### PR TITLE
fix: lazy import scipy and matplotlib

### DIFF
--- a/tidy3d/components/dispersion_fitter.py
+++ b/tidy3d/components/dispersion_fitter.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Optional, Tuple
 
 import numpy as np
-import scipy
 from pydantic.v1 import Field, NonNegativeFloat, PositiveFloat, PositiveInt, validator
 from rich.progress import Progress
 
@@ -493,6 +492,11 @@ class FastFitterData(AdvancedFastFitterParam):
     def iterate_poles(self) -> FastFitterData:
         """Perform a single iteration of the pole-updating procedure."""
 
+        try:
+            import scipy
+        except ImportError:
+            raise ImportError("scipy is required to fit the dispersion.")
+
         def compute_zeros(residues: ArrayComplex1D, d_tilde: float) -> ArrayComplex1D:
             """Compute the zeros from the residues."""
             size = len(self.real_poles) + 2 * len(self.complex_poles)
@@ -593,6 +597,12 @@ class FastFitterData(AdvancedFastFitterParam):
 
     def fit_residues(self) -> FastFitterData:
         """Fit residues."""
+
+        try:
+            import scipy
+        except ImportError:
+            raise ImportError("scipy is required to fit the dispersion.")
+
         # build the matrices
         if self.optimize_eps_inf:
             poly_len = 1
@@ -649,6 +659,11 @@ class FastFitterData(AdvancedFastFitterParam):
 
     def iterate_passivity(self, passivity_omega: ArrayFloat1D) -> Tuple[FastFitterData, int]:
         """Iterate passivity enforcement algorithm."""
+
+        try:
+            import scipy
+        except ImportError:
+            raise ImportError("scipy is required to fit the dispersion.")
 
         size = len(self.real_poles) + 2 * len(self.complex_poles)
         constraint_matrix = np.imag(self.pole_matrix_omega(passivity_omega))

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -15,7 +15,6 @@ import autograd.numpy as np
 import numpy as npo
 import pydantic.v1 as pd
 import xarray as xr
-from scipy import signal
 
 from tidy3d.components.material.tcad.heat import ThermalSpecType
 
@@ -3481,6 +3480,11 @@ class PoleResidue(DispersiveMedium):
             ``tuple`` is an array of coefficients representing any direct polynomial term.
 
         """
+
+        try:
+            from scipy import signal
+        except ImportError:
+            raise ImportError("scipy is required to use this method.")
 
         if a.ndim != 1 or np.any(np.iscomplex(a)):
             raise ValidationError(

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -11,8 +11,6 @@ from typing import Dict, List, Tuple, Union
 import numpy as np
 import pydantic.v1 as pydantic
 import xarray as xr
-from matplotlib.collections import PatchCollection
-from matplotlib.patches import Rectangle
 
 from ...constants import C_0
 from ...exceptions import SetupError, ValidationError
@@ -2315,6 +2313,13 @@ class ModeSolver(Tidy3dBaseModel):
         cls, simulation: Simulation, plane: Box, mode_spec: ModeSpec, ax: Ax = None
     ) -> Ax:
         """Plot the mode plane absorbing boundaries."""
+
+        try:
+            from matplotlib.collections import PatchCollection
+            from matplotlib.patches import Rectangle
+        except ImportError:
+            raise ImportError("matplotlib is required to plot the mode plane absorbing boundaries.")
+
         # Get the mode plane normal axis, center, and limits.
         _, h_lim, v_lim, _ = cls._center_and_lims(simulation=simulation, plane=plane)
 


### PR DESCRIPTION
MC ran into an issue with this since scipy and matplotlib are not installed in the minimal tidy3d install and tidy3d still needs to be importable.

@caseyflex @dmarek-flex fyi