### PR TITLE
add solver_version parameter to run_async and fix associated bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Revert overly restrictive validation of `freqs` in the `ComponentModeler` and `TerminalComponentModeler`.
 - Fixed `ElectromagneticFieldData.to_zbf()` to support single frequency monitors and apply the correct flattening order.
 - Bug in `TerminalComponentModeler.get_antenna_metrics_data` when port amplitudes are set to zero.
+- Added missing `solver_version` keyword argument to `run_async`.
 
 ## [2.9.0] - 2025-08-04
 

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -273,7 +273,6 @@ class AbstractComponentModeler(ABC, Generic[IndexType, ElementType], Tidy3dBaseM
                 "type",
                 "path_dir",
                 "attrs",
-                "solver_version",
                 "jobs_cached",
                 "num_workers",
                 "simulations",

--- a/tidy3d/web/api/asynchronous.py
+++ b/tidy3d/web/api/asynchronous.py
@@ -19,6 +19,7 @@ def run_async(
     num_workers: Optional[int] = None,
     verbose: bool = True,
     simulation_type: str = "tidy3d",
+    solver_version: Optional[str] = None,
     parent_tasks: Optional[dict[str, list[str]]] = None,
     reduce_simulation: Literal["auto", True, False] = "auto",
     pay_type: Union[PayType, str] = PayType.AUTO,
@@ -43,6 +44,10 @@ def run_async(
         Number of tasks to submit at once in a batch, if None, will run all at the same time.
     verbose : bool = True
         If ``True``, will print progressbars and status, otherwise, will run silently.
+    simulation_type : str = "tidy3d"
+        Type of simulation being uploaded.
+    solver_version: Optional[str] = None
+        Target solver version.
     reduce_simulation: Literal["auto", True, False] = "auto"
         Whether to reduce structures in the simulation to the simulation domain only. Note: currently only implemented for the mode solver.
     pay_type: Union[PayType, str] = PayType.AUTO
@@ -79,6 +84,7 @@ def run_async(
         callback_url=callback_url,
         verbose=verbose,
         simulation_type=simulation_type,
+        solver_version=solver_version,
         parent_tasks=parent_tasks,
         reduce_simulation=reduce_simulation,
         pay_type=pay_type,

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -247,6 +247,7 @@ def run_async(
     num_workers: typing.Optional[int] = None,
     verbose: bool = True,
     simulation_type: str = "tidy3d",
+    solver_version: typing.Optional[str] = None,
     parent_tasks: typing.Optional[dict[str, list[str]]] = None,
     local_gradient: bool = LOCAL_GRADIENT,
     max_num_adjoint_per_fwd: int = MAX_NUM_ADJOINT_PER_FWD,
@@ -273,6 +274,10 @@ def run_async(
         Number of tasks to submit at once in a batch, if None, will run all at the same time.
     verbose : bool = True
         If ``True``, will print progressbars and status, otherwise, will run silently.
+    simulation_type : str = "tidy3d"
+        Type of simulation being uploaded.
+    solver_version: Optional[str] = None
+        Target solver version.
     local_gradient: bool = False
         Whether to perform gradient calculations locally, requiring more downloads but potentially
         more stable with experimental features.
@@ -307,6 +312,7 @@ def run_async(
             num_workers=num_workers,
             verbose=verbose,
             simulation_type="tidy3d_autograd_async",
+            solver_version=solver_version,
             parent_tasks=parent_tasks,
             local_gradient=local_gradient,
             max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
@@ -321,6 +327,7 @@ def run_async(
         num_workers=num_workers,
         verbose=verbose,
         simulation_type=simulation_type,
+        solver_version=solver_version,
         parent_tasks=parent_tasks,
         reduce_simulation=reduce_simulation,
         pay_type=pay_type,


### PR DESCRIPTION
plus some docstring updates

<!-- greptile_comment -->

## Greptile Summary

This PR adds the `solver_version` parameter to the `run_async` function across the Tidy3D web API to enable users to specify which solver version to use when running batch simulations asynchronously. The change brings consistency to the web API by ensuring that `run_async` supports the same solver version control that's available in other web functions like `webapi.run()`, `Job`, and `Batch`.

The implementation touches four key areas:
1. **Core async functionality** - Adds the parameter to the main `run_async` function in `tidy3d/web/api/asynchronous.py`
2. **Autograd integration** - Extends the autograd wrapper's `run_async` function to expose this parameter and properly forward it to both autograd-specific and regular web API calls
3. **Component modelers** - Fixes a bug in `ComponentModeler` and `TerminalComponentModeler` where the `solver_version` field was being excluded from the parameters passed to `run_async`
4. **Documentation** - Updates the changelog to document both the new feature and the bug fix

The change ensures that users can maintain reproducible results and compatibility requirements by controlling solver versions in all async execution contexts, whether using the base web API, autograd functionality, or component modeling tools. The implementation follows established patterns in the codebase by adding the parameter with proper type hints, documentation, and default values.

<details>
<summary>Important Files Changed</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/web/api/asynchronous.py` | 5/5 | Adds `solver_version` parameter to core `run_async` function with proper documentation |
| `tidy3d/web/api/autograd/autograd.py` | 5/5 | Extends autograd `run_async` wrapper to support and forward `solver_version` parameter |
| `tidy3d/plugins/smatrix/component_modelers/base.py` | 5/5 | Fixes bug by removing `solver_version` from exclude set in `batch_data` property |
| `CHANGELOG.md` | 4/5 | Documents new feature and bug fix with minor typo ('propely' vs 'properly') |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it adds a well-implemented optional parameter with proper defaults
- Score reflects clean implementation following established patterns, comprehensive coverage across related modules, and proper documentation
- Minor typo in CHANGELOG.md is the only issue requiring attention

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant run_async_webapi as "run_async (webapi)"
    participant run_async_autograd as "run_async (autograd)"
    participant Batch
    participant ComponentModeler as "AbstractComponentModeler"
    participant run_async_primitive as "_run_async_primitive"
    participant _run_async_tidy3d as "_run_async_tidy3d"

    User->>run_async_webapi: "run_async(simulations, solver_version=version)"
    
    alt autograd simulation
        run_async_webapi->>run_async_autograd: "_run_async(solver_version=version, **kwargs)"
        run_async_autograd->>run_async_primitive: "_run_async_primitive(solver_version=version)"
        run_async_primitive->>_run_async_tidy3d: "parse solver_version in batch_init_kwargs"
        _run_async_tidy3d->>Batch: "Batch(solver_version=version, **kwargs)"
        Batch-->>_run_async_tidy3d: "batch with solver_version"
        _run_async_tidy3d-->>run_async_primitive: "BatchData with task_ids"
        run_async_primitive-->>run_async_autograd: "field_map_fwd_dict"
        run_async_autograd-->>run_async_webapi: "BatchData"
    else regular simulation
        run_async_webapi->>Batch: "Batch(solver_version=version, **kwargs)"
        Batch-->>run_async_webapi: "BatchData"
    end
    
    run_async_webapi-->>User: "BatchData"
    
    Note over ComponentModeler: Bug Fix: solver_version propagation
    ComponentModeler->>ComponentModeler: "batch property creates Batch with solver_version"
    ComponentModeler->>run_async_webapi: "run_async with solver_version from ComponentModeler.solver_version"
    
    Note over ComponentModeler: Fixed: solver_version now properly propagated to web run_async
```

<!-- /greptile_comment -->