### PR TITLE
fix: wrongly decorated `_validate_inplane_pec` validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ with fewer layers than recommended.
 - Fixed incorrect gradient computation in PyTorch plugin (`to_torch`) for functions returning multi-element arrays.
 - `MonitorData.get_amplitude()` no longers multiplies by a factor of `1j` and now directly returns the complex value of the data.
 - `EMESimulationData.port_modes_tuple` is now symmetry-expanded.
+- Fixed `Medium2D` validation error message when invalid data is passed to `ss`.
 
 ## [2.9.0rc1] - 2025-06-10
 

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -7036,8 +7036,8 @@ class Medium2D(AbstractMedium):
             )
         return val
 
-    @skip_if_fields_missing(["ss"])
     @pd.validator("tt", always=True)
+    @skip_if_fields_missing(["ss"])
     def _validate_inplane_pec(cls, val, values):
         """ss/tt components must be both PEC or non-PEC."""
         if isinstance(val, PECMedium) != isinstance(values["ss"], PECMedium):

--- a/tidy3d/components/tcad/simulation/heat_charge.py
+++ b/tidy3d/components/tcad/simulation/heat_charge.py
@@ -889,7 +889,6 @@ class HeatChargeSimulation(AbstractSimulation):
             )
         return values
 
-    @skip_if_fields_missing(["analysis_spec", "monitors", "structures", "size"])
     @pd.root_validator(skip_on_failure=True)
     def check_transient_heat(cls, values):
         """Make sure transient heat simulations can run."""


### PR DESCRIPTION
The `skip_if_fields_missing` decorator must be applied _after_ the validator decorator in order to execute correctly.

Previously, the following snippet:
```py
import tidy3d as td

med = td.Medium(permittivity=2)
ani = td.AnisotropicMedium(xx=med, yy=med, zz=med)

td.Medium2D(ss=ani, tt=med)
```
would error with:
```
KeyError: 'ss'
```
instead of showing the intended validation error. After the changes:
```
pydantic.v1.error_wrappers.ValidationError: 1 validation error for Medium2D
ss
  No match for discriminator 'type' and value 'AnisotropicMedium' (allowed values: 'Medium', 'LossyMetalMedium', 'PoleResidue', 'Sellmeier', 'Lorentz', 'Debye', 'Drude', 'PECMedium') (type=value_error.discriminated_union.invalid_discriminator; discriminator_key=type; discriminator_value=AnisotropicMedium; allowed_values='Medium', 'LossyMetalMedium', 'PoleResidue', 'Sellmeier', 'Lorentz', 'Debye', 'Drude', 'PECMedium')
```

I also removed the `skip_if_fields_missing` decorator from the `check_transient_heat` validator since it has the same problem. Also, `skip_if_fields_missing` can only be applied to field validators, not root validators @marc-flex.

<!-- greptile_comment -->

## Greptile Summary

Fixed decorator ordering in validator methods to properly handle validation errors, particularly in Medium2D class.

- Reordered `@skip_if_fields_missing` to be applied after `@pd.validator` in `_validate_inplane_pec` method
- Removed `skip_if_fields_missing` from `check_transient_heat` root validator where it wasn't applicable
- Fixed validation to properly reject invalid AnisotropicMedium values instead of raising KeyError
- Ensures proper validation error messages instead of cryptic KeyError exceptions



<!-- /greptile_comment -->