### PR TITLE
feature: scene support plot3d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for gradients with respect to the `conductivity` of a `CustomMedium`.
 - Added `VerticalNaturalConvectionCoeffModel`, a model for heat transfer due to natural convection from a vertical plate. It can be used in `ConvectionBC` to compute the heat transfer coefficient from fluid properties, using standard Nusselt number correlations for both laminar and turbulent flow.
 - Added `BroadbandModeABCSpec` class for setting broadband absorbing boundary conditions that can absorb waveguide modes over a specified frequency range using a pole-residue pair model.
+- `Scene.plot_3d()` method to make 3D rendering of scene.
 
 ### Changed
 - Validate mode solver object for large number of grid points on the modal plane.
 - Adaptive minimum spacing for `PolySlab` integration is now wavelength relative and a minimum discretization is set for computing gradients for cylinders.
 - The `TerminalComponentModeler` defaults to the pseudo wave definition of scattering parameters. The new field `s_param_def` can be used to switch between either pseudo or power wave definitions.
-- Add support for `np.unwrap` in `tidy3d.plugins.autograd`.
 
 ### Fixed
 - Fixed missing amplitude factor and handling of negative normal direction case when making adjoint sources from `DiffractionMonitor`.

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -69,6 +69,7 @@ from .viz import (
     equal_aspect,
     plot_params_fluid,
     plot_params_structure,
+    plot_scene_3d,
     polygon_path,
 )
 
@@ -1955,3 +1956,15 @@ class Scene(Tidy3dBaseModel):
             alpha=alpha,
             clip_box=ax.bbox,
         )
+
+    def plot_3d(self, width=800, height=800) -> None:
+        """Render 3D plot of ``Scene`` (in jupyter notebook only).
+        Parameters
+        ----------
+        width : float = 800
+            width of the 3d view dom's size
+        height : float = 800
+            height of the 3d view dom's size
+
+        """
+        return plot_scene_3d(self, width=width, height=height)

--- a/tidy3d/components/viz/__init__.py
+++ b/tidy3d/components/viz/__init__.py
@@ -23,7 +23,7 @@ from .plot_params import (
     plot_params_structure,
     plot_params_symmetry,
 )
