### PR TITLE
fix(style): remove global styles that interfere with structure plots (FXC-1802)

### DIFF
--- a/tests/test_components/test_viz.py
+++ b/tests/test_components/test_viz.py
@@ -336,6 +336,9 @@ def test_sim_plot_structures_fill():
 
 def test_tidy3d_matplotlib_style_application_on_import():
     """Test restore_matplotlib_rcparams() to reset the automatically applied matplotlib.rcParams"""
-    assert mpl.rcParams.get("axes.edgecolor") == "#ECEBEA"
+    assert mpl.rcParams.get("axes.prop_cycle").by_key()["color"][0] == "#176737"
     restore_matplotlib_rcparams()
-    assert mpl.rcParams.get("axes.edgecolor") == mpl.rcParamsDefault.get("axes.edgecolor")
+    assert (
+        mpl.rcParams.get("axes.prop_cycle").by_key()["color"][0]
+        == mpl.rcParamsDefault.get("axes.prop_cycle").by_key()["color"][0]
+    )

--- a/tidy3d/style.mplstyle
+++ b/tidy3d/style.mplstyle
@@ -1,4 +1,1 @@
 axes.prop_cycle : cycler(color=["#176737", "#FF7B0D", "#979BAA", "#F44E6A", "#0062FF", "#26AB5B", "#6D3EF2", "#F59E0B"])
-axes.grid       : True
-grid.linestyle  : :
-axes.edgecolor  : "#ECEBEA"


### PR DESCRIPTION
This PR reverts some of the automatic global styles that were added in https://github.com/flexcompute/tidy3d/pull/2428 due to visualisation issues in structure plots.

<!-- greptile_comment -->

## Greptile Summary

This PR makes a focused change to the global matplotlib style settings in `tidy3d/style.mplstyle` to fix visualization issues with structure plots. The changes remove automatic grid lines and custom edge colors that were causing interference with structure plot rendering, while maintaining the color cycle definition.

Specifically, the PR:
- Removes the automatic grid lines setting (`axes.grid: True` and `grid.linestyle: :`)
- Removes the custom edge color setting (`axes.edgecolor: "#ECEBEA"`)
- Preserves the color cycle definition for consistent plot coloring

This change reverts part of PR #2428 where these global styles were initially added, as they were found to cause unintended effects on structure plot visualizations.

## Confidence score: 5/5

1. This PR is very safe to merge as it only removes interfering style settings without affecting core functionality.
2. The changes are minimal, well-documented, and directly address a specific visualization issue.
3. Focus areas: `tidy3d/style.mplstyle` - verify that removing these style settings doesn't negatively impact other visualization use cases.

<sub>1 file reviewed, no comments</sub>
<sub>[Edit PR Review Bot Settings](https://app.greptile.com/review/github) | [Greptile](https://greptile.com?utm_source=greptile_expert&utm_medium=github&utm_campaign=code_reviews&utm_content=tidy3d_2659)</sub>

<!-- /greptile_comment -->