### PR TITLE
ci: Not require local-tests to merge

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -346,10 +346,8 @@ jobs:
             exit 1 # Given remote-tests always run after a PR is approved
           elif [[ "${{ needs.local-tests.result }}" != 'success' ]]; then
             echo "❌ local-tests failed or were skipped."
-            exit 1
           elif [[ "${{ needs.determine-test-scope.outputs.pr_approval_state }}" == 'true' && github.event.pull_request ]]; then
             echo "❌ PR requires approval."
             exit 1
-          else 
-            echo "✅ All required test jobs passed!"
           fi
+          echo "✅ All required test jobs passed!"


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Modified CI workflow to make local test failures non-blocking for PR merges, allowing PRs to be merged even when local tests fail as long as remote tests and linting pass.

- Changed `.github/workflows/run_tests.yml` to remove the exit 1 command after local test failures
- This change introduces potential risks by relaxing merge requirements and could impact code reliability
- Consider adding clear documentation about which tests are mandatory vs optional for merging
- Consider adding warning notifications when merging with failed local tests



<!-- /greptile_comment -->