### PR TITLE
Determining zero dimesnions in slices

### DIFF
--- a/tidy3d/components/data/unstructured/triangular.py
+++ b/tidy3d/components/data/unstructured/triangular.py
@@ -159,7 +159,7 @@ class TriangularGridDataset(UnstructuredGridDataset):
 
         # detect zero size dimension
         bounds = np.max(points_numpy, axis=0) - np.min(points_numpy, axis=0)
-        zero_dims = np.where(np.isclose(bounds, 0))[0]
+        zero_dims = np.where(np.isclose(bounds, 0, atol=1e-6))[0]
 
         if len(zero_dims) != 1:
             raise DataError(


### PR DESCRIPTION
So for the time being I have included tolerance in `isclose` and so this will consider these tolerances in all `TriangularGridDataset`s loaded with `_from_vtk_obj`. 

A different option would be to include the tolerance as an argument to `_from_vtk_obj` so that we only consider this increased tolerance in slices coming from the Flow360 slicer. 