### PR TITLE
fix shaping of custom medium derivatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed bug in broadband adjoint source creation when forward simulation had a pulse amplitude greater than 1 or a nonzero pulse phase.
+- Fixed shaping of `CustomMedium` gradients when permittivity data includes a frequency dimension with multiple entries.
 
 ### Changed
 - Relaxed bounds checking of path integrals during `WavePort` validation.
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Drop the dependency on `gdspy`, which has been unmaintained for over two years. Interfaces previously relying on `gdspy` now use its maintained successor, `gdstk`, with equivalent functionality.
 - Small (around 1e-4) numerical precision improvements in EME solver.
 - Adjoint source frequency width is adjusted to decay sufficiently before zero frequency when possible to improve accuracy of simulation normalization when using custom current sources.
+- Change `VisualizationSpec` validator for checking validity of user specified colors to only issue a warning if matplotlib is not installed instead of an error.
 
 ## [2.8.4] - 2025-05-15
 

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -1672,6 +1672,8 @@ class AbstractCustomMedium(AbstractMedium, ABC):
         coords_interp = {key: val for key, val in eps_data.coords.items() if len(val) > 1}
         dims_sum = {dim for dim in eps_data.coords.keys() if dim not in coords_interp}
 
+        eps_coordinate_shape = [len(eps_data.coords[dim]) for dim in eps_data.dims if dim in "xyz"]
+
         # compute sizes along each of the interpolation dimensions
         sizes_list = []
         for _, coords in coords_interp.items():
@@ -1703,7 +1705,7 @@ class AbstractCustomMedium(AbstractMedium, ABC):
             E_der_dim.interp(**coords_interp, assume_sorted=True).fillna(0.0).sum(dims_sum).sum("f")
         )
         vjp_array = np.array(E_der_dim_interp.values).astype(complex)
-        vjp_array = vjp_array.reshape(eps_data.shape)
+        vjp_array = vjp_array.reshape(eps_coordinate_shape)
 
         # multiply by volume elements (if possible, being defensive here..)
         try:
@@ -2871,9 +2873,10 @@ class CustomMedium(AbstractCustomMedium):
         freqs: NDArray,
     ) -> np.ndarray:
         """Compute derivative with respect to the ``dim`` components within the custom medium."""
-
         coords_interp = {key: eps_data.coords[key] for key in "xyz"}
         coords_interp = {key: val for key, val in coords_interp.items() if len(val) > 1}
+
+        eps_coordinate_shape = [len(eps_data.coords[dim]) for dim in eps_data.dims if dim in "xyz"]
 
         E_der_dim_interp = E_der_map[f"E{dim}"].sel(f=freqs)
 
@@ -2928,7 +2931,7 @@ class CustomMedium(AbstractCustomMedium):
                 "message and some information about your simulation setup and we will investigate. "
             )
         vjp_array = E_der_dim_interp.values
-        vjp_array = vjp_array.reshape(eps_data.shape)
+        vjp_array = vjp_array.reshape(eps_coordinate_shape)
 
         return vjp_array
 


### PR DESCRIPTION
Rahul ran into a problem last week (I believe when implementing the clip operations) where the eps_data he was using sometimes had more than one entry in the frequency dimension and then the shaping of the overall derivative was incorrect when using _derivative_field_cmp. This wasn't an issue in the current adjoint flow as far as I'm aware, but to be safe, this PR updates to only use the spatial coordinates now to get the shape for times when multifrequency datasets are passed into the function.