### PR TITLE
Delegate PEC check from MultiPhysicsMedium to its Optical Medium

### DIFF
--- a/tests/test_components/test_scene.py
+++ b/tests/test_components/test_scene.py
@@ -52,19 +52,22 @@ def test_plot_eps():
     SCENE_FULL._add_cbar_eps(eps_min=1, eps_max=2, ax=ax)
     plt.close()
 
+
 def test_plot_eps_multiphysics():
-    s = td.Scene(structures=[td.Structure(
-            geometry=td.Box(
-                size=(1, 1, 1),
-                center=(-1, 0.5, 0.5)
-            ),
-            medium=td.MultiPhysicsMedium(
-                optical=td.Medium(permittivity=3.9),
-                charge=td.ChargeInsulatorMedium(permittivity=3.9), 
-                name="SiO2"
+    s = td.Scene(
+        structures=[
+            td.Structure(
+                geometry=td.Box(size=(1, 1, 1), center=(-1, 0.5, 0.5)),
+                medium=td.MultiPhysicsMedium(
+                    optical=td.Medium(permittivity=3.9),
+                    charge=td.ChargeInsulatorMedium(permittivity=3.9),
+                    name="SiO2",
+                ),
             )
-        )])
+        ]
+    )
     s.plot_eps(x=0)
+
 
 def test_plot_eps_bounds():
     _ = SCENE_FULL.plot_eps(x=0, hlim=[-0.45, 0.45])

--- a/tests/test_components/test_scene.py
+++ b/tests/test_components/test_scene.py
@@ -66,6 +66,7 @@ def test_plot_eps_multiphysics():
             )
         ]
     )
+    assert s.structures[0].medium.name == "SiO2"
     s.plot_eps(x=0)
 
 

--- a/tests/test_components/test_scene.py
+++ b/tests/test_components/test_scene.py
@@ -52,6 +52,19 @@ def test_plot_eps():
     SCENE_FULL._add_cbar_eps(eps_min=1, eps_max=2, ax=ax)
     plt.close()
 
+def test_plot_eps_multiphysics():
+    s = td.Scene(structures=[td.Structure(
+            geometry=td.Box(
+                size=(1, 1, 1),
+                center=(-1, 0.5, 0.5)
+            ),
+            medium=td.MultiPhysicsMedium(
+                optical=td.Medium(permittivity=3.9),
+                charge=td.ChargeInsulatorMedium(permittivity=3.9), 
+                name="SiO2"
+            )
+        )])
+    s.plot_eps(x=0)
 
 def test_plot_eps_bounds():
     _ = SCENE_FULL.plot_eps(x=0, hlim=[-0.45, 0.45])

--- a/tidy3d/components/material/multi_physics.py
+++ b/tidy3d/components/material/multi_physics.py
@@ -103,7 +103,7 @@ class MultiPhysicsMedium(Tidy3dBaseModel):
         if self.optical is not None:
             return self.optical.is_pec
         else:
-            return True
+            return False
 
     @property
     def heat_spec(self):

--- a/tidy3d/components/material/multi_physics.py
+++ b/tidy3d/components/material/multi_physics.py
@@ -100,7 +100,15 @@ class MultiPhysicsMedium(Tidy3dBaseModel):
 
     def __getattr__(self, name: str):
         """Delegates calls to a fixed set of missing attributes to their respective inner medium."""
-        DELEGATED_ATTRIBUTES = {"is_pec": self.optical, "_eps_plot": self.optical}
+        IGNORED_ATTRIBUTES = ["__deepcopy__"]
+        if name in IGNORED_ATTRIBUTES:
+            return None
+
+        DELEGATED_ATTRIBUTES = {
+            "is_pec": self.optical,
+            "_eps_plot": self.optical,
+            "viz_spec": self.optical,
+        }
         # NOTE(frederikschubertflex): this dictionary might need to be extended as we transition our code towards using this `MultiPhysicsMedium`.
 
         if name in DELEGATED_ATTRIBUTES:

--- a/tidy3d/components/material/multi_physics.py
+++ b/tidy3d/components/material/multi_physics.py
@@ -107,7 +107,7 @@ class MultiPhysicsMedium(Tidy3dBaseModel):
             return getattr(DELEGATED_ATTRIBUTES[name], name)
         else:
             raise ValueError(
-                f"MultiPhysicsMedium has no attribute called {name}. Did you meant to access the attribute of one of the optical, heat or charge media?"
+                f"MultiPhysicsMedium has no attribute called {name}. Did you mean to access the attribute of one of the optical, heat or charge media?"
             )
 
     @property

--- a/tidy3d/components/material/multi_physics.py
+++ b/tidy3d/components/material/multi_physics.py
@@ -99,13 +99,14 @@ class MultiPhysicsMedium(Tidy3dBaseModel):
     )
 
     def __getattr__(self, name: str):
-        """Delegates calls to missing attributes to the inner `optical` medium."""
-        if self.optical is not None:
+        """Delegates calls to missing attributes to the inner media."""
+        if self.optical is not None and hasattr(self.optical, name):
             return getattr(self.optical, name)
