### PR TITLE
linking FixedAngleSpec notebook to PlaneWave docstring

### DIFF
--- a/tidy3d/components/source/field.py
+++ b/tidy3d/components/source/field.py
@@ -489,6 +489,14 @@ class FixedAngleSpec(AbstractAngularSpec):
 class PlaneWave(AngledFieldSource, PlanarSource, BroadbandSource):
     """Uniform current distribution on an infinite extent plane. One element of size must be zero.
 
+    Notes
+    -----
+
+        For oblique incidence, there are two possible settings: fixed in-plane k-vector and fixed-angle mode.
+        The first requires Bloch periodic boundary conditions, and the incidence angle is exact only at the central wavelength.
+        The latter requires periodic boundary conditions and maintains a constant propagation angle over a broadband spectrum.
+        For more information and important notes, see this example: `Broadband PlaneWave With Constant Oblique Incident Angle <https://docs.simulation.cloud/projects/tidy3d/en/latest/notebooks/BroadbandPlaneWaveWithConstantObliqueIncidentAngle.html>`_.
+
     Example
     -------
     >>> from tidy3d import GaussianPulse


### PR DESCRIPTION
Hi all. A user was trying to understand how to use the different angle specification options and mentioned that the relevant information was a bit hard to find. I agree, so I'm proposing to add a note to the PlaneWave docstring and the PlaneWave FAQ about this, with a link to Tom’s tutorial.

It looks like this:

![image](https://github.com/user-attachments/assets/edb66726-0442-49c9-95e0-9d21419c40a2)


Any comments are welcome!