### PR TITLE
ABC broadband

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `conjugated_dot_product` field in `ModeMonitor` (default: `True`) and `WavePort` (default: `False`) to allow selecting the conjugated or non-conjugated dot product for mode decomposition.
 - Support for gradients with respect to the `conductivity` of a `CustomMedium`.
 - Added `VerticalNaturalConvectionCoeffModel`, a model for heat transfer due to natural convection from a vertical plate. It can be used in `ConvectionBC` to compute the heat transfer coefficient from fluid properties, using standard Nusselt number correlations for both laminar and turbulent flow.
+- Added `BroadbandModeABCSpec` class for setting broadband absorbing boundary conditions that can absorb waveguide modes over a specified frequency range using a pole-residue pair model.
 
 ### Changed
 - Validate mode solver object for large number of grid points on the modal plane.

--- a/docs/api/boundary_conditions.rst
+++ b/docs/api/boundary_conditions.rst
@@ -51,6 +51,8 @@ Absorber Parameters
 
    tidy3d.AbsorberParams
    tidy3d.PMLParams
+   tidy3d.BroadbandModeABCSpec
+   tidy3d.BroadbandModeABCFitterParam
 
 
 Internal Absorbers

--- a/schemas/EMESimulation.json
+++ b/schemas/EMESimulation.json
@@ -9772,9 +9772,114 @@
       },
       "additionalProperties": false
     },
