### PR TITLE
Use slurm-container for self-hosted python test

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -247,10 +247,7 @@ jobs:
     needs: determine-test-scope
     if: needs.determine-test-scope.outputs.local_tests == 'true'
     name: python-${{ matrix.python-version }}-self-hosted-runner 
-    runs-on: [ slurm-runner, 4xcpu ]
-    container: 
-      image: ghcr.io/astral-sh/uv:debian
-      options: --user 31001:61001 # Required slurm-batch UID: slurm GID for tmp/ file removal
+    runs-on: [ slurm-runner, 4xcpu, container=ghcr.io/astral-sh/uv:debian ]
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name }}-${{ matrix.python-version }}-local
       cancel-in-progress: true


### PR DESCRIPTION
Test: https://github.com/flexcompute/tidy3d/actions/runs/16499106204

<!-- greptile_comment -->

## Greptile Summary

This PR modernizes the self-hosted runner configuration for local Python tests by migrating from GitHub Actions' native container support to a new slurm-container infrastructure. The change modifies the `.github/workflows/tidy3d-python-client-tests.yml` file by removing the explicit `container` block that specified the `ghcr.io/astral-sh/uv:debian` image with manual user options (`--user 31001:61001`) and instead embeds the container specification directly in the `runs-on` array as `container=ghcr.io/astral-sh/uv:debian`.

The previous configuration required manual UID/GID specification (31001:61001) to ensure proper file permissions and cleanup in the `/tmp` directory when running containerized jobs on the slurm infrastructure. The new approach delegates container management entirely to the slurm runner system, which automatically handles the required user mappings that were previously managed manually through GitHub Actions' container runtime.

This change aligns with the adoption of a new slurm-container system that can handle containerized job execution more efficiently while maintaining the same container image. The migration simplifies the workflow configuration by removing the need for explicit user permission handling while preserving the containerized test environment.

## Confidence score: 4/5

- This change appears to be a straightforward infrastructure migration with minimal risk of breaking existing functionality.
- The confidence score reflects that this is primarily a configuration change for CI infrastructure rather than core application logic, though the effectiveness depends on the new slurm-container system working as expected.
- The `.github/workflows/tidy3d-python-client-tests.yml` file needs attention to ensure the new container specification syntax is correct and that the slurm-container system properly handles the container execution.

<!-- /greptile_comment -->