### PR TITLE
Feat: Add `PointDipole.from_angles()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add support for `np.unwrap` in `tidy3d.plugins.autograd`.
 - Add Nunley variant to germanium material library based on Nunley et al. 2016 data.
-- Add `PointDipole.from_angles()` that constructs a list of `PointDipole` objects needed to emulate a dipole oriented at a user-provided set of theta and azimuth angles.
+- Add `PointDipole.from_angles()` that constructs a list of `PointDipole` objects needed to emulate a dipole oriented at a user-provided set of polar and azimuthal angles.
 
 ### Changed
 - Switched to an analytical gradient calculation for spatially-varying pole-residue models (`CustomPoleResidue`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add support for `np.unwrap` in `tidy3d.plugins.autograd`.
 - Add Nunley variant to germanium material library based on Nunley et al. 2016 data.
-- Add `PointDipole.from_angles()` that constructs a list of `PointDipole` objects needed to emulate a dipole oriented at a user-provided set of polar and azimuthal angles.
+- Add `PointDipole.sources_from_angles()` that constructs a list of `PointDipole` objects needed to emulate a dipole oriented at a user-provided set of polar and azimuthal angles.
 
 ### Changed
 - Switched to an analytical gradient calculation for spatially-varying pole-residue models (`CustomPoleResidue`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add support for `np.unwrap` in `tidy3d.plugins.autograd`.
 - Add Nunley variant to germanium material library based on Nunley et al. 2016 data.
+- Add `PointDipole.from_angles()` that constructs a list of `PointDipole` objects needed to emulate a dipole oriented at a user-provided set of theta and azimuth angles.
 
 ### Changed
 - Switched to an analytical gradient calculation for spatially-varying pole-residue models (`CustomPoleResidue`).

--- a/tests/test_components/test_source.py
+++ b/tests/test_components/test_source.py
@@ -148,6 +148,67 @@ def test_dipole():
         _ = td.PointDipole(size=(1, 1, 1), source_time=g, center=(1, 2, 3), polarization="Ex")
 
 
+def test_dipole_from_angles():
+    g = td.GaussianPulse(freq0=1e12, fwidth=0.1e12)
+
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.PointDipole.from_angles(
+            size=(1, 1, 1),
+            source_time=g,
+            center=(1, 2, 3),
+            angle_theta=np.pi / 4,
+            angle_phi=np.pi / 4,
+        )
+
+    with pytest.raises(ValueError):
+        _ = td.PointDipole.from_angles(
+            source_time=g,
+            angle_theta=np.pi / 4,
+            angle_phi=np.pi / 4,
+            component="invalid",
+            center=(1, 2, 3),
+        )
+
+    assert (
+        len(
+            td.PointDipole.from_angles(
+                source_time=g,
+                angle_theta=np.pi / 4,
+                angle_phi=np.pi / 4,
+                component="electric",
+                center=(1, 2, 3),
+            )
+        )
+        == 3
+    )
+
+    assert (
+        len(
+            td.PointDipole.from_angles(
+                source_time=g,
+                angle_theta=np.pi / 4,
+                angle_phi=np.pi / 2,
+                component="electric",
+                center=(1, 2, 3),
+            )
+        )
+        == 2
+    )
+
+    assert (
+        len(
+            td.PointDipole.from_angles(
+                source_time=g,
+                angle_theta=np.pi / 2,
+                angle_phi=np.pi / 2,
+                component="electric",
+                center=(1, 2, 3),
+            )
+        )
+        == 1
+    )
+
+
 def test_FieldSource():
     g = td.GaussianPulse(freq0=1e12, fwidth=0.1e12)
     mode_spec = td.ModeSpec(num_modes=2)

--- a/tests/test_components/test_source.py
+++ b/tests/test_components/test_source.py
@@ -148,11 +148,11 @@ def test_dipole():
         _ = td.PointDipole(size=(1, 1, 1), source_time=g, center=(1, 2, 3), polarization="Ex")
 
 
-def test_dipole_from_angles():
+def test_dipole_sources_from_angles():
     g = td.GaussianPulse(freq0=1e12, fwidth=0.1e12)
 
     with pytest.raises(pydantic.ValidationError):
-        _ = td.PointDipole.from_angles(
+        _ = td.PointDipole.sources_from_angles(
             size=(1, 1, 1),
             source_time=g,
             center=(1, 2, 3),
@@ -161,7 +161,7 @@ def test_dipole_from_angles():
         )
 
     with pytest.raises(ValueError):
-        _ = td.PointDipole.from_angles(
+        _ = td.PointDipole.sources_from_angles(
             source_time=g,
             angle_theta=np.pi / 4,
             angle_phi=np.pi / 4,
@@ -171,7 +171,7 @@ def test_dipole_from_angles():
 
     assert (
         len(
-            td.PointDipole.from_angles(
+            td.PointDipole.sources_from_angles(
                 source_time=g,
                 angle_theta=np.pi / 4,
                 angle_phi=np.pi / 4,
@@ -184,7 +184,7 @@ def test_dipole_from_angles():
 
     assert (
         len(
-            td.PointDipole.from_angles(
+            td.PointDipole.sources_from_angles(
                 source_time=g,
                 angle_theta=np.pi / 4,
                 angle_phi=np.pi / 2,
@@ -197,7 +197,7 @@ def test_dipole_from_angles():
 
     assert (
         len(
-            td.PointDipole.from_angles(
+            td.PointDipole.sources_from_angles(
                 source_time=g,
                 angle_theta=np.pi / 2,
                 angle_phi=np.pi / 2,

--- a/tidy3d/components/source/current.py
+++ b/tidy3d/components/source/current.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC
+from math import cos, isclose, sin
 from typing import Optional
 
 import pydantic.v1 as pydantic
@@ -16,6 +17,7 @@ from tidy3d.components.validators import assert_single_freq_in_range, warn_if_da
 from tidy3d.constants import MICROMETER
 
 from .base import Source
+from .time import SourceTimeType
 
 
 class CurrentSource(Source, ABC):
@@ -106,6 +108,40 @@ class PointDipole(CurrentSource, ReverseInterpolatedSource):
         description="Size in x, y, and z directions, constrained to ``(0, 0, 0)``.",
         units=MICROMETER,
     )
+
+    @classmethod
+    def from_angles(
+        cls,
+        source_time: SourceTimeType,
+        angle_theta: float,
+        angle_phi: float,
+        electrical_component: bool = True,
+        **kwargs,
+    ) -> list[PointDipole]:
+        """Returns a list of `PointDipole` objects used to emulate a single dipole polarized in an arbitrary direction. The direction is specificed using a polar and azimuthal angle."""
+        dipoles: list[PointDipole] = []
+        polarizations = ["Ex", "Ey", "Ez"] if electrical_component else ["Hx", "Hy", "Hz"]
+
+        multipliers = [
+            sin(angle_theta) * cos(angle_phi),
+            sin(angle_theta) * sin(angle_phi),
+            cos(angle_theta),
+        ]
+
+        for polarization, mult in zip(polarizations, multipliers):
+            if not isclose(mult, 0.0, rel_tol=0.0, abs_tol=1e-9):
+                modulated_source_time = source_time.updated_copy(
+                    amplitude=source_time.amplitude * mult
+                )
+                dipoles.append(
+                    cls(
+                        source_time=modulated_source_time,
+                        polarization=polarization,
+                        **kwargs,
+                    )
+                )
+
+        return dipoles
 
 
 class CustomCurrentSource(ReverseInterpolatedSource):

--- a/tidy3d/components/source/current.py
+++ b/tidy3d/components/source/current.py
@@ -115,12 +115,34 @@ class PointDipole(CurrentSource, ReverseInterpolatedSource):
         source_time: SourceTimeType,
         angle_theta: float,
         angle_phi: float,
-        electrical_component: bool = True,
+        component: Literal["electric", "magnetic"] = "electric",
         **kwargs,
     ) -> list[PointDipole]:
-        """Returns a list of `PointDipole` objects used to emulate a single dipole polarized in an arbitrary direction. The direction is specificed using a polar and azimuthal angle."""
+        """Returns a list of `PointDipole` objects used to emulate a single dipole polarized in an arbitrary direction. The direction is specificed using a polar and azimuthal angle.
+
+        Parameters
+        ----------
+        source_time: :class:`.SourceTime`
+            Specification of the source time-dependence.
+        angle_theta : float
+            Polar angle w.r.t. the z-axis.
+        angle_phi : float
+            Azimuth angle around the z-axis.
+        component : Literal["electric", "magnetic"] = "electric"
+            The type of polarization.
+        kwargs : dict
+            Keyword arguments passed to ``PointDipole()``, excluding ``source_time`` and ``polarization``
+
+        Returns
+        -------
+        list[PointDipole]
+            A list of ``PointDipole`` objects that emulate a single dipole with an arbitrary direction of polarization.
+        """
+        if not (component == "electric" or component == "magnetic"):
+            raise ValueError('Component must be "electric" or "magnetic"')
+
         dipoles: list[PointDipole] = []
-        polarizations = ["Ex", "Ey", "Ez"] if electrical_component else ["Hx", "Hy", "Hz"]
+        polarizations = ["Ex", "Ey", "Ez"] if component == "electric" else ["Hx", "Hy", "Hz"]
 
         multipliers = [
             sin(angle_theta) * cos(angle_phi),

--- a/tidy3d/components/source/current.py
+++ b/tidy3d/components/source/current.py
@@ -110,7 +110,7 @@ class PointDipole(CurrentSource, ReverseInterpolatedSource):
     )
 
     @classmethod
-    def from_angles(
+    def sources_from_angles(
         cls,
         source_time: SourceTimeType,
         angle_theta: float,


### PR DESCRIPTION
Resolves #2617 

Class method that returns a list of `PointDipole` objects used to emulate a single dipole polarized in an arbitrary direction. The direction is specified using a polar and azimuthal angle.