### PR TITLE
Change return values to None instead of ValueError

### DIFF
--- a/tidy3d/components/material/tcad/charge.py
+++ b/tidy3d/components/material/tcad/charge.py
@@ -142,7 +142,7 @@ class SemiconductorMedium(AbstractChargeMedium):
             \\mathbf{F_{n,p}} = \\nabla \\psi
         \\end{equation}
 
-    i.e., we are not considering the effect of band-gab narrowing and degeneracy on the effective
+    i.e., we are not considering the effect of band-gap narrowing and degeneracy on the effective
     electric field :math:`\\mathbf{F_{n,p}}`. This is a good approximation for non-degenerate semiconductors.
 
     Let's explore how material properties are defined as class parameters or other classes.

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -867,24 +867,19 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
 
     @property
     def charge(self):
-        return ValueError(f"A `charge` medium does not exist in this Medium definition: {self}")
+        return None
 
     @property
     def electrical(self):
-        return ValueError(
-            f"An `electrical` medium does not exist in this Medium definition: {self}"
-        )
+        return None
 
     @property
     def heat(self):
-        if self.heat_spec:
-            return self.heat_spec
-        else:
-            return ValueError(f"A `heat` medium does not exist in this Medium definition: {self}")
+        return self.heat_spec
 
     @property
     def optical(self):
-        return ValueError(f"An `optical` medium does not exist in this Medium definition: {self}")
+        return None
 
     @pd.validator("modulation_spec", always=True)
     @skip_if_fields_missing(["nonlinear_spec"])

--- a/tidy3d/components/tcad/simulation/heat_charge.py
+++ b/tidy3d/components/tcad/simulation/heat_charge.py
@@ -189,6 +189,7 @@ class HeatChargeSimulation(AbstractSimulation):
     ... )
 
     To run a drift-diffusion (``Charge`` |:zap:|) system:
+
     >>> import tidy3d as td
     >>> air = td.FluidMedium(
     ...     name="air"


### PR DESCRIPTION
AbstractMedium was returning a `ValueError` instead of raising it. This seems like a bit too hard of a behavior so instead returning `None`. 

One question that I have (for @daquinteroflex ) is whether we should return `seff` in the `optical` case?

I have also added some minor improvements to the docs as pointed out by Xin Lei.