### PR TITLE
Add check for conduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ModeSimulation.plot()` method that plots the mode simulation plane by default, or the containing FDTD simulation if any of ``x``, ``y``, or ``z`` is passed. 
 - Enable singularity correction at PEC and lossy metal edges.
 - New `VolumeMesher` simulation type and associated `VolumeMeshMonitor` and `VolumeMesherData`, which can be used to run the unstructured meshing for a `HeatChargeSimulation` separately before running the solver.
+- The current validator for Conduction simulations has been modified so that it checks that in a Conduction simulation there is at least one structure defined with `ChargeConductorMedium` in the `charge` field of a `MultiPhysicsMedium`. This is necessary to ensure simulations are properly set up in the back-end since it relies on the `conductivity` field of `ChargeConductorMedium` and not that of `Medium`.
 
 ### Changed
 - Switched to an analytical gradient calculation for spatially-varying pole-residue models (`CustomPoleResidue`).

--- a/tests/test_components/test_heat_charge.py
+++ b/tests/test_components/test_heat_charge.py
@@ -1364,7 +1364,7 @@ def test_heat_charge_sim_bounds(shift_amount, log_level):
             structures=[
                 td.Structure(
                     geometry=td.Box(size=(1, 1, 1), center=shifted_center),
-                    medium=td.Medium(),
+                    medium=td.MultiPhysicsMedium(charge=td.ChargeConductorMedium(conductivity=1)),
                 )
             ],
             boundary_spec=[
@@ -1409,7 +1409,10 @@ def test_heat_charge_sim_bounds(shift_amount, log_level):
 )
 def test_sim_structure_extent(box_size, log_level):
     """Ensure we warn if structure extends exactly to simulation edges."""
-    box = td.Structure(geometry=td.Box(size=box_size), medium=td.Medium(permittivity=2))
+    box = td.Structure(
+        geometry=td.Box(size=box_size),
+        medium=td.MultiPhysicsMedium(charge=td.ChargeConductorMedium(conductivity=1)),
+    )
 
     with AssertLogLevel(log_level):
         _ = td.HeatChargeSimulation(
@@ -2040,3 +2043,15 @@ def test_heat_conduction_simulations():
     with pytest.raises(pd.ValidationError):
         # This should error since the conduction simulation doesn't have a monitor
         _ = sim.updated_copy(monitors=[temp_monitor])
+
+    # test error if structures defined with Medium instead of MultiPhysicsMedium
+    with pytest.raises(pd.ValidationError):
+        struct_error = struct1.updated_copy(medium=td.Medium(conductivity=1))
+        _ = sim.updated_copy(structures=[struct_error])
+
+    # test error if structures aren't conducting
+    with pytest.raises(pd.ValidationError):
+        struct_error = struct1.updated_copy(
+            medium=struct1.medium.updated_copy(charge=td.ChargeInsulatorMedium)
+        )
+        _ = sim.updated_copy(structures=[struct_error])

--- a/tidy3d/components/tcad/simulation/heat_charge.py
+++ b/tidy3d/components/tcad/simulation/heat_charge.py
@@ -835,6 +835,19 @@ class HeatChargeSimulation(AbstractSimulation):
                                 "has been defined. This is not supported in Conduction simulations."
                             )
 
+            # make sure that at least one structure has appropriate charge medium
+            ValidConductionMediums = ChargeConductorMedium
+            structures = values.get("structures")
+            if all(isinstance(s.medium, Medium) for s in structures):
+                raise SetupError(
+                    "Conduction simulations must be defined using 'MultiPhysicsMedium' but none have been defined."
+                )
+            if not any(isinstance(s.medium.charge, ValidConductionMediums) for s in structures):
+                raise SetupError(
+                    "Conduction simulations require at least one structure with a 'ChargeConductorMedium' "
+                    "but none have been defined."
+                )
+
         return values
 
     @pd.root_validator(skip_on_failure=True)


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR adds critical validation checks to the HeatChargeSimulation class to ensure that conduction simulations are properly configured with appropriate mediums. The changes enforce two key requirements:

1. All structures in conduction simulations must use `MultiPhysicsMedium` instead of basic `Medium`
2. At least one structure must have a `ChargeConductorMedium` for conduction simulations

These validations are implemented through new error checks in the simulation class and are thoroughly tested with corresponding test cases. The changes help catch configuration errors early in the development process, preventing runtime failures and providing clear error messages to users about missing or incorrect medium types.

## Confidence score: 5/5

1. This PR is extremely safe to merge as it adds defensive validation without modifying core behavior
2. The changes are well-tested with explicit test cases covering both validation scenarios
3. Key files to review:
   - tidy3d/components/tcad/simulation/heat_charge.py
   - tests/test_components/test_heat_charge.py

<sub>2 files reviewed, no comments</sub>
<sub>[Edit PR Review Bot Settings](https://app.greptile.com/review/github) | [Greptile](https://greptile.com?utm_source=greptile_expert&utm_medium=github&utm_campaign=code_reviews&utm_content=tidy3d_2666)</sub>

<!-- /greptile_comment -->