### PR TITLE
KLayout DRC integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Selective simulation capabilities to `TerminalComponentModeler` via `run_only` and `element_mappings` fields, allowing users to run fewer simulations and extract only needed scattering matrix elements.
+- Added KLayout plugin, with DRC functionality for running design rule checks in `plugins.klayout.drc`. Supports running DRC on GDS files as well as `Geometry`, `Structure`, and `Simulation` objects.
 
 ### Changed
 - Validate mode solver object for large number of grid points on the modal plane.

--- a/docs/api/plugins/index.rst
+++ b/docs/api/plugins/index.rst
@@ -15,6 +15,7 @@ Plugins
     ./design
     ./waveguide
     ./microwave
+    ./klayout
 
 
 .. include:: /api/plugins/mode_solver.rst
@@ -28,3 +29,4 @@ Plugins
 .. include:: /api/plugins/design.rst
 .. include:: /api/plugins/waveguide.rst
 .. include:: /api/plugins/microwave.rst
+.. include:: /api/plugins/klayout.rst

--- a/docs/api/plugins/klayout.rst
+++ b/docs/api/plugins/klayout.rst
@@ -1,0 +1,64 @@
+.. currentmodule:: tidy3d
+
+KLayout Integration
+-------------------
+
+.. toctree::
+
+    ./../../../tidy3d/plugins/klayout/README.md
+
+DRC
+~~~
+
+.. toctree::
+
+    ./../../../tidy3d/plugins/klayout/drc/README.md
+
+DRC Configuration
+^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+    tidy3d.plugins.klayout.DRCConfig
+
+DRC Runner
+^^^^^^^^^^
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+    tidy3d.plugins.klayout.DRCRunner
+    tidy3d.plugins.klayout.run_drc_on_gds
+
+DRC Results
+^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+    tidy3d.plugins.klayout.DRCResults
+    tidy3d.plugins.klayout.drc.DRCViolation
+
+DRC Markers
+^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+    tidy3d.plugins.klayout.drc.EdgeMarker
+    tidy3d.plugins.klayout.drc.EdgePairMarker
+    tidy3d.plugins.klayout.drc.MultiPolygonMarker
+
+Utilities
+~~~~~~~~~
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+    tidy3d.plugins.klayout.check_installation 

--- a/tests/test_plugins/klayout/drc/drc_results.lyrdb
+++ b/tests/test_plugins/klayout/drc/drc_results.lyrdb
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<report-database>
+ <description>DRC results</description>
+ <original-file/>
+ <generator>drc: script='my_drc_runset.drc'</generator>
+ <top-cell>TOP</top-cell>
+ <tags>
+ </tags>
+ <categories>
+  <category>
+   <name>min_width</name>
+   <description>minimum width</description>
+   <categories>
+   </categories>
+  </category>
+  <category>
+   <name>min_gap</name>
+   <description>minimum gap</description>
+   <categories>
+   </categories>
+  </category>
+  <category>
+   <name>min_area</name>
+   <description>minimum area</description>
+   <categories>
+   </categories>
+  </category>
+  <category>
+   <name>min_hole</name>
+   <description>minimum hole</description>
+   <categories>
+   </categories>
+  </category>
+ </categories>
+ <cells>
+  <cell>
+   <name>TOP</name>
+   <variant/>
+   <layout-name/>
+   <references>
+   </references>
+  </cell>
+ </cells>
+ <items>
+  <item>
+   <tags/>
+   <category>min_width</category>
+   <cell>TOP</cell>
+   <visited>false</visited>
+   <multiplicity>1</multiplicity>
+   <comment/>
+   <image/>
+   <values>
+    <value>edge-pair: (-0.6,0.163;-0.6,0.419)|(-0.31,0.342;-0.31,0.24)</value>
+   </values>
+  </item>
+  <item>
+   <tags/>
+   <category>min_width</category>
+   <cell>TOP</cell>
+   <visited>false</visited>
+   <multiplicity>1</multiplicity>
+   <comment/>
+   <image/>
+   <values>
+    <value>edge-pair: (-0.206,0.342;-0.31,0.342)|(-0.521,0.555;0.005,0.555)</value>
+   </values>
+  </item>
+  <item>
+   <tags/>
+   <category>min_gap</category>
+   <cell>TOP</cell>
+   <visited>false</visited>
+   <multiplicity>1</multiplicity>
+   <comment/>
+   <image/>
+   <values>
+    <value>edge-pair: (-0.31,0.24;-0.206,0.24)|(-0.206,0.342;-0.31,0.342)</value>
+   </values>
+  </item>
+  <item>
+   <tags/>
+   <category>min_gap</category>
+   <cell>TOP</cell>
+   <visited>false</visited>
+   <multiplicity>1</multiplicity>
+   <comment/>
+   <image/>
+   <values>
+    <value>edge-pair: (-0.206,0.24;-0.206,0.342)|(-0.31,0.342;-0.31,0.24)</value>
+   </values>
+  </item>
+  <item>
+   <tags/>
+   <category>min_area</category>
+   <cell>TOP</cell>
+   <visited>false</visited>
+   <multiplicity>1</multiplicity>
+   <comment/>
+   <image/>
+   <values>
+    <value>polygon: (-0.6,-0.112;-0.6,0.555;0.217,0.555;0.217,-0.112/-0.31,0.24;-0.206,0.24;-0.206,0.342;-0.31,0.342)</value>
+   </values>
+  </item>
+  <item>
+   <tags/>
+   <category>min_hole</category>
+   <cell>TOP</cell>
+   <visited>false</visited>
+   <multiplicity>1</multiplicity>
+   <comment/>
+   <image/>
+   <values>
+    <value>polygon: (-0.31,0.24;-0.31,0.342;-0.206,0.342;-0.206,0.24)</value>
+   </values>
+  </item>
+ </items>
+</report-database>

--- a/tests/test_plugins/klayout/drc/drc_results_widthonly_clean.lyrdb
+++ b/tests/test_plugins/klayout/drc/drc_results_widthonly_clean.lyrdb
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<report-database>
+ <description>DRC results</description>
+ <original-file/>
+ <generator>drc: script='testwidthonly.drc'</generator>
+ <top-cell>MAIN</top-cell>
+ <tags>
+ </tags>
+ <categories>
+  <category>
+   <name>min_width</name>
+   <description>minimum width</description>
+   <categories>
+   </categories>
+  </category>
+ </categories>
+ <cells>
+  <cell>
+   <name>MAIN</name>
+   <variant/>
+   <layout-name/>
+   <references>
+   </references>
+  </cell>
+ </cells>
+ <items>
+ </items>
+</report-database>

