### PR TITLE
ci: pr-requirements-tests only on PR events

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -189,7 +189,8 @@ jobs:
           # We use '|| true' to prevent the workflow from stopping here on failure.
           cd $GITHUB_WORKSPACE
           ls $GITHUB_WORKSPACE/develop
-          diff_output=$(git diff --no-index --name-status $GITHUB_WORKSPACE/develop/tidy3d/schemas $GITHUB_WORKSPACE/pr/tidy3d/schemas || true)
+          ls $GITHUB_WORKSPACE/pr
+          diff_output=$(git diff --no-index --name-status $GITHUB_WORKSPACE/develop/schemas $GITHUB_WORKSPACE/pr/tidy3d/schemas || true)
 
           # Check if there are any changes
           if [ -z "$diff_output" ]; then

--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -187,10 +187,8 @@ jobs:
           # Use git diff to compare the two directories and get a list of changes
           # The command exits with 0 if no changes, 1 if changes are found.
           # We use '|| true' to prevent the workflow from stopping here on failure.
-          cd $GITHUB_WORKSPACE
-          ls $GITHUB_WORKSPACE/develop
-          ls $GITHUB_WORKSPACE/pr
-          diff_output=$(git diff --no-index --name-status $GITHUB_WORKSPACE/develop/schemas $GITHUB_WORKSPACE/pr/tidy3d/schemas || true)
+          cd $GITHUB_WORKSPACE/develop
+          diff_output=$(git diff --no-index --name-status $GITHUB_WORKSPACE/develop/schemas $GITHUB_WORKSPACE/pr/schemas || true)
 
           # Check if there are any changes
           if [ -z "$diff_output" ]; then

--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -234,7 +234,7 @@ jobs:
     # Run on open PRs OR when manually triggered with local_tests=true
     needs: determine-test-scope
     if: needs.determine-test-scope.outputs.local_tests == 'true'
-    name: Python ${{ matrix.python-version }} - self-hosted-runner 
+    name: python-${{ matrix.python-version }}-self-hosted-runner 
     runs-on: [ slurm-runner, 4xcpu ]
     container: 
       image: ghcr.io/astral-sh/uv:debian
@@ -258,7 +258,7 @@ jobs:
         fetch-depth: 0 # Required 0 for diff report.
         submodules: false
 
-    - name: Install project
+    - name: install-project
       env:
         PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
@@ -279,7 +279,7 @@ jobs:
         echo "Testing vtk is correctly installed."
         python -c "import vtk"
 
-    - name: Run tests with coverage
+    - name: run-tests-coverage
       env:
         PYTHONUNBUFFERED: "1"
       run: |
@@ -292,7 +292,7 @@ jobs:
         echo "total=$TOTAL_COVERAGE" >> "$GITHUB_ENV"
         echo "### Total coverage: ${TOTAL_COVERAGE}%"
 
-    - name: Produce the diff coverage report
+    - name: diff-coverage-report
       if: >- 
         matrix.python-version == '3.13' &&
         github.event_name == 'pull_request' &&
