### PR TITLE
refactor: remove debug print statement from sim_data.py

### DIFF
--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -1242,8 +1242,6 @@ class SimulationData(AbstractYeeGridSimulationData):
                 "This can introduce errors into the gradient computation."
             )
 
-        print(f"source widths: {decay_by_f0_fwidth}, {fwidth_to_min_f0}")
-
         # Choose a wider pulse width in frequency especially when the min/max frequencies
         # for the broadband pulse might be very close together
         adj_src_fwidth = np.maximum(decay_by_f0_fwidth, fwidth_to_min_f0)


### PR DESCRIPTION
Accidentally left this one in :grimacing: 

<!-- greptile_comment -->

## Greptile Summary

Removes an accidentally committed debug print statement from the `_adjoint_src_width_broadband` function in `tidy3d/components/data/sim_data.py`.

- Removed debug print that was outputting source width calculations (decay_by_f0_fwidth and fwidth_to_min_f0) used in adjoint source calculations



<!-- /greptile_comment -->