### PR TITLE
ci: forbid module-level import of scipy & matplotlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -277,6 +277,9 @@ extend-ignore = [
 [tool.ruff.lint.isort]
 required-imports = ["from __future__ import annotations"]
 
+[tool.ruff.lint.flake8-tidy-imports]
+banned-module-level-imports = ["scipy", "matplotlib"]
+
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*" = [
     "B015",   # useless comparison
@@ -287,6 +290,10 @@ required-imports = ["from __future__ import annotations"]
     "S101",   # asserts allowed in tests
     "NPY201", # numpy 2.* compatibility check
     "TID252", # allow relative imports in tests
+    "TID253", # allow heavy imports in tests
+]
+"tidy3d/plugins/**/*" = [
+    "TID253", # allow heavy imports in plugins (not used by MC)
 ]
 
 [tool.pytest.ini_options]

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -11,8 +11,6 @@ from typing import Literal, Optional, Union, get_args
 import numpy as np
 import pydantic.v1 as pydantic
 import xarray as xr
-from matplotlib.collections import PatchCollection
-from matplotlib.patches import Rectangle
 
 from tidy3d.components.base import Tidy3dBaseModel, cached_property, skip_if_fields_missing
 from tidy3d.components.boundary import PML, Absorber, Boundary, BoundarySpec, PECBoundary, StablePML
@@ -2394,6 +2392,10 @@ class ModeSolver(Tidy3dBaseModel):
         cls, simulation: Simulation, plane: Box, mode_spec: ModeSpec, ax: Ax = None
     ) -> Ax:
         """Plot the mode plane absorbing boundaries."""
+
+        from matplotlib.collections import PatchCollection
+        from matplotlib.patches import Rectangle
+
         # Get the mode plane normal axis, center, and limits.
         _, h_lim, v_lim, _ = cls._center_and_lims(simulation=simulation, plane=plane)
 

--- a/tidy3d/components/viz/axes_utils.py
+++ b/tidy3d/components/viz/axes_utils.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 from functools import wraps
 from typing import Optional
 
-import matplotlib.pyplot as plt
-import matplotlib.ticker as ticker
-
 from tidy3d.components.types import Ax, Axis, LengthUnit
 from tidy3d.constants import UnitScaling
 from tidy3d.exceptions import Tidy3dKeyError
@@ -13,6 +10,8 @@ from tidy3d.exceptions import Tidy3dKeyError
 
 def make_ax() -> Ax:
     """makes an empty ``ax``."""
+    import matplotlib.pyplot as plt
+
     _, ax = plt.subplots(1, 1, tight_layout=True)
     return ax
 
@@ -60,6 +59,9 @@ def set_default_labels_and_title(
     When the ``plot_length_units`` are specified, the plot axes are scaled, and
     the title and axis labels include the desired units.
     """
+
+    import matplotlib.ticker as ticker
+
     xlabel = axis_labels[0]
     ylabel = axis_labels[1]
     if plot_length_units is not None:


### PR DESCRIPTION
MC was running into issues with these again. I added a lint rule to prevent this from happening in the future.

<!-- greptile_comment -->

## Greptile Summary

This PR makes an important change to how heavy dependencies (matplotlib and scipy) are imported in the Tidy3D codebase. The changes address specific issues encountered with Monte Carlo (MC) simulations by:

1. Moving matplotlib imports from module-level to function-level in multiple files (`axes_utils.py`, `mode_solver.py`)
2. Adding explicit bans on module-level imports of scipy and matplotlib using ruff's flake8-tidy-imports configuration
3. Adding appropriate exceptions for tests and plugins where these restrictions don't need to apply

This change improves the codebase by:
- Reducing initial module load times
- Preventing import-time side effects from matplotlib
- Only loading heavy dependencies when actually needed
- Making the codebase more efficient for scenarios where visualization isn't required

## Confidence score: 5/5

1. This PR is extremely safe to merge and represents a clear improvement in code organization
2. The changes are mechanical in nature, moving imports without changing functionality, and include appropriate exceptions where needed
3. Key files to review: `pyproject.toml` to ensure exceptions are comprehensive

<sub>3 files reviewed, 1 comment</sub>
<sub>[Edit PR Review Bot Settings](https://app.greptile.com/review/github) | [Greptile](https://greptile.com?utm_source=greptile_expert&utm_medium=github&utm_campaign=code_reviews&utm_content=tidy3d_2658)</sub>

<!-- /greptile_comment -->