### PR TITLE
Bumping version to 2.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tidy3d"
-version = "2.9.0rc2"
+version = "2.9.0"
 description = "A fast FDTD solver"
 authors = ["Tyler Hughes <tyler@flexcompute.com>"]
 license = "LGPLv2+"

--- a/tidy3d/version.py
+++ b/tidy3d/version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "2.9.0rc2"
+__version__ = "2.9.0"


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR finalizes version 2.9.0 by removing the release candidate (rc2) suffix from the version number in both `tidy3d/version.py` and `pyproject.toml`. This is a standard version bump that promotes 2.9.0rc2 to the stable release 2.9.0, indicating that the release candidate testing phase has been completed successfully.

PR Description Notes:
- No PR description was provided. While this is a straightforward version bump, it would be helpful to include a brief description of the changes and features included in 2.9.0.

## Confidence score: 5/5

1. This PR is very safe to merge as it only modifies version strings in version-tracking files.
2. The score is 5/5 because the changes are minimal, strictly version-related, and follow the standard release process.
3. Both changed files (`tidy3d/version.py` and `pyproject.toml`) have been updated consistently.

<sub>2 files reviewed, no comments</sub>
<sub>[Edit PR Review Bot Settings](https://app.greptile.com/review/github) | [Greptile](https://greptile.com?utm_source=greptile_expert&utm_medium=github&utm_campaign=code_reviews&utm_content=tidy3d_2676)</sub>

<!-- /greptile_comment -->