### PR TITLE
Tests for simulation reduction in `upload()`

### DIFF
--- a/tests/test_web/test_webapi_mode.py
+++ b/tests/test_web/test_webapi_mode.py
@@ -108,10 +108,21 @@ def mock_upload(monkeypatch, set_api_key):
         status=200,
     )
 
+    # store the uploaded stub for verification
+    uploaded_stub = {}
+
+    def mock_upload_simulation(self, stub, **kwargs):
+        uploaded_stub["stub"] = stub
+
     def mock_upload_file(*args, **kwargs):
         pass
 
+    monkeypatch.setattr(
+        "tidy3d.web.core.task_core.SimulationTask.upload_simulation", mock_upload_simulation
+    )
     monkeypatch.setattr("tidy3d.web.core.task_core.upload_file", mock_upload_file)
+
+    return uploaded_stub
 
 
 @pytest.fixture
@@ -267,6 +278,26 @@ def test_upload(monkeypatch, mock_upload, mock_get_info, mock_metadata):
     sim = make_mode_sim()
     assert sim != get_reduced_simulation(sim, reduce_simulation=True)
     assert upload(sim, TASK_NAME, PROJECT_NAME, reduce_simulation=True)
+
+
+@pytest.mark.parametrize("reduce_simulation", [True, False])
+@responses.activate
+def test_upload_with_reduction_parameter(
+    monkeypatch, mock_upload, mock_get_info, mock_metadata, reduce_simulation
+):
+    """Test that simulation reduction is properly applied before upload based on reduce_simulation parameter."""
+    sim = make_mode_sim()
+
+    upload(sim, TASK_NAME, PROJECT_NAME, reduce_simulation=reduce_simulation)
+
+    if reduce_simulation:
+        expected_sim = get_reduced_simulation(sim, reduce_simulation=True)
+        assert sim != expected_sim
+    else:
+        expected_sim = sim
+
+    uploaded_sim = mock_upload["stub"].simulation
+    assert uploaded_sim == expected_sim
 
 
 @responses.activate

--- a/tests/test_web/test_webapi_mode_sim.py
+++ b/tests/test_web/test_webapi_mode_sim.py
@@ -104,10 +104,21 @@ def mock_upload(monkeypatch, set_api_key):
         status=200,
     )
 
+    # store the uploaded stub for verification
+    uploaded_stub = {}
+
+    def mock_upload_simulation(self, stub, **kwargs):
+        uploaded_stub["stub"] = stub
+
     def mock_upload_file(*args, **kwargs):
         pass
 
+    monkeypatch.setattr(
+        "tidy3d.web.core.task_core.SimulationTask.upload_simulation", mock_upload_simulation
+    )
     monkeypatch.setattr("tidy3d.web.core.task_core.upload_file", mock_upload_file)
+
+    return uploaded_stub
 
 
 @pytest.fixture
@@ -263,6 +274,26 @@ def test_upload(monkeypatch, mock_upload, mock_get_info, mock_metadata):
     sim = make_mode_sim()
     assert sim != get_reduced_simulation(sim, reduce_simulation=True)
     assert upload(sim, TASK_NAME, PROJECT_NAME, reduce_simulation=True)
+
+
+@pytest.mark.parametrize("reduce_simulation", [True, False])
+@responses.activate
+def test_upload_with_reduction_parameter(
+    monkeypatch, mock_upload, mock_get_info, mock_metadata, reduce_simulation
+):
+    """Test that simulation reduction is properly applied before upload based on reduce_simulation parameter."""
+    sim = make_mode_sim()
+
+    upload(sim, TASK_NAME, PROJECT_NAME, reduce_simulation=reduce_simulation)
+
+    if reduce_simulation:
+        expected_sim = get_reduced_simulation(sim, reduce_simulation=True)
+        assert sim != expected_sim
+    else:
+        expected_sim = sim
+
+    uploaded_sim = mock_upload["stub"].simulation
+    assert uploaded_sim == expected_sim
 
 
 @responses.activate


### PR DESCRIPTION
tests for https://github.com/flexcompute/tidy3d/pull/2583 @momchil-flex 

<!-- greptile_comment -->

## Greptile Summary

Added test coverage for simulation reduction during upload in `test_webapi_mode.py` and `test_webapi_mode_sim.py`.

- Added parameterized test `test_upload_with_reduction_parameter` to verify simulation reduction behavior
- Modified `mock_upload` fixture to track and expose uploaded simulation stubs for verification
- Added test cases to validate simulation state when `reduce_simulation=True` and `reduce_simulation=False`



<!-- /greptile_comment -->