### PR TITLE
Disable local subpixel by default

### DIFF
--- a/tidy3d/config.py
+++ b/tidy3d/config.py
@@ -38,7 +38,7 @@ class Tidy3dConfig(pd.BaseModel):
     )
 
     use_local_subpixel: Optional[bool] = pd.Field(
-        None,
+        False,
         title="Whether to use local subpixel averaging. If 'None', local subpixel "
         "averaging will be used if 'tidy3d-extras' is installed and not used otherwise. "
         "NOTE: This feature is not yet supported.",


### PR DESCRIPTION
Disabling local subpixel by default seems to be safer than automatically setting it based on the presence of the python package.

And this replaces the previous PR, eliminates the need for `subpixel=False` (the alternative there would have been carefully disabling local subpixel wherever needed. But better to just have it off by default)