### PR TITLE
remove pulse amplitude and phase of forward source time in broadband adjoint source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed issue with `CustomMedium` gradients where other frequencies would wrongly contribute to the gradient.
 - Fixed bug when computing `PolySlab` bounds in plotting functions.
+- Fixed bug in broadband adjoint source creation when forward simulation had a pulse amplitude greater than 1 or a nonzero pulse phase.
 
 ## [2.8.3] - 2025-04-24
 

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -1188,7 +1188,9 @@ class SimulationData(AbstractYeeGridSimulationData):
         """Make a broadband source for a set of adjoint sources."""
 
         source_index = self.simulation.normalize_index or 0
-        src_time_base = self.simulation.sources[source_index].source_time.copy()
+        src_time_base = self.simulation.sources[source_index].source_time.updated_copy(
+            amplitude=1.0, phase=0.0
+        )
         src_broadband = adj_srcs[0].updated_copy(source_time=src_time_base)
 
         return src_broadband


### PR DESCRIPTION
For a broadband source, the post norm values are set assuming the adjoint source time has amplitude=1 and phase=0, but the source_time is being extracted from the forward simulation. If the user has a phase or amplitude in it, then we aren't normalizing properly with the post norm. We could either update the post norm or just remove this amplitude and phase, which is what I did. Examples of numerical gradients are below.