### PR TITLE
fix: set the width and height of the injected iframe for the `plot_sim_3d` function

### DIFF
--- a/tidy3d/components/viz.py
+++ b/tidy3d/components/viz.py
@@ -398,6 +398,7 @@ def plot_sim_3d(sim, width=800, height=800) -> None:
                         var frame = document.createElement("iframe");
                         frame.width = node.dataset.width || 800;
                         frame.height = node.dataset.height || 800;
+                        frame.style.cssText = `width:${frame.width}px;height:${frame.height}px;max-width:none;border:0;display:block`
                         frame.src = VIEWER_URL + "?uuid=" + uuid;
 
                         var postMessageToViewer;
@@ -426,7 +427,7 @@ def plot_sim_3d(sim, width=800, height=800) -> None:
         })();
     """
     html_code = f"""
-    <div class="simulation-viewer" data-width="{escape(str(width))}" data-height="{escape(str(height))}" data-simulation="{escape(base64)}" />
+    <div class="simulation-viewer" data-width="{escape(str(width))}" data-height="{escape(str(height))}" data-simulation="{escape(base64)}" ></div>
     <script>
         {js_code}
     </script>


### PR DESCRIPTION
This PR fixes an issue when building the [quickstart](https://docs.flexcompute.com/projects/tidy3d/en/develop/notebooks/StartHere.html) notebook for the documentation. This prevented the simulation from being rendered due to the iframe having width of 0.