--- a/tests/test_plugins/klayout/drc/test_drc.py
+++ b/tests/test_plugins/klayout/drc/test_drc.py
@@ -1,0 +1,432 @@
+"""Tests tidy3d/plugins/klayout/drc/drc.py"""
+
+from __future__ import annotations
+
+import os
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pydantic.v1 as pd
+import pytest
+
+import tidy3d as td
+from tidy3d.exceptions import FileError
+from tidy3d.plugins.klayout.drc.drc import DRCRunner
+from tidy3d.plugins.klayout.drc.results import DRCResults, parse_violation_value
+from tidy3d.plugins.klayout.util import check_installation
+
+filepath = Path(os.path.dirname(os.path.abspath(__file__)))
+
+
+def test_check_klayout_not_installed():
+    """Test that _check_klayout_on_path raises RuntimeError if klayout is not in the system path.
+    Assumes this is the case on the CI machine.
+    """
+    with pytest.raises(RuntimeError):
+        check_installation(raise_error=True)
+
+
+class TestDRCRunner:
+    """Test DRCRunner"""
+
+    @staticmethod
+    def write_drcrunset(tmp_path, drcrunset_name, drcrunset_content):
+        """Write a DRC file to a temporary path"""
+        with Path(tmp_path / drcrunset_name).open("w") as f:
+            f.write(drcrunset_content)
+
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def good_drcrunset_content():
+        """The content of a valid DRC file"""
+        return """
+        source($gdsfile)
+        report("DRC results", $resultsfile)
+        """
+
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def bad_drcrunset_content_source():
+        """The content of a DRC file with a bad source declaration"""
+        return """
+        source($gfdsfile)
+        report("DRC results", $resultsfile)
+        """
+
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def bad_drcrunset_content_report():
+        """The content of a DRC file with a bad report declaration"""
+        return """
+        source($gdsfile)
+        report("DRC results", $refsultsfile)
+        """
+
+    @staticmethod
+    def write_gdsfile(tmp_path, gdsfile_name):
+        """Write a geometry to a GDS file"""
+        geom = TestDRCRunner.make_geom()
+        geom.to_gds_file(tmp_path / gdsfile_name, **TestDRCRunner.geom_to_gds_kwargs())
+
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def geom():
+        """Make a simple geometry"""
+        vertices = [(-2, 0), (-1, 1), (0, 0.5), (1, 1), (2, 0), (0, -1)]
+        return td.PolySlab(vertices=vertices, slab_bounds=(0, 0.22), axis=2)
+
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def geom_to_gds_kwargs():
+        """The kwargs to pass to the geometry's to_gds_file() method"""
+        return {"z": 0.1, "gds_layer": 0, "gds_dtype": 0}
+
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def structure(geom):
+        """Make a structure with a geometry"""
+        return td.Structure(geometry=geom, medium=td.Medium(permittivity=12))
+
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def structure_to_gds_kwargs():
+        """The kwargs to pass to the structure's to_gds_file() method"""
+        return {"z": 0.1, "gds_layer": 0, "gds_dtype": 0}
+
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def sim(structure):
+        """Make a simulation with a structure"""
+        return td.Simulation(
+            size=(10, 10, 1),
+            grid_spec=td.GridSpec.uniform(dl=0.02),
+            structures=[structure],
+            boundary_spec=td.BoundarySpec.all_sides(boundary=td.PML()),
+            run_time=1e-12,
+        )
+
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def sim_to_gds_kwargs():
+        """The kwargs to pass to the simulation's to_gds_file() method"""
+        return {"z": 0.1, "gds_layer_dtype_map": {td.Medium(permittivity=12): (0, 0)}}
+
+    @staticmethod
+    def run(
+        monkeypatch,
+        drc_runsetfile,
+        verbose,
+        source,
+        td_object_gds_savefile,
+        resultsfile,
+        **to_gds_file_kwargs,
+    ):
+        """Calls DRCRunner.run with dummy run_drc_on_gds()"""
+
+        # monkeypatch run_drc_on_gds() since the test machines do not have KLayout installed
+        def mock_run_drc_on_gds(config):
+            return DRCResults.load(filepath / "drc_results.lyrdb")
+
+        monkeypatch.setattr("tidy3d.plugins.klayout.drc.drc.run_drc_on_gds", mock_run_drc_on_gds)
+
+        runner = DRCRunner(drc_runset=drc_runsetfile, verbose=verbose)
+        return runner.run(
+            source=source,
+            td_object_gds_savefile=td_object_gds_savefile,
+            resultsfile=resultsfile,
+            **to_gds_file_kwargs,
+        )
+
+    @pytest.mark.parametrize("verbose", [True, False])
+    def test_valid_run_on_gds(
+        self, monkeypatch, tmp_path, verbose, geom, geom_to_gds_kwargs, good_drcrunset_content
+    ):
+        """Test that no error is raised when runs on a gds are valid"""
+        geom.to_gds_file(tmp_path / "test.gds", **geom_to_gds_kwargs)
+        self.write_drcrunset(tmp_path, "good_drcfile.drc", good_drcrunset_content)
+        self.run(
+            monkeypatch=monkeypatch,
+            drc_runsetfile=tmp_path / "good_drcfile.drc",
+            verbose=verbose,
+            source=tmp_path / "test.gds",
+            td_object_gds_savefile=tmp_path / "test.gds",
+            resultsfile=filepath / "drc_results.lyrdb",
+        )
+
+    @pytest.mark.parametrize("verbose", [True, False])
+    @pytest.mark.parametrize(
+        "td_object, obj_to_gds_kwargs",
+        [
+            ("geom", "geom_to_gds_kwargs"),
+            ("structure", "structure_to_gds_kwargs"),
+            ("sim", "sim_to_gds_kwargs"),
+        ],
+    )
+    def test_valid_run_on_td_object(
+        self,
+        request,
+        monkeypatch,
+        tmp_path,
+        verbose,
+        td_object,
+        obj_to_gds_kwargs,
+        good_drcrunset_content,
+    ):
+        """Test that no error is raised when runs on a Geometry, Structure, or Simulation are valid"""
+        self.write_drcrunset(tmp_path, "good_drcfile.drc", good_drcrunset_content)
+        self.run(
+            monkeypatch=monkeypatch,
+            drc_runsetfile=tmp_path / "good_drcfile.drc",
+            verbose=verbose,
+            source=request.getfixturevalue(td_object),
+            td_object_gds_savefile=tmp_path / "test.gds",
+            resultsfile=filepath / "drc_results.lyrdb",
+            **request.getfixturevalue(obj_to_gds_kwargs),
+        )
+
+    @pytest.mark.parametrize(
+        "bad_drcrunset_content", ["bad_drcrunset_content_source", "bad_drcrunset_content_report"]
+    )
+    def test_check_drcfile_format_invalid(
+        self, request, monkeypatch, tmp_path, geom, geom_to_gds_kwargs, bad_drcrunset_content
+    ):
+        """Tests that ValidationError is raised when the drc file content is invalid"""
+        geom.to_gds_file(tmp_path / "test.gds", **geom_to_gds_kwargs)
+        self.write_drcrunset(
+            tmp_path, "bad_drcrunset.drc", request.getfixturevalue(bad_drcrunset_content)
+        )
+        with pytest.raises(pd.ValidationError) as e:
+            self.run(
+                monkeypatch=monkeypatch,
+                drc_runsetfile=tmp_path / "bad_drcrunset.drc",
+                verbose=True,
+                source=tmp_path / "test.gds",
+                td_object_gds_savefile=None,
+                resultsfile=filepath / "drc_results.lyrdb",
+            )
+
+    def test_check_gdsfile_exists(self, monkeypatch, tmp_path, good_drcrunset_content):
+        """Test gdsfile existence checking works"""
+        self.write_drcrunset(tmp_path, "good_drcfile.drc", good_drcrunset_content)
+        with pytest.raises(pd.ValidationError):
+            self.run(
+                monkeypatch=monkeypatch,
+                drc_runsetfile=tmp_path / "good_drcfile.drc",
+                verbose=True,
+                source=tmp_path / "test.gds",
+                td_object_gds_savefile=None,
+                resultsfile=filepath / "drc_results.lyrdb",
+            )
+
+    def test_check_gdsfile_filetype(
+        self, monkeypatch, tmp_path, good_drcrunset_content, geom, geom_to_gds_kwargs
+    ):
+        """Test gdsfile filetype checking works"""
+        self.write_drcrunset(tmp_path, "good_drcfile.drc", good_drcrunset_content)
+        geom.to_gds_file(tmp_path / "test.g2ds", **geom_to_gds_kwargs)
+        with pytest.raises(pd.ValidationError):
+            self.run(
+                monkeypatch=monkeypatch,
+                drc_runsetfile=tmp_path / "good_drcfile.drc",
+                verbose=True,
+                source=tmp_path / "test.g2ds",
+                td_object_gds_savefile=None,
+                resultsfile=filepath / "drc_results.lyrdb",
+            )
+
+    def test_check_designrulefile_exists(self, monkeypatch, tmp_path, geom, geom_to_gds_kwargs):
+        """Test design rule file existence checking works"""
+        geom.to_gds_file(tmp_path / "test.gds", **geom_to_gds_kwargs)
+        with pytest.raises(pd.ValidationError):
+            self.run(
+                monkeypatch=monkeypatch,
+                drc_runsetfile=tmp_path / "not_a_drc_file.drc",
+                verbose=True,
+                source=tmp_path / "test.gds",
+                td_object_gds_savefile=None,
+                resultsfile=filepath / "drc_results.lyrdb",
+            )
+
+    def test_check_designrulefile_filetype(
+        self, monkeypatch, tmp_path, geom, geom_to_gds_kwargs, good_drcrunset_content
+    ):
+        """Test design rule file filetype checking works"""
+        geom.to_gds_file(tmp_path / "test.gds", **geom_to_gds_kwargs)
+        self.write_drcrunset(tmp_path, "good_drcfile.drc2", good_drcrunset_content)
+        with pytest.raises(pd.ValidationError):
+            self.run(
+                monkeypatch=monkeypatch,
+                drc_runsetfile=tmp_path / "good_drcfile.drc2",
+                verbose=True,
+                source=tmp_path / "test.gds",
+                td_object_gds_savefile=None,
+                resultsfile=filepath / "drc_results.lyrdb",
+            )
+
+
+class TestDRCResults:
+    """Test DRCResults"""
+
+    @pytest.fixture(scope="class")
+    def drc_results(self):
+        """Load the DRC results"""
+        return DRCResults.load(filepath / "drc_results.lyrdb")
+
+    @pytest.fixture(scope="class")
+    def drc_results_widthonly_clean(self):
+        """Load the DRC results"""
+        return DRCResults.load(filepath / "drc_results_widthonly_clean.lyrdb")
+
+    def test_result_file_load(self, tmp_path):
+        """Test that result file loading works"""
+        # this should not raise an error
+        DRCResults.load(filepath / "drc_results.lyrdb")
+
+        # file not found
+        with pytest.raises(FileError):
+            DRCResults.load(tmp_path / "not_a_results_file.lyrdb")
+
+        # not xml file
+        with Path(tmp_path / "bad_resultsfile.lyrdb").open("w") as f:
+            f.write("""
+        not a valid xml file
+        """)
+        with pytest.raises(ET.ParseError):
+            DRCResults.load(tmp_path / "bad_resultsfile.lyrdb")
+
+    def test_is_drc_clean(self, drc_results, drc_results_widthonly_clean):
+        """Test DRCResults.is_clean"""
+        assert not drc_results.is_clean
+        assert drc_results_widthonly_clean.is_clean
+
+    def test_count_drc_violations(self, drc_results):
+        """Test that counting violations works"""
+        assert drc_results["min_width"].count == 2
+        assert drc_results["min_gap"].count == 2
+        assert drc_results["min_area"].count == 1
+        assert drc_results["min_hole"].count == 1
+
+    def test_drc_result_markers(self, drc_results):
+        """Test that the DRC result markers are correct"""
+        assert drc_results["min_width"].markers[0].edge_pair[0] == ((-0.6, 0.163), (-0.6, 0.419))
+        assert drc_results["min_width"].markers[0].edge_pair[1] == ((-0.31, 0.342), (-0.31, 0.24))
+        assert drc_results["min_width"].markers[1].edge_pair[0] == ((-0.206, 0.342), (-0.31, 0.342))
+        assert drc_results["min_width"].markers[1].edge_pair[1] == ((-0.521, 0.555), (0.005, 0.555))
+        assert drc_results["min_gap"].markers[0].edge_pair[0] == ((-0.31, 0.24), (-0.206, 0.24))
+        assert drc_results["min_gap"].markers[0].edge_pair[1] == ((-0.206, 0.342), (-0.31, 0.342))
+        assert drc_results["min_gap"].markers[1].edge_pair[0] == ((-0.206, 0.24), (-0.206, 0.342))
+        assert drc_results["min_gap"].markers[1].edge_pair[1] == ((-0.31, 0.342), (-0.31, 0.24))
+        assert len(drc_results["min_area"].markers[0].polygons) == 2
+        assert drc_results["min_area"].markers[0].polygons[0] == (
+            (-0.6, -0.112),
+            (-0.6, 0.555),
+            (0.217, 0.555),
+            (0.217, -0.112),
+        )
+        assert drc_results["min_area"].markers[0].polygons[1] == (
+            (-0.31, 0.24),
+            (-0.206, 0.24),
+            (-0.206, 0.342),
+            (-0.31, 0.342),
+        )
+        assert len(drc_results["min_hole"].markers[0].polygons) == 1
+        assert drc_results["min_hole"].markers[0].polygons[0] == (
+            (-0.31, 0.24),
+            (-0.31, 0.342),
+            (-0.206, 0.342),
+            (-0.206, 0.24),
+        )
+
+    @pytest.mark.parametrize(
+        "edge_value, expected_edge",
+        [
+            ("edge: (1.0,2.0;3.0,4.0)", ((1.0, 2.0), (3.0, 4.0))),
+            ("edge: (-1.0,-2.0;-3.0,-4.0)", ((-1.0, -2.0), (-3.0, -4.0))),
+        ],
+    )
+    def test_parse_edge(self, edge_value, expected_edge):
+        """Test parsing edge violation values."""
+        edge_result = parse_violation_value(edge_value)
+        assert edge_result.edge == expected_edge
+
+    def test_parse_edge_pair(self):
+        """Test parsing edge-pair violation values."""
+        edge_pair_value = "edge-pair: (1.0,2.0;3.0,4.0)|(5.0,6.0;7.0,8.0)"
+        edge_pair_result = parse_violation_value(edge_pair_value)
+        assert edge_pair_result.edge_pair[0] == ((1.0, 2.0), (3.0, 4.0))
+        assert edge_pair_result.edge_pair[1] == ((5.0, 6.0), (7.0, 8.0))
+
+    def test_parse_polygon(self):
+        """Test parsing a single polygon violation string."""
+        polygon_value = "polygon: (1.0,2.0;3.0,4.0;5.0,6.0;1.0,2.0)"
+        polygon_result = parse_violation_value(polygon_value)
+        assert polygon_result.polygons[0] == ((1.0, 2.0), (3.0, 4.0), (5.0, 6.0), (1.0, 2.0))
+
+    def test_parse_multiple_polygons(self):
+        """Test parsing multiple polygons violation string."""
+        polygon_value = (
+            "polygon: (1.0,2.0;3.0,4.0;5.0,6.0;1.0,2.0/7.0,8.0;9.0,10.0;11.0,12.0;7.0,8.0)"
+        )
+        polygon_result = parse_violation_value(polygon_value)
+        assert polygon_result.polygons[0] == ((1.0, 2.0), (3.0, 4.0), (5.0, 6.0), (1.0, 2.0))
+        assert polygon_result.polygons[1] == ((7.0, 8.0), (9.0, 10.0), (11.0, 12.0), (7.0, 8.0))
+
+    @pytest.mark.parametrize(
+        "invalid_edge",
+        [
+            "edge: invalid_format",
+            "edge: (1.,3.,4.,1.)",
+            "edge: (1.0,2.0;3.0,4.0;5.0,6.0)",
+            "edge: (1.0,;3.0,)",
+            "edge: (1.0,2.0;3e.0,4.0)",
+            "edge: (1.0,;3.0,4.0)",
+        ],
+    )
+    def test_parse_invalid_edge_format(self, invalid_edge):
+        """Test parsing invalid violation format."""
+        with pytest.raises(ValueError):
+            parse_violation_value(invalid_edge)
+
+    @pytest.mark.parametrize(
+        "invalid_edge_pair",
+        [
+            "edge-pair: (1.0,2.0;3.0,4.0)|(5.0,6.0;7.0,8.0;9.0,10.0)",
+            "edge-pair: (1b.0,2.0;3.0,4.0)|(5.0,6.0;7.0,8.0)",
+            "edge-pair: (1.0,2.0;3.0,4.0)|(5.0,)",
+        ],
+    )
+    def test_parse_invalid_edge_pair_format(self, invalid_edge_pair):
+        """Test parsing invalid edge-pair violation format."""
+        with pytest.raises(ValueError):
+            parse_violation_value(invalid_edge_pair)
+
+    @pytest.mark.parametrize(
+        "invalid_polygon",
+        [
+            "polygon: (1b.0,2.0;3.0,4.0;5.0,6.0;1.0,2.0;1.0,2.0)",
+            "polygon: (1.0,2.0;3.0,4.0;|5.0,6.0;1.0,2.0;1.0,2.0)",
+            "polygon: (1.0,;3.0,4.0;5.0,6.0;1.0,2.0;1.0,2.0)",
+        ],
+    )
+    def test_parse_invalid_polygon_format(self, invalid_polygon):
+        """Test parsing invalid polygon violation format."""
+        with pytest.raises(ValueError):
+            parse_violation_value(invalid_polygon)
+
+    @pytest.mark.parametrize(
+        "invalid_polygons",
+        [
+            "polygon: (1.0,2.0;3.0,4.0;5.0,6.0;1.0,2.0//7.0,8.0;9.0,10.0;11.0,12.0;7.0,8.0)",
+            "polygon: (1.0,2.0;3.0,4.0;5.0,6.0;1.0,2.0/",
+            "polygon: (1.0,2.0;3.0,4/.0;5.0,6.0;1.0,2.0)",
+        ],
+    )
+    def test_parse_invalid_polygon_format_multiple_polygons(self, invalid_polygons):
+        """Test parsing invalid polygon violation format with multiple polygons."""
+        with pytest.raises(ValueError) as e:
+            parse_violation_value(invalid_polygons)
+
+    def test_parse_violation_value_unknown_type(self):
+        """Test parsing unknown violation type."""
+        with pytest.raises(ValueError):
+            parse_violation_value("unknown: (1.0,2.0)")

