### PR TITLE
Bug fix for EME _extract_mode_solver_data introduced in last PR

### DIFF
--- a/tests/test_components/test_eme.py
+++ b/tests/test_components/test_eme.py
@@ -1160,6 +1160,14 @@ def test_eme_sim_data():
     _ = sim_data.port_modes_tuple
     assert len(sim_data.port_modes_list_sweep) == 1
 
+    with AssertLogLevel("WARNING", contains_str="flux"):
+        _ = sim_data._extract_mode_solver_data(
+            data=sim_data.port_modes.updated_copy(
+                monitor=sim.port_modes_monitor.updated_copy(size=(0, td.inf, td.inf))
+            ),
+            eme_cell_index=0,
+        )
+
     # test freq sweep smatrix_in_basis
     sim = sim.updated_copy(sweep_spec=td.EMEFreqSweep(freq_scale_factors=np.linspace(1, 2, 10)))
     port_modes = _get_eme_port_modes(num_sweep=10)

--- a/tidy3d/components/eme/data/sim_data.py
+++ b/tidy3d/components/eme/data/sim_data.py
@@ -15,6 +15,7 @@ from tidy3d.components.eme.simulation import EMESimulation
 from tidy3d.components.geometry.base import Box
 from tidy3d.components.types import annotate_type
 from tidy3d.exceptions import SetupError
+from tidy3d.log import log
 
 from .dataset import EMESMatrixDataset
 from .monitor_data import EMEFieldData, EMEModeSolverData, EMEMonitorDataType
@@ -73,12 +74,20 @@ class EMESimulationData(AbstractYeeGridSimulationData):
             }
 
         monitor = self.simulation.mode_solver_monitors[eme_cell_index]
+        monitor = monitor.updated_copy(colocate=data.monitor.colocate)
         box = Box.from_bounds(
             *Box.bounds_intersection(monitor.geometry.bounds, data.monitor.geometry.bounds)
         )
         size = box.size
         center = box.center
-        monitor = monitor.updated_copy(colocate=data.monitor.colocate, size=size, center=center)
+        if size.count(0.0) == 1:
+            monitor = monitor.updated_copy(size=size, center=center)
+        else:
+            log.warning(
+                "'ModeSolverData' extracted from 'EMEModeSolverData' "
+                "is not 2D, so it may not be possible to compute "
+                "certain derived quantities, like the flux."
+            )
         grid_expanded = self.simulation.discretize_monitor(monitor=monitor)
         return ModeSolverData(**update_dict, monitor=monitor, grid_expanded=grid_expanded)
 

--- a/tidy3d/components/eme/simulation.py
+++ b/tidy3d/components/eme/simulation.py
@@ -27,7 +27,7 @@ from tidy3d.components.simulation import (
 from tidy3d.components.types import Ax, Axis, FreqArray, Symmetry, annotate_type
 from tidy3d.components.validators import MIN_FREQUENCY, validate_freqs_min, validate_freqs_not_empty
 from tidy3d.components.viz import add_ax_if_none, equal_aspect
-from tidy3d.constants import C_0
+from tidy3d.constants import C_0, inf
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
 
@@ -560,9 +560,11 @@ class EMESimulation(AbstractYeeGridSimulation):
     @property
     def port_modes_monitor(self) -> EMEModeSolverMonitor:
         """EME Mode solver monitor for only the port modes."""
+        size = [inf, inf, inf]
+        size[self.axis] = self.size[self.axis]
         return EMEModeSolverMonitor(
             center=self.center,
-            size=self.size,
+            size=size,
             eme_cell_interval_space=self.eme_grid.num_cells,
             name="_eme_port_modes_monitor",
             colocate=False,


### PR DESCRIPTION
This PR: https://github.com/flexcompute/tidy3d/pull/2526

introduced a bug in `_extract_mode_solver_data` when the new `ModeSolverMonitor` is 1D. This shouldn't really be an issue except in 2D EME simulations, when looking at `port_modes_tuple`. This PR fixes it in two ways -- the `port_modes_monitor` now extends infinitely in transverse directions, and the handling of this case in `_extract_mode_solver_data` is more graceful.