-from .plot_sim_3d import plot_sim_3d
+from .plot_sim_3d import plot_scene_3d, plot_sim_3d
 from .styles import (
     ARROW_ALPHA,
     ARROW_COLOR_ABSORBER,
@@ -81,6 +81,7 @@ __all__ = [
     "plot_params_source",
     "plot_params_structure",
     "plot_params_symmetry",
+    "plot_scene_3d",
     "plot_sim_3d",
     "polygon_patch",
     "polygon_path",

--- a/tidy3d/components/viz/plot_sim_3d.py
+++ b/tidy3d/components/viz/plot_sim_3d.py
@@ -5,8 +5,63 @@ from html import escape
 from tidy3d.exceptions import SetupError
 
 
-def plot_sim_3d(sim, width=800, height=800) -> None:
-    """Make 3D display of simulation in ipyython notebook."""
+def plot_scene_3d(scene, width=800, height=800) -> None:
+    import gzip
+    import json
+    from base64 import b64encode
+    from io import BytesIO
+
+    import h5py
+
+    # Serialize scene to HDF5 in-memory
+    buffer = BytesIO()
+    scene.to_hdf5(buffer)
+    buffer.seek(0)
+
+    # Open source HDF5 for reading and prepare modified copy
+    with h5py.File(buffer, "r") as src:
+        buffer2 = BytesIO()
+        with h5py.File(buffer2, "w") as dst:
+
+            def copy_item(name, obj):
+                if isinstance(obj, h5py.Group):
+                    dst.create_group(name)
+                    for k, v in obj.attrs.items():
+                        dst[name].attrs[k] = v
+                elif isinstance(obj, h5py.Dataset):
+                    data = obj[()]
+                    if name == "JSON_STRING":
+                        # Parse and update JSON string
+                        json_str = (
+                            data.decode("utf-8") if isinstance(data, (bytes, bytearray)) else data
+                        )
+                        json_data = json.loads(json_str)
+                        json_data["size"] = list(scene.size)
+                        json_data["center"] = list(scene.center)
+                        json_data["grid_spec"] = {}
+                        new_str = json.dumps(json_data)
+                        dst.create_dataset(name, data=new_str.encode("utf-8"))
+                    else:
+                        dst.create_dataset(name, data=data)
+                        for k, v in obj.attrs.items():
+                            dst[name].attrs[k] = v
+
+            src.visititems(copy_item)
+        buffer2.seek(0)
+
+    # Gzip the modified HDF5
+    gz_buffer = BytesIO()
+    with gzip.GzipFile(fileobj=gz_buffer, mode="wb") as gz:
+        gz.write(buffer2.read())
+    gz_buffer.seek(0)
+
+    # Base64 encode and display with gzipped flag
+    sim_base64 = b64encode(gz_buffer.read()).decode("utf-8")
+    plot_sim_3d(sim_base64, width=width, height=height, is_gz_base64=True)
+
+
+def plot_sim_3d(sim, width=800, height=800, is_gz_base64=False) -> None:
+    """Make 3D display of simulation in ipython notebook."""
 
     try:
         from IPython.display import HTML, display
@@ -19,10 +74,14 @@ def plot_sim_3d(sim, width=800, height=800) -> None:
     from base64 import b64encode
     from io import BytesIO
 
-    buffer = BytesIO()
-    sim.to_hdf5_gz(buffer)
-    buffer.seek(0)
-    base64 = b64encode(buffer.read()).decode("utf-8")
+    if not is_gz_base64:
+        buffer = BytesIO()
+        sim.to_hdf5_gz(buffer)
+        buffer.seek(0)
+        base64 = b64encode(buffer.read()).decode("utf-8")
+    else:
+        base64 = sim
+
     js_code = """
         /**
         * Simulation Viewer Injector


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR adds 3D visualization support for Scene objects in the Tidy3D framework. The implementation introduces a new `plot_scene_3d` function that enables users to visualize Scene geometries in Jupyter notebooks using the existing 3D plotting infrastructure.

The core approach involves creating a compatibility layer between Scene objects and the existing `plot_sim_3d` visualization system. Since Scene objects lack simulation-specific properties like grid specifications, the implementation serializes the Scene to HDF5 format, modifies the JSON metadata to include scene-specific properties (size, center, and an empty grid_spec), compresses the data, and passes it to the existing 3D viewer.

The changes span three files: adding the function to the viz module's public API (`__init__.py`), implementing the core `plot_scene_3d` function and modifying `plot_sim_3d` to handle pre-encoded data (`plot_sim_3d.py`), and adding a convenient `plot_3d` method to the Scene class (`scene.py`). This design maintains separation of concerns by keeping complex visualization logic in the dedicated viz module while providing an intuitive interface on the Scene class.

The implementation reuses the existing JavaScript-based 3D viewer infrastructure, avoiding code duplication while extending visualization capabilities to Scene objects that represent geometric and material properties common to all simulation types.

## Important Files Changed

<details>
<summary>File Changes Summary</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/components/viz/__init__.py` | 4/5 | Adds `plot_scene_3d` to public API exports and imports |
| `tidy3d/components/scene.py` | 1/5 | Critical indentation issue makes `plot_3d` a standalone function instead of class method |
| `tidy3d/components/viz/plot_sim_3d.py` | 2/5 | Implements `plot_scene_3d` with variable scope issues and misleading parameter names |

</details>

## Confidence score: 1/5

- This PR has critical implementation issues that make it completely unsafe to merge
- Score reflects fundamental problems including incorrect indentation that completely breaks the intended Scene method functionality and variable scope errors
- Pay close attention to `tidy3d/components/scene.py` where the indentation issue makes the method unusable and `tidy3d/components/viz/plot_sim_3d.py` where variable scope issues will cause runtime errors

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant Scene
    participant plot_scene_3d
    participant BytesIO
    participant h5py
    participant JSON
    participant gzip
    participant base64
    participant plot_sim_3d
    participant IPython
    participant Browser
    
    User->>Scene: "plot_3d(width=800, height=800)"
    Scene->>plot_scene_3d: "plot_scene_3d(self, width, height)"
    
    plot_scene_3d->>BytesIO: "BytesIO()"
    plot_scene_3d->>Scene: "to_hdf5(buffer)"
    plot_scene_3d->>h5py: "File(buffer, 'r')"
    
    loop "for each item in HDF5"
        h5py->>plot_scene_3d: "visititems(copy_item)"
        alt "if name == 'JSON_STRING'"
            plot_scene_3d->>JSON: "loads(json_str)"
            plot_scene_3d->>JSON: "update with scene.size, scene.center, empty grid_spec"
            plot_scene_3d->>JSON: "dumps(json_data)"
        end
    end
    
    plot_scene_3d->>gzip: "GzipFile(fileobj=gz_buffer, mode='wb')"
    plot_scene_3d->>base64: "b64encode(gz_buffer.read())"
    plot_scene_3d->>plot_sim_3d: "plot_sim_3d(sim_base64, width, height, is_gz_base64=True)"
    
    plot_sim_3d->>IPython: "from IPython.display import HTML, display"
    plot_sim_3d->>Browser: "display(HTML(html_code))"
    
    Note over Browser: "JavaScript injector creates iframe"
    Note over Browser: "Iframe loads viewer from tidy3d.simulation.cloud"
    Note over Browser: "PostMessage API transfers simulation data"
    
    Browser-->>User: "3D visualization rendered"
```

<!-- /greptile_comment -->