### PR TITLE
Improve mode solver handling of 1D simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Zero-size dimensions automatically receive periodic boundary conditions, raising a warning where previously they would error.
+- Plane used for mode solving can be automatically inferred for 1D and 2D simulations.
+
 ## [2.8.4] - 2025-05-15
 
 ### Added

--- a/tests/test_components/test_mode.py
+++ b/tests/test_components/test_mode.py
@@ -95,8 +95,9 @@ def get_mode_sim():
 
 
 def test_mode_sim():
-    with AssertLogLevel(None):
+    with AssertLogLevel("WARNING", contains_str="2D"):
         sim = get_mode_sim()
+    with AssertLogLevel(None):
         _ = sim.plot(y=0, ax=AX)
         _ = sim.plot_mode_plane(ax=AX)
         _ = sim.plot_eps_mode_plane(ax=AX)
@@ -244,3 +245,53 @@ def get_mode_sim_data():
 def test_mode_sim_data():
     sim_data = get_mode_sim_data()
     _ = sim_data.plot_field("Ey", ax=AX, mode_index=0, f=FS[0])
+
+
+def test_mode_sim_infer_plane():
+    # 3d sim cannot infer plane
+    with pytest.raises(pydantic.ValidationError):
+        sim = td.ModeSimulation(
+            size=(1, 1, 1),
+            freqs=FS,
+            mode_spec=MODE_SPEC,
+            grid_spec=td.GridSpec.auto(wavelength=td.C_0 / FS[0]),
+            monitors=[],
+        )
+    # 2d sim plane defaults to whole sim geometry
+    sim = td.ModeSimulation(
+        size=(1, 1, 0),
+        freqs=FS,
+        mode_spec=MODE_SPEC,
+        grid_spec=td.GridSpec.auto(wavelength=td.C_0 / FS[0]),
+        monitors=[],
+    )
+    assert sim.plane.size.index(0.0) == 2
+    # but can manually set it to a 1D cross-section
+    sim = td.ModeSimulation(
+        size=(1, 1, 0),
+        freqs=FS,
+        mode_spec=MODE_SPEC,
+        grid_spec=td.GridSpec.auto(wavelength=td.C_0 / FS[0]),
+        monitors=[],
+        plane=td.Box(size=(td.inf, 0, td.inf), center=(0, 0, 0)),
+    )
+    assert sim.plane.size.index(0.0) == 1
+    # 1d sim plane defaults to extending first zero dim
+    sim = td.ModeSimulation(
+        size=(1, 0, 0),
+        freqs=FS,
+        mode_spec=MODE_SPEC,
+        grid_spec=td.GridSpec.auto(wavelength=td.C_0 / FS[0]),
+        monitors=[],
+    )
+    assert sim.plane.size.index(0.0) == 2
+    # but can manually set it differently
+    sim = td.ModeSimulation(
+        size=(1, 0, 0),
+        freqs=FS,
+        mode_spec=MODE_SPEC,
+        grid_spec=td.GridSpec.auto(wavelength=td.C_0 / FS[0]),
+        monitors=[],
+        plane=td.Box(size=(td.inf, 0, td.inf), center=(0, 0, 0)),
+    )
+    assert sim.plane.size.index(0.0) == 1

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -560,7 +560,7 @@ def test_validate_zero_dim_boundaries():
         pol_angle=0.0,
     )
 
-    with pytest.raises(pydantic.ValidationError):
+    with AssertLogLevel("WARNING", contains_str="Periodic"):
         td.Simulation(
             size=(1, 1, 0),
             run_time=1e-12,

--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -1244,3 +1244,17 @@ def test_translated_dot():
 
     assert np.allclose(data2.outer_dot(data_translated), data2.outer_dot(data2), atol=atol)
     assert np.allclose(data_translated.outer_dot(data2), data2.outer_dot(data2), atol=atol)
+
+
+def test_mode_solver_1d():
+    lda0 = 1.55
+    freq0 = td.C_0 / lda0
+    fwidth = 0.1 * freq0
+    run_time = 30 / fwidth
+
+    sim_size = (lda0, 0, 0)
+    sim = td.Simulation(
+        size=sim_size, run_time=run_time, grid_spec=td.GridSpec.auto(wavelength=lda0)
+    )
+    mode_solver = ModeSolver(simulation=sim, mode_spec=td.ModeSpec(), freqs=[freq0])
+    _ = mode_solver.data

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from functools import wraps
 from math import isclose
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pydantic.v1 as pydantic
@@ -14,7 +14,7 @@ import xarray as xr
 from matplotlib.collections import PatchCollection
 from matplotlib.patches import Rectangle
 
-from ...constants import C_0
+from ...constants import C_0, inf
 from ...exceptions import SetupError, ValidationError
 from ...log import log
 from ..base import Tidy3dBaseModel, cached_property, skip_if_fields_missing
@@ -138,8 +138,8 @@ class ModeSolver(Tidy3dBaseModel):
         discriminator="type",
     )
 
