### PR TITLE
ci: Trigger requirement-pass on merge_group

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -435,7 +435,7 @@ jobs:
     name: pr-requirements-pass
     if: |
       always() &&
-      ((github.event_name == 'pull_request') || (github.event_name == 'pull_request_review'))  && 
+      ((github.event_name == 'pull_request') || (github.event_name == 'pull_request_review') || (github.event_name == 'merge_group' ))  && 
       (( needs.determine-test-scope.outputs.pr_approval_state == 'true' ) && 
       ( needs.determine-test-scope.outputs.local_tests == 'true' ) || 
       ( needs.determine-test-scope.outputs.remote_tests == 'true' ))


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR adds `merge_group` to the conditional trigger for the `pr-requirements-pass` job in the GitHub Actions workflow. The change ensures that the requirements validation job runs consistently when GitHub's merge queue feature is used.

The modification aligns the `pr-requirements-pass` job with the existing `determine-test-scope` job, which already handles `merge_group` events (lines 96-99) by setting both `local_tests` and `remote_tests` to true. Without this change, there was an inconsistency where merge queue events would trigger the test determination logic but skip the final validation step.

This is a CI/CD configuration fix that ensures proper test validation across all supported GitHub event types: `pull_request`, `pull_request_review`, and now `merge_group`. The change maintains the same rigorous testing standards for merge queue operations as for manual merges.

## Confidence score: 5/5

- This is a safe CI configuration fix that adds missing event handling without changing existing logic
- The change follows the established pattern already present in the workflow file and fixes a clear gap in event handling
- No files need additional attention - this is a straightforward one-line addition to align job triggers

<!-- /greptile_comment -->