### PR TITLE
only trigger symmetric adjoint simulation warning when grouping by more than 1 port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed missing amplitude factor and handling of negative normal direction case when making adjoint sources from `DiffractionMonitor`.
 - Improved the robustness of batch jobs. The batch state, including all `task_ids`, is now saved to `batch.hdf5` immediately after upload. This fixes an issue where an interrupted batch (e.g., due to a kernel crash or network loss) would be unrecoverable.
+- Fixed warning for running symmetric adjoint simulations by port to not trigger when there is a single port.
 
 ## [2.9.0] - 2025-08-04
 

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -1192,7 +1192,7 @@ class SimulationData(AbstractYeeGridSimulationData):
             # warn if the forward simulation had symmetry and we are grouping by port, which
             # which means the individual adjoint simulations may not respect the original symmetry
             #
-            if np.any(np.abs(self.simulation.symmetry) > 0):
+            if np.any(np.abs(self.simulation.symmetry) > 0) and (num_ports > 1):
                 log.warning(
                     "The adjoint simulations for this problem are being broken into "
                     "multiple simulations that may not individually respect the symmetry of the "


### PR DESCRIPTION
This warning shouldn't happen when there is only one port in which case there is no issue with the adjoint simulations being grouped by port with symmetry turned on.

<!-- greptile_comment -->

## Greptile Summary

This PR fixes a false positive warning in the Tidy3D adjoint simulation system. The warning was designed to alert users when symmetric adjoint simulations are grouped by port, which can potentially make gradients unreliable due to symmetry violations. However, the warning was incorrectly triggering even when there was only a single port present.

The core issue was in the `sim_data.py` file where the symmetry warning logic didn't account for the number of ports. When there's only one port, no grouping occurs and the adjoint simulation maintains the same structure as the original simulation, so symmetry concerns don't apply. The fix adds a simple condition (`num_ports > 1`) to ensure the warning only appears when there are actually multiple ports that could cause symmetry issues.

This change integrates well with the existing adjoint simulation framework in Tidy3D, which handles electromagnetic simulations with symmetry constraints. The fix is targeted and doesn't affect the underlying adjoint computation logic - it only improves the user experience by eliminating unnecessary warnings.

## Important Files Changed

<details>
<summary>Files Modified</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/components/data/sim_data.py` | 5/5 | Added condition to only show symmetry warning when multiple ports exist |
| `CHANGELOG.md` | 5/5 | Added changelog entry documenting the bug fix for symmetric adjoint simulation warnings |

</details>

## Confidence score: 5/5

• This PR is extremely safe to merge as it only fixes a false positive warning without affecting core functionality.
• The logic is straightforward and well-targeted - adding a simple condition to prevent unnecessary warnings when there's only one port.
• No files need additional attention; both changes are minimal, clear, and well-justified.

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant SimulationData
    participant AdjointProcessor
    participant Logger
    
    User->>SimulationData: Process adjoint sources
    SimulationData->>AdjointProcessor: _process_adjoint_sources(adj_srcs)
    
    AdjointProcessor->>AdjointProcessor: Group sources by spatial location
    Note over AdjointProcessor: Creates hashes_to_sources dictionary
    
    AdjointProcessor->>AdjointProcessor: Count unique ports and frequencies
    Note over AdjointProcessor: num_ports = len(hashes_to_sources)<br/>num_unique_freqs = count unique freq0 values
    
    AdjointProcessor->>AdjointProcessor: Determine grouping strategy
    alt num_unique_freqs <= num_ports
        AdjointProcessor->>Logger: log.info("Grouping adjoint sources by frequency")
        AdjointProcessor->>AdjointProcessor: Group by frequency
    else num_unique_freqs > num_ports
        AdjointProcessor->>Logger: log.info("Grouping adjoint sources by port")
        
        alt simulation has symmetry AND num_ports > 1
            AdjointProcessor->>Logger: log.warning("Adjoint simulations may not respect symmetry")
            Note over Logger: WARNING: Only triggered when<br/>grouping by port AND more than 1 port
        end
        
        AdjointProcessor->>AdjointProcessor: Group by port location
    end
    
    AdjointProcessor->>AdjointProcessor: Create AdjointSourceInfo objects
    AdjointProcessor-->>SimulationData: Return list of adjoint source infos
    SimulationData-->>User: Processed adjoint sources
```

<!-- /greptile_comment -->