### PR TITLE
ci: Yet another test of protection rules

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -264,7 +264,7 @@ jobs:
       MPLBACKEND: agg
 
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ matrix.platform }}-${{ matrix.python-version }}-remote
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.event_name }}-${{ matrix.platform }}-${{ matrix.python-version }}-remote
       cancel-in-progress: true
 
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -336,6 +336,7 @@ jobs:
     steps:
       - name: check-passing-remote-tests
         run: |
+          echo "Local tests result: ${{ needs.local-tests.result }}"
           echo "Remote tests result: ${{ needs.remote-tests.result }}"
 
           if [[ "${{ needs.lint.result }}" != 'success' ]]; then


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Enhanced CI workflow logging in `.github/workflows/run_tests.yml` by adding result visibility for local tests in the final check-passing step.

- Modified `.github/workflows/run_tests.yml` to echo local test results alongside remote test outcomes in final status check
- Improves debugging capability by providing more comprehensive test status visibility in CI logs



<!-- /greptile_comment -->