### PR TITLE
fix[adjoint]: remove frequency summing in polyslab gradient calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed `reverse` property of `td.Scene.plot_structures_property()` to also reverse the colorbar.
 
+### Fixed
+- Fixed bug in surface gradient computation where fields, instead of gradients, were being summed in frequency.
+
 ## [2.8.2] - 2025-04-09
 
 ### Added

--- a/tests/test_components/test_autograd_mode_polyslab_numerical.py
+++ b/tests/test_components/test_autograd_mode_polyslab_numerical.py
@@ -1,0 +1,470 @@
+# test autograd and compares to numerically computed finite difference gradients
+
+import operator
+import sys
+
+import autograd as ag
+import matplotlib.pylab as plt
+import numpy as np
+import pytest
+import tidy3d as td
+import tidy3d.web as web
+from scipy.ndimage import gaussian_filter
+
+PLOT_FD_ADJ_COMPARISON = False
+NUM_FINITE_DIFFERENCE = 10
+SAVE_FD_ADJ_DATA = False
+SAVE_FD_LOC = 0
+SAVE_ADJ_LOC = 1
+LOCAL_GRADIENT = True
+VERBOSE = False
+NUMERICAL_RESULTS_DATA_DIR = "./numerical_mode_polyslab_test/"
+SHOW_PRINT_STATEMENTS = False
+
+NUM_MODE_MONITOR_FREQUENCIES = 4
+
+RMS_THRESHOLD = 0.25
+
+if PLOT_FD_ADJ_COMPARISON:
+    pytestmark = pytest.mark.usefixtures("mpl_config_interactive")
+else:
+    pytestmark = pytest.mark.usefixtures("mpl_config_noninteractive")
+
+if SHOW_PRINT_STATEMENTS:
+    sys.stdout = sys.stderr
+
+MESH_FACTOR_DESIGN = 60.0
+
+
+def get_sim_geometry(mesh_wvl_um, offset_y_size_wvl=0):
+    return td.Box(size=(7 * mesh_wvl_um, 7 * mesh_wvl_um, 3 * mesh_wvl_um), center=(0, 0, 0))
+
+
+def make_base_sim(
+    mesh_wvl_um,
+    adj_wvl_um,
+    geometry_size_wvl,
+    box_for_override,
+    run_time=5e-11,
+):
+    """Creates a base simulation with input/output waveguides, mode sources, and mode monitors."""
+    sim_geometry = get_sim_geometry(mesh_wvl_um)
+    sim_size_um = sim_geometry.size
+    sim_center_um = sim_geometry.center
+
+    boundary_spec = td.BoundarySpec(
+        x=td.Boundary.pml(),
+        y=td.Boundary.pml(),
+        z=td.Boundary.pml(),
+    )
+
+    dl_design = mesh_wvl_um / MESH_FACTOR_DESIGN
+
+    mesh_overrides = []
+    mesh_overrides.extend(
+        [
+            td.MeshOverrideStructure(
+                geometry=box_for_override,
+                dl=[dl_design, dl_design, dl_design],
+            ),
+        ]
+    )
+
+    src_size = sim_size_um[0:2] + (0,)
+
+    wl_min_src_um = 0.9 * adj_wvl_um
+    wl_max_src_um = 1.1 * adj_wvl_um
+
+    fwidth_src = td.C_0 * ((1.0 / wl_min_src_um) - (1.0 / wl_max_src_um))
+    freq0 = td.C_0 / adj_wvl_um
+
+    pulse = td.GaussianPulse(freq0=freq0, fwidth=fwidth_src)
+    src = td.PlaneWave(
+        center=(0, 0, -2 * mesh_wvl_um),
+        size=src_size,
+        source_time=pulse,
+        direction="+",
+    )
+
+    wg_input_left = -0.75 * sim_size_um[0]
+    wg_input_right = sim_center_um[0] - 0.5 * geometry_size_wvl[0] * mesh_wvl_um
+
+    wg_output_left = sim_center_um[0] + 0.5 * geometry_size_wvl[0] * mesh_wvl_um
+    wg_output_right = 0.75 * sim_size_um[0]
+
+    wg_input_center = 0.5 * (wg_input_left + wg_input_right)
+    wg_output_center = 0.5 * (wg_output_left + wg_output_right)
+
+    wg_input_length = wg_input_right - wg_input_left
+    wg_output_length = wg_output_right - wg_output_left
+
+    src_input_center = 0.5 * (-0.5 * sim_size_um[0] + wg_input_right)
+    monitor_output_center = 0.5 * (0.5 * sim_size_um[0] + wg_output_left)
+
+    output_wg_y_offset_um = 0.5 * mesh_wvl_um
+
+    mode_layer_height_um = MODE_LAYER_HEIGHT_WVL * adj_wvl_um
+    input_waveguide_geometry = td.Box(
+        center=(wg_input_center, 0, 0.5 * mode_layer_height_um),
+        size=(wg_input_length, WG_WIDTH_WVL * adj_wvl_um, mode_layer_height_um),
+    )
+    output_waveguide_geometry = td.Box(
+        center=(wg_output_center, output_wg_y_offset_um, 0.5 * mode_layer_height_um),
+        size=(wg_output_length, WG_WIDTH_WVL * adj_wvl_um, mode_layer_height_um),
+    )
+    output_waveguide_geometry2 = td.Box(
+        center=(wg_output_center, -output_wg_y_offset_um, 0.5 * mode_layer_height_um),
+        size=(wg_output_length, WG_WIDTH_WVL * adj_wvl_um, mode_layer_height_um),
+    )
+
+    input_waveguide = td.Structure(
+        geometry=input_waveguide_geometry, medium=td.Medium(permittivity=WG_INDEX**2)
+    )
+    output_waveguide = td.Structure(
+        geometry=output_waveguide_geometry, medium=td.Medium(permittivity=WG_INDEX**2)
+    )
+    output_waveguide2 = td.Structure(
+        geometry=output_waveguide_geometry2, medium=td.Medium(permittivity=WG_INDEX**2)
+    )
+
+    substrate_max = 0
+    substrate_min = -0.75 * sim_size_um[2]
+    substrate = td.Structure(
+        geometry=td.Box(
+            center=(sim_center_um[0], sim_center_um[1], 0.5 * (substrate_max + substrate_min)),
+            size=(1.5 * sim_size_um[0], 1.5 * sim_size_um[1], (substrate_max - substrate_min)),
+        ),
+        medium=td.Medium(permittivity=SUBSTRATE_INDEX**2),
+    )
+
+    mode_monitor_freqs = np.linspace(0.9 * freq0, 1.05 * freq0, NUM_MODE_MONITOR_FREQUENCIES)
+    mode_monitor_top = td.ModeMonitor(
+        center=(
+            monitor_output_center + 0.15 * mesh_wvl_um,
+            output_wg_y_offset_um,
+            0.5 * mode_layer_height_um,
+        ),
+        size=(0, 5 * WG_WIDTH_WVL * mesh_wvl_um, 5 * mode_layer_height_um),
+        name="monitor_mode_top",
+        freqs=mode_monitor_freqs,
+    )
+
+    mode_monitor_bottom = td.ModeMonitor(
+        center=(monitor_output_center, -output_wg_y_offset_um, 0.5 * mode_layer_height_um),
+        size=(0, 5 * WG_WIDTH_WVL * mesh_wvl_um, 5 * mode_layer_height_um),
+        name="monitor_mode_bottom",
+        freqs=mode_monitor_freqs,
+    )
+
+    pulse = td.GaussianPulse(freq0=freq0, fwidth=fwidth_src)
+    mode_src = td.ModeSource(
+        center=(src_input_center, 0, 0.5 * mode_layer_height_um),
+        size=(0, 5 * WG_WIDTH_WVL * mesh_wvl_um, 5 * mode_layer_height_um),
+        name="src_mode",
+        source_time=pulse,
+        direction="+",
+    )
+
+    monitor_index_block = td.Box(
+        center=(0, 0, 0.25 * sim_size_um[2] + mesh_wvl_um),
+        size=tuple(2 * size for size in sim_size_um[0:2]) + (mesh_wvl_um + 0.5 * sim_size_um[2],),
+    )
+
+    sim_base = td.Simulation(
+        center=sim_center_um,
+        size=sim_size_um,
+        grid_spec=td.GridSpec.auto(
+            min_steps_per_wvl=20,
+            wavelength=mesh_wvl_um,
+            override_structures=mesh_overrides,
+        ),
+        structures=[input_waveguide, output_waveguide, output_waveguide2, substrate],
+        sources=[mode_src],
+        monitors=[mode_monitor_top, mode_monitor_bottom],
+        run_time=run_time,
+        boundary_spec=boundary_spec,
+        subpixel=True,
+    )
+
+    return sim_base
+
+
+def create_objective_function(
+    create_sim_base,
+    eval_fn,
+    sim_path_dir,
+    mode_layer_height_um,
+    polyslab_height_um,
+    polyslab_permittivity,
+):
+    """Create an objective function for the test based on the base simulation, type of evaluation function on
+    the electromagnetic data, and geometric and material parameters."""
+
+    def objective(vertices):
+        sim_base = create_sim_base()
+
+        simulation_dict = {}
+        for idx in range(0, len(vertices)):
+            vertices_x = vertices[idx][0:NUM_VERTICES]
+            vertices_y = vertices[idx][NUM_VERTICES:]
+
+            max_x = np.max(vertices_x)
+            min_x = np.min(vertices_x)
+            max_y = np.max(vertices_y)
+            min_y = np.min(vertices_y)
+
+            width = max_x - min_x
+            height = max_y - min_y
+            center_x = 0.5 * (min_x + max_x)
+            center_y = 0.5 * (min_y + max_y)
+
+            make_polyslab = td.PolySlab(
+                slab_bounds=(
+                    0.5 * mode_layer_height_um - 0.5 * polyslab_height_um,
+                    0.5 * mode_layer_height_um + 0.5 * polyslab_height_um,
+                ),
+                axis=2,
+                vertices=tuple(zip(vertices_x, vertices_y)),
+            )
+
+            polyslab_structure = td.Structure(
+                geometry=make_polyslab, medium=td.Medium(permittivity=polyslab_permittivity)
+            )
+
+            sim_with_polyslab = sim_base.updated_copy(
+                structures=sim_base.structures + (polyslab_structure,)
+            )
+
+            simulation_dict[f"numerical_mode_polyslab_testing_{idx}"] = sim_with_polyslab.copy()
+
+        sim_data = web.run_async(
+            simulation_dict, path_dir=sim_path_dir, local_gradient=LOCAL_GRADIENT, verbose=VERBOSE
+        )
+
+        objective_vals = []
+        for idx in range(0, len(vertices)):
+            objective_vals.append(eval_fn(sim_data[f"numerical_mode_polyslab_testing_{idx}"]))
+
+        if len(vertices) == 1:
+            return objective_vals[0]
+
+        return objective_vals
+
+    return objective
+
+
+# Parameters for controlling the test geometry and material parameters as well as the
+# array of tests to run.
+MODE_LAYER_HEIGHT_WVL = 0.25
+POLYSLAB_HEIGHT_WVL = MODE_LAYER_HEIGHT_WVL / 8.0
+WG_WIDTH_WVL = 0.275
+SUBSTRATE_INDEX = 1.5
+
+WG_INDEX = 3.5
+
+FINITE_DIFF_PERM_SEED = 0.5 * (1.0**2 + WG_INDEX**2)
+
+# Number of vertices to put in the test polyslab.
+NUM_VERTICES = 15
+
+mesh_wvls_um = [1.55, 1.55, 10 * 1.55, 10 * 1.55]
+adj_wvls_um = [1.5, 2.0, 10 * 1.55, 10 * 2.0]
+# mesh_wvls_um = [1.55, 1.55, 10 * 1.55, 10 * 1.55]
+# adj_wvls_um = [2.0, 2.0, 10 * 1.55, 10 * 2.0]
+geometry_sizes_wvl = [(3.0, 3.0, MODE_LAYER_HEIGHT_WVL)]
+polyslab_indices = np.linspace(SUBSTRATE_INDEX, WG_INDEX, 5)
+
+mode_data_test_parameters = []
+
+test_number = 0
+for idx in range(0, len(mesh_wvls_um)):
+    mesh_wvl_um = mesh_wvls_um[idx]
+    adj_wvl_um = adj_wvls_um[idx]
+
+    for geometry_size_wvl in geometry_sizes_wvl:
+        for polyslab_index in polyslab_indices:
+            polyslab_permittivity = polyslab_index**2
+
+            mode_data_test_parameters.append(
+                {
+                    "mesh_wvl_um": mesh_wvl_um,
+                    "adj_wvl_um": adj_wvl_um,
+                    "geometry_size_wvl": geometry_size_wvl,
+                    "polyslab_permittivity": polyslab_permittivity,
+                    "test_number": test_number,
+                }
+            )
+
+            test_number += 1
+
+
+@pytest.mark.numerical
+@pytest.mark.parametrize(
+    "mode_data_test_parameters, dir_name",
+    zip(
+        mode_data_test_parameters,
+        ([NUMERICAL_RESULTS_DATA_DIR] if SAVE_FD_ADJ_DATA else [None])
+        * len(mode_data_test_parameters),
+    ),
+    indirect=["dir_name"],
+)
+def test_finite_difference_mode_data_polyslab(
+    mode_data_test_parameters, rng, tmp_path, create_directory
+):
+    """Test a variety of autograd permittivity gradients for ModeData in combination with polyslab by"""
+    """comparing them to numerical finite difference."""
+
+    test_results = np.zeros((2, NUM_FINITE_DIFFERENCE))
+
+    test_number = mode_data_test_parameters["test_number"]
+
+    (
+        mesh_wvl_um,
+        adj_wvl_um,
+        geometry_size_wvl,
+        polyslab_permittivity,
+        test_number,
+    ) = operator.itemgetter(
+        "mesh_wvl_um",
+        "adj_wvl_um",
+        "geometry_size_wvl",
+        "polyslab_permittivity",
+        "test_number",
+    )(mode_data_test_parameters)
+
+    adj_freq = td.C_0 / adj_wvl_um
+
+    dim_x_um = geometry_size_wvl[0] * mesh_wvl_um * 2
+    dim_y_um = geometry_size_wvl[1] * mesh_wvl_um * 2
+    thickness_um = geometry_size_wvl[2] * mesh_wvl_um
+
+    dim_x = 1 + int(dim_x_um / (mesh_wvl_um / MESH_FACTOR_DESIGN))
+    dim_y = 1 + int(dim_y_um / (mesh_wvl_um / MESH_FACTOR_DESIGN))
+    Nz = 1 + int(thickness_um / (mesh_wvl_um / MESH_FACTOR_DESIGN))
+
+    sim_geometry = get_sim_geometry(mesh_wvl_um)
+
+    box_for_override = td.Box(
+        center=(0, 0, 0),
+        size=(np.inf, np.inf) + (MODE_LAYER_HEIGHT_WVL * mesh_wvl_um + mesh_wvl_um,),
+    )
+
+    sim_path_dir = tmp_path / f"test{test_number}"
+    sim_path_dir.mkdir()
+
+    # Weights for creating a random objective function over multiple frequencies by
+    # summing their contributions by random weights. This helps verify gradient errors
+    # due to a multifrequency objective function.
+    monitor_top_weights = rng.random(NUM_MODE_MONITOR_FREQUENCIES)
+    monitor_bottom_weights = rng.random(NUM_MODE_MONITOR_FREQUENCIES)
+
+    def eval_fn(sim_data):
+        return np.sum(
+            monitor_top_weights
+            * np.abs(sim_data["monitor_mode_top"].amps.sel(direction="+").values) ** 2
+        ) + np.sum(
+            monitor_bottom_weights
+            * np.abs(sim_data["monitor_mode_bottom"].amps.sel(direction="+").values) ** 2
+        )
+
+    polyslab_height_um = POLYSLAB_HEIGHT_WVL * adj_wvl_um
+
+    objective = create_objective_function(
+        lambda mesh_wvl_um=mesh_wvl_um,
+        adj_wvl_um=adj_wvl_um,
+        geometry_size_wvl=geometry_size_wvl,
+        polyslab_permittivity=polyslab_permittivity,
+        box_for_override=box_for_override: make_base_sim(
+            mesh_wvl_um=mesh_wvl_um,
+            adj_wvl_um=adj_wvl_um,
+            geometry_size_wvl=geometry_size_wvl,
+            box_for_override=box_for_override,
+        ),
+        eval_fn,
+        sim_path_dir=str(sim_path_dir),
+        mode_layer_height_um=MODE_LAYER_HEIGHT_WVL * mesh_wvl_um,
+        polyslab_height_um=polyslab_height_um,
+        polyslab_permittivity=polyslab_permittivity,
+    )
+
+    obj_val_and_grad = ag.value_and_grad(objective)
+
+    # Empirically chosen step size for these tests to get good finite difference gradients.
+    # In the future, can be replaced by checking convergence of finite difference gradient with
+    # chosen step size.
+    fd_step = (
+        0.2 * adj_wvl_um
+    )  # 0.5 * mesh_wvl_um#0.1 * mesh_wvl_um# 0.3 * mesh_wvl_um#0.2 * mesh_wvl_um
+
+    all_vertex = []
+    pattern_dot_adj_gradient = np.zeros(NUM_FINITE_DIFFERENCE)
+
+    angles = np.linspace(0, 2 * np.pi, NUM_VERTICES + 1)[0:-1]
+    vertex_centers_x = 1.1 * mesh_wvl_um * np.cos(angles)
+    vertex_centers_y = 0.8 * mesh_wvl_um * np.sin(angles)
+
+    obj, adj_grad = obj_val_and_grad([list(vertex_centers_x) + list(vertex_centers_y)])
+
+    for fd_idx in range(0, NUM_FINITE_DIFFERENCE):
+        # Create random perturbation of vertices to check against the computed adjoint gradient.
+        random_pattern = rng.random(2 * NUM_VERTICES) - 0.5
+        random_pattern = gaussian_filter(random_pattern, sigma=1)
+        random_pattern /= np.linalg.norm(random_pattern)
+
+        pattern_dot_adj_gradient[fd_idx] = np.sum(random_pattern * adj_grad)
+
+        vertex_centers_up_x = vertex_centers_x + random_pattern[0:NUM_VERTICES] * fd_step
+        vertex_centers_up_y = vertex_centers_y + random_pattern[NUM_VERTICES:] * fd_step
+
+        vertex_centers_down_x = vertex_centers_x - random_pattern[0:NUM_VERTICES] * fd_step
+        vertex_centers_down_y = vertex_centers_y - random_pattern[NUM_VERTICES:] * fd_step
+
+        all_vertex.append(list(vertex_centers_up_x) + list(vertex_centers_up_y))
+        all_vertex.append(list(vertex_centers_down_x) + list(vertex_centers_down_y))
+
+    all_obj = objective(all_vertex)
+
+    fd_grad = np.zeros(NUM_FINITE_DIFFERENCE)
+    for fd_idx in range(0, NUM_FINITE_DIFFERENCE):
+        obj_up_location = 2 * fd_idx
+        obj_down_location = 2 * fd_idx + 1
+
+        fd_grad[fd_idx] = (all_obj[obj_up_location] - all_obj[obj_down_location]) / (2 * fd_step)
+
+    rms_error = np.linalg.norm(fd_grad - pattern_dot_adj_gradient)
+    fd_mag = np.linalg.norm(fd_grad)
+    adj_mag = np.linalg.norm(pattern_dot_adj_gradient)
+    percentage_error = 100.0 * np.mean(
+        (fd_grad - pattern_dot_adj_gradient) / (fd_grad + np.finfo(np.float64).eps)
+    )
+
+    print("\n" * 3)
+    print("-" * 20)
+    print(f"Numerical test #{test_number}")
+    print(f"Mesh and adjoint wavelengths: {mesh_wvl_um}, {adj_wvl_um}")
+    print(f"Geometry size: {geometry_size_wvl}")
+    print(f"RMS Error: {rms_error}")
+    print(f"FD, Adj magnitudes: {fd_mag}, {adj_mag}")
+    print(f"Percentage Error: {percentage_error}")
+    print("-" * 20)
+    print("\n" * 3)
+
+    assert rms_error < RMS_THRESHOLD * fd_mag, "RMS error magnitude too large"
+
+    test_results[SAVE_FD_LOC, :] = fd_grad
+    test_results[SAVE_ADJ_LOC, :] = pattern_dot_adj_gradient
+
+    test_number += 1
+
+    if PLOT_FD_ADJ_COMPARISON:
+        plt.plot(pattern_dot_adj_gradient, color="g", linewidth=2.0)
+        plt.plot(fd_grad, color="b", linewidth=1.5, linestyle="--")
+        plt.title("Gradient:")
+        plt.legend(["Adjoint", "Finite difference"])
+        plt.xlabel("Sample number")
+        plt.ylabel("Gradient value")
+        plt.legend()
+        plt.show()
+
+    if SAVE_FD_ADJ_DATA:
+        np.save(f"{NUMERICAL_RESULTS_DATA_DIR}/results_{test_number}.npy", test_results)

