### PR TITLE
Validate against EMEFieldMonitor with EMELengthSweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Giving opposite boundaries different names no longer causes a symmetry validator failure.
+- Fixed issue with parameters in `InverseDesignResult` sometimes being outside of the valid parameter range.
+- Disallow `EMEFieldMonitor` in EME simulations with `EMELengthSweep`.
 
 
 ## [2.9.0] - 2025-08-04

--- a/tests/test_components/test_eme.py
+++ b/tests/test_components/test_eme.py
@@ -492,7 +492,14 @@ def test_eme_simulation():
     assert sim_tmp._monitor_num_freqs(monitor=sim_tmp.monitors[0]) == 1
 
     # test sweep
-    sweep_sim = sim.updated_copy(
+    with pytest.raises(SetupError):
+        _ = sim.updated_copy(
+            sweep_spec=td.EMELengthSweep(scale_factors=list(np.linspace(1, 2, 10)))
+        )
+    sim_no_field = sim.updated_copy(
+        monitors=[mnt for mnt in sim.monitors if not isinstance(mnt, td.EMEFieldMonitor)]
+    )
+    sweep_sim = sim_no_field.updated_copy(
         sweep_spec=td.EMELengthSweep(scale_factors=list(np.linspace(1, 2, 10)))
     )
     assert sweep_sim._sweep_cells
@@ -500,15 +507,15 @@ def test_eme_simulation():
     assert sweep_sim._num_sweep_cells == 10
     assert sweep_sim._num_sweep_interfaces == 1
     assert sweep_sim._num_sweep_modes == 1
-    _ = sim.updated_copy(
+    _ = sim_no_field.updated_copy(
         sweep_spec=td.EMELengthSweep(
             scale_factors=np.stack((np.linspace(1, 2, 7), np.linspace(1, 2, 7)))
-        )
+        ),
     )
     with pytest.raises(SetupError):
-        _ = sim.updated_copy(sweep_spec=td.EMELengthSweep(scale_factors=[]))
+        _ = sim_no_field.updated_copy(sweep_spec=td.EMELengthSweep(scale_factors=[]))
     with pytest.raises(SetupError):
-        _ = sim.updated_copy(
+        _ = sim_no_field.updated_copy(
             sweep_spec=td.EMELengthSweep(
                 scale_factors=np.stack(
                     (
@@ -520,12 +527,14 @@ def test_eme_simulation():
         )
     # second shape of length sweep must equal number of cells
     with pytest.raises(SetupError):
-        _ = sim.updated_copy(sweep_spec=td.EMELengthSweep(scale_factors=np.array([[1, 2], [3, 4]])))
+        _ = sim_no_field.updated_copy(
+            sweep_spec=td.EMELengthSweep(scale_factors=np.array([[1, 2], [3, 4]]))
+        )
     _ = sim.updated_copy(sweep_spec=td.EMEModeSweep(num_modes=list(np.arange(1, 5))))
     # test sweep size limit
     with pytest.raises(SetupError):
-        _ = sim.updated_copy(sweep_spec=td.EMELengthSweep(scale_factors=[]))
-    sim_bad = sim.updated_copy(
+        _ = sim_no_field.updated_copy(sweep_spec=td.EMELengthSweep(scale_factors=[]))
+    sim_bad = sim_no_field.updated_copy(
         sweep_spec=td.EMELengthSweep(scale_factors=list(np.linspace(1, 2, 200)))
     )
     with pytest.raises(SetupError):
@@ -562,7 +571,7 @@ def test_eme_simulation():
     sim = sim.updated_copy(sweep_spec=None)
     assert sim._num_sweep == 1
     assert not sim._sweep_modes
-    sim = sim.updated_copy(sweep_spec=td.EMELengthSweep(scale_factors=[1, 2]))
+    sim = sim_no_field.updated_copy(sweep_spec=td.EMELengthSweep(scale_factors=[1, 2]))
     assert not sim._sweep_modes
     assert sim._num_sweep == 2
     sim = sim.updated_copy(sweep_spec=td.EMEFreqSweep(freq_scale_factors=[1, 2]))
@@ -1090,9 +1099,11 @@ def test_eme_sim_data():
 
     # test smatrix in basis with sweep
     smatrix = _get_eme_smatrix_dataset(num_modes_1=5, num_modes_2=5, num_sweep=10)
-    sim = sim.updated_copy(sweep_spec=td.EMELengthSweep(scale_factors=np.linspace(1, 2, 10)))
+    sim_sweep = sim.updated_copy(
+        sweep_spec=td.EMELengthSweep(scale_factors=np.linspace(1, 2, 10)), monitors=[]
+    )
     sim_data = td.EMESimulationData(
-        simulation=sim, data=data, smatrix=smatrix, port_modes_raw=port_modes
+        simulation=sim_sweep, data=[], smatrix=smatrix, port_modes_raw=port_modes
     )
 
     # test smatrix_in_basis

--- a/tidy3d/components/eme/simulation.py
+++ b/tidy3d/components/eme/simulation.py
@@ -706,6 +706,12 @@ class EMESimulation(AbstractYeeGridSimulation):
                         "must equal the number of EME cells in the simulation, which is "
                         f"'{self.eme_grid.num_cells}'."
                     )
+            for i, monitor in enumerate(self.monitors):
+                if isinstance(monitor, EMEFieldMonitor):
+                    raise SetupError(
+                        f"Monitor '{monitor.name}' at 'monitors[{i}]' is an 'EMEFieldMonitor', "
+                        "which is not compatible with 'EMELengthSweep'."
+                    )
         elif isinstance(self.sweep_spec, EMEFreqSweep):
             for i, scale_factor in enumerate(self.sweep_spec.freq_scale_factors):
                 scaled_freqs = np.array(self.freqs) * scale_factor
@@ -719,12 +725,12 @@ class EMESimulation(AbstractYeeGridSimulation):
             for i, monitor in enumerate(self.monitors):
                 if isinstance(monitor, EMEFieldMonitor):
                     raise SetupError(
-                        f"Monitor at 'monitors[{i}]' is an 'EMEFieldMonitor', "
+                        f"Monitor '{monitor.name}' at 'monitors[{i}]' is an 'EMEFieldMonitor', "
                         "which is not compatible with 'EMEPeriodicitySweep'."
                     )
                 if isinstance(monitor, EMECoefficientMonitor):
                     raise SetupError(
-                        f"Monitor at 'monitors[{i}]' is an 'EMECoefficientMonitor', "
+                        f"Monitor '{monitor.name}' at 'monitors[{i}]' is an 'EMECoefficientMonitor', "
                         "which is not compatible with 'EMEPeriodicitySweep'."
                     )
 
@@ -785,7 +791,7 @@ class EMESimulation(AbstractYeeGridSimulation):
                     self.eme_grid_spec.virtual_cell_indices, self.eme_grid_spec.real_cell_indices
                 ):
                     raise SetupError(
-                        f"Monitor at 'monitors[{i}]' is an 'EMEFieldMonitor', "
+                        f"Monitor '{monitor.name}' at 'monitors[{i}]' is an 'EMEFieldMonitor', "
                         "which is not compatible with periodic repetition "
                         "('num_reps != 1' in any 'EMEGridSpec'.)"
                     )


### PR DESCRIPTION
docs PR: https://github.com/flexcompute/tidy3d-notebooks/pull/340

EMEFieldMonitor gives misleading / incorrect results in EME simulations with EMELengthSweep. This is because while the coefficients and smatrix are swept correctly, the field data is still calculated on the original simulation geometry and grid.

This PR just validates against the combination.

<!-- greptile_comment -->

## Greptile Summary

This PR addresses a technical limitation in EME (Eigenmode Expansion) simulations by adding validation to prevent the problematic combination of `EMEFieldMonitor` with `EMELengthSweep`. The core issue is that during length sweeps, while the EME coefficients and S-matrix are correctly recalculated for each swept geometry, the `EMEFieldMonitor` field data remains calculated on the original simulation geometry and grid, creating a fundamental mismatch that leads to misleading or incorrect field results.

The solution implements validation in the `_validate_sweep_spec` method of the EME simulation class that checks all monitors and raises a `SetupError` if an `EMEFieldMonitor` is detected when the sweep specification is an `EMELengthSweep`. This validation follows the existing pattern used for other incompatible monitor/sweep combinations like `EMEPeriodicitySweep` and `EMEFreqSweep`.

The changes also include comprehensive test updates to ensure the validation works correctly and that existing length sweep tests continue to function by filtering out `EMEFieldMonitor` instances from monitor lists when testing sweep functionality. A changelog entry documents this as a fix that disallows the problematic combination.

This approach prioritizes user safety by preventing incorrect results rather than attempting to fix the underlying architectural complexity of making field monitors work properly with geometry changes during sweeps.

## Confidence score: 5/5

- This PR is extremely safe to merge as it only adds validation to prevent a known problematic configuration that produces incorrect results.
- The validation is straightforward, follows existing patterns in the codebase, and includes comprehensive test coverage to ensure it works as expected.
- All files have clear, focused changes with no complex logic or potential edge cases that could introduce bugs.

<!-- /greptile_comment -->