### PR TITLE
relax wave port bounds check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `eps_lim` keyword argument to `Simulation.plot_eps()` for manual control over the permittivity color limits.
 
+### Changed
+- Relaxed bounds checking of path integrals during `WavePort` validation.
+
 ## [2.8.4] - 2025-05-15
 
 ### Added

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -564,6 +564,21 @@ def test_wave_port_path_integral_validation():
             current_integral=custom_current_path,
         )
 
+    # Test integral path only slightly larger than port bounds
+    wave_port = WavePort(
+        center=(0, 10000, 115.00000022351743),
+        size=(500, 0, 160.00000000000003),
+        name="wave_port_1",
+        mode_spec=mode_spec,
+        direction="+",
+        voltage_integral=voltage_path.updated_copy(
+            size=(0, 0, 70.000000298023424), center=(0, 10000, 70.000000298023424)
+        ),
+        current_integral=None,
+    )
+    # Make sure validation would have failed if a strict comparison was used
+    assert wave_port.bounds[0][2] > wave_port.voltage_integral.bounds[0][2]
+
 
 def test_wave_port_to_mode_solver(tmp_path):
     """Checks that wave port can be converted to a mode solver."""

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -28,6 +28,7 @@ from ...constants import (
 )
 from ...exceptions import DataError, FileError
 from ..autograd import TidyArrayBox, get_static, interpn, is_tidy_box
+from ..geometry.bound_ops import bounds_contains
 from ..types import Axis, Bound
 
 # maps the dimension names to their attributes
@@ -627,7 +628,7 @@ class AbstractSpatialDataArray(DataArray, ABC):
 
         return sorted_self.isel(x=inds_list[0], y=inds_list[1], z=inds_list[2])
 
