### PR TITLE
fix contains check for lumped element, which was too strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed bug in broadband adjoint source creation when forward simulation had a pulse amplitude greater than 1 or a nonzero pulse phase.
 - Fixed shaping of `CustomMedium` gradients when permittivity data includes a frequency dimension with multiple entries.
+- Bug in contains check for `LumpedElement`, which should allow the case of a `LumpedElement` touching the simulation boundaries.
 
 ### Changed
 - Relaxed bounds checking of path integrals during `WavePort` validation.

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -1604,6 +1604,25 @@ def test_warn_lumped_elements_outside_sim_bounds():
         )
     assert len(sim_good.volumetric_structures) == 1
 
+    # Lumped element is touching the boundary along one of its nonzero dims
+    resistor_in = td.LumpedResistor(
+        size=(0.5, 1, 0),
+        center=(0, 0.5, 0),
+        voltage_axis=1,
+        resistance=50,
+        name="resistor_touching",
+    )
+    with AssertLogLevel("INFO"):
+        sim_good = td.Simulation(
+            size=sim_size,
+            center=sim_center,
+            sources=[src],
+            run_time=1e-12,
+            lumped_elements=[resistor_in],
+            boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
+        )
+    assert len(sim_good.volumetric_structures) == 1
+
     # Lumped element outside - should emit warning and not be added
     resistor_out = td.LumpedResistor(
         size=(0.5, 1, 0),
@@ -1616,16 +1635,16 @@ def test_warn_lumped_elements_outside_sim_bounds():
         sim_bad = sim_good.updated_copy(lumped_elements=[resistor_out])
     assert len(sim_bad.volumetric_structures) == 0
 
-    # Lumped element extends to boundary and is not strictly inside simulation
+    # Lumped element is flush against boundary along its zero size dimension
     resistor_edge = td.LumpedResistor(
         size=(0.5, 1, 0),
-        center=(0, 0.5, 0),
+        center=(0, 0.5, 1),
         voltage_axis=1,
         resistance=50,
         name="resistor_edge",
     )
     with AssertLogLevel("WARNING"):
-        _ = sim_good.updated_copy(lumped_elements=[resistor_edge])
+        sim_bad = sim_good.updated_copy(lumped_elements=[resistor_edge])
     assert len(sim_bad.volumetric_structures) == 0
 
 

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -1613,8 +1613,9 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
 
         # Convert lumped elements into structures
         lumped_structures = []
-        strict_ineq = 3 * [True]
         for lumped_element in self.lumped_elements:
+            strict_ineq = 3 * [False]
+            strict_ineq[lumped_element.normal_axis] = True
             if self.geometry.contains(lumped_element.geometry, strict_inequality=strict_ineq):
                 lumped_structures += lumped_element.to_structures(self.grid)
 
@@ -2660,7 +2661,7 @@ class Simulation(AbstractYeeGridSimulation):
 
     _sources_in_bounds = assert_objects_in_sim_bounds("sources", strict_inequality=True)
     _lumped_elements_in_bounds = assert_objects_contained_in_sim_bounds(
-        "lumped_elements", error=False, strict_inequality=True
+        "lumped_elements", error=False, strict_inequality=False, strict_for_zero_size_dim=True
     )
     _mode_sources_symmetries = validate_mode_objects_symmetry("sources")
     _mode_monitors_symmetries = validate_mode_objects_symmetry("monitors")

--- a/tidy3d/components/validators.py
+++ b/tidy3d/components/validators.py
@@ -214,7 +214,10 @@ def assert_objects_in_sim_bounds(
 
 
 def assert_objects_contained_in_sim_bounds(
-    field_name: str, error: bool = True, strict_inequality: bool = False
+    field_name: str,
+    error: bool = True,
+    strict_inequality: bool = False,
+    strict_for_zero_size_dim: bool = False,
 ):
     """Makes sure all objects in field are completely inside the simulation bounds."""
 
@@ -228,10 +231,17 @@ def assert_objects_contained_in_sim_bounds(
 
         # Do a strict check, unless simulation is 0D along a dimension
         strict_ineq = [size != 0 and strict_inequality for size in sim_size]
-
         with log as consolidated_logger:
             for position_index, geometric_object in enumerate(val):
-                if not sim_box.contains(geometric_object.geometry, strict_inequality=strict_ineq):
+                geo_strict_ineq = list(strict_ineq)
+                # Optionally ensure that zero size dimensions are strictly contained
+                if strict_for_zero_size_dim:
+                    zero_dims = geometric_object.geometry.zero_dims
+                    for zero_dim in zero_dims:
+                        geo_strict_ineq[zero_dim] = True
+                if not sim_box.contains(
+                    geometric_object.geometry, strict_inequality=geo_strict_ineq
+                ):
                     message = (
                         f"'simulation.{field_name}[{position_index}]' "
                         "is not completely inside the simulation domain."


### PR DESCRIPTION
I introduced this bug a couple of months ago, when fixing a bug related to lumped elements outside the simulation domain.

We should allow lumped elements to touch the boundary.