### PR TITLE
only warning on VisualizationSpec color validation when matplotlib is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Warn if more than 20 frequencies are used in EME, as this may lead to slower or more expensive simulations.
 - EME now supports 2D simulations.
 - 'EMESimulation' now supports 'PermittivityMonitor'.
+- Change `VisualizationSpec` validator for checking validity of user specified colors to only issue a warning if matplotlib is not installed instead of an error.
 
 ### Fixed
 - Fixed issue with `CustomMedium` gradients where other frequencies would wrongly contribute to the gradient.

--- a/tests/test_components/test_viz.py
+++ b/tests/test_components/test_viz.py
@@ -10,6 +10,8 @@ from tidy3d.components.viz import Polygon, set_default_labels_and_title
 from tidy3d.constants import inf
 from tidy3d.exceptions import Tidy3dKeyError
 
+from ..utils import AssertLogLevel
+
 pytestmark = pytest.mark.usefixtures("mpl_config_noninteractive")
 
 
@@ -216,6 +218,17 @@ def plot_with_multi_viz_spec(alphas, facecolors, edgecolors, rng, use_viz_spec=T
 
     sim.plot(z=0.0)
     plt.show()
+
+
+def test_no_matlab_install(monkeypatch):
+    """Test that the `VisualizationSpec` only throws a warning on validation if matplotlib is not installed."""
+    monkeypatch.setattr("tidy3d.components.viz.MATPLOTLIB_IMPORTED", False)
+
+    EXPECTED_WARNING_MSG_PIECE = (
+        "matplotlib was not successfully imported, but is required to validate colors"
+    )
+    with AssertLogLevel("WARNING", contains_str=EXPECTED_WARNING_MSG_PIECE):
+        viz_spec = td.VisualizationSpec(facecolor="green")
 
 
 @pytest.mark.skip(reason="Skipping test for CI, but useful for debugging locally with graphics.")

--- a/tidy3d/components/viz.py
+++ b/tidy3d/components/viz.py
@@ -7,7 +7,15 @@ from html import escape
 from typing import Any, Dict, Optional
 
 import pydantic.v1 as pd
+from numpy import array, concatenate, inf, ones
 
+from ..constants import UnitScaling
+from ..exceptions import SetupError, Tidy3dKeyError
+from ..log import log
+from .base import Tidy3dBaseModel
+from .types import Ax, Axis, LengthUnit
+
+MATPLOTLIB_IMPORTED = True
 try:
     import matplotlib.pyplot as plt
     import matplotlib.ticker as ticker
@@ -19,13 +27,7 @@ try:
     arrow_style = ArrowStyle.Simple(head_length=12, head_width=9, tail_width=4)
 except ImportError:
     arrow_style = None
-
-from numpy import array, concatenate, inf, ones
-
-from ..constants import UnitScaling
-from ..exceptions import SetupError, Tidy3dKeyError
-from .base import Tidy3dBaseModel
-from .types import Ax, Axis, LengthUnit
+    MATPLOTLIB_IMPORTED = False
 
 """ Constants """
 
@@ -185,8 +187,15 @@ STRUCTURE_HEAT_COND_CMAP = "gist_yarg"
 
 
 def is_valid_color(value: str) -> str:
-    if not is_color_like(value):
-        raise pd.ValidationError(f"{value} is not a valid plotting color")
+    if not MATPLOTLIB_IMPORTED:
+        log.warning(
+            "matplotlib was not successfully imported, but is required "
+            "to validate colors in the VisualizationSpec. The specified colors "
+            "have not been validated."
+        )
+    else:
+        if not is_color_like(value):
+            raise ValueError(f"{value} is not a valid plotting color")
 
     return value
 


### PR DESCRIPTION
I'm not quite sure the best way to test this in CI. I've tested locally to make sure the warning pops up if I fake that the import couldn't happen, but I couldn't figure out a way to make python think matplotlib doesn't exist in the unit tests. Open to ideas here!