--- a/tidy3d/plugins/klayout/README.md
+++ b/tidy3d/plugins/klayout/README.md
@@ -1,0 +1,9 @@
+# KLayout Integration for Tidy3D
+
+This module provides integration between [Tidy3D](https://docs.flexcompute.com/projects/tidy3d/en/latest/) and [KLayout](https://www.klayout.de).
+
+## Design Rule Checking (DRC)
+
+The DRC submodule provides integration between [Tidy3D](https://docs.flexcompute.com/projects/tidy3d/en/latest/) and [KLayout](https://www.klayout.de)'s [Design Rule Check (DRC) engine](https://www.klayout.de/doc/manual/drc.html), allowing you to perform design rule checks on GDS files and Tidy3D objects.
+
+For more details, please see the [DRC README](https://github.com/flexcompute/tidy3d/blob/develop/tidy3d/plugins/klayout/drc/README.md).

--- a/tidy3d/plugins/klayout/__init__.py
+++ b/tidy3d/plugins/klayout/__init__.py
@@ -1,0 +1,16 @@
+"""
+This module provides integration between Tidy3D and KLayout.
+"""
+
+from __future__ import annotations
+
+from .drc import DRCConfig, DRCResults, DRCRunner, run_drc_on_gds
+from .util import check_installation
+
+__all__ = [
+    "DRCConfig",
+    "DRCResults",
+    "DRCRunner",
+    "check_installation",
+    "run_drc_on_gds",
+]

--- a/tidy3d/plugins/klayout/drc/README.md
+++ b/tidy3d/plugins/klayout/drc/README.md
@@ -1,0 +1,134 @@
+# KLayout DRC Integration for Tidy3D
+
+This module provides integration between [Tidy3D](https://docs.flexcompute.com/projects/tidy3d/en/latest/) and [KLayout](https://www.klayout.de)'s [Design Rule Check (DRC) engine](https://www.klayout.de/doc/manual/drc.html), allowing you to perform design rule checks on GDS files and Tidy3D objects.
+
+## Quickstart
+
+For a full quickstart example, please see [this quickstart notebook](https://github.com/flexcompute/tidy3d-notebooks/blob/develop/KLayoutPlugin_DRCQuickstart.ipynb).
+
+## Features
+
+- Run DRC on GDS files or Tidy3D objects ([Geometry](https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.Geometry.html), [Structure](https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.Structure.html#tidy3d.Structure), or [Simulation](https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.Simulation.html#tidy3d.Simulation)) with `DRCRunner.run()`.
+- Load DRC results into a `DRCResults` data structure with `DRCResults.load()`.
+
+## Prerequisites
+
+1. Have the full KLayout application installed and added to your system PATH.
+
+To install KLayout, please refer to https://www.klayout.de/build.html. 
+
+After installation, the application may need to be manually added to the system PATH. The method to add KLayout to your system PATH depends on your operating system. For example, on MacOS, you can add the following line to your `~/.zshrc` file. This will permanently add KLayout to your PATH:
+```zsh
+export PATH="$PATH:/Applications/klayout.app/Contents/MacOS"
+```
+
+To check if KLayout has been added to the system PATH, you can use the provided `check_installation()` utility:
+```python
+from tidy3d.plugins.klayout import check_installation
+# Prints the full path to the executable if found, otherwise returns None
+print(check_installation())
+```
+
+The full path to the application should be displayed if KLayout has been added to the system PATH.
+
+2. Provide a KLayout DRC runset script that defines the source (input gds) using `source($gdsfile)` and the report (output result file) using `report("DRC results", $resultsfile)`. Please refer to the [DRC Runset Formatting section below](#drc-runset-file-formatting).
+
+## DRC Runset File Formatting
+
+DRC runsets are defined in KLayout DRC's domain-specific-language. Please refer to the [KLayout User Manual](https://www.klayout.de/doc/manual/drc.html) for details regarding syntax and functionality.
+
+**Importantly**, for compatibility with this plugin, the runset must include the following:
+
+1. The source must be defined as: `source($gdsfile)`
+2. The report (output result file) must be defined as: `report("DRC results", $resultsfile)`
+
+This is to ensure that the GDS file created from a Tidy3D object is properly loaded into KLayout, and the results are saved to a file of the user's choosing.
+
+Here is an example DRC runset script that checks for minimum width, space, area, and hole on layer (0,0):
+
+```
+# Simple DRC rules for testing
+
+# Define the source and output (report)
+source($gdsfile)
+report("DRC results", $resultsfile)
+
+# Checks minimum width of 300 nm
+input(0, 0).width(300.nm).output("min_width", "minimum width")
+
+# Checks minimum gap of 300 nm
+input(0, 0).space(300.nm).output("min_gap", "minimum gap")
+
+# Checks minimum area of 1e5 nm^2
+input(0, 0).drc(area < 100000).output("min_area", "minimum area")
+
+# Checks minimum hole of 1e5 nm^2
+input(0, 0).holes.drc(area < 100000).output("min_hole", "minimum hole")
+```
+
+### Running DRC
+
+To run DRC, create an instance of `DRCRunner` and use `DRCRunner.run()`
+You can run DRC on a GDS file as follows:
+
+```python
+from tidy3d.plugins.klayout.drc import DRCRunner
+
+# Run DRC on a Tidy3D object
+runner = DRCRunner(
+    drc_runset="example_runset.drc",
+    verbose=True,
+)
+results = runner.run("geom.gds")
+```
+
+Or you can run DRC on a Tidy3D [Geometry](https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.Geometry.html), [Structure](https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.Structure.html#tidy3d.Structure), or [Simulation](https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.Simulation.html#tidy3d.Simulation) object:
+
+```python
+# Create a simple polygon geometry
+vertices = [(-2, 0), (-1, 1), (0, 0.5), (1, 1), (2, 0), (0, -1)]
+geom = td.PolySlab(vertices=vertices, slab_bounds=(0, 0.22), axis=2)
+
+# Run DRC and get results
+runner = DRCRunner(
+    drc_runset="example_runset.drc",
+    verbose=True,
+)
+results = runner.run(geom, z=0.1, gds_layer=0, gds_dtype=0)
+```
+
+In the case of running DRC on a Tidy3D object, the object will first be saved to a GDS file, with additional keyword args passed into the object's `to_gds_file()` method (eg. [Simulation.to_gds_file()](https://docs.flexcompute.com/projects/tidy3d/en/latest/api/_autosummary/tidy3d.Simulation.html#tidy3d.Simulation.to_gds_file)).
+
+### Analyzing DRC Results
+
+The output of `DRCRunner.run_drc()` is a `DRCResults` object that stores the results of the DRC run.
+
+The user can check whether DRC passed with `DRCResults.is_clean`:
+
+```python
+print(results.is_clean)
+```
+
+A summary of DRC violations can be displayed by printing `DRCResults`:
+
+```python
+print(results)
+```
+
+Individual violation categories can be indexed by key:
+
+```python
+# This will show how many violation shapes were found for the 'min_width' rule.
+print(results['min_width'].count)
+
+# This will show all of the violation marker shapes for the 'min_width' rule
+print(results['min_width'].markers)
+```
+
+Results can also be loaded from a KLayout DRC database file with `DRCResults.load(resultsfile)`:
+
+```python
+from tidy3d.plugins.klayout.drc import DRCResults
+
+print(DRCResults.load("drc_results.lyrdb"))
+```

--- a/tidy3d/plugins/klayout/drc/__init__.py
+++ b/tidy3d/plugins/klayout/drc/__init__.py
@@ -1,0 +1,22 @@
+"""
+This module provides integration between Tidy3D and KLayout's Design Rule Check (DRC) engine, allowing you to perform design rule checks on GDS files and Tidy3D objects.
+
+For more information, please see the README.md file in this directory.
+For a quickstart example, please see `this notebook <link/to/notebook>`_.
+"""
+
+from __future__ import annotations
+
+from .drc import (
+    DRCConfig,
+    DRCRunner,
+    run_drc_on_gds,
+)
+from .results import DRCResults
+
+__all__ = [
+    "DRCConfig",
+    "DRCResults",
+    "DRCRunner",
+    "run_drc_on_gds",
+]

--- a/tidy3d/plugins/klayout/drc/defaults.py
+++ b/tidy3d/plugins/klayout/drc/defaults.py
@@ -1,0 +1,9 @@
+"""Default values for KLayout DRC."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+DEFAULT_GDSFILE = Path("layout.gds")
+DEFAULT_RESULTSFILE = Path("drc_results.lyrdb")
+DEFAULT_VERBOSE = True

--- a/tidy3d/plugins/klayout/drc/drc.py
+++ b/tidy3d/plugins/klayout/drc/drc.py
@@ -1,0 +1,226 @@
+"""Methods for integrating KLayout's DRC with Tidy3D."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from subprocess import run
+from typing import Union
+
+import pydantic.v1 as pd
+from pydantic.v1 import validator
+
+from tidy3d.components.base import Tidy3dBaseModel
+from tidy3d.components.geometry.base import Geometry
+from tidy3d.components.simulation import Simulation
+from tidy3d.components.structure import Structure
+from tidy3d.exceptions import ValidationError
+from tidy3d.log import get_logging_console
+from tidy3d.plugins.klayout.drc.defaults import (
+    DEFAULT_GDSFILE,
+    DEFAULT_RESULTSFILE,
+    DEFAULT_VERBOSE,
+)
+from tidy3d.plugins.klayout.drc.results import DRCResults
+from tidy3d.plugins.klayout.util import check_installation
+
+
+class DRCConfig(Tidy3dBaseModel):
+    """Configuration for KLayout DRC."""
+
+    gdsfile: pd.FilePath = pd.Field(
+        title="GDS File",
+        description="The path to the GDS file to write the Tidy3D object to.",
+    )
+    drc_runset: pd.FilePath = pd.Field(
+        title="DRC Runset file",
+        description="Path to the KLayout DRC runset file.",
+    )
+    resultsfile: Path = pd.Field(
+        title="DRC Results File",
+        description="Path to the KLayout DRC results file.",
+    )
+    verbose: bool = pd.Field(
+        title="Verbose",
+        description="Whether to print logging.",
+    )
+
+    @validator("gdsfile")
+    def _validate_gdsfile_filetype(cls, v: pd.FilePath) -> pd.FilePath:
+        """Check GDS filetype is ``.gds``."""
+        if v.suffix != ".gds":
+            raise ValidationError(f"GDS file '{v}' must end with '.gds'.")
+        return v
+
+    @validator("drc_runset")
+    def _validate_drc_runset_filetype(cls, v: pd.FilePath) -> pd.FilePath:
+        """Check DRC runset filetype is ``.drc``."""
+        if v.suffix != ".drc":
+            raise ValidationError(f"DRC runset file '{v}' must end with '.drc'.")
+        return v
+
+    @validator("drc_runset")
+    def _validate_drc_runset_format(cls, v: pd.FilePath) -> pd.FilePath:
+        """Check if the DRC runset file is formatted correctly.
+        The checks are:
+        1. The GDS source must be loaded with 'source($gdsfile)'.
+        2. The report must be defined as 'report("<your string>", $resultsfile)'.
+        """
+        with Path(v).open("r") as f:
+            content = f.read()
+            if not re.search(r"source\(\s*\$gdsfile\s*\)", content):
+                raise ValidationError(
+                    "DRC runset is not formatted correctly. The GDS source must be loaded with 'source($gdsfile)'. Please refer to the documentation at 'tidy3d/plugins/klayout/drc/README.md' for more details."
+                )
+            if not re.search(r"""report\(['"](.*?)['"],\s*\$resultsfile\)""", content):
+                raise ValidationError(
+                    "DRC runset is not formatted correctly. The report must be defined as 'report(\"<your report name>\", $resultsfile)'. Please refer to the documentation at 'tidy3d/plugins/klayout/drc/README.md' for more details."
+                )
+        return v
+
+
+class DRCRunner(Tidy3dBaseModel):
+    """A class for running KLayout DRC. Can be used to run DRC on a Tidy3D object or a GDS file.
+
+    Parameters
+    ----------
+    drc_runset : Path
+        The path to the KLayout DRC runset file.
+    verbose : bool
+        Whether to print logging. Default is ``True``.
+
+    Example
+    -------
+    >>> # Running DRC on a GDS file:
+    >>> from tidy3d.plugins.klayout.drc import DRCRunner
+    >>> runner = DRCRunner(drc_runset="my_drc_runset.drc", verbose=True) # doctest: +SKIP
+    >>> results = runner.run(source="my_layout.gds", resultsfile="drc_results.lyrdb") # doctest: +SKIP
+    >>> print(results) # doctest: +SKIP
+    >>> # Running DRC on a Tidy3D object:
+    >>> import tidy3d as td
+    >>> from tidy3d.plugins.klayout.drc import DRCRunner
+    >>> vertices = [(-2, 0), (-1, 1), (0, 0.5), (1, 1), (2, 0), (0, -1)]
+    >>> geom = td.PolySlab(vertices=vertices, slab_bounds=(0, 0.22), axis=2)
+    >>> runner = DRCRunner(drc_runset="my_drc_runset.drc", verbose=True) # doctest: +SKIP
+    >>> results = runner.run(source=geom, td_object_gds_savefile="geom.gds", resultsfile="drc_results.lyrdb", z=0.1, gds_layer=0, gds_dtype=0) # doctest: +SKIP
+    >>> print(results) # doctest: +SKIP
+    """
+
+    drc_runset: pd.FilePath = pd.Field(
+        title="DRC Runset file",
+        description="Path to the KLayout DRC runset file.",
+    )
+    verbose: bool = pd.Field(
+        default=DEFAULT_VERBOSE,
+        title="Verbose",
+        description="Whether to print logging.",
+    )
+
+    def run(
+        self,
+        source: Union[Geometry, Structure, Simulation, Path],
+        td_object_gds_savefile: Path = DEFAULT_GDSFILE,
+        resultsfile: Path = DEFAULT_RESULTSFILE,
+        **to_gds_file_kwargs,
+    ) -> None:
+        """Runs KLayout's DRC on a GDS file or a Tidy3D object. The Tidy3D object can be a :class:`.Geometry`, :class:`.Structure`, or :class:`.Simulation`.
+
+        Parameters
+        ----------
+        source : Union[:class:`.Geometry`, :class:`.Structure`, :class:`.Simulation`, Path]
+            The :class:`.Geometry`, :class:`.Structure`, :class:`.Simulation`, or GDS file to run DRC on.
+        td_object_gds_savefile : Path
+            The path to save the Tidy3D object to. Defaults to ``"layout.gds"``.
+        resultsfile : Path
+            The path to save the KLayout DRC results file to. Defaults to ``"drc_results.lyrdb"``.
+        **to_gds_file_kwargs
+            Additional keyword arguments to pass to the Tidy3D object-specific ``to_gds_file()`` method.
+
+        Returns
+        -------
+        :class:`.DRCResults`
+            The DRC results object containing violations and status.
+
+        Example
+        -------
+        Running DRC on a GDS file:
+        >>> from tidy3d.plugins.klayout.drc import DRCRunner
+        >>> runner = DRCRunner(drc_runset="my_drc_runset.drc", verbose=True) # doctest: +SKIP
+        >>> results = runner.run(source="my_layout.gds") # doctest: +SKIP
+        >>> print(results) # doctest: +SKIP
+
+        Running DRC on a Tidy3D object:
+        >>> import tidy3d as td
+        >>> from tidy3d.plugins.klayout.drc import DRCRunner
+        >>> vertices = [(-2, 0), (-1, 1), (0, 0.5), (1, 1), (2, 0), (0, -1)]
+        >>> geom = td.PolySlab(vertices=vertices, slab_bounds=(0, 0.22), axis=2)
+        >>> runner = DRCRunner(drc_runset="my_drc_runset.drc", verbose=True) # doctest: +SKIP
+        >>> results = runner.run(source=geom, z=0.1, gds_layer=0, gds_dtype=0) # doctest: +SKIP
+        >>> print(results) # doctest: +SKIP
+        """
+        if isinstance(source, (Geometry, Structure, Simulation)):
+            gdsfile = td_object_gds_savefile
+            if self.verbose:
+                console = get_logging_console()
+                console.log(f"Writing Tidy3D object to GDS file '{gdsfile}'.")
+            source.to_gds_file(fname=gdsfile, **to_gds_file_kwargs)
+        else:
+            gdsfile = source
+
+        config = DRCConfig(
+            gdsfile=gdsfile,
+            drc_runset=self.drc_runset,
+            resultsfile=resultsfile,
+            verbose=self.verbose,
+        )
+        return run_drc_on_gds(config=config)
+
+
+def run_drc_on_gds(config: DRCConfig) -> DRCResults:
+    """Runs KLayout's DRC on a GDS file.
+
+    Parameters
+    ----------
+    config : :class:`.DRCConfig`
+        The configuration for the DRC run.
+
+    Returns
+    -------
+    :class:`.DRCResults`
+        The DRC results object containing violations and status.
+
+    Example
+    -------
+    >>> from tidy3d.plugins.klayout.drc import run_drc_on_gds, DRCConfig
+    >>> config = DRCConfig(gdsfile="geom.gds", drc_runset="my_drc_runset.drc", resultsfile="drc_results.lyrdb", verbose=True) # doctest: +SKIP
+    >>> results = run_drc_on_gds(config) # doctest: +SKIP
+    >>> print(results) # doctest: +SKIP
+    """
+    check_installation(raise_error=True)
+
+    if config.verbose:
+        console = get_logging_console()
+        console.log(
+            f"Running KLayout DRC on GDS file '{config.gdsfile}' with runset '{config.drc_runset}' and saving results to '{config.resultsfile}'..."
+        )
+    # run klayout DRC as a subprocess
+    output = run(
+        [
+            "klayout",
+            "-b",
+            "-r",
+            config.drc_runset,
+            "-rd",
+            f"gdsfile={config.gdsfile}",
+            "-rd",
+            f"resultsfile={config.resultsfile}",
+        ],
+        capture_output=True,
+    )
+
+    if output.returncode != 0:
+        raise RuntimeError(f"KLayout DRC failed with error message: '{output.stderr}'.")
+    if config.verbose:
+        console.log("KLayout DRC completed successfully.")
+
+    return DRCResults.load(resultsfile=config.resultsfile)

--- a/tidy3d/plugins/klayout/drc/results.py
+++ b/tidy3d/plugins/klayout/drc/results.py
@@ -1,0 +1,364 @@
+"""Methods for loading and parsing KLayout DRC results."""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Union
+
+import pydantic.v1 as pd
+
+from tidy3d.components.base import Tidy3dBaseModel, cached_property
+from tidy3d.components.types import Coordinate2D
+from tidy3d.exceptions import FileError
+
+# Types for DRC markers
+DRCEdge = tuple[Coordinate2D, Coordinate2D]
+DRCEdgePair = tuple[DRCEdge, DRCEdge]
+DRCPolygon = tuple[Coordinate2D, ...]
+DRCMultiPolygon = tuple[DRCPolygon, ...]
+
+
+def parse_edge(value: str) -> EdgeMarker:
+    """
+    Extract coordinates from edge format: ``(x1,y1;x2,y2)``.
+
+    Parameters
+    ----------
+    value : str
+        The edge value string from DRC result database, with format ``(x1,y1;x2,y2)``.
+
+    Returns
+    -------
+    :class:`.EdgeMarker`
+        :class:`.EdgeMarker` containing start and end points of the edge.
+
+    Raises
+    ------
+    ValueError
+        If the edge format is invalid.
+    """
+    # Extract coordinates from edge format: (x1,y1;x2,y2)
+    pattern = r"\(([\d.-]+),([\d.-]+);([\d.-]+),([\d.-]+)\)"
+    match = re.match(pattern, value)
+    if match:
+        coords = [float(x) for x in match.groups()]
+        return EdgeMarker(edge=((coords[0], coords[1]), (coords[2], coords[3])))
+    raise ValueError(f"Invalid edge format: '{value}'.")
+
+
+def parse_edge_pair(value: str) -> EdgePairMarker:
+    """
+    Extract coordinates from edge-pair format: ``(x1,y1;x2,y2)|(x3,y3;x4,y4)``.
+
+    Parameters
+    ----------
+    value : str
+        The edge-pair value string from DRC result database, with format ``(x1,y1;x2,y2)|(x3,y3;x4,y4)``.
+
+    Returns
+    -------
+    :class:`.EdgePairMarker`
+        :class:`.EdgePairMarker` containing both edges' coordinates.
+
+    Raises
+    ------
+    ValueError
+        If the edge-pair format is invalid.
+    """
+    # Extract coordinates from edge-pair format: (x1,y1;x2,y2)|(x3,y3;x4,y4)
+    pattern = (
+        r"\(([\d.-]+),([\d.-]+);([\d.-]+),([\d.-]+)\)\|\(([\d.-]+),([\d.-]+);([\d.-]+),([\d.-]+)\)"
+    )
+    match = re.match(pattern, value)
+    if match:
+        coords = [float(x) for x in match.groups()]
+        return EdgePairMarker(
+            edge_pair=(
+                ((coords[0], coords[1]), (coords[2], coords[3])),
+                ((coords[4], coords[5]), (coords[6], coords[7])),
+            )
+        )
+    raise ValueError(f"Invalid edge-pair format: '{value}'.")
+
+
+def parse_polygon_coordinates(coords_str: str) -> DRCPolygon:
+    """Parse coordinates for a single polygon into a tuple of (x, y) pairs.
+
+    Parameters
+    ----------
+    coords_str : str
+        The string of coordinates for a single polygon, with format ``x1,y1;x2,y2;...``.
+
+    Returns
+    -------
+    DRCPolygon
+        A tuple of (x, y) pairs for the polygon.
+
+    Raises
+    ------
+    ValueError
+        If the coordinate format is invalid.
+    """
+    coords_pattern = r"([\d.-]+),([\d.-]+)"  # match the coordinates
+
+    # Split by semicolon to validate each coordinate pair
+    coord_pairs = coords_str.split(";")
+
+    # Each coordinate pair should match the pattern exactly
+    coords = []
+    for pair in coord_pairs:
+        match = re.match(coords_pattern, pair)
+        if not match:
+            raise ValueError(f"Invalid coordinate pair in polygon: '{pair}'.")
+        coords.append((float(match.group(1)), float(match.group(2))))
+
+    return tuple(coords)
+
+
+def parse_polygons(value: str) -> MultiPolygonMarker:
+    """
+    Extract coordinates from polygon format: ``(x1,y1;x2,y2;...)`` including multiple polygons separated by ``/``.
+
+    Parameters
+    ----------
+    value : str
+        The polygon value string from DRC result database, with format ``(x1,y1;x2,y2;...)``
+        or multiple polygons separated by ``/`` like ``(x1,y1;.../x3,y3;...)``.
+
+    Returns
+    -------
+    :class:`.MultiPolygonMarker`
+        :class:`.MultiPolygonMarker` containing one or more polygon shapes.
+
+    Raises
+    ------
+    ValueError
+        If the polygon format is invalid or contains incomplete coordinate pairs.
+    """
+    # Extract the full content inside outer parentheses
+    outer_pattern = r"\((.*)\)"
+    match = re.match(outer_pattern, value)
+    if not match:
+        raise ValueError(f"Invalid polygon format: '{value}'.")
+
+    coords_content = match.group(1)
+
+    # Parse multiple polygons separated by '/'
+    polygon_parts = coords_content.split("/")
+    polygons = []
+    for part in polygon_parts:
+        polygons.append(parse_polygon_coordinates(part.strip()))
+
+    return MultiPolygonMarker(polygons=tuple(polygons))
+
+
+def parse_violation_value(value: str) -> Union[EdgeMarker, EdgePairMarker, MultiPolygonMarker]:
+    """
+    Parse a violation value based on its type (edge, edge-pair, or polygon).
+
+    Parameters
+    ----------
+    value : str
+        The value string from DRC result database.
+
+    Returns
+    -------
+    Union[:class:`.EdgeMarker`, :class:`.EdgePairMarker`, :class:`.MultiPolygonMarker`]
+        The parsed violation marker.
+
+    Raises
+    ------
+    ValueError
+        If the violation marker type is invalid.
+    """
+    if value.startswith("edge: "):
+        return parse_edge(value=value.replace("edge: ", ""))
+    elif value.startswith("edge-pair: "):
+        return parse_edge_pair(value=value.replace("edge-pair: ", ""))
+    elif value.startswith("polygon: "):
+        return parse_polygons(value=value.replace("polygon: ", ""))
+    raise ValueError(
+        f"Invalid marker type (should start with 'edge:', 'edge-pair:', or 'polygon:'): '{value}'."
+    )
+
+
+class EdgeMarker(Tidy3dBaseModel):
+    """A class for storing KLayout DRC edge marker results."""
+
+    edge: DRCEdge = pd.Field(
+        title="DRC Edge Marker",
+        description="The edge marker of the DRC violation. The format is ((x1, y1), (x2, y2)).",
+    )
+
+
+class EdgePairMarker(Tidy3dBaseModel):
+    """A class for storing KLayout DRC edge pair marker results."""
+
+    edge_pair: DRCEdgePair = pd.Field(
+        title="DRC Edge Pair Marker",
+        description="The edge pair marker of the DRC violation. The format is (edge1, edge2), where an edge has format ((x1, y1), (x2, y2)).",
+    )
+
+
+class MultiPolygonMarker(Tidy3dBaseModel):
+    """A class for storing KLayout DRC multi-polygon marker results."""
+
+    polygons: DRCMultiPolygon = pd.Field(
+        title="DRC Multi-Polygon Marker",
+        description="The multi-polygon marker of the DRC violation. The format is (polygon1, polygon2, ...), where each polygon has format ((x1, y1), (x2, y2), ...).",
+    )
+
+
+DRCMarker = Union[EdgeMarker, EdgePairMarker, MultiPolygonMarker]
+
+
+class DRCViolation(Tidy3dBaseModel):
+    """A class for storing KLayout DRC violation results for a single category."""
+
+    category: str = pd.Field(
+        title="DRC Violation Category", description="The category of the DRC violation."
+    )
+    markers: tuple[DRCMarker, ...] = pd.Field(
+        title="DRC Markers", description="Tuple of DRC markers in this category."
+    )
+
+    @cached_property
+    def count(self) -> int:
+        """The number of DRC markers in this category."""
+        return len(self.markers)
+
+    def __str__(self) -> str:
+        """Get a nice string summary of the number of markers in this category."""
+        return f"{self.category}: {self.count}"
+
+
+class DRCResults(Tidy3dBaseModel):
+    """A class for loading and storing KLayout DRC results."""
+
+    violations_by_category: dict[str, DRCViolation] = pd.Field(
+        title="DRC Violations", description="Dictionary of DRC violations by category."
+    )
+
+    @cached_property
+    def is_clean(self) -> bool:
+        """Whether the DRC is clean (no violations)."""
+        return all(v.count == 0 for v in self.violations_by_category.values())
+
+    @cached_property
+    def violation_counts(self) -> dict[str, int]:
+        """Counts violations by category.
+
+        Returns
+        -------
+        dict[str, int]
+            A dictionary of violation counts for each category.
+        """
+        return {
+            category: violation.count for category, violation in self.violations_by_category.items()
+        }
+
+    @cached_property
+    def categories(self) -> tuple[str, ...]:
+        """A tuple of all DRC categories."""
+        return tuple(self.violations_by_category.keys())
+
+    def __getitem__(self, category: str) -> DRCViolation:
+        """Get DRC violation result by category.
+
+        Parameters
+        ----------
+        category : str
+            The category of the DRC violation.
+
+        Returns
+        -------
+        :class:`.DRCViolation`
+            The DRC violation result for the given category.
+        """
+        return self.violations_by_category[category]
+
+    def __str__(self) -> str:
+        """Get a nice string representation of the DRC results."""
+        summary = "DRC results summary\n"
+        summary += "--------------------------------\n"
+        summary += f"Total violations: {sum(violation.count for violation in self.violations_by_category.values())}\n\n"
+        summary += "Violations by category:\n"
+        for violation in self.violations_by_category.values():
+            summary += violation.__str__() + "\n"
+        return summary
+
+    @classmethod
+    def load(cls, resultsfile: Union[str, Path]) -> DRCResults:
+        """Create a :class:`.DRCResults` instance from a results file.
+
+        Parameters
+        ----------
+        resultsfile : Union[str, Path]
+            Path to the KLayout DRC results file.
+
+        Returns
+        -------
+        :class:`.DRCResults`
+            A :class:`.DRCResults` object containing the DRC results.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the DRC result file is not found.
+        ET.ParseError
+            If the DRC result file is not a valid XML file.
+
+        Example
+        -------
+        >>> from tidy3d.plugins.klayout.drc import DRCResults
+        >>> results = DRCResults.load(resultsfile="drc_results.lyrdb") # doctest: +SKIP
+        >>> print(results) # doctest: +SKIP
+        """
+        return cls(violations_by_category=violations_from_file(resultsfile=resultsfile))
+
+
+def violations_from_file(resultsfile: Union[str, Path]) -> dict[str, DRCViolation]:
+    """Loads a KLayout DRC results file and returns the results as a dictionary of :class:`.DRCViolation` objects.
+
+    Parameters
+    ----------
+    resultsfile : Union[str, Path]
+        Path to the KLayout DRC results file.
+
+    Returns
+    -------
+    dict[str, :class:`.DRCViolation`]
+        A dictionary of :class:`.DRCViolation` objects for each category.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the DRC result file is not found.
+    ET.ParseError
+        If the DRC result file is not a valid XML file.
+    """
+    # Parse the results file
+    try:
+        xmltree = ET.parse(resultsfile)
+    except FileNotFoundError as err:
+        raise FileError(f"DRC result file not found: '{resultsfile}'.") from err
+    except ET.ParseError as err:
+        raise ET.ParseError(f"Invalid XML format in DRC result file: '{resultsfile}'.") from err
+
+    # Initialize violations dict with all the categories
+    violations = {}
+    for category in xmltree.getroot().findall(".//categories/category/name"):
+        violations[category.text] = DRCViolation(category=category.text, markers=())
+
+    # Parse markers
+    for item in xmltree.getroot().findall(".//item"):
+        category = item.find("category").text
+        value = item.find("values/value").text
+        marker = parse_violation_value(value)
+        violations[category] = DRCViolation(
+            category=category,
+            markers=(*violations[category].markers, marker),
+        )
+    return violations

--- a/tidy3d/plugins/klayout/util.py
+++ b/tidy3d/plugins/klayout/util.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from shutil import which
+from typing import Union
+
+import tidy3d as td
+
+
+def check_installation(raise_error: bool = False) -> Union[str, None]:
+    """Checks if KLayout is installed and added to the system PATH.
+    If it is, this returns the path to the executable. Otherwise, returns ``None``.
+    Equivalent to $which("klayout") in the terminal.
+
+    Parameters
+    ----------
+    raise_error : bool
+        Whether to raise an error if KLayout is not found. If ``False``, a warning is shown.
+
+    Returns
+    -------
+    Union[str, None]
+        The path to the KLayout executable. If KLayout is not found, returns ``None``.
+    """
+    path = which("klayout")
+    msg = "KLayout was not found in the system PATH. Please ensure KLayout is installed and added to your system PATH before running KLayout."
+    if path is None:
+        if raise_error:
+            raise RuntimeError(msg)
+        else:
+            td.log.warning(msg)
+    return path


### PR DESCRIPTION
Adds a new plugin that integrates KLayout's DRC.

### Features

- Run DRC checks on Tidy3D objects that support exporting to GDS (`Geometry`, `Structure`, `Simulation`)
- Basic DRC result parsing (check if DRC clean, gather violation counts)

### Main functions

1. `run_drc()`: Main function to run DRC on Tidy3D objects
2. `is_drc_clean()`: Check if a DRC result file has no violations
3. `count_drc_violations()`: Get a count of DRC violations by category

### Usage Example

```python
import tidy3d as td
from tidy3d.plugins.klayout.drc import run_drc

# Create a Tidy3D geometry
vertices = [(-2, 0), (-1, 1), (0, 0.5), (1, 1), (2, 0), (0, -1)]
geom = td.PolySlab(vertices=vertices, slab_bounds=(0, 0.22), axis=2)

# Run DRC
run_drc(
    geom,                # Tidy3D object
    "output.gds",       # Output GDS file
    "rules.drc",        # DRC rules file
    "results.lyrdb",    # Results file
    z=0.1,             # Additional GDS export parameters
    gds_layer=0,
    gds_dtype=0
)

# Check results
if is_drc_clean("results.lyrdb"):
    print("DRC passed!")
else:
    violations = count_drc_violations("results.lyrdb")
    print("DRC violations found:", violations)
```

### Documentation

A README is included with detailed instructions and usage examples. More documentation can be added elsewhere as needed (perhaps we add an example notebook as well)

<!-- greptile_comment -->

## Greptile Summary

This PR introduces a new plugin that integrates KLayout's Design Rule Check (DRC) functionality into Tidy3D, enabling geometric validation of designs before simulation. The implementation provides a clean, well-structured API for running DRC checks on both GDS files and Tidy3D objects that can be exported to GDS format.

The changes include a complete plugin architecture with configuration handling, result parsing, and comprehensive test coverage. Key additions include support for multi-polygon DRC markers, improved error handling, and clear documentation with usage examples.

## Confidence score: 4/5

1. This PR is quite safe to merge as it adds new functionality without modifying existing core behavior.
2. High confidence due to comprehensive test coverage and clean implementation, though minor API documentation improvements could be beneficial.
3. Files needing attention:
   - `tidy3d/plugins/klayout/drc/drc.py`: Core implementation file that wasn't fully visible in the context
   - `tidy3d/plugins/klayout/drc/README.md`: Documentation might need expansion for advanced use cases

<sub>11 files reviewed, no comments</sub>
<sub>[Edit PR Review Bot Settings](https://app.greptile.com/review/github) | [Greptile](https://greptile.com?utm_source=greptile_expert&utm_medium=github&utm_campaign=code_reviews&utm_content=tidy3d_2586)</sub>

<!-- /greptile_comment -->