### PR TITLE
feat: Add natural convection BC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `absorber` field (default: `True`) to `WavePort` for automatically placing an absorber behind the port.
 - Added `conjugated_dot_product` field in `ModeMonitor` (default: `True`) and `WavePort` (default: `False`) to allow selecting the conjugated or non-conjugated dot product for mode decomposition.
 - Support for gradients with respect to the `conductivity` of a `CustomMedium`.
+- Added `VerticalNaturalConvectionCoeffModel`, a model for heat transfer due to natural convection from a vertical plate. It can be used in `ConvectionBC` to compute the heat transfer coefficient from fluid properties, using standard Nusselt number correlations for both laminar and turbulent flow.
 
 ### Changed
 - Validate mode solver object for large number of grid points on the modal plane.

--- a/schemas/EMESimulation.json
+++ b/schemas/EMESimulation.json
@@ -1268,7 +1268,7 @@
     },
     "FluidSpec": {
       "title": "FluidSpec",
-      "description": "Fluid medium class for backwards compatibility\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.",
+      "description": "Fluid medium class for backwards compatibility\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.\nthermal_conductivity : Optional[NonNegativeFloat] = None\n    [units = W/(um*K)].  Thermal conductivity (k) of the fluid.\nviscosity : Optional[NonNegativeFloat] = None\n    [units = kg/(um*s)].  Dynamic viscosity (\u03bc) of the fluid.\nspecific_heat : Optional[NonNegativeFloat] = None\n    [units = um^2/(s^2*K)].  Specific heat of the fluid at constant pressure.\ndensity : Optional[NonNegativeFloat] = None\n    [units = kg/um^3].  Density (\u03c1) of the fluid.\nexpansivity : Optional[NonNegativeFloat] = None\n    [units = 1/K].  Thermal expansion coefficient (\u03b2) of the fluid.",
       "type": "object",
       "properties": {
         "attrs": {
@@ -1289,6 +1289,41 @@
             "FluidSpec"
           ],
           "type": "string"
+        },
+        "thermal_conductivity": {
+          "title": "Fluid Thermal Conductivity",
+          "description": "Thermal conductivity (k) of the fluid.",
+          "units": "W/(um*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "viscosity": {
+          "title": "Fluid Dynamic Viscosity",
+          "description": "Dynamic viscosity (\u03bc) of the fluid.",
+          "units": "kg/(um*s)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "specific_heat": {
+          "title": "Fluid Specific Heat",
+          "description": "Specific heat of the fluid at constant pressure.",
+          "units": "um^2/(s^2*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "density": {
+          "title": "Fluid Density",
+          "description": "Density (\u03c1) of the fluid.",
+          "units": "kg/um^3",
+          "minimum": 0,
+          "type": "number"
+        },
+        "expansivity": {
+          "title": "Fluid Thermal Expansivity",
+          "description": "Thermal expansion coefficient (\u03b2) of the fluid.",
+          "units": "1/K",
+          "minimum": 0,
+          "type": "number"
         }
       },
       "additionalProperties": false
@@ -1397,7 +1432,7 @@
     },
     "FluidMedium": {
       "title": "FluidMedium",
-      "description": "Fluid medium. Heat simulations will not solve for temperature\nin a structure that has a medium with this 'heat_spec'.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.\n\nExample\n-------\n>>> solid = FluidMedium()",
+      "description": "Fluid medium. Heat simulations will not solve for temperature\nin a structure that has a medium with this 'heat_spec'.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.\nthermal_conductivity : Optional[NonNegativeFloat] = None\n    [units = W/(um*K)].  Thermal conductivity (k) of the fluid.\nviscosity : Optional[NonNegativeFloat] = None\n    [units = kg/(um*s)].  Dynamic viscosity (\u03bc) of the fluid.\nspecific_heat : Optional[NonNegativeFloat] = None\n    [units = um^2/(s^2*K)].  Specific heat of the fluid at constant pressure.\ndensity : Optional[NonNegativeFloat] = None\n    [units = kg/um^3].  Density (\u03c1) of the fluid.\nexpansivity : Optional[NonNegativeFloat] = None\n    [units = 1/K].  Thermal expansion coefficient (\u03b2) of the fluid.\n\nThe full set of parameters is primarily intended for calculations involving natural\nconvection, where they are used to determine the heat transfer coefficient.\nIn the current version, these specific properties may not be utilized for\nother boundary condition types.\n\nAttributes\n----------\nthermal_conductivity : float, optional\n    Thermal conductivity ($k$) of the fluid in $W/(\\mu m \\cdot K)$.\nviscosity : float, optional\n    Dynamic viscosity ($\\mu$) of the fluid in $kg/(\\mu m \\cdot s)$.\nspecific_heat : float, optional\n    Specific heat ($c_p$) of the fluid in $\\mu m^2/(s^2 \\cdot K)$.\ndensity : float, optional\n    Density ($\rho$) of the fluid in $kg/\\mu m^3$.\nexpansivity : float, optional\n    Thermal expansion coefficient ($\beta$) of the fluid in $1/K$.\n\nExamples\n--------\n>>> # If you are using a boundary condition without a natural convection model,\n>>> # the specific properties of the fluid are not required. In this common\n>>> # scenario, you can instantiate the class without arguments.\n>>> air = FluidMedium()\n\n>>> # It is most convenient to define the fluid from standard SI units\n>>> # using the `from_si_units` classmethod.\n>>> # The following defines air at approximately 20\u00b0C.\n>>> air_from_si = FluidMedium.from_si_units(\n...     thermal_conductivity=0.0257,  # Unit: W/(m*K)\n...     viscosity=1.81e-5,          # Unit: Pa*s\n...     specific_heat=1005,         # Unit: J/(kg*K)\n...     density=1.204,              # Unit: kg/m^3\n...     expansivity=1/293.15        # Unit: 1/K\n... )\n\n>>> # One can also define the medium directly in Tidy3D units.\n>>> # The following is equivalent to the example above.\n>>> air_direct = FluidMedium(\n...     thermal_conductivity=2.57e-8,\n...     viscosity=1.81e-11,\n...     specific_heat=1.005e+15,\n...     density=1.204e-18,\n...     expansivity=1/293.15\n... )",
       "type": "object",
       "properties": {
         "attrs": {
@@ -1418,6 +1453,41 @@
             "FluidMedium"
           ],
           "type": "string"
+        },
+        "thermal_conductivity": {
+          "title": "Fluid Thermal Conductivity",
+          "description": "Thermal conductivity (k) of the fluid.",
+          "units": "W/(um*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "viscosity": {
+          "title": "Fluid Dynamic Viscosity",
+          "description": "Dynamic viscosity (\u03bc) of the fluid.",
+          "units": "kg/(um*s)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "specific_heat": {
+          "title": "Fluid Specific Heat",
+          "description": "Specific heat of the fluid at constant pressure.",
+          "units": "um^2/(s^2*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "density": {
+          "title": "Fluid Density",
+          "description": "Density (\u03c1) of the fluid.",
+          "units": "kg/um^3",
+          "minimum": 0,
+          "type": "number"
+        },
+        "expansivity": {
+          "title": "Fluid Thermal Expansivity",
+          "description": "Thermal expansion coefficient (\u03b2) of the fluid.",
+          "units": "1/K",
+          "minimum": 0,
+          "type": "number"
         }
       },
       "additionalProperties": false

--- a/schemas/HeatChargeSimulation.json
+++ b/schemas/HeatChargeSimulation.json
@@ -1064,7 +1064,7 @@
     },
     "FluidSpec": {
       "title": "FluidSpec",
-      "description": "Fluid medium class for backwards compatibility\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.",
+      "description": "Fluid medium class for backwards compatibility\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.\nthermal_conductivity : Optional[NonNegativeFloat] = None\n    [units = W/(um*K)].  Thermal conductivity (k) of the fluid.\nviscosity : Optional[NonNegativeFloat] = None\n    [units = kg/(um*s)].  Dynamic viscosity (\u03bc) of the fluid.\nspecific_heat : Optional[NonNegativeFloat] = None\n    [units = um^2/(s^2*K)].  Specific heat of the fluid at constant pressure.\ndensity : Optional[NonNegativeFloat] = None\n    [units = kg/um^3].  Density (\u03c1) of the fluid.\nexpansivity : Optional[NonNegativeFloat] = None\n    [units = 1/K].  Thermal expansion coefficient (\u03b2) of the fluid.",
       "type": "object",
       "properties": {
         "attrs": {
@@ -1085,6 +1085,41 @@
             "FluidSpec"
           ],
           "type": "string"
+        },
+        "thermal_conductivity": {
+          "title": "Fluid Thermal Conductivity",
+          "description": "Thermal conductivity (k) of the fluid.",
+          "units": "W/(um*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "viscosity": {
+          "title": "Fluid Dynamic Viscosity",
+          "description": "Dynamic viscosity (\u03bc) of the fluid.",
+          "units": "kg/(um*s)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "specific_heat": {
+          "title": "Fluid Specific Heat",
+          "description": "Specific heat of the fluid at constant pressure.",
+          "units": "um^2/(s^2*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "density": {
+          "title": "Fluid Density",
+          "description": "Density (\u03c1) of the fluid.",
+          "units": "kg/um^3",
+          "minimum": 0,
+          "type": "number"
+        },
+        "expansivity": {
+          "title": "Fluid Thermal Expansivity",
+          "description": "Thermal expansion coefficient (\u03b2) of the fluid.",
+          "units": "1/K",
+          "minimum": 0,
+          "type": "number"
         }
       },
       "additionalProperties": false
