### PR TITLE
feat: autograd support for Clip Operations

### DIFF
--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -2187,24 +2187,3 @@ def test_sim_traced_center_size(use_emulated_run):
 
     with AssertLogLevel("WARNING", contains_str="autograd tracer"):
         grad = ag.grad(objective, argnum=1)(base_sim.center, base_sim.size)
-
-
-def test_error_clip(use_emulated_run):
-    """Make sure proper error raised if differentiating a ``ClipOperation``."""
-
-    def objective(x):
-        box1 = td.Box(center=(0, 0, 0), size=(x, x, x))
-        box2 = td.Box(center=(1, 1, 1), size=(x, x, x))
-        union = td.ClipOperation(operation="union", geometry_a=box1, geometry_b=box2)
-        structure = td.Structure(geometry=union, medium=td.Medium(permittivity=2))
-        sim = SIM_BASE.updated_copy(
-            structures=[structure],
-            monitors=[
-                td.FieldMonitor(size=(0, 0, 0), center=(0, 0, 0), freqs=[FREQ0], name="field"),
-            ],
-        )
-        data = run(sim, task_name="clip_error")
-        return anp.sum(data["field"].intensity.item())
-
-    with pytest.raises(ValueError):
-        g = ag.grad(objective)(1.0)

--- a/tests/test_components/test_autograd_clip_operations.py
+++ b/tests/test_components/test_autograd_clip_operations.py
@@ -1,0 +1,327 @@
+"""
+Finite‑difference (FD) vs Autograd (AD) checks for td.ClipOperation
+covering all four Boolean operations: union, intersection, difference,
+symmetric_difference.
+
+The test contains *two distinct PolySlabs* that are combined by the
+chosen Boolean op.
+"""
+
+from __future__ import annotations
+
+import atexit
+from collections import defaultdict
+from pathlib import Path
+
+import autograd
+import autograd.numpy as anp
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+import tidy3d as td
+import tidy3d.web as web
+
+# simulation constants
+wavelength = 1.5
+freq0 = td.C_0 / wavelength
+L = 10 * wavelength
+buffer = 1.0 * wavelength
+run_time = 120 / freq0
+
+source = td.PointDipole(
+    center=(-L / 2 + buffer, 0.0, 0.0),
+    source_time=td.GaussianPulse(freq0=freq0, fwidth=freq0 / 10.0),
+    polarization="Ez",
+)
+monitor = td.FieldMonitor(
+    center=(+L / 2 - buffer, 0.5 * buffer, 0.5 * buffer),
+    size=(0, 0, 0),
+    freqs=[freq0],
+    name="point_out",
+)
+
+
+SCENARIOS: dict[str, list[dict[str, tuple | str | float]]] = {
+    # ------------------------------------------------------------------  intersection
+    "intersection": [
+        {
+            "name": " separated in z",
+            "box_eps": 2.0,
+            "center1": (0.0, 0.00, -0.25),
+            "size1": (1.8, 1.5, 2.5),
+            "center2": (0.0, 0.00, 0.25),
+            "size2": (1.8, 1.5, 2.5),
+        },
+    ],
+    # ------------------------------------------------------------------  difference
+    "difference": [
+        {
+            "name": " separated in z",
+            "box_eps": 2.0,
+            "center1": (0.0, 0.00, -0.25),
+            "size1": (1.8, 1.5, 2.5),
+            "center2": (0.0, 0.00, 0.25),
+            "size2": (1.8, 1.5, 2.5),
+        },
+    ],
+    # ------------------------------------------------------------------  union
+    "union": [
+        {
+            "name": " separated in z",
+            "box_eps": 2.0,
+            "center1": (0.0, 0.00, -0.25),
+            "size1": (2.0, 1.5, 1.5),
+            "center2": (0.0, 0.00, 0.25),
+            "size2": (2.0, 1.5, 1.5),
+        },
+    ],
+    # ------------------------------------------------------------------  symmetric_difference
+    "symmetric_difference": [
+        {
+            "name": " separated in z",
+            "box_eps": 2.5,
+            "center1": (0.0, 0.45, -0.3),
+            "size1": (1.9, 1.5, 2.5),
+            "center2": (0.0, 0.45, 0.4),
+            "size2": (1.9, 1.5, 2.5),
+        },
+    ],
+}
+
+# all Boolean ops we want to check
+OPERATIONS = ["union", "intersection", "difference", "symmetric_difference"]
+
+# geometric parameter labels --------------------------------------------------
+PARAM_LABELS = [
+    "p1_center_x",
+    "p1_center_y",
+    "p1_center_z",
+    "p1_size_x",
+    "p1_size_y",
+    "p1_size_z",
+    "p2_center_x",
+    "p2_center_y",
+    "p2_center_z",
+    "p2_size_x",
+    "p2_size_y",
+    "p2_size_z",
+]
+_PARAM_MAP = {
+    # poly‑1
+    "p1_center_x": (0, "center1"),
+    "p1_center_y": (1, "center1"),
+    "p1_center_z": (2, "center1"),
+    "p1_size_x": (0, "size1"),
+    "p1_size_y": (1, "size1"),
+    "p1_size_z": (2, "size1"),
+    # poly‑2
+    "p2_center_x": (0, "center2"),
+    "p2_center_y": (1, "center2"),
+    "p2_center_z": (2, "center2"),
+    "p2_size_x": (0, "size2"),
+    "p2_size_y": (1, "size2"),
+    "p2_size_z": (2, "size2"),
+}
+
+# bookkeeping for optional plots / raw data ----------------------------------
+SAVE_RESULTS = False
+PLOT_RESULTS = True
+RESULTS_DIR = Path("./clipop_fd_ad_results")
+results_collector = defaultdict(list)
+
+
+# helper: build simulation for a given op & geometry
+def make_simulation(
+    center1: tuple[float, float, float],
+    size1: tuple[float, float, float],
+    center2: tuple[float, float, float],
+    size2: tuple[float, float, float],
+    eps_box: float,
+    operation: str,
+) -> td.Simulation:
+    """Scene with two PolySlabs combined by *operation*."""
+
+    # PolySlab‑1 -----------------------------------------------------------
+    cx1, cy1, cz1 = center1
+    sx1, sy1, sz1 = size1
+    hx1, hy1, hz1 = sx1 / 2, sy1 / 2, sz1 / 2
+    verts1 = anp.array(
+        [
+            [cx1 - hx1, cz1 - hz1],
+            [cx1 + hx1, cz1 - hz1],
+            [cx1 + hx1, cz1 + hz1],
+            [cx1 - hx1, cz1 + hz1],
+        ]
+    )
+    slab_bounds1 = (cy1 - hy1, cy1 + hy1)
+    poly1 = td.PolySlab(axis=1, vertices=verts1, slab_bounds=slab_bounds1)
+
+    # PolySlab‑2 -----------------------------------------------------------
+    cx2, cy2, cz2 = center2
+    sx2, sy2, sz2 = size2
+    hx2, hy2, hz2 = sx2 / 2, sy2 / 2, sz2 / 2
+    verts2 = anp.array(
+        [
+            [cx2 - hx2, cz2 - hz2],
+            [cx2 + hx2, cz2 - hz2],
+            [cx2 + hx2, cz2 + hz2],
+            [cx2 - hx2, cz2 + hz2],
+        ]
+    )
+    slab_bounds2 = (cy2 - hy2, cy2 + hy2)
+    poly2 = td.PolySlab(axis=1, vertices=verts2, slab_bounds=slab_bounds2)
+
+    # Boolean operation ----------------------------------------------------
+    geometry_union = td.ClipOperation(operation=operation, geometry_a=poly1, geometry_b=poly2)
+
+    scatter = td.Structure(
+        geometry=geometry_union,
+        medium=td.Medium(permittivity=eps_box),
+    )
+    min_steps_per_wvl = 55
+    if operation == "symmetric_difference":
+        min_steps_per_wvl = 60
+
+    return td.Simulation(
+        size=(L, L, L),
+        grid_spec=td.GridSpec.auto(min_steps_per_wvl=min_steps_per_wvl),
+        sources=[source],
+        monitors=[monitor],
+        structures=[scatter],
+        run_time=run_time,
+    )
+
+
+# objective fn
+def objective_fn(params: dict, scenario: dict, operation: str) -> anp.ndarray:
+    """Intensity at the output monitor."""
+    sim = make_simulation(
+        params["center1"],
+        params["size1"],
+        params["center2"],
+        params["size2"],
+        eps_box=scenario["box_eps"],
+        operation=operation,
+    )
+    sim_data = web.run(sim, task_name="clipop_fd_vs_ad", local_gradient=True, verbose=False)
+    return anp.sum(sim_data.get_intensity("point_out").values)
+
+
+# FD vs AD for a single parameter
+def fd_vs_ad_single_param(
+    params: dict, scenario: dict, operation: str, param_label: str, delta: float = 3.0e-2
+):
+    def pack(p: dict) -> anp.ndarray:
+        return anp.concatenate([p["center1"], p["size1"], p["center2"], p["size2"]])
+
+    def unpack(vec: anp.ndarray) -> dict:
+        return dict(
+            center1=tuple(vec[0:3]),
+            size1=tuple(vec[3:6]),
+            center2=tuple(vec[6:9]),
+            size2=tuple(vec[9:12]),
+        )
+
+    x0 = pack(params)
+
+    val_grad = autograd.value_and_grad(lambda v: objective_fn(unpack(v), scenario, operation))
+    _, grad_vec = val_grad(x0)
+
+    # index of the parameter being tested
+    idx, which_key = _PARAM_MAP[param_label]
+    flat_offset = {"center1": 0, "size1": 3, "center2": 6, "size2": 9}[which_key]
+    flat_idx = flat_offset + idx
+    ad_val = grad_vec[flat_idx]
+
+    # centred FD
+    x_plus = x0.copy()
+    x_plus[flat_idx] += delta
+    x_minus = x0.copy()
+    x_minus[flat_idx] -= delta
+    p_plus = objective_fn(unpack(x_plus), scenario, operation)
+    p_minus = objective_fn(unpack(x_minus), scenario, operation)
+    fd_val = (p_plus - p_minus) / (2.0 * delta)
+
+    return fd_val, ad_val, p_plus, p_minus
+
+
+# parametric pytest
+@pytest.mark.numerical
+@pytest.mark.parametrize("operation", OPERATIONS, ids=OPERATIONS)
+@pytest.mark.parametrize("param_label", PARAM_LABELS)
+def test_clipop_fd_vs_ad(operation: str, param_label: str):
+    # initial geometry
+    for scenario in SCENARIOS[operation]:
+        params0 = dict(
+            center1=scenario["center1"],
+            size1=scenario["size1"],
+            center2=scenario["center2"],
+            size2=scenario["size2"],
+        )
+        fd_val, ad_val, p_plus, p_minus = fd_vs_ad_single_param(
+            params0, scenario, operation, param_label, delta=0.06
+        )
+
+        # basic sanity
+        assert np.isfinite(fd_val), f"FD derivative NaN/Inf ({param_label}, {operation})"
+        assert np.isfinite(ad_val), f"AD derivative NaN/Inf ({param_label}, {operation})"
+
+        # relative agreement
+        denom = max(abs(fd_val), 1e-12)
+        rel_diff = abs(fd_val - ad_val) / denom
+        assert rel_diff < 0.4, (
+            f"{operation} – {param_label} – {scenario['name']}: "
+            f"FD–AD mismatch (rel diff {rel_diff:.2%}), (fd_val {fd_val:.2}), (ad_val {ad_val:.2})"
+        )
+
+        results_collector[(param_label, operation)].append((scenario["name"], rel_diff))
+
+        # optional saving
+        if SAVE_RESULTS:
+            RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+            np.save(
+                RESULTS_DIR / f"fd_ad_{scenario['name'].replace(' ', '_')}"
+                f"_{operation}_{param_label}.npy",
+                dict(
+                    scenario_name=scenario["name"],
+                    operation=operation,
+                    param_label=param_label,
+                    fd_val=float(fd_val),
+                    ad_val=float(ad_val),
+                    p_plus=float(p_plus),
+                    p_minus=float(p_minus),
+                    rel_diff=float(rel_diff),
+                ),
+            )
+
+
+# optional bar‑plot
+def _finalize_plotting():
+    if not PLOT_RESULTS:
+        return
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    for param in PARAM_LABELS:
+        # collect labels and errors across ALL operations for this param
+        labels, rel_diffs = [], []
+        for op in OPERATIONS:
+            for scenario_name, rel_diff in results_collector.get((param, op), []):
+                labels.append(f"{op}\n{scenario_name}")
+                rel_diffs.append(rel_diff)
+
+        if not rel_diffs:
+            continue
+
+        plt.figure(figsize=(8, 4))
+        plt.bar(labels, rel_diffs)
+        plt.xticks(rotation=45, ha="right")
+        plt.ylabel("relative |FD–AD| / max(|FD|)")
+        plt.title(f"FD vs AD rel error for {param}")
+        plt.tight_layout()
+        fname = RESULTS_DIR / f"rel_error_{param}.png"
+        plt.savefig(fname)
+        plt.close()
+        print(f"Saved {fname}")
+
+
+atexit.register(_finalize_plotting)

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -11,11 +11,15 @@ import autograd.numpy as np
 import pydantic.v1 as pydantic
 import shapely
 import xarray as xr
