### PR TITLE
Fix field colocation in EMEModeSolverMonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed shaping of `CustomMedium` gradients when permittivity data includes a frequency dimension with multiple entries.
 - Bug in contains check for `LumpedElement`, which should allow the case of a `LumpedElement` touching the simulation boundaries.
 - Bug when generating a grid with snapping points near the simulation boundaries.
+- Fixed field colocation in `EMEModeSolverMonitor`.
 
 ### Changed
 - Relaxed bounds checking of path integrals during `WavePort` validation.

--- a/tidy3d/components/eme/data/sim_data.py
+++ b/tidy3d/components/eme/data/sim_data.py
@@ -12,6 +12,7 @@ from tidy3d.components.data.data_array import EMEScalarFieldDataArray, EMESMatri
 from tidy3d.components.data.monitor_data import FieldData, ModeData, ModeSolverData
 from tidy3d.components.data.sim_data import AbstractYeeGridSimulationData
 from tidy3d.components.eme.simulation import EMESimulation
+from tidy3d.components.geometry.base import Box
 from tidy3d.components.types import annotate_type
 from tidy3d.exceptions import SetupError
 
@@ -72,9 +73,12 @@ class EMESimulationData(AbstractYeeGridSimulationData):
             }
 
         monitor = self.simulation.mode_solver_monitors[eme_cell_index]
-        monitor = monitor.updated_copy(
-            colocate=data.monitor.colocate,
+        box = Box.from_bounds(
+            *Box.bounds_intersection(monitor.geometry.bounds, data.monitor.geometry.bounds)
         )
+        size = box.size
+        center = box.center
+        monitor = monitor.updated_copy(colocate=data.monitor.colocate, size=size, center=center)
         grid_expanded = self.simulation.discretize_monitor(monitor=monitor)
         return ModeSolverData(**update_dict, monitor=monitor, grid_expanded=grid_expanded)
 


### PR DESCRIPTION
When `colocate=True`, previously the field was not properly colocated in an `EMEModeSolverMonitor`.

Also fixes `grid_expanded` in `EMESimulationData._extract_mode_solver_data`.