### PR TITLE
split validators to help avoid circular dependencies

### DIFF
--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -60,9 +60,11 @@ from ..types import (
 from ..validators import (
     validate_freqs_min,
     validate_freqs_not_empty,
-    validate_mode_plane_radius,
 )
 from ..viz import make_ax, plot_params_pml
+from .validators import (
+    validate_mode_plane_radius,
+)
 
 # Importing the local solver may not work if e.g. scipy is not installed
 IMPORT_ERROR_MSG = """Could not import local solver, 'ModeSolver' objects can still be constructed

--- a/tidy3d/components/mode/simulation.py
+++ b/tidy3d/components/mode/simulation.py
@@ -26,8 +26,10 @@ from ..types import (
     EMField,
     FreqArray,
 )
-from ..validators import validate_mode_plane_radius
 from .mode_solver import ModeSolver
+from .validators import (
+    validate_mode_plane_radius,
+)
 
 ModeSimulationMonitorType = PermittivityMonitor
 

--- a/tidy3d/components/mode/validators.py
+++ b/tidy3d/components/mode/validators.py
@@ -1,0 +1,24 @@
+"""Defines various validation functions that are specific to the mode solver"""
+
+import numpy as np
+
+from ..geometry.base import Box
+from ..mode_spec import ModeSpec
+
+
+def validate_mode_plane_radius(mode_spec: ModeSpec, plane: Box, msg_prefix: str = ""):
+    """Validate that the radius of a mode spec with a bend is not smaller than half the size of
+    the plane along the radial direction."""
+
+    if not mode_spec.bend_radius:
+        return
+
+    # radial axis is the plane axis that is not the bend axis
+    _, plane_axs = plane.pop_axis([0, 1, 2], plane.size.index(0.0))
+    radial_ax = plane_axs[(mode_spec.bend_axis + 1) % 2]
+
+    if np.abs(mode_spec.bend_radius) < plane.size[radial_ax] / 2:
+        raise ValueError(
+            f"{msg_prefix} bend radius is smaller than half the mode plane size "
+            "along the radial axis, which can produce wrong results."
+        )

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -64,6 +64,9 @@ from .medium import (
     MediumType,
     MediumType3D,
 )
+from .mode.validators import (
+    validate_mode_plane_radius,
+)
 from .monitor import (
     AbstractFieldProjectionMonitor,
     AbstractModeMonitor,
@@ -117,7 +120,6 @@ from .validators import (
     assert_objects_contained_in_sim_bounds,
     assert_objects_in_sim_bounds,
     validate_mode_objects_symmetry,
-    validate_mode_plane_radius,
 )
 from .viz import (
     PlotParams,

--- a/tidy3d/components/validators.py
+++ b/tidy3d/components/validators.py
@@ -10,7 +10,6 @@ from .autograd.utils import get_static
 from .base import DATA_ARRAY_MAP, skip_if_fields_missing
 from .data.dataset import Dataset, FieldDataset
 from .geometry.base import Box
-from .mode_spec import ModeSpec
 from .types import Tuple
 
 """ Explanation of pydantic validators:
@@ -448,24 +447,6 @@ def validate_freqs_not_empty():
         return val
 
     return freqs_not_empty
-
-
-def validate_mode_plane_radius(mode_spec: ModeSpec, plane: Box, msg_prefix: str = ""):
-    """Validate that the radius of a mode spec with a bend is not smaller than half the size of
-    the plane along the radial direction."""
-
-    if not mode_spec.bend_radius:
-        return
-
-    # radial axis is the plane axis that is not the bend axis
-    _, plane_axs = plane.pop_axis([0, 1, 2], plane.size.index(0.0))
-    radial_ax = plane_axs[(mode_spec.bend_axis + 1) % 2]
-
-    if np.abs(mode_spec.bend_radius) < plane.size[radial_ax] / 2:
-        raise ValueError(
-            f"{msg_prefix} bend radius is smaller than half the mode plane size "
-            "along the radial axis, which can produce wrong results."
-        )
 
 
 def _warn_unsupported_traced_argument(name: str):


### PR DESCRIPTION
Can we do something like in this PR to help avoid circular dependencies? In my upcoming feature branch `ModeSpec` is importing my own module which itself importing validators. I already resolved many other circular dependencies by splitting my own modules, but this seems like a fairly reasonable split to me.