### PR TITLE
fix: validate parameters for InverseDesignResult are in valid range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Giving opposite boundaries different names no longer causes a symmetry validator failure.
+- Fixed issue with parameters in `InverseDesignResult` sometimes being outside of the valid parameter range.
 
 ## [2.9.0rc2] - 2025-07-17
 

--- a/tests/test_plugins/test_invdes.py
+++ b/tests/test_plugins/test_invdes.py
@@ -645,3 +645,35 @@ def test_pixel_size_warn_validator_no_sources():
 
     with AssertLogLevel("WARNING", contains_str="Cannot validate pixel size"):
         invdes_multi = invdes_multi.updated_copy(design_region=region_coarse)
+
+
+def test_result_params_out_of_bounds():
+    """Test that out-of-bounds parameters are automatically clipped with warning."""
+    invdes = make_invdes()
+
+    # create result with out-of-bounds parameters
+    out_of_bounds_params = np.ones(invdes.design_region.params_shape)
+    out_of_bounds_params[0, 0, 0] = 1.5  # above 1
+    out_of_bounds_params[1, 1, 0] = -0.1  # below 0
+
+    # the validator should trigger when creating the result
+    with AssertLogLevel("WARNING", contains_str="Parameters outside [0,1] bounds"):
+        result = tdi.InverseDesignResult(
+            design=invdes,
+            params=(out_of_bounds_params,),
+            objective_fn_val=(1.0,),
+            grad=(out_of_bounds_params * 0,),
+            penalty=(0.0,),
+            post_process_val=(1.0,),
+            opt_state=({"test": 1},),
+        )
+
+    # verify parameters were clipped
+    clipped_params = result.params[0]
+    assert np.all(clipped_params >= 0.0)
+    assert np.all(clipped_params <= 1.0)
+    assert clipped_params[0, 0, 0] == 1.0
+    assert clipped_params[1, 1, 0] == 0.0
+
+    # get_sim should work without issues
+    sim = result.get_sim(index=0)

--- a/tidy3d/plugins/invdes/result.py
+++ b/tidy3d/plugins/invdes/result.py
@@ -67,6 +67,41 @@ class InverseDesignResult(InvdesBaseModel):
         description="History of optimizer states throughout the optimization.",
     )
 
+    @pd.validator("params", pre=False, allow_reuse=True)
+    def _validate_and_clip_params(cls, params_tuple):
+        """Ensure all parameters in history are within [0,1] bounds, clipping if necessary."""
+        if not params_tuple:
+            return params_tuple
+
+        clipped_params = []
+        total_below = 0
+        total_above = 0
+
+        for param_array in params_tuple:
+            if param_array is None:
+                clipped_params.append(param_array)
+                continue
+
+            below = np.sum(param_array < 0)
+            above = np.sum(param_array > 1)
+
+            if below > 0 or above > 0:
+                total_below += below
+                total_above += above
+                param_array = np.clip(param_array, 0.0, 1.0)
+
+            clipped_params.append(param_array)
+
+        if total_below > 0 or total_above > 0:
+            td.log.warning(
+                f"Parameters outside [0,1] bounds detected in optimization history "
+                f"({total_below} total below 0, {total_above} total above 1). "
+                f"Automatically clipped to valid range. This may indicate an issue "
+                f"with the optimization process or loading from a legacy file."
+            )
+
+        return tuple(clipped_params)
+
     @property
     def history(self) -> dict[str, list]:
         """The history-containing fields as a dictionary of lists."""


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR implements parameter validation for the `InverseDesignResult` class in the inverse design plugin. The change adds a pydantic validator that automatically clips parameter values to the valid [0,1] range when they fall outside these bounds.

The core modification is in `tidy3d/plugins/invdes/result.py`, where a new `_validate_and_clip_params` validator is added to the `InverseDesignResult` class. This validator processes the `params` tuple containing optimization history arrays, counts how many values are below 0 or above 1, clips them using `np.clip(param_array, 0.0, 1.0)`, and logs a warning message indicating the total number of out-of-bounds parameters that were corrected.

This validation addresses data integrity issues that can occur during inverse design optimization workflows. Parameters in topology optimization are expected to represent normalized design variables in the [0,1] range, but can sometimes fall outside this range due to numerical precision issues, optimizer behavior exploring bounds, or when loading legacy optimization result files. The validator ensures backward compatibility by automatically correcting invalid data rather than raising errors, while still alerting users to potential issues through warning messages.

The implementation includes comprehensive test coverage in `tests/test_plugins/test_invdes.py` with a new `test_result_params_out_of_bounds()` function that verifies the clipping behavior works correctly and that downstream functionality like `get_sim()` continues to operate normally after parameter correction.

## Confidence score: 4/5

- This is a safe defensive programming fix that improves data integrity without breaking existing functionality
- The automatic clipping approach with warnings is more user-friendly than throwing errors, maintaining backward compatibility
- The `tidy3d/plugins/invdes/result.py` file needs careful review to ensure the validator logic handles edge cases correctly and doesn't introduce performance issues

<!-- /greptile_comment -->