### PR TITLE
Fix small error in doping computation

### DIFF
--- a/tidy3d/components/tcad/doping.py
+++ b/tidy3d/components/tcad/doping.py
@@ -46,6 +46,10 @@ class AbstractDopingBox(Box):
                 normal_axis = dim
                 # normal_position = coords[var_name][0]
 
+        if all(len(coords[var_name]) == 1 for var_name in "xyz"):
+            # if all coordinates have 1 point, we don't assume  2D unless the box itself is.
+            normal_axis = None
+
         # if provided coordinates are 3D, check if box is 2D
         if normal_axis is None:
             normal_axis = self._normal_dim()


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR addresses a subtle but important bug in the doping computation functionality of Tidy3D. Previously, when processing doping regions, the code would incorrectly assume 2D geometry for any coordinate set that had single points, even when dealing with truly 0D (point) coordinates. The fix modifies the `_get_indices_in_box` method to only treat single-point coordinates as 2D when the doping box geometry itself is actually 2D.

This change is particularly important for accurate simulation of doping profiles in semiconductor devices, especially when dealing with point-like doping regions. The fix ensures that the dimensionality of doping regions is correctly interpreted, leading to more accurate physical simulations.

## Confidence score: 5/5

1. This PR is extremely safe to merge as it fixes a clear logical error without introducing new complexity.
2. The change is minimal, focused, and the logic is sound - it prevents incorrect dimensional assumptions in a very specific case.
3. Files needing attention: None - the change is straightforward and self-contained in tidy3d/components/tcad/doping.py.

<sub>1 file reviewed, no comments</sub>
<sub>[Edit PR Review Bot Settings](https://app.greptile.com/review/github) | [Greptile](https://greptile.com?utm_source=greptile_expert&utm_medium=github&utm_campaign=code_reviews&utm_content=tidy3d_2675)</sub>

<!-- /greptile_comment -->