### PR TITLE
Limiting number of pytest workers to 4

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -138,7 +138,7 @@ jobs:
     needs: determine-test-scope
     if: needs.determine-test-scope.outputs.local_tests == 'true'
     name: Python ${{ matrix.python-version }} - self-hosted-runner 
-    runs-on: [ slurm-runner ]
+    runs-on: [ deploynode ]
     container: ghcr.io/astral-sh/uv:debian 
     strategy:
       matrix:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -138,7 +138,7 @@ jobs:
     needs: determine-test-scope
     if: needs.determine-test-scope.outputs.local_tests == 'true'
     name: Python ${{ matrix.python-version }} - self-hosted-runner 
-    runs-on: [ deploynode ]
+    runs-on: [ slurm-runner ]
     container: ghcr.io/astral-sh/uv:debian 
     strategy:
       matrix:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,9 +71,10 @@ def pytest_xdist_auto_num_workers(config):
 
     cores = min(cores, mem_limited_cores)
 
+    MAX_WORKERS = 4
     if os.getenv("GITHUB_ACTIONS"):
-        return cores
-    return max(1, cores - 1)
+        return min(MAX_WORKERS, cores)
+    return min(MAX_WORKERS, max(1, cores - 1))
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,9 @@ def pytest_xdist_auto_num_workers(config):
     cores = min(cores, mem_limited_cores)
 
     if os.getenv("GITHUB_ACTIONS"):
+        if os.getenv("RUNNER_ENVIRONMENT") == "self-hosted":
+            MAX_SELF_HOSTED_CORES = 8
+            return min(MAX_SELF_HOSTED_CORES, cores)
         return cores
     return max(1, cores - 1)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,10 +71,9 @@ def pytest_xdist_auto_num_workers(config):
 
     cores = min(cores, mem_limited_cores)
 
-    MAX_WORKERS = 4
     if os.getenv("GITHUB_ACTIONS"):
-        return min(MAX_WORKERS, cores)
-    return min(MAX_WORKERS, max(1, cores - 1))
+        return cores
+    return max(1, cores - 1)
 
 
 @pytest.fixture


### PR DESCRIPTION
Avoid crashing self-hosted runners by limiting to 4 workers max.

Fixing: https://github.com/flexcompute/tidy3d/actions/runs/15340356898/attempts/1 and https://flow360.atlassian.net/browse/EMA-70