### PR TITLE
Issue license warning for RF simulations

### DIFF
--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -174,6 +174,9 @@ PML_HEIGHT_FOR_0_DIMS = inf
 # additional (safety) time step reduction factor for fixed angle simulations
 FIXED_ANGLE_DT_SAFETY_FACTOR = 0.9
 
+# RF frequency warning
+RF_FREQ_WARNING = 1e12
+
 
 def validate_boundaries_for_zero_dims():
     """Error if absorbing boundaries, bloch boundaries, unmatching pec/pmc, or symmetry is used along a zero dimension."""
@@ -3596,6 +3599,38 @@ class Simulation(AbstractYeeGridSimulation):
         self._validate_custom_source_time()
         self._validate_mode_object_bends()
         self._warn_mode_object_pml()
+        self._warn_rf_simulation()
+
+    def _warn_rf_simulation(self) -> None:
+        """Warn about new licensing requirements for RF simulations."""
+
+        # RF component messages
+        comp_msg = []
+        # 1) lossy metal
+        for mat in self.scene.mediums:
+            if isinstance(mat, LossyMetalMedium):
+                comp_msg += ["it contains 'LossyMetalMedium'"]
+                break
+
+        # 2) lumped elements
+        if len(self.lumped_elements) > 0:
+            comp_msg += ["it contains lumped elements"]
+
+        # 3) source frequency is in RF range
+        if self.frequency_range[0] < RF_FREQ_WARNING:
+            comp_msg += ["frequency of some sources is in the RF range"]
+
+        # 4) monitor frequency is in RF range
+        for monitor in self.monitors:
+            if isinstance(monitor, FreqMonitor) and monitor.frequency_range[0] < RF_FREQ_WARNING:
+                comp_msg += ["frequency of some monitors is in the RF range"]
+                break
+
+        # issue warning
+        if len(comp_msg) > 0:
+            msg = "This is an RF simulation because " + ", and ".join(comp_msg)
+            msg += ". Please note that RF simulations are subject to new licensing requirements in the future."
+            log.warning(msg)
 
     def _warn_mode_object_pml(self) -> None:
         """Warn if any mode objects have large pml."""

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -17,6 +17,7 @@ from ....components.types import FreqArray
 from ....config import config
 from ....constants import HERTZ
 from ....exceptions import SetupError, Tidy3dKeyError
+from ....log import log
 from ....web.api.container import Batch, BatchData
 from ..ports.coaxial_lumped import CoaxialLumpedPort
 from ..ports.modal import Port
@@ -112,6 +113,21 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
         """Make sure simulation has no sources as they interfere with tool."""
         if len(val.sources) > 0:
             raise SetupError("'AbstractComponentModeler.simulation' must not have any sources.")
+        return val
+
+    @pd.validator("ports", always=True)
+    def _RF_ports_warning(cls, val):
+        """Warn about new licensing requirements for RF ports."""
+        rf_port = False
+        for port in val:
+            if isinstance(port, TerminalPortType):
+                rf_port = True
+                break
+        if rf_port:
+            log.warning(
+                "This is an RF modeling because it contains RF ports. "
+                "Please note that RF simulations are subject to new licensing requirements in the future."
+            )
         return val
 
     @staticmethod

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -25,6 +25,7 @@ from ....components.types import Ax
 from ....components.viz import add_ax_if_none, equal_aspect
 from ....constants import C_0, OHM
 from ....exceptions import Tidy3dError, Tidy3dKeyError, ValidationError
+from ....log import log
 from ....web.api.container import BatchData
 from ..data.terminal import PortDataArray, TerminalPortDataArray
 from ..ports.base_lumped import AbstractLumpedPort
@@ -51,6 +52,16 @@ class TerminalComponentModeler(AbstractComponentModeler):
         description="Facilitates the calculation of figures-of-merit for antennas. "
         "These monitor will be included in every simulation and record the radiated fields. ",
     )
+
+    @pd.validator("radiation_monitors", always=True)
+    def RF_monitors_warning(cls, val):
+        """Warn about new licensing requirements for RF monitors."""
+        if len(val) > 0:
+            log.warning(
+                "This is an RF modeling because it contains RF monitors. "
+                "Please note that RF simulations are subject to new licensing requirements in the future."
+            )
+        return val
 
     @equal_aspect
     @add_ax_if_none


### PR DESCRIPTION
Sample warning messages:

> 25-05-09 15:25:44.512][USER   ]: WARNING: This is an RF simulation because it contains             
> [25-05-09 15:25:44.512][USER   ]: 'LossyMetalMedium', and frequency of some sources is in the RF    
> [25-05-09 15:25:44.512][USER   ]: range. Please note that RF simulations are subject to new         
> [25-05-09 15:25:44.512][USER   ]: licensing requirements in the future.    
>                          
> [25-05-09 15:25:44.514][USER   ]: WARNING: This is an RF modeling because it contains RF ports.     
> [25-05-09 15:25:44.514][USER   ]: Please note that RF simulations are subject to new licensing      
> [25-05-09 15:25:44.514][USER   ]: requirements in the future.       