+from autograd import grad
+from autograd.scipy.special import logsumexp
 
 try:
     from matplotlib import patches
 except ImportError:
     pass
+
+import tidy3d as td
 
 from ...constants import LARGE_NUMBER, MICROMETER, RADIAN, fp_eps, inf
 from ...exceptions import (
@@ -1993,8 +1997,7 @@ class Box(SimplePlaneIntersection, Centered):
         """Axis normal to the Box. Errors if box is not planar."""
         if self.size.count(0.0) != 1:
             raise ValidationError(
-                "Tried to get 'normal_axis' of 'Box' that is not planar. "
-                f"Given 'size={self.size}.'"
+                f"Tried to get 'normal_axis' of 'Box' that is not planar. Given 'size={self.size}.'"
             )
         return self.size.index(0.0)
 
@@ -2959,6 +2962,135 @@ class Transformed(Geometry):
         return self.updated_copy(geometry=new_geometry)
 
 
+def softmin(x, axis=1, lam=30.0):
+    return -1.0 / lam * logsumexp(-lam * x, axis=axis)
+
+
+def _point_segment_dist(
+    px: np.ndarray,
+    py: np.ndarray,
+    x1: np.ndarray,
+    y1: np.ndarray,
+    x2: np.ndarray,
+    y2: np.ndarray,
+    eps: float = 1e-12,
+) -> np.ndarray:
+    """Distance from a batch of points (px,py) to a batch of line segments (x1,y1)->(x2,y2)."""
+    vx = x2 - x1
+    vy = y2 - y1
+    seg_len_sq = vx * vx + vy * vy
+
+    wx = px - x1
+    wy = py - y1
+    t = (wx * vx + wy * vy) / (seg_len_sq + eps)
+    t_clamped = np.clip(t, 0.0, 1.0)
+
+    cx = x1 + t_clamped * vx
+    cy = y1 + t_clamped * vy
+    dx = px - cx
+    dy = py - cy
+
+    return np.sqrt(dx * dx + dy * dy + eps)
+
+
+def _winding_angle(verts: np.ndarray, points: np.ndarray) -> np.ndarray:
+    """Total winding angle around each point in 'points' for polygon 'verts'"""
+    # expand dims for broadcast
+    points_expanded = points[:, np.newaxis, :]  # (M,1,2)
+    verts_expanded = verts[np.newaxis, :, :]  # (1,N,2)
+
+    # edges (v[i], v[i+1])
+    verts_shifted = np.roll(verts_expanded, shift=-1, axis=1)  # (1,N,2)
+
+    # v1, v2 have shape (M,N,2)
+    v1 = verts_expanded - points_expanded
+    v2 = verts_shifted - points_expanded
+
+    cross = v1[:, :, 0] * v2[:, :, 1] - v1[:, :, 1] * v2[:, :, 0]  # (M,N)
+    dot = v1[:, :, 0] * v2[:, :, 0] + v1[:, :, 1] * v2[:, :, 1]  # (M,N)
+
+    angles = np.arctan2(cross, dot)  # (M,N)
+    angle_sum = np.sum(angles, axis=1)  # (M,)
+    return angle_sum
+
+
+def polygon_soft_membership_2d(
+    verts: np.ndarray,
+    points: np.ndarray,
+    alpha: float = 20.0,
+    beta: float = 5.0,
+) -> np.ndarray:
+    """Vectorized "soft membership" for polygon 'verts' on 'points'.
+
+    Steps:
+      1) dist_min = min. distance from each point to polygon edges
+      2) angle_sum => sign = -tanh[ beta*(angle_sum - pi) ]
+      3) signed_dist = dist_min * sign
+      4) membership = 1 / (1 + exp(alpha * signed_dist))
+    """
+    # prepare shapes for broadcasting
+    points_exp = points[:, np.newaxis, :]  # (M,1,2)
+    verts_exp = verts[np.newaxis, :, :]  # (1,N,2)
+    verts_shifted = np.roll(verts_exp, shift=-1, axis=1)
+
+    # distances to each edge
+    x1 = verts_exp[:, :, 0]  # shape (1,N)
+    y1 = verts_exp[:, :, 1]  # shape (1,N)
+    x2 = verts_shifted[:, :, 0]  # shape (1,N)
+    y2 = verts_shifted[:, :, 1]  # shape (1,N)
+
+    px = points_exp[:, :, 0]  # shape (M,1)
+    py = points_exp[:, :, 1]  # shape (M,1)
+
+    dist_each_edge = _point_segment_dist(px, py, x1, y1, x2, y2)  # (M,N)
+    dist_min = softmin(dist_each_edge, axis=1, lam=alpha)  # shape (M,)
+
+    # winding angle => sign
+    angle_sum = _winding_angle(verts, points)  # shape (M,)
+    s = -np.tanh(beta * (angle_sum - np.pi))  # shape (M,)
+
+    signed_dist = dist_min * s  # shape (M,)
+    membership = 1 / (1 + np.exp(alpha * signed_dist))  # shape (M,)
+
+    return membership
+
+
+def slab_1d_soft_membership(
+    coords: np.ndarray, slab_bounds: np.ndarray, *, alpha_slab: float = 20.0
+) -> np.ndarray:
+    """
+    coords      : (M,)   points along the slab axis
+    slab_bounds : (2,)   (min_b, max_b)
+    Returns     : (M,)   smooth indicator in [0,1]
+    """
+    min_b, max_b = slab_bounds
+
+    # two opposing sigmoids
+    mem_min = 1.0 / (1.0 + np.exp(-alpha_slab * (coords - min_b)))
+    mem_max = 1.0 / (1.0 + np.exp(alpha_slab * (coords - max_b)))
+    return mem_min * mem_max
+
+
+def _boolean_coeff(
+    mask_a: np.ndarray,
+    mask_b: np.ndarray,
+    op: ClipOperationType,
+) -> tuple[np.ndarray, np.ndarray]:
+    coeffs = {
+        "intersection": (mask_b, mask_a),  # M = ρ_a ρ_b
+        "union": (1.0 - mask_b, 1.0 - mask_a),  # M = ρ_a + ρ_b – ρ_a ρ_b
+        "difference": (1.0 - mask_b, -mask_a),  # M = ρ_a – ρ_a ρ_b
+        "symmetric_difference": (
+            1.0 - 2.0 * mask_b,
+            1.0 - 2.0 * mask_a,
+        ),  # M = ρ_a + ρ_b – 2 ρ_a ρ_b
+    }
+    try:
+        return coeffs[op]
+    except KeyError:
+        raise ValueError(f"Unsupported clip operation {op!r}")
+
+
 class ClipOperation(Geometry):
     """Class representing the result of a set operation between geometries."""
 
@@ -2980,17 +3112,6 @@ class ClipOperation(Geometry):
         title="Geometry B",
         description="Second operand for the set operation. It can also be any geometry type.",
     )
