### PR TITLE
Optionally set voxel size for subpixel averaging

### DIFF
--- a/tidy3d/components/subpixel_spec.py
+++ b/tidy3d/components/subpixel_spec.py
@@ -1,7 +1,7 @@
 # Defines specifications for subpixel averaging
 from __future__ import annotations
 
-from typing import Union
+from typing import Literal, Union
 
 import pydantic.v1 as pd
 
@@ -15,8 +15,8 @@ DEFAULT_COURANT_REDUCTION_PEC_CONFORMAL = 0.3
 DEFAULT_COURANT_REDUCTION_SIBC_CONFORMAL = 0.0
 
 
-class AbstractSubpixelAveragingMethod(Tidy3dBaseModel):
-    """Base class defining how to handle material assignment on structure interfaces."""
+class AbstractYeeCellDiscretizationMethod(Tidy3dBaseModel):
+    """Base class defining how to handle material assignment in a Yee Cell."""
 
     @cached_property
     def courant_ratio(self) -> float:
@@ -26,7 +26,25 @@ class AbstractSubpixelAveragingMethod(Tidy3dBaseModel):
         return 1.0
 
 
-class Staircasing(AbstractSubpixelAveragingMethod):
+class AbstractSubpixelAveragingMethod(AbstractYeeCellDiscretizationMethod):
+    """Base class defining how material properties are averaged in a voxel around the grid point."""
+
+    voxel_size_comp: Literal[1, 2] = pd.Field(
+        1,
+        title="Voxel Size Along Component Direction",
+        description="Voxel size along component direction for performing subpixel averaging, "
+        "in unit of local grid step size.",
+    )
+
+    voxel_size_trans: Literal[1, 2] = pd.Field(
+        1,
+        title="Voxel Size Along Transverse Direction",
+        description="Voxel size along transverse direction for performing subpixel averaging, "
+        "in unit of local grid step size.",
+    )
+
+
+class Staircasing(AbstractYeeCellDiscretizationMethod):
     """Apply staircasing scheme to material assignment of Yee grids on structure boundaries.
 
     Note
@@ -86,13 +104,13 @@ class VolumetricAveraging(AbstractSubpixelAveragingMethod):
 MetalSubpixelType = Union[Staircasing, VolumetricAveraging]
 
 
-class HeuristicPECStaircasing(AbstractSubpixelAveragingMethod):
+class HeuristicPECStaircasing(AbstractYeeCellDiscretizationMethod):
     """Apply a variant of staircasing scheme to PEC boundaries: the electric field grid is set to PEC
     if the field is substantially parallel to the interface.
     """
 
 
-class PECConformal(AbstractSubpixelAveragingMethod):
+class PECConformal(AbstractYeeCellDiscretizationMethod):
     """Apply a subpixel averaging method known as conformal mesh scheme to PEC boundaries.
 
     Note


### PR DESCRIPTION
The size of the control volume for VPEP, CPEP, and volumetric averaging can be customized; default value to be determined.

<!-- greptile_comment -->

## Greptile Summary

This PR enhances the subpixel averaging functionality in Tidy3D by introducing customizable control over voxel sizes. The changes introduce two key parameters:

1. `voxel_size_comp`: Controls voxel size along the component direction
2. `voxel_size_trans`: Controls voxel size along the transverse direction

Both parameters are measured in units of local grid step size and default to 1 to maintain backward compatibility.

The PR also improves code organization by introducing a new abstract base class `AbstractYeeCellDiscretizationMethod`, which better separates the concerns of Yee cell discretization from subpixel averaging methods. This architectural change provides a clearer hierarchy for different discretization methods while maintaining the existing functionality.

PR Description Notes:
- The description mentions that default values are 'to be determined', but the code shows they are set to 1

## Confidence score: 3/5

1. This PR is moderately safe to merge but requires careful testing of numerical results
2. While the code structure is solid, the impact on simulation accuracy with different voxel sizes needs validation
3. Files needing attention:
   - `tidy3d/components/subpixel_spec.py`: Verify that the default values of 1 are indeed the correct choice
   - Any test files that verify numerical accuracy of the subpixel averaging methods

<!-- /greptile_comment -->