### PR TITLE
feat(adjoint): sidewall angle gradients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added check and exception for NaN data in the adjoint pipeline to raise issue to user before adjoint source creation failure.
 - Added autograd support for `TerminalComponentModeler` and `ModalComponentModeler`.
 - Added `initialize_params_from_simulation` to `tidy3d.plugins.autograd.invdes` to initialize topology design regions from an underlying simulation geometry.
+- Added autograd support for sidewall angles in `td.Cylinder` and `td.PolySlab`.
 
 ### Changed
 - Validate mode solver object for large number of grid points on the modal plane.

--- a/schemas/EMESimulation.json
+++ b/schemas/EMESimulation.json
@@ -1684,8 +1684,15 @@
           "type": "string"
         },
         "sidewall_angle": {
-          "default": 0.0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "autograd.tracer.Box"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.0
         },
         "slab_bounds": {
           "items": [
@@ -3542,8 +3549,15 @@
           "type": "string"
         },
         "sidewall_angle": {
-          "default": 0.0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "autograd.tracer.Box"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.0
         },
         "type": {
           "default": "Cylinder",
@@ -8886,8 +8900,15 @@
           "type": "string"
         },
         "sidewall_angle": {
-          "default": 0.0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "autograd.tracer.Box"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.0
         },
         "slab_bounds": {
           "items": [

--- a/schemas/HeatChargeSimulation.json
+++ b/schemas/HeatChargeSimulation.json
@@ -1015,8 +1015,15 @@
           "type": "string"
         },
         "sidewall_angle": {
-          "default": 0.0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "autograd.tracer.Box"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.0
         },
         "slab_bounds": {
           "items": [
@@ -2818,8 +2825,15 @@
           "type": "string"
         },
         "sidewall_angle": {
-          "default": 0.0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "autograd.tracer.Box"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.0
         },
         "type": {
           "default": "Cylinder",
@@ -6149,8 +6163,15 @@
           "type": "string"
         },
         "sidewall_angle": {
-          "default": 0.0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "autograd.tracer.Box"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.0
         },
         "slab_bounds": {
           "items": [

--- a/schemas/HeatSimulation.json
+++ b/schemas/HeatSimulation.json
@@ -1015,8 +1015,15 @@
           "type": "string"
         },
         "sidewall_angle": {
-          "default": 0.0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "autograd.tracer.Box"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.0
         },
         "slab_bounds": {
           "items": [
@@ -2818,8 +2825,15 @@
           "type": "string"
         },
         "sidewall_angle": {
-          "default": 0.0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "autograd.tracer.Box"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.0
         },
         "type": {
           "default": "Cylinder",
@@ -6149,8 +6163,15 @@
           "type": "string"
         },
         "sidewall_angle": {
-          "default": 0.0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "autograd.tracer.Box"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.0
         },
         "slab_bounds": {
           "items": [

--- a/schemas/ModeSimulation.json
+++ b/schemas/ModeSimulation.json
@@ -1684,8 +1684,15 @@
           "type": "string"
         },
         "sidewall_angle": {
-          "default": 0.0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "autograd.tracer.Box"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.0
         },
         "slab_bounds": {
           "items": [
@@ -3635,8 +3642,15 @@
           "type": "string"
         },
         "sidewall_angle": {
-          "default": 0.0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "autograd.tracer.Box"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.0
         },
         "type": {
           "default": "Cylinder",
@@ -8552,8 +8566,15 @@
           "type": "string"
         },
         "sidewall_angle": {
-          "default": 0.0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "autograd.tracer.Box"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.0
         },
         "slab_bounds": {
           "items": [

--- a/schemas/Simulation.json
+++ b/schemas/Simulation.json
@@ -2061,8 +2061,15 @@
           "type": "string"
         },
         "sidewall_angle": {
-          "default": 0.0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "autograd.tracer.Box"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.0
         },
         "slab_bounds": {
           "items": [
@@ -4318,8 +4325,15 @@
           "type": "string"
         },
         "sidewall_angle": {
-          "default": 0.0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "autograd.tracer.Box"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.0
         },
         "type": {
           "default": "Cylinder",
@@ -12367,8 +12381,15 @@
           "type": "string"
         },
         "sidewall_angle": {
-          "default": 0.0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "autograd.tracer.Box"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.0
         },
         "slab_bounds": {
           "items": [

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -2165,8 +2165,15 @@
           "type": "string"
         },
         "sidewall_angle": {
-          "default": 0.0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "autograd.tracer.Box"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.0
         },
         "slab_bounds": {
           "items": [
@@ -4626,8 +4633,15 @@
           "type": "string"
         },
         "sidewall_angle": {
-          "default": 0.0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "autograd.tracer.Box"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.0
         },
         "type": {
           "default": "Cylinder",
@@ -12850,8 +12864,15 @@
           "type": "string"
         },
         "sidewall_angle": {
-          "default": 0.0,
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "autograd.tracer.Box"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "default": 0.0
         },
         "slab_bounds": {
           "items": [

--- a/tests/test_components/autograd/numerical/test_autograd_polyslab_sidewall_numerical.py
+++ b/tests/test_components/autograd/numerical/test_autograd_polyslab_sidewall_numerical.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import autograd.numpy as anp
+import numpy as np
+import pytest
+from autograd import value_and_grad
+
+import tidy3d as td
+import tidy3d.web as web
+
+THETAS_DEG = [-10, -5, 0, 5, 10]
+AXES = [0, 1, 2]
+REF_PLANES = ["bottom", "middle", "top"]
+H = 2e-2  # finite-difference step in degrees
+RTOL = 5e-2
+ATOL = 1e-3
+MSPW = 20  # min steps per wavelength for auto grid
+UNIFORM_DX = None  # set to float to force uniform grid
+DOMAIN = (4.0, 4.0, 4.0)
+
+
+def _build_sim(theta_deg: float, axis: int, reference_plane: str) -> td.Simulation:
+    """Construct simulation matching the runner's setup (Gaussian beam + field monitor)."""
+    wvl = 1.0
+    freq0 = td.C_0 / wvl
+
+    half_x = DOMAIN[0] / 2.0
+    src_x = -(half_x - 0.1)
+    mnt_x = half_x - 0.1
+
+    src = td.GaussianBeam(
+        center=(src_x, 0, 0),
+        size=(0, td.inf, td.inf),
+        direction="+",
+        waist_radius=0.5,
+        source_time=td.GaussianPulse(freq0=freq0, fwidth=freq0 / 10),
+    )
+    mnt = td.FieldMonitor(
+        size=(0, 3, 3),
+        center=(mnt_x, 0, 0),
+        freqs=[freq0],
+        name="field",
+    )
+
+    theta = anp.deg2rad(theta_deg)
+    verts = anp.array([[-1, -1], [1, -1], [1, 1], [-1, 1]])
+    geom = td.PolySlab(
+        vertices=verts,
+        slab_bounds=(-1, 1),
+        axis=axis,
+        sidewall_angle=theta,
+        dilation=0.0,
+        reference_plane=reference_plane,
+    )
+    struct = td.Structure(geometry=geom, medium=td.Medium(permittivity=2))
+
+    grid_spec = (
+        td.GridSpec.uniform(dl=UNIFORM_DX)
+        if UNIFORM_DX is not None
+        else td.GridSpec.auto(min_steps_per_wvl=MSPW)
+    )
+
+    return td.Simulation(
+        size=DOMAIN,
+        grid_spec=grid_spec,
+        boundary_spec=td.BoundarySpec.pml(x=True, y=True, z=True),
+        sources=[src],
+        structures=[struct],
+        monitors=[mnt],
+        run_time=1e-12,
+    )
+
+
+def _objective(theta_deg: float, axis: int, reference_plane: str, case_dir, verbose: bool) -> float:
+    sim = _build_sim(theta_deg, axis=axis, reference_plane=reference_plane)
+    task_name = f"obj_axis{axis}_ref{reference_plane}_t{float(theta_deg):+0.3f}"
+    out_path = case_dir / "objective.hdf5"
+    data = web.run(
+        sim,
+        task_name=task_name,
+        local_gradient=True,
+        verbose=verbose,
+        path=str(out_path),
+    )
+    return float(data["field"].flux.item())
+
+
+@pytest.mark.numerical
+@pytest.mark.parametrize("axis", AXES)
+@pytest.mark.parametrize("reference_plane", REF_PLANES)
+@pytest.mark.parametrize("theta0_deg", THETAS_DEG)
+def test_autograd_polyslab_sidewall_vs_fd(axis, reference_plane, theta0_deg, tmp_path):
+    """Adjoint dJ/dtheta matches centered FD for PolySlab.sidewall_angle across axes/ref planes."""
+
+    verbose = False
+
+    # objective and adjoint grad
+    obj_fun = lambda tdeg: _objective(tdeg, axis, reference_plane, tmp_path, verbose)
+    obj, grad_adj = value_and_grad(obj_fun)(anp.array(theta0_deg))
+
+    # centered finite difference
+    uid = f"axis{axis}_ref{reference_plane}_t{float(theta0_deg):+0.3f}"
+    sims = {
+        f"plus_{uid}": _build_sim(theta0_deg + H, axis=axis, reference_plane=reference_plane),
+        f"minus_{uid}": _build_sim(theta0_deg - H, axis=axis, reference_plane=reference_plane),
+    }
+    datas = web.run_async(
+        sims,
+        path_dir=str(tmp_path),
+        local_gradient=True,
+        verbose=verbose,
+    )
+
+    obj_plus = float(datas[f"plus_{uid}"]["field"].flux.item())
+    obj_minus = float(datas[f"minus_{uid}"]["field"].flux.item())
+    grad_fd = (obj_plus - obj_minus) / (2 * H)
+
+    assert np.isfinite(grad_adj)
+    assert np.isclose(grad_adj, grad_fd, rtol=RTOL, atol=ATOL)

--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -2834,3 +2834,35 @@ def test_vjp_nan(use_emulated_run, structure_key, monitor_key):
 
     with pytest.raises(AdjointError, match="aN values detected for data field"):
         grad = ag.grad(objective)(params0)
+
+
+@pytest.mark.parametrize("monitor_key", ("mode",))
+def test_autograd_polyslab_sidewall(use_emulated_run, monitor_key):
+    """Sidewall-angle gradient propagates via autograd."""
+    monitor, _ = make_monitors()[monitor_key]
+
+    def make_polyslab(theta):
+        verts = anp.array([[-0.4, -0.3], [0.4, -0.3], [0.4, 0.3], [-0.4, 0.3]])
+        return td.PolySlab(
+            vertices=verts,
+            slab_bounds=(-0.5, 0.5),
+            axis=POLYSLAB_AXIS,
+            sidewall_angle=theta,
+            dilation=0.0,
+        )
+
+    def make_sim(theta):
+        geom = make_polyslab(theta)
+        struct = td.Structure(geometry=geom, medium=td.Medium(permittivity=2.5))
+        return SIM_BASE.updated_copy(structures=[struct], monitors=[monitor])
+
+    def objective(theta_raw):
+        theta = 0.30 * anp.tanh(theta_raw)
+        sim = make_sim(theta)
+        data = run(sim, task_name="autograd_sidewall_e2e", verbose=False)
+        return anp.sum(anp.abs(data[monitor.name].amps)).item()
+
+    val, grad = ag.value_and_grad(objective)(0.2)
+
+    assert np.isfinite(val)
+    assert grad != 0.0

--- a/tests/test_components/autograd/test_autograd_polyslab_sidewall.py
+++ b/tests/test_components/autograd/test_autograd_polyslab_sidewall.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from tidy3d.components.geometry.polyslab import PolySlab  # adjust import path if needed
+
+
+# ---- test helpers ----
+class FakeDerivativeInfo:
+    def __init__(self, g_func, dx):
+        self._g = g_func
+        self._dx = dx
+
+    def adaptive_vjp_spacing(self, *_, **__):
+        return self._dx
+
+    def create_interpolators(self, dtype=None):
+        return {}  # unused by our g
+
+    def evaluate_gradient_at_points(self, spatial_coords, normals, perps1, perps2, interpolators):
+        return self._g(spatial_coords)
+
+
+def perimeter_2d(verts):
+    v = np.asarray(verts, float)
+    e = np.roll(v, -1, axis=0) - v
+    return np.linalg.norm(e, axis=1).sum()
+
+
+def make_square(L=1.0):
+    return np.array([[0, 0], [L, 0], [L, L], [0, L]], float)
+
+
+# ---- fixtures ----
+@pytest.fixture
+def geom():
+    H = 2.0
+    theta = np.deg2rad(15.0)
+    verts = make_square(1.0)
+    ps = PolySlab(vertices=verts, axis=2, slab_bounds=(-H / 2, H / 2), sidewall_angle=theta)
+    P = perimeter_2d(verts)
+    return ps, H, theta, P
+
+
+@pytest.fixture
+def sim_bounds():
+    return np.array([-10, -10, -10], float), np.array([10, 10, 10], float)
+
+
+# ---- tests ----
+
+
+def test_constant_g_zero(geom, sim_bounds):
+    ps, H, theta, P = geom
+    sim_min, sim_max = sim_bounds
+    g = lambda xyz: np.ones(xyz.shape[0], dtype=float)
+    di = FakeDerivativeInfo(g, dx=H / 50)
+    val = ps._compute_derivative_sidewall_angle(
+        di, sim_min, sim_max, is_2d=False, interpolators=None
+    )
+    assert abs(val) < 1e-8 * max(1.0, P * H)  # essentially zero
+
+
+def test_linear_z_matches_closed_form(geom, sim_bounds):
+    ps, H, theta, P = geom
+    sim_min, sim_max = sim_bounds
+    z0 = ps.center_axis
+    g = lambda xyz: (xyz[:, 2] - z0)  # g(z)=z_local
+    di = FakeDerivativeInfo(g, dx=H / 80)
+    val = ps._compute_derivative_sidewall_angle(
+        di, sim_min, sim_max, is_2d=False, interpolators=None
+    )
+    expected = -(P / (np.cos(theta) ** 2)) * (H**3) / 12.0
+    assert np.isclose(val, expected, rtol=5e-3, atol=1e-10)
+
+
+def test_2d_returns_zero(geom, sim_bounds):
+    ps, H, theta, P = geom
+    sim_min, sim_max = sim_bounds
+    z0 = ps.center_axis
+    g = lambda xyz: (xyz[:, 2] - z0)
+    di = FakeDerivativeInfo(g, dx=H / 40)
+    val = ps._compute_derivative_sidewall_angle(
+        di, sim_min, sim_max, is_2d=True, interpolators=None
+    )
+    assert val == 0.0
+
+
+def test_vertex_order_invariance(geom, sim_bounds):
+    ps, H, theta, P = geom
+    sim_min, sim_max = sim_bounds
+    z0 = ps.center_axis
+    g = lambda xyz: (xyz[:, 2] - z0)
+    di = FakeDerivativeInfo(g, dx=H / 80)
+
+    val_ccw = ps._compute_derivative_sidewall_angle(
+        di, sim_min, sim_max, is_2d=False, interpolators=None
+    )
+
+    ps_rev = PolySlab(
+        vertices=ps.vertices[::-1],
+        axis=2,
+        slab_bounds=ps.slab_bounds,
+        sidewall_angle=ps.sidewall_angle,
+    )
+    val_cw = ps_rev._compute_derivative_sidewall_angle(
+        di, sim_min, sim_max, is_2d=False, interpolators=None
+    )
+
+    assert np.isclose(val_ccw, val_cw, rtol=1e-4, atol=1e-10)
+
+
+def test_z_clipping_interval(geom):
+    ps, H, theta, P = geom
+    # clip to upper quarter: [0, H/4] in z_local
+    z0 = ps.center_axis
+    sim_min = np.array([-10, -10, z0], float)
+    sim_max = np.array([10, 10, z0 + H / 4], float)
+
+    g = lambda xyz: (xyz[:, 2] - z0)
+    di = FakeDerivativeInfo(g, dx=H / 80)
+    val = ps._compute_derivative_sidewall_angle(
+        di, sim_min, sim_max, is_2d=False, interpolators=None
+    )
+
+    a, b = 0.0, H / 4
+    expected = -(P / (np.cos(theta) ** 2)) * (b**3 - a**3) / 3.0
+    assert np.isclose(val, expected, rtol=1e-3, atol=1e-10)
+
+
+@pytest.mark.parametrize("dx_factor", [1 / 20, 1 / 40, 1 / 80])
+def test_convergence_on_dx(geom, sim_bounds, dx_factor):
+    ps, H, theta, P = geom
+    sim_min, sim_max = sim_bounds
+    z0 = ps.center_axis
+    g = lambda xyz: (xyz[:, 2] - z0)
+    di = FakeDerivativeInfo(g, dx=H * dx_factor)
+    val = ps._compute_derivative_sidewall_angle(
+        di, sim_min, sim_max, is_2d=False, interpolators=None
+    )
+    expected = -(P / (np.cos(theta) ** 2)) * (H**3) / 12.0
+    # allow tighter tolerance as dx shrinks
+    tol = {1 / 20: 2e-2, 1 / 40: 1.0e-2, 1 / 80: 5e-3}[dx_factor]
+    assert np.isclose(val, expected, rtol=tol, atol=1e-10)
+
+
+@pytest.mark.parametrize("ref_plane", ["bottom", "middle", "top"])
+def test_hinge_reference_plane_constant_g(geom, ref_plane):
+    ps, H, theta, P = geom
+
+    # use a slightly reduced thickness to avoid self-intersections for bottom/top hinges
+    H_eff = 0.9 * H
+    half = 0.5 * H_eff
+
+    ps = PolySlab(
+        vertices=ps.vertices,
+        axis=ps.axis,
+        slab_bounds=(-half, half),
+        sidewall_angle=ps.sidewall_angle,
+        reference_plane=ref_plane,
+    )
+
+    # asymmetric clipping interval relative to center_axis to expose hinge dependence
+    z0 = ps.center_axis
+    a, b = z0, z0 + H_eff / 4
+    sim_min = np.array([-10, -10, a], float)
+    sim_max = np.array([10, 10, b], float)
+
+    # constant integrand g(z) = 1
+    di = FakeDerivativeInfo(lambda xyz: np.ones(xyz.shape[0], dtype=float), dx=H_eff / 80)
+    val = ps._compute_derivative_sidewall_angle(
+        di, sim_min, sim_max, is_2d=False, interpolators=None
+    )
+
+    # closed form: -(P / cos^2(theta)) * 0.5 * [ (b - z_ref)^2 - (a - z_ref)^2 ]
+    z_ref = ps.reference_axis_pos
+    expected = -(P / (np.cos(theta) ** 2)) * 0.5 * ((b - z_ref) ** 2 - (a - z_ref) ** 2)
+    assert np.isclose(val, expected, rtol=1e-2, atol=1e-10)

--- a/tests/test_components/autograd/test_sidewall_edge_cases.py
+++ b/tests/test_components/autograd/test_sidewall_edge_cases.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import autograd.numpy as anp
+import numpy as np
+
+import tidy3d as td
+
+
+class _DummyDerivativeInfo:
+    """Minimal stub to drive PolySlab VJP helpers in unit tests.
+
+    - bounds_intersect: ((xmin, ymin, zmin), (xmax, ymax, zmax))
+    - adaptive_vjp_spacing: returns dx
+    - create_interpolators: unused in these tests
+    - evaluate_gradient_at_points: returns g(center) for each patch
+    """
+
+    def __init__(self, bounds_intersect, g_fun, dx=0.05):
+        self.bounds_intersect = bounds_intersect
+        self._g_fun = g_fun
+        self._dx = dx
+
+    def adaptive_vjp_spacing(self):
+        return self._dx
+
+    def create_interpolators(self, dtype=None):
+        return {}
+
+    def evaluate_gradient_at_points(self, centers, normals, perps1, perps2, interpolators):
+        return self._g_fun(centers)
+
+
+def _make_rect(axis=2, theta=0.1, ref_plane="bottom"):
+    verts = anp.array([[-0.4, -0.3], [0.4, -0.3], [0.4, 0.3], [-0.4, 0.3]])
+    return td.PolySlab(
+        vertices=verts,
+        slab_bounds=(-0.5, 0.5),
+        axis=axis,
+        sidewall_angle=theta,
+        dilation=0.0,
+        reference_plane=ref_plane,
+    )
+
+
+def test_sidewall_constant_g_zero():
+    poly = _make_rect(axis=2, theta=0.2)
+    # g == 0 everywhere
+    di = _DummyDerivativeInfo(
+        bounds_intersect=((-1, -1, -1), (1, 1, 1)), g_fun=lambda c: anp.zeros(len(c))
+    )
+    val = poly._compute_derivative_sidewall_angle(di, anp.array([-1, -1, -1]), anp.array([1, 1, 1]))
+    assert np.isclose(val, 0.0)
+
+
+def test_sidewall_reference_plane_invariance():
+    # g ∝ z to avoid zero
+    g_fun = lambda centers: centers[:, 2]
+    bounds = ((-1, -1, -1), (1, 1, 1))
+    di = _DummyDerivativeInfo(bounds_intersect=bounds, g_fun=g_fun)
+    vals = []
+    for ref in ("bottom", "middle", "top"):
+        poly = _make_rect(axis=2, theta=0.2, ref_plane=ref)
+        vals.append(
+            poly._compute_derivative_sidewall_angle(di, anp.array(bounds[0]), anp.array(bounds[1]))
+        )
+    assert np.allclose(vals[0], vals[1]) and np.allclose(vals[1], vals[2])
+
+
+def test_sidewall_orientation_invariance():
+    # same polygon, reversed orientation
+    g_fun = lambda centers: centers[:, 2]
+    di = _DummyDerivativeInfo(bounds_intersect=((-1, -1, -1), (1, 1, 1)), g_fun=g_fun)
+    poly = _make_rect(axis=2, theta=0.15)
+    val_fwd = poly._compute_derivative_sidewall_angle(
+        di, anp.array([-1, -1, -1]), anp.array([1, 1, 1])
+    )
+    verts_rev = poly.vertices[::-1]
+    poly_rev = td.PolySlab(vertices=verts_rev, slab_bounds=(-0.5, 0.5), axis=2, sidewall_angle=0.15)
+    val_rev = poly_rev._compute_derivative_sidewall_angle(
+        di, anp.array([-1, -1, -1]), anp.array([1, 1, 1])
+    )
+    assert np.allclose(val_fwd, val_rev)
+
+
+def test_sidewall_2d_returns_zero():
+    poly = _make_rect(axis=2, theta=0.25)
+    di = _DummyDerivativeInfo(
+        bounds_intersect=((0, 0, 0), (0, 0, 0)), g_fun=lambda c: anp.ones(len(c))
+    )
+    # Explicitly signal 2D path
+    val = poly._compute_derivative_sidewall_angle(
+        di, anp.array([-1, -1, -1]), anp.array([1, 1, 1]), is_2d=True
+    )
+    assert np.isclose(val, 0.0)
+
+
+def test_sidewall_negative_angle_parity():
+    # magnitude should be similar for ±theta for a symmetric g; sign may differ
+    g_fun = lambda centers: anp.ones(len(centers))
+    di = _DummyDerivativeInfo(bounds_intersect=((-1, -1, -1), (1, 1, 1)), g_fun=g_fun)
+    poly_pos = _make_rect(axis=2, theta=0.2)
+    poly_neg = _make_rect(axis=2, theta=-0.2)
+    v_pos = poly_pos._compute_derivative_sidewall_angle(
+        di, anp.array([-1, -1, -1]), anp.array([1, 1, 1])
+    )
+    v_neg = poly_neg._compute_derivative_sidewall_angle(
+        di, anp.array([-1, -1, -1]), anp.array([1, 1, 1])
+    )
+    assert np.isclose(abs(v_pos), abs(v_neg))
+
+
+def test_sidewall_xy_clipping():
+    # clip half the polygon in x; result should be finite and smaller in magnitude than unclipped
+    g_fun = lambda centers: centers[:, 2]
+    di_full = _DummyDerivativeInfo(bounds_intersect=((-1, -1, -1), (1, 1, 1)), g_fun=g_fun)
+    di_clip = _DummyDerivativeInfo(bounds_intersect=((0, -1, -1), (1, 1, 1)), g_fun=g_fun)
+    poly = _make_rect(axis=2, theta=0.2)
+    v_full = poly._compute_derivative_sidewall_angle(
+        di_full, anp.array([-1, -1, -1]), anp.array([1, 1, 1])
+    )
+    v_clip = poly._compute_derivative_sidewall_angle(
+        di_clip, anp.array([0, -1, -1]), anp.array([1, 1, 1])
+    )
+    assert np.isfinite(v_clip)
+    assert abs(v_clip) <= abs(v_full) + 1e-12

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -18,7 +18,13 @@ except ImportError:
     pass
 
 from tidy3d.compat import _shapely_is_older_than
-from tidy3d.components.autograd import AutogradFieldMap, TracedCoordinate, TracedSize, get_static
+from tidy3d.components.autograd import (
+    AutogradFieldMap,
+    TracedCoordinate,
+    TracedFloat,
+    TracedSize,
+    get_static,
+)
 from tidy3d.components.autograd.constants import GRADIENT_DTYPE_FLOAT
 from tidy3d.components.autograd.derivative_utils import (
     DerivativeInfo,
@@ -1623,7 +1629,7 @@ class Planar(SimplePlaneIntersection, Geometry, ABC):
         2, title="Axis", description="Specifies dimension of the planar axis (0,1,2) -> (x,y,z)."
     )
 
-    sidewall_angle: float = pydantic.Field(
+    sidewall_angle: TracedFloat = pydantic.Field(
         0.0,
         title="Sidewall angle",
         description="Angle of the sidewall. "
@@ -1672,6 +1678,23 @@ class Planar(SimplePlaneIntersection, Geometry, ABC):
         If the length is td.inf, return ``LARGE_NUMBER``
         """
         return min(self.length_axis, LARGE_NUMBER)
+
+    @property
+    def reference_axis_pos(self) -> float:
+        """Coordinate along the slab axis at the reference plane.
+
+        Returns the axis coordinate corresponding to the selected
+        reference_plane:
+        - "bottom": lower bound of slab_bounds
+        - "middle": center_axis
+        - "top": upper bound of slab_bounds
+        """
+        if self.reference_plane == "bottom":
+            return self.slab_bounds[0]
+        if self.reference_plane == "top":
+            return self.slab_bounds[1]
+        # default to middle
+        return self.center_axis
 
     def intersections_plane(
         self, x: Optional[float] = None, y: Optional[float] = None, z: Optional[float] = None

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -209,7 +209,8 @@ class PolySlab(base.Planar):
         """
 
         # no need to validate anything here
-        if math.isclose(values["sidewall_angle"], 0):
+        # sidewall_angle may be autograd-traced; use static value for this check only
+        if math.isclose(getval(values["sidewall_angle"]), 0):
             return val
 
         # apply dilation
@@ -1009,7 +1010,8 @@ class PolySlab(base.Planar):
 
         # check for the maximum possible contribution from dilation/slant on each side
         max_offset = self.dilation
-        if not math.isclose(self.sidewall_angle, 0):
+        # sidewall_angle may be autograd-traced; unbox for this check
+        if not math.isclose(getval(self.sidewall_angle), 0):
             if self.reference_plane == "bottom":
                 max_offset += max(0, -self._tanq * self.finite_length_axis)
             elif self.reference_plane == "top":
@@ -1285,7 +1287,8 @@ class PolySlab(base.Planar):
             Shift along x and y direction.
         """
 
-        if math.isclose(dist, 0):
+        # 'dist' may be autograd-traced; unbox for the zero-check only
+        if math.isclose(getval(dist), 0):
             return vertices, np.zeros(vertices.shape[0], dtype=float), None
 
         def rot90(v):
@@ -1476,6 +1479,10 @@ class PolySlab(base.Planar):
                     derivative_info, sim_min, sim_max, is_2d, interpolators
                 )
 
+            elif path == ("sidewall_angle",):
+                vjps[path] = self._compute_derivative_sidewall_angle(
+                    derivative_info, sim_min, sim_max, is_2d, interpolators
+                )
             elif path[0] == "slab_bounds":
                 idx = path[1]
                 face_coord = self.slab_bounds[idx]
@@ -1499,6 +1506,355 @@ class PolySlab(base.Planar):
                 raise ValueError(f"No derivative defined w.r.t. 'PolySlab' field '{path}'.")
 
         return vjps
+
+    # ---- Shared helpers for VJP surface integrations ----
+    def _z_slices(self, sim_min: np.ndarray, sim_max: np.ndarray, is_2d: bool, dx: float):
+        """Compute z-slice centers and spacing within bounds.
+
+        Returns (z_centers, dz, z0, z1). For 2D, returns single center and dz=1.
+        """
+        if is_2d:
+            zc = np.array([self.center_axis], dtype=GRADIENT_DTYPE_FLOAT)
+            return zc, 1.0, self.center_axis, self.center_axis
+
+        z0 = max(self.slab_bounds[0], sim_min[self.axis])
+        z1 = min(self.slab_bounds[1], sim_max[self.axis])
+        if z1 <= z0:
+            return np.array([], dtype=GRADIENT_DTYPE_FLOAT), 0.0, z0, z1
+
+        n_z = max(1, int(np.ceil((z1 - z0) / dx)))
+        dz = (z1 - z0) / n_z
+        z_centers = np.linspace(z0 + dz / 2, z1 - dz / 2, n_z, dtype=GRADIENT_DTYPE_FLOAT)
+        return z_centers, dz, z0, z1
+
+    @staticmethod
+    def _clip_edge_to_bounds_t(
+        v0_3d: np.ndarray, v1_3d: np.ndarray, sim_min: np.ndarray, sim_max: np.ndarray
+    ) -> Optional[tuple[float, float]]:
+        """Parametric bounds [t0,t1] of segment within [sim_min, sim_max]."""
+        t_start, t_end = 0.0, 1.0
+
+        for dim in range(3):
+            v0_d, v1_d = v0_3d[dim], v1_3d[dim]
+            min_d, max_d = sim_min[dim], sim_max[dim]
+
+            if np.isclose(v0_d, v1_d):
+                if v0_d < (min_d - EDGE_CLIP_TOLERANCE) or v0_d > (max_d + EDGE_CLIP_TOLERANCE):
+                    return None
+                continue
+
+            t_min = (min_d - v0_d) / (v1_d - v0_d)
+            t_max = (max_d - v0_d) / (v1_d - v0_d)
+            if t_min > t_max:
+                t_min, t_max = t_max, t_min
+
+            t_start = max(t_start, t_min)
+            t_end = min(t_end, t_max)
+            if t_start >= t_end:
+                return None
+
+        if t_end <= t_start + EDGE_CLIP_TOLERANCE:
+            return None
+
+        return (t_start, t_end)
+
+    @staticmethod
+    def _adaptive_edge_samples(L: float, dx: float, t_start: float = 0.0, t_end: float = 1.0):
+        """Gauss samples and weights along [t_start,t_end] with adaptive count."""
+        L_eff = L * max(0.0, t_end - t_start)
+        n_uniform = max(1, int(np.ceil(L_eff / dx)))
+        n_gauss = n_uniform if n_uniform <= 3 else max(2, int(n_uniform * QUAD_SAMPLE_FRACTION))
+        if n_gauss <= GAUSS_QUADRATURE_ORDER:
+            g, w = leggauss(n_gauss)
+            s = (0.5 * (t_end - t_start) * g + 0.5 * (t_end + t_start)).astype(
+                GRADIENT_DTYPE_FLOAT, copy=False
+            )
+            wt = (w * 0.5 * (t_end - t_start)).astype(GRADIENT_DTYPE_FLOAT, copy=False)
+            return s, wt
+
+        # composite Gauss with fixed local order
+        g_loc, w_loc = leggauss(GAUSS_QUADRATURE_ORDER)
+        segs = n_uniform
+        edges_t = np.linspace(t_start, t_end, segs + 1, dtype=GRADIENT_DTYPE_FLOAT)
+        S, W = [], []
+        for i in range(segs):
+            a, b = edges_t[i], edges_t[i + 1]
+            S.append(
+                (0.5 * (b - a) * g_loc + 0.5 * (b + a)).astype(GRADIENT_DTYPE_FLOAT, copy=False)
+            )
+            W.append((w_loc * 0.5 * (b - a)).astype(GRADIENT_DTYPE_FLOAT, copy=False))
+        return np.concatenate(S), np.concatenate(W)
+
+    def _collect_sidewall_patches(
+        self,
+        vertices: np.ndarray,
+        next_v: np.ndarray,
+        edges: np.ndarray,
+        basis: dict,
+        sim_min: np.ndarray,
+        sim_max: np.ndarray,
+        is_2d: bool,
+        dx: float,
+    ) -> dict:
+        """Collect sidewall patch geometry for batched VJP evaluation.
+
+        Returns a dict with keys:
+        - centers: (N,3)
+        - normals: (N,3)
+        - perps1: (N,3)
+        - perps2: (N,3)
+        - Ls: (N,)
+        - s_vals: (N,)
+        - s_weights: (N,)
+        - zc_vals: (N,)
+        - dz: float (slice thickness; 1.0 for 2D)
+        - edge_indices: (N,) int edge index per patch
+        """
+        theta = get_static(self.sidewall_angle)
+        z_ref = self.reference_axis_pos
+
+        cos_th = np.cos(theta)
+        cos_th = np.clip(cos_th, 1e-12, 1.0)
+        tan_th = np.tan(theta)
+        dprime = -tan_th  # dd/dz
+
+        # axis unit vector in 3D
+        axis_vec = np.zeros(3, dtype=GRADIENT_DTYPE_FLOAT)
+        axis_vec[self.axis] = 1.0
+
+        # densify along axis as |theta| grows: dz scales with cos(theta)
+        z_centers, dz, z0, z1 = self._z_slices(sim_min, sim_max, is_2d=is_2d, dx=dx * cos_th)
+
+        # early exit: no slices
+        if (not is_2d) and len(z_centers) == 0:
+            return {
+                "centers": np.empty((0, 3), dtype=GRADIENT_DTYPE_FLOAT),
+                "normals": np.empty((0, 3), dtype=GRADIENT_DTYPE_FLOAT),
+                "perps1": np.empty((0, 3), dtype=GRADIENT_DTYPE_FLOAT),
+                "perps2": np.empty((0, 3), dtype=GRADIENT_DTYPE_FLOAT),
+                "Ls": np.empty((0,), dtype=GRADIENT_DTYPE_FLOAT),
+                "s_vals": np.empty((0,), dtype=GRADIENT_DTYPE_FLOAT),
+                "s_weights": np.empty((0,), dtype=GRADIENT_DTYPE_FLOAT),
+                "zc_vals": np.empty((0,), dtype=GRADIENT_DTYPE_FLOAT),
+                "dz": dz,
+                "edge_indices": np.empty((0,), dtype=int),
+            }
+
+        # estimate patches for pre-allocation
+        n_edges = len(vertices)
+        estimated_patches = 0
+        denom_edge = max(dx * cos_th, 1e-12)
+        for ei in range(n_edges):
+            v0, v1 = vertices[ei], next_v[ei]
+            L = np.linalg.norm(v1 - v0)
+            if not np.isclose(L, 0.0):
+                # prealloc guided by actual step; ds_phys scales with cos(theta)
+                n_samples = max(1, int(np.ceil(L / denom_edge) * 0.6))
+                estimated_patches += n_samples * max(1, len(z_centers))
+        estimated_patches = int(max(1, estimated_patches) * 1.2)
+
+        # pre-allocate arrays
+        centers = np.empty((estimated_patches, 3), dtype=GRADIENT_DTYPE_FLOAT)
+        normals = np.empty((estimated_patches, 3), dtype=GRADIENT_DTYPE_FLOAT)
+        perps1 = np.empty((estimated_patches, 3), dtype=GRADIENT_DTYPE_FLOAT)
+        perps2 = np.empty((estimated_patches, 3), dtype=GRADIENT_DTYPE_FLOAT)
+        Ls = np.empty((estimated_patches,), dtype=GRADIENT_DTYPE_FLOAT)
+        s_vals = np.empty((estimated_patches,), dtype=GRADIENT_DTYPE_FLOAT)
+        s_weights = np.empty((estimated_patches,), dtype=GRADIENT_DTYPE_FLOAT)
+        zc_vals = np.empty((estimated_patches,), dtype=GRADIENT_DTYPE_FLOAT)
+        edge_indices = np.empty((estimated_patches,), dtype=int)
+
+        patch_idx = 0
+
+        # if the simulation is effectively 2D (one tangential dimension collapsed),
+        # slightly expand degenerate bounds to enable finite-length clipping of edges.
+        sim_min_eff = np.array(sim_min, dtype=GRADIENT_DTYPE_FLOAT)
+        sim_max_eff = np.array(sim_max, dtype=GRADIENT_DTYPE_FLOAT)
+        for dim in range(3):
+            if dim == self.axis:
+                continue
+            if np.isclose(sim_max_eff[dim] - sim_min_eff[dim], 0.0):
+                sim_min_eff[dim] -= 0.5 * dx
+                sim_max_eff[dim] += 0.5 * dx
+
+        for ei, (v0, v1) in enumerate(zip(vertices, next_v)):
+            edge_vec = v1 - v0
+            L = np.linalg.norm(edge_vec)
+            if np.isclose(L, 0.0):
+                continue
+
+            # constant along edge: unit tangent in 3D (no axis component)
+            t_edge = basis["perp1"][ei]
+            # outward in-plane normal from canonical basis normal (axis-consistent)
+            n2d = basis["norm"][ei].copy()
+            n2d[self.axis] = 0.0
+            nrm = np.linalg.norm(n2d)
+            if not np.isclose(nrm, 0.0):
+                n2d = n2d / nrm
+            else:
+                # fallback to right-handed construction if degenerate
+                tmp = np.cross(axis_vec, t_edge)
+                n2d = tmp / (np.linalg.norm(tmp) + 1e-20)
+
+            for zc in z_centers:
+                # offset at this slice along the in-plane outward normal
+                d = -(zc - z_ref) * tan_th
+                offset3d = d * n2d
+
+                # clip offset edge against simulation bounds in 3D
+                v0_3d = (
+                    self.unpop_axis_vect(np.array([zc], dtype=GRADIENT_DTYPE_FLOAT), v0[None])[0]
+                    + offset3d
+                )
+                v1_3d = (
+                    self.unpop_axis_vect(np.array([zc], dtype=GRADIENT_DTYPE_FLOAT), v1[None])[0]
+                    + offset3d
+                )
+                clip = self._clip_edge_to_bounds_t(v0_3d, v1_3d, sim_min_eff, sim_max_eff)
+                if clip is None:
+                    continue
+                t0, t1 = clip
+
+                # densify tangentially as |theta| grows: ds_phys scales with cos(theta)
+                s_list, w_list = self._adaptive_edge_samples(L, denom_edge, t0, t1)
+                if len(s_list) == 0:
+                    continue
+
+                pts2d = v0 + np.outer(s_list, edge_vec)
+                xyz = (
+                    self.unpop_axis_vect(
+                        np.full(len(s_list), zc, dtype=GRADIENT_DTYPE_FLOAT), pts2d
+                    )
+                    + offset3d
+                )
+
+                n_patches = len(s_list)
+                new_size_needed = patch_idx + n_patches
+                if new_size_needed > centers.shape[0]:
+                    # grow arrays by 1.5x
+                    new_size = int(new_size_needed * 1.5)
+                    centers.resize((new_size, 3), refcheck=False)
+                    normals.resize((new_size, 3), refcheck=False)
+                    perps1.resize((new_size, 3), refcheck=False)
+                    perps2.resize((new_size, 3), refcheck=False)
+                    Ls.resize((new_size,), refcheck=False)
+                    s_vals.resize((new_size,), refcheck=False)
+                    s_weights.resize((new_size,), refcheck=False)
+                    zc_vals.resize((new_size,), refcheck=False)
+                    edge_indices.resize((new_size,), refcheck=False)
+
+                sl = slice(patch_idx, patch_idx + n_patches)
+                centers[sl] = xyz
+
+                # slanted local basis at this z
+                rz = axis_vec + dprime * n2d
+                T1_vec = t_edge
+                N_vec = np.cross(T1_vec, rz)
+                N_norm = np.linalg.norm(N_vec)
+                if not np.isclose(N_norm, 0.0):
+                    N_vec = N_vec / N_norm
+
+                # align N with canonical outward edge normal
+                if float(np.dot(N_vec, basis["norm"][ei])) < 0.0:
+                    N_vec = -N_vec
+                T2_vec = np.cross(N_vec, T1_vec)
+                T2_norm = np.linalg.norm(T2_vec)
+                if not np.isclose(T2_norm, 0.0):
+                    T2_vec = T2_vec / T2_norm
+
+                normals[sl] = N_vec
+                perps1[sl] = T1_vec
+                perps2[sl] = T2_vec
+                Ls[sl] = L
+                s_vals[sl] = s_list
+                s_weights[sl] = w_list
+                zc_vals[sl] = zc
+                edge_indices[sl] = ei
+
+                patch_idx += n_patches
+
+        # trim arrays
+        centers = centers[:patch_idx]
+        normals = normals[:patch_idx]
+        perps1 = perps1[:patch_idx]
+        perps2 = perps2[:patch_idx]
+        Ls = Ls[:patch_idx]
+        s_vals = s_vals[:patch_idx]
+        s_weights = s_weights[:patch_idx]
+        zc_vals = zc_vals[:patch_idx]
+        edge_indices = edge_indices[:patch_idx]
+
+        return {
+            "centers": centers,
+            "normals": normals,
+            "perps1": perps1,
+            "perps2": perps2,
+            "Ls": Ls,
+            "s_vals": s_vals,
+            "s_weights": s_weights,
+            "zc_vals": zc_vals,
+            "dz": dz,
+            "edge_indices": edge_indices,
+        }
+
+    def _compute_derivative_sidewall_angle(
+        self,
+        derivative_info: DerivativeInfo,
+        sim_min: np.ndarray,
+        sim_max: np.ndarray,
+        is_2d: bool = False,
+        interpolators: Optional[dict] = None,
+    ) -> float:
+        """VJP for dJ/dtheta where theta = sidewall_angle.
+
+        Use dJ/dtheta = integral_S g(x) * V_n(x; theta) * dA, with g(x) from
+        `evaluate_gradient_at_points`. For a ruled sidewall built by
+        offsetting the mid-plane polygon by d(z) = -(z - z_ref) * tan(theta),
+        the normal velocity is V_n = (dd/dtheta) * cos(theta) = -(z - z_ref)/cos(theta)
+        and the area element is dA = (dz/cos(theta)) * d_ell.
+        Therefore each patch weight is w = L * dz * (-(z - z_ref)) / cos(theta)^2.
+        """
+        if interpolators is None:
+            interpolators = derivative_info.create_interpolators(dtype=GRADIENT_DTYPE_FLOAT)
+
+        # 2D sim => no dependence on theta (z_local=0)
+        if is_2d:
+            return 0.0
+
+        vertices, next_v, edges, basis = self._edge_geometry_arrays()
+
+        dx = derivative_info.adaptive_vjp_spacing()
+
+        # collect patches once
+        patch = self._collect_sidewall_patches(
+            vertices=vertices,
+            next_v=next_v,
+            edges=edges,
+            basis=basis,
+            sim_min=sim_min,
+            sim_max=sim_max,
+            is_2d=False,
+            dx=dx,
+        )
+        if patch["centers"].shape[0] == 0:
+            return 0.0
+
+        # Shape-derivative factors:
+        # - Offset: d(z) = -(z - z_ref) * tan(theta)
+        # - Tangential rate: dd/dtheta = -(z - z_ref) * sec(theta)^2
+        # - Normal velocity (project to surface normal): V_n = (dd/dtheta) * cos(theta) = -(z - z_ref)/cos(theta)
+        # - Area element of slanted strip: dA = (dz/cos(theta)) * d_ell
+        # => Patch weight scales as: V_n * dA = -(z - z_ref) * dz * d_ell / cos(theta)^2
+        cos_theta = np.cos(get_static(self.sidewall_angle))
+        inv_cos2 = 1.0 / (cos_theta * cos_theta)
+        z_ref = self.reference_axis_pos
+
+        g = derivative_info.evaluate_gradient_at_points(
+            patch["centers"], patch["normals"], patch["perps1"], patch["perps2"], interpolators
+        )
+        z_local = patch["zc_vals"] - z_ref
+        weights = patch["Ls"] * patch["s_weights"] * patch["dz"] * (-z_local) * inv_cos2
+        return float(np.real(np.sum(g * weights)))
 
     def _compute_derivative_slab_bounds(
         self, derivative_info: DerivativeInfo, min_max_index: int, interpolators: dict
@@ -1718,266 +2074,74 @@ class PolySlab(base.Planar):
     ) -> np.ndarray:
         """VJP for the vertices of a ``PolySlab``.
 
-        Each side-wall is sliced in the **in-plane** direction (along the edge)
-        and, when applicable, in the **out-of-plane** direction (along the
-        extrusion axis) so that every rectangular surface patch is no larger
-        than ``_VJP_SAMPLE_SPACING`` in any dimension.  The adjoint surface
-        integral is evaluated on every retained patch; the resulting force is
-        split (weighted) between the two vertices that bound the edge segment.
-
-        Special cases:
-        - Pure 2d simulations - integral collapses to a line; only one z-slice is taken.
-        - Partial overlap with the simulation box - patches falling
-          outside ``[sim_min, sim_max]`` are skipped.
-        - Degenerate edges (zero length) - ignored.
+        Uses shared sidewall patch collection and batched field evaluation.
         """
-        vertices = np.asarray(self.vertices, dtype=GRADIENT_DTYPE_FLOAT)
-        next_v = np.roll(vertices, -1, axis=0)
-        edges = next_v - vertices
-        basis = self.edge_basis_vectors(edges)
+        vertices, next_v, edges, basis = self._edge_geometry_arrays()
         dx = derivative_info.adaptive_vjp_spacing()
 
-        # compute z‐slices
-        z0 = max(self.slab_bounds[0], sim_min[self.axis])
-        z1 = min(self.slab_bounds[1], sim_max[self.axis])
+        # collect patches once
+        patch = self._collect_sidewall_patches(
+            vertices=vertices,
+            next_v=next_v,
+            edges=edges,
+            basis=basis,
+            sim_min=sim_min,
+            sim_max=sim_max,
+            is_2d=is_2d,
+            dx=dx,
+        )
 
-        # early return if no z-slices
-        if (not is_2d) and z1 <= z0:
+        # early return if no patches
+        if patch["centers"].shape[0] == 0:
             return np.zeros_like(vertices)
 
-        if is_2d:
-            z_centers = np.array([self.center_axis], dtype=GRADIENT_DTYPE_FLOAT)
-            dz_surf = 1.0
-        else:
-            n_z = max(1, int(np.ceil((z1 - z0) / dx)))
-            dz = (z1 - z0) / n_z
-            dz_surf = dz / np.cos(self.sidewall_angle)
-            z_centers = np.linspace(z0 + dz / 2, z1 - dz / 2, n_z, dtype=GRADIENT_DTYPE_FLOAT)
-
-        vjp_per_vertex = np.zeros_like(vertices, dtype=float)
-        normals_2d = np.delete(basis["norm"], self.axis, axis=1)
+        dz = patch["dz"]
+        dz_surf = 1.0 if is_2d else dz / np.cos(self.sidewall_angle)
 
         # use provided interpolators or create them if not provided
         if interpolators is None:
             interpolators = derivative_info.create_interpolators(dtype=GRADIENT_DTYPE_FLOAT)
 
-        def compute_edge_clip_bounds(v0_3d, v1_3d, sim_min, sim_max):
-            """
-            Compute parametric bounds [t_start, t_end] for the portion of edge
-            (v0_3d -> v1_3d) that lies within [sim_min, sim_max].
+        # evaluate integrand
+        g = derivative_info.evaluate_gradient_at_points(
+            patch["centers"], patch["normals"], patch["perps1"], patch["perps2"], interpolators
+        )
 
-            Returns:
-            - (t_start, t_end): parametric bounds, or None if edge is fully outside
-            """
-            t_start, t_end = 0.0, 1.0
+        # compute area-based weights and weighted vjps
+        areas = patch["Ls"] * patch["s_weights"] * dz_surf
+        patch_vjps = (g * areas).real
 
-            for dim in range(3):
-                v0_d, v1_d = v0_3d[dim], v1_3d[dim]
-                min_d, max_d = sim_min[dim], sim_max[dim]
+        # distribute to vertices using vectorized accumulation
+        normals_2d = np.delete(basis["norm"], self.axis, axis=1)
+        edge_idx = patch["edge_indices"]
+        s = patch["s_vals"]
+        w0 = (1.0 - s) * patch_vjps
+        w1 = s * patch_vjps
+        edge_norms = normals_2d[edge_idx]
 
-                if np.isclose(v0_d, v1_d):
-                    if v0_d < min_d or v0_d > max_d:
-                        return None
-                    continue
+        # Accumulate per-vertex contributions using bincount (O(N_patches))
+        num_vertices = vertices.shape[0]
+        contrib0 = w0[:, None] * edge_norms  # (n_patches, 2)
+        contrib1 = w1[:, None] * edge_norms  # (n_patches, 2)
 
-                t_min = (min_d - v0_d) / (v1_d - v0_d)
-                t_max = (max_d - v0_d) / (v1_d - v0_d)
+        idx0 = edge_idx
+        idx1 = (edge_idx + 1) % num_vertices
 
-                if t_min > t_max:
-                    t_min, t_max = t_max, t_min
+        v0x = np.bincount(idx0, weights=contrib0[:, 0], minlength=num_vertices)
+        v0y = np.bincount(idx0, weights=contrib0[:, 1], minlength=num_vertices)
+        v1x = np.bincount(idx1, weights=contrib1[:, 0], minlength=num_vertices)
+        v1y = np.bincount(idx1, weights=contrib1[:, 1], minlength=num_vertices)
 
-                t_start = max(t_start, t_min)
-                t_end = min(t_end, t_max)
-
-                if t_start >= t_end:
-                    return None
-
-            # avoid numerical issues at boundaries
-            if t_end <= t_start + EDGE_CLIP_TOLERANCE:
-                return None
-
-            return (t_start, t_end)
-
-        # estimate total number of patches for pre-allocation
-        # this avoids repeated list.extend calls
-        estimated_patches = 0
-        n_edges = len(vertices)
-        for ei in range(n_edges):
-            v0, v1 = vertices[ei], next_v[ei]
-            L = np.linalg.norm(v1 - v0)
-            if not np.isclose(L, 0.0):
-                # estimate samples per edge (conservative estimate)
-                n_samples = max(1, int(np.ceil(L / dx) * 0.4))  # 40% of uniform for Gauss
-                estimated_patches += n_samples * len(z_centers)
-
-        # pre-allocate arrays with estimated size
-        # over-allocate by 20% to handle edge cases, will trim later
-        estimated_patches = int(estimated_patches * 1.2)
-        all_centers = np.empty((estimated_patches, 3), dtype=GRADIENT_DTYPE_FLOAT)
-        all_areas = np.empty(estimated_patches, dtype=GRADIENT_DTYPE_FLOAT)
-        all_normals = np.empty((estimated_patches, 3), dtype=GRADIENT_DTYPE_FLOAT)
-        all_perps1 = np.empty((estimated_patches, 3), dtype=GRADIENT_DTYPE_FLOAT)
-        all_perps2 = np.empty((estimated_patches, 3), dtype=GRADIENT_DTYPE_FLOAT)
-        all_edge_info = []  # keep as list since it stores tuples
-
-        # track actual number of patches
-        patch_idx = 0
-
-        def get_adaptive_samples(L, dx, t_start=0.0, t_end=1.0):
-            """Get sampling points and weights along edge using optimal quadrature.
-
-            Parameters:
-            - L: Full edge length
-            - dx: Target spacing
-            - t_start, t_end: Parametric bounds for clipped edges (0 <= t_start < t_end <= 1)
-
-            Returns:
-            - s: Parametric coordinates in [t_start, t_end]
-            - weights: Quadrature weights (sum to t_end - t_start)
-            """
-            # compute effective length for the clipped portion
-            L_effective = L * (t_end - t_start)
-            n_uniform = max(1, int(np.ceil(L_effective / dx)))
-
-            # Gauss quadrature is more accurate than uniform sampling
-            if n_uniform <= 3:
-                n_gauss = n_uniform  # for very short edges, keep same number
-            else:
-                n_gauss = max(
-                    2, int(n_uniform * QUAD_SAMPLE_FRACTION)
-                )  # use 40% of points for longer edges
-
-            if n_gauss <= GAUSS_QUADRATURE_ORDER:
-                g, w = leggauss(n_gauss)
-
-                # map from [-1, 1] to [t_start, t_end]
-                s = (0.5 * (t_end - t_start) * g + 0.5 * (t_end + t_start)).astype(
-                    GRADIENT_DTYPE_FLOAT, copy=False
-                )
-                weights = (w * 0.5 * (t_end - t_start)).astype(GRADIENT_DTYPE_FLOAT, copy=False)
-            else:
-                # for longer edges, use composite Gauss quadrature
-                pts_per_interval = GAUSS_QUADRATURE_ORDER
-                n_intervals = max(1, (n_gauss + pts_per_interval - 1) // pts_per_interval)
-
-                g_ref, w_ref = leggauss(pts_per_interval)
-
-                s_list = []
-                w_list = []
-
-                for i in range(n_intervals):
-                    # sub-interval bounds in [0, 1]
-                    a = i / n_intervals
-                    b = (i + 1) / n_intervals
-
-                    # map to [t_start, t_end]
-                    a_mapped = t_start + a * (t_end - t_start)
-                    b_mapped = t_start + b * (t_end - t_start)
-
-                    # transform Gauss points to sub-interval [a_mapped, b_mapped]
-                    s_interval = 0.5 * (b_mapped - a_mapped) * g_ref + 0.5 * (b_mapped + a_mapped)
-                    w_interval = 0.5 * (b_mapped - a_mapped) * w_ref
-
-                    s_list.extend(s_interval)
-                    w_list.extend(w_interval)
-
-                s = np.array(s_list, dtype=GRADIENT_DTYPE_FLOAT)
-                weights = np.array(w_list, dtype=GRADIENT_DTYPE_FLOAT)
-
-            return s, weights
-
-        # pre-compute 2D bounding box for edge clipping optimization
-        sim_min_2d = np.delete(sim_min, self.axis)
-        sim_max_2d = np.delete(sim_max, self.axis)
-
-        for ei, (v0, v1) in enumerate(zip(vertices, next_v)):
-            edge_vec = v1 - v0
-            L = np.linalg.norm(edge_vec)
-            if np.isclose(L, 0.0):
-                continue
-
-            # check if edge is definitely inside 2D bounds
-            edge_min_2d = np.minimum(v0, v1)
-            edge_max_2d = np.maximum(v0, v1)
-            definitely_inside_2d = np.all(edge_min_2d >= sim_min_2d) and np.all(
-                edge_max_2d <= sim_max_2d
-            )
-
-            # process each z-slice with proper clipping
-            for zc in z_centers:
-                # fast path: if edge is definitely inside 2D bounds AND z is in bounds, skip clipping
-                if definitely_inside_2d and z0 <= zc <= z1:
-                    t_start, t_end = 0.0, 1.0
-                else:
-                    v0_3d = self.unpop_axis_vect(np.array([zc]), v0[None])[0]
-                    v1_3d = self.unpop_axis_vect(np.array([zc]), v1[None])[0]
-
-                    clip_bounds = compute_edge_clip_bounds(v0_3d, v1_3d, sim_min, sim_max)
-                    if clip_bounds is None:
-                        continue  # edge is entirely outside bounds
-
-                    t_start, t_end = clip_bounds
-
-                s_list, s_weights = get_adaptive_samples(L, dx, t_start, t_end)
-
-                pts2d = v0 + np.outer(s_list, edge_vec)
-
-                # patch areas include quadrature weights for accurate integration
-                patch_areas = L * s_weights * (dz_surf if not is_2d else 1.0)
-
-                # all points are within bounds by construction due to clipping
-                xyz = self.unpop_axis_vect(np.full(len(s_list), zc), pts2d)
-
-                n_patches = len(s_list)
-
-                # ensure we don't exceed pre-allocated size
-                if patch_idx + n_patches > estimated_patches:
-                    # resize arrays if needed (rare case)
-                    new_size = int((patch_idx + n_patches) * 1.5)
-
-                    # at this stage, no other views into these arrays exist _yet_
-                    # so `refcheck=False` should be safe
-                    all_centers.resize((new_size, 3), refcheck=False)
-                    all_areas.resize(new_size, refcheck=False)
-                    all_normals.resize((new_size, 3), refcheck=False)
-                    all_perps1.resize((new_size, 3), refcheck=False)
-                    all_perps2.resize((new_size, 3), refcheck=False)
-
-                all_centers[patch_idx : patch_idx + n_patches] = xyz
-                all_areas[patch_idx : patch_idx + n_patches] = patch_areas
-
-                all_normals[patch_idx : patch_idx + n_patches] = basis["norm"][ei]
-                all_perps1[patch_idx : patch_idx + n_patches] = basis["perp1"][ei]
-                all_perps2[patch_idx : patch_idx + n_patches] = basis["perp2"][ei]
-
-                edge_norm_2d = normals_2d[ei]
-                all_edge_info.extend([(ei, s_val, edge_norm_2d) for s_val in s_list])
-
-                patch_idx += n_patches
-
-        if patch_idx > 0:
-            # trim arrays to actual size used
-            centers = all_centers[:patch_idx]
-            areas = all_areas[:patch_idx]
-            normals = all_normals[:patch_idx]
-            perps1 = all_perps1[:patch_idx]
-            perps2 = all_perps2[:patch_idx]
-
-            patch_vjps = derivative_info.evaluate_gradient_at_points(
-                centers, normals, perps1, perps2, interpolators
-            )
-            patch_vjps = (patch_vjps * areas).real
-
-            for vjp, (ei, s_val, edge_norm_2d) in zip(patch_vjps, all_edge_info):
-                # vertex weights: (1-s) for vertex i, s for vertex i+1
-                # quadrature weights are already included in areas via patch_areas
-                w0 = 1.0 - s_val
-                w1 = s_val
-
-                vjp_per_vertex[ei] += (w0 * vjp) * edge_norm_2d
-                vjp_per_vertex[(ei + 1) % len(vertices)] += (w1 * vjp) * edge_norm_2d
-
+        vjp_per_vertex = np.stack((v0x + v1x, v0y + v1y), axis=1)
         return vjp_per_vertex
+
+    def _edge_geometry_arrays(self, dtype: np.dtype = GRADIENT_DTYPE_FLOAT):
+        """Return (vertices, next_v, edges, basis) arrays for sidewall edge geometry."""
+        vertices = np.asarray(self.vertices, dtype=dtype)
+        next_v = np.roll(vertices, -1, axis=0)
+        edges = next_v - vertices
+        basis = self.edge_basis_vectors(edges)
+        return vertices, next_v, edges, basis
 
     def edge_basis_vectors(
         self,
@@ -1997,8 +2161,8 @@ class PolySlab(base.Planar):
         edges_norm_xyz = self.unpop_axis_vect(zeros, edges_norm_in_plane)
 
         # normalized vectors from base of edges to tops of edges
-        cos_angle = np.cos(self.sidewall_angle, dtype=GRADIENT_DTYPE_FLOAT)
-        sin_angle = np.sin(self.sidewall_angle, dtype=GRADIENT_DTYPE_FLOAT)
+        cos_angle = np.cos(self.sidewall_angle)
+        sin_angle = np.sin(self.sidewall_angle)
         slabs_axis_components = cos_angle * ones
 
         # create axis_norm as array directly to avoid tuple->array conversion in np.cross

--- a/tidy3d/components/geometry/primitives.py
+++ b/tidy3d/components/geometry/primitives.py
@@ -317,9 +317,26 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
         # construct equivalent polyslab and compute the derivatives
         polyslab = self.to_polyslab(num_pts_circumference=num_pts_circumference)
 
+        # build PolySlab derivative paths based on requested Cylinder paths
+        ps_paths = set()
+        for path in derivative_info.paths:
+            if path == ("length",):
+                ps_paths.update({("slab_bounds", 0), ("slab_bounds", 1)})
+            elif path == ("radius",):
+                ps_paths.add(("vertices",))
+            elif "center" in path:
+                _, center_index = path
+                _, (index_x, index_y) = self.pop_axis((0, 1, 2), axis=self.axis)
+                if center_index in (index_x, index_y):
+                    ps_paths.add(("vertices",))
+                else:
+                    ps_paths.update({("slab_bounds", 0), ("slab_bounds", 1)})
+            elif path == ("sidewall_angle",):
+                ps_paths.add(("sidewall_angle",))
+
         # pass interpolators to PolySlab if available to avoid redundant conversions
         update_kwargs = {
-            "paths": [("vertices",), ("slab_bounds", 0), ("slab_bounds", 1)],
+            "paths": list(ps_paths),
             "deep": False,
         }
         if derivative_info.interpolators is not None:
@@ -328,32 +345,47 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
         derivative_info_polyslab = derivative_info.updated_copy(**update_kwargs)
         vjps_polyslab = polyslab._compute_derivatives(derivative_info_polyslab)
 
-        vjps_vertices_xs, vjps_vertices_ys = vjps_polyslab[("vertices",)].T
-        vjp_top = vjps_polyslab[("slab_bounds", 0)]
-        vjp_bot = vjps_polyslab[("slab_bounds", 1)]
-
-        # transform polyslab vertices derivatives into Cylinder parameter derivatives
-        xs_, ys_ = self._points_unit_circle(num_pts_circumference=num_pts_circumference)
-        vjp_xs = np.sum(xs_ * vjps_vertices_xs)
-        vjp_ys = np.sum(ys_ * vjps_vertices_ys)
-
         vjps = {}
         for path in derivative_info.paths:
             if path == ("length",):
+                vjp_top = vjps_polyslab.get(("slab_bounds", 0), 0.0)
+                vjp_bot = vjps_polyslab.get(("slab_bounds", 1), 0.0)
                 vjps[path] = vjp_top - vjp_bot
 
             elif path == ("radius",):
-                vjps[path] = vjp_xs + vjp_ys
+                # transform polyslab vertices derivatives into radius derivative
+                xs_, ys_ = self._points_unit_circle(num_pts_circumference=num_pts_circumference)
+                if ("vertices",) not in vjps_polyslab:
+                    vjps[path] = 0.0
+                else:
+                    vjps_vertices_xs, vjps_vertices_ys = vjps_polyslab[("vertices",)].T
+                    vjp_xs = np.sum(xs_ * vjps_vertices_xs)
+                    vjp_ys = np.sum(ys_ * vjps_vertices_ys)
+                    vjps[path] = vjp_xs + vjp_ys
 
             elif "center" in path:
                 _, center_index = path
                 _, (index_x, index_y) = self.pop_axis((0, 1, 2), axis=self.axis)
                 if center_index == index_x:
-                    vjps[path] = np.sum(vjps_vertices_xs)
+                    if ("vertices",) not in vjps_polyslab:
+                        vjps[path] = 0.0
+                    else:
+                        vjps_vertices_xs = vjps_polyslab[("vertices",)][:, 0]
+                        vjps[path] = np.sum(vjps_vertices_xs)
                 elif center_index == index_y:
-                    vjps[path] = np.sum(vjps_vertices_ys)
+                    if ("vertices",) not in vjps_polyslab:
+                        vjps[path] = 0.0
+                    else:
+                        vjps_vertices_ys = vjps_polyslab[("vertices",)][:, 1]
+                        vjps[path] = np.sum(vjps_vertices_ys)
                 else:
+                    vjp_top = vjps_polyslab.get(("slab_bounds", 0), 0.0)
+                    vjp_bot = vjps_polyslab.get(("slab_bounds", 1), 0.0)
                     vjps[path] = vjp_top + vjp_bot
+
+            elif path == ("sidewall_angle",):
+                # direct mapping: cylinder angle equals polyslab angle
+                vjps[path] = vjps_polyslab.get(("sidewall_angle",), 0.0)
 
             else:
                 raise NotImplementedError(

--- a/tidy3d/components/geometry/utils.py
+++ b/tidy3d/components/geometry/utils.py
@@ -9,6 +9,7 @@ from typing import Any, Optional, Union
 import numpy as np
 import pydantic
 
+from tidy3d.components.autograd.utils import get_static
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.geometry.base import Box
 from tidy3d.components.grid.grid import Grid
@@ -306,8 +307,9 @@ def validate_no_transformed_polyslabs(geometry: GeometryType, transform: MatrixR
     if transform is None:
         transform = np.eye(4)
     if isinstance(geometry, polyslab.PolySlab):
+        # sidewall_angle may be autograd-traced; unbox for the check only
         if not (
-            isclose(geometry.sidewall_angle, 0)
+            isclose(get_static(geometry.sidewall_angle), 0)
             or base.Transformed.preserves_axis(transform, geometry.axis)
         ):
             raise Tidy3dError(


### PR DESCRIPTION

<img width="1200" height="800" alt="gradients_axis_0_ref_bottom" src="https://github.com/user-attachments/assets/250ff5b2-9356-465d-a867-a5c106486d28" />
<img width="1200" height="800" alt="gradients_axis_0_ref_middle" src="https://github.com/user-attachments/assets/629448d7-d99b-456c-94a8-6afcf002c3c0" />
<img width="1200" height="800" alt="gradients_axis_0_ref_top" src="https://github.com/user-attachments/assets/1aa61e8f-274c-4d55-b46b-80352af90c06" />
<img width="1200" height="800" alt="gradients_axis_1_ref_bottom" src="https://github.com/user-attachments/assets/8366cf00-5571-4555-a047-3934828ecba5" />
<img width="1200" height="800" alt="gradients_axis_1_ref_middle" src="https://github.com/user-attachments/assets/b719dae1-9d15-4ff1-a60f-2deb1aa0e273" />
<img width="1200" height="800" alt="gradients_axis_1_ref_top" src="https://github.com/user-attachments/assets/d547ba7e-84f3-4a52-9f00-bcab8180b299" />
<img width="1200" height="800" alt="gradients_axis_2_ref_bottom" src="https://github.com/user-attachments/assets/c5e92618-bc4f-4afc-a14e-a9f3289ecf5d" />
<img width="1200" height="800" alt="gradients_axis_2_ref_middle" src="https://github.com/user-attachments/assets/2962e77e-a7a2-4359-a84e-35d632dee938" />
<img width="1200" height="800" alt="gradients_axis_2_ref_top" src="https://github.com/user-attachments/assets/6c4ab00b-7c66-45c9-bd20-6c45993c545b" />

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-04 13:18:06 UTC

This PR implements sidewall angle gradients for automatic differentiation (adjoint optimization) in PolySlab and Cylinder geometries. The changes enable users to compute gradients with respect to sidewall angles, expanding Tidy3D's inverse design capabilities beyond existing vertex and bounds optimization.

The implementation consists of several key architectural changes:

**Core Infrastructure**: The `sidewall_angle` field in the `Planar` base class is upgraded from `float` to `TracedFloat`, enabling autograd tracking. A new `reference_axis_pos` property is added to standardize reference point calculations across different reference plane configurations.

**Gradient Computation**: A comprehensive `_compute_derivative_sidewall_angle()` method is implemented in PolySlab that calculates Vector-Jacobian Products (VJP) through surface integration over sidewall patches. The mathematical approach correctly handles the relationship between sidewall angle changes and surface normal velocities, with proper area element corrections for slanted surfaces.

**Cylinder Support**: The Cylinder class is enhanced to map sidewall angle gradients to its underlying PolySlab representation, with defensive programming to handle edge cases where derivative paths may not exist.

**Web Platform Integration**: New batch category types (`'tidy3d_autograd'`, `'tidy3d_autograd_async'`, `'autograd_fwd'`, `'autograd_bwd'`) are added to properly categorize and route different phases of autograd computations.

**Validation Compatibility**: Existing validation functions are updated to handle autograd-traced sidewall angles using `get_static()` and `getval()` functions, ensuring validation logic remains functional while preserving autograd traceability.

The feature integrates seamlessly with Tidy3D's existing adjoint framework, following established patterns for parameter tracing and gradient computation. The implementation includes extensive mathematical handling of sidewall geometry transformations and proper numerical integration techniques.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/web/api/container.py` | 5/5 | Adds new batch category types for autograd workflow classification |
| `tests/test_components/autograd/test_autograd.py` | 5/5 | Adds end-to-end test validating sidewall angle gradient propagation |
| `CHANGELOG.md` | 5/5 | Documents new autograd support for sidewall angles in Cylinder and PolySlab |
| `tidy3d/components/geometry/primitives.py` | 4/5 | Implements sidewall angle gradient mapping for Cylinder class with defensive programming |
| `tidy3d/components/geometry/base.py` | 5/5 | Upgrades sidewall_angle to TracedFloat and adds reference_axis_pos property |
| `tidy3d/components/geometry/utils.py` | 5/5 | Updates validation to handle autograd-traced sidewall angles using get_static |
| `tidy3d/components/geometry/polyslab.py` | 4/5 | Major implementation of sidewall angle gradient computation with VJP calculation |
| `tests/test_components/autograd/numerical/test_autograd_polyslab_sidewall_numerical.py` | 4/5 | New numerical validation test comparing adjoint vs finite difference gradients |
| `tests/test_components/autograd/test_autograd_polyslab_sidewall.py` | 4/5 | Comprehensive unit tests for sidewall angle gradient computation scenarios |
| `tests/test_components/autograd/test_sidewall_edge_cases.py` | 4/5 | Edge case tests covering geometric transformations and boundary conditions |

</details>

## Confidence score: 4/5

- This PR implements a complex mathematical feature with comprehensive testing, but the mathematical complexity and integration points create some risk
- Score reflects the thorough testing coverage and well-structured implementation, but lowered due to complex VJP calculations and potential for numerical precision issues
- Pay close attention to the PolySlab gradient computation method and numerical validation tests for mathematical correctness

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant JaxPolySlab
    participant ModeSolver as "Mode Solver"
    participant WebAPI as "Web API"
    participant AutogradEngine as "Autograd Engine"
    participant DerivativeComputer as "Derivative Computer"

    User->>JaxPolySlab: "Create PolySlab with traced sidewall_angle"
    JaxPolySlab->>JaxPolySlab: "Validate sidewall_angle bounds"
    User->>ModeSolver: "Create simulation with JaxPolySlab"
    User->>AutogradEngine: "Define objective function"
    AutogradEngine->>WebAPI: "Run forward simulation"
    WebAPI-->>AutogradEngine: "Return SimulationData"
    AutogradEngine->>DerivativeComputer: "Compute gradient w.r.t. sidewall_angle"
    DerivativeComputer->>DerivativeComputer: "_compute_derivative_sidewall_angle()"
    DerivativeComputer->>DerivativeComputer: "_collect_sidewall_patches()"
    DerivativeComputer->>DerivativeComputer: "_adaptive_edge_samples()"
    DerivativeComputer->>DerivativeComputer: "evaluate_gradient_at_points()"
    DerivativeComputer->>DerivativeComputer: "Compute shape-derivative factors"
    DerivativeComputer-->>AutogradEngine: "Return VJP gradients"
    AutogradEngine-->>User: "Return objective value and gradients"
```

<!-- /greptile_comment -->