-
-    @pydantic.validator("geometry_a", "geometry_b", always=True)
-    def _geometries_untraced(cls, val):
-        """Make sure that ``ClipOperation`` geometries do not contain tracers."""
-        traced = val.strip_traced_fields()
-        if traced:
-            raise ValidationError(
-                f"{val.type} contains traced fields {list(traced.keys())}. Note that "
-                "'ClipOperation' does not currently support automatic differentiation."
-            )
-        return val
 
     @staticmethod
     def to_polygon_list(base_geometry: Shapely) -> List[Shapely]:
@@ -3209,6 +3330,124 @@ class ClipOperation(Geometry):
         new_geom_a = self.geometry_a._update_from_bounds(bounds=bounds, axis=axis)
         new_geom_b = self.geometry_b._update_from_bounds(bounds=bounds, axis=axis)
         return self.updated_copy(geometry_a=new_geom_a, geometry_b=new_geom_b)
+
+    # compute_derivatives
+    def compute_derivatives(
+        self: ClipOperation,
+        derivative_info: DerivativeInfo,
+    ) -> AutogradFieldMap:
+        """
+        Derivatives for Boolean‑combined geometries.
+        """
+
+        # gather Yee‑grid data component‑wise ----------------------------
+        component_map = {"x": "eps_xx", "y": "eps_yy", "z": "eps_zz"}
+        grids: dict[str, dict[str, Any]] = {}
+
+        for dim in "xyz":
+            eps_da = derivative_info.eps_data[component_map[dim]]
+            xg, yg, zg = (eps_da.coords[c].values for c in ("x", "y", "z"))
+            X, Y, Z = np.meshgrid(xg, yg, zg, indexing="ij", sparse=True)
+            Xb, Yb, Zb = np.broadcast_arrays(X, Y, Z)
+            axis_cols = (Xb.ravel(), Yb.ravel(), Zb.ravel())
+            planar_pts = {
+                0: np.stack([axis_cols[1], axis_cols[2]], axis=1),  # (y,z)
+                1: np.stack([axis_cols[0], axis_cols[2]], axis=1),  # (x,z)
+                2: np.stack([axis_cols[0], axis_cols[1]], axis=1),  # (x,y)
+            }
+
+            grids[dim] = {
+                "shape": Xb.shape,
+                "axis_cols": axis_cols,
+                "planar_pts": planar_pts,
+                "Δε": derivative_info.delta_eps(np.stack(axis_cols, axis=1))
+                .real.astype(np.float32)
+                .reshape(Xb.shape),
+                "G": td.CustomMedium._derivative_field_cmp(
+                    self,
+                    E_der_map=derivative_info.E_der_map,
+                    eps_data=eps_da,
+                    dim=dim,
+                    freqs=np.atleast_1d(derivative_info.frequency),
+                )
+                .real.astype(np.float32)
+                .reshape(Xb.shape),
+            }
+
+        def _membership_3d(vertices, bounds, axis, dim):
+            """Compute the soft membership function for a 3D polyslab."""
+            axis_coord = grids[dim]["axis_cols"][axis]
+            planar_pts = grids[dim]["planar_pts"][axis]
+
+            mem2d = polygon_soft_membership_2d(
+                vertices,
+                planar_pts,
+            )
+            mem1d = slab_1d_soft_membership(axis_coord, bounds)
+
+            return (mem2d * mem1d).reshape(grids[dim]["shape"])
+
+        verts_a, bounds_a, axis_a = (
+            self.geometry_a.vertices,
+            np.asarray(self.geometry_a.slab_bounds),
+            self.geometry_a.axis,
+        )
+        verts_b, bounds_b, axis_b = (
+            self.geometry_b.vertices,
+            np.asarray(self.geometry_b.slab_bounds),
+            self.geometry_b.axis,
+        )
+
+        mem_fix_a, mem_fix_b = {}, {}
+        der_var_a, der_var_b = {}, {}
+
+        for d in "xyz":
+            # membership of the *fixed* slabs on each Yee grid
+            mem_fix_a[d] = _membership_3d(verts_a, bounds_a, axis_a, d)
+            mem_fix_b[d] = _membership_3d(verts_b, bounds_b, axis_b, d)
+            der_var_a[d], der_var_b[d] = _boolean_coeff(mem_fix_a[d], mem_fix_b[d], self.operation)
+
+        def _obj_vertices(v, bounds_var, axis_var, der_bool):
+            total = 0.0
+            for d in "xyz":
+                mask_var = _membership_3d(v, bounds_var, axis_var, d)
+
+                integrand = der_bool[d] * mask_var
+
+                total = total + np.sum(grids[d]["G"] * grids[d]["Δε"] * integrand)
+            return np.real(total)
+
+        def _obj_bounds(
+            b,
+            verts_var,
+            axis_var,
+            der_bool,
+        ):
+            total = 0.0
+            for d in "xyz":
+                mask_var = _membership_3d(verts_var, b, axis_var, d)
+                integrand = der_bool[d] * mask_var
+
+                total = total + np.sum(grids[d]["G"] * grids[d]["Δε"] * integrand)
+            return np.real(total)
+
+        # --- Autograd gradients ---------------------------------------------
+        dL_dv_a = grad(lambda v: _obj_vertices(v, bounds_a, axis_a, der_var_a))(verts_a)
+
+        dL_dv_b = grad(lambda v: _obj_vertices(v, bounds_b, axis_b, der_var_b))(verts_b)
+
+        dL_db_a = grad(lambda b: _obj_bounds(b, verts_a, axis_a, der_var_a))(bounds_a)
+
+        dL_db_b = grad(lambda b: _obj_bounds(b, verts_b, axis_b, der_var_b))(bounds_b)
+
+        vjps: AutogradFieldMap = {}
+        vjps[("geometry_a", "vertices")] = dL_dv_a
+        vjps[("geometry_a", "slab_bounds", 0)] = dL_db_a[0]
+        vjps[("geometry_a", "slab_bounds", 1)] = dL_db_a[1]
+        vjps[("geometry_b", "vertices")] = dL_dv_b
+        vjps[("geometry_b", "slab_bounds", 0)] = dL_db_b[0]
+        vjps[("geometry_b", "slab_bounds", 1)] = dL_db_b[1]
+        return vjps
 
 
 class GeometryGroup(Geometry):

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -10,6 +10,8 @@ import autograd.numpy as anp
 import numpy as np
 import pydantic.v1 as pydantic
 
