### PR TITLE
ci: Add merge_group trigger

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -1,6 +1,7 @@
 name: "public/tidy3d/python-client-tests"
 
 on:
+  merge_group:
   workflow_dispatch:
     inputs:
       remote_tests:
@@ -12,7 +13,7 @@ on:
         type: boolean
         default: false
   push:
-    branches: [ develop, latest , 'pre/*']
+    branches: [ develop, latest ]
   pull_request:
     branches:
       - latest
@@ -103,6 +104,11 @@ jobs:
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
               local_tests=true
               [[ "$APPROVED" == "true" ]] && remote_tests=true
+          fi
+
+          if [[ "$EVENT_NAME" == "merge_group" ]]; then
+              local_tests=true
+              remote_tests=true
           fi
 
           # If it's a push to develop


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR enhances the CI pipeline by integrating GitHub's merge queue feature into the testing workflow. The changes are focused on the `.github/workflows/tidy3d-python-client-tests.yml` file and include:

1. Adding a `merge_group` trigger to run tests when PRs are in the merge queue
2. Removing 'pre/*' from push event branches, simplifying to just 'develop' and 'latest'
3. Configuring both local and remote tests to run during merge queue events

These changes improve the robustness of the CI pipeline by ensuring thorough testing when multiple PRs are queued for merging, helping prevent integration issues before they reach the main branches.

## Confidence score: 5/5

1. This PR is very safe to merge as it only enhances CI functionality without touching production code
2. The changes are straightforward, well-structured, and follow GitHub Actions best practices
3. Files needing attention: `.github/workflows/tidy3d-python-client-tests.yml` (verify branch triggers are correct)

<sub>1 file reviewed, no comments</sub>
<sub>[Edit PR Review Bot Settings](https://app.greptile.com/review/github) | [Greptile](https://greptile.com?utm_source=greptile_expert&utm_medium=github&utm_campaign=code_reviews&utm_content=tidy3d_2665)</sub>

<!-- /greptile_comment -->