### PR TITLE
Add PermittivityMonitor to EMESimulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ClipOperation` now fails validation if traced fields are detected.
 - Warn if more than 20 frequencies are used in EME, as this may lead to slower or more expensive simulations.
 - EME now supports 2D simulations.
+- 'EMESimulation' now supports 'PermittivityMonitor'.
 
 ## [2.8.3] - 2025-04-24
 

--- a/tidy3d/components/eme/data/monitor_data.py
+++ b/tidy3d/components/eme/data/monitor_data.py
@@ -7,7 +7,7 @@ from typing import Union
 import pydantic.v1 as pd
 
 from ...base_sim.data.monitor_data import AbstractMonitorData
-from ...data.monitor_data import ElectromagneticFieldData, ModeSolverData
+from ...data.monitor_data import ElectromagneticFieldData, ModeSolverData, PermittivityData
 from ..monitor import EMECoefficientMonitor, EMEFieldMonitor, EMEModeSolverMonitor
 from .dataset import EMECoefficientDataset, EMEFieldDataset, EMEModeSolverDataset
 
@@ -40,4 +40,6 @@ class EMECoefficientData(AbstractMonitorData, EMECoefficientDataset):
     )
 
 
-EMEMonitorDataType = Union[EMEModeSolverData, EMEFieldData, EMECoefficientData, ModeSolverData]
+EMEMonitorDataType = Union[
+    EMEModeSolverData, EMEFieldData, EMECoefficientData, ModeSolverData, PermittivityData
+]

--- a/tidy3d/components/eme/monitor.py
+++ b/tidy3d/components/eme/monitor.py
@@ -8,7 +8,7 @@ from typing import Literal, Optional, Tuple, Union
 import pydantic.v1 as pd
 
 from ..base_sim.monitor import AbstractMonitor
-from ..monitor import AbstractFieldMonitor, ModeSolverMonitor
+from ..monitor import AbstractFieldMonitor, ModeSolverMonitor, PermittivityMonitor
 from ..types import FreqArray
 
 BYTES_COMPLEX = 8
@@ -298,5 +298,9 @@ class EMECoefficientMonitor(EMEMonitor):
 
 
 EMEMonitorType = Union[
-    EMEModeSolverMonitor, EMEFieldMonitor, EMECoefficientMonitor, ModeSolverMonitor
+    EMEModeSolverMonitor,
+    EMEFieldMonitor,
+    EMECoefficientMonitor,
+    ModeSolverMonitor,
+    PermittivityMonitor,
 ]

--- a/tidy3d/components/mode/simulation.py
+++ b/tidy3d/components/mode/simulation.py
@@ -82,16 +82,22 @@ class ModeSimulation(AbstractYeeGridSimulation):
 
     Example
     -------
-    >>> from tidy3d import C_0, ModeSpec
+    >>> from tidy3d import C_0, ModeSpec, BoundarySpec, Boundary
     >>> lambda0 = 1
     >>> freq0 = C_0 / lambda0
     >>> freqs = [freq0]
     >>> sim_size = lambda0, lambda0, 0
     >>> mode_spec = ModeSpec(num_modes=4)
+    >>> boundary_spec = BoundarySpec(
+    ...     x=Boundary.pec(),
+    ...     y=Boundary.pec(),
+    ...     z=Boundary.periodic()
+    ... )
     >>> sim = ModeSimulation(
     ...     size=sim_size,
     ...     freqs=freqs,
-    ...     mode_spec=mode_spec
+    ...     mode_spec=mode_spec,
+    ...     boundary_spec=boundary_spec
     ... )
 
     See Also


### PR DESCRIPTION
A small extension of the earlier PR adding PermittivityMonitor to ModeSimulation. It is also convenient to allow it directly in EMESimulation.