### PR TITLE
addresses performance issue when computing gradient over many frequencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ with fewer layers than recommended.
 - Warnings are now generated (instead of errors) when instantiating `PML`, `StablePML`, or `Absorber` classes (or when invoking `pml()`, `stable_pml()`, or `absorber()` functions) with fewer layers than recommended.
 - `Simulation.subsection` can no longer take `symmetry` as an argument - the symmetry is always taken from the original simulation.
 - If a mode simulation is crossing a symmetry plane of the larger simulation domain, but the mode plane is not symmetric, a warning is issued that it will be expanded symmetrically. Previously this warning only happened during the solver run.
+- Changed iteration and summation of adjoint gradients for different frequencies to improve postprocessing speed.
 
 ### Fixed
 - Arrow lengths are now scaled consistently in the X and Y directions, and their lengths no longer exceed the height of the plot window.

--- a/tests/test_components/test_autograd.py
+++ b/tests/test_components/test_autograd.py
@@ -1578,7 +1578,7 @@ def test_pole_residue(monkeypatch):
     monkeypatch.setattr(
         td.PoleResidue,
         "_derivative_eps_complex_volume",
-        lambda self, E_der_map, bounds, freqs: dJ_deps,
+        lambda self, E_der_map, bounds: dJ_deps,
     )
 
     import importlib
@@ -1605,8 +1605,12 @@ def test_pole_residue(monkeypatch):
         eps_out=1.0,
         frequency=freq,
         bounds=((-1, -1, -1), (1, 1, 1)),
-        eps_no_structure=td.SpatialDataArray([[[1.0]]], coords={"x": [0], "y": [0], "z": [0]}),
-        eps_inf_structure=td.SpatialDataArray([[[2.0]]], coords={"x": [0], "y": [0], "z": [0]}),
+        eps_no_structure=td.ScalarFieldDataArray(
+            [[[[1.0]]]], coords={"x": [0], "y": [0], "z": [0], "f": [1.94e14]}
+        ),
+        eps_inf_structure=td.ScalarFieldDataArray(
+            [[[[2.0]]]], coords={"x": [0], "y": [0], "z": [0], "f": [1.94e14]}
+        ),
         bounds_intersect=((-1, -1, -1), (1, 1, 1)),
     )
 
@@ -1661,7 +1665,7 @@ def test_custom_pole_residue(monkeypatch):
     monkeypatch.setattr(
         td.CustomPoleResidue,
         "_derivative_field_cmp",
-        lambda self, E_der_map, eps_data, dim, freqs: dJ_deps / 3.0,
+        lambda self, E_der_map, eps_data, dim: dJ_deps / 3.0,
     )
 
     import importlib
@@ -1687,8 +1691,12 @@ def test_custom_pole_residue(monkeypatch):
         eps_out=1.0,
         frequency=freq,
         bounds=((-1, -1, -1), (1, 1, 1)),
-        eps_no_structure=td.SpatialDataArray([[[1.0]]], coords={"x": [0], "y": [0], "z": [0]}),
-        eps_inf_structure=td.SpatialDataArray([[[2.0]]], coords={"x": [0], "y": [0], "z": [0]}),
+        eps_no_structure=td.ScalarFieldDataArray(
+            [[[[1.0]]]], coords={"x": [0], "y": [0], "z": [0], "f": [1.94e14]}
+        ),
+        eps_inf_structure=td.ScalarFieldDataArray(
+            [[[[2.0]]]], coords={"x": [0], "y": [0], "z": [0], "f": [1.94e14]}
+        ),
         bounds_intersect=((-1, -1, -1), (1, 1, 1)),
     )
 

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -1,12 +1,14 @@
 # utilities for autograd derivative passing
 from __future__ import annotations
 
+import typing
+
 import numpy as np
 import pydantic.v1 as pd
 import xarray as xr
 
 from tidy3d.components.base import Tidy3dBaseModel