+import tidy3d as td
+
 from ..constants import MICROMETER
 from ..exceptions import SetupError, Tidy3dError, Tidy3dImportError
 from ..log import log
@@ -255,27 +257,69 @@ class Structure(AbstractStructure):
 
         return monitor_name_map[data_type]
 
+    def _poly_bbox(self, polyslab: PolySlab):
+        """Axis‑aligned bbox (min,max) ∈ ℝ³ for a single PolySlab."""
+        axis = polyslab.axis  # 0,1,2
+        planar = [i for i in range(3) if i != axis]
+
+        lo = np.zeros(3)
+        hi = np.zeros(3)
+
+        # planar coordinates come from the 2‑D vertices
+        lo[planar[0]] = polyslab.vertices[:, 0].min()
+        hi[planar[0]] = polyslab.vertices[:, 0].max()
+        lo[planar[1]] = polyslab.vertices[:, 1].min()
+        hi[planar[1]] = polyslab.vertices[:, 1].max()
+
+        # slab thickness along the extrusion axis
+        lo[axis] = polyslab.slab_bounds[0]
+        hi[axis] = polyslab.slab_bounds[1]
+        return lo, hi
+
     def make_adjoint_monitors(
-        self, freqs: list[float], index: int, field_keys: list[str]
-    ) -> (FieldMonitor, PermittivityMonitor):
-        """Generate the field and permittivity monitor for this structure."""
+        self,
+        freqs: list[float],
+        index: int,
+        field_keys: list[str],
+    ) -> tuple[FieldMonitor, PermittivityMonitor]:
+        """
+        Generate field & permittivity monitors with optional padding for ClipOperation.
+        """
 
         geometry = self.geometry
