### PR TITLE
ability to read unstructured data from legacy vtk format

### DIFF
--- a/tidy3d/components/data/unstructured/base.py
+++ b/tidy3d/components/data/unstructured/base.py
@@ -483,6 +483,17 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
 
         return grid
 
+    @staticmethod
+    @requires_vtk
+    def _read_vtkLegacyFile(fname: str):
+        """Load a grid from a legacy `.vtk` file."""
+        reader = vtk["mod"].vtkGenericDataObjectReader()
+        reader.SetFileName(fname)
+        reader.Update()
+        grid = reader.GetOutput()
+
+        return grid
+
     @classmethod
     @abstractmethod
     @requires_vtk
@@ -494,6 +505,7 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
         remove_unused_points: bool = False,
         values_type=IndexedDataArray,
         expect_complex=None,
+        ignore_invalid_cells=False,
     ) -> UnstructuredGridDataset:
         """Initialize from a vtk object."""
 
@@ -524,6 +536,7 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
         field: Optional[str] = None,
         remove_degenerate_cells: bool = False,
         remove_unused_points: bool = False,
+        ignore_invalid_cells: bool = False,
     ) -> UnstructuredGridDataset:
         """Load unstructured data from a vtu file.
 
@@ -549,6 +562,44 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
             field=field,
             remove_degenerate_cells=remove_degenerate_cells,
             remove_unused_points=remove_unused_points,
+            ignore_invalid_cells=ignore_invalid_cells,
+        )
+
+    @classmethod
+    @requires_vtk
+    def from_vtk(
+        cls,
+        file: str,
+        field: Optional[str] = None,
+        remove_degenerate_cells: bool = False,
+        remove_unused_points: bool = False,
+        ignore_invalid_cells: bool = False,
+    ) -> UnstructuredGridDataset:
+        """Load unstructured data from a vtk file.
+
+        Parameters
+        ----------
+        fname : str
+            Full path to the .vtk file to load the unstructured data from.
+        field : str = None
+            Name of the field to load.
+        remove_degenerate_cells : bool = False
+            Remove explicitly degenerate cells.
+        remove_unused_points : bool = False
+            Remove unused points.
+
+        Returns
+        -------
+        UnstructuredGridDataset
+            Unstructured data.
+        """
+        grid = cls._read_vtkLegacyFile(file)
+        return cls._from_vtk_obj(
+            grid,
+            field=field,
+            remove_degenerate_cells=remove_degenerate_cells,
+            remove_unused_points=remove_unused_points,
+            ignore_invalid_cells=ignore_invalid_cells,
         )
 
     @requires_vtk
@@ -586,7 +637,7 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
                 "No point data is found in a VTK object. '.values' will be initialized to zeros."
             )
             values_numpy = np.zeros(num_points)
-            values_coords = {"index": []}
+            values_coords = {"index": np.arange(num_points)}
             values_name = None
 
         else:

--- a/tidy3d/components/data/unstructured/tetrahedral.py
+++ b/tidy3d/components/data/unstructured/tetrahedral.py
@@ -97,6 +97,7 @@ class TetrahedralGridDataset(UnstructuredGridDataset):
         remove_unused_points: bool = False,
         values_type=IndexedDataArray,
         expect_complex: bool = False,
+        ignore_invalid_cells: bool = False,
     ) -> TetrahedralGridDataset:
         """Initialize from a vtkUnstructuredGrid instance."""
 
@@ -109,8 +110,16 @@ class TetrahedralGridDataset(UnstructuredGridDataset):
 
         # verify cell_types
         cells_types = vtk["vtk_to_numpy"](vtk_obj.GetCellTypesArray())
-        if not np.all(cells_types == cls._vtk_cell_type()):
-            raise DataError("Only tetrahedral 'vtkUnstructuredGrid' is currently supported")
+        invalid_cells = cells_types != cls._vtk_cell_type()
+        if any(invalid_cells):
+            if ignore_invalid_cells:
+                cell_offsets = vtk["vtk_to_numpy"](vtk_obj.GetCells().GetOffsetsArray())
+                valid_cell_offsets = cell_offsets[:-1][invalid_cells == 0]
+                cells_numpy = cells_numpy[
+                    np.ravel(valid_cell_offsets[:, None] + np.arange(4, dtype=int)[None, :])
+                ]
+            else:
+                raise DataError("Only tetrahedral 'vtkUnstructuredGrid' is currently supported")
 
         # pack point and cell information into Tidy3D arrays
         num_cells = len(cells_numpy) // cls._cell_num_vertices()

--- a/tidy3d/components/data/unstructured/triangular.py
+++ b/tidy3d/components/data/unstructured/triangular.py
@@ -132,6 +132,7 @@ class TriangularGridDataset(UnstructuredGridDataset):
         remove_unused_points: bool = False,
         values_type=IndexedDataArray,
         expect_complex=None,
+        ignore_invalid_cells: bool = False,
     ):
         """Initialize from a vtkUnstructuredGrid instance."""
 
@@ -143,12 +144,20 @@ class TriangularGridDataset(UnstructuredGridDataset):
 
         cells_numpy = vtk["vtk_to_numpy"](cells_vtk.GetConnectivityArray())
 
+        # verify cell_types
         cell_offsets = vtk["vtk_to_numpy"](cells_vtk.GetOffsetsArray())
-        if not np.all(np.diff(cell_offsets) == cls._cell_num_vertices()):
-            raise DataError(
-                "Only triangular 'vtkUnstructuredGrid' or 'vtkPolyData' can be converted into "
-                "'TriangularGridDataset'."
-            )
+        invalid_cells = np.diff(cell_offsets) != cls._cell_num_vertices()
+        if any(invalid_cells):
+            if ignore_invalid_cells:
+                valid_cell_offsets = cell_offsets[:-1][invalid_cells == 0]
+                cells_numpy = cells_numpy[
+                    np.ravel(valid_cell_offsets[:, None] + np.arange(3, dtype=int)[None, :])
+                ]
+            else:
+                raise DataError(
+                    "Only triangular 'vtkUnstructuredGrid' or 'vtkPolyData' can be converted into "
+                    "'TriangularGridDataset'."
+                )
 
         points_numpy = vtk["vtk_to_numpy"](vtk_obj.GetPoints().GetData())
 


### PR DESCRIPTION
- adds the ability to read from legacy VTK format `.vtk` in addition to existing `.vtu`
- adds an option to not error when loading unstructured grid with non-triangle/-tetrahedral cells (for example, to skip triangle elements that are not relevant)
- fixes a bug when loading from vtk file without any point data

todo:
- [ ] unit tests
- [ ] changelog entry
- [ ] missing docstrings

<!-- greptile_comment -->

## Greptile Summary

Enhances VTK file support by adding legacy `.vtk` format compatibility and flexible cell type handling in unstructured grids.

- Added support for reading legacy VTK format (`.vtk`) files in addition to existing `.vtu` format
- Introduced `ignore_invalid_cells` parameter to gracefully handle non-triangular/-tetrahedral cells instead of erroring
- Fixed bug when loading VTK files without point data by properly handling empty coordinate lists
- Modified cell type validation in `_from_vtk_obj` to support mixed cell types when `ignore_invalid_cells=True`
- Missing unit tests, changelog entry, and docstrings need to be addressed



<!-- /greptile_comment -->