### PR TITLE
fix[autograd]: sample fields along slab height and polygon edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ with fewer layers than recommended.
 - Warnings are now generated (instead of errors) when instantiating `PML`, `StablePML`, or `Absorber` classes (or when invoking `pml()`, `stable_pml()`, or `absorber()` functions) with fewer layers than recommended.
 - `Simulation.subsection` can no longer take `symmetry` as an argument - the symmetry is always taken from the original simulation.
 - If a mode simulation is crossing a symmetry plane of the larger simulation domain, but the mode plane is not symmetric, a warning is issued that it will be expanded symmetrically. Previously this warning only happened during the solver run.
+- Enhanced `PolySlab` and `Cylinder` gradient computation via adaptive field sampling along geometry boundaries instead of fixed-grid center sampling.
+- Shape derivatives have been sped up significantly, especially for simulations containing many structures in a `GeometryGroup`.
 
 ### Fixed
 - Arrow lengths are now scaled consistently in the X and Y directions, and their lengths no longer exceed the height of the plot window.

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -812,7 +812,7 @@ def test_autograd_async(use_emulated_run, structure_key, monitor_key):
     make_sim = fn_dict["sim"]
     postprocess = fn_dict["postprocess"]
 
-    task_names = {"test_a", "adjoint", "task1", "_test"}
+    task_names = {"test_a", "adjoint", "_test"}
 
     def objective(*args):
         sims = {task_name: make_sim(*args) for task_name in task_names}