@@ -1193,7 +1228,7 @@
     },
     "FluidMedium": {
       "title": "FluidMedium",
-      "description": "Fluid medium. Heat simulations will not solve for temperature\nin a structure that has a medium with this 'heat_spec'.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.\n\nExample\n-------\n>>> solid = FluidMedium()",
+      "description": "Fluid medium. Heat simulations will not solve for temperature\nin a structure that has a medium with this 'heat_spec'.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.\nthermal_conductivity : Optional[NonNegativeFloat] = None\n    [units = W/(um*K)].  Thermal conductivity (k) of the fluid.\nviscosity : Optional[NonNegativeFloat] = None\n    [units = kg/(um*s)].  Dynamic viscosity (\u03bc) of the fluid.\nspecific_heat : Optional[NonNegativeFloat] = None\n    [units = um^2/(s^2*K)].  Specific heat of the fluid at constant pressure.\ndensity : Optional[NonNegativeFloat] = None\n    [units = kg/um^3].  Density (\u03c1) of the fluid.\nexpansivity : Optional[NonNegativeFloat] = None\n    [units = 1/K].  Thermal expansion coefficient (\u03b2) of the fluid.\n\nThe full set of parameters is primarily intended for calculations involving natural\nconvection, where they are used to determine the heat transfer coefficient.\nIn the current version, these specific properties may not be utilized for\nother boundary condition types.\n\nAttributes\n----------\nthermal_conductivity : float, optional\n    Thermal conductivity ($k$) of the fluid in $W/(\\mu m \\cdot K)$.\nviscosity : float, optional\n    Dynamic viscosity ($\\mu$) of the fluid in $kg/(\\mu m \\cdot s)$.\nspecific_heat : float, optional\n    Specific heat ($c_p$) of the fluid in $\\mu m^2/(s^2 \\cdot K)$.\ndensity : float, optional\n    Density ($\rho$) of the fluid in $kg/\\mu m^3$.\nexpansivity : float, optional\n    Thermal expansion coefficient ($\beta$) of the fluid in $1/K$.\n\nExamples\n--------\n>>> # If you are using a boundary condition without a natural convection model,\n>>> # the specific properties of the fluid are not required. In this common\n>>> # scenario, you can instantiate the class without arguments.\n>>> air = FluidMedium()\n\n>>> # It is most convenient to define the fluid from standard SI units\n>>> # using the `from_si_units` classmethod.\n>>> # The following defines air at approximately 20\u00b0C.\n>>> air_from_si = FluidMedium.from_si_units(\n...     thermal_conductivity=0.0257,  # Unit: W/(m*K)\n...     viscosity=1.81e-5,          # Unit: Pa*s\n...     specific_heat=1005,         # Unit: J/(kg*K)\n...     density=1.204,              # Unit: kg/m^3\n...     expansivity=1/293.15        # Unit: 1/K\n... )\n\n>>> # One can also define the medium directly in Tidy3D units.\n>>> # The following is equivalent to the example above.\n>>> air_direct = FluidMedium(\n...     thermal_conductivity=2.57e-8,\n...     viscosity=1.81e-11,\n...     specific_heat=1.005e+15,\n...     density=1.204e-18,\n...     expansivity=1/293.15\n... )",
       "type": "object",
       "properties": {
         "attrs": {
@@ -1214,6 +1249,41 @@
             "FluidMedium"
           ],
           "type": "string"
+        },
+        "thermal_conductivity": {
+          "title": "Fluid Thermal Conductivity",
+          "description": "Thermal conductivity (k) of the fluid.",
+          "units": "W/(um*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "viscosity": {
+          "title": "Fluid Dynamic Viscosity",
+          "description": "Dynamic viscosity (\u03bc) of the fluid.",
+          "units": "kg/(um*s)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "specific_heat": {
+          "title": "Fluid Specific Heat",
+          "description": "Specific heat of the fluid at constant pressure.",
+          "units": "um^2/(s^2*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "density": {
+          "title": "Fluid Density",
+          "description": "Density (\u03c1) of the fluid.",
+          "units": "kg/um^3",
+          "minimum": 0,
+          "type": "number"
+        },
+        "expansivity": {
+          "title": "Fluid Thermal Expansivity",
+          "description": "Thermal expansion coefficient (\u03b2) of the fluid.",
+          "units": "1/K",
+          "minimum": 0,
+          "type": "number"
         }
       },
       "additionalProperties": false
@@ -9336,9 +9406,58 @@
       ],
       "additionalProperties": false
     },
+    "VerticalNaturalConvectionCoeffModel": {
+      "title": "VerticalNaturalConvectionCoeffModel",
+      "description": "Specification for natural convection from a vertical plate.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nmedium : Optional[FluidMedium] = None\n    The `FluidMedium` used for the heat transfer coefficient calculation. If `None`, the fluid is automatically deduced from the interface, which can be definedby either a `MediumMediumInterface` or a `StructureStructureInterface`.\nplate_length : NonNegativeFloat\n    [units = um].  Characteristic length (L), defined as the height of the vertical plate.\ngravity : NonNegativeFloat = 9806650.0\n    [units = um/s^2].  Gravitational acceleration (g).\n\nThis class calculates the heat transfer coefficient (h) based on fluid\nproperties and an expected temperature difference, then provides these\nvalues as 'base' and 'exponent' for a generalized heat flux equation\nq = base * (T_surf - T_fluid)^exponent + base * (T_surf - T_fluid).",
+      "type": "object",
+      "properties": {
+        "attrs": {
+          "title": "Attributes",
+          "description": "Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.",
+          "default": {},
+          "type": "object"
+        },
+        "medium": {
+          "title": "Interface medium",
+          "description": "The `FluidMedium` used for the heat transfer coefficient calculation. If `None`, the fluid is automatically deduced from the interface, which can be definedby either a `MediumMediumInterface` or a `StructureStructureInterface`.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FluidMedium"
+            }
+          ]
+        },
+        "plate_length": {
+          "title": "Plate Characteristic Length",
+          "description": "Characteristic length (L), defined as the height of the vertical plate.",
+          "units": "um",
+          "minimum": 0,
+          "type": "number"
+        },
+        "gravity": {
+          "title": "Gravitational Acceleration",
+          "description": "Gravitational acceleration (g).",
+          "default": 9806650.0,
+          "units": "um/s^2",
+          "minimum": 0,
+          "type": "number"
+        },
+        "type": {
+          "title": "Type",
+          "default": "VerticalNaturalConvectionCoeffModel",
+          "enum": [
+            "VerticalNaturalConvectionCoeffModel"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "plate_length"
+      ],
+      "additionalProperties": false
+    },
     "ConvectionBC": {
       "title": "ConvectionBC",
-      "description": "Convective thermal boundary conditions.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nambient_temperature : PositiveFloat\n    [units = K].  Ambient temperature value in units of K.\ntransfer_coeff : NonNegativeFloat\n    [units = W/(um^2*K)].  Heat flux value in units of W/(um^2*K).\n\nExample\n-------\n>>> import tidy3d as td\n>>> bc = td.ConvectionBC(ambient_temperature=300, transfer_coeff=1)",
+      "description": "Convective thermal boundary conditions.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nambient_temperature : PositiveFloat\n    [units = K].  Ambient temperature value in units of K.\ntransfer_coeff : Union[NonNegativeFloat, VerticalNaturalConvectionCoeffModel]\n    [units = W/(um^2*K)].  Heat flux value in units of W/(um^2*K).\n\nExample\n-------\n>>> import tidy3d as td\n>>> bc = td.ConvectionBC(ambient_temperature=300, transfer_coeff=1)\n\n>>> # Convection with a natural convection model.\n>>> # First, define the fluid medium (e.g. air at 300 K).\n>>> air = td.FluidMedium.from_si_units(\n...     thermal_conductivity=0.0257,  # Unit: W/(m*K)\n...     viscosity=1.81e-5,          # Unit: Pa*s\n...     specific_heat=1005,         # Unit: J/(kg*K)\n...     density=1.204,              # Unit: kg/m^3\n...     expansivity=1/293.15        # Unit: 1/K\n... )\n>>>\n>>> # Next, create the model, which requires the fluid and a characteristic length.\n>>> natural_conv_model = td.VerticalNaturalConvectionCoeffModel.from_si_units(\n...     medium=air, plate_length=1e-5\n... )\n>>>\n>>> # Finally, create the boundary condition using this model.\n>>> bc_natural = td.ConvectionBC(\n...     ambient_temperature=300, transfer_coeff=natural_conv_model\n... )\n\n>>> # If the fluid medium is not provided to the coefficient model, it is automatically retrieved from\n>>> # the interface.\n>>> natural_conv_model = td.VerticalNaturalConvectionCoeffModel.from_si_units(plate_length=1e-5)\n>>> bc_natural_nom = td.ConvectionBC(\n...     ambient_temperature=300, transfer_coeff=natural_conv_model\n... )",
       "type": "object",
       "properties": {
         "attrs": {
@@ -9366,8 +9485,15 @@
           "title": "Heat Transfer Coefficient",
           "description": "Heat flux value in units of W/(um^2*K).",
           "units": "W/(um^2*K)",
-          "minimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number",
+              "minimum": 0
+            },
+            {
+              "$ref": "#/definitions/VerticalNaturalConvectionCoeffModel"
+            }
+          ]
         }
       },
       "required": [

--- a/schemas/HeatSimulation.json
+++ b/schemas/HeatSimulation.json
@@ -1064,7 +1064,7 @@
     },
     "FluidSpec": {
       "title": "FluidSpec",
-      "description": "Fluid medium class for backwards compatibility\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.",
+      "description": "Fluid medium class for backwards compatibility\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.\nthermal_conductivity : Optional[NonNegativeFloat] = None\n    [units = W/(um*K)].  Thermal conductivity (k) of the fluid.\nviscosity : Optional[NonNegativeFloat] = None\n    [units = kg/(um*s)].  Dynamic viscosity (\u03bc) of the fluid.\nspecific_heat : Optional[NonNegativeFloat] = None\n    [units = um^2/(s^2*K)].  Specific heat of the fluid at constant pressure.\ndensity : Optional[NonNegativeFloat] = None\n    [units = kg/um^3].  Density (\u03c1) of the fluid.\nexpansivity : Optional[NonNegativeFloat] = None\n    [units = 1/K].  Thermal expansion coefficient (\u03b2) of the fluid.",
       "type": "object",
       "properties": {
         "attrs": {
@@ -1085,6 +1085,41 @@
             "FluidSpec"
           ],
           "type": "string"
+        },
+        "thermal_conductivity": {
+          "title": "Fluid Thermal Conductivity",
+          "description": "Thermal conductivity (k) of the fluid.",
+          "units": "W/(um*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "viscosity": {
+          "title": "Fluid Dynamic Viscosity",
+          "description": "Dynamic viscosity (\u03bc) of the fluid.",
+          "units": "kg/(um*s)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "specific_heat": {
+          "title": "Fluid Specific Heat",
+          "description": "Specific heat of the fluid at constant pressure.",
+          "units": "um^2/(s^2*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "density": {
+          "title": "Fluid Density",
+          "description": "Density (\u03c1) of the fluid.",
+          "units": "kg/um^3",
+          "minimum": 0,
+          "type": "number"
+        },
+        "expansivity": {
+          "title": "Fluid Thermal Expansivity",
+          "description": "Thermal expansion coefficient (\u03b2) of the fluid.",
+          "units": "1/K",
+          "minimum": 0,
+          "type": "number"
         }
       },
       "additionalProperties": false
