### PR TITLE
Validating that structure rotation in the mode solver can be done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed field colocation in `EMEModeSolverMonitor`.
 - Solver error for EME simulations with bends, introduced when support for 2D EME simulations was added.
 - Internal interpolation errors with some versions of `xarray` and `numpy`.
+- If `ModeSpec.angle_rotation=True` for a mode object, validate that the structure rotation can be successfully done. Also, error if the medium cannot be rotated (e.g. anisotropic or custom medium), which would previously have just produced wrong results.
 
 ### Changed
 - Relaxed bounds checking of path integrals during `WavePort` validation.
@@ -36,8 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adjoint source frequency width is adjusted to decay sufficiently before zero frequency when possible to improve accuracy of simulation normalization when using custom current sources.
 - Change `VisualizationSpec` validator for checking validity of user specified colors to only issue a warning if matplotlib is not installed instead of an error.
 - Improved performance of `tidy3d.web.delete_old()` for large folders.
-
-### Changed
+- Upon initialization, an FDTD `Simulation` will now try to create all `ModeSolver` objects associated to `ModeSource`-s and `ModeMonitor`-s so they can be validated.
 - `tidy3d.plugins.autograd.interpolate_spline()` and `tidy3d.plugins.autograd.add_at()` can now be called with keyword arguments during tracing.
 
 ## [2.8.4] - 2025-05-15

--- a/tests/test_components/test_mode.py
+++ b/tests/test_components/test_mode.py
@@ -78,6 +78,92 @@ def test_angle_rotation_with_phi():
         td.ModeSpec(angle_phi=np.pi / 3, angle_rotation=True)
 
 
