### PR TITLE
Some more autograd validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Attempting to differentiate server-side field projections now raises a clear error instead of silently failing.
+
 ## [2.8.3] - 2025-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Supplying autograd-traced values to geometric fields (`center`, `size`) of simulations, monitors, and sources now logs a warning and falls back to the static value instead of erroring.
 - Attempting to differentiate server-side field projections now raises a clear error instead of silently failing.
 
 ## [2.8.3] - 2025-04-24

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -1260,7 +1260,7 @@ def test_interp_objectives(use_emulated_run, colocate, objtype):
 class TestFieldProjection:
     @staticmethod
     def setup(far_field_approx, projection_type, sim_2d):
-        if sim_2d and not far_field_approx:
+        if (sim_2d or not IS_3D) and not far_field_approx:
             pytest.skip("Exact field projection not implemented for 2d simulations")
 
         r_proj = 50 * WVL
@@ -1274,25 +1274,23 @@ class TestFieldProjection:
 
         if projection_type == "angular":
             theta_proj = np.linspace(np.pi / 10, np.pi - np.pi / 10, 2)
-            phi_proj = np.linspace(np.pi / 10, np.pi - np.pi / 10, 3)
             monitor_far = td.FieldProjectionAngleMonitor(
                 center=monitor.center,
                 size=monitor.size,
                 freqs=monitor.freqs,
-                phi=tuple(phi_proj),
+                phi=(np.pi / 2, 3 * np.pi / 2),
                 theta=tuple(theta_proj),
                 proj_distance=r_proj,
                 far_field_approx=far_field_approx,
                 name="far_field",
             )
         elif projection_type == "cartesian":
-            x_proj = np.linspace(-10, 10, 2)
             y_proj = np.linspace(-10, 10, 3)
             monitor_far = td.FieldProjectionCartesianMonitor(
                 center=monitor.center,
                 size=monitor.size,
                 freqs=monitor.freqs,
-                x=x_proj,
+                x=[0],
                 y=y_proj,
                 proj_axis=1,
                 proj_distance=r_proj,
@@ -1300,13 +1298,12 @@ class TestFieldProjection:
                 name="far_field",
             )
         elif projection_type == "kspace":
-            ux = np.linspace(-0.7, 0.7, 2)
             uy = np.linspace(-0.7, 0.7, 3)
             monitor_far = td.FieldProjectionKSpaceMonitor(
                 center=monitor.center,
                 size=monitor.size,
                 freqs=monitor.freqs,
-                ux=ux,
+                ux=[0],
                 uy=uy,
                 proj_axis=1,
                 proj_distance=r_proj,
@@ -1369,6 +1366,26 @@ class TestFieldProjection:
             return self.objective(sim_data, monitor_far)
 
         check_grads(objective, modes=["rev"], order=1)(1.0)
+
+    def test_error_if_server_side_projection(
+        self, use_emulated_run, far_field_approx, projection_type, sim_2d
+    ):
+        """Using a far field monitor directly should error"""
+        # build a projection‐only monitor sim
+        sim_base, monitor_far = self.setup(far_field_approx, projection_type, sim_2d)
+        sim_base = sim_base.updated_copy(monitors=[monitor_far])
+
+        def objective(args):
+            structures_traced_dict = make_structures(args)
+            structures = list(SIM_BASE.structures)
+            for structure_key in structure_keys_:
+                structures.append(structures_traced_dict[structure_key])
+            sim = sim_base.updated_copy(structures=structures)
+            sim_data = run(sim, task_name="field_projection_test")
+            return sim_data["far_field"].power.sum().item()
+
+        with pytest.raises(NotImplementedError):
+            ag.grad(objective)(params0)
 
 
 def test_autograd_deepcopy():

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -2167,3 +2167,21 @@ def test_dispersive_no_inf(use_emulated_run):
     # model is called without a frequency
     with AssertLogLevel("INFO"):
         grad = ag.grad(objective)(params0)
+
+
+def test_sim_traced_center_size(use_emulated_run):
+    fn_dict = get_functions(args[0][0], args[0][1])
+    make_sim = fn_dict["sim"]
+    postprocess = fn_dict["postprocess"]
+    base_sim = make_sim(params0)
+
+    def objective(center, size):
+        sim = base_sim.updated_copy(center=center, size=size)
+        sim_data = run_emulated(sim, task_name="adjoint_test")
+        return postprocess(sim_data)
+
+    with AssertLogLevel("WARNING", contains_str="autograd tracer"):
+        grad = ag.grad(objective, argnum=0)(base_sim.center, base_sim.size)
+
+    with AssertLogLevel("WARNING", contains_str="autograd tracer"):
+        grad = ag.grad(objective, argnum=1)(base_sim.center, base_sim.size)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1092,6 +1092,112 @@ def run_emulated(simulation: td.Simulation, path=None, **kwargs) -> td.Simulatio
             projection_surfaces=monitor.projection_surfaces,
         )
 
