### PR TITLE
Adding some missing classes

### DIFF
--- a/docs/api/charge/mediums.rst
+++ b/docs/api/charge/mediums.rst
@@ -18,6 +18,7 @@ Mobility
    :toctree: ../_autosummary/
    :template: module.rst
 
+   tidy3d.ConstantMobilityModel
    tidy3d.CaugheyThomasMobility
 
 

--- a/docs/api/mediums.rst
+++ b/docs/api/mediums.rst
@@ -75,6 +75,7 @@ Medium Perturbations
    tidy3d.PerturbationMedium
    tidy3d.PerturbationPoleResidue
    tidy3d.NedeljkovicSorefMashanovich
+   tidy3d.ParameterPerturbation
 
 
 General Mediums (can be both dispersive and non-dispersive)

--- a/docs/api/spice.rst
+++ b/docs/api/spice.rst
@@ -11,6 +11,7 @@ Sources
    :template: module.rst
 
    tidy3d.DCVoltageSource
+   tidy3d.DCCurrentSource
 
 
 Analysis

--- a/tidy3d/components/tcad/boundary/charge.py
+++ b/tidy3d/components/tcad/boundary/charge.py
@@ -62,8 +62,8 @@ class InsulatingBC(HeatChargeBC):
     Notes
     -----
 
-        Ensures the electric potential to the normal :math:`\\nabla \\psi \\dot \\mathbf{n}  = 0` as well as the
-        surface recombination current density :math:`J_s = \\mathbf{J} \\dot \\mathbf{n} = 0` are set to zero where
+        Ensures the electric potential to the normal :math:`\\nabla \\psi \\cdot \\mathbf{n}  = 0` as well as the
+        surface recombination current density :math:`J_s = \\mathbf{J} \\cdot \\mathbf{n} = 0` are set to zero where
         the current density is :math:`\\mathbf{J_n}` and the normal vector is :math:`\\mathbf{n}`
 
     Example


### PR DESCRIPTION
@FilipeFcp let me know if this addresses your comments in https://github.com/flexcompute/tidy3d/pull/2594
if it does we can cancel your PR and make this one ready for review

<!-- greptile_comment -->

## Greptile Summary

Documentation improvements addressing missing class documentation and mathematical notation corrections. The changes span charge, mediums, and SPICE components of the Tidy3D framework.

- Added missing documentation for `ConstantMobilityModel` class in `docs/api/charge/mediums.rst`
- Added `DCCurrentSource` class documentation to `docs/api/spice.rst`
- Added `ParameterPerturbation` class to the Medium Perturbations section in `docs/api/mediums.rst`
- Fixed mathematical notation in `tidy3d/components/tcad/boundary/charge.py`, replacing `\dot` with `\cdot` for correct equation representation



<!-- /greptile_comment -->