### PR TITLE
docs[webapi]: add missing webapi methods to docs and reorganize sections

### DIFF
--- a/docs/api/plugins/autograd.rst
+++ b/docs/api/plugins/autograd.rst
@@ -7,28 +7,74 @@ Automatic Differentiation with Autograd
 
     ./../../../tidy3d/plugins/autograd/README
 
+Differential Operators
+~~~~~~~~~~~~~~~~~~~~~~
+
 .. autosummary::
    :toctree: ../_autosummary/
    :template: module.rst
 
-    tidy3d.plugins.autograd.functions.threshold
-    tidy3d.plugins.autograd.functions.rescale
+    tidy3d.plugins.autograd.differential_operators.grad
+    tidy3d.plugins.autograd.differential_operators.value_and_grad
+
+Functions
+~~~~~~~~~
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+    tidy3d.plugins.autograd.functions.add_at
+    tidy3d.plugins.autograd.functions.convolve
+    tidy3d.plugins.autograd.functions.grey_closing
+    tidy3d.plugins.autograd.functions.grey_dilation
+    tidy3d.plugins.autograd.functions.grey_erosion
+    tidy3d.plugins.autograd.functions.grey_opening
+    tidy3d.plugins.autograd.functions.interpn
+    tidy3d.plugins.autograd.functions.least_squares
+    tidy3d.plugins.autograd.functions.morphological_gradient
     tidy3d.plugins.autograd.functions.morphological_gradient_external
     tidy3d.plugins.autograd.functions.morphological_gradient_internal
-    tidy3d.plugins.autograd.functions.morphological_gradient
-    tidy3d.plugins.autograd.functions.grey_closing
-    tidy3d.plugins.autograd.functions.grey_opening
-    tidy3d.plugins.autograd.functions.grey_erosion
-    tidy3d.plugins.autograd.functions.grey_dilation
     tidy3d.plugins.autograd.functions.pad
-    tidy3d.plugins.autograd.functions.convolve
+    tidy3d.plugins.autograd.functions.rescale
+    tidy3d.plugins.autograd.functions.smooth_max
+    tidy3d.plugins.autograd.functions.smooth_min
+    tidy3d.plugins.autograd.functions.threshold
+    tidy3d.plugins.autograd.functions.trapz
+
+Utilities
+~~~~~~~~~
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
 
     tidy3d.plugins.autograd.utilities.chain
-    tidy3d.plugins.autograd.utilities.make_kernel
     tidy3d.plugins.autograd.utilities.get_kernel_size_px
+    tidy3d.plugins.autograd.utilities.make_kernel
+    tidy3d.plugins.autograd.utilities.scalar_objective
+
+Primitives
+~~~~~~~~~~
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
 
     tidy3d.plugins.autograd.primitives.gaussian_filter
+    tidy3d.plugins.autograd.primitives.interpolate_spline
 
+Inverse Design
+~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+    tidy3d.plugins.autograd.invdes.CircularFilter
+    tidy3d.plugins.autograd.invdes.ConicFilter
+    tidy3d.plugins.autograd.invdes.ErosionDilationPenalty
+    tidy3d.plugins.autograd.invdes.FilterAndProject
     tidy3d.plugins.autograd.invdes.grey_indicator
     tidy3d.plugins.autograd.invdes.make_circular_filter
     tidy3d.plugins.autograd.invdes.make_conic_filter
@@ -38,7 +84,4 @@ Automatic Differentiation with Autograd
     tidy3d.plugins.autograd.invdes.make_filter_and_project
     tidy3d.plugins.autograd.invdes.ramp_projection
     tidy3d.plugins.autograd.invdes.tanh_projection
-
-    tidy3d.plugins.autograd.types.PaddingType
-    tidy3d.plugins.autograd.types.KernelType
 

--- a/docs/api/submit_simulations.rst
+++ b/docs/api/submit_simulations.rst
@@ -1,4 +1,3 @@
-
 .. currentmodule:: tidy3d
 
 Submitting Simulations
@@ -7,24 +6,74 @@ Submitting Simulations
 Generic Web API
 ----------------
 
+Core Workflow
+~~~~~~~~~~~~~
+
 .. autosummary::
    :toctree: _autosummary/
    :template: module.rst
 
    tidy3d.web.api.webapi.run
    tidy3d.web.api.webapi.upload