-    def does_cover(self, bounds: Bound) -> bool:
+    def does_cover(self, bounds: Bound, rtol: float = 0.0, atol: float = 0.0) -> bool:
         """Check whether data fully covers specified by ``bounds`` spatial region. If data contains
         only one point along a given direction, then it is assumed the data is constant along that
         direction and coverage is not checked.
@@ -637,6 +638,10 @@ class AbstractSpatialDataArray(DataArray, ABC):
         ----------
         bounds : Tuple[float, float, float], Tuple[float, float float]
             Min and max bounds packaged as ``(minx, miny, minz), (maxx, maxy, maxz)``.
+        rtol : float = 0.0
+            Relative tolerance for comparing bounds
+        atol : float = 0.0
+            Absolute tolerance for comparing bounds
 
         Returns
         -------
@@ -647,12 +652,19 @@ class AbstractSpatialDataArray(DataArray, ABC):
             raise DataError(
                 "Min and max bounds must be packaged as '(minx, miny, minz), (maxx, maxy, maxz)'."
             )
-
-        coords = (self.x, self.y, self.z)
-        return all(
-            (np.min(coord) <= smin and np.max(coord) >= smax) or len(coord) == 1
-            for coord, smin, smax in zip(coords, bounds[0], bounds[1])
-        )
+        xyz = [self.x, self.y, self.z]
+        self_min = [0] * 3
+        self_max = [0] * 3
+        for dim in range(3):
+            coords = xyz[dim]
+            if len(coords) == 1:
+                self_min[dim] = bounds[0][dim]
+                self_max[dim] = bounds[1][dim]
+            else:
+                self_min[dim] = np.min(coords)
+                self_max[dim] = np.max(coords)
+        self_bounds = (tuple(self_min), tuple(self_max))
+        return bounds_contains(self_bounds, bounds, rtol=rtol, atol=atol)
 
 
 class SpatialDataArray(AbstractSpatialDataArray):

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -59,6 +59,7 @@ from ..viz import (
     polygon_patch,
     set_default_labels_and_title,
 )
+from .bound_ops import bounds_intersection, bounds_union
 
 POLY_GRID_SIZE = 1e-12
 
@@ -408,20 +409,12 @@ class Geometry(Tidy3dBaseModel, ABC):
     @staticmethod
     def bounds_intersection(bounds1: Bound, bounds2: Bound) -> Bound:
         """Return the bounds that are the intersection of two bounds."""
-        rmin1, rmax1 = bounds1
-        rmin2, rmax2 = bounds2
-        rmin = tuple(max(v1, v2) for v1, v2 in zip(rmin1, rmin2))
-        rmax = tuple(min(v1, v2) for v1, v2 in zip(rmax1, rmax2))
-        return (rmin, rmax)
+        return bounds_intersection(bounds1, bounds2)
 
     @staticmethod
     def bounds_union(bounds1: Bound, bounds2: Bound) -> Bound:
         """Return the bounds that are the union of two bounds."""
-        rmin1, rmax1 = bounds1
-        rmin2, rmax2 = bounds2
-        rmin = tuple(min(v1, v2) for v1, v2 in zip(rmin1, rmin2))
-        rmax = tuple(max(v1, v2) for v1, v2 in zip(rmax1, rmax2))
-        return (rmin, rmax)
+        return bounds_union(bounds1, bounds2)
 
     @cached_property
     def bounding_box(self):

--- a/tidy3d/components/geometry/bound_ops.py
+++ b/tidy3d/components/geometry/bound_ops.py
@@ -1,0 +1,66 @@
+"""Geometry operations for bounding box type with minimal imports."""
+
+from math import isclose
+
+from ...constants import fp_eps
+from ..types import Bound
+
+
+def bounds_intersection(bounds1: Bound, bounds2: Bound) -> Bound:
+    """Return the bounds that are the intersection of two bounds."""
+    rmin1, rmax1 = bounds1
+    rmin2, rmax2 = bounds2
+    rmin = tuple(max(v1, v2) for v1, v2 in zip(rmin1, rmin2))
+    rmax = tuple(min(v1, v2) for v1, v2 in zip(rmax1, rmax2))
+    return (rmin, rmax)
+
+
+def bounds_union(bounds1: Bound, bounds2: Bound) -> Bound:
+    """Return the bounds that are the union of two bounds."""
+    rmin1, rmax1 = bounds1
+    rmin2, rmax2 = bounds2
+    rmin = tuple(min(v1, v2) for v1, v2 in zip(rmin1, rmin2))
+    rmax = tuple(max(v1, v2) for v1, v2 in zip(rmax1, rmax2))
+    return (rmin, rmax)
+
+
+def bounds_contains(
+    outer_bounds: Bound, inner_bounds: Bound, rtol: float = fp_eps, atol: float = 0.0
+) -> bool:
+    """Checks whether ``inner_bounds`` is contained within ``outer_bounds`` within specified tolerances.
+
+    Parameters
+    ----------
+    outer_bounds : Bound
+        The outer bounds to check containment against
+    inner_bounds : Bound
+        The inner bounds to check if contained
+    rtol : float = fp_eps
+        Relative tolerance for comparing bounds
+    atol : float = 0.0
+        Absolute tolerance for comparing bounds
+
+    Returns
+    -------
+    bool
+        True if ``inner_bounds`` is contained within ``outer_bounds`` within tolerances
+    """
+    outer_min, outer_max = outer_bounds
+    inner_min, inner_max = inner_bounds
+    for dim in range(3):
+        outer_min_dim = outer_min[dim]
+        outer_max_dim = outer_max[dim]
+        inner_min_dim = inner_min[dim]
+        inner_max_dim = inner_max[dim]
+        within_min = (
+            isclose(outer_min_dim, inner_min_dim, rel_tol=rtol, abs_tol=atol)
+            or outer_min_dim <= inner_min_dim
+        )
+        within_max = (
+            isclose(outer_max_dim, inner_max_dim, rel_tol=rtol, abs_tol=atol)
+            or outer_max_dim >= inner_max_dim
+        )
+
+        if not within_min or not within_max:
+            return False
+    return True

--- a/tidy3d/plugins/microwave/path_integrals.py
+++ b/tidy3d/plugins/microwave/path_integrals.py
@@ -105,7 +105,7 @@ class AxisAlignedPathIntegral(AbstractAxesRH, Box):
     def compute_integral(self, scalar_field: EMScalarFieldType) -> IntegralResultTypes:
         """Computes the defined integral given the input ``scalar_field``."""
 
-        if not scalar_field.does_cover(self.bounds):
+        if not scalar_field.does_cover(self.bounds, fp_eps, np.finfo(np.float32).smallest_normal):
             raise DataError("Scalar field does not cover the integration domain.")
         coord = "xyz"[self.main_axis]
 

--- a/tidy3d/plugins/smatrix/ports/wave.py
+++ b/tidy3d/plugins/smatrix/ports/wave.py
@@ -10,12 +10,14 @@ from ....components.data.data_array import FreqDataArray, FreqModeDataArray
 from ....components.data.monitor_data import ModeData
 from ....components.data.sim_data import SimulationData
 from ....components.geometry.base import Box
+from ....components.geometry.bound_ops import bounds_contains
 from ....components.grid.grid import Grid
 from ....components.monitor import ModeMonitor
 from ....components.simulation import Simulation
 from ....components.source.field import ModeSource, ModeSpec
 from ....components.source.time import GaussianPulse
-from ....components.types import Bound, Direction, FreqArray
+from ....components.types import Direction, FreqArray
+from ....constants import fp_eps
 from ....exceptions import ValidationError
 from ...microwave import (
     CurrentIntegralTypes,
@@ -183,22 +185,15 @@ class WavePort(AbstractTerminalPort, Box):
         impedance_array = impedance_calc.compute_impedance(mode_data)
         return impedance_array
 
-    @staticmethod
-    def _within_port_bounds(path_bounds: Bound, port_bounds: Bound) -> bool:
-        """Helper to check if one bounding box is completely within the other."""
-        path_min = np.array(path_bounds[0])
-        path_max = np.array(path_bounds[1])
-        bound_min = np.array(port_bounds[0])
-        bound_max = np.array(port_bounds[1])
-        return (bound_min <= path_min).all() and (bound_max >= path_max).all()
-
     @pd.validator("voltage_integral", "current_integral")
     def _validate_path_integrals_within_port(cls, val, values):
         """Raise ``ValidationError`` when the supplied path integrals are not within the port bounds."""
         center = values["center"]
         size = values["size"]
         box = Box(center=center, size=size)
-        if val and not WavePort._within_port_bounds(val.bounds, box.bounds):
+        if val and not bounds_contains(
+            box.bounds, val.bounds, fp_eps, np.finfo(np.float32).smallest_normal
+        ):
             raise ValidationError(
                 f"'{cls.__name__}' must be setup with all path integrals defined within the bounds "
                 f"of the port. Path bounds are '{val.bounds}', but port bounds are '{box.bounds}'."


### PR DESCRIPTION
Relaxed validation step of wave port bounds. As long as the path is almost coincident with the boundaries of the mode field data the voltage/current calculations will work accurately.

Also need to modify the `does_cover` helper, to enable the same type of check. I moved some `Bound` related functions to their own file to avoid a circular dependency.

TODO:

- [x] Changelog