### PR TITLE
fix broken port reference impedance calc

### DIFF
--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -1163,8 +1163,8 @@ def test_run_only_and_element_mappings(monkeypatch, tmp_path):
     modeler_data = run_component_modeler(monkeypatch, modeler_run1)
     s_matrix = modeler_data.smatrix()
     with pytest.raises(ValueError):
-        validate_square_matrix(s_matrix, "test_method")
-    _ = modeler_run1.port_reference_impedances
+        validate_square_matrix(s_matrix.data, "test_method")
+    _ = modeler_data.port_reference_impedances
 
     assert len(modeler_run1.sim_dict) == 1
     S11 = (port0_idx, port0_idx)
@@ -1178,7 +1178,8 @@ def test_run_only_and_element_mappings(monkeypatch, tmp_path):
     # Column 1 is mapped to column 2, resulting in one simulation
     element_mappings = ((S11, S22, 1), (S21, S12, 1))
     modeler_with_mappings = modeler.updated_copy(element_mappings=element_mappings)
-    s_matrix = run_component_modeler(monkeypatch, modeler_with_mappings)
+    tcm_data = run_component_modeler(monkeypatch, modeler_with_mappings)
+    s_matrix = tcm_data.smatrix().data
     assert np.all(s_matrix.values[:, 0, 0] == s_matrix.values[:, 1, 1])
     assert np.all(s_matrix.values[:, 0, 1] == s_matrix.values[:, 1, 0])
     assert len(modeler_with_mappings.sim_dict) == 1

--- a/tidy3d/plugins/smatrix/analysis/terminal.py
+++ b/tidy3d/plugins/smatrix/analysis/terminal.py
@@ -124,15 +124,19 @@ def port_reference_impedances(modeler_data: TerminalComponentModelerData) -> Por
         "port": list(modeler_data.modeler.matrix_indices_monitor),
     }
     port_impedances = PortDataArray(values, coords=coords)
+    # Each simulation will store the results from the ModeMonitors,
+    # so here we just choose the first one.
+    first_sim_index = modeler_data.modeler.matrix_indices_run_sim[0]
+    port, mode_index = modeler_data.modeler.network_dict[first_sim_index]
+    sim_data = modeler_data.data[
+        modeler_data.modeler.get_task_name(port=port, mode_index=mode_index)
+    ]
     for network_index in modeler_data.modeler.matrix_indices_monitor:
         port, mode_index = modeler_data.modeler.network_dict[network_index]
         indexer = {"port": network_index}
         if isinstance(port, WavePort):
             # WavePorts have a port impedance calculated from its associated modal field distribution
             # and is frequency dependent.
-            sim_data = modeler_data.data[
-                modeler_data.modeler.get_task_name(port=port, mode_index=mode_index)
-            ]
             data = port.compute_port_impedance(sim_data).data
             port_impedances = port_impedances._with_updated_data(data=data, coords=indexer)
         else:

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -169,16 +169,13 @@ class TerminalComponentModeler(AbstractComponentModeler[NetworkIndex, NetworkEle
     @cached_property
     def matrix_indices_monitor(self) -> tuple[NetworkIndex, ...]:
         """Tuple of all the possible matrix indices."""
-        if self.run_only is not None:
-            return self.run_only
-        else:
-            matrix_indices = []
-            for port in self.ports:
-                if isinstance(port, WavePort):
-                    matrix_indices.append(self.network_index(port, port.mode_index))
-                else:
-                    matrix_indices.append(self.network_index(port))
-            return tuple(matrix_indices)
+        matrix_indices = []
+        for port in self.ports:
+            if isinstance(port, WavePort):
+                matrix_indices.append(self.network_index(port, port.mode_index))
+            else:
+                matrix_indices.append(self.network_index(port))
+        return tuple(matrix_indices)
 
     @cached_property
     def sim_dict(self) -> dict[str, Simulation]:

--- a/tidy3d/plugins/smatrix/utils.py
+++ b/tidy3d/plugins/smatrix/utils.py
@@ -8,6 +8,7 @@ from tidy3d.components.data.data_array import DataArray, FreqDataArray
 from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.exceptions import Tidy3dError
 from tidy3d.plugins.smatrix.component_modelers.base import (
+    AbstractComponentModeler,
     TerminalPortType,
 )
 from tidy3d.plugins.smatrix.data.data_array import PortDataArray, TerminalPortDataArray
@@ -37,7 +38,7 @@ def ab_to_s(
     a_vals = s_matrix.copy(deep=True).values
     b_vals = b_matrix.copy(deep=True).values
 
-    s_vals = np.matmul(b_vals, np.linalg.inv(a_vals))
+    s_vals = np.matmul(b_vals, AbstractComponentModeler.inv(a_vals))
 
     s_matrix.data = s_vals
     return s_matrix


### PR DESCRIPTION
Main issue was where to find mode monitor data when a subset of simulations are run. Also had to replace the inverse with a monkey patchable version, which is a bug I introduced in the dataarray PR I think.

All TCM tests pass except for the last one.

`test_internal_construct_smatrix_with_port_vi`

This one is a bit trickier since it uses a lot of monkeypatching and the assumption that most "data" acts like a dict.

<!-- greptile_comment -->

## Greptile Summary

This PR fixes a critical bug in the Terminal Component Modeler (TCM) system related to port reference impedance calculations when running partial simulation sets. The main issue was that the system couldn't properly locate mode monitor data when only a subset of simulations were executed using the `run_only` parameter.

The changes implement several interconnected fixes:

1. **Data Access Strategy**: Modified `matrix_indices_monitor` property in `terminal.py` to always return indices for all ports, not just the subset being run. This ensures monitor data collection is comprehensive even during partial runs.

2. **Impedance Calculation Logic**: Updated the `port_reference_impedances` function in `analysis/terminal.py` to extract simulation data from the first available simulation and reuse it for all WavePort calculations, since mode monitor data contains intrinsic port properties regardless of which simulation excited them.

3. **Matrix Operations Consistency**: Centralized matrix inversion operations by replacing direct `np.linalg.inv()` calls with `AbstractComponentModeler.inv()` method calls, providing a unified approach to numerical operations across the S-matrix framework.

4. **Test Infrastructure Updates**: Fixed test cases to properly handle the new data flow patterns, including correcting data access patterns and validation function calls.

These changes address the architectural challenge of maintaining full port characterization capabilities while supporting efficient partial simulation workflows, which is essential for large S-matrix computations where running all port combinations may be computationally prohibitive.

## Important Files Changed

<details>
<summary>Click to expand file changes</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/plugins/smatrix/component_modelers/terminal.py` | 4/5 | Removed conditional logic in matrix_indices_monitor to ensure all port indices are always available |
| `tidy3d/plugins/smatrix/analysis/terminal.py` | 4/5 | Fixed port reference impedance calculation to use first available simulation data for all ports |
| `tidy3d/plugins/smatrix/utils.py` | 4/5 | Centralized matrix inversion by replacing np.linalg.inv with AbstractComponentModeler.inv method |
| `tests/test_plugins/smatrix/test_terminal_component_modeler.py` | 4/5 | Updated test cases to handle new data access patterns and validation requirements |

</details>

## Confidence score: 4/5

- This PR addresses a well-defined architectural issue with a systematic approach across multiple related files
- Score reflects solid understanding of the problem domain and consistent implementation of fixes across the codebase
- One failing test remains (`test_internal_construct_smatrix_with_port_vi`) which may indicate incomplete resolution of edge cases

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant TCM as "TerminalComponentModeler"
    participant Analysis as "terminal_construct_smatrix"
    participant Utils as "port_reference_impedances"
    participant Port as "WavePort/LumpedPort"
    participant SimData as "SimulationData"

    User->>TCM: "Create modeler with ports"
    TCM->>TCM: "Setup base simulation"
    User->>TCM: "Run component modeler"
    
    loop For each port excitation
        TCM->>SimData: "Run simulation with port source"
        TCM->>Analysis: "Construct S-matrix from sim data"
        Analysis->>Utils: "Get port reference impedances"
        
        alt WavePort
            Utils->>Port: "compute_port_impedance(sim_data)"
            Port-->>Utils: "Frequency-dependent impedance"
        else LumpedPort
            Utils->>Port: "Get constant impedance"
            Port-->>Utils: "Constant impedance value"
        end
        
        Utils-->>Analysis: "PortDataArray with impedances"
        Analysis->>Analysis: "compute_wave_amplitudes_at_each_port"
        
        loop For each monitor port
            Analysis->>Port: "compute_port_VI(port, sim_data)"
            Port->>SimData: "Extract voltage and current"
            SimData-->>Port: "V and I frequency arrays"
            Port-->>Analysis: "Voltage, current data"
        end
        
        Analysis->>Analysis: "Calculate incident/reflected amplitudes"
        Analysis->>Analysis: "Build a_matrix and b_matrix"
    end
    
    Analysis->>Analysis: "Compute S = b * a^(-1)"
    Analysis-->>TCM: "TerminalPortDataArray S-matrix"
    TCM-->>User: "Complete S-parameter results"
```

<!-- /greptile_comment -->