### PR TITLE
add a TerminalSpec for RF specific mode information

### DIFF
--- a/tests/test_components/test_microwave.py
+++ b/tests/test_components/test_microwave.py
@@ -26,12 +26,13 @@ from tidy3d.components.microwave.formulas.circuit_parameters import (
 )
 from tidy3d.components.microwave.path_integrals.path_integral_factory import (
     make_current_integral,
+    make_path_integrals,
     make_voltage_integral,
 )
 from tidy3d.components.microwave.path_integrals.path_spec_generator import PathSpecGenerator
 from tidy3d.components.types import Ax, Shapely
 from tidy3d.constants import EPSILON_0
-from tidy3d.exceptions import ValidationError
+from tidy3d.exceptions import SetupError, ValidationError
 
 from ..test_data.test_monitor_data import make_directivity_data
 
@@ -43,6 +44,9 @@ if MAKE_PLOTS:
     from matplotlib import use
 
     use("TkAgg")
+
+COAX_R1 = 0.04
+COAX_R2 = 0.5
 
 
 def make_mw_sim(
@@ -211,7 +215,7 @@ def make_mw_sim(
 
 
 def plot_auto_path_spec(
-    path_spec: tidy3d.components.microwave.path_integrals.current_spec.CompositeCurrentIntegralSpec,
+    path_spec: td.CompositeCurrentIntegralSpec,
     geoms: list[Shapely],
     ax: Ax = None,
 ) -> Ax:
@@ -318,6 +322,53 @@ def test_antenna_parameters():
         antenna_params.partial_gain("invalid")
     with pytest.raises(ValueError):
         antenna_params.partial_realized_gain("invalid")
+
+
+def test_path_integral_plotting():
+    """Test that all types of path integrals correctly plot themselves."""
+
+    mean_radius = (COAX_R2 + COAX_R1) * 0.5
+    size = [COAX_R2 - COAX_R1, 0, 0]
+    center = [mean_radius, 0, 0]
+
+    voltage_integral = td.VoltageIntegralAxisAlignedSpec(
+        center=center, size=size, sign="-", extrapolate_to_endpoints=True, snap_path_to_grid=True
+    )
+
+    current_integral = td.CustomCurrentIntegral2DSpec.from_circular_path(
+        center=(0, 0, 0), radius=0.4, num_points=31, normal_axis=2, clockwise=False
+    )
+
+    ax = voltage_integral.plot(z=0)
+    current_integral.plot(z=0, ax=ax)
+    plt.close()
+
+    # Test off center plotting
+    ax = voltage_integral.plot(z=2)
+    current_integral.plot(z=2, ax=ax)
+    plt.close()
+
+    # Plot
+    voltage_integral = td.CustomVoltageIntegral2DSpec(
+        axis=1, position=0, vertices=[(-1, -1), (0, 0), (1, 1)]
+    )
+
+    current_integral = td.CurrentIntegralAxisAlignedSpec(
+        center=(0, 0, 0),
+        size=(2, 0, 1),
+        sign="-",
+        extrapolate_to_endpoints=False,
+        snap_contour_to_grid=False,
+    )
+
+    ax = voltage_integral.plot(y=0)
+    current_integral.plot(y=0, ax=ax)
+    plt.close()
+
+    # Test off center plotting
+    ax = voltage_integral.plot(y=2)
+    current_integral.plot(y=2, ax=ax)
+    plt.close()
 
 
 @pytest.mark.parametrize("colocate", [False, True])
@@ -451,20 +502,10 @@ def test_auto_path_spec_validation():
 def test_composite_current_integral_validation():
     """Ensures that the CompositeCurrentIntegralSpec is validated correctly."""
 
-    current_spec = (
-        tidy3d.components.microwave.path_integrals.current_spec.CurrentIntegralAxisAlignedSpec(
-            center=(1, 2, 3), size=(0, 1, 1), sign="-"
-        )
-    )
-    voltage_spec = (
-        tidy3d.components.microwave.path_integrals.voltage_spec.VoltageIntegralAxisAlignedSpec(
-            center=(1, 2, 3), size=(0, 0, 1), sign="-"
-        )
-    )
-    path_spec = (
-        tidy3d.components.microwave.path_integrals.current_spec.CompositeCurrentIntegralSpec(
-            center=(1, 2, 3), size=(0, 1, 1), path_specs=[current_spec], sum_spec="sum"
-        )
+    current_spec = td.CurrentIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 1, 1), sign="-")
+    voltage_spec = td.VoltageIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 0, 1), sign="-")
+    path_spec = td.CompositeCurrentIntegralSpec(
+        center=(1, 2, 3), size=(0, 1, 1), path_specs=[current_spec], sum_spec="sum"
     )
 
     with pytest.raises(pd.ValidationError):
@@ -491,12 +532,10 @@ def test_path_integral_creation():
     )
     current_integral = make_current_integral(path_spec)
 
-    path_spec = tidy3d.components.microwave.path_integrals.voltage_spec.CustomVoltageIntegral2DSpec(
-        vertices=[(0, 1), (0, 4)], axis=1, position=2
-    )
+    path_spec = td.CustomVoltageIntegral2DSpec(vertices=[(0, 1), (0, 4)], axis=1, position=2)
     voltage_integral = make_voltage_integral(path_spec)
 
-    path_spec = tidy3d.components.microwave.path_integrals.current_spec.CustomCurrentIntegral2DSpec(
+    path_spec = td.CustomCurrentIntegral2DSpec(
         vertices=[
             (0, 1),
             (0, 4),
@@ -509,17 +548,15 @@ def test_path_integral_creation():
     _ = make_current_integral(path_spec)
 
     with pytest.raises(pd.ValidationError):
-        path_spec = (
-            tidy3d.components.microwave.path_integrals.current_spec.CustomCurrentIntegral2DSpec(
-                vertices=[
-                    (0, 1, 3),
-                    (0, 4, 5),
-                    (3, 4, 5),
-                    (3, 1, 5),
-                ],
-                axis=1,
-                position=2,
-            )
+        path_spec = td.CustomCurrentIntegral2DSpec(
+            vertices=[
+                (0, 1, 3),
+                (0, 4, 5),
+                (3, 4, 5),
+                (3, 1, 5),
+            ],
+            axis=1,
+            position=2,
         )
 
 
@@ -529,12 +566,8 @@ def test_microwave_mode_spec_validation():
     _ = td.MicrowaveModeSpec()
     _ = td.MicrowaveModeSpec(voltage_spec=None, current_spec=None)
 
-    v_spec = tidy3d.components.microwave.path_integrals.voltage_spec.VoltageIntegralAxisAlignedSpec(
-        center=(1, 2, 3), size=(0, 0, 1), sign="-"
-    )
-    i_spec = tidy3d.components.microwave.path_integrals.current_spec.CurrentIntegralAxisAlignedSpec(
-        center=(1, 2, 3), size=(0, 1, 1), sign="-"
-    )
+    v_spec = td.VoltageIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 0, 1), sign="-")
+    i_spec = td.CurrentIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 1, 1), sign="-")
 
     # All valid methods
     _ = td.MicrowaveModeSpec(voltage_spec=(v_spec,), current_spec=(i_spec,))
@@ -560,3 +593,241 @@ def test_microwave_mode_spec_validation():
 
     with pytest.raises(pd.ValidationError):
         _ = td.MicrowaveModeSpec(current_spec=(None, i_spec))
+
+
+def test_path_integral_factory_voltage_validation():
+    """Test make_voltage_integral validation and error handling."""
+
+    # Valid voltage specs
+    axis_aligned_spec = td.VoltageIntegralAxisAlignedSpec(
+        center=(1, 2, 3), size=(0, 0, 1), sign="-"
+    )
+    custom_2d_spec = td.CustomVoltageIntegral2DSpec(vertices=[(0, 1), (0, 4)], axis=1, position=2)
+
+    # Test successful creation with axis-aligned spec
+    voltage_integral = make_voltage_integral(axis_aligned_spec)
+    assert voltage_integral is not None
+    assert voltage_integral.center == (1, 2, 3)
+    assert voltage_integral.size == (0, 0, 1)
+
+    # Test successful creation with custom 2D spec
+    voltage_integral = make_voltage_integral(custom_2d_spec)
+    assert voltage_integral is not None
+    assert voltage_integral.axis == 1
+    assert voltage_integral.position == 2
+
+    # Test ValidationError with unsupported type
+    class UnsupportedVoltageSpec:
+        def dict(self, exclude=None):
+            return {}
+
+    with pytest.raises(ValidationError, match="Unsupported voltage path specification type"):
+        make_voltage_integral(UnsupportedVoltageSpec())
+
+
+def test_path_integral_factory_current_validation():
+    """Test make_current_integral validation and error handling."""
+
+    # Valid current specs
+    axis_aligned_spec = td.CurrentIntegralAxisAlignedSpec(
+        center=(1, 2, 3), size=(0, 1, 1), sign="-"
+    )
+    custom_2d_spec = td.CustomCurrentIntegral2DSpec(
+        vertices=[(0, 1), (0, 4), (3, 4), (3, 1)], axis=1, position=2
+    )
+    composite_spec = td.CompositeCurrentIntegralSpec(
+        center=(1, 2, 3), size=(0, 1, 1), path_specs=[axis_aligned_spec], sum_spec="sum"
+    )
+
+    # Test successful creation with axis-aligned spec
+    current_integral = make_current_integral(axis_aligned_spec)
+    assert current_integral is not None
+    assert current_integral.center == (1, 2, 3)
+    assert current_integral.size == (0, 1, 1)
+
+    # Test successful creation with custom 2D spec
+    current_integral = make_current_integral(custom_2d_spec)
+    assert current_integral is not None
+    assert current_integral.axis == 1
+    assert current_integral.position == 2
+
+    # Test successful creation with composite spec
+    current_integral = make_current_integral(composite_spec)
+    assert current_integral is not None
+    assert current_integral.center == (1, 2, 3)
+    assert len(current_integral.path_specs) == 1
+
+    # Test ValidationError with unsupported type
+    class UnsupportedCurrentSpec:
+        def dict(self, exclude=None):
+            return {}
+
+    with pytest.raises(ValidationError, match="Unsupported current path specification type"):
+        make_current_integral(UnsupportedCurrentSpec())
+
+
+def test_make_path_integrals_validation():
+    """Test make_path_integrals validation and error handling."""
+
+    # Create a basic simulation setup
+    sim = make_mw_sim(False, False, "microstrip")
+    mode_monitor = sim.monitors[0]
+
+    # Valid microwave mode spec with explicit specs
+    v_spec = td.VoltageIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 0, 1), sign="-")
+    i_spec = td.CurrentIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 1, 1), sign="-")
+
+    microwave_mode_spec = td.MicrowaveModeSpec(voltage_spec=(v_spec,), current_spec=(i_spec,))
+
+    # Test successful creation
+    voltage_integrals, current_integrals = make_path_integrals(
+        microwave_mode_spec, mode_monitor, sim
+    )
+    assert len(voltage_integrals) == 1
+    assert len(current_integrals) == 1
+    assert voltage_integrals[0] is not None
+    assert current_integrals[0] is not None
+
+    # Test with None specs - when both are None, use_automatic_setup is True
+    # This means current integrals will be auto-generated, not None
+    microwave_mode_spec_none = td.MicrowaveModeSpec(voltage_spec=None, current_spec=None)
+
+    voltage_integrals, current_integrals = make_path_integrals(
+        microwave_mode_spec_none, mode_monitor, sim
+    )
+    assert len(voltage_integrals) == mode_monitor.mode_spec.num_modes
+    assert len(current_integrals) == mode_monitor.mode_spec.num_modes
+    assert all(vi is None for vi in voltage_integrals)
+    # When use_automatic_setup=True, current integrals are auto-generated
+    assert all(ci is not None for ci in current_integrals)
+
+    # Test with automatic setup enabled (same as above, but explicit)
+    microwave_mode_spec_auto = td.MicrowaveModeSpec()
+
+    voltage_integrals_auto, current_integrals_auto = make_path_integrals(
+        microwave_mode_spec_auto, mode_monitor, sim
+    )
+    assert len(voltage_integrals_auto) == mode_monitor.mode_spec.num_modes
+    assert len(current_integrals_auto) == mode_monitor.mode_spec.num_modes
+    assert all(vi is None for vi in voltage_integrals_auto)
+    assert all(ci is not None for ci in current_integrals_auto)
+
+
+def test_make_path_integrals_setup_errors():
+    """Test that make_path_integrals raises appropriate SetupErrors."""
+
+    # Create a simulation that will cause path spec generation to fail
+    sim = make_mw_sim(False, False, "microstrip")
+    mode_monitor = sim.monitors[0]
+
+    # Create a microwave mode spec that will trigger auto-generation but fail
+    # We'll modify the simulation to have structures that will cause validation errors
+    bad_coax = td.GeometryGroup(
+        geometries=(
+            td.ClipOperation(
+                operation="difference",
+                geometry_a=td.Cylinder(axis=0, radius=2 * mm, center=(0, 0, 5 * mm), length=td.inf),
+                geometry_b=td.Cylinder(
+                    axis=0, radius=1.4 * mm, center=(0, 0, 5 * mm), length=td.inf
+                ),
+            ),
+            td.Cylinder(axis=0, radius=1 * mm, center=(0, 0, 5 * mm), length=td.inf),
+        )
+    )
+    bad_struct = td.Structure(geometry=bad_coax, medium=td.PEC)
+    bad_sim = sim.updated_copy(structures=[bad_struct])
+
+    microwave_mode_spec_auto = td.MicrowaveModeSpec()
+
+    # This should raise a SetupError due to auto-generation failure
+    with pytest.raises(SetupError, match="Failed to auto-generate path specification"):
+        make_path_integrals(microwave_mode_spec_auto, mode_monitor, bad_sim)
+
+
+def test_make_path_integrals_construction_errors(monkeypatch):
+    """Test that make_path_integrals handles construction errors properly."""
+
+    sim = make_mw_sim(False, False, "microstrip")
+    mode_monitor = sim.monitors[0]
+
+    # Create a valid spec
+    v_spec = td.VoltageIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 0, 1), sign="-")
+
+    microwave_mode_spec = td.MicrowaveModeSpec(voltage_spec=(v_spec,), current_spec=(None,))
+
+    # Mock make_voltage_integral to raise an exception
+    def mock_make_voltage_integral(path_spec):
+        raise RuntimeError("Intentional construction failure")
+
+    monkeypatch.setattr(
+        "tidy3d.components.microwave.path_integrals.path_integral_factory.make_voltage_integral",
+        mock_make_voltage_integral,
+    )
+
+    # This should raise a SetupError due to construction failure
+    with pytest.raises(SetupError, match="Failed to construct path integrals"):
+        make_path_integrals(microwave_mode_spec, mode_monitor, sim)
+
+
+def test_path_integral_factory_composite_current():
+    """Test make_current_integral with CompositeCurrentIntegralSpec and integration."""
+
+    # Create base specs for the composite
+    axis_aligned_spec1 = td.CurrentIntegralAxisAlignedSpec(
+        center=(1, 2, 3), size=(0, 1, 1), sign="-"
+    )
+    axis_aligned_spec2 = td.CurrentIntegralAxisAlignedSpec(
+        center=(2, 2, 3), size=(0, 1, 1), sign="+"
+    )
+
+    # Test creation of CompositeCurrentIntegralSpec
+    composite_spec = td.CompositeCurrentIntegralSpec(
+        center=(1.5, 2, 3),
+        size=(2, 1, 1),
+        path_specs=[axis_aligned_spec1, axis_aligned_spec2],
+        sum_spec="sum",
+    )
+
+    # Test successful creation with composite spec
+    current_integral = make_current_integral(composite_spec)
+    assert current_integral is not None
+    assert current_integral.center == (1.5, 2, 3)
+    assert len(current_integral.path_specs) == 2
+
+    # Test with different sum_spec options
+    composite_spec_split = td.CompositeCurrentIntegralSpec(
+        center=(1.5, 2, 3),
+        size=(2, 1, 1),
+        path_specs=[axis_aligned_spec1, axis_aligned_spec2],
+        sum_spec="split",
+    )
+    current_integral_split = make_current_integral(composite_spec_split)
+    assert current_integral_split is not None
+    assert current_integral_split.sum_spec == "split"
+
+
+def test_path_integral_factory_mixed_specs():
+    """Test make_path_integrals with mixed voltage and current specs (some None)."""
+
+    sim = make_mw_sim(False, False, "microstrip")
+    mode_monitor = sim.monitors[0]
+
+    # Create specs where some are None
+    v_spec = td.VoltageIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 0, 1), sign="-")
+    i_spec = td.CurrentIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 1, 1), sign="-")
+
+    # Test with mixed specs - some None, some specified
+    microwave_mode_spec = td.MicrowaveModeSpec(
+        voltage_spec=(v_spec, None), current_spec=(None, i_spec)
+    )
+
+    voltage_integrals, current_integrals = make_path_integrals(
+        microwave_mode_spec, mode_monitor, sim
+    )
+
+    assert len(voltage_integrals) == 2
+    assert len(current_integrals) == 2
+    assert voltage_integrals[0] is not None  # First mode has voltage spec
+    assert voltage_integrals[1] is None  # Second mode has no voltage spec
+    assert current_integrals[0] is None  # First mode has no current spec
+    assert current_integrals[1] is not None  # Second mode has current spec

--- a/tests/test_components/test_microwave.py
+++ b/tests/test_components/test_microwave.py
@@ -16,7 +16,7 @@ from shapely.plotting import plot_line, plot_polygon
 import tidy3d as td
 import tidy3d.components.microwave.path_integrals.current_spec
 import tidy3d.components.microwave.path_integrals.voltage_spec
-from tidy3d.components.data.monitor_data import FreqDataArray
+from tidy3d.components.data.monitor_data import FreqDataArray, ModeSolverData
 from tidy3d.components.microwave.formulas.circuit_parameters import (
     capacitance_colinear_cylindrical_wire_segments,
     capacitance_rectangular_sheets,
@@ -30,6 +30,7 @@ from tidy3d.components.microwave.path_integrals.path_integral_factory import (
     make_voltage_integral,
 )
 from tidy3d.components.microwave.path_integrals.path_spec_generator import PathSpecGenerator
+from tidy3d.components.mode.mode_solver import ModeSolver
 from tidy3d.components.types import Ax, Shapely
 from tidy3d.constants import EPSILON_0
 from tidy3d.exceptions import SetupError, ValidationError
@@ -53,6 +54,8 @@ def make_mw_sim(
     use_2D: bool = False,
     colocate: bool = False,
     transmission_line_type: Literal["microstrip", "cpw", "coax", "stripline"] = "microstrip",
+    width=3 * mm,
+    height=1 * mm,
 ) -> td.Simulation:
     """Helper to create a microwave simulation with a single type of transmission line present."""
 
@@ -66,8 +69,6 @@ def make_mw_sim(
     run_time = 60 / fwidth
 
     length = 40 * mm
-    width = 3 * mm
-    height = 1 * mm
     thickness = 0.2 * mm
     sim_width = length
 
@@ -137,13 +138,13 @@ def make_mw_sim(
         gnd_width = 10 * width
         metal_geos.append(
             td.Box(
-                center=[0, 0, height + thickness],
+                center=[0, 0, height + thickness / 2],
                 size=[td.inf, gnd_width, thickness],
             )
         )
         metal_geos.append(
             td.Box(
-                center=[0, 0, -height - thickness],
+                center=[0, 0, -height - thickness / 2],
                 size=[td.inf, gnd_width, thickness],
             )
         )
@@ -563,36 +564,36 @@ def test_path_integral_creation():
 def test_microwave_mode_spec_validation():
     """Check that the various allowed methods for supplying path specifications are validated."""
 
-    _ = td.MicrowaveModeSpec()
-    _ = td.MicrowaveModeSpec(voltage_spec=None, current_spec=None)
+    _ = td.AutoImpedanceSpec()
+    _ = td.CustomImpedanceSpec(voltage_spec=None, current_spec=None)
 
     v_spec = td.VoltageIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 0, 1), sign="-")
     i_spec = td.CurrentIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 1, 1), sign="-")
 
     # All valid methods
-    _ = td.MicrowaveModeSpec(voltage_spec=(v_spec,), current_spec=(i_spec,))
-    _ = td.MicrowaveModeSpec(voltage_spec=(v_spec,))
-    _ = td.MicrowaveModeSpec(current_spec=(i_spec,))
-    _ = td.MicrowaveModeSpec(voltage_spec=(v_spec, v_spec), current_spec=(i_spec, i_spec))
+    _ = td.CustomImpedanceSpec(voltage_spec=(v_spec,), current_spec=(i_spec,))
+    _ = td.CustomImpedanceSpec(voltage_spec=(v_spec,))
+    _ = td.CustomImpedanceSpec(current_spec=(i_spec,))
+    _ = td.CustomImpedanceSpec(voltage_spec=(v_spec, v_spec), current_spec=(i_spec, i_spec))
 
     # Different lengths is not valid
     with pytest.raises(pd.ValidationError):
-        _ = td.MicrowaveModeSpec(voltage_spec=(v_spec, v_spec), current_spec=(i_spec,))
+        _ = td.CustomImpedanceSpec(voltage_spec=(v_spec, v_spec), current_spec=(i_spec,))
     with pytest.raises(pd.ValidationError):
-        _ = td.MicrowaveModeSpec(voltage_spec=(v_spec,), current_spec=(i_spec, i_spec))
+        _ = td.CustomImpedanceSpec(voltage_spec=(v_spec,), current_spec=(i_spec, i_spec))
 
     # Only one path spec missing is ok
-    _ = td.MicrowaveModeSpec(voltage_spec=(v_spec, None), current_spec=(None, i_spec))
+    _ = td.CustomImpedanceSpec(voltage_spec=(v_spec, None), current_spec=(None, i_spec))
 
     # But at least one must be given for each pair
     with pytest.raises(pd.ValidationError):
-        _ = td.MicrowaveModeSpec(voltage_spec=(v_spec, None), current_spec=(None, None))
+        _ = td.CustomImpedanceSpec(voltage_spec=(v_spec, None), current_spec=(None, None))
 
     with pytest.raises(pd.ValidationError):
-        _ = td.MicrowaveModeSpec(voltage_spec=(v_spec, None))
+        _ = td.CustomImpedanceSpec(voltage_spec=(v_spec, None))
 
     with pytest.raises(pd.ValidationError):
-        _ = td.MicrowaveModeSpec(current_spec=(None, i_spec))
+        _ = td.CustomImpedanceSpec(current_spec=(None, i_spec))
 
 
 def test_path_integral_factory_voltage_validation():
@@ -677,12 +678,10 @@ def test_make_path_integrals_validation():
     v_spec = td.VoltageIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 0, 1), sign="-")
     i_spec = td.CurrentIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 1, 1), sign="-")
 
-    microwave_mode_spec = td.MicrowaveModeSpec(voltage_spec=(v_spec,), current_spec=(i_spec,))
+    impedance_spec = td.CustomImpedanceSpec(voltage_spec=(v_spec,), current_spec=(i_spec,))
 
     # Test successful creation
-    voltage_integrals, current_integrals = make_path_integrals(
-        microwave_mode_spec, mode_monitor, sim
-    )
+    voltage_integrals, current_integrals = make_path_integrals(impedance_spec, mode_monitor, sim)
     assert len(voltage_integrals) == 1
     assert len(current_integrals) == 1
     assert voltage_integrals[0] is not None
@@ -690,7 +689,7 @@ def test_make_path_integrals_validation():
 
     # Test with None specs - when both are None, use_automatic_setup is True
     # This means current integrals will be auto-generated, not None
-    microwave_mode_spec_none = td.MicrowaveModeSpec(voltage_spec=None, current_spec=None)
+    microwave_mode_spec_none = td.CustomImpedanceSpec(voltage_spec=None, current_spec=None)
 
     voltage_integrals, current_integrals = make_path_integrals(
         microwave_mode_spec_none, mode_monitor, sim
@@ -698,11 +697,10 @@ def test_make_path_integrals_validation():
     assert len(voltage_integrals) == mode_monitor.mode_spec.num_modes
     assert len(current_integrals) == mode_monitor.mode_spec.num_modes
     assert all(vi is None for vi in voltage_integrals)
-    # When use_automatic_setup=True, current integrals are auto-generated
-    assert all(ci is not None for ci in current_integrals)
+    assert all(ci is None for ci in current_integrals)
 
     # Test with automatic setup enabled (same as above, but explicit)
-    microwave_mode_spec_auto = td.MicrowaveModeSpec()
+    microwave_mode_spec_auto = td.AutoImpedanceSpec()
 
     voltage_integrals_auto, current_integrals_auto = make_path_integrals(
         microwave_mode_spec_auto, mode_monitor, sim
@@ -737,7 +735,7 @@ def test_make_path_integrals_setup_errors():
     bad_struct = td.Structure(geometry=bad_coax, medium=td.PEC)
     bad_sim = sim.updated_copy(structures=[bad_struct])
 
-    microwave_mode_spec_auto = td.MicrowaveModeSpec()
+    microwave_mode_spec_auto = td.AutoImpedanceSpec()
 
     # This should raise a SetupError due to auto-generation failure
     with pytest.raises(SetupError, match="Failed to auto-generate path specification"):
@@ -753,7 +751,7 @@ def test_make_path_integrals_construction_errors(monkeypatch):
     # Create a valid spec
     v_spec = td.VoltageIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 0, 1), sign="-")
 
-    microwave_mode_spec = td.MicrowaveModeSpec(voltage_spec=(v_spec,), current_spec=(None,))
+    impedance_spec = td.CustomImpedanceSpec(voltage_spec=(v_spec,), current_spec=(None,))
 
     # Mock make_voltage_integral to raise an exception
     def mock_make_voltage_integral(path_spec):
@@ -766,7 +764,7 @@ def test_make_path_integrals_construction_errors(monkeypatch):
 
     # This should raise a SetupError due to construction failure
     with pytest.raises(SetupError, match="Failed to construct path integrals"):
-        make_path_integrals(microwave_mode_spec, mode_monitor, sim)
+        make_path_integrals(impedance_spec, mode_monitor, sim)
 
 
 def test_path_integral_factory_composite_current():
@@ -817,13 +815,11 @@ def test_path_integral_factory_mixed_specs():
     i_spec = td.CurrentIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 1, 1), sign="-")
 
     # Test with mixed specs - some None, some specified
