### PR TITLE
Fix to mode solver simulation reduction in web.upload

### DIFF
--- a/tests/test_web/test_webapi_mode.py
+++ b/tests/test_web/test_webapi_mode.py
@@ -108,10 +108,21 @@ def mock_upload(monkeypatch, set_api_key):
         status=200,
     )
 
+    # store the uploaded stub for verification
+    uploaded_stub = {}
+
+    def mock_upload_simulation(self, stub, **kwargs):
+        uploaded_stub["stub"] = stub
+
     def mock_upload_file(*args, **kwargs):
         pass
 
+    monkeypatch.setattr(
+        "tidy3d.web.core.task_core.SimulationTask.upload_simulation", mock_upload_simulation
+    )
     monkeypatch.setattr("tidy3d.web.core.task_core.upload_file", mock_upload_file)
+
+    return uploaded_stub
 
 
 @pytest.fixture
@@ -267,6 +278,26 @@ def test_upload(monkeypatch, mock_upload, mock_get_info, mock_metadata):
     sim = make_mode_sim()
     assert sim != get_reduced_simulation(sim, reduce_simulation=True)
     assert upload(sim, TASK_NAME, PROJECT_NAME, reduce_simulation=True)
+
+
+@pytest.mark.parametrize("reduce_simulation", [True, False])
+@responses.activate
+def test_upload_with_reduction_parameter(
+    monkeypatch, mock_upload, mock_get_info, mock_metadata, reduce_simulation
+):
+    """Test that simulation reduction is properly applied before upload based on reduce_simulation parameter."""
+    sim = make_mode_sim()
+
+    upload(sim, TASK_NAME, PROJECT_NAME, reduce_simulation=reduce_simulation)
+
+    if reduce_simulation:
+        expected_sim = get_reduced_simulation(sim, reduce_simulation=True)
+        assert sim != expected_sim
+    else:
+        expected_sim = sim
+
+    uploaded_sim = mock_upload["stub"].simulation
+    assert uploaded_sim == expected_sim
 
 
 @responses.activate

--- a/tests/test_web/test_webapi_mode_sim.py
+++ b/tests/test_web/test_webapi_mode_sim.py
@@ -104,10 +104,21 @@ def mock_upload(monkeypatch, set_api_key):
         status=200,
     )
 
+    # store the uploaded stub for verification
+    uploaded_stub = {}
+
+    def mock_upload_simulation(self, stub, **kwargs):
+        uploaded_stub["stub"] = stub
+
     def mock_upload_file(*args, **kwargs):
         pass
 
+    monkeypatch.setattr(
+        "tidy3d.web.core.task_core.SimulationTask.upload_simulation", mock_upload_simulation
+    )
     monkeypatch.setattr("tidy3d.web.core.task_core.upload_file", mock_upload_file)
+
+    return uploaded_stub
 
 
 @pytest.fixture
@@ -263,6 +274,26 @@ def test_upload(monkeypatch, mock_upload, mock_get_info, mock_metadata):
     sim = make_mode_sim()
     assert sim != get_reduced_simulation(sim, reduce_simulation=True)
     assert upload(sim, TASK_NAME, PROJECT_NAME, reduce_simulation=True)
+
+
+@pytest.mark.parametrize("reduce_simulation", [True, False])
+@responses.activate
+def test_upload_with_reduction_parameter(
+    monkeypatch, mock_upload, mock_get_info, mock_metadata, reduce_simulation
+):
+    """Test that simulation reduction is properly applied before upload based on reduce_simulation parameter."""
+    sim = make_mode_sim()
+
+    upload(sim, TASK_NAME, PROJECT_NAME, reduce_simulation=reduce_simulation)
+
+    if reduce_simulation:
+        expected_sim = get_reduced_simulation(sim, reduce_simulation=True)
+        assert sim != expected_sim
+    else:
+        expected_sim = sim
+
+    uploaded_sim = mock_upload["stub"].simulation
+    assert uploaded_sim == expected_sim
 
 
 @responses.activate

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -250,6 +250,9 @@ def upload(
 
     """
 
+    if isinstance(simulation, (ModeSolver, ModeSimulation)):
+        simulation = get_reduced_simulation(simulation, reduce_simulation)
+
     stub = Tidy3dStub(simulation=simulation)
     stub.validate_pre_upload(source_required=source_required)
     log.debug("Creating task.")
@@ -279,8 +282,6 @@ def upload(
     remote_sim_file = SIM_FILE_HDF5_GZ
     if task_type == "MODE_SOLVER":
         remote_sim_file = MODE_FILE_HDF5_GZ
-    if task_type == "MODE_SOLVER" or task_type == "MODE":
-        simulation = get_reduced_simulation(simulation, reduce_simulation)
 
     task.upload_simulation(
         stub=stub,
@@ -322,7 +323,6 @@ def get_reduced_simulation(simulation, reduce_simulation):
     there. Note that if we do the latter we may want to also modify the warning below to only
     happen if there are custom media *and* they extend beyond the simulation domain.
     """
-
     if reduce_simulation == "auto":
         if isinstance(simulation, ModeSimulation):
             sim_mediums = simulation.scene.mediums
@@ -339,7 +339,6 @@ def get_reduced_simulation(simulation, reduce_simulation):
                 " Setting 'reduce_simulation=True' will force simulation reduction in all cases and"
                 " silence this warning."
             )
-
     if reduce_simulation:
         return simulation.reduced_simulation_copy
     return simulation


### PR DESCRIPTION
The simulation reduction was happening only *after* the simulation was already uploaded. :facepalm:

I don't know if this never worked right, or if it broke at some point - I think the latter.

We have a test [here](https://github.com/flexcompute/tidy3d/blob/82bf4baca3e2a6169eb5980f432e36fd435e84b0/tests/test_web/test_webapi_mode.py#L268-L269) that the reduction function works, but not that the reduced simulation is actually uploaded. I'm not sure if the latter is possible within our mock web tests?  

<!-- greptile_comment -->

## Greptile Summary

Fixed a critical performance issue in mode solver simulations where the simulation reduction was incorrectly occurring after upload instead of before, causing unnecessary data transfer. This bug impacted the efficiency of mode solver tasks by uploading full-sized simulations when reduced versions would suffice.

- Modified `tidy3d/web/api/webapi.py` to perform mode solver simulation reduction before Tidy3dStub initialization and upload
- Existing test confirms reduction function works but lacks verification of reduced simulation upload
- Improves server-side efficiency by transmitting only the necessary simulation data



<!-- /greptile_comment -->