### PR TITLE
Turning a few validators into root validators

### DIFF
--- a/tidy3d/components/base_sim/data/sim_data.py
+++ b/tidy3d/components/base_sim/data/sim_data.py
@@ -52,15 +52,15 @@ class AbstractSimulationData(Tidy3dBaseModel, ABC):
         """Dictionary mapping monitor name to its associated :class:`AbstractMonitorData`."""
         return {monitor_data.monitor.name: monitor_data for monitor_data in self.data}
 
-    @pd.validator("data", always=True)
-    @skip_if_fields_missing(["simulation"])
-    def data_monitors_match_sim(cls, val, values):
+    @pd.root_validator(skip_on_failure=True)
+    def data_monitors_match_sim(cls, values):
         """Ensure each :class:`AbstractMonitorData` in ``.data`` corresponds to a monitor in
         ``.simulation``.
         """
         sim = values.get("simulation")
+        data = values.get("data")
 
-        for mnt_data in val:
+        for mnt_data in data:
             try:
                 monitor_name = mnt_data.monitor.name
                 sim.get_monitor_by_name(monitor_name)
@@ -69,7 +69,7 @@ class AbstractSimulationData(Tidy3dBaseModel, ABC):
                     f"Data with monitor name '{monitor_name}' supplied "
                     f"but not found in the original '{sim.type}'."
                 ) from exc
-        return val
+        return values
 
     @pd.validator("data", always=True)
     @skip_if_fields_missing(["simulation"])

--- a/tidy3d/components/data/unstructured/base.py
+++ b/tidy3d/components/data/unstructured/base.py
@@ -114,20 +114,21 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
             )
         return val
 
-    @pd.validator("values", always=True)
-    @skip_if_fields_missing(["points"])
-    def number_of_values_matches_points(cls, val, values):
+    @pd.root_validator(skip_on_failure=True)
+    def number_of_values_matches_points(cls, values):
         """Check that the number of data values matches the number of grid points."""
-        num_values = len(val.index)
-
         points = values.get("points")
-        num_points = len(points)
-        if num_points != num_values:
-            raise ValidationError(
-                f"The number of data values ({num_values}) does not match the number of grid "
-                f"points ({num_points})."
-            )
-        return val
+        vals = values.get("values")
+
+        if points is not None and vals is not None:
+            num_points = len(points)
+            num_values = len(vals.index)
+            if num_points != num_values:
+                raise ValidationError(
+                    f"The number of data values ({num_values}) does not match the number of grid "
+                    f"points ({num_points})."
+                )
+        return values
 
     @pd.validator("cells", always=True)
     def match_cells_to_vtk_type(cls, val):

--- a/tidy3d/components/tcad/data/sim_data.py
+++ b/tidy3d/components/tcad/data/sim_data.py
@@ -8,7 +8,7 @@ from typing import Literal, Optional
 import numpy as np
 import pydantic.v1 as pd
 
-from tidy3d.components.base import Tidy3dBaseModel, skip_if_fields_missing
+from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.base_sim.data.sim_data import AbstractSimulationData
 from tidy3d.components.data.data_array import (
     SpatialDataArray,
@@ -560,23 +560,23 @@ class VolumeMesherData(AbstractHeatChargeSimulationData):
             monitors=self.monitors,
         )
 
-    @pd.validator("data", always=True)
-    @skip_if_fields_missing(["monitors"])
-    def data_monitors_match_sim(cls, val, values):
+    @pd.root_validator(skip_on_failure=True)
+    def data_monitors_match_sim(cls, values):
         """Ensure each :class:`AbstractMonitorData` in ``.data`` corresponds to a monitor in
         ``.simulation``.
         """
         monitors = values.get("monitors")
+        data = values.get("data")
         mnt_names = {mnt.name for mnt in monitors}
 
-        for mnt_data in val:
+        for mnt_data in data:
             monitor_name = mnt_data.monitor.name
             if monitor_name not in mnt_names:
                 raise DataError(
                     f"Data with monitor name '{monitor_name}' supplied "
                     f"but not found in the list of monitors."
                 )
-        return val
+        return values
 
     def get_monitor_by_name(self, name: str) -> VolumeMeshMonitor:
         """Return monitor named 'name'."""


### PR DESCRIPTION
Some validators were causing loading a `VolumeMesherData` to issue spurious warnings due to `skip_if_fields_missing`. One fix is to just these into root validators - and the issue should anyway be addressed in the pydantic v2 migration which completely eliminates `skip_if_fields_missing`.

![image](https://github.com/user-attachments/assets/1f905e54-da55-4fcb-aa75-88b02a51c582)


<!-- greptile_comment -->

## Greptile Summary

Converts several field validators to root validators to fix spurious warnings when loading VolumeMesherData caused by `skip_if_fields_missing`. This change affects validation logic in simulation data handling and unstructured grid datasets.

- Modified `data_monitors_match_sim` in `components/base_sim/data/sim_data.py` to use root validation instead of field validation
- Converted validation in `components/tcad/data/sim_data.py` to use root validators for monitor data correspondence
- Updated `UnstructuredGridDataset` in `components/data/unstructured/base.py` to handle point and value count validation at root level
- Serves as temporary solution until pydantic v2 migration removes need for `skip_if_fields_missing`



<!-- /greptile_comment -->