-        box = geometry.bounding_box
 
-        # we dont want these fields getting traced by autograd, otherwise it messes stuff up
+        # Construct bounding box (with padding if ClipOperation)
+        if isinstance(geometry, td.ClipOperation):
+            lo_a, hi_a = self._poly_bbox(geometry.geometry_a)
+            lo_b, hi_b = self._poly_bbox(geometry.geometry_b)
 
-        size = [get_static(x) for x in box.size]
-        center = [get_static(x) for x in box.center]
+            lo = np.minimum(lo_a, lo_b)
+            hi = np.maximum(hi_a, hi_b)
 
-        # polyslab only needs fields at the midpoint along axis
-        if (
-            isinstance(geometry, PolySlab)
-            and not isinstance(self.medium, AbstractCustomMedium)
-            and field_keys == [("vertices",)]
-        ):
-            size[geometry.axis] = 0
+            lengths = hi - lo  # [Lx, Ly, Lz]
+            pad_vec = 0.05 * lengths  # 5 % on every side
 
+            lo -= pad_vec
+            hi += pad_vec
+
+            size = (hi - lo).tolist()
+            center = ((hi + lo) * 0.5).tolist()
+
+        else:
+            # --- original behaviour --------------------------------------
+            box = geometry.bounding_box
+            # we dont want these fields getting traced by autograd, otherwise it messes stuff up
+            size = [get_static(v) for v in box.size]
+            center = [get_static(v) for v in box.center]
+            # polyslab only needs fields at the midpoint along axis
+            if (
+                isinstance(geometry, PolySlab)
+                and not isinstance(self.medium, AbstractCustomMedium)
+                and field_keys == [("vertices",)]
+            ):
+                size[geometry.axis] = 0.0
+
+        # Build monitors
         mnt_fld = FieldMonitor(
             size=size,
             center=center,


### PR DESCRIPTION
Autograd support for ClipOperation with respect to the vertices and slab_bounds of its constituent PolySlab.

**Key Changes**:
**Differentiable Geometry Representation:**
Introduces a "soft membership" function. It provides a smooth, differentiable approximation of the sharp boundaries and non-differentiable nature of boolean geometric operations (intersection, union, difference and symmetric-difference), enabling gradient computation.

**Adjoint-Based Derivative Calculation:**
Computes gradients using the adjoint method, integrating permittivity sensitivity , and the gradient of the soft membership function wrt polylab params.

**Expanded Monitor Bounds**: 
Adjoint monitors now encompass both input geometries with padding, ensuring accurate field capture for derivative calculations near boundaries.

**Validation**: 
Results verified against finite-difference checks for all parameters and boolean operation types (attached).

<img width="416" alt="Screenshot 2025-05-12 at 6 18 47 PM" src="https://github.com/user-attachments/assets/6b55870d-0e9f-41d7-a84d-2d77b7893430" />

<img width="408" alt="Screenshot 2025-05-12 at 6 19 14 PM" src="https://github.com/user-attachments/assets/80192860-7516-4b35-91e2-f7482560ef93" />

<img width="446" alt="Screenshot 2025-05-12 at 6 19 28 PM" src="https://github.com/user-attachments/assets/26e7ebc4-a8b4-49e3-ac10-b908ea89c209" />

<img width="518" alt="Screenshot 2025-05-12 at 6 20 02 PM" src="https://github.com/user-attachments/assets/929ed799-872d-4acd-af8f-f1e47882f0c9" />
<img width="436" alt="Screenshot 2025-05-12 at 6 20 36 PM" src="https://github.com/user-attachments/assets/5622d83a-c0d8-4078-9f3c-287e137d3f7c" />
<img width="412" alt="Screenshot 2025-05-12 at 6 20 49 PM" src="https://github.com/user-attachments/assets/bd4e51f5-a704-4430-b55f-5ebee1013c05" />

<img width="542" alt="Screenshot 2025-05-12 at 6 21 07 PM" src="https://github.com/user-attachments/assets/338c191a-608e-43fc-ad27-658fc93da17c" />
<img width="491" alt="Screenshot 2025-05-12 at 6 21 23 PM" src="https://github.com/user-attachments/assets/f28bc51a-fb0e-427a-8113-cc384ff2345a" />
<img width="574" alt="Screenshot 2025-05-12 at 6 36 09 PM" src="https://github.com/user-attachments/assets/b42f857d-adc1-4fcf-be6a-935f9b528f47" />



<img width="493" alt="Screenshot 2025-05-12 at 6 22 23 PM" src="https://github.com/user-attachments/assets/88e949c8-19b5-47bf-abb1-e64c564ffca8" />
<img width="575" alt="Screenshot 2025-05-12 at 6 22 50 PM" src="https://github.com/user-attachments/assets/8377d206-413f-4551-aabd-a027d0a4e62c" />

<img width="483" alt="Screenshot 2025-05-12 at 6 34 19 PM" src="https://github.com/user-attachments/assets/9ea8002c-2c1b-4533-b5c3-19595532ffb4" />




<!-- greptile_comment -->

## Greptile Summary

Implements automatic differentiation support for ClipOperation geometries, enabling gradient calculations for boolean operations between PolySlabs through differentiable approximations.

- Added "soft membership" function in `tidy3d/components/geometry/base.py` to create smooth, differentiable approximations of boolean operations (union, intersection, difference)
- Expanded monitor bounds in `tidy3d/components/structure.py` with 5% padding to ensure accurate field capture near boundaries
- Implemented compute_derivatives() for ClipOperation to calculate gradients with respect to vertices and slab_bounds
- Added comprehensive test suite in `tests/test_components/test_autograd_clip_operations.py` validating derivatives against finite-difference checks
- Removed `test_error_clip` from `tests/test_components/test_autograd.py` as ClipOperations now support differentiation



<!-- /greptile_comment -->