### PR TITLE
Prevent arrow lengths from being too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Arrow lengths are now scaled consistently in the X and Y directions,
+  and their lengths no longer exceed the height of the plot window.
+
 ## [2.9.0rc1] - 2025-06-10
 
 ### Added

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -2292,7 +2292,9 @@ class Box(SimplePlaneIntersection, Centered):
             event.canvas.mpl_disconnect(arrow.set_shape_cb[0])
 
             transform = arrow.axes.transData.transform
-            scale = transform((1, 0))[0] - transform((0, 0))[0]
+            scale_x = transform((1, 0))[0] - transform((0, 0))[0]
+            scale_y = transform((0, 1))[1] - transform((0, 0))[1]
+            scale = max(scale_x, scale_y)  # <-- Hack: This is a somewhat arbitrary choice.
             arrow_length = ARROW_LENGTH * event.canvas.figure.get_dpi() / scale
 
             if bend_radius:


### PR DESCRIPTION
### This PR is an attempt to address [issue #2575](https://github.com/flexcompute/tidy3d/issues/2575).

After this PR, arrows will always fit within plot window, regardless of their direction and regardless of the aspect ratio of the plot (`ax.set_aspect()`).

**Screenshots**

***Before this PR***

Before this PR, the vertical arrows could easily grow too long to fit within the plot window:
![Image](https://github.com/user-attachments/assets/8663a250-a60b-4b98-acc6-def048d519f1)

***After this PR***

After this PR, the green arrow is visible, regardless of it's orientation and regardless of the aspect ratio:
![fix_arrow_autoscale_after](https://github.com/user-attachments/assets/3ac92e69-1bc8-4025-b1f3-f11453fc3bf0)

**Test files**
The plot above was made using this file:
[test_arrow_autoscale.ipynb.zip](https://github.com/user-attachments/files/20747335/test_arrow_autoscale.ipynb.zip)

Download it, unzip it, and run the cells.

(NOTE: I disabled the plot on the right because it depends on https://github.com/flexcompute/tidy3d/pull/2544. That PR might not be merged by the time you are reading this. But it's not necessary to show this plot to see the problem. It just makes it more obvious.)

**Notes:**
- Previously, autoscaling worked in the horizontal direction, but not the vertical direction.
- Now it works in both horizontal and vertical directions.
- This PR fixes the problem of ***long*** arrows.  In this example, the other arrow (the grey arrow) is now too short to see clearly.  But I'm less concerned about short arrows because all arrows are still visible, regardless of how short they are. *(To see they grey arrow in this example, you just need to make the 2nd graph wider.  You can do that by adding `hlim=[-20,20]` to the 2nd plot() argument list.  The short grey arrow will resemble a small sideways triangle.)*  If you want to preserve the length of *short arrows* as well, a [different approach](https://docs.google.com/document/d/1JZ1dAv_0V_B7NaobwO1DcLnuR9rtFLDb3M7WdMuaHww/edit?usp=drive_link) is needed.  (I did not try this because it is more complicated.  See [below](https://github.com/flexcompute/tidy3d/pull/2576#issuecomment-2975060699).)
- ***More notes are listed in the comments below.***

**Additional context**

[This problem](https://github.com/flexcompute/tidy3d/issues/2575) is making it hard to implement [PR2544](https://github.com/flexcompute/tidy3d/pull/2544).


<!-- greptile_comment -->

## Greptile Summary

Fixed visualization issue in `tidy3d/components/geometry/base.py` where arrows could extend beyond plot boundaries by modifying `_arrow_shape_cb` to consider both horizontal and vertical scales when computing arrow lengths.

- Updated arrow length calculation in Box class to use both axes scales instead of just horizontal
- Ensures arrows remain visible within plot window regardless of direction/aspect ratio
- Trade-off: While long arrows are now properly constrained, some short arrows may appear smaller
- Visual improvement verified through test notebook with different aspect ratios
- Critical fix needed to unblock implementation of PR#2544



<!-- /greptile_comment -->