### PR TITLE
fix(pytorch): Correct gradient for array-valued functions in wrapper

### DIFF
--- a/tidy3d/plugins/pytorch/wrapper.py
+++ b/tidy3d/plugins/pytorch/wrapper.py
@@ -1,10 +1,7 @@
-from __future__ import annotations
-
 import inspect
 
 import torch
 from autograd import make_vjp
-from autograd.extend import vspace
 
 
 def to_torch(fun):
@@ -79,10 +76,11 @@ def to_torch(fun):
 
         @staticmethod
         def backward(ctx, grad_output):
-            _grads = ctx.vjp(vspace(grad_output.detach().cpu().numpy()).ones())
+            numpy_grad_output = grad_output.detach().cpu().numpy()
+            _grads = ctx.vjp(numpy_grad_output)
             grads = [None] * ctx.num_args
             for idx, grad in zip(ctx.grad_argnums, _grads):
-                grads[idx] = torch.as_tensor(grad, device=ctx.device) * grad_output
+                grads[idx] = torch.as_tensor(grad, device=ctx.device)
             return tuple(grads)
 
     def apply(*args, **kwargs):


### PR DESCRIPTION
The `to_torch` wrapper, which connects `autograd` functions to PyTorch's autograd system, failed to compute correct gradients for functions that returned multi-element arrays.

The root cause was in the `_Wrapper.backward` method:
1.  The vector-Jacobian product function (`vjp`) was called with an array of ones instead of the true upstream gradient (`grad_output`).
2.  The result was then incorrectly multiplied by `grad_output` again.

This worked by coincidence for scalar outputs, where the upstream gradient is often `1.0`, but produced incorrect gradients for array outputs.

This commit corrects the implementation by passing the NumPy-converted `grad_output` directly to the `vjp` function and removing the subsequent redundant multiplication. The wrapper now correctly supports differentiation through functions that return tensors of any shape.