### PR TITLE
Adding 'precision' option to Simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `PointDipole.sources_from_angles()` that constructs a list of `PointDipole` objects needed to emulate a dipole oriented at a user-provided set of polar and azimuthal angles.
 - Added `priority` parameter to `web.run()` and related functions to allow vGPU users to set task priority (1-10) in the queue.
 - `EMEFieldMonitor` now supports `interval_space`.
+- `Simulation.precision` option allows to select `"double"` precision for very high-accuracy results. Note that this is very rarely needed, and doubles the simulation computational weight and correpsondingly FlexCredit cost.
 
 ### Changed
 - Switched to an analytical gradient calculation for spatially-varying pole-residue models (`CustomPoleResidue`).

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -2127,6 +2127,17 @@ class Simulation(AbstractYeeGridSimulation):
         gt=0.0,
         le=1.0,
     )
+
+    precision: Literal["hybrid", "double"] = pydantic.Field(
+        "hybrid",
+        title="Floating-point Precision",
+        description="Floating point precision to use in the computations. By default, Tidy3D uses "
+        "a hybrid approach that offers a good balance of speed and accuracy for almost all "
+        "simulations. However, for large simulations (or simulations with a long run time), "
+        "where very high accuracy is needed, the precision can be set to double everywhere. "
+        "Note that this doubles the FlexCredit cost of the simulation.",
+    )
+
     """The Courant-Friedrichs-Lewy (CFL) stability factor :math:`C`, controls time step to spatial step ratio.  A
     physical wave has to propagate slower than the numerical information propagation in a Yee-cell grid. This is
     because in this spatially-discrete grid, information propagates over 1 spatial step :math:`\\Delta x`


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Added new 'precision' field to Simulation class enabling control over floating-point precision with 'hybrid' (default) or 'double' options.

- Added field `precision` in `tidy3d/components/simulation.py` to control numerical precision in computations
- 'hybrid' mode balances speed and accuracy for typical use cases
- 'double' precision mode provides higher accuracy at 2x FlexCredit cost
- Particularly valuable for large-scale or long-running simulations requiring high numerical precision



<!-- /greptile_comment -->