### PR TITLE
Include RF data structures immutability

### DIFF
--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -20,7 +20,6 @@ from tidy3d.plugins.microwave import (
     VoltageIntegralAxisAligned,
 )
 from tidy3d.plugins.smatrix import (
-    AbstractComponentModeler,
     CoaxialLumpedPort,
     LumpedPort,
     PortDataArray,
@@ -48,7 +47,9 @@ def run_component_modeler(
         values=tuple(batch_data.values()),
     )
     modeler_data = TerminalComponentModelerData(modeler=modeler, data=port_data)
-    monkeypatch.setattr(AbstractComponentModeler, "inv", lambda matrix: np.eye(len(modeler.ports)))
+    monkeypatch.setattr(
+        td.plugins.smatrix.utils, "port_array_inv", lambda matrix: np.eye(len(modeler.ports))
+    )
     monkeypatch.setattr(
         td.plugins.smatrix.utils,
         "compute_F",

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -23,11 +23,14 @@ from tidy3d.components.autograd import TidyArrayBox, get_static, interpn, is_tid
 from tidy3d.components.geometry.bound_ops import bounds_contains
 from tidy3d.components.types import Axis, Bound
 from tidy3d.constants import (
+    AMP,
     HERTZ,
     MICROMETER,
+    OHM,
     PICOSECOND_PER_NANOMETER_PER_KILOMETER,
     RADIAN,
     SECOND,
+    VOLT,
     WATT,
 )
 from tidy3d.exceptions import DataError, FileError
@@ -1338,6 +1341,165 @@ class PerturbationCoefficientDataArray(DataArray):
     _dims = ("wvl", "coeff")
 
 
+class VoltageArray(DataArray):
+    # Always set __slots__ = () to avoid xarray warnings
+    __slots__ = ()
+    _data_attrs = {"units": VOLT, "long_name": "voltage"}
+
+
+class CurrentArray(DataArray):
+    # Always set __slots__ = () to avoid xarray warnings
+    __slots__ = ()
+    _data_attrs = {"units": AMP, "long_name": "current"}
+
+
+class ImpedanceArray(DataArray):
+    # Always set __slots__ = () to avoid xarray warnings
+    __slots__ = ()
+    _data_attrs = {"units": OHM, "long_name": "impedance"}
+
+
+# Voltage arrays
+class VoltageFreqDataArray(VoltageArray, FreqDataArray):
+    """Voltage data array in frequency domain.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> f = [2e9, 3e9, 4e9]
+    >>> coords = dict(f=f)
+    >>> data = np.random.random(3) + 1j * np.random.random(3)
+    >>> vfd = VoltageFreqDataArray(data, coords=coords)
+    """
+
+    __slots__ = ()
+
+
+class VoltageTimeDataArray(VoltageArray, TimeDataArray):
+    """Voltage data array in time domain.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> t = [0, 1e-9, 2e-9, 3e-9]
+    >>> coords = dict(t=t)
+    >>> data = np.sin(2 * np.pi * 1e9 * np.array(t))
+    >>> vtd = VoltageTimeDataArray(data, coords=coords)
+    """
+
+    __slots__ = ()
+
+
+class VoltageFreqModeDataArray(VoltageArray, FreqModeDataArray):
+    """Voltage data array in frequency-mode domain.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> f = [2e9, 3e9]
+    >>> mode_index = [0, 1]
+    >>> coords = dict(f=f, mode_index=mode_index)
+    >>> data = np.random.random((2, 2)) + 1j * np.random.random((2, 2))
+    >>> vfmd = VoltageFreqModeDataArray(data, coords=coords)
+    """
+
+    __slots__ = ()
+
+
+# Current arrays
+class CurrentFreqDataArray(CurrentArray, FreqDataArray):
+    """Current data array in frequency domain.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> f = [2e9, 3e9, 4e9]
+    >>> coords = dict(f=f)
+    >>> data = np.random.random(3) + 1j * np.random.random(3)
+    >>> cfd = CurrentFreqDataArray(data, coords=coords)
+    """
+
+    __slots__ = ()
+
+
+class CurrentTimeDataArray(CurrentArray, TimeDataArray):
+    """Current data array in time domain.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> t = [0, 1e-9, 2e-9, 3e-9]
+    >>> coords = dict(t=t)
+    >>> data = np.cos(2 * np.pi * 1e9 * np.array(t))
+    >>> ctd = CurrentTimeDataArray(data, coords=coords)
+    """
+
+    __slots__ = ()
+
+
+class CurrentFreqModeDataArray(CurrentArray, FreqModeDataArray):
+    """Current data array in frequency-mode domain.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> f = [2e9, 3e9]
+    >>> mode_index = [0, 1]
+    >>> coords = dict(f=f, mode_index=mode_index)
+    >>> data = np.random.random((2, 2)) + 1j * np.random.random((2, 2))
+    >>> cfmd = CurrentFreqModeDataArray(data, coords=coords)
+    """
+
+    __slots__ = ()
+
+
+# Impedance arrays
+class ImpedanceFreqDataArray(ImpedanceArray, FreqDataArray):
+    """Impedance data array in frequency domain.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> f = [2e9, 3e9, 4e9]
+    >>> coords = dict(f=f)
+    >>> data = 50.0 + 1j * np.random.random(3)
+    >>> zfd = ImpedanceFreqDataArray(data, coords=coords)
+    """
+
+    __slots__ = ()
+
+
+class ImpedanceTimeDataArray(ImpedanceArray, TimeDataArray):
+    """Impedance data array in time domain.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> t = [0, 1e-9, 2e-9, 3e-9]
+    >>> coords = dict(t=t)
+    >>> data = 50.0 * np.ones_like(t)
+    >>> ztd = ImpedanceTimeDataArray(data, coords=coords)
+    """
+
+    __slots__ = ()
+
+
+class ImpedanceFreqModeDataArray(ImpedanceArray, FreqModeDataArray):
+    """Impedance data array in frequency-mode domain.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> f = [2e9, 3e9]
+    >>> mode_index = [0, 1]
+    >>> coords = dict(f=f, mode_index=mode_index)
+    >>> data = 50.0 + 10.0 * np.random.random((2, 2))
+    >>> zfmd = ImpedanceFreqModeDataArray(data, coords=coords)
+    """
+
+    __slots__ = ()
+
+
 DATA_ARRAY_TYPES = [
     SpatialDataArray,
     ScalarFieldDataArray,
@@ -1375,6 +1537,15 @@ DATA_ARRAY_TYPES = [
     SpatialVoltageDataArray,
     PerturbationCoefficientDataArray,
     IndexedTimeDataArray,
+    VoltageFreqDataArray,
+    VoltageTimeDataArray,
+    VoltageFreqModeDataArray,
+    CurrentFreqDataArray,
+    CurrentTimeDataArray,
+    CurrentFreqModeDataArray,
+    ImpedanceFreqDataArray,
+    ImpedanceTimeDataArray,
+    ImpedanceFreqModeDataArray,
 ]
 DATA_ARRAY_MAP = {data_array.__name__: data_array for data_array in DATA_ARRAY_TYPES}
 
@@ -1384,4 +1555,15 @@ IndexedDataArrayTypes = Union[
     IndexedTimeDataArray,
     IndexedFieldVoltageDataArray,
     PointDataArray,
+]
+
+IntegralResultTypes = Union[FreqDataArray, FreqModeDataArray, TimeDataArray]
+VoltageIntegralResultTypes = Union[
+    VoltageFreqDataArray, VoltageFreqModeDataArray, VoltageTimeDataArray
+]
+CurrentIntegralResultTypes = Union[
+    CurrentFreqDataArray, CurrentFreqModeDataArray, CurrentTimeDataArray
+]
+ImpedanceResultTypes = Union[
+    ImpedanceFreqDataArray, ImpedanceFreqModeDataArray, ImpedanceTimeDataArray
 ]

--- a/tidy3d/plugins/microwave/custom_path_integrals.py
+++ b/tidy3d/plugins/microwave/custom_path_integrals.py
@@ -19,10 +19,10 @@ from tidy3d.exceptions import SetupError
 from .path_integrals import (
     AbstractAxesRH,
     AxisAlignedPathIntegral,
-    CurrentIntegralAxisAligned,
+    CurrentIntegralResultTypes,
     IntegralResultTypes,
     MonitorDataTypes,
-    VoltageIntegralAxisAligned,
+    VoltageIntegralResultTypes,
 )
 from .viz import (
     ARROW_CURRENT,
@@ -89,6 +89,10 @@ class CustomPathIntegral2D(AbstractAxesRH):
             Result of integral over remaining dimensions (frequency, time, mode indices).
         """
 
+        from tidy3d.plugins.smatrix.utils import (
+            _make_base_result_data_array,
+        )
+
         (dim1, dim2, dim3) = self.local_dims
 
         h_field_name = f"{field}{dim1}"
@@ -130,7 +134,7 @@ class CustomPathIntegral2D(AbstractAxesRH):
         # Integrate along the path
         result = integrand.integrate(coord="s")
         result = result.reset_coords(drop=True)
-        return AxisAlignedPathIntegral._make_result_data_array(result)
+        return _make_base_result_data_array(result)
 
     @staticmethod
     def _compute_dl_component(coord_array: xr.DataArray, closed_contour=False) -> np.array:
@@ -243,7 +247,7 @@ class CustomVoltageIntegral2D(CustomPathIntegral2D):
 
     .. TODO Improve by including extrapolate_to_endpoints field, non-trivial extension."""
 
-    def compute_voltage(self, em_field: MonitorDataTypes) -> IntegralResultTypes:
+    def compute_voltage(self, em_field: MonitorDataTypes) -> VoltageIntegralResultTypes:
         """Compute voltage along path defined by a line.
 
         Parameters
@@ -253,13 +257,16 @@ class CustomVoltageIntegral2D(CustomPathIntegral2D):
 
         Returns
         -------
-        :class:`.IntegralResultTypes`
+        :class:`.VoltageIntegralResultTypes`
             Result of voltage computation over remaining dimensions (frequency, time, mode indices).
         """
+        from tidy3d.plugins.smatrix.utils import (
+            _make_voltage_data_array,
+        )
+
         AxisAlignedPathIntegral._check_monitor_data_supported(em_field=em_field)
         voltage = -1.0 * self.compute_integral(field="E", em_field=em_field)
-        voltage = VoltageIntegralAxisAligned._set_data_array_attributes(voltage)
-        return voltage
+        return _make_voltage_data_array(voltage)
 
     @add_ax_if_none
     def plot(
@@ -316,7 +323,7 @@ class CustomCurrentIntegral2D(CustomPathIntegral2D):
     To compute the current flowing in the positive ``axis`` direction, the vertices should be
     ordered in a counterclockwise direction."""
 
-    def compute_current(self, em_field: MonitorDataTypes) -> IntegralResultTypes:
+    def compute_current(self, em_field: MonitorDataTypes) -> CurrentIntegralResultTypes:
         """Compute current flowing in a custom loop.
 
         Parameters
@@ -326,13 +333,16 @@ class CustomCurrentIntegral2D(CustomPathIntegral2D):
 
         Returns
         -------
-        :class:`.IntegralResultTypes`
+        :class:`.CurrentIntegralResultTypes`
             Result of current computation over remaining dimensions (frequency, time, mode indices).
         """
+        from tidy3d.plugins.smatrix.utils import (
+            _make_current_data_array,
+        )
+
         AxisAlignedPathIntegral._check_monitor_data_supported(em_field=em_field)
         current = self.compute_integral(field="H", em_field=em_field)
-        current = CurrentIntegralAxisAligned._set_data_array_attributes(current)
-        return current
+        return _make_current_data_array(current)
 
     @add_ax_if_none
     def plot(

--- a/tidy3d/plugins/microwave/impedance_calculator.py
+++ b/tidy3d/plugins/microwave/impedance_calculator.py
@@ -8,10 +8,9 @@ import numpy as np
 import pydantic.v1 as pd
 
 from tidy3d.components.base import Tidy3dBaseModel
-from tidy3d.components.data.data_array import FreqDataArray, FreqModeDataArray, TimeDataArray
+from tidy3d.components.data.data_array import ImpedanceResultTypes
 from tidy3d.components.data.monitor_data import FieldTimeData
 from tidy3d.components.monitor import ModeMonitor, ModeSolverMonitor
-from tidy3d.constants import OHM
 from tidy3d.exceptions import ValidationError
 from tidy3d.log import log
 
@@ -19,7 +18,6 @@ from .custom_path_integrals import CustomCurrentIntegral2D, CustomVoltageIntegra
 from .path_integrals import (
     AxisAlignedPathIntegral,
     CurrentIntegralAxisAligned,
-    IntegralResultTypes,
     MonitorDataTypes,
     VoltageIntegralAxisAligned,
 )
@@ -43,7 +41,7 @@ class ImpedanceCalculator(Tidy3dBaseModel):
         description="Definition of contour integral for computing current.",
     )
 
-    def compute_impedance(self, em_field: MonitorDataTypes) -> IntegralResultTypes:
+    def compute_impedance(self, em_field: MonitorDataTypes) -> ImpedanceResultTypes:
         """Compute impedance for the supplied ``em_field`` using ``voltage_integral`` and
         ``current_integral``. If only a single integral has been defined, impedance is
         computed using the total flux in ``em_field``.
@@ -56,9 +54,11 @@ class ImpedanceCalculator(Tidy3dBaseModel):
 
         Returns
         -------
-        :class:`.IntegralResultTypes`
+        :class:`.ImpedanceResultTypes`
             Result of impedance computation over remaining dimensions (frequency, time, mode indices).
         """
+        from tidy3d.plugins.smatrix.utils import _make_impedance_data_array
+
         AxisAlignedPathIntegral._check_monitor_data_supported(em_field=em_field)
 
         # If both voltage and current integrals have been defined then impedance is computed directly
@@ -98,7 +98,7 @@ class ImpedanceCalculator(Tidy3dBaseModel):
                 impedance = np.real(voltage) / np.real(current)
             else:
                 impedance = voltage / current
-        impedance = ImpedanceCalculator._set_data_array_attributes(impedance)
+        impedance = _make_impedance_data_array(impedance)
         return impedance
 
     @pd.validator("current_integral", always=True)
@@ -110,19 +110,6 @@ class ImpedanceCalculator(Tidy3dBaseModel):
                 "At least one of 'voltage_integral' or 'current_integral' must be provided."
             )
         return val
-
-    @staticmethod
-    def _set_data_array_attributes(data_array: IntegralResultTypes) -> IntegralResultTypes:
-        """Helper to set additional metadata for ``IntegralResultTypes``."""
-        # Determine type based on coords present
-        if "mode_index" in data_array.coords:
-            data_array = FreqModeDataArray(data_array)
-        elif "f" in data_array.coords:
-            data_array = FreqDataArray(data_array)
-        else:
-            data_array = TimeDataArray(data_array)
-        data_array.name = "Z0"
-        return data_array.assign_attrs(units=OHM, long_name="characteristic impedance")
 
     @pd.root_validator(pre=False)
     def _warn_rf_license(cls, values):

--- a/tidy3d/plugins/microwave/path_integrals.py
+++ b/tidy3d/plugins/microwave/path_integrals.py
@@ -7,23 +7,22 @@ from typing import Optional, Union
 
 import numpy as np
 import pydantic.v1 as pd
-import xarray as xr
 
 from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.data.data_array import (
-    FreqDataArray,
-    FreqModeDataArray,
+    CurrentIntegralResultTypes,
+    IntegralResultTypes,
     ScalarFieldDataArray,
     ScalarFieldTimeDataArray,
     ScalarModeFieldDataArray,
-    TimeDataArray,
+    VoltageIntegralResultTypes,
 )
 from tidy3d.components.data.monitor_data import FieldData, FieldTimeData, ModeData, ModeSolverData
 from tidy3d.components.geometry.base import Box, Geometry
 from tidy3d.components.types import Ax, Axis, Coordinate2D, Direction
 from tidy3d.components.validators import assert_line, assert_plane
 from tidy3d.components.viz import add_ax_if_none
-from tidy3d.constants import AMP, VOLT, fp_eps
+from tidy3d.constants import fp_eps
 from tidy3d.exceptions import DataError, Tidy3dError
 from tidy3d.log import log
 
@@ -37,7 +36,6 @@ from .viz import (
 
 MonitorDataTypes = Union[FieldData, FieldTimeData, ModeData, ModeSolverData]
 EMScalarFieldType = Union[ScalarFieldDataArray, ScalarFieldTimeDataArray, ScalarModeFieldDataArray]
-IntegralResultTypes = Union[FreqDataArray, FreqModeDataArray, TimeDataArray]
 
 
 class AbstractAxesRH(Tidy3dBaseModel, ABC):
@@ -103,6 +101,9 @@ class AxisAlignedPathIntegral(AbstractAxesRH, Box):
 
     def compute_integral(self, scalar_field: EMScalarFieldType) -> IntegralResultTypes:
         """Computes the defined integral given the input ``scalar_field``."""
+        from tidy3d.plugins.smatrix.utils import (
+            _make_base_result_data_array,
+        )
 
         if not scalar_field.does_cover(self.bounds, fp_eps, np.finfo(np.float32).smallest_normal):
             raise DataError("Scalar field does not cover the integration domain.")
@@ -137,7 +138,7 @@ class AxisAlignedPathIntegral(AbstractAxesRH, Box):
             coords_interp, method=method, kwargs={"fill_value": "extrapolate"}
         )
         result = scalar_field.integrate(coord=coord)
-        return self._make_result_data_array(result)
+        return _make_base_result_data_array(result)
 
     def _get_field_along_path(self, scalar_field: EMScalarFieldType) -> EMScalarFieldType:
         """Returns a selection of the input ``scalar_field`` ready for integration."""
@@ -205,15 +206,6 @@ class AxisAlignedPathIntegral(AbstractAxesRH, Box):
                 f"{supported_types}"
             )
 
-    @staticmethod
-    def _make_result_data_array(result: xr.DataArray) -> IntegralResultTypes:
-        """Helper for creating the proper result type."""
-        if "t" in result.coords:
-            return TimeDataArray(data=result.data, coords=result.coords)
-        if "f" in result.coords and "mode_index" in result.coords:
-            return FreqModeDataArray(data=result.data, coords=result.coords)
-        return FreqDataArray(data=result.data, coords=result.coords)
-
 
 class VoltageIntegralAxisAligned(AxisAlignedPathIntegral):
     """Class for computing the voltage between two points defined by an axis-aligned line."""
@@ -224,8 +216,12 @@ class VoltageIntegralAxisAligned(AxisAlignedPathIntegral):
         description="Positive indicates V=Vb-Va where position b has a larger coordinate along the axis of integration.",
     )
 
-    def compute_voltage(self, em_field: MonitorDataTypes) -> IntegralResultTypes:
+    def compute_voltage(self, em_field: MonitorDataTypes) -> VoltageIntegralResultTypes:
         """Compute voltage along path defined by a line."""
+        from tidy3d.plugins.smatrix.utils import (
+            _make_voltage_data_array,
+        )
+
         self._check_monitor_data_supported(em_field=em_field)
         e_component = "xyz"[self.main_axis]
         field_name = f"E{e_component}"
@@ -238,15 +234,7 @@ class VoltageIntegralAxisAligned(AxisAlignedPathIntegral):
         if self.sign == "+":
             voltage *= -1
 
-        voltage = VoltageIntegralAxisAligned._set_data_array_attributes(voltage)
-        # Return data array of voltage while keeping coordinates of frequency|time|mode index
-        return voltage
-
-    @staticmethod
-    def _set_data_array_attributes(data_array: IntegralResultTypes) -> IntegralResultTypes:
-        """Add explanatory attributes to the data array."""
-        data_array.name = "V"
-        return data_array.assign_attrs(units=VOLT, long_name="voltage")
+        return _make_voltage_data_array(voltage)
 
     @staticmethod
     def from_terminal_positions(
@@ -381,8 +369,12 @@ class CurrentIntegralAxisAligned(AbstractAxesRH, Box):
         description="This parameter is passed to :class:`AxisAlignedPathIntegral` objects when computing the contour integral.",
     )
 
-    def compute_current(self, em_field: MonitorDataTypes) -> IntegralResultTypes:
+    def compute_current(self, em_field: MonitorDataTypes) -> CurrentIntegralResultTypes:
         """Compute current flowing in loop defined by the outer edge of a rectangle."""
+        from tidy3d.plugins.smatrix.utils import (
+            _make_current_data_array,
+        )
+
         AxisAlignedPathIntegral._check_monitor_data_supported(em_field=em_field)
         ax1 = self.remaining_axes[0]
         ax2 = self.remaining_axes[1]
@@ -407,8 +399,7 @@ class CurrentIntegralAxisAligned(AbstractAxesRH, Box):
 
         if self.sign == "-":
             current *= -1
-        current = CurrentIntegralAxisAligned._set_data_array_attributes(current)
-        return current
+        return _make_current_data_array(current)
 
     @cached_property
     def main_axis(self) -> Axis:
@@ -497,12 +488,6 @@ class CurrentIntegralAxisAligned(AbstractAxesRH, Box):
         )
 
         return (bottom, right, top, left)
-
-    @staticmethod
-    def _set_data_array_attributes(data_array: IntegralResultTypes) -> IntegralResultTypes:
-        """Add explanatory attributes to the data array."""
-        data_array.name = "I"
-        return data_array.assign_attrs(units=AMP, long_name="current")
 
     @add_ax_if_none
     def plot(

--- a/tidy3d/plugins/smatrix/data/terminal.py
+++ b/tidy3d/plugins/smatrix/data/terminal.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 import numpy as np
 import pydantic.v1 as pd
@@ -28,6 +28,9 @@ from tidy3d.plugins.smatrix.utils import (
     s_to_z,
 )
 
+# The definition of wave amplitudes used to construct scattering matrix
+SParamDef = Literal["pseudo", "power"]
+
 
 class MicrowaveSMatrixData(Tidy3dBaseModel):
     """Stores the computed S-matrix and reference impedances for the terminal ports."""
@@ -42,6 +45,12 @@ class MicrowaveSMatrixData(Tidy3dBaseModel):
         ...,
         title="S-Matrix Data",
         description="An array containing the computed S-matrix of the device. The data is organized by terminal ports, representing the scattering parameters between them.",
+    )
+
+    s_param_def: SParamDef = pd.Field(
+        "pseudo",
+        title="Scattering Parameter Definition",
+        description="Whether to scattering parameters are defined using the 'pseudo' or 'power' wave definitions.",
     )
 
 

--- a/tidy3d/plugins/smatrix/utils.py
+++ b/tidy3d/plugins/smatrix/utils.py
@@ -4,7 +4,25 @@ from typing import Union
 
 import numpy as np
 
-from tidy3d.components.data.data_array import DataArray, FreqDataArray
+from tidy3d.components.data.data_array import (
+    CurrentFreqDataArray,
+    CurrentFreqModeDataArray,
+    CurrentIntegralResultTypes,
+    CurrentTimeDataArray,
+    DataArray,
+    FreqDataArray,
+    FreqModeDataArray,
+    ImpedanceFreqDataArray,
+    ImpedanceFreqModeDataArray,
+    ImpedanceResultTypes,
+    ImpedanceTimeDataArray,
+    IntegralResultTypes,
+    TimeDataArray,
+    VoltageFreqDataArray,
+    VoltageFreqModeDataArray,
+    VoltageIntegralResultTypes,
+    VoltageTimeDataArray,
+)
 from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.types import ArrayFloat1D
 from tidy3d.exceptions import Tidy3dError
@@ -16,6 +34,13 @@ from tidy3d.plugins.smatrix.data.data_array import PortDataArray, TerminalPortDa
 from tidy3d.plugins.smatrix.network import SParamDef
 from tidy3d.plugins.smatrix.ports.coaxial_lumped import CoaxialLumpedPort
 from tidy3d.plugins.smatrix.ports.rectangular_lumped import LumpedPort
+from tidy3d.plugins.smatrix.data.data_array import PortDataArray, TerminalPortDataArray
+from tidy3d.plugins.smatrix.ports.types import LumpedPortType, TerminalPortType
+
+
+def port_array_inv(matrix: DataArray):
+    """Helper to invert a port matrix."""
+    return np.linalg.inv(matrix)
 
 
 def ab_to_s(
@@ -114,7 +139,7 @@ def compute_port_VI(
 
 
 def compute_power_wave_amplitudes(
-    port: Union[LumpedPort, CoaxialLumpedPort], sim_data: SimulationData
+    port: LumpedPortType, sim_data: SimulationData
 ) -> tuple[FreqDataArray, FreqDataArray]:
     """Calculates the unnormalized power wave amplitudes from port voltage (V),
     current (I), and impedance (Z0) using:
@@ -125,7 +150,7 @@ def compute_power_wave_amplitudes(
 
     Parameters
     ----------
-    port : Union[:class:`.LumpedPort`, :class:`.CoaxialLumpedPort`]
+    port : :class:`.LumpedPortType`
         Port for computing voltage and current.
     sim_data : :class:`.SimulationData`
         Results from the simulation.
@@ -143,7 +168,7 @@ def compute_power_wave_amplitudes(
 
 
 def compute_power_delivered_by_port(
-    port: Union[LumpedPort, CoaxialLumpedPort], sim_data: SimulationData
+    port: LumpedPortType, sim_data: SimulationData
 ) -> FreqDataArray:
     """Compute the power delivered to the network by a lumped port.
 
@@ -152,7 +177,7 @@ def compute_power_delivered_by_port(
 
     Parameters
     ----------
-    port : Union[:class:`.LumpedPort`, :class:`.CoaxialLumpedPort`]
+    port : :class:`.LumpedPortType`
         Port for computing voltage and current.
     sim_data : :class:`.SimulationData`
         Results from the simulation.
@@ -246,3 +271,42 @@ def validate_square_matrix(matrix: TerminalPortDataArray, method_name: str) -> N
             "was run with only a subset of port excitations. Please ensure that the `run_only` field in "
             "the 'TerminalComponentModeler' is not being used."
         )
+
+def _make_base_result_data_array(result: DataArray) -> IntegralResultTypes:
+    """Helper for creating the proper base result type."""
+    cls = FreqDataArray
+    if "t" in result.coords:
+        cls = TimeDataArray
+    if "f" in result.coords and "mode_index" in result.coords:
+        cls = FreqModeDataArray
+    return cls.assign_data_attrs(cls(data=result.data, coords=result.coords))
+
+
+def _make_voltage_data_array(result: DataArray) -> CurrentIntegralResultTypes:
+    """Helper for creating the proper voltage array type."""
+    cls = CurrentFreqDataArray
+    if "t" in result.coords:
+        cls = CurrentTimeDataArray
+    if "f" in result.coords and "mode_index" in result.coords:
+        cls = CurrentFreqModeDataArray
+    return cls.assign_data_attrs(cls(data=result.data, coords=result.coords))
+
+
+def _make_current_data_array(result: DataArray) -> VoltageIntegralResultTypes:
+    """Helper for creating the proper current array type."""
+    cls = VoltageFreqDataArray
+    if "t" in result.coords:
+        cls = VoltageTimeDataArray
+    if "f" in result.coords and "mode_index" in result.coords:
+        cls = VoltageFreqModeDataArray
+    return cls.assign_data_attrs(cls(data=result.data, coords=result.coords))
+
+
+def _make_impedance_data_array(result: DataArray) -> ImpedanceResultTypes:
+    """Helper for creating the proper impedance array type."""
+    cls = ImpedanceFreqDataArray
+    if "t" in result.coords:
+        cls = ImpedanceTimeDataArray
+    if "f" in result.coords and "mode_index" in result.coords:
+        cls = ImpedanceFreqModeDataArray
+    return cls.assign_data_attrs(cls(data=result.data, coords=result.coords))


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR implements immutable RF data structures for Tidy3D's microwave simulation capabilities. The changes consolidate RF data array creation logic into centralized utility functions and introduce specialized data array types for voltage, current, and impedance measurements across frequency, time, and modal domains.

The main architectural changes include:

1. **New RF Data Structures**: Added comprehensive voltage, current, and impedance array classes (`VoltageArray`, `CurrentArray`, `ImpedanceArray`) with domain-specific subclasses (frequency, time, frequency-mode variants) in `data_array.py`

2. **Centralized Utility Functions**: Moved data array creation logic from individual classes to centralized helper functions in `smatrix/utils.py` (`_make_voltage_data_array`, `_make_current_data_array`, `_make_impedance_data_array`)

3. **S-Parameter Definition Tracking**: Added `s_param_def` field to `MicrowaveSMatrixData` to track whether scattering parameters use 'pseudo' or 'power' wave definitions

4. **Matrix Operations Refactoring**: Moved matrix inversion from class methods to utility functions (`port_array_inv`) to support immutability patterns

5. **Type Safety Improvements**: Updated return types throughout the RF modules to use specific type aliases (`CurrentIntegralResultTypes`, `VoltageIntegralResultTypes`, `ImpedanceResultTypes`) instead of generic types

These changes align with functional programming principles by moving operations from instance methods to pure utility functions, supporting the goal of making RF data structures immutable. The refactoring affects microwave path integrals, impedance calculations, and S-matrix computations across the RF simulation framework.

## Important Files Changed

<details>
<summary>Click to expand file changes</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/components/data/data_array.py` | 2/5 | Added comprehensive RF data structures for voltage/current/impedance arrays with critical naming bugs in helper functions |
| `tidy3d/plugins/smatrix/utils.py` | 3/5 | Expanded with new RF data types and utility functions, includes duplicate imports and type annotation mismatches |
| `tidy3d/plugins/microwave/custom_path_integrals.py` | 1/5 | Refactored to use centralized utility functions but affected by critical bugs in the utility functions |
| `tidy3d/plugins/microwave/path_integrals.py` | 4/5 | Clean refactoring to use centralized utilities with improved type safety and code organization |
| `tidy3d/plugins/microwave/impedance_calculator.py` | 4/5 | Successfully consolidated impedance data array creation logic into centralized utility function |
| `tidy3d/plugins/smatrix/data/terminal.py` | 2/5 | Added S-parameter definition tracking but has duplicate SParamDef definition and incomplete implementation |
| `tests/test_plugins/smatrix/test_terminal_component_modeler.py` | 4/5 | Clean update to mock new utility function location instead of old class method |

</details>

## Confidence score: 1/5

- This PR has critical implementation bugs that will cause runtime failures in RF simulation functionality
- Score reflects serious issues including swapped return types in helper functions, duplicate definitions, and incomplete implementations
- Pay close attention to `tidy3d/components/data/data_array.py` and `tidy3d/plugins/smatrix/utils.py` which contain the most critical bugs that need fixing before merge

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant TerminalComponentModeler
    participant SimulationRunner
    participant DataProcessor
    participant SMatrixCalculator

    User->>TerminalComponentModeler: "Create modeler with ports and simulation"
    TerminalComponentModeler->>TerminalComponentModeler: "Validate configuration"
    TerminalComponentModeler->>TerminalComponentModeler: "Generate simulation dictionary"
    
    User->>SimulationRunner: "Run component modeler simulations"
    loop For each port excitation
        SimulationRunner->>SimulationRunner: "Run FDTD simulation"
        SimulationRunner->>DataProcessor: "Extract field data"
        DataProcessor->>DataProcessor: "Compute voltage and current"
    end
    
    DataProcessor->>SMatrixCalculator: "Process all simulation results"
    SMatrixCalculator->>SMatrixCalculator: "Compute wave amplitudes"
    SMatrixCalculator->>SMatrixCalculator: "Calculate S-matrix"
    SMatrixCalculator->>SMatrixCalculator: "Validate impedance consistency"
    
    SMatrixCalculator-->>User: "Return S-matrix and impedance data"
```

<!-- /greptile_comment -->