@@ -1193,7 +1228,7 @@
     },
     "FluidMedium": {
       "title": "FluidMedium",
-      "description": "Fluid medium. Heat simulations will not solve for temperature\nin a structure that has a medium with this 'heat_spec'.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.\n\nExample\n-------\n>>> solid = FluidMedium()",
+      "description": "Fluid medium. Heat simulations will not solve for temperature\nin a structure that has a medium with this 'heat_spec'.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.\nthermal_conductivity : Optional[NonNegativeFloat] = None\n    [units = W/(um*K)].  Thermal conductivity (k) of the fluid.\nviscosity : Optional[NonNegativeFloat] = None\n    [units = kg/(um*s)].  Dynamic viscosity (\u03bc) of the fluid.\nspecific_heat : Optional[NonNegativeFloat] = None\n    [units = um^2/(s^2*K)].  Specific heat of the fluid at constant pressure.\ndensity : Optional[NonNegativeFloat] = None\n    [units = kg/um^3].  Density (\u03c1) of the fluid.\nexpansivity : Optional[NonNegativeFloat] = None\n    [units = 1/K].  Thermal expansion coefficient (\u03b2) of the fluid.\n\nThe full set of parameters is primarily intended for calculations involving natural\nconvection, where they are used to determine the heat transfer coefficient.\nIn the current version, these specific properties may not be utilized for\nother boundary condition types.\n\nAttributes\n----------\nthermal_conductivity : float, optional\n    Thermal conductivity ($k$) of the fluid in $W/(\\mu m \\cdot K)$.\nviscosity : float, optional\n    Dynamic viscosity ($\\mu$) of the fluid in $kg/(\\mu m \\cdot s)$.\nspecific_heat : float, optional\n    Specific heat ($c_p$) of the fluid in $\\mu m^2/(s^2 \\cdot K)$.\ndensity : float, optional\n    Density ($\rho$) of the fluid in $kg/\\mu m^3$.\nexpansivity : float, optional\n    Thermal expansion coefficient ($\beta$) of the fluid in $1/K$.\n\nExamples\n--------\n>>> # If you are using a boundary condition without a natural convection model,\n>>> # the specific properties of the fluid are not required. In this common\n>>> # scenario, you can instantiate the class without arguments.\n>>> air = FluidMedium()\n\n>>> # It is most convenient to define the fluid from standard SI units\n>>> # using the `from_si_units` classmethod.\n>>> # The following defines air at approximately 20\u00b0C.\n>>> air_from_si = FluidMedium.from_si_units(\n...     thermal_conductivity=0.0257,  # Unit: W/(m*K)\n...     viscosity=1.81e-5,          # Unit: Pa*s\n...     specific_heat=1005,         # Unit: J/(kg*K)\n...     density=1.204,              # Unit: kg/m^3\n...     expansivity=1/293.15        # Unit: 1/K\n... )\n\n>>> # One can also define the medium directly in Tidy3D units.\n>>> # The following is equivalent to the example above.\n>>> air_direct = FluidMedium(\n...     thermal_conductivity=2.57e-8,\n...     viscosity=1.81e-11,\n...     specific_heat=1.005e+15,\n...     density=1.204e-18,\n...     expansivity=1/293.15\n... )",
       "type": "object",
       "properties": {
         "attrs": {
@@ -1214,6 +1249,41 @@
             "FluidMedium"
           ],
           "type": "string"
+        },
+        "thermal_conductivity": {
+          "title": "Fluid Thermal Conductivity",
+          "description": "Thermal conductivity (k) of the fluid.",
+          "units": "W/(um*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "viscosity": {
+          "title": "Fluid Dynamic Viscosity",
+          "description": "Dynamic viscosity (\u03bc) of the fluid.",
+          "units": "kg/(um*s)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "specific_heat": {
+          "title": "Fluid Specific Heat",
+          "description": "Specific heat of the fluid at constant pressure.",
+          "units": "um^2/(s^2*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "density": {
+          "title": "Fluid Density",
+          "description": "Density (\u03c1) of the fluid.",
+          "units": "kg/um^3",
+          "minimum": 0,
+          "type": "number"
+        },
+        "expansivity": {
+          "title": "Fluid Thermal Expansivity",
+          "description": "Thermal expansion coefficient (\u03b2) of the fluid.",
+          "units": "1/K",
+          "minimum": 0,
+          "type": "number"
         }
       },
       "additionalProperties": false
@@ -9336,9 +9406,58 @@
       ],
       "additionalProperties": false
     },
+    "VerticalNaturalConvectionCoeffModel": {
+      "title": "VerticalNaturalConvectionCoeffModel",
+      "description": "Specification for natural convection from a vertical plate.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nmedium : Optional[FluidMedium] = None\n    The `FluidMedium` used for the heat transfer coefficient calculation. If `None`, the fluid is automatically deduced from the interface, which can be definedby either a `MediumMediumInterface` or a `StructureStructureInterface`.\nplate_length : NonNegativeFloat\n    [units = um].  Characteristic length (L), defined as the height of the vertical plate.\ngravity : NonNegativeFloat = 9806650.0\n    [units = um/s^2].  Gravitational acceleration (g).\n\nThis class calculates the heat transfer coefficient (h) based on fluid\nproperties and an expected temperature difference, then provides these\nvalues as 'base' and 'exponent' for a generalized heat flux equation\nq = base * (T_surf - T_fluid)^exponent + base * (T_surf - T_fluid).",
+      "type": "object",
+      "properties": {
+        "attrs": {
+          "title": "Attributes",
+          "description": "Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.",
+          "default": {},
+          "type": "object"
+        },
+        "medium": {
+          "title": "Interface medium",
+          "description": "The `FluidMedium` used for the heat transfer coefficient calculation. If `None`, the fluid is automatically deduced from the interface, which can be definedby either a `MediumMediumInterface` or a `StructureStructureInterface`.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FluidMedium"
+            }
+          ]
+        },
+        "plate_length": {
+          "title": "Plate Characteristic Length",
+          "description": "Characteristic length (L), defined as the height of the vertical plate.",
+          "units": "um",
+          "minimum": 0,
+          "type": "number"
+        },
+        "gravity": {
+          "title": "Gravitational Acceleration",
+          "description": "Gravitational acceleration (g).",
+          "default": 9806650.0,
+          "units": "um/s^2",
+          "minimum": 0,
+          "type": "number"
+        },
+        "type": {
+          "title": "Type",
+          "default": "VerticalNaturalConvectionCoeffModel",
+          "enum": [
+            "VerticalNaturalConvectionCoeffModel"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "plate_length"
+      ],
+      "additionalProperties": false
+    },
     "ConvectionBC": {
       "title": "ConvectionBC",
-      "description": "Convective thermal boundary conditions.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nambient_temperature : PositiveFloat\n    [units = K].  Ambient temperature value in units of K.\ntransfer_coeff : NonNegativeFloat\n    [units = W/(um^2*K)].  Heat flux value in units of W/(um^2*K).\n\nExample\n-------\n>>> import tidy3d as td\n>>> bc = td.ConvectionBC(ambient_temperature=300, transfer_coeff=1)",
+      "description": "Convective thermal boundary conditions.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nambient_temperature : PositiveFloat\n    [units = K].  Ambient temperature value in units of K.\ntransfer_coeff : Union[NonNegativeFloat, VerticalNaturalConvectionCoeffModel]\n    [units = W/(um^2*K)].  Heat flux value in units of W/(um^2*K).\n\nExample\n-------\n>>> import tidy3d as td\n>>> bc = td.ConvectionBC(ambient_temperature=300, transfer_coeff=1)\n\n>>> # Convection with a natural convection model.\n>>> # First, define the fluid medium (e.g. air at 300 K).\n>>> air = td.FluidMedium.from_si_units(\n...     thermal_conductivity=0.0257,  # Unit: W/(m*K)\n...     viscosity=1.81e-5,          # Unit: Pa*s\n...     specific_heat=1005,         # Unit: J/(kg*K)\n...     density=1.204,              # Unit: kg/m^3\n...     expansivity=1/293.15        # Unit: 1/K\n... )\n>>>\n>>> # Next, create the model, which requires the fluid and a characteristic length.\n>>> natural_conv_model = td.VerticalNaturalConvectionCoeffModel.from_si_units(\n...     medium=air, plate_length=1e-5\n... )\n>>>\n>>> # Finally, create the boundary condition using this model.\n>>> bc_natural = td.ConvectionBC(\n...     ambient_temperature=300, transfer_coeff=natural_conv_model\n... )\n\n>>> # If the fluid medium is not provided to the coefficient model, it is automatically retrieved from\n>>> # the interface.\n>>> natural_conv_model = td.VerticalNaturalConvectionCoeffModel.from_si_units(plate_length=1e-5)\n>>> bc_natural_nom = td.ConvectionBC(\n...     ambient_temperature=300, transfer_coeff=natural_conv_model\n... )",
       "type": "object",
       "properties": {
         "attrs": {
@@ -9366,8 +9485,15 @@
           "title": "Heat Transfer Coefficient",
           "description": "Heat flux value in units of W/(um^2*K).",
           "units": "W/(um^2*K)",
-          "minimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number",
+              "minimum": 0
+            },
+            {
+              "$ref": "#/definitions/VerticalNaturalConvectionCoeffModel"
+            }
+          ]
         }
       },
       "required": [

--- a/schemas/ModeSimulation.json
+++ b/schemas/ModeSimulation.json
@@ -1313,7 +1313,7 @@
     },
     "FluidSpec": {
       "title": "FluidSpec",
-      "description": "Fluid medium class for backwards compatibility\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.",
+      "description": "Fluid medium class for backwards compatibility\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.\nthermal_conductivity : Optional[NonNegativeFloat] = None\n    [units = W/(um*K)].  Thermal conductivity (k) of the fluid.\nviscosity : Optional[NonNegativeFloat] = None\n    [units = kg/(um*s)].  Dynamic viscosity (\u03bc) of the fluid.\nspecific_heat : Optional[NonNegativeFloat] = None\n    [units = um^2/(s^2*K)].  Specific heat of the fluid at constant pressure.\ndensity : Optional[NonNegativeFloat] = None\n    [units = kg/um^3].  Density (\u03c1) of the fluid.\nexpansivity : Optional[NonNegativeFloat] = None\n    [units = 1/K].  Thermal expansion coefficient (\u03b2) of the fluid.",
       "type": "object",
       "properties": {
         "attrs": {
@@ -1334,6 +1334,41 @@
             "FluidSpec"
           ],
           "type": "string"
+        },
+        "thermal_conductivity": {
+          "title": "Fluid Thermal Conductivity",
+          "description": "Thermal conductivity (k) of the fluid.",
+          "units": "W/(um*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "viscosity": {
+          "title": "Fluid Dynamic Viscosity",
+          "description": "Dynamic viscosity (\u03bc) of the fluid.",
+          "units": "kg/(um*s)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "specific_heat": {
+          "title": "Fluid Specific Heat",
+          "description": "Specific heat of the fluid at constant pressure.",
+          "units": "um^2/(s^2*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "density": {
+          "title": "Fluid Density",
+          "description": "Density (\u03c1) of the fluid.",
+          "units": "kg/um^3",
+          "minimum": 0,
+          "type": "number"
+        },
+        "expansivity": {
+          "title": "Fluid Thermal Expansivity",
+          "description": "Thermal expansion coefficient (\u03b2) of the fluid.",
+          "units": "1/K",
+          "minimum": 0,
+          "type": "number"
         }
       },
       "additionalProperties": false
