### PR TITLE
Avoid interpolation errors with some xarray versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug when generating a grid with snapping points near the simulation boundaries.
 - Fixed field colocation in `EMEModeSolverMonitor`.
 - Solver error for EME simulations with bends, introduced when support for 2D EME simulations was added.
+- Internal interpolation errors with some versions of `xarray` and `numpy`.
 
 ### Changed
 - Relaxed bounds checking of path integrals during `WavePort` validation.

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -1146,6 +1146,13 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
                 "'freq' was not specified for 'FieldData.to_zbf()'. Defaulting to the mean frequency of the dataset."
             )
             freq = np.mean(e_x.coords["f"].values)
+        else:
+            freq = np.array(freq)
+
+        if freq.size > 1:
+            raise ValueError("'freq' must be a single value, not an array.")
+        else:
+            freq = freq.item()
 
         mode_area = mode_area.interp(f=freq)
         e_x = e_x.interp(f=freq)

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -583,6 +583,9 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
 
         # select the extra coordinates out of the data from user-specified kwargs
         for coord_name, coord_val in sel_kwargs.items():
+            interp_val = np.array(coord_val)
+            if interp_val.size == 1:
+                interp_val = interp_val.item()
             if (
                 field_data.coords[coord_name].size <= 1
                 or coord_name == "eme_port_index"
@@ -590,10 +593,10 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
                 or coord_name == "sweep_index"
                 or coord_name == "mode_index"
             ):
-                field_data = field_data.sel(**{coord_name: coord_val}, method=None)
+                field_data = field_data.sel(**{coord_name: interp_val}, method=None)
             else:
                 field_data = field_data.interp(
-                    **{coord_name: coord_val}, kwargs={"bounds_error": True}
+                    **{coord_name: interp_val}, kwargs={"bounds_error": True}
                 )
 
         # before dropping coordinates, check if a frequency can be derived from the data that can

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -1699,7 +1699,7 @@ class ModeSolver(Tidy3dBaseModel):
             Copy of the data with renormalized fields.
         """
         normal_axis = plane.size.index(0.0)
-        normal_pos = plane.center[normal_axis]
+        normal_pos = float(plane.center[normal_axis])
         normal_dim = "xyz"[normal_axis]
 
         # Primal and dual grid along the normal direction,

--- a/tidy3d/components/parameter_perturbation.py
+++ b/tidy3d/components/parameter_perturbation.py
@@ -942,6 +942,10 @@ class CustomChargePerturbation(ChargePerturbation):
         if isinstance(h_vals, UnstructuredGridDataset):
             h_vals = h_vals.values
 
+        # Needed to avoid error in some xarray / numpy versions
+        e_vals = e_vals.item() if e_vals.size == 1 else e_vals
+        h_vals = h_vals.item() if h_vals.size == 1 else h_vals
+
         # note that the dimensionality of this operation differs depending on whether xarrays
         # or simple unlabeled arrays are provided:
         # - for unlabeled arrays, values are broadcasted


### PR DESCRIPTION
Fixes #2535 , as well as a few other instances where the `TypeError` occurs. I found that this is specific to older `xarray` versions and has been fixed in newer ones, but I guess we can get these fixes in anyway to avoid user confusion.