+    "BroadbandModeABCFitterParam": {
+      "title": "BroadbandModeABCFitterParam",
+      "description": "Parameters for fitting the mode propagation index over the frequency range using pole-residue pair model.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nmax_num_poles : ConstrainedIntValue = 5\n    Maximal number of poles in complex-conjugate pole residue model for fitting the mode propagation index.\ntolerance_rms : NonNegativeFloat = 1e-06\n    Tolerance in fitting the mode propagation index.\nfrequency_sampling_points : ConstrainedIntValue = 15\n    Number of sampling frequencies used in fitting the mode propagation index.\n\nNotes\n-----\nThe number of poles and frequency sampling points are constrained to be within the range [1, 10] and [1, 101] respectively.\n\nExample\n-------\n>>> fitter_param = BroadbandModeABCFitterParam(max_num_poles=5, tolerance_rms=1e-4, frequency_sampling_points=10)",
+      "type": "object",
+      "properties": {
+        "attrs": {
+          "title": "Attributes",
+          "description": "Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.",
+          "default": {},
+          "type": "object"
+        },
+        "max_num_poles": {
+          "title": "Maximal Number Of Poles",
+          "description": "Maximal number of poles in complex-conjugate pole residue model for fitting the mode propagation index.",
+          "default": 5,
+          "exclusiveMinimum": 0,
+          "maximum": 10,
+          "type": "integer"
+        },
+        "tolerance_rms": {
+          "title": "Fitting Tolerance",
+          "description": "Tolerance in fitting the mode propagation index.",
+          "default": 1e-06,
+          "minimum": 0,
+          "type": "number"
+        },
+        "frequency_sampling_points": {
+          "title": "Number Of Frequencies",
+          "description": "Number of sampling frequencies used in fitting the mode propagation index.",
+          "default": 15,
+          "exclusiveMinimum": 0,
+          "maximum": 101,
+          "type": "integer"
+        },
+        "type": {
+          "title": "Type",
+          "default": "BroadbandModeABCFitterParam",
+          "enum": [
+            "BroadbandModeABCFitterParam"
+          ],
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "BroadbandModeABCSpec": {
+      "title": "BroadbandModeABCSpec",
+      "description": "Specifies the broadband mode absorption boundary conditions. The mode propagation index is approximated by a sum of pole-residue pairs.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nfrequency_range : Tuple[float, float]\n    [units = (Hz, Hz)].  Frequency range for the broadband mode absorption boundary conditions.\nfit_param : BroadbandModeABCFitterParam = BroadbandModeABCFitterParam(attrs={}, max_num_poles=5, tolerance_rms=1e-06, frequency_sampling_points=15, type='BroadbandModeABCFitterParam')\n    Parameters for fitting the mode propagation index over the frequency range using pole-residue pair model.\n\nExample\n-------\n>>> broadband_mode_abc_spec = BroadbandModeABCSpec(frequency_range=(100e12, 120e12), fit_param=BroadbandModeABCFitterParam())",
+      "type": "object",
+      "properties": {
+        "attrs": {
+          "title": "Attributes",
+          "description": "Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.",
+          "default": {},
+          "type": "object"
+        },
+        "frequency_range": {
+          "title": "Frequency Range",
+          "description": "Frequency range for the broadband mode absorption boundary conditions.",
+          "units": [
+            "Hz",
+            "Hz"
+          ],
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "fit_param": {
+          "title": "Fitting Parameters For Broadband Mode Absorption Boundary Conditions",
+          "description": "Parameters for fitting the mode propagation index over the frequency range using pole-residue pair model.",
+          "default": {
+            "attrs": {},
+            "max_num_poles": 5,
+            "tolerance_rms": 1e-06,
+            "frequency_sampling_points": 15,
+            "type": "BroadbandModeABCFitterParam"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/BroadbandModeABCFitterParam"
+            }
+          ]
+        },
+        "type": {
+          "title": "Type",
+          "default": "BroadbandModeABCSpec",
+          "enum": [
+            "BroadbandModeABCSpec"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "frequency_range"
+      ],
+      "additionalProperties": false
+    },
     "ModeABCBoundary": {
       "title": "ModeABCBoundary",
-      "description": "One-way wave equation absorbing boundary conditions for absorbing a waveguide mode.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for boundary.\nmode_spec : ModeSpec = ModeSpec(attrs={}, num_modes=1, target_neff=None, num_pml=(0,, 0), filter_pol=None, angle_theta=0.0, angle_phi=0.0, precision='double', bend_radius=None, bend_axis=None, angle_rotation=False, track_freq='central', group_index_step=False, type='ModeSpec')\n    Parameters that determine the modes computed by the mode solver.\nmode_index : NonNegativeInt = 0\n    Index into the collection of modes returned by mode solver. The absorbing boundary conditions are configured to absorb the specified mode. If larger than ``mode_spec.num_modes``, ``num_modes`` in the solver will be set to ``mode_index + 1``.\nfrequency : Optional[PositiveFloat] = None\n    Frequency at which the absorbed mode is evaluated. If ``None``, then the central frequency of the source is used.\nplane : Box\n    Cross-sectional plane in which the absorbed mode will be computed.",
+      "description": "One-way wave equation absorbing boundary conditions for absorbing a waveguide mode.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for boundary.\nmode_spec : ModeSpec = ModeSpec(attrs={}, num_modes=1, target_neff=None, num_pml=(0,, 0), filter_pol=None, angle_theta=0.0, angle_phi=0.0, precision='double', bend_radius=None, bend_axis=None, angle_rotation=False, track_freq='central', group_index_step=False, type='ModeSpec')\n    Parameters that determine the modes computed by the mode solver.\nmode_index : NonNegativeInt = 0\n    Index into the collection of modes returned by mode solver. The absorbing boundary conditions are configured to absorb the specified mode. If larger than ``mode_spec.num_modes``, ``num_modes`` in the solver will be set to ``mode_index + 1``.\nfreq_spec : Union[PositiveFloat, BroadbandModeABCSpec, NoneType] = None\n    Specifies the frequency at which field is absorbed. If ``None``, then the central frequency of the source is used. If ``BroadbandModeABCSpec``, then the field is absorbed over the specified frequency range.\nplane : Box\n    Cross-sectional plane in which the absorbed mode will be computed.",
       "type": "object",
       "properties": {
         "attrs": {
@@ -9831,11 +9936,18 @@
           "minimum": 0,
           "type": "integer"
         },
-        "frequency": {
-          "title": "Frequency",
-          "description": "Frequency at which the absorbed mode is evaluated. If ``None``, then the central frequency of the source is used.",
-          "exclusiveMinimum": 0,
-          "type": "number"
+        "freq_spec": {
+          "title": "Absorption Frequency Specification",
+          "description": "Specifies the frequency at which field is absorbed. If ``None``, then the central frequency of the source is used. If ``BroadbandModeABCSpec``, then the field is absorbed over the specified frequency range.",
+          "anyOf": [
+            {
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            {
+              "$ref": "#/definitions/BroadbandModeABCSpec"
+            }
+          ]
         },
         "plane": {
           "title": "Plane",

--- a/schemas/ModeSimulation.json
+++ b/schemas/ModeSimulation.json
@@ -9817,9 +9817,114 @@
       },
       "additionalProperties": false
     },
+    "BroadbandModeABCFitterParam": {
+      "title": "BroadbandModeABCFitterParam",
+      "description": "Parameters for fitting the mode propagation index over the frequency range using pole-residue pair model.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nmax_num_poles : ConstrainedIntValue = 5\n    Maximal number of poles in complex-conjugate pole residue model for fitting the mode propagation index.\ntolerance_rms : NonNegativeFloat = 1e-06\n    Tolerance in fitting the mode propagation index.\nfrequency_sampling_points : ConstrainedIntValue = 15\n    Number of sampling frequencies used in fitting the mode propagation index.\n\nNotes\n-----\nThe number of poles and frequency sampling points are constrained to be within the range [1, 10] and [1, 101] respectively.\n\nExample\n-------\n>>> fitter_param = BroadbandModeABCFitterParam(max_num_poles=5, tolerance_rms=1e-4, frequency_sampling_points=10)",
+      "type": "object",
+      "properties": {
+        "attrs": {
+          "title": "Attributes",
+          "description": "Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.",
+          "default": {},
+          "type": "object"
+        },
+        "max_num_poles": {
+          "title": "Maximal Number Of Poles",
+          "description": "Maximal number of poles in complex-conjugate pole residue model for fitting the mode propagation index.",
+          "default": 5,
+          "exclusiveMinimum": 0,
+          "maximum": 10,
+          "type": "integer"
+        },
+        "tolerance_rms": {
+          "title": "Fitting Tolerance",
+          "description": "Tolerance in fitting the mode propagation index.",
+          "default": 1e-06,
+          "minimum": 0,
+          "type": "number"
+        },
+        "frequency_sampling_points": {
+          "title": "Number Of Frequencies",
+          "description": "Number of sampling frequencies used in fitting the mode propagation index.",
+          "default": 15,
+          "exclusiveMinimum": 0,
+          "maximum": 101,
+          "type": "integer"
+        },
+        "type": {
+          "title": "Type",
+          "default": "BroadbandModeABCFitterParam",
+          "enum": [
+            "BroadbandModeABCFitterParam"
+          ],
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "BroadbandModeABCSpec": {
+      "title": "BroadbandModeABCSpec",
+      "description": "Specifies the broadband mode absorption boundary conditions. The mode propagation index is approximated by a sum of pole-residue pairs.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nfrequency_range : Tuple[float, float]\n    [units = (Hz, Hz)].  Frequency range for the broadband mode absorption boundary conditions.\nfit_param : BroadbandModeABCFitterParam = BroadbandModeABCFitterParam(attrs={}, max_num_poles=5, tolerance_rms=1e-06, frequency_sampling_points=15, type='BroadbandModeABCFitterParam')\n    Parameters for fitting the mode propagation index over the frequency range using pole-residue pair model.\n\nExample\n-------\n>>> broadband_mode_abc_spec = BroadbandModeABCSpec(frequency_range=(100e12, 120e12), fit_param=BroadbandModeABCFitterParam())",
+      "type": "object",
+      "properties": {
+        "attrs": {
+          "title": "Attributes",
+          "description": "Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.",
+          "default": {},
+          "type": "object"
+        },
+        "frequency_range": {
+          "title": "Frequency Range",
+          "description": "Frequency range for the broadband mode absorption boundary conditions.",
+          "units": [
+            "Hz",
+            "Hz"
+          ],
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "fit_param": {
+          "title": "Fitting Parameters For Broadband Mode Absorption Boundary Conditions",
+          "description": "Parameters for fitting the mode propagation index over the frequency range using pole-residue pair model.",
+          "default": {
+            "attrs": {},
+            "max_num_poles": 5,
+            "tolerance_rms": 1e-06,
+            "frequency_sampling_points": 15,
+            "type": "BroadbandModeABCFitterParam"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/BroadbandModeABCFitterParam"
+            }
+          ]
+        },
+        "type": {
+          "title": "Type",
+          "default": "BroadbandModeABCSpec",
+          "enum": [
+            "BroadbandModeABCSpec"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "frequency_range"
+      ],
+      "additionalProperties": false
+    },
     "ModeABCBoundary": {
       "title": "ModeABCBoundary",
-      "description": "One-way wave equation absorbing boundary conditions for absorbing a waveguide mode.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for boundary.\nmode_spec : ModeSpec = ModeSpec(attrs={}, num_modes=1, target_neff=None, num_pml=(0,, 0), filter_pol=None, angle_theta=0.0, angle_phi=0.0, precision='double', bend_radius=None, bend_axis=None, angle_rotation=False, track_freq='central', group_index_step=False, type='ModeSpec')\n    Parameters that determine the modes computed by the mode solver.\nmode_index : NonNegativeInt = 0\n    Index into the collection of modes returned by mode solver. The absorbing boundary conditions are configured to absorb the specified mode. If larger than ``mode_spec.num_modes``, ``num_modes`` in the solver will be set to ``mode_index + 1``.\nfrequency : Optional[PositiveFloat] = None\n    Frequency at which the absorbed mode is evaluated. If ``None``, then the central frequency of the source is used.\nplane : Box\n    Cross-sectional plane in which the absorbed mode will be computed.",
+      "description": "One-way wave equation absorbing boundary conditions for absorbing a waveguide mode.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for boundary.\nmode_spec : ModeSpec = ModeSpec(attrs={}, num_modes=1, target_neff=None, num_pml=(0,, 0), filter_pol=None, angle_theta=0.0, angle_phi=0.0, precision='double', bend_radius=None, bend_axis=None, angle_rotation=False, track_freq='central', group_index_step=False, type='ModeSpec')\n    Parameters that determine the modes computed by the mode solver.\nmode_index : NonNegativeInt = 0\n    Index into the collection of modes returned by mode solver. The absorbing boundary conditions are configured to absorb the specified mode. If larger than ``mode_spec.num_modes``, ``num_modes`` in the solver will be set to ``mode_index + 1``.\nfreq_spec : Union[PositiveFloat, BroadbandModeABCSpec, NoneType] = None\n    Specifies the frequency at which field is absorbed. If ``None``, then the central frequency of the source is used. If ``BroadbandModeABCSpec``, then the field is absorbed over the specified frequency range.\nplane : Box\n    Cross-sectional plane in which the absorbed mode will be computed.",
       "type": "object",
       "properties": {
         "attrs": {
@@ -9876,11 +9981,18 @@
           "minimum": 0,
           "type": "integer"
         },
-        "frequency": {
-          "title": "Frequency",
-          "description": "Frequency at which the absorbed mode is evaluated. If ``None``, then the central frequency of the source is used.",
-          "exclusiveMinimum": 0,
-          "type": "number"
+        "freq_spec": {
+          "title": "Absorption Frequency Specification",
+          "description": "Specifies the frequency at which field is absorbed. If ``None``, then the central frequency of the source is used. If ``BroadbandModeABCSpec``, then the field is absorbed over the specified frequency range.",
+          "anyOf": [
+            {
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            {
+              "$ref": "#/definitions/BroadbandModeABCSpec"
+            }
+          ]
         },
         "plane": {
           "title": "Plane",

--- a/schemas/Simulation.json
+++ b/schemas/Simulation.json
@@ -12136,9 +12136,114 @@
       },
       "additionalProperties": false
     },
+    "BroadbandModeABCFitterParam": {
+      "title": "BroadbandModeABCFitterParam",
+      "description": "Parameters for fitting the mode propagation index over the frequency range using pole-residue pair model.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nmax_num_poles : ConstrainedIntValue = 5\n    Maximal number of poles in complex-conjugate pole residue model for fitting the mode propagation index.\ntolerance_rms : NonNegativeFloat = 1e-06\n    Tolerance in fitting the mode propagation index.\nfrequency_sampling_points : ConstrainedIntValue = 15\n    Number of sampling frequencies used in fitting the mode propagation index.\n\nNotes\n-----\nThe number of poles and frequency sampling points are constrained to be within the range [1, 10] and [1, 101] respectively.\n\nExample\n-------\n>>> fitter_param = BroadbandModeABCFitterParam(max_num_poles=5, tolerance_rms=1e-4, frequency_sampling_points=10)",
+      "type": "object",
+      "properties": {
+        "attrs": {
+          "title": "Attributes",
+          "description": "Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.",
+          "default": {},
+          "type": "object"
+        },
+        "max_num_poles": {
+          "title": "Maximal Number Of Poles",
+          "description": "Maximal number of poles in complex-conjugate pole residue model for fitting the mode propagation index.",
+          "default": 5,
+          "exclusiveMinimum": 0,
+          "maximum": 10,
+          "type": "integer"
+        },
+        "tolerance_rms": {
+          "title": "Fitting Tolerance",
+          "description": "Tolerance in fitting the mode propagation index.",
+          "default": 1e-06,
+          "minimum": 0,
+          "type": "number"
+        },
+        "frequency_sampling_points": {
+          "title": "Number Of Frequencies",
+          "description": "Number of sampling frequencies used in fitting the mode propagation index.",
+          "default": 15,
+          "exclusiveMinimum": 0,
+          "maximum": 101,
+          "type": "integer"
+        },
+        "type": {
+          "title": "Type",
+          "default": "BroadbandModeABCFitterParam",
+          "enum": [
+            "BroadbandModeABCFitterParam"
+          ],
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "BroadbandModeABCSpec": {
+      "title": "BroadbandModeABCSpec",
+      "description": "Specifies the broadband mode absorption boundary conditions. The mode propagation index is approximated by a sum of pole-residue pairs.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nfrequency_range : Tuple[float, float]\n    [units = (Hz, Hz)].  Frequency range for the broadband mode absorption boundary conditions.\nfit_param : BroadbandModeABCFitterParam = BroadbandModeABCFitterParam(attrs={}, max_num_poles=5, tolerance_rms=1e-06, frequency_sampling_points=15, type='BroadbandModeABCFitterParam')\n    Parameters for fitting the mode propagation index over the frequency range using pole-residue pair model.\n\nExample\n-------\n>>> broadband_mode_abc_spec = BroadbandModeABCSpec(frequency_range=(100e12, 120e12), fit_param=BroadbandModeABCFitterParam())",
+      "type": "object",
+      "properties": {
+        "attrs": {
+          "title": "Attributes",
+          "description": "Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.",
+          "default": {},
+          "type": "object"
+        },
+        "frequency_range": {
+          "title": "Frequency Range",
+          "description": "Frequency range for the broadband mode absorption boundary conditions.",
+          "units": [
+            "Hz",
+            "Hz"
+          ],
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "fit_param": {
+          "title": "Fitting Parameters For Broadband Mode Absorption Boundary Conditions",
+          "description": "Parameters for fitting the mode propagation index over the frequency range using pole-residue pair model.",
+          "default": {
+            "attrs": {},
+            "max_num_poles": 5,
+            "tolerance_rms": 1e-06,
+            "frequency_sampling_points": 15,
+            "type": "BroadbandModeABCFitterParam"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/BroadbandModeABCFitterParam"
+            }
+          ]
+        },
+        "type": {
+          "title": "Type",
+          "default": "BroadbandModeABCSpec",
+          "enum": [
+            "BroadbandModeABCSpec"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "frequency_range"
+      ],
+      "additionalProperties": false
+    },
     "ModeABCBoundary": {
       "title": "ModeABCBoundary",
-      "description": "One-way wave equation absorbing boundary conditions for absorbing a waveguide mode.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for boundary.\nmode_spec : ModeSpec = ModeSpec(attrs={}, num_modes=1, target_neff=None, num_pml=(0,, 0), filter_pol=None, angle_theta=0.0, angle_phi=0.0, precision='double', bend_radius=None, bend_axis=None, angle_rotation=False, track_freq='central', group_index_step=False, type='ModeSpec')\n    Parameters that determine the modes computed by the mode solver.\nmode_index : NonNegativeInt = 0\n    Index into the collection of modes returned by mode solver. The absorbing boundary conditions are configured to absorb the specified mode. If larger than ``mode_spec.num_modes``, ``num_modes`` in the solver will be set to ``mode_index + 1``.\nfrequency : Optional[PositiveFloat] = None\n    Frequency at which the absorbed mode is evaluated. If ``None``, then the central frequency of the source is used.\nplane : Box\n    Cross-sectional plane in which the absorbed mode will be computed.",
+      "description": "One-way wave equation absorbing boundary conditions for absorbing a waveguide mode.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for boundary.\nmode_spec : ModeSpec = ModeSpec(attrs={}, num_modes=1, target_neff=None, num_pml=(0,, 0), filter_pol=None, angle_theta=0.0, angle_phi=0.0, precision='double', bend_radius=None, bend_axis=None, angle_rotation=False, track_freq='central', group_index_step=False, type='ModeSpec')\n    Parameters that determine the modes computed by the mode solver.\nmode_index : NonNegativeInt = 0\n    Index into the collection of modes returned by mode solver. The absorbing boundary conditions are configured to absorb the specified mode. If larger than ``mode_spec.num_modes``, ``num_modes`` in the solver will be set to ``mode_index + 1``.\nfreq_spec : Union[PositiveFloat, BroadbandModeABCSpec, NoneType] = None\n    Specifies the frequency at which field is absorbed. If ``None``, then the central frequency of the source is used. If ``BroadbandModeABCSpec``, then the field is absorbed over the specified frequency range.\nplane : Box\n    Cross-sectional plane in which the absorbed mode will be computed.",
       "type": "object",
       "properties": {
         "attrs": {
@@ -12195,11 +12300,18 @@
           "minimum": 0,
           "type": "integer"
         },
-        "frequency": {
-          "title": "Frequency",
-          "description": "Frequency at which the absorbed mode is evaluated. If ``None``, then the central frequency of the source is used.",
-          "exclusiveMinimum": 0,
-          "type": "number"
+        "freq_spec": {
+          "title": "Absorption Frequency Specification",
+          "description": "Specifies the frequency at which field is absorbed. If ``None``, then the central frequency of the source is used. If ``BroadbandModeABCSpec``, then the field is absorbed over the specified frequency range.",
+          "anyOf": [
+            {
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            {
+              "$ref": "#/definitions/BroadbandModeABCSpec"
+            }
+          ]
         },
         "plane": {
           "title": "Plane",

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -11536,9 +11536,114 @@
       },
       "additionalProperties": false
     },
+    "BroadbandModeABCFitterParam": {
+      "title": "BroadbandModeABCFitterParam",
+      "description": "Parameters for fitting the mode propagation index over the frequency range using pole-residue pair model.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nmax_num_poles : ConstrainedIntValue = 5\n    Maximal number of poles in complex-conjugate pole residue model for fitting the mode propagation index.\ntolerance_rms : NonNegativeFloat = 1e-06\n    Tolerance in fitting the mode propagation index.\nfrequency_sampling_points : ConstrainedIntValue = 15\n    Number of sampling frequencies used in fitting the mode propagation index.\n\nNotes\n-----\nThe number of poles and frequency sampling points are constrained to be within the range [1, 10] and [1, 101] respectively.\n\nExample\n-------\n>>> fitter_param = BroadbandModeABCFitterParam(max_num_poles=5, tolerance_rms=1e-4, frequency_sampling_points=10)",
+      "type": "object",
+      "properties": {
+        "attrs": {
+          "title": "Attributes",
+          "description": "Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.",
+          "default": {},
+          "type": "object"
+        },
+        "max_num_poles": {
+          "title": "Maximal Number Of Poles",
+          "description": "Maximal number of poles in complex-conjugate pole residue model for fitting the mode propagation index.",
+          "default": 5,
+          "exclusiveMinimum": 0,
+          "maximum": 10,
+          "type": "integer"
+        },
+        "tolerance_rms": {
+          "title": "Fitting Tolerance",
+          "description": "Tolerance in fitting the mode propagation index.",
+          "default": 1e-06,
+          "minimum": 0,
+          "type": "number"
+        },
+        "frequency_sampling_points": {
+          "title": "Number Of Frequencies",
+          "description": "Number of sampling frequencies used in fitting the mode propagation index.",
+          "default": 15,
+          "exclusiveMinimum": 0,
+          "maximum": 101,
+          "type": "integer"
+        },
+        "type": {
+          "title": "Type",
+          "default": "BroadbandModeABCFitterParam",
+          "enum": [
+            "BroadbandModeABCFitterParam"
+          ],
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "BroadbandModeABCSpec": {
+      "title": "BroadbandModeABCSpec",
+      "description": "Specifies the broadband mode absorption boundary conditions. The mode propagation index is approximated by a sum of pole-residue pairs.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nfrequency_range : Tuple[float, float]\n    [units = (Hz, Hz)].  Frequency range for the broadband mode absorption boundary conditions.\nfit_param : BroadbandModeABCFitterParam = BroadbandModeABCFitterParam(attrs={}, max_num_poles=5, tolerance_rms=1e-06, frequency_sampling_points=15, type='BroadbandModeABCFitterParam')\n    Parameters for fitting the mode propagation index over the frequency range using pole-residue pair model.\n\nExample\n-------\n>>> broadband_mode_abc_spec = BroadbandModeABCSpec(frequency_range=(100e12, 120e12), fit_param=BroadbandModeABCFitterParam())",
+      "type": "object",
+      "properties": {
+        "attrs": {
+          "title": "Attributes",
+          "description": "Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.",
+          "default": {},
+          "type": "object"
+        },
+        "frequency_range": {
+          "title": "Frequency Range",
+          "description": "Frequency range for the broadband mode absorption boundary conditions.",
+          "units": [
+            "Hz",
+            "Hz"
+          ],
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "fit_param": {
+          "title": "Fitting Parameters For Broadband Mode Absorption Boundary Conditions",
+          "description": "Parameters for fitting the mode propagation index over the frequency range using pole-residue pair model.",
+          "default": {
+            "attrs": {},
+            "max_num_poles": 5,
+            "tolerance_rms": 1e-06,
+            "frequency_sampling_points": 15,
+            "type": "BroadbandModeABCFitterParam"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/BroadbandModeABCFitterParam"
+            }
+          ]
+        },
+        "type": {
+          "title": "Type",
+          "default": "BroadbandModeABCSpec",
+          "enum": [
+            "BroadbandModeABCSpec"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "frequency_range"
+      ],
+      "additionalProperties": false
+    },
     "ModeABCBoundary": {
       "title": "ModeABCBoundary",
-      "description": "One-way wave equation absorbing boundary conditions for absorbing a waveguide mode.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for boundary.\nmode_spec : ModeSpec = ModeSpec(attrs={}, num_modes=1, target_neff=None, num_pml=(0,, 0), filter_pol=None, angle_theta=0.0, angle_phi=0.0, precision='double', bend_radius=None, bend_axis=None, angle_rotation=False, track_freq='central', group_index_step=False, type='ModeSpec')\n    Parameters that determine the modes computed by the mode solver.\nmode_index : NonNegativeInt = 0\n    Index into the collection of modes returned by mode solver. The absorbing boundary conditions are configured to absorb the specified mode. If larger than ``mode_spec.num_modes``, ``num_modes`` in the solver will be set to ``mode_index + 1``.\nfrequency : Optional[PositiveFloat] = None\n    Frequency at which the absorbed mode is evaluated. If ``None``, then the central frequency of the source is used.\nplane : Box\n    Cross-sectional plane in which the absorbed mode will be computed.",
+      "description": "One-way wave equation absorbing boundary conditions for absorbing a waveguide mode.\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\nname : Optional[str] = None\n    Optional unique name for boundary.\nmode_spec : ModeSpec = ModeSpec(attrs={}, num_modes=1, target_neff=None, num_pml=(0,, 0), filter_pol=None, angle_theta=0.0, angle_phi=0.0, precision='double', bend_radius=None, bend_axis=None, angle_rotation=False, track_freq='central', group_index_step=False, type='ModeSpec')\n    Parameters that determine the modes computed by the mode solver.\nmode_index : NonNegativeInt = 0\n    Index into the collection of modes returned by mode solver. The absorbing boundary conditions are configured to absorb the specified mode. If larger than ``mode_spec.num_modes``, ``num_modes`` in the solver will be set to ``mode_index + 1``.\nfreq_spec : Union[PositiveFloat, BroadbandModeABCSpec, NoneType] = None\n    Specifies the frequency at which field is absorbed. If ``None``, then the central frequency of the source is used. If ``BroadbandModeABCSpec``, then the field is absorbed over the specified frequency range.\nplane : Box\n    Cross-sectional plane in which the absorbed mode will be computed.",
       "type": "object",
       "properties": {
         "attrs": {
@@ -11595,11 +11700,18 @@
           "minimum": 0,
           "type": "integer"
         },
-        "frequency": {
-          "title": "Frequency",
-          "description": "Frequency at which the absorbed mode is evaluated. If ``None``, then the central frequency of the source is used.",
-          "exclusiveMinimum": 0,
-          "type": "number"
+        "freq_spec": {
+          "title": "Absorption Frequency Specification",
+          "description": "Specifies the frequency at which field is absorbed. If ``None``, then the central frequency of the source is used. If ``BroadbandModeABCSpec``, then the field is absorbed over the specified frequency range.",
+          "anyOf": [
+            {
+              "type": "number",
+              "exclusiveMinimum": 0
+            },
+            {
+              "$ref": "#/definitions/BroadbandModeABCSpec"
+            }
+          ]
         },
         "plane": {
           "title": "Plane",
@@ -19400,7 +19512,7 @@
     },
     "WavePort": {
       "title": "WavePort",
-      "description": "Class representing a single wave port\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\ncenter : Union[tuple[Union[float, autograd.tracer.Box], Union[float, autograd.tracer.Box], Union[float, autograd.tracer.Box]], Box] = (0.0, 0.0, 0.0)\n    [units = um].  Center of object in x, y, and z.\nsize : Union[tuple[Union[pydantic.v1.types.NonNegativeFloat, autograd.tracer.Box], Union[pydantic.v1.types.NonNegativeFloat, autograd.tracer.Box], Union[pydantic.v1.types.NonNegativeFloat, autograd.tracer.Box]], Box]\n    [units = um].  Size in x, y, and z directions.\nname : ConstrainedStrValue\n    Unique name for the port.\ndirection : Literal['+', '-']\n    '+' or '-', defining which direction is considered 'input'.\nmode_spec : ModeSpec = ModeSpec(attrs={}, num_modes=1, target_neff=None, num_pml=(0,, 0), filter_pol=None, angle_theta=0.0, angle_phi=0.0, precision='double', bend_radius=None, bend_axis=None, angle_rotation=False, track_freq='central', group_index_step=False, type='ModeSpec')\n    Parameters to feed to mode solver which determine modes measured by monitor.\nmode_index : NonNegativeInt = 0\n    Index into the collection of modes returned by mode solver.  Specifies which mode to inject using this source. If larger than ``mode_spec.num_modes``, ``num_modes`` in the solver will be set to ``mode_index + 1``.\nvoltage_integral : Union[VoltageIntegralAxisAligned, CustomVoltageIntegral2D, NoneType] = None\n    Definition of voltage integral used to compute voltage and the characteristic impedance.\ncurrent_integral : Union[CurrentIntegralAxisAligned, CustomCurrentIntegral2D, NoneType] = None\n    Definition of current integral used to compute current and the characteristic impedance.\nnum_grid_cells : Optional[ConstrainedIntValue] = 5\n    Number of mesh grid cells in the transverse plane of the `WavePort`. Used in generating the suggested list of :class:`.MeshOverrideStructure` objects. Must be greater than or equal to 3. When set to `None`, no grid refinement is performed.\nconjugated_dot_product : bool = False\n    Use conjugated or non-conjugated dot product for mode decomposition.\nframe : Optional[PECFrame] = PECFrame(attrs={}, length=2, type='PECFrame')\n    Add a thin frame around the source during FDTD run for an improved injection.\nabsorber : bool = True\n    Place a mode absorber in the port.",
+      "description": "Class representing a single wave port\n\nParameters\n----------\nattrs : dict = {}\n    Dictionary storing arbitrary metadata for a Tidy3D object. This dictionary can be freely used by the user for storing data without affecting the operation of Tidy3D as it is not used internally. Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects that can not be serialized. One can check if ``attrs`` are serializable by calling ``obj.json()``.\ncenter : Union[tuple[Union[float, autograd.tracer.Box], Union[float, autograd.tracer.Box], Union[float, autograd.tracer.Box]], Box] = (0.0, 0.0, 0.0)\n    [units = um].  Center of object in x, y, and z.\nsize : Union[tuple[Union[pydantic.v1.types.NonNegativeFloat, autograd.tracer.Box], Union[pydantic.v1.types.NonNegativeFloat, autograd.tracer.Box], Union[pydantic.v1.types.NonNegativeFloat, autograd.tracer.Box]], Box]\n    [units = um].  Size in x, y, and z directions.\nname : ConstrainedStrValue\n    Unique name for the port.\ndirection : Literal['+', '-']\n    '+' or '-', defining which direction is considered 'input'.\nmode_spec : ModeSpec = ModeSpec(attrs={}, num_modes=1, target_neff=None, num_pml=(0,, 0), filter_pol=None, angle_theta=0.0, angle_phi=0.0, precision='double', bend_radius=None, bend_axis=None, angle_rotation=False, track_freq='central', group_index_step=False, type='ModeSpec')\n    Parameters to feed to mode solver which determine modes measured by monitor.\nmode_index : NonNegativeInt = 0\n    Index into the collection of modes returned by mode solver.  Specifies which mode to inject using this source. If larger than ``mode_spec.num_modes``, ``num_modes`` in the solver will be set to ``mode_index + 1``.\nvoltage_integral : Union[VoltageIntegralAxisAligned, CustomVoltageIntegral2D, NoneType] = None\n    Definition of voltage integral used to compute voltage and the characteristic impedance.\ncurrent_integral : Union[CurrentIntegralAxisAligned, CustomCurrentIntegral2D, NoneType] = None\n    Definition of current integral used to compute current and the characteristic impedance.\nnum_grid_cells : Optional[ConstrainedIntValue] = 5\n    Number of mesh grid cells in the transverse plane of the `WavePort`. Used in generating the suggested list of :class:`.MeshOverrideStructure` objects. Must be greater than or equal to 3. When set to `None`, no grid refinement is performed.\nconjugated_dot_product : bool = False\n    Use conjugated or non-conjugated dot product for mode decomposition.\nframe : Optional[PECFrame] = PECFrame(attrs={}, length=2, type='PECFrame')\n    Add a thin frame around the source during FDTD run for an improved injection.\nabsorber : Union[bool, ABCBoundary, ModeABCBoundary] = True\n    Place a mode absorber in the port. If ``True``, an automatically generated mode absorber is placed in the port. If ``ABCBoundary`` or ``ModeABCBoundary``, a mode absorber is placed in the port with the specified boundary conditions.",
       "type": "object",
       "properties": {
         "attrs": {
@@ -19630,9 +19742,19 @@
         },
         "absorber": {
           "title": "Absorber.",
-          "description": "Place a mode absorber in the port.",
+          "description": "Place a mode absorber in the port. If ``True``, an automatically generated mode absorber is placed in the port. If ``ABCBoundary`` or ``ModeABCBoundary``, a mode absorber is placed in the port with the specified boundary conditions.",
           "default": true,
-          "type": "boolean"
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/ABCBoundary"
+            },
+            {
+              "$ref": "#/definitions/ModeABCBoundary"
+            }
+          ]
         }
       },
       "required": [

--- a/tests/test_components/test_absorbers.py
+++ b/tests/test_components/test_absorbers.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pydantic.v1 as pydantic
 import pytest
 
 import tidy3d as td
+from tidy3d.components.boundary import DEFAULT_BROADBAND_MODE_ABC_NUM_FREQS
 from tidy3d.exceptions import SetupError
 
 from ..utils import AssertLogLevel
@@ -133,7 +135,7 @@ def test_port_absorbers_simulations():
             td.InternalAbsorber(
                 size=(0.4, 0.5, 0),
                 direction="-",
-                boundary_spec=td.ModeABCBoundary(plane=td.Box(size=(1, 1, 0)), frequency=freq0),
+                boundary_spec=td.ModeABCBoundary(plane=td.Box(size=(1, 1, 0)), freq_spec=freq0),
             )
         ],
     )
@@ -207,7 +209,7 @@ def test_abc_boundaries_alone():
         plane=td.Box(size=(1, 1, 0)),
         mode_spec=td.ModeSpec(num_modes=2),
         mode_index=1,
-        frequency=freq0,
+        freq_spec=freq0,
     )
 
     with pytest.raises(pydantic.ValidationError):
@@ -215,7 +217,7 @@ def test_abc_boundaries_alone():
             plane=td.Box(size=(1, 1, 0)),
             mode_spec=td.ModeSpec(num_modes=2),
             mode_index=1,
-            frequency=-1,
+            freq_spec=-1,
         )
 
     with pytest.raises(pydantic.ValidationError):
@@ -223,7 +225,7 @@ def test_abc_boundaries_alone():
             plane=td.Box(size=(1, 1, 0)),
             mode_spec=td.ModeSpec(num_modes=2),
             mode_index=-1,
-            frequency=freq0,
+            freq_spec=freq0,
         )
 
     with pytest.raises(pydantic.ValidationError):
@@ -231,7 +233,7 @@ def test_abc_boundaries_alone():
             plane=td.Box(size=(1, 1, 1)),
             mode_spec=td.ModeSpec(num_modes=2),
             mode_index=0,
-            frequency=freq0,
+            freq_spec=freq0,
         )
 
     # from mode source
@@ -250,7 +252,7 @@ def test_abc_boundaries_alone():
         size=(1, 1, 0), mode_spec=td.ModeSpec(num_modes=2), freqs=[freq0], name="mnt"
     )
     mode_abc_from_monitor = td.ModeABCBoundary.from_monitor(
-        mode_monitor, mode_index=1, frequency=freq0
+        mode_monitor, mode_index=1, freq_spec=freq0
     )
     assert mode_abc == mode_abc_from_monitor
 
@@ -263,11 +265,11 @@ def test_abc_boundaries_alone():
         plane=td.Box(size=(1, 1, 0)),
         mode_spec=td.ModeSpec(num_modes=2),
         mode_index=1,
-        frequency=freq0,
+        freq_spec=freq0,
     )
     abc_boundary_from_source = td.Boundary.mode_abc_from_source(mode_source)
     abc_boundary_from_monitor = td.Boundary.mode_abc_from_monitor(
-        mode_monitor, mode_index=1, frequency=freq0
+        mode_monitor, mode_index=1, freq_spec=freq0
     )
     assert abc_boundary == abc_boundary_from_source
     assert abc_boundary == abc_boundary_from_monitor
@@ -430,7 +432,7 @@ def test_abc_boundaries_simulations():
         sources=[],
         run_time=1e-20,
         boundary_spec=td.BoundarySpec.all_sides(
-            td.ModeABCBoundary(plane=td.Box(size=(1, 1, 0)), frequency=freq0)
+            td.ModeABCBoundary(plane=td.Box(size=(1, 1, 0)), freq_spec=freq0)
         ),
     )
     # or at least one source
@@ -532,4 +534,65 @@ def test_abc_boundaries_simulations():
             boundary_spec=td.BoundarySpec.all_sides(
                 td.ABCBoundary(permittivity=2, conductivity=1e-5)
             ),
+        )
+
+
+def test_abc_boundaries_broadband():
+    # test broadband fitter params
+    fitter_params = td.BroadbandModeABCFitterParam(
+        max_num_poles=10, tolerance_rms=1e-4, frequency_sampling_points=10
+    )
+
+    # test max num poles > 0
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.BroadbandModeABCFitterParam(max_num_poles=0)
+    # test max num poles <= 10
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.BroadbandModeABCFitterParam(max_num_poles=11)
+
+    # test tolerance rms >= 0
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.BroadbandModeABCFitterParam(tolerance_rms=-1)
+
+    # test frequency sampling points > 0
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.BroadbandModeABCFitterParam(frequency_sampling_points=0)
+    # test frequency sampling points <= 21
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.BroadbandModeABCFitterParam(frequency_sampling_points=102)
+
+    # test basic instance
+    fmin = 100e12
+    fmax = 200e12
+    abc_boundary = td.BroadbandModeABCSpec(frequency_range=(fmin, fmax))
+    assert np.allclose(
+        abc_boundary._frequency_grid,
+        np.linspace(fmin, fmax, DEFAULT_BROADBAND_MODE_ABC_NUM_FREQS),
+    )
+
+    # test max frequency > min frequency
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.BroadbandModeABCSpec(frequency_range=(fmax, fmin))
+
+    # test min frequency > 0
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.BroadbandModeABCSpec(frequency_range=(0, fmax))
+
+    # test from_wavelength_range
+    wvl_min = td.C_0 / fmax
+    wvl_max = td.C_0 / fmin
+    abc_boundary = td.BroadbandModeABCSpec.from_wavelength_range(
+        wavelength_range=(wvl_min, wvl_max), fit_param=fitter_params
+    )
+    assert abc_boundary.frequency_range == (fmin, fmax)
+    assert abc_boundary.fit_param == fitter_params
+
+    with pytest.raises(SetupError):
+        _ = td.BroadbandModeABCSpec.from_wavelength_range(
+            wavelength_range=(wvl_max, wvl_min), fit_param=fitter_params
+        )
+
+    with pytest.raises(SetupError):
+        _ = td.BroadbandModeABCSpec.from_wavelength_range(
+            wavelength_range=(-1, wvl_min), fit_param=fitter_params
         )

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -8,6 +8,7 @@ import skrf
 import xarray as xr
 
 import tidy3d as td
+from tidy3d.components.boundary import BroadbandModeABCSpec
 from tidy3d.components.data.data_array import FreqDataArray
 from tidy3d.exceptions import SetupError, Tidy3dError, Tidy3dKeyError
 from tidy3d.plugins.microwave import (
@@ -1296,3 +1297,45 @@ def test_internal_construct_smatrix_with_port_vi(monkeypatch):
     # Check power wave S matrix
     S_computed = modeler._internal_construct_smatrix(batch_data, s_param_def="power").values
     check_S_matrix(S_computed, S_power)
+
+
+def test_wave_port_to_absorber(tmp_path):
+    """Test that wave port absorber can be specified as a boolean, ABCBoundary, or ModeABCBoundary."""
+
+    # test automatic absorber
+    modeler = make_coaxial_component_modeler(
+        path_dir=str(tmp_path), port_types=(WavePort, WavePort)
+    )
+    sim = list(modeler.sim_dict.values())[0]
+
+    absorber = sim.internal_absorbers[0]
+
+    assert absorber.boundary_spec.mode_spec == modeler.ports[0].mode_spec
+    assert absorber.boundary_spec.mode_index == modeler.ports[0].mode_index
+    assert absorber.boundary_spec.plane == modeler.ports[0].geometry
+    assert absorber.boundary_spec.freq_spec == BroadbandModeABCSpec(
+        frequency_range=(np.min(modeler.freqs), np.max(modeler.freqs))
+    )
+
+    # test to_absorber()
+    absorber = modeler.ports[0].to_absorber(freq_spec=1e9)
+    assert absorber.boundary_spec.freq_spec == 1e9
+
+    absorber = modeler.ports[0].to_absorber(
+        freq_spec=BroadbandModeABCSpec(frequency_range=(1e9, 2e9))
+    )
+    assert absorber.boundary_spec.freq_spec == BroadbandModeABCSpec(frequency_range=(1e9, 2e9))
+
+    # test no automatic absorber
+    modeler = modeler.updated_copy(ports=[modeler.ports[0].updated_copy(absorber=False)])
+    sim = list(modeler.sim_dict.values())[0]
+    assert len(sim.internal_absorbers) == 0
+
+    # test custom boundary spec
+    custom_boundary_spec = td.ModeABCBoundary(plane=td.Box(size=(0.1, 0.1, 0)), freq_spec=1e9)
+    modeler = modeler.updated_copy(
+        ports=[modeler.ports[0].updated_copy(absorber=custom_boundary_spec)]
+    )
+    sim = list(modeler.sim_dict.values())[0]
+    absorber = sim.internal_absorbers[0]
+    assert absorber.boundary_spec == custom_boundary_spec

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from tidy3d.components.boundary import BroadbandModeABCFitterParam, BroadbandModeABCSpec
 from tidy3d.components.material.multi_physics import MultiPhysicsMedium
 from tidy3d.components.material.tcad.charge import (
     ChargeConductorMedium,
@@ -449,6 +450,8 @@ __all__ = [
     "BoundaryEdgeType",
     "BoundarySpec",
     "Box",
+    "BroadbandModeABCFitterParam",
+    "BroadbandModeABCSpec",
     "CaugheyThomasMobility",
     "CellDataArray",
     "ChargeConductorMedium",

--- a/tidy3d/components/boundary.py
+++ b/tidy3d/components/boundary.py
@@ -8,14 +8,14 @@ from typing import Optional, Union
 import numpy as np
 import pydantic.v1 as pd
 
-from tidy3d.components.validators import assert_plane
+from tidy3d.components.validators import _assert_min_freq, assert_plane
 from tidy3d.components.viz import (
     ARROW_ALPHA,
     ARROW_COLOR_ABSORBER,
     PlotParams,
     plot_params_absorber,
 )
-from tidy3d.constants import CONDUCTIVITY, EPSILON_0, MU_0, PML_SIGMA
+from tidy3d.constants import C_0, CONDUCTIVITY, EPSILON_0, HERTZ, MU_0, PML_SIGMA
 from tidy3d.exceptions import DataError, SetupError, ValidationError
 from tidy3d.log import log
 
@@ -25,7 +25,7 @@ from .medium import Medium
 from .mode_spec import ModeSpec
 from .monitor import ModeMonitor, ModeSolverMonitor
 from .source.field import TFSF, GaussianBeam, ModeSource, PlaneWave
-from .types import TYPE_TAG_STR, Ax, Axis, Complex, Direction
+from .types import TYPE_TAG_STR, Ax, Axis, Complex, Direction, FreqBound
 
 MIN_NUM_PML_LAYERS = 6
 MIN_NUM_STABLE_PML_LAYERS = 6
@@ -55,6 +55,11 @@ def warn_num_layers_factory(min_num_layers: int, descr: str):
 
 
 DEFAULT_MODE_SPEC_MODE_ABC = ModeSpec()
+DEFAULT_BROADBAND_MODE_ABC_FITTER_TOLERANCE = 1e-6
+DEFAULT_BROADBAND_MODE_ABC_NUM_FREQS = 15
+DEFAULT_BROADBAND_MODE_ABC_NUM_POLES = 5
+MAX_BROADBAND_MODE_ABC_NUM_POLES = 10
+MAX_BROADBAND_MODE_ABC_NUM_FREQS = 101
 
 
 class BoundaryEdge(ABC, Tidy3dBaseModel):
@@ -126,6 +131,118 @@ class ABCBoundary(AbstractABCBoundary):
         return val
 
 
+class BroadbandModeABCFitterParam(Tidy3dBaseModel):
+    """Parameters for fitting the mode propagation index over the frequency range using pole-residue pair model.
+
+    Notes
+    -----
+    The number of poles and frequency sampling points are constrained to be within the range [1, 10] and [1, 101] respectively.
+
+    Example
+    -------
+    >>> fitter_param = BroadbandModeABCFitterParam(max_num_poles=5, tolerance_rms=1e-4, frequency_sampling_points=10)
+    """
+
+    max_num_poles: int = pd.Field(
+        DEFAULT_BROADBAND_MODE_ABC_NUM_POLES,
+        title="Maximal Number Of Poles",
+        description="Maximal number of poles in complex-conjugate pole residue model for "
+        "fitting the mode propagation index.",
+        gt=0,
+        le=MAX_BROADBAND_MODE_ABC_NUM_POLES,
+    )
+
+    tolerance_rms: pd.NonNegativeFloat = pd.Field(
+        DEFAULT_BROADBAND_MODE_ABC_FITTER_TOLERANCE,
+        title="Fitting Tolerance",
+        description="Tolerance in fitting the mode propagation index.",
+    )
+
+    frequency_sampling_points: int = pd.Field(
+        DEFAULT_BROADBAND_MODE_ABC_NUM_FREQS,
+        title="Number Of Frequencies",
+        description="Number of sampling frequencies used in fitting the mode propagation index.",
+        gt=0,
+        le=MAX_BROADBAND_MODE_ABC_NUM_FREQS,
+    )
+
+
+DEFAULT_BROADBAND_MODE_ABC_FITTER_PARAMS = BroadbandModeABCFitterParam()
+
+
+class BroadbandModeABCSpec(Tidy3dBaseModel):
+    """Specifies the broadband mode absorption boundary conditions. The mode propagation index is approximated by a sum of pole-residue pairs.
+
+    Example
+    -------
+    >>> broadband_mode_abc_spec = BroadbandModeABCSpec(frequency_range=(100e12, 120e12), fit_param=BroadbandModeABCFitterParam())
+    """
+
+    frequency_range: FreqBound = pd.Field(
+        ...,
+        title="Frequency Range",
+        description="Frequency range for the broadband mode absorption boundary conditions.",
+        units=(HERTZ, HERTZ),
+    )
+
+    fit_param: BroadbandModeABCFitterParam = pd.Field(
+        DEFAULT_BROADBAND_MODE_ABC_FITTER_PARAMS,
+        title="Fitting Parameters For Broadband Mode Absorption Boundary Conditions",
+        description="Parameters for fitting the mode propagation index over the frequency range using pole-residue pair model.",
+    )
+
+    @pd.validator("frequency_range", always=True)
+    def validate_frequency_range(cls, val, values):
+        """Validate that max frequency is greater than min frequency."""
+        _assert_min_freq(val[0], "min frequency")
+        if val[1] <= val[0]:
+            raise ValidationError("max frequency must be greater than min frequency.")
+        return val
+
+    @classmethod
+    def from_wavelength_range(
+        cls,
+        wavelength_range: FreqBound,
+        fit_param: BroadbandModeABCFitterParam = DEFAULT_BROADBAND_MODE_ABC_FITTER_PARAMS,
+    ) -> BroadbandModeABCSpec:
+        """Instantiate from a wavelength range.
+
+        Parameters
+        ----------
+        wavelength_range : FreqBound
+            Wavelength range for the broadband mode absorption boundary conditions.
+        fit_param : BroadbandModeABCFitterParam = DEFAULT_BROADBAND_MODE_ABC_FITTER_PARAMS
+            Parameters for fitting the mode propagation index over the frequency range using pole-residue pair model.
+
+        Returns
+        -------
+        :class:`BroadbandModeABCSpec`
+            Broadband mode absorption boundary conditions.
+        """
+        # check that min wavelength > 0
+        if wavelength_range[0] <= 0:
+            raise SetupError("min wavelength must be greater than 0.")
+        # check that max wavelength > min wavelength
+        if wavelength_range[1] <= wavelength_range[0]:
+            raise SetupError("max wavelength must be greater than min wavelength.")
+
+        return cls(
+            frequency_range=(C_0 / wavelength_range[1], C_0 / wavelength_range[0]),
+            fit_param=fit_param,
+        )
+
+    @property
+    def _frequency_grid(self) -> np.ndarray:
+        """Frequency grid for the broadband mode absorption boundary conditions.
+        Propagation constant is sampled at these frequencies and fitted using pole-residue pair model.
+        """
+        return np.linspace(
+            self.frequency_range[0],
+            self.frequency_range[1],
+            self.fit_param.frequency_sampling_points,
+        )
+
+
 class ModeABCBoundary(AbstractABCBoundary):
     """One-way wave equation absorbing boundary conditions for absorbing a waveguide mode."""
 
@@ -144,10 +261,10 @@ class ModeABCBoundary(AbstractABCBoundary):
         "``num_modes`` in the solver will be set to ``mode_index + 1``.",
     )
 
-    frequency: Optional[pd.PositiveFloat] = pd.Field(
+    freq_spec: Optional[Union[pd.PositiveFloat, BroadbandModeABCSpec]] = pd.Field(
         None,
-        title="Frequency",
-        description="Frequency at which the absorbed mode is evaluated. If ``None``, then the central frequency of the source is used.",
+        title="Absorption Frequency Specification",
+        description="Specifies the frequency at which field is absorbed. If ``None``, then the central frequency of the source is used. If ``BroadbandModeABCSpec``, then the field is absorbed over the specified frequency range.",
     )
 
     plane: Box = pd.Field(
@@ -166,13 +283,19 @@ class ModeABCBoundary(AbstractABCBoundary):
         return val
 
     @classmethod
-    def from_source(cls, source: ModeSource) -> ModeABCBoundary:
+    def from_source(
+        cls,
+        source: ModeSource,
+        freq_spec: Optional[Union[pd.PositiveFloat, BroadbandModeABCSpec]] = None,
+    ) -> ModeABCBoundary:
         """Instantiate from a ``ModeSource``.
 
         Parameters
         ----------
         source : :class:`ModeSource`
             Mode source.
+        freq_spec : Optional[Union[pd.PositiveFloat, BroadbandModeABCSpec]] = None
+            Specifies the frequency at which field is absorbed. If ``None``, then the central frequency of the source is used. If ``BroadbandModeABCSpec``, then the field is absorbed over the specified frequency range.
 
         Returns
         -------
@@ -187,11 +310,14 @@ class ModeABCBoundary(AbstractABCBoundary):
         >>> abc_boundary = ModeABCBoundary.from_source(source=source)
         """
 
+        if freq_spec is None:
+            freq_spec = source.source_time.freq0
+
         return cls(
             plane=source.bounding_box,
             mode_spec=source.mode_spec,
             mode_index=source.mode_index,
-            frequency=source.source_time.freq0,
+            freq_spec=freq_spec,
         )
 
     @classmethod
@@ -199,7 +325,7 @@ class ModeABCBoundary(AbstractABCBoundary):
         cls,
         monitor: Union[ModeMonitor, ModeSolverMonitor],
         mode_index: pd.NonNegativeInt = 0,
-        frequency: Optional[pd.PositiveFloat] = None,
+        freq_spec: Optional[Union[pd.PositiveFloat, BroadbandModeABCSpec]] = None,
     ) -> ModeABCBoundary:
         """Instantiate from a ``ModeMonitor`` or ``ModeSolverMonitor``.
 
@@ -209,8 +335,8 @@ class ModeABCBoundary(AbstractABCBoundary):
             Mode monitor.
         mode_index : pd.NonNegativeInt = 0
             Mode index.
-        frequency : Optional[pd.PositiveFloat] = None
-            Frequency for estimating propagation index of absorbed mode.
+        freq_spec : Optional[Union[pd.PositiveFloat, BroadbandModeABCSpec]] = None
+            Specifies the frequency at which field is absorbed. If ``None``, then the central frequency of the source is used. If ``BroadbandModeABCSpec``, then the field is absorbed over the specified frequency range.
 
         Returns
         -------
@@ -228,7 +354,7 @@ class ModeABCBoundary(AbstractABCBoundary):
             plane=monitor.bounding_box,
             mode_spec=monitor.mode_spec,
             mode_index=mode_index,
-            frequency=frequency,
+            freq_spec=freq_spec,
         )
 
 
@@ -993,7 +1119,7 @@ class Boundary(Tidy3dBaseModel):
         plane: Box,
         mode_spec: ModeSpec = DEFAULT_MODE_SPEC_MODE_ABC,
         mode_index: pd.NonNegativeInt = 0,
-        frequency: Optional[pd.PositiveFloat] = None,
+        freq_spec: Optional[Union[pd.PositiveFloat, BroadbandModeABCSpec]] = None,
     ):
         """One-way wave equation mode ABC boundary specification on both sides along a dimension.
 
@@ -1005,8 +1131,8 @@ class Boundary(Tidy3dBaseModel):
             Parameters that determine the modes computed by the mode solver.
         mode_index : pd.NonNegativeInt = 0
             Mode index.
-        frequency : Optional[pd.PositiveFloat] = None
-            Frequency for estimating propagation index of absorbed mode.
+        freq_spec : Optional[Union[pd.PositiveFloat, BroadbandModeABCSpec]] = None
+            Specifies the frequency at which field is absorbed. If ``None``, then the central frequency of the source is used. If ``BroadbandModeABCSpec``, then the field is absorbed over the specified frequency range.
 
         Example
         -------
@@ -1018,25 +1144,31 @@ class Boundary(Tidy3dBaseModel):
             plane=plane,
             mode_spec=mode_spec,
             mode_index=mode_index,
-            frequency=frequency,
+            freq_spec=freq_spec,
         )
         minus = ModeABCBoundary(
             plane=plane,
             mode_spec=mode_spec,
             mode_index=mode_index,
-            frequency=frequency,
+            freq_spec=freq_spec,
         )
 
         return cls(plus=plus, minus=minus)
 
     @classmethod
-    def mode_abc_from_source(cls, source: ModeSource):
+    def mode_abc_from_source(
+        cls,
+        source: ModeSource,
+        freq_spec: Optional[Union[pd.PositiveFloat, BroadbandModeABCSpec]] = None,
+    ):
         """One-way wave equation mode ABC boundary specification on both sides along a dimension constructed from a mode source.
 
         Parameters
         ----------
         source : :class:`ModeSource`
             Mode source.
+        freq_spec : Optional[Union[pd.PositiveFloat, BroadbandModeABCSpec]] = None
+            Specifies the frequency at which field is absorbed. If ``None``, then the central frequency of the source is used. If ``BroadbandModeABCSpec``, then the field is absorbed over the specified frequency range.
 
         Example
         -------
@@ -1045,8 +1177,8 @@ class Boundary(Tidy3dBaseModel):
         >>> source = ModeSource(size=(1, 1, 0), source_time=pulse, direction='+')
         >>> abc = Boundary.mode_abc_from_source(source=source)
         """
-        plus = ModeABCBoundary.from_source(source=source)
-        minus = ModeABCBoundary.from_source(source=source)
+        plus = ModeABCBoundary.from_source(source=source, freq_spec=freq_spec)
+        minus = ModeABCBoundary.from_source(source=source, freq_spec=freq_spec)
         return cls(plus=plus, minus=minus)
 
     @classmethod
@@ -1054,7 +1186,7 @@ class Boundary(Tidy3dBaseModel):
         cls,
         monitor: Union[ModeMonitor, ModeSolverMonitor],
         mode_index: pd.NonNegativeInt = 0,
-        frequency: Optional[pd.PositiveFloat] = None,
+        freq_spec: Optional[Union[pd.PositiveFloat, BroadbandModeABCSpec]] = None,
     ):
         """One-way wave equation mode ABC boundary specification on both sides along a dimension constructed from a mode monitor.
 
@@ -1067,12 +1199,12 @@ class Boundary(Tidy3dBaseModel):
         plus = ModeABCBoundary.from_monitor(
             monitor=monitor,
             mode_index=mode_index,
-            frequency=frequency,
+            freq_spec=freq_spec,
         )
         minus = ModeABCBoundary.from_monitor(
             monitor=monitor,
             mode_index=mode_index,
-            frequency=frequency,
+            freq_spec=freq_spec,
         )
         return cls(plus=plus, minus=minus)
 

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -3104,7 +3104,7 @@ class Simulation(AbstractYeeGridSimulation):
         """Warn if ModeABCBoundary expects a frequency from a source, but there are multiple sources with different central frequencies."""
 
         def boundary_needs_freq(boundary):
-            return (isinstance(boundary, ModeABCBoundary) and boundary.frequency is None) or (
+            return (isinstance(boundary, ModeABCBoundary) and boundary.freq_spec is None) or (
                 isinstance(boundary, ABCBoundary)
                 and (
                     (boundary.conductivity is not None and boundary.conductivity != 0)

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -8,6 +8,7 @@ import autograd.numpy as np
 import pydantic.v1 as pd
 
 from tidy3d.components.base import cached_property
+from tidy3d.components.boundary import BroadbandModeABCSpec
 from tidy3d.components.data.data_array import DataArray, FreqDataArray
 from tidy3d.components.data.monitor_data import MonitorData
 from tidy3d.components.data.sim_data import SimulationData
@@ -253,7 +254,10 @@ class TerminalComponentModeler(AbstractComponentModeler[NetworkIndex, NetworkEle
                     wave_port.injection_axis
                 ] + self._shift_value_signed(wave_port)
                 port_absorber = wave_port.to_absorber(
-                    snap_center=mode_src_pos, frequency=0.5 * (min(self.freqs) + max(self.freqs))
+                    snap_center=mode_src_pos,
+                    freq_spec=BroadbandModeABCSpec(
+                        frequency_range=(np.min(self.freqs), np.max(self.freqs))
+                    ),
                 )
                 new_absorbers.append(port_absorber)
 

--- a/tidy3d/plugins/smatrix/ports/wave.py
+++ b/tidy3d/plugins/smatrix/ports/wave.py
@@ -8,7 +8,7 @@ import numpy as np
 import pydantic.v1 as pd
 
 from tidy3d.components.base import cached_property, skip_if_fields_missing
-from tidy3d.components.boundary import InternalAbsorber, ModeABCBoundary
+from tidy3d.components.boundary import ABCBoundary, InternalAbsorber, ModeABCBoundary
 from tidy3d.components.data.data_array import FreqDataArray, FreqModeDataArray
 from tidy3d.components.data.monitor_data import ModeData
 from tidy3d.components.data.sim_data import SimulationData
@@ -91,10 +91,11 @@ class WavePort(AbstractTerminalPort, Box):
         description="Add a thin frame around the source during FDTD run for an improved injection.",
     )
 
-    absorber: bool = pd.Field(
+    absorber: Union[bool, ABCBoundary, ModeABCBoundary] = pd.Field(
         True,
         title="Absorber.",
-        description="Place a mode absorber in the port.",
+        description="Place a mode absorber in the port. If ``True``, an automatically generated mode absorber is placed in the port. "
+        "If ``ABCBoundary`` or ``ModeABCBoundary``, a mode absorber is placed in the port with the specified boundary conditions.",
     )
 
     def _mode_voltage_coefficients(self, mode_data: ModeData) -> FreqModeDataArray:
@@ -193,21 +194,25 @@ class WavePort(AbstractTerminalPort, Box):
         return mode_solver
 
     def to_absorber(
-        self, snap_center: Optional[float] = None, frequency: Optional[pd.NonNegativeFloat] = None
+        self, snap_center: Optional[float] = None, freq_spec: Optional[pd.NonNegativeFloat] = None
     ) -> InternalAbsorber:
         """Create an internal absorber from the wave port."""
         center = list(self.center)
         if snap_center:
             center[self.injection_axis] = snap_center
+        if isinstance(self.absorber, (ABCBoundary, ModeABCBoundary)):
+            boundary_spec = self.absorber
+        else:
+            boundary_spec = ModeABCBoundary(
+                mode_spec=self.mode_spec,
+                mode_index=self.mode_index,
+                plane=self.geometry,
+                freq_spec=freq_spec,
+            )
         return InternalAbsorber(
             center=center,
             size=self.size,
-            boundary_spec=ModeABCBoundary(
-                mode_spec=self.mode_spec,
-                mode_index=self.mode_index,
-                plane=self.bounding_box,
-                frequency=frequency,
-            ),
+            boundary_spec=boundary_spec,
             direction="-"
             if self.direction == "+"
             else "+",  # absorb in the opposite direction of source


### PR DESCRIPTION
Implements python interface to broadband ABC boundary conditions. overall structure and implementation is similar to `LossyMetalMedium`. Specifically:
- introduced `BroadbandModeABCSpec(frequency_range=...)` to specify range in which absorption is desired. It can be passed as argument `freq_spec` (previously, `frequency`) in `ModeABCBoundary(..., freq_spec=...)`
- introduced `BroadbandModeABCFitterParam` to control max number of poles, number of frequency points, and fit tolerance, it is passed as `fit_param` in `BroadbandModeABCSpec`

<!-- greptile_comment -->

## Greptile Summary

This PR introduces broadband absorbing boundary conditions (ABC) for electromagnetic simulations in Tidy3D. The implementation extends the existing single-frequency mode absorption capabilities to work over frequency ranges, following a similar design pattern to the existing `LossyMetalMedium` functionality.

The core changes involve:

1. **New Classes**: Introduction of `BroadbandModeABCFitterParam` and `BroadbandModeABCSpec` classes that define broadband absorption behavior using pole-residue fitting to approximate mode propagation index over frequency ranges.

2. **API Evolution**: The `ModeABCBoundary` class has been updated to replace the `frequency` field with `freq_spec`, which accepts either a single frequency (float) or a `BroadbandModeABCSpec` object for broadband operation.

3. **Enhanced Wave Port Support**: Wave ports now support custom boundary conditions through an expanded `absorber` field that accepts boolean values, `ABCBoundary`, or `ModeABCBoundary` objects.

4. **Backward Compatibility**: The changes maintain full backward compatibility - existing code using single-frequency absorption continues to work unchanged, while new broadband capabilities are available through the updated API.

The broadband functionality uses pole-residue pairs to model frequency-dependent absorption characteristics, which is a standard electromagnetics approach for approximating complex frequency-dependent material properties. The implementation includes proper parameter validation, frequency range constraints, and utilities for converting between wavelength and frequency specifications. This enhancement allows users to achieve effective absorption across entire simulation frequency ranges rather than being limited to single frequency points, which is particularly valuable for broadband electromagnetic simulations.

## Important Files Changed

<details>
<summary>Files Changed</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/boundary.py | 4/5 | Adds new `BroadbandModeABCFitterParam` and `BroadbandModeABCSpec` classes and updates `ModeABCBoundary` to use `freq_spec` instead of `frequency` |
| tidy3d/__init__.py | 5/5 | Exposes the two new broadband ABC classes in the public API through proper imports and `__all__` additions |
| tests/test_components/test_absorbers.py | 5/5 | Updates all test cases to use `freq_spec` parameter and adds comprehensive tests for broadband ABC functionality |
| tidy3d/components/simulation.py | 5/5 | Updates validation logic to check `freq_spec` field instead of deprecated `frequency` field |
| tidy3d/plugins/smatrix/ports/wave.py | 4/5 | Expands wave port absorber support to accept custom boundary conditions and updates parameter naming |
| tidy3d/plugins/smatrix/component_modelers/terminal.py | 4/5 | Updates wave port absorber creation to use broadband frequency specifications over the full simulation range |
| tests/test_plugins/smatrix/test_terminal_component_modeler.py | 5/5 | Adds test coverage for the new broadband wave port absorber functionality |

</details>

## Confidence score: 4/5

- This PR is generally safe to merge with some considerations for the complexity of the broadband fitting implementation
- Score reflects well-structured changes with comprehensive testing, but the mathematical complexity of pole-residue fitting requires careful validation
- Pay close attention to `tidy3d/components/boundary.py` and `tidy3d/plugins/smatrix/ports/wave.py` for the core broadband implementation logic

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant BroadbandModeABCSpec
    participant BroadbandModeABCFitterParam
    participant ModeABCBoundary
    participant Simulation
    participant Grid
    participant Solver

    User->>BroadbandModeABCFitterParam: "Create fitter parameters"
    Note over BroadbandModeABCFitterParam: max_num_poles=5<br/>tolerance_rms=1e-4<br/>frequency_sampling_points=10
    BroadbandModeABCFitterParam->>User: "Return fitter parameters"

    User->>BroadbandModeABCSpec: "Create frequency specification"
    Note over BroadbandModeABCSpec: frequency_range=(100e12, 120e12)<br/>fit_param=fitter_params
    BroadbandModeABCSpec->>User: "Return frequency spec"

    User->>ModeABCBoundary: "Create boundary with broadband spec"
    Note over ModeABCBoundary: plane=Box(...)<br/>freq_spec=broadband_spec
    ModeABCBoundary->>User: "Return configured boundary"

    User->>Simulation: "Create simulation with ABC boundary"
    Note over Simulation: boundary_spec=BoundarySpec(...)<br/>internal_absorbers=[abc_boundary]
    Simulation->>Grid: "Discretize simulation domain"
    Grid->>Simulation: "Return grid configuration"

    Simulation->>ModeABCBoundary: "Validate frequency specification"
    ModeABCBoundary->>BroadbandModeABCSpec: "Check frequency range validity"
    BroadbandModeABCSpec->>BroadbandModeABCFitterParam: "Validate fitting parameters"
    BroadbandModeABCFitterParam->>BroadbandModeABCSpec: "Parameters valid"
    BroadbandModeABCSpec->>ModeABCBoundary: "Frequency range valid"
    ModeABCBoundary->>Simulation: "Boundary configuration valid"

    User->>Simulation: "Run FDTD simulation"
    Simulation->>Solver: "Initialize with broadband ABC"
    Note over Solver: Apply pole-residue fitting<br/>for mode propagation index<br/>across frequency range
    Solver->>Simulation: "Return simulation results"
    Simulation->>User: "Return completed simulation data"
```

<!-- /greptile_comment -->