### PR TITLE
Add subpixel parameter to epsilon and epsilon_on_grid

### DIFF
--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -2172,6 +2172,27 @@ def test_warn_large_epsilon(size, num_struct, log_level):
         sim.epsilon(box=td.Box(size=(size, size, size)))
 
 
+def test_error_no_local_subpixel():
+    sim = td.Simulation(
+        size=(1, 1, 1),
+        grid_spec=td.GridSpec.uniform(dl=0.1),
+        run_time=1e-12,
+        boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
+        sources=[
+            td.ModeSource(
+                center=(0, 0, 0),
+                size=(td.inf, td.inf, 0),
+                direction="+",
+                source_time=td.GaussianPulse(freq0=1e12, fwidth=0.1e12),
+            )
+        ],
+        structures=[],
+    )
+
+    with pytest.raises(SetupError):
+        _ = sim.epsilon(box=td.Box(size=(0, 0, 0)), subpixel=True)
+
+
 @pytest.mark.parametrize("dl, log_level", [(0.1, None), (0.005, "WARNING")])
 def test_warn_large_mode_monitor(dl, log_level):
     """Make sure we get a warning if the mode monitor grid is too large."""

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -1426,6 +1426,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         box: Box,
         coord_key: str = "centers",
         freq: Optional[float] = None,
+        subpixel: bool = False,
     ) -> xr.DataArray:
         """Get array of permittivity at volume specified by box and freq.
 
@@ -1444,6 +1445,10 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         freq : float = None
             The frequency to evaluate the mediums at.
             If not specified, evaluates at infinite frequency.
+        subpixel : bool = False
+            Whether to use subpixel averaging.
+            Requires installing the ``tidy3d-extras`` package.
+            NOTE: This feature is not yet supported.
 
         Returns
         -------
@@ -1460,7 +1465,9 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         """
 
         sub_grid = self.discretize(box)
-        return self.epsilon_on_grid(grid=sub_grid, coord_key=coord_key, freq=freq)
+        return self.epsilon_on_grid(
+            grid=sub_grid, coord_key=coord_key, freq=freq, subpixel=subpixel
+        )
 
     @supports_local_subpixel
     def epsilon_on_grid(
@@ -1468,6 +1475,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         grid: Grid,
         coord_key: str = "centers",
         freq: Optional[float] = None,
+        subpixel: bool = False,
     ) -> xr.DataArray:
         """Get array of permittivity at a given freq on a given grid.
 
@@ -1486,6 +1494,11 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         freq : float = None
             The frequency to evaluate the mediums at.
             If not specified, evaluates at infinite frequency.
+        subpixel : bool = False
+            Whether to use subpixel averaging.
+            Requires installing the ``tidy3d-extras`` package.
+            NOTE: This feature is not yet supported.
+
         Returns
         -------
         xarray.DataArray
@@ -1507,9 +1520,18 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
                 "Epsilon calculation may be slow."
             )
 
-        if tidy3d_extras["use_local_subpixel"]:
-            subpixel_sim = tidy3d_extras["mod"].SubpixelSimulation.from_simulation(self)
-            return subpixel_sim.epsilon_on_grid(grid=grid, coord_key=coord_key, freq=freq)
+        if subpixel:
+            if tidy3d_extras["use_local_subpixel"]:
+                subpixel_sim = tidy3d_extras["mod"].SubpixelSimulation.from_simulation(self)
+                return subpixel_sim.epsilon_on_grid(
+                    grid=grid, coord_key=coord_key, freq=freq, subpixel=True
+                )
+            else:
+                raise SetupError(
+                    "Local subpixel ('subpixel=True') requires the 'tidy3d-extras' "
+                    "package as well as setting 'config.use_local_subpixel'. "
+                    "NOTE: This feature is not yet supported."
+                )
 
         def get_eps(structure: Structure, frequency: float, coords: Coords):
             """Select the correct epsilon component if field locations are requested."""


### PR DESCRIPTION
EDIT: superceded by this: https://github.com/flexcompute/tidy3d/pull/2521


Some functions (like TFSF validators) use `Simulation.epsilon` in a way that assumes subpixel is not being applied. Adding a flag here makes it more explicit whether you want to use subpixel or not, even if globally `use_local_subpixel` is True. The global flag made more sense to me for the mode solver, since it makes heavy use of cached properties `data` and `data_raw`.