### PR TITLE
Fix bug when symmetry + non-symmetric boundary conditions are defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - The method `Geometry.reflected` can be used to create a reflected copy of any geometry off a plane. As for other transformations, for efficiency, `reflected` `PolySlab` directly returns an updated `PolySlab` object rather than a `Transformed` object, except when the normal of the plane of reflection has a non-zero component along the slab axis, in which case `Transformed` is still returned.
 - Validation check for unit error in grid spacing.
+- Validation that when symmetry is imposed along a given axis, the boundary conditions on each side of the axis are identical.
 
 ### Changed
 - Supplying autograd-traced values to geometric fields (`center`, `size`) of simulations, monitors, and sources now logs a warning and falls back to the static value instead of erroring.

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -585,6 +585,33 @@ def test_validate_zero_dim_boundaries():
     )
 
 
+def test_validate_symmetry_boundaries():
+    # simulation with symmetry along an axis should have the same boundaries defined on both sides
+    td.Simulation(
+        size=(1, 1, 1),
+        symmetry=(0, 1, 0),
+        grid_spec=td.GridSpec.uniform(dl=0.1),
+        run_time=1e-12,
+        boundary_spec=td.BoundarySpec(
+            x=td.Boundary.periodic(),
+            y=td.Boundary.periodic(),
+            z=td.Boundary.pml(),
+        ),
+    )
+    with pytest.raises(pydantic.ValidationError):
+        td.Simulation(
+            size=(1, 1, 1),
+            symmetry=(0, 1, 0),
+            grid_spec=td.GridSpec.uniform(dl=0.1),
+            run_time=1e-12,
+            boundary_spec=td.BoundarySpec(
+                x=td.Boundary.periodic(),
+                y=td.Boundary(plus=td.Boundary.pml(), minus=td.Boundary.periodic()),
+                z=td.Boundary.pml(),
+            ),
+        )
+
+
 def test_validate_components_none():
     assert SIM._structures_not_at_edges(val=None, values=SIM.dict()) is None
     assert SIM._validate_num_sources(val=None) is None
@@ -2757,7 +2784,16 @@ def test_sim_subsection(unstructured, nz):
     # Ensure that in this first test case the lumped element is safely excluded
     assert len(sim_red.lumped_elements) == 0
     assert sim_red.structures != SIM_FULL.structures
-    sim_red = SIM_FULL.subsection(
+
+    sim_full_sym = SIM_FULL.updated_copy(
+        boundary_spec=td.BoundarySpec(
+            x=td.Boundary.pml(),
+            y=td.Boundary.periodic(),
+            z=td.Boundary.periodic(),
+        )
+    )
+    # Need to update BCs to be symmetrice when we include symmetries
+    sim_red = sim_full_sym.subsection(
         region=region,
         symmetry=(1, 0, -1),
         monitors=[mnt for mnt in SIM_FULL.monitors if not isinstance(mnt, td.ModeMonitor)],
@@ -2807,7 +2843,7 @@ def test_sim_subsection(unstructured, nz):
     sim_red = sim.subsection(region=region, remove_outside_custom_mediums=True)
 
     # check automatic symmetry expansion
-    sim_sym = SIM_FULL.updated_copy(
+    sim_sym = sim_full_sym.updated_copy(
         symmetry=(-1, 0, 1),
         sources=[src for src in SIM_FULL.sources if not isinstance(src, td.TFSF)],
     )

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -361,6 +361,19 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
             return sum(num_cells_in_monitor(mnt) for mnt in monitor.integration_surfaces)
         return num_cells_in_monitor(monitor)
 
+    @pydantic.validator("boundary_spec")
+    def _validate_boundary_spec_symmetry(cls, val, values):
+        """Error if symmetry is imposed along an axis but the boundary conditions are not the same
+        on both sides."""
+        boundaries = [val.x, val.y, val.z]
+        for ax, symmetry, ax_bounds in zip("xyz", values.get("symmetry"), boundaries):
+            if symmetry != 0 and ax_bounds.plus != ax_bounds.minus:
+                raise ValidationError(
+                    f"Symmetry '{symmetry}' along axis {ax} requires the same boundary "
+                    f"condition on both sides of the axis."
+                )
+        return val
+
     @cached_property
     def _subpixel(self) -> SubpixelSpec:
         """Subpixel averaging method evaluated based on self.subpixel."""


### PR DESCRIPTION
This fixes a bug a user encountered which was brought to my attention by @FilipeFcp. Basically, when a simulation is created with symmetry applied along a given axis, but with boundary conditions that differ on the left and right side, physically we just ignore the left side. However, in the case of PML/Absorber boundaries with a different number of layers, the simulation grid that would be created would still use the left-side number of layers, and create a non-symmetric grid on which the "expanded fields" are defined.

The initial fix I tried (the code change here) just fixes the grid generation to use whatever number of layers is on the right. This fixes the issue that was observed in the recorded field data, however I realize that the current state can still be kind of confusing. For example, if I plot such a simulation, I get this:

![image](https://github.com/user-attachments/assets/fc329e09-13dd-47f6-8c24-2a6ca1f7df24)

Obviously something is going wrong here too as the overlaid "symmetry region" extends into the large absorber region on the right. Ideally, if we are neglecting the boundary definition on the left, we should actually incorporate this everywhere, and e.g. display the simulation with the right-side boundary on the left, too.

I'm afraid doing this automatically may be a bit frustrating though. For example, one option is to create a `_boundary_spec` property that mirrors `boundary_spec`, but replaces any minus-side boundaries with the plus-side ones, if a symmetry is applied - then use this everywhere internally. The issue though is that what is written to the json will not correspond to what is e.g. displayed, which can again be confusing. Maybe better is to take the route of introducing a validator that would modify the `boundary_spec` upon creation - but might that be confusing to the user too? Meaning that their input will be modified - but in some sense, it will be "made right".

The last alternative is to just add a validator to require that the user makes the boundary specs symmetric, if symmetry is applied. More strict from a user perspective, but at least fool- and confusion-proof.

After writing all this out, maybe the best is to add the dynamic validator that modifies `boundary_spec` if needed. What do you think @yaugenst ?