### PR TITLE
ci: Update RTD sync

### DIFF
--- a/.github/workflows/tidy3d-docs-sync-readthedocs-repo.yml
+++ b/.github/workflows/tidy3d-docs-sync-readthedocs-repo.yml
@@ -2,6 +2,11 @@ name: "docs/tidy3d/sync-to-readthedocs-repo"
 
 on:
   workflow_dispatch:
+    inputs:
+      target_branch:
+        description: 'Target mirror repo branch. Defaults to source branch/tag.'
+        required: false
+        type: string
   push:
     branches:
       - main
@@ -24,7 +29,7 @@ jobs:
         shell: bash
         run: |
           REF_NAME="${GITHUB_REF#refs/*/}"
-          echo "::set-output name=ref_name::$REF_NAME"
+          echo "ref_name=$REF_NAME" >> $GITHUB_OUTPUT
           echo "Extracted ref: $REF_NAME"
 
   build-and-deploy:
@@ -33,29 +38,8 @@ jobs:
     needs: extract_branch_or_tag
     runs-on: ubuntu-latest
     steps:
-      # Conditional Checkout for Branch
-      - name: Checkout Branch if branch-triggered-sync
-        if: contains(github.ref, 'refs/heads/')
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-          token: ${{ secrets.GH_PAT }}
-          ref: ${{ needs.extract_branch_or_tag.outputs.ref_name }}
-
-      - name: Push corresponding reference to mirror repo if a branch
-        if: contains(github.ref, 'refs/heads/')
-        run: |
-          git fetch --unshallow origin ${{ needs.extract_branch_or_tag.outputs.ref_name }}
-          git pull origin ${{ needs.extract_branch_or_tag.outputs.ref_name }}
-          git remote add mirror https://github.com/flexcompute-readthedocs/tidy3d-docs.git
-          git push mirror ${{ needs.extract_branch_or_tag.outputs.ref_name }} --force # overwrites always
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-
-      # Conditional Checkout for Tag
-      - name: Checkout Tag if tag-triggered-sync
-        if: contains(github.ref, 'refs/tags/')
-        uses: actions/checkout@v3
+      - name: full-checkout
+        uses: actions/checkout@v4
         with:
           submodules: true
           token: ${{ secrets.GH_PAT }}
@@ -63,11 +47,21 @@ jobs:
           ref: ${{ needs.extract_branch_or_tag.outputs.ref_name }}
           fetch-tags: true
 
-
-      - name: Push corresponding reference to mirror repo if a tag
-        if: contains(github.ref, 'refs/tags/')
-        run: |
-          git remote add mirror https://github.com/flexcompute-readthedocs/tidy3d-docs.git
-          git push mirror ${{ needs.extract_branch_or_tag.outputs.ref_name }} --force # overwrites always
+      - name: push-mirror-repo
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+          SOURCE_REF: ${{ needs.extract_branch_or_tag.outputs.ref_name }}
+          TARGET_BRANCH_INPUT: ${{ github.event.inputs.target_branch }}
+        run: |
+          echo "Source reference: $SOURCE_REF"
+          git pull origin "$SOURCE_REF"
+          git remote add mirror https://github.com/flexcompute-readthedocs/tidy3d-docs.git
+         
+          if [[ -n "$TARGET_BRANCH_INPUT" && "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "Manual trigger detected. Pushing contents of '$SOURCE_REF' to remote branch '$TARGET_BRANCH_INPUT'."
+            git push mirror "$SOURCE_REF:refs/heads/$TARGET_BRANCH_INPUT" --force
+          else
+            echo "Automatic trigger or manual run without target. Pushing '$SOURCE_REF' to the same ref on the mirror."
+            # This preserves the original behavior: pushes a branch to a branch, or a tag to a tag.
+            git push mirror "$SOURCE_REF" --force
+          fi


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR enhances the GitHub Actions workflow that synchronizes documentation from the main repository to a Read the Docs mirror repository. The changes add manual workflow dispatch capability, allowing developers to manually trigger documentation syncs and optionally specify a target branch different from the source branch. This provides more flexibility for documentation deployment strategies, testing changes on different branches, and preparing releases.

The workflow maintains backward compatibility - when triggered automatically (via push/tag events), it continues to mirror content to the same branch/tag names as before. However, when manually triggered, users can now specify a target branch parameter to push content from any source branch to a specific target branch in the mirror repository.

Additionally, the PR includes maintenance updates to keep the workflow compatible with current GitHub Actions standards: upgrading from deprecated `set-output` syntax to `GITHUB_OUTPUT` environment files, and updating checkout actions from v3 to v4. The logic for pushing to the mirror repository has been consolidated and made conditional based on the trigger type.

The submodule update for `docs/notebooks` brings in newer notebook content that will be included in the synchronized documentation.

## Important Files Changed

<details>
<summary>File Changes</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `.github/workflows/tidy3d-docs-sync-readthedocs-repo.yml` | 4/5 | Added manual workflow dispatch with target branch parameter and updated GitHub Actions syntax |
| `docs/notebooks` | 5/5 | Updated submodule reference to bring in newer notebook content |

</details>

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it primarily adds optional functionality and performs maintenance updates
- Score reflects well-structured workflow enhancements with proper conditional logic and backward compatibility preservation
- Pay close attention to the workflow file to ensure the conditional branching logic works correctly in both manual and automatic trigger scenarios

<!-- /greptile_comment -->