### PR TITLE
fix[frontend]: fix computation of finite axis length for PolySlab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed issue with `CustomMedium` gradients where other frequencies would wrongly contribute to the gradient.
+- Fixed bug when computing `PolySlab` bounds in plotting functions.
 
 ## [2.8.3] - 2025-04-24
 

--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -307,6 +307,37 @@ def test_polyslab_bounds():
         td.PolySlab(vertices=((0, 0), (1, 0), (1, 1)), slab_bounds=(0.5, -0.5), axis=2)
 
 
+@pytest.mark.parametrize("axis", (0, 1, 2))
+def test_polyslab_inf_to_finite_bounds(axis):
+    """Test that finite_length_axis for PolySlab first clips at LARGE_NUMBER and then computes the length."""
+    axis_bound = 20
+    ps_low_inf = td.PolySlab(
+        axis=axis,
+        slab_bounds=[-td.inf, axis_bound],
+        vertices=[[0, 0], [2.5, 1], [2, 3], [0.5, 4], [-1.5, 2.5]],
+    )
+    ps_high_inf = td.PolySlab(
+        axis=axis,
+        slab_bounds=[-axis_bound, td.inf],
+        vertices=[[0, 0], [2.5, 1], [2, 3], [0.5, 4], [-1.5, 2.5]],
+    )
+    ps_inf = td.PolySlab(
+        axis=axis,
+        slab_bounds=[-td.inf, td.inf],
+        vertices=[[0, 0], [2.5, 1], [2, 3], [0.5, 4], [-1.5, 2.5]],
+    )
+
+    assert ps_low_inf.finite_length_axis == (
+        LARGE_NUMBER + axis_bound
+    ), "Unexpected finite length for polyslab axis with -inf bound"
+    assert ps_high_inf.finite_length_axis == (
+        LARGE_NUMBER + axis_bound
+    ), "Unexpected finite length for polyslab axis with inf bound"
+    assert (
+        ps_inf.finite_length_axis == 2 * LARGE_NUMBER
+    ), "Unexpected finite length for polyslab axis with two inf bounds"
+
+
 def test_validate_polyslab_vertices_valid():
     with pytest.raises(pydantic.ValidationError):
         POLYSLAB.copy(update=dict(vertices=(1, 2, 3)))

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -388,6 +388,16 @@ class PolySlab(base.Planar):
         zmin, zmax = self.slab_bounds
         return zmax - zmin
 
+    @property
+    def finite_length_axis(self) -> float:
+        """Gets the length of the PolySlab along the out of plane dimension.
+        First clips the slab bounds to LARGE_NUMBER and then returns difference.
+        """
+        zmin, zmax = self.slab_bounds
+        zmin = max(zmin, -LARGE_NUMBER)
+        zmax = min(zmax, LARGE_NUMBER)
+        return zmax - zmin
+
     @cached_property
     def reference_polygon(self) -> np.ndarray:
         """The polygon at the reference plane.


### PR DESCRIPTION
I believe this was only affecting the plotting function, but came from debugging the issue Filipe was seeing when plotting PolySlab with an infinite slab bound. Since the bounds are capped at +/- LARGE_NUMBER, we need the finite length to be able to be larger than LARGE_NUMBER and at a maximum up to 2 * LARGE_NUMBER.