### PR TITLE
Updates for fully anisotropic mode solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `TerminalComponentModeler` defaults to the pseudo wave definition of scattering parameters. The new field `s_param_def` can be used to switch between either pseudo or power wave definitions.
 - Restructured the smatrix plugin with backwards-incompatible changes for a more robust architecture. Notably, `ComponentModeler` has been renamed to `ModalComponentModeler` and internal web API methods have been removed. Please see our migration guide for details on updating your workflows.
 - Prevent small bandwidth sources from being created in `TerminalComponentModeler` when modeler frequencies are close together.
+- `Simulation.epsilon` now samples off-diagonal elements of fully tensorial permittivity at grid *boundaries*, to be consistent with the how these enter the FDTD simulation. This means that all off-diagonal components are now sampled at the same locations.
 
 ### Fixed
 - Fixed missing amplitude factor and handling of negative normal direction case when making adjoint sources from `DiffractionMonitor`.

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -346,7 +346,7 @@ class ModeSolver(Tidy3dBaseModel):
         normal_axis = plane.size.index(0.0)
         mode_symmetry = list(simulation.symmetry)
         for dim in range(3):
-            if simulation.center[dim] != plane.center[dim]:
+            if not isclose(simulation.center[dim], plane.center[dim]):
                 mode_symmetry[dim] = 0
         _, solver_sym = plane.pop_axis(mode_symmetry, axis=normal_axis)
         return solver_sym

--- a/tidy3d/components/mode/solver.py
+++ b/tidy3d/components/mode/solver.py
@@ -274,6 +274,8 @@ class EigSolver(Tidy3dBaseModel):
             direction,
             enable_incidence_matrices,
             basis_E=basis_E,
+            dls=dls,
+            dmin_pmc=dmin_pmc,
         )
 
         # Transform back to original axes, E = J^T E'
@@ -308,6 +310,8 @@ class EigSolver(Tidy3dBaseModel):
         direction,
         enable_incidence_matrices,
         basis_E,