-    microwave_mode_spec = td.MicrowaveModeSpec(
+    impedance_spec = td.CustomImpedanceSpec(
         voltage_spec=(v_spec, None), current_spec=(None, i_spec)
     )
 
-    voltage_integrals, current_integrals = make_path_integrals(
-        microwave_mode_spec, mode_monitor, sim
-    )
+    voltage_integrals, current_integrals = make_path_integrals(impedance_spec, mode_monitor, sim)
 
     assert len(voltage_integrals) == 2
     assert len(current_integrals) == 2
@@ -831,3 +827,57 @@ def test_path_integral_factory_mixed_specs():
     assert voltage_integrals[1] is None  # Second mode has no voltage spec
     assert current_integrals[0] is None  # First mode has no current spec
     assert current_integrals[1] is not None  # Second mode has current spec
+
+
+def test_mode_solver_with_microwave_mode_spec():
+    """Test make_path_integrals with mixed voltage and current specs (some None)."""
+
+    def analytical_stripline_impedance(er, width, height, thickness):
+        assert width > 0.35 * height
+        term1 = 1 - thickness / height
+        Cf = 2 / np.pi * np.log(1 / term1 + 1)
+        if thickness > 0:
+            Cf -= thickness / np.pi / height * np.log(1 / term1**2 - 1)
+        return 30 * np.pi / np.sqrt(er) * (term1) / (width / height + Cf)
+
+    stripline_sim = make_mw_sim(transmission_line_type="stripline", width=2 * mm, height=1 * mm)
+
+    stripline_sim = stripline_sim.updated_copy(grid_spec=td.GridSpec.uniform(dl=0.05 * mm))
+    analytical_stripline_impedance(5.6, 0.5, 1, 0)
+    height = 1 * mm
+    width = 10 * mm
+    thickness = 0.1 * mm
+    plane = td.Box(center=(0, 0, 0), size=(0, width, 2 * height))
+    num_modes = 3
+
+    mode_spec = td.ModeSpec(
+        num_modes=num_modes,
+        target_neff=2.2,
+        microwave_mode_spec=td.MicrowaveModeSpec(),
+    )
+
+    mms = ModeSolver(
+        simulation=stripline_sim,
+        plane=plane,
+        mode_spec=mode_spec,
+        freqs=[1e9, 5e9, 10e9],
+    )
+    snapped_grid: td.Grid = mms.grid_snapped
+
+    print(snapped_grid.num_cells)
+
+    mms_data: ModeSolverData = mms.data
+    print(mms_data.to_dataframe())
+    print(mms_data.microwave_data.Z0)
+    print(mms_data.microwave_data.voltage_coeffs)
+    print(mms_data.microwave_data.current_coeffs)
+    print(analytical_stripline_impedance(4.4, 2 * mm, 2 * height, thickness))
+
+    _, ax = plt.subplots(1, 1, tight_layout=True, figsize=(15, 15))
+    mms.plot(ax=ax)
+    mms.plot_grid(ax=ax)
+    ax.set_aspect("equal")
+    # ax.set_xlim(modal_plane.bounds[0][1], modal_plane.bounds[1][1])
+    # ax.set_ylim(modal_plane.bounds[0][2], modal_plane.bounds[1][2])
+    if MAKE_PLOTS:
+        plt.show()

--- a/tests/test_components/test_microwave.py
+++ b/tests/test_components/test_microwave.py
@@ -3,13 +3,20 @@
 from __future__ import annotations
 
 from math import isclose
+from typing import Literal
 
+import matplotlib.pyplot as plt
 import numpy as np
+import pydantic.v1 as pd
 import pytest
 import xarray as xr
+from shapely.geometry import LineString, Polygon
+from shapely.plotting import plot_line, plot_polygon
 
+import tidy3d as td
+import tidy3d.components.microwave.path_integrals.current_spec
+import tidy3d.components.microwave.path_integrals.voltage_spec
 from tidy3d.components.data.monitor_data import FreqDataArray
-from tidy3d.components.microwave.data.monitor_data import AntennaMetricsData
 from tidy3d.components.microwave.formulas.circuit_parameters import (
     capacitance_colinear_cylindrical_wire_segments,
     capacitance_rectangular_sheets,
@@ -17,9 +24,208 @@ from tidy3d.components.microwave.formulas.circuit_parameters import (
     mutual_inductance_colinear_wire_segments,
     total_inductance_colinear_rectangular_wire_segments,
 )
+from tidy3d.components.microwave.path_integrals.path_integral_factory import (
+    make_current_integral,
+    make_voltage_integral,
+)
+from tidy3d.components.microwave.path_integrals.path_spec_generator import PathSpecGenerator
+from tidy3d.components.types import Ax, Shapely
 from tidy3d.constants import EPSILON_0
+from tidy3d.exceptions import ValidationError
 
 from ..test_data.test_monitor_data import make_directivity_data
+
+mm = 1e3
+
+MAKE_PLOTS = False
+if MAKE_PLOTS:
+    # Interative plotting for debugging
+    from matplotlib import use
+
+    use("TkAgg")
+
+
+def make_mw_sim(
+    use_2D: bool = False,
+    colocate: bool = False,
+    transmission_line_type: Literal["microstrip", "cpw", "coax", "stripline"] = "microstrip",
+) -> td.Simulation:
+    """Helper to create a microwave simulation with a single type of transmission line present."""
+
+    freq_start = 1e9
+    freq_stop = 10e9
+
+    freq0 = (freq_start + freq_stop) / 2
+    fwidth = freq_stop - freq_start
+    freqs = np.arange(freq_start, freq_stop, 1e9)
+
+    run_time = 60 / fwidth
+
+    length = 40 * mm
+    width = 3 * mm
+    height = 1 * mm
+    thickness = 0.2 * mm
+    sim_width = length
+
+    pec = td.PEC
+    if use_2D:
+        thickness = 0.0
+        pec = td.PEC2D
+
+    epsr = 4.4
+    diel = td.Medium(permittivity=epsr)
+
+    metal_geos = []
+
+    if transmission_line_type == "microstrip":
+        metal_geos.append(
+            td.Box(
+                center=[0, 0, height + thickness / 2],
+                size=[td.inf, width, thickness],
+            )
+        )
+    elif transmission_line_type == "cpw":
+        metal_geos.append(
+            td.Box(
+                center=[0, 0, height + thickness / 2],
+                size=[td.inf, width, thickness],
+            )
+        )
+        gnd_width = 10 * width
+        gap = width / 5
+        gnd_shift = gnd_width / 2 + gap + width / 2
+        metal_geos.append(
+            td.Box(
+                center=[0, -gnd_shift, height + thickness / 2],
+                size=[td.inf, gnd_width, thickness],
+            )
+        )
+        metal_geos.append(
+            td.Box(
+                center=[0, gnd_shift, height + thickness / 2],
+                size=[td.inf, gnd_width, thickness],
+            )
+        )
+    elif transmission_line_type == "coax":
+        metal_geos.append(
+            td.GeometryGroup(
+                geometries=(
+                    td.ClipOperation(
+                        operation="difference",
+                        geometry_a=td.Cylinder(
+                            axis=0, radius=2 * mm, center=(0, 0, 5 * mm), length=td.inf
+                        ),
+                        geometry_b=td.Cylinder(
+                            axis=0, radius=1.8 * mm, center=(0, 0, 5 * mm), length=td.inf
+                        ),
+                    ),
+                    td.Cylinder(axis=0, radius=0.6 * mm, center=(0, 0, 5 * mm), length=td.inf),
+                )
+            )
+        )
+    elif transmission_line_type == "stripline":
+        metal_geos.append(
+            td.Box(
+                center=[0, 0, 0],
+                size=[td.inf, width, thickness],
+            )
+        )
+        gnd_width = 10 * width
+        metal_geos.append(
+            td.Box(
+                center=[0, 0, height + thickness],
+                size=[td.inf, gnd_width, thickness],
+            )
+        )
+        metal_geos.append(
+            td.Box(
+                center=[0, 0, -height - thickness],
+                size=[td.inf, gnd_width, thickness],
+            )
+        )
+    else:
+        raise AssertionError("Incorrect argument")
+
+    metal_structures = [td.Structure(geometry=geo, medium=pec) for geo in metal_geos]
+    substrate = td.Structure(
+        geometry=td.Box(
+            center=[0, 0, 0],
+            size=[td.inf, td.inf, 2 * height],
+        ),
+        medium=diel,
+    )
+
+    structures = [substrate, *metal_structures]
+    boundary_spec = td.BoundarySpec(
+        x=td.Boundary(plus=td.PML(), minus=td.PML()),
+        y=td.Boundary(plus=td.PML(), minus=td.PML()),
+        z=td.Boundary(plus=td.PML(), minus=td.PECBoundary()),
+    )
+
+    size_sim = [
+        length + 2 * width,
+        sim_width,
+        20 * mm + height + thickness,
+    ]
+    center_sim = [0, 0, size_sim[2] / 2]
+    # Slightly different setup for stripline substrate sandwiched between ground planes
+    if transmission_line_type == "stripline":
+        center_sim[2] = 0
+        boundary_spec = td.BoundarySpec(
+            x=td.Boundary(plus=td.PML(), minus=td.PML()),
+            y=td.Boundary(plus=td.PML(), minus=td.PML()),
+            z=td.Boundary(plus=td.PML(), minus=td.PML()),
+        )
+    size_port = [0, sim_width, size_sim[2]]
+    center_port = [0, 0, center_sim[2]]
+    mode_spec = td.ModeSpec(
+        num_modes=4, target_neff=1.8, microwave_mode_spec=td.MicrowaveModeSpec()
+    )
+
+    mode_monitor = td.ModeMonitor(
+        center=center_port, size=size_port, freqs=freqs, name="mode_1", colocate=colocate
+    )
+
+    gaussian = td.GaussianPulse(freq0=freq0, fwidth=fwidth)
+    mode_src = td.ModeSource(
+        center=(-length / 2, 0, center_sim[2]),
+        size=size_port,
+        direction="+",
+        mode_spec=mode_spec,
+        mode_index=0,
+        source_time=gaussian,
+    )
+    sim = td.Simulation(
+        center=center_sim,
+        size=size_sim,
+        grid_spec=td.GridSpec.uniform(dl=0.1 * mm),
+        structures=structures,
+        sources=[mode_src],
+        monitors=[mode_monitor],
+        run_time=run_time,
+        boundary_spec=boundary_spec,
+        plot_length_units="mm",
+        symmetry=(0, 0, 0),
+    )
+    return sim
+
+
+def plot_auto_path_spec(
+    path_spec: tidy3d.components.microwave.path_integrals.current_spec.CompositeCurrentIntegralSpec,
+    geoms: list[Shapely],
+    ax: Ax = None,
+) -> Ax:
+    """Helper to plot composite path specifications along with the Shapely geometries used to generate them."""
+    if ax is None:
+        _, ax = plt.subplots(1, 1, tight_layout=True, figsize=(15, 15))
+
+    for geom in geoms:
+        if isinstance(geom, Polygon):
+            plot_polygon(geom, ax=ax)
+        elif isinstance(geom, LineString):
+            plot_line(geom, ax=ax)
+    i_integral = make_current_integral(path_spec)
+    i_integral.plot(x=i_integral.center[0], ax=ax)
 
 
 def test_inductance_formulas():
@@ -68,7 +274,7 @@ def test_antenna_parameters():
     f = directivity_data.coords["f"]
     power_inc = FreqDataArray(0.8 * np.ones(len(f)), coords={"f": f})
     power_refl = 0.25 * power_inc
-    antenna_params = AntennaMetricsData.from_directivity_data(
+    antenna_params = td.AntennaMetricsData.from_directivity_data(
         directivity_data, power_inc, power_refl
     )
 
@@ -112,3 +318,245 @@ def test_antenna_parameters():
         antenna_params.partial_gain("invalid")
     with pytest.raises(ValueError):
         antenna_params.partial_realized_gain("invalid")
+
+
+@pytest.mark.parametrize("colocate", [False, True])
+@pytest.mark.parametrize("tline_type", ["microstrip", "cpw", "coax"])
+def test_auto_path_spec_canonical_shapes(colocate, tline_type):
+    """Test canonical transmission line types to make sure the correct path integrals are generated."""
+    sim = make_mw_sim(False, colocate, tline_type)
+    mode_monitor = sim.monitors[0]
+    modal_plane = td.Box(center=mode_monitor.center, size=mode_monitor.size)
+    comp_path_spec, geos = PathSpecGenerator.create_current_path_specs(
+        modal_plane,
+        sim.structures,
+        sim.grid,
+        sim.symmetry,
+        sim.bounding_box,
+        field_data_colocated=mode_monitor.colocate,
+    )
+
+    if tline_type == "coax":
+        assert len(comp_path_spec.path_specs) == 2
+        for path_spec in comp_path_spec.path_specs:
+            assert np.all(np.isclose(path_spec.center, (0, 0, 5 * mm)))
+    else:
+        assert len(comp_path_spec.path_specs) == 1
+        assert np.all(np.isclose(comp_path_spec.path_specs[0].center, (0, 0, 1.1 * mm)))
+
+    _, ax = plt.subplots(1, 1, tight_layout=True, figsize=(15, 15))
+    sim.plot(x=modal_plane.center[0], ax=ax, monitor_alpha=0)
+    sim.plot_grid(x=modal_plane.center[0], ax=ax, monitor_alpha=0)
+    plot_auto_path_spec(comp_path_spec, geos, ax)
+    ax.set_aspect("equal")
+    ax.set_xlim(modal_plane.bounds[0][1], modal_plane.bounds[1][1])
+    ax.set_ylim(modal_plane.bounds[0][2], modal_plane.bounds[1][2])
+    if MAKE_PLOTS:
+        plt.show()
+
+
+@pytest.mark.parametrize("use_2D", [False, True])
+@pytest.mark.parametrize("symmetry", [(0, 0, 1), (0, 1, 1), (0, 1, 0)])
+def test_auto_path_spec_advanced(use_2D, symmetry):
+    """The various symmetry permutations as well as with and without 2D structures."""
+    sim = make_mw_sim(use_2D, False, "stripline")
+
+    # Add shapes outside the portion considered for the symmetric simulation
+    bottom_left = td.Structure(
+        geometry=td.Box(
+            center=[0, -5 * mm, -5 * mm],
+            size=[td.inf, 1 * mm, 1 * mm],
+        ),
+        medium=td.PEC,
+    )
+    # Add shape only in the symmetric portion
+    top_right = td.Structure(
+        geometry=td.Box(
+            center=[0, 5 * mm, 5 * mm],
+            size=[td.inf, 1 * mm, 1 * mm],
+        ),
+        medium=td.PEC,
+    )
+
+    structures = [*list(sim.structures), bottom_left, top_right]
+    sim = sim.updated_copy(symmetry=symmetry, structures=structures)
+    mode_monitor = sim.monitors[0]
+
+    modal_plane = td.Box(center=mode_monitor.center, size=mode_monitor.size)
+    comp_path_spec, geos = PathSpecGenerator.create_current_path_specs(
+        modal_plane,
+        sim.structures,
+        sim.grid,
+        sim.symmetry,
+        sim.bounding_box,
+        field_data_colocated=mode_monitor.colocate,
+    )
+
+    if symmetry[1] == 1 and symmetry[2] == 1:
+        assert len(comp_path_spec.path_specs) == 7
+    else:
+        assert len(comp_path_spec.path_specs) == 5
+
+    _, ax = plt.subplots(1, 1, tight_layout=True, figsize=(15, 15))
+    sim.plot(x=modal_plane.center[0], ax=ax, monitor_alpha=0)
+    sim.plot_grid(x=modal_plane.center[0], ax=ax, monitor_alpha=0)
+    plot_auto_path_spec(comp_path_spec, geos, ax)
+    ax.set_aspect("equal")
+    ax.set_xlim(modal_plane.bounds[0][1], modal_plane.bounds[1][1])
+    ax.set_ylim(modal_plane.bounds[0][2], modal_plane.bounds[1][2])
+    if MAKE_PLOTS:
+        plt.show()
+
+
+def test_auto_path_spec_validation():
+    """Check that the auto path specs are validated properly."""
+
+    # First some quick sanity checks with the helper
+    test_path = td.Box(center=(0, 0, 0), size=(0, 0.9, 0.1))
+    test_shapely = [LineString([(-1, 0), (1, 0)])]
+    assert PathSpecGenerator._check_path_intersects_with_conductors(test_shapely, test_path)
+
+    test_path = td.Box(center=(0, 0, 0), size=(0, 2.1, 0.1))
+    test_shapely = [LineString([(-1, 0), (1, 0)])]
+    assert not PathSpecGenerator._check_path_intersects_with_conductors(test_shapely, test_path)
+
+    sim = make_mw_sim(False, False, "microstrip")
+    coax = td.GeometryGroup(
+        geometries=(
+            td.ClipOperation(
+                operation="difference",
+                geometry_a=td.Cylinder(axis=0, radius=2 * mm, center=(0, 0, 5 * mm), length=td.inf),
+                geometry_b=td.Cylinder(
+                    axis=0, radius=1.4 * mm, center=(0, 0, 5 * mm), length=td.inf
+                ),
+            ),
+            td.Cylinder(axis=0, radius=1 * mm, center=(0, 0, 5 * mm), length=td.inf),
+        )
+    )
+    coax_struct = td.Structure(geometry=coax, medium=td.PEC)
+    sim = sim.updated_copy(structures=[coax_struct])
+    mode_monitor = sim.monitors[0]
+    modal_plane = td.Box(center=mode_monitor.center, size=mode_monitor.size)
+    with pytest.raises(ValidationError):
+        PathSpecGenerator.create_current_path_specs(
+            modal_plane,
+            sim.structures,
+            sim.grid,
+            sim.symmetry,
+            sim.bounding_box,
+            field_data_colocated=mode_monitor.colocate,
+        )
+
+
+def test_composite_current_integral_validation():
+    """Ensures that the CompositeCurrentIntegralSpec is validated correctly."""
+
+    current_spec = (
+        tidy3d.components.microwave.path_integrals.current_spec.CurrentIntegralAxisAlignedSpec(
+            center=(1, 2, 3), size=(0, 1, 1), sign="-"
+        )
+    )
+    voltage_spec = (
+        tidy3d.components.microwave.path_integrals.voltage_spec.VoltageIntegralAxisAlignedSpec(
+            center=(1, 2, 3), size=(0, 0, 1), sign="-"
+        )
+    )
+    path_spec = (
+        tidy3d.components.microwave.path_integrals.current_spec.CompositeCurrentIntegralSpec(
+            center=(1, 2, 3), size=(0, 1, 1), path_specs=[current_spec], sum_spec="sum"
+        )
+    )
+
+    with pytest.raises(pd.ValidationError):
+        path_spec.updated_copy(path_specs=[])
+
+    with pytest.raises(pd.ValidationError):
+        path_spec.updated_copy(path_specs=[voltage_spec])
+
+
+def test_path_integral_creation():
+    """Check that path integrals are correctly constructed from path specifications."""
+
+    path_spec = (
+        tidy3d.components.microwave.path_integrals.voltage_spec.VoltageIntegralAxisAlignedSpec(
+            center=(1, 2, 3), size=(0, 0, 1), sign="-"
+        )
+    )
+    voltage_integral = make_voltage_integral(path_spec)
+
+    path_spec = (
+        tidy3d.components.microwave.path_integrals.current_spec.CurrentIntegralAxisAlignedSpec(
+            center=(1, 2, 3), size=(0, 1, 1), sign="-"
+        )
+    )
+    current_integral = make_current_integral(path_spec)
+
+    path_spec = tidy3d.components.microwave.path_integrals.voltage_spec.CustomVoltageIntegral2DSpec(
+        vertices=[(0, 1), (0, 4)], axis=1, position=2
+    )
+    voltage_integral = make_voltage_integral(path_spec)
+
+    path_spec = tidy3d.components.microwave.path_integrals.current_spec.CustomCurrentIntegral2DSpec(
+        vertices=[
+            (0, 1),
+            (0, 4),
+            (3, 4),
+            (3, 1),
+        ],
+        axis=1,
+        position=2,
+    )
+    _ = make_current_integral(path_spec)
+
+    with pytest.raises(pd.ValidationError):
+        path_spec = (
+            tidy3d.components.microwave.path_integrals.current_spec.CustomCurrentIntegral2DSpec(
+                vertices=[
+                    (0, 1, 3),
+                    (0, 4, 5),
+                    (3, 4, 5),
+                    (3, 1, 5),
+                ],
+                axis=1,
+                position=2,
+            )
+        )
+
+
+def test_microwave_mode_spec_validation():
+    """Check that the various allowed methods for supplying path specifications are validated."""
+
+    _ = td.MicrowaveModeSpec()
+    _ = td.MicrowaveModeSpec(voltage_spec=None, current_spec=None)
+
+    v_spec = tidy3d.components.microwave.path_integrals.voltage_spec.VoltageIntegralAxisAlignedSpec(
+        center=(1, 2, 3), size=(0, 0, 1), sign="-"
+    )
+    i_spec = tidy3d.components.microwave.path_integrals.current_spec.CurrentIntegralAxisAlignedSpec(
+        center=(1, 2, 3), size=(0, 1, 1), sign="-"
+    )
+
+    # All valid methods
+    _ = td.MicrowaveModeSpec(voltage_spec=(v_spec,), current_spec=(i_spec,))
+    _ = td.MicrowaveModeSpec(voltage_spec=(v_spec,))
+    _ = td.MicrowaveModeSpec(current_spec=(i_spec,))
+    _ = td.MicrowaveModeSpec(voltage_spec=(v_spec, v_spec), current_spec=(i_spec, i_spec))
+
+    # Different lengths is not valid
+    with pytest.raises(pd.ValidationError):
+        _ = td.MicrowaveModeSpec(voltage_spec=(v_spec, v_spec), current_spec=(i_spec,))
+    with pytest.raises(pd.ValidationError):
+        _ = td.MicrowaveModeSpec(voltage_spec=(v_spec,), current_spec=(i_spec, i_spec))
+
+    # Only one path spec missing is ok
+    _ = td.MicrowaveModeSpec(voltage_spec=(v_spec, None), current_spec=(None, i_spec))
+
+    # But at least one must be given for each pair
+    with pytest.raises(pd.ValidationError):
+        _ = td.MicrowaveModeSpec(voltage_spec=(v_spec, None), current_spec=(None, None))
+
+    with pytest.raises(pd.ValidationError):
+        _ = td.MicrowaveModeSpec(voltage_spec=(v_spec, None))
+
+    with pytest.raises(pd.ValidationError):
+        _ = td.MicrowaveModeSpec(current_spec=(None, i_spec))

--- a/tests/test_components/test_microwave.py
+++ b/tests/test_components/test_microwave.py
@@ -24,12 +24,12 @@ from tidy3d.components.microwave.formulas.circuit_parameters import (
     mutual_inductance_colinear_wire_segments,
     total_inductance_colinear_rectangular_wire_segments,
 )
+from tidy3d.components.microwave.path_integrals.impedance_spec import PathSpecGenerator
 from tidy3d.components.microwave.path_integrals.path_integral_factory import (
     make_current_integral,
     make_path_integrals,
     make_voltage_integral,
 )
-from tidy3d.components.microwave.path_integrals.path_spec_generator import PathSpecGenerator
 from tidy3d.components.mode.mode_solver import ModeSolver
 from tidy3d.components.types import Ax, Shapely
 from tidy3d.constants import EPSILON_0
@@ -183,8 +183,11 @@ def make_mw_sim(
         )
     size_port = [0, sim_width, size_sim[2]]
     center_port = [0, 0, center_sim[2]]
+    impedance_spec = (td.AutoImpedanceSpec(),) * 4
     mode_spec = td.ModeSpec(
-        num_modes=4, target_neff=1.8, microwave_mode_spec=td.MicrowaveModeSpec()
+        num_modes=4,
+        target_neff=1.8,
+        microwave_mode_spec=td.MicrowaveModeSpec(impedance_spec=impedance_spec),
     )
 
     mode_monitor = td.ModeMonitor(
@@ -379,13 +382,16 @@ def test_auto_path_spec_canonical_shapes(colocate, tline_type):
     sim = make_mw_sim(False, colocate, tline_type)
     mode_monitor = sim.monitors[0]
     modal_plane = td.Box(center=mode_monitor.center, size=mode_monitor.size)
-    comp_path_spec, geos = PathSpecGenerator.create_current_path_specs(
-        modal_plane,
+    path_spec_gen = PathSpecGenerator(
+        center=modal_plane.center,
+        size=modal_plane.size,
+        field_data_colocated=mode_monitor.colocate,
+    )
+    comp_path_spec, geos = path_spec_gen.create_current_path_specs(
         sim.structures,
         sim.grid,
         sim.symmetry,
         sim.bounding_box,
-        field_data_colocated=mode_monitor.colocate,
     )
 
     if tline_type == "coax":
@@ -435,13 +441,16 @@ def test_auto_path_spec_advanced(use_2D, symmetry):
     mode_monitor = sim.monitors[0]
 
     modal_plane = td.Box(center=mode_monitor.center, size=mode_monitor.size)
-    comp_path_spec, geos = PathSpecGenerator.create_current_path_specs(
-        modal_plane,
+    path_spec_gen = PathSpecGenerator(
+        center=modal_plane.center,
+        size=modal_plane.size,
+        field_data_colocated=mode_monitor.colocate,
+    )
+    comp_path_spec, geos = path_spec_gen.create_current_path_specs(
         sim.structures,
         sim.grid,
         sim.symmetry,
         sim.bounding_box,
-        field_data_colocated=mode_monitor.colocate,
     )
 
     if symmetry[1] == 1 and symmetry[2] == 1:
@@ -489,14 +498,17 @@ def test_auto_path_spec_validation():
     sim = sim.updated_copy(structures=[coax_struct])
     mode_monitor = sim.monitors[0]
     modal_plane = td.Box(center=mode_monitor.center, size=mode_monitor.size)
+    path_spec_gen = PathSpecGenerator(
+        center=modal_plane.center,
+        size=modal_plane.size,
+        field_data_colocated=mode_monitor.colocate,
+    )
     with pytest.raises(ValidationError):
-        PathSpecGenerator.create_current_path_specs(
-            modal_plane,
+        path_spec_gen.create_current_path_specs(
             sim.structures,
             sim.grid,
             sim.symmetry,
             sim.bounding_box,
-            field_data_colocated=mode_monitor.colocate,
         )
 
 
@@ -565,35 +577,20 @@ def test_microwave_mode_spec_validation():
     """Check that the various allowed methods for supplying path specifications are validated."""
 
     _ = td.AutoImpedanceSpec()
-    _ = td.CustomImpedanceSpec(voltage_spec=None, current_spec=None)
 
     v_spec = td.VoltageIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 0, 1), sign="-")
     i_spec = td.CurrentIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 1, 1), sign="-")
 
     # All valid methods
-    _ = td.CustomImpedanceSpec(voltage_spec=(v_spec,), current_spec=(i_spec,))
-    _ = td.CustomImpedanceSpec(voltage_spec=(v_spec,))
-    _ = td.CustomImpedanceSpec(current_spec=(i_spec,))
-    _ = td.CustomImpedanceSpec(voltage_spec=(v_spec, v_spec), current_spec=(i_spec, i_spec))
+    both = td.CustomImpedanceSpec(voltage_spec=v_spec, current_spec=i_spec)
+    voltage_only = td.CustomImpedanceSpec(
+        voltage_spec=v_spec,
+    )
+    current_only = td.CustomImpedanceSpec(
+        current_spec=i_spec,
+    )
 
-    # Different lengths is not valid
-    with pytest.raises(pd.ValidationError):
-        _ = td.CustomImpedanceSpec(voltage_spec=(v_spec, v_spec), current_spec=(i_spec,))
-    with pytest.raises(pd.ValidationError):
-        _ = td.CustomImpedanceSpec(voltage_spec=(v_spec,), current_spec=(i_spec, i_spec))
-
-    # Only one path spec missing is ok
-    _ = td.CustomImpedanceSpec(voltage_spec=(v_spec, None), current_spec=(None, i_spec))
-
-    # But at least one must be given for each pair
-    with pytest.raises(pd.ValidationError):
-        _ = td.CustomImpedanceSpec(voltage_spec=(v_spec, None), current_spec=(None, None))
-
-    with pytest.raises(pd.ValidationError):
-        _ = td.CustomImpedanceSpec(voltage_spec=(v_spec, None))
-
-    with pytest.raises(pd.ValidationError):
-        _ = td.CustomImpedanceSpec(current_spec=(None, i_spec))
+    _ = td.MicrowaveModeSpec(impedance_spec=(both, voltage_only, current_only, None))
 
 
 def test_path_integral_factory_voltage_validation():
@@ -678,10 +675,16 @@ def test_make_path_integrals_validation():
     v_spec = td.VoltageIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 0, 1), sign="-")
     i_spec = td.CurrentIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 1, 1), sign="-")
 
-    impedance_spec = td.CustomImpedanceSpec(voltage_spec=(v_spec,), current_spec=(i_spec,))
+    impedance_spec = td.CustomImpedanceSpec(
+        voltage_spec=v_spec,
+        current_spec=i_spec,
+    )
+    microwave_mode_spec = td.MicrowaveModeSpec(impedance_spec=(impedance_spec,))
 
     # Test successful creation
-    voltage_integrals, current_integrals = make_path_integrals(impedance_spec, mode_monitor, sim)
+    voltage_integrals, current_integrals = make_path_integrals(
+        microwave_mode_spec, mode_monitor, sim
+    )
     assert len(voltage_integrals) == 1
     assert len(current_integrals) == 1
     assert voltage_integrals[0] is not None
@@ -689,8 +692,7 @@ def test_make_path_integrals_validation():
 
     # Test with None specs - when both are None, use_automatic_setup is True
     # This means current integrals will be auto-generated, not None
-    microwave_mode_spec_none = td.CustomImpedanceSpec(voltage_spec=None, current_spec=None)
-
+    microwave_mode_spec_none = td.MicrowaveModeSpec(impedance_spec=(None,))
     voltage_integrals, current_integrals = make_path_integrals(
         microwave_mode_spec_none, mode_monitor, sim
     )
@@ -700,7 +702,7 @@ def test_make_path_integrals_validation():
     assert all(ci is None for ci in current_integrals)
 
     # Test with automatic setup enabled (same as above, but explicit)
-    microwave_mode_spec_auto = td.AutoImpedanceSpec()
+    microwave_mode_spec_auto = td.MicrowaveModeSpec(impedance_spec=(td.AutoImpedanceSpec(),))
 
     voltage_integrals_auto, current_integrals_auto = make_path_integrals(
         microwave_mode_spec_auto, mode_monitor, sim
@@ -735,8 +737,7 @@ def test_make_path_integrals_setup_errors():
     bad_struct = td.Structure(geometry=bad_coax, medium=td.PEC)
     bad_sim = sim.updated_copy(structures=[bad_struct])
 
-    microwave_mode_spec_auto = td.AutoImpedanceSpec()
-
+    microwave_mode_spec_auto = td.MicrowaveModeSpec(impedance_spec=(td.AutoImpedanceSpec(),))
     # This should raise a SetupError due to auto-generation failure
     with pytest.raises(SetupError, match="Failed to auto-generate path specification"):
         make_path_integrals(microwave_mode_spec_auto, mode_monitor, bad_sim)
@@ -751,7 +752,8 @@ def test_make_path_integrals_construction_errors(monkeypatch):
     # Create a valid spec
     v_spec = td.VoltageIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 0, 1), sign="-")
 
-    impedance_spec = td.CustomImpedanceSpec(voltage_spec=(v_spec,), current_spec=(None,))
+    impedance_spec = td.CustomImpedanceSpec(voltage_spec=v_spec, current_spec=None)
+    microwave_mode_spec = td.MicrowaveModeSpec(impedance_spec=(impedance_spec,))
 
     # Mock make_voltage_integral to raise an exception
     def mock_make_voltage_integral(path_spec):
@@ -764,7 +766,7 @@ def test_make_path_integrals_construction_errors(monkeypatch):
 
     # This should raise a SetupError due to construction failure
     with pytest.raises(SetupError, match="Failed to construct path integrals"):
-        make_path_integrals(impedance_spec, mode_monitor, sim)
+        make_path_integrals(microwave_mode_spec, mode_monitor, sim)
 
 
 def test_path_integral_factory_composite_current():
@@ -815,11 +817,17 @@ def test_path_integral_factory_mixed_specs():
     i_spec = td.CurrentIntegralAxisAlignedSpec(center=(1, 2, 3), size=(0, 1, 1), sign="-")
 
     # Test with mixed specs - some None, some specified
-    impedance_spec = td.CustomImpedanceSpec(
-        voltage_spec=(v_spec, None), current_spec=(None, i_spec)
+    impedance_spec1 = td.CustomImpedanceSpec(voltage_spec=v_spec, current_spec=None)
+    impedance_spec2 = td.CustomImpedanceSpec(voltage_spec=None, current_spec=i_spec)
+    microwave_mode_spec = td.MicrowaveModeSpec(
+        impedance_spec=(
+            impedance_spec1,
+            impedance_spec2,
+        )
     )
-
-    voltage_integrals, current_integrals = make_path_integrals(impedance_spec, mode_monitor, sim)
+    voltage_integrals, current_integrals = make_path_integrals(
+        microwave_mode_spec, mode_monitor, sim
+    )
 
     assert len(voltage_integrals) == 2
     assert len(current_integrals) == 2
@@ -849,11 +857,11 @@ def test_mode_solver_with_microwave_mode_spec():
     thickness = 0.1 * mm
     plane = td.Box(center=(0, 0, 0), size=(0, width, 2 * height))
     num_modes = 3
-
+    impedance_spec = (td.AutoImpedanceSpec(), None, None)
     mode_spec = td.ModeSpec(
         num_modes=num_modes,
         target_neff=2.2,
-        microwave_mode_spec=td.MicrowaveModeSpec(),
+        microwave_mode_spec=td.MicrowaveModeSpec(impedance_spec=impedance_spec),
     )
 
     mms = ModeSolver(
@@ -877,7 +885,5 @@ def test_mode_solver_with_microwave_mode_spec():
     mms.plot(ax=ax)
     mms.plot_grid(ax=ax)
     ax.set_aspect("equal")
-    # ax.set_xlim(modal_plane.bounds[0][1], modal_plane.bounds[1][1])
-    # ax.set_ylim(modal_plane.bounds[0][2], modal_plane.bounds[1][2])
     if MAKE_PLOTS:
         plt.show()

--- a/tests/test_components/test_mode.py
+++ b/tests/test_components/test_mode.py
@@ -381,3 +381,12 @@ def test_plane_crosses_symmetry_plane_warning(monkeypatch):
             mode_spec=td.ModeSpec(),
             freqs=[td.C_0],
         )
+
+
+def test_mode_spec_with_microwave_mode_spec():
+    """Test that the number of impedance specs is validated against the number of modes."""
+
+    impedance_spec = (td.AutoImpedanceSpec(),)
+    mw_mode_spec = td.MicrowaveModeSpec(impedance_spec=impedance_spec)
+    with pytest.raises(pydantic.ValidationError):
+        td.ModeSpec(num_modes=2, microwave_mode_spec=mw_mode_spec)

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -3777,3 +3777,56 @@ def test_structures_per_medium(monkeypatch):
             grid_spec=td.GridSpec.uniform(dl=0.02),
             structures=structs,
         )
