### PR TITLE
adding to_file after uploading batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed missing amplitude factor and handling of negative normal direction case when making adjoint sources from `DiffractionMonitor`.
+- Improved the robustness of batch jobs. The batch state, including all `task_ids`, is now saved to `batch.hdf5` immediately after upload. This fixes an issue where an interrupted batch (e.g., due to a kernel crash or network loss) would be unrecoverable.
 
 ## [2.9.0] - 2025-08-04
 

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -1,6 +1,8 @@
 # Tests webapi and things that depend on it
 from __future__ import annotations
 
+import os
+
 import numpy as np
 import pytest
 import responses
@@ -654,6 +656,40 @@ def test_create_output_dirs(mock_webapi, tmp_path, monkeypatch):
 
     assert non_existent_dirs_batch.exists()
     assert non_existent_dirs_batch.is_dir()
+
+
+@responses.activate
+def test_batch_run_saves_file_after_upload(mock_webapi, mock_job_status, tmp_path, monkeypatch):
+    """Test that batch.run() saves batch file with task_ids immediately after upload."""
+    sims = {TASK_NAME: make_sim()}
+    batch = Batch(simulations=sims, folder_name=PROJECT_NAME)
+
+    batch_file_saved = {"saved": False, "has_task_ids": False}
+    original_to_file = Batch.to_file
+
+    def track_to_file(self, fname):
+        batch_file_saved["saved"] = True
+        batch_file_saved["has_task_ids"] = self.jobs is not None and TASK_NAME in self.jobs
+        return original_to_file(self, fname)
+
+    # mock start to interrupt run() after upload and to_file
+    def mock_start_interrupt(self):
+        # at this point, upload() and to_file() should have been called
+        assert batch_file_saved["saved"], "Batch file should be saved before start()"
+        assert batch_file_saved["has_task_ids"], "Batch file should have task_ids"
+        # verify file actually exists and can be loaded
+        batch_path = self._batch_path(path_dir=str(tmp_path))
+        assert os.path.exists(batch_path)
+        recovered = Batch.from_file(batch_path)
+        assert recovered.jobs[TASK_NAME].task_id == TASK_ID
+        raise RuntimeError("Simulated interruption after upload")
+
+    monkeypatch.setattr(Batch, "to_file", track_to_file)
+    monkeypatch.setattr(Batch, "start", mock_start_interrupt)
+
+    # run should save the batch file after upload, even if interrupted
+    with pytest.raises(RuntimeError, match="Simulated interruption"):
+        batch.run(path_dir=str(tmp_path))
 
 
 """ Async """

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -601,6 +601,7 @@ class Batch(WebContainer):
         """
         self._check_path_dir(path_dir)
         self.upload()
+        self.to_file(self._batch_path(path_dir=path_dir))
         self.start()
         self.monitor()
         return self.load(path_dir=path_dir)
@@ -988,7 +989,6 @@ class Batch(WebContainer):
         allowing one to load this :class:`Batch` later using ``batch = Batch.from_file()``.
         """
         self._check_path_dir(path_dir=path_dir)
-        self.download(path_dir=path_dir, replace_existing=replace_existing)
 
         if self.jobs is None:
             raise DataError("Can't load batch results, hasn't been uploaded.")
@@ -1009,6 +1009,8 @@ class Batch(WebContainer):
             if isinstance(job.simulation, ModeSolver):
                 job_data = data[task_name]
                 job.simulation._patch_data(data=job_data)
+
+        self.download(path_dir=path_dir, replace_existing=replace_existing)
 
         return data
 


### PR DESCRIPTION
Hi @momchil-flex,

I'm not sure if you're the right person to review this. If not, please feel free to add the correct reviwer.

While assisting a user, I realized it would be straightforward to save the batch file after uploading the tasks but **before** running it, so that the `batch.hdf5` file contains the correct task_ids. If, for some reason, the kernel crashes or there is an internet disconnection before the batch completes, the user can easily load the batch.hdf5 and call the .load method.

Currently, the batch.hdf5 file is created initially without task_ids. If something happens before the batch finishes, it becomes a headache to recover.

<!-- greptile_comment -->

## Greptile Summary

This PR improves the batch workflow robustness by addressing a critical user experience issue where batch executions could become unrecoverable if interrupted. The main change adds a `to_file()` call in the `run()` method immediately after `upload()` but before `start()`, ensuring that the `batch.hdf5` file contains the necessary task_ids for recovery. Additionally, the `load()` method has been restructured to handle ModeSolver data patching before downloading.

The core problem being solved is that previously, if a batch execution was interrupted (due to kernel crashes, network disconnections, etc.) before completion, users were left with `batch.hdf5` files lacking task_ids, making recovery difficult. With this change, users can now easily recover from interruptions by loading the saved batch file and calling the `load()` method.

The secondary change in the `load()` method reorders operations to process ModeSolver simulations' data patching before downloading, which could optimize performance by avoiding unnecessary downloads for mode solver simulations that may have different data handling requirements.

## Important Files Changed

<details>
<summary>Files Changed</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/web/api/container.py | 4/5 | Added batch file saving after upload but before execution, and reordered load method operations |

</details>

## Confidence score: 4/5

• This PR addresses a legitimate user experience problem and the solution is straightforward and low-risk
• The change follows a logical execution order and doesn't introduce breaking changes to existing functionality
• The file needs attention to ensure the reordering in the load method doesn't introduce subtle timing issues with ModeSolver data handling

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant Batch
    participant Job
    participant WebAPI
    participant FileSystem

    User->>Batch: run(path_dir)
    Batch->>Batch: _check_path_dir(path_dir)
    Batch->>Batch: upload()
    Batch->>Batch: _check_folder(folder_name)
    
    loop For each simulation
        Batch->>Job: create job instance
        Batch->>Job: upload()
        Job->>WebAPI: upload simulation
        WebAPI-->>Job: return task_id
    end
    
    Note over Batch: NEW: Save batch with task_ids
    Batch->>Batch: to_file(_batch_path(path_dir))
    Batch->>FileSystem: save batch.hdf5 with task_ids
    
    Batch->>Batch: start()
    
    loop For each job
        Batch->>Job: start()
        Job->>WebAPI: start task
    end
    
    Batch->>Batch: monitor()
    Batch->>Batch: load(path_dir)
    Batch-->>User: return BatchData
```

<!-- /greptile_comment -->