+    def make_field_projection_angle_data(
+        monitor: td.FieldProjectionAngleMonitor,
+    ) -> td.FieldProjectionAngleData:
+        """Random FieldProjectionAngleData from a FieldProjectionAngleMonitor."""
+        f = list(monitor.freqs)
+        r = np.atleast_1d(getattr(monitor, "proj_distance", 1.0))
+        theta = list(monitor.theta)
+        phi = list(monitor.phi)
+
+        coords = dict(r=r, theta=theta, phi=phi, f=f)
+        scalar_field = make_data(
+            coords=coords,
+            data_array_type=td.FieldProjectionAngleDataArray,
+            is_complex=True,
+        )
+
+        return td.FieldProjectionAngleData(
+            monitor=monitor,
+            Er=scalar_field,
+            Etheta=scalar_field,
+            Ephi=scalar_field,
+            Hr=scalar_field,
+            Htheta=scalar_field,
+            Hphi=scalar_field,
+            projection_surfaces=monitor.projection_surfaces,
+        )
+
+    def make_field_projection_cartesian_data(
+        monitor: td.FieldProjectionCartesianMonitor,
+    ) -> td.FieldProjectionCartesianData:
+        """Random FieldProjectionCartesianData from a FieldProjectionCartesianMonitor."""
+
+        f = list(monitor.freqs)
+        proj_distance = getattr(monitor, "proj_distance", 1.0)
+
+        # in-plane grids always come from monitor.x and monitor.y
+        x_plane = list(monitor.x)
+        y_plane = list(monitor.y)
+
+        # map the two planes to global (x, y, z) depending on the normal axis
+        if monitor.proj_axis == 0:  # (y, z)
+            coords = dict(
+                x=np.atleast_1d(proj_distance),
+                y=x_plane,
+                z=y_plane,
+                f=f,
+            )
+        elif monitor.proj_axis == 1:  # (x, z)
+            coords = dict(
+                x=x_plane,
+                y=np.atleast_1d(proj_distance),
+                z=y_plane,
+                f=f,
+            )
+        else:  # (x, y)
+            coords = dict(
+                x=x_plane,
+                y=y_plane,
+                z=np.atleast_1d(proj_distance),
+                f=f,
+            )
+
+        scalar_field = make_data(
+            coords=coords,
+            data_array_type=td.FieldProjectionCartesianDataArray,
+            is_complex=True,
+        )
+
+        return td.FieldProjectionCartesianData(
+            monitor=monitor,
+            Er=scalar_field,
+            Etheta=scalar_field,
+            Ephi=scalar_field,
+            Hr=scalar_field,
+            Htheta=scalar_field,
+            Hphi=scalar_field,
+            projection_surfaces=monitor.projection_surfaces,
+        )
+
+    def make_field_projection_kspace_data(
+        monitor: td.FieldProjectionKSpaceMonitor,
+    ) -> td.FieldProjectionKSpaceData:
+        """Random FieldProjectionKSpaceData from a FieldProjectionKSpaceMonitor."""
+        f = list(monitor.freqs)
+        r = np.atleast_1d(getattr(monitor, "proj_distance", 1.0))
+        ux = list(monitor.ux)
+        uy = list(monitor.uy)
+
+        coords = dict(ux=ux, uy=uy, r=r, f=f)
+        scalar_field = make_data(
+            coords=coords,
+            data_array_type=td.FieldProjectionKSpaceDataArray,
+            is_complex=True,
+        )
+
+        return td.FieldProjectionKSpaceData(
+            monitor=monitor,
+            Er=scalar_field,
+            Etheta=scalar_field,
+            Ephi=scalar_field,
+            Hr=scalar_field,
+            Htheta=scalar_field,
+            Hphi=scalar_field,
+            projection_surfaces=monitor.projection_surfaces,
+        )
+
     MONITOR_MAKER_MAP = {
         td.FieldMonitor: make_field_data,
         td.FieldTimeMonitor: make_field_time_data,
@@ -1101,6 +1207,9 @@ def run_emulated(simulation: td.Simulation, path=None, **kwargs) -> td.Simulatio
         td.DiffractionMonitor: make_diff_data,
         td.FluxMonitor: make_flux_data,
         td.DirectivityMonitor: make_directivity_data,
+        td.FieldProjectionAngleMonitor: make_field_projection_angle_data,
+        td.FieldProjectionCartesianMonitor: make_field_projection_cartesian_data,
+        td.FieldProjectionKSpaceMonitor: make_field_projection_kspace_data,
     }
 
     data = [MONITOR_MAKER_MAP[type(mnt)](mnt) for mnt in simulation.monitors]

--- a/tidy3d/components/base_sim/monitor.py
+++ b/tidy3d/components/base_sim/monitor.py
@@ -9,6 +9,7 @@ import pydantic.v1 as pd
 from ..base import cached_property
 from ..geometry.base import Box
 from ..types import ArrayFloat1D, Axis, Numpy
+from ..validators import _warn_unsupported_traced_argument
 from ..viz import PlotParams, plot_params_monitor
 
 
@@ -21,6 +22,9 @@ class AbstractMonitor(Box, ABC):
         description="Unique name for monitor.",
         min_length=1,
     )
+
+    _warn_traced_center = _warn_unsupported_traced_argument("center")
+    _warn_traced_size = _warn_unsupported_traced_argument("size")
 
     @cached_property
     def plot_params(self) -> PlotParams:

