### PR TITLE
Warning about symmetry expansion in ModeSolver and ModeSimulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `EMEFieldMonitor` now supports `interval_space`.
 - `Simulation.precision` option allows to select `"double"` precision for very high-accuracy results. Note that this is very rarely needed, and doubles the simulation computational weight and correpsondingly FlexCredit cost.
 - Added material type `PMCMedium` for perfect magnetic conductor.
+- `ModeSimulation.plot()` method that plots the mode simulation plane by default, or the containing FDTD simulation if any of ``x``, ``y``, or ``z`` is passed. 
 
 ### Changed
 - Switched to an analytical gradient calculation for spatially-varying pole-residue models (`CustomPoleResidue`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ or `Absorber` classes (or when invoking `pml()`, `stable_pml()`, or `absorber()`
 with fewer layers than recommended.
 - Warnings and error messages originating from `Structure`, `Source`, or `Monitor` classes now refer to problematic objects by their user-supplied `name` attribute, alongside their index.
 - File downloads are atomic. Interruptions or failures during download will no longer result in incomplete files.
+- Warnings are now generated (instead of errors) when instantiating `PML`, `StablePML`, or `Absorber` classes (or when invoking `pml()`, `stable_pml()`, or `absorber()` functions) with fewer layers than recommended.
+- `Simulation.subsection` can no longer take `symmetry` as an argument - the symmetry is always taken from the original simulation.
+- If a mode simulation is crossing a symmetry plane of the larger simulation domain, but the mode plane is not symmetric, a warning is issued that it will be expanded symmetrically. Previously this warning only happened during the solver run.
 
 ### Fixed
 - Arrow lengths are now scaled consistently in the X and Y directions, and their lengths no longer exceed the height of the plot window.

--- a/tests/test_components/test_mode.py
+++ b/tests/test_components/test_mode.py
@@ -176,6 +176,8 @@ def get_mode_sim():
 def test_mode_sim():
     with AssertLogLevel(None):
         sim = get_mode_sim()
+        _ = sim.plot(ax=AX)
+        _ = sim.plot(ax=AX, fill_structures=False, hlim=(-1, 1), vlim=(-1, 1))
         _ = sim.plot(y=0, ax=AX)
         _ = sim.plot_mode_plane(ax=AX)
         _ = sim.plot_eps_mode_plane(ax=AX)

--- a/tests/test_components/test_mode.py
+++ b/tests/test_components/test_mode.py
@@ -328,3 +328,54 @@ def get_mode_sim_data():
 def test_mode_sim_data():
     sim_data = get_mode_sim_data()
     _ = sim_data.plot_field("Ey", ax=AX, mode_index=0, f=FS[0])
+
+
+def test_plane_crosses_symmetry_plane_warning(monkeypatch):
+    """Test that a warning is issued if the mode plane crosses a symmetry plane but the centers do not match."""
+
+    # Simulation with symmetry in x (axis 0), center at (0, 0, 0)
+    sim_center = (0, 0, 0)
+    sim_size = (10, 5, 5)
+    sim_symmetry = (1, 0, 0)  # symmetry in x
+
+    # Plane crosses x=0 (symmetry plane), but plane center != sim center
+    plane_center = (2, 0, 0)
+    plane_size = (5, 0, 5)
+    plane = td.Box(center=plane_center, size=plane_size)
+
+    # Should warn
+    with AssertLogLevel("WARNING"):
+        _ = td.ModeSimulation(
+            center=sim_center,
+            size=sim_size,
+            symmetry=sim_symmetry,
+            plane=plane,
+            mode_spec=td.ModeSpec(),
+            freqs=[td.C_0],
+        )
+
+    # Now, plane center matches sim center: should NOT warn
+    plane_center2 = (0, 0, 0)
+    plane2 = td.Box(center=plane_center2, size=plane_size)
+    with AssertLogLevel("INFO"):
+        _ = td.ModeSimulation(
+            center=sim_center,
+            size=sim_size,
+            symmetry=sim_symmetry,
+            plane=plane2,
+            mode_spec=td.ModeSpec(),
+            freqs=[td.C_0],
+        )
+
+    # Plane does NOT cross symmetry plane: should NOT warn
+    plane_center3 = (5, 0, 0)
+    plane3 = td.Box(center=plane_center3, size=plane_size)
+    with AssertLogLevel("INFO"):
+        _ = td.ModeSimulation(
+            center=sim_center,
+            size=sim_size,
+            symmetry=sim_symmetry,
+            plane=plane3,
+            mode_spec=td.ModeSpec(),
+            freqs=[td.C_0],
+        )

--- a/tidy3d/components/eme/simulation.py
+++ b/tidy3d/components/eme/simulation.py
@@ -1097,6 +1097,7 @@ class EMESimulation(AbstractYeeGridSimulation):
         grid_spec: Union[GridSpec, Literal["identical"]] = None,
         eme_grid_spec: Union[EMEGridSpec, Literal["identical"]] = None,
         symmetry: Optional[tuple[Symmetry, Symmetry, Symmetry]] = None,
+        warn_symmetry_expansion: bool = True,
         monitors: Optional[tuple[MonitorType, ...]] = None,
         remove_outside_structures: bool = True,
         remove_outside_custom_mediums: bool = False,
@@ -1123,6 +1124,8 @@ class EMESimulation(AbstractYeeGridSimulation):
             New simulation symmetry. If ``None``, then it is inherited from the original
             simulation. Note that in this case the size and placement of new simulation domain
             must be commensurate with the original symmetry.
+        warn_symmetry_expansion : bool = True
+            Whether to warn when the subsection is expanded to preserve symmetry.
         monitors : Tuple[MonitorType, ...] = None
             New list of monitors. If ``None``, then the monitors intersecting the new simulation
             domain are inherited from the original simulation.
@@ -1160,7 +1163,7 @@ class EMESimulation(AbstractYeeGridSimulation):
         new_sim = super().subsection(
             region=new_region,
             grid_spec=grid_spec,
-            symmetry=symmetry,
+            warn_symmetry_expansion=warn_symmetry_expansion,
             monitors=monitors,
             remove_outside_structures=remove_outside_structures,
             remove_outside_custom_mediums=remove_outside_custom_mediums,

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -211,6 +211,30 @@ class ModeSolver(Tidy3dBaseModel):
             raise SetupError("'ModeSolver.plane' must intersect 'ModeSolver.simulation'.")
         return val
 
+    @pydantic.validator("plane", always=True)
+    @skip_if_fields_missing(["simulation"])
+    def _warn_plane_crosses_symmetry(cls, val, values):
+        """Warn if the mode plane crosses the symmetry plane of the underlying simulation but
+        the centers do not match."""
+        simulation = values.get("simulation")
+        bounds = val.bounds
+        # now check in each dimension whether we cross symmetry plane
+        for dim in range(3):
+            if simulation.symmetry[dim] != 0:
+                crosses_symmetry = (
+                    bounds[0][dim] < simulation.center[dim]
+                    and bounds[1][dim] > simulation.center[dim]
+                )
+                if crosses_symmetry:
+                    if not isclose(val.center[dim], simulation.center[dim]):
+                        log.warning(
+                            f"The original simulation is symmetric along {'xyz'[dim]} direction. "
+                            "The mode simulation region does cross the symmetry plane but is "
+                            "not symmetric with respect to it. To preserve correct symmetry, "
+                            "the requested simulation region will be expanded by the solver."
+                        )
+        return val
+
     def _post_init_validators(self) -> None:
         self._validate_mode_plane_radius(
             mode_spec=self.mode_spec,
@@ -2539,6 +2563,7 @@ class ModeSolver(Tidy3dBaseModel):
             region=new_sim_box,
             monitors=[],
             sources=[],
+            warn_symmetry_expansion=False,  # we already warn upon mode solver creation
             grid_spec="identical",
             boundary_spec=new_bspec,
             remove_outside_custom_mediums=True,

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -2117,6 +2117,9 @@ class ModeSolver(Tidy3dBaseModel):
     def plot(
         self,
         ax: Ax = None,
+        hlim: Optional[tuple[float, float]] = None,
+        vlim: Optional[tuple[float, float]] = None,
+        fill_structures: bool = True,
         **patch_kwargs,
     ) -> Ax:
         """Plot the mode plane simulation's components.
@@ -2125,6 +2128,12 @@ class ModeSolver(Tidy3dBaseModel):
         ----------
         ax : matplotlib.axes._subplots.Axes = None
             Matplotlib axes to plot on, if not specified, one is created.
+        hlim : Tuple[float, float] = None
+            The x range if plotting on xy or xz planes, y range if plotting on yz plane.
+        vlim : Tuple[float, float] = None
+            The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
+        fill_structures : bool = True
+            Whether to fill structures with color or just draw outlines.
 
         Returns
         -------
@@ -2139,20 +2148,26 @@ class ModeSolver(Tidy3dBaseModel):
 
         """
         # Get the mode plane normal axis, center, and limits.
-        a_center, h_lim, v_lim, _ = self._center_and_lims(
+        a_center, hlim_plane, vlim_plane, _ = self._center_and_lims(
             simulation=self.simulation, plane=self.plane
         )
+
+        if hlim is None:
+            hlim = hlim_plane
+        if vlim is None:
+            vlim = vlim_plane
 
         ax = self.simulation.plot(
             x=a_center[0],
             y=a_center[1],
             z=a_center[2],
-            hlim=h_lim,
-            vlim=v_lim,
+            hlim=hlim,
+            vlim=vlim,
             source_alpha=0,
             monitor_alpha=0,
             lumped_element_alpha=0,
             ax=ax,
+            fill_structures=fill_structures,
             **patch_kwargs,
         )
 

--- a/tidy3d/components/mode/simulation.py
+++ b/tidy3d/components/mode/simulation.py
@@ -361,6 +361,75 @@ class ModeSimulation(AbstractYeeGridSimulation):
         )
         return mode_sim
 
+    def plot(
+        self,
+        x: Optional[float] = None,
+        y: Optional[float] = None,
+        z: Optional[float] = None,
+        ax: Ax = None,
+        source_alpha: Optional[float] = 0,
+        monitor_alpha: Optional[float] = 0,
+        lumped_element_alpha: Optional[float] = 0,
+        hlim: Optional[tuple[float, float]] = None,
+        vlim: Optional[tuple[float, float]] = None,
+        fill_structures: bool = True,
+        **patch_kwargs,
+    ) -> Ax:
+        """Plot the mode simulation. If any of ``x``, ``y``, or ``z`` is provided, the potentially
+        larger FDTD simulation containing the mode plane is plotted at the desired location.
+        Otherwise, the mode plane is plotted by default.
+
+        Parameters
+        ----------
+        fill_structures : bool = True
+            Whether to fill structures with color or just draw outlines.
+        x : float = None
+            position of plane in x direction, only one of x, y, z must be specified to define plane.
+        y : float = None
+            position of plane in y direction, only one of x, y, z must be specified to define plane.
+        z : float = None
+            position of plane in z direction, only one of x, y, z must be specified to define plane.
+        source_alpha : float = 0
+            Opacity of the sources. If ``None``, uses Tidy3d default.
+        monitor_alpha : float = 0
+            Opacity of the monitors. If ``None``, uses Tidy3d default.
+        lumped_element_alpha : float = 0
+            Opacity of the lumped elements. If ``None``, uses Tidy3d default.
+        ax : matplotlib.axes._subplots.Axes = None
+            Matplotlib axes to plot on, if not specified, one is created.
+        hlim : Tuple[float, float] = None
+            The x range if plotting on xy or xz planes, y range if plotting on yz plane.
+        vlim : Tuple[float, float] = None
+            The z range if plotting on xz or yz planes, y plane if plotting on xy plane.
+
+        Returns
+        -------
+        matplotlib.axes._subplots.Axes
+            The supplied or created matplotlib axes.
+        """
+
+        if x is not None or y is not None or z is not None:
+            return super().plot(
+                x=x,
+                y=y,
+                z=z,
+                ax=ax,
+                source_alpha=source_alpha,
+                monitor_alpha=monitor_alpha,
+                lumped_element_alpha=lumped_element_alpha,
+                hlim=hlim,
+                vlim=vlim,
+                fill_structures=fill_structures,
+                **patch_kwargs,
+            )
+        return self._mode_solver.plot(
+            ax=ax,
+            hlim=hlim,
+            vlim=vlim,
+            fill_structures=fill_structures,
+            **patch_kwargs,
+        )
+
     def plot_mode_plane(
         self,
         ax: Ax = None,

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -1701,6 +1701,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         boundary_spec: BoundarySpec = None,
         grid_spec: Union[GridSpec, Literal["identical"]] = None,
         symmetry: Optional[tuple[Symmetry, Symmetry, Symmetry]] = None,
+        warn_symmetry_expansion: bool = True,
         sources: Optional[tuple[SourceType, ...]] = None,
         monitors: Optional[tuple[MonitorType, ...]] = None,
         remove_outside_structures: bool = True,
@@ -1728,6 +1729,8 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
             New simulation symmetry. If ``None``, then it is inherited from the original
             simulation. Note that in this case the size and placement of new simulation domain
             must be commensurate with the original symmetry.
+        warn_symmetry_expansion : bool = True
+            Whether to warn when the subsection is expanded to preserve symmetry.
         sources : Tuple[SourceType, ...] = None
             New list of sources. If ``None``, then the sources intersecting the new simulation
             domain are inherited from the original simulation.
@@ -1805,12 +1808,13 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
                         center = (new_bounds[0][dim] + new_bounds[1][dim]) / 2
 
                         if not math.isclose(center, self.center[dim]):
-                            log.warning(
-                                f"The original simulation is symmetric along {'xyz'[dim]} direction. "
-                                "The requested new simulation region does cross the symmetry plane but is "
-                                "not symmetric with respect to it. To preserve correct symmetry, "
-                                "the requested simulation region is expanded symmetrically."
-                            )
+                            if warn_symmetry_expansion:
+                                log.warning(
+                                    f"The original simulation is symmetric along {'xyz'[dim]} direction. "
+                                    "The requested new simulation region does cross the symmetry plane but is "
+                                    "not symmetric with respect to it. To preserve correct symmetry, "
+                                    "the requested simulation region is expanded symmetrically."
+                                )
                             new_bounds[0][dim] = 2 * self.center[dim] - new_bounds[1][dim]
 
         # symmetry and grid spec treatments could change new simulation bounds


### PR DESCRIPTION
I wanted to add one more improvement related to the plotting, but I need to go now and I wanted to open this up for @dbochkov 's consideration especially because I ended up removing the 'symmetry' argument from 'subsection', because it wasn't really used anywhere (including backend), except in one test. So now the `symmetry` is always inherited from the original simulation - do you have any concerns with that?

Otherwise, the point of this PR is to address [this ticket](https://flow360.atlassian.net/browse/SCEM-10245?focusedCommentId=68509), and then I didn't want the warning to appear both when creating the mode simulation and when running it, so I added an option to supress it.

<!-- greptile_comment -->

## Greptile Summary

Improves symmetry handling in mode simulations by adding warnings and simplifying the API. This PR focuses on notifying users when a mode plane crosses a symmetry plane without proper center alignment.

- Added validator `_warn_plane_crosses_symmetry` in `tidy3d/components/mode/mode_solver.py` to warn users about automatic simulation region expansion
- Removed unused 'symmetry' argument from `subsection()` method in `tidy3d/components/eme/simulation.py`, making symmetry always inherit from parent simulation
- Added new test cases in `tests/test_components/test_mode.py` to verify warning behavior for different plane-symmetry crossing scenarios
- Added option to suppress duplicate warnings when creating and running mode simulations



<!-- /greptile_comment -->