### PR TITLE
Add FreqRange utility class and unit tests (related issue #2529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Implemented `FreqRange` utility class for frequency/wavelength handling with constructor methods `from_freq_interval()`, `from_wavelength()`, and `from_wvl_interval()`. 
 - Add support for `np.unwrap` in `tidy3d.plugins.autograd`.
 - Add Nunley variant to germanium material library based on Nunley et al. 2016 data.
 - Add `PointDipole.sources_from_angles()` that constructs a list of `PointDipole` objects needed to emulate a dipole oriented at a user-provided set of polar and azimuthal angles.

--- a/tests/test_components/test_freq_range.py
+++ b/tests/test_components/test_freq_range.py
@@ -1,0 +1,188 @@
+"""Test class ``FreqRange`` for frequency and wavelength handling."""
+
+from __future__ import annotations
+
+import numpy as np
+
+import tidy3d.constants as td_const
+from tidy3d.components.source.freq_range import FreqRange
+from tidy3d.components.source.time import GaussianPulse
+
+
+def test_constructor():
+    """
+    test construction of ``FreqRange`` from central frequency
+    ``freq0`` and bandwidth ``fwidth``.
+    """
+    # set initial params
+    freq0 = 1e9  # set central frequency
+    fwidth = 1e8  # set one-side bandwidth
+
+    # construct instance of FreqRange class
+    freq_range = FreqRange(freq0=freq0, fwidth=fwidth)
+
+    fmin = freq0 - fwidth
+    fmax = freq0 + fwidth
+
+    lmin = td_const.C_0 / fmax
+    lmax = td_const.C_0 / fmin
+
+    # validated if class atributes were initialized correctly
+    assert freq_range.fmin == fmin
+    assert freq_range.fmax == fmax
+    assert freq_range.lda0 == (lmin + lmax) / 2
+    assert freq_range.freq0 == freq0
+    assert freq_range.fwidth == fwidth
+
+
+def test_from_freq_interval():
+    """
+    test construction of ``FreqRange`` from frequency interval.
+    """
+
+    fmin = 1e10  # new min frequency
+    fmax = 1e11  # new max frequency
+
+    lmin = td_const.C_0 / fmax
+    lmax = td_const.C_0 / fmin
+
+    # update object given new frequencies
+    freq_range = FreqRange.from_freq_interval(fmin=fmin, fmax=fmax)
+
+    # validate if frequencies were updated correctly
+    assert freq_range.fmin == fmin
+    assert freq_range.fmax == fmax
+    assert np.isclose(freq_range.freq0, (fmin + fmax) / 2, rtol=1e-14)
+    assert np.isclose(freq_range.fwidth, (fmax - fmin) / 2, rtol=1e-14)
+    assert np.isclose(freq_range.lda0, (lmin + lmax) / 2, rtol=1e-14)
+
+
+def test_from_wavelength():
+    """
+    test construction of ``FreqRange`` from a central wavelength and a wavelength.
+    """
+    # set initial params
+    wvl0 = 1
+    wvl_width = 0.1
+
+    # get the shortest and the longest wavelengths
+    wvl_min = wvl0 - wvl_width
+    wvl_max = wvl0 + wvl_width
+
+    # define frequency range
+    freq_range = FreqRange.from_wavelength(wvl0=wvl0, wvl_width=wvl_width)
+
+    #
+    assert freq_range.lda0 == wvl0
+
+    fmin = td_const.C_0 / wvl_max
+    fmax = td_const.C_0 / wvl_min
+
+    assert np.isclose(freq_range.fmin, fmin, rtol=1e-14)
+    assert np.isclose(freq_range.fmax, fmax, rtol=1e-14)
+    assert np.isclose(freq_range.freq0, 0.5 * (fmin + fmax), rtol=1e-14)
+    assert np.isclose(freq_range.fwidth, 0.5 * (fmax - fmin), rtol=1e-14)
+
+
+def test_from_wvl_interval():
+    """
+    test construction of ``FreqRange`` from an interval of wavelengths.
+    """
+    # set initial params
+    wvl_min = 0.1
+    wvl_max = 1
+    fmin = td_const.C_0 / wvl_max
+    fmax = td_const.C_0 / wvl_min
+
+    # freq_range = FreqRange(freq0, fwidth)
+
+    # update frequencies based on wavelength
+    freq_range = FreqRange.from_wvl_interval(wvl_min=wvl_min, wvl_max=wvl_max)
+
+    # ensure that parameters are updated correctly
+    assert np.isclose(freq_range.lda0, (wvl_min + wvl_max) / 2, rtol=1e-14)
+    assert np.isclose(freq_range.freq0, 0.5 * (fmin + fmax), rtol=1e-14)
+    assert np.isclose(freq_range.fmax, fmax, rtol=1e-14)
+    assert np.isclose(freq_range.fmin, fmin, rtol=1e-14)
+    assert np.isclose(freq_range.fwidth, 0.5 * (fmax - fmin), rtol=1e-14)
+
+
+def test_freqs():
+    """
+    test generation of uniformly distributed frequency samples
+    from a given frequency interval.
+    """
+    # set initial params
+    freq0 = 1e9  # set central frequency
+    fwidth = 1e8  # set one-side bandwidth
+    num_points = 11
+
+    # construct instance of FreqRange class
+    freq_range = FreqRange(freq0=freq0, fwidth=fwidth)
+
+    # form sampling frequency points
+    freqs = freq_range.freqs(num_points=num_points)
+
+    # make sure
+    assert np.array_equal(freqs, np.linspace(freq0 - fwidth, freq0 + fwidth, num_points))
+
+    # reset number of sampling points to 1
+    num_points = 1
+    freqs = freq_range.freqs(num_points=num_points)
+
+    # check if freqs == freq0
+    assert np.array_equal(freqs, np.array([freq0]))
+
+
+def test_ldas():
+    """
+    test generation of uniformly distributed wavelength samples
+    from a given wavelength interval.
+    """
+    # set initial params
+    freq0 = 1e9  # set central frequency
+    fwidth = 1e8  # set one-side bandwidth
+    num_points = 11
+
+    lmin = td_const.C_0 / (freq0 + fwidth)
+    lmax = td_const.C_0 / (freq0 - fwidth)
+    lda0 = (lmin + lmax) / 2
+
+    # construct instance of FreqRange class
+    freq_range = FreqRange(freq0=freq0, fwidth=fwidth)
+
+    # form sampling frequency points
+    ldas = freq_range.ldas(num_points=num_points)
+
+    # make sure
+    assert np.array_equal(ldas, np.linspace(lmin, lmax, num_points))
+
+    # reset number of sampling points to 1
+    num_points = 1
+    ldas = freq_range.ldas(num_points=num_points)
+
+    # check if freqs == freq0
+    assert np.array_equal(ldas, np.array([lda0]))
+
+
+def test_gaussian_pulse():
+    """
+    test generation of a ``GaussianPulse`` with frequency parameters
+    defined in ``FreqRange``.
+    """
+
+    # set initial params
+    freq0 = 1e9  # set central frequency
+    fwidth = 1e8  # set one-side bandwidth
+    fmin = freq0 - fwidth
+    fmax = freq0 + fwidth
+
+    # construct instance of FreqRange class
+    freq_range = FreqRange(freq0=freq0, fwidth=fwidth)
+
+    pulse_exp = GaussianPulse.from_frequency_range(
+        fmin=fmin, fmax=fmax
+    )  # instantiate GaussianPulse explicitly
+    pulse_imp = freq_range.to_gaussian_pulse()  # get instance by calling a method gaussian_pulse()
+
+    assert pulse_exp == pulse_imp  # compare two pulses

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -337,6 +337,7 @@ from .components.source.field import (
     ModeSource,
     PlaneWave,
 )
+from .components.source.freq_range import FreqRange
 
 # sources
 from .components.source.time import (
@@ -540,6 +541,7 @@ __all__ = [
     "FluxTimeDataArray",
     "FluxTimeMonitor",
     "FossumCarrierLifetime",
+    "FreqRange",
     "FullyAnisotropicMedium",
     "GaussianBeam",
     "GaussianBeamProfile",

--- a/tidy3d/components/source/freq_range.py
+++ b/tidy3d/components/source/freq_range.py
@@ -1,0 +1,228 @@
+"""Utility class ``FreqRange`` for frequency and wavelength handling."""
+
+from __future__ import annotations
+
+import numpy as np
+import pydantic.v1 as pydantic
+from numpy.typing import NDArray
+
+from tidy3d import constants as td_const
+from tidy3d.components.base import Tidy3dBaseModel
+from tidy3d.components.source.time import GaussianPulse
+
+
+class FreqRange(Tidy3dBaseModel):
+    """
+    Convenience class for handling frequency/wavelength conversion; it simplifies specification
+    of frequency ranges and sample points for sources and monitors.
+
+    Notes
+    -----
+        Depending on the context the user can define desired frequency range by specifying:
+        - central frequency ``freq0`` and frequency bandwidth ``fwidth``;
+        - frequency interval [``fmin``,``fmax``];
+        - central wavelength ``wvl0`` and wavelength range ``wvl_width``;
+        - wavelength interval [``wvl_min``, ``wvl_max``].
+
+    Example
+    -------
+    >>> import tidy3d as td
+    >>> freq0  = 1e12
+    >>> fwidth = 1e11
+    >>> freq_range = td.FreqRange(freq0=freq0, fwidth=fwidth)
+    >>> central_freq = freq_range.freqs(num_points=1)
+    >>> freqs = freq_range.freqs(num_points=11)
+    >>> source = freq_range.to_gaussian_pulse()
+    """
+
+    freq0: pydantic.PositiveFloat = pydantic.Field(
+        ...,
+        title="Central frequency",
+        description="Real-valued positive central frequency.",
+        units="Hz",
+    )
+
+    fwidth: pydantic.PositiveFloat = pydantic.Field(
+        ...,
+        title="Frequency bandwidth",
+        description="Real-valued positive width of the frequency range (bandwidth).",
+        units="Hz",
+    )
+
+    @property
+    def fmin(self) -> float:
+        """Infer lowest frequency ``fmin`` from central frequency ``freq0`` and bandwidth ``fwidth``."""
+        return self.freq0 - self.fwidth
+
+    @property
+    def fmax(self) -> float:
+        """Infer highest frequency ``fmax`` from central frequency ``freq0`` and bandwidth ``fwidth``."""
+        return self.freq0 + self.fwidth
+
+    @property
+    def lda0(self) -> float:
+        """Get central wavelength from central frequency and bandwidth."""
+        lmin = td_const.C_0 / (self.freq0 + self.fwidth)
+        lmax = td_const.C_0 / (self.freq0 - self.fwidth)
+        return 0.5 * (lmin + lmax)
+
+    @classmethod
+    def from_freq_interval(cls, fmin: float, fmax: float) -> FreqRange:
+        """
+        method ``from_freq_interval()`` creates instance of class ``FreqRange`` from frequency interval
+        defined by arguments  ``fmin`` and ``fmax``.
+
+        NB: central frequency never corresponds to central wavelength!
+        ``freq0 = (fmin + fmax) / 2`` implies that ``lda0 != (lda_min + lda_max) / 2`` and vise-versa.
+
+        Parameters
+        ----------
+        fmin : float
+            Lower bound of frequency of interest.
+        fmax : float
+            Upper bound of frequency of interest.
+
+        Returns
+        -------
+        FreqRange
+            An instance of ``FreqRange`` defined by frequency interval [``fmin``, ``fmax``].
+        """
+
+        # extract frequency-related info
+        freq0 = 0.5 * (fmax + fmin)  # extract central freq
+        fwidth = 0.5 * (fmax - fmin)  # extract bandwidth
+        return cls(freq0=freq0, fwidth=fwidth)
+
+    @classmethod
+    def from_wavelength(cls, wvl0: float, wvl_width: float) -> FreqRange:
+        """
+        method ``from_wavelength()`` updated instance of class ``FreqRange`` by reassigning new
+        frequency- and wavelength-related parameters.
+
+        NB: central frequency never corresponds to central wavelength!
+        ``lda0 = (lda_min + lda_max) / 2`` implies that ``freq0 != (fmin + fmax) / 2`` and vise versa.
+
+        Parameters
+        ----------
+        wvl0 : float
+            Real-valued central wavelength.
+        wvl_width : float
+            Real-valued wavelength range.
+
+        Returns
+        -------
+        FreqRange
+            An instance of ``FreqRange`` defined by central wavelength ``wvl0`` and wavelength range ``wvl_width``.
+        """
+
+        # calculate lowest and highest frequencies
+        fmin = td_const.C_0 / (wvl0 + wvl_width)
+        fmax = td_const.C_0 / (wvl0 - wvl_width)
+
+        return cls.from_freq_interval(fmin=fmin, fmax=fmax)
+
+    @classmethod
+    def from_wvl_interval(cls, wvl_min: float, wvl_max: float) -> FreqRange:
+        """
+        method ``from_wvl_interval()`` updated instance of class ``FreqRange`` by reassigning new
+        frequency- and wavelength-related parameters.
+
+        NB: central frequency never corresponds to central wavelength!
+        ``lda0 = (lda_min + lda_max) / 2`` implies that ``freq0 != (fmin + fmax) / 2``.
+
+        Parameters
+        ----------
+        wvl_min : float
+            The lowest wavelength of interest.
+        wvl_max : float
+            The longest wavelength of interest.
+
+        Returns
+        -------
+        FreqRange
+            An instance of ``FreqRange`` defined by the wavelength interval [``wvl_min``, ``wvl_max``].
+        """
+
+        # convert wavelength intervals to frequency interval
+        fmax = td_const.C_0 / wvl_min
+        fmin = td_const.C_0 / wvl_max
+
+        return cls.from_freq_interval(fmin=fmin, fmax=fmax)
+
+    def freqs(self, num_points: int) -> NDArray[np.float64]:
+        """
+        method ``freqs()`` returns a numpy array of ``num_point`` frequencies uniformly
+        sampled from the specified frequency range;
+        if ``num_points == 1`` method returns the central frequency ``freq0``.
+
+        Parameters
+        ----------
+        num_points : int
+            Number of frequency points in a frequency range of interest.
+
+        Returns
+        -------
+        np.ndarray
+            a numpy array of uniformly distributed frequency samples in a frequency range of interest.
+        """
+
+        if num_points == 1:  # return central frequency
+            return np.array([self.freq0])
+        else:
+            # calculate frequency points and corresponding wavelengths
+            return np.linspace(self.fmin, self.fmax, num_points)
+
+    def ldas(self, num_points: int) -> NDArray[np.float64]:
+        """
+        method ``ldas()`` returns a numpy array of ``num_points`` wavelengths uniformly
+        sampled from the range of wavelengths;
+        if ``num_points == 1`` the method returns central wavelength ``lda0``.
+
+        Parameters
+        ----------
+        num_points : int
+            Number of wavelength points in a range of wavelengths of interest.
+
+        Returns
+        -------
+        np.ndarray
+            a numpy array of uniformly distributed wavelength samples in ascending order.
+        """
+        if num_points == 1:  # return central wavelength
+            return np.array([self.lda0])
+        else:
+            # define shortest and longest wavelengths
+            lmin = td_const.C_0 / self.fmax
+            lmax = td_const.C_0 / self.fmin
+
+            # generate array of wavelengths (in ascending order)
+            return np.linspace(lmin, lmax, num_points)
+
+    def to_gaussian_pulse(self, **kwargs) -> GaussianPulse:
+        """
+        method ``to_gaussian_pulse()`` returns instance of class ``GaussianPulse``
+        with frequency-specific parameters defined in ``FreqRange``.
+
+        Parameters
+        ----------
+        kwargs : dict
+            Keyword arguments passed to ``GaussianPulse()``, excluding ``freq0`` & ``fwidth``.
+
+        Returns
+        -------
+        GaussianPulse
+            A ``GaussianPulse`` that maximizes its amplitude in the frequency range [``fmin``, ``fmax``].
+        """
+
+        duplicate_keys = {"fmin", "fmax"} & kwargs.keys()
+        if duplicate_keys:
+            is_plural = len(duplicate_keys) > 1
+            keys_str = ", ".join(f"'{key}'" for key in sorted(duplicate_keys, reverse=True))
+            raise ValueError(
+                f"Keyword argument{'s' if is_plural else ''} {keys_str} "
+                f"conflict{'' if is_plural else 's'} with values already set in the 'FreqRange' object. "
+                f"Please exclude {'them' if is_plural else 'it'} from the 'to_gaussian_pulse()' call."
+            )
+
+        # create an instance of GaussianPulse class with defined frequency params
+        return GaussianPulse.from_frequency_range(fmin=self.fmin, fmax=self.fmax, **kwargs)


### PR DESCRIPTION
## Summary 
This pull request implements a new utility class `FreqRange` for convenient handling of frequency and wavelength conversions in simulations.

### Related issue
Convenience class for handling frequency/wavelength conversion and assignment #2529

### What was implemented
- Created FreqRange class to:
   - Accept central frequency and bandwidth as input (SI units).
   - Provide computed fmin, fmax, freqs, and ldas.
   - Support construction from wavelength ranges and intervals.
   - Include sampling method for generating frequency arrays.
   - Provide compatibility with GaussianPulse.
   
- Added unit tests in tests/test_FreqRange.py to validate:
   - Constructor and class methods (frequency- and wavelength-based initializations)
   - Sampling behavior
   - Instantiation of GaussianPulse with given central frequency and bandwidth






<!-- greptile_comment -->

## Greptile Summary

Added new `FreqRange` utility class for standardized handling of frequency/wavelength conversions in simulations, with support for various initialization methods and Gaussian pulse compatibility.

- Added `tidy3d/components/source/freq_range.py` implementing core frequency range handling with computed properties for fmin, fmax, freqs, and wavelengths
- Potential floating-point precision issues in frequency calculations need attention (using == for comparisons)
- Factory methods provide flexible initialization from frequency/wavelength ranges
- Added comprehensive test suite in `tests/test_components/test_FreqRange.py` covering core functionality
- Documentation and changelog entries properly reflect the new feature addition



<!-- /greptile_comment -->