### PR TITLE
tighter tolerance used for mode solvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - By default, batch downloads will skip files that already exist locally. To force re-downloading and replace existing files, pass the `replace_existing=True` argument to `Batch.load()`, `Batch.download()`, or `BatchData.load()`.
 - The `BatchData.load_sim_data()` function now overwrites any previously downloaded simulation files (instead of skipping them).
+- Tighter `TOL_EIGS` used for mode solver, since `scipy` sometimes failed to find modes.
 
 ### Fixed
 - Giving opposite boundaries different names no longer causes a symmetry validator failure.

--- a/tidy3d/components/mode/solver.py
+++ b/tidy3d/components/mode/solver.py
@@ -17,7 +17,7 @@ from .transforms import angled_transform, radial_transform
 # Consider vec to be complex if norm(vec.imag)/norm(vec) > TOL_COMPLEX
 TOL_COMPLEX = 1e-10
 # Tolerance for eigs
-TOL_EIGS = fp_eps
+TOL_EIGS = fp_eps / 10
 # Tolerance for deciding on the matrix to be diagonal or tensorial
 TOL_TENSORIAL = 1e-6
 # shift target neff by this value, both rel and abs, whichever results in larger shift


### PR DESCRIPTION
This fixes a [backend test](https://github.com/flexcompute/compute/pull/1847), where scipy failed to find the correct modes. Usng a tighter tolerance fixed the problem.

<!-- greptile_comment -->

## Greptile Summary

This PR addresses a robustness issue in the mode solver by tightening the tolerance value (`TOL_EIGS`) used in scipy's eigenvalue solver. The changes involve:

1. Reducing `TOL_EIGS` from `fp_eps` to `fp_eps/10` in the mode solver
2. Applying this tighter tolerance to the `scipy.sparse.linalg.eigs` function call

This change was motivated by failing backend tests where scipy was unable to find the correct modes. By making the tolerance stricter, the solver is forced to compute eigenvalues and eigenvectors with higher precision, preventing convergence to incorrect solutions.

## Confidence score: 5/5

1. This PR is very safe to merge as it only tightens numerical precision requirements
2. The change is conservative and can only improve numerical accuracy without introducing new failure modes
3. Key files to review:
   - tidy3d/components/mode/solver.py
   - CHANGELOG.md

<sub>2 files reviewed, no comments</sub>
<sub>[Edit PR Review Bot Settings](https://app.greptile.com/review/github) | [Greptile](https://greptile.com?utm_source=greptile_expert&utm_medium=github&utm_campaign=code_reviews&utm_content=tidy3d_2671)</sub>

<!-- /greptile_comment -->