-    plane: MODE_PLANE_TYPE = pydantic.Field(
-        ...,
+    plane: Optional[MODE_PLANE_TYPE] = pydantic.Field(
+        None,
         title="Plane",
         description="Cross-sectional plane in which the mode will be computed.",
         discriminator=TYPE_TAG_STR,
@@ -188,9 +188,45 @@ class ModeSolver(Tidy3dBaseModel):
             )
         return val
 
+    @classmethod
+    def _infer_plane(cls, sim_geom: Box) -> Box:
+        """If the mode plane is not explicitly specified,
+        we infer it from the simulation geometry. This only works
+        when the simulation is 2D or 1D."""
+        new_size = list(sim_geom.size)
+        num_zero_dims = new_size.count(0.0)
+        nonzero_dims = list("xyz")
+        if num_zero_dims == 0:
+            raise ValidationError(
+                "The simulation geometry is 3D, so 'plane' cannot be inferred "
+                "and must be specified explicitly."
+            )
+        elif num_zero_dims == 1:
+            nonzero_dims.pop(new_size.index(0.0))
+            log.warning(
+                "The simulation geometry is 2D; the mode solver 'plane' "
+                "is taken by default to be the entire simulation geometry "
+                f"(the {nonzero_dims}-plane)."
+            )
+        elif num_zero_dims == 2:
+            new_size[new_size.index(0.0)] = inf
+            nonzero_dims.pop(new_size.index(0.0))
+            log.warning(
+                "The simulation geometry is 1D; the mode solver 'plane' "
+                "is taken by default as the span of the nonzero-size dimension "
+                "together with the first zero-size dimension "
+                f"(the {nonzero_dims}-plane)."
+            )
+        sim_geom = sim_geom.updated_copy(size=new_size)
+        num_zero_dims = sim_geom.size.count(0.0)
+        return sim_geom
+
     @pydantic.validator("plane", always=True)
-    def is_plane(cls, val):
+    @skip_if_fields_missing(["simulation"])
+    def is_plane(cls, val, values):
         """Raise validation error if not planar."""
+        if val is None:
+            val = cls._infer_plane(sim_geom=values.get("simulation").geometry)
         if val.size.count(0.0) != 1:
             raise ValidationError(f"ModeSolver plane must be planar, given size={val}")
         return val

--- a/tidy3d/components/mode/simulation.py
+++ b/tidy3d/components/mode/simulation.py
@@ -193,13 +193,8 @@ class ModeSimulation(AbstractYeeGridSimulation):
         if val is None:
             sim_center = values.get("center")
             sim_size = values.get("size")
-            val = Box(size=sim_size, center=sim_center)
-            if val.size.count(0.0) != 1:
-                raise ValidationError(
-                    "If the 'ModeSimulation' geometry is not planar, "
-                    "then 'plane' must be specified."
-                )
-            return val
+            sim_geom = Box(size=sim_size, center=sim_center)
+            val = ModeSolver._infer_plane(sim_geom=sim_geom)
         if val.size.count(0.0) != 1:
             raise ValidationError(f"'ModeSimulation.plane' must be planar, given 'size={val}'")
         return val

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -198,10 +198,13 @@ def validate_boundaries_for_zero_dims():
                 num_bloch_bdries = sum(isinstance(bnd, BlochBoundary) for bnd in boundary)
 
                 if num_absorbing_bdries > 0:
-                    raise SetupError(
+                    pbc = Boundary(minus=Periodic(), plus=Periodic())
+                    val = val.updated_copy(**{axis: pbc})
+                    log.warning(
                         f"The simulation has zero size along the {axis} axis, so "
                         "using a PML or absorbing boundary along that axis is incorrect. "
-                        f"Use either 'Periodic' or 'BlochBoundary' along {axis}."
+                        f"Use either 'Periodic' or 'BlochBoundary' along {axis}. "
+                        "Using 'Periodic' boundary by default."
                     )
 
                 if num_bloch_bdries > 0:


### PR DESCRIPTION
Addresses this issue:
https://github.com/flexcompute/tidy3d/issues/2471

Changes:

- Instead of erroring when a simulation has 0 thickness dimension and the boundary is not Periodic or Bloch, the boundary is automatically replaced with Periodic (giving a warning)
- The mode plane can be inferred in mode solver and mode simulation for 1D and 2D simulations (previously, it was inferred in 2d mode simulations only)

<!-- greptile_comment -->

## Greptile Summary

Enhances mode solver functionality for 1D/2D simulations by improving boundary condition handling and plane inference capabilities.

- Automatically converts non-Periodic/Bloch boundaries to Periodic (with warning) for zero-thickness dimensions in `components/simulation.py`
- Added automatic mode plane inference for both 1D and 2D simulations in `components/mode/mode_solver.py`
- Made 'plane' parameter optional in mode solver, letting it be inferred from simulation geometry
- Added comprehensive test coverage in `tests/test_components/test_mode.py` for new 1D/2D simulation handling
- Updated validation logic in `components/mode/simulation.py` to support these lower-dimensional cases



<!-- /greptile_comment -->