### PR TITLE
Avoiding overflow in Simulation.num_cells

### DIFF
--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -4821,7 +4821,7 @@ class Simulation(AbstractYeeGridSimulation):
             Number of yee cells in the simulation.
         """
 
-        return np.prod(self.grid.num_cells, dtype=np.int64)
+        return int(np.prod([float(nc) for nc in self.grid.num_cells]))
 
     @property
     def _num_computational_grid_points_dim(self):


### PR DESCRIPTION
For wrong settings, it was possible to get overflow in the `Simulation.num_cells` even with 64-bit precision integers.