### PR TITLE
revert overly strict validation of 'freqs'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Calculation of voltage and current in the `WavePort`, when one type of path integral is supplied and the transmission line mode is lossy.
 - Polygon vertices cleanup in `ClipOperation.intersections_plane`.
 - Removed sources from `sim_inf_structure` simulation object in `postprocess_adj` to avoid source and background medium validation errors.
+- Revert overly restrictive validation of `freqs` in the `ComponentModeler` and `TerminalComponentModeler`.
 
 ## [2.9.0] - 2025-08-04
 

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -235,18 +235,16 @@ def test_validate_no_sources(tmp_path):
 
 
 def test_validate_freqs():
-    """Ensure the 'freqs' array is strictly increasing and length of at least 2."""
+    """Ensure the 'freqs' array does not contain negative values nor duplicate entries."""
     modeler = make_component_modeler(planar_pec=False)
-    freqs = np.array([1.0])
+    # It should be possible to provide a single frequency point
+    freqs = np.array([1.0e6])
+    modeler = modeler.updated_copy(freqs=freqs)
+    _ = modeler._source_time
+    # Negative frequencies are not allowed
+    freqs = np.array([-1.0, 5]) * 1e9
     with pytest.raises(pd.ValidationError):
         _ = modeler.updated_copy(freqs=freqs)
-    freqs = np.array([-1.0, 5])
-    with pytest.raises(pd.ValidationError):
-        _ = modeler.updated_copy(freqs=freqs)
-    freqs = np.array([1, 2, 1.9])
-    with pytest.raises(pd.ValidationError):
-        _ = modeler.updated_copy(freqs=freqs)
-
     # Test case with non-unique value
     f_min, f_max = (0.5e9, 1.5e9)
     f0 = (f_min + f_max) / 2

--- a/tidy3d/components/validators.py
+++ b/tidy3d/components/validators.py
@@ -465,6 +465,19 @@ def validate_freqs_not_empty():
     return freqs_not_empty
 
 
+def validate_freqs_unique():
+    """Validate that the array of frequencies does not have duplicate entries."""
+
+    @pydantic.validator("freqs", always=True, allow_reuse=True)
+    def freqs_unique(cls, val):
+        """Raise validation error if ``freqs`` has duplicate entries."""
+        if len(set(val)) != len(val):
+            raise ValidationError(f"'{cls.__name__}.freqs' must not contain duplicate entries.")
+        return val
+
+    return freqs_unique
+
+
 def _warn_unsupported_traced_argument(name: str):
     @pydantic.validator(name, always=True, allow_reuse=True)
     def _warn_traced_arg(cls, val, values):

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -14,7 +14,12 @@ from tidy3d.components.data.data_array import DataArray
 from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.simulation import Simulation
 from tidy3d.components.types import Complex, FreqArray
-from tidy3d.components.validators import assert_unique_names
+from tidy3d.components.validators import (
+    assert_unique_names,
+    validate_freqs_min,
+    validate_freqs_not_empty,
+    validate_freqs_unique,
+)
 from tidy3d.config import config
 from tidy3d.constants import HERTZ
 from tidy3d.exceptions import SetupError, Tidy3dKeyError
@@ -150,24 +155,9 @@ class AbstractComponentModeler(ABC, Generic[IndexType, ElementType], Tidy3dBaseM
             raise SetupError(f"'{cls.__name__}.simulation' must not have any sources.")
         return val
 
-    @pd.validator("freqs", always=True)
-    def _validate_freqs(cls, val):
-        """The array of frequencies must be sorted, unique and non-negative."""
-        if len(val) < 2:
-            raise SetupError(f"You must supply at least 2 entries for '{cls.__name__}.freqs'.")
-        np_val = np.array(val)
-        if not np.all(np_val >= 0):
-            raise SetupError(f"'{cls.__name__}.freqs' must be an array of non-negative numbers.")
-        # Ensure freqs is sorted
-        diff = np.diff(np_val)
-        if not np.all(diff > 0):
-            violations = np.where(diff <= 0)[0] + 1
-            raise SetupError(
-                f"'{cls.__name__}.freqs' must be strictly increasing (unique values sorted "
-                "in ascending order). "
-                f"The entries at the following indices violated this requirement: {violations}."
-            )
-        return val
+    _freqs_not_empty = validate_freqs_not_empty()
+    _freqs_lower_bound = validate_freqs_min()
+    _freqs_unique = validate_freqs_unique()
 
     @pd.validator("ports", always=True)
     def _warn_rf_license(cls, val):

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -28,7 +28,7 @@ from tidy3d.plugins.smatrix.ports.rectangular_lumped import LumpedPort
 from tidy3d.plugins.smatrix.ports.wave import WavePort
 from tidy3d.web.api.container import BatchData
 
-from .base import AbstractComponentModeler, TerminalPortType
+from .base import FWIDTH_FRAC, AbstractComponentModeler, TerminalPortType
 
 NetworkIndex = str  # the 'i' in S_ij
 NetworkElement = tuple[NetworkIndex, NetworkIndex]  # the 'ij' in S_ij
@@ -272,6 +272,9 @@ class TerminalComponentModeler(AbstractComponentModeler[NetworkIndex, NetworkEle
     @cached_property
     def _source_time(self):
         """Helper to create a time domain pulse for the frequency range of interest."""
+        if len(self.freqs) == 1:
+            freq0 = self.freqs[0]
+            return GaussianPulse(freq0=self.freqs[0], fwidth=freq0 * FWIDTH_FRAC)
         return GaussianPulse.from_frequency_range(
             fmin=min(self.freqs), fmax=max(self.freqs), remove_dc_component=self.remove_dc_component
         )


### PR DESCRIPTION
Makes sense to allow `freqs` in descending order when creating the array from wavelengths, which is used in some tests. Unsorted `freqs` is allowed again, but we still do not allow duplicate entries in `freqs`.

<!-- greptile_comment -->

## Greptile Summary

This PR reverts overly restrictive frequency validation in the ComponentModeler and TerminalComponentModeler classes. The original validation required frequencies to be strictly sorted in ascending order with a minimum of 2 elements, which was too restrictive for practical use cases.

The main changes involve replacing the comprehensive `_validate_freqs` method with three modular validators: `validate_freqs_not_empty()`, `validate_freqs_min()`, and `validate_freqs_unique()`. This approach allows frequency arrays to be in any order (including descending) while maintaining important constraints like preventing negative frequencies and duplicate entries.

The modification addresses a common workflow where frequency arrays are created from wavelength arrays. Since frequency is inversely proportional to wavelength, converting from ascending wavelength arrays naturally produces descending frequency arrays. This is particularly relevant in optical simulations and is used in some existing tests.

Additionally, the TerminalComponentModeler now properly handles single-frequency scenarios by creating Gaussian pulses with appropriate frequency width when only one frequency is provided, using the `FWIDTH_FRAC` constant for proper pulse characterization.

<details>
<summary>Important Files Changed</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `CHANGELOG.md` | 5/5 | Added changelog entry documenting the frequency validation fix |
| `tidy3d/components/validators.py` | 4/5 | Added new `validate_freqs_unique()` validator function for duplicate checking |
| `tidy3d/plugins/smatrix/component_modelers/base.py` | 4/5 | Replaced comprehensive frequency validation with modular validators |
| `tidy3d/plugins/smatrix/component_modelers/terminal.py` | 5/5 | Added single-frequency handling and imported FWIDTH_FRAC constant |
| `tests/test_plugins/smatrix/test_terminal_component_modeler.py` | 4/5 | Updated tests to reflect new validation behavior |

</details>

## Confidence score: 4/5

- This PR safely relaxes overly strict validation while maintaining data integrity
- Score reflects well-structured changes with proper separation of concerns and comprehensive testing
- Pay close attention to the validation logic changes in the base ComponentModeler class

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant TerminalComponentModeler
    participant Validator
    participant SimulationRunner
    participant BatchData

    User->>TerminalComponentModeler: create modeler with freqs
    TerminalComponentModeler->>Validator: validate_freqs_not_empty()
    Validator-->>TerminalComponentModeler: validation result
    TerminalComponentModeler->>Validator: validate_freqs_min()
    Validator-->>TerminalComponentModeler: validation result
    TerminalComponentModeler->>Validator: validate_freqs_unique()
    Note over Validator: Check for duplicate entries only<br/>(not strict ordering)
    Validator-->>TerminalComponentModeler: validation result
    TerminalComponentModeler-->>User: modeler instance

    User->>TerminalComponentModeler: run simulation
    TerminalComponentModeler->>TerminalComponentModeler: _construct_smatrix()
    TerminalComponentModeler->>SimulationRunner: batch_data
    SimulationRunner-->>TerminalComponentModeler: simulation results
    TerminalComponentModeler->>TerminalComponentModeler: _internal_construct_smatrix()
    TerminalComponentModeler-->>User: S-matrix results
```

<!-- /greptile_comment -->