@@ -1442,7 +1477,7 @@
     },
     "FluidMedium": {
       "title": "FluidMedium",
-      "description": "Fluid medium. Heat simulations will not solve for temperature\nin a structure that has a medium with this 'heat_spec'.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.\n\nExample\n-------\n>>> solid = FluidMedium()",
+      "description": "Fluid medium. Heat simulations will not solve for temperature\nin a structure that has a medium with this 'heat_spec'.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.\nthermal_conductivity : Optional[NonNegativeFloat] = None\n    [units = W/(um*K)].  Thermal conductivity (k) of the fluid.\nviscosity : Optional[NonNegativeFloat] = None\n    [units = kg/(um*s)].  Dynamic viscosity (\u03bc) of the fluid.\nspecific_heat : Optional[NonNegativeFloat] = None\n    [units = um^2/(s^2*K)].  Specific heat of the fluid at constant pressure.\ndensity : Optional[NonNegativeFloat] = None\n    [units = kg/um^3].  Density (\u03c1) of the fluid.\nexpansivity : Optional[NonNegativeFloat] = None\n    [units = 1/K].  Thermal expansion coefficient (\u03b2) of the fluid.\n\nThe full set of parameters is primarily intended for calculations involving natural\nconvection, where they are used to determine the heat transfer coefficient.\nIn the current version, these specific properties may not be utilized for\nother boundary condition types.\n\nAttributes\n----------\nthermal_conductivity : float, optional\n    Thermal conductivity ($k$) of the fluid in $W/(\\mu m \\cdot K)$.\nviscosity : float, optional\n    Dynamic viscosity ($\\mu$) of the fluid in $kg/(\\mu m \\cdot s)$.\nspecific_heat : float, optional\n    Specific heat ($c_p$) of the fluid in $\\mu m^2/(s^2 \\cdot K)$.\ndensity : float, optional\n    Density ($\rho$) of the fluid in $kg/\\mu m^3$.\nexpansivity : float, optional\n    Thermal expansion coefficient ($\beta$) of the fluid in $1/K$.\n\nExamples\n--------\n>>> # If you are using a boundary condition without a natural convection model,\n>>> # the specific properties of the fluid are not required. In this common\n>>> # scenario, you can instantiate the class without arguments.\n>>> air = FluidMedium()\n\n>>> # It is most convenient to define the fluid from standard SI units\n>>> # using the `from_si_units` classmethod.\n>>> # The following defines air at approximately 20\u00b0C.\n>>> air_from_si = FluidMedium.from_si_units(\n...     thermal_conductivity=0.0257,  # Unit: W/(m*K)\n...     viscosity=1.81e-5,          # Unit: Pa*s\n...     specific_heat=1005,         # Unit: J/(kg*K)\n...     density=1.204,              # Unit: kg/m^3\n...     expansivity=1/293.15        # Unit: 1/K\n... )\n\n>>> # One can also define the medium directly in Tidy3D units.\n>>> # The following is equivalent to the example above.\n>>> air_direct = FluidMedium(\n...     thermal_conductivity=2.57e-8,\n...     viscosity=1.81e-11,\n...     specific_heat=1.005e+15,\n...     density=1.204e-18,\n...     expansivity=1/293.15\n... )",
       "type": "object",
       "properties": {
         "attrs": {
@@ -1463,6 +1498,41 @@
             "FluidMedium"
           ],
           "type": "string"
+        },
+        "thermal_conductivity": {
+          "title": "Fluid Thermal Conductivity",
+          "description": "Thermal conductivity (k) of the fluid.",
+          "units": "W/(um*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "viscosity": {
+          "title": "Fluid Dynamic Viscosity",
+          "description": "Dynamic viscosity (\u03bc) of the fluid.",
+          "units": "kg/(um*s)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "specific_heat": {
+          "title": "Fluid Specific Heat",
+          "description": "Specific heat of the fluid at constant pressure.",
+          "units": "um^2/(s^2*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "density": {
+          "title": "Fluid Density",
+          "description": "Density (\u03c1) of the fluid.",
+          "units": "kg/um^3",
+          "minimum": 0,
+          "type": "number"
+        },
+        "expansivity": {
+          "title": "Fluid Thermal Expansivity",
+          "description": "Thermal expansion coefficient (\u03b2) of the fluid.",
+          "units": "1/K",
+          "minimum": 0,
+          "type": "number"
         }
       },
       "additionalProperties": false

--- a/schemas/Simulation.json
+++ b/schemas/Simulation.json
@@ -1369,7 +1369,7 @@
     },
     "FluidSpec": {
       "title": "FluidSpec",
-      "description": "Fluid medium class for backwards compatibility\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.",
+      "description": "Fluid medium class for backwards compatibility\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.\nthermal_conductivity : Optional[NonNegativeFloat] = None\n    [units = W/(um*K)].  Thermal conductivity (k) of the fluid.\nviscosity : Optional[NonNegativeFloat] = None\n    [units = kg/(um*s)].  Dynamic viscosity (\u03bc) of the fluid.\nspecific_heat : Optional[NonNegativeFloat] = None\n    [units = um^2/(s^2*K)].  Specific heat of the fluid at constant pressure.\ndensity : Optional[NonNegativeFloat] = None\n    [units = kg/um^3].  Density (\u03c1) of the fluid.\nexpansivity : Optional[NonNegativeFloat] = None\n    [units = 1/K].  Thermal expansion coefficient (\u03b2) of the fluid.",
       "type": "object",
       "properties": {
         "attrs": {
@@ -1390,6 +1390,41 @@
             "FluidSpec"
           ],
           "type": "string"
+        },
+        "thermal_conductivity": {
+          "title": "Fluid Thermal Conductivity",
+          "description": "Thermal conductivity (k) of the fluid.",
+          "units": "W/(um*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "viscosity": {
+          "title": "Fluid Dynamic Viscosity",
+          "description": "Dynamic viscosity (\u03bc) of the fluid.",
+          "units": "kg/(um*s)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "specific_heat": {
+          "title": "Fluid Specific Heat",
+          "description": "Specific heat of the fluid at constant pressure.",
+          "units": "um^2/(s^2*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "density": {
+          "title": "Fluid Density",
+          "description": "Density (\u03c1) of the fluid.",
+          "units": "kg/um^3",
+          "minimum": 0,
+          "type": "number"
+        },
+        "expansivity": {
+          "title": "Fluid Thermal Expansivity",
+          "description": "Thermal expansion coefficient (\u03b2) of the fluid.",
+          "units": "1/K",
+          "minimum": 0,
+          "type": "number"
         }
       },
       "additionalProperties": false
