### PR TITLE
Add interval_space to EMEFieldMonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Nunley variant to germanium material library based on Nunley et al. 2016 data.
 - Add `PointDipole.sources_from_angles()` that constructs a list of `PointDipole` objects needed to emulate a dipole oriented at a user-provided set of polar and azimuthal angles.
 - Added `priority` parameter to `web.run()` and related functions to allow vGPU users to set task priority (1-10) in the queue.
+- `EMEFieldMonitor` now supports `interval_space`.
 
 ### Changed
 - Switched to an analytical gradient calculation for spatially-varying pole-residue models (`CustomPoleResidue`).

--- a/tidy3d/components/eme/monitor.py
+++ b/tidy3d/components/eme/monitor.py
@@ -198,10 +198,10 @@ class EMEFieldMonitor(EMEMonitor, AbstractFieldMonitor):
     ... )
     """
 
-    interval_space: tuple[Literal[1], Literal[1], Literal[1]] = pd.Field(
+    interval_space: tuple[pd.PositiveInt, pd.PositiveInt, pd.PositiveInt] = pd.Field(
         (1, 1, 1),
         title="Spatial Interval",
-        description="Note: not yet supported. Number of grid step intervals between monitor recordings. If equal to 1, "
+        description="Number of grid step intervals between monitor recordings. If equal to 1, "
         "there will be no downsampling. If greater than 1, the step will be applied, but the "
         "first and last point of the monitor grid are always included.",
     )


### PR DESCRIPTION
Adds downsampling support in EMEFieldMonitor, to allow user to reduce data generation, storage, transfer when possible.

<!-- greptile_comment -->

## Greptile Summary

Adds downsampling capability to EMEFieldMonitor by modifying interval_space to accept PositiveInt values, enabling reduced data generation and storage requirements.

- Modified `tidy3d/components/eme/monitor.py` to allow custom interval spacing in EMEFieldMonitor recordings
- Updated CHANGELOG.md with an entry under [Unreleased] for the new downsampling feature
- Feature enables more efficient data handling while maintaining EME simulation capabilities



<!-- /greptile_comment -->