### PR TITLE
Fix bug in EME simulations with bends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed shaping of `CustomMedium` gradients when permittivity data includes a frequency dimension with multiple entries.
 - Bug in contains check for `LumpedElement`, which should allow the case of a `LumpedElement` touching the simulation boundaries.
 - Bug when generating a grid with snapping points near the simulation boundaries.
+- Solver error for EME simulations with bends, introduced when support for 2D EME simulations was added.
 
 ### Changed
 - Relaxed bounds checking of path integrals during `WavePort` validation.

--- a/tests/test_components/test_monitor.py
+++ b/tests/test_components/test_monitor.py
@@ -309,7 +309,7 @@ def test_mode_bend_radius():
             size=(5, 0, 1),
             freqs=np.linspace(1e14, 2e14, 100),
             name="test",
-            mode_spec=td.ModeSpec(num_modes=1, bend_radius=1, bend_axis=1),
+            mode_spec=td.ModeSpec(num_modes=1, bend_radius=1, bend_axis=2),
         )
         _ = td.Simulation(
             size=(2, 2, 2),

--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -1131,13 +1131,29 @@ def test_modes_eme_sim(mock_remote_api, local):
 
 def test_mode_small_bend_radius_fail():
     """Test that small bend radius fails."""
-
+    simulation = td.Simulation(
+        size=SIM_SIZE,
+        grid_spec=td.GridSpec(wavelength=1.0),
+        structures=[WAVEGUIDE],
+        run_time=1e-12,
+        symmetry=(1, 0, -1),
+        boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
+        sources=[SRC],
+    )
     with pytest.raises(ValueError):
         ms = ModeSolver(
             plane=PLANE,
             freqs=np.linspace(1e14, 2e14, 100),
             mode_spec=td.ModeSpec(num_modes=1, bend_radius=1, bend_axis=0),
+            simulation=simulation,
         )
+    # should work for infinite mode plane
+    ms = ModeSolver(
+        plane=td.Box(center=(0, 0, 0), size=(td.inf, 0, td.inf)),
+        freqs=np.linspace(1e14, 2e14, 100),
+        mode_spec=td.ModeSpec(num_modes=1, bend_radius=10000, bend_axis=0),
+        simulation=simulation,
+    )
 
 
 def make_high_order_mode_solver(sign, dim=3):

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -56,7 +56,6 @@ from tidy3d.components.types import (
 from tidy3d.components.validators import (
     validate_freqs_min,
     validate_freqs_not_empty,
-    validate_mode_plane_radius,
 )
 from tidy3d.components.viz import make_ax, plot_params_pml
 from tidy3d.constants import C_0
@@ -211,8 +210,11 @@ class ModeSolver(Tidy3dBaseModel):
         return val
 
     def _post_init_validators(self) -> None:
-        validate_mode_plane_radius(
-            mode_spec=self.mode_spec, plane=self.plane, msg_prefix="Mode solver"
+        self._validate_mode_plane_radius(
+            mode_spec=self.mode_spec,
+            plane=self.plane,
+            sim_geom=self.simulation.geometry,
+            msg_prefix="Mode solver",
         )
         self._warn_thick_pml(simulation=self.simulation, plane=self.plane, mode_spec=self.mode_spec)
 
@@ -238,6 +240,35 @@ class ModeSolver(Tidy3dBaseModel):
                     "mode plane cells. Consider using a larger mode plane "
                     "or smaller 'num_pml'."
                 )
+
+    @staticmethod
+    def _mode_plane(plane: Box, sim_geom: Box) -> Box:
+        """Intersect the mode plane with the sim geometry to get the effective
+        mode plane."""
+        mode_plane_bnds = plane.bounds_intersection(plane.bounds, sim_geom.bounds)
+        return Box.from_bounds(*mode_plane_bnds)
+
+    @classmethod
+    def _validate_mode_plane_radius(
+        cls, mode_spec: ModeSpec, plane: Box, sim_geom: Box, msg_prefix: str = ""
+    ):
+        """Validate that the radius of a mode spec with a bend is not smaller than half the size of
+        the plane along the radial direction."""
+
+        if not mode_spec.bend_radius:
+            return
+
+        mode_plane = cls._mode_plane(plane=plane, sim_geom=sim_geom)
+
+        # radial axis is the plane axis that is not the bend axis
+        _, plane_axs = mode_plane.pop_axis([0, 1, 2], mode_plane.size.index(0.0))
+        radial_ax = plane_axs[(mode_spec.bend_axis + 1) % 2]
+
+        if np.abs(mode_spec.bend_radius) < mode_plane.size[radial_ax] / 2:
+            raise ValueError(
+                f"{msg_prefix} bend radius is smaller than half the mode plane size "
+                "along the radial axis, which can produce wrong results."
+            )
 
     @cached_property
     def normal_axis(self) -> Axis:

--- a/tidy3d/components/mode/simulation.py
+++ b/tidy3d/components/mode/simulation.py
@@ -21,7 +21,6 @@ from tidy3d.components.simulation import (
 )
 from tidy3d.components.source.field import ModeSource
 from tidy3d.components.types import TYPE_TAG_STR, Ax, Direction, EMField, FreqArray
-from tidy3d.components.validators import validate_mode_plane_radius
 from tidy3d.constants import C_0
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
@@ -228,8 +227,11 @@ class ModeSimulation(AbstractYeeGridSimulation):
 
     def _post_init_validators(self) -> None:
         """Call validators taking `self` that get run after init."""
-        validate_mode_plane_radius(
-            mode_spec=self.mode_spec, plane=self.plane, msg_prefix="'ModeSimulation'"
+        ModeSolver._validate_mode_plane_radius(
+            mode_spec=self.mode_spec,
+            plane=self.plane,
+            sim_geom=self.geometry,
+            msg_prefix="'ModeSimulation'",
         )
         _ = self._mode_solver
         _ = self.grid

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -118,7 +118,6 @@ from .validators import (
     assert_objects_contained_in_sim_bounds,
     assert_objects_in_sim_bounds,
     validate_mode_objects_symmetry,
-    validate_mode_plane_radius,
 )
 from .viz import (
     PlotParams,
@@ -3729,18 +3728,22 @@ class Simulation(AbstractYeeGridSimulation):
 
     def _validate_mode_object_bends(self) -> None:
         """Error if any mode sources or monitors with bends have a radius that is too small."""
+        from .mode.mode_solver import ModeSolver
+
         for imnt, monitor in enumerate(self.monitors):
             if isinstance(monitor, AbstractModeMonitor):
-                validate_mode_plane_radius(
+                ModeSolver._validate_mode_plane_radius(
                     mode_spec=monitor.mode_spec,
                     plane=monitor.geometry,
+                    sim_geom=self.geometry,
                     msg_prefix=f"Monitor at 'monitors[{imnt}]' ",
                 )
         for isrc, source in enumerate(self.sources):
             if isinstance(source, ModeSource):
-                validate_mode_plane_radius(
+                ModeSolver._validate_mode_plane_radius(
                     mode_spec=source.mode_spec,
                     plane=source.geometry,
+                    sim_geom=self.geometry,
                     msg_prefix=f"Source at 'sources[{isrc}]' ",
                 )
 

--- a/tidy3d/components/validators.py
+++ b/tidy3d/components/validators.py
@@ -15,7 +15,6 @@ from .autograd.utils import get_static
 from .base import DATA_ARRAY_MAP, skip_if_fields_missing
 from .data.dataset import Dataset, FieldDataset
 from .geometry.base import Box
-from .mode_spec import ModeSpec
 
 """ Explanation of pydantic validators:
 
@@ -462,24 +461,6 @@ def validate_freqs_not_empty():
         return val
 
     return freqs_not_empty
-
-
-def validate_mode_plane_radius(mode_spec: ModeSpec, plane: Box, msg_prefix: str = ""):
-    """Validate that the radius of a mode spec with a bend is not smaller than half the size of
-    the plane along the radial direction."""
-
-    if not mode_spec.bend_radius:
-        return
-
-    # radial axis is the plane axis that is not the bend axis
-    _, plane_axs = plane.pop_axis([0, 1, 2], plane.size.index(0.0))
-    radial_ax = plane_axs[(mode_spec.bend_axis + 1) % 2]
-
-    if np.abs(mode_spec.bend_radius) < plane.size[radial_ax] / 2:
-        raise ValueError(
-            f"{msg_prefix} bend radius is smaller than half the mode plane size "
-            "along the radial axis, which can produce wrong results."
-        )
 
 
 def _warn_unsupported_traced_argument(name: str):


### PR DESCRIPTION
A bug was introduced by a combination of the validator here:
https://github.com/flexcompute/tidy3d/pull/2053
and the change made here:
https://github.com/flexcompute/tidy3d/pull/2410

The validator compares the bend radius to the mode plane size, without taking the simulation size into account. Thus when the mode plane in EME was made infinite (so it was still a plane for 2D EME simulations), no bend radius was allowed. This broke EME simulations with nonzero bend radius in v2.8.4; they would just give a solver error.