### PR TITLE
Fix adjoint postprocessing frequency batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-### Changed
-
-### Fixed
-- Giving opposite boundaries different names no longer causes a symmetry validator failure.
-- Fixed issue with parameters in `InverseDesignResult` sometimes being outside of the valid parameter range.
-- Disallow `EMEFieldMonitor` in EME simulations with `EMELengthSweep`.
-
-
 ## [2.9.0] - 2025-08-04
 
 ### Added
@@ -94,6 +84,10 @@ with fewer layers than recommended.
 - Giving opposite boundaries different names no longer causes a symmetry validator failure.
 - Fixed issue with parameters in `InverseDesignResult` sometimes being outside of the valid parameter range.
 - Fixed performance regression for multi-frequency adjoint calculations.
+- Disallow `EMEFieldMonitor` in EME simulations with `EMELengthSweep`.
+- Fixed bug in adjoint postprocessing frequency batching that was causing gradients to be zero or incorrect. The error was surfacing when selecting a subset of the monitor frequencies in the objective function.
+
+
 
 ## [2.8.5] - 2025-07-07
 

--- a/tests/test_components/test_autograd_mode_polyslab_numerical.py
+++ b/tests/test_components/test_autograd_mode_polyslab_numerical.py
@@ -359,14 +359,34 @@ def test_finite_difference_mode_data_polyslab(
     # due to a multifrequency objective function.
     monitor_top_weights = rng.random(NUM_MODE_MONITOR_FREQUENCIES)
     monitor_bottom_weights = rng.random(NUM_MODE_MONITOR_FREQUENCIES)
+    frequency_selection_mask = np.arange(0, NUM_MODE_MONITOR_FREQUENCIES)
+
+    # sometimes, test what happens when we only use one of the frequencies from the mode monitors
+    # to catch handling of different frequencies being present in the forward and adjoint monitors
+    if rng.random() > 0.5:
+        frequency_selection_mask = rng.integers(1, NUM_MODE_MONITOR_FREQUENCIES)
+        monitor_top_weights = monitor_top_weights[frequency_selection_mask]
+        monitor_bottom_weights = monitor_bottom_weights[frequency_selection_mask]
 
     def eval_fn(sim_data):
         return np.sum(
             monitor_top_weights
-            * np.abs(sim_data["monitor_mode_top"].amps.sel(direction="+").values) ** 2
+            * np.abs(
+                sim_data["monitor_mode_top"]
+                .amps.sel(direction="+")
+                .isel(f=frequency_selection_mask)
+                .data
+            )
+            ** 2
         ) + np.sum(
             monitor_bottom_weights
-            * np.abs(sim_data["monitor_mode_bottom"].amps.sel(direction="+").values) ** 2
+            * np.abs(
+                sim_data["monitor_mode_bottom"]
+                .amps.sel(direction="+")
+                .isel(f=frequency_selection_mask)
+                .data
+            )
+            ** 2
         )
 
     polyslab_height_um = POLYSLAB_HEIGHT_WVL * adj_wvl_um

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -989,22 +989,25 @@ def _compute_eps_array(medium, frequencies):
     return DataArray(data=np.array(eps_data), dims=("f",), coords={"f": frequencies})
 
 
-def _slice_field_data(field_data: dict, freq_slice: slice) -> dict:
+def _slice_field_data(
+    field_data: dict,
+    freqs: np.ndarray,
+) -> dict:
     """Slice field data dictionary along frequency dimension.
 
     Parameters
     ----------
     field_data : dict
         Dictionary of field components.
-    freq_slice : slice
-        Frequency slice to apply.
+    freqs : np.ndarray
+        Frequencies to select.
 
     Returns
     -------
     dict
         Sliced field data dictionary.
     """
-    return {k: v.isel(f=freq_slice) for k, v in field_data.items()}
+    return {k: v.sel(f=freqs) for k, v in field_data.items()}
 
 
 def postprocess_adj(
@@ -1119,26 +1122,32 @@ def postprocess_adj(
             chunk_end = min(chunk_start + freq_chunk_size, n_freqs)
             freq_slice = slice(chunk_start, chunk_end)
 
+            select_adjoint_freqs = adjoint_frequencies[freq_slice]
+
             # slice field data for current chunk
-            E_der_map_chunk = _slice_field_data(E_der_map.field_components, freq_slice)
-            D_der_map_chunk = _slice_field_data(D_der_map.field_components, freq_slice)
-            E_fwd_chunk = _slice_field_data(E_fwd.field_components, freq_slice)
-            E_adj_chunk = _slice_field_data(E_adj.field_components, freq_slice)
-            D_fwd_chunk = _slice_field_data(D_fwd.field_components, freq_slice)
-            D_adj_chunk = _slice_field_data(D_adj.field_components, freq_slice)
-            eps_data_chunk = _slice_field_data(eps_fwd.field_components, freq_slice)
+            E_der_map_chunk = _slice_field_data(E_der_map.field_components, select_adjoint_freqs)
+            D_der_map_chunk = _slice_field_data(D_der_map.field_components, select_adjoint_freqs)
+            E_fwd_chunk = _slice_field_data(E_fwd.field_components, select_adjoint_freqs)
+            E_adj_chunk = _slice_field_data(E_adj.field_components, select_adjoint_freqs)
+            D_fwd_chunk = _slice_field_data(D_fwd.field_components, select_adjoint_freqs)
+            D_adj_chunk = _slice_field_data(D_adj.field_components, select_adjoint_freqs)
+            eps_data_chunk = _slice_field_data(eps_fwd.field_components, select_adjoint_freqs)
 
             # slice epsilon arrays
-            eps_in_chunk = eps_in.isel(f=freq_slice)
-            eps_out_chunk = eps_out.isel(f=freq_slice)
+            eps_in_chunk = eps_in.sel(f=select_adjoint_freqs)
+            eps_out_chunk = eps_out.sel(f=select_adjoint_freqs)
             eps_background_chunk = (
-                eps_background.isel(f=freq_slice) if eps_background is not None else None
+                eps_background.sel(f=select_adjoint_freqs) if eps_background is not None else None
             )
             eps_no_structure_chunk = (
-                eps_no_structure.isel(f=freq_slice) if eps_no_structure is not None else None
+                eps_no_structure.sel(f=select_adjoint_freqs)
+                if eps_no_structure is not None
+                else None
             )
             eps_inf_structure_chunk = (
-                eps_inf_structure.isel(f=freq_slice) if eps_inf_structure is not None else None
+                eps_inf_structure.sel(f=select_adjoint_freqs)
+                if eps_inf_structure is not None
+                else None
             )
 
             # create derivative info with sliced data


### PR DESCRIPTION
This was a little bit tricky to track down, but the core of what was going on is this:
When the frequency batching happens, it is based on indexes into the frequency dimension of the xarrays (as opposed to directly selecting the frequencies in the batch) containing the data from the adjoint monitors. However, when someone selects a subset of the frequencies from a monitor in their objective function, the adjoint monitors from the adjoint simulation don't always contain the same frequencies as the adjoint monitors from the forward simulation (or the permittivity data since we take those from the forward simulation). An example of this happening is a monitor containing two frequencies (say f0 and f1), but a user computing something like this in their objective function:  `np.sum(np.abs(sim_data["monitor"].amps(direction="+", f=f1).data)**2)`  This is how this came up initially for me since I had a monitor that I was only computing an objective function on the middle of three frequencies for.

In these cases, the frequency dimensions are not in alignment for the forward data and the adjoint data. When the isel happens, it pulls data for misaligned frequencies and passes this data into the compute derivative functions. One place that goes wrong is using the permittivity xarray in an operation with the D_der_map xarray which returns an empty array because they have different frequencies in the f dimension (or it could return an array with less frequencies than should be there and then the frequency dimension is summed over). If the fields are used outside of their xarrays then this can cause fields of different frequencies to be used in the gradient computation.

<!-- greptile_comment -->

## Greptile Summary

This PR fixes a critical bug in the adjoint postprocessing frequency batching system that was causing gradients to be zero or incorrect when users selected subsets of monitor frequencies in their objective functions. The core issue was that frequency batching used index-based selection (`isel`) rather than value-based selection (`sel`), which caused frequency dimension misalignment between forward and adjoint simulation data.

When users filter monitor data to specific frequencies in their objective functions (e.g., `sim_data["monitor"].amps(direction="+", f=f1)`), the adjoint monitors don't contain the same frequency set as the forward simulation monitors. This misalignment caused operations between xarrays with different frequency coordinates to return empty arrays or incorrect results, breaking gradient computation.

The fix changes the `_slice_field_data` function to use `.sel(f=freqs)` instead of index-based slicing, ensuring that both forward and adjoint data are aligned using actual frequency values rather than array positions. This maintains proper frequency coordination across all field components (E_der_map, D_der_map, H_der_map, B_der_map) and epsilon arrays during the frequency batching process. The change integrates seamlessly with the existing autograd infrastructure and preserves the batching optimization while ensuring gradient correctness.

## Important Files Changed

<details>
<summary>Files Modified</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `CHANGELOG.md` | 5/5 | Added changelog entry documenting the frequency batching bug fix |
| `tidy3d/web/api/autograd/autograd.py` | 4/5 | Core fix changing frequency slicing from index-based to value-based selection |
| `tests/test_components/test_autograd_mode_polyslab_numerical.py` | 4/5 | Added test case to reproduce and validate the frequency batching fix |

</details>

## Confidence score: 4/5

- This PR addresses a critical bug with a well-targeted fix that maintains system integrity
- Score reflects the importance of the fix and clear understanding of the root cause, though the complexity of autograd systems requires careful validation
- Pay close attention to the test file modifications which include debugging changes that should be reviewed

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant WebAPI as "tidy3d.web.run"
    participant AutogradModule as "Autograd Module"
    participant ForwardSim as "Forward Simulation"
    participant AdjointSim as "Adjoint Simulation"
    participant GradientProcessor as "Gradient Processor"

    User->>WebAPI: "Call run() with traced simulation"
    WebAPI->>AutogradModule: "Check is_valid_for_autograd()"
    AutogradModule->>WebAPI: "Return True"
    WebAPI->>AutogradModule: "_run_primitive()"
    
    AutogradModule->>ForwardSim: "setup_fwd() - create forward sim with adjoint monitors"
    ForwardSim->>AutogradModule: "Return combined simulation"
    AutogradModule->>ForwardSim: "_run_tidy3d()"
    ForwardSim->>AutogradModule: "Return sim_data_combined, task_id"
    
    AutogradModule->>AutogradModule: "postprocess_fwd() - split original/fwd data"
    AutogradModule->>User: "Return traced field data"
    
    Note over User: "User computes objective function"
    User->>AutogradModule: "VJP call with gradient data"
    
    AutogradModule->>AutogradModule: "setup_adj() - create adjoint simulations"
    AutogradModule->>AdjointSim: "_run_async_tidy3d() - run adjoint batch"
    AdjointSim->>AutogradModule: "Return batch_data_adj"
    
    AutogradModule->>GradientProcessor: "postprocess_adj() - compute gradients"
    GradientProcessor->>GradientProcessor: "_slice_field_data() - slice by frequency"
    GradientProcessor->>GradientProcessor: "_compute_eps_array() - compute permittivity"
    GradientProcessor->>GradientProcessor: "get_derivative_maps() - align field data"
    GradientProcessor->>GradientProcessor: "Process frequency chunks"
    GradientProcessor->>AutogradModule: "Return vjp_traced_fields"
    
    AutogradModule->>User: "Return final gradients"
```

<!-- /greptile_comment -->