### PR TITLE
feat(autograd): add primitive for np.unwrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add support for `np.unwrap` in `tidy3d.plugins.autograd`.
+
 ### Fixed
 - Arrow lengths are now scaled consistently in the X and Y directions,
   and their lengths no longer exceed the height of the plot window.

--- a/tests/test_plugins/autograd/primitives/test_misc.py
+++ b/tests/test_plugins/autograd/primitives/test_misc.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import autograd.numpy as np
 import pytest
 from autograd.test_util import check_grads
 
@@ -22,3 +23,19 @@ from tidy3d.plugins.autograd.primitives import gaussian_filter
 def test_gaussian_filter_grad(rng, size, ndim, sigma, mode):
     x = rng.random((size,) * ndim)
     check_grads(lambda x: gaussian_filter(x, sigma=sigma, mode=mode), modes=["rev"], order=2)(x)
+
+
+@pytest.mark.parametrize("shape, axis", [((100,), -1), ((10, 12), 0), ((10, 12), 1)])
+@pytest.mark.parametrize("period", [np.pi, 2 * np.pi])
+@pytest.mark.parametrize("discont", [None, 0.6])
+def test_unwrap_grad(rng, shape, axis, period, discont):
+    """Test the gradient of the unwrap function with various arguments."""
+    if discont is not None:
+        # discont must be > period / 2 to have an effect
+        discont = discont * period
+
+    x = rng.uniform(-4 * period, 4 * period, shape)
+
+    check_grads(
+        lambda x: np.unwrap(x, discont=discont, axis=axis, period=period), modes=["fwd", "rev"]
+    )(x)

--- a/tidy3d/plugins/autograd/primitives/misc.py
+++ b/tidy3d/plugins/autograd/primitives/misc.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import autograd.numpy as np
 import scipy.ndimage
-from autograd.extend import defvjp, primitive
+from autograd.extend import defjvp, defvjp, primitive
 
 gaussian_filter = primitive(scipy.ndimage.gaussian_filter)
 defvjp(
     gaussian_filter,
     lambda ans, x, *args, **kwargs: lambda g: gaussian_filter(g, *args, **kwargs),
 )
+
+np.unwrap = primitive(np.unwrap)
+defjvp(np.unwrap, lambda g, ans, x, *args, **kwargs: g)
+defvjp(np.unwrap, lambda ans, x, *args, **kwargs: lambda g: g)


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Added autograd support for `np.unwrap` function to handle phase unwrapping in gradient computations, enabling automatic differentiation through phase discontinuity removal operations.

- Implemented `np.unwrap` primitive in `tidy3d/plugins/autograd/primitives/misc.py` with identity-based forward and reverse mode derivatives
- Added comprehensive test coverage in `test_misc.py` verifying gradient behavior over [-8π, 8π] range
- Potential concern: Implementation treats derivatives as identity functions which may not handle all edge cases correctly



<!-- /greptile_comment -->