### PR TITLE
Polygon vertices cleanup and corner default distance threshold change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug in `CoaxialLumpedPort` where source injection is off when the `normal_axis` is not `z`.
 - Validation of `freqs` in the `ComponentModeler` and `TerminalComponentModeler`.
 - Calculation of voltage and current in the `WavePort`, when one type of path integral is supplied and the transmission line mode is lossy.
+- Polygon vertices cleanup in `ClipOperation.intersections_plane`.
 
 ## [2.9.0] - 2025-08-04
 

--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -1288,8 +1288,7 @@ def test_cleanup_shapely_object():
     # Test using a non-empty exterior polygon (big_square_5x5)
     orig_polygon = shapely.Polygon(exterior_coords, interior_coords_list)
     new_polygon = cleanup_shapely_object(orig_polygon, tolerance_ratio=1e-12)
-    # Delete any nearby or overlapping vertices (cleanup_shapely_object() does not do this).
-    new_polygon = shapely.simplify(new_polygon, tolerance=1e-10)
+    # Delete any nearby or overlapping vertices (cleanup_shapely_object() now does this).
     # Now `new_polygon` should only contain the coordinates of the square (with a duplicate at end).
     assert len(new_polygon.exterior.coords) == 5  # squares have 4 vertices but shapely adds 1
     assert len(new_polygon.interiors) == 1  # only the "triangle_empty_tails" interior hole survives
@@ -1298,5 +1297,4 @@ def test_cleanup_shapely_object():
     exterior_coords = triangle_collinear  # has zero area
     orig_polygon = shapely.Polygon(exterior_coords)
     new_polygon = cleanup_shapely_object(orig_polygon, tolerance_ratio=1e-12)
-    new_polygon = shapely.simplify(new_polygon, tolerance=1e-10)
     assert len(new_polygon.exterior.coords) == 0  # empty / collinear polygons should get deleted

--- a/tests/test_components/test_layerrefinement.py
+++ b/tests/test_components/test_layerrefinement.py
@@ -801,3 +801,72 @@ def test_gap_meshing():
     # sim.plot(x=0, ax=ax)
     # sim.plot_grid(x=0, ax=ax)
     # plt.show()
+
+
+def test_gap_meshing_skip_small_gap():
+    """When the gap is very small, make sure it's skipped."""
+
+    f0 = 7e9
+
+    mm = 1000  # Conversion mm to micron
+    H = 0.8 * mm  # Substrate thickness
+    T = 0.035 * mm  # Metal thickness
+
+    # Resonator dimensions
+    MA, MB, MC, MD = (3.9 * mm, 7.1 * mm, 3.1 * mm, 2.3 * mm)
+    ME, MF, MG, MH = (0.6 * mm, 0.2 * mm, 1.2 * mm, 0.5 * mm)
+    MJ, MK, MM, MN = (4.8 * mm, 0.3 * mm, 0.1 * mm, 0.7 * mm)
+    MP, MQ, MR, MS = (0.1 * mm, 0.7 * mm, 0.4 * mm, 0.3 * mm)
+    Lsub, Wsub = (2 * MC + MH, 2 * (MH + MK + MB))
+
+    geom_patch = td.Box.from_bounds(
+        rmin=(-MA / 2, MH / 2 + MK, 0), rmax=(MA / 2, MH / 2 + MK + MB, T)
+    )
+    geom_hole1 = td.Box.from_bounds(
+        rmin=(-MH / 2 - MN - MF - ME, MH / 2 + MK + MS, 0),
+        rmax=(-MH / 2 - MN - MF, MH / 2 + MK + MS + MG, T),
+    )
+    geom_hole5 = td.Box.from_bounds(
+        rmin=(-MA / 2 + 1.5 * MF, MH / 2 + MK + MS + MG + MQ, 0),
+        rmax=(-MA / 2 + 1.5 * MF + MM, MH / 2 + MK + MB - MP, T),
+    )
+    geom_hole6 = geom_hole5.translated(-2 * geom_hole5.center[0], 0, 0)
+    geom_hole7 = td.Box.from_bounds(
+        rmin=(-MH / 2 - MN, MH / 2 + MK, 0), rmax=(MH / 2 + MN, MH / 2 + MD, T)
+    )
+    for hole in [geom_hole1, geom_hole5, geom_hole6, geom_hole7]:
+        geom_patch -= hole
+
+    x0, y0, z0 = geom_patch.bounding_box.center
+    struct_patch = td.Structure(geometry=geom_patch, medium=td.PEC)
+
+    # Add padding
+    padding = td.C_0 / f0 / 2
+    sim_LX = Lsub + padding
+    sim_LY = Wsub + padding
+    sim_LZ = H + padding
+
+    # Layer refinement on resonator
+    lr_spec = td.LayerRefinementSpec.from_structures(
+        structures=[struct_patch],
+        min_steps_along_axis=1,
+        corner_refinement=td.GridRefinement(dl=T, num_cells=2),
+        dl_min_from_gap_width=True,
+    )
+
+    # Define overall grid spec
+    grid_spec = td.GridSpec.auto(
+        wavelength=td.C_0 / f0,
+        min_steps_per_wvl=12,
+        layer_refinement_specs=[lr_spec],
+    )
+
+    # Define simulation object
+    sim = td.Simulation(
+        center=(x0, y0, z0),
+        size=(sim_LX, sim_LY, sim_LZ),
+        structures=[struct_patch],
+        grid_spec=grid_spec,
+        run_time=1e-9,
+    )
+    assert sim.grid_info["min_grid_size"] > 20

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -66,6 +66,7 @@ from .bound_ops import bounds_intersection, bounds_union
 
 POLY_GRID_SIZE = 1e-12
 POLY_TOLERANCE_RATIO = 1e-12