@@ -1498,7 +1533,7 @@
     },
     "FluidMedium": {
       "title": "FluidMedium",
-      "description": "Fluid medium. Heat simulations will not solve for temperature\nin a structure that has a medium with this 'heat_spec'.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.\n\nExample\n-------\n>>> solid = FluidMedium()",
+      "description": "Fluid medium. Heat simulations will not solve for temperature\nin a structure that has a medium with this 'heat_spec'.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.\nthermal_conductivity : Optional[NonNegativeFloat] = None\n    [units = W/(um*K)].  Thermal conductivity (k) of the fluid.\nviscosity : Optional[NonNegativeFloat] = None\n    [units = kg/(um*s)].  Dynamic viscosity (\u03bc) of the fluid.\nspecific_heat : Optional[NonNegativeFloat] = None\n    [units = um^2/(s^2*K)].  Specific heat of the fluid at constant pressure.\ndensity : Optional[NonNegativeFloat] = None\n    [units = kg/um^3].  Density (\u03c1) of the fluid.\nexpansivity : Optional[NonNegativeFloat] = None\n    [units = 1/K].  Thermal expansion coefficient (\u03b2) of the fluid.\n\nThe full set of parameters is primarily intended for calculations involving natural\nconvection, where they are used to determine the heat transfer coefficient.\nIn the current version, these specific properties may not be utilized for\nother boundary condition types.\n\nAttributes\n----------\nthermal_conductivity : float, optional\n    Thermal conductivity ($k$) of the fluid in $W/(\\mu m \\cdot K)$.\nviscosity : float, optional\n    Dynamic viscosity ($\\mu$) of the fluid in $kg/(\\mu m \\cdot s)$.\nspecific_heat : float, optional\n    Specific heat ($c_p$) of the fluid in $\\mu m^2/(s^2 \\cdot K)$.\ndensity : float, optional\n    Density ($\rho$) of the fluid in $kg/\\mu m^3$.\nexpansivity : float, optional\n    Thermal expansion coefficient ($\beta$) of the fluid in $1/K$.\n\nExamples\n--------\n>>> # If you are using a boundary condition without a natural convection model,\n>>> # the specific properties of the fluid are not required. In this common\n>>> # scenario, you can instantiate the class without arguments.\n>>> air = FluidMedium()\n\n>>> # It is most convenient to define the fluid from standard SI units\n>>> # using the `from_si_units` classmethod.\n>>> # The following defines air at approximately 20\u00b0C.\n>>> air_from_si = FluidMedium.from_si_units(\n...     thermal_conductivity=0.0257,  # Unit: W/(m*K)\n...     viscosity=1.81e-5,          # Unit: Pa*s\n...     specific_heat=1005,         # Unit: J/(kg*K)\n...     density=1.204,              # Unit: kg/m^3\n...     expansivity=1/293.15        # Unit: 1/K\n... )\n\n>>> # One can also define the medium directly in Tidy3D units.\n>>> # The following is equivalent to the example above.\n>>> air_direct = FluidMedium(\n...     thermal_conductivity=2.57e-8,\n...     viscosity=1.81e-11,\n...     specific_heat=1.005e+15,\n...     density=1.204e-18,\n...     expansivity=1/293.15\n... )",
       "type": "object",
       "properties": {
         "attrs": {
@@ -1519,6 +1554,41 @@
             "FluidMedium"
           ],
           "type": "string"
+        },
+        "thermal_conductivity": {
+          "title": "Fluid Thermal Conductivity",
+          "description": "Thermal conductivity (k) of the fluid.",
+          "units": "W/(um*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "viscosity": {
+          "title": "Fluid Dynamic Viscosity",
+          "description": "Dynamic viscosity (\u03bc) of the fluid.",
+          "units": "kg/(um*s)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "specific_heat": {
+          "title": "Fluid Specific Heat",
+          "description": "Specific heat of the fluid at constant pressure.",
+          "units": "um^2/(s^2*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "density": {
+          "title": "Fluid Density",
+          "description": "Density (\u03c1) of the fluid.",
+          "units": "kg/um^3",
+          "minimum": 0,
+          "type": "number"
+        },
+        "expansivity": {
+          "title": "Fluid Thermal Expansivity",
+          "description": "Thermal expansion coefficient (\u03b2) of the fluid.",
+          "units": "1/K",
+          "minimum": 0,
+          "type": "number"
         }
       },
       "additionalProperties": false

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -769,7 +769,7 @@
     },
     "FluidSpec": {
       "title": "FluidSpec",
-      "description": "Fluid medium class for backwards compatibility\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.",
+      "description": "Fluid medium class for backwards compatibility\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.\nthermal_conductivity : Optional[NonNegativeFloat] = None\n    [units = W/(um*K)].  Thermal conductivity (k) of the fluid.\nviscosity : Optional[NonNegativeFloat] = None\n    [units = kg/(um*s)].  Dynamic viscosity (\u03bc) of the fluid.\nspecific_heat : Optional[NonNegativeFloat] = None\n    [units = um^2/(s^2*K)].  Specific heat of the fluid at constant pressure.\ndensity : Optional[NonNegativeFloat] = None\n    [units = kg/um^3].  Density (\u03c1) of the fluid.\nexpansivity : Optional[NonNegativeFloat] = None\n    [units = 1/K].  Thermal expansion coefficient (\u03b2) of the fluid.",
       "type": "object",
       "properties": {
         "attrs": {
@@ -790,6 +790,41 @@
             "FluidSpec"
           ],
           "type": "string"
+        },
+        "thermal_conductivity": {
+          "title": "Fluid Thermal Conductivity",
+          "description": "Thermal conductivity (k) of the fluid.",
+          "units": "W/(um*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "viscosity": {
+          "title": "Fluid Dynamic Viscosity",
+          "description": "Dynamic viscosity (\u03bc) of the fluid.",
+          "units": "kg/(um*s)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "specific_heat": {
+          "title": "Fluid Specific Heat",
+          "description": "Specific heat of the fluid at constant pressure.",
+          "units": "um^2/(s^2*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "density": {
+          "title": "Fluid Density",
+          "description": "Density (\u03c1) of the fluid.",
+          "units": "kg/um^3",
+          "minimum": 0,
+          "type": "number"
+        },
+        "expansivity": {
+          "title": "Fluid Thermal Expansivity",
+          "description": "Thermal expansion coefficient (\u03b2) of the fluid.",
+          "units": "1/K",
+          "minimum": 0,
+          "type": "number"
         }
       },
       "additionalProperties": false
@@ -898,7 +933,7 @@
     },
     "FluidMedium": {
       "title": "FluidMedium",
-      "description": "Fluid medium. Heat simulations will not solve for temperature\nin a structure that has a medium with this 'heat_spec'.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.\n\nExample\n-------\n>>> solid = FluidMedium()",
+      "description": "Fluid medium. Heat simulations will not solve for temperature\nin a structure that has a medium with this 'heat_spec'.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for medium.\nthermal_conductivity : Optional[NonNegativeFloat] = None\n    [units = W/(um*K)].  Thermal conductivity (k) of the fluid.\nviscosity : Optional[NonNegativeFloat] = None\n    [units = kg/(um*s)].  Dynamic viscosity (\u03bc) of the fluid.\nspecific_heat : Optional[NonNegativeFloat] = None\n    [units = um^2/(s^2*K)].  Specific heat of the fluid at constant pressure.\ndensity : Optional[NonNegativeFloat] = None\n    [units = kg/um^3].  Density (\u03c1) of the fluid.\nexpansivity : Optional[NonNegativeFloat] = None\n    [units = 1/K].  Thermal expansion coefficient (\u03b2) of the fluid.\n\nThe full set of parameters is primarily intended for calculations involving natural\nconvection, where they are used to determine the heat transfer coefficient.\nIn the current version, these specific properties may not be utilized for\nother boundary condition types.\n\nAttributes\n----------\nthermal_conductivity : float, optional\n    Thermal conductivity ($k$) of the fluid in $W/(\\mu m \\cdot K)$.\nviscosity : float, optional\n    Dynamic viscosity ($\\mu$) of the fluid in $kg/(\\mu m \\cdot s)$.\nspecific_heat : float, optional\n    Specific heat ($c_p$) of the fluid in $\\mu m^2/(s^2 \\cdot K)$.\ndensity : float, optional\n    Density ($\rho$) of the fluid in $kg/\\mu m^3$.\nexpansivity : float, optional\n    Thermal expansion coefficient ($\beta$) of the fluid in $1/K$.\n\nExamples\n--------\n>>> # If you are using a boundary condition without a natural convection model,\n>>> # the specific properties of the fluid are not required. In this common\n>>> # scenario, you can instantiate the class without arguments.\n>>> air = FluidMedium()\n\n>>> # It is most convenient to define the fluid from standard SI units\n>>> # using the `from_si_units` classmethod.\n>>> # The following defines air at approximately 20\u00b0C.\n>>> air_from_si = FluidMedium.from_si_units(\n...     thermal_conductivity=0.0257,  # Unit: W/(m*K)\n...     viscosity=1.81e-5,          # Unit: Pa*s\n...     specific_heat=1005,         # Unit: J/(kg*K)\n...     density=1.204,              # Unit: kg/m^3\n...     expansivity=1/293.15        # Unit: 1/K\n... )\n\n>>> # One can also define the medium directly in Tidy3D units.\n>>> # The following is equivalent to the example above.\n>>> air_direct = FluidMedium(\n...     thermal_conductivity=2.57e-8,\n...     viscosity=1.81e-11,\n...     specific_heat=1.005e+15,\n...     density=1.204e-18,\n...     expansivity=1/293.15\n... )",
       "type": "object",
       "properties": {
         "attrs": {
@@ -919,6 +954,41 @@
             "FluidMedium"
           ],
           "type": "string"
+        },
+        "thermal_conductivity": {
+          "title": "Fluid Thermal Conductivity",
+          "description": "Thermal conductivity (k) of the fluid.",
+          "units": "W/(um*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "viscosity": {
+          "title": "Fluid Dynamic Viscosity",
+          "description": "Dynamic viscosity (\u03bc) of the fluid.",
+          "units": "kg/(um*s)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "specific_heat": {
+          "title": "Fluid Specific Heat",
+          "description": "Specific heat of the fluid at constant pressure.",
+          "units": "um^2/(s^2*K)",
+          "minimum": 0,
+          "type": "number"
+        },
+        "density": {
+          "title": "Fluid Density",
+          "description": "Density (\u03c1) of the fluid.",
+          "units": "kg/um^3",
+          "minimum": 0,
+          "type": "number"
+        },
+        "expansivity": {
+          "title": "Fluid Thermal Expansivity",
+          "description": "Thermal expansion coefficient (\u03b2) of the fluid.",
+          "units": "1/K",
+          "minimum": 0,
+          "type": "number"
         }
       },
       "additionalProperties": false
@@ -19996,9 +20066,58 @@
       ],
       "additionalProperties": false
     },
