### PR TITLE
data array autograd compatible method for endpoint extrapolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `ElectromagneticFieldData.to_zbf()` to support single frequency monitors and apply the correct flattening order.
 - Bug in `TerminalComponentModeler.get_antenna_metrics_data` when port amplitudes are set to zero.
 - Added missing `solver_version` keyword argument to `run_async`.
+- Fixed `interpn` data array method to be compatible with extrapolation outside of data array coordinates. 
 
 ## [2.9.0] - 2025-08-04
 

--- a/tests/test_data/test_data_arrays.py
+++ b/tests/test_data/test_data_arrays.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import autograd as ag
 import autograd.numpy as np
+import numpy
 import pytest
 import xarray.testing as xrt
 from autograd.test_util import check_grads
@@ -516,3 +517,66 @@ def test_with_updated_data_shape():
 
     with pytest.raises(ValueError):
         arr2 = arr._with_updated_data(data=data, coords=coords)
+
+
+@pytest.mark.parametrize("method", ["nearest", "linear"])
+def test_interpn_with_extrapolation(rng, method):
+    """Checks that the extrapolation in `interpn` works as expected and that
+    it is autograd compatible."""
+    arr = td.SpatialDataArray(
+        rng.random((1, 3, 4, 5), dtype=np.float64),
+        coords={"x": [1], "y": [1, 2, 3], "z": [2, 3, 4, 5], "f": [0, 1, 2, 3, 4]},
+    )
+
+    for coord in arr.dims:
+        endpoints = [
+            arr.coords[coord].values[0] - 1.0,
+            arr.coords[coord].values[-1] + 1.0,
+        ]
+
+        method_coord = method if (len(arr.coords[coord]) > 1) else "nearest"
+
+        offset_interp_coords = arr.coords[coord].values + 0.5
+        coords_interp = {coord: [endpoints[0], *offset_interp_coords, endpoints[1]]}
+
+        extrapolate = arr._ag_interp(
+            coords_interp, method=method_coord, kwargs={"fill_value": "extrapolate"}
+        )
+
+        compare = arr.interp(
+            coords_interp, method=method_coord, kwargs={"fill_value": "extrapolate"}
+        )
+
+        numpy.testing.assert_allclose(
+            extrapolate.data, compare.data, err_msg="Expected data to be close!"
+        )
+
+    def f(params):
+        arr = td.SpatialDataArray(
+            params.reshape((1, 3, 4, 5)),
+            coords={"x": [1], "y": [1, 2, 3], "z": [2, 3, 4, 5], "f": [0, 1, 2, 3, 4]},
+        )
+
+        result = 0.0
+
+        for coord in arr.dims:
+            endpoints = [
+                arr.coords[coord].values[0] - 1.0,
+                arr.coords[coord].values[-1] + 1.0,
+            ]
+
+            method_coord = method if (len(arr.coords[coord]) > 1) else "nearest"
+
+            offset_interp_coords = arr.coords[coord].values + 0.5
+            coords_interp = {coord: [endpoints[0], *offset_interp_coords, endpoints[1]]}
+
+            interp_data = arr.interp(
+                coords_interp, method=method_coord, kwargs={"fill_value": "extrapolate"}
+            )
+
+            result += np.sum(interp_data.data)
+
+        return result
+
+    data = rng.random((1, 3, 4, 5), dtype=np.float64)
+    check_grads(f, order=1, modes=["rev"])(data)