+POLY_DISTANCE_TOLERANCE = 8e-12
 
 
 _shapely_operations = {
@@ -3397,6 +3398,9 @@ def cleanup_shapely_object(obj: Shapely, tolerance_ratio: float = POLY_TOLERANCE
         cap_style="square",
         quad_segs=3,
     )
+    # Clean vertices of very close distances created during the erosion/dilation process.
+    # The distance value is heuristic.
+    cleaned_obj = cleaned_obj.simplify(POLY_DISTANCE_TOLERANCE, preserve_topology=True)
     # Revert to the original scale and position.
     rescaled_clean_obj = shapely.affinity.affine_transform(
         cleaned_obj,

--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -10,6 +10,7 @@ import pydantic.v1 as pd
 
 from tidy3d.components.base import Tidy3dBaseModel, cached_property, skip_if_fields_missing
 from tidy3d.components.geometry.base import Box, ClipOperation
+from tidy3d.components.geometry.utils_2d import increment_float
 from tidy3d.components.lumped_element import LumpedElementType
 from tidy3d.components.source.utils import SourceType
 from tidy3d.components.structure import MeshOverrideStructure, Structure, StructureType
@@ -1323,6 +1324,13 @@ class LayerRefinementSpec(Box):
             self.size[(self.axis + 2) % 3]
         )
 
+    @cached_property
+    def _slightly_enlarged_box(self) -> Box:
+        """Slightly enlarged box for robust point containment querying."""
+        # increase size slightly
+        size = [increment_float(orig_length, 1) for orig_length in self.size]
+        return Box(center=self.center, size=size)
+
     def _unpop_axis(self, ax_coord: float, plane_coord: Any) -> CoordinateOptional:
         """Combine coordinate along axis with identical coordinates on the plane tangential to the axis.
 
@@ -1411,7 +1419,7 @@ class LayerRefinementSpec(Box):
         point_3d = self.unpop_axis(
             ax_coord=self.center[self.axis], plane_coords=point, axis=self.axis
         )
-        return self.inside(point_3d[0], point_3d[1], point_3d[2])
+        return self._slightly_enlarged_box.inside(point_3d[0], point_3d[1], point_3d[2])
 
     def _corners_and_convexity_2d(
         self, structure_list: list[Structure], ravel: bool

--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -1630,6 +1630,14 @@ class LayerRefinementSpec(Box):
             if ind_end == ind_beg:
                 continue
 
+            # intersects one grid line but almost parallel to it
+            if np.abs(ind_end - ind_beg) == 1 and np.abs(
+                v_beg[0] - v_end[0]
+            ) < 2 * GAP_MESHING_TOL * np.abs(
+                grid_x_coords[ind_beg - 1] - grid_x_coords[ind_end - 1]
+            ):
+                continue
+
             # sort vertices in ascending order to make treatmeant unifrom
             reverse = False
             if ind_beg > ind_end:


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR focuses on improving polygon vertex handling and geometric precision throughout the Tidy3D codebase. The changes address two main areas: corner detection precision and polygon vertex cleanup during geometric operations.

The primary change modifies the default value of `CornerFinderSpec.distance_threshold` from `None` to `fp_eps` (single floating-point precision epsilon ≈ 1.19e-07). This change enables automatic vertex simplification during corner detection using the Douglas-Peucker algorithm. Previously, when the threshold was `None`, no vertex simplification was performed, which could lead to redundant vertices that are essentially at the same location but differ by tiny floating-point precision amounts.

The second significant change enhances the `cleanup_shapely_object` function in the geometry base module by adding an explicit vertex simplification step. After the erosion/dilation process used to clean up polygon boundaries, the function now calls `simplify()` with a tolerance of `6 * tolerance_ratio` to remove closely spaced vertices that can be created during buffering operations.

These improvements work together to provide more robust polygon processing throughout the framework. The corner finder now automatically handles floating-point precision issues in polygon vertices, while the geometry cleanup function ensures that buffering operations don't introduce unnecessary vertex density. The changes maintain backward compatibility since users can still disable simplification in the corner finder by explicitly setting `distance_threshold=None`.

Corresponding test updates reflect that vertex cleanup is now handled internally by `cleanup_shapely_object()`, eliminating the need for external calls to shapely's simplify method in test code.

## Important Files Changed

<details>
<summary>Files Modified</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| CHANGELOG.md | 5/5 | Documents the changes with appropriate categorization under 'Changed' and 'Fixed' sections |
| tidy3d/components/grid/corner_finder.py | 4/5 | Changes default distance_threshold from None to fp_eps for automatic vertex cleanup |
| tidy3d/components/geometry/base.py | 4/5 | Adds vertex simplification step to cleanup_shapely_object function after buffering operations |
| tests/test_components/test_geometry.py | 4/5 | Updates test to reflect that vertex cleanup is now handled internally by cleanup_shapely_object |

</details>

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it primarily improves geometric precision handling
- Score reflects well-structured changes to address floating-point precision issues, though the geometric operations are complex
- Pay close attention to tidy3d/components/geometry/base.py and corner_finder.py for potential precision-related edge cases

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
```

<!-- /greptile_comment -->