@@ -376,12 +376,12 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: set-python-${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install project
+    - name: install-project
       run: |
         poetry --version
         poetry env use python
@@ -390,11 +390,11 @@ jobs:
         poetry run pip install gdstk --only-binary gdstk
         poetry install -E dev
 
-    - name: Run doctests
+    - name: run-doctests
       run: |
         poetry run pytest -rF --tb=short tidy3d
 
-    - name: Run tests with coverage
+    - name: run-tests-coverage
       env:
         PYTHONUNBUFFERED: "1"
       run: |
@@ -405,7 +405,7 @@ jobs:
         echo "total=$TOTAL_COVERAGE" >> "$GITHUB_ENV"
         echo "### Total coverage: ${TOTAL_COVERAGE}%"
 
-    - name: "Create badge"
+    - name: create-badge
       if: ${{ github.ref == 'refs/heads/develop' }}
       # https://gist.githubusercontent.com/nedbat/8c6980f77988a327348f9b02bbaf67f5
       uses: schneegans/dynamic-badges-action@v1.7.0
@@ -423,10 +423,11 @@ jobs:
   pr-requirements-pass:
     name: pr-requirements-pass
     if: |
-      always() && 
-      ( needs.determine-test-scope.outputs.pr_approval_state == 'true' ) && 
+      always() &&
+      ((github.event_name == 'pull_request') || (github.event_name == 'pull_request_review'))  && 
+      (( needs.determine-test-scope.outputs.pr_approval_state == 'true' ) && 
       ( needs.determine-test-scope.outputs.local_tests == 'true' ) || 
-      ( needs.determine-test-scope.outputs.remote_tests == 'true' )
+      ( needs.determine-test-scope.outputs.remote_tests == 'true' ))
     needs: [local-tests, remote-tests, lint, verify-schema-change]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -187,7 +187,9 @@ jobs:
           # Use git diff to compare the two directories and get a list of changes
           # The command exits with 0 if no changes, 1 if changes are found.
           # We use '|| true' to prevent the workflow from stopping here on failure.
-          diff_output=$(git diff --no-index --name-status ./develop/tidy3d/schemas ./pr/tidy3d/schemas || true)
+          cd GITHUB_WORKSPACE
+          ls
+          diff_output=$(git diff --no-index --name-status $GITHUB_WORKSPACE/develop/tidy3d/schemas $GITHUB_WORKSPACE/pr/tidy3d/schemas || true)
 
           # Check if there are any changes
           if [ -z "$diff_output" ]; then

--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -150,7 +150,7 @@ jobs:
         with:
           path: 'pr' 
 
-      - name: checkou-develop-branch
+      - name: checkout-develop-branch
         uses: actions/checkout@v4
         with:
           ref: 'develop' 
@@ -187,7 +187,7 @@ jobs:
           # Use git diff to compare the two directories and get a list of changes
           # The command exits with 0 if no changes, 1 if changes are found.
           # We use '|| true' to prevent the workflow from stopping here on failure.
-          cd GITHUB_WORKSPACE
+          cd $GITHUB_WORKSPACE
           ls
           diff_output=$(git diff --no-index --name-status $GITHUB_WORKSPACE/develop/tidy3d/schemas $GITHUB_WORKSPACE/pr/tidy3d/schemas || true)
 

--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -343,7 +343,7 @@ jobs:
     # Run tests on a push event OR a workflow dispatch with remote_tests
     needs: determine-test-scope
     if: needs.determine-test-scope.outputs.remote_tests == 'true'
-    name: Python ${{ matrix.python-version }} - ${{ matrix.platform }}
+    name: python-${{ matrix.python-version }}-${{ matrix.platform }}
     runs-on: ${{ matrix.platform }}
     permissions:
       contents: read
@@ -369,7 +369,7 @@ jobs:
         fetch-depth: 1
         submodules: false
 
-    - name: Install Poetry
+    - name: install-poetry
       uses: snok/install-poetry@v1
       with:
         version: 2.1.1

--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -153,7 +153,7 @@ jobs:
       - name: checkout-develop-branch
         uses: actions/checkout@v4
         with:
-          ref: 'develop' 
+          ref: develop 
           path: 'develop' 
 
       - name: install-depedencies
@@ -188,7 +188,7 @@ jobs:
           # The command exits with 0 if no changes, 1 if changes are found.
           # We use '|| true' to prevent the workflow from stopping here on failure.
           cd $GITHUB_WORKSPACE
-          ls
+          ls $GITHUB_WORKSPACE/develop
           diff_output=$(git diff --no-index --name-status $GITHUB_WORKSPACE/develop/tidy3d/schemas $GITHUB_WORKSPACE/pr/tidy3d/schemas || true)
 
           # Check if there are any changes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,3 @@ repos:
        args: [ --fix ]
      - id: ruff-format
 
-  - repo: local
-    hooks:
-      - id: regenerate-schema
-        name: regenerate-schema
-        entry: python scripts/regenerate_schema.py
-        language: system
-        files: ^tidy3d/.*\.py$  # Run only when Python files in the core 'tidy3d' directory are modified.
-        stages: [pre-commit] # Explicitly run during the commit stage.


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary
This PR optimizes the GitHub Actions CI workflow by modifying when PR requirement checks are executed. The main change restricts the `pr-requirements-pass` job to only run during pull request events (`pull_request` or `pull_request_review`), preventing unnecessary validation steps during direct merges to the develop branch. The PR also includes workflow hygiene improvements by standardizing job and step names to use consistent hyphenation.

The changes fit well with CI/CD best practices by reducing unnecessary workflow runs while maintaining the integrity of the PR review process. The standardization of naming conventions improves the maintainability of the workflow file.

## Confidence score: 4/5

1. This PR is safe to merge as it only affects CI workflow behavior, not production code.
2. High confidence score given because the changes are isolated to CI configuration and follow clear logic, though CI changes always warrant careful testing.
3. Files needing attention:
   - `.github/workflows/tidy3d-python-client-tests.yml` - Verify the conditional logic for PR requirements is correct

<sub>1 file reviewed, 2 comments</sub>
<sub>[Edit PR Review Bot Settings](https://app.greptile.com/review/github) | [Greptile](https://greptile.com?utm_source=greptile_expert&utm_medium=github&utm_campaign=code_reviews&utm_content=tidy3d_2656)</sub>

<!-- /greptile_comment -->