+        dls,
+        dmin_pmc=None,
     ):
         """Solve for the electromagnetic modes of a system defined by in-plane permittivity and
         permeability and assuming translational invariance in the normal direction.
@@ -323,7 +327,7 @@ class EigSolver(Tidy3dBaseModel):
         mu_tensor : np.ndarray
             Shape (3, 3, N), the permittivity tensor at every point in the plane.
         der_mats : List[scipy.sparse.csr_matrix]
-            The sparce derivative matrices dxf, dxb, dyf, dyb, including the PML.
+            The sparse derivative matrices dxf, dxb, dyf, dyb, including the PML.
         num_modes : int
             Number of modes to solve for.
         neff_guess : float
@@ -334,6 +338,10 @@ class EigSolver(Tidy3dBaseModel):
             Direction of mode propagation.
         basis_E: np.ndarray
             Basis for mode solving.
+        dls: Tuple[List[np.ndarray], List[np.ndarray]]
+            Primal and dual grid steps along each of the two tangential dimensions.
+        dmin_pmc: List[bool]
+            List of booleans indicating whether to apply PMC at the near end of the grid.
 
         Returns
         -------
@@ -377,8 +385,8 @@ class EigSolver(Tidy3dBaseModel):
         # initial vector for eigensolver in correct data type
         vec_init = cls.set_initial_vec(Nx, Ny, is_tensorial=is_tensorial)
 
-        # call solver
-        kwargs = {
+        # call solver: base kwargs shared by diagonal and tensorial solvers
+        base_kwargs = {
             "eps": eps_tensor,
             "mu": mu_tensor,
             "der_mats": der_mats,
@@ -388,18 +396,19 @@ class EigSolver(Tidy3dBaseModel):
             "mat_precision": mat_precision,
         }
 
-        is_eps_complex = cls.isinstance_complex(eps_tensor)
-
         if basis_E is not None and is_tensorial:
             raise RuntimeError(
                 "Tensorial eps not yet supported in relative mode solver "
                 "(with basis fields provided)."
             )
 
+        # Determine if epsilon has complex values (used to select real vs complex tensorial solver)
+        is_eps_complex = cls.isinstance_complex(eps_tensor)
+
         if not is_tensorial:
             eps_spec = "diagonal"
             E, H, neff, keff = cls.solver_diagonal(
-                **kwargs,
+                **base_kwargs,
                 enable_incidence_matrices=enable_incidence_matrices,
                 basis_E=basis_E,
             )
@@ -410,51 +419,28 @@ class EigSolver(Tidy3dBaseModel):
 
         elif not is_eps_complex:
             eps_spec = "tensorial_real"
-            E, H, neff, keff = cls.solver_tensorial(**kwargs, direction="+")
+            E, H, neff, keff = cls.solver_tensorial(
+                **base_kwargs,
+                direction="+",
+                dls=dls,
+                Nxy=(Nx, Ny),
+                dmin_pmc=dmin_pmc,
+            )
             if direction == "-":
                 E = np.conj(E)
                 H = -np.conj(H)
 
         else:
             eps_spec = "tensorial_complex"
-            E, H, neff, keff = cls.solver_tensorial(**kwargs, direction=direction)
+            E, H, neff, keff = cls.solver_tensorial(
+                **base_kwargs,
+                direction=direction,
+                dls=dls,
+                Nxy=(Nx, Ny),
+                dmin_pmc=dmin_pmc,
+            )
 
         return E, H, neff, keff, eps_spec
-
-    @classmethod
-    def matrix_data_type(cls, eps, mu, der_mats, mat_precision, is_tensorial):
-        """Determine data type that should be used for the matrix for diagonalization."""
-        mat_dtype = np.float32
-        # In tensorial case, even though the matrix can be real, the
-        # expected eigenvalue is purely imaginary. So for now we enforce
-        # the matrix to be complex type so that it will look for the right eigenvalues.
-        if is_tensorial:
-            mat_dtype = np.complex128 if mat_precision == "double" else np.complex64
-        else:
-            # 1) check if complex or not
-            complex_solver = (
-                cls.isinstance_complex(eps)
-                or cls.isinstance_complex(mu)
-                or np.any([cls.isinstance_complex(f) for f in der_mats])
-            )
-            # 2) determine precision
-            if complex_solver:
-                mat_dtype = np.complex128 if mat_precision == "double" else np.complex64
-            else:
-                if mat_precision == "double":
-                    mat_dtype = np.float64
-
-        return mat_dtype
-
-    @classmethod
-    def trim_small_values(cls, mat: sp.csr_matrix, tol: float) -> sp.csr_matrix:
-        """Eliminate elements of matrix ``mat`` for which ``abs(element) / abs(max_element) < tol``,
-        or ``np.abs(mat_data) < tol``. This operates in-place on mat so there is no return.
-        """
-        max_element = np.amax(np.abs(mat))
-        mat.data *= np.logical_or(np.abs(mat.data) / max_element > tol, np.abs(mat.data) > tol)
-        mat.eliminate_zeros()
-        return mat
 
     @classmethod
     def solver_diagonal(
@@ -685,8 +671,54 @@ class EigSolver(Tidy3dBaseModel):
         return E, H, neff, keff
 
     @classmethod
+    def matrix_data_type(cls, eps, mu, der_mats, mat_precision, is_tensorial):
+        """Determine data type that should be used for the matrix for diagonalization."""
+        mat_dtype = np.float32
+        # In tensorial case, even though the matrix can be real, the
+        # expected eigenvalue is purely imaginary. So for now we enforce
+        # the matrix to be complex type so that it will look for the right eigenvalues.
+        if is_tensorial:
+            mat_dtype = np.complex128 if mat_precision == "double" else np.complex64
+        else:
+            # 1) check if complex or not
+            complex_solver = (
+                cls.isinstance_complex(eps)
+                or cls.isinstance_complex(mu)
+                or np.any([cls.isinstance_complex(f) for f in der_mats])
+            )
+            # 2) determine precision
+            if complex_solver:
+                mat_dtype = np.complex128 if mat_precision == "double" else np.complex64
+            else:
+                if mat_precision == "double":
+                    mat_dtype = np.float64
+
+        return mat_dtype
+
+    @classmethod
+    def trim_small_values(cls, mat: sp.csr_matrix, tol: float) -> sp.csr_matrix:
+        """Eliminate elements of matrix ``mat`` for which ``abs(element) / abs(max_element) < tol``,
+        or ``np.abs(mat_data) < tol``. This operates in-place on mat so there is no return.
+        """
+        max_element = np.amax(np.abs(mat))
+        mat.data *= np.logical_or(np.abs(mat.data) / max_element > tol, np.abs(mat.data) > tol)
+        mat.eliminate_zeros()
+        return mat
+
+    @classmethod
     def solver_tensorial(
-        cls, eps, mu, der_mats, num_modes, neff_guess, vec_init, mat_precision, direction
+        cls,
+        eps,
+        mu,
+        der_mats,
+        num_modes,
+        neff_guess,
+        vec_init,
+        mat_precision,
+        direction,
+        dls,
+        Nxy=None,
+        dmin_pmc=None,
     ):
         """EM eigenmode solver assuming ``eps`` or ``mu`` have off-diagonal elements."""
         import scipy.sparse as sp

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -1694,9 +1694,10 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
             return xr.DataArray(eps_array, coords=coords, dims=("x", "y", "z"))
 
         # combine all data into dictionary
-        if coord_key[0] == "E":
-            # off-diagonal components are sampled at respective locations (eg. `eps_xy` at `Ex`)
-            coords = grid[coord_key[0:2]]
+        if coord_key[0] == "E" and len(coord_key) > 2:
+            # off-diagonal components are sampled at grid boundaries
+            coords = grid["boundaries"]
+            coords = Coords(x=coords.x[:-1], y=coords.y[:-1], z=coords.z[:-1])
         else:
             coords = grid[coord_key]
         return make_eps_data(coords)


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR enhances the Tidy3D mode solver to support fully anisotropic materials by implementing proper grid positioning for off-diagonal permittivity tensor components and improving numerical robustness in symmetry detection.

The changes span three key areas:

1. **Epsilon Calculation Fix (`simulation.py`)**: Updates the grid coordinate handling for off-diagonal permittivity tensor components (like `eps_xy`, `eps_xz`, etc.). These components are now correctly positioned at grid boundaries with proper coordinate truncation, ensuring accurate electromagnetic field calculations on the Yee grid for anisotropic materials.

2. **Symmetry Detection Robustness (`mode_solver.py`)**: Replaces direct floating-point equality comparison with tolerance-based comparison using `isclose()` when checking if the mode plane center aligns with simulation symmetry center. This prevents numerical precision errors from incorrectly breaking symmetry assumptions.

3. **Tensorial Solver Enhancement (`solver.py`)**: Extends the mode solver with new parameters (`dls` for grid steps, `dmin_pmc` for PMC boundary conditions, and `Nxy` for grid dimensions) to enable full anisotropic mode solving capabilities. The code also includes organizational improvements by relocating utility methods.

These modifications work together to enable accurate mode solving for materials with full anisotropic permittivity and permeability tensors, which is critical for advanced photonic applications involving complex material properties.

## Important Files Changed

<details>
<summary>Files Overview</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/components/simulation.py` | 4/5 | Fixed grid positioning for off-diagonal permittivity tensor components |
| `tidy3d/components/mode/mode_solver.py` | 5/5 | Replaced direct float comparison with tolerance-based `isclose()` for symmetry detection |
| `tidy3d/components/mode/solver.py` | 2/5 | Added anisotropic solver parameters but contains critical missing parameter bug |

</details>

## Confidence score: 3/5

- This PR contains important enhancements for anisotropic mode solving but has a critical bug that could cause runtime errors
- Score lowered due to missing `col_mats` parameter in the complex case of the tensorial solver, which could cause inconsistent behavior or crashes
- Pay close attention to `tidy3d/components/mode/solver.py` where the `col_mats` parameter is missing in the complex solver call

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant ModeSolver
    participant EigSolver
    participant Simulation
    participant Grid
    participant Structure

    User->>ModeSolver: "Create mode solver with anisotropic materials"
    ModeSolver->>Simulation: "Get simulation structures and medium"
    Simulation->>Structure: "Check for fully anisotropic mediums"
    Structure-->>Simulation: "Return medium properties"
    Simulation-->>ModeSolver: "Return simulation data"
    
    User->>ModeSolver: "solve() - compute modes"
    ModeSolver->>ModeSolver: "_validate_rotate_structures()"
    alt angle_rotation enabled and angle_theta > 0
        ModeSolver->>ModeSolver: "_rotate_structures"
        ModeSolver->>Structure: "Rotate intersecting structures"
        Structure-->>ModeSolver: "Return rotated structures"
    end
    
    ModeSolver->>ModeSolver: "data_raw - get mode solver data"
    alt angle_rotation with bend
        ModeSolver->>ModeSolver: "rotated_mode_solver_data"
        ModeSolver->>ModeSolver: "rotated_structures_copy"
        ModeSolver->>ModeSolver: "_car_2_cyn() - convert to cylindrical"
        ModeSolver->>ModeSolver: "_mode_rotation() - rotate fields"
    else standard solve
        ModeSolver->>ModeSolver: "_data_on_yee_grid()"
    end
    
    ModeSolver->>Grid: "discretize_monitor() - get grid"
    Grid-->>ModeSolver: "Return discretized grid"
    
    ModeSolver->>EigSolver: "compute_modes()"
    EigSolver->>EigSolver: "format_medium_data() - process epsilon tensor"
    alt fully tensorial case
        EigSolver->>EigSolver: "solver_tensorial() - solve tensorial eigenvalue problem"
    else diagonal case  
        EigSolver->>EigSolver: "solver_diagonal() - solve diagonal eigenvalue problem"
    end
    EigSolver->>EigSolver: "solver_eigs() - eigenvalue solver"
    EigSolver-->>ModeSolver: "Return eigenvalues and eigenvectors"
    
    ModeSolver->>ModeSolver: "_postprocess_solver_fields() - convert to field components"
    alt colocate fields
        ModeSolver->>ModeSolver: "_colocate_data() - interpolate to grid boundaries"
    end
    ModeSolver->>ModeSolver: "_normalize_modes() - normalize field amplitudes"
    ModeSolver-->>User: "Return ModeSolverData with fields and effective indices"
```

### Context used:
**Rule -** Use a tolerance-based comparison (e.g., np.isclose) for floating-point numbers instead of direct equality (==) to avoid precision issues. ([link](https://app.greptile.com/review/custom-context?memory=4a0cb6d3-6973-448b-b5dd-168bc7b26dc3))

<!-- /greptile_comment -->