### PR TITLE
maint[autograd]: validator for catching traced structures in `ClipOperation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Supplying autograd-traced values to geometric fields (`center`, `size`) of simulations, monitors, and sources now logs a warning and falls back to the static value instead of erroring.
 - Attempting to differentiate server-side field projections now raises a clear error instead of silently failing.
 - Improved error message and handling when attempting to load a non-existent task ID.
+- `ClipOperation` now fails validation if traced fields are detected.
 
 ## [2.8.3] - 2025-04-24
 

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -2185,3 +2185,24 @@ def test_sim_traced_center_size(use_emulated_run):
 
     with AssertLogLevel("WARNING", contains_str="autograd tracer"):
         grad = ag.grad(objective, argnum=1)(base_sim.center, base_sim.size)
+
+
+def test_error_clip(use_emulated_run):
+    """Make sure proper error raised if differentiating a ``ClipOperation``."""
+
+    def objective(x):
+        box1 = td.Box(center=(0, 0, 0), size=(x, x, x))
+        box2 = td.Box(center=(1, 1, 1), size=(x, x, x))
+        union = td.ClipOperation(operation="union", geometry_a=box1, geometry_b=box2)
+        structure = td.Structure(geometry=union, medium=td.Medium(permittivity=2))
+        sim = SIM_BASE.updated_copy(
+            structures=[structure],
+            monitors=[
+                td.FieldMonitor(size=(0, 0, 0), center=(0, 0, 0), freqs=[FREQ0], name="field"),
+            ],
+        )
+        data = run(sim, task_name="clip_error")
+        return anp.sum(data["field"].intensity.item())
+
+    with pytest.raises(ValueError):
+        g = ag.grad(objective)(1.0)

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -2981,6 +2981,17 @@ class ClipOperation(Geometry):
         description="Second operand for the set operation. It can also be any geometry type.",
     )
 
+    @pydantic.validator("geometry_a", "geometry_b", always=True)
+    def _geometries_untraced(cls, val):
+        """Make sure that ``ClipOperation`` geometries do not contain tracers."""
+        traced = val.strip_traced_fields()
+        if traced:
+            raise ValidationError(
+                f"{val.type} contains traced fields {list(traced.keys())}. Note that "
+                "'ClipOperation' does not currently support automatic differentiation."
+            )
+        return val
+
     @staticmethod
     def to_polygon_list(base_geometry: Shapely) -> List[Shapely]:
         """Return a list of valid polygons from a shapely geometry, discarding points, lines, and


### PR DESCRIPTION
This will fail in the forward pass _before_ simulations are submitted.