+    "VerticalNaturalConvectionCoeffModel": {
+      "title": "VerticalNaturalConvectionCoeffModel",
+      "description": "Specification for natural convection from a vertical plate.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nmedium : Optional[FluidMedium] = None\n    The `FluidMedium` used for the heat transfer coefficient calculation. If `None`, the fluid is automatically deduced from the interface, which can be definedby either a `MediumMediumInterface` or a `StructureStructureInterface`.\nplate_length : NonNegativeFloat\n    [units = um].  Characteristic length (L), defined as the height of the vertical plate.\ngravity : NonNegativeFloat = 9806650.0\n    [units = um/s^2].  Gravitational acceleration (g).\n\nThis class calculates the heat transfer coefficient (h) based on fluid\nproperties and an expected temperature difference, then provides these\nvalues as 'base' and 'exponent' for a generalized heat flux equation\nq = base * (T_surf - T_fluid)^exponent + base * (T_surf - T_fluid).",
+      "type": "object",
+      "properties": {
+        "attrs": {
+          "title": "Attributes",
+          "description": "Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.",
+          "default": {},
+          "type": "object"
+        },
+        "medium": {
+          "title": "Interface medium",
+          "description": "The `FluidMedium` used for the heat transfer coefficient calculation. If `None`, the fluid is automatically deduced from the interface, which can be definedby either a `MediumMediumInterface` or a `StructureStructureInterface`.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/FluidMedium"
+            }
+          ]
+        },
+        "plate_length": {
+          "title": "Plate Characteristic Length",
+          "description": "Characteristic length (L), defined as the height of the vertical plate.",
+          "units": "um",
+          "minimum": 0,
+          "type": "number"
+        },
+        "gravity": {
+          "title": "Gravitational Acceleration",
+          "description": "Gravitational acceleration (g).",
+          "default": 9806650.0,
+          "units": "um/s^2",
+          "minimum": 0,
+          "type": "number"
+        },
+        "type": {
+          "title": "Type",
+          "default": "VerticalNaturalConvectionCoeffModel",
+          "enum": [
+            "VerticalNaturalConvectionCoeffModel"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "plate_length"
+      ],
+      "additionalProperties": false
+    },
     "ConvectionBC": {
       "title": "ConvectionBC",
-      "description": "Convective thermal boundary conditions.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nambient_temperature : PositiveFloat\n    [units = K].  Ambient temperature value in units of K.\ntransfer_coeff : NonNegativeFloat\n    [units = W/(um^2*K)].  Heat flux value in units of W/(um^2*K).\n\nExample\n-------\n>>> import tidy3d as td\n>>> bc = td.ConvectionBC(ambient_temperature=300, transfer_coeff=1)",
+      "description": "Convective thermal boundary conditions.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nambient_temperature : PositiveFloat\n    [units = K].  Ambient temperature value in units of K.\ntransfer_coeff : Union[NonNegativeFloat, VerticalNaturalConvectionCoeffModel]\n    [units = W/(um^2*K)].  Heat flux value in units of W/(um^2*K).\n\nExample\n-------\n>>> import tidy3d as td\n>>> bc = td.ConvectionBC(ambient_temperature=300, transfer_coeff=1)\n\n>>> # Convection with a natural convection model.\n>>> # First, define the fluid medium (e.g. air at 300 K).\n>>> air = td.FluidMedium.from_si_units(\n...     thermal_conductivity=0.0257,  # Unit: W/(m*K)\n...     viscosity=1.81e-5,          # Unit: Pa*s\n...     specific_heat=1005,         # Unit: J/(kg*K)\n...     density=1.204,              # Unit: kg/m^3\n...     expansivity=1/293.15        # Unit: 1/K\n... )\n>>>\n>>> # Next, create the model, which requires the fluid and a characteristic length.\n>>> natural_conv_model = td.VerticalNaturalConvectionCoeffModel.from_si_units(\n...     medium=air, plate_length=1e-5\n... )\n>>>\n>>> # Finally, create the boundary condition using this model.\n>>> bc_natural = td.ConvectionBC(\n...     ambient_temperature=300, transfer_coeff=natural_conv_model\n... )\n\n>>> # If the fluid medium is not provided to the coefficient model, it is automatically retrieved from\n>>> # the interface.\n>>> natural_conv_model = td.VerticalNaturalConvectionCoeffModel.from_si_units(plate_length=1e-5)\n>>> bc_natural_nom = td.ConvectionBC(\n...     ambient_temperature=300, transfer_coeff=natural_conv_model\n... )",
       "type": "object",
       "properties": {
         "attrs": {
@@ -20026,8 +20145,15 @@
           "title": "Heat Transfer Coefficient",
           "description": "Heat flux value in units of W/(um^2*K).",
           "units": "W/(um^2*K)",
-          "minimum": 0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number",
+              "minimum": 0
+            },
+            {
+              "$ref": "#/definitions/VerticalNaturalConvectionCoeffModel"
+            }
+          ]
         }
       },
       "required": [

--- a/tests/test_components/test_heat.py
+++ b/tests/test_components/test_heat.py
@@ -125,6 +125,25 @@ def test_heat_bcs():
     with pytest.raises(pd.ValidationError):
         _ = ConvectionBC(ambient_temperature=400, transfer_coeff=-0.2)
 
+    # Test vertical natural convection model in ConvectionBC
+    air = td.MultiPhysicsMedium(
+        heat=td.FluidMedium.from_si_units(
+            thermal_conductivity=0.026,
+            viscosity=1.8e-5,
+            specific_heat=1005,
+            density=1.2,
+            expansivity=1 / 300.0,
+        ),
+        name="air",
+    )
+
+    with pytest.raises(pd.ValidationError):
+        td.VerticalNaturalConvectionCoeffModel(medium=air.heat, plate_length=-10)
+
+    _, solid_medium = make_heat_mediums()
+    with pytest.raises(pd.ValidationError):
+        td.VerticalNaturalConvectionCoeffModel(medium=solid_medium.heat_spec, plate_length=1e5)
+
 
 def make_heat_mnts():
     temp_mnt1 = TemperatureMonitor(size=(1.6, 2, 3), name="test")

--- a/tests/test_components/test_heat_charge.py
+++ b/tests/test_components/test_heat_charge.py
@@ -896,6 +896,132 @@ def test_heat_charge_bcs_validation(boundary_conditions):
         td.VoltageBC(source=td.DCVoltageSource(voltage=np.array([td.inf, 0, 1])))
 
 
+def test_vertical_natural_convection():
+    solid_box_l = td.Box(center=(0, 0, 0), size=(2, 2, 2))
+    solid_box_r = td.Box(center=(1, 1, 1), size=(2, 2, 2))
+    fluid_box_r = td.Box(center=(1, 1, 1), size=(2, 2, 2))
+
+    solid_medium = td.MultiPhysicsMedium(
+        heat=td.SolidMedium(conductivity=1, capacity=1), name="solid"
+    )
+    air = td.MultiPhysicsMedium(
+        heat=td.FluidMedium.from_si_units(
+            thermal_conductivity=0.026,
+            viscosity=1.8e-5,
+            specific_heat=1005,
+            density=1.2,
+            expansivity=1 / 300.0,
+        ),
+        name="air",
+    )
+    solid_structure_l = td.Structure(
+        geometry=solid_box_l,
+        medium=solid_medium,
+        name="solid_l",
+    )
+    solid_structure_r = td.Structure(
+        geometry=solid_box_r,
+        medium=solid_medium,
+        name="solid_r",
+    )
+    fluid_structure_r = td.Structure(
+        geometry=fluid_box_r,
+        medium=air,
+        name="fluid_r",
+    )
+
+    coeff_model = td.VerticalNaturalConvectionCoeffModel(plate_length=1)
+    sim = td.HeatChargeSimulation(
+        size=(2, 2, 2),
+        center=(0, 0, 0),
+        medium=td.MultiPhysicsMedium(heat=td.FluidMedium()),
+        structures=[solid_structure_l, fluid_structure_r],
+        boundary_spec=[
+            td.HeatBoundarySpec(
+                placement=td.MediumMediumInterface(mediums=["air", "solid"]),
+                condition=td.ConvectionBC(ambient_temperature=300, transfer_coeff=coeff_model),
+            )
+        ],
+        grid_spec=td.UniformUnstructuredGrid(dl=0.1),
+        monitors=[
+            td.TemperatureMonitor(
+                center=(0, 0, 0),
+                size=(td.inf, td.inf, td.inf),
+                name="test_monitor",
+                unstructured=True,
+            )
+        ],
+    )
+
+    # Test that the model can be placed on an interface defined by structures
+    sim.updated_copy(
+        boundary_spec=[
+            td.HeatBoundarySpec(
+                placement=td.StructureStructureInterface(structures=["solid_l", "fluid_r"]),
+                condition=td.ConvectionBC(ambient_temperature=300, transfer_coeff=coeff_model),
+            )
+        ],
+    )
+
+    # Verify that placing the model on an interface between two solid media
+    # correctly raises a validation error.
+    with pytest.raises(pd.ValidationError):
+        sim.updated_copy(
+            structures=[solid_structure_l, solid_structure_r],
+            boundary_spec=[
+                td.HeatBoundarySpec(
+                    placement=td.StructureStructureInterface(structures=["solid_l", "solid_r"]),
+                    condition=td.ConvectionBC(ambient_temperature=300, transfer_coeff=coeff_model),
+                )
+            ],
+        )
+
+    # Verify that using a fluid medium with incomplete physical properties
+    # for the natural convection calculation raises a validation error.
+    incomplete_air = td.MultiPhysicsMedium(
+        heat=td.FluidMedium(expansivity=1 / 300.0), name="incomplete_air"
+    )
+    with pytest.raises(pd.ValidationError):
+        new_fluid_structure_r = fluid_structure_r.updated_copy(medium=incomplete_air)
+        sim.updated_copy(
+            structures=[solid_structure_l, new_fluid_structure_r],
+            boundary_spec=[
+                td.HeatBoundarySpec(
+                    placement=td.MediumMediumInterface(mediums=["incomplete_air", "solid"]),
+                    condition=td.ConvectionBC(ambient_temperature=300, transfer_coeff=coeff_model),
+                )
+            ],
+        )
+
+    # Test the case where the convection model has its own fluid medium explicitly defined.
+    # The simulation should use the properties from the model's medium and ignore the
+    # fluid present at the interface.
+    full_coeff_model = td.VerticalNaturalConvectionCoeffModel(medium=air.heat, plate_length=1)
+    sim.updated_copy(
+        boundary_spec=[
+            td.HeatBoundarySpec(
+                placement=td.StructureStructureInterface(structures=["solid_l", "fluid_r"]),
+                condition=td.ConvectionBC(ambient_temperature=300, transfer_coeff=full_coeff_model),
+            )
+        ],
+    )
+
+    # Verify that a validation error is raised if the medium supplied directly to the
+    # coefficient model has incomplete properties for the natural convection calculation.
+    incomplete_coeff_model = coeff_model.updated_copy(medium=incomplete_air.heat)
+    with pytest.raises(pd.ValidationError):
+        sim.updated_copy(
+            boundary_spec=[
+                td.HeatBoundarySpec(
+                    placement=td.MediumMediumInterface(mediums=["air", "solid"]),
+                    condition=td.ConvectionBC(
+                        ambient_temperature=300, transfer_coeff=incomplete_coeff_model
+                    ),
+                ),
+            ]
+        )
+
+
 def test_heat_charge_monitors_validation(monitors):
     """Checks for no name and negative size in monitors."""
     temp_mnt = monitors[0]

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -24,6 +24,7 @@ from tidy3d.components.spice.analysis.dc import (
 from tidy3d.components.spice.sources.dc import DCCurrentSource, DCVoltageSource
 from tidy3d.components.spice.sources.types import VoltageSourceType
 from tidy3d.components.tcad.analysis.heat_simulation_type import UnsteadyHeatAnalysis, UnsteadySpec
+from tidy3d.components.tcad.boundary.heat import VerticalNaturalConvectionCoeffModel
 from tidy3d.components.tcad.boundary.specification import (
     HeatBoundarySpec,
     HeatChargeBoundarySpec,
@@ -708,6 +709,7 @@ __all__ = [
     "UnsteadyHeatAnalysis",
     "UnsteadySpec",
     "Updater",
+    "VerticalNaturalConvectionCoeffModel",
     "VisualizationSpec",
     "VoltageBC",
     "VoltageSourceType",

--- a/tidy3d/components/material/tcad/heat.py
+++ b/tidy3d/components/material/tcad/heat.py
@@ -10,8 +10,11 @@ import pydantic.v1 as pd
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.constants import (
     DENSITY,
+    DYNAMIC_VISCOSITY,
+    SPECIFIC_HEAT,
     SPECIFIC_HEAT_CAPACITY,
     THERMAL_CONDUCTIVITY,
+    THERMAL_EXPANSIVITY,
 )
 
 
@@ -46,10 +49,104 @@ class FluidMedium(AbstractHeatMedium):
     """Fluid medium. Heat simulations will not solve for temperature
     in a structure that has a medium with this 'heat_spec'.
 
-    Example
-    -------
-    >>> solid = FluidMedium()
+    The full set of parameters is primarily intended for calculations involving natural
+    convection, where they are used to determine the heat transfer coefficient.
+    In the current version, these specific properties may not be utilized for
+    other boundary condition types.
+
+    Attributes
+    ----------
+    thermal_conductivity : float, optional
+        Thermal conductivity ($k$) of the fluid in $W/(\\mu m \\cdot K)$.
+    viscosity : float, optional
+        Dynamic viscosity ($\\mu$) of the fluid in $kg/(\\mu m \\cdot s)$.
+    specific_heat : float, optional
+        Specific heat ($c_p$) of the fluid in $\\mu m^2/(s^2 \\cdot K)$.
+    density : float, optional
+        Density ($\rho$) of the fluid in $kg/\\mu m^3$.
+    expansivity : float, optional
+        Thermal expansion coefficient ($\beta$) of the fluid in $1/K$.
+
+    Examples
+    --------
+    >>> # If you are using a boundary condition without a natural convection model,
+    >>> # the specific properties of the fluid are not required. In this common
+    >>> # scenario, you can instantiate the class without arguments.
+    >>> air = FluidMedium()
+
+    >>> # It is most convenient to define the fluid from standard SI units
+    >>> # using the `from_si_units` classmethod.
+    >>> # The following defines air at approximately 20°C.
+    >>> air_from_si = FluidMedium.from_si_units(
+    ...     thermal_conductivity=0.0257,  # Unit: W/(m*K)
+    ...     viscosity=1.81e-5,          # Unit: Pa*s
+    ...     specific_heat=1005,         # Unit: J/(kg*K)
+    ...     density=1.204,              # Unit: kg/m^3
+    ...     expansivity=1/293.15        # Unit: 1/K
+    ... )
+
+    >>> # One can also define the medium directly in Tidy3D units.
+    >>> # The following is equivalent to the example above.
+    >>> air_direct = FluidMedium(
+    ...     thermal_conductivity=2.57e-8,
+    ...     viscosity=1.81e-11,
+    ...     specific_heat=1.005e+15,
+    ...     density=1.204e-18,
+    ...     expansivity=1/293.15
+    ... )
     """
+
+    thermal_conductivity: pd.NonNegativeFloat = pd.Field(
+        default=None,
+        title="Fluid Thermal Conductivity",
+        description="Thermal conductivity (k) of the fluid.",
+        units=THERMAL_CONDUCTIVITY,
+    )
+    viscosity: pd.NonNegativeFloat = pd.Field(
+        default=None,
+        title="Fluid Dynamic Viscosity",
+        description="Dynamic viscosity (μ) of the fluid.",
+        units=DYNAMIC_VISCOSITY,
+    )
+    specific_heat: pd.NonNegativeFloat = pd.Field(
+        default=None,
+        title="Fluid Specific Heat",
+        description="Specific heat of the fluid at constant pressure.",
+        units=SPECIFIC_HEAT,
+    )
+    density: pd.NonNegativeFloat = pd.Field(
+        default=None,
+        title="Fluid Density",
+        description="Density (ρ) of the fluid.",
+        units=DENSITY,
+    )
+    expansivity: pd.NonNegativeFloat = pd.Field(
+        default=None,
+        title="Fluid Thermal Expansivity",
+        description="Thermal expansion coefficient (β) of the fluid.",
+        units=THERMAL_EXPANSIVITY,
+    )
+
+    def from_si_units(
+        thermal_conductivity: pd.NonNegativeFloat,
+        viscosity: pd.NonNegativeFloat,
+        specific_heat: pd.NonNegativeFloat,
+        density: pd.NonNegativeFloat,
+        expansivity: pd.NonNegativeFloat,
+    ):
+        thermal_conductivity_tidy = thermal_conductivity / 1e6  # W/(m*K) -> W/(um*K)
+        viscosity_tidy = viscosity / 1e6  # Pa*s -> kg/(um*s)
+        specific_heat_tidy = specific_heat * 1e12  # J/(kg*K) -> um**2/(s**2*K)
+        density_tidy = density / 1e18  # kg/m**3 -> kg/um**3
+        expansivity_tidy = expansivity  # 1/K -> 1/K (no change)
+
+        return FluidMedium(
+            thermal_conductivity=thermal_conductivity_tidy,
+            viscosity=viscosity_tidy,
+            specific_heat=specific_heat_tidy,
+            density=density_tidy,
+            expansivity=expansivity_tidy,
+        )
 
 
 class FluidSpec(FluidMedium):

--- a/tidy3d/components/tcad/boundary/heat.py
+++ b/tidy3d/components/tcad/boundary/heat.py
@@ -2,10 +2,21 @@
 
 from __future__ import annotations
 
+from typing import Union
+
 import pydantic.v1 as pd
 
+from tidy3d.components.base import Tidy3dBaseModel
+from tidy3d.components.material.tcad.heat import FluidMedium
 from tidy3d.components.tcad.boundary.abstract import HeatChargeBC
-from tidy3d.constants import HEAT_FLUX, HEAT_TRANSFER_COEFF, KELVIN
+from tidy3d.constants import (
+    ACCELERATION,
+    GRAV_ACC,
+    HEAT_FLUX,
+    HEAT_TRANSFER_COEFF,
+    KELVIN,
+    MICROMETER,
+)
 
 
 class TemperatureBC(HeatChargeBC):
@@ -40,6 +51,68 @@ class HeatFluxBC(HeatChargeBC):
     )
 
 
+class VerticalNaturalConvectionCoeffModel(Tidy3dBaseModel):
+    """
+    Specification for natural convection from a vertical plate.
+
+    This class calculates the heat transfer coefficient (h) based on fluid
+    properties and an expected temperature difference, then provides these
+    values as 'base' and 'exponent' for a generalized heat flux equation
+    q = base * (T_surf - T_fluid)^exponent + base * (T_surf - T_fluid).
+    """
+
+    medium: FluidMedium = pd.Field(
+        default=None,
+        title="Interface medium",
+        description=(
+            "The `FluidMedium` used for the heat transfer coefficient calculation. "
+            "If `None`, the fluid is automatically deduced from the interface, which can be defined"
+            "by either a `MediumMediumInterface` or a `StructureStructureInterface`."
+        ),
+    )
+
+    plate_length: pd.NonNegativeFloat = pd.Field(
+        title="Plate Characteristic Length",
+        description="Characteristic length (L), defined as the height of the vertical plate.",
+        units=MICROMETER,
+    )
+
+    gravity: pd.NonNegativeFloat = pd.Field(
+        default=GRAV_ACC,
+        title="Gravitational Acceleration",
+        description="Gravitational acceleration (g).",
+        units=ACCELERATION,
+    )
+
+    def from_si_units(
+        plate_length: pd.NonNegativeFloat,
+        medium: FluidMedium = None,
+        gravity: pd.NonNegativeFloat = GRAV_ACC * 1e-6,
+    ):
+        """
+        Create an instance from standard SI units.
+
+        Args:
+            plate_length: Plate characteristic length in [m].
+            gravity: Gravitational acceleration in [m/s**2].
+
+        Returns:
+            An instance of VerticalNaturalConvectionCoeffModel with all values
+            converted to Tidy3D's internal unit system.
+        """
+
+        # --- Apply conversion factors ---
+        # value_tidy = value_si * factor
+        plate_length_tidy = plate_length * 1e6  # m -> um
+        g_tidy = gravity * 1e6  # m/s**2 -> um/s**2
+
+        return VerticalNaturalConvectionCoeffModel(
+            medium=medium,
+            plate_length=plate_length_tidy,
+            gravity=g_tidy,
+        )
+
+
 class ConvectionBC(HeatChargeBC):
     """Convective thermal boundary conditions.
 
@@ -47,6 +120,33 @@ class ConvectionBC(HeatChargeBC):
     -------
     >>> import tidy3d as td
     >>> bc = td.ConvectionBC(ambient_temperature=300, transfer_coeff=1)
+
+    >>> # Convection with a natural convection model.
+    >>> # First, define the fluid medium (e.g. air at 300 K).
+    >>> air = td.FluidMedium.from_si_units(
+    ...     thermal_conductivity=0.0257,  # Unit: W/(m*K)
+    ...     viscosity=1.81e-5,          # Unit: Pa*s
+    ...     specific_heat=1005,         # Unit: J/(kg*K)
+    ...     density=1.204,              # Unit: kg/m^3
+    ...     expansivity=1/293.15        # Unit: 1/K
+    ... )
+    >>>
+    >>> # Next, create the model, which requires the fluid and a characteristic length.
+    >>> natural_conv_model = td.VerticalNaturalConvectionCoeffModel.from_si_units(
+    ...     medium=air, plate_length=1e-5
+    ... )
+    >>>
+    >>> # Finally, create the boundary condition using this model.
+    >>> bc_natural = td.ConvectionBC(
+    ...     ambient_temperature=300, transfer_coeff=natural_conv_model
+    ... )
+
+    >>> # If the fluid medium is not provided to the coefficient model, it is automatically retrieved from
+    >>> # the interface.
+    >>> natural_conv_model = td.VerticalNaturalConvectionCoeffModel.from_si_units(plate_length=1e-5)
+    >>> bc_natural_nom = td.ConvectionBC(
+    ...     ambient_temperature=300, transfer_coeff=natural_conv_model
+    ... )
     """
 
     ambient_temperature: pd.PositiveFloat = pd.Field(
@@ -55,7 +155,7 @@ class ConvectionBC(HeatChargeBC):
         units=KELVIN,
     )
 
-    transfer_coeff: pd.NonNegativeFloat = pd.Field(
+    transfer_coeff: Union[pd.NonNegativeFloat, VerticalNaturalConvectionCoeffModel] = pd.Field(
         title="Heat Transfer Coefficient",
         description=f"Heat flux value in units of {HEAT_TRANSFER_COEFF}.",
         units=HEAT_TRANSFER_COEFF,

--- a/tidy3d/components/tcad/simulation/heat_charge.py
+++ b/tidy3d/components/tcad/simulation/heat_charge.py
@@ -9,6 +9,8 @@ from typing import Optional, Union
 import numpy as np
 import pydantic.v1 as pd
 
+from tidy3d import FluidMedium, VerticalNaturalConvectionCoeffModel
+
 try:
     from matplotlib import colormaps
 except ImportError:
@@ -454,6 +456,82 @@ class HeatChargeSimulation(AbstractSimulation):
                 "Voltage arrays can be included in a source in this manner: "
                 "'VoltageBC(source=DCVoltageSource(voltage=yourArray))'"
             )
+        return values
+
+    @pd.root_validator(skip_on_failure=True)
+    def check_natural_convection_bc(cls, values):
+        """Make sure that natural convection BCs are defined correctly."""
+        boundary_spec = values.get("boundary_spec")
+        if not boundary_spec:
+            return values
+
+        structures = values["structures"]
+        boundary_spec = values["boundary_spec"]
+        bg_medium = values["medium"]
+
+        # Create mappings for easy lookup of media and structures by name.
+        media = {s.medium.name: s.medium for s in structures if s.medium.name}
+        if bg_medium and bg_medium.name:
+            media[bg_medium.name] = bg_medium
+        structures_map = {s.name: s for s in structures if s.name}
+
+        def check_fluid_medium_attr(fluid_medium):
+            if (
+                (fluid_medium.thermal_conductivity is None)
+                or (fluid_medium.viscosity is None)
+                or (fluid_medium.specific_heat is None)
+                or (fluid_medium.density is None)
+                or (fluid_medium.expansivity is None)
+            ):
+                raise SetupError(
+                    f"Boundary spec at index {i}: The fluid medium at the natural convection interface "
+                    f"must have 'thermal_conductivity', 'viscosity', 'specific_heat', 'density' and 'expansivity' defined."
+                )
+
+        for i, bc in enumerate(boundary_spec):
+            if not (
+                isinstance(bc.condition, ConvectionBC)
+                and isinstance(bc.condition.transfer_coeff, VerticalNaturalConvectionCoeffModel)
+            ):
+                continue
+
+            natural_conv_model = bc.condition.transfer_coeff
+            placement = bc.placement
+
+            # Case 1: The fluid medium is inferred from the placement interface.
+            # We use direct dictionary access, assuming 'names_exist_bcs' validator has already run.
+            if natural_conv_model.medium is None:
+                if isinstance(placement, MediumMediumInterface):
+                    med1 = media[placement.mediums[0]]
+                    med2 = media[placement.mediums[1]]
+                elif isinstance(placement, StructureStructureInterface):
+                    med1 = structures_map[placement.structures[0]].medium
+                    med2 = structures_map[placement.structures[1]].medium
+                else:
+                    raise SetupError(
+                        f"Boundary spec at index {i}: 'VerticalNaturalConvectionCoeffModel' with no medium specified requires "
+                        f"the 'placement' to be of type 'MediumMediumInterface' or 'StructureStructureInterface', "
+                        f"but got '{type(placement).__name__}'."
+                    )
+                specs = [
+                    med1.heat if isinstance(med1, MultiPhysicsMedium) else med1,
+                    med2.heat if isinstance(med2, MultiPhysicsMedium) else med2,
+                ]
+
+                # Check for a single fluid in the interface.
+                is_fluid = [isinstance(s, FluidMedium) for s in specs]
+                if is_fluid.count(True) != 1:
+                    raise SetupError(
+                        f"Boundary spec at index {i}: A natural convection boundary at an interface "
+                        f"must be between exactly one solid and one fluid medium. "
+                        f"Found types '{type(specs[0]).__name__}' and '{type(specs[1]).__name__}'."
+                    )
+                fluid_medium = specs[is_fluid.index(True)]
+                check_fluid_medium_attr(fluid_medium)
+
+            # Case 2: The fluid medium IS specified directly in the convection model.
+            else:
+                check_fluid_medium_attr(natural_conv_model.medium)
         return values
 
     @pd.validator("size", always=True)

--- a/tidy3d/components/tcad/types.py
+++ b/tidy3d/components/tcad/types.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from tidy3d.components.tcad.bandgap import SlotboomBandGapNarrowing
 from tidy3d.components.tcad.boundary.charge import CurrentBC, InsulatingBC, VoltageBC
-from tidy3d.components.tcad.boundary.heat import ConvectionBC, HeatFluxBC, TemperatureBC
+from tidy3d.components.tcad.boundary.heat import (
+    ConvectionBC,
+    HeatFluxBC,
+    TemperatureBC,
+)
 from tidy3d.components.tcad.generation_recombination import (
     AugerRecombination,
     RadiativeRecombination,

--- a/tidy3d/constants.py
+++ b/tidy3d/constants.py
@@ -53,6 +53,11 @@ K_B = 8.617333262e-5
 Boltzmann constant [eV/K]
 """
 
+GRAV_ACC = 9.80665 * 1e6
+"""
+Gravitational acceleration (g) [um/s^2].",
+"""
+
 # floating point precisions
 dp_eps = np.finfo(np.float64).eps
 """
@@ -219,6 +224,26 @@ Watts per (square micrometer Kelvin).
 CURRENT_DENSITY = "A/um^2"
 """
 Amperes per square micrometer
+"""
+
+DYNAMIC_VISCOSITY = "kg/(um*s)"
+"""
+Kilograms per (micrometer second)
+"""
+
+SPECIFIC_HEAT = "um^2/(s^2*K)"
+"""
+Square micrometers per (square second Kelvin).
+"""
+
+THERMAL_EXPANSIVITY = "1/K"
+"""
+Inverse Kelvin.
+"""
+
+ACCELERATION = "um/s^2"
+"""
+Acceleration unit.
 """
 
 LARGE_NUMBER = 1e10


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR introduces a new `NaturalConvectionVerticalSpec` class to enhance thermal boundary condition modeling in the Tidy3D framework. The class enables automatic calculation of heat transfer coefficients for natural convection from vertical plates based on fluid properties rather than requiring manual coefficient specification.

The implementation follows standard heat transfer engineering practices by using Rayleigh number calculations and appropriate Nusselt number correlations to determine heat transfer coefficients. It supports both laminar and turbulent flow regimes based on critical Rayleigh number thresholds. The class accepts comprehensive fluid property inputs including thermal conductivity, viscosity, density, specific heat, and thermal expansion coefficient.

The integration is achieved by extending the existing `ConvectionBC.transfer_coeff` field to accept either a simple float (existing behavior) or the new `NaturalConvectionVerticalSpec` object, maintaining backward compatibility. The class is properly exported through the main package interface and integrated into the TCAD types system, following established patterns in the codebase for thermal boundary conditions.

## Confidence score: 2/5

- This PR has significant issues that could cause problems if merged, particularly around unit consistency and incomplete implementation
- The unit system mismatch between SI units and Tidy3D's micrometer-based system could lead to incorrect calculations, and the `_compute_parameters` method returns unused values suggesting incomplete integration
- Files `tidy3d/components/tcad/boundary/heat.py` needs immediate attention for unit consistency, parameter validation, and completion of the computation logic

<!-- /greptile_comment -->