### PR TITLE
Move imaginary factor in `MonitorData.get_amplitude()` to internal adjoint calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ with fewer layers than recommended.
 - Bug in `PlaneWave` defined with a negative `angle_theta` which would lead to wrong injection.
 - Plots of objects defined by shape intersection logic will no longer display thin line artifacts.
 - Fixed incorrect gradient computation in PyTorch plugin (`to_torch`) for functions returning multi-element arrays.
+- `MonitorData.get_amplitude()` no longers multiplies by a factor of `1j` and now directly returns the complex value of the data.
 
 ## [2.9.0rc1] - 2025-06-10
 

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -185,9 +185,9 @@ class MonitorData(AbstractMonitorData, ABC):
         """Get the complex amplitude out of some data."""
 
         if isinstance(x, DataArray):
-            x = complex(x.values)
+            x = x.values
 
-        return 1j * complex(x)
+        return complex(x)
 
 
 class AbstractFieldData(MonitorData, AbstractFieldDataset, ABC):
@@ -2115,7 +2115,7 @@ class ModeData(ModeSolverDataset, ElectromagneticFieldData):
                 for mode_index in coords["mode_index"]:
                     amp_single = self.amps.sel(f=freq, direction=direction, mode_index=mode_index)
 
-                    if self.get_amplitude(amp_single) == 0.0:
+                    if abs(self.get_amplitude(amp_single)) == 0.0:
                         continue
 
                     adjoint_source = self._adjoint_source_amp(amp=amp_single, fwidth=fwidth)
@@ -2138,7 +2138,7 @@ class ModeData(ModeSolverDataset, ElectromagneticFieldData):
         amp_complex = self.get_amplitude(amp)
         k0 = 2 * np.pi * freq0 / C_0
         grad_const = k0 / 4 / ETA_0
-        src_amp = grad_const * amp_complex
+        src_amp = 1j * grad_const * amp_complex
 
         # construct source
         src_adj = ModeSource(
@@ -3404,7 +3404,7 @@ class DiffractionData(AbstractFieldProjectionData):
 
                         # ignore any amplitudes of 0.0 or nan
                         amp_complex = self.get_amplitude(amp_single)
-                        if (amp_complex == 0.0) or np.isnan(amp_complex):
+                        if (abs(amp_complex) == 0.0) or np.isnan(amp_complex):
                             continue
 
                         # compute a plane wave for this amplitude (if propagating / not None)


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Modifies the complex amplitude handling in `MonitorData.get_amplitude()` by relocating the imaginary factor to the adjoint source calculation for improved logical separation.

- Removes factor of `1j` from `tidy3d/components/data/monitor_data.py:get_amplitude()`, moving it to `_adjoint_source_amp()`
- Changes flux calculations to use `abs()` instead of direct comparison for zero amplitude checks
- Updates documentation in `CHANGELOG.md` to reflect breaking change in amplitude calculations
- Potential breaking change for users relying on complex phase in amplitude calculations



<!-- /greptile_comment -->