### PR TITLE
Thin conductor thickness in LossyMetalMedium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `eps_lim` keyword argument to `Simulation.plot_eps()` for manual control over the permittivity color limits.
+- Added `thickness` parameter to `LossyMetalMedium` for computing surface impedance of a thin conductor.
 
 ### Changed
 - Relaxed bounds checking of path integrals during `WavePort` validation.

--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -174,6 +174,11 @@ def test_lossy_metal():
     model = mat.scaled_surface_impedance_model
     num_poles = mat.num_poles
 
+    # thickness
+    mat = td.LossyMetalMedium(conductivity=1.0, frequency_range=(1e14, 4e14), thickness=0.1)
+    model = mat.scaled_surface_impedance_model
+    num_poles = mat.num_poles
+
 
 def test_lossy_metal_surface_roughness():
     mat_orig = td.LossyMetalMedium(

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -5509,6 +5509,14 @@ class LossyMetalMedium(Medium):
         discriminator=TYPE_TAG_STR,
     )
 
+    thickness: pd.PositiveFloat = pd.Field(
+        None,
+        title="Conductor Thickness",
+        description="When the thickness of the conductor is not much greater than skin depth, "
+        "1D transmission line model is applied to compute the surface impedance of the thin conductor.",
+        units=MICROMETER,
+    )
+
     frequency_range: FreqBound = pd.Field(
         ...,
         title="Frequency Range",
@@ -5594,6 +5602,10 @@ class LossyMetalMedium(Medium):
         if self.roughness is not None:
             skin_depths = 1 / np.sqrt(np.pi * frequencies * MU_0 * self.conductivity)
             correction = self.roughness.roughness_correction_factor(frequencies, skin_depths)
+
+        if self.thickness is not None:
+            k_wave = self.Hz_to_angular_freq(frequencies) / C_0 * (n + 1j * k)
+            correction /= -np.tanh(1j * k_wave * self.thickness)
 
         return correction * ETA_0 / (n + 1j * k)
 


### PR DESCRIPTION
Not sure how useful this feature is, but it seems to be a common option. The implementation here is based on the formula  [here](https://www.jpier.org/ac_api/download.php?id=0007011).

When I try computing attenuation constant of a CPW of 1 micron thickness, I need to set the thickness here to be 0.25 micron to get a good match.