@@ -912,7 +912,7 @@ def test_autograd_async_some_zero_grad(use_emulated_run, structure_key, monitor_
     make_sim = fn_dict["sim"]
     postprocess = fn_dict["postprocess"]
 
-    task_names = {"1", "2", "3", "4"}
+    task_names = {"1", "2"}
 
     def objective(*args):
         sims = {task_name: make_sim(*args) for task_name in task_names}
@@ -934,7 +934,7 @@ def test_autograd_async_all_zero_grad(use_emulated_run):
     make_sim = fn_dict["sim"]
     postprocess = fn_dict["postprocess"]
 
-    task_names = {"1", "2", "3", "4"}
+    task_names = {"1", "2"}
 
     def objective(*args):
         sims = {task_name: make_sim(*args) for task_name in task_names}
@@ -1926,11 +1926,6 @@ checks = list(MULT_FREQ_TEST_CASES.items())
 @pytest.mark.parametrize("structure_key", ("custom_med",))
 def test_multi_freq_edge_cases(use_emulated_run, structure_key, label, check_fn, monkeypatch):
     # test multi-frequency adjoint handling
-
-    import tidy3d.components.data.sim_data as sd
-
-    monkeypatch.setattr(sd, "RESIDUAL_CUTOFF_ADJOINT", 1)
-    reload(td)
 
     postprocess_fn = check_fn(structure_key=structure_key)
 

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -19,13 +19,13 @@ from autograd.test_util import check_grads
 
 import tidy3d as td
 import tidy3d.web as web
+from tidy3d.components.autograd.constants import MAX_NUM_TRACED_STRUCTURES
 from tidy3d.components.autograd.derivative_utils import DerivativeInfo
 from tidy3d.components.autograd.utils import is_tidy_box
 from tidy3d.components.data.data_array import DataArray
 from tidy3d.exceptions import AdjointError
 from tidy3d.plugins.polyslab import ComplexPolySlab
 from tidy3d.web import run, run_async
-from tidy3d.web.api.autograd.autograd import MAX_NUM_TRACED_STRUCTURES
 from tidy3d.web.api.autograd.utils import FieldMap
 
 from ..utils import SIM_FULL, AssertLogLevel, run_emulated, tracer_arr

--- a/tests/test_components/test_autograd_polyslab.py
+++ b/tests/test_components/test_autograd_polyslab.py
@@ -1,0 +1,852 @@
+"""
+Tests for ``td.PolySlab._compute_derivatives`` using an integrand of the form
+
+    k(u, v, w) = a u + b v + c w + d
+
+where (u, v) are the in-plane coordinates and w is the extrusion axis.
+
+Test coverage:
+ - 3d slabs for each extrusion axis (0, 1, 2)
+ - 2d simulation slice (``is_2d``) where the slab is entirely in-plane
+ - 2d cross-section where the slab is intersected by a clipping plane
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+import shapely.geometry as sgeom
+from shapely.geometry.polygon import orient
+
+import tidy3d as td
+from tidy3d.components.autograd.derivative_utils import DerivativeInfo
+
+# irregular convex pentagon in the XY-plane
+VERTS_2D: np.ndarray = np.array(
+    [
+        (0.0, 0.0),
+        (3.0, 0.0),
+        (4.0, 2.0),
+        (2.0, 4.0),
+        (0.0, 3.0),
+    ],
+    dtype=float,
+)
+
+# slab bounds along the extrusion axis (z-min, z-max)
+SLAB_BOUNDS: tuple[float, float] = (0.5, 2.0)
+
+a, b, c, d = 0.3, -0.1, 0.5, 0.8
+COEFFS: dict[str, float] = {"a": a, "b": b, "c": c, "d": d}
+
+
+def polygon_area_centroid(verts: np.ndarray) -> tuple[float, float, float]:
+    """Return (area, x dA, y dA) for a CCW polygon (shoelace formulas)"""
+    x, y = verts.T
+    x1, y1 = np.roll(x, -1), np.roll(y, -1)
+    cross = x * y1 - y * x1
+    area = 0.5 * np.sum(cross)
+    mx = np.sum((x + x1) * cross) / 6
+    my = np.sum((y + y1) * cross) / 6
+    return abs(area), mx, my
+
+
+def edge_integrals(verts: np.ndarray):
+    """Per-edge geometric quantities"""
+    v0 = verts
+    v1 = np.roll(verts, -1, axis=0)
+    seg = v1 - v0
+
+    L = np.linalg.norm(seg, axis=1)  # segment length
+    n = np.stack([seg[:, 1], -seg[:, 0]], axis=1) / L[:, None]  # outward normal
+
+    int_x = 0.5 * (v0[:, 0] + v1[:, 0]) * L  # x ds per segment
+    int_y = 0.5 * (v0[:, 1] + v1[:, 1]) * L  # y ds per segment
+
+    return L, n, int_x, int_y
+
+
+def get_edge_intersection(v0, v1, x_clip):
+    """Find intersection of edge (v0, v1) with line x=x_clip."""
+    x0, y0 = v0
+    x1, y1 = v1
+    if np.isclose(x0, x1):  # vertical edge
+        return None, None
+    if (x0 <= x_clip and x1 <= x_clip) or (x0 > x_clip and x1 > x_clip):  # edge doesn't cross
+        return None, None
+
+    t = (x_clip - x0) / (x1 - x0)
+    if 0 <= t <= 1:
+        Iy = y0 + t * (y1 - y0)
+        I = np.array([x_clip, Iy])  # noqa: E741
+        return I, t
+    return None, None
+
+
+class DummyDI:
+    """Stand-in for ``tidy3d.components.autograd.derivative_utils.DerivativeInfo``."""
+
+    def __init__(
+        self,
+        *,
+        paths,
+        axis: int,
+        coeffs: dict[str, float],
+        bounds_intersect: Optional[tuple[tuple[float, ...], tuple[float, ...]]] = None,
+    ) -> None:
+        self.paths = paths
+        self.axis = axis
+        self.a = coeffs["a"]
+        self.b = coeffs["b"]
+        self.c = coeffs["c"]
+        self.d = coeffs["d"]
+        self.frequency = 200e12
+        self.eps_in = 12.0
+        self.interpolators = None
+
+        self.bounds_intersect = (
+            bounds_intersect
+            if bounds_intersect is not None
+            else ((-1e3, -1e3, -1e3), (1e3, 1e3, 1e3))
+        )
+
+    adaptive_vjp_spacing = DerivativeInfo.adaptive_vjp_spacing
+
+    def create_interpolators(self, dtype=None):
+        return {}
+
+    def evaluate_gradient_at_points(
+        self, spatial_coords, normals, perps1, perps2, interpolators=None
+    ):
+        centers = spatial_coords
+        plane_axes = [i for i in (0, 1, 2) if i != self.axis]
+        u, v = centers[:, plane_axes[0]], centers[:, plane_axes[1]]
+        w = centers[:, self.axis]
+
+        vals = self.a * u + self.b * v + self.c * w + self.d
+        return vals
+
+
+def analytic_faces(verts: np.ndarray, coeffs: dict[str, float], z0: float, z1: float):
+    """Return the (bottom, top) face forces with our sign convention."""
+    area, mx, my = polygon_area_centroid(verts)
+
+    bot = -(coeffs["a"] * mx + coeffs["b"] * my + (coeffs["c"] * z0 + coeffs["d"]) * area)
+    top = coeffs["a"] * mx + coeffs["b"] * my + (coeffs["c"] * z1 + coeffs["d"]) * area
+    return bot, top
+
+
+def analytic_vertex_forces(
+    verts: np.ndarray, coeffs: dict[str, float], z0: float, z1: float
+) -> np.ndarray:
+    """
+    Return per-vertex forces projected onto the polygon plane,
+    using weighted distribution (1-s, s) consistent with linear shape functions.
+    """
+    a, b, c, d = coeffs["a"], coeffs["b"], coeffs["c"], coeffs["d"]
+    thickness = z1 - z0
+    n_verts = len(verts)
+    vf = np.zeros_like(verts, dtype=float)
+
+    v0 = verts
+    v1 = np.roll(verts, -1, axis=0)
+    seg = v1 - v0
+    L = np.linalg.norm(seg, axis=1)  # segment length (N,)
+    L_safe = np.where(L <= np.finfo(float).eps, 1.0, L)
+
+    # ensure normal calculation handles potential zero length segments safely
+    n = np.zeros_like(seg)
+    valid_edge = L > np.finfo(float).eps
+    n[valid_edge] = (
+        np.stack([seg[valid_edge, 1], -seg[valid_edge, 0]], axis=1) / L_safe[valid_edge, None]
+    )
+
+    x0, y0 = v0[:, 0], v0[:, 1]
+    x1, y1 = v1[:, 0], v1[:, 1]
+
+    z_integral_term_half = L * (c / 4.0) * (z1**2 - z0**2)
+
+    # weighted scalar contribution from edge i to vertex i
+    F_scalar_i = (
+        L * thickness * ((a / 6.0) * (2 * x0 + x1) + (b / 6.0) * (2 * y0 + y1) + d / 2.0)
+        + z_integral_term_half
+    )
+
+    # weighted scalar contribution from edge 'i' to vertex 'i+1'
+    F_scalar_i_plus_1 = (
+        L * thickness * ((a / 6.0) * (x0 + 2 * x1) + (b / 6.0) * (y0 + 2 * y1) + d / 2.0)
+        + z_integral_term_half
+    )
+
+    for i in range(n_verts):
+        if not valid_edge[i]:
+            continue
+        vf[i] += F_scalar_i[i] * n[i]
+        vf[(i + 1) % n_verts] += F_scalar_i_plus_1[i] * n[i]
+
+    return vf
+
+
+@pytest.mark.parametrize("axis", [0, 1, 2])
+class TestPolySlab3D:
+    """3d test for arbitrary extrusion axis."""
+
+    @pytest.fixture
+    def slab(self, axis):
+        return td.PolySlab(vertices=VERTS_2D, axis=axis, slab_bounds=SLAB_BOUNDS)
+
+    @pytest.fixture
+    def results(self, slab, axis):
+        di = DummyDI(
+            paths=[("slab_bounds", 0), ("slab_bounds", 1), ("vertices",)],
+            axis=axis,
+            coeffs=COEFFS,
+        )
+        return slab._compute_derivatives(di)
+
+    def test_face_forces(self, results):
+        bot_exp, top_exp = analytic_faces(VERTS_2D, COEFFS, *SLAB_BOUNDS)
+        npt.assert_allclose(results[("slab_bounds", 0)], bot_exp, rtol=1e-2)
+        npt.assert_allclose(results[("slab_bounds", 1)], top_exp, rtol=1e-2)
+
+    def test_vertex_forces(self, results):
+        vf_exp = analytic_vertex_forces(VERTS_2D, COEFFS, *SLAB_BOUNDS)
+        npt.assert_allclose(results[("vertices",)], vf_exp, rtol=1e-2)
+
+
+class TestPolySlab2DInPlane:
+    """Simulation slice exactly through the slab mid-plane (``is_2d == True``)."""
+
+    AXIS = 2
+
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        self.slab = td.PolySlab(vertices=VERTS_2D, axis=self.AXIS, slab_bounds=SLAB_BOUNDS)
+
+        z_mid = 0.5 * sum(SLAB_BOUNDS)
+        self.di = DummyDI(
+            paths=[("slab_bounds", 0), ("slab_bounds", 1), ("vertices",)],
+            axis=self.AXIS,
+            coeffs=COEFFS,
+            bounds_intersect=((-1e3, -1e3, z_mid), (1e3, 1e3, z_mid)),
+        )
+        self.results = self.slab._compute_derivatives(self.di)
+        self.z_mid = z_mid
+
+    def test_faces_are_zero(self):
+        assert self.results[("slab_bounds", 0)] == 0.0
+        assert self.results[("slab_bounds", 1)] == 0.0
+
+    def test_vertex_forces(self):
+        verts = VERTS_2D
+        coeffs = COEFFS
+        z_mid = self.z_mid
+        a, b, c, d = coeffs["a"], coeffs["b"], coeffs["c"], coeffs["d"]
+        n_verts = len(verts)
+        vf = np.zeros_like(verts, dtype=float)  # Use float
+
+        v0 = verts
+        v1 = np.roll(verts, -1, axis=0)
+        seg = v1 - v0
+        L = np.linalg.norm(seg, axis=1)
+        valid_edge = L > np.finfo(float).eps
+        L_safe = np.where(valid_edge, L, 1.0)
+        n = np.zeros_like(seg)
+        n[valid_edge] = (
+            np.stack([seg[valid_edge, 1], -seg[valid_edge, 0]], axis=1) / L_safe[valid_edge, None]
+        )
+
+        x0, y0 = v0[:, 0], v0[:, 1]
+        x1, y1 = v1[:, 0], v1[:, 1]
+
+        # calculate k = (a*x(s) + b*y(s) + c*z_mid + d)
+        k_at_z_mid_common_half = (c * z_mid + d) / 2.0
+
+        # weighted scalar contribution to vertex 'i' (start, weight 1-s)
+        F_scalar_i = L * (
+            (a / 6.0) * (2 * x0 + x1) + (b / 6.0) * (2 * y0 + y1) + k_at_z_mid_common_half
+        )
+
+        # weighted scalar contribution to vertex 'i+1' (end, weight s)
+        F_scalar_i_plus_1 = L * (
+            (a / 6.0) * (x0 + 2 * x1) + (b / 6.0) * (y0 + 2 * y1) + k_at_z_mid_common_half
+        )
+
+        for i in range(n_verts):
+            if not valid_edge[i]:
+                continue
+            vf[i] += F_scalar_i[i] * n[i]
+            vf[(i + 1) % n_verts] += F_scalar_i_plus_1[i] * n[i]
+
+        npt.assert_allclose(self.results[("vertices",)], vf, rtol=1e-2)
+
+
+class TestPolySlab2DCrossSection:
+    """Case where the slab surface intersects a vertical clipping plane."""
+
+    AXIS = 2
+    X_CLIP = 1.5  # x-coordinate of the clipping plane
+
+    @classmethod
+    def setup_class(cls):
+        cls.slab = td.PolySlab(vertices=VERTS_2D, axis=cls.AXIS, slab_bounds=SLAB_BOUNDS)
+
+        sim_min = (-1e3, -1e3, -1e3)
+        sim_max = (cls.X_CLIP, 1e3, 1e3)
+
+        cls.di = DummyDI(
+            paths=[("slab_bounds", 0), ("slab_bounds", 1), ("vertices",)],
+            axis=cls.AXIS,
+            coeffs=COEFFS,
+            bounds_intersect=(sim_min, sim_max),
+        )
+        cls.results = cls.slab._compute_derivatives(cls.di)
+
+        # intersection geometry: line segments at x == X_CLIP
+        poly = sgeom.Polygon(VERTS_2D)
+        line = sgeom.LineString([(cls.X_CLIP, -1e3), (cls.X_CLIP, 1e3)])
+        inter = poly.intersection(line)
+
+        if inter.is_empty:
+            cls.y_segments: list[list[tuple[float, float]]] = []
+        elif isinstance(inter, sgeom.MultiLineString):
+            cls.y_segments = [list(seg.coords) for seg in inter.geoms]
+        else:  # single segment
+            cls.y_segments = [list(inter.coords)]
+
+    @classmethod
+    def _analytic_face(cls, z) -> float:
+        """Exact integral over the clipped face x <= X_CLIP."""
+        poly = sgeom.Polygon(VERTS_2D)
+
+        clip = sgeom.box(-1e3, -1e3, cls.X_CLIP, 1e3)
+        face = poly.intersection(clip)
+
+        if face.is_empty:
+            return 0.0
+
+        face = orient(face, sign=1.0)
+
+        verts = np.asarray(face.exterior.coords[:-1])
+        area, mx, my = polygon_area_centroid(verts)
+
+        a_, b_, c_, d_ = (COEFFS[k] for k in ("a", "b", "c", "d"))
+        return a_ * mx + b_ * my + (c_ * z + d_) * area
+
+    @staticmethod
+    def _integrate_weighted_term(p0, p1, t_start, t_end, weight_s):
+        """Integrates ((1-s)p0 + s p1) * weight(s) ds from t_start to t_end."""
+        t2_end, t3_end = t_end * t_end, t_end * t_end * t_end
+        t2_start, t3_start = t_start * t_start, t_start * t_start * t_start
+
+        if weight_s == "s":
+            val_end = p0 * (0.5 * t2_end - t3_end / 3.0) + p1 * (t3_end / 3.0)
+            val_start = p0 * (0.5 * t2_start - t3_start / 3.0) + p1 * (t3_start / 3.0)
+            return val_end - val_start
+        else:  # weight 1-s
+            val_end = p0 * (t_end - t2_end + t3_end / 3.0) + p1 * (0.5 * t2_end - t3_end / 3.0)
+            val_start = p0 * (t_start - t2_start + t3_start / 3.0) + p1 * (
+                0.5 * t2_start - t3_start / 3.0
+            )
+            return val_end - val_start
+
+    @staticmethod
+    def _vertex_forces_clipped(
+        original_verts: np.ndarray,
+        x_clip: float,
+        coeffs: dict[str, float],
+        z0: float,
+        z1: float,
+    ) -> np.ndarray:
+        """
+        Exact force on each original vertex after clipping ``x <= x_clip``,
+        by directly integrating k*N_j over the clipped portion of each original edge.
+        """
+        a, b, c, d = coeffs["a"], coeffs["b"], coeffs["c"], coeffs["d"]
+        thickness = z1 - z0
+        n_original_verts = len(original_verts)
+        original_vf = np.zeros_like(original_verts, dtype=float)
+
+        v0_all = original_verts
+        v1_all = np.roll(original_verts, -1, axis=0)
+
+        for i in range(n_original_verts):
+            v0, v1 = v0_all[i], v1_all[i]
+            x0, y0 = v0
+            x1, y1 = v1
+
+            seg = v1 - v0
+            L = np.linalg.norm(seg)
+            valid_edge = L > np.finfo(float).eps
+            if not valid_edge:
+                continue
+
+            n = np.array([seg[1], -seg[0]]) / L  # outward normal
+
+            # determine intersection parameter t (0<=t<=1) for x=x_clip
+            t_intersect = 1.0  # full edge potentially inside
+            if not np.isclose(x0, x1):
+                t_cand = (x_clip - x0) / (x1 - x0)
+                if 0 < t_cand < 1:
+                    t_intersect = t_cand
+
+            tol = 1e-9
+            inside0 = x0 <= x_clip + tol
+            inside1 = x1 <= x_clip + tol
+
+            t_start, t_end = 0.0, 1.0
+
+            if not inside0 and not inside1:  # fully outside
+                continue
+            elif inside0 and not inside1:  # starts inside, ends outside
+                t_end = t_intersect
+            elif not inside0 and inside1:  # starts outside, ends inside
+                t_start = t_intersect
+
+            if t_end <= t_start + tol:
+                continue
+
+            t_start = max(0.0, t_start)
+            t_end = min(1.0, t_end)
+            if t_end <= t_start:
+                continue
+
+            # integrate terms weighted by (1-s) for vertex v0 (index i)
+            int_s_w0 = (t_end - 0.5 * t_end**2) - (t_start - 0.5 * t_start**2)
+            int_x_w0 = TestPolySlab2DCrossSection._integrate_weighted_term(
+                x0, x1, t_start, t_end, "1-s"
+            )
+            int_y_w0 = TestPolySlab2DCrossSection._integrate_weighted_term(
+                y0, y1, t_start, t_end, "1-s"
+            )
+
+            # integrate terms weighted by s for vertex v1 (index i+1)
+            int_s_w1 = (0.5 * t_end**2) - (0.5 * t_start**2)
+            int_x_w1 = TestPolySlab2DCrossSection._integrate_weighted_term(
+                x0, x1, t_start, t_end, "s"
+            )
+            int_y_w1 = TestPolySlab2DCrossSection._integrate_weighted_term(
+                y0, y1, t_start, t_end, "s"
+            )
+
+            # combine with z-integration and coefficients
+            z_int_val = 0.5 * (z1**2 - z0**2)
+
+            # scalar force contribution to v0
+            F_scalar_i = L * (
+                (a * int_x_w0 + b * int_y_w0 + d * int_s_w0) * thickness + c * z_int_val * int_s_w0
+            )
+            # scalar force contribution to v1
+            F_scalar_i_plus_1 = L * (
+                (a * int_x_w1 + b * int_y_w1 + d * int_s_w1) * thickness + c * z_int_val * int_s_w1
+            )
+
+            original_vf[i] += F_scalar_i * n
+            original_vf[(i + 1) % n_original_verts] += F_scalar_i_plus_1 * n
+
+        return original_vf
+
+    def test_vertex_forces(self):
+        vf_exp = self._vertex_forces_clipped(VERTS_2D, self.X_CLIP, COEFFS, *SLAB_BOUNDS)
+        npt.assert_allclose(self.results[("vertices",)], vf_exp, rtol=1e-2)
+
+
+class TestPolySlabShortEdges:
+    """Test with very short edges to trigger ``n_uniform <= 3`` quadrature path.
+
+    This test uses a small square with edge lengths of 0.05 units. Based on the
+    quadrature selection logic in ``PolySlab.get_adaptive_samples()``, edges this short
+    should trigger the direct Gauss quadrature path with very few points, as
+    ``n_uniform = edge_length / adaptive_vjp_spacing`` will be <= 3.
+    """
+
+    AXIS = 2
+    # square with very small edge lengths (0.05 units)
+    SHORT_EDGE_VERTS = np.array(
+        [
+            (0.0, 0.0),
+            (0.05, 0.0),
+            (0.05, 0.05),
+            (0.0, 0.05),
+        ],
+        dtype=float,
+    )
+
+    @pytest.fixture
+    def slab(self):
+        return td.PolySlab(vertices=self.SHORT_EDGE_VERTS, axis=self.AXIS, slab_bounds=SLAB_BOUNDS)
+
+    @pytest.fixture
+    def results(self, slab):
+        di = DummyDI(
+            paths=[("slab_bounds", 0), ("slab_bounds", 1), ("vertices",)],
+            axis=self.AXIS,
+            coeffs=COEFFS,
+        )
+        return slab._compute_derivatives(di)
+
+    def test_face_forces(self, results):
+        bot_exp, top_exp = analytic_faces(self.SHORT_EDGE_VERTS, COEFFS, *SLAB_BOUNDS)
+        npt.assert_allclose(results[("slab_bounds", 0)], bot_exp, rtol=1e-2)
+        npt.assert_allclose(results[("slab_bounds", 1)], top_exp, rtol=1e-2)
+
+    def test_vertex_forces(self, results):
+        vf_exp = analytic_vertex_forces(self.SHORT_EDGE_VERTS, COEFFS, *SLAB_BOUNDS)
+        npt.assert_allclose(results[("vertices",)], vf_exp, rtol=1e-2)
+
+
+class TestPolySlabLongEdges:
+    """Test with very long edges to trigger composite Gauss quadrature (n_gauss > 7).
+
+    This test uses a rectangle with 20-unit long edges. For typical ``adaptive_vjp_spacing``
+    values (around 0.1-1.0 wavelength fraction), this results in n_uniform >> 3,
+    leading to n_gauss > 7, which triggers the composite Gauss quadrature path that
+    breaks the edge into segments with 4-point quadrature each.
+    """
+
+    AXIS = 2
+    # rectangle with very long edges (20 units)
+    LONG_EDGE_VERTS = np.array(
+        [
+            (0.0, 0.0),
+            (20.0, 0.0),
+            (20.0, 1.0),
+            (0.0, 1.0),
+        ],
+        dtype=float,
+    )
+
+    @pytest.fixture
+    def slab(self):
+        return td.PolySlab(vertices=self.LONG_EDGE_VERTS, axis=self.AXIS, slab_bounds=SLAB_BOUNDS)
+
+    @pytest.fixture
+    def results(self, slab):
+        di = DummyDI(
+            paths=[("slab_bounds", 0), ("slab_bounds", 1), ("vertices",)],
+            axis=self.AXIS,
+            coeffs=COEFFS,
+        )
+        return slab._compute_derivatives(di)
+
+    def test_face_forces(self, results):
+        bot_exp, top_exp = analytic_faces(self.LONG_EDGE_VERTS, COEFFS, *SLAB_BOUNDS)
+        npt.assert_allclose(results[("slab_bounds", 0)], bot_exp, rtol=1e-2)
+        npt.assert_allclose(results[("slab_bounds", 1)], top_exp, rtol=1e-2)
+
+    def test_vertex_forces(self, results):
+        vf_exp = analytic_vertex_forces(self.LONG_EDGE_VERTS, COEFFS, *SLAB_BOUNDS)
+        npt.assert_allclose(results[("vertices",)], vf_exp, rtol=1e-2)
+
+
+class TestPolySlabMixedEdges:
+    """Test with mixed edge lengths in the same polygon.
+
+    This test creates a polygon with edges of varying lengths to verify that the
+    implementation correctly handles different quadrature methods on different edges
+    within the same polygon:
+    - Very short edges (0.05 units): Should use direct Gauss quadrature with few points
+    - Medium edge (0.95 units): Should use direct Gauss-Legendre quadrature
+    - Long edges (10+ units): Should use composite Gauss quadrature
+
+    This tests the robustness of the edge-by-edge quadrature selection.
+    """
+
+    AXIS = 2
+    # polygon with both very short and very long edges
+    MIXED_EDGE_VERTS = np.array(
+        [
+            (0.0, 0.0),
+            (10.0, 0.0),  # long edge: 10 units
+            (10.0, 0.05),  # very short edge: 0.05 units
+            (10.05, 0.05),  # very short edge: 0.05 units
+            (10.05, 1.0),  # medium edge: 0.95 units
+            (0.0, 1.0),  # long edge: 10.05 units
+        ],
+        dtype=float,
+    )
+
+    @pytest.fixture
+    def slab(self):
+        return td.PolySlab(vertices=self.MIXED_EDGE_VERTS, axis=self.AXIS, slab_bounds=SLAB_BOUNDS)
+
+    @pytest.fixture
+    def results(self, slab):
+        di = DummyDI(
+            paths=[("slab_bounds", 0), ("slab_bounds", 1), ("vertices",)],
+            axis=self.AXIS,
+            coeffs=COEFFS,
+        )
+        return slab._compute_derivatives(di)
+
+    def test_face_forces(self, results):
+        bot_exp, top_exp = analytic_faces(self.MIXED_EDGE_VERTS, COEFFS, *SLAB_BOUNDS)
+        npt.assert_allclose(results[("slab_bounds", 0)], bot_exp, rtol=1e-2)
+        npt.assert_allclose(results[("slab_bounds", 1)], top_exp, rtol=1e-2)
+
+    def test_vertex_forces(self, results):
+        vf_exp = analytic_vertex_forces(self.MIXED_EDGE_VERTS, COEFFS, *SLAB_BOUNDS)
+        npt.assert_allclose(results[("vertices",)], vf_exp, rtol=1e-2)
+
+
+class TestPolySlabDegenerateEdges:
+    """Test with near-degenerate edges to verify numerical stability.
+
+    Note: We use small edges (0.001) rather than truly degenerate edges
+    (duplicate vertices) because PolySlab validation rejects invalid polygons.
+    This tests numerical stability for very small but valid edge lengths.
+    """
+
+    AXIS = 2
+
+    @pytest.fixture
+    def degenerate_verts(self):
+        # pentagon with one small edge to test numerical stability
+        return np.array(
+            [
+                (0.0, 0.0),
+                (1.0, 0.0),
+                (1.0, 0.001),  # small edge but above validator tolerance
+                (1.0, 1.0),
+                (0.0, 1.0),
+            ],
+            dtype=float,
+        )
+
+    @pytest.fixture
+    def slab(self, degenerate_verts):
+        return td.PolySlab(vertices=degenerate_verts, axis=self.AXIS, slab_bounds=SLAB_BOUNDS)
+
+    @pytest.fixture
+    def results(self, slab):
+        di = DummyDI(
+            paths=[("slab_bounds", 0), ("slab_bounds", 1), ("vertices",)],
+            axis=self.AXIS,
+            coeffs=COEFFS,
+        )
+        return slab._compute_derivatives(di)
+
+    def test_derivatives_are_finite(self, results):
+        """Ensure derivatives don't have NaN or inf values."""
+        for path, value in results.items():
+            if isinstance(value, np.ndarray):
+                assert np.all(np.isfinite(value)), f"Non-finite values in {path}"
+            else:
+                assert np.isfinite(value), f"Non-finite value in {path}"
+
+    def test_face_forces(self, results, degenerate_verts):
+        # test face forces for polygons with small edges
+        bot_exp, top_exp = analytic_faces(degenerate_verts, COEFFS, *SLAB_BOUNDS)
+        npt.assert_allclose(results[("slab_bounds", 0)], bot_exp, rtol=1e-2)
+        npt.assert_allclose(results[("slab_bounds", 1)], top_exp, rtol=1e-2)
+
+
+@pytest.mark.parametrize(
+    "edge_length,expected_path",
+    [
+        (0.02, "short"),  # very short edge: n_uniform <= 3
+        (0.05, "short"),  # short edge: n_uniform <= 3
+        (0.5, "medium"),  # medium edge: direct Gauss quadrature (n_gauss <= 7)
+        (2.0, "composite"),  # long edge: composite quadrature (n_gauss > 7)
+        (10.0, "composite"),  # long edge: composite quadrature
+        (50.0, "composite"),  # very long edge: composite quadrature
+    ],
+)
+class TestQuadraturePaths:
+    """Parametrized test to verify correct quadrature path selection based on edge length."""
+
+    AXIS = 2
+
+    @pytest.fixture
+    def square_verts(self, edge_length):
+        """Create a square with the specified edge length."""
+        return np.array(
+            [
+                (0.0, 0.0),
+                (edge_length, 0.0),
+                (edge_length, edge_length),
+                (0.0, edge_length),
+            ],
+            dtype=float,
+        )
+
+    @pytest.fixture
+    def slab(self, square_verts):
+        return td.PolySlab(vertices=square_verts, axis=self.AXIS, slab_bounds=SLAB_BOUNDS)
+
+    def test_correct_quadrature_path(self, slab, edge_length, expected_path):
+        """Verify that the expected quadrature path is used for the given edge length."""
+        di = DummyDI(
+            paths=[("vertices",)],
+            axis=self.AXIS,
+            coeffs=COEFFS,
+        )
+
+        # get the adaptive spacing to compute expected path
+        # this is not super elegant because it literally copies the implementation
+        # but it's better than nothing...
+        dx = di.adaptive_vjp_spacing()
+        n_uniform = max(1, int(np.ceil(edge_length / dx)))
+
+        if n_uniform <= 3:
+            actual_path = "short"
+        else:
+            n_gauss = max(2, int(n_uniform * 0.4))
+            if n_gauss <= 7:
+                actual_path = "medium"
+            else:
+                actual_path = "composite"
+
+        assert actual_path == expected_path, (
+            f"Edge length {edge_length} with dx={dx:.6f} gives n_uniform={n_uniform}, "
+            f"expected {expected_path} path but got {actual_path}"
+        )
+
+        # also verify the derivatives are computed correctly
+        results = slab._compute_derivatives(di)
+        assert ("vertices",) in results
+        assert results[("vertices",)].shape == (4, 2)
+
+
+class TestPolySlabConcave:
+    """Test with concave polygons."""
+
+    AXIS = 2
+    # L-shaped concave polygon
+    CONCAVE_VERTS = np.array(
+        [
+            (0.0, 0.0),
+            (2.0, 0.0),
+            (2.0, 1.0),
+            (1.0, 1.0),
+            (1.0, 2.0),
+            (0.0, 2.0),
+        ],
+        dtype=float,
+    )
+
+    @pytest.fixture
+    def slab(self):
+        return td.PolySlab(vertices=self.CONCAVE_VERTS, axis=self.AXIS, slab_bounds=SLAB_BOUNDS)
+
+    @pytest.fixture
+    def results(self, slab):
+        di = DummyDI(
+            paths=[("slab_bounds", 0), ("slab_bounds", 1), ("vertices",)],
+            axis=self.AXIS,
+            coeffs=COEFFS,
+        )
+        return slab._compute_derivatives(di)
+
+    def test_face_forces(self, results):
+        bot_exp, top_exp = analytic_faces(self.CONCAVE_VERTS, COEFFS, *SLAB_BOUNDS)
+        npt.assert_allclose(results[("slab_bounds", 0)], bot_exp, rtol=1e-2)
+        npt.assert_allclose(results[("slab_bounds", 1)], top_exp, rtol=1e-2)
+
+    def test_vertex_forces(self, results):
+        vf_exp = analytic_vertex_forces(self.CONCAVE_VERTS, COEFFS, *SLAB_BOUNDS)
+        npt.assert_allclose(results[("vertices",)], vf_exp, rtol=1e-2)
+
+
+@pytest.mark.parametrize("sidewall_angle", [0.0, np.pi / 12, np.pi / 6])
+class TestPolySlabSidewallAngles:
+    """Test with different sidewall angles.
+
+    Note: We use angles up to pi/6 instead of larger angles like pi/4
+    because large sidewall angles with the given slab thickness can cause
+    self-intersecting geometry, which fails PolySlab validation.
+    """
+
+    AXIS = 2
+    TRIANGLE_VERTS = np.array(
+        [
+            (0.0, 0.0),
+            (2.0, 0.0),
+            (1.0, 1.5),
+        ],
+        dtype=float,
+    )
+
+    @pytest.fixture
+    def slab(self, sidewall_angle):
+        return td.PolySlab(
+            vertices=self.TRIANGLE_VERTS,
+            axis=self.AXIS,
+            slab_bounds=SLAB_BOUNDS,
+            sidewall_angle=sidewall_angle,
+        )
+
+    @pytest.fixture
+    def results(self, slab):
+        di = DummyDI(
+            paths=[("slab_bounds", 0), ("slab_bounds", 1), ("vertices",)],
+            axis=self.AXIS,
+            coeffs=COEFFS,
+        )
+        return slab._compute_derivatives(di)
+
+    def test_derivatives_are_finite(self, results):
+        """Ensure derivatives are finite for slanted sidewalls."""
+        for path, value in results.items():
+            if isinstance(value, np.ndarray):
+                assert np.all(np.isfinite(value)), f"Non-finite values in {path}"
+            else:
+                assert np.isfinite(value), f"Non-finite value in {path}"
+
+    def test_face_forces_scale_with_polygon_area(self, slab, results, sidewall_angle):
+        """Face forces should scale with the actual polygon areas at each face."""
+        base_polygon = slab.base_polygon
+        top_polygon = slab.top_polygon
+
+        bot_exp, _ = analytic_faces(base_polygon, COEFFS, *SLAB_BOUNDS)
+        _, top_exp = analytic_faces(top_polygon, COEFFS, *SLAB_BOUNDS)
+
+        npt.assert_allclose(results[("slab_bounds", 0)], bot_exp, rtol=1e-2)
+        npt.assert_allclose(results[("slab_bounds", 1)], top_exp, rtol=1e-2)
+
+    def test_face_force_area_relationship(self, slab, results, sidewall_angle):
+        """Verify that face forces scale linearly with polygon areas."""
+        if sidewall_angle == 0.0:
+            return
+
+        base_area, _, _ = polygon_area_centroid(slab.base_polygon)
+        top_area, _, _ = polygon_area_centroid(slab.top_polygon)
+        ref_area, _, _ = polygon_area_centroid(self.TRIANGLE_VERTS)
+
+        # for a linear integrand f(x,y,z) = ax + by + cz + d,
+        # the force scales with area when the centroid term dominates
+        # this is a sanity check that the implementation is consistent
+
+        # get the reference case (vertical sidewalls)
+        slab_vertical = td.PolySlab(
+            vertices=self.TRIANGLE_VERTS,
+            axis=self.AXIS,
+            slab_bounds=SLAB_BOUNDS,
+            sidewall_angle=0.0,
+        )
+        di_vertical = DummyDI(
+            paths=[("slab_bounds", 0), ("slab_bounds", 1)],
+            axis=self.AXIS,
+            coeffs=COEFFS,
+        )
+        results_vertical = slab_vertical._compute_derivatives(di_vertical)
+
+        # check that the force ratios are reasonable compared to area ratios
+        # we don't expect exact proportionality due to centroid shifts,
+        # but the relationship should be monotonic and roughly linear
+        bot_force_ratio = results[("slab_bounds", 0)] / results_vertical[("slab_bounds", 0)]
+        top_force_ratio = results[("slab_bounds", 1)] / results_vertical[("slab_bounds", 1)]
+
+        bot_area_ratio = base_area / ref_area
+        top_area_ratio = top_area / ref_area
+
+        # forces should increase/decrease in the same direction as areas
+        assert (bot_force_ratio > 1.0) == (bot_area_ratio > 1.0), (
+            f"Bottom force ratio {bot_force_ratio} inconsistent with area ratio {bot_area_ratio}"
+        )
+        assert (top_force_ratio > 1.0) == (top_area_ratio > 1.0), (
+            f"Top force ratio {top_force_ratio} inconsistent with area ratio {top_area_ratio}"
+        )

--- a/tidy3d/compat.py
+++ b/tidy3d/compat.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import importlib
 
 from packaging.version import parse as parse_version
@@ -12,13 +13,9 @@ except ImportError:
     from xarray.core import alignment
 
 
-_SHAPELY_VERSION = parse_version(importlib.metadata.version("shapely"))
-
-
+@functools.lru_cache(maxsize=8)
 def _shapely_is_older_than(version: str) -> bool:
-    if _SHAPELY_VERSION < parse_version(version):
-        return True
-    return False
+    return parse_version(importlib.metadata.version("shapely")) < parse_version(version)
 
 
 __all__ = ["alignment"]

--- a/tidy3d/components/autograd/constants.py
+++ b/tidy3d/components/autograd/constants.py
@@ -1,8 +1,24 @@
-# interval space for adjoint monitors (half of sim resolution)
 from __future__ import annotations
+
+import numpy as np
 
 # default number of points per wvl in material for discretizing cylinder in autograd derivative
 PTS_PER_WVL_MAT_CYLINDER_DISCRETIZE = 10
 
 MAX_NUM_TRACED_STRUCTURES = 500
 MAX_NUM_ADJOINT_PER_FWD = 10
+
+GRADIENT_PRECISION = "single"  # Options: "single", "double"
+GRADIENT_DTYPE_FLOAT = np.float32 if GRADIENT_PRECISION == "single" else np.float64
+GRADIENT_DTYPE_COMPLEX = np.complex64 if GRADIENT_PRECISION == "single" else np.complex128
+
+GAUSS_QUADRATURE_ORDER = 7
+QUAD_SAMPLE_FRACTION = 0.4
+
+AUTOGRAD_MONITOR_INTERVAL_SPACE_POLY = (1, 1, 1)
+AUTOGRAD_MONITOR_INTERVAL_SPACE_CUSTOM = (1, 1, 1)
+
+DEFAULT_WAVELENGTH_FRACTION = 0.1
+MINIMUM_SPACING = 1e-2
+
+EDGE_CLIP_TOLERANCE = 1e-9

--- a/tidy3d/components/autograd/constants.py
+++ b/tidy3d/components/autograd/constants.py
@@ -1,0 +1,8 @@
+# interval space for adjoint monitors (half of sim resolution)
+from __future__ import annotations
+
+# default number of points per wvl in material for discretizing cylinder in autograd derivative
+PTS_PER_WVL_MAT_CYLINDER_DISCRETIZE = 10
+
+MAX_NUM_TRACED_STRUCTURES = 500
+MAX_NUM_ADJOINT_PER_FWD = 10

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -1,391 +1,474 @@
-# utilities for autograd derivative passing
+"""Utilities for autograd derivative computation and field gradient evaluation."""
+
 from __future__ import annotations
 
+from dataclasses import dataclass, field, replace
+from typing import Callable, Optional
+
 import numpy as np
-import pydantic.v1 as pd
 import xarray as xr
 
-from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.data.data_array import ScalarFieldDataArray, SpatialDataArray
-from tidy3d.components.types import ArrayLike, Bound, tidycomplex
-from tidy3d.constants import LARGE_NUMBER
+from tidy3d.components.types import Bound, tidycomplex
+from tidy3d.constants import C_0, LARGE_NUMBER
 
+from .constants import (
+    DEFAULT_WAVELENGTH_FRACTION,
+    GRADIENT_DTYPE_COMPLEX,
+    GRADIENT_DTYPE_FLOAT,
+    MINIMUM_SPACING,
+)
 from .types import PathType
 from .utils import get_static
 
-# we do this because importing these creates circular imports
 FieldData = dict[str, ScalarFieldDataArray]
 PermittivityData = dict[str, ScalarFieldDataArray]
 
 
-class DerivativeSurfaceMesh(Tidy3dBaseModel):
-    """Stores information about the surfaces of an object to be used for derivative calculation.
+class LazyInterpolator:
+    """Lazy wrapper for interpolators that creates them on first access."""
 
-    User guide: this class is used to construct derivatives with respect to surface elements
-    given some forward and adjoint fields stored in a ``DerivativeInfo`` class. To use it,
-    you must specify the central locations of all the surface elements in ``centers``,
-    along with the area of each element in ``areas``. Then you need to specify three orthogonal
-    vectors (``normals``, ``perps1`` and ``perps2``). The derivative will be computed with
-    respect to a change in material along the ``normals`` direction. It is important to note
-    that the sign of these basis vectors is irrelevant since we end up multiplying the forward
-    and adjoint fields together in these bases.
+    def __init__(self, creator_func: Callable):
+        """Initialize with a function that creates the interpolator when called."""
+        self.creator_func = creator_func
+        self._interpolator = None
 
-    The gradient is with respect to a change from the surface element permittivity from the
-    ``eps_in`` to ``eps_out`` field. So in principle it is always computing gradients with
-    respect to an infinitesimal outward shift in the normal direction. For example, for
-    ``PolySlab.vertices``, this means shifting each edge to the background.
-    For ``PolySlab.slab_bounds``, this means shifting the bound in either + or - direction if it
-    is index ``[1]`` or ``[0]`` respectively. This renders the sign of the normal vector
-    irrelevant.
+    def __call__(self, *args, **kwargs):
+        """Create interpolator on first call and delegate to it."""
+        if self._interpolator is None:
+            self._interpolator = self.creator_func()
+        return self._interpolator(*args, **kwargs)
 
-    After this ``DerivativeSurfaceMesh`` is constructed, given some ``DerivativeInfo`` in the
-    gradient calculation, a call to ``DerivativeInfo.grad_surfaces(x: DerivativeSurfaceMesh)``
-    will return the gradient with respect to a change in all of the provided surfaces.
 
+@dataclass
+class DerivativeInfo:
+    """Stores derivative information passed to the ``._compute_derivatives`` methods.
+
+    This dataclass contains all the field data and parameters needed for computing
+    gradients with respect to geometry perturbations.
     """
 
-    centers: ArrayLike = pd.Field(
-        ...,
-        title="Centers",
-        description="(N, 3) array storing the centers of each surface element.",
-    )
+    # Required fields
+    paths: list[PathType]
+    """List of paths to the traced fields that need derivatives calculated."""
 
-    areas: ArrayLike = pd.Field(
-        ...,
-        title="Area Elements",
-        description="(N,) array storing the first perpendicular vectors of each surface element.",
-    )
+    E_der_map: FieldData
+    """Electric field gradient map.
+    Dataset where the field components ("Ex", "Ey", "Ez") store the multiplication
+    of the forward and adjoint electric fields. The tangential components of this
+    dataset are used when computing adjoint gradients for shifting boundaries.
+    All components are used when computing volume-based gradients."""
 
-    normals: ArrayLike = pd.Field(
-        ...,
-        title="Normals",
-        description="(N, 3) array storing the normal vectors of each surface element.",
-    )
+    D_der_map: FieldData
+    """Displacement field gradient map.
+    Dataset where the field components ("Ex", "Ey", "Ez") store the multiplication
+    of the forward and adjoint displacement fields. The normal component of this
+    dataset is used when computing adjoint gradients for shifting boundaries."""
 
-    perps1: ArrayLike = pd.Field(
-        ...,
-        title="Perpendiculars 1",
-        description="(N, 3) array storing the first perpendicular vectors of each surface element.",
-    )
+    E_fwd: FieldData
+    """Forward electric fields.
+    Dataset where the field components ("Ex", "Ey", "Ez") represent the forward
+    electric fields used for computing gradients for a given structure."""
 
-    perps2: ArrayLike = pd.Field(
-        ...,
-        title="Perpendiculars 1",
-        description="(N, 3) array storing the first perpendicular vectors of each surface element.",
-    )
+    E_adj: FieldData
+    """Adjoint electric fields.
+    Dataset where the field components ("Ex", "Ey", "Ez") represent the adjoint
+    electric fields used for computing gradients for a given structure."""
 
+    D_fwd: FieldData
+    """Forward displacement fields.
+    Dataset where the field components ("Ex", "Ey", "Ez") represent the forward
+    displacement fields used for computing gradients for a given structure."""
 
-class DerivativeInfo(Tidy3dBaseModel):
-    """Stores derivative information passed to the ``.compute_derivatives`` methods."""
+    D_adj: FieldData
+    """Adjoint displacement fields.
+    Dataset where the field components ("Ex", "Ey", "Ez") represent the adjoint
+    displacement fields used for computing gradients for a given structure."""
 
-    paths: list[PathType] = pd.Field(
-        ...,
-        title="Paths to Traced Fields",
-        description="List of paths to the traced fields that need derivatives calculated.",
-    )
+    eps_data: PermittivityData
+    """Permittivity dataset.
+    Dataset of relative permittivity values along all three dimensions.
+    Used for automatically computing permittivity inside or outside of a simple geometry."""
 
-    E_der_map: FieldData = pd.Field(
-        ...,
-        title="Electric Field Gradient Map",
-        description='Dataset where the field components ``("Ex", "Ey", "Ez")`` store the '
-        "multiplication of the forward and adjoint electric fields. The tangential components "
-        "of this dataset is used when computing adjoint gradients for shifting boundaries. "
-        "All components are used when computing volume-based gradients.",
-    )
+    eps_in: tidycomplex
+    """Permittivity inside the Structure.
+    Typically computed from Structure.medium.eps_model.
+    Used when it cannot be computed from eps_data or when eps_approx=True."""
 
-    D_der_map: FieldData = pd.Field(
-        ...,
-        title="Displacement Field Gradient Map",
-        description='Dataset where the field components ``("Ex", "Ey", "Ez")`` store the '
-        "multiplication of the forward and adjoint displacement fields. The normal component "
-        "of this dataset is used when computing adjoint gradients for shifting boundaries.",
-    )
+    eps_out: tidycomplex
+    """Permittivity outside the Structure.
+    Typically computed from Simulation.medium.eps_model.
+    Used when it cannot be computed from eps_data or when eps_approx=True."""
 
-    E_fwd: FieldData = pd.Field(
-        ...,
-        title="Forward Electric Fields",
-        description='Dataset where the field components ``("Ex", "Ey", "Ez")`` represent the '
-        "forward electric fields used for computing gradients for a given structure.",
-    )
+    bounds: Bound
+    """Geometry bounds.
+    Bounds corresponding to the structure, used in Medium calculations."""
 
-    E_adj: FieldData = pd.Field(
-        ...,
-        title="Adjoint Electric Fields",
-        description='Dataset where the field components ``("Ex", "Ey", "Ez")`` represent the '
-        "adjoint electric fields used for computing gradients for a given structure.",
-    )
+    bounds_intersect: Bound
+    """Geometry and simulation intersection bounds.
+    Bounds corresponding to the minimum intersection between the structure
+    and the simulation it is contained in."""
 
-    D_fwd: FieldData = pd.Field(
-        ...,
-        title="Forward Displacement Fields",
-        description='Dataset where the field components ``("Ex", "Ey", "Ez")`` represent the '
-        "forward displacement fields used for computing gradients for a given structure.",
-    )
+    frequency: float
+    """Frequency of adjoint simulation at which the gradient is computed."""
 
-    D_adj: FieldData = pd.Field(
-        ...,
-        title="Adjoint Displacement Fields",
-        description='Dataset where the field components ``("Ex", "Ey", "Ez")`` represent the '
-        "adjoint displacement fields used for computing gradients for a given structure.",
-    )
+    # Optional fields with defaults
+    eps_background: Optional[tidycomplex] = None
+    """Permittivity in background.
+    Permittivity outside of the Structure as manually specified by
+    Structure.background_medium."""
 
-    eps_data: PermittivityData = pd.Field(
-        ...,
-        title="Permittivity Dataset",
-        description="Dataset of relative permittivity values along all three dimensions. "
-        "Used for automatically computing permittivity inside or outside of a simple geometry.",
-    )
+    eps_no_structure: Optional[SpatialDataArray] = None
+    """Permittivity without structure.
+    The permittivity of the original simulation without the structure that is
+    being differentiated with respect to. Used to approximate permittivity
+    outside of the structure for shape optimization."""
 
-    eps_in: tidycomplex = pd.Field(
-        title="Permittivity Inside",
-        description="Permittivity inside of the ``Structure``. "
-        "Typically computed from ``Structure.medium.eps_model``."
-        "Used when it can not be computed from ``eps_data`` or when ``eps_approx==True``.",
-    )
+    eps_inf_structure: Optional[SpatialDataArray] = None
+    """Permittivity with infinite structure.
+    The permittivity of the original simulation where the structure being
+    differentiated with respect to is infinitely large. Used to approximate
+    permittivity inside of the structure for shape optimization."""
 
-    eps_out: tidycomplex = pd.Field(
-        ...,
-        title="Permittivity Outside",
-        description="Permittivity outside of the ``Structure``. "
-        "Typically computed from ``Simulation.medium.eps_model``."
-        "Used when it can not be computed from ``eps_data`` or when ``eps_approx==True``.",
-    )
+    eps_approx: bool = False
+    """Use permittivity approximation.
+    If True, approximates outside permittivity using Simulation.medium and
+    the inside permittivity using Structure.medium. Only set True for
+    GeometryGroup handling where it is difficult to automatically evaluate
+    the inside and outside relative permittivity for each geometry."""
 
-    eps_background: tidycomplex = pd.Field(
-        None,
-        title="Permittivity in Background",
-        description="Permittivity outside of the ``Structure`` as manually specified by. "
-        "``Structure.background_medium``. ",
-    )
+    interpolators: Optional[dict] = None
+    """Pre-computed interpolators.
+    Optional pre-computed interpolators for field components and permittivity data.
+    When provided, avoids redundant interpolator creation for multiple geometries
+    sharing the same field data. This significantly improves performance for
+    GeometryGroup processing."""
 
-    bounds: Bound = pd.Field(
-        ...,
-        title="Geometry Bounds",
-        description="Bounds corresponding to the structure, used in ``Medium`` calculations.",
-    )
+    # private cache for interpolators
+    _interpolators_cache: dict = field(default_factory=dict, init=False, repr=False)
 
-    bounds_intersect: Bound = pd.Field(
-        ...,
-        title="Geometry and Simulation Intersections Bounds",
-        description="Bounds corresponding to the minimum intersection between the "
-        "structure and the simulation it is contained in.",
-    )
+    def updated_copy(self, **kwargs):
+        """Create a copy with updated fields."""
+        kwargs.pop("deep", None)
+        kwargs.pop("validate", None)
+        return replace(self, **kwargs)
 
-    frequency: float = pd.Field(
-        ...,
-        title="Frequency of adjoint simulation",
-        description="Frequency at which the adjoint gradient is computed.",
-    )
+    @staticmethod
+    def _get_freq_index(arr: ScalarFieldDataArray, freq: float) -> int:
+        """Get the index of the frequency in the array's frequency coordinates."""
+        if "f" not in arr.dims:
+            return None
+        freq_coords = arr.coords["f"].data
+        idx = np.argmin(np.abs(freq_coords - freq))
+        return int(idx)
 
-    eps_no_structure: SpatialDataArray = pd.Field(
-        None,
-        title="Permittivity Without Structure",
-        description="The permittivity of the original simulation without the structure that is "
-        "being differentiated with respect to. Used to approximate permittivity outside of the "
-        "structure for shape optimization.",
-    )
+    @staticmethod
+    def _nan_to_num_if_needed(coords: np.ndarray) -> np.ndarray:
+        """Convert NaN and infinite values to finite numbers, optimized for finite inputs."""
+        # skip check for small arrays - overhead exceeds benefit
+        if coords.size < 1000:
+            return np.nan_to_num(coords, posinf=LARGE_NUMBER, neginf=-LARGE_NUMBER)
 
-    eps_inf_structure: SpatialDataArray = pd.Field(
-        None,
-        title="Permittivity With Infinite Structure",
-        description="The permittivity of the original simulation where the structure being "
-        " differentiated with respect to is inifinitely large. Used to approximate permittivity "
-        "inside of the structure for shape optimization.",
-    )
+        if np.isfinite(coords).all():
+            return coords
+        return np.nan_to_num(coords, posinf=LARGE_NUMBER, neginf=-LARGE_NUMBER)
 
-    eps_approx: bool = pd.Field(
-        False,
-        title="Use Permittivity Approximation",
-        description="If ``True``, approximates outside permittivity using ``Simulation.medium``"
-        "and the inside permittivity using ``Structure.medium``. "
-        "Only set ``True`` for ``GeometryGroup`` handling where it is difficult to automatically "
-        "evaluate the inside and outside relative permittivity for each geometry.",
-    )
+    @staticmethod
+    def _evaluate_with_interpolators(
+        interpolators: dict, coords: np.ndarray
+    ) -> dict[str, np.ndarray]:
+        """Evaluate field components at coordinates using cached interpolators.
 
-    def updated_paths(self, paths: list[PathType]) -> DerivativeInfo:
-        """Update this ``DerivativeInfo`` with new set of paths."""
-        return self.updated_copy(paths=paths)
+        Parameters
+        ----------
+        interpolators : dict
+            Dictionary mapping field component names to ``RegularGridInterpolator`` objects.
+        coords : np.ndarray
+            Spatial coordinates (N, 3) where fields are evaluated.
 
-    def _eps_in(self, spatial_coords: np.ndarray) -> complex | np.ndarray:
-        """permittivity inside, used internally."""
-        # determine inside medium
+        Returns
+        -------
+        dict[str, np.ndarray]
+            Dictionary mapping component names to field values at coordinates.
+        """
+        coords = DerivativeInfo._nan_to_num_if_needed(coords)
+        if coords.dtype != GRADIENT_DTYPE_FLOAT and coords.dtype != GRADIENT_DTYPE_COMPLEX:
+            coords = coords.astype(GRADIENT_DTYPE_FLOAT, copy=False)
+        return {name: interp(coords) for name, interp in interpolators.items()}
+
+    def create_interpolators(self, dtype=GRADIENT_DTYPE_FLOAT) -> dict:
+        """Create interpolators for field components and permittivity data.
+
+        Creates and caches ``RegularGridInterpolator`` objects for all field components
+        (E_fwd, E_adj, D_fwd, D_adj) and permittivity data (eps_inf, eps_no).
+        This caching strategy significantly improves performance by avoiding
+        repeated interpolator construction in gradient evaluation loops.
+
+        Parameters
+        ----------
+        dtype : np.dtype = GRADIENT_DTYPE_FLOAT
+            Data type for interpolation coordinates and values.
+
+        Returns
+        -------
+        dict
+            Nested dictionary structure:
+            - Field data: {"E_fwd": {"Ex": interpolator, ...}, ...}
+            - Permittivity: {"eps_inf": interpolator, "eps_no": interpolator}
+        """
+        from scipy.interpolate import RegularGridInterpolator
+
+        cache_key = str(dtype)
+        if cache_key in self._interpolators_cache:
+            return self._interpolators_cache[cache_key]
+
+        interpolators = {}
+        coord_cache = {}
+
+        def _make_lazy_interpolator_group(field_data_dict, group_key, is_field_group=True):
+            """Helper to create a group of lazy interpolators."""
+            if is_field_group:
+                interpolators[group_key] = {}
+
+            for component_name, arr in field_data_dict.items():
+                # use object ID for caching to handle shared grids
+                arr_id = id(arr.data)
+                if arr_id not in coord_cache:
+                    points = tuple(c.data.astype(dtype, copy=False) for c in (arr.x, arr.y, arr.z))
+                    coord_cache[arr_id] = points
+                points = coord_cache[arr_id]
+
+                # defer data selection until the interpolator is called
+                def creator_func(arr=arr, points=points):
+                    freq_idx = self._get_freq_index(arr, self.frequency)
+                    data = arr.data if freq_idx is None else arr.isel(f=freq_idx).data
+                    data = data.astype(
+                        GRADIENT_DTYPE_COMPLEX if np.iscomplexobj(data) else dtype, copy=False
+                    )
+                    return RegularGridInterpolator(
+                        points, data, method="linear", bounds_error=False, fill_value=None
+                    )
+
+                if is_field_group:
+                    interpolators[group_key][component_name] = LazyInterpolator(creator_func)
+                else:
+                    # for permittivity, store directly with the key (not nested)
+                    interpolators[component_name] = LazyInterpolator(creator_func)
+
+        # process field interpolators (nested dictionaries)
+        for group_key, data_dict in [
+            ("E_fwd", self.E_fwd),
+            ("E_adj", self.E_adj),
+            ("D_fwd", self.D_fwd),
+            ("D_adj", self.D_adj),
+        ]:
+            _make_lazy_interpolator_group(data_dict, group_key, is_field_group=True)
+
+        # process permittivity interpolators
         if self.eps_inf_structure is not None:
-            return self.evaluate_eps(spatial_coords, is_inside=True)
-
-        return self.eps_in
-
-    def _eps_out(self, spatial_coords: np.ndarray) -> complex | np.ndarray:
-        """permittivity outside, used internally."""
-
-        # determine background medium
-        if self.eps_background is not None:
-            return self.eps_background
-
+            _make_lazy_interpolator_group(
+                {"eps_inf": self.eps_inf_structure}, None, is_field_group=False
+            )
         if self.eps_no_structure is not None:
-            return self.evaluate_eps(spatial_coords, is_inside=False)
+            _make_lazy_interpolator_group(
+                {"eps_no": self.eps_no_structure}, None, is_field_group=False
+            )
 
-        return self.eps_out
+        self._interpolators_cache[cache_key] = interpolators
+        return interpolators
 
-    def delta_eps(self, spatial_coords: np.ndarray) -> complex | np.ndarray:
-        """Change in the permittivity across interface (for E field grads)."""
-        return self._eps_in(spatial_coords) - self._eps_out(spatial_coords)
+    def evaluate_gradient_at_points(
+        self,
+        spatial_coords: np.ndarray,
+        normals: np.ndarray,
+        perps1: np.ndarray,
+        perps2: np.ndarray,
+        interpolators: Optional[dict] = None,
+    ) -> np.ndarray:
+        """Compute adjoint gradients at surface points for shape optimization.
 
-    def delta_eps_inv(self, spatial_coords: np.ndarray) -> complex | np.ndarray:
-        """Change in 1 / permittivity across interface (for D field grads)."""
-        return 1.0 / self._eps_in(spatial_coords) - 1.0 / self._eps_out(spatial_coords)
+        Implements the surface integral formulation for computing gradients with respect
+        to geometry perturbations.
 
-    def grad_surfaces(self, surface_mesh: DerivativeSurfaceMesh) -> dict:
-        """Derivative with respect to the surface mesh elements, given the derivative fields."""
+        Parameters
+        ----------
+        spatial_coords : np.ndarray
+            (N, 3) array of surface evaluation points.
+        normals : np.ndarray
+            (N, 3) array of outward-pointing normal vectors at each surface point.
+        perps1 : np.ndarray
+            (N, 3) array of first tangent vectors perpendicular to normals.
+        perps2 : np.ndarray
+            (N, 3) array of second tangent vectors perpendicular to both normals and perps1.
+        interpolators : dict = None
+            Pre-computed field interpolators for efficiency.
 
-        # strip out relevant info from `surface_mesh`
-        spatial_coords = surface_mesh.centers
-        normals = surface_mesh.normals
-        perps1 = surface_mesh.perps1
-        perps2 = surface_mesh.perps2
+        Returns
+        -------
+        np.ndarray
+            (N,) array of gradient values at each surface point. Must be integrated
+            with appropriate quadrature weights to get total gradient.
+        """
+        if interpolators is None:
+            raise NotImplementedError(
+                "Direct field evaluation without interpolators is not implemented. "
+                "Please create interpolators using 'create_interpolators()' first."
+            )
 
-        # unpack electric and displacement fields
-        E_fwd = self.E_fwd
-        E_adj = self.E_adj
-        D_fwd = self.D_fwd
-        D_adj = self.D_adj
+        # evaluate all field components at surface points
+        E_fwd_at_coords = {
+            name: interp(spatial_coords) for name, interp in interpolators["E_fwd"].items()
+        }
+        E_adj_at_coords = {
+            name: interp(spatial_coords) for name, interp in interpolators["E_adj"].items()
+        }
+        D_fwd_at_coords = {
+            name: interp(spatial_coords) for name, interp in interpolators["D_fwd"].items()
+        }
+        D_adj_at_coords = {
+            name: interp(spatial_coords) for name, interp in interpolators["D_adj"].items()
+        }
 
-        # compute the E and D fields at the edge centers
-        E_fwd_at_coords = self.evaluate_flds_at(
-            fld_dataset=E_fwd, spatial_coords=spatial_coords, freq=self.frequency
-        )
-        E_adj_at_coords = self.evaluate_flds_at(
-            fld_dataset=E_adj, spatial_coords=spatial_coords, freq=self.frequency
-        )
-        D_fwd_at_coords = self.evaluate_flds_at(
-            fld_dataset=D_fwd, spatial_coords=spatial_coords, freq=self.frequency
-        )
-        D_adj_at_coords = self.evaluate_flds_at(
-            fld_dataset=D_adj, spatial_coords=spatial_coords, freq=self.frequency
-        )
+        # project fields onto local surface basis (normal + two tangents)
+        D_fwd_norm = self._project_in_basis(D_fwd_at_coords, basis_vector=normals)
+        D_adj_norm = self._project_in_basis(D_adj_at_coords, basis_vector=normals)
 
-        # project the relevant field quantities into their respective basis for gradient calculation
-        D_fwd_norm = self.project_in_basis(D_fwd_at_coords, basis_vector=normals)
-        D_adj_norm = self.project_in_basis(D_adj_at_coords, basis_vector=normals)
+        E_fwd_perp1 = self._project_in_basis(E_fwd_at_coords, basis_vector=perps1)
+        E_adj_perp1 = self._project_in_basis(E_adj_at_coords, basis_vector=perps1)
 
-        E_fwd_perp1 = self.project_in_basis(E_fwd_at_coords, basis_vector=perps1)
-        E_adj_perp1 = self.project_in_basis(E_adj_at_coords, basis_vector=perps1)
+        E_fwd_perp2 = self._project_in_basis(E_fwd_at_coords, basis_vector=perps2)
+        E_adj_perp2 = self._project_in_basis(E_adj_at_coords, basis_vector=perps2)
 
-        E_fwd_perp2 = self.project_in_basis(E_fwd_at_coords, basis_vector=perps2)
-        E_adj_perp2 = self.project_in_basis(E_adj_at_coords, basis_vector=perps2)
-
-        # multiply forward and adjoint
+        # compute field products
         D_der_norm = D_fwd_norm * D_adj_norm
         E_der_perp1 = E_fwd_perp1 * E_adj_perp1
         E_der_perp2 = E_fwd_perp2 * E_adj_perp2
 
-        # approximate permittivity in and out
-        delta_eps_inv = self.delta_eps_inv(spatial_coords=spatial_coords)
-        delta_eps = self.delta_eps(spatial_coords=spatial_coords)
+        # get permittivity jumps across interface
+        if "eps_inf" in interpolators:
+            eps_in = interpolators["eps_inf"](spatial_coords)
+        else:
+            eps_in = self.eps_in
 
-        # put together VJP using D_normal and E_perp integration
-        vjps = 0.0
+        if "eps_no" in interpolators:
+            eps_out = interpolators["eps_no"](spatial_coords)
+        elif self.eps_background is not None:
+            eps_out = self.eps_background
+        else:
+            eps_out = self.eps_out
 
-        # perform D-normal integral
-        contrib_D = -delta_eps_inv * D_der_norm
-        vjps += contrib_D
+        delta_eps_inv = 1.0 / eps_in - 1.0 / eps_out
+        delta_eps = eps_in - eps_out
 
-        # perform E-perpendicular integrals
-        for E_der in (E_der_perp1, E_der_perp2):
-            contrib_E = E_der * delta_eps
-            vjps += contrib_E
+        vjps = -delta_eps_inv * D_der_norm + E_der_perp1 * delta_eps + E_der_perp2 * delta_eps
 
-        return surface_mesh.areas * vjps
-
-    def evaluate_eps(
-        self,
-        spatial_coords: np.ndarray,  # (N, 3)
-        is_inside: bool,
-    ) -> SpatialDataArray:
-        """Evaluate permittivity without the structure at a set of points."""
-
-        permittivity_array = self.eps_inf_structure if is_inside else self.eps_no_structure
-
-        if permittivity_array is None:
-            raise ValueError("Can't evaluate eps because the permittivity array is missing.")
-
-        key = "key"
-        eps_out = self.evaluate_flds_at(
-            fld_dataset={key: permittivity_array},
-            spatial_coords=spatial_coords,
-            freq=self.frequency,
-        )[key]
-        return eps_out.values
+        return vjps
 
     @staticmethod
-    def evaluate_flds_at(
-        fld_dataset: dict[str, ScalarFieldDataArray],
-        spatial_coords: np.ndarray,  # (N, 3)
-        freq: float,
-    ) -> dict[str, ScalarFieldDataArray]:
-        """Compute the value of an dict with keys Ex, Ey, Ez at a set of spatial locations."""
-
-        from scipy.interpolate import RegularGridInterpolator
-
-        coords = np.nan_to_num(spatial_coords, posinf=LARGE_NUMBER, neginf=-LARGE_NUMBER)
-        components = {}
-
-        edge_index_dim = "edge_index"
-        n_points = coords.shape[0]
-
-        for fld_name, arr in fld_dataset.items():
-            data = arr.sel(f=freq).values if "f" in arr.dims else arr.values
-            points = tuple(arr.coords[dim].values for dim in "xyz")
-
-            interpolator = RegularGridInterpolator(
-                points, data, method="linear", bounds_error=False, fill_value=None
-            )
-            result = interpolator(coords)
-
-            components[fld_name] = xr.DataArray(
-                result,
-                coords={edge_index_dim: np.arange(n_points)},
-                dims=[edge_index_dim],
-                name=fld_name,
-            )
-
-        return components
-
-    @staticmethod
-    def project_in_basis(
-        der_dataset: xr.Dataset,
+    def _project_in_basis(
+        field_components: dict[str, np.ndarray],
         basis_vector: np.ndarray,
-    ) -> xr.DataArray:
-        """Project a derivative dataset along a supplied basis vector."""
-        value = 0.0
-        for coeffs, dim in zip(basis_vector.T, "xyz"):
-            value += coeffs * der_dataset[f"E{dim}"]
-        return value
+    ) -> np.ndarray:
+        """Project 3D field components onto a basis vector.
+
+        Parameters
+        ----------
+        field_components : dict[str, np.ndarray]
+            Dictionary with keys like "Ex", "Ey", "Ez" or "Dx", "Dy", "Dz" containing field values.
+        basis_vector : np.ndarray
+            (N, 3) array of basis vectors, one per evaluation point.
+
+        Returns
+        -------
+        np.ndarray
+            (N,) array of projected field values.
+        """
+        prefix = next(iter(field_components.keys()))[0]
+        field_matrix = np.stack([field_components[f"{prefix}{dim}"] for dim in "xyz"], axis=1)
+        return np.einsum("ij,ij->i", field_matrix, basis_vector)
+
+    def adaptive_vjp_spacing(
+        self,
+        wl_fraction: float = DEFAULT_WAVELENGTH_FRACTION,
+        min_allowed_spacing: float = MINIMUM_SPACING,
+    ) -> float:
+        """Compute adaptive spacing for finite-difference gradient evaluation.
+
+        Determines an appropriate spatial resolution based on the material
+        properties and electromagnetic wavelength/skin depth.
+
+        Parameters
+        ----------
+        wl_fraction : float = 0.1
+            Fraction of wavelength/skin depth to use as spacing.
+        min_allowed_spacing : float = 1e-2
+            Minimum allowed spacing to prevent numerical issues.
+
+        Returns
+        -------
+        float
+            Adaptive spacing value for gradient evaluation.
+        """
+        eps_real = np.asarray(self.eps_in, dtype=np.complex128).real
+
+        dx_candidates = []
+
+        # wavelength-based sampling for dielectric materials
+        if np.any(eps_real > 0):
+            eps_max = eps_real[eps_real > 0].max()
+            lambda_min = C_0 / (self.frequency * np.sqrt(eps_max))
+            dx_candidates.append(wl_fraction * lambda_min)
+
+        # skin depth-based sampling for metallic materials
+        if np.any(eps_real <= 0):
+            omega = 2 * np.pi * self.frequency
+            eps_neg = eps_real[eps_real <= 0]
+            delta_min = C_0 / (omega * np.sqrt(np.abs(eps_neg).max()))
+            dx_candidates.append(wl_fraction * delta_min)
+
+        return max(min(dx_candidates), min_allowed_spacing)
 
 
-# TODO: could we move this into a DataArray method?
 def integrate_within_bounds(arr: xr.DataArray, dims: list[str], bounds: Bound) -> xr.DataArray:
-    """integrate a data array within bounds, assumes bounds are [2, N] for N dims."""
+    """Integrate a data array within specified spatial bounds.
 
-    # order bounds with dimension first (N, 2)
+    Clips the integration domain to the specified bounds and performs
+    numerical integration using the trapezoidal rule.
+
+    Parameters
+    ----------
+    arr : xr.DataArray
+        Data array to integrate.
+    dims : list[str]
+        Dimensions to integrate over (e.g., ['x', 'y', 'z']).
+    bounds : Bound
+        Integration bounds as [[xmin, ymin, zmin], [xmax, ymax, zmax]].
+
+    Returns
+    -------
+    xr.DataArray
+        Result of integration with specified dimensions removed.
+
+    Notes
+    -----
+    - Coordinates outside bounds are clipped, effectively setting dL=0
+    - Only integrates dimensions with more than one coordinate point
+    - Uses xarray's integrate method (trapezoidal rule)
+    """
     bounds = np.asarray(bounds).T
     all_coords = {}
 
-    # loop over all dimensions
     for dim, (bmin, bmax) in zip(dims, bounds):
         bmin = get_static(bmin)
         bmax = get_static(bmax)
 
-        coord_values = np.copy(arr.coords[dim].data)
-
-        # reset all coordinates outside of bounds to the bounds, so that dL = 0 in integral
-        np.clip(coord_values, bmin, bmax, out=coord_values)
-
-        all_coords[dim] = coord_values
+        # clip coordinates to bounds (sets dL=0 outside bounds)
+        coord_values = arr.coords[dim].data
+        all_coords[dim] = np.clip(coord_values, bmin, bmax)
 
     _arr = arr.assign_coords(**all_coords)
 
-    # uses trapezoidal rule
-    # https://docs.xarray.dev/en/stable/generated/xarray.DataArray.integrate.html
+    # only integrate dimensions with multiple points
     dims_integrate = [dim for dim in dims if len(_arr.coords[dim]) > 1]
     return _arr.integrate(coord=dims_integrate)
 

--- a/tidy3d/components/autograd/utils.py
+++ b/tidy3d/components/autograd/utils.py
@@ -1,28 +1,41 @@
 # utilities for working with autograd
 from __future__ import annotations
 
-import typing
+from collections.abc import Iterable
+from typing import Any
 
 from autograd.tracer import getval
 
 
-def get_static(x: typing.Any) -> typing.Any:
+def get_static(x: Any) -> Any:
     """Get the 'static' (untraced) version of some value."""
     return getval(x)
 
 
-def split_list(x: list[typing.Any], index: int) -> (list[typing.Any], list[typing.Any]):
+def split_list(x: list[Any], index: int) -> (list[Any], list[Any]):
     """Split a list at a given index."""
     x = list(x)
     return x[:index], x[index:]
 
 
-def is_tidy_box(x: typing.Any) -> bool:
+def is_tidy_box(x: Any) -> bool:
     """Check if a value is a tidy box."""
     return getattr(x, "_tidy", False)
 
 
+def contains(target: Any, seq: Iterable[Any]) -> bool:
+    """Return ``True`` if target occurs anywhere within arbitrarily nested iterables."""
+    for x in seq:
+        if x == target:
+            return True
+        if isinstance(x, Iterable) and not isinstance(x, (str, bytes)):
+            if contains(target, x):
+                return True
+    return False
+
+
 __all__ = [
+    "contains",
     "get_static",
     "is_tidy_box",
     "split_list",

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -19,6 +19,7 @@ except ImportError:
 
 from tidy3d.compat import _shapely_is_older_than
 from tidy3d.components.autograd import AutogradFieldMap, TracedCoordinate, TracedSize, get_static
+from tidy3d.components.autograd.constants import GRADIENT_DTYPE_FLOAT
 from tidy3d.components.autograd.derivative_utils import DerivativeInfo, integrate_within_bounds
 from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.transformation import ReflectionFromPlane, RotationAroundAxis
@@ -3302,19 +3303,29 @@ class GeometryGroup(Geometry):
 
         grad_vjps = {}
 
+        # create interpolators once for all geometries to avoid redundant field data conversions
+        interpolators = derivative_info.interpolators or derivative_info.create_interpolators(
+            dtype=GRADIENT_DTYPE_FLOAT
+        )
+
         for field_path in derivative_info.paths:
             _, index, *geo_path = field_path
             geo = self.geometries[index]
+            # pass pre-computed interpolators if available
             geo_info = derivative_info.updated_copy(
-                paths=[geo_path], bounds=geo.bounds, eps_approx=True, deep=False
+                paths=[tuple(geo_path)],
+                bounds=geo.bounds,
+                eps_approx=True,
+                deep=False,
+                interpolators=interpolators,
             )
-            vjp_dict_geo = geo._compute_derivatives(geo_info)
-            grad_vjp_values = list(vjp_dict_geo.values())
 
-            if len(grad_vjp_values) != 1:
+            vjp_dict_geo = geo._compute_derivatives(geo_info)
+
+            if len(vjp_dict_geo) != 1:
                 raise AssertionError("Got multiple gradients for single geometry field.")
 
-            grad_vjps[field_path] = grad_vjp_values[0]
+            grad_vjps[field_path] = vjp_dict_geo.popitem()[1]
 
         return grad_vjps
 

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -4,15 +4,23 @@ from __future__ import annotations
 
 import math
 from copy import copy
+from functools import lru_cache
 from typing import Optional, Union
 
 import autograd.numpy as np
 import pydantic.v1 as pydantic
 import shapely
 from autograd.tracer import getval, isbox
+from numpy.polynomial.legendre import leggauss as _leggauss
 
 from tidy3d.components.autograd import AutogradFieldMap, TracedVertices, get_static
-from tidy3d.components.autograd.derivative_utils import DerivativeInfo, DerivativeSurfaceMesh
+from tidy3d.components.autograd.constants import (
+    EDGE_CLIP_TOLERANCE,
+    GAUSS_QUADRATURE_ORDER,
+    GRADIENT_DTYPE_FLOAT,
+    QUAD_SAMPLE_FRACTION,
+)
+from tidy3d.components.autograd.derivative_utils import DerivativeInfo
 from tidy3d.components.autograd.types import TracedFloat
 from tidy3d.components.base import cached_property, skip_if_fields_missing
 from tidy3d.components.transformation import ReflectionFromPlane, RotationAroundAxis
@@ -48,8 +56,12 @@ _MAX_POLYSLAB_VERTICES_FOR_TRIANGULATION = 500
 
 _MIN_POLYGON_AREA = fp_eps
 
-# number of points per dimension when discretizing polyslab faces for slab bounds gradients
-_NUM_PTS_DIM_SLAB_BOUNDS = 30
+
+@lru_cache(maxsize=128)
+def leggauss(n):
+    """Cached version of leggauss with dtype conversions."""
+    g, w = _leggauss(n)
+    return g.astype(GRADIENT_DTYPE_FLOAT, copy=False), w.astype(GRADIENT_DTYPE_FLOAT, copy=False)
 
 
 class PolySlab(base.Planar):
@@ -209,7 +221,7 @@ class PolySlab(base.Planar):
         slab_min, slab_max = values["slab_bounds"]
         slab_bounds = [getval(slab_min), getval(slab_max)]
 
-        # Fist, check vertex-vertex crossing at any point during extrusion
+        # first, check vertex-vertex crossing at any point during extrusion
         length = slab_bounds[1] - slab_bounds[0]
         dist = [-length * np.tan(values["sidewall_angle"])]
         # reverse the dilation value if it's defined on the top
@@ -358,7 +370,10 @@ class PolySlab(base.Planar):
             )
 
         all_vertices = base.Geometry.load_gds_vertices_gdstk(
-            gds_cell=gds_cell, gds_layer=gds_layer, gds_dtype=gds_dtype, gds_scale=gds_scale
+            gds_cell=gds_cell,
+            gds_layer=gds_layer,
+            gds_dtype=gds_dtype,
+            gds_scale=gds_scale,
         )
 
         # convert vertices into polyslabs
@@ -522,14 +537,6 @@ class PolySlab(base.Planar):
         z_local = z - z0  # distance to the middle
         dist = -z_local * self._tanq
 
-        # # Leaving this function and commented out lines using it below in case we want to revert
-        # # to it at some point, e.g. if we introduce a MATPLOTLIB_INSTALLED flag.
-        # def contains_pointwise(face_polygon):
-        #     def fun_contain(xy_point):
-        #         point = shapely.Point(xy_point)
-        #         return face_polygon.covers(point)
-        #     return fun_contain
-
         if isinstance(x, np.ndarray):
             inside_polygon = np.zeros_like(inside_height)
             xs_slab = x[inside_height]
@@ -600,7 +607,8 @@ class PolySlab(base.Planar):
 
         if len(self.base_polygon) > _MAX_POLYSLAB_VERTICES_FOR_TRIANGULATION:
             log.warning(
-                "Processing of PolySlabs with large numbers of vertices can be slow.", log_once=True
+                f"Processing PolySlabs with over {_MAX_POLYSLAB_VERTICES_FOR_TRIANGULATION} vertices can be slow.",
+                log_once=True,
             )
         base_triangles = triangulation.triangulate(self.base_polygon)
         top_triangles = (
@@ -798,7 +806,11 @@ class PolySlab(base.Planar):
         return height
 
     def _find_intersecting_ys_angle_vertical(
-        self, vertices: np.ndarray, position: float, axis: int, exclude_on_vertices: bool = False
+        self,
+        vertices: np.ndarray,
+        position: float,
+        axis: int,
+        exclude_on_vertices: bool = False,
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
         """Finds pairs of forward and backwards vertices where polygon intersects position at axis,
         Find intersection point (in y) assuming straight line,and intersecting angle between plane
@@ -1147,7 +1159,10 @@ class PolySlab(base.Planar):
             return True
 
         # sample at a few dilation values
-        dist_list = dilation * np.linspace(0, 1, 1 + _N_SAMPLE_POLYGON_INTERSECT)[1:]
+        dist_list = (
+            dilation
+            * np.linspace(0, 1, 1 + _N_SAMPLE_POLYGON_INTERSECT, dtype=GRADIENT_DTYPE_FLOAT)[1:]
+        )
         for dist in dist_list:
             # offset: we offset the vertices first, and then use shapely to make it proper
             # in principle, one can offset with shapely.buffer directly, but shapely somehow
@@ -1309,10 +1324,16 @@ class PolySlab(base.Planar):
         shift_x = shift_total[0, :]
         shift_y = shift_total[1, :]
 
-        return np.swapaxes(vs_orig + shift_total, -2, -1), parallel_shift, (shift_x, shift_y)
+        return (
+            np.swapaxes(vs_orig + shift_total, -2, -1),
+            parallel_shift,
+            (shift_x, shift_y),
+        )
 
     @staticmethod
-    def _edge_length_and_reduction_rate(vertices: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    def _edge_length_and_reduction_rate(
+        vertices: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray]:
         """Edge length of reduction rate of each edge with unit offset length.
 
         Parameters
@@ -1415,219 +1436,579 @@ class PolySlab(base.Planar):
     """ Autograd code """
 
     def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
-        """Compute the adjoint derivatives for this object."""
+        """
+        Return VJPs while handling several edge-cases:
 
-        vjps = {}
+        - If the slab volume does not overlap the simulation, all grads are zero
+          (one warning is issued).
+        - Faces that lie completely outside the simulation give zero ``slab_bounds``
+          gradients; this includes the +/- inf cases.
+        - A 2d simulation collapses the surface integral to a line integral
+        """
+        vjps: AutogradFieldMap = {}
 
-        for key in derivative_info.paths:
-            if key == ("vertices",):
-                vjp = self._compute_derivative_vertices(derivative_info=derivative_info)
-                vjps[key] = vjp
+        sim_min, sim_max = map(np.asarray, derivative_info.bounds_intersect)
+        extents = sim_max - sim_min
+        is_2d = np.isclose(extents[self.axis], 0.0)
 
-            elif key[0] == "slab_bounds":
-                min_max_index = key[1]
-                vjp_face = self._compute_derivative_slab_face(
-                    derivative_info=derivative_info, min_max_index=min_max_index
+        # early return if polyslab is not in simulation domain
+        slab_min, slab_max = self.slab_bounds
+        if (slab_max <= sim_min[self.axis]) or (slab_min >= sim_max[self.axis]):
+            log.warning(
+                "'PolySlab' lies completely outside the simulation domain.",
+                log_once=True,
+            )
+            for p in derivative_info.paths:
+                vjps[p] = np.zeros_like(self.vertices) if p == ("vertices",) else 0.0
+            return vjps
+
+        # create interpolators once for ALL derivative computations
+        # use provided interpolators if available to avoid redundant field data conversions
+        interpolators = derivative_info.interpolators or derivative_info.create_interpolators(
+            dtype=GRADIENT_DTYPE_FLOAT
+        )
+
+        for path in derivative_info.paths:
+            if path == ("vertices",):
+                vjps[path] = self._compute_derivative_vertices(
+                    derivative_info, sim_min, sim_max, is_2d, interpolators
                 )
+            elif path[0] == "slab_bounds":
+                idx = path[1]
+                face_coord = self.slab_bounds[idx]
 
-                # for ``slab_bounds[0]``, the ``VJP_face`` gives VJP for shifting face out.
-                # corresponds to a decrease ``slab_bounds[0]``. So we need -1 sign.
-                if min_max_index == 0:
-                    vjp_face *= -1
+                # face entirely outside -> gradient 0
+                if (
+                    np.isinf(face_coord)
+                    or face_coord < sim_min[self.axis]
+                    or face_coord > sim_max[self.axis]
+                    or is_2d
+                ):
+                    vjps[path] = 0.0
+                    continue
 
-                vjps[key] = vjp_face
-
+                v = self._compute_derivative_slab_bounds(derivative_info, idx, interpolators)
+                # outward-normal convention
+                if idx == 0:
+                    v *= -1
+                vjps[path] = v
             else:
-                raise ValueError(f"No derivative defined with respect to 'PolySlab' field '{key}'.")
+                raise ValueError(f"No derivative defined w.r.t. 'PolySlab' field '{path}'.")
 
         return vjps
 
-    def _compute_derivative_slab_face(
-        self, derivative_info: DerivativeInfo, min_max_index: int
-    ) -> TracedVertices:
-        """Derivative with respect to slab_bounds."""
+    def _compute_derivative_slab_bounds(
+        self, derivative_info: DerivativeInfo, min_max_index: int, interpolators: dict
+    ) -> float:
+        """VJP for one of the two horizontal faces of a ``PolySlab``.
 
-        rmin, rmax = derivative_info.bounds
-        ax_min, (r1_min, r2_min) = self.pop_axis(rmin, axis=self.axis)
-        ax_max, (r1_max, r2_max) = self.pop_axis(rmax, axis=self.axis)
+        The face is discretized into a Cartesian grid of small planar patches
+        whose linear size does not exceed ``_VJP_SAMPLE_SPACING``. The adjoint surface
+        integral is evaluated on every retained patch; the resulting derivative
+        is split equally between the two vertices that bound the edge segment.
+        """
+        # rmin/rmax over the geometry and simulation box
+        rmin, rmax = derivative_info.bounds_intersect
+        _, (r1_min, r2_min) = self.pop_axis(rmin, axis=self.axis)
+        _, (r1_max, r2_max) = self.pop_axis(rmax, axis=self.axis)
+        ax_val = self.slab_bounds[min_max_index]
 
-        num_1 = 1 if r1_min == r1_max else _NUM_PTS_DIM_SLAB_BOUNDS
-        num_2 = 1 if r2_min == r2_max else _NUM_PTS_DIM_SLAB_BOUNDS
+        # planar grid resolution, clipped to polygon bounding box
+        face_verts = self.base_polygon if min_max_index == 0 else self.top_polygon
+        face_poly = shapely.Polygon(face_verts).buffer(fp_eps)
 
-        num_cells = num_1 * num_2
-        ones = np.ones(num_cells)
-        zeros = np.zeros(num_cells)
+        # limit the patch grid to the face that lives inside the simulation box
+        poly_min_r1, poly_min_r2, poly_max_r1, poly_max_r2 = face_poly.bounds
+        r1_min = max(r1_min, poly_min_r1)
+        r1_max = min(r1_max, poly_max_r1)
+        r2_min = max(r2_min, poly_min_r2)
+        r2_max = min(r2_max, poly_max_r2)
 
-        def meshgrid_flatten_stack(*args) -> np.ndarray:
-            """Take set of `d` coords, meshgrid them, flatten, and assemble in `(N, d)` array."""
-            coords = np.meshgrid(*args, indexing="ij")
-            coords = [c.flatten() for c in coords]
-            return np.stack(coords, axis=-1)
+        if (r1_max <= r1_min) and (r2_max <= r2_min):
+            # the polygon does not intersect the current simulation slice
+            return 0.0
 
-        # get center points and areas
-        r1_centers = np.linspace(r1_min, r1_max, 2 * num_1 + 1)[1::2]
-        r2_centers = np.linspace(r2_min, r2_max, 2 * num_2 + 1)[1::2]
-        planar_centers = meshgrid_flatten_stack(r1_centers, r2_centers)
+        # re-compute the extents after clipping to the polygon bounds
+        extents = np.array([r1_max - r1_min, r2_max - r2_min])
 
-        area = 1.0
-        for rmin, rmax in zip((r1_min, r2_min), (r1_max, r2_max)):
-            if rmin != rmax:
-                area *= rmax - rmin
+        # choose surface or line integral
+        integral_fun = (
+            self.compute_derivative_slab_bounds_line
+            if np.isclose(extents, 0).any()
+            else self.compute_derivative_slab_bounds_surface
+        )
+        return integral_fun(
+            derivative_info,
+            extents,
+            r1_min,
+            r1_max,
+            r2_min,
+            r2_max,
+            ax_val,
+            face_poly,
+            min_max_index,
+            interpolators,
+        )
 
-        areas = area * np.ones(num_cells) / num_cells
+    def compute_derivative_slab_bounds_line(
+        self,
+        derivative_info: DerivativeInfo,
+        extents: np.ndarray,
+        r1_min: float,
+        r1_max: float,
+        r2_min: float,
+        r2_max: float,
+        ax_val: float,
+        face_poly: shapely.Polygon,
+        min_max_index: int,
+        interpolators: dict,
+    ) -> float:
+        """Handle degenerate line cross-section case"""
+        line_dim = 1 if np.isclose(extents[0], 0) else 0
 
-        def get_grad(min_max_index: int) -> float:
-            """Compute gradient for either min or max dimension."""
+        poly_min_r1, poly_min_r2, poly_max_r1, poly_max_r2 = face_poly.bounds
+        if line_dim == 0:  # x varies, y is fixed
+            l_min = max(r1_min, poly_min_r1)
+            l_max = min(r1_max, poly_max_r1)
+        else:  # y varies, x is fixed
+            l_min = max(r2_min, poly_min_r2)
+            l_max = min(r2_max, poly_max_r2)
 
-            # select the normal sign and the axis value
-            if min_max_index == 0:
-                ax_val = ax_min
+        length = l_max - l_min
+        if np.isclose(length, 0):
+            return 0.0
+
+        dx = derivative_info.adaptive_vjp_spacing()
+        n_seg = max(1, int(np.ceil(length / dx)))
+        coords = np.linspace(l_min, l_max, 2 * n_seg + 1, dtype=GRADIENT_DTYPE_FLOAT)[1::2]
+
+        # build XY coordinates and in-plane direction vectors
+        if line_dim == 0:
+            xy = np.column_stack((coords, np.full_like(coords, r2_min)))
+            dir_vec_plane = np.column_stack((np.ones_like(coords), np.zeros_like(coords)))
+        else:
+            xy = np.column_stack((np.full_like(coords, r1_min), coords))
+            dir_vec_plane = np.column_stack((np.zeros_like(coords), np.ones_like(coords)))
+
+        inside = shapely.contains_xy(face_poly, xy[:, 0], xy[:, 1])
+        if not inside.any():
+            return 0.0
+
+        xy = xy[inside]
+        dir_vec_plane = dir_vec_plane[inside]
+        n_pts = len(xy)
+
+        centers_xyz = self.unpop_axis_vect(np.full(n_pts, ax_val), xy)
+        areas = np.full(n_pts, length / n_seg)  # patch length
+
+        normals_xyz = self.unpop_axis_vect(
+            np.full(n_pts, -1 if min_max_index == 0 else 1),
+            np.zeros_like(xy),
+        )
+        perps1_xyz = self.unpop_axis_vect(np.zeros(n_pts), dir_vec_plane)
+        perps2_xyz = self.unpop_axis_vect(np.zeros(n_pts), np.zeros_like(dir_vec_plane))
+
+        vjps = derivative_info.evaluate_gradient_at_points(
+            centers_xyz, normals_xyz, perps1_xyz, perps2_xyz, interpolators
+        )
+        return np.real(np.sum(vjps * areas)).item()
+
+    def compute_derivative_slab_bounds_surface(
+        self,
+        derivative_info: DerivativeInfo,
+        extents: np.ndarray,
+        r1_min: float,
+        r1_max: float,
+        r2_min: float,
+        r2_max: float,
+        ax_val: float,
+        face_poly: shapely.Polygon,
+        min_max_index: int,
+        interpolators: dict,
+    ) -> float:
+        """2d surface integral on a Gauss quadrature grid"""
+        dx = derivative_info.adaptive_vjp_spacing()
+
+        # uniform grid would use n1 x n2 points
+        n1_uniform, n2_uniform = np.maximum(1, np.ceil(extents / dx).astype(int))
+
+        # use ~1/2 Gauss points in each direction for similar accuracy
+        n1 = max(2, n1_uniform // 2)
+        n2 = max(2, n2_uniform // 2)
+
+        g1, w1 = leggauss(n1)
+        g2, w2 = leggauss(n2)
+
+        coords1 = (0.5 * (r1_max - r1_min) * g1 + 0.5 * (r1_max + r1_min)).astype(
+            GRADIENT_DTYPE_FLOAT, copy=False
+        )
+        coords2 = (0.5 * (r2_max - r2_min) * g2 + 0.5 * (r2_max + r2_min)).astype(
+            GRADIENT_DTYPE_FLOAT, copy=False
+        )
+
+        r1_grid, r2_grid = np.meshgrid(coords1, coords2, indexing="ij")
+        r1_flat = r1_grid.flatten()
+        r2_flat = r2_grid.flatten()
+        pts = np.column_stack((r1_flat, r2_flat))
+
+        in_face = shapely.contains_xy(face_poly, pts[:, 0], pts[:, 1])
+        if not in_face.any():
+            return 0.0
+
+        xyz = self.unpop_axis_vect(
+            np.full(in_face.sum(), ax_val, dtype=GRADIENT_DTYPE_FLOAT), pts[in_face]
+        )
+        n_patches = xyz.shape[0]
+
+        normals_xyz = self.unpop_axis_vect(
+            np.full(n_patches, -1 if min_max_index == 0 else 1, dtype=GRADIENT_DTYPE_FLOAT),
+            np.zeros((n_patches, 2), dtype=GRADIENT_DTYPE_FLOAT),
+        )
+        perps1_xyz = self.unpop_axis_vect(
+            np.zeros(n_patches, dtype=GRADIENT_DTYPE_FLOAT),
+            np.column_stack(
+                (
+                    np.ones(n_patches, dtype=GRADIENT_DTYPE_FLOAT),
+                    np.zeros(n_patches, dtype=GRADIENT_DTYPE_FLOAT),
+                )
+            ),
+        )
+        perps2_xyz = self.unpop_axis_vect(
+            np.zeros(n_patches, dtype=GRADIENT_DTYPE_FLOAT),
+            np.column_stack(
+                (
+                    np.zeros(n_patches, dtype=GRADIENT_DTYPE_FLOAT),
+                    np.ones(n_patches, dtype=GRADIENT_DTYPE_FLOAT),
+                )
+            ),
+        )
+
+        w1_grid, w2_grid = np.meshgrid(w1, w2, indexing="ij")
+        weights_flat = (w1_grid * w2_grid).flatten()[in_face]
+        jacobian = 0.25 * (r1_max - r1_min) * (r2_max - r2_min)
+
+        # area-based correction for non-rectangular domains (e.g. concave polygon)
+        # for constant integrand, integral should equal polygon area
+        sum_weights = np.sum(weights_flat)
+        if sum_weights > 0:
+            area_correction = face_poly.area / (sum_weights * jacobian)
+            weights_flat = weights_flat * area_correction
+
+        vjps = derivative_info.evaluate_gradient_at_points(
+            xyz, normals_xyz, perps1_xyz, perps2_xyz, interpolators
+        )
+        return np.real(np.sum(vjps * weights_flat * jacobian)).item()
+
+    def _compute_derivative_vertices(
+        self,
+        derivative_info: DerivativeInfo,
+        sim_min: np.ndarray,
+        sim_max: np.ndarray,
+        is_2d: bool = False,
+        interpolators: Optional[dict] = None,
+    ) -> np.ndarray:
+        """VJP for the vertices of a ``PolySlab``.
+
+        Each side-wall is sliced in the **in-plane** direction (along the edge)
+        and, when applicable, in the **out-of-plane** direction (along the
+        extrusion axis) so that every rectangular surface patch is no larger
+        than ``_VJP_SAMPLE_SPACING`` in any dimension.  The adjoint surface
+        integral is evaluated on every retained patch; the resulting force is
+        split (weighted) between the two vertices that bound the edge segment.
+
+        Special cases:
+        - Pure 2d simulations - integral collapses to a line; only one z-slice is taken.
+        - Partial overlap with the simulation box - patches falling
+          outside ``[sim_min, sim_max]`` are skipped.
+        - Degenerate edges (zero length) - ignored.
+        """
+        vertices = np.asarray(self.vertices, dtype=GRADIENT_DTYPE_FLOAT)
+        next_v = np.roll(vertices, -1, axis=0)
+        edges = next_v - vertices
+        basis = self.edge_basis_vectors(edges)
+        dx = derivative_info.adaptive_vjp_spacing()
+
+        # compute z‐slices
+        z0 = max(self.slab_bounds[0], sim_min[self.axis])
+        z1 = min(self.slab_bounds[1], sim_max[self.axis])
+
+        # early return if no z-slices
+        if (not is_2d) and z1 <= z0:
+            return np.zeros_like(vertices)
+
+        if is_2d:
+            z_centers = np.array([self.center_axis], dtype=GRADIENT_DTYPE_FLOAT)
+            dz_surf = 1.0
+        else:
+            n_z = max(1, int(np.ceil((z1 - z0) / dx)))
+            dz = (z1 - z0) / n_z
+            dz_surf = dz / np.cos(self.sidewall_angle)
+            z_centers = np.linspace(z0 + dz / 2, z1 - dz / 2, n_z, dtype=GRADIENT_DTYPE_FLOAT)
+
+        vjp_per_vertex = np.zeros_like(vertices, dtype=float)
+        normals_2d = np.delete(basis["norm"], self.axis, axis=1)
+
+        # use provided interpolators or create them if not provided
+        if interpolators is None:
+            interpolators = derivative_info.create_interpolators(dtype=GRADIENT_DTYPE_FLOAT)
+
+        def compute_edge_clip_bounds(v0_3d, v1_3d, sim_min, sim_max):
+            """
+            Compute parametric bounds [t_start, t_end] for the portion of edge
+            (v0_3d -> v1_3d) that lies within [sim_min, sim_max].
+
+            Returns:
+            - (t_start, t_end): parametric bounds, or None if edge is fully outside
+            """
+            t_start, t_end = 0.0, 1.0
+
+            for dim in range(3):
+                v0_d, v1_d = v0_3d[dim], v1_3d[dim]
+                min_d, max_d = sim_min[dim], sim_max[dim]
+
+                if np.isclose(v0_d, v1_d):
+                    if v0_d < min_d or v0_d > max_d:
+                        return None
+                    continue
+
+                t_min = (min_d - v0_d) / (v1_d - v0_d)
+                t_max = (max_d - v0_d) / (v1_d - v0_d)
+
+                if t_min > t_max:
+                    t_min, t_max = t_max, t_min
+
+                t_start = max(t_start, t_min)
+                t_end = min(t_end, t_max)
+
+                if t_start >= t_end:
+                    return None
+
+            # avoid numerical issues at boundaries
+            if t_end <= t_start + EDGE_CLIP_TOLERANCE:
+                return None
+
+            return (t_start, t_end)
+
+        # estimate total number of patches for pre-allocation
+        # this avoids repeated list.extend calls
+        estimated_patches = 0
+        n_edges = len(vertices)
+        for ei in range(n_edges):
+            v0, v1 = vertices[ei], next_v[ei]
+            L = np.linalg.norm(v1 - v0)
+            if not np.isclose(L, 0.0):
+                # estimate samples per edge (conservative estimate)
+                n_samples = max(1, int(np.ceil(L / dx) * 0.4))  # 40% of uniform for Gauss
+                estimated_patches += n_samples * len(z_centers)
+
+        # pre-allocate arrays with estimated size
+        # over-allocate by 20% to handle edge cases, will trim later
+        estimated_patches = int(estimated_patches * 1.2)
+        all_centers = np.empty((estimated_patches, 3), dtype=GRADIENT_DTYPE_FLOAT)
+        all_areas = np.empty(estimated_patches, dtype=GRADIENT_DTYPE_FLOAT)
+        all_normals = np.empty((estimated_patches, 3), dtype=GRADIENT_DTYPE_FLOAT)
+        all_perps1 = np.empty((estimated_patches, 3), dtype=GRADIENT_DTYPE_FLOAT)
+        all_perps2 = np.empty((estimated_patches, 3), dtype=GRADIENT_DTYPE_FLOAT)
+        all_edge_info = []  # keep as list since it stores tuples
+
+        # track actual number of patches
+        patch_idx = 0
+
+        def get_adaptive_samples(L, dx, t_start=0.0, t_end=1.0):
+            """Get sampling points and weights along edge using optimal quadrature.
+
+            Parameters:
+            - L: Full edge length
+            - dx: Target spacing
+            - t_start, t_end: Parametric bounds for clipped edges (0 <= t_start < t_end <= 1)
+
+            Returns:
+            - s: Parametric coordinates in [t_start, t_end]
+            - weights: Quadrature weights (sum to t_end - t_start)
+            """
+            # compute effective length for the clipped portion
+            L_effective = L * (t_end - t_start)
+            n_uniform = max(1, int(np.ceil(L_effective / dx)))
+
+            # Gauss quadrature is more accurate than uniform sampling
+            if n_uniform <= 3:
+                n_gauss = n_uniform  # for very short edges, keep same number
             else:
-                ax_val = ax_max
+                n_gauss = max(
+                    2, int(n_uniform * QUAD_SAMPLE_FRACTION)
+                )  # use 40% of points for longer edges
 
-            edge_centers_xyz = self.unpop_axis_vect(ones * ax_val, planar_centers)
+            if n_gauss <= GAUSS_QUADRATURE_ORDER:
+                g, w = leggauss(n_gauss)
 
-            # construct basis functions
-            normals = self.unpop_axis_vect(ones, np.stack((zeros, zeros), axis=-1))
-            perps1 = self.unpop_axis_vect(zeros, np.stack((ones, zeros), axis=-1))
-            perps2 = self.unpop_axis_vect(zeros, np.stack((zeros, ones), axis=-1))
+                # map from [-1, 1] to [t_start, t_end]
+                s = (0.5 * (t_end - t_start) * g + 0.5 * (t_end + t_start)).astype(
+                    GRADIENT_DTYPE_FLOAT, copy=False
+                )
+                weights = (w * 0.5 * (t_end - t_start)).astype(GRADIENT_DTYPE_FLOAT, copy=False)
+            else:
+                # for longer edges, use composite Gauss quadrature
+                pts_per_interval = GAUSS_QUADRATURE_ORDER
+                n_intervals = max(1, (n_gauss + pts_per_interval - 1) // pts_per_interval)
 
-            rr1, rr2, axx_val = meshgrid_flatten_stack(r1_centers, r2_centers, ax_val).T
+                g_ref, w_ref = leggauss(pts_per_interval)
 
-            xx, yy, zz = self.unpop_axis_vect(axx_val, np.stack((rr1, rr2), axis=-1)).T
+                s_list = []
+                w_list = []
 
-            inside = self.inside(xx, yy, zz).squeeze().flatten()
+                for i in range(n_intervals):
+                    # sub-interval bounds in [0, 1]
+                    a = i / n_intervals
+                    b = (i + 1) / n_intervals
 
-            areas_masked = areas * inside
+                    # map to [t_start, t_end]
+                    a_mapped = t_start + a * (t_end - t_start)
+                    b_mapped = t_start + b * (t_end - t_start)
 
-            # compute DerivativeSurfaceMesh for each top and bottom.
-            surface_mesh = DerivativeSurfaceMesh(
-                centers=edge_centers_xyz,
-                areas=areas_masked,
-                normals=normals,
-                perps1=perps1,
-                perps2=perps2,
+                    # transform Gauss points to sub-interval [a_mapped, b_mapped]
+                    s_interval = 0.5 * (b_mapped - a_mapped) * g_ref + 0.5 * (b_mapped + a_mapped)
+                    w_interval = 0.5 * (b_mapped - a_mapped) * w_ref
+
+                    s_list.extend(s_interval)
+                    w_list.extend(w_interval)
+
+                s = np.array(s_list, dtype=GRADIENT_DTYPE_FLOAT)
+                weights = np.array(w_list, dtype=GRADIENT_DTYPE_FLOAT)
+
+            return s, weights
+
+        # pre-compute 2D bounding box for edge clipping optimization
+        sim_min_2d = np.delete(sim_min, self.axis)
+        sim_max_2d = np.delete(sim_max, self.axis)
+
+        for ei, (v0, v1) in enumerate(zip(vertices, next_v)):
+            edge_vec = v1 - v0
+            L = np.linalg.norm(edge_vec)
+            if np.isclose(L, 0.0):
+                continue
+
+            # check if edge is definitely inside 2D bounds
+            edge_min_2d = np.minimum(v0, v1)
+            edge_max_2d = np.maximum(v0, v1)
+            definitely_inside_2d = np.all(edge_min_2d >= sim_min_2d) and np.all(
+                edge_max_2d <= sim_max_2d
             )
 
-            grads = derivative_info.grad_surfaces(surface_mesh=surface_mesh)
-            vjp = np.real(np.sum(grads).item())
+            # process each z-slice with proper clipping
+            for zc in z_centers:
+                # fast path: if edge is definitely inside 2D bounds AND z is in bounds, skip clipping
+                if definitely_inside_2d and z0 <= zc <= z1:
+                    t_start, t_end = 0.0, 1.0
+                else:
+                    v0_3d = self.unpop_axis_vect(np.array([zc]), v0[None])[0]
+                    v1_3d = self.unpop_axis_vect(np.array([zc]), v1[None])[0]
 
-            return vjp
+                    clip_bounds = compute_edge_clip_bounds(v0_3d, v1_3d, sim_min, sim_max)
+                    if clip_bounds is None:
+                        continue  # edge is entirely outside bounds
 
-        return get_grad(min_max_index)
+                    t_start, t_end = clip_bounds
 
-    def _compute_derivative_slab_face_single_pt(
-        self, derivative_info: DerivativeInfo, min_max_index: int
-    ) -> TracedVertices:
-        """Derivative with respect to slab faces (single point approximation)."""
+                s_list, s_weights = get_adaptive_samples(L, dx, t_start, t_end)
 
-        self_static = self.to_static()
+                pts2d = v0 + np.outer(s_list, edge_vec)
 
-        center_r1, center_r2 = np.mean(self_static.vertices, axis=0)
-        center_axis = self_static.slab_bounds[min_max_index]
-        center_xyz = self.unpop_axis(center_axis, (center_r1, center_r2), axis=self.axis)
+                # patch areas include quadrature weights for accurate integration
+                patch_areas = L * s_weights * (dz_surf if not is_2d else 1.0)
 
-        area = self_static._area(self_static.vertices)
+                # all points are within bounds by construction due to clipping
+                xyz = self.unpop_axis_vect(np.full(len(s_list), zc), pts2d)
 
-        norm = self.unpop_axis(1, (0, 0), axis=self.axis)
-        perp1 = self.unpop_axis(0, (0, 1), axis=self.axis)
-        perp2 = self.unpop_axis(0, (1, 0), axis=self.axis)
+                n_patches = len(s_list)
 
-        surface_mesh = DerivativeSurfaceMesh(
-            centers=[center_xyz],
-            areas=[area],
-            normals=[norm],
-            perps1=[perp1],
-            perps2=[perp2],
-        )
+                # ensure we don't exceed pre-allocated size
+                if patch_idx + n_patches > estimated_patches:
+                    # resize arrays if needed (rare case)
+                    new_size = int((patch_idx + n_patches) * 1.5)
 
-        grads = derivative_info.grad_surfaces(surface_mesh=surface_mesh)
-        vjp = np.real(np.sum(grads).item())
+                    # at this stage, no other views into these arrays exist _yet_
+                    # so `refcheck=False` should be safe
+                    all_centers.resize((new_size, 3), refcheck=False)
+                    all_areas.resize(new_size, refcheck=False)
+                    all_normals.resize((new_size, 3), refcheck=False)
+                    all_perps1.resize((new_size, 3), refcheck=False)
+                    all_perps2.resize((new_size, 3), refcheck=False)
 
-        return vjp
+                all_centers[patch_idx : patch_idx + n_patches] = xyz
+                all_areas[patch_idx : patch_idx + n_patches] = patch_areas
 
-    def _compute_derivative_vertices(self, derivative_info: DerivativeInfo) -> TracedVertices:
-        # derivative w.r.t each edge
+                all_normals[patch_idx : patch_idx + n_patches] = basis["norm"][ei]
+                all_perps1[patch_idx : patch_idx + n_patches] = basis["perp1"][ei]
+                all_perps2[patch_idx : patch_idx + n_patches] = basis["perp2"][ei]
 
-        vertices = np.array(self.vertices)
-        num_vertices, _ = vertices.shape
+                edge_norm_2d = normals_2d[ei]
+                all_edge_info.extend([(ei, s_val, edge_norm_2d) for s_val in s_list])
 
-        # compute edges between vertices
+                patch_idx += n_patches
 
-        vertices_next = np.roll(self.vertices, axis=0, shift=-1)
-        edges = vertices_next - vertices
+        if patch_idx > 0:
+            # trim arrays to actual size used
+            centers = all_centers[:patch_idx]
+            areas = all_areas[:patch_idx]
+            normals = all_normals[:patch_idx]
+            perps1 = all_perps1[:patch_idx]
+            perps2 = all_perps2[:patch_idx]
 
-        # compute center positions between each edge
-        edge_centers_plane = (vertices_next + vertices) / 2.0
-        edge_centers_axis = self.center_axis * np.ones(num_vertices)
-        edge_centers_xyz = self.unpop_axis_vect(edge_centers_axis, edge_centers_plane)
+            patch_vjps = derivative_info.evaluate_gradient_at_points(
+                centers, normals, perps1, perps2, interpolators
+            )
+            patch_vjps = (patch_vjps * areas).real
 
-        if edge_centers_xyz.shape != (num_vertices, 3):
-            raise AssertionError("something bad happened")
+            for vjp, (ei, s_val, edge_norm_2d) in zip(patch_vjps, all_edge_info):
+                # vertex weights: (1-s) for vertex i, s for vertex i+1
+                # quadrature weights are already included in areas via patch_areas
+                w0 = 1.0 - s_val
+                w1 = s_val
 
-        # get basis vectors for every edge segment
-        basis_vectors = self.edge_basis_vectors(edges=edges)
+                vjp_per_vertex[ei] += (w0 * vjp) * edge_norm_2d
+                vjp_per_vertex[(ei + 1) % len(vertices)] += (w1 * vjp) * edge_norm_2d
 
-        # scale by edge area
-        edge_lengths = np.linalg.norm(edges, axis=-1)
-        edge_areas = edge_lengths
-
-        # correction to edge area based on sidewall distance along slab axis
-        slab_height = abs(float(np.squeeze(np.diff(self.slab_bounds))))
-        if not np.isinf(slab_height):
-            edge_areas *= slab_height
-
-        surface_mesh = DerivativeSurfaceMesh(
-            centers=edge_centers_xyz,
-            areas=edge_areas,
-            normals=basis_vectors["norm"],
-            perps1=basis_vectors["perp1"],
-            perps2=basis_vectors["perp2"],
-        )
-
-        vjps_edges = derivative_info.grad_surfaces(surface_mesh=surface_mesh)
-
-        _, normal_vectors_in_plane = self.pop_axis_vect(basis_vectors["norm"])
-
-        vjps_edges_in_plane = vjps_edges.values.reshape((num_vertices, 1)) * normal_vectors_in_plane
-
-        vjps_vertices = vjps_edges_in_plane + np.roll(vjps_edges_in_plane, axis=0, shift=1)
-        vjps_vertices /= 2.0  # each vertex is effected only 1/2 by each edge
-
-        # sign change if counter clockwise, because normal direction is flipped
-        if self.is_ccw:
-            vjps_vertices *= -1
-
-        return vjps_vertices.real
+        return vjp_per_vertex
 
     def edge_basis_vectors(
         self,
         edges: np.ndarray,  # (N, 2)
     ) -> dict[str, np.ndarray]:  # (N, 3)
-        """Normalized basis vectors for 'normal' direction, 'slab' tangent direction and 'edge'."""
+        """Normalized basis vectors for ``normal`` direction, ``slab`` tangent direction and ``edge``."""
+
+        # ensure edges have consistent dtype
+        edges = edges.astype(GRADIENT_DTYPE_FLOAT, copy=False)
 
         num_vertices, _ = edges.shape
-        zeros = np.zeros(num_vertices)
-        ones = np.ones(num_vertices)
+        zeros = np.zeros(num_vertices, dtype=GRADIENT_DTYPE_FLOAT)
+        ones = np.ones(num_vertices, dtype=GRADIENT_DTYPE_FLOAT)
 
         # normalized vectors along edges
         edges_norm_in_plane = self.normalize_vect(edges)
         edges_norm_xyz = self.unpop_axis_vect(zeros, edges_norm_in_plane)
 
         # normalized vectors from base of edges to tops of edges
-        slabs_axis_components = np.cos(self.sidewall_angle) * ones
-        axis_norm = self.unpop_axis(1.0, (0.0, 0.0), axis=self.axis)
-        slab_normal_xyz = -np.sin(self.sidewall_angle) * np.cross(edges_norm_xyz, axis_norm)
+        cos_angle = np.cos(self.sidewall_angle, dtype=GRADIENT_DTYPE_FLOAT)
+        sin_angle = np.sin(self.sidewall_angle, dtype=GRADIENT_DTYPE_FLOAT)
+        slabs_axis_components = cos_angle * ones
+
+        # create axis_norm as array directly to avoid tuple->array conversion in np.cross
+        axis_norm = np.zeros(3, dtype=GRADIENT_DTYPE_FLOAT)
+        axis_norm[self.axis] = 1.0
+        slab_normal_xyz = -sin_angle * np.cross(edges_norm_xyz, axis_norm)
         _, slab_normal_in_plane = self.pop_axis_vect(slab_normal_xyz)
         slabs_norm_xyz = self.unpop_axis_vect(slabs_axis_components, slab_normal_in_plane)
 
         # normalized vectors pointing in normal direction of edge
-        normals_norm_xyz = np.cross(edges_norm_xyz, slabs_norm_xyz)
+        # cross yields inward normal when the extrusion axis is y, so negate once for axis==1
+        sign = (-1 if self.axis == 1 else 1) * (-1 if not self.is_ccw else 1)
+        normals_norm_xyz = sign * np.cross(edges_norm_xyz, slabs_norm_xyz)
 
-        if self.axis != 1:
-            normals_norm_xyz *= -1
-
-        return {"norm": normals_norm_xyz, "perp1": edges_norm_xyz, "perp2": slabs_norm_xyz}
+        return {
+            "norm": normals_norm_xyz,
+            "perp1": edges_norm_xyz,
+            "perp2": slabs_norm_xyz,
+        }
 
     def unpop_axis_vect(self, ax_coords: np.ndarray, plane_coords: np.ndarray) -> np.ndarray:
         """Combine coordinate along axis with coordinates on the plane tangent to the axis.
@@ -1635,10 +2016,15 @@ class PolySlab(base.Planar):
         ax_coords.shape == [N]
         plane_coords.shape == [N, 2]
         return shape == [N, 3]
-
         """
-        arr_xyz = self.unpop_axis(ax_coords, plane_coords.T, axis=self.axis)
-        arr_xyz = np.stack(arr_xyz, axis=-1)
+        n_pts = ax_coords.shape[0]
+        arr_xyz = np.zeros((n_pts, 3), dtype=ax_coords.dtype)
+
+        plane_axes = [i for i in range(3) if i != self.axis]
+
+        arr_xyz[:, self.axis] = ax_coords
+        arr_xyz[:, plane_axes] = plane_coords
+
         return arr_xyz
 
     def pop_axis_vect(self, coord: np.ndarray) -> tuple[np.ndarray, tuple[np.ndarray, np.ndarray]]:
@@ -1646,7 +2032,6 @@ class PolySlab(base.Planar):
 
         coord.shape == [N, 3]
         return shape == ([N], [N, 2]
-
         """
 
         arr_axis, arrs_plane = self.pop_axis(coord.T, axis=self.axis)

--- a/tidy3d/components/geometry/primitives.py
+++ b/tidy3d/components/geometry/primitives.py
@@ -296,9 +296,15 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
         # construct equivalent polyslab and compute the derivatives
         polyslab = self.to_polyslab(num_pts_circumference=num_pts_circumference)
 
-        derivative_info_polyslab = derivative_info.updated_copy(
-            paths=[("vertices",), ("slab_bounds", 0), ("slab_bounds", 1)], deep=False
-        )
+        # pass interpolators to PolySlab if available to avoid redundant conversions
+        update_kwargs = {
+            "paths": [("vertices",), ("slab_bounds", 0), ("slab_bounds", 1)],
+            "deep": False,
+        }
+        if derivative_info.interpolators is not None:
+            update_kwargs["interpolators"] = derivative_info.interpolators
+
+        derivative_info_polyslab = derivative_info.updated_copy(**update_kwargs)
         vjps_polyslab = polyslab._compute_derivatives(derivative_info_polyslab)
 
         vjps_vertices_xs, vjps_vertices_ys = vjps_polyslab[("vertices",)].T

--- a/tidy3d/components/geometry/primitives.py
+++ b/tidy3d/components/geometry/primitives.py
@@ -11,6 +11,7 @@ import pydantic.v1 as pydantic
 import shapely
 
 from tidy3d.components.autograd import AutogradFieldMap, TracedSize1D
+from tidy3d.components.autograd.constants import PTS_PER_WVL_MAT_CYLINDER_DISCRETIZE
 from tidy3d.components.autograd.derivative_utils import DerivativeInfo
 from tidy3d.components.base import cached_property, skip_if_fields_missing
 from tidy3d.components.types import Axis, Bound, Coordinate, MatrixReal4x4, Shapely
@@ -29,9 +30,6 @@ _N_SHAPELY_QUAD_SEGS = 200
 
 # Default number of points to discretize polyslab in `Cylinder.to_polyslab()`
 _N_PTS_CYLINDER_POLYSLAB = 51
-
-# Default number of points per wvl in material for discretizing cylinder in autograd derivative
-_PTS_PER_WVL_MAT_CYLINDER_DISCRETIZE = 10
 
 
 class Sphere(base.Centered, base.Circular):
@@ -291,7 +289,7 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
         wvls_in_circumference = circumference / wvl_mat
 
         num_pts_circumference = int(
-            np.ceil(_PTS_PER_WVL_MAT_CYLINDER_DISCRETIZE * wvls_in_circumference)
+            np.ceil(PTS_PER_WVL_MAT_CYLINDER_DISCRETIZE * wvls_in_circumference)
         )
         num_pts_circumference = max(3, num_pts_circumference)
 

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -11,6 +11,10 @@ import autograd.numpy as anp
 import numpy as np
 import pydantic.v1 as pydantic
 
+from tidy3d.components.autograd.constants import (
+    AUTOGRAD_MONITOR_INTERVAL_SPACE_CUSTOM,
+    AUTOGRAD_MONITOR_INTERVAL_SPACE_POLY,
+)
 from tidy3d.constants import MICROMETER
 from tidy3d.exceptions import SetupError, Tidy3dImportError
 from tidy3d.log import log
@@ -18,11 +22,10 @@ from tidy3d.log import log
 from .autograd.derivative_utils import DerivativeInfo
 from .autograd.types import AutogradFieldMap
 from .autograd.types import Box as AutogradBox
-from .autograd.utils import get_static
+from .autograd.utils import contains, get_static
 from .base import Tidy3dBaseModel, skip_if_fields_missing
 from .data.data_array import ScalarFieldDataArray
 from .geometry.base import Box, Geometry
-from .geometry.polyslab import PolySlab
 from .geometry.utils import GeometryType, validate_no_transformed_polyslabs
 from .grid.grid import Coords
 from .material.types import StructureMediumType
@@ -310,17 +313,13 @@ class Structure(AbstractStructure):
         box = geometry.bounding_box
 
         # we dont want these fields getting traced by autograd, otherwise it messes stuff up
-
         size = [get_static(x) for x in box.size]
         center = [get_static(x) for x in box.center]
 
-        # polyslab only needs fields at the midpoint along axis
-        if (
-            isinstance(geometry, PolySlab)
-            and not isinstance(self.medium, AbstractCustomMedium)
-            and field_keys == [("vertices",)]
-        ):
-            size[geometry.axis] = 0
+        if contains("medium", field_keys):
+            interval_space = AUTOGRAD_MONITOR_INTERVAL_SPACE_CUSTOM
+        else:
+            interval_space = AUTOGRAD_MONITOR_INTERVAL_SPACE_POLY
 
         mnt_fld = FieldMonitor(
             size=size,
@@ -328,6 +327,7 @@ class Structure(AbstractStructure):
             freqs=freqs,
             fields=("Ex", "Ey", "Ez"),
             name=self._get_monitor_name(index=index, data_type="fld"),
+            interval_space=interval_space,
             colocate=False,
         )
 
@@ -336,6 +336,7 @@ class Structure(AbstractStructure):
             center=center,
             freqs=freqs,
             name=self._get_monitor_name(index=index, data_type="eps"),
+            interval_space=interval_space,
             colocate=False,
         )
 

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -14,6 +14,7 @@ from autograd.extend import defvjp, primitive
 
 import tidy3d as td
 from tidy3d.components.autograd import AutogradFieldMap, get_static
+from tidy3d.components.autograd.constants import MAX_NUM_ADJOINT_PER_FWD, MAX_NUM_TRACED_STRUCTURES
 from tidy3d.components.autograd.derivative_utils import DerivativeInfo
 from tidy3d.exceptions import AdjointError
 from tidy3d.web.api.asynchronous import DEFAULT_DATA_DIR
@@ -34,9 +35,6 @@ AUX_KEY_SIM_ORIGINAL = "sim_original"
 # server-side auxiliary files to upload/download
 SIM_VJP_FILE = "output/autograd_sim_vjp.hdf5"
 SIM_FIELDS_KEYS_FILE = "autograd_sim_fields_keys.hdf5"
-
-MAX_NUM_TRACED_STRUCTURES = 500
-MAX_NUM_ADJOINT_PER_FWD = 10
 
 # default value for whether to do local gradient calculation (True) or server side (False)
 LOCAL_GRADIENT = False


### PR DESCRIPTION
Previously face gradients came from a fixed 30 × 30 grid so the accuracy depended on the size of the polygon. Edge gradients were evaluated only at the center of each face, so long edges and tall slabs produced incorrect adjoint results depending on the simulation.

Changed:
 - Adaptive, spacing-based sampling for both faces and vertices/edges.
 - Extra edge-cases covered: slab fully outside sim, faces at +/- inf, and fix for correct normal sign for axis==1.

I also added pretty comprehensive analytic tests for the face and edge integration.

The new implementation is also significantly faster, especially for cases where many structures are included in a geometry group:
![image](https://github.com/user-attachments/assets/c04feb15-72db-4eda-a03e-e0a08202f3f6)

Memory usage is about the same as before.

The speedup comes mainly from interpolator caching and removing Pydantic and xarray overhead. `DerivativeInfo` is now a regular `dataclass`, and the `DerivativeSurfaceMesh` abstraction is gone in favor of a new `evaluate_gradient_at_points` function in `DerivativeInfo`. Most operations in the "hot path" now use numpy instead of xarray interpolation.

### Quadrature scheme

First, the code determines a hypothetical number of uniform samples to classify an edge as "short" or "long." Short edges are then evaluated with a direct Gauss quadrature that uses about 40% fewer points than the uniform method. Long edges, which would require more than seven sample points, are instead broken into smaller segments. A 7-point Gauss quadrature is then applied to each segment to maintain accuracy without excessive computational cost.

<!-- greptile_comment -->

## Greptile Summary

Significantly improves polyslab gradient calculations in autograd by implementing adaptive sampling and performance optimizations. Key changes:

- Replaced fixed 30x30 grid with adaptive spacing-based sampling for faces and edges, making accuracy independent of polygon size
- Improved performance through interpolator caching and reduced overhead by replacing Pydantic/xarray operations with numpy, showing significant speedup
- Added intelligent quadrature scheme that uses fewer points (~40%) for short edges while segmenting long edges with 7-point Gauss quadrature
- Added comprehensive handling of edge cases including slabs outside simulation bounds, faces at infinity, and correct normal sign for axis==1
- Added extensive analytic tests validating face and edge integration accuracy



<!-- /greptile_comment -->