### PR TITLE
Bug fix in CoaxialLumpedPort.to_source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed missing amplitude factor and handling of negative normal direction case when making adjoint sources from `DiffractionMonitor`.
 - Improved the robustness of batch jobs. The batch state, including all `task_ids`, is now saved to `batch.hdf5` immediately after upload. This fixes an issue where an interrupted batch (e.g., due to a kernel crash or network loss) would be unrecoverable.
 - Fixed warning for running symmetric adjoint simulations by port to not trigger when there is a single port.
+- Bug in `CoaxialLumpedPort` where source injection is off when the `normal_axis` is not `z`.
 
 ## [2.9.0] - 2025-08-04
 

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -386,6 +386,22 @@ def test_coaxial_port_snapping(tmp_path):
     check_lumped_port_components_snapped_correctly(modeler=modeler)
 
 
+@pytest.mark.parametrize("axis", [0, 1, 2])
+def test_coaxial_port_source_size(axis):
+    """Make sure source size is correct."""
+    port = CoaxialLumpedPort(
+        center=(0, 0, 0),
+        inner_diameter=1,
+        outer_diameter=2,
+        normal_axis=axis,
+        direction="+",
+        name="port",
+        impedance=50,
+    )
+    source = port.to_source(td.GaussianPulse(freq0=1e10, fwidth=1e9))
+    assert np.isclose(source.size[axis], 0)
+
+
 def test_power_delivered_helper(monkeypatch, tmp_path):
     """Test computations involving power waves are correct by manually setting voltage and current
     at ports using monkeypatch.

--- a/tidy3d/plugins/smatrix/ports/coaxial_lumped.py
+++ b/tidy3d/plugins/smatrix/ports/coaxial_lumped.py
@@ -192,7 +192,7 @@ class CoaxialLumpedPort(AbstractLumpedPort, AbstractAxesRH):
 
         return CustomCurrentSource(
             center=center,
-            size=(self.outer_diameter, self.outer_diameter, 0),
+            size=size,
             source_time=source_time,
             name=self.name,
             interpolate=True,


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR fixes a coordinate system bug in the `CoaxialLumpedPort.to_source()` method within the Tidy3D electromagnetic simulation framework. The issue occurred when creating current sources for coaxial lumped ports with non-z normal axes.

The core problem was in the source size calculation. While the code correctly computed a `size` array that sets the injection axis dimension to 0 and transverse dimensions to `outer_diameter`, the actual source creation was hardcoded to use `(self.outer_diameter, self.outer_diameter, 0)`. This hardcoded tuple assumed the injection axis was always z, causing incorrect source geometries when `normal_axis` was set to x or y.

The fix replaces the hardcoded size tuple with the properly computed `size` variable, ensuring that the source geometry correctly matches the port orientation regardless of which axis is chosen as the normal. This is essential for proper electromagnetic field injection in coaxial transmission line simulations across all coordinate orientations.

The changes integrate well with the existing codebase architecture, where `CoaxialLumpedPort` inherits from base port classes and follows the established pattern of orientation-agnostic implementations. The fix maintains backward compatibility while extending correct functionality to all supported orientations.

## Important Files Changed

<details>
<summary>Files Modified</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `CHANGELOG.md` | 5/5 | Added changelog entry documenting the bug fix in `CoaxialLumpedPort` |
| `tidy3d/plugins/smatrix/ports/coaxial_lumped.py` | 5/5 | Fixed hardcoded source size to use computed size variable for correct axis handling |
| `tests/test_plugins/smatrix/test_terminal_component_modeler.py` | 5/5 | Added parametrized test to verify source size correctness across all axes |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk
- Score reflects a focused bug fix with clear test coverage and proper documentation
- No files require special attention

<!-- /greptile_comment -->