--- a/tidy3d/components/base_sim/simulation.py
+++ b/tidy3d/components/base_sim/simulation.py
@@ -17,7 +17,11 @@ from ..medium import Medium, MediumType3D
 from ..scene import Scene
 from ..structure import Structure
 from ..types import TYPE_TAG_STR, Ax, Axis, Bound, LengthUnit, Symmetry
-from ..validators import assert_objects_in_sim_bounds, assert_unique_names
+from ..validators import (
+    _warn_unsupported_traced_argument,
+    assert_objects_in_sim_bounds,
+    assert_unique_names,
+)
 from ..viz import (
     PlotParams,
     add_ax_if_none,
@@ -136,6 +140,9 @@ class AbstractSimulation(Box, ABC):
 
     _monitors_in_bounds = assert_objects_in_sim_bounds("monitors", strict_inequality=True)
     _structures_in_bounds = assert_objects_in_sim_bounds("structures", error=False)
+
+    _warn_traced_center = _warn_unsupported_traced_argument("center")
+    _warn_traced_size = _warn_unsupported_traced_argument("size")
 
     @pd.validator("structures", always=True)
     @skip_if_fields_missing(["size", "center"])

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -2433,6 +2433,20 @@ class AbstractFieldProjectionData(MonitorData):
 
         return self.make_data_array(data=rcs_data)
 
+    def make_adjoint_sources(
+        self, dataset_names: list[str], fwidth: float
+    ) -> List[Union[CustomCurrentSource, PointDipole]]:
+        """Error if server-side field projection is used for autograd"""
+
+        raise NotImplementedError(
+            "Adjoint is currently not implemented for server-side field projections. "
+            "To compute derivatives with respect to field projection data, please use a 'FieldMonitor' "
+            "and use a local projection in your objective function via 'FieldProjector.from_near_field_monitors'. "
+            "Using field projection monitors directly is not supported as the full field information is required "
+            "to construct the adjoint source for this problem. The field projection data does not contain the "
+            "information necessary for gradient computation."
+        )
+
 
 class FieldProjectionAngleData(AbstractFieldProjectionData):
     """Data associated with a :class:`.FieldProjectionAngleMonitor`: components of projected fields.

--- a/tidy3d/components/source/base.py
+++ b/tidy3d/components/source/base.py
@@ -11,7 +11,7 @@ from ..base import cached_property
 from ..base_sim.source import AbstractSource
 from ..geometry.base import Box
 from ..types import TYPE_TAG_STR, Ax
-from ..validators import _assert_min_freq
+from ..validators import _assert_min_freq, _warn_unsupported_traced_argument
 from ..viz import (
     ARROW_ALPHA,
     ARROW_COLOR_POLARIZATION,
@@ -57,6 +57,9 @@ class Source(Box, AbstractSource, ABC):
     def _pol_vector(self) -> Tuple[float, float, float]:
         """Returns a vector indicating the source polarization for arrow plotting, if not None."""
         return None
+
+    _warn_traced_center = _warn_unsupported_traced_argument("center")
+    _warn_traced_size = _warn_unsupported_traced_argument("size")
 
     @pydantic.validator("source_time", always=True)
     def _freqs_lower_bound(cls, val):

--- a/tidy3d/components/validators.py
+++ b/tidy3d/components/validators.py
@@ -2,9 +2,11 @@
 
 import numpy as np
 import pydantic.v1 as pydantic
+from autograd.tracer import isbox
 
 from ..exceptions import SetupError, ValidationError
 from ..log import log
+from .autograd.utils import get_static
 from .base import DATA_ARRAY_MAP, skip_if_fields_missing
 from .data.dataset import Dataset, FieldDataset
 from .geometry.base import Box
@@ -464,3 +466,21 @@ def validate_mode_plane_radius(mode_spec: ModeSpec, plane: Box, msg_prefix: str 
             f"{msg_prefix} bend radius is smaller than half the mode plane size "
             "along the radial axis, which can produce wrong results."
         )
+
+
+def _warn_unsupported_traced_argument(name: str):
+    @pydantic.validator(name, always=True, allow_reuse=True)
+    def _warn_traced_arg(cls, val, values):
+        if isbox(val):
+            log.warning(
+                f"Field '{name}' of '{cls.__name__}' received an autograd tracer "
+                f"(i.e., a value being tracked for automatic differentiation). "
+                f"Automatic differentiation through this field is unsupported, "
+                f"so the tracer has been converted to its static value. "
+                f"If you want to avoid this warning, you manually unbox the value "
+                f"using the 'autograd.tracer.getval' function before passing it to Tidy3D."
+            )
+            return get_static(val)
+        return val
+
+    return _warn_traced_arg


### PR DESCRIPTION
This PR adds two new checks when using autodiff:
1. Error if using a server-side field projection (would fail silently before)
2. Warn if a tracer enters geometry construction and extract the untraced value. All classes that inherit from `Box` accept traced values, and sometimes tracers entering would cause an error deep in to the validation stack which was hard to debug.

Should fix/address #2365 