-   tidy3d.web.api.webapi.estimate_cost
-   tidy3d.web.api.webapi.real_cost
-   tidy3d.web.api.webapi.get_info
    tidy3d.web.api.webapi.start
    tidy3d.web.api.webapi.monitor
    tidy3d.web.api.webapi.download
    tidy3d.web.api.webapi.load
-   tidy3d.web.api.webapi.delete
-   tidy3d.web.api.webapi.download_log
-   tidy3d.web.api.webapi.download_json
-   tidy3d.web.api.webapi.load_simulation
    tidy3d.web.api.asynchronous.run_async
+
+Download Utilities
+~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: _autosummary/
+   :template: module.rst
+
+   tidy3d.web.api.webapi.download_json
+   tidy3d.web.api.webapi.download_hdf5
+   tidy3d.web.api.webapi.download_log
+   tidy3d.web.api.webapi.load_simulation
+
+Task Information
+~~~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: _autosummary/
+   :template: module.rst
+
+   tidy3d.web.api.webapi.get_info
+   tidy3d.web.api.webapi.get_run_info
+   tidy3d.web.api.webapi.get_tasks
+
+Cost Estimation
+~~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: _autosummary/
+   :template: module.rst
+
+   tidy3d.web.api.webapi.estimate_cost
+   tidy3d.web.api.webapi.real_cost
+
+Task Management
+~~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: _autosummary/
+   :template: module.rst
+
+   tidy3d.web.api.webapi.delete
+   tidy3d.web.api.webapi.delete_old
+   tidy3d.web.api.webapi.abort
+
+Account and System
+~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: _autosummary/
+   :template: module.rst
+
+   tidy3d.web.api.webapi.account
+   tidy3d.web.api.webapi.test
 
 Job and Batch Containers
 -------------------------

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -400,7 +400,7 @@ def start(
 
 
 @wait_for_connection
-def get_run_info(task_id: TaskId):
+def get_run_info(task_id: TaskId) -> tuple[Optional[float], Optional[float]]:
     """Gets the % done and field_decay for a running task.
 
     Parameters
@@ -865,7 +865,7 @@ def delete_old(
 
 
 @wait_for_connection
-def abort(task_id: TaskId):
+def abort(task_id: TaskId) -> TaskInfo:
     """Abort server-side data associated with task.
 
     Parameters
@@ -1077,6 +1077,31 @@ def real_cost(task_id: str, verbose=True) -> float:
 
 @wait_for_connection
 def account(verbose=True) -> Account:
+    """Get account information including FlexCredit balance and usage limits.
+
+    Parameters
+    ----------
+    verbose : bool = True
+        If ``True``, prints account information including credit balance, expiration,
+        and free simulation counts.
+
+    Returns
+    -------
+    Account
+        Object containing account information such as credit balance, expiration dates,
+        and daily free simulation counts.
+
+    Examples
+    --------
+    Get account information:
+
+    .. code-block:: python
+
+        account_info = web.account()
+        # Displays:
+        # Current FlexCredit balance: 10.00 and expiration date: 2024-12-31 23:59:59.
+        # Remaining daily free simulations: 3.
+    """
     account_info = Account.get()
     if verbose and account_info:
         console = get_logging_console()
@@ -1109,8 +1134,28 @@ def account(verbose=True) -> Account:
 
 @wait_for_connection
 def test() -> None:
-    """
-    Confirm whether Tidy3D authentication is configured. Raises exception if not.
+    """Confirm whether Tidy3D authentication is configured.
+
+    Raises
+    ------
+    WebError
+        If Tidy3D authentication is not configured correctly.
+
+    Notes
+    -----
+    This method tests the authentication configuration by attempting to retrieve
+    the task list. If authentication is not properly set up, it will raise an
+    exception with instructions on how to configure authentication.
+
+    Examples
+    --------
+    Test authentication:
+
+    .. code-block:: python
+
+        web.test()
+        # If successful, displays:
+        # Authentication configured successfully!
     """
     try:
         # note, this is a little slow, but the only call that doesn't require providing a task id.


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Documentation improvements for Web API methods, focusing on better organization and type annotations in the Tidy3D codebase.

- Added precise return type annotations for `get_run_info()` and `abort()` in `tidy3d/web/api/webapi.py`
- Enhanced docstrings for `account()` and `test()` functions with comprehensive sections (Parameters, Returns, Examples)
- Restructured `docs/api/submit_simulations.rst` into logical sections (Core Workflow, Download Utilities, etc.)
- Added documentation for previously undocumented API methods like `download_hdf5`, `get_run_info`, and `get_tasks`



<!-- /greptile_comment -->