### PR TITLE
Setting default mode precision to 'double', except in EME solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upon initialization, an FDTD `Simulation` will now try to create all `ModeSolver` objects associated to `ModeSource`-s and `ModeMonitor`-s so they can be validated.
 - `tidy3d.plugins.autograd.interpolate_spline()` and `tidy3d.plugins.autograd.add_at()` can now be called with keyword arguments during tracing.
 - Zero-size dimensions automatically receive periodic boundary conditions instead of raising an error.
+- Set `ModeSpec` precision to `double` by deafult for more accurate mode solver results. Does not apply to `EMEModeSpec`, where the `auto` precision is still default for speed and cost.
 
 ## [2.8.4] - 2025-05-15
 

--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -312,6 +312,7 @@ def test_mode_solver_group_index_warning(group_index_step, log_level):
         mode_spec = td.ModeSpec(
             num_modes=1,
             group_index_step=group_index_step,
+            precision="auto",
         )
 
     _ = ModeSolver(

--- a/tidy3d/components/eme/grid.py
+++ b/tidy3d/components/eme/grid.py
@@ -54,6 +54,15 @@ class EMEModeSpec(ModeSpec):
         units=RADIAN,
     )
 
+    precision: Literal["auto", "single", "double"] = pd.Field(
+        "auto",
+        title="single, double, or automatic precision in mode solver",
+        description="The solver will be faster and using less memory under "
+        "single precision, but more accurate under double precision. "
+        "Choose ``'auto'`` to apply double precision if the simulation contains a good "
+        "conductor, single precision otherwise.",
+    )
+
     # this method is not supported because not all ModeSpec features are supported
     # @classmethod
     # def _from_mode_spec(cls, mode_spec: ModeSpec) -> EMEModeSpec:
@@ -74,19 +83,9 @@ class EMEModeSpec(ModeSpec):
 
     def _to_mode_spec(self) -> ModeSpec:
         """Convert to ordinary :class:`.ModeSpec`."""
-        return ModeSpec(
-            num_modes=self.num_modes,
-            target_neff=self.target_neff,
-            num_pml=self.num_pml,
-            filter_pol=self.filter_pol,
-            angle_theta=self.angle_theta,
-            angle_phi=self.angle_phi,
-            precision=self.precision,
-            bend_radius=self.bend_radius,
-            bend_axis=self.bend_axis,
-            track_freq=self.track_freq,
-            group_index_step=self.group_index_step,
-        )
+        ms_dict = self.dict()
+        ms_dict.pop("type")
+        return ModeSpec.parse_obj(ms_dict)
 
 
 class EMEGridSpec(Tidy3dBaseModel, ABC):

--- a/tidy3d/components/mode_spec.py
+++ b/tidy3d/components/mode_spec.py
@@ -106,11 +106,11 @@ class ModeSpec(Tidy3dBaseModel):
     )
 
     precision: Literal["auto", "single", "double"] = pd.Field(
-        "auto",
+        "double",
         title="single, double, or automatic precision in mode solver",
         description="The solver will be faster and using less memory under "
         "single precision, but more accurate under double precision. "
-        "With the default ``'auto'``, apply double precision if the simulation contains a good "
+        "Choose ``'auto'`` to apply double precision if the simulation contains a good "
         "conductor, single precision otherwise.",
     )
 


### PR DESCRIPTION
Fixes #2518 (well, and it goes beyond it to set 'double' by default)

@caseyflex note that I changed the `EMEModeSpec_to_mode_spec` method to be more stable if we e.g. add a new field in the `ModeSpec` that we just want to directly propagate.