--- a/tidy3d/components/autograd/functions.py
+++ b/tidy3d/components/autograd/functions.py
@@ -98,6 +98,7 @@ def interpn(
     xi: tuple[NDArray[np.float64], ...],
     *,
     method: InterpolationType = "linear",
+    **kwargs,
 ) -> NDArray[np.float64]:
     """Interpolate over a rectilinear grid in arbitrary dimensions.
 
@@ -137,7 +138,12 @@ def interpn(
     else:
         raise ValueError(f"Unsupported interpolation method: {method}")
 
-    itrp = RegularGridInterpolator(points, values, method=method)
+    if kwargs.get("fill_value") == "extrapolate":
+        itrp = RegularGridInterpolator(
+            points, values, method=method, fill_value=None, bounds_error=False
+        )
+    else:
+        itrp = RegularGridInterpolator(points, values, method=method)
 
     # Prepare the grid for interpolation
     # This step reshapes the grid, checks for NaNs and out-of-bounds values

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -467,12 +467,7 @@ class DataArray(xr.DataArray):
             data = anp.transpose(var.data, combined_permutation)
             xi = anp.stack([anp.ravel(new_xi.data) for new_xi in new_x], axis=-1)
 
-            result = interpn(
-                [xn.data for xn in x],
-                data,
-                xi,
-                method=method,
-            )
+            result = interpn([xn.data for xn in x], data, xi, method=method, **kwargs)
 
             result = anp.moveaxis(result, 0, -1)
             result = anp.reshape(result, result.shape[:-1] + new_x[0].shape)

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Literal, Optional, Union
 
-import numpy as np
+import autograd.numpy as np
 import pydantic.v1 as pd
 
 from tidy3d.components.base import cached_property


### PR DESCRIPTION
To make the terminal component modeler autograd compatible, we need an autograd friendly version of extrapolation in path_integrals. While interp can extrapolate outside the coordinate dimension on the forward pass, the backward pass was causing an autograd error. The added data array method extends the data array and fills in the extrapolated values so that autograd works.

@dmarek-flex - originally tagged you because I thought this would affect path_integrals, but it ended up having more to do with an autograd fix.

<!-- greptile_comment -->

## Greptile Summary

This PR adds autograd-compatible extrapolation functionality to the Tidy3D framework by implementing a new private method `_extrapolate_to_endpoints` in the `DataArray` class. The primary motivation is to enable autograd compatibility for the terminal component modeler, which requires field extrapolation beyond coordinate boundaries during path integral calculations.

The key change addresses a limitation where xarray's native `interp()` method with `fill_value='extrapolate'` works correctly during forward passes but fails during autograd backward passes when computing gradients. This breaks the differentiability required for optimization workflows in RF/microwave applications.

The solution implements a two-step approach: first extending the data array's coordinate dimension by adding endpoint values outside the current range, then filling these positions with extrapolated values using either nearest or linear interpolation methods. This pre-computation of extrapolated values ensures that autograd can properly trace through the entire computation graph.

The implementation is integrated into the path integrals module where it replaces the previous extrapolation logic when `extrapolate_to_endpoints=True`. The method maintains mathematical equivalence to the original approach while providing the necessary autograd compatibility for inverse design and optimization workflows that depend on gradient computation.

## Important Files Changed

<details>
<summary>File Changes</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/data/data_array.py | 4/5 | Added `_extrapolate_to_endpoints` method for autograd-compatible extrapolation with nearest and linear interpolation support |
| tidy3d/plugins/microwave/path_integrals.py | 4/5 | Updated `compute_integral` method to use new autograd-compatible extrapolation instead of native xarray interpolation |
| CHANGELOG.md | 5/5 | Added changelog entry documenting the new private method for autograd-compatible extrapolation |
| tests/test_data/test_data_arrays.py | 4/5 | Added comprehensive parametrized tests validating equivalence between new method and native xarray extrapolation |

</details>

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it adds functionality without breaking existing behavior
- Score reflects well-tested implementation with comprehensive validation, though the complexity of autograd compatibility warrants careful attention
- Pay close attention to the DataArray extrapolation method implementation for potential edge cases in coordinate handling

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant PathIntegral as VoltageIntegralAxisAligned
    participant DataArray as DataArray
    participant InterpMethod as interp method
    participant ExtrapolateMethod as _extrapolate_to_endpoints

    User->>PathIntegral: compute_voltage(em_field)
    PathIntegral->>PathIntegral: compute_integral(e_field)
    
    alt extrapolate_to_endpoints is True
        PathIntegral->>DataArray: _extrapolate_to_endpoints(coord, endpoints, method)
        DataArray->>DataArray: validate endpoints and method
        
        alt method is "nearest"
            DataArray->>DataArray: isel nearest values at boundaries
        else method is "linear"  
            DataArray->>DataArray: calculate linear extrapolation from boundary points
            DataArray->>DataArray: _interp_data_linear for low and high endpoints
        end
        
        DataArray->>DataArray: _with_updated_data for low endpoint
        DataArray->>DataArray: _with_updated_data for high endpoint
        DataArray-->>PathIntegral: extended data array
        
        PathIntegral->>DataArray: interp(coords_interp, method)
        DataArray-->>PathIntegral: interpolated field
    else extrapolate_to_endpoints is False
        PathIntegral->>DataArray: interp(coords_interp, method, fill_value="extrapolate")
        DataArray-->>PathIntegral: interpolated field
    end
    
    PathIntegral->>DataArray: integrate(coord)
    DataArray-->>PathIntegral: integrated result
    PathIntegral-->>User: voltage data array
```

<!-- /greptile_comment -->