### PR TITLE
feat[FieldData]: export to ZBF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Differentiable function `td.plugins.autograd.interpolate_spline` for 1D linear, quadratic, and cubic spline interpolation, supporting differentiation with respect to the interpolated values (`y_points`) and optional endpoint derivative constraints.
 - `SteadyEnergyBandMonitor` in the Charge solver.
 - Pretty printing enabled with `rich.print` for the material library, materials, and their variants. In notebooks, this can be accessed using `rich.print` or `display`, or by evaluating the material library, a material, or a variant in a cell.
+- `FieldData` and `ModeData` support exporting E fields to a Zemax Beam File (ZBF) with `.to_zbf()` (warning: experimental feature).
+- `FieldDataset` supports reading E fields from a Zemax Beam File (ZBF) with `.from_zbf()` (warning: experimental feature).
 
 ### Changed
 - Performance enhancement for adjoint gradient calculations by optimizing field interpolation.

--- a/tests/test_data/test_monitor_data.py
+++ b/tests/test_data/test_monitor_data.py
@@ -21,9 +21,11 @@ from tidy3d.components.data.monitor_data import (
     ModeData,
     PermittivityData,
 )
+from tidy3d.components.data.zbf import ZBFData
+from tidy3d.constants import UnitScaling
 from tidy3d.exceptions import DataError
 
-from ..utils import AssertLogLevel
+from ..utils import AssertLogLevel, run_emulated
 from .test_data_arrays import (
     AUX_FIELD_TIME_MONITOR,
     DIFFRACTION_MONITOR,
@@ -865,3 +867,190 @@ def test_no_nans():
     )
     with pytest.raises(pydantic.ValidationError):
         td.CustomMedium(eps_dataset=eps_dataset_nan)
+
+
+class TestZBF:
+    """Tests exporting field data to a zbf file"""
+
+    freq0 = td.C_0 / 0.75
+    freqs = (freq0, freq0 * 1.01)
+
+    def simdata(self, monitor) -> td.SimulationData:
+        """Returns emulated simulation data"""
+        source = td.PointDipole(
+            center=(-1.5, 0, 0),
+            source_time=td.GaussianPulse(freq0=self.freq0, fwidth=self.freq0 / 10.0),
+            polarization="Ey",
+        )
+        sim = td.Simulation(
+            size=(4, 3, 3),
+            grid_spec=td.GridSpec.auto(min_steps_per_wvl=10),
+            structures=[],
+            sources=[source],
+            monitors=[monitor],
+            run_time=120 / self.freq0,
+        )
+        return run_emulated(sim)
+
+    @pytest.fixture(scope="class")
+    def field_data(self) -> td.FieldData:
+        """Make random field data from an emulated simulation run."""
+        monitor = td.FieldMonitor(
+            size=(td.inf, td.inf, 0),
+            freqs=self.freqs,
+            name="fields",
+            colocate=True,
+        )
+        return self.simdata(monitor)["fields"]
+
+    @pytest.fixture(scope="class")
+    def mode_data(self) -> td.ModeData:
+        """Make random ModeData from an emulated simulation run."""
+        monitor = td.ModeMonitor(
+            size=(td.inf, td.inf, 0),
+            freqs=self.freqs,
+            name="modes",
+            colocate=True,
+            mode_spec=td.ModeSpec(num_modes=2, target_neff=4.0),
+            store_fields_direction="+",
+        )
+        return self.simdata(monitor)["modes"]
+
+    @pytest.mark.parametrize("background_index", [1, 2, 3])
+    @pytest.mark.parametrize("freq", list(freqs) + [None])
+    @pytest.mark.parametrize("n_x", [2**5, 2**6])
+    @pytest.mark.parametrize("n_y", [2**5, 2**6])
+    @pytest.mark.parametrize("units", ["mm", "cm", "in", "m"])
+    def test_fielddata_tozbf_readzbf(
+        self, tmp_path, field_data, background_index, freq, n_x, n_y, units
+    ):
+        """Test that FieldData.to_zbf() -> ZBFData.read_zbf() works"""
+        zbf_filename = tmp_path / "testzbf.zbf"
+
+        # write to zbf and then load it back in
+        ex, ey = field_data.to_zbf(
+            fname=zbf_filename,
+            background_refractive_index=background_index,
+            freq=freq,
+            n_x=n_x,
+            n_y=n_y,
+            units=units,
+        )
+        zbfdata = ZBFData.read_zbf(zbf_filename)
+
+        assert zbfdata.background_refractive_index == background_index
+
+        unitscaling = UnitScaling[units]
+
+        if freq is not None:
+            assert np.isclose(zbfdata.wavelength / unitscaling, td.C_0 / freq)
+        else:
+            assert np.isclose(
+                zbfdata.wavelength / unitscaling,
+                td.C_0 / np.mean(field_data.monitor.freqs),
+            )
+
+        assert zbfdata.nx == n_x
+        assert zbfdata.ny == n_y
+
+        # check that fields are close
+        assert np.allclose(ex.values, zbfdata.Ex)
+        assert np.allclose(ey.values, zbfdata.Ey)
+
+    @pytest.mark.parametrize("mode_index", [0, 1])
+    def test_tozbf_modedata(self, tmp_path, mode_data, mode_index):
+        """Tests ModeData.to_zbf()"""
+        zbf_filename = tmp_path / "testzbf_modedata.zbf"
+
+        # write to zbf and then load it back in
+        ex, ey = mode_data.to_zbf(
+            fname=zbf_filename,
+            background_refractive_index=1,
+            freq=self.freq0,
+            mode_index=mode_index,
+            n_x=32,
+            n_y=32,
+            units="mm",
+        )
+        zbfdata = ZBFData.read_zbf(zbf_filename)
+
+        # check that fields are close
+        assert np.allclose(ex.values, zbfdata.Ex)
+        assert np.allclose(ey.values, zbfdata.Ey)
+
+    def test_tozbf_modedata_fails(self, tmp_path, mode_data):
+        """Asserts that Modedata.to_zbf() fails if mode_index is not specified"""
+        with pytest.raises(ValueError) as e:
+            _ = mode_data.to_zbf(
+                fname=tmp_path / "testzbf_modedata_fail.zbf",
+                background_refractive_index=1,
+                freq=self.freq0,
+                mode_index=None,
+                n_x=32,
+                n_y=32,
+                units="mm",
+            )
+
+    @pytest.mark.parametrize("n_x", [16, 2**14, 33])
+    @pytest.mark.parametrize("n_y", [16, 2**14, 33])
+    def test_tozbf_nxny_fails(self, tmp_path, field_data, n_x, n_y):
+        """Asserts that to_zbf() fails when n_x and n_y are invalid values."""
+        with pytest.raises(ValueError) as e:
+            _ = field_data.to_zbf(
+                fname=tmp_path / "testzbf_nxny_fail.zbf",
+                background_refractive_index=1,
+                freq=self.freq0,
+                n_x=n_x,
+                n_y=n_y,
+                units="mm",
+            )
+
+    @pytest.mark.parametrize("units", ["mmm", "123"])
+    def test_tozbf_units_fails(self, tmp_path, field_data, units):
+        """Asserts that to_zbf() fails when units are invalid."""
+        with pytest.raises(ValueError) as e:
+            _ = field_data.to_zbf(
+                fname=tmp_path / "testzbf_nxny_fail.zbf",
+                background_refractive_index=1,
+                freq=self.freq0,
+                n_x=32,
+                n_y=32,
+                units=units,
+            )
+
+    def test_from_zbf(self, tmp_path, field_data):
+        """Tests creating a field dataset from a zbf"""
+        zbf_filename = tmp_path / "testzbf.zbf"
+        # write to zbf and then load it back in
+        ex, ey = field_data.to_zbf(
+            fname=zbf_filename,
+            background_refractive_index=1,
+            n_x=32,
+            n_y=32,
+            units="mm",
+        )
+
+        # create a field dataset from the zbf file
+        fd = td.FieldDataset.from_zbf(filename=zbf_filename, dim1="x", dim2="y")
+
+        # compare loaded field data to saved data
+        assert np.allclose(ex.values, fd.Ex.values.squeeze())
+        assert np.allclose(ey.values, fd.Ey.values.squeeze())
+
+    @pytest.mark.parametrize(
+        "dim1,dim2", [("x", "x"), ("y", "y"), ("z", "z"), ("1", "2"), ("c", "z")]
+    )
+    def test_from_zbf_dimsfail(self, tmp_path, field_data, dim1, dim2):
+        """Tests fail cases when the dimensions to populate are wrong."""
+        zbf_filename = tmp_path / "testzbf.zbf"
+        # write to zbf and then load it back in
+        _, _ = field_data.to_zbf(
+            fname=zbf_filename,
+            background_refractive_index=1,
+            n_x=32,
+            n_y=32,
+            units="mm",
+        )
+        # this should fail
+        with pytest.raises(ValueError) as e:
+            _ = td.FieldDataset.from_zbf(filename=zbf_filename, dim1=dim1, dim2=dim2)

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -3,17 +3,17 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union, get_args
 
 import numpy as np
 import pydantic.v1 as pd
 import xarray as xr
 
-from ...constants import PICOSECOND_PER_NANOMETER_PER_KILOMETER
+from ...constants import C_0, PICOSECOND_PER_NANOMETER_PER_KILOMETER, UnitScaling
 from ...exceptions import DataError
 from ...log import log
 from ..base import Tidy3dBaseModel
-from ..types import Axis
+from ..types import Axis, xyz
 from .data_array import (
     DataArray,
     EMEScalarFieldDataArray,
@@ -28,6 +28,7 @@ from .data_array import (
     TimeDataArray,
     TriangleMeshDataArray,
 )
+from .zbf import ZBFData
 
 DEFAULT_MAX_SAMPLES_PER_STEP = 10_000
 DEFAULT_MAX_CELLS_PER_STEP = 10_000
@@ -256,6 +257,92 @@ class FieldDataset(ElectromagneticFieldDataset):
         title="Hz",
         description="Spatial distribution of the z-component of the magnetic field.",
     )
+
+    def from_zbf(filename: str, dim1: xyz, dim2: xyz) -> FieldDataset:
+        """Creates a :class:`.FieldDataset` from a Zemax Beam File (``.zbf``).
+
+        Parameters
+        ----------
+        filename: str
+            The file name of the .zbf file to read.
+        dim1: xyz
+            Tangential field component to map the x-dimension of the zbf data to.
+            eg. ``dim1 = "z"`` sets ``FieldDataset.Ez`` to ``Ex`` of the zbf data.
+        dim2: xyz
+            Tangential field component to map the y-dimension of the zbf data to.
+            eg. ``dim2 = "z"`` sets ``FieldDataset.Ez`` to ``Ey`` of the zbf data.
+
+        Returns
+        -------
+        :class:`.FieldDataset`
+            A :class:`.FieldDataset` object with two tangential E field components populated
+            by zbf data.
+
+        See Also
+        --------
+        :class:`.ZBFData`:
+            A class containing data read in from a ``.zbf`` file.
+        """
+        log.warning(
+            "'FieldDataset.from_zbf()' is currently an experimental feature."
+            " If any issues are encountered, please contact Flexcompute support 'https://www.flexcompute.com/tidy3d/technical-support/'"
+        )
+
+        if dim1 not in get_args(xyz):
+            raise ValueError(f"'dim1' = '{dim1}' is not allowed, must be one of 'x', 'y', or 'z'.")
+        if dim2 not in get_args(xyz):
+            raise ValueError(f"'dim2' = '{dim2}' is not allowed, must be one of 'x', 'y', or 'z'.")
+        if dim1 == dim2:
+            raise ValueError("'dim1' and 'dim2' must be different.")
+
+        # get the third dimension
+        dim3 = list(set(get_args(xyz)) - {dim1, dim2})[0]
+        dims = {"x": 0, "y": 1, "z": 2}
+        dim2expand = dims[dim3]  # this is for expanding E field arrays
+
+        # load zbf data
+        zbfdata = ZBFData.read_zbf(filename)
+
+        # Grab E fields, dimensions, wavelength
+        edim1 = zbfdata.Ex
+        edim2 = zbfdata.Ey
+        n1 = zbfdata.nx
+        n2 = zbfdata.ny
+        d1 = zbfdata.dx / UnitScaling[zbfdata.unit]
+        d2 = zbfdata.dy / UnitScaling[zbfdata.unit]
+        wavelength = zbfdata.wavelength / UnitScaling[zbfdata.unit]
+
+        # make scalar field data arrays
+        len1 = d1 * (n1 - 1)
+        len2 = d2 * (n2 - 1)
+        coords1 = np.linspace(-len1 / 2, len1 / 2, n1)
+        coords2 = np.linspace(-len2 / 2, len2 / 2, n2)
+        f = [C_0 / wavelength]
+        Edim1 = ScalarFieldDataArray(
+            np.expand_dims(edim1, axis=(dim2expand, 3)),
+            coords={
+                dim1: coords1,
+                dim2: coords2,
+                dim3: [0],
+                "f": f,
+            },
+        )
+        Edim2 = ScalarFieldDataArray(
+            np.expand_dims(edim2, axis=(dim2expand, 3)),
+            coords={
+                dim1: coords1,
+                dim2: coords2,
+                dim3: [0],
+                "f": f,
+            },
+        )
+
+        return FieldDataset(
+            **{
+                f"E{dim1}": Edim1,
+                f"E{dim2}": Edim2,
+            }
+        )
 
 
 class FieldTimeDataset(ElectromagneticFieldDataset):

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import struct
 import warnings
 from abc import ABC
 from math import isclose
-from typing import Any, Callable, Dict, List, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, get_args
 
 import autograd.numpy as np
 import pydantic.v1 as pd
@@ -13,7 +14,7 @@ import xarray as xr
 from pandas import DataFrame
 from xarray.core.types import Self
 
-from ...constants import C_0, EPSILON_0, ETA_0, MICROMETER
+from ...constants import C_0, EPSILON_0, ETA_0, MICROMETER, UnitScaling
 from ...exceptions import DataError, SetupError, Tidy3dNotImplementedError, ValidationError
 from ...log import log
 from ..base import TYPE_TAG_STR, cached_property, skip_if_fields_missing
@@ -63,6 +64,7 @@ from ..types import (
     Size,
     Symmetry,
     TrackFreq,
+    UnitsZBF,
 )
 from ..validators import enforce_monitor_fields_present, required_if_symmetry_present
 from .data_array import (
@@ -1065,6 +1067,177 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
             **self._grid_correction_dict,
             **field_kwargs,
         )
+
+    def to_zbf(
+        self,
+        fname: str,
+        units: UnitsZBF = "mm",
+        background_refractive_index: float = 1,
+        n_x: Optional[int] = None,
+        n_y: Optional[int] = None,
+        freq: Optional[float] = None,
+        mode_index: Optional[int] = None,
+        r_x: float = 0,
+        r_y: float = 0,
+        z_x: float = 0,
+        z_y: float = 0,
+        rec_efficiency: float = 0,
+        sys_efficiency: float = 0,
+    ) -> Tuple[ScalarFieldDataArray, ScalarFieldDataArray]:
+        """For a 2D monitor, export the fields to a Zemax Beam File (``.zbf``).
+
+        The mode area is used to approximate the beam waist, which is only valid
+        if the beam profile approximates a Gaussian beam.
+
+        Parameters
+        ----------
+        fname : str
+            Full path to the ``.zbf`` file to be written.
+        units : UnitsZBF = "mm"
+            Spatial units used for the ``.zbf`` file. Options are ``"mm"``, ``"cm"``, ``"in"``, or ``"m"``.
+            Defaults to ``"mm"``.
+        background_refractive_index : float = 1
+            Refractive index of the medium surrounding the monitor. Defaults to ``1``.
+        n_x : Optional[int] = None
+            Number of field samples along x.
+            Must be a power of 2, between 2^5 and 2^13 inclusive per Zemax's requirements.
+            Defaults to ``None``, in which case a value is chosen for the user depending on the coordinates in the field data.
+        n_y : Optional[int] = None
+            Number of field samples along y.
+            Must be a power of 2, between 2^5 and 2^13 inclusive per Zemax's requirements.
+            Defaults to ``None``, in which case a value is chosen for the user depending on the coordinates in the field data.
+        freq : Optional[float] = None
+            Field frequency selection. If ``None``, the average of the recorded frequencies is used.
+        mode_index : Optional[int] = None
+            For :class:`.ModeData`, choose which mode to save.
+        r_x : float = 0
+            Pilot beam Rayleigh distance in x, um. Defaults to ``0``.
+        r_y : float = 0
+            Pilot beam Rayleigh distance in y, um. Defaults to ``0``.
+        z_x : float = 0
+            Pilot beam z position with respect to the waist in x, um. Defaults to ``0``.
+        z_y : float = 0
+            Pilot beam z position with respect to the waist in y, um. Defaults to ``0``.
+        rec_efficiency : float = 0
+            Receiver efficiency, zero if fiber coupling is not computed. Defaults to ``0``.
+        sys_efficiency : float = 0
+            System efficiency, zero if fiber coupling is not computed. Defaults to ``0``.
+
+        Returns
+        -------
+        Tuple[:class:`.ScalarFieldDataArray`,:class:`.ScalarFieldDataArray`]
+            The two E field components being exported to ``.zbf``.
+        """
+        log.warning(
+            "'FieldData.to_zbf()' is currently an experimental feature."
+            " If any issues are encountered, please contact Flexcompute support 'https://www.flexcompute.com/tidy3d/technical-support/'"
+        )
+
+        # Check that appropriate units are used
+        if units not in get_args(UnitsZBF):
+            raise ValueError("'units' must be either 'mm', 'cm', 'in', or 'm'.")
+
+        # Mode area calculation ensures all E components are present
+        mode_area = self.mode_area
+        dim1, dim2 = self._tangential_dims
+
+        # Using file-local coordinates x, y for the tangential components
+        e_x = self._tangential_fields["E" + dim1]
+        e_y = self._tangential_fields["E" + dim2]
+        x = e_x.coords[dim1].values
+        y = e_x.coords[dim2].values
+
+        # Use the mean frequency if freq is not specified
+        if freq is None:
+            log.warning(
+                "'freq' was not specified for 'FieldData.to_zbf()'. Defaulting to the mean frequency of the dataset."
+            )
+            freq = np.mean(e_x.coords["f"].values)
+
+        mode_area = mode_area.interp(f=freq)
+        e_x = e_x.interp(f=freq)
+        e_y = e_y.interp(f=freq)
+
+        # If the data is ModeData, choose one of the modes to save
+        if "mode_index" in e_x.coords:
+            if mode_index is None:
+                raise ValueError("'mode_index' is required for 'ModeData.to_zbf()'")
+            mode_area = mode_area.isel(mode_index=mode_index, drop=True)
+            e_x = e_x.isel(mode_index=mode_index, drop=True)
+            e_y = e_y.isel(mode_index=mode_index, drop=True)
+
+        # Header info
+        version = 1
+        polarized = 1
+        unit_mapping = {"mm": 0, "cm": 1, "in": 2, "m": 3}
+        unit_key = unit_mapping[units]
+        unit_scaling = UnitScaling[units]
+        lda = C_0 / freq * unit_scaling
+
+        # Pilot (reference) beam waist: use the mode area to approximate the expected value
+        w_x = (mode_area.item() / np.pi) ** 0.5 * unit_scaling
+        w_y = w_x
+
+        # Pilot beam Rayleigh distance (ignored on input)
+        r_x *= unit_scaling
+        r_y *= unit_scaling
+
+        # Pilot beam z position w.r.t. the waist
+        z_x *= unit_scaling
+        z_y *= unit_scaling
+
+        # defaults for n_x and n_y
+        if n_x is None:
+            n_x = 2 ** min(13, max(5, int(np.log2(x.size) + 1)))
+            log.warning(
+                f"'n_x' was not specified for 'FieldData.to_zbf()'. Defaulting to 'n_x' = {n_x}."
+            )
+        if n_y is None:
+            n_y = 2 ** min(13, max(5, int(np.log2(y.size) + 1)))
+            log.warning(
+                f"'n_y' was not specified for 'FieldData.to_zbf()'. Defaulting to 'n_y' = {n_y}."
+            )
+
+        # Check that requirements are met for n_x and n_y
+        # n_x and n_y must be powers of 2
+        if (n_x & (n_x - 1)) != 0:
+            raise ValueError("'n_x' must be a power of 2.")
+        if (n_y & (n_y - 1)) != 0:
+            raise ValueError("'n_y' must be a power of 2.")
+        # 32 <= n_x and n_y <= 2^13
+        if n_x < 32 or n_x > 2**13:
+            raise ValueError("'n_x' must be between 2^5 and 2^13, inclusive.")
+        if n_y < 32 or n_y > 2**13:
+            raise ValueError("'n_y' must be between 2^5 and 2^13, inclusive.")
+
+        # Interpolating coordinates
+        x = np.linspace(x.min(), x.max(), n_x)
+        y = np.linspace(y.min(), y.max(), n_y)
+
+        # Interpolate fields
+        coords = {dim1: x, dim2: y}
+        e_x = e_x.interp(coords, assume_sorted=True)
+        e_y = e_y.interp(coords, assume_sorted=True)
+
+        # Sampling distance
+        d_x = np.mean(np.diff(x)) * unit_scaling
+        d_y = np.mean(np.diff(y)) * unit_scaling
+
+        with open(fname, "wb") as fout:
+            fout.write(struct.pack("<5I", version, n_x, n_y, polarized, unit_key))
+            fout.write(struct.pack("<4I", 0, 0, 0, 0))  # unused values
+            fout.write(struct.pack("<8d", d_x, d_y, z_x, r_x, w_x, z_y, r_y, w_y))
+            fout.write(
+                struct.pack("<4d", lda, background_refractive_index, rec_efficiency, sys_efficiency)
+            )
+            fout.write(struct.pack("<8d", 0, 0, 0, 0, 0, 0, 0, 0))  # unused values
+            for e in (e_x, e_y):
+                e_flat = e.values.flatten(order="C")
+                # Interweave real and imaginary parts
+                e_values = np.ravel(np.column_stack((e_flat.real, e_flat.imag)))
+                fout.write(struct.pack(f"<{2 * n_x*n_y}d", *e_values))
+
+        return e_x, e_y
 
 
 class FieldData(FieldDataset, ElectromagneticFieldData):

--- a/tidy3d/components/data/zbf.py
+++ b/tidy3d/components/data/zbf.py
@@ -1,0 +1,156 @@
+"""ZBF utilities"""
+
+from __future__ import annotations
+
+from struct import unpack
+
+import numpy as np
+import pydantic.v1 as pd
+
+from ..base import Tidy3dBaseModel
+
+
+class ZBFData(Tidy3dBaseModel):
+    """
+    Contains data read in from a ``.zbf`` file
+    """
+
+    version: int = pd.Field(title="Version", description="File format version number.")
+    nx: int = pd.Field(title="Samples in X", description="Number of samples in the x direction.")
+    ny: int = pd.Field(title="Samples in Y", description="Number of samples in the y direction.")
+    ispol: bool = pd.Field(
+        title="Is Polarized",
+        description="``True`` if the beam is polarized, ``False`` otherwise.",
+    )
+    unit: str = pd.Field(
+        title="Spatial Units", description="Spatial units, either 'mm', 'cm', 'in', or 'm'."
+    )
+    dx: float = pd.Field(title="Grid Spacing, X", description="Grid spacing in x.")
+    dy: float = pd.Field(title="Grid Spacing, Y", description="Grid spacing in y.")
+    zposition_x: float = pd.Field(
+        title="Z Position, X Direction",
+        description="The pilot beam z position with respect to the pilot beam waist, x direction.",
+    )
+    zposition_y: float = pd.Field(
+        title="Z Position, Y Direction",
+        description="The pilot beam z position with respect to the pilot beam waist, y direction.",
+    )
+    rayleigh_x: float = pd.Field(
+        title="Rayleigh Distance, X Direction",
+        description="The pilot beam Rayleigh distance in the x direction.",
+    )
+    rayleigh_y: float = pd.Field(
+        title="Rayleigh Distance, Y Direction",
+        description="The pilot beam Rayleigh distance in the y direction.",
+    )
+    waist_x: float = pd.Field(
+        title="Beam Waist, X", description="The pilot beam waist in the x direction."
+    )
+    waist_y: float = pd.Field(
+        title="Beam Waist, Y", description="The pilot beam waist in the y direction."
+    )
+    wavelength: float = pd.Field(..., title="Wavelength", description="The wavelength of the beam.")
+    background_refractive_index: float = pd.Field(
+        title="Background Refractive Index",
+        description="The index of refraction in the current medium.",
+    )
+    receiver_eff: float = pd.Field(
+        title="Receiver Efficiency",
+        description="The receiver efficiency. Zero if fiber coupling is not computed.",
+    )
+    system_eff: float = pd.Field(
+        title="System Efficiency",
+        description="The system efficiency. Zero if fiber coupling is not computed.",
+    )
+    Ex: np.ndarray = pd.Field(
+        title="Electric Field, X Component",
+        description="Complex-valued electric field, x component.",
+    )
+    Ey: np.ndarray = pd.Field(
+        title="Electric Field, Y Component",
+        description="Complex-valued electric field, y component.",
+    )
+
+    def read_zbf(filename: str) -> ZBFData:
+        """Reads a Zemax Beam File (``.zbf``)
+
+        Parameters
+        ----------
+        filename : str
+            The file name of the ``.zbf`` file to read.
+
+        Returns
+        -------
+        :class:`.ZBFData`
+        """
+
+        # Read the zbf file
+        with open(filename, "rb") as f:
+            # Load the header
+            version, nx, ny, ispol, units = unpack("<5I", f.read(20))
+            f.read(16)  # unused values
+            (
+                dx,
+                dy,
+                zposition_x,
+                rayleigh_x,
+                waist_x,
+                zposition_y,
+                rayleigh_y,
+                waist_y,
+                wavelength,
+                background_refractive_index,
+                receiver_eff,
+                system_eff,
+            ) = unpack("<12d", f.read(96))
+            f.read(64)  # unused values
+
+            # read E field
+            nsamps = 2 * nx * ny
+            rawx = list(unpack(f"<{nsamps}d", f.read(8 * nsamps)))
+            if ispol:
+                rawy = list(unpack(f"<{nsamps}d", f.read(8 * nsamps)))
+
+        # convert unit key to unit string
+        map_units = {0: "mm", 1: "cm", 2: "in", 3: "m"}
+        try:
+            unit = map_units[units]
+        except KeyError:
+            raise KeyError(
+                f"Invalid units specified in the zbf file (expected '0', '1', '2', or '3', got '{units}')."
+            )
+
+        # load E field
+        Ex_real = np.asarray(rawx[0::2]).reshape(nx, ny)
+        Ex_imag = np.asarray(rawx[1::2]).reshape(nx, ny)
+        if ispol:
+            Ey_real = np.asarray(rawy[0::2]).reshape(nx, ny)
+            Ey_imag = np.asarray(rawy[1::2]).reshape(nx, ny)
+        else:
+            Ey_real = np.zeros((nx, ny))
+            Ey_imag = np.zeros((nx, ny))
+
+        Ex = Ex_real + 1j * Ex_imag
+        Ey = Ey_real + 1j * Ey_imag
+
+        return ZBFData(
+            version=version,
+            nx=nx,
+            ny=ny,
+            ispol=ispol,
+            unit=unit,
+            dx=dx,
+            dy=dy,
+            zposition_x=zposition_x,
+            zposition_y=zposition_y,
+            rayleigh_x=rayleigh_x,
+            rayleigh_y=rayleigh_y,
+            waist_x=waist_x,
+            waist_y=waist_y,
+            wavelength=wavelength,
+            background_refractive_index=background_refractive_index,
+            receiver_eff=receiver_eff,
+            system_eff=system_eff,
+            Ex=Ex,
+            Ey=Ey,
+        )

--- a/tidy3d/components/types.py
+++ b/tidy3d/components/types.py
@@ -252,3 +252,8 @@ TrackFreq = Literal["central", "lowest", "highest"]
 """ lumped elements"""
 
 LumpDistType = Literal["off", "laterally_only", "on"]
+
+""" dataset """
+
+xyz = Literal["x", "y", "z"]
+UnitsZBF = Literal["mm", "cm", "in", "m"]

--- a/tidy3d/constants.py
+++ b/tidy3d/constants.py
@@ -238,6 +238,7 @@ UnitScaling = MappingProxyType(
         "mm": 1e-3,
         "cm": 1e-4,
         "m": 1e-6,
+        "in": 1.0 / 25400,
     }
 )
-"""Immutable dictionary for converting a unit specification to a scaling factor."""
+"""Immutable dictionary for converting microns to another spatial unit, eg. nm = um * UnitScaling["nm"]."""


### PR DESCRIPTION
- Adds a `to_zbf()` method to `FieldData` for exporting E fields to a ZBF file.
- Adds a `from_zbf()` method to `FieldDataset` for importing E fields from a ZBF file.
- Adds a `ZBFData` class for reading ZBF files

Closes https://github.com/flexcompute/tidy3d/issues/2321