-from tidy3d.components.data.data_array import ScalarFieldDataArray, SpatialDataArray
+from tidy3d.components.data.data_array import FreqDataArray, ScalarFieldDataArray, SpatialDataArray
 from tidy3d.components.types import ArrayLike, Bound, tidycomplex
 from tidy3d.constants import LARGE_NUMBER
 
@@ -136,14 +138,14 @@ class DerivativeInfo(Tidy3dBaseModel):
         "Used for automatically computing permittivity inside or outside of a simple geometry.",
     )
 
-    eps_in: tidycomplex = pd.Field(
+    eps_in: typing.Union[tidycomplex, FreqDataArray] = pd.Field(
         title="Permittivity Inside",
         description="Permittivity inside of the ``Structure``. "
         "Typically computed from ``Structure.medium.eps_model``."
         "Used when it can not be computed from ``eps_data`` or when ``eps_approx==True``.",
     )
 
-    eps_out: tidycomplex = pd.Field(
+    eps_out: typing.Union[tidycomplex, FreqDataArray] = pd.Field(
         ...,
         title="Permittivity Outside",
         description="Permittivity outside of the ``Structure``. "
@@ -151,7 +153,7 @@ class DerivativeInfo(Tidy3dBaseModel):
         "Used when it can not be computed from ``eps_data`` or when ``eps_approx==True``.",
     )
 
-    eps_background: tidycomplex = pd.Field(
+    eps_background: typing.Union[tidycomplex, FreqDataArray] = pd.Field(
         None,
         title="Permittivity in Background",
         description="Permittivity outside of the ``Structure`` as manually specified by. "
@@ -171,13 +173,13 @@ class DerivativeInfo(Tidy3dBaseModel):
         "structure and the simulation it is contained in.",
     )
 
-    frequency: float = pd.Field(
+    frequencies: ArrayLike = pd.Field(
         ...,
-        title="Frequency of adjoint simulation",
-        description="Frequency at which the adjoint gradient is computed.",
+        title="Adjoint Gradient Frequencies",
+        description="Frequencies at which the adjoint gradient should be computed.",
     )
 
-    eps_no_structure: SpatialDataArray = pd.Field(
+    eps_no_structure: ScalarFieldDataArray = pd.Field(
         None,
         title="Permittivity Without Structure",
         description="The permittivity of the original simulation without the structure that is "
@@ -185,7 +187,7 @@ class DerivativeInfo(Tidy3dBaseModel):
         "structure for shape optimization.",
     )
 
-    eps_inf_structure: SpatialDataArray = pd.Field(
+    eps_inf_structure: ScalarFieldDataArray = pd.Field(
         None,
         title="Permittivity With Infinite Structure",
         description="The permittivity of the original simulation where the structure being "
@@ -251,16 +253,20 @@ class DerivativeInfo(Tidy3dBaseModel):
 
         # compute the E and D fields at the edge centers
         E_fwd_at_coords = self.evaluate_flds_at(
-            fld_dataset=E_fwd, spatial_coords=spatial_coords, freq=self.frequency
+            fld_dataset=E_fwd,
+            spatial_coords=spatial_coords,
         )
         E_adj_at_coords = self.evaluate_flds_at(
-            fld_dataset=E_adj, spatial_coords=spatial_coords, freq=self.frequency
+            fld_dataset=E_adj,
+            spatial_coords=spatial_coords,
         )
         D_fwd_at_coords = self.evaluate_flds_at(
-            fld_dataset=D_fwd, spatial_coords=spatial_coords, freq=self.frequency
+            fld_dataset=D_fwd,
+            spatial_coords=spatial_coords,
         )
         D_adj_at_coords = self.evaluate_flds_at(
-            fld_dataset=D_adj, spatial_coords=spatial_coords, freq=self.frequency
+            fld_dataset=D_adj,
+            spatial_coords=spatial_coords,
         )
 
         # project the relevant field quantities into their respective basis for gradient calculation
@@ -294,7 +300,7 @@ class DerivativeInfo(Tidy3dBaseModel):
             contrib_E = E_der * delta_eps
             vjps += contrib_E
 
-        return surface_mesh.areas * vjps
+        return (surface_mesh.areas * vjps).sum("f")
 
     def evaluate_eps(
         self,
@@ -312,7 +318,6 @@ class DerivativeInfo(Tidy3dBaseModel):
         eps_out = self.evaluate_flds_at(
             fld_dataset={key: permittivity_array},
             spatial_coords=spatial_coords,
-            freq=self.frequency,
         )[key]
         return eps_out.values
 
@@ -320,7 +325,6 @@ class DerivativeInfo(Tidy3dBaseModel):
     def evaluate_flds_at(
         fld_dataset: dict[str, ScalarFieldDataArray],
         spatial_coords: np.ndarray,  # (N, 3)
-        freq: float,
     ) -> dict[str, ScalarFieldDataArray]:
         """Compute the value of an dict with keys Ex, Ey, Ez at a set of spatial locations."""
 
@@ -333,19 +337,27 @@ class DerivativeInfo(Tidy3dBaseModel):
         n_points = coords.shape[0]
 
         for fld_name, arr in fld_dataset.items():
-            data = arr.sel(f=freq).values if "f" in arr.dims else arr.values
-            points = tuple(arr.coords[dim].values for dim in "xyz")
+            components_by_freq = []
+            for freq in arr.coords["f"]:
+                data = arr.sel(f=freq).values
+                points = tuple(arr.coords[dim].values for dim in "xyz")
 
-            interpolator = RegularGridInterpolator(
-                points, data, method="linear", bounds_error=False, fill_value=None
-            )
-            result = interpolator(coords)
+                interpolator = RegularGridInterpolator(
+                    points, data, method="linear", bounds_error=False, fill_value=None
+                )
+                result = interpolator(coords)
 
-            components[fld_name] = xr.DataArray(
-                result,
-                coords={edge_index_dim: np.arange(n_points)},
-                dims=[edge_index_dim],
-                name=fld_name,
+                components_by_freq.append(
+                    xr.DataArray(
+                        result,
+                        coords={edge_index_dim: np.arange(n_points)},
+                        dims=[edge_index_dim],
+                        name=fld_name,
+                    )
+                )
+
+            components[fld_name] = xr.concat(components_by_freq, dim="f").assign_coords(
+                f=arr.coords["f"]
             )
 
         return components

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     pass
 
+
 from tidy3d.compat import _shapely_is_older_than
 from tidy3d.components.autograd import AutogradFieldMap, TracedCoordinate, TracedSize, get_static
 from tidy3d.components.autograd.derivative_utils import DerivativeInfo, integrate_within_bounds
@@ -2441,10 +2442,8 @@ class Box(SimplePlaneIntersection, Centered):
         fld_normal, flds_perp = self.pop_axis(("Ex", "Ey", "Ez"), axis=axis_normal)
 
         # normal and tangential fields
-        D_normal = derivative_info.D_der_map[fld_normal].sel(f=derivative_info.frequency)
-        Es_perp = tuple(
-            derivative_info.E_der_map[key].sel(f=derivative_info.frequency) for key in flds_perp
-        )
+        D_normal = derivative_info.D_der_map[fld_normal]
+        Es_perp = tuple(derivative_info.E_der_map[key] for key in flds_perp)
 
         # normal and tangential bounds
         bounds_T = np.array(derivative_info.bounds).T  # put (xyz) first dimension
@@ -2469,10 +2468,7 @@ class Box(SimplePlaneIntersection, Centered):
             return 0.0
 
         # grab permittivity data inside and outside edge in normal direction
-        eps_xyz = [
-            derivative_info.eps_data[f"eps_{dim}{dim}"].sel(f=derivative_info.frequency)
-            for dim in "xyz"
-        ]
+        eps_xyz = [derivative_info.eps_data[f"eps_{dim}{dim}"] for dim in "xyz"]
 
         # number of cells from the edge of data to register "inside" (index = num_cells_in - 1)
         num_cells_in = 4
@@ -2513,7 +2509,7 @@ class Box(SimplePlaneIntersection, Centered):
                 bounds=bounds_perp,
             )
 
-            return complex(integral_result)
+            return complex(integral_result.sum("f"))
 
         # put together VJP using D_normal and E_perp integration
         vjp_value = 0.0

--- a/tidy3d/components/geometry/primitives.py
+++ b/tidy3d/components/geometry/primitives.py
@@ -285,7 +285,7 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
 
         # compute number of points in the circumference of the polyslab using resolution info
         wvl0 = C_0 / derivative_info.frequency
-        wvl_mat = wvl0 / max(1.0, np.sqrt(abs(derivative_info.eps_in)))
+        wvl_mat = wvl0 / np.max([1.0, np.max(np.sqrt(abs(derivative_info.eps_in)))])
 
         circumference = 2 * np.pi * self.radius
         wvls_in_circumference = circumference / wvl_mat

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -13,7 +13,6 @@ import autograd.numpy as np
 import numpy as npo
 import pydantic.v1 as pd
 import xarray as xr
-from numpy.typing import NDArray
 
 from tidy3d.components.material.tcad.heat import ThermalSpecType
 from tidy3d.constants import (
@@ -1384,17 +1383,15 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
         raise NotImplementedError(f"Can't compute derivative for 'Medium': '{type(self)}'.")
 
     def _derivative_eps_sigma_volume(
-        self, E_der_map: ElectromagneticFieldDataset, bounds: Bound, freqs: NDArray
+        self, E_der_map: ElectromagneticFieldDataset, bounds: Bound
     ) -> dict[str, xr.DataArray]:
         """Get the derivative w.r.t permittivity and conductivity in the volume."""
 
-        vjp_eps_complex = self._derivative_eps_complex_volume(
-            E_der_map=E_der_map, bounds=bounds, freqs=freqs
-        )
+        vjp_eps_complex = self._derivative_eps_complex_volume(E_der_map=E_der_map, bounds=bounds)
 
         values = vjp_eps_complex.values
 
-        eps_vjp, sigma_vjp = self.eps_complex_to_eps_sigma(eps_complex=values, freq=freqs)
+        eps_vjp, sigma_vjp = self.eps_complex_to_eps_sigma(eps_complex=values)
 
         eps_vjp = np.sum(eps_vjp)
         sigma_vjp = np.sum(sigma_vjp)
@@ -1402,13 +1399,15 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
         return {"permittivity": eps_vjp, "conductivity": sigma_vjp}
 
     def _derivative_eps_complex_volume(
-        self, E_der_map: ElectromagneticFieldDataset, bounds: Bound, freqs: NDArray
+        self,
+        E_der_map: ElectromagneticFieldDataset,
+        bounds: Bound,  # , freqs: NDArray
     ) -> xr.DataArray:
         """Get the derivative w.r.t complex-valued permittivity in the volume."""
 
         vjp_value = 0.0
         for field_name in ("Ex", "Ey", "Ez"):
-            fld = E_der_map[field_name].sel(f=freqs)
+            fld = E_der_map[field_name]
             vjp_value_fld = integrate_within_bounds(
                 arr=fld,
                 dims=("x", "y", "z"),
@@ -1668,7 +1667,6 @@ class AbstractCustomMedium(AbstractMedium, ABC):
         E_der_map: ElectromagneticFieldDataset,
         eps_data: PermittivityDataset,
         dim: str,
-        freqs: NDArray,
     ) -> np.ndarray:
         coords_interp = {key: val for key, val in eps_data.coords.items() if len(val) > 1}
         dims_sum = {dim for dim in eps_data.coords.keys() if dim not in coords_interp}
@@ -1701,7 +1699,7 @@ class AbstractCustomMedium(AbstractMedium, ABC):
             d_vol = np.array(1.0)
 
         # TODO: probably this could be more robust. eg if the DataArray has weird edge cases
-        E_der_dim = E_der_map[f"E{dim}"].sel(f=freqs)
+        E_der_dim = E_der_map[f"E{dim}"]
         E_der_dim_interp = (
             E_der_dim.interp(**coords_interp, assume_sorted=True).fillna(0.0).sum(dims_sum).sum("f")
         )
@@ -1969,9 +1967,7 @@ class Medium(AbstractMedium):
 
         # get vjps w.r.t. permittivity and conductivity of the bulk
         vjps_volume = self._derivative_eps_sigma_volume(
-            E_der_map=derivative_info.E_der_map,
-            bounds=derivative_info.bounds,
-            freqs=np.atleast_1d(derivative_info.frequency),
+            E_der_map=derivative_info.E_der_map, bounds=derivative_info.bounds
         )
 
         # store the fields asked for by ``field_paths``
@@ -1984,18 +1980,16 @@ class Medium(AbstractMedium):
         return derivative_map
 
     def _derivative_eps_sigma_volume(
-        self, E_der_map: ElectromagneticFieldDataset, bounds: Bound, freqs: NDArray
+        self, E_der_map: ElectromagneticFieldDataset, bounds: Bound
     ) -> dict[str, xr.DataArray]:
         """Get the derivative w.r.t permittivity and conductivity in the volume."""
 
-        vjp_eps_complex = self._derivative_eps_complex_volume(
-            E_der_map=E_der_map, bounds=bounds, freqs=freqs
-        )
+        vjp_eps_complex = self._derivative_eps_complex_volume(E_der_map=E_der_map, bounds=bounds)
 
         values = vjp_eps_complex.values
 
         # vjp of eps_complex_to_eps_sigma
-        omegas = 2 * np.pi * freqs
+        omegas = 2 * np.pi * vjp_eps_complex.coords["f"].values
         eps_vjp = np.real(values)
         sigma_vjp = -np.imag(values) / omegas / EPSILON_0
 
@@ -2005,13 +1999,13 @@ class Medium(AbstractMedium):
         return {"permittivity": eps_vjp, "conductivity": sigma_vjp}
 
     def _derivative_eps_complex_volume(
-        self, E_der_map: ElectromagneticFieldDataset, bounds: Bound, freqs: NDArray
+        self, E_der_map: ElectromagneticFieldDataset, bounds: Bound
     ) -> xr.DataArray:
         """Get the derivative w.r.t complex-valued permittivity in the volume."""
 
         vjp_value = 0.0
         for field_name in ("Ex", "Ey", "Ez"):
-            fld = E_der_map[field_name].sel(f=freqs)
+            fld = E_der_map[field_name]
             vjp_value_fld = integrate_within_bounds(
                 arr=fld,
                 dims=("x", "y", "z"),
@@ -2019,7 +2013,7 @@ class Medium(AbstractMedium):
             )
             vjp_value += vjp_value_fld
 
-        return vjp_value.sum("f")
+        return vjp_value
 
 
 class CustomIsotropicMedium(AbstractCustomMedium, Medium):
@@ -2891,7 +2885,6 @@ class CustomMedium(AbstractCustomMedium):
                         E_der_map=derivative_info.E_der_map,
                         eps_data=self.permittivity,
                         dim=dim,
-                        freqs=np.atleast_1d(derivative_info.frequency),
                     )
                 vjps[field_path] = vjp_array
 
@@ -2902,7 +2895,6 @@ class CustomMedium(AbstractCustomMedium):
                     E_der_map=derivative_info.E_der_map,
                     eps_data=self.eps_dataset.field_components[key],
                     dim=dim,
-                    freqs=np.atleast_1d(derivative_info.frequency),
                 )
 
             else:
@@ -2917,7 +2909,6 @@ class CustomMedium(AbstractCustomMedium):
         E_der_map: ElectromagneticFieldDataset,
         eps_data: PermittivityDataset,
         dim: str,
-        freqs: NDArray,
     ) -> np.ndarray:
         """Compute derivative with respect to the ``dim`` components within the custom medium."""
         coords_interp = {key: eps_data.coords[key] for key in "xyz"}
@@ -2925,7 +2916,7 @@ class CustomMedium(AbstractCustomMedium):
 
         eps_coordinate_shape = [len(eps_data.coords[dim]) for dim in eps_data.dims if dim in "xyz"]
 
-        E_der_dim_interp = E_der_map[f"E{dim}"].sel(f=freqs)
+        E_der_dim_interp = E_der_map[f"E{dim}"]
 
         for dim_ in "xyz":
             if dim_ not in coords_interp:
@@ -3509,7 +3500,6 @@ class PoleResidue(DispersiveMedium):
         dJ_deps_complex = self._derivative_eps_complex_volume(
             E_der_map=derivative_info.E_der_map,
             bounds=derivative_info.bounds,
-            freqs=np.atleast_1d(derivative_info.frequency),
         )
 
         poles_vals = [(complex(a), complex(c)) for a, c in self.poles]
@@ -3962,7 +3952,6 @@ class CustomPoleResidue(CustomDispersiveMedium, PoleResidue):
                 E_der_map=derivative_info.E_der_map,
                 eps_data=self.eps_inf,
                 dim=dim,
-                freqs=np.atleast_1d(derivative_info.frequency),
             )
 
         poles_vals = [

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -9,12 +9,14 @@ from os.path import basename, dirname, join
 from pathlib import Path
 
 import numpy as np
+import xarray as xr
 from autograd.builtins import dict as dict_ag
 from autograd.extend import defvjp, primitive
 
 import tidy3d as td
 from tidy3d.components.autograd import AutogradFieldMap, get_static
 from tidy3d.components.autograd.derivative_utils import DerivativeInfo
+from tidy3d.components.data.data_array import DataArray
 from tidy3d.exceptions import AdjointError
 from tidy3d.web.api.asynchronous import DEFAULT_DATA_DIR
 from tidy3d.web.api.asynchronous import run_async as run_async_webapi
@@ -1009,87 +1011,105 @@ def postprocess_adj(
         # compute the derivatives for this structure
         structure = sim_data_fwd.simulation.structures[structure_index]
 
-        adjoint_frequencies = E_adj.monitor.freqs
-        for freq_idx, freq_adj in enumerate(adjoint_frequencies):
-            eps_in = np.mean(structure.medium.eps_model(freq_adj))
-            eps_out = np.mean(sim_data_orig.simulation.medium.eps_model(freq_adj))
-            if structure.background_medium:
-                eps_background = structure.background_medium.eps_model(freq_adj)
-            else:
-                eps_background = None
+        adjoint_frequencies = np.array(E_adj.monitor.freqs)
 
-            # manually override simulation medium as the background structure
-            if not isinstance(structure.geometry, td.Box):
-                # auto permittivity detection
-                sim_orig = sim_data_orig.simulation
-                plane_eps = eps_fwd.monitor.geometry
+        eps_in_data = []
+        eps_out_data = []
 
-                # get permittivity without this structure
-                structs_no_struct = list(sim_orig.structures)
-                structs_no_struct.pop(structure_index)
-                sim_no_structure = sim_orig.updated_copy(structures=structs_no_struct)
-                eps_no_structure = sim_no_structure.epsilon(
-                    box=plane_eps, coord_key="centers", freq=freq_adj
+        for freq_adj in adjoint_frequencies:
+            eps_in_data.append(np.mean(structure.medium.eps_model(freq_adj)))
+            eps_out_data.append(np.mean(sim_data_orig.simulation.medium.eps_model(freq_adj)))
+
+        eps_in = DataArray(
+            data=np.array(eps_in_data), dims=("f",), coords={"f": adjoint_frequencies}
+        )
+        eps_out = DataArray(
+            data=np.array(eps_out_data), dims=("f",), coords={"f": adjoint_frequencies}
+        )
+
+        eps_background_data = []
+        if structure.background_medium:
+            for freq_adj in adjoint_frequencies:
+                eps_background_data.append(structure.background_medium.eps_model(freq_adj))
+
+            eps_background = DataArray(
+                data=eps_background_data, dims=("f",), coords={"f": adjoint_frequencies}
+            )
+        else:
+            eps_background = None
+
+        # manually override simulation medium as the background structure
+        if not isinstance(structure.geometry, td.Box):
+            # auto permittivity detection
+            sim_orig = sim_data_orig.simulation
+            plane_eps = eps_fwd.monitor.geometry
+
+            # get permittivity without this structure
+            structs_no_struct = list(sim_orig.structures)
+            structs_no_struct.pop(structure_index)
+            sim_no_structure = sim_orig.updated_copy(structures=structs_no_struct)
+
+            eps_no_structure_data = []
+            for freq_adj in adjoint_frequencies:
+                eps_no_structure_data.append(
+                    sim_no_structure.epsilon(box=plane_eps, coord_key="centers", freq=freq_adj)
                 )
 
-                # get permittivity with structures on top of an infinite version of this structure
-                structs_inf_struct = list(sim_orig.structures)[structure_index + 1 :]
-                sim_inf_structure = sim_orig.updated_copy(
-                    structures=structs_inf_struct,
-                    medium=structure.medium,
-                    monitors=[],
-                )
-                eps_inf_structure = sim_inf_structure.epsilon(
-                    box=plane_eps, coord_key="centers", freq=freq_adj
-                )
-
-            else:
-                eps_no_structure = eps_inf_structure = None
-
-            # get minimum intersection of bounds with structure and sim
-            struct_bounds = rmin_struct, rmax_struct = structure.geometry.bounds
-            rmin_sim, rmax_sim = sim_data_orig.simulation.bounds
-            rmin_intersect = tuple([max(a, b) for a, b in zip(rmin_sim, rmin_struct)])
-            rmax_intersect = tuple([min(a, b) for a, b in zip(rmax_sim, rmax_struct)])
-            bounds_intersect = (rmin_intersect, rmax_intersect)
-
-            derivative_info = DerivativeInfo(
-                paths=structure_paths,
-                E_der_map=E_der_map.field_components,
-                D_der_map=D_der_map.field_components,
-                E_fwd=E_fwd.field_components,
-                E_adj=E_adj.field_components,
-                D_fwd=D_fwd.field_components,
-                D_adj=D_adj.field_components,
-                eps_data=eps_fwd.field_components,
-                eps_in=eps_in,
-                eps_out=eps_out,
-                eps_background=eps_background,
-                frequency=freq_adj,
-                eps_no_structure=eps_no_structure,
-                eps_inf_structure=eps_inf_structure,
-                bounds=struct_bounds,
-                bounds_intersect=bounds_intersect,
+            # get permittivity with structures on top of an infinite version of this structure
+            structs_inf_struct = list(sim_orig.structures)[structure_index + 1 :]
+            sim_inf_structure = sim_orig.updated_copy(
+                structures=structs_inf_struct,
+                medium=structure.medium,
+                monitors=[],
             )
 
-            vjp_value_map = structure._compute_derivatives(derivative_info)
+            eps_inf_structure_data = []
+            for freq_adj in adjoint_frequencies:
+                eps_inf_structure_data.append(
+                    sim_inf_structure.epsilon(box=plane_eps, coord_key="centers", freq=freq_adj)
+                )
 
-            # extract VJPs and put back into sim_fields_vjp AutogradFieldMap
-            for structure_path, vjp_value in vjp_value_map.items():
-                sim_path = ("structures", structure_index, *list(structure_path))
-                if freq_idx == 0:
-                    sim_fields_vjp[sim_path] = vjp_value
-                else:
-                    if isinstance(sim_fields_vjp[sim_path], (list, tuple)):
-                        if not isinstance(sim_fields_vjp[sim_path], type(vjp_value)):
-                            raise AdjointError(
-                                f"Unexpected vjp value type for gradient field {sim_path}"
-                            )
-                        sim_fields_vjp[sim_path] = type(sim_fields_vjp[sim_path])(
-                            x + y for x, y in zip(vjp_value, sim_fields_vjp[sim_path])
-                        )
-                    else:
-                        sim_fields_vjp[sim_path] += vjp_value
+            eps_no_structure = xr.concat(eps_no_structure_data, dim="f").assign_coords(
+                f=adjoint_frequencies
+            )
+            eps_inf_structure = xr.concat(eps_inf_structure_data, dim="f").assign_coords(
+                f=adjoint_frequencies
+            )
+        else:
+            eps_no_structure = eps_inf_structure = None
+
+        # get minimum intersection of bounds with structure and sim
+        struct_bounds = rmin_struct, rmax_struct = structure.geometry.bounds
+        rmin_sim, rmax_sim = sim_data_orig.simulation.bounds
+        rmin_intersect = tuple([max(a, b) for a, b in zip(rmin_sim, rmin_struct)])
+        rmax_intersect = tuple([min(a, b) for a, b in zip(rmax_sim, rmax_struct)])
+        bounds_intersect = (rmin_intersect, rmax_intersect)
+
+        derivative_info = DerivativeInfo(
+            paths=structure_paths,
+            E_der_map=E_der_map.field_components,
+            D_der_map=D_der_map.field_components,
+            E_fwd=E_fwd.field_components,
+            E_adj=E_adj.field_components,
+            D_fwd=D_fwd.field_components,
+            D_adj=D_adj.field_components,
+            eps_data=eps_fwd.field_components,
+            eps_in=eps_in,
+            eps_out=eps_out,
+            eps_background=eps_background,
+            frequencies=adjoint_frequencies,
+            eps_no_structure=eps_no_structure,
+            eps_inf_structure=eps_inf_structure,
+            bounds=struct_bounds,
+            bounds_intersect=bounds_intersect,
+        )
+
+        vjp_value_map = structure._compute_derivatives(derivative_info)
+
+        # extract VJPs and put back into sim_fields_vjp AutogradFieldMap
+        for structure_path, vjp_value in vjp_value_map.items():
+            sim_path = ("structures", structure_index, *list(structure_path))
+            sim_fields_vjp[sim_path] = vjp_value
 
     return sim_fields_vjp
 


### PR DESCRIPTION
timed the Autograd19ApodizedCoupler.py example: before was ~75sec to post process on my Mac, now is ~3sec


@yaugenst-flex - I think this will have some conflicts with your polyslab integration PR, so I'm happy to get that one merged first and then I can resolve conflicts on this change.

<!-- greptile_comment -->

## Greptile Summary

This PR implements significant performance optimizations for gradient computations over multiple frequencies in Tidy3D's autograd system. The key changes include:

1. Vectorizing permittivity calculations across frequencies instead of processing each frequency individually
2. Removing unnecessary frequency selection operations in derivative computations
3. Using numpy's vectorized operations (np.max) for efficient material wavelength calculations
4. Restructuring data handling to work with frequency-dependent arrays more efficiently

The changes result in a dramatic performance improvement, reducing processing time from ~75 seconds to ~3 seconds in the Autograd19ApodizedCoupler.py example (~25x speedup).

## Confidence score: 4 /5

1. This PR is safe to merge as it maintains mathematical correctness while significantly improving performance
2. High confidence due to clear performance metrics, well-structured changes, and updated tests, though polyslab integration conflicts need resolution
3. Key files needing attention:
   - tidy3d/components/autograd/derivative_utils.py
   - tidy3d/web/api/autograd/autograd.py
   - tidy3d/components/geometry/base.py

<sub>7 files reviewed, 1 comment</sub>
<sub>[Edit PR Review Bot Settings](https://app.greptile.com/review/github) | [Greptile](https://greptile.com?utm_source=greptile_expert&utm_medium=github&utm_campaign=code_reviews&utm_content=tidy3d_2662)</sub>

<!-- /greptile_comment -->