### PR TITLE
remove sources from adjoint postprocessing dummy simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validation of `freqs` in the `ComponentModeler` and `TerminalComponentModeler`.
 - Calculation of voltage and current in the `WavePort`, when one type of path integral is supplied and the transmission line mode is lossy.
 - Polygon vertices cleanup in `ClipOperation.intersections_plane`.
+- Removed sources from `sim_inf_structure` simulation object in `postprocess_adj` to avoid source and background medium validation errors.
 
 ## [2.9.0] - 2025-08-04
 

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -22,6 +22,7 @@ from tidy3d.components.autograd.constants import (
 )
 from tidy3d.components.autograd.derivative_utils import DerivativeInfo
 from tidy3d.components.data.data_array import DataArray
+from tidy3d.components.grid.grid_spec import GridSpec
 from tidy3d.exceptions import AdjointError
 from tidy3d.web.api.asynchronous import DEFAULT_DATA_DIR
 from tidy3d.web.api.asynchronous import run_async as run_async_webapi
@@ -1070,10 +1071,14 @@ def postprocess_adj(
             sim_orig = sim_data_orig.simulation
             plane_eps = eps_fwd.monitor.geometry
 
+            sim_orig_grid_spec = GridSpec.from_grid(sim_orig.grid)
+
             # permittivity without this structure
             structs_no_struct = list(sim_orig.structures)
             structs_no_struct.pop(structure_index)
-            sim_no_structure = sim_orig.updated_copy(structures=structs_no_struct)
+            sim_no_structure = sim_orig.updated_copy(
+                structures=structs_no_struct, monitors=[], sources=[], grid_spec=sim_orig_grid_spec
+            )
 
             eps_no_structure_data = [
                 sim_no_structure.epsilon(box=plane_eps, coord_key="centers", freq=f)
@@ -1086,6 +1091,8 @@ def postprocess_adj(
                 structures=structs_inf_struct,
                 medium=structure.medium,
                 monitors=[],
+                sources=[],
+                grid_spec=sim_orig_grid_spec,
             )
 
             eps_inf_structure_data = [


### PR DESCRIPTION
This fixes an error a user was seeing where they had an anisotropic medium in their structure. During adjoint postprocessing, when `sim_inf_structure` is made, the structure medium becomes the simulation background medium. This was failing a validator for having a plane wave inject into an anisotropic medium. We shouldn't need sources in this dummy simulation object since we are just using it to get permittivities.

I tested this on the failing notebook from the user to verify this fixes their problem with computing gradients with an anisotropic structure medium.