--- a/tests/test_components/test_autograd_numerical.py
+++ b/tests/test_components/test_autograd_numerical.py
@@ -31,6 +31,7 @@ else:
 if SHOW_PRINT_STATEMENTS:
     sys.stdout = sys.stderr
 
+
 FINITE_DIFF_PERM_SEED = 1.5**2
 MESH_FACTOR_DESIGN = 30.0
 
@@ -255,9 +256,6 @@ def test_finite_difference_field_data(field_data_test_parameters, rng, tmp_path,
         "test_number",
     )(field_data_test_parameters)
 
-    mesh_wvl_um = mesh_wvls_um[idx]
-    adj_wvl_um = adj_wvls_um[idx]
-
     dim_um = mesh_wvl_um
     dim_um = mesh_wvl_um
     thickness_um = 0.5 * mesh_wvl_um
@@ -296,7 +294,7 @@ def test_finite_difference_field_data(field_data_test_parameters, rng, tmp_path,
 
     obj_val_and_grad = ag.value_and_grad(objective)
 
-    perm_init = FINITE_DIFF_PERM_SEED**2 * np.ones((dim, dim, Nz))
+    perm_init = FINITE_DIFF_PERM_SEED * np.ones((dim, dim, Nz))
 
     obj, adj_grad = obj_val_and_grad([perm_init])
 

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -249,10 +249,18 @@ class DerivativeInfo(Tidy3dBaseModel):
         D_adj = self.D_adj
 
         # compute the E and D fields at the edge centers
-        E_fwd_at_coords = self.evaluate_flds_at(fld_dataset=E_fwd, spatial_coords=spatial_coords)
-        E_adj_at_coords = self.evaluate_flds_at(fld_dataset=E_adj, spatial_coords=spatial_coords)
-        D_fwd_at_coords = self.evaluate_flds_at(fld_dataset=D_fwd, spatial_coords=spatial_coords)
-        D_adj_at_coords = self.evaluate_flds_at(fld_dataset=D_adj, spatial_coords=spatial_coords)
+        E_fwd_at_coords = self.evaluate_flds_at(
+            fld_dataset=E_fwd, spatial_coords=spatial_coords, freq=self.frequency
+        )
+        E_adj_at_coords = self.evaluate_flds_at(
+            fld_dataset=E_adj, spatial_coords=spatial_coords, freq=self.frequency
+        )
+        D_fwd_at_coords = self.evaluate_flds_at(
+            fld_dataset=D_fwd, spatial_coords=spatial_coords, freq=self.frequency
+        )
+        D_adj_at_coords = self.evaluate_flds_at(
+            fld_dataset=D_adj, spatial_coords=spatial_coords, freq=self.frequency
+        )
 
         # project the relevant field quantities into their respective basis for gradient calculation
         D_fwd_norm = self.project_in_basis(D_fwd_at_coords, basis_vector=normals)
@@ -303,6 +311,7 @@ class DerivativeInfo(Tidy3dBaseModel):
         eps_out = self.evaluate_flds_at(
             fld_dataset={key: permittivity_array},
             spatial_coords=spatial_coords,
+            freq=self.frequency,
         )[key]
         return eps_out.values
 
@@ -310,6 +319,7 @@ class DerivativeInfo(Tidy3dBaseModel):
     def evaluate_flds_at(
         fld_dataset: dict[str, ScalarFieldDataArray],
         spatial_coords: np.ndarray,  # (N, 3)
+        freq: float,
     ) -> dict[str, ScalarFieldDataArray]:
         """Compute the value of an dict with keys Ex, Ey, Ez at a set of spatial locations."""
 
@@ -317,28 +327,18 @@ class DerivativeInfo(Tidy3dBaseModel):
 
         coords = np.nan_to_num(spatial_coords, posinf=LARGE_NUMBER, neginf=-LARGE_NUMBER)
         components = {}
+
         edge_index_dim = "edge_index"
         n_points = coords.shape[0]
 
         for fld_name, arr in fld_dataset.items():
-            data = arr.values
+            data = arr.sel(f=freq).values if "f" in arr.dims else arr.values
             points = tuple(arr.coords[dim].values for dim in "xyz")
-            interp_kwargs = {"method": "linear", "bounds_error": False, "fill_value": None}
 
-            if "f" in arr.dims:
-                f_dim_idx = arr.dims.index("f")
-                result = np.zeros(n_points, dtype=data.dtype)
-
-                for f_idx in range(data.shape[f_dim_idx]):
-                    slicer = [slice(None)] * data.ndim
-                    slicer[f_dim_idx] = f_idx
-                    interpolator = RegularGridInterpolator(
-                        points, data[tuple(slicer)], **interp_kwargs
-                    )
-                    result += interpolator(coords)
-            else:
-                interpolator = RegularGridInterpolator(points, data, **interp_kwargs)
-                result = interpolator(coords)
+            interpolator = RegularGridInterpolator(
+                points, data, method="linear", bounds_error=False, fill_value=None
+            )
+            result = interpolator(coords)
 
             components[fld_name] = xr.DataArray(
                 result,

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -2554,8 +2554,10 @@ class Box(SimplePlaneIntersection, Centered):
         fld_normal, flds_perp = self.pop_axis(("Ex", "Ey", "Ez"), axis=axis_normal)
 
         # normal and tangential fields
-        D_normal = derivative_info.D_der_map[fld_normal]
-        Es_perp = tuple(derivative_info.E_der_map[key] for key in flds_perp)
+        D_normal = derivative_info.D_der_map[fld_normal].sel(f=derivative_info.frequency)
+        Es_perp = tuple(
+            derivative_info.E_der_map[key].sel(f=derivative_info.frequency) for key in flds_perp
+        )
 
         # normal and tangential bounds
         bounds_T = np.array(derivative_info.bounds).T  # put (xyz) first dimension
@@ -2580,7 +2582,10 @@ class Box(SimplePlaneIntersection, Centered):
             return 0.0
 
         # grab permittivity data inside and outside edge in normal direction
-        eps_xyz = [derivative_info.eps_data[f"eps_{dim}{dim}"] for dim in "xyz"]
+        eps_xyz = [
+            derivative_info.eps_data[f"eps_{dim}{dim}"].sel(f=derivative_info.frequency)
+            for dim in "xyz"
+        ]
 
         # number of cells from the edge of data to register "inside" (index = num_cells_in - 1)
         num_cells_in = 4
@@ -2621,7 +2626,7 @@ class Box(SimplePlaneIntersection, Centered):
                 bounds=bounds_perp,
             )
 
-            return complex(integral_result.sum(dim="f"))
+            return complex(integral_result)
 
         # put together VJP using D_normal and E_perp integration
         vjp_value = 0.0

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -977,11 +977,11 @@ def postprocess_adj(
         eps_adj = sim_data_adj.get_adjoint_data(structure_index, data_type="eps")
 
         # post normalize the adjoint fields if a single, broadband source
-        fwd_flds_normed = {}
+        adj_flds_normed = {}
         for key, val in E_adj.field_components.items():
-            fwd_flds_normed[key] = val * sim_data_adj.simulation.post_norm
+            adj_flds_normed[key] = val * sim_data_adj.simulation.post_norm
 
-        E_adj = E_adj.updated_copy(**fwd_flds_normed)
+        E_adj = E_adj.updated_copy(**adj_flds_normed)
 
         # maps of the E_fwd * E_adj and D_fwd * D_adj, each as as td.FieldData & 'Ex', 'Ey', 'Ez'
         der_maps = get_derivative_maps(
@@ -996,78 +996,87 @@ def postprocess_adj(
         # compute the derivatives for this structure
         structure = sim_data_fwd.simulation.structures[structure_index]
 
-        # todo: handle multi-frequency, move to a property?
-        frequencies = {src.source_time.freq0 for src in sim_data_adj.simulation.sources}
-        frequencies = list(frequencies)
-        freq_adj = frequencies[0] or None
+        adjoint_frequencies = E_adj.monitor.freqs
+        for freq_idx, freq_adj in enumerate(adjoint_frequencies):
+            eps_in = np.mean(structure.medium.eps_model(freq_adj))
+            eps_out = np.mean(sim_data_orig.simulation.medium.eps_model(freq_adj))
+            if structure.background_medium:
+                eps_background = structure.background_medium.eps_model(freq_adj)
+            else:
+                eps_background = None
 
-        eps_in = np.mean(structure.medium.eps_model(freq_adj))
-        eps_out = np.mean(sim_data_orig.simulation.medium.eps_model(freq_adj))
-        if structure.background_medium:
-            eps_background = structure.background_medium.eps_model(freq_adj)
-        else:
-            eps_background = None
+            # manually override simulation medium as the background structure
+            if not isinstance(structure.geometry, td.Box):
+                # auto permittivity detection
+                sim_orig = sim_data_orig.simulation
+                plane_eps = eps_fwd.monitor.geometry
 
-        # manually override simulation medium as the background structure
-        if not isinstance(structure.geometry, td.Box):
-            # auto permittivity detection
-            sim_orig = sim_data_orig.simulation
-            plane_eps = eps_fwd.monitor.geometry
+                # get permittivity without this structure
+                structs_no_struct = list(sim_orig.structures)
+                structs_no_struct.pop(structure_index)
+                sim_no_structure = sim_orig.updated_copy(structures=structs_no_struct)
+                eps_no_structure = sim_no_structure.epsilon(
+                    box=plane_eps, coord_key="centers", freq=freq_adj
+                )
 
-            # get permittivity without this structure
-            structs_no_struct = list(sim_orig.structures)
-            structs_no_struct.pop(structure_index)
-            sim_no_structure = sim_orig.updated_copy(structures=structs_no_struct)
-            eps_no_structure = sim_no_structure.epsilon(
-                box=plane_eps, coord_key="centers", freq=freq_adj
+                # get permittivity with structures on top of an infinite version of this structure
+                structs_inf_struct = list(sim_orig.structures)[structure_index + 1 :]
+                sim_inf_structure = sim_orig.updated_copy(
+                    structures=structs_inf_struct,
+                    medium=structure.medium,
+                    monitors=[],
+                )
+                eps_inf_structure = sim_inf_structure.epsilon(
+                    box=plane_eps, coord_key="centers", freq=freq_adj
+                )
+
+            else:
+                eps_no_structure = eps_inf_structure = None
+
+            # get minimum intersection of bounds with structure and sim
+            struct_bounds = rmin_struct, rmax_struct = structure.geometry.bounds
+            rmin_sim, rmax_sim = sim_data_orig.simulation.bounds
+            rmin_intersect = tuple([max(a, b) for a, b in zip(rmin_sim, rmin_struct)])
+            rmax_intersect = tuple([min(a, b) for a, b in zip(rmax_sim, rmax_struct)])
+            bounds_intersect = (rmin_intersect, rmax_intersect)
+
+            derivative_info = DerivativeInfo(
+                paths=structure_paths,
+                E_der_map=E_der_map.field_components,
+                D_der_map=D_der_map.field_components,
+                E_fwd=E_fwd.field_components,
+                E_adj=E_adj.field_components,
+                D_fwd=D_fwd.field_components,
+                D_adj=D_adj.field_components,
+                eps_data=eps_fwd.field_components,
+                eps_in=eps_in,
+                eps_out=eps_out,
+                eps_background=eps_background,
+                frequency=freq_adj,
+                eps_no_structure=eps_no_structure,
+                eps_inf_structure=eps_inf_structure,
+                bounds=struct_bounds,
+                bounds_intersect=bounds_intersect,
             )
 
-            # get permittivity with structures on top of an infinite version of this structure
-            structs_inf_struct = list(sim_orig.structures)[structure_index + 1 :]
-            sim_inf_structure = sim_orig.updated_copy(
-                structures=structs_inf_struct,
-                medium=structure.medium,
-                monitors=[],
-            )
-            eps_inf_structure = sim_inf_structure.epsilon(
-                box=plane_eps, coord_key="centers", freq=freq_adj
-            )
+            vjp_value_map = structure.compute_derivatives(derivative_info)
 
-        else:
-            eps_no_structure = eps_inf_structure = None
-
-        # get minimum intersection of bounds with structure and sim
-        struct_bounds = rmin_struct, rmax_struct = structure.geometry.bounds
-        rmin_sim, rmax_sim = sim_data_orig.simulation.bounds
-        rmin_intersect = tuple([max(a, b) for a, b in zip(rmin_sim, rmin_struct)])
-        rmax_intersect = tuple([min(a, b) for a, b in zip(rmax_sim, rmax_struct)])
-        bounds_intersect = (rmin_intersect, rmax_intersect)
-
-        derivative_info = DerivativeInfo(
-            paths=structure_paths,
-            E_der_map=E_der_map.field_components,
-            D_der_map=D_der_map.field_components,
-            E_fwd=E_fwd.field_components,
-            E_adj=E_adj.field_components,
-            D_fwd=D_fwd.field_components,
-            D_adj=D_adj.field_components,
-            eps_data=eps_fwd.field_components,
-            eps_in=eps_in,
-            eps_out=eps_out,
-            eps_background=eps_background,
-            frequency=freq_adj,
-            eps_no_structure=eps_no_structure,
-            eps_inf_structure=eps_inf_structure,
-            bounds=struct_bounds,
-            bounds_intersect=bounds_intersect,
-        )
-
-        vjp_value_map = structure.compute_derivatives(derivative_info)
-
-        # extract VJPs and put back into sim_fields_vjp AutogradFieldMap
-        for structure_path, vjp_value in vjp_value_map.items():
-            sim_path = tuple(["structures", structure_index] + list(structure_path))
-            sim_fields_vjp[sim_path] = vjp_value
+            # extract VJPs and put back into sim_fields_vjp AutogradFieldMap
+            for structure_path, vjp_value in vjp_value_map.items():
+                sim_path = tuple(["structures", structure_index] + list(structure_path))
+                if freq_idx == 0:
+                    sim_fields_vjp[sim_path] = vjp_value
+                else:
+                    if isinstance(sim_fields_vjp[sim_path], (list, tuple)):
+                        if not isinstance(sim_fields_vjp[sim_path], type(vjp_value)):
+                            raise AdjointError(
+                                f"Unexpected vjp value type for gradient field {sim_path}"
+                            )
+                        sim_fields_vjp[sim_path] = type(sim_fields_vjp[sim_path])(
+                            x + y for x, y in zip(vjp_value, sim_fields_vjp[sim_path])
+                        )
+                    else:
+                        sim_fields_vjp[sim_path] += vjp_value
 
     return sim_fields_vjp
 


### PR DESCRIPTION
Fixes error in grad_surfaces where the fields were being summed in frequency when boundary fields were being queried. The frequency summing is moved outside of the grad_surfaces and box gradient calls and gradients at each frequency are summed over.

We also add a polyslab numerical testing with mode sources that can be run by specifying "-m numerical" in pytest call.