### PR TITLE
Fix to plane wave with negative azimuth angle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Arrow lengths are now scaled consistently in the X and Y directions,
-  and their lengths no longer exceed the height of the plot window.
+- Arrow lengths are now scaled consistently in the X and Y directions, and their lengths no longer exceed the height of the plot window.
+- Bug in `PlaneWave` defined with a negative `angle_theta` which would lead to wrong injection.
 
 ## [2.9.0rc1] - 2025-06-10
 

--- a/tidy3d/components/beam.py
+++ b/tidy3d/components/beam.py
@@ -318,7 +318,7 @@ class PlaneWaveBeamProfile(BeamProfile):
         k0 = 2 * np.pi * np.array(self.freqs) / C_0 * background_n
         kx, ky = self.in_plane_k(background_n)
         k_perp = np.sqrt(kx**2 + ky**2)
-        return np.real(np.arcsin(k_perp / k0))
+        return np.real(np.arcsin(k_perp / k0)) * np.sign(self.angle_theta)
 
     def _rotate_points_z(self, points: Numpy, background_n: Numpy) -> Numpy:
         """Rotate points to new coordinates where z is the propagation axis."""


### PR DESCRIPTION
Fixes #2591 but requires a solver that's built with the fix.

<!-- greptile_comment -->

## Greptile Summary

Fixed plane wave source handling of negative azimuth angles, particularly important for Bloch boundary conditions.

- Modified `_angle_theta_actual` in `tidy3d/components/beam.py` to preserve sign in arcsin calculation for correct propagation with negative polar angles
- Change requires corresponding solver update to function properly
- Directly addresses issue #2591 affecting plane wave sources with Bloch boundaries



<!-- /greptile_comment -->