### PR TITLE
Jax plugin deprecation

### DIFF
--- a/tidy3d/plugins/adjoint/__init__.py
+++ b/tidy3d/plugins/adjoint/__init__.py
@@ -1,7 +1,30 @@
 """Imports for adjoint plugin."""
+# ruff: noqa: E402
 
 # import the jax version of tidy3d components
 from __future__ import annotations
+
+from textwrap import dedent
+
+from tidy3d.log import log
+
+_DOC_URL = "https://github.com/flexcompute/tidy3d/blob/develop/tidy3d/plugins/autograd/README.md"
+
+_MSG = dedent(
+    f"""
+    The 'adjoint' plugin (legacy JAX-based adjoint plugin) was deprecated in Tidy3D '2.7.0' and will be disabled as of '2.9.0'.
+
+    ➤ Migrate to the native autograd workflow:
+        import tidy3d as td
+        import autograd.numpy as np
+        from autograd import grad
+
+      It uses standard 'td.' objects, has fewer dependencies, and offers a smoother optimization experience.
+      Full guide ↗ {_DOC_URL}
+    """
+).strip()
+
+log.warning(_MSG)
 
 try:
     import jax


### PR DESCRIPTION
I took most of the code from the pydantic v2 PR but just made it a warning for now.

@tylerflex also when should we do [this](https://github.com/flexcompute/tidy3d/issues/2545)?