+
+
+def test_validate_microwave_mode_spec_generation():
+    """Test that auto generation of path specs is correctly validated for currently unsupported structures."""
+    freq0 = 10e9
+    mm = 1e3
+    run_time_spec = td.RunTimeSpec(quality_factor=3.0)
+    size = (10 * mm, 10 * mm, 10 * mm)
+    size_mon = (0, 8 * mm, 8 * mm)
+
+    # Currently limited to generation of axis aligned boxes around conductors,
+    # so the path may intersect other nearby conductors, like in this coaxial cable
+    coaxial = td.Structure(
+        geometry=td.GeometryGroup(
+            geometries=(
+                td.ClipOperation(
+                    operation="difference",
+                    geometry_a=td.Cylinder(
+                        axis=0, radius=2.5 * mm, center=(0, 0, 0), length=td.inf
+                    ),
+                    geometry_b=td.Cylinder(
+                        axis=0, radius=1.3 * mm, center=(0, 0, 0), length=td.inf
+                    ),
+                ),
+                td.Cylinder(axis=0, radius=1 * mm, center=(0, 0, 0), length=td.inf),
+            )
+        ),
+        medium=td.PEC,
+    )
+    mode_spec = td.ModeSpec(
+        num_modes=2, target_neff=1.8, microwave_mode_spec=td.MicrowaveModeSpec()
+    )
+
+    mode_mon = td.ModeMonitor(
+        center=(0, 0, 0),
+        size=size_mon,
+        freqs=[freq0],
+        name="mode_1",
+        colocate=False,
+        mode_spec=mode_spec,
+    )
+    sim = td.Simulation(
+        run_time=run_time_spec,
+        size=size,
+        sources=[],
+        structures=[coaxial],
+        grid_spec=td.GridSpec.uniform(dl=0.1 * mm),
+        monitors=[mode_mon],
+    )
+
+    # check that validation error is caught
+    with pytest.raises(SetupError):
+        sim._validate_microwave_mode_specs()

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -3807,7 +3807,11 @@ def test_validate_microwave_mode_spec_generation():
         medium=td.PEC,
     )
     mode_spec = td.ModeSpec(
-        num_modes=2, target_neff=1.8, microwave_mode_spec=td.MicrowaveModeSpec()
+        num_modes=2,
+        target_neff=1.8,
+        microwave_mode_spec=td.MicrowaveModeSpec(
+            impedance_spec=(td.AutoImpedanceSpec(), td.AutoImpedanceSpec())
+        ),
     )
 
     mode_mon = td.ModeMonitor(

--- a/tests/test_data/test_data_arrays.py
+++ b/tests/test_data/test_data_arrays.py
@@ -319,6 +319,16 @@ def test_abs():
     _ = data.abs
 
 
+def test_angle():
+    # Make sure works on real data and the type is correct
+    data = make_scalar_field_time_data_array("Ex")
+    angle_data = data.angle
+    assert type(data) is type(angle_data)
+    data = make_mode_amps_data_array()
+    angle_data = data.angle
+    assert type(data) is type(angle_data)
+
+
 def test_heat_data_array():
     T = [0, 1e-12, 2e-12]
     _ = td.HeatDataArray((1 + 1j) * np.random.random((3,)), coords={"T": T})

--- a/tests/test_plugins/test_microwave.py
+++ b/tests/test_plugins/test_microwave.py
@@ -12,12 +12,21 @@ from skrf import Frequency
 from skrf.media import MLine
 
 import tidy3d as td
+import tidy3d.components.microwave.path_integrals.current_spec
 import tidy3d.plugins.microwave as mw
 from tidy3d import FieldData
+from tidy3d.components.data.data_array import FreqModeDataArray
 from tidy3d.constants import ETA_0
 from tidy3d.exceptions import DataError
 
-from ..utils import get_spatial_coords_dict, run_emulated
+from ..utils import AssertLogLevel, get_spatial_coords_dict, run_emulated
+
+MAKE_PLOTS = False
+if MAKE_PLOTS:
+    # Interative plotting for debugging
+    from matplotlib import use
+
+    use("TkAgg")
 
 # Using similar code as "test_data/test_data_arrays.py"
 MON_SIZE = (2, 1, 0)
@@ -527,6 +536,45 @@ def test_custom_current_integral_normal_y():
     current_integral.compute_current(SIM_Z_DATA["field"])
 
 
+def test_composite_current_integral_warnings():
+    """Ensures that the checks function correctly on some test data."""
+    f = [2e9, 3e9, 4e9]
+    mode_index = list(np.arange(5))
+    coords = {"f": f, "mode_index": mode_index}
+    values = np.ones((3, 5))
+
+    path_spec = (
+        tidy3d.components.microwave.path_integrals.current_spec.CurrentIntegralAxisAlignedSpec(
+            center=(0, 0, 0), size=(2, 2, 0), sign="+"
+        )
+    )
+    composite_integral = mw.CompositeCurrentIntegral(
+        center=(0, 0, 0), size=(4, 4, 0), path_specs=[path_spec], sum_spec="split"
+    )
+
+    phase_diff = FreqModeDataArray(np.angle(values), coords=coords)
+    with AssertLogLevel(None):
+        assert composite_integral._check_phase_sign_consistency(phase_diff)
+
+    values[1, 2:] = -1
+    phase_diff = FreqModeDataArray(np.angle(values), coords=coords)
+    with AssertLogLevel("WARNING"):
+        assert not composite_integral._check_phase_sign_consistency(phase_diff)
+
+    values = np.ones((3, 5))
+    in_phase = FreqModeDataArray(values, coords=coords)
+    values = 0.5 * np.ones((3, 5))
+    out_phase = FreqModeDataArray(values, coords=coords)
+    with AssertLogLevel(None):
+        assert composite_integral._check_phase_amplitude_consistency(in_phase, out_phase)
+
+    values = 0.5 * np.ones((3, 5))
+    values[2, 4:] = 1.5
+    out_phase = FreqModeDataArray(values, coords=coords)
+    with AssertLogLevel("WARNING"):
+        assert not composite_integral._check_phase_amplitude_consistency(in_phase, out_phase)
+
+
 def test_custom_path_integral_accuracy():
     """Test the accuracy of the custom path integral."""
     field_data = make_coax_field_data()
@@ -785,12 +833,11 @@ def test_lobe_measurements(apply_cyclic_extension, include_endpoint):
 @pytest.mark.parametrize("min_value", [0.0, 1.0])
 def test_lobe_plots(min_value):
     """Run the lobe measurer on some test data and plot the results."""
-    # Interative plotting for debugging
-    # from matplotlib import use
-    # use("TkAgg")
     theta = np.linspace(0, 2 * np.pi, 301)
     Urad = np.cos(theta) ** 2 * np.cos(3 * theta) ** 2 + min_value
     lobe_measurer = mw.LobeMeasurer(angle=theta, radiation_pattern=Urad)
     _, ax = plt.subplots(1, 1, subplot_kw={"projection": "polar"})
     ax.plot(theta, Urad, "k")
     lobe_measurer.plot(0, ax)
+    if MAKE_PLOTS:
+        plt.show()

--- a/tests/test_plugins/test_microwave.py
+++ b/tests/test_plugins/test_microwave.py
@@ -620,57 +620,13 @@ def test_impedance_accuracy_on_coaxial():
     assert np.allclose(Z_calc, Z_analytic, rtol=0.04)
 
 
-def test_path_integral_plotting():
-    """Test that all types of path integrals correctly plot themselves."""
-
-    mean_radius = (COAX_R2 + COAX_R1) * 0.5
-    size = [COAX_R2 - COAX_R1, 0, 0]
-    center = [mean_radius, 0, 0]
-
-    voltage_integral = mw.VoltageIntegralAxisAligned(
-        center=center, size=size, sign="-", extrapolate_to_endpoints=True, snap_path_to_grid=True
-    )
-
-    current_integral = mw.CustomCurrentIntegral2D.from_circular_path(
-        center=(0, 0, 0), radius=0.4, num_points=31, normal_axis=2, clockwise=False
-    )
-
-    ax = voltage_integral.plot(z=0)
-    current_integral.plot(z=0, ax=ax)
-    plt.close()
-
-    # Test off center plotting
-    ax = voltage_integral.plot(z=2)
-    current_integral.plot(z=2, ax=ax)
-    plt.close()
-
-    # Plot
-    voltage_integral = mw.CustomVoltageIntegral2D(
-        axis=1, position=0, vertices=[(-1, -1), (0, 0), (1, 1)]
-    )
-
-    current_integral = mw.CurrentIntegralAxisAligned(
-        center=(0, 0, 0),
-        size=(2, 0, 1),
-        sign="-",
-        extrapolate_to_endpoints=False,
-        snap_contour_to_grid=False,
-    )
-
-    ax = voltage_integral.plot(y=0)
-    current_integral.plot(y=0, ax=ax)
-    plt.close()
-
-    # Test off center plotting
-    ax = voltage_integral.plot(y=2)
-    current_integral.plot(y=2, ax=ax)
-    plt.close()
-
-
 def test_creation_from_terminal_positions():
     """Test creating an VoltageIntegralAxisAligned using terminal positions."""
     _ = mw.VoltageIntegralAxisAligned.from_terminal_positions(
         plus_terminal=2, minus_terminal=1, y=2.2, z=1
+    )
+    _ = mw.VoltageIntegralAxisAligned.from_terminal_positions(
+        plus_terminal=1, minus_terminal=2, y=2.2, z=1
     )
 
 
@@ -841,3 +797,224 @@ def test_lobe_plots(min_value):
     lobe_measurer.plot(0, ax)
     if MAKE_PLOTS:
         plt.show()
+
+
+def test_composite_current_integral_compute_current():
+    """Test CompositeCurrentIntegral.compute_current method with different sum_spec behaviors."""
+
+    # Create individual path specs for the composite
+    path_spec1 = mw.CurrentIntegralAxisAligned(center=(0, 0, 0), size=(0.5, 0.5, 0), sign="+")
+    path_spec2 = mw.CurrentIntegralAxisAligned(center=(0.25, 0, 0), size=(0.5, 0.5, 0), sign="-")
+
+    # Test with sum_spec="sum"
+    composite_integral_sum = mw.CompositeCurrentIntegral(
+        center=(0, 0, 0), size=(1, 1, 0), path_specs=[path_spec1, path_spec2], sum_spec="sum"
+    )
+
+    current_sum = composite_integral_sum.compute_current(SIM_Z_DATA["field"])
+    assert current_sum is not None
+    assert hasattr(current_sum, "values")
+
+    # Test with sum_spec="split"
+    composite_integral_split = mw.CompositeCurrentIntegral(
+        center=(0, 0, 0), size=(1, 1, 0), path_specs=[path_spec1, path_spec2], sum_spec="split"
+    )
+
+    current_split = composite_integral_split.compute_current(SIM_Z_DATA["field"])
+    assert current_split is not None
+    assert hasattr(current_split, "values")
+
+    # Test that both methods return results with the same dimensions
+    assert current_sum.dims == current_split.dims
+
+
+def test_composite_current_integral_time_domain_error():
+    """Test that CompositeCurrentIntegral raises error for time domain data with split sum_spec."""
+
+    path_spec = mw.CurrentIntegralAxisAligned(center=(0, 0, 0), size=(0.5, 0.5, 0), sign="+")
+
+    composite_integral = mw.CompositeCurrentIntegral(
+        center=(0, 0, 0), size=(1, 1, 0), path_specs=[path_spec], sum_spec="split"
+    )
+
+    # Should raise DataError for time domain data with split sum_spec
+    with pytest.raises(
+        td.exceptions.DataError, match="Only frequency domain field data is supported"
+    ):
+        composite_integral.compute_current(SIM_Z_DATA["field_time"])
+
+
+def test_composite_current_integral_phase_consistency_warnings():
+    """Test CompositeCurrentIntegral phase consistency warning methods."""
+    from tidy3d.components.data.data_array import FreqModeDataArray
+
+    # Create a composite integral for testing
+    path_spec = mw.CurrentIntegralAxisAligned(center=(0, 0, 0), size=(0.5, 0.5, 0), sign="+")
+
+    composite_integral = mw.CompositeCurrentIntegral(
+        center=(0, 0, 0), size=(1, 1, 0), path_specs=[path_spec], sum_spec="split"
+    )
+
+    # Test _check_phase_sign_consistency with consistent data
+    f = [2e9, 3e9, 4e9]
+    mode_index = list(np.arange(3))
+    coords = {"f": f, "mode_index": mode_index}
+
+    # Phase difference data that is consistent (all in phase)
+    consistent_phase_values = np.zeros((3, 3))  # All zeros = in phase
+    consistent_phase_diff = FreqModeDataArray(consistent_phase_values, coords=coords)
+
+    # This should return True (no warning)
+    result = composite_integral._check_phase_sign_consistency(consistent_phase_diff)
+    assert result is True
+
+    # Phase difference data that is inconsistent
+    inconsistent_phase_values = np.array([[0, 0, 0], [0, np.pi, 0], [0, 0, np.pi]])  # Mixed phases
+    inconsistent_phase_diff = FreqModeDataArray(inconsistent_phase_values, coords=coords)
+
+    # This should return False and emit a warning
+    # Note: The warning is logged, but we'll just test the return value here
+    result = composite_integral._check_phase_sign_consistency(inconsistent_phase_diff)
+    assert result is False
+
+    # Test _check_phase_amplitude_consistency
+    current_values = np.ones((3, 3))
+    current_in_phase = FreqModeDataArray(current_values, coords=coords)
+    current_out_phase = FreqModeDataArray(0.5 * current_values, coords=coords)
+
+    # Consistent amplitudes (in_phase always larger)
+    result = composite_integral._check_phase_amplitude_consistency(
+        current_in_phase, current_out_phase
+    )
+    assert result is True
+
+    # Inconsistent amplitudes (mix of which is larger)
+    inconsistent_out_phase = FreqModeDataArray(
+        np.array([[0.5, 0.5, 0.5], [1.5, 0.5, 0.5], [0.5, 1.5, 0.5]]), coords=coords
+    )
+
+    # This should return False and emit a warning
+    # Note: The warning is logged, but we'll just test the return value here
+    result = composite_integral._check_phase_amplitude_consistency(
+        current_in_phase, inconsistent_out_phase
+    )
+    assert result is False
+
+
+def test_impedance_calculator_compute_impedance_with_return_extras():
+    """Test ImpedanceCalculator.compute_impedance with return_voltage_and_current=True."""
+
+    # Setup path integrals
+    voltage_integral = mw.VoltageIntegralAxisAligned(
+        center=(0, 0, 0), size=(0, 0.5, 0), sign="+", extrapolate_to_endpoints=True
+    )
+    current_integral = mw.CurrentIntegralAxisAligned(center=(0, 0, 0), size=(0.5, 0.5, 0), sign="+")
+
+    # Test with both voltage and current integrals
+    Z_calc = mw.ImpedanceCalculator(
+        voltage_integral=voltage_integral, current_integral=current_integral
+    )
+
+    # Test with mode data that supports flux calculations
+    result = Z_calc.compute_impedance(SIM_Z_DATA["mode"], return_voltage_and_current=True)
+
+    # Should return a tuple of (impedance, voltage, current)
+    assert isinstance(result, tuple)
+    assert len(result) == 3
+    impedance, voltage, current = result
+
+    assert impedance is not None
+    assert voltage is not None
+    assert current is not None
+    assert hasattr(impedance, "values")
+    assert hasattr(voltage, "values")
+    assert hasattr(current, "values")
+
+    # Test with only voltage integral (current computed from flux)
+    Z_calc_voltage_only = mw.ImpedanceCalculator(voltage_integral=voltage_integral)
+
+    result_voltage_only = Z_calc_voltage_only.compute_impedance(
+        SIM_Z_DATA["mode"], return_voltage_and_current=True
+    )
+
+    assert isinstance(result_voltage_only, tuple)
+    assert len(result_voltage_only) == 3
+    impedance_v, voltage_v, current_v = result_voltage_only
+
+    assert impedance_v is not None
+    assert voltage_v is not None
+    assert current_v is not None  # Should be computed from flux
+
+    # Test with only current integral (voltage computed from flux)
+    Z_calc_current_only = mw.ImpedanceCalculator(current_integral=current_integral)
+
+    result_current_only = Z_calc_current_only.compute_impedance(
+        SIM_Z_DATA["mode"], return_voltage_and_current=True
+    )
+
+    assert isinstance(result_current_only, tuple)
+    assert len(result_current_only) == 3
+    impedance_c, voltage_c, current_c = result_current_only
+
+    assert impedance_c is not None
+    assert voltage_c is not None  # Should be computed from flux
+    assert current_c is not None
+
+
+def test_composite_current_integral_freq_mode_data():
+    """Test CompositeCurrentIntegral works correctly with FreqModeDataArray."""
+
+    # Create individual path specs for the composite
+    path_spec1 = mw.CurrentIntegralAxisAligned(center=(0, 0, 0), size=(0.5, 0.5, 0), sign="+")
+    path_spec2 = mw.CurrentIntegralAxisAligned(center=(0.25, 0, 0), size=(0.5, 0.5, 0), sign="-")
+
+    # Test with sum_spec="sum" - should work with FreqModeDataArray
+    composite_integral_sum = mw.CompositeCurrentIntegral(
+        center=(0, 0, 0), size=(1, 1, 0), path_specs=[path_spec1, path_spec2], sum_spec="sum"
+    )
+
+    # Use mode data which provides FreqModeDataArray
+    current_sum = composite_integral_sum.compute_current(SIM_Z_DATA["mode"])
+    assert current_sum is not None
+    assert hasattr(current_sum, "values")
+
+    # Verify it's a FreqModeDataArray by checking dimensions
+    assert "f" in current_sum.dims
+    assert "mode_index" in current_sum.dims
+
+    # Test with sum_spec="split" - should also work with FreqModeDataArray
+    composite_integral_split = mw.CompositeCurrentIntegral(
+        center=(0, 0, 0), size=(1, 1, 0), path_specs=[path_spec1, path_spec2], sum_spec="split"
+    )
+
+    current_split = composite_integral_split.compute_current(SIM_Z_DATA["mode"])
+    assert current_split is not None
+    assert hasattr(current_split, "values")
+
+    # Verify it's a FreqModeDataArray by checking dimensions
+    assert "f" in current_split.dims
+    assert "mode_index" in current_split.dims
+
+    # Test that both methods return compatible results
+    assert current_sum.dims == current_split.dims
+    assert current_sum.shape == current_split.shape
+
+
+def test_impedance_calculator_mode_direction_handling():
+    """Test that ImpedanceCalculator properly handles mode direction for flux calculation."""
+
+    current_integral = mw.CurrentIntegralAxisAligned(center=(0, 0, 0), size=(0.5, 0.5, 0), sign="+")
+
+    # Test with ModeSolverMonitor data
+    Z_calc = mw.ImpedanceCalculator(current_integral=current_integral)
+
+    impedance_mode_solver = Z_calc.compute_impedance(SIM_Z_DATA["mode_solver"])
+    assert impedance_mode_solver is not None
+
+    # Test with ModeMonitor data
+    impedance_mode = Z_calc.compute_impedance(SIM_Z_DATA["mode"])
+    assert impedance_mode is not None
+
+    # Both should produce valid impedance values
+    assert hasattr(impedance_mode_solver, "values")
+    assert hasattr(impedance_mode, "values")

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -21,14 +21,16 @@ from tidy3d.components.microwave.data.monitor_data import (
     AntennaMetricsData,
 )
 from tidy3d.components.microwave.microwave_mode_spec import (
-    AutoImpedanceSpec,
-    CustomImpedanceSpec,
     MicrowaveModeSpec,
 )
 from tidy3d.components.microwave.path_integrals.current_spec import (
     CompositeCurrentIntegralSpec,
     CurrentIntegralAxisAlignedSpec,
     CustomCurrentIntegral2DSpec,
+)
+from tidy3d.components.microwave.path_integrals.impedance_spec import (
+    AutoImpedanceSpec,
+    CustomImpedanceSpec,
 )
 from tidy3d.components.microwave.path_integrals.voltage_spec import (
     CustomVoltageIntegral2DSpec,

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -21,6 +21,8 @@ from tidy3d.components.microwave.data.monitor_data import (
     AntennaMetricsData,
 )
 from tidy3d.components.microwave.microwave_mode_spec import (
+    AutoImpedanceSpec,
+    CustomImpedanceSpec,
     MicrowaveModeSpec,
 )
 from tidy3d.components.microwave.path_integrals.current_spec import (
@@ -461,6 +463,7 @@ __all__ = [
     "AstigmaticGaussianBeamProfile",
     "AugerRecombination",
     "AutoGrid",
+    "AutoImpedanceSpec",
     "AuxFieldTimeData",
     "AuxFieldTimeMonitor",
     "BlochBoundary",
@@ -501,6 +504,7 @@ __all__ = [
     "CustomGrid",
     "CustomGridBoundaries",
     "CustomHeatPerturbation",
+    "CustomImpedanceSpec",
     "CustomLorentz",
     "CustomMedium",
     "CustomPoleResidue",

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -20,6 +20,18 @@ from tidy3d.components.material.tcad.heat import (
 from tidy3d.components.microwave.data.monitor_data import (
     AntennaMetricsData,
 )
+from tidy3d.components.microwave.microwave_mode_spec import (
+    MicrowaveModeSpec,
+)
+from tidy3d.components.microwave.path_integrals.current_spec import (
+    CompositeCurrentIntegralSpec,
+    CurrentIntegralAxisAlignedSpec,
+    CustomCurrentIntegral2DSpec,
+)
+from tidy3d.components.microwave.path_integrals.voltage_spec import (
+    CustomVoltageIntegral2DSpec,
+    VoltageIntegralAxisAlignedSpec,
+)
 from tidy3d.components.spice.analysis.dc import (
     ChargeToleranceSpec,
     IsothermalSteadyChargeDCAnalysis,
@@ -467,6 +479,7 @@ __all__ = [
     "ChargeToleranceSpec",
     "ClipOperation",
     "CoaxialLumpedResistor",
+    "CompositeCurrentIntegralSpec",
     "ConstantDoping",
     "ConstantMobilityModel",
     "ContinuousWave",
@@ -477,8 +490,10 @@ __all__ = [
     "Coords1D",
     "CornerFinderSpec",
     "CurrentBC",
+    "CurrentIntegralAxisAlignedSpec",
     "CustomAnisotropicMedium",
     "CustomChargePerturbation",
+    "CustomCurrentIntegral2DSpec",
     "CustomCurrentSource",
     "CustomDebye",
     "CustomDrude",
@@ -491,6 +506,7 @@ __all__ = [
     "CustomPoleResidue",
     "CustomSellmeier",
     "CustomSourceTime",
+    "CustomVoltageIntegral2DSpec",
     "Cylinder",
     "DCCurrentSource",
     "DCVoltageSource",
@@ -616,6 +632,7 @@ __all__ = [
     "MediumMediumInterface",
     "MediumMonitor",
     "MeshOverrideStructure",
+    "MicrowaveModeSpec",
     "ModeABCBoundary",
     "ModeAmpsDataArray",
     "ModeData",
@@ -728,6 +745,7 @@ __all__ = [
     "VerticalNaturalConvectionCoeffModel",
     "VisualizationSpec",
     "VoltageBC",
+    "VoltageIntegralAxisAlignedSpec",
     "VoltageSourceType",
     "VolumeMeshData",
     "VolumeMeshMonitor",

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -209,6 +209,13 @@ class DataArray(xr.DataArray):
         return abs(self)
 
     @property
+    def angle(self):
+        """Angle or phase value of data array."""
+        values = np.angle(self.values)
+        SelfType = type(self)
+        return SelfType(values, coords=self.coords)
+
+    @property
     def is_uniform(self):
         """Whether each element is of equal value in the data array"""
         raw_data = self.data.ravel()

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -63,6 +63,7 @@ from tidy3d.exceptions import DataError, SetupError, Tidy3dNotImplementedError, 
 from tidy3d.log import log
 
 from .data_array import (
+    CurrentFreqModeDataArray,
     DataArray,
     DiffractionDataArray,
     EMEFreqModeDataArray,
@@ -74,12 +75,14 @@ from .data_array import (
     FreqDataArray,
     FreqModeDataArray,
     GroupIndexDataArray,
+    ImpedanceFreqModeDataArray,
     MixedModeDataArray,
     ModeAmpsDataArray,
     ModeDispersionDataArray,
     ScalarFieldDataArray,
     ScalarFieldTimeDataArray,
     TimeDataArray,
+    VoltageFreqModeDataArray,
 )
 from .dataset import (
     AbstractFieldDataset,
@@ -1645,9 +1648,35 @@ class ModeData(ModeSolverDataset, ElectromagneticFieldData):
 
     eps_spec: list[EpsSpecType] = pd.Field(
         None,
-        title="Permettivity Specification",
+        title="Permittivity Specification",
         description="Characterization of the permittivity profile on the plane where modes are "
         "computed. Possible values are 'diagonal', 'tensorial_real', 'tensorial_complex'.",
+    )
+
+    Z0: Optional[ImpedanceFreqModeDataArray] = pd.Field(
+        None,
+        title="Characteristic Impedance",
+        description="Optional quantity calculated for transmission lines. "
+        "The characteristic impedance is only calculated when a :class:`MicrowaveModeSpec` "
+        "is provided to the :class:`ModeSpec` associated with this data.",
+    )
+
+    voltage_coeffs: Optional[VoltageFreqModeDataArray] = pd.Field(
+        None,
+        title="Mode Voltage Coefficients",
+        description="Optional quantity calculated for transmission lines, which associates "
+        "a voltage-like quantity with each mode profile that scales linearly with the "
+        "complex-valued mode amplitude. The mode voltages are only calculated when a :class:`MicrowaveModeSpec` "
+        "is provided to the :class:`ModeSpec` associated with this data.",
+    )
+
+    current_coeffs: Optional[CurrentFreqModeDataArray] = pd.Field(
+        None,
+        title="Mode Current Coefficients",
+        description="Optional quantity calculated for transmission lines, which associates "
+        "a current-like quantity with each mode profile that scales linearly with the "
+        "complex-valued mode amplitude. The mode currents are only calculated when a :class:`MicrowaveModeSpec`"
+        " is provided to the :class:`ModeSpec` associated with this data.",
     )
 
     @pd.validator("eps_spec", always=True)
@@ -2107,6 +2136,10 @@ class ModeData(ModeSolverDataset, ElectromagneticFieldData):
             info[f"TE (E{self._tangential_dims[0]}) fraction"] = self.pol_fraction["te"]
             info["wg TE fraction"] = self.pol_fraction_waveguide["te"]
             info["wg TM fraction"] = self.pol_fraction_waveguide["tm"]
+
+        if self.Z0 is not None:
+            info["Re(Z0)"] = self.Z0.real
+            info["Im(Z0)"] = self.Z0.imag
 
         return xr.Dataset(data_vars=info)
 

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -18,6 +18,7 @@ from tidy3d.components.base import cached_property, skip_if_fields_missing
 from tidy3d.components.base_sim.data.monitor_data import AbstractMonitorData
 from tidy3d.components.grid.grid import Coords, Grid
 from tidy3d.components.medium import Medium, MediumType
+from tidy3d.components.microwave.data.dataset import MicrowaveModeDataset
 from tidy3d.components.monitor import (
     AuxFieldTimeMonitor,
     DiffractionMonitor,
@@ -63,7 +64,6 @@ from tidy3d.exceptions import DataError, SetupError, Tidy3dNotImplementedError, 
 from tidy3d.log import log
 
 from .data_array import (
-    CurrentFreqModeDataArray,
     DataArray,
     DiffractionDataArray,
     EMEFreqModeDataArray,
@@ -75,14 +75,12 @@ from .data_array import (
     FreqDataArray,
     FreqModeDataArray,
     GroupIndexDataArray,
-    ImpedanceFreqModeDataArray,
     MixedModeDataArray,
     ModeAmpsDataArray,
     ModeDispersionDataArray,
     ScalarFieldDataArray,
     ScalarFieldTimeDataArray,
     TimeDataArray,
-    VoltageFreqModeDataArray,
 )
 from .dataset import (
     AbstractFieldDataset,
@@ -1653,30 +1651,11 @@ class ModeData(ModeSolverDataset, ElectromagneticFieldData):
         "computed. Possible values are 'diagonal', 'tensorial_real', 'tensorial_complex'.",
     )
 
-    Z0: Optional[ImpedanceFreqModeDataArray] = pd.Field(
+    microwave_data: Optional[MicrowaveModeDataset] = pd.Field(
         None,
-        title="Characteristic Impedance",
-        description="Optional quantity calculated for transmission lines. "
-        "The characteristic impedance is only calculated when a :class:`MicrowaveModeSpec` "
-        "is provided to the :class:`ModeSpec` associated with this data.",
-    )
-
-    voltage_coeffs: Optional[VoltageFreqModeDataArray] = pd.Field(
-        None,
-        title="Mode Voltage Coefficients",
-        description="Optional quantity calculated for transmission lines, which associates "
-        "a voltage-like quantity with each mode profile that scales linearly with the "
-        "complex-valued mode amplitude. The mode voltages are only calculated when a :class:`MicrowaveModeSpec` "
-        "is provided to the :class:`ModeSpec` associated with this data.",
-    )
-
-    current_coeffs: Optional[CurrentFreqModeDataArray] = pd.Field(
-        None,
-        title="Mode Current Coefficients",
-        description="Optional quantity calculated for transmission lines, which associates "
-        "a current-like quantity with each mode profile that scales linearly with the "
-        "complex-valued mode amplitude. The mode currents are only calculated when a :class:`MicrowaveModeSpec`"
-        " is provided to the :class:`ModeSpec` associated with this data.",
+        title="Microwave Mode Dataset",
+        description="Additional data relevant to RF and microwave applications, like characteristic impedance. "
+        "This field is populated when a :class:`MicrowaveModeSpec` has been provided to the :class:`ModeSpec`.",
     )
 
     @pd.validator("eps_spec", always=True)
@@ -2137,9 +2116,9 @@ class ModeData(ModeSolverDataset, ElectromagneticFieldData):
             info["wg TE fraction"] = self.pol_fraction_waveguide["te"]
             info["wg TM fraction"] = self.pol_fraction_waveguide["tm"]
 
-        if self.Z0 is not None:
-            info["Re(Z0)"] = self.Z0.real
-            info["Im(Z0)"] = self.Z0.imag
+        if self.microwave_data is not None:
+            info["Re(Z0)"] = self.microwave_data.Z0.real
+            info["Im(Z0)"] = self.microwave_data.Z0.imag
 
         return xr.Dataset(data_vars=info)
 

--- a/tidy3d/components/geometry/utils.py
+++ b/tidy3d/components/geometry/utils.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from enum import Enum
 from math import isclose
 from typing import Any, Optional, Union
 
 import numpy as np
-import pydantic
+import pydantic.v1 as pydantic
+from shapely.geometry import (
+    GeometryCollection,
+    MultiLineString,
+    MultiPoint,
+    MultiPolygon,
+    Polygon,
+)
+from shapely.geometry.base import BaseGeometry
 
 from tidy3d.components.autograd.utils import get_static
 from tidy3d.components.base import Tidy3dBaseModel
@@ -39,6 +48,46 @@ GeometryType = Union[
     polyslab.ComplexPolySlabBase,
     mesh.TriangleMesh,
 ]
+
+
+def flatten_shapely_geometries(
+    geoms: Union[Shapely, Iterable[Shapely]], keep_types: tuple[type, ...] = (Polygon,)
+) -> list[Shapely]:
+    """
+    Flatten nested geometries into a flat list, while only keeping the specified types.
+
+    Recursively extracts and returns non-empty geometries of the given types from input geometries,
+    expanding any GeometryCollections or Multi* types.
+
+    Parameters
+    ----------
+    geoms : Union[Shapely, Iterable[Shapely]]
+        Input geometries to flatten.
+
+    keep_types : tuple[type, ...]
+        Geometry types to keep (e.g., (Polygon, LineString)). Default is
+        (Polygon).
+
+    Returns
+    -------
+    list[Shapely]
+        Flat list of non-empty geometries matching the specified types.
+    """
+    # Handle single Shapely object by wrapping it in a list
+    if isinstance(geoms, Shapely):
+        geoms = [geoms]
+
+    flat = []
+    for geom in geoms:
+        if geom.is_empty:
+            continue
+        if isinstance(geom, keep_types):
+            flat.append(geom)
+        elif isinstance(geom, (MultiPolygon, MultiLineString, MultiPoint, GeometryCollection)):
+            flat.extend(flatten_shapely_geometries(geom.geoms, keep_types))
+        elif isinstance(geom, BaseGeometry) and hasattr(geom, "geoms"):
+            flat.extend(flatten_shapely_geometries(geom.geoms, keep_types))
+    return flat
 
 
 def merging_geometries_on_plane(
@@ -356,7 +405,15 @@ class SnapBehavior(Enum):
     Snaps the interval's endpoints to the closest grid points,
     while guaranteeing that the snapping location will never move endpoints outwards.
     """
-    Off = 4
+    StrictExpand = 4
+    """
+    Same as Expand, but will always move endpoints outwards, even if already coincident with grid.
+    """
+    StrictContract = 5
+    """
+    Same as Contract, but will always move endpoints inwards, even if already coincident with grid.
+    """
+    Off = 6
     """
     Do not use snapping.
     """
@@ -375,6 +432,15 @@ class SnappingSpec(Tidy3dBaseModel):
         ...,
         title="Behavior",
         description="Describes how snapping positions will be chosen.",
+    )
+
+    margin: Optional[
+        tuple[pydantic.NonNegativeInt, pydantic.NonNegativeInt, pydantic.NonNegativeInt]
+    ] = pydantic.Field(
+        (0, 0, 0),
+        title="Margin",
+        description="Number of additional grid points to consider when expanding or contracting "
+        "during snapping. Only applies when ``SnapBehavior`` is ``Expand`` or ``Contract``.",
     )
 
 
@@ -402,33 +468,65 @@ def snap_box_to_grid(grid: Grid, box: Box, snap_spec: SnappingSpec, rtol=fp_eps)
     """
 
     def get_lower_bound(
-        test: float, coords: np.ArrayLike, upper_bound_idx: int, rel_tol: float
+        test: float,
+        coords: np.ArrayLike,
+        upper_bound_idx: int,
+        rel_tol: float,
+        strict_bounds: bool,
     ) -> float:
         """Helper to choose the lower bound in an array for a given test value,
         using the index of the upper bound. If the test value is close to the upper
         bound, it assumes they are equal, and in that case the upper bound is returned.
         """
+        upper_bound_idx = min(upper_bound_idx, len(coords))
+        upper_bound_idx = max(upper_bound_idx, 0)
         if upper_bound_idx == len(coords):
             return coords[upper_bound_idx - 1]
-        if upper_bound_idx == 0 or isclose(coords[upper_bound_idx], test, rel_tol=rel_tol):
+        if upper_bound_idx == 0 or (
+            isclose(coords[upper_bound_idx], test, rel_tol=rel_tol) and not strict_bounds
+        ):
             return coords[upper_bound_idx]
+        if (
+            strict_bounds
+            and upper_bound_idx - 1 > 0
+            and isclose(coords[upper_bound_idx - 1], test, rel_tol=rel_tol)
+        ):
+            return coords[upper_bound_idx - 2]
         return coords[upper_bound_idx - 1]
 
     def get_upper_bound(
-        test: float, coords: np.ArrayLike, upper_bound_idx: int, rel_tol: float
+        test: float,
+        coords: np.ArrayLike,
+        upper_bound_idx: int,
+        rel_tol: float,
+        strict_bounds: bool,
     ) -> float:
         """Helper to choose the upper bound in an array for a given test value,
         using the index of the upper bound. If the test value is close to the lower
         bound, it assumes they are equal, and in that case the lower bound is returned.
         """
+        upper_bound_idx = min(upper_bound_idx, len(coords))
+        upper_bound_idx = max(upper_bound_idx, 0)
         if upper_bound_idx == len(coords):
             return coords[upper_bound_idx - 1]
-        if upper_bound_idx > 0 and isclose(coords[upper_bound_idx - 1], test, rel_tol=rel_tol):
+        if upper_bound_idx > 0 and (
+            isclose(coords[upper_bound_idx - 1], test, rel_tol=rel_tol) and not strict_bounds
+        ):
             return coords[upper_bound_idx - 1]
+        if (
+            strict_bounds
+            and upper_bound_idx + 1 < len(coords)
+            and isclose(coords[upper_bound_idx], test, rel_tol=rel_tol)
+        ):
+            return coords[upper_bound_idx + 1]
         return coords[upper_bound_idx]
 
     def find_snapping_locations(
-        interval_min: float, interval_max: float, coords: np.ndarray, snap_type: SnapBehavior
+        interval_min: float,
+        interval_max: float,
+        coords: np.ndarray,
+        snap_type: SnapBehavior,
+        snap_margin: pydantic.NonNegativeInt,
     ) -> tuple[float, float]:
         """Helper that snaps a supplied interval [interval_min, interval_max] to a
         sorted array representing coordinate values.
@@ -436,15 +534,32 @@ def snap_box_to_grid(grid: Grid, box: Box, snap_spec: SnappingSpec, rtol=fp_eps)
         # Locate the interval that includes the min and max
         min_upper_bound_idx = np.searchsorted(coords, interval_min, side="left")
         max_upper_bound_idx = np.searchsorted(coords, interval_max, side="left")
+        strict_bounds = (
+            snap_type == SnapBehavior.StrictExpand or snap_type == SnapBehavior.StrictContract
+        )
         if snap_type == SnapBehavior.Closest:
             min_snap = get_closest_value(interval_min, coords, min_upper_bound_idx)
             max_snap = get_closest_value(interval_max, coords, max_upper_bound_idx)
-        elif snap_type == SnapBehavior.Expand:
-            min_snap = get_lower_bound(interval_min, coords, min_upper_bound_idx, rel_tol=rtol)
-            max_snap = get_upper_bound(interval_max, coords, max_upper_bound_idx, rel_tol=rtol)
+        elif snap_type == SnapBehavior.Expand or snap_type == SnapBehavior.StrictExpand:
+            min_upper_bound_idx -= snap_margin
+            max_upper_bound_idx += snap_margin
+            min_snap = get_lower_bound(
+                interval_min, coords, min_upper_bound_idx, rel_tol=rtol, strict_bounds=strict_bounds
+            )
+            max_snap = get_upper_bound(
+                interval_max, coords, max_upper_bound_idx, rel_tol=rtol, strict_bounds=strict_bounds
+            )
         else:  # SnapType.Contract
-            min_snap = get_upper_bound(interval_min, coords, min_upper_bound_idx, rel_tol=rtol)
-            max_snap = get_lower_bound(interval_max, coords, max_upper_bound_idx, rel_tol=rtol)
+            min_upper_bound_idx += snap_margin
+            max_upper_bound_idx -= snap_margin
+            if max_upper_bound_idx < min_upper_bound_idx:
+                raise SetupError("The supplied 'snap_buffer' is too large for this contraction.")
+            min_snap = get_upper_bound(
+                interval_min, coords, min_upper_bound_idx, rel_tol=rtol, strict_bounds=strict_bounds
+            )
+            max_snap = get_lower_bound(
+                interval_max, coords, max_upper_bound_idx, rel_tol=rtol, strict_bounds=strict_bounds
+            )
         return (min_snap, max_snap)
 
     # Iterate over each axis and apply the specified snapping behavior.
@@ -454,6 +569,7 @@ def snap_box_to_grid(grid: Grid, box: Box, snap_spec: SnappingSpec, rtol=fp_eps)
     for axis in range(3):
         snap_location = snap_spec.location[axis]
         snap_type = snap_spec.behavior[axis]
+        snap_margin = snap_spec.margin[axis]
         if snap_type == SnapBehavior.Off:
             continue
         if snap_location == SnapLocation.Boundary:
@@ -464,7 +580,9 @@ def snap_box_to_grid(grid: Grid, box: Box, snap_spec: SnappingSpec, rtol=fp_eps)
         box_min = min_b[axis]
         box_max = max_b[axis]
 
-        (new_min, new_max) = find_snapping_locations(box_min, box_max, snap_coords, snap_type)
+        (new_min, new_max) = find_snapping_locations(
+            box_min, box_max, snap_coords, snap_type, snap_margin
+        )
         min_b[axis] = new_min
         max_b[axis] = new_max
     return Box.from_bounds(min_b, max_b)

--- a/tidy3d/components/microwave/data/dataset.py
+++ b/tidy3d/components/microwave/data/dataset.py
@@ -1,0 +1,46 @@
+"""Post-processing data and figures of merit for antennas, including radiation efficiency,
+reflection efficiency, gain, and realized gain.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pydantic.v1 as pd
+
+from tidy3d.components.data.data_array import (
+    CurrentFreqModeDataArray,
+    ImpedanceFreqModeDataArray,
+    VoltageFreqModeDataArray,
+)
+from tidy3d.components.data.dataset import Dataset
+
+
+class MicrowaveModeDataset(Dataset):
+    """Holds mode data that is specific to microwave and RF applications, like characteristic impedance."""
+
+    Z0: Optional[ImpedanceFreqModeDataArray] = pd.Field(
+        None,
+        title="Characteristic Impedance",
+        description="Optional quantity calculated for transmission lines. "
+        "The characteristic impedance is only calculated when a :class:`MicrowaveModeSpec` "
+        "is provided to the :class:`ModeSpec` associated with this data.",
+    )
+
+    voltage_coeffs: Optional[VoltageFreqModeDataArray] = pd.Field(
+        None,
+        title="Mode Voltage Coefficients",
+        description="Optional quantity calculated for transmission lines, which associates "
+        "a voltage-like quantity with each mode profile that scales linearly with the "
+        "complex-valued mode amplitude. The mode voltages are only calculated when a :class:`MicrowaveModeSpec` "
+        "is provided to the :class:`ModeSpec` associated with this data.",
+    )
+
+    current_coeffs: Optional[CurrentFreqModeDataArray] = pd.Field(
+        None,
+        title="Mode Current Coefficients",
+        description="Optional quantity calculated for transmission lines, which associates "
+        "a current-like quantity with each mode profile that scales linearly with the "
+        "complex-valued mode amplitude. The mode currents are only calculated when a :class:`MicrowaveModeSpec`"
+        " is provided to the :class:`ModeSpec` associated with this data.",
+    )

--- a/tidy3d/components/microwave/microwave_mode_spec.py
+++ b/tidy3d/components/microwave/microwave_mode_spec.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Union
 
 import pydantic.v1 as pd
 
-from tidy3d.components.base import Tidy3dBaseModel
+from tidy3d.components.base import TYPE_TAG_STR, Tidy3dBaseModel
 from tidy3d.exceptions import SetupError
 
 from .path_integrals.types import CurrentPathSpecTypes, VoltagePathSpecTypes
 
 
-class MicrowaveModeSpec(Tidy3dBaseModel):
+class AutoImpedanceSpec(Tidy3dBaseModel):
     """Specification for computing transmission line voltages and currents in mode solvers.
 
     The :class:`.MicrowaveModeSpec` class specifies how quantities related to transmission line
@@ -22,9 +22,19 @@ class MicrowaveModeSpec(Tidy3dBaseModel):
     Users may supply their own voltage and current path specifications to control where these integrals
     are evaluated. If neither voltage nor current specifications are provided, an automatic choice of
     paths will be made based on the simulation geometry and context.
+    """
 
-    TODO
-        Validate that either all specs are voltage specs/ all current specs or all a pair of VI specs
+
+class CustomImpedanceSpec(Tidy3dBaseModel):
+    """Specification for computing transmission line voltages and currents in mode solvers.
+
+    The :class:`.MicrowaveModeSpec` class specifies how quantities related to transmission line
+    modes are computed. For example, it defines the paths for line integrals, which are used to
+    compute voltage, current, and characteristic impedance of the transmission line.
+
+    Users may supply their own voltage and current path specifications to control where these integrals
+    are evaluated. If neither voltage nor current specifications are provided, an automatic choice of
+    paths will be made based on the simulation geometry and context.
     """
 
     voltage_spec: Optional[tuple[Optional[VoltagePathSpecTypes], ...]] = pd.Field(
@@ -44,22 +54,16 @@ class MicrowaveModeSpec(Tidy3dBaseModel):
     )
 
     @property
-    def use_automatic_setup(self) -> bool:
-        """Whether to setup the :class:`.MicrowaveModeSpec` automatically or use the supplied
-        path specifications."""
-        return self.voltage_spec is None and self.current_spec is None
-
-    @property
     def num_voltage_specs(self) -> Optional[int]:
         """The number of voltage specifications supplied."""
-        if type(self.voltage_spec) is tuple:
+        if self.voltage_spec is not None:
             return len(self.voltage_spec)
         return None
 
     @property
     def num_current_specs(self) -> Optional[int]:
         """The number of current specifications supplied."""
-        if type(self.current_spec) is tuple:
+        if self.current_spec is not None:
             return len(self.current_spec)
         return None
 
@@ -98,3 +102,21 @@ class MicrowaveModeSpec(Tidy3dBaseModel):
                 )
 
         return val
+
+
+ImpedanceSpecTypes = Union[AutoImpedanceSpec, CustomImpedanceSpec]
+
+
+class MicrowaveModeSpec(Tidy3dBaseModel):
+    """
+    The :class:`.MicrowaveModeSpec` class specifies how quantities related to transmission line
+    modes and microwave waveguides are computed. For example, it defines the paths for line integrals, which are used to
+    compute voltage, current, and characteristic impedance of the transmission line.
+    """
+
+    impedance_spec: Optional[ImpedanceSpecTypes] = pd.Field(
+        AutoImpedanceSpec(),
+        title="Impedance Specification",
+        description="Field controls how the impedance is calculated from mode solver data.",
+        discriminator=TYPE_TAG_STR,
+    )

--- a/tidy3d/components/microwave/microwave_mode_spec.py
+++ b/tidy3d/components/microwave/microwave_mode_spec.py
@@ -1,0 +1,100 @@
+"""Specification for modes associated with transmission lines."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pydantic.v1 as pd
+
+from tidy3d.components.base import Tidy3dBaseModel
+from tidy3d.exceptions import SetupError
+
+from .path_integrals.types import CurrentPathSpecTypes, VoltagePathSpecTypes
+
+
+class MicrowaveModeSpec(Tidy3dBaseModel):
+    """Specification for computing transmission line voltages and currents in mode solvers.
+
+    The :class:`.MicrowaveModeSpec` class specifies how quantities related to transmission line
+    modes are computed. For example, it defines the paths for line integrals, which are used to
+    compute voltage, current, and characteristic impedance of the transmission line.
+
+    Users may supply their own voltage and current path specifications to control where these integrals
+    are evaluated. If neither voltage nor current specifications are provided, an automatic choice of
+    paths will be made based on the simulation geometry and context.
+
+    TODO
+        Validate that either all specs are voltage specs/ all current specs or all a pair of VI specs
+    """
+
+    voltage_spec: Optional[tuple[Optional[VoltagePathSpecTypes], ...]] = pd.Field(
+        None,
+        title="Voltage Integration Path",
+        description="Path specification for computing the voltage associated with each mode. "
+        "The number of path specifications should equal the 'num_modes' field "
+        "in the 'ModeSpec'.",
+    )
+
+    current_spec: Optional[tuple[Optional[CurrentPathSpecTypes], ...]] = pd.Field(
+        None,
+        title="Current Integration Path",
+        description="Path specification for computing the current associated with each mode. "
+        "The number of path specifications should equal the 'num_modes' field "
+        "in the 'ModeSpec'.",
+    )
+
+    @property
+    def use_automatic_setup(self) -> bool:
+        """Whether to setup the :class:`.MicrowaveModeSpec` automatically or use the supplied
+        path specifications."""
+        return self.voltage_spec is None and self.current_spec is None
+
+    @property
+    def num_voltage_specs(self) -> Optional[int]:
+        """The number of voltage specifications supplied."""
+        if type(self.voltage_spec) is tuple:
+            return len(self.voltage_spec)
+        return None
+
+    @property
+    def num_current_specs(self) -> Optional[int]:
+        """The number of current specifications supplied."""
+        if type(self.current_spec) is tuple:
+            return len(self.current_spec)
+        return None
+
+    @pd.validator("current_spec", always=True)
+    def check_path_spec_combinations(cls, val, values):
+        """In order to define voltage/current/impedance, either a voltage or current path spec
+        must be provided for each associated mode index.
+        """
+
+        voltage_specs = values["voltage_spec"]
+        if val is None and voltage_specs is None:
+            return val
+        elif val is not None and voltage_specs is not None:
+            if len(val) != len(voltage_specs):
+                raise SetupError(
+                    f"The length of 'voltage_spec' is {len(voltage_specs)}, which is not equal to the length "
+                    f"of 'current_spec' {len(val)}. Please ensure that the same number of voltage and current "
+                    "specifications have been supplied."
+                )
+
+        if val is None:
+            current_specs = (None,) * len(voltage_specs)
+        else:
+            current_specs = val
+
+        if voltage_specs is None:
+            voltage_specs = (None,) * len(val)
+
+        for current_spec, voltage_spec, index in zip(
+            current_specs, voltage_specs, range(len(current_specs))
+        ):
+            if current_spec is None and voltage_spec is None:
+                raise SetupError(
+                    f"Both entries in 'voltage_spec' and 'current_spec' at position {index} are "
+                    "'None'. Please ensure at least one of them is a valid path specification."
+                )
+
+        return val

--- a/tidy3d/components/microwave/microwave_mode_spec.py
+++ b/tidy3d/components/microwave/microwave_mode_spec.py
@@ -114,7 +114,7 @@ class MicrowaveModeSpec(Tidy3dBaseModel):
     compute voltage, current, and characteristic impedance of the transmission line.
     """
 
-    impedance_spec: Optional[ImpedanceSpecTypes] = pd.Field(
+    impedance_spec: ImpedanceSpecTypes = pd.Field(
         AutoImpedanceSpec(),
         title="Impedance Specification",
         description="Field controls how the impedance is calculated from mode solver data.",

--- a/tidy3d/components/microwave/microwave_mode_spec.py
+++ b/tidy3d/components/microwave/microwave_mode_spec.py
@@ -2,109 +2,16 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Optional
 
 import pydantic.v1 as pd
 
-from tidy3d.components.base import TYPE_TAG_STR, Tidy3dBaseModel
-from tidy3d.exceptions import SetupError
-
-from .path_integrals.types import CurrentPathSpecTypes, VoltagePathSpecTypes
-
-
-class AutoImpedanceSpec(Tidy3dBaseModel):
-    """Specification for computing transmission line voltages and currents in mode solvers.
-
-    The :class:`.MicrowaveModeSpec` class specifies how quantities related to transmission line
-    modes are computed. For example, it defines the paths for line integrals, which are used to
-    compute voltage, current, and characteristic impedance of the transmission line.
-
-    Users may supply their own voltage and current path specifications to control where these integrals
-    are evaluated. If neither voltage nor current specifications are provided, an automatic choice of
-    paths will be made based on the simulation geometry and context.
-    """
-
-
-class CustomImpedanceSpec(Tidy3dBaseModel):
-    """Specification for computing transmission line voltages and currents in mode solvers.
-
-    The :class:`.MicrowaveModeSpec` class specifies how quantities related to transmission line
-    modes are computed. For example, it defines the paths for line integrals, which are used to
-    compute voltage, current, and characteristic impedance of the transmission line.
-
-    Users may supply their own voltage and current path specifications to control where these integrals
-    are evaluated. If neither voltage nor current specifications are provided, an automatic choice of
-    paths will be made based on the simulation geometry and context.
-    """
-
-    voltage_spec: Optional[tuple[Optional[VoltagePathSpecTypes], ...]] = pd.Field(
-        None,
-        title="Voltage Integration Path",
-        description="Path specification for computing the voltage associated with each mode. "
-        "The number of path specifications should equal the 'num_modes' field "
-        "in the 'ModeSpec'.",
-    )
-
-    current_spec: Optional[tuple[Optional[CurrentPathSpecTypes], ...]] = pd.Field(
-        None,
-        title="Current Integration Path",
-        description="Path specification for computing the current associated with each mode. "
-        "The number of path specifications should equal the 'num_modes' field "
-        "in the 'ModeSpec'.",
-    )
-
-    @property
-    def num_voltage_specs(self) -> Optional[int]:
-        """The number of voltage specifications supplied."""
-        if self.voltage_spec is not None:
-            return len(self.voltage_spec)
-        return None
-
-    @property
-    def num_current_specs(self) -> Optional[int]:
-        """The number of current specifications supplied."""
-        if self.current_spec is not None:
-            return len(self.current_spec)
-        return None
-
-    @pd.validator("current_spec", always=True)
-    def check_path_spec_combinations(cls, val, values):
-        """In order to define voltage/current/impedance, either a voltage or current path spec
-        must be provided for each associated mode index.
-        """
-
-        voltage_specs = values["voltage_spec"]
-        if val is None and voltage_specs is None:
-            return val
-        elif val is not None and voltage_specs is not None:
-            if len(val) != len(voltage_specs):
-                raise SetupError(
-                    f"The length of 'voltage_spec' is {len(voltage_specs)}, which is not equal to the length "
-                    f"of 'current_spec' {len(val)}. Please ensure that the same number of voltage and current "
-                    "specifications have been supplied."
-                )
-
-        if val is None:
-            current_specs = (None,) * len(voltage_specs)
-        else:
-            current_specs = val
-
-        if voltage_specs is None:
-            voltage_specs = (None,) * len(val)
-
-        for current_spec, voltage_spec, index in zip(
-            current_specs, voltage_specs, range(len(current_specs))
-        ):
-            if current_spec is None and voltage_spec is None:
-                raise SetupError(
-                    f"Both entries in 'voltage_spec' and 'current_spec' at position {index} are "
-                    "'None'. Please ensure at least one of them is a valid path specification."
-                )
-
-        return val
-
-
-ImpedanceSpecTypes = Union[AutoImpedanceSpec, CustomImpedanceSpec]
+from tidy3d.components.base import Tidy3dBaseModel, cached_property
+from tidy3d.components.microwave.path_integrals.impedance_spec import (
+    AutoImpedanceSpec,
+    ImpedanceSpecTypes,
+)
+from tidy3d.components.types import annotate_type
 
 
 class MicrowaveModeSpec(Tidy3dBaseModel):
@@ -114,9 +21,20 @@ class MicrowaveModeSpec(Tidy3dBaseModel):
     compute voltage, current, and characteristic impedance of the transmission line.
     """
 
-    impedance_spec: ImpedanceSpecTypes = pd.Field(
-        AutoImpedanceSpec(),
+    impedance_spec: tuple[Optional[annotate_type(ImpedanceSpecTypes)], ...] = pd.Field(
+        ...,
         title="Impedance Specification",
-        description="Field controls how the impedance is calculated from mode solver data.",
-        discriminator=TYPE_TAG_STR,
+        description="Field controls how the impedance is calculated for each mode calculated by the mode solver.",
     )
+
+    @cached_property
+    def _using_auto_current_spec(self) -> bool:
+        """Checks whether at least one of the modes will require an auto setup of the current path specification."""
+        return any(
+            isinstance(impedance_spec, AutoImpedanceSpec) for impedance_spec in self.impedance_spec
+        )
+
+    @cached_property
+    def num_impedance_specs(self) -> int:
+        """The number of impedance specifications to be used."""
+        return len(self.impedance_spec)

--- a/tidy3d/components/microwave/path_integrals/base_spec.py
+++ b/tidy3d/components/microwave/path_integrals/base_spec.py
@@ -1,0 +1,248 @@
+"""Module containing specifications for path integrals."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+import pydantic.v1 as pd
+import shapely
+import xarray as xr
+
+from tidy3d.components.base import Tidy3dBaseModel, cached_property
+from tidy3d.components.geometry.base import Box, Geometry
+from tidy3d.components.types import ArrayFloat2D, Bound, Coordinate, Coordinate2D
+from tidy3d.components.types.base import Axis, Direction
+from tidy3d.components.validators import assert_line
+from tidy3d.constants import MICROMETER, fp_eps
+from tidy3d.exceptions import SetupError, Tidy3dError
+from tidy3d.log import log
+
+
+class AbstractAxesRH(Tidy3dBaseModel, ABC):
+    """Represents an axis-aligned right-handed coordinate system with one axis preferred.
+    Typically `main_axis` would refer to the normal axis of a plane.
+    """
+
+    @cached_property
+    @abstractmethod
+    def main_axis(self) -> Axis:
+        """Get the preferred axis."""
+
+    @cached_property
+    def remaining_axes(self) -> tuple[Axis, Axis]:
+        """Get in-plane axes, ordered to maintain a right-handed coordinate system."""
+        axes: list[Axis] = [0, 1, 2]
+        axes.pop(self.main_axis)
+        if self.main_axis == 1:
+            return (axes[1], axes[0])
+        else:
+            return (axes[0], axes[1])
+
+    @cached_property
+    def remaining_dims(self) -> tuple[str, str]:
+        """Get in-plane dimensions, ordered to maintain a right-handed coordinate system."""
+        dim1 = "xyz"[self.remaining_axes[0]]
+        dim2 = "xyz"[self.remaining_axes[1]]
+        return (dim1, dim2)
+
+    @cached_property
+    def local_dims(self) -> tuple[str, str, str]:
+        """Get in-plane dimensions with in-plane dims first, followed by the `main_axis` dimension."""
+        dim3 = "xyz"[self.main_axis]
+        return self.remaining_dims + tuple(dim3)
+
+    @pd.root_validator(pre=False)
+    def _warn_rf_license(cls, values):
+        log.warning(
+            "ℹ️ ⚠️ RF simulations are subject to new license requirements in the future. You have instantiated at least one RF-specific component.",
+            log_once=True,
+        )
+        return values
+
+
+class AxisAlignedPathIntegralSpec(AbstractAxesRH, Box):
+    """Class for defining the simplest type of path integral, which is aligned with Cartesian axes."""
+
+    _line_validator = assert_line()
+
+    extrapolate_to_endpoints: bool = pd.Field(
+        False,
+        title="Extrapolate to Endpoints",
+        description="If the endpoints of the path integral terminate at or near a material interface, "
+        "the field is likely discontinuous. When this field is ``True``, fields that are outside and on the bounds "
+        "of the integral are ignored. Should be enabled when computing voltage between two conductors.",
+    )
+
+    snap_path_to_grid: bool = pd.Field(
+        False,
+        title="Snap Path to Grid",
+        description="It might be desirable to integrate exactly along the Yee grid associated with "
+        "a field. When this field is ``True``, the integration path will be snapped to the grid.",
+    )
+
+    @cached_property
+    def main_axis(self) -> Axis:
+        """Axis for performing integration."""
+        for index, value in enumerate(self.size):
+            if value != 0:
+                return index
+        raise Tidy3dError("Failed to identify axis.")
+
+    def _vertices_2D(self, axis: Axis) -> tuple[Coordinate2D, Coordinate2D]:
+        """Returns the two vertices of this path in the plane defined by ``axis``."""
+        min = self.bounds[0]
+        max = self.bounds[1]
+        _, min = Box.pop_axis(min, axis)
+        _, max = Box.pop_axis(max, axis)
+
+        u = [min[0], max[0]]
+        v = [min[1], max[1]]
+        return (u, v)
+
+
+class CustomPathIntegral2DSpec(AbstractAxesRH):
+    """Class for specifying a custom path integral defined as a curve on an axis-aligned plane.
+
+    Notes
+    -----
+
+    Given a set of vertices :math:`\\vec{r}_i`, this class approximates path integrals over
+    vector fields of the form :math:`\\int{\\vec{F} \\cdot \\vec{dl}}`
+    as :math:`\\sum_i{\\vec{F}(\\vec{r}_i) \\cdot \\vec{dl}_i}`,
+    where the differential length :math:`\\vec{dl}` is approximated using central differences
+    :math:`\\vec{dl}_i = \\frac{\\vec{r}_{i+1} - \\vec{r}_{i-1}}{2}`.
+    If the path is not closed, forward and backward differences are used at the endpoints.
+    """
+
+    axis: Axis = pd.Field(
+        2, title="Axis", description="Specifies dimension of the planar axis (0,1,2) -> (x,y,z)."
+    )
+
+    position: float = pd.Field(
+        ...,
+        title="Position",
+        description="Position of the plane along the ``axis``.",
+    )
+
+    vertices: ArrayFloat2D = pd.Field(
+        ...,
+        title="Vertices",
+        description="List of (d1, d2) defining the 2 dimensional positions of the path. "
+        "The index of dimension should be in the ascending order, which means "
+        "if the axis corresponds with ``y``, the coordinates of the vertices should be (x, z). "
+        "If you wish to indicate a closed contour, the final vertex should be made "
+        "equal to the first vertex, i.e., ``vertices[-1] == vertices[0]``",
+        units=MICROMETER,
+    )
+
+    @staticmethod
+    def _compute_dl_component(coord_array: xr.DataArray, closed_contour=False) -> np.array:
+        """Computes the differential length element along the integration path."""
+        dl = np.gradient(coord_array)
+        if closed_contour:
+            # If the contour is closed, we can use central difference on the starting/end point
+            # which will be more accurate than the default forward/backward choice in np.gradient
+            grad_end = np.gradient([coord_array[-2], coord_array[0], coord_array[1]])
+            dl[0] = dl[-1] = grad_end[1]
+        return dl
+
+    @classmethod
+    def from_circular_path(
+        cls, center: Coordinate, radius: float, num_points: int, normal_axis: Axis, clockwise: bool
+    ) -> CustomPathIntegral2DSpec:
+        """Creates a ``CustomPathIntegral2DSpec`` from a circular path given a desired number of points
+        along the perimeter.
+
+        Parameters
+        ----------
+        center : Coordinate
+            The center of the circle.
+        radius : float
+            The radius of the circle.
+        num_points : int
+            The number of equidistant points to use along the perimeter of the circle.
+        normal_axis : Axis
+            The axis normal to the defined circle.
+        clockwise : bool
+            When ``True``, the points will be ordered clockwise with respect to the positive
+            direction of the ``normal_axis``.
+
+        Returns
+        -------
+        :class:`.CustomPathIntegral2DSpec`
+            A path integral defined on a circular path.
+        """
+
+        def generate_circle_coordinates(radius: float, num_points: int, clockwise: bool):
+            """Helper for generating x,y vertices around a circle in the local coordinate frame."""
+            sign = 1.0
+            if clockwise:
+                sign = -1.0
+            angles = np.linspace(0, sign * 2 * np.pi, num_points, endpoint=True)
+            xt = radius * np.cos(angles)
+            yt = radius * np.sin(angles)
+            return (xt, yt)
+
+        # Get transverse axes
+        normal_center, trans_center = Geometry.pop_axis(center, normal_axis)
+
+        # These x,y coordinates in the local coordinate frame
+        if normal_axis == 1:
+            # Handle special case when y is the axis that is popped
+            clockwise = not clockwise
+        xt, yt = generate_circle_coordinates(radius, num_points, clockwise)
+        xt += trans_center[0]
+        yt += trans_center[1]
+        circle_vertices = np.column_stack((xt, yt))
+        # Close the contour exactly
+        circle_vertices[-1, :] = circle_vertices[0, :]
+        return cls(axis=normal_axis, position=normal_center, vertices=circle_vertices)
+
+    @cached_property
+    def is_closed_contour(self) -> bool:
+        """Returns ``true`` when the first vertex equals the last vertex."""
+        return np.isclose(
+            self.vertices[0, :],
+            self.vertices[-1, :],
+            rtol=fp_eps,
+            atol=np.finfo(np.float32).smallest_normal,
+        ).all()
+
+    @cached_property
+    def main_axis(self) -> Axis:
+        """Axis for performing integration."""
+        return self.axis
+
+    @pd.validator("vertices", always=True)
+    def _correct_shape(cls, val):
+        """Makes sure vertices size is correct."""
+        # overall shape of vertices
+        if val.shape[1] != 2:
+            raise SetupError(
+                "'CustomPathIntegral2DSpec.vertices' must be a 2 dimensional array shaped (N, 2). "
+                f"Given array with shape of '{val.shape}'."
+            )
+        return val
+
+    @cached_property
+    def bounds(self) -> Bound:
+        """Helper to get the geometric bounding box of the path integral."""
+        path_min = np.amin(self.vertices, axis=0)
+        path_max = np.amax(self.vertices, axis=0)
+        min_bound = Geometry.unpop_axis(self.position, path_min, self.axis)
+        max_bound = Geometry.unpop_axis(self.position, path_max, self.axis)
+        return (min_bound, max_bound)
+
+    @cached_property
+    def sign(self) -> Direction:
+        """Uses the ordering of the vertices to determine the direction of the current flow."""
+        linestr = shapely.LineString(coordinates=self.vertices)
+        is_ccw = shapely.is_ccw(linestr)
+        # Invert statement when the vertices are given as (x, z)
+        if self.axis == 1:
+            is_ccw = not is_ccw
+        if is_ccw:
+            return "+"
+        else:
+            return "-"

--- a/tidy3d/components/microwave/path_integrals/base_spec.py
+++ b/tidy3d/components/microwave/path_integrals/base_spec.py
@@ -8,6 +8,7 @@ import numpy as np
 import pydantic.v1 as pd
 import shapely
 import xarray as xr
+from typing_extensions import Self
 
 from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.geometry.base import Box, Geometry
@@ -150,7 +151,7 @@ class CustomPathIntegral2DSpec(AbstractAxesRH):
     @classmethod
     def from_circular_path(
         cls, center: Coordinate, radius: float, num_points: int, normal_axis: Axis, clockwise: bool
-    ) -> CustomPathIntegral2DSpec:
+    ) -> Self:
         """Creates a ``CustomPathIntegral2DSpec`` from a circular path given a desired number of points
         along the perimeter.
 

--- a/tidy3d/components/microwave/path_integrals/current_spec.py
+++ b/tidy3d/components/microwave/path_integrals/current_spec.py
@@ -6,7 +6,6 @@ from typing import Literal, Optional, Union
 
 import numpy as np
 import pydantic.v1 as pd
-import shapely
 
 from tidy3d.components.base import cached_property
 from tidy3d.components.geometry.base import Box, Geometry
@@ -268,19 +267,6 @@ class CustomCurrentIntegral2DSpec(CustomPathIntegral2DSpec):
             arrowprops=ARROW_CURRENT,
         )
         return ax
-
-    @cached_property
-    def sign(self) -> Direction:
-        """Uses the ordering of the vertices to determine the direction of the current flow."""
-        linestr = shapely.LineString(coordinates=self.vertices)
-        is_ccw = shapely.is_ccw(linestr)
-        # Invert statement when the vertices are given as (x, z)
-        if self.axis == 1:
-            is_ccw = not is_ccw
-        if is_ccw:
-            return "+"
-        else:
-            return "-"
 
 
 class CompositeCurrentIntegralSpec(Box):

--- a/tidy3d/components/microwave/path_integrals/current_spec.py
+++ b/tidy3d/components/microwave/path_integrals/current_spec.py
@@ -1,0 +1,354 @@
+"""Module containing specifications for current path integrals."""
+
+from __future__ import annotations
+
+from typing import Literal, Optional, Union
+
+import numpy as np
+import pydantic.v1 as pd
+import shapely
+
+from tidy3d.components.base import cached_property
+from tidy3d.components.geometry.base import Box, Geometry
+from tidy3d.components.microwave.path_integrals.base_spec import (
+    AbstractAxesRH,
+    AxisAlignedPathIntegralSpec,
+    CustomPathIntegral2DSpec,
+)
+from tidy3d.components.microwave.path_integrals.viz import ARROW_CURRENT, plot_params_current_path
+from tidy3d.components.types import Ax
+from tidy3d.components.types.base import Axis, Direction
+from tidy3d.components.validators import assert_plane
+from tidy3d.components.viz import add_ax_if_none
+from tidy3d.constants import fp_eps
+from tidy3d.exceptions import SetupError, Tidy3dError
+
+
+class CurrentIntegralAxisAlignedSpec(AbstractAxesRH, Box):
+    """Class for specifying the computation of conduction current via Ampère's circuital law on an axis-aligned loop."""
+
+    _plane_validator = assert_plane()
+
+    sign: Direction = pd.Field(
+        ...,
+        title="Direction of Contour Integral",
+        description="Positive indicates current flowing in the positive normal axis direction.",
+    )
+
+    extrapolate_to_endpoints: bool = pd.Field(
+        False,
+        title="Extrapolate to Endpoints",
+        description="This parameter is passed to :class:`AxisAlignedPathIntegral` objects when computing the contour integral.",
+    )
+
+    snap_contour_to_grid: bool = pd.Field(
+        False,
+        title="Snap Contour to Grid",
+        description="This parameter is passed to :class:`AxisAlignedPathIntegral` objects when computing the contour integral.",
+    )
+
+    @cached_property
+    def main_axis(self) -> Axis:
+        """Axis normal to loop"""
+        for index, value in enumerate(self.size):
+            if value == 0:
+                return index
+        raise Tidy3dError("Failed to identify axis.")
+
+    def _to_path_integral_specs(
+        self, h_horizontal=None, h_vertical=None
+    ) -> tuple[AxisAlignedPathIntegralSpec, ...]:
+        """Returns four ``AxisAlignedPathIntegralSpec`` instances, which represent a contour
+        integral around the surface defined by ``self.size``."""
+        ax1 = self.remaining_axes[0]
+        ax2 = self.remaining_axes[1]
+
+        horizontal_passed = h_horizontal is not None
+        vertical_passed = h_vertical is not None
+        if self.snap_contour_to_grid and horizontal_passed and vertical_passed:
+            (coord1, coord2) = self.remaining_dims
+
+            # Locations where horizontal paths will be snapped
+            v_bounds = [
+                self.center[ax2] - self.size[ax2] / 2,
+                self.center[ax2] + self.size[ax2] / 2,
+            ]
+            h_snaps = h_horizontal.sel({coord2: v_bounds}, method="nearest").coords[coord2].values
+            # Locations where vertical paths will be snapped
+            h_bounds = [
+                self.center[ax1] - self.size[ax1] / 2,
+                self.center[ax1] + self.size[ax1] / 2,
+            ]
+            v_snaps = h_vertical.sel({coord1: h_bounds}, method="nearest").coords[coord1].values
+
+            bottom_bound = h_snaps[0]
+            top_bound = h_snaps[1]
+            left_bound = v_snaps[0]
+            right_bound = v_snaps[1]
+        else:
+            bottom_bound = self.bounds[0][ax2]
+            top_bound = self.bounds[1][ax2]
+            left_bound = self.bounds[0][ax1]
+            right_bound = self.bounds[1][ax1]
+
+        # Horizontal paths
+        path_size = list(self.size)
+        path_size[ax1] = right_bound - left_bound
+        path_size[ax2] = 0
+        path_center = list(self.center)
+        path_center[ax2] = bottom_bound
+
+        bottom = AxisAlignedPathIntegralSpec(
+            center=path_center,
+            size=path_size,
+            extrapolate_to_endpoints=self.extrapolate_to_endpoints,
+            snap_path_to_grid=self.snap_contour_to_grid,
+        )
+        path_center[ax2] = top_bound
+        top = AxisAlignedPathIntegralSpec(
+            center=path_center,
+            size=path_size,
+            extrapolate_to_endpoints=self.extrapolate_to_endpoints,
+            snap_path_to_grid=self.snap_contour_to_grid,
+        )
+
+        # Vertical paths
+        path_size = list(self.size)
+        path_size[ax1] = 0
+        path_size[ax2] = top_bound - bottom_bound
+        path_center = list(self.center)
+
+        path_center[ax1] = left_bound
+        left = AxisAlignedPathIntegralSpec(
+            center=path_center,
+            size=path_size,
+            extrapolate_to_endpoints=self.extrapolate_to_endpoints,
+            snap_path_to_grid=self.snap_contour_to_grid,
+        )
+        path_center[ax1] = right_bound
+        right = AxisAlignedPathIntegralSpec(
+            center=path_center,
+            size=path_size,
+            extrapolate_to_endpoints=self.extrapolate_to_endpoints,
+            snap_path_to_grid=self.snap_contour_to_grid,
+        )
+
+        return (bottom, right, top, left)
+
+    @add_ax_if_none
+    def plot(
+        self,
+        x: Optional[float] = None,
+        y: Optional[float] = None,
+        z: Optional[float] = None,
+        ax: Ax = None,
+        **path_kwargs,
+    ) -> Ax:
+        """Plot path integral at single (x,y,z) coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            Position of plane in x direction, only one of x,y,z can be specified to define plane.
+        y : float = None
+            Position of plane in y direction, only one of x,y,z can be specified to define plane.
+        z : float = None
+            Position of plane in z direction, only one of x,y,z can be specified to define plane.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        **path_kwargs
+            Optional keyword arguments passed to the matplotlib plotting of the line.
+            For details on accepted values, refer to
+            `Matplotlib's documentation <https://tinyurl.com/36marrat>`_.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+        axis, position = self.parse_xyz_kwargs(x=x, y=y, z=z)
+        if axis != self.main_axis or not np.isclose(position, self.center[axis], rtol=fp_eps):
+            return ax
+
+        plot_params = plot_params_current_path.include_kwargs(**path_kwargs)
+        plot_kwargs = plot_params.to_kwargs()
+        path_integrals = self._to_path_integral_specs()
+        # Plot the path
+        for path in path_integrals:
+            (xs, ys) = path._vertices_2D(axis)
+            ax.plot(xs, ys, **plot_kwargs)
+
+        (ax1, ax2) = self.remaining_axes
+
+        # Add arrow to bottom path, unless right path is longer
+        arrow_path = path_integrals[0]
+        if self.size[ax2] > self.size[ax1]:
+            arrow_path = path_integrals[1]
+
+        (xs, ys) = arrow_path._vertices_2D(axis)
+        X = (xs[0] + xs[1]) / 2
+        Y = (ys[0] + ys[1]) / 2
+        center = np.array([X, Y])
+        dx = xs[1] - xs[0]
+        dy = ys[1] - ys[0]
+        direction = np.array([dx, dy])
+        segment_length = np.linalg.norm(direction)
+        unit_dir = direction / segment_length
+
+        # Change direction of arrow depending on sign of current definition
+        if self.sign == "-":
+            unit_dir *= -1.0
+        # Change direction of arrow when the "y" axis is dropped,
+        # since the plotted coordinate system will be left-handed (x, z)
+        if self.main_axis == 1:
+            unit_dir *= -1.0
+
+        start = center - unit_dir * segment_length
+        end = center
+        ax.annotate(
+            "",
+            xytext=(start[0], start[1]),
+            xy=(end[0], end[1]),
+            arrowprops=ARROW_CURRENT,
+        )
+        return ax
+
+
+class CustomCurrentIntegral2DSpec(CustomPathIntegral2DSpec):
+    """Class for specifying the computation of conduction current via Ampère's circuital law on a custom path.
+    To compute the current flowing in the positive ``axis`` direction, the vertices should be
+    ordered in a counterclockwise direction."""
+
+    @add_ax_if_none
+    def plot(
+        self,
+        x: Optional[float] = None,
+        y: Optional[float] = None,
+        z: Optional[float] = None,
+        ax: Ax = None,
+        **path_kwargs,
+    ) -> Ax:
+        """Plot path integral at single (x,y,z) coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            Position of plane in x direction, only one of x,y,z can be specified to define plane.
+        y : float = None
+            Position of plane in y direction, only one of x,y,z can be specified to define plane.
+        z : float = None
+            Position of plane in z direction, only one of x,y,z can be specified to define plane.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        **path_kwargs
+            Optional keyword arguments passed to the matplotlib plotting of the line.
+            For details on accepted values, refer to
+            `Matplotlib's documentation <https://tinyurl.com/36marrat>`_.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+        axis, position = Geometry.parse_xyz_kwargs(x=x, y=y, z=z)
+        if axis != self.main_axis or not np.isclose(position, self.position, rtol=fp_eps):
+            return ax
+
+        plot_params = plot_params_current_path.include_kwargs(**path_kwargs)
+        plot_kwargs = plot_params.to_kwargs()
+        xs = self.vertices[:, 0]
+        ys = self.vertices[:, 1]
+        ax.plot(xs, ys, **plot_kwargs)
+
+        # Add arrow at start of contour
+        ax.annotate(
+            "",
+            xytext=(xs[0], ys[0]),
+            xy=(xs[1], ys[1]),
+            arrowprops=ARROW_CURRENT,
+        )
+        return ax
+
+    @cached_property
+    def sign(self) -> Direction:
+        """Uses the ordering of the vertices to determine the direction of the current flow."""
+        linestr = shapely.LineString(coordinates=self.vertices)
+        is_ccw = shapely.is_ccw(linestr)
+        # Invert statement when the vertices are given as (x, z)
+        if self.axis == 1:
+            is_ccw = not is_ccw
+        if is_ccw:
+            return "+"
+        else:
+            return "-"
+
+
+class CompositeCurrentIntegralSpec(Box):
+    """Specification for a composite current integral.
+
+    This class is used to set up a CompositeCurrentIntegral, which combines
+    multiple current integrals. It does not perform any integration itself.
+    """
+
+    path_specs: tuple[Union[CurrentIntegralAxisAlignedSpec, CustomCurrentIntegral2DSpec], ...] = (
+        pd.Field(
+            ...,
+            title="Path Specifications",
+            description="Definition of the disjoint path specifications for each isolated contour integral.",
+        )
+    )
+
+    sum_spec: Literal["sum", "split"] = pd.Field(
+        ...,
+        title="Sum Specification",
+        description="Determines the method used to combine the currents calculated by the different "
+        "current integrals defined by ``path_specs``. ``sum`` simply adds all currents, while ``split`` "
+        "keeps contributions with opposite phase separate, which allows for isolating the current "
+        "flowing in opposite directions. In ``split`` version, the current returned is the maximum "
+        "of the two contributions.",
+    )
+
+    @add_ax_if_none
+    def plot(
+        self,
+        x: Optional[float] = None,
+        y: Optional[float] = None,
+        z: Optional[float] = None,
+        ax: Ax = None,
+        **path_kwargs,
+    ) -> Ax:
+        """Plot path integral at single (x,y,z) coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            Position of plane in x direction, only one of x,y,z can be specified to define plane.
+        y : float = None
+            Position of plane in y direction, only one of x,y,z can be specified to define plane.
+        z : float = None
+            Position of plane in z direction, only one of x,y,z can be specified to define plane.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        **path_kwargs
+            Optional keyword arguments passed to the matplotlib plotting of the line.
+            For details on accepted values, refer to
+            `Matplotlib's documentation <https://tinyurl.com/36marrat>`_.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+        for path_spec in self.path_specs:
+            ax = path_spec.plot(x=x, y=y, z=z, ax=ax, **path_kwargs)
+        return ax
+
+    @pd.validator("path_specs", always=True)
+    def _path_specs_not_empty(cls, val):
+        """Makes sure at least one path spec has been supplied"""
+        # overall shape of vertices
+        if len(val) < 1:
+            raise SetupError(
+                "'CompositeCurrentIntegralSpec.path_specs' must be a list of one or more current integrals. "
+            )
+        return val

--- a/tidy3d/components/microwave/path_integrals/impedance_spec.py
+++ b/tidy3d/components/microwave/path_integrals/impedance_spec.py
@@ -1,18 +1,16 @@
-"""Module for automatic determination of voltage and current integration specifications."""
+"""Specification for impedance computation in transmission lines and waveguides."""
 
 from __future__ import annotations
 
 from itertools import chain
 from math import isclose
-from typing import Union, get_args
+from typing import Optional, Union
 
+import pydantic.v1 as pd
 import shapely
-from shapely.geometry import (
-    LineString,
-    Polygon,
-)
+from shapely.geometry import LineString, Polygon
 
-from tidy3d.components.base import Tidy3dBaseModel
+from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.geometry.base import Box, Geometry
 from tidy3d.components.geometry.bound_ops import bounds_intersection
 from tidy3d.components.geometry.utils import (
@@ -24,70 +22,82 @@ from tidy3d.components.geometry.utils import (
     snap_box_to_grid,
 )
 from tidy3d.components.grid.grid import Grid
-from tidy3d.components.medium import LossyMetalMedium, Medium, PECMedium
-from tidy3d.components.structure import Structure
+from tidy3d.components.medium import LossyMetalMedium, Medium
+from tidy3d.components.microwave.path_integrals.current_spec import (
+    CompositeCurrentIntegralSpec,
+    CurrentIntegralAxisAlignedSpec,
+)
+from tidy3d.components.microwave.path_integrals.types import (
+    CurrentPathSpecTypes,
+    VoltagePathSpecTypes,
+)
 from tidy3d.components.types import Axis, Bound, Coordinate, Shapely, Symmetry
-from tidy3d.exceptions import ValidationError
-
-from .current_spec import CompositeCurrentIntegralSpec, CurrentIntegralAxisAlignedSpec
-
-ConductorTypes = Union[PECMedium, LossyMetalMedium]
+from tidy3d.components.validators import assert_plane
+from tidy3d.exceptions import SetupError, ValidationError
 
 
-class PathSpecGenerator(Tidy3dBaseModel):
-    """Automatically determines current integration paths based on structure geometry.
+class PathSpecGenerator(Box):
+    """Generates current integration path specifications based on structure geometry.
 
     This class analyzes the geometry of conductors in a simulation cross-section to determine
     appropriate paths for computing current line integrals. These paths are typically used
     for setting up a :class:`.MicrowaveModeSpec` automatically.
-
-    The paths are chosen by:
-    1. Finding and merging conductor surfaces that intersect with the plane
-    2. Creating current paths that enclose isolated conductors
     """
 
-    @staticmethod
-    def _create_snap_spec(normal_axis: Axis, field_data_colocated: bool) -> SnappingSpec:
+    _plane_validator = assert_plane()
+
+    @cached_property
+    def normal_axis(self) -> Axis:
+        """Axis normal to the monitor's plane."""
+        return self.size.index(0.0)
+
+    field_data_colocated: bool = pd.Field(
+        False,
+        title="Field Data Colocated",
+        description="Whether field data is colocated with grid points. When True, integration paths "
+        "are placed with additional margin to avoid interpolated field values near conductor surfaces.",
+    )
+
+    @cached_property
+    def _snap_spec(self) -> SnappingSpec:
         """Creates snapping specification for grid alignment."""
         behavior = [SnapBehavior.StrictExpand] * 3
         location = [SnapLocation.Center] * 3
-        behavior[normal_axis] = SnapBehavior.Off
+        behavior[self.normal_axis] = SnapBehavior.Off
         # To avoid interpolated H field near metal surface
-        margin = (2, 2, 2) if field_data_colocated else (0, 0, 0)
+        margin = (2, 2, 2) if self.field_data_colocated else (0, 0, 0)
         return SnappingSpec(location=location, behavior=behavior, margin=margin)
 
-    @staticmethod
-    def _create_port_boundary(mode_plane: Box, normal_axis: Axis) -> shapely.LineString:
+    @cached_property
+    def _create_port_boundary(self) -> shapely.LineString:
         """Creates a Shapely LineString representing the port boundary."""
-        _, min_b = Geometry.pop_axis(mode_plane.bounds[0], normal_axis)
-        _, max_b = Geometry.pop_axis(mode_plane.bounds[1], normal_axis)
+        _, min_b = Geometry.pop_axis(self.bounds[0], self.normal_axis)
+        _, max_b = Geometry.pop_axis(self.bounds[1], self.normal_axis)
         port = Geometry.make_shapely_box(min_b[0], min_b[1], max_b[0], max_b[1])
         return shapely.LineString(port.exterior)
 
-    @staticmethod
     def _get_mode_symmetry(
-        mode_plane: Box, sim_box: Box, sym_symmetry: tuple[Symmetry, Symmetry, Symmetry]
+        self, sim_box: Box, sym_symmetry: tuple[Symmetry, Symmetry, Symmetry]
     ) -> tuple[Symmetry, Symmetry, Symmetry]:
         """Get the mode symmetry, considering the mode plane, the simulation box and the simulation symmetry."""
         mode_symmetry = list(sym_symmetry)
         for dim in range(3):
-            if sim_box.center[dim] != mode_plane.center[dim] or mode_plane.size[dim] == 0:
+            if sim_box.center[dim] != self.center[dim] or self.size[dim] == 0:
                 mode_symmetry[dim] = 0
 
         return mode_symmetry
 
-    @staticmethod
     def _get_mode_limits(
-        mode_plane: Box, sim_box: Box, mode_symmetry: tuple[Symmetry, Symmetry, Symmetry]
+        self, sim_box: Box, mode_symmetry: tuple[Symmetry, Symmetry, Symmetry]
     ) -> Bound:
-        """Restrict mode plane bounds to the simulation bounds taking into account symmetry conditions.s"""
+        """Restrict mode plane bounds to the simulation bounds taking into account symmetry conditions."""
         # Restrict mode plane to the simulation size, if it is smaller
-        min_b, max_b = bounds_intersection(mode_plane.bounds, sim_box.bounds)
+        min_b, max_b = bounds_intersection(self.bounds, sim_box.bounds)
 
         min_b_2d_list = list(min_b)
         for dim in range(3):
             if mode_symmetry[dim] != 0:
-                min_b_2d_list[dim] = mode_plane.center[dim]
+                min_b_2d_list[dim] = self.center[dim]
 
         return (tuple(min_b_2d_list), max_b)
 
@@ -102,10 +112,10 @@ class PathSpecGenerator(Tidy3dBaseModel):
             snap_contour_to_grid=True,
         )
 
-    @staticmethod
     def _get_isolated_conductors_as_shapely(
+        self,
         plane: Box,
-        structures: list[Structure],
+        structures: list,  # list[Structure] - avoiding import for circular dependency
     ) -> list[Shapely]:
         """Find and merge all conductor structures that intersect the given plane.
 
@@ -113,7 +123,7 @@ class PathSpecGenerator(Tidy3dBaseModel):
         ----------
         plane : Box
             The plane to check for conductor intersections
-        structures : list[Structure]
+        structures : list
             List of all simulation structures to analyze
 
         Returns
@@ -124,8 +134,7 @@ class PathSpecGenerator(Tidy3dBaseModel):
         """
 
         def is_conductor(med: Medium) -> bool:
-            union_types = get_args(ConductorTypes)
-            return med.is_pec or isinstance(med, union_types)
+            return med.is_pec or isinstance(med, LossyMetalMedium)
 
         geometry_list = [structure.geometry for structure in structures]
         # For metal, we don't distinguish between LossyMetal and PEC,
@@ -168,14 +177,12 @@ class PathSpecGenerator(Tidy3dBaseModel):
         ml_pec_bounds = shapely.MultiLineString(shapely_pec_bounds)
         return [shape for shape in conductor_polygons if not ml_pec_bounds.intersects(shape)]
 
-    @staticmethod
     def create_current_path_specs(
-        mode_plane: Box,
-        structures: list[Structure],
+        self,
+        structures: list,  # list[Structure] - avoiding import for circular dependency
         grid: Grid,
         symmetry: tuple[Symmetry, Symmetry, Symmetry],
         sim_box: Box,
-        field_data_colocated: bool = False,
     ) -> tuple[CompositeCurrentIntegralSpec, list[Shapely]]:
         """Creates path specifications for path integrals that encompass each isolated conductor
         in the mode plane.
@@ -186,9 +193,7 @@ class PathSpecGenerator(Tidy3dBaseModel):
 
         Parameters
         ----------
-        mode_plane : Box
-            The cross-sectional plane where current paths are determined.
-        structures : list[Structure]
+        structures : list
             List of structures in the simulation.
         grid : Grid
             Simulation grid for snapping paths.
@@ -196,68 +201,56 @@ class PathSpecGenerator(Tidy3dBaseModel):
             Symmetry conditions for the simulation in (x, y, z) directions.
         sim_box : Box
             Simulation domain box used for boundary conditions.
-        field_data_colocated : bool
-            Whether field data is colocated with grid points.
 
         Returns
         -------
-            tuple[CompositeCurrentIntegralSpec, list[Shapely]]
-                Composite path specification and list of merged conductor geometries.
+        tuple[CompositeCurrentIntegralSpec, list[Shapely]]
+            Composite path specification and list of merged conductor geometries.
         """
 
-        normal_axis = mode_plane.size.index(0.0)
-
-        def bounding_box_from_shapely(
-            geom: Shapely, normal_axis: Axis, normal_center: float
-        ) -> Box:
+        def bounding_box_from_shapely(geom: Shapely) -> Box:
             """Helper to convert the shapely geometry bounds to a Box."""
             bounds = geom.bounds
-            rmin = Geometry.unpop_axis(normal_center, (bounds[0], bounds[1]), normal_axis)
-            rmax = Geometry.unpop_axis(normal_center, (bounds[2], bounds[3]), normal_axis)
+            normal_center = self.center[self.normal_axis]
+            rmin = Geometry.unpop_axis(normal_center, (bounds[0], bounds[1]), self.normal_axis)
+            rmax = Geometry.unpop_axis(normal_center, (bounds[2], bounds[3]), self.normal_axis)
             return Box.from_bounds(rmin, rmax)
 
-        mode_symmetry_3d = PathSpecGenerator._get_mode_symmetry(mode_plane, sim_box, symmetry)
-        min_b_3d, max_b_3d = PathSpecGenerator._get_mode_limits(
-            mode_plane, sim_box, mode_symmetry_3d
-        )
+        mode_symmetry_3d = self._get_mode_symmetry(sim_box, symmetry)
+        min_b_3d, max_b_3d = self._get_mode_limits(sim_box, mode_symmetry_3d)
 
         intersection_plane = Box.from_bounds(min_b_3d, max_b_3d)
-        conductor_polygons = PathSpecGenerator._get_isolated_conductors_as_shapely(
+        conductor_polygons = self._get_isolated_conductors_as_shapely(
             intersection_plane, structures
         )
 
-        conductor_polygons = PathSpecGenerator._filter_conductors_touching_sim_bounds(
-            (min_b_3d, max_b_3d), mode_symmetry_3d, normal_axis, conductor_polygons
+        conductor_polygons = self._filter_conductors_touching_sim_bounds(
+            (min_b_3d, max_b_3d), mode_symmetry_3d, self.normal_axis, conductor_polygons
         )
 
         if len(conductor_polygons) < 1:
-            expected_types = ", ".join(t.__name__ for t in get_args(ConductorTypes))
             raise ValidationError(
                 "No valid isolated conductors were found in the mode plane. Please ensure that a 'Structure' "
-                f"with a medium of type {expected_types} intersects the mode plane and is not touching "
+                "with a medium of type 'PEC' or 'LossyMetalMedium' intersects the mode plane and is not touching "
                 "the boundaries of the mode plane."
             )
 
         # Get desired snapping behavior of box enclosed conductors.
         # Ideally, just large enough to coincide with the H field positions outside of the conductor.
         # So a half grid cell, when the metal boundary is coincident with grid boundaries.
-        snap_spec = PathSpecGenerator._create_snap_spec(normal_axis, field_data_colocated)
-
-        # shapely_port_boundary = PathSpecGenerator._create_port_boundary(mode_plane, normal_axis)
+        snap_spec = self._snap_spec
 
         current_integral_specs = []
         for shape in conductor_polygons:
-            box = bounding_box_from_shapely(shape, normal_axis, mode_plane.center[normal_axis])
-            boxes = PathSpecGenerator._apply_symmetry(symmetry, sim_box.center, normal_axis, box)
+            box = bounding_box_from_shapely(shape)
+            boxes = self._apply_symmetry(symmetry, sim_box.center, self.normal_axis, box)
             for box in boxes:
                 box_snapped = snap_box_to_grid(grid, box, snap_spec)
-                path_spec = PathSpecGenerator._create_path_spec(box_snapped)
+                path_spec = self._create_path_spec(box_snapped)
                 current_integral_specs.append(path_spec)
 
         for path_spec in current_integral_specs:
-            if PathSpecGenerator._check_path_intersects_with_conductors(
-                conductor_polygons, path_spec
-            ):
+            if self._check_path_intersects_with_conductors(conductor_polygons, path_spec):
                 raise ValidationError(
                     "Failed to automatically generate path specification. "
                     "Please create a github issue so that the problem can be investigated. "
@@ -265,12 +258,14 @@ class PathSpecGenerator(Tidy3dBaseModel):
                 )
 
         path_spec = CompositeCurrentIntegralSpec(
-            center=mode_plane.center,
-            size=mode_plane.size,
+            center=self.center,
+            size=self.size,
             path_specs=current_integral_specs,
             sum_spec="split",
         )
-        return path_spec, conductor_polygons
+
+        result = (path_spec, conductor_polygons)
+        return result
 
     @staticmethod
     def _check_path_intersects_with_conductors(shapely_list: Shapely, path: Box) -> bool:
@@ -285,7 +280,7 @@ class PathSpecGenerator(Tidy3dBaseModel):
 
         Returns
         -------
-            bool: True if the path intersects with any conductor geometry, False otherwise.
+        bool: True if the path intersects with any conductor geometry, False otherwise.
         """
         normal_axis = path.size.index(0.0)
         min_b, max_b = path.bounds
@@ -390,3 +385,56 @@ class PathSpecGenerator(Tidy3dBaseModel):
                 ]
                 result = list(chain.from_iterable(tmp_list))
         return result
+
+
+class AutoImpedanceSpec(Tidy3dBaseModel):
+    """Specification for fully automatic transmission line impedance computation.
+
+    This specification automatically calculates impedance by calculating the current associated
+    with each conductor that intersects the mode plane.
+    """
+
+
+class CustomImpedanceSpec(Tidy3dBaseModel):
+    """Specification for custom transmission line voltages and currents in mode solvers.
+
+    The :class:`.CustomImpedanceSpec` class specifies how quantities related to transmission line
+    modes are computed. For example, it defines the paths for line integrals, which are used to
+    compute voltage, current, and characteristic impedance of the transmission line.
+
+    Users may supply their own voltage and current path specifications to control where these integrals
+    are evaluated. If neither voltage nor current specifications are provided, an automatic choice of
+    paths will be made based on the simulation geometry and context.
+    """
+
+    voltage_spec: Optional[VoltagePathSpecTypes] = pd.Field(
+        None,
+        title="Voltage Integration Path",
+        description="Path specification for computing the voltage associated with each mode. "
+        "The number of path specifications should equal the 'num_modes' field "
+        "in the 'ModeSpec'.",
+    )
+
+    current_spec: Optional[CurrentPathSpecTypes] = pd.Field(
+        None,
+        title="Current Integration Path",
+        description="Path specification for computing the current associated with each mode. "
+        "The number of path specifications should equal the 'num_modes' field "
+        "in the 'ModeSpec'.",
+    )
+
+    @pd.validator("current_spec", always=True)
+    def check_path_spec_combinations(cls, val, values):
+        """In order to define voltage/current/impedance, either a voltage or current path specification
+        must be provided.
+        """
+
+        voltage_spec = values["voltage_spec"]
+        if val is None and voltage_spec is None:
+            raise SetupError(
+                "Not a valid 'CustomImpedanceSpec', the 'voltage_spec' and 'current_spec' cannot both be 'None'."
+            )
+        return val
+
+
+ImpedanceSpecTypes = Union[AutoImpedanceSpec, CustomImpedanceSpec]

--- a/tidy3d/components/microwave/path_integrals/path_integral_factory.py
+++ b/tidy3d/components/microwave/path_integrals/path_integral_factory.py
@@ -2,18 +2,18 @@
 
 from __future__ import annotations
 
-from typing import Union
+from typing import Optional, Union
 
-from tidy3d.components.microwave.microwave_mode_spec import (
-    AutoImpedanceSpec,
-    ImpedanceSpecTypes,
-)
+from tidy3d.components.microwave.microwave_mode_spec import MicrowaveModeSpec
 from tidy3d.components.microwave.path_integrals.current_spec import (
     CompositeCurrentIntegralSpec,
     CurrentIntegralAxisAlignedSpec,
     CustomCurrentIntegral2DSpec,
 )
-from tidy3d.components.microwave.path_integrals.path_spec_generator import PathSpecGenerator
+from tidy3d.components.microwave.path_integrals.impedance_spec import (
+    AutoImpedanceSpec,
+    PathSpecGenerator,
+)
 from tidy3d.components.microwave.path_integrals.types import (
     CurrentPathSpecTypes,
     VoltagePathSpecTypes,
@@ -87,10 +87,10 @@ def make_current_integral(path_spec: CurrentPathSpecTypes) -> CurrentIntegralTyp
 
 
 def make_path_integrals(
-    impedance_spec: ImpedanceSpecTypes,
+    microwave_mode_spec: MicrowaveModeSpec,
     monitor: Union[ModeMonitor, ModeSolverMonitor],
     sim: Simulation,
-) -> tuple[tuple[VoltageIntegralTypes], tuple[CurrentIntegralTypes]]:
+) -> tuple[tuple[Optional[VoltageIntegralTypes]], tuple[Optional[CurrentIntegralTypes]]]:
     """
     Given an impedance specification, monitor, and simulation instance, create the voltage and
     current path integrals used for the impedance computation.
@@ -115,48 +115,50 @@ def make_path_integrals(
         If path specifications cannot be auto-generated or path integrals cannot be constructed.
     """
 
-    v_specs = None
-    i_specs = None
-    if isinstance(impedance_spec, AutoImpedanceSpec):
+    if microwave_mode_spec._using_auto_current_spec:
+        i_spec_gen = PathSpecGenerator(
+            center=monitor.center, size=monitor.size, field_data_colocated=monitor.colocate
+        )
         try:
-            i_spec, _ = PathSpecGenerator.create_current_path_specs(
-                monitor.bounding_box,
+            auto_i_spec, _ = i_spec_gen.create_current_path_specs(
                 sim.structures,
                 sim.grid,
                 sim.symmetry,
                 sim.bounding_box,
-                monitor.colocate,
             )
-            i_specs = (i_spec,) * monitor.mode_spec.num_modes
         except ValidationError as e:
             raise SetupError(
                 f"Failed to auto-generate path specification for impedance calculation in monitor '{monitor.name}'."
             ) from e
-    else:
-        v_specs = impedance_spec.voltage_spec
-        i_specs = impedance_spec.current_spec
 
-    if v_specs is None:
-        v_specs = (None,) * monitor.mode_spec.num_modes
-    if i_specs is None:
-        i_specs = (None,) * monitor.mode_spec.num_modes
+    v_integrals = []
+    i_integrals = []
+    for idx, impedance_spec in enumerate(microwave_mode_spec.impedance_spec):
+        if impedance_spec is None:
+            # Do not calculate impedance for this mode
+            v_integrals.append(None)
+            i_integrals.append(None)
+            continue
+        elif isinstance(impedance_spec, AutoImpedanceSpec):
+            v_spec = None
+            i_spec = auto_i_spec
+        else:
+            v_spec = impedance_spec.voltage_spec
+            i_spec = impedance_spec.current_spec
 
-    try:
-        voltage_integrals = []
-        current_integrals = []
-        for v_spec, i_spec in zip(v_specs, i_specs):
+        try:
             v_integral = None
             i_integral = None
             if v_spec is not None:
                 v_integral = make_voltage_integral(v_spec)
             if i_spec is not None:
                 i_integral = make_current_integral(i_spec)
-            voltage_integrals.append(v_integral)
-            current_integrals.append(i_integral)
-        path_integrals = (tuple(voltage_integrals), tuple(current_integrals))
-    except Exception as e:
-        raise SetupError(
-            f"Failed to construct path integrals from the impedance specification in monitor '{monitor.name}'. "
-            "Please create a github issue so that the problem can be investigated."
-        ) from e
-    return path_integrals
+            v_integrals.append(v_integral)
+            i_integrals.append(i_integral)
+        except Exception as e:
+            raise SetupError(
+                f"Failed to construct path integrals for the mode index {idx} in monitor '{monitor.name}' "
+                "from the impedance specification. "
+                "Please create a github issue so that the problem can be investigated."
+            ) from e
+    return (tuple(v_integrals), tuple(i_integrals))

--- a/tidy3d/components/microwave/path_integrals/path_integral_factory.py
+++ b/tidy3d/components/microwave/path_integrals/path_integral_factory.py
@@ -1,0 +1,154 @@
+"""Factory functions for creating current and voltage path integrals from path specifications."""
+
+from __future__ import annotations
+
+from typing import Union
+
+from tidy3d.components.microwave.microwave_mode_spec import MicrowaveModeSpec
+from tidy3d.components.microwave.path_integrals.current_spec import (
+    CompositeCurrentIntegralSpec,
+    CurrentIntegralAxisAlignedSpec,
+    CustomCurrentIntegral2DSpec,
+)
+from tidy3d.components.microwave.path_integrals.path_spec_generator import PathSpecGenerator
+from tidy3d.components.microwave.path_integrals.types import (
+    CurrentPathSpecTypes,
+    VoltagePathSpecTypes,
+)
+from tidy3d.components.microwave.path_integrals.voltage_spec import (
+    CustomVoltageIntegral2DSpec,
+    VoltageIntegralAxisAlignedSpec,
+)
+from tidy3d.components.monitor import ModeMonitor, ModeSolverMonitor
+from tidy3d.components.simulation import Simulation
+from tidy3d.exceptions import SetupError, ValidationError
+from tidy3d.plugins.microwave import (
+    CompositeCurrentIntegral,
+    CurrentIntegralAxisAligned,
+    CurrentIntegralTypes,
+    CustomCurrentIntegral2D,
+    CustomVoltageIntegral2D,
+    VoltageIntegralAxisAligned,
+    VoltageIntegralTypes,
+)
+
+
+def make_voltage_integral(path_spec: VoltagePathSpecTypes) -> VoltageIntegralTypes:
+    """Create a voltage path integral from a path specification.
+
+    Parameters
+    ----------
+    path_spec : VoltagePathSpecTypes
+        Specification defining the path for voltage integration. Can be either an axis-aligned or
+        custom path specification.
+
+    Returns
+    -------
+    VoltageIntegralTypes
+        Voltage path integral instance corresponding to the provided specification type.
+    """
+    v_integral = None
+    if isinstance(path_spec, VoltageIntegralAxisAlignedSpec):
+        v_integral = VoltageIntegralAxisAligned(**path_spec.dict(exclude={"type"}))
+    elif isinstance(path_spec, CustomVoltageIntegral2DSpec):
+        v_integral = CustomVoltageIntegral2D(**path_spec.dict(exclude={"type"}))
+    else:
+        raise ValidationError(f"Unsupported voltage path specification type: {type(path_spec)}")
+    return v_integral
+
+
+def make_current_integral(path_spec: CurrentPathSpecTypes) -> CurrentIntegralTypes:
+    """Create a current path integral from a path specification.
+
+    Parameters
+    ----------
+    path_spec : CurrentPathSpecTypes
+        Specification defining the path for current integration. Can be either an axis-aligned,
+        custom, or composite path specification.
+
+    Returns
+    -------
+    CurrentIntegralTypes
+        Current path integral instance corresponding to the provided specification type.
+    """
+    i_integral = None
+    if isinstance(path_spec, CurrentIntegralAxisAlignedSpec):
+        i_integral = CurrentIntegralAxisAligned(**path_spec.dict(exclude={"type"}))
+    elif isinstance(path_spec, CustomCurrentIntegral2DSpec):
+        i_integral = CustomCurrentIntegral2D(**path_spec.dict(exclude={"type"}))
+    elif isinstance(path_spec, CompositeCurrentIntegralSpec):
+        i_integral = CompositeCurrentIntegral(**path_spec.dict(exclude={"type"}))
+    else:
+        raise ValidationError(f"Unsupported current path specification type: {type(path_spec)}")
+    return i_integral
+
+
+def make_path_integrals(
+    microwave_mode_spec: MicrowaveModeSpec,
+    monitor: Union[ModeMonitor, ModeSolverMonitor],
+    sim: Simulation,
+) -> tuple[tuple[VoltageIntegralTypes], tuple[CurrentIntegralTypes]]:
+    """
+    Given a ``MicrowaveModeSpec``, monitor, and simulation instance, create the voltage and current path integrals used for impedance computation.
+
+    Parameters
+    ----------
+    mw_mode_spec : MicrowaveModeSpec
+        Terminal specification containing voltage and current path specifications.
+    monitor : Union[ModeMonitor, ModeSolverMonitor]
+        The monitor for which the path integrals are being generated.
+    sim : Simulation
+        The simulation instance providing structures, grid, symmetry, and bounding box.
+
+    Returns
+    -------
+    tuple[tuple[VoltageIntegralTypes], tuple[CurrentIntegralTypes]]
+        Tuple containing the voltage and current path integral instances for each mode.
+
+    Raises
+    ------
+    SetupError
+        If path specifications cannot be auto-generated or path integrals cannot be constructed.
+    """
+    try:
+        v_specs = microwave_mode_spec.voltage_spec
+        i_specs = microwave_mode_spec.current_spec
+        if microwave_mode_spec.use_automatic_setup:
+            i_spec, _ = PathSpecGenerator.create_current_path_specs(
+                monitor.bounding_box,
+                sim.structures,
+                sim.grid,
+                sim.symmetry,
+                sim.bounding_box,
+                monitor.colocate,
+            )
+            i_specs = (i_spec,) * monitor.mode_spec.num_modes
+        if v_specs is None:
+            v_specs = (None,) * monitor.mode_spec.num_modes
+        if i_specs is None:
+            i_specs = (None,) * monitor.mode_spec.num_modes
+
+    except ValidationError as e:
+        raise SetupError(
+            f"Failed to auto-generate path specification for impedance calculation in monitor '{monitor.name}'."
+        ) from e
+
+    try:
+        voltage_integrals = []
+        current_integrals = []
+        for v_spec, i_spec in zip(v_specs, i_specs):
+            v_integral = None
+            i_integral = None
+            if v_spec is not None:
+                v_integral = make_voltage_integral(v_spec)
+            if i_spec is not None:
+                i_integral = make_current_integral(i_spec)
+            voltage_integrals.append(v_integral)
+            current_integrals.append(i_integral)
+        path_integrals = (tuple(voltage_integrals), tuple(current_integrals))
+    except Exception as e:
+        raise SetupError(
+            f"Failed to construct path integrals from the microwave mode specification for monitor '{monitor.name}'. "
+            "Please create a github issue so that the problem can be investigated."
+        ) from e
+    return path_integrals

--- a/tidy3d/components/microwave/path_integrals/path_integral_factory.py
+++ b/tidy3d/components/microwave/path_integrals/path_integral_factory.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from typing import Union
 
-from tidy3d.components.microwave.microwave_mode_spec import MicrowaveModeSpec
+from tidy3d.components.microwave.microwave_mode_spec import (
+    AutoImpedanceSpec,
+    ImpedanceSpecTypes,
+)
 from tidy3d.components.microwave.path_integrals.current_spec import (
     CompositeCurrentIntegralSpec,
     CurrentIntegralAxisAlignedSpec,
@@ -84,17 +87,18 @@ def make_current_integral(path_spec: CurrentPathSpecTypes) -> CurrentIntegralTyp
 
 
 def make_path_integrals(
-    microwave_mode_spec: MicrowaveModeSpec,
+    impedance_spec: ImpedanceSpecTypes,
     monitor: Union[ModeMonitor, ModeSolverMonitor],
     sim: Simulation,
 ) -> tuple[tuple[VoltageIntegralTypes], tuple[CurrentIntegralTypes]]:
     """
-    Given a ``MicrowaveModeSpec``, monitor, and simulation instance, create the voltage and current path integrals used for impedance computation.
+    Given an impedance specification, monitor, and simulation instance, create the voltage and
+    current path integrals used for the impedance computation.
 
     Parameters
     ----------
-    mw_mode_spec : MicrowaveModeSpec
-        Terminal specification containing voltage and current path specifications.
+    impedance_spec : ImpedanceSpecTypes
+        Impedance specification for creating voltage and current path specifications.
     monitor : Union[ModeMonitor, ModeSolverMonitor]
         The monitor for which the path integrals are being generated.
     sim : Simulation
@@ -110,10 +114,11 @@ def make_path_integrals(
     SetupError
         If path specifications cannot be auto-generated or path integrals cannot be constructed.
     """
-    try:
-        v_specs = microwave_mode_spec.voltage_spec
-        i_specs = microwave_mode_spec.current_spec
-        if microwave_mode_spec.use_automatic_setup:
+
+    v_specs = None
+    i_specs = None
+    if isinstance(impedance_spec, AutoImpedanceSpec):
+        try:
             i_spec, _ = PathSpecGenerator.create_current_path_specs(
                 monitor.bounding_box,
                 sim.structures,
@@ -123,15 +128,18 @@ def make_path_integrals(
                 monitor.colocate,
             )
             i_specs = (i_spec,) * monitor.mode_spec.num_modes
-        if v_specs is None:
-            v_specs = (None,) * monitor.mode_spec.num_modes
-        if i_specs is None:
-            i_specs = (None,) * monitor.mode_spec.num_modes
+        except ValidationError as e:
+            raise SetupError(
+                f"Failed to auto-generate path specification for impedance calculation in monitor '{monitor.name}'."
+            ) from e
+    else:
+        v_specs = impedance_spec.voltage_spec
+        i_specs = impedance_spec.current_spec
 
-    except ValidationError as e:
-        raise SetupError(
-            f"Failed to auto-generate path specification for impedance calculation in monitor '{monitor.name}'."
-        ) from e
+    if v_specs is None:
+        v_specs = (None,) * monitor.mode_spec.num_modes
+    if i_specs is None:
+        i_specs = (None,) * monitor.mode_spec.num_modes
 
     try:
         voltage_integrals = []
@@ -148,7 +156,7 @@ def make_path_integrals(
         path_integrals = (tuple(voltage_integrals), tuple(current_integrals))
     except Exception as e:
         raise SetupError(
-            f"Failed to construct path integrals from the microwave mode specification for monitor '{monitor.name}'. "
+            f"Failed to construct path integrals from the impedance specification in monitor '{monitor.name}'. "
             "Please create a github issue so that the problem can be investigated."
         ) from e
     return path_integrals

--- a/tidy3d/components/microwave/path_integrals/path_spec_generator.py
+++ b/tidy3d/components/microwave/path_integrals/path_spec_generator.py
@@ -1,0 +1,391 @@
+"""Module for automatic determination of voltage and current integration specifications."""
+
+from __future__ import annotations
+
+from itertools import chain
+from math import isclose
+from typing import Union, get_args
+
+import shapely
+from shapely.geometry import (
+    LineString,
+    Polygon,
+)
+
+from tidy3d.components.base import Tidy3dBaseModel
+from tidy3d.components.geometry.base import Box, Geometry
+from tidy3d.components.geometry.bound_ops import bounds_intersection
+from tidy3d.components.geometry.utils import (
+    SnapBehavior,
+    SnapLocation,
+    SnappingSpec,
+    flatten_shapely_geometries,
+    merging_geometries_on_plane,
+    snap_box_to_grid,
+)
+from tidy3d.components.grid.grid import Grid
+from tidy3d.components.medium import LossyMetalMedium, Medium, PECMedium
+from tidy3d.components.structure import Structure
+from tidy3d.components.types import Axis, Bound, Coordinate, Shapely, Symmetry
+from tidy3d.exceptions import ValidationError
+
+from .current_spec import CompositeCurrentIntegralSpec, CurrentIntegralAxisAlignedSpec
+
+ConductorType = Union[PECMedium, LossyMetalMedium]
+
+
+class PathSpecGenerator(Tidy3dBaseModel):
+    """Automatically determines current integration paths based on structure geometry.
+
+    This class analyzes the geometry of conductors in a simulation cross-section to determine
+    appropriate paths for computing current line integrals. These paths are typically used
+    for setting up a :class:`.MicrowaveModeSpec` automatically.
+
+    The paths are chosen by:
+    1. Finding and merging conductor surfaces that intersect with the plane
+    2. Creating current paths that enclose isolated conductors
+    """
+
+    @staticmethod
+    def _create_snap_spec(normal_axis: Axis, field_data_colocated: bool) -> SnappingSpec:
+        """Creates snapping specification for grid alignment."""
+        behavior = [SnapBehavior.StrictExpand] * 3
+        location = [SnapLocation.Center] * 3
+        behavior[normal_axis] = SnapBehavior.Off
+        # To avoid interpolated H field near metal surface
+        margin = (2, 2, 2) if field_data_colocated else (0, 0, 0)
+        return SnappingSpec(location=location, behavior=behavior, margin=margin)
+
+    @staticmethod
+    def _create_port_boundary(mode_plane: Box, normal_axis: Axis) -> shapely.LineString:
+        """Creates a Shapely LineString representing the port boundary."""
+        _, min_b = Geometry.pop_axis(mode_plane.bounds[0], normal_axis)
+        _, max_b = Geometry.pop_axis(mode_plane.bounds[1], normal_axis)
+        port = Geometry.make_shapely_box(min_b[0], min_b[1], max_b[0], max_b[1])
+        return shapely.LineString(port.exterior)
+
+    @staticmethod
+    def _get_mode_symmetry(
+        mode_plane: Box, sim_box: Box, sym_symmetry: tuple[Symmetry, Symmetry, Symmetry]
+    ) -> tuple[Symmetry, Symmetry, Symmetry]:
+        """Get the mode symmetry, considering the mode plane, the simulation box and the simulation symmetry."""
+        mode_symmetry = list(sym_symmetry)
+        for dim in range(3):
+            if sim_box.center[dim] != mode_plane.center[dim] or mode_plane.size[dim] == 0:
+                mode_symmetry[dim] = 0
+
+        return mode_symmetry
+
+    @staticmethod
+    def _get_mode_limits(
+        mode_plane: Box, sim_box: Box, mode_symmetry: tuple[Symmetry, Symmetry, Symmetry]
+    ) -> Bound:
+        """Restrict mode plane bounds to the simulation bounds taking into account symmetry conditions.s"""
+        # Restrict mode plane to the simulation size, if it is smaller
+        min_b, max_b = bounds_intersection(mode_plane.bounds, sim_box.bounds)
+
+        min_b_2d_list = list(min_b)
+        for dim in range(3):
+            if mode_symmetry[dim] != 0:
+                min_b_2d_list[dim] = mode_plane.center[dim]
+
+        return (tuple(min_b_2d_list), max_b)
+
+    @staticmethod
+    def _create_path_spec(box_snapped: Box) -> CurrentIntegralAxisAlignedSpec:
+        """Creates a current integral specification from a snapped box."""
+        return CurrentIntegralAxisAlignedSpec(
+            center=box_snapped.center,
+            size=box_snapped.size,
+            sign="+",
+            extrapolate_to_endpoints=False,
+            snap_contour_to_grid=True,
+        )
+
+    @staticmethod
+    def _get_isolated_conductors_as_shapely(
+        plane: Box,
+        structures: list[Structure],
+    ) -> list[Shapely]:
+        """Find and merge all conductor structures that intersect the given plane.
+
+        Parameters
+        ----------
+        plane : Box
+            The plane to check for conductor intersections
+        structures : list[Structure]
+            List of all simulation structures to analyze
+
+        Returns
+        -------
+        list[Shapely]
+            List of merged conductor geometries as Shapely Polygons and LineStrings
+            that intersect with the given plane
+        """
+
+        def is_conductor(med: Medium) -> bool:
+            return med.is_pec or isinstance(med, ConductorType)
+
+        geometry_list = [structure.geometry for structure in structures]
+        # For metal, we don't distinguish between LossyMetal and PEC,
+        # so they'll be merged to PEC. Other materials are considered as dielectric.
+        prop_list = [is_conductor(structure.medium) for structure in structures]
+        # merge geometries
+        geos = merging_geometries_on_plane(geometry_list, plane, prop_list)
+        conductor_geos = [item[1] for item in geos if item[0]]
+        shapely_list = flatten_shapely_geometries(conductor_geos, keep_types=(Polygon, LineString))
+        return shapely_list
+
+    @staticmethod
+    def _filter_conductors_touching_sim_bounds(
+        mode_limits: Bound,
+        mode_symmetry_3d: tuple[Symmetry, Symmetry, Symmetry],
+        normal_axis: Axis,
+        conductor_polygons: list[Shapely],
+    ) -> list[Shapely]:
+        min_b_3d, max_b_3d = mode_limits[0], mode_limits[1]
+        _, mode_symmetry = Geometry.pop_axis(mode_symmetry_3d, normal_axis)
+        _, min_b = Geometry.pop_axis(min_b_3d, normal_axis)
+        _, max_b = Geometry.pop_axis(max_b_3d, normal_axis)
+
+        # Add top, right, left, bottom
+        shapely_pec_bounds = [
+            shapely.LineString([(min_b[0], max_b[1]), (max_b[0], max_b[1])]),
+            shapely.LineString([(max_b[0], min_b[1]), (max_b[0], max_b[1])]),
+            shapely.LineString([(min_b[0], min_b[1]), (min_b[0], max_b[1])]),
+            shapely.LineString([(min_b[0], min_b[1]), (max_b[0], min_b[1])]),
+        ]
+
+        # If bottom bound is PMC remove
+        if mode_symmetry[1] == 1:
+            shapely_pec_bounds.pop(3)
+
+        # If left bound is PMC remove
+        if mode_symmetry[0] == 1:
+            shapely_pec_bounds.pop(2)
+
+        ml_pec_bounds = shapely.MultiLineString(shapely_pec_bounds)
+        return [shape for shape in conductor_polygons if not ml_pec_bounds.intersects(shape)]
+
+    @staticmethod
+    def create_current_path_specs(
+        mode_plane: Box,
+        structures: list[Structure],
+        grid: Grid,
+        symmetry: tuple[Symmetry, Symmetry, Symmetry],
+        sim_box: Box,
+        field_data_colocated: bool = False,
+    ) -> tuple[CompositeCurrentIntegralSpec, list[Shapely]]:
+        """Creates path specifications for path integrals that encompass each isolated conductor
+        in the mode plane.
+
+        This method identifies isolated conductor geometries in the given plane and creates
+        current paths that enclose each conductor. The paths are snapped to the simulation grid
+        to ensure alignment with field data.
+
+        Parameters
+        ----------
+        mode_plane : Box
+            The cross-sectional plane where current paths are determined.
+        structures : list[Structure]
+            List of structures in the simulation.
+        grid : Grid
+            Simulation grid for snapping paths.
+        symmetry : tuple[Symmetry, Symmetry, Symmetry]
+            Symmetry conditions for the simulation in (x, y, z) directions.
+        sim_box : Box
+            Simulation domain box used for boundary conditions.
+        field_data_colocated : bool
+            Whether field data is colocated with grid points.
+
+        Returns
+        -------
+            tuple[CompositeCurrentIntegralSpec, list[Shapely]]
+                Composite path specification and list of merged conductor geometries.
+        """
+
+        normal_axis = mode_plane.size.index(0.0)
+
+        def bounding_box_from_shapely(
+            geom: Shapely, normal_axis: Axis, normal_center: float
+        ) -> Box:
+            """Helper to convert the shapely geometry bounds to a Box."""
+            bounds = geom.bounds
+            rmin = Geometry.unpop_axis(normal_center, (bounds[0], bounds[1]), normal_axis)
+            rmax = Geometry.unpop_axis(normal_center, (bounds[2], bounds[3]), normal_axis)
+            return Box.from_bounds(rmin, rmax)
+
+        mode_symmetry_3d = PathSpecGenerator._get_mode_symmetry(mode_plane, sim_box, symmetry)
+        min_b_3d, max_b_3d = PathSpecGenerator._get_mode_limits(
+            mode_plane, sim_box, mode_symmetry_3d
+        )
+
+        intersection_plane = Box.from_bounds(min_b_3d, max_b_3d)
+        conductor_polygons = PathSpecGenerator._get_isolated_conductors_as_shapely(
+            intersection_plane, structures
+        )
+
+        conductor_polygons = PathSpecGenerator._filter_conductors_touching_sim_bounds(
+            (min_b_3d, max_b_3d), mode_symmetry_3d, normal_axis, conductor_polygons
+        )
+
+        if len(conductor_polygons) < 1:
+            expected_types = ", ".join(t.__name__ for t in get_args(ConductorType))
+            raise ValidationError(
+                "No valid isolated conductors were found in the mode plane. Please ensure that a 'Structure' "
+                f"with a medium of type {expected_types} intersects the mode plane and is not touching "
+                "the boundaries of the mode plane."
+            )
+
+        # Get desired snapping behavior of box enclosed conductors.
+        # Ideally, just large enough to coincide with the H field positions outside of the conductor.
+        # So a half grid cell, when the metal boundary is coincident with grid boundaries.
+        snap_spec = PathSpecGenerator._create_snap_spec(normal_axis, field_data_colocated)
+
+        # shapely_port_boundary = PathSpecGenerator._create_port_boundary(mode_plane, normal_axis)
+
+        current_integral_specs = []
+        for shape in conductor_polygons:
+            box = bounding_box_from_shapely(shape, normal_axis, mode_plane.center[normal_axis])
+            boxes = PathSpecGenerator._apply_symmetry(symmetry, sim_box.center, normal_axis, box)
+            for box in boxes:
+                box_snapped = snap_box_to_grid(grid, box, snap_spec)
+                path_spec = PathSpecGenerator._create_path_spec(box_snapped)
+                current_integral_specs.append(path_spec)
+
+        for path_spec in current_integral_specs:
+            if PathSpecGenerator._check_path_intersects_with_conductors(
+                conductor_polygons, path_spec
+            ):
+                raise ValidationError(
+                    "Failed to automatically generate path specification. "
+                    "Please create a github issue so that the problem can be investigated. "
+                    "In the meantime, please provide an explicit path specification for this structure."
+                )
+
+        path_spec = CompositeCurrentIntegralSpec(
+            center=mode_plane.center,
+            size=mode_plane.size,
+            path_specs=current_integral_specs,
+            sum_spec="split",
+        )
+        return path_spec, conductor_polygons
+
+    @staticmethod
+    def _check_path_intersects_with_conductors(shapely_list: Shapely, path: Box) -> bool:
+        """Makes sure the path of the integral does not intersect with conductor shapes.
+
+        Parameters
+        ----------
+        shapely_list : Shapely
+            Merged conductor geometries, expected to be Polygons or LineStrings.
+        path : Box
+            Box corresponding with path specification.
+
+        Returns
+        -------
+            bool: True if the path intersects with any conductor geometry, False otherwise.
+        """
+        normal_axis = path.size.index(0.0)
+        min_b, max_b = path.bounds
+        _, min_b = Geometry.pop_axis(min_b, normal_axis)
+        _, max_b = Geometry.pop_axis(max_b, normal_axis)
+        path_shapely = shapely.box(min_b[0], min_b[1], max_b[0], max_b[1])
+        for shapely_geo in shapely_list:
+            if path_shapely.intersects(shapely_geo) and not path_shapely.contains(shapely_geo):
+                return True
+        return False
+
+    @staticmethod
+    def _reflect_box(box: Box, axis: Axis, position: float) -> Box:
+        """Reflects a box across a plane perpendicular to the given axis at the specified position.
+
+        Parameters
+        ----------
+        box : Box
+            The box to reflect
+        axis : Axis
+            The axis perpendicular to the reflection plane (0,1,2) -> (x,y,z)
+        position : float
+            Position along the axis where the reflection plane is located
+
+        Returns
+        -------
+        Box
+            The reflected box
+        """
+        new_center = list(box.center)
+        new_center[axis] = 2 * position - box.center[axis]
+        return box.updated_copy(center=new_center)
+
+    @staticmethod
+    def _apply_symmetry_to_box(box: Box, axis: Axis, position: float) -> list[Box]:
+        """Applies symmetry operation to a box along specified axis.
+
+        If the box touches the symmetry plane, merges the box with its reflection.
+        Otherwise returns both the original and reflected box.
+
+        Parameters
+        ----------
+        box : Box
+            The box to apply symmetry to
+        axis : Axis
+            The axis along which to apply symmetry (0,1,2) -> (x,y,z)
+        position : float
+            Position of the symmetry plane along the axis
+
+        Returns
+        -------
+        list[Box]
+            List containing either merged box or original and reflected boxes
+        """
+        new_box = PathSpecGenerator._reflect_box(box, axis, position)
+        if isclose(new_box.bounds[0][axis], box.bounds[1][axis]) or isclose(
+            new_box.bounds[1][axis], box.bounds[0][axis]
+        ):
+            new_size = list(box.size)
+            new_size[axis] = 2 * box.size[axis]
+            new_center = list(box.center)
+            new_center[axis] = position
+            new_box = Box(size=new_size, center=new_center)
+            return [new_box]
+        return [box, new_box]
+
+    @staticmethod
+    def _apply_symmetry(
+        symmetry: tuple[Symmetry, Symmetry, Symmetry],
+        sim_center: Coordinate,
+        normal_axis: Axis,
+        box: Box,
+    ) -> list[Box]:
+        """Applies multiple symmetry operations to a box.
+
+        Parameters
+        ----------
+        symmetry : tuple[Symmetry, Symmetry, Symmetry]
+            Symmetry conditions for each axis
+        sim_center : Coordinate
+            Center coordinates where symmetry planes intersect
+        normal_axis : Axis
+            Axis normal to the plane of interest
+        box : Box
+            The box to apply symmetries to
+
+        Returns
+        -------
+        list[Box]
+            List of boxes after applying all symmetry operations
+        """
+        symmetry = list(symmetry)
+        dims = [0, 1, 2]
+        symmetry.pop(normal_axis)
+        dims.pop(normal_axis)
+        result = [box]
+        for dim, sym in zip(dims, symmetry):
+            if sym != 0:
+                tmp_list = [
+                    PathSpecGenerator._apply_symmetry_to_box(box, dim, sim_center[dim])
+                    for box in result
+                ]
+                result = list(chain.from_iterable(tmp_list))
+        return result

--- a/tidy3d/components/microwave/path_integrals/path_spec_generator.py
+++ b/tidy3d/components/microwave/path_integrals/path_spec_generator.py
@@ -31,7 +31,7 @@ from tidy3d.exceptions import ValidationError
 
 from .current_spec import CompositeCurrentIntegralSpec, CurrentIntegralAxisAlignedSpec
 
-ConductorType = Union[PECMedium, LossyMetalMedium]
+ConductorTypes = Union[PECMedium, LossyMetalMedium]
 
 
 class PathSpecGenerator(Tidy3dBaseModel):
@@ -124,7 +124,8 @@ class PathSpecGenerator(Tidy3dBaseModel):
         """
 
         def is_conductor(med: Medium) -> bool:
-            return med.is_pec or isinstance(med, ConductorType)
+            union_types = get_args(ConductorTypes)
+            return med.is_pec or isinstance(med, union_types)
 
         geometry_list = [structure.geometry for structure in structures]
         # For metal, we don't distinguish between LossyMetal and PEC,
@@ -230,7 +231,7 @@ class PathSpecGenerator(Tidy3dBaseModel):
         )
 
         if len(conductor_polygons) < 1:
-            expected_types = ", ".join(t.__name__ for t in get_args(ConductorType))
+            expected_types = ", ".join(t.__name__ for t in get_args(ConductorTypes))
             raise ValidationError(
                 "No valid isolated conductors were found in the mode plane. Please ensure that a 'Structure' "
                 f"with a medium of type {expected_types} intersects the mode plane and is not touching "

--- a/tidy3d/components/microwave/path_integrals/types.py
+++ b/tidy3d/components/microwave/path_integrals/types.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Union
+
+from tidy3d.components.microwave.path_integrals.current_spec import (
+    CompositeCurrentIntegralSpec,
+    CurrentIntegralAxisAlignedSpec,
+    CustomCurrentIntegral2DSpec,
+)
+from tidy3d.components.microwave.path_integrals.voltage_spec import (
+    CustomVoltageIntegral2DSpec,
+    VoltageIntegralAxisAlignedSpec,
+)
+
+VoltagePathSpecTypes = Union[VoltageIntegralAxisAlignedSpec, CustomVoltageIntegral2DSpec]
+CurrentPathSpecTypes = Union[
+    CurrentIntegralAxisAlignedSpec, CustomCurrentIntegral2DSpec, CompositeCurrentIntegralSpec
+]

--- a/tidy3d/components/microwave/path_integrals/viz.py
+++ b/tidy3d/components/microwave/path_integrals/viz.py
@@ -1,0 +1,56 @@
+"""Utilities for plotting microwave components"""
+
+from __future__ import annotations
+
+from numpy import inf
+
+from tidy3d.components.viz import PathPlotParams
+
+""" Constants """
+VOLTAGE_COLOR = "red"
+CURRENT_COLOR = "blue"
+PATH_LINEWIDTH = 2
+ARROW_CURRENT = {
+    "arrowstyle": "-|>",
+    "mutation_scale": 32,
+    "linestyle": "",
+    "lw": PATH_LINEWIDTH,
+    "color": CURRENT_COLOR,
+}
+
+plot_params_voltage_path = PathPlotParams(
+    alpha=1.0,
+    zorder=inf,
+    color=VOLTAGE_COLOR,
+    linestyle="--",
+    linewidth=PATH_LINEWIDTH,
+    marker="o",
+    markersize=10,
+    markeredgecolor=VOLTAGE_COLOR,
+    markerfacecolor="white",
+)
+
+plot_params_voltage_plus = PathPlotParams(
+    alpha=1.0,
+    zorder=inf,
+    color=VOLTAGE_COLOR,
+    marker="+",
+    markersize=6,
+)
+
+plot_params_voltage_minus = PathPlotParams(
+    alpha=1.0,
+    zorder=inf,
+    color=VOLTAGE_COLOR,
+    marker="_",
+    markersize=6,
+)
+
+plot_params_current_path = PathPlotParams(
+    alpha=1.0,
+    zorder=inf,
+    color=CURRENT_COLOR,
+    linestyle="--",
+    linewidth=PATH_LINEWIDTH,
+    marker="",
+)

--- a/tidy3d/components/microwave/path_integrals/voltage_spec.py
+++ b/tidy3d/components/microwave/path_integrals/voltage_spec.py
@@ -1,0 +1,204 @@
+"""Module containing specifications for voltage path integrals."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import pydantic.v1 as pd
+
+from tidy3d.components.geometry.base import Geometry
+from tidy3d.components.microwave.path_integrals.base_spec import (
+    AxisAlignedPathIntegralSpec,
+    CustomPathIntegral2DSpec,
+)
+from tidy3d.components.microwave.path_integrals.viz import (
+    plot_params_voltage_minus,
+    plot_params_voltage_path,
+    plot_params_voltage_plus,
+)
+from tidy3d.components.types import Ax
+from tidy3d.components.types.base import Direction
+from tidy3d.components.viz import add_ax_if_none
+from tidy3d.constants import fp_eps
+
+
+class VoltageIntegralAxisAlignedSpec(AxisAlignedPathIntegralSpec):
+    """Class for specifying the voltage calculation between two points defined by an axis-aligned line."""
+
+    sign: Direction = pd.Field(
+        ...,
+        title="Direction of Path Integral",
+        description="Positive indicates V=Vb-Va where position b has a larger coordinate along the axis of integration.",
+    )
+
+    @staticmethod
+    def from_terminal_positions(
+        plus_terminal: float,
+        minus_terminal: float,
+        x: Optional[float] = None,
+        y: Optional[float] = None,
+        z: Optional[float] = None,
+        extrapolate_to_endpoints: bool = True,
+        snap_path_to_grid: bool = True,
+    ) -> VoltageIntegralAxisAlignedSpec:
+        """Helper to create a :class:`VoltageIntegralAxisAlignedSpec` from two coordinates that
+        define a line and two positions indicating the endpoints of the path integral.
+
+        Parameters
+        ----------
+        plus_terminal : float
+            Position along the voltage axis of the positive terminal.
+        minus_terminal : float
+            Position along the voltage axis of the negative terminal.
+        x : float = None
+            Position in x direction, only two of x,y,z can be specified to define line.
+        y : float = None
+            Position in y direction, only two of x,y,z can be specified to define line.
+        z : float = None
+            Position in z direction, only two of x,y,z can be specified to define line.
+        extrapolate_to_endpoints: bool = True
+            Passed directly to :class:`VoltageIntegralAxisAlignedSpec`
+        snap_path_to_grid: bool = True
+            Passed directly to :class:`VoltageIntegralAxisAlignedSpec`
+
+        Returns
+        -------
+        VoltageIntegralAxisAlignedSpec
+            The created path integral for computing voltage between the two terminals.
+        """
+        axis_positions = Geometry.parse_two_xyz_kwargs(x=x, y=y, z=z)
+        # Calculate center and size of the future box
+        midpoint = (plus_terminal + minus_terminal) / 2
+        length = np.abs(plus_terminal - minus_terminal)
+        center = [midpoint, midpoint, midpoint]
+        size = [length, length, length]
+        for axis, position in axis_positions:
+            size[axis] = 0
+            center[axis] = position
+
+        direction = "+"
+        if plus_terminal < minus_terminal:
+            direction = "-"
+
+        return VoltageIntegralAxisAlignedSpec(
+            center=center,
+            size=size,
+            extrapolate_to_endpoints=extrapolate_to_endpoints,
+            snap_path_to_grid=snap_path_to_grid,
+            sign=direction,
+        )
+
+    @add_ax_if_none
+    def plot(
+        self,
+        x: Optional[float] = None,
+        y: Optional[float] = None,
+        z: Optional[float] = None,
+        ax: Ax = None,
+        **path_kwargs,
+    ) -> Ax:
+        """Plot path integral at single (x,y,z) coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            Position of plane in x direction, only one of x,y,z can be specified to define plane.
+        y : float = None
+            Position of plane in y direction, only one of x,y,z can be specified to define plane.
+        z : float = None
+            Position of plane in z direction, only one of x,y,z can be specified to define plane.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        **path_kwargs
+            Optional keyword arguments passed to the matplotlib plotting of the line.
+            For details on accepted values, refer to
+            `Matplotlib's documentation <https://tinyurl.com/36marrat>`_.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+        axis, position = self.parse_xyz_kwargs(x=x, y=y, z=z)
+        if axis == self.main_axis or not np.isclose(position, self.center[axis], rtol=fp_eps):
+            return ax
+
+        (xs, ys) = self._vertices_2D(axis)
+        # Plot the path
+        plot_params = plot_params_voltage_path.include_kwargs(**path_kwargs)
+        plot_kwargs = plot_params.to_kwargs()
+        ax.plot(xs, ys, markevery=[0, -1], **plot_kwargs)
+
+        # Plot special end points
+        end_kwargs = plot_params_voltage_plus.include_kwargs(**path_kwargs).to_kwargs()
+        start_kwargs = plot_params_voltage_minus.include_kwargs(**path_kwargs).to_kwargs()
+
+        if self.sign == "-":
+            start_kwargs, end_kwargs = end_kwargs, start_kwargs
+
+        ax.plot(xs[0], ys[0], **start_kwargs)
+        ax.plot(xs[1], ys[1], **end_kwargs)
+        return ax
+
+
+class CustomVoltageIntegral2DSpec(CustomPathIntegral2DSpec):
+    """Class for specfying the computation of voltage between two points defined by a custom path.
+    Computed voltage is :math:`V=V_b-V_a`, where position b is the final vertex in the supplied path.
+
+    Notes
+    -----
+
+    Use :class:`.VoltageIntegralAxisAlignedSpec` if possible, since interpolation
+    near conductors will not be accurate.
+
+    .. TODO Improve by including extrapolate_to_endpoints field, non-trivial extension."""
+
+    @add_ax_if_none
+    def plot(
+        self,
+        x: Optional[float] = None,
+        y: Optional[float] = None,
+        z: Optional[float] = None,
+        ax: Ax = None,
+        **path_kwargs,
+    ) -> Ax:
+        """Plot path integral at single (x,y,z) coordinate.
+
+        Parameters
+        ----------
+        x : float = None
+            Position of plane in x direction, only one of x,y,z can be specified to define plane.
+        y : float = None
+            Position of plane in y direction, only one of x,y,z can be specified to define plane.
+        z : float = None
+            Position of plane in z direction, only one of x,y,z can be specified to define plane.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        **path_kwargs
+            Optional keyword arguments passed to the matplotlib plotting of the line.
+            For details on accepted values, refer to
+            `Matplotlib's documentation <https://tinyurl.com/36marrat>`_.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+        axis, position = Geometry.parse_xyz_kwargs(x=x, y=y, z=z)
+        if axis != self.main_axis or not np.isclose(position, self.position, rtol=fp_eps):
+            return ax
+
+        plot_params = plot_params_voltage_path.include_kwargs(**path_kwargs)
+        plot_kwargs = plot_params.to_kwargs()
+        xs = self.vertices[:, 0]
+        ys = self.vertices[:, 1]
+        ax.plot(xs, ys, markevery=[0, -1], **plot_kwargs)
+
+        # Plot special end points
+        end_kwargs = plot_params_voltage_plus.include_kwargs(**path_kwargs).to_kwargs()
+        start_kwargs = plot_params_voltage_minus.include_kwargs(**path_kwargs).to_kwargs()
+        ax.plot(xs[0], ys[0], **start_kwargs)
+        ax.plot(xs[-1], ys[-1], **end_kwargs)
+
+        return ax

--- a/tidy3d/components/microwave/path_integrals/voltage_spec.py
+++ b/tidy3d/components/microwave/path_integrals/voltage_spec.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import numpy as np
 import pydantic.v1 as pd
+from typing_extensions import Self
 
 from tidy3d.components.geometry.base import Geometry
 from tidy3d.components.microwave.path_integrals.base_spec import (
@@ -32,8 +33,9 @@ class VoltageIntegralAxisAlignedSpec(AxisAlignedPathIntegralSpec):
         description="Positive indicates V=Vb-Va where position b has a larger coordinate along the axis of integration.",
     )
 
-    @staticmethod
+    @classmethod
     def from_terminal_positions(
+        cls,
         plus_terminal: float,
         minus_terminal: float,
         x: Optional[float] = None,
@@ -41,7 +43,7 @@ class VoltageIntegralAxisAlignedSpec(AxisAlignedPathIntegralSpec):
         z: Optional[float] = None,
         extrapolate_to_endpoints: bool = True,
         snap_path_to_grid: bool = True,
-    ) -> VoltageIntegralAxisAlignedSpec:
+    ) -> Self:
         """Helper to create a :class:`VoltageIntegralAxisAlignedSpec` from two coordinates that
         define a line and two positions indicating the endpoints of the path integral.
 
@@ -81,7 +83,7 @@ class VoltageIntegralAxisAlignedSpec(AxisAlignedPathIntegralSpec):
         if plus_terminal < minus_terminal:
             direction = "-"
 
-        return VoltageIntegralAxisAlignedSpec(
+        return cls(
             center=center,
             size=size,
             extrapolate_to_endpoints=extrapolate_to_endpoints,

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -19,6 +19,9 @@ from tidy3d.components.data.data_array import (
     ModeIndexDataArray,
     ScalarModeFieldCylindricalDataArray,
     ScalarModeFieldDataArray,
+    _make_current_data_array,
+    _make_impedance_data_array,
+    _make_voltage_data_array,
 )
 from tidy3d.components.data.monitor_data import ModeSolverData
 from tidy3d.components.data.sim_data import SimulationData
@@ -31,6 +34,7 @@ from tidy3d.components.medium import (
     IsotropicUniformMediumType,
     LossyMetalMedium,
 )
+from tidy3d.components.microwave.path_integrals.path_integral_factory import make_path_integrals
 from tidy3d.components.mode_spec import ModeSpec
 from tidy3d.components.monitor import ModeMonitor, ModeSolverMonitor
 from tidy3d.components.scene import Scene
@@ -64,6 +68,7 @@ from tidy3d.constants import C_0
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
 from tidy3d.packaging import supports_local_subpixel, tidy3d_extras
+from tidy3d.plugins.microwave.impedance_calculator import ImpedanceCalculator
 
 # Importing the local solver may not work if e.g. scipy is not installed
 IMPORT_ERROR_MSG = """Could not import local solver, 'ModeSolver' objects can still be constructed
@@ -533,6 +538,9 @@ class ModeSolver(Tidy3dBaseModel):
         self._field_decay_warning(mode_solver_data.symmetry_expanded)
 
         mode_solver_data = self._filter_components(mode_solver_data)
+        # Calculate and add the characteristic impedance
+        if self.mode_spec.microwave_mode_spec is not None:
+            mode_solver_data = self._add_microwave_data(mode_solver_data)
         return mode_solver_data
 
     @cached_property
@@ -1357,6 +1365,42 @@ class ModeSolver(Tidy3dBaseModel):
             ]:
                 data.values[..., ifreq, :] = data.values[..., ifreq, sort_inds]
 
+    def _add_microwave_data(self, mode_solver_data: ModeSolverData) -> ModeSolverData:
+        """Calculate and add microwave data to ``mode_solver_data`` which uses the path specifications.
+        If they were not supplied by the user, then create a specification automatically.
+        """
+        voltage_integrals, current_integrals = make_path_integrals(
+            self.mode_spec.microwave_mode_spec,
+            self.to_monitor(name=MODE_MONITOR_NAME),
+            self.simulation,
+        )
+        # Need to operate on the full symmetry expanded fields
+        mode_solver_data_expanded = mode_solver_data.symmetry_expanded_copy
+        Z0_list = []
+        V_list = []
+        I_list = []
+        for mode_index in range(self.mode_spec.num_modes):
+            impedance_calc = ImpedanceCalculator(
+                voltage_integral=voltage_integrals[mode_index],
+                current_integral=current_integrals[mode_index],
+            )
+            single_mode_data = mode_solver_data_expanded._isel(mode_index=[mode_index])
+            Z0, voltage, current = impedance_calc.compute_impedance(
+                single_mode_data, return_voltage_and_current=True
+            )
+            Z0_list.append(Z0)
+            V_list.append(voltage)
+            I_list.append(current)
+        all_mode_Z0 = xr.concat(Z0_list, dim="mode_index")
+        all_mode_Z0 = _make_impedance_data_array(all_mode_Z0)
+        all_mode_V = xr.concat(V_list, dim="mode_index")
+        all_mode_V = _make_voltage_data_array(all_mode_V)
+        all_mode_I = xr.concat(I_list, dim="mode_index")
+        all_mode_I = _make_current_data_array(all_mode_I)
+        return mode_solver_data.updated_copy(
+            Z0=all_mode_Z0, voltage_coeffs=all_mode_V, current_coeffs=all_mode_I
+        )
+
     @cached_property
     def data(self) -> ModeSolverData:
         """:class:`.ModeSolverData` containing the field and effective index data.
@@ -1955,6 +1999,7 @@ class ModeSolver(Tidy3dBaseModel):
             size=self.plane.size,
             freqs=freqs,
             mode_spec=self.mode_spec,
+            colocate=self.colocate,
             conjugated_dot_product=self.conjugated_dot_product,
             name=name,
         )

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -1373,7 +1373,7 @@ class ModeSolver(Tidy3dBaseModel):
         if self.mode_spec.microwave_mode_spec is None:
             return mode_solver_data
         voltage_integrals, current_integrals = make_path_integrals(
-            self.mode_spec.microwave_mode_spec.impedance_spec,
+            self.mode_spec.microwave_mode_spec,
             self.to_monitor(name=MODE_MONITOR_NAME),
             self.simulation,
         )
@@ -1386,21 +1386,18 @@ class ModeSolver(Tidy3dBaseModel):
             vi = voltage_integrals[mode_index]
             ci = current_integrals[mode_index]
             if vi is None and ci is None:
-                Z0_list.append(None)
-                V_list.append(None)
-                I_list.append(None)
-            else:
-                impedance_calc = ImpedanceCalculator(
-                    voltage_integral=voltage_integrals[mode_index],
-                    current_integral=current_integrals[mode_index],
-                )
-                single_mode_data = mode_solver_data_expanded._isel(mode_index=[mode_index])
-                Z0, voltage, current = impedance_calc.compute_impedance(
-                    single_mode_data, return_voltage_and_current=True
-                )
-                Z0_list.append(Z0)
-                V_list.append(voltage)
-                I_list.append(current)
+                continue
+            impedance_calc = ImpedanceCalculator(
+                voltage_integral=voltage_integrals[mode_index],
+                current_integral=current_integrals[mode_index],
+            )
+            single_mode_data = mode_solver_data_expanded._isel(mode_index=[mode_index])
+            Z0, voltage, current = impedance_calc.compute_impedance(
+                single_mode_data, return_voltage_and_current=True
+            )
+            Z0_list.append(Z0)
+            V_list.append(voltage)
+            I_list.append(current)
         all_mode_Z0 = xr.concat(Z0_list, dim="mode_index")
         all_mode_Z0 = _make_impedance_data_array(all_mode_Z0)
         all_mode_V = xr.concat(V_list, dim="mode_index")

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -34,6 +34,7 @@ from tidy3d.components.medium import (
     IsotropicUniformMediumType,
     LossyMetalMedium,
 )
+from tidy3d.components.microwave.data.dataset import MicrowaveModeDataset
 from tidy3d.components.microwave.path_integrals.path_integral_factory import make_path_integrals
 from tidy3d.components.mode_spec import ModeSpec
 from tidy3d.components.monitor import ModeMonitor, ModeSolverMonitor
@@ -1369,8 +1370,10 @@ class ModeSolver(Tidy3dBaseModel):
         """Calculate and add microwave data to ``mode_solver_data`` which uses the path specifications.
         If they were not supplied by the user, then create a specification automatically.
         """
+        if self.mode_spec.microwave_mode_spec.impedance_spec is None:
+            return mode_solver_data
         voltage_integrals, current_integrals = make_path_integrals(
-            self.mode_spec.microwave_mode_spec,
+            self.mode_spec.microwave_mode_spec.impedance_spec,
             self.to_monitor(name=MODE_MONITOR_NAME),
             self.simulation,
         )
@@ -1380,26 +1383,34 @@ class ModeSolver(Tidy3dBaseModel):
         V_list = []
         I_list = []
         for mode_index in range(self.mode_spec.num_modes):
-            impedance_calc = ImpedanceCalculator(
-                voltage_integral=voltage_integrals[mode_index],
-                current_integral=current_integrals[mode_index],
-            )
-            single_mode_data = mode_solver_data_expanded._isel(mode_index=[mode_index])
-            Z0, voltage, current = impedance_calc.compute_impedance(
-                single_mode_data, return_voltage_and_current=True
-            )
-            Z0_list.append(Z0)
-            V_list.append(voltage)
-            I_list.append(current)
+            vi = voltage_integrals[mode_index]
+            ci = current_integrals[mode_index]
+            if vi is None and ci is None:
+                Z0_list.append(None)
+                V_list.append(None)
+                I_list.append(None)
+            else:
+                impedance_calc = ImpedanceCalculator(
+                    voltage_integral=voltage_integrals[mode_index],
+                    current_integral=current_integrals[mode_index],
+                )
+                single_mode_data = mode_solver_data_expanded._isel(mode_index=[mode_index])
+                Z0, voltage, current = impedance_calc.compute_impedance(
+                    single_mode_data, return_voltage_and_current=True
+                )
+                Z0_list.append(Z0)
+                V_list.append(voltage)
+                I_list.append(current)
         all_mode_Z0 = xr.concat(Z0_list, dim="mode_index")
         all_mode_Z0 = _make_impedance_data_array(all_mode_Z0)
         all_mode_V = xr.concat(V_list, dim="mode_index")
         all_mode_V = _make_voltage_data_array(all_mode_V)
         all_mode_I = xr.concat(I_list, dim="mode_index")
         all_mode_I = _make_current_data_array(all_mode_I)
-        return mode_solver_data.updated_copy(
+        mw_data = MicrowaveModeDataset(
             Z0=all_mode_Z0, voltage_coeffs=all_mode_V, current_coeffs=all_mode_I
         )
+        return mode_solver_data.updated_copy(microwave_data=mw_data)
 
     @cached_property
     def data(self) -> ModeSolverData:

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -1370,7 +1370,7 @@ class ModeSolver(Tidy3dBaseModel):
         """Calculate and add microwave data to ``mode_solver_data`` which uses the path specifications.
         If they were not supplied by the user, then create a specification automatically.
         """
-        if self.mode_spec.microwave_mode_spec.impedance_spec is None:
+        if self.mode_spec.microwave_mode_spec is None:
             return mode_solver_data
         voltage_integrals, current_integrals = make_path_integrals(
             self.mode_spec.microwave_mode_spec.impedance_spec,

--- a/tidy3d/components/mode_spec.py
+++ b/tidy3d/components/mode_spec.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from math import isclose
-from typing import Literal, Union
+from typing import Literal, Optional, Union
 
 import numpy as np
 import pydantic.v1 as pd
@@ -13,6 +13,7 @@ from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
 
 from .base import Tidy3dBaseModel, skip_if_fields_missing
+from .microwave.microwave_mode_spec import MicrowaveModeSpec
 from .types import Axis2D, TrackFreq
 
 GROUP_INDEX_STEP = 0.005
@@ -20,7 +21,7 @@ GROUP_INDEX_STEP = 0.005
 
 class ModeSpec(Tidy3dBaseModel):
     """
-    Stores specifications for the mode solver to find an electromagntic mode.
+    Stores specifications for the mode solver to find an electromagnetic mode.
 
     Notes
     -----
@@ -163,6 +164,14 @@ class ModeSpec(Tidy3dBaseModel):
         f"default of {GROUP_INDEX_STEP} is used.",
     )
 
+    microwave_mode_spec: Optional[MicrowaveModeSpec] = pd.Field(
+        None,
+        title="Microwave Mode Specification",
+        description="Additional specification for microwave specific mode properties. For example, "
+        "it is used for setting up the computation for the characteristic impedance of a transmission "
+        "line mode.",
+    )
+
     @pd.validator("bend_axis", always=True)
     @skip_if_fields_missing(["bend_radius"])
     def bend_axis_given(cls, val, values):
@@ -233,5 +242,34 @@ class ModeSpec(Tidy3dBaseModel):
             raise ValidationError(
                 "Parameter 'angle_phi' must be a multiple of 'np.pi / 2' when 'angle_rotation' is "
                 "enabled."
+            )
+        return val
+
+    @pd.validator("microwave_mode_spec")
+    def check_microwave_mode_spec_consistent(cls, val, values):
+        """Either the user has requested an automatic impedance calculation by leaving the path specifications empty
+        or the number of path specifications is equal to the number of modes.
+        """
+        if val is None:
+            return val
+        num_modes = values["num_modes"]
+        valid_number_voltage_specs = (
+            val.num_voltage_specs is None or val.num_voltage_specs == num_modes
+        )
+        valid_number_current_specs = (
+            val.num_current_specs is None or val.num_current_specs == num_modes
+        )
+
+        if not valid_number_voltage_specs:
+            raise SetupError(
+                f"Given {val.num_voltage_specs} voltage specifications, but the number of modes requested is {num_modes}. "
+                "Please either ensure that the number of voltage specifications is equal to the "
+                "number of modes or leave this field as 'None' in the 'MicrowaveModeSpec'."
+            )
+        if not valid_number_current_specs:
+            raise SetupError(
+                f"Given {val.num_current_specs} current specifications, but the number of modes requested is {num_modes}. "
+                "Please either ensure that the number of voltage specifications is equal to the "
+                "number of modes or leave this field as 'None' in the 'MicrowaveModeSpec'."
             )
         return val

--- a/tidy3d/components/mode_spec.py
+++ b/tidy3d/components/mode_spec.py
@@ -13,7 +13,7 @@ from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
 
 from .base import Tidy3dBaseModel, skip_if_fields_missing
-from .microwave.microwave_mode_spec import CustomImpedanceSpec, MicrowaveModeSpec
+from .microwave.microwave_mode_spec import MicrowaveModeSpec
 from .types import Axis2D, TrackFreq
 
 GROUP_INDEX_STEP = 0.005
@@ -247,34 +247,19 @@ class ModeSpec(Tidy3dBaseModel):
 
     @pd.validator("microwave_mode_spec")
     def check_microwave_mode_spec_consistent(cls, val, values):
-        """Either the user has requested an automatic impedance calculation by leaving the path specifications empty
-        or the number of path specifications is equal to the number of modes.
-        """
+        """Check that the number of impedance specifications is equal to the number of modes."""
         if val is None:
             return val
 
-        if isinstance(val, CustomImpedanceSpec):
-            impedance_spec = val.impedance_spec
-            num_modes = values["num_modes"]
-            valid_number_voltage_specs = (
-                impedance_spec.num_voltage_specs is None
-                or impedance_spec.num_voltage_specs == num_modes
-            )
-            valid_number_current_specs = (
-                impedance_spec.num_current_specs is None
-                or impedance_spec.num_current_specs == num_modes
+        num_modes = values["num_modes"]
+        valid_number_impedance_specs = val.num_impedance_specs == num_modes
+
+        if not valid_number_impedance_specs:
+            raise SetupError(
+                f"Given {val.num_impedance_specs} impedance specifications in the 'MicrowaveModeSpec, "
+                f"but the number of modes requested is {num_modes}. Please either ensure that the "
+                "number of impedance specifications is equal to the number of modes or leave the "
+                "'MicrowaveModeSpec' field as 'None', if impedances are not needed."
             )
 
-            if not valid_number_voltage_specs:
-                raise SetupError(
-                    f"Given {impedance_spec.num_voltage_specs} voltage specifications, but the number of modes requested is {num_modes}. "
-                    "Please either ensure that the number of voltage specifications is equal to the "
-                    "number of modes or leave this field as 'None' in the 'MicrowaveModeSpec'."
-                )
-            if not valid_number_current_specs:
-                raise SetupError(
-                    f"Given {impedance_spec.num_current_specs} current specifications, but the number of modes requested is {num_modes}. "
-                    "Please either ensure that the number of voltage specifications is equal to the "
-                    "number of modes or leave this field as 'None' in the 'MicrowaveModeSpec'."
-                )
         return val

--- a/tidy3d/components/mode_spec.py
+++ b/tidy3d/components/mode_spec.py
@@ -13,7 +13,7 @@ from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
 
 from .base import Tidy3dBaseModel, skip_if_fields_missing
-from .microwave.microwave_mode_spec import MicrowaveModeSpec
+from .microwave.microwave_mode_spec import CustomImpedanceSpec, MicrowaveModeSpec
 from .types import Axis2D, TrackFreq
 
 GROUP_INDEX_STEP = 0.005
@@ -252,24 +252,29 @@ class ModeSpec(Tidy3dBaseModel):
         """
         if val is None:
             return val
-        num_modes = values["num_modes"]
-        valid_number_voltage_specs = (
-            val.num_voltage_specs is None or val.num_voltage_specs == num_modes
-        )
-        valid_number_current_specs = (
-            val.num_current_specs is None or val.num_current_specs == num_modes
-        )
 
-        if not valid_number_voltage_specs:
-            raise SetupError(
-                f"Given {val.num_voltage_specs} voltage specifications, but the number of modes requested is {num_modes}. "
-                "Please either ensure that the number of voltage specifications is equal to the "
-                "number of modes or leave this field as 'None' in the 'MicrowaveModeSpec'."
+        if isinstance(val, CustomImpedanceSpec):
+            impedance_spec = val.impedance_spec
+            num_modes = values["num_modes"]
+            valid_number_voltage_specs = (
+                impedance_spec.num_voltage_specs is None
+                or impedance_spec.num_voltage_specs == num_modes
             )
-        if not valid_number_current_specs:
-            raise SetupError(
-                f"Given {val.num_current_specs} current specifications, but the number of modes requested is {num_modes}. "
-                "Please either ensure that the number of voltage specifications is equal to the "
-                "number of modes or leave this field as 'None' in the 'MicrowaveModeSpec'."
+            valid_number_current_specs = (
+                impedance_spec.num_current_specs is None
+                or impedance_spec.num_current_specs == num_modes
             )
+
+            if not valid_number_voltage_specs:
+                raise SetupError(
+                    f"Given {impedance_spec.num_voltage_specs} voltage specifications, but the number of modes requested is {num_modes}. "
+                    "Please either ensure that the number of voltage specifications is equal to the "
+                    "number of modes or leave this field as 'None' in the 'MicrowaveModeSpec'."
+                )
+            if not valid_number_current_specs:
+                raise SetupError(
+                    f"Given {impedance_spec.num_current_specs} current specifications, but the number of modes requested is {num_modes}. "
+                    "Please either ensure that the number of voltage specifications is equal to the "
+                    "number of modes or leave this field as 'None' in the 'MicrowaveModeSpec'."
+                )
         return val

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -4525,7 +4525,7 @@ class Simulation(AbstractYeeGridSimulation):
                 continue
             mw_mode_spec = monitor.mode_spec.microwave_mode_spec
             if mw_mode_spec is not None:
-                _ = make_path_integrals(mw_mode_spec, monitor, self)
+                _ = make_path_integrals(mw_mode_spec.impedance_spec, monitor, self)
 
     @cached_property
     def monitors_data_size(self) -> dict[str, float]:

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -4525,7 +4525,7 @@ class Simulation(AbstractYeeGridSimulation):
                 continue
             mw_mode_spec = monitor.mode_spec.microwave_mode_spec
             if mw_mode_spec is not None:
-                _ = make_path_integrals(mw_mode_spec.impedance_spec, monitor, self)
+                _ = make_path_integrals(mw_mode_spec, monitor, self)
 
     @cached_property
     def monitors_data_size(self) -> dict[str, float]:

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -4327,7 +4327,9 @@ class Simulation(AbstractYeeGridSimulation):
         self._warn_time_monitors_outside_run_time()
         self._validate_time_monitors_num_steps()
         self._validate_freq_monitors_freq_range()
+        self._validate_microwave_mode_specs()
         self._validate_finalized()
+
         log.end_capture(self)
         if source_required and len(self.sources) == 0:
             raise SetupError("No sources in simulation.")
@@ -4513,6 +4515,17 @@ class Simulation(AbstractYeeGridSimulation):
                     f"outside of the simulation frequency range ({sci_fmin}, {sci_fmax})"
                     "(Hz) as defined by the sources."
                 )
+
+    def _validate_microwave_mode_specs(self) -> None:
+        """Raise error if any microwave mode specifications fail to instantiate path integrals."""
+        from .microwave.path_integrals.path_integral_factory import make_path_integrals
+
+        for monitor in self.monitors:
+            if not isinstance(monitor, AbstractModeMonitor):
+                continue
+            mw_mode_spec = monitor.mode_spec.microwave_mode_spec
+            if mw_mode_spec is not None:
+                _ = make_path_integrals(mw_mode_spec, monitor, self)
 
     @cached_property
     def monitors_data_size(self) -> dict[str, float]:

--- a/tidy3d/plugins/microwave/__init__.py
+++ b/tidy3d/plugins/microwave/__init__.py
@@ -17,6 +17,7 @@ from .array_factor import (
 )
 from .auto_path_integrals import path_integrals_from_lumped_element
 from .custom_path_integrals import (
+    CompositeCurrentIntegral,
     CustomCurrentIntegral2D,
     CustomPathIntegral2D,
     CustomVoltageIntegral2D,
@@ -35,6 +36,7 @@ __all__ = [
     "BlackmanHarrisWindow",
     "BlackmanWindow",
     "ChebWindow",
+    "CompositeCurrentIntegral",
     "CurrentIntegralAxisAligned",
     "CurrentIntegralTypes",
     "CustomCurrentIntegral2D",

--- a/tidy3d/plugins/microwave/custom_path_integrals.py
+++ b/tidy3d/plugins/microwave/custom_path_integrals.py
@@ -9,14 +9,12 @@ import xarray as xr
 
 from tidy3d.components.data.data_array import FreqDataArray, FreqModeDataArray
 from tidy3d.components.data.monitor_data import FieldTimeData
-from tidy3d.components.geometry.base import Geometry
 from tidy3d.components.microwave.path_integrals.base_spec import CustomPathIntegral2DSpec
 from tidy3d.components.microwave.path_integrals.current_spec import (
     CompositeCurrentIntegralSpec,
     CustomCurrentIntegral2DSpec,
 )
 from tidy3d.components.microwave.path_integrals.voltage_spec import CustomVoltageIntegral2DSpec
-from tidy3d.components.types import Axis, Coordinate
 from tidy3d.exceptions import DataError
 from tidy3d.log import log
 
@@ -98,8 +96,8 @@ class CustomPathIntegral2D(CustomPathIntegral2DSpec):
         field2_interp = field2.interp(path_indexer, method="linear")
 
         # Determine the differential length elements along the path
-        dl_x = self._compute_dl_component(x_path, self.is_closed_contour)
-        dl_y = self._compute_dl_component(y_path, self.is_closed_contour)
+        dl_x = CustomPathIntegral2DSpec._compute_dl_component(x_path, self.is_closed_contour)
+        dl_y = CustomPathIntegral2DSpec._compute_dl_component(y_path, self.is_closed_contour)
         dl_x = xr.DataArray(dl_x, dims="s")
         dl_y = xr.DataArray(dl_y, dims="s")
 
@@ -109,69 +107,6 @@ class CustomPathIntegral2D(CustomPathIntegral2DSpec):
         result = integrand.integrate(coord="s")
         result = result.reset_coords(drop=True)
         return _make_base_result_data_array(result)
-
-    @staticmethod
-    def _compute_dl_component(coord_array: xr.DataArray, closed_contour=False) -> np.array:
-        """Computes the differential length element along the integration path."""
-        dl = np.gradient(coord_array)
-        if closed_contour:
-            # If the contour is closed, we can use central difference on the starting/end point
-            # which will be more accurate than the default forward/backward choice in np.gradient
-            grad_end = np.gradient([coord_array[-2], coord_array[0], coord_array[1]])
-            dl[0] = dl[-1] = grad_end[1]
-        return dl
-
-    @classmethod
-    def from_circular_path(
-        cls, center: Coordinate, radius: float, num_points: int, normal_axis: Axis, clockwise: bool
-    ) -> CustomPathIntegral2D:
-        """Creates a ``CustomPathIntegral2D`` from a circular path given a desired number of points
-        along the perimeter.
-
-        Parameters
-        ----------
-        center : Coordinate
-            The center of the circle.
-        radius : float
-            The radius of the circle.
-        num_points : int
-            THe number of equidistant points to use along the perimeter of the circle.
-        normal_axis : Axis
-            The axis normal to the defined circle.
-        clockwise : bool
-            When ``True``, the points will be ordered clockwise with respect to the positive
-            direction of the ``normal_axis``.
-
-        Returns
-        -------
-        :class:`.CustomPathIntegral2D`
-            A path integral defined on a circular path.
-        """
-
-        def generate_circle_coordinates(radius: float, num_points: int, clockwise: bool):
-            """Helper for generating x,y vertices around a circle in the local coordinate frame."""
-            sign = 1.0
-            if clockwise:
-                sign = -1.0
-            angles = np.linspace(0, sign * 2 * np.pi, num_points, endpoint=True)
-            xt = radius * np.cos(angles)
-            yt = radius * np.sin(angles)
-            return (xt, yt)
-
-        # Get transverse axes
-        normal_center, trans_center = Geometry.pop_axis(center, normal_axis)
-
-        # These x,y coordinates in the local coordinate frame
-        if normal_axis == 1:
-            # Handle special case when y is the axis that is popped
-            clockwise = not clockwise
-        xt, yt = generate_circle_coordinates(radius, num_points, clockwise)
-        xt += trans_center[0]
-        yt += trans_center[1]
-        circle_vertices = np.column_stack((xt, yt))
-        # Close the contour exactly
-        circle_vertices[-1, :] = circle_vertices[0, :]
-        return cls(axis=normal_axis, position=normal_center, vertices=circle_vertices)
 
 
 class CustomVoltageIntegral2D(CustomPathIntegral2D, CustomVoltageIntegral2DSpec):

--- a/tidy3d/plugins/microwave/custom_path_integrals.py
+++ b/tidy3d/plugins/microwave/custom_path_integrals.py
@@ -2,22 +2,25 @@
 
 from __future__ import annotations
 
-from typing import Literal, Optional
+from typing import Literal, Union
 
 import numpy as np
-import pydantic.v1 as pd
-import shapely
 import xarray as xr
 
-from tidy3d.components.base import cached_property
+from tidy3d.components.data.data_array import FreqDataArray, FreqModeDataArray
+from tidy3d.components.data.monitor_data import FieldTimeData
 from tidy3d.components.geometry.base import Geometry
-from tidy3d.components.types import ArrayFloat2D, Ax, Axis, Bound, Coordinate, Direction
-from tidy3d.components.viz import add_ax_if_none
-from tidy3d.constants import MICROMETER, fp_eps
-from tidy3d.exceptions import SetupError
+from tidy3d.components.microwave.path_integrals.base_spec import CustomPathIntegral2DSpec
+from tidy3d.components.microwave.path_integrals.current_spec import (
+    CompositeCurrentIntegralSpec,
+    CustomCurrentIntegral2DSpec,
+)
+from tidy3d.components.microwave.path_integrals.voltage_spec import CustomVoltageIntegral2DSpec
+from tidy3d.components.types import Axis, Coordinate
+from tidy3d.exceptions import DataError
+from tidy3d.log import log
 
 from .path_integrals import (
-    AbstractAxesRH,
     AxisAlignedPathIntegral,
     CurrentIntegralResultTypes,
     IntegralResultTypes,
@@ -27,18 +30,11 @@ from .path_integrals import (
     _make_current_data_array,
     _make_voltage_data_array,
 )
-from .viz import (
-    ARROW_CURRENT,
-    plot_params_current_path,
-    plot_params_voltage_minus,
-    plot_params_voltage_path,
-    plot_params_voltage_plus,
-)
 
 FieldParameter = Literal["E", "H"]
 
 
-class CustomPathIntegral2D(AbstractAxesRH):
+class CustomPathIntegral2D(CustomPathIntegral2DSpec):
     """Class for defining a custom path integral defined as a curve on an axis-aligned plane.
 
     Notes
@@ -51,27 +47,6 @@ class CustomPathIntegral2D(AbstractAxesRH):
     :math:`\\vec{dl}_i = \\frac{\\vec{r}_{i+1} - \\vec{r}_{i-1}}{2}`.
     If the path is not closed, forward and backward differences are used at the endpoints.
     """
-
-    axis: Axis = pd.Field(
-        2, title="Axis", description="Specifies dimension of the planar axis (0,1,2) -> (x,y,z)."
-    )
-
-    position: float = pd.Field(
-        ...,
-        title="Position",
-        description="Position of the plane along the ``axis``.",
-    )
-
-    vertices: ArrayFloat2D = pd.Field(
-        ...,
-        title="Vertices",
-        description="List of (d1, d2) defining the 2 dimensional positions of the path. "
-        "The index of dimension should be in the ascending order, which means "
-        "if the axis corresponds with ``y``, the coordinates of the vertices should be (x, z). "
-        "If you wish to indicate a closed contour, the final vertex should be made "
-        "equal to the first vertex, i.e., ``vertices[-1] == vertices[0]``",
-        units=MICROMETER,
-    )
 
     def compute_integral(
         self, field: FieldParameter, em_field: MonitorDataTypes
@@ -198,43 +173,8 @@ class CustomPathIntegral2D(AbstractAxesRH):
         circle_vertices[-1, :] = circle_vertices[0, :]
         return cls(axis=normal_axis, position=normal_center, vertices=circle_vertices)
 
-    @cached_property
-    def is_closed_contour(self) -> bool:
-        """Returns ``true`` when the first vertex equals the last vertex."""
-        return np.isclose(
-            self.vertices[0, :],
-            self.vertices[-1, :],
-            rtol=fp_eps,
-            atol=np.finfo(np.float32).smallest_normal,
-        ).all()
 
-    @cached_property
-    def main_axis(self) -> Axis:
-        """Axis for performing integration."""
-        return self.axis
-
-    @pd.validator("vertices", always=True)
-    def _correct_shape(cls, val):
-        """Makes sure vertices size is correct."""
-        # overall shape of vertices
-        if val.shape[1] != 2:
-            raise SetupError(
-                "'CustomPathIntegral2D.vertices' must be a 2 dimensional array shaped (N, 2). "
-                f"Given array with shape of '{val.shape}'."
-            )
-        return val
-
-    @cached_property
-    def bounds(self) -> Bound:
-        """Helper to get the geometric bounding box of the path integral."""
-        path_min = np.amin(self.vertices, axis=0)
-        path_max = np.amax(self.vertices, axis=0)
-        min_bound = Geometry.unpop_axis(self.position, path_min, self.axis)
-        max_bound = Geometry.unpop_axis(self.position, path_max, self.axis)
-        return (min_bound, max_bound)
-
-
-class CustomVoltageIntegral2D(CustomPathIntegral2D):
+class CustomVoltageIntegral2D(CustomPathIntegral2D, CustomVoltageIntegral2DSpec):
     """Class for computing the voltage between two points defined by a custom path.
     Computed voltage is :math:`V=V_b-V_a`, where position b is the final vertex in the supplied path.
 
@@ -264,57 +204,8 @@ class CustomVoltageIntegral2D(CustomPathIntegral2D):
         voltage = -1.0 * self.compute_integral(field="E", em_field=em_field)
         return _make_voltage_data_array(voltage)
 
-    @add_ax_if_none
-    def plot(
-        self,
-        x: Optional[float] = None,
-        y: Optional[float] = None,
-        z: Optional[float] = None,
-        ax: Ax = None,
-        **path_kwargs,
-    ) -> Ax:
-        """Plot path integral at single (x,y,z) coordinate.
 
-        Parameters
-        ----------
-        x : float = None
-            Position of plane in x direction, only one of x,y,z can be specified to define plane.
-        y : float = None
-            Position of plane in y direction, only one of x,y,z can be specified to define plane.
-        z : float = None
-            Position of plane in z direction, only one of x,y,z can be specified to define plane.
-        ax : matplotlib.axes._subplots.Axes = None
-            Matplotlib axes to plot on, if not specified, one is created.
-        **path_kwargs
-            Optional keyword arguments passed to the matplotlib plotting of the line.
-            For details on accepted values, refer to
-            `Matplotlib's documentation <https://tinyurl.com/36marrat>`_.
-
-        Returns
-        -------
-        matplotlib.axes._subplots.Axes
-            The supplied or created matplotlib axes.
-        """
-        axis, position = Geometry.parse_xyz_kwargs(x=x, y=y, z=z)
-        if axis != self.main_axis or not np.isclose(position, self.position, rtol=fp_eps):
-            return ax
-
-        plot_params = plot_params_voltage_path.include_kwargs(**path_kwargs)
-        plot_kwargs = plot_params.to_kwargs()
-        xs = self.vertices[:, 0]
-        ys = self.vertices[:, 1]
-        ax.plot(xs, ys, markevery=[0, -1], **plot_kwargs)
-
-        # Plot special end points
-        end_kwargs = plot_params_voltage_plus.include_kwargs(**path_kwargs).to_kwargs()
-        start_kwargs = plot_params_voltage_minus.include_kwargs(**path_kwargs).to_kwargs()
-        ax.plot(xs[0], ys[0], **start_kwargs)
-        ax.plot(xs[-1], ys[-1], **end_kwargs)
-
-        return ax
-
-
-class CustomCurrentIntegral2D(CustomPathIntegral2D):
+class CustomCurrentIntegral2D(CustomPathIntegral2D, CustomCurrentIntegral2DSpec):
     """Class for computing conduction current via Ampère's circuital law on a custom path.
     To compute the current flowing in the positive ``axis`` direction, the vertices should be
     ordered in a counterclockwise direction."""
@@ -337,64 +228,170 @@ class CustomCurrentIntegral2D(CustomPathIntegral2D):
         current = self.compute_integral(field="H", em_field=em_field)
         return _make_current_data_array(current)
 
-    @add_ax_if_none
-    def plot(
-        self,
-        x: Optional[float] = None,
-        y: Optional[float] = None,
-        z: Optional[float] = None,
-        ax: Ax = None,
-        **path_kwargs,
-    ) -> Ax:
-        """Plot path integral at single (x,y,z) coordinate.
 
-        Parameters
-        ----------
-        x : float = None
-            Position of plane in x direction, only one of x,y,z can be specified to define plane.
-        y : float = None
-            Position of plane in y direction, only one of x,y,z can be specified to define plane.
-        z : float = None
-            Position of plane in z direction, only one of x,y,z can be specified to define plane.
-        ax : matplotlib.axes._subplots.Axes = None
-            Matplotlib axes to plot on, if not specified, one is created.
-        **path_kwargs
-            Optional keyword arguments passed to the matplotlib plotting of the line.
-            For details on accepted values, refer to
-            `Matplotlib's documentation <https://tinyurl.com/36marrat>`_.
+class CompositeCurrentIntegral(CompositeCurrentIntegralSpec):
+    """Current integral comprising one or more disjoint paths"""
 
-        Returns
-        -------
-        matplotlib.axes._subplots.Axes
-            The supplied or created matplotlib axes.
-        """
-        axis, position = Geometry.parse_xyz_kwargs(x=x, y=y, z=z)
-        if axis != self.main_axis or not np.isclose(position, self.position, rtol=fp_eps):
-            return ax
+    def compute_current(self, em_field: MonitorDataTypes) -> IntegralResultTypes:
+        """Compute current flowing in loop defined by the outer edge of a rectangle."""
+        if isinstance(em_field, FieldTimeData) and self.sum_spec == "split":
+            raise DataError(
+                "Only frequency domain field data is supported when using the 'split' sum_spec. "
+                "Either switch the sum_spec to 'sum' or supply frequency domain data."
+            )
 
-        plot_params = plot_params_current_path.include_kwargs(**path_kwargs)
-        plot_kwargs = plot_params.to_kwargs()
-        xs = self.vertices[:, 0]
-        ys = self.vertices[:, 1]
-        ax.plot(xs, ys, **plot_kwargs)
-
-        # Add arrow at start of contour
-        ax.annotate(
-            "",
-            xytext=(xs[0], ys[0]),
-            xy=(xs[1], ys[1]),
-            arrowprops=ARROW_CURRENT,
+        from tidy3d.components.microwave.path_integrals.path_integral_factory import (
+            make_current_integral,
         )
-        return ax
 
-    @cached_property
-    def sign(self) -> Direction:
-        """Uses the ordering of the vertices to determine the direction of the current flow."""
-        linestr = shapely.LineString(coordinates=self.vertices)
-        is_ccw = shapely.is_ccw(linestr)
-        # Invert statement when the vertices are given as (x, z)
-        if self.axis == 1:
-            is_ccw = not is_ccw
-        if is_ccw:
-            return "+"
-        return "-"
+        current_integrals = [make_current_integral(path_spec) for path_spec in self.path_specs]
+
+        # Calculate currents from each path integral and store in dataarray with path index dimension
+        path_currents = []
+        for path in current_integrals:
+            term = path.compute_current(em_field)
+            path_currents.append(term)
+
+        # Stack all path currents along a new 'path_index' dimension
+        path_currents_array = xr.concat(path_currents, dim="path_index")
+        path_currents_array = path_currents_array.assign_coords(
+            path_index=range(len(path_currents))
+        )
+
+        # Initialize output arrays with zeros
+        first_term = path_currents[0]
+        current_in_phase = xr.zeros_like(first_term)
+        current_out_phase = xr.zeros_like(first_term)
+
+        # Choose phase reference for each frequency using phase from current with largest magnitude
+        path_magnitudes = np.abs(path_currents_array)
+        max_magnitude_indices = path_magnitudes.argmax(dim="path_index")
+
+        # Get the phase reference for each frequency from the path resulting in the largest magnitude current
+        phase_reference = xr.zeros_like(first_term.angle)
+        for freq_idx in range(len(first_term.f.values)):
+            if hasattr(first_term, "mode_index"):
+                max_path_indices = max_magnitude_indices.isel(f=freq_idx).values
+                for mode_idx in range(len(first_term.mode_index.values)):
+                    max_path_idx = max_path_indices[mode_idx]
+                    phase_reference[freq_idx, mode_idx] = path_currents_array.isel(
+                        path_index=max_path_idx, f=freq_idx, mode_index=mode_idx
+                    ).angle.values
+            else:
+                max_path_idx = max_magnitude_indices.isel(f=freq_idx).values
+                phase_reference[freq_idx] = path_currents_array.isel(
+                    path_index=max_path_idx, f=freq_idx
+                ).angle.values
+
+        # Perform phase splitting into in and out of phase for each frequency separately
+        for term in path_currents:
+            if np.all(term.abs == 0):
+                continue
+
+            # Compare phase to reference for each frequency
+            phase_diff = term.angle - phase_reference
+            # Wrap phase difference to [-pi, pi]
+            phase_diff.values = np.mod(phase_diff.values + np.pi, 2 * np.pi) - np.pi
+
+            # Add to in-phase or out-of-phase current based on phase difference
+            is_in_phase = np.abs(phase_diff) <= np.pi / 2
+            current_in_phase += xr.where(is_in_phase, term, 0)
+            current_out_phase += xr.where(~is_in_phase, term, 0)
+
+        current_in_phase = _make_current_data_array(current_in_phase)
+        current_out_phase = _make_current_data_array(current_out_phase)
+
+        if self.sum_spec == "sum":
+            return current_in_phase + current_out_phase
+
+        # Check amplitude consistency across frequencies
+        self._check_phase_amplitude_consistency(current_in_phase, current_out_phase)
+
+        # For split mode, return the larger magnitude current
+        current = xr.where(
+            abs(current_in_phase) >= abs(current_out_phase), current_in_phase, current_out_phase
+        )
+        return _make_current_data_array(current)
+
+    def _check_phase_sign_consistency(
+        self,
+        phase_difference: Union[FreqDataArray, FreqModeDataArray],
+    ) -> bool:
+        """
+        Check that the provided current data has a consistent phase with respect to the reference
+        phase. A consistent phase allows for the automatic identification of currents flowing in
+        opposite directions. However, when the provided data does not correspond with a transmission
+        line mode, this consistent phase condition will likely fail, so we emit a warning here to
+        notify the user.
+        """
+
+        # Check phase consistency across frequencies
+        freq_axis = phase_difference.get_axis_num("f")
+        all_in_phase = np.all(abs(phase_difference) <= np.pi / 2, axis=freq_axis)
+        all_out_of_phase = np.all(abs(phase_difference) > np.pi / 2, axis=freq_axis)
+        consistent_phase = np.logical_or(all_in_phase, all_out_of_phase)
+
+        if not np.all(consistent_phase) and self.sum_spec == "split":
+            warning_msg = (
+                "Phase alignment of computed current is not consistent across frequencies. "
+                "The provided fields are not suitable for the 'split' method of computing current. "
+                "Please provide the current path specifications manually."
+            )
+
+            if isinstance(phase_difference, FreqModeDataArray):
+                inconsistent_modes = []
+                mode_indices = phase_difference.mode_index.values
+                for mode_idx in range(len(mode_indices)):
+                    if not consistent_phase[mode_idx]:
+                        inconsistent_modes.append(mode_idx)
+
+                warning_msg += (
+                    f" Modes with indices {inconsistent_modes} violated the phase consistency "
+                    "requirement."
+                )
+
+            log.warning(warning_msg)
+
+            return False
+        return True
+
+    def _check_phase_amplitude_consistency(
+        self,
+        current_in_phase: Union[FreqDataArray, FreqModeDataArray],
+        current_out_phase: Union[FreqDataArray, FreqModeDataArray],
+    ) -> bool:
+        """
+        Check that the summed in phase and out of phase components of current have a consistent relative amplitude.
+        A consistent amplitude across frequencies allows for the automatic identification of the total conduction
+        current flowing in the transmission line. If the amplitudes are not consistent, we emit a warning.
+        """
+
+        # For split mode, return the larger magnitude current
+        freq_axis = current_in_phase.get_axis_num("f")
+        in_all_larger = np.all(abs(current_in_phase) >= abs(current_out_phase), axis=freq_axis)
+        in_all_smaller = np.all(abs(current_in_phase) < abs(current_out_phase), axis=freq_axis)
+        consistent_max_current = np.logical_or(in_all_larger, in_all_smaller)
+        if not np.all(consistent_max_current) and self.sum_spec == "split":
+            warning_msg = (
+                "There is not a consistently larger current across frequencies between the in-phase "
+                "and out-of-phase components. The provided fields are not suitable for the "
+                "'split' method of computing current. Please provide the current path "
+                "specifications manually."
+            )
+
+            if isinstance(current_in_phase, FreqModeDataArray):
+                inconsistent_modes = []
+                mode_indices = current_in_phase.mode_index.values
+                for mode_idx in range(len(mode_indices)):
+                    if not consistent_max_current[mode_idx]:
+                        inconsistent_modes.append(int(mode_indices[mode_idx]))
+
+                warning_msg += (
+                    f" Modes with indices {inconsistent_modes} violated the amplitude consistency "
+                    "requirement."
+                )
+
+            log.warning(warning_msg)
+
+            return False
+        return True

--- a/tidy3d/plugins/microwave/impedance_calculator.py
+++ b/tidy3d/plugins/microwave/impedance_calculator.py
@@ -58,7 +58,7 @@ class ImpedanceCalculator(Tidy3dBaseModel):
         self, em_field: MonitorDataTypes, return_voltage_and_current=False
     ) -> Union[
         ImpedanceResultTypes,
-        tuple[VoltageIntegralResultTypes, CurrentIntegralResultTypes, ImpedanceResultTypes],
+        tuple[ImpedanceResultTypes, VoltageIntegralResultTypes, CurrentIntegralResultTypes],
     ]:
         """Compute impedance for the supplied ``em_field`` using ``voltage_integral`` and
         ``current_integral``. If only a single integral has been defined, impedance is

--- a/tidy3d/plugins/microwave/impedance_calculator.py
+++ b/tidy3d/plugins/microwave/impedance_calculator.py
@@ -8,13 +8,24 @@ import numpy as np
 import pydantic.v1 as pd
 
 from tidy3d.components.base import Tidy3dBaseModel
-from tidy3d.components.data.data_array import ImpedanceResultTypes, _make_impedance_data_array
+from tidy3d.components.data.data_array import (
+    CurrentIntegralResultTypes,
+    ImpedanceResultTypes,
+    VoltageIntegralResultTypes,
+    _make_current_data_array,
+    _make_impedance_data_array,
+    _make_voltage_data_array,
+)
 from tidy3d.components.data.monitor_data import FieldTimeData
 from tidy3d.components.monitor import ModeMonitor, ModeSolverMonitor
 from tidy3d.exceptions import ValidationError
 from tidy3d.log import log
 
-from .custom_path_integrals import CustomCurrentIntegral2D, CustomVoltageIntegral2D
+from .custom_path_integrals import (
+    CompositeCurrentIntegral,
+    CustomCurrentIntegral2D,
+    CustomVoltageIntegral2D,
+)
 from .path_integrals import (
     AxisAlignedPathIntegral,
     CurrentIntegralAxisAligned,
@@ -23,7 +34,9 @@ from .path_integrals import (
 )
 
 VoltageIntegralTypes = Union[VoltageIntegralAxisAligned, CustomVoltageIntegral2D]
-CurrentIntegralTypes = Union[CurrentIntegralAxisAligned, CustomCurrentIntegral2D]
+CurrentIntegralTypes = Union[
+    CurrentIntegralAxisAligned, CustomCurrentIntegral2D, CompositeCurrentIntegral
+]
 
 
 class ImpedanceCalculator(Tidy3dBaseModel):
@@ -41,7 +54,12 @@ class ImpedanceCalculator(Tidy3dBaseModel):
         description="Definition of contour integral for computing current.",
     )
 
-    def compute_impedance(self, em_field: MonitorDataTypes) -> ImpedanceResultTypes:
+    def compute_impedance(
+        self, em_field: MonitorDataTypes, return_voltage_and_current=False
+    ) -> Union[
+        ImpedanceResultTypes,
+        tuple[VoltageIntegralResultTypes, CurrentIntegralResultTypes, ImpedanceResultTypes],
+    ]:
         """Compute impedance for the supplied ``em_field`` using ``voltage_integral`` and
         ``current_integral``. If only a single integral has been defined, impedance is
         computed using the total flux in ``em_field``.
@@ -51,15 +69,22 @@ class ImpedanceCalculator(Tidy3dBaseModel):
         em_field : :class:`.MonitorDataTypes`
             The electromagnetic field data that will be used for computing the characteristic
             impedance.
+        return_voltage_and_current: bool
+            When ``True``, returns additional :class:`.IntegralResultTypes` that represent the voltage
+            and current associated with the supplied fields.
 
         Returns
         -------
-        :class:`.ImpedanceResultTypes`
-            Result of impedance computation over remaining dimensions (frequency, time, mode indices).
+        :class:`.IntegralResultTypes` or tuple[VoltageIntegralResultTypes, CurrentIntegralResultTypes, ImpedanceResultTypes]
+            If ``return_extras=False``, single result of impedance computation
+            over remaining dimensions (frequency, time, mode indices). If ``return_extras=True``,
+            tuple of (impedance, voltage, current).
         """
 
         AxisAlignedPathIntegral._check_monitor_data_supported(em_field=em_field)
 
+        voltage = None
+        current = None
         # If both voltage and current integrals have been defined then impedance is computed directly
         if self.voltage_integral is not None:
             voltage = self.voltage_integral.compute_voltage(em_field)
@@ -98,6 +123,12 @@ class ImpedanceCalculator(Tidy3dBaseModel):
             else:
                 impedance = voltage / current
         impedance = _make_impedance_data_array(impedance)
+        if return_voltage_and_current:
+            if voltage is None:
+                voltage = _make_voltage_data_array(impedance * current)
+            if current is None:
+                current = _make_current_data_array(voltage / impedance)
+            return (impedance, voltage, current)
         return impedance
 
     @pd.validator("current_integral", always=True)

--- a/tidy3d/plugins/microwave/path_integrals.py
+++ b/tidy3d/plugins/microwave/path_integrals.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Union
 
 import numpy as np
 
@@ -18,7 +18,6 @@ from tidy3d.components.data.data_array import (
     _make_voltage_data_array,
 )
 from tidy3d.components.data.monitor_data import FieldData, FieldTimeData, ModeData, ModeSolverData
-from tidy3d.components.geometry.base import Geometry
 from tidy3d.components.microwave.path_integrals.base_spec import AxisAlignedPathIntegralSpec
 from tidy3d.components.microwave.path_integrals.current_spec import (
     CurrentIntegralAxisAlignedSpec,
@@ -139,63 +138,6 @@ class VoltageIntegralAxisAligned(AxisAlignedPathIntegral, VoltageIntegralAxisAli
             voltage *= -1
 
         return _make_voltage_data_array(voltage)
-
-    @staticmethod
-    def from_terminal_positions(
-        plus_terminal: float,
-        minus_terminal: float,
-        x: Optional[float] = None,
-        y: Optional[float] = None,
-        z: Optional[float] = None,
-        extrapolate_to_endpoints: bool = True,
-        snap_path_to_grid: bool = True,
-    ) -> VoltageIntegralAxisAligned:
-        """Helper to create a :class:`VoltageIntegralAxisAligned` from two coordinates that
-        define a line and two positions indicating the endpoints of the path integral.
-
-        Parameters
-        ----------
-        plus_terminal : float
-            Position along the voltage axis of the positive terminal.
-        minus_terminal : float
-            Position along the voltage axis of the negative terminal.
-        x : float = None
-            Position in x direction, only two of x,y,z can be specified to define line.
-        y : float = None
-            Position in y direction, only two of x,y,z can be specified to define line.
-        z : float = None
-            Position in z direction, only two of x,y,z can be specified to define line.
-        extrapolate_to_endpoints: bool = True
-            Passed directly to :class:`VoltageIntegralAxisAligned`
-        snap_path_to_grid: bool = True
-            Passed directly to :class:`VoltageIntegralAxisAligned`
-
-        Returns
-        -------
-        VoltageIntegralAxisAligned
-            The created path integral for computing voltage between the two terminals.
-        """
-        axis_positions = Geometry.parse_two_xyz_kwargs(x=x, y=y, z=z)
-        # Calculate center and size of the future box
-        midpoint = (plus_terminal + minus_terminal) / 2
-        length = np.abs(plus_terminal - minus_terminal)
-        center = [midpoint, midpoint, midpoint]
-        size = [length, length, length]
-        for axis, position in axis_positions:
-            size[axis] = 0
-            center[axis] = position
-
-        direction = "+"
-        if plus_terminal < minus_terminal:
-            direction = "-"
-
-        return VoltageIntegralAxisAligned(
-            center=center,
-            size=size,
-            extrapolate_to_endpoints=extrapolate_to_endpoints,
-            snap_path_to_grid=snap_path_to_grid,
-            sign=direction,
-        )
 
 
 class CurrentIntegralAxisAligned(CurrentIntegralAxisAlignedSpec):

--- a/tidy3d/plugins/microwave/path_integrals.py
+++ b/tidy3d/plugins/microwave/path_integrals.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from typing import Optional, Union
 
 import numpy as np
-import pydantic.v1 as pd
 
-from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.data.data_array import (
     CurrentIntegralResultTypes,
     IntegralResultTypes,
@@ -21,86 +18,21 @@ from tidy3d.components.data.data_array import (
     _make_voltage_data_array,
 )
 from tidy3d.components.data.monitor_data import FieldData, FieldTimeData, ModeData, ModeSolverData
-from tidy3d.components.geometry.base import Box, Geometry
-from tidy3d.components.types import Ax, Axis, Coordinate2D, Direction
-from tidy3d.components.validators import assert_line, assert_plane
-from tidy3d.components.viz import add_ax_if_none
-from tidy3d.constants import fp_eps
-from tidy3d.exceptions import DataError, Tidy3dError
-from tidy3d.log import log
-
-from .viz import (
-    ARROW_CURRENT,
-    plot_params_current_path,
-    plot_params_voltage_minus,
-    plot_params_voltage_path,
-    plot_params_voltage_plus,
+from tidy3d.components.geometry.base import Geometry
+from tidy3d.components.microwave.path_integrals.base_spec import AxisAlignedPathIntegralSpec
+from tidy3d.components.microwave.path_integrals.current_spec import (
+    CurrentIntegralAxisAlignedSpec,
 )
+from tidy3d.components.microwave.path_integrals.voltage_spec import VoltageIntegralAxisAlignedSpec
+from tidy3d.constants import fp_eps
+from tidy3d.exceptions import DataError
 
 MonitorDataTypes = Union[FieldData, FieldTimeData, ModeData, ModeSolverData]
 EMScalarFieldType = Union[ScalarFieldDataArray, ScalarFieldTimeDataArray, ScalarModeFieldDataArray]
 
 
-class AbstractAxesRH(Tidy3dBaseModel, ABC):
-    """Represents an axis-aligned right-handed coordinate system with one axis preferred.
-    Typically `main_axis` would refer to the normal axis of a plane.
-    """
-
-    @cached_property
-    @abstractmethod
-    def main_axis(self) -> Axis:
-        """Get the preferred axis."""
-
-    @cached_property
-    def remaining_axes(self) -> tuple[Axis, Axis]:
-        """Get in-plane axes, ordered to maintain a right-handed coordinate system."""
-        axes: list[Axis] = [0, 1, 2]
-        axes.pop(self.main_axis)
-        if self.main_axis == 1:
-            return (axes[1], axes[0])
-        return (axes[0], axes[1])
-
-    @cached_property
-    def remaining_dims(self) -> tuple[str, str]:
-        """Get in-plane dimensions, ordered to maintain a right-handed coordinate system."""
-        dim1 = "xyz"[self.remaining_axes[0]]
-        dim2 = "xyz"[self.remaining_axes[1]]
-        return (dim1, dim2)
-
-    @cached_property
-    def local_dims(self) -> tuple[str, str, str]:
-        """Get in-plane dimensions with in-plane dims first, followed by the `main_axis` dimension."""
-        dim3 = "xyz"[self.main_axis]
-        return self.remaining_dims + tuple(dim3)
-
-    @pd.root_validator(pre=False)
-    def _warn_rf_license(cls, values):
-        log.warning(
-            "ℹ️ ⚠️ RF simulations are subject to new license requirements in the future. You have instantiated at least one RF-specific component.",
-            log_once=True,
-        )
-        return values
-
-
-class AxisAlignedPathIntegral(AbstractAxesRH, Box):
+class AxisAlignedPathIntegral(AxisAlignedPathIntegralSpec):
     """Class for defining the simplest type of path integral, which is aligned with Cartesian axes."""
-
-    _line_validator = assert_line()
-
-    extrapolate_to_endpoints: bool = pd.Field(
-        False,
-        title="Extrapolate to Endpoints",
-        description="If the endpoints of the path integral terminate at or near a material interface, "
-        "the field is likely discontinuous. When this field is ``True``, fields that are outside and on the bounds "
-        "of the integral are ignored. Should be enabled when computing voltage between two conductors.",
-    )
-
-    snap_path_to_grid: bool = pd.Field(
-        False,
-        title="Snap Path to Grid",
-        description="It might be desireable to integrate exactly along the Yee grid associated with "
-        "a field. When this field is ``True``, the integration path will be snapped to the grid.",
-    )
 
     def compute_integral(self, scalar_field: EMScalarFieldType) -> IntegralResultTypes:
         """Computes the defined integral given the input ``scalar_field``."""
@@ -177,25 +109,6 @@ class AxisAlignedPathIntegral(AbstractAxesRH, Box):
         scalar_field = scalar_field.reset_coords(drop=True)
         return scalar_field
 
-    @cached_property
-    def main_axis(self) -> Axis:
-        """Axis for performing integration."""
-        for index, value in enumerate(self.size):
-            if value != 0:
-                return index
-        raise Tidy3dError("Failed to identify axis.")
-
-    def _vertices_2D(self, axis: Axis) -> tuple[Coordinate2D, Coordinate2D]:
-        """Returns the two vertices of this path in the plane defined by ``axis``."""
-        min = self.bounds[0]
-        max = self.bounds[1]
-        _, min = Box.pop_axis(min, axis)
-        _, max = Box.pop_axis(max, axis)
-
-        u = [min[0], max[0]]
-        v = [min[1], max[1]]
-        return (u, v)
-
     @staticmethod
     def _check_monitor_data_supported(em_field: MonitorDataTypes):
         """Helper for validating that monitor data is supported."""
@@ -207,14 +120,8 @@ class AxisAlignedPathIntegral(AbstractAxesRH, Box):
             )
 
 
-class VoltageIntegralAxisAligned(AxisAlignedPathIntegral):
+class VoltageIntegralAxisAligned(AxisAlignedPathIntegral, VoltageIntegralAxisAlignedSpec):
     """Class for computing the voltage between two points defined by an axis-aligned line."""
-
-    sign: Direction = pd.Field(
-        ...,
-        title="Direction of Path Integral",
-        description="Positive indicates V=Vb-Va where position b has a larger coordinate along the axis of integration.",
-    )
 
     def compute_voltage(self, em_field: MonitorDataTypes) -> VoltageIntegralResultTypes:
         """Compute voltage along path defined by a line."""
@@ -290,81 +197,9 @@ class VoltageIntegralAxisAligned(AxisAlignedPathIntegral):
             sign=direction,
         )
 
-    @add_ax_if_none
-    def plot(
-        self,
-        x: Optional[float] = None,
-        y: Optional[float] = None,
-        z: Optional[float] = None,
-        ax: Ax = None,
-        **path_kwargs,
-    ) -> Ax:
-        """Plot path integral at single (x,y,z) coordinate.
 
-        Parameters
-        ----------
-        x : float = None
-            Position of plane in x direction, only one of x,y,z can be specified to define plane.
-        y : float = None
-            Position of plane in y direction, only one of x,y,z can be specified to define plane.
-        z : float = None
-            Position of plane in z direction, only one of x,y,z can be specified to define plane.
-        ax : matplotlib.axes._subplots.Axes = None
-            Matplotlib axes to plot on, if not specified, one is created.
-        **path_kwargs
-            Optional keyword arguments passed to the matplotlib plotting of the line.
-            For details on accepted values, refer to
-            `Matplotlib's documentation <https://tinyurl.com/36marrat>`_.
-
-        Returns
-        -------
-        matplotlib.axes._subplots.Axes
-            The supplied or created matplotlib axes.
-        """
-        axis, position = self.parse_xyz_kwargs(x=x, y=y, z=z)
-        if axis == self.main_axis or not np.isclose(position, self.center[axis], rtol=fp_eps):
-            return ax
-
-        (xs, ys) = self._vertices_2D(axis)
-        # Plot the path
-        plot_params = plot_params_voltage_path.include_kwargs(**path_kwargs)
-        plot_kwargs = plot_params.to_kwargs()
-        ax.plot(xs, ys, markevery=[0, -1], **plot_kwargs)
-
-        # Plot special end points
-        end_kwargs = plot_params_voltage_plus.include_kwargs(**path_kwargs).to_kwargs()
-        start_kwargs = plot_params_voltage_minus.include_kwargs(**path_kwargs).to_kwargs()
-
-        if self.sign == "-":
-            start_kwargs, end_kwargs = end_kwargs, start_kwargs
-
-        ax.plot(xs[0], ys[0], **start_kwargs)
-        ax.plot(xs[1], ys[1], **end_kwargs)
-        return ax
-
-
-class CurrentIntegralAxisAligned(AbstractAxesRH, Box):
+class CurrentIntegralAxisAligned(CurrentIntegralAxisAlignedSpec):
     """Class for computing conduction current via Ampère's circuital law on an axis-aligned loop."""
-
-    _plane_validator = assert_plane()
-
-    sign: Direction = pd.Field(
-        ...,
-        title="Direction of Contour Integral",
-        description="Positive indicates current flowing in the positive normal axis direction.",
-    )
-
-    extrapolate_to_endpoints: bool = pd.Field(
-        False,
-        title="Extrapolate to Endpoints",
-        description="This parameter is passed to :class:`AxisAlignedPathIntegral` objects when computing the contour integral.",
-    )
-
-    snap_contour_to_grid: bool = pd.Field(
-        False,
-        title="Snap Contour to Grid",
-        description="This parameter is passed to :class:`AxisAlignedPathIntegral` objects when computing the contour integral.",
-    )
 
     def compute_current(self, em_field: MonitorDataTypes) -> CurrentIntegralResultTypes:
         """Compute current flowing in loop defined by the outer edge of a rectangle."""
@@ -395,168 +230,13 @@ class CurrentIntegralAxisAligned(AbstractAxesRH, Box):
             current *= -1
         return _make_current_data_array(current)
 
-    @cached_property
-    def main_axis(self) -> Axis:
-        """Axis normal to loop"""
-        for index, value in enumerate(self.size):
-            if value == 0:
-                return index
-        raise Tidy3dError("Failed to identify axis.")
-
     def _to_path_integrals(
         self, h_horizontal=None, h_vertical=None
     ) -> tuple[AxisAlignedPathIntegral, ...]:
         """Returns four ``AxisAlignedPathIntegral`` instances, which represent a contour
         integral around the surface defined by ``self.size``."""
-        ax1 = self.remaining_axes[0]
-        ax2 = self.remaining_axes[1]
-
-        horizontal_passed = h_horizontal is not None
-        vertical_passed = h_vertical is not None
-        if self.snap_contour_to_grid and horizontal_passed and vertical_passed:
-            (coord1, coord2) = self.remaining_dims
-
-            # Locations where horizontal paths will be snapped
-            v_bounds = [
-                self.center[ax2] - self.size[ax2] / 2,
-                self.center[ax2] + self.size[ax2] / 2,
-            ]
-            h_snaps = h_horizontal.sel({coord2: v_bounds}, method="nearest").coords[coord2].values
-            # Locations where vertical paths will be snapped
-            h_bounds = [
-                self.center[ax1] - self.size[ax1] / 2,
-                self.center[ax1] + self.size[ax1] / 2,
-            ]
-            v_snaps = h_vertical.sel({coord1: h_bounds}, method="nearest").coords[coord1].values
-
-            bottom_bound = h_snaps[0]
-            top_bound = h_snaps[1]
-            left_bound = v_snaps[0]
-            right_bound = v_snaps[1]
-        else:
-            bottom_bound = self.bounds[0][ax2]
-            top_bound = self.bounds[1][ax2]
-            left_bound = self.bounds[0][ax1]
-            right_bound = self.bounds[1][ax1]
-
-        # Horizontal paths
-        path_size = list(self.size)
-        path_size[ax1] = right_bound - left_bound
-        path_size[ax2] = 0
-        path_center = list(self.center)
-        path_center[ax2] = bottom_bound
-
-        bottom = AxisAlignedPathIntegral(
-            center=path_center,
-            size=path_size,
-            extrapolate_to_endpoints=self.extrapolate_to_endpoints,
-            snap_path_to_grid=self.snap_contour_to_grid,
+        path_specs = self._to_path_integral_specs(h_horizontal=h_horizontal, h_vertical=h_vertical)
+        path_integrals = tuple(
+            AxisAlignedPathIntegral(**path_spec.dict(exclude={"type"})) for path_spec in path_specs
         )
-        path_center[ax2] = top_bound
-        top = AxisAlignedPathIntegral(
-            center=path_center,
-            size=path_size,
-            extrapolate_to_endpoints=self.extrapolate_to_endpoints,
-            snap_path_to_grid=self.snap_contour_to_grid,
-        )
-
-        # Vertical paths
-        path_size = list(self.size)
-        path_size[ax1] = 0
-        path_size[ax2] = top_bound - bottom_bound
-        path_center = list(self.center)
-
-        path_center[ax1] = left_bound
-        left = AxisAlignedPathIntegral(
-            center=path_center,
-            size=path_size,
-            extrapolate_to_endpoints=self.extrapolate_to_endpoints,
-            snap_path_to_grid=self.snap_contour_to_grid,
-        )
-        path_center[ax1] = right_bound
-        right = AxisAlignedPathIntegral(
-            center=path_center,
-            size=path_size,
-            extrapolate_to_endpoints=self.extrapolate_to_endpoints,
-            snap_path_to_grid=self.snap_contour_to_grid,
-        )
-
-        return (bottom, right, top, left)
-
-    @add_ax_if_none
-    def plot(
-        self,
-        x: Optional[float] = None,
-        y: Optional[float] = None,
-        z: Optional[float] = None,
-        ax: Ax = None,
-        **path_kwargs,
-    ) -> Ax:
-        """Plot path integral at single (x,y,z) coordinate.
-
-        Parameters
-        ----------
-        x : float = None
-            Position of plane in x direction, only one of x,y,z can be specified to define plane.
-        y : float = None
-            Position of plane in y direction, only one of x,y,z can be specified to define plane.
-        z : float = None
-            Position of plane in z direction, only one of x,y,z can be specified to define plane.
-        ax : matplotlib.axes._subplots.Axes = None
-            Matplotlib axes to plot on, if not specified, one is created.
-        **path_kwargs
-            Optional keyword arguments passed to the matplotlib plotting of the line.
-            For details on accepted values, refer to
-            `Matplotlib's documentation <https://tinyurl.com/36marrat>`_.
-
-        Returns
-        -------
-        matplotlib.axes._subplots.Axes
-            The supplied or created matplotlib axes.
-        """
-        axis, position = self.parse_xyz_kwargs(x=x, y=y, z=z)
-        if axis != self.main_axis or not np.isclose(position, self.center[axis], rtol=fp_eps):
-            return ax
-
-        plot_params = plot_params_current_path.include_kwargs(**path_kwargs)
-        plot_kwargs = plot_params.to_kwargs()
-        path_integrals = self._to_path_integrals()
-        # Plot the path
-        for path in path_integrals:
-            (xs, ys) = path._vertices_2D(axis)
-            ax.plot(xs, ys, **plot_kwargs)
-
-        (ax1, ax2) = self.remaining_axes
-
-        # Add arrow to bottom path, unless right path is longer
-        arrow_path = path_integrals[0]
-        if self.size[ax2] > self.size[ax1]:
-            arrow_path = path_integrals[1]
-
-        (xs, ys) = arrow_path._vertices_2D(axis)
-        X = (xs[0] + xs[1]) / 2
-        Y = (ys[0] + ys[1]) / 2
-        center = np.array([X, Y])
-        dx = xs[1] - xs[0]
-        dy = ys[1] - ys[0]
-        direction = np.array([dx, dy])
-        segment_length = np.linalg.norm(direction)
-        unit_dir = direction / segment_length
-
-        # Change direction of arrow depending on sign of current definition
-        if self.sign == "-":
-            unit_dir *= -1.0
-        # Change direction of arrow when the "y" axis is dropped,
-        # since the plotted coordinate system will be left-handed (x, z)
-        if self.main_axis == 1:
-            unit_dir *= -1.0
-
-        start = center - unit_dir * segment_length
-        end = center
-        ax.annotate(
-            "",
-            xytext=(start[0], start[1]),
-            xy=(end[0], end[1]),
-            arrowprops=ARROW_CURRENT,
-        )
-        return ax
+        return path_integrals

--- a/tidy3d/plugins/microwave/viz.py
+++ b/tidy3d/plugins/microwave/viz.py
@@ -7,56 +7,9 @@ from numpy import inf
 from tidy3d.components.viz import PathPlotParams
 
 """ Constants """
-VOLTAGE_COLOR = "red"
-CURRENT_COLOR = "blue"
 LOBE_PEAK_COLOR = "tab:red"
 LOBE_WIDTH_COLOR = "tab:orange"
 LOBE_FNBW_COLOR = "tab:blue"
-PATH_LINEWIDTH = 2
-ARROW_CURRENT = {
-    "arrowstyle": "-|>",
-    "mutation_scale": 32,
-    "linestyle": "",
-    "lw": PATH_LINEWIDTH,
-    "color": CURRENT_COLOR,
-}
-
-plot_params_voltage_path = PathPlotParams(
-    alpha=1.0,
-    zorder=inf,
-    color=VOLTAGE_COLOR,
-    linestyle="--",
-    linewidth=PATH_LINEWIDTH,
-    marker="o",
-    markersize=10,
-    markeredgecolor=VOLTAGE_COLOR,
-    markerfacecolor="white",
-)
-
-plot_params_voltage_plus = PathPlotParams(
-    alpha=1.0,
-    zorder=inf,
-    color=VOLTAGE_COLOR,
-    marker="+",
-    markersize=6,
-)
-
-plot_params_voltage_minus = PathPlotParams(
-    alpha=1.0,
-    zorder=inf,
-    color=VOLTAGE_COLOR,
-    marker="_",
-    markersize=6,
-)
-
-plot_params_current_path = PathPlotParams(
-    alpha=1.0,
-    zorder=inf,
-    color=CURRENT_COLOR,
-    linestyle="--",
-    linewidth=PATH_LINEWIDTH,
-    marker="",
-)
 
 plot_params_lobe_peak = PathPlotParams(
     alpha=1.0,

--- a/tidy3d/plugins/smatrix/ports/coaxial_lumped.py
+++ b/tidy3d/plugins/smatrix/ports/coaxial_lumped.py
@@ -15,6 +15,7 @@ from tidy3d.components.geometry.base import Box, Geometry
 from tidy3d.components.geometry.utils_2d import increment_float
 from tidy3d.components.grid.grid import Grid, YeeGrid
 from tidy3d.components.lumped_element import CoaxialLumpedResistor
+from tidy3d.components.microwave.path_integrals.base_spec import AbstractAxesRH
 from tidy3d.components.monitor import FieldMonitor
 from tidy3d.components.source.current import CustomCurrentSource
 from tidy3d.components.source.time import GaussianPulse
@@ -23,7 +24,6 @@ from tidy3d.components.validators import skip_if_fields_missing
 from tidy3d.constants import MICROMETER
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.plugins.microwave import CustomCurrentIntegral2D, VoltageIntegralAxisAligned
-from tidy3d.plugins.microwave.path_integrals import AbstractAxesRH
 
 from .base_lumped import AbstractLumpedPort
 


### PR DESCRIPTION
Calculating impedance automatically:

1. Find all conductors in mode plane and merge into isolated conductors, each possible carrying a conduction current.
2. Place current integrals around each conductor (right now just using bounding box)
3. Calculate total current using a new type of current integral (`CompositeCurrentIntegral`) made up of multiple current integrals. The total current flowing in a transmission line is net 0 because of current flowing in and out . To isolate these two terms, we split the currents based on their phase (using an initial reference phase). Then we choose the maximum of the two at the end. We choose the max, because it is possible that some current is flowing back in the PEC boundary or ground plane, which are not totally enclosed by the modal plane and their contribution will be missing.

Need at least one small [backend](https://github.com/flexcompute/compute/pull/1699) change


Todo on:
- [ ] Update Changelog
- [ ] Check coverage and improve


<!-- greptile_comment -->

## Greptile Summary

Implements automated impedance calculation for RF transmission lines by introducing a new TerminalSpec system that detects conductors and computes characteristic impedance using voltage/current path integrals.

- Added `tidy3d.components.microwave.terminal_spec.TerminalSpec` class for automated transmission line impedance calculation using conductor detection
- Introduced `CompositeCurrentIntegral` to handle complex current flows with phase-based current isolation for accurate impedance measurements
- Added `PathSpecGenerator` in `components/microwave/path_spec_generator.py` to automatically detect conductors and generate appropriate current paths
- Enhanced `ModeSolver` with characteristic impedance (Z0) calculations integrated with the new terminal system
- Improved code organization by moving visualization code to dedicated `components/microwave/viz.py` module



<!-- /greptile_comment -->