### PR TITLE
Giving opposite boundaries different names no longer causes a symmetry validator failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Giving opposite boundaries different names no longer causes a symmetry validator failure.
+
 ## [2.9.0rc2] - 2025-07-17
 
 ### Added

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -595,24 +595,28 @@ def test_validate_symmetry_boundaries():
     # simulation with symmetry along an axis should have the same boundaries defined on both sides
     td.Simulation(
         size=(1, 1, 1),
-        symmetry=(0, 1, 0),
+        symmetry=(1, 1, 1),
         grid_spec=td.GridSpec.uniform(dl=0.1),
         run_time=1e-12,
         boundary_spec=td.BoundarySpec(
             x=td.Boundary.periodic(),
-            y=td.Boundary.periodic(),
+            y=td.Boundary(
+                # Now give the plus and minus boundaries different names to confirm it does not matter.
+                plus=td.PML(name="b1"),
+                minus=td.PML(name="b2"),
+            ),
             z=td.Boundary.pml(),
         ),
     )
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(pydantic.ValidationError, match="Symmetry"):
         td.Simulation(
             size=(1, 1, 1),
-            symmetry=(0, 1, 0),
+            symmetry=(1, 1, 1),
             grid_spec=td.GridSpec.uniform(dl=0.1),
             run_time=1e-12,
             boundary_spec=td.BoundarySpec(
                 x=td.Boundary.periodic(),
-                y=td.Boundary(plus=td.Boundary.pml(), minus=td.Boundary.periodic()),
+                y=td.Boundary(plus=td.PML(num_layers=10), minus=td.PML(num_layers=20)),
                 z=td.Boundary.pml(),
             ),
         )

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -420,9 +420,17 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
     def _validate_boundary_spec_symmetry(cls, val, values):
         """Error if symmetry is imposed along an axis but the boundary conditions are not the same
         on both sides."""
+
+        def equivalent(plus: BoundarySpec, minus: BoundarySpec) -> bool:
+            """Returns whether two boundary conditions are physically identical."""
+            # Make copies of `plus` and `minus` with the `name` attribute set to "".
+            plus_cpy = plus.updated_copy(name="")
+            minus_cpy = minus.updated_copy(name="")
+            return plus_cpy == minus_cpy
+
         boundaries = [val.x, val.y, val.z]
         for ax, symmetry, ax_bounds in zip("xyz", values.get("symmetry"), boundaries):
-            if symmetry != 0 and ax_bounds.plus != ax_bounds.minus:
+            if symmetry != 0 and not equivalent(ax_bounds.plus, ax_bounds.minus):
                 raise ValidationError(
                     f"Symmetry '{symmetry}' along axis {ax} requires the same boundary "
                     f"condition on both sides of the axis."


### PR DESCRIPTION
This small PR solves issue #2635 .

- The validator ignores the `name` attribute of the `plus` and `minus` boundary conditions, when deciding whether `plus` and `minus` are identical.
- Previously the validator would fail if the boundaries were given different names.
- Fixes the original unit test.

## Test instructions
### Automatic Tests
```
pytest -s -n0 tests/test_components/test_simulation.py::test_validate_symmetry_boundaries
```
### Manual tests
To test manually, run the following code snippet and confirm that no errors are generated:
```
import tidy3d as td

_ = td.Simulation(
    size=(1, 1, 1),
    symmetry=(1, 1, 1),
    grid_spec=td.GridSpec.uniform(dl=0.1),
    run_time=1e-12,
    boundary_spec=td.BoundarySpec(
        x=td.Boundary.pml(),
        y=td.Boundary.pml(),
        z=td.Boundary(
            # Give the plus and minus boundaries different names to confirm it does not matter.
            plus=td.PML(name="b1"),
            minus=td.PML(name="b2"),
        ),
    ),
)
```
*(Previously, the `_validate_boundary_spec_symmetry()` validator would fail.)*

<!-- greptile_comment -->

## Greptile Summary

This PR fixes a bug in the boundary condition symmetry validation logic. Previously, when users set different names for physically identical boundary conditions on opposite sides (plus/minus), the validator would incorrectly fail. The fix modifies the validation to ignore the `name` attribute when comparing boundaries, focusing only on their physical properties.

The changes involve:
1. Updating the `equivalent()` function to make copies of boundaries with empty names before comparison
2. Using Pydantic's immutable `copy(update=...)` method to properly handle the comparison
3. Adding appropriate changelog entry under the 'Fixed' section

This change improves usability by allowing users to give meaningful names to their boundary conditions without triggering false validation errors, while still maintaining proper symmetry validation for the physical properties that matter.

## Confidence score: 5/5

1. This PR is very safe to merge as it fixes a clear validator bug without affecting simulation behavior
2. The fix is simple, well-tested, and only affects validation logic, not the actual simulation mechanics
3. Key files to review:
   - tidy3d/components/simulation.py
   - test_simulation.py (test updates)

<sub>2 files reviewed, no comments</sub>
<sub>[Edit PR Review Bot Settings](https://app.greptile.com/review/github) | [Greptile](https://greptile.com?utm_source=greptile_expert&utm_medium=github&utm_campaign=code_reviews&utm_content=tidy3d_2682)</sub>

<!-- /greptile_comment -->