### PR TITLE
ci: Skip diff-changes if fork

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -213,7 +213,8 @@ jobs:
       if: >- 
         matrix.python-version == '3.13' &&
         github.event_name == 'pull_request' &&
-        !contains(github.event.pull_request.labels.*.name, 'ignore_diff_coverage')
+        !contains(github.event.pull_request.labels.*.name, 'ignore_diff_coverage') &&
+        github.event.pull_request.head.repo.fork == false
       with:
         result-encoding: string
         script: |


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Enhanced security in CI workflow by skipping diff coverage reporting for fork-based pull requests to prevent potential permission-related issues.

- Modified `.github/workflows/tidy3d-python-client-tests.yml` to only generate diff coverage reports for PRs from internal branches
- Added explicit fork check condition `github.event.pull_request.head.repo.fork == false` to protect sensitive operations



<!-- /greptile_comment -->