-        else:
-            raise ValueError(
-                f"Tried to access {name} of MultiPhysicsMedium without optical medium definition."
-            )
+        if self.heat is not None and hasattr(self.heat, name):
+            return getattr(self.heat, name)
+        if self.charge is not None and hasattr(self.charge, name):
+            return getattr(self.charge, name)
+        return None
 
     @property
     def heat_spec(self):

--- a/tidy3d/components/material/multi_physics.py
+++ b/tidy3d/components/material/multi_physics.py
@@ -99,14 +99,16 @@ class MultiPhysicsMedium(Tidy3dBaseModel):
     )
 
     def __getattr__(self, name: str):
-        """Delegates calls to missing attributes to the inner media."""
-        if self.optical is not None and hasattr(self.optical, name):
-            return getattr(self.optical, name)
-        if self.heat is not None and hasattr(self.heat, name):
-            return getattr(self.heat, name)
-        if self.charge is not None and hasattr(self.charge, name):
-            return getattr(self.charge, name)
-        return None
+        """Delegates calls to a fixed set of missing attributes to their respective inner medium."""
+        DELEGATED_ATTRIBUTES = {"is_pec": self.optical, "_eps_plot": self.optical}
+        # NOTE(frederikschubertflex): this dictionary might need to be extended as we transition our code towards using this `MultiPhysicsMedium`.
+
+        if name in DELEGATED_ATTRIBUTES:
+            return getattr(DELEGATED_ATTRIBUTES[name], name)
+        else:
+            raise ValueError(
+                f"MultiPhysicsMedium has no attribute called {name}. Did you meant to access the attribute of one of the optical, heat or charge media?"
+            )
 
     @property
     def heat_spec(self):

--- a/tidy3d/components/material/multi_physics.py
+++ b/tidy3d/components/material/multi_physics.py
@@ -99,6 +99,13 @@ class MultiPhysicsMedium(Tidy3dBaseModel):
     )
 
     @property
+    def is_pec(self):
+        if self.optical is not None:
+            return self.optical.is_pec
+        else:
+            return True
+
+    @property
     def heat_spec(self):
         if self.heat is not None:
             return self.heat

--- a/tidy3d/components/material/multi_physics.py
+++ b/tidy3d/components/material/multi_physics.py
@@ -98,12 +98,14 @@ class MultiPhysicsMedium(Tidy3dBaseModel):
         None, title="Charge properties", description="Specifies properties for Charge simulations."
     )
 
-    @property
-    def is_pec(self):
+    def __getattr__(self, name: str):
+        """Delegates calls to missing attributes to the inner `optical` medium."""
         if self.optical is not None:
-            return self.optical.is_pec
+            return getattr(self.optical, name)
         else:
-            return False
+            raise ValueError(
+                f"Tried to access {name} of MultiPhysicsMedium without optical medium definition."
+            )
 
     @property
     def heat_spec(self):

--- a/tidy3d/components/material/multi_physics.py
+++ b/tidy3d/components/material/multi_physics.py
@@ -99,7 +99,35 @@ class MultiPhysicsMedium(Tidy3dBaseModel):
     )
 
     def __getattr__(self, name: str):
-        """Delegates calls to a fixed set of missing attributes to their respective inner medium."""
+        """
+        Delegate attribute lookup to inner media or fail fast.
+
+        Parameters
+        ----------
+        name : str
+            The attribute that could not be found on the ``MultiPhysicsMedium`` itself.
+
+        Returns
+        -------
+        Any
+            * The attribute value obtained from a delegated sub-medium when
+            ``name`` is listed in ``DELEGATED_ATTRIBUTES``.
+            * ``None`` when ``name`` is explicitly ignored (e.g. ``"__deepcopy__"``).
+
+        Raises
+        ------
+        ValueError
+            If ``name`` is neither ignored nor in the delegation map, signalling that
+            the caller may have intended to access ``optical``, ``heat``, or
+            ``charge`` directly.
+
+        Notes
+        -----
+        Only the attributes enumerated in the local ``DELEGATED_ATTRIBUTES`` dict are
+        forwarded.
+        Extend that mapping as additional cross-medium shim behaviour becomes
+        necessary.
+        """
         IGNORED_ATTRIBUTES = ["__deepcopy__"]
         if name in IGNORED_ATTRIBUTES:
             return None
@@ -109,7 +137,6 @@ class MultiPhysicsMedium(Tidy3dBaseModel):
             "_eps_plot": self.optical,
             "viz_spec": self.optical,
         }
-        # NOTE(frederikschubertflex): this dictionary might need to be extended as we transition our code towards using this `MultiPhysicsMedium`.
 
         if name in DELEGATED_ATTRIBUTES:
             return getattr(DELEGATED_ATTRIBUTES[name], name)


### PR DESCRIPTION
The check is used for plotting the permittivity in the https://github.com/flexcompute/tidy3d/blame/9c8ca5ff9310a681352ae0c2624c9a142275cd6f/tidy3d/components/scene.py#L1040C9-L1040C20 `_eps_bounds` method. I am not sure whether this should depend solely on the optical medium or if the other media are relevant as well.

Fixes https://github.com/flexcompute/tidy3d-core/issues/956