+def test_validation_from_simulation():
+    """Test that a ModeSolver created from a simulation ModeMonitor validates correctly."""
+
+    sim = td.Simulation(
+        size=(10, 10, 10),
+        grid_spec=td.GridSpec(wavelength=1.0),
+        structures=[],
+        run_time=1e-12,
+        monitors=[],
+    )
+
+    inf_geometry = td.Structure(
+        geometry=td.Box.from_bounds((-td.inf, -1, -100), (td.inf, 1, 0)),
+        medium=td.Medium(permittivity=4.0, conductivity=1e-4),
+    )
+
+    anisotropic_geometry = td.Structure(
+        geometry=td.Box.from_bounds((-1, -1, -100), (1, 1, 0)),
+        medium=td.AnisotropicMedium(
+            xx=td.Medium(permittivity=4.0, conductivity=1e-4),
+            yy=td.Medium(permittivity=4.0, conductivity=1e-4),
+            zz=td.Medium(permittivity=3.0, conductivity=1e-4),
+        ),
+    )
+
+    rot_monitor = td.ModeMonitor(
+        size=(0, 5, 5),
+        name="mode_solver",
+        mode_spec=td.ModeSpec(angle_rotation=True, angle_theta=np.pi / 4),
+        freqs=[td.C_0],
+    )
+
+    rot_source = td.ModeSource(
+        size=(0, 5, 5),
+        mode_spec=td.ModeSpec(angle_rotation=True, angle_theta=np.pi / 4),
+        source_time=td.GaussianPulse(freq0=td.C_0, fwidth=td.C_0 / 10),
+        direction="+",
+    )
+
+    # Test that transforming a geometry with an infinite extent raises an error
+    with pytest.raises(SetupError):
+        sim.updated_copy(
+            structures=[inf_geometry],
+            monitors=[rot_monitor],
+        )
+
+    # Test that transforming an anisotropic medium raises an error
+    with pytest.raises(SetupError):
+        sim.updated_copy(
+            structures=[anisotropic_geometry],
+            monitors=[rot_monitor],
+        )
+
+    # Same thing with a ModeSource
+    with pytest.raises(SetupError):
+        sim.updated_copy(
+            structures=[inf_geometry],
+            sources=[rot_source],
+        )
+
+    with pytest.raises(SetupError):
+        sim.updated_copy(
+            structures=[anisotropic_geometry],
+            monitors=[rot_monitor],
+        )
+
+    # Same thing with ModeSimulation
+    with pytest.raises(SetupError):
+        td.ModeSimulation(
+            structures=[inf_geometry],
+            size=(0, 5, 5),
+            mode_spec=td.ModeSpec(angle_rotation=True, angle_theta=np.pi / 4),
+            freqs=[td.C_0],
+            boundary_spec=td.BoundarySpec.all_sides(td.Periodic()),
+        )
+
+    with pytest.raises(SetupError):
+        td.ModeSimulation(
+            structures=[anisotropic_geometry],
+            size=(0, 5, 5),
+            mode_spec=td.ModeSpec(angle_rotation=True, angle_theta=np.pi / 4),
+            freqs=[td.C_0],
+            boundary_spec=td.BoundarySpec.all_sides(td.Periodic()),
+        )
+
+
 def get_mode_sim():
     mode_spec = MODE_SPEC.updated_copy(filter_pol="tm")
     permittivity_monitor = td.PermittivityMonitor(

--- a/tests/test_plugins/test_adjoint.py
+++ b/tests/test_plugins/test_adjoint.py
@@ -574,7 +574,13 @@ def test_adjoint_pipeline(local, use_emulated_run, tmp_path):
 def test_adjoint_pipeline_2d(local, use_emulated_run, tmp_path):
     run_fn = run_local if local else run
 
-    sim = make_sim(permittivity=EPS, size=SIZE, vertices=VERTICES, base_eps_val=BASE_EPS_VAL)
+    sim = make_sim(
+        permittivity=EPS,
+        size=SIZE,
+        vertices=VERTICES,
+        base_eps_val=BASE_EPS_VAL,
+        custom_medium=False,
+    )
 
     sim_size_2d = list(sim.size)
     sim_size_2d[1] = 0
@@ -584,7 +590,11 @@ def test_adjoint_pipeline_2d(local, use_emulated_run, tmp_path):
 
     def f(permittivity, size, vertices, base_eps_val):
         sim = make_sim(
-            permittivity=permittivity, size=size, vertices=vertices, base_eps_val=base_eps_val
+            permittivity=permittivity,
+            size=size,
+            vertices=vertices,
+            base_eps_val=base_eps_val,
+            custom_medium=False,
         )
         sim_size_2d = list(sim.size)
         sim_size_2d[1] = 0
@@ -1262,7 +1272,11 @@ def test_adjoint_run_async(local, use_emulated_run_async, tmp_path):
     def make_sim_simple(permittivity: float) -> JaxSimulation:
         """Make a sim as a function of a single parameter."""
         return make_sim(
-            permittivity=permittivity, size=SIZE, vertices=VERTICES, base_eps_val=BASE_EPS_VAL
+            permittivity=permittivity,
+            size=SIZE,
+            vertices=VERTICES,
+            base_eps_val=BASE_EPS_VAL,
+            custom_medium=False,
         )
 
     def f(x):
@@ -1804,10 +1818,8 @@ def test_adjoint_run_time(use_emulated_run, tmp_path, fwidth, run_time, run_time
     assert sim_adj.run_time == run_time_expected
 
 
-@pytest.mark.parametrize("has_adj_src, log_level_expected", [(True, None), (False, "WARNING")])
-def test_no_adjoint_sources(
-    monkeypatch, use_emulated_run, tmp_path, has_adj_src, log_level_expected
-):
+@pytest.mark.parametrize("has_adj_src", [True, False])
+def test_no_adjoint_sources(monkeypatch, use_emulated_run, tmp_path, has_adj_src):
     """Make sure warning (not error) if no adjoint sources."""
 
     def make_sim(eps):
@@ -1839,8 +1851,9 @@ def test_no_adjoint_sources(
     data = run(sim, task_name="test", path=str(tmp_path / RUN_FILE))
 
     # check whether we got a warning for no sources?
-    with AssertLogLevel(log_level_expected, contains_str="No adjoint sources"):
-        data.make_adjoint_simulation(fwidth=src.source_time.fwidth, run_time=sim.run_time)
+    if not has_adj_src:
+        with AssertLogLevel("WARNING", contains_str="No adjoint sources"):
+            data.make_adjoint_simulation(fwidth=src.source_time.fwidth, run_time=sim.run_time)
 
     jnp.sum(jnp.abs(jnp.array(data["mnt"].amps.values)) ** 2)
 

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -28,7 +28,11 @@ from tidy3d.components.eme.data.sim_data import EMESimulationData
 from tidy3d.components.eme.simulation import EMESimulation
 from tidy3d.components.geometry.base import Box
 from tidy3d.components.grid.grid import Coords, Grid
-from tidy3d.components.medium import FullyAnisotropicMedium, LossyMetalMedium
+from tidy3d.components.medium import (
+    FullyAnisotropicMedium,
+    IsotropicUniformMediumType,
+    LossyMetalMedium,
+)
 from tidy3d.components.mode_spec import ModeSpec
 from tidy3d.components.monitor import ModeMonitor, ModeSolverMonitor
 from tidy3d.components.scene import Scene
@@ -217,6 +221,7 @@ class ModeSolver(Tidy3dBaseModel):
             msg_prefix="Mode solver",
         )
         self._warn_thick_pml(simulation=self.simulation, plane=self.plane, mode_spec=self.mode_spec)
+        self._validate_rotate_structures()
 
     @classmethod
     def _warn_thick_pml(
@@ -269,6 +274,18 @@ class ModeSolver(Tidy3dBaseModel):
                 f"{msg_prefix} bend radius is smaller than half the mode plane size "
                 "along the radial axis, which can produce wrong results."
             )
+
+    def _validate_rotate_structures(self) -> None:
+        """Validate that structures can be rotated if angle_rotation is True."""
+        if not self.mode_spec.angle_rotation:
+            return
+        try:
+            _ = self._rotate_structures
+        except Exception as e:
+            raise SetupError(
+                "Mode object defined with 'angle_rotation=True' but failed "
+                f"to create rotated structures: {e!s}"
+            ) from e
 
     @cached_property
     def normal_axis(self) -> Axis:
@@ -578,7 +595,7 @@ class ModeSolver(Tidy3dBaseModel):
         to the simulation and updates the ModeSpec to disable bend correction
         and reset angles to normal."""
 
-        rotated_structures = self._rotate_structures()
+        rotated_structures = self._rotate_structures
         rotated_simulation = self.simulation.updated_copy(structures=rotated_structures)
         rotated_mode_spec = self.mode_spec.updated_copy(
             angle_rotation=False, angle_theta=0, angle_phi=0
@@ -586,6 +603,7 @@ class ModeSolver(Tidy3dBaseModel):
 
         return self.updated_copy(simulation=rotated_simulation, mode_spec=rotated_mode_spec)
 
+    @cached_property
     def _rotate_structures(self) -> list[Structure]:
         """Rotate the structures intersecting with modal plane by angle theta
         if bend_correction is enabeled for bend simulations."""
@@ -611,11 +629,14 @@ class ModeSolver(Tidy3dBaseModel):
         translate_coords[idx_u] = mnt_center[idx_u]
         translate_coords[idx_v] = mnt_center[idx_v]
 
-        reduced_sim_solver = self.reduced_simulation_copy
         rotated_structures = []
-        for structure in Scene.intersecting_structures(
-            self.plane, reduced_sim_solver.simulation.structures
-        ):
+        for structure in Scene.intersecting_structures(self.plane, self.simulation.structures):
+            if not isinstance(structure.medium, IsotropicUniformMediumType):
+                raise NotImplementedError(
+                    "Mode solver plane intersects an unsupported "
+                    "medium. Only uniform isotropic media are supported for the plane rotation. "
+                )
+
             # Rotate and apply translations
             geometry = structure.geometry
             geometry = (

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -3665,8 +3665,7 @@ class Simulation(AbstractYeeGridSimulation):
         self._validate_tfsf_aux_sources()
         self._validate_nonlinear_specs()
         self._validate_custom_source_time()
-        self._validate_mode_object_bends()
-        self._warn_mode_object_pml()
+        self._validate_mode_objects()
         self._warn_rf_license()
 
     def _warn_rf_license(self):
@@ -3703,49 +3702,35 @@ class Simulation(AbstractYeeGridSimulation):
             msg += rf_component_breakdown_msg
             log.warning(msg, log_once=True)
 
-    def _warn_mode_object_pml(self) -> None:
-        """Warn if any mode objects have large pml."""
+    def _validate_mode_objects(self) -> None:
+        """Create a ModeSolver for each mode object in order to validate."""
         from .mode.mode_solver import ModeSolver
 
         for imnt, monitor in enumerate(self.monitors):
             if isinstance(monitor, AbstractModeMonitor):
-                warn_str = f"'monitors[{imnt}]'"
-                ModeSolver._warn_thick_pml(
-                    simulation=self,
-                    plane=monitor.geometry,
-                    mode_spec=monitor.mode_spec,
-                    warn_str=warn_str,
-                )
+                try:
+                    _ = ModeSolver(
+                        mode_spec=monitor.mode_spec,
+                        plane=monitor.geometry,
+                        simulation=self,
+                        freqs=monitor.freqs,
+                    )
+                except Exception as e:
+                    raise SetupError(
+                        f"Monitor at 'monitors[{imnt}]' failed validation: {e!s}"
+                    ) from e
+
         for isrc, source in enumerate(self.sources):
             if isinstance(source, ModeSource):
-                warn_str = f"'sources[{isrc}]'"
-                ModeSolver._warn_thick_pml(
-                    simulation=self,
-                    plane=source.geometry,
-                    mode_spec=source.mode_spec,
-                    warn_str=warn_str,
-                )
-
-    def _validate_mode_object_bends(self) -> None:
-        """Error if any mode sources or monitors with bends have a radius that is too small."""
-        from .mode.mode_solver import ModeSolver
-
-        for imnt, monitor in enumerate(self.monitors):
-            if isinstance(monitor, AbstractModeMonitor):
-                ModeSolver._validate_mode_plane_radius(
-                    mode_spec=monitor.mode_spec,
-                    plane=monitor.geometry,
-                    sim_geom=self.geometry,
-                    msg_prefix=f"Monitor at 'monitors[{imnt}]' ",
-                )
-        for isrc, source in enumerate(self.sources):
-            if isinstance(source, ModeSource):
-                ModeSolver._validate_mode_plane_radius(
-                    mode_spec=source.mode_spec,
-                    plane=source.geometry,
-                    sim_geom=self.geometry,
-                    msg_prefix=f"Source at 'sources[{isrc}]' ",
-                )
+                try:
+                    _ = ModeSolver(
+                        mode_spec=source.mode_spec,
+                        plane=source.geometry,
+                        simulation=self,
+                        freqs=source.source_time.freq0,
+                    )
+                except Exception as e:
+                    raise SetupError(f"Source at 'sources[{isrc}]' failed validation: {e!s}") from e
 
     def _validate_custom_source_time(self):
         """Warn if all simulation times are outside CustomSourceTime definition range."""


### PR DESCRIPTION
Adding a `.rotated` method to optical media which errors for all except a simple `td.Medium`.

This addresses #2531 and also @lucas-flexcompute 's observation that using `angle_rotation` with anisotropic media can produce wrong results. For now we just validate this out - in the future, if a `rotated` method is implemented for a given medium, it will then work automatically.

EDIT: In principle, translation should also be added for Custom-type media. However, I am not sure how much effort we should put into this.