### PR TITLE
fix bug in TerminalComponentModeler.get_antenna_metrics_data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed sources from `sim_inf_structure` simulation object in `postprocess_adj` to avoid source and background medium validation errors.
 - Revert overly restrictive validation of `freqs` in the `ComponentModeler` and `TerminalComponentModeler`.
 - Fixed `ElectromagneticFieldData.to_zbf()` to support single frequency monitors and apply the correct flattening order.
+- Bug in `TerminalComponentModeler.get_antenna_metrics_data` when port amplitudes are set to zero.
 
 ## [2.9.0] - 2025-08-04
 

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -1141,6 +1141,15 @@ def test_get_combined_antenna_parameters_data(monkeypatch, tmp_path):
         antenna_params.radiation_efficiency, single_port_params.radiation_efficiency
     )
 
+    # Define port amplitudes
+    port_amplitudes = {modeler.ports[0].name: 1.0, modeler.ports[1].name: 0.0}
+    port2_zero_params = modeler.get_antenna_metrics_data(port_amplitudes)
+    # Should give idential results to only exciting one port
+    assert np.allclose(port2_zero_params.gain, single_port_params.gain)
+    assert np.allclose(
+        port2_zero_params.radiation_efficiency, single_port_params.radiation_efficiency
+    )
+
 
 def test_run_only_and_element_mappings(monkeypatch, tmp_path):
     """Checks the terminal component modeler works when running with a subset of excitations."""

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -808,9 +808,10 @@ class TerminalComponentModeler(AbstractComponentModeler[NetworkIndex, NetworkEle
         Parameters
         ----------
         port_amplitudes : dict[str, complex] = None
-            Dictionary mapping port names to their desired excitation amplitudes. For each port,
+            Dictionary mapping port names to their desired excitation amplitudes, ``a``. For each port,
             :math:`\\frac{1}{2}|a|^2` represents the incident power from that port into the system.
-            If None, uses only the first port without any scaling of the raw simulation data.
+            If ``None``, uses only the first port without any scaling of the raw simulation data.
+            When ``None`` is passed as a port amplitude, the raw simulation data is used for that port.
             Note that in this method ``a`` represents the incident wave amplitude
             using the power wave definition in [2].
         monitor_name : str = None
@@ -849,6 +850,8 @@ class TerminalComponentModeler(AbstractComponentModeler[NetworkIndex, NetworkEle
         # Retrieve associated simulation data
         combined_directivity_data = None
         for port, amplitude in port_dict.items():
+            if amplitude == 0.0:
+                continue
             sim_data_port = self.batch_data[self._task_name(port=port)]
             radiation_data = sim_data_port[rad_mon.name]
 


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR fixes a bug in the `TerminalComponentModeler.get_antenna_metrics_data` method that occurred when port amplitudes were set to zero. The fix prevents potential numerical issues (NaN values or division by zero) by adding a simple check to skip ports with zero amplitude during antenna metrics calculations.

The core change is in the `terminal.py` file where a guard clause `if amplitude == 0.0: continue` was added to skip zero-amplitude ports in the processing loop. This prevents the method from attempting mathematical operations on ports that shouldn't contribute to the antenna metrics. The docstring was also enhanced to clarify the distinction between `None` (uses raw simulation data) and `0.0` (skips port entirely) for port amplitudes.

A comprehensive test case was added to validate the fix, ensuring that when one port has amplitude 1.0 and another has amplitude 0.0, the results are identical to exciting only the first port. This test provides regression protection and confirms the mathematical correctness of the zero-amplitude handling. The changelog entry properly documents this bug fix in the 'Fixed' section under '[Unreleased]', following the project's established documentation practices.

<details>
<summary>Important Files Changed</summary>

| Filename | Score | Overview |
|----------|--------|----------|
| `tidy3d/plugins/smatrix/component_modelers/terminal.py` | 4/5 | Added zero-amplitude check and improved docstring clarity for antenna metrics calculation |
| `tests/test_plugins/smatrix/test_terminal_component_modeler.py` | 5/5 | Added comprehensive test case to validate zero-amplitude port handling |
| `CHANGELOG.md` | 5/5 | Added proper changelog entry documenting the bug fix |

</details>

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it addresses a specific edge case bug
- Score reflects a straightforward defensive programming fix with proper test coverage
- The terminal.py file needs attention to ensure the zero-amplitude check doesn't inadvertently skip valid use cases

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant TerminalComponentModeler
    participant SimulationData
    participant AntennaMetricsData
    
    User->>TerminalComponentModeler: "get_antenna_metrics_data(port_amplitudes, monitor_name)"
    
    alt port_amplitudes is None
        TerminalComponentModeler->>TerminalComponentModeler: "Set default: {first_port.name: None}"
    end
    
    TerminalComponentModeler->>TerminalComponentModeler: "Validate port names and create port_dict"
    
    alt monitor_name is None
        TerminalComponentModeler->>TerminalComponentModeler: "Use first radiation monitor"
    else
        TerminalComponentModeler->>TerminalComponentModeler: "get_radiation_monitor_by_name(monitor_name)"
    end
    
    TerminalComponentModeler->>TerminalComponentModeler: "Initialize a_sum and b_sum arrays"
    TerminalComponentModeler->>TerminalComponentModeler: "Set combined_directivity_data = None"
    
    loop For each port, amplitude in port_dict
        alt amplitude == 0.0
            TerminalComponentModeler->>TerminalComponentModeler: "continue (skip to next port)"
            Note over TerminalComponentModeler: Bug: This skips processing but doesn't<br/>handle combined_directivity_data properly
        else
            TerminalComponentModeler->>SimulationData: "Get sim_data_port from batch_data"
            TerminalComponentModeler->>SimulationData: "Get radiation_data from sim_data_port"
            
            TerminalComponentModeler->>TerminalComponentModeler: "compute_wave_amplitudes_at_each_port()"
            TerminalComponentModeler->>TerminalComponentModeler: "Select frequency subset"
            
            alt amplitude is None
                TerminalComponentModeler->>TerminalComponentModeler: "No scaling, scale_factor = 1.0"
                Note over TerminalComponentModeler: scaled_directivity_data = raw data
            else
                TerminalComponentModeler->>TerminalComponentModeler: "_monitor_data_at_port_amplitude()"
                TerminalComponentModeler->>TerminalComponentModeler: "Calculate scale_factor = amplitude / a_raw"
            end
            
            TerminalComponentModeler->>TerminalComponentModeler: "Scale a and b by scale_factor"
            
            alt combined_directivity_data is None
                TerminalComponentModeler->>TerminalComponentModeler: "combined_directivity_data = scaled_directivity_data"
            else
                TerminalComponentModeler->>TerminalComponentModeler: "combined_directivity_data += scaled_directivity_data"
            end
            
            TerminalComponentModeler->>TerminalComponentModeler: "a_sum += a, b_sum += b"
        end
    end
    
    TerminalComponentModeler->>TerminalComponentModeler: "Calculate power_incident and power_reflected"
    TerminalComponentModeler->>AntennaMetricsData: "from_directivity_data(combined_directivity_data, power_incident, power_reflected)"
    AntennaMetricsData-->>User: "Return AntennaMetricsData"
```

<!-- /greptile_comment -->