### PR TITLE
fix: validation of 'freqs' in component modelers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved the robustness of batch jobs. The batch state, including all `task_ids`, is now saved to `batch.hdf5` immediately after upload. This fixes an issue where an interrupted batch (e.g., due to a kernel crash or network loss) would be unrecoverable.
 - Fixed warning for running symmetric adjoint simulations by port to not trigger when there is a single port.
 - Bug in `CoaxialLumpedPort` where source injection is off when the `normal_axis` is not `z`.
+- Validation of `freqs` in the `ComponentModeler` and `TerminalComponentModeler`.
 
 ## [2.9.0] - 2025-08-04
 

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -87,6 +87,28 @@ def test_validate_no_sources(tmp_path):
         _ = modeler.copy(update={"simulation": sim_w_source})
 
 
+def test_validate_freqs():
+    """Ensure the 'freqs' array is strictly increasing and length of at least 2."""
+    modeler = make_component_modeler(planar_pec=False)
+    freqs = np.array([1.0])
+    with pytest.raises(pd.ValidationError):
+        _ = modeler.updated_copy(freqs=freqs)
+    freqs = np.array([-1.0, 5])
+    with pytest.raises(pd.ValidationError):
+        _ = modeler.updated_copy(freqs=freqs)
+    freqs = np.array([1, 2, 1.9])
+    with pytest.raises(pd.ValidationError):
+        _ = modeler.updated_copy(freqs=freqs)
+
+    # Test case with non-unique value
+    f_min, f_max = (0.5e9, 1.5e9)
+    f0 = (f_min + f_max) / 2
+    f_target = 1.35e9
+    freqs = np.sort(np.append(np.linspace(f_min, f_max, 21), f_target))
+    with pytest.raises(pd.ValidationError):
+        _ = modeler.updated_copy(freqs=freqs)
+
+
 def test_validate_3D_sim(tmp_path):
     modeler = make_component_modeler(planar_pec=False, path_dir=str(tmp_path))
     sim = td.Simulation(

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -143,7 +143,26 @@ class AbstractComponentModeler(ABC, Generic[IndexType, ElementType], Tidy3dBaseM
     def _sim_has_no_sources(cls, val):
         """Make sure simulation has no sources as they interfere with tool."""
         if len(val.sources) > 0:
-            raise SetupError("'AbstractComponentModeler.simulation' must not have any sources.")
+            raise SetupError(f"'{cls.__name__}.simulation' must not have any sources.")
+        return val
+
+    @pd.validator("freqs", always=True)
+    def _validate_freqs(cls, val):
+        """The array of frequencies must be sorted, unique and non-negative."""
+        if len(val) < 2:
+            raise SetupError(f"You must supply at least 2 entries for '{cls.__name__}.freqs'.")
+        np_val = np.array(val)
+        if not np.all(np_val >= 0):
+            raise SetupError(f"'{cls.__name__}.freqs' must be an array of non-negative numbers.")
+        # Ensure freqs is sorted
+        diff = np.diff(np_val)
+        if not np.all(diff > 0):
+            violations = np.where(diff <= 0)[0] + 1
+            raise SetupError(
+                f"'{cls.__name__}.freqs' must be strictly increasing (unique values sorted "
+                "in ascending order). "
+                f"The entries at the following indices violated this requirement: {violations}."
+            )
         return val
 
     @pd.validator("ports", always=True)


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR adds validation logic for the `freqs` field in S-matrix component modeler classes to prevent runtime errors and ensure data integrity. The changes introduce a new pydantic validator `_validate_freqs` in the `AbstractComponentModeler` base class that enforces three key requirements: frequency arrays must contain at least 2 entries, be non-negative, and be strictly increasing (unique values in ascending order).

The validation is implemented using numpy array operations and provides detailed error messages that include the specific indices where violations occur. This early validation prevents users from creating component modelers with invalid frequency specifications that would later cause confusing simulation failures or produce incorrect S-parameter results.

The changes integrate well with the existing codebase by following established patterns: using pydantic validators for field validation, raising `SetupError` exceptions with descriptive messages, and maintaining consistency with other validation methods in the framework. The fix is documented in the changelog under the "Fixed" section and includes comprehensive test coverage to verify all validation scenarios.

## Important Files Changed

<details>
<summary>File changes summary</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `CHANGELOG.md` | 5/5 | Documents the frequency validation fix in the changelog following project standards |
| `tidy3d/plugins/smatrix/component_modelers/base.py` | 5/5 | Adds comprehensive frequency array validation to prevent invalid S-matrix configurations |
| `tests/test_plugins/smatrix/test_terminal_component_modeler.py` | 5/5 | Adds thorough test coverage for the new frequency validation logic |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk
- Score reflects well-tested validation logic with comprehensive error handling and clear documentation
- No files require special attention

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant ComponentModeler
    participant Validator
    participant SetupError

    User->>ComponentModeler: "Create TerminalComponentModeler with freqs array"
    ComponentModeler->>Validator: "_validate_freqs(freqs)"
    
    alt freqs array length < 2
        Validator->>SetupError: "Raise: Must supply at least 2 entries"
        SetupError->>User: "ValidationError: Too few frequencies"
    else freqs contains negative values
        Validator->>SetupError: "Raise: Must be non-negative numbers"
        SetupError->>User: "ValidationError: Negative frequencies"
    else freqs not strictly increasing
        Validator->>SetupError: "Raise: Must be strictly increasing"
        SetupError->>User: "ValidationError: Non-unique or unsorted frequencies"
    else freqs valid
        Validator->>ComponentModeler: "Validation passed"
        ComponentModeler->>User: "ComponentModeler created successfully"
    end
```

### Context used:
**Rule -** In changelogs, enclose code identifiers (class, function names) in backticks and use specific names rather than generic descriptions. ([link](https://app.greptile.com/review/custom-context?memory=0af1d6df-6cf7-4988-b3fc-f5f8ec5cae30))
**Rule -** Use changelog categories correctly: "Fixed" for bug fixes, "Changed" for modifications to existing functionality, and "Added" for new features. ([link](https://app.greptile.com/review/custom-context?memory=17997812-233f-4a81-bee2-4d7666605061))
**Rule -** Require a changelog entry for any PR that is not purely an internal refactor. ([link](https://app.greptile.com/review/custom-context?memory=b72c7231-b258-4d03-aed2-51a50a9fe757))

<!-- /greptile_comment -->