### PR TITLE
maint[tests]: reduce runtime of most expensive tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,3 +100,32 @@ def dir_name(request):
 def create_directory(dir_name):
     if dir_name is not None:
         directory = Path(dir_name).mkdir(parents=True, exist_ok=True)
+
+
+@pytest.fixture
+def novalidate(monkeypatch):
+    """
+    Swaps the pydantic constructor used by all tidy3d models for a
+    zero-validation ``construct`` version for the duration of the test.
+
+    Usage
+    -----
+    def test_something(novalidate):
+        ...      # gets the fast objects
+
+    or
+
+    @pytest.mark.usefixtures("novalidate")
+    def test_other():
+        ...
+    """
+
+    def noop(self, *a, **kw):
+        return None
+
+    monkeypatch.setattr(td.Simulation, "_post_init_validators", noop, raising=True)
+    monkeypatch.setattr(td.Simulation, "validate_pre_upload", noop, raising=True)
+    monkeypatch.setattr(td, "Simulation", td.Simulation.construct, raising=True)
+    monkeypatch.setattr(
+        td.web.api.autograd.autograd, "is_valid_for_autograd", lambda *a, **kw: True, raising=True
+    )

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -4,6 +4,7 @@ import copy
 import cProfile
 import typing
 import warnings
+from functools import cache
 from importlib import reload
 from os.path import join
 
@@ -139,7 +140,7 @@ SIM_BASE = td.Simulation(
         )
     ],
     boundary_spec=td.BoundarySpec.pml(x=PML_X, y=True, z=True),
-    grid_spec=td.GridSpec.uniform(dl=0.01 * td.C_0 / FREQ0),
+    grid_spec=td.GridSpec.uniform(dl=0.1 * td.C_0 / FREQ0),
 )
 
 # variable to store whether the emulated run as used
@@ -489,6 +490,7 @@ def make_structures(params: anp.ndarray) -> dict[str, td.Structure]:
     )
 
 
+@cache
 def make_monitors() -> dict[str, tuple[td.Monitor, typing.Callable[[td.SimulationData], float]]]:
     """Make a dictionary of all the possible monitors in the simulation."""
 
@@ -605,6 +607,7 @@ if TEST_POLYSLAB_SPEED:
 # args = [("polyslab", "mode")]
 
 
+@cache
 def get_functions(structure_key: str, monitor_key: str) -> typing.Callable:
     if structure_key == ALL_KEY:
         structure_keys = structure_keys_
@@ -802,6 +805,7 @@ def test_autograd_objective(use_emulated_run, structure_key, monitor_key):
         assert anp.all(grad != 0.0), "some gradients are 0"
 
 
+@pytest.mark.usefixtures("novalidate")
 @pytest.mark.parametrize("structure_key, monitor_key", args)
 def test_autograd_async(use_emulated_run, structure_key, monitor_key):
     """Test an objective function through tidy3d autograd."""
@@ -810,7 +814,7 @@ def test_autograd_async(use_emulated_run, structure_key, monitor_key):
     make_sim = fn_dict["sim"]
     postprocess = fn_dict["postprocess"]
 
-    task_names = {"test_a", "adjoint", "task1", "_test"}
+    task_names = {"test_a", "_test"}
 
     def objective(*args):
         sims = {task_name: make_sim(*args) for task_name in task_names}
@@ -859,7 +863,7 @@ class TestTupleGrads:
             sources=[src],
             monitors=[mnt],
             boundary_spec=td.BoundarySpec.all_sides(td.PML()),
-            grid_spec=td.GridSpec.auto(min_steps_per_wvl=30),
+            grid_spec=td.GridSpec.auto(min_steps_per_wvl=10),
         )
 
     @pytest.mark.parametrize("run_async", [False, True])
@@ -2137,12 +2141,16 @@ def test_dispersive_no_inf(use_emulated_run):
     """
 
     fn_dict = get_functions(args[0][0], args[0][1])
-    make_sim = fn_dict["sim"]
+    base_sim = fn_dict["sim"](params0).updated_copy(
+        grid_spec=td.GridSpec.auto(min_steps_per_wvl=20)
+    )
     postprocess = fn_dict["postprocess"]
 
     def objective(args):
         structure_traced = make_structures(args)["polyslab_dispersive"]
-        sim = make_sim(args).updated_copy(structures=[structure_traced])
+        sim = base_sim.updated_copy(
+            structures=[structure_traced],
+        )
         sim_data = run(sim, task_name="adjoint_test", verbose=False)
         return postprocess(sim_data)
 

--- a/tests/test_plugins/test_design.py
+++ b/tests/test_plugins/test_design.py
@@ -11,6 +11,8 @@ from tidy3d.plugins import design as tdd
 
 from ..utils import run_emulated
 
+# td.Simulation = functools.partial(td.Simulation.construct)
+
 SWEEP_METHODS = dict(
     grid=tdd.MethodGrid(),
     monte_carlo=tdd.MethodMonteCarlo(num_points=5, seed=1),
@@ -319,7 +321,7 @@ def init_design_space(sweep_method):
     radius_variable = tdd.ParameterFloat(
         name="radius",
         span=(0, 1.5),
-        num_points=5,  # note: only used for MethodGrid
+        num_points=2,  # note: only used for MethodGrid
     )
 
     num_spheres_variable = tdd.ParameterInt(
@@ -339,6 +341,7 @@ def init_design_space(sweep_method):
     return design_space
 
 
+@pytest.mark.usefixtures("novalidate")
 @pytest.mark.parametrize("sweep_method", SWEEP_METHODS.values())
 def test_sweep(sweep_method, monkeypatch):
     # Problem, simulate scattering cross section of sphere ensemble


### PR DESCRIPTION
Shaves a good amount of seconds off from the slowest running tests. Introduces a fixture that allows disabling most of the `td.Simulation` validation. Some of these are still slower than they should be probably but it's a start.

Before:
```
75.52s call     tests/test_plugins/test_design.py::test_sweep[sweep_method0]
40.89s call     tests/test_components/test_autograd.py::test_autograd_async[<ALL>-diff]
34.13s call     tests/test_components/test_autograd.py::test_autograd_async[<ALL>-field_vol]
33.85s call     tests/test_components/test_simulation.py::test_num_lumped_elements
31.11s call     tests/test_components/test_autograd.py::test_autograd_async[<ALL>-mode]
24.55s call     tests/test_components/test_autograd.py::test_autograd_async[<ALL>-field_point]
22.17s call     tests/test_plugins/test_adjoint.py::test_adjoint_pipeline[True]
20.26s call     tests/test_components/test_scene.py::test_num_mediums
19.62s call     tests/test_components/test_IO.py::test_validation_speed
19.13s call     tests/test_components/test_autograd.py::test_autograd_async_server[<ALL>-diff]
```

After:
```
42.02s call     tests/test_components/test_simulation.py::test_num_lumped_elements
24.76s call     tests/test_plugins/test_adjoint.py::TestJaxComplexPolySlab::test_vertices_grads[-0.02-10-3-base_vertices1]
24.61s call     tests/test_components/test_autograd.py::test_autograd_async_server[<ALL>-diff]
23.64s call     tests/test_plugins/test_adjoint.py::test_adjoint_pipeline[True]
23.14s call     tests/test_components/test_autograd.py::test_autograd_async_some_zero_grad[<ALL>-field_vol]
22.75s call     tests/test_components/test_autograd.py::test_autograd_async[<ALL>-diff]
22.29s call     tests/test_components/test_eme.py::test_eme_sim_data
21.59s call     tests/test_components/test_autograd.py::test_autograd_async_some_zero_grad[<ALL>-mode]
21.50s call     tests/test_components/test_scene.py::test_num_mediums
21.35s call     tests/test_components/test_autograd.py::test_autograd_async_server[<ALL>-field_vol]
```

Note: Not sure where the 42s spent on `test_num_lumped_elements` comes from, might have gotten unlucky on an efficiency core.