### PR TITLE
Fix EME port modes symmetry expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ with fewer layers than recommended.
 - Plots of objects defined by shape intersection logic will no longer display thin line artifacts.
 - Fixed incorrect gradient computation in PyTorch plugin (`to_torch`) for functions returning multi-element arrays.
 - `MonitorData.get_amplitude()` no longers multiplies by a factor of `1j` and now directly returns the complex value of the data.
+- `EMESimulationData.port_modes_tuple` is now symmetry-expanded.
 
 ## [2.9.0rc1] - 2025-06-10
 

--- a/tests/test_components/test_eme.py
+++ b/tests/test_components/test_eme.py
@@ -967,14 +967,14 @@ def test_eme_sim_data():
     port_modes = _get_eme_port_modes()
     smatrix = _get_eme_smatrix_dataset(num_modes_1=5, num_modes_2=5)
 
-    sim_data = td.EMESimulationData(simulation=sim, data=data, smatrix=smatrix, port_modes=None)
+    sim_data = td.EMESimulationData(simulation=sim, data=data, smatrix=smatrix, port_modes_raw=None)
     with pytest.raises(SetupError):
         _ = sim_data.port_modes_tuple
     with pytest.raises(SetupError):
         _ = sim_data.port_modes_list_sweep
 
     sim_data = td.EMESimulationData(
-        simulation=sim, data=data, smatrix=smatrix, port_modes=port_modes
+        simulation=sim, data=data, smatrix=smatrix, port_modes_raw=port_modes
     )
     _ = sim_data.port_modes_tuple
     _ = sim_data.port_modes_list_sweep
@@ -1028,11 +1028,11 @@ def test_eme_sim_data():
     assert len(smatrix_in_basis.S22.coords) == 1
 
     with pytest.raises(SetupError):
-        _ = sim_data.updated_copy(port_modes=None).smatrix_in_basis(
+        _ = sim_data.updated_copy(port_modes_raw=None).smatrix_in_basis(
             modes1=modes_in_data, modes2=modes_out_data
         )
     with pytest.raises(SetupError):
-        _ = sim_data.updated_copy(port_modes=None).field_in_basis(
+        _ = sim_data.updated_copy(port_modes_raw=None).field_in_basis(
             field=sim_data["field"], modes=modes_in_data, port_index=0
         )
 
@@ -1092,7 +1092,7 @@ def test_eme_sim_data():
     smatrix = _get_eme_smatrix_dataset(num_modes_1=5, num_modes_2=5, num_sweep=10)
     sim = sim.updated_copy(sweep_spec=td.EMELengthSweep(scale_factors=np.linspace(1, 2, 10)))
     sim_data = td.EMESimulationData(
-        simulation=sim, data=data, smatrix=smatrix, port_modes=port_modes
+        simulation=sim, data=data, smatrix=smatrix, port_modes_raw=port_modes
     )
 
     # test smatrix_in_basis
@@ -1172,7 +1172,7 @@ def test_eme_sim_data():
     sim = sim.updated_copy(sweep_spec=td.EMEFreqSweep(freq_scale_factors=np.linspace(1, 2, 10)))
     port_modes = _get_eme_port_modes(num_sweep=10)
     sim_data = td.EMESimulationData(
-        simulation=sim, data=data, smatrix=smatrix, port_modes=port_modes
+        simulation=sim, data=data, smatrix=smatrix, port_modes_raw=port_modes
     )
     with pytest.raises(SetupError):
         _ = sim_data.port_modes_tuple

--- a/tidy3d/components/eme/data/sim_data.py
+++ b/tidy3d/components/eme/data/sim_data.py
@@ -39,12 +39,22 @@ class EMESimulationData(AbstractYeeGridSimulationData):
         None, title="S Matrix", description="Scattering matrix of the EME simulation."
     )
 
-    port_modes: Optional[EMEModeSolverData] = pd.Field(
+    port_modes_raw: Optional[EMEModeSolverData] = pd.Field(
         None,
         title="Port Modes",
         description="Modes associated with the two ports of the EME device. "
-        "The scattering matrix is expressed in this basis.",
+        "The scattering matrix is expressed in this basis. "
+        "Note: these modes are not symmetry expanded; use 'port_modes' instead.",
     )
+
+    @cached_property
+    def port_modes(self):
+        """Modes associated with the two ports of the EME device.
+        The scattering matrix is expressed in this basis.
+        Note: these modes are symmetry expanded."""
+        if self.port_modes_raw is None:
+            return None
+        return self.port_modes_raw.symmetry_expanded_copy
 
     def _extract_mode_solver_data(
         self, data: EMEModeSolverData, eme_cell_index: int, sweep_index: Optional[int] = None
@@ -89,7 +99,13 @@ class EMESimulationData(AbstractYeeGridSimulationData):
                 "certain derived quantities, like the flux."
             )
         grid_expanded = self.simulation.discretize_monitor(monitor=monitor)
-        return ModeSolverData(**update_dict, monitor=monitor, grid_expanded=grid_expanded)
+        return ModeSolverData(
+            **update_dict,
+            monitor=monitor,
+            grid_expanded=grid_expanded,
+            symmetry=data.symmetry,
+            symmetry_center=data.symmetry_center,
+        )
 
     @cached_property
     def port_modes_tuple(self) -> tuple[ModeSolverData, ModeSolverData]:


### PR DESCRIPTION
This fixes two related issues:

- The port modes were not symmetry expanded. This was introduced in this PR: https://github.com/flexcompute/tidy3d/pull/2526
- The function `EMESimulationData._extract_mode_solver_data` did not retain symmetry information.