### PR TITLE
ci: Fix concurrency failure

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -145,7 +145,7 @@ jobs:
       image: ghcr.io/astral-sh/uv:debian
       options: --user 31001:61001 # Required slurm-batch UID: slurm GID for tmp/ file removal
     concurrency:
-      group: local-tests-${{ github.ref }}-${{ matrix.python-version }}
+      group: local-tests-${{ github.ref }}-${{ github.event_name }}-python-${{ matrix.python-version }}
       cancel-in-progress: true # Required so it does not use previous state
     strategy:
       matrix:


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updates CI workflow concurrency settings to prevent workflow interference between different event types (push, pull_request) by adding event name to the group identifier.

- Modified `.github/workflows/run_tests.yml` to include `github.event_name` in concurrency group key, improving isolation between different CI trigger events



<!-- /greptile_comment -->