### PR TITLE
Update batch web status names

### DIFF
--- a/tidy3d/web/api/mode.py
+++ b/tidy3d/web/api/mode.py
@@ -490,7 +490,7 @@ class ModeSolverTask(ResourceLifecycle, Submittable, extra=pydantic.Extra.allow)
         http.delete(f"tidy3d/tasks/{self.task_id}")
 
     def abort(self):
-        """Abort the mode solver and its corresponding task from the server."""
+        """aborting the mode solver and its corresponding task from the server."""
         return http.put(
             "tidy3d/tasks/abort", json={"taskType": "MODE_SOLVER", "taskId": self.solver_id}
         )

--- a/tidy3d/web/api/mode.py
+++ b/tidy3d/web/api/mode.py
@@ -490,7 +490,7 @@ class ModeSolverTask(ResourceLifecycle, Submittable, extra=pydantic.Extra.allow)
         http.delete(f"tidy3d/tasks/{self.task_id}")
 
     def abort(self):
-        """aborting the mode solver and its corresponding task from the server."""
+        """Abort the mode solver and its corresponding task from the server."""
         return http.put(
             "tidy3d/tasks/abort", json={"taskType": "MODE_SOLVER", "taskId": self.solver_id}
         )

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -498,7 +498,7 @@ def start(
         check_resp = batch.check(solver_version=solver_version, batch_type="RF_SWEEP")
         detail = batch.wait_for_validate(batch_type="RF_SWEEP")
         status = detail.status
-        if status not in ("Validate_Success", "Validate_Warn"):
+        if status not in ("validate_success", "validate_warn"):
             # Surface server-provided reason if available
             reason = None
             try:
@@ -773,7 +773,7 @@ def monitor(task_id: TaskId, verbose: bool = True) -> None:
 
 @wait_for_connection
 def abort(task_id: TaskId) -> TaskInfo:
-    """Abort a running task without deleting it."""
+    """aborting a running task without deleting it."""
     task = SimulationTask(taskId=task_id)
     task.abort()
     return get_info(task_id)
@@ -823,7 +823,7 @@ def download(
                 total = resp.totalTask or 0
                 post_succ = resp.postprocessSuccess or 0
                 status = resp.status
-                if status in {"Run_Failed", "Run_Diverged", "Blocked", "Aborted", "Abort"}:
+                if status in {"error", "diverged", "blocked", "aborted", "aborting"}:
                     raise WebError(
                         f"Batch task {task_id} failed during postprocess: {status}"
                     ) from None
@@ -989,19 +989,19 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
     console = get_logging_console() if verbose else None
 
     def _status_to_stage(status: str) -> tuple[str, int]:
-        if status in ("Created",):
-            return ("Created", 0)
-        if status in ("Preprocess",):
-            return ("Preprocess", 1)
-        if status in ("Validating",):
-            return ("Validating", 2)
-        if status in ("Validate_Success", "Validate_Warn"):
+        if status in ("draft",):
+            return ("draft", 0)
+        if status in ("preprocess",):
+            return ("preprocess", 1)
+        if status in ("validating",):
+            return ("validating", 2)
+        if status in ("validate_success", "validate_warn"):
             return ("Validate", 3)
-        if status in ("Running",):
-            return ("Running", 4)
-        if status in ("Postprocess",):
-            return ("Postprocess", 5)
-        if status in ("Run_Success",):
+        if status in ("running",):
+            return ("running", 4)
+        if status in ("postprocess",):
+            return ("postprocess", 5)
+        if status in ("run_success",):
             return ("Success", 6)
         return (status, 6)
 
@@ -1025,23 +1025,23 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
         with Progress(*progress_columns, console=console, transient=False) as progress:
             p_validate = progress.add_task("Validate", total=1.0)
             p_run = progress.add_task("Run", total=1.0)
-            p_post = progress.add_task("Postprocess", total=1.0)
+            p_post = progress.add_task("postprocess", total=1.0)
 
             task_bars = {}
             total_task = detail.totalTask or 0
             if total_task and total_task <= max_detail_tasks:
                 run_statuses = [
-                    "Created",
-                    "Preprocess",
-                    "Validating",
+                    "draft",
+                    "preprocess",
+                    "validating",
                     "Validate",
-                    "Running",
-                    "Postprocess",
+                    "running",
+                    "postprocess",
                     "Success",
                 ]
                 for t in detail.tasks or []:
                     tname = t.taskName or t.taskId
-                    status = t.status or "Created"
+                    status = t.status or "draft"
                     _, idx = _status_to_stage(status)
                     pbar = progress.add_task(
                         f"{tname}",
@@ -1051,12 +1051,12 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
                     task_bars[tname] = pbar
 
             terminal_errors = {
-                "Validate_Failed",
-                "Run_Failed",
-                "Run_Diverged",
-                "Blocked",
-                "Abort",
-                "Aborted",
+                "validate_fail",
+                "error",
+                "diverged",
+                "blocked",
+                "aborting",
+                "aborted",
             }
 
             postprocess_triggered = False
@@ -1085,14 +1085,14 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
                 if task_bars:
                     for t in detail.tasks or []:
                         tname = t.taskName or t.taskId
-                        status = t.status or "Created"
+                        status = t.status or "draft"
                         _, idx = _status_to_stage(status)
                         pbar = task_bars.get(tname)
                         if pbar is not None:
                             progress.update(pbar, completed=min(idx, 6), refresh=False)
 
                 # If run succeeded but postprocess not yet complete, trigger it and keep waiting
-                if status in ("Run_Success", "Postprocess") or r >= total:
+                if status in ("run_success", "postprocess") or r >= total:
                     if not postprocess_triggered:
                         # Kick off postprocess once
                         try:
@@ -1113,12 +1113,12 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
                 time.sleep(REFRESH_TIME)
     else:
         terminal_errors = {
-            "Validate_Failed",
-            "Run_Failed",
-            "Run_Diverged",
-            "Blocked",
-            "Abort",
-            "Aborted",
+            "validate_fail",
+            "error",
+            "diverged",
+            "blocked",
+            "aborting",
+            "aborted",
         }
         postprocess_triggered = False
         while True:
@@ -1127,7 +1127,7 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
             total = d.totalTask or 0
             p = d.postprocessSuccess or 0
             r = d.runSuccess or 0
-            if (s in ("Run_Success", "Postprocess") or r >= total) and total:
+            if (s in ("run_success", "postprocess") or r >= total) and total:
                 if p < total and not postprocess_triggered:
                     try:
                         BatchTask(batch_id).postprocess(batch_type="RF_SWEEP")

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -773,7 +773,7 @@ def monitor(task_id: TaskId, verbose: bool = True) -> None:
 
 @wait_for_connection
 def abort(task_id: TaskId) -> TaskInfo:
-    """aborting a running task without deleting it."""
+    """Abort a running task without deleting it."""
     task = SimulationTask(taskId=task_id)
     task.abort()
     return get_info(task_id)

--- a/tidy3d/web/core/task_core.py
+++ b/tidy3d/web/core/task_core.py
@@ -713,7 +713,7 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
         )
 
     def abort(self):
-        """Abort current task from server."""
+        """aborting current task from server."""
         if not self.task_id:
             raise ValueError("Task id not found.")
         return http.put(
@@ -839,9 +839,9 @@ class BatchTask:
         while True:
             d = self.detail(batch_type=batch_type)
             status = d.status
-            if status in ("Validate_Success", "Validate_Warn", "Validate_Failed"):
+            if status in ("validate_success", "validate_warn", "validate_fail"):
                 return d
-            if status in ("Blocked", "Abort", "Aborted"):
+            if status in ("blocked", "aborting", "aborted"):
                 return d
             if timeout is not None and (datetime.now().timestamp() - start) > timeout:
                 return d
@@ -853,12 +853,12 @@ class BatchTask:
             d = self.detail(batch_type=batch_type)
             status = d.status
             if status in (
-                "Run_Success",
-                "Run_Failed",
-                "Run_Diverged",
-                "Blocked",
-                "Abort",
-                "Aborted",
+                "run_success",
+                "run_failed",
+                "diverged",
+                "blocked",
+                "aborting",
+                "aborted",
             ):
                 return d
             if timeout is not None and (datetime.now().timestamp() - start) > timeout:

--- a/tidy3d/web/core/task_core.py
+++ b/tidy3d/web/core/task_core.py
@@ -713,7 +713,7 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
         )
 
     def abort(self):
-        """aborting current task from server."""
+        """Aborting current task from server."""
         if not self.task_id:
             raise ValueError("Task id not found.")
         return http.put(

--- a/tidy3d/web/core/task_info.py
+++ b/tidy3d/web/core/task_info.py
@@ -173,21 +173,20 @@ class RunInfo(TaskBase):
 
 
 class BatchStatus(str, Enum):
-    Created = "Created"
-    Preprocess = "Preprocess"
-    Validating = "Validating"
-    Validate_Success = "Validate_Success"
-    Validate_Warn = "Validate_Warn"
-    Validate_Failed = "Validate_Failed"
-    Blocked = "Blocked"
-    Running = "Running"
-    Aborting = "Aborting"
-    Run_Success = "Run_Success"
-    Postprocess = "Postprocess"
-    Run_Failed = "Run_Failed"
-    Run_Diverged = "Run_Diverged"
-    Abort = "Abort"
-    Aborted = "Aborted"
+    draft = "draft"
+    preprocess = "preprocess"
+    validating = "validating"
+    validate_success = "validate_success"
+    validate_warn = "validate_warn"
+    validate_fail = "validate_fail"
+    blocked = "blocked"
+    running = "running"
+    aborting = "aborting"
+    run_success = "run_success"
+    postprocess = "postprocess"
+    run_failed = "run_failed"
+    diverged = "diverged"
+    aborted = "aborted"
 
 
 class BatchTaskBlockInfo(TaskBlockInfo):


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR standardizes the batch web status names used in the RF/component modeler API from mixed PascalCase/CamelCase formats to consistent snake_case naming. The changes update three key files that handle RF batch task operations:

1. **Status Enum Definition**: The `BatchStatus` enum in `task_info.py` has been completely updated with all 14 status values converted from formats like `Created`, `Validate_Success`, `Run_Failed` to `draft`, `validate_success`, `run_failed` respectively.

2. **Task Management Logic**: The `BatchTask` class methods in `task_core.py` that monitor validation and execution progress have been updated to check for the new snake_case status values in their conditional logic.

3. **Web API Integration**: The `webapi.py` file has been systematically updated across all RF batch-related functions to use the new status naming convention for validation checks, error handling, progress monitoring, and postprocessing triggers.

This change aligns the client-side code with updated backend API expectations that now return status values in snake_case format. The update ensures proper communication between the Tidy3D web client and the RF batch processing services. Some statuses have been consolidated (e.g., `Run_Diverged` → `diverged`) and refined (e.g., `Created` → `draft`, `Abort` → `aborting`) to better represent the actual task states.

<details>
<summary>Important Files Changed</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/web/core/task_info.py` | 4/5 | Updated BatchStatus enum from PascalCase to snake_case format for all 14 status values |
| `tidy3d/web/core/task_core.py` | 4/5 | Modified status checking logic in BatchTask validation and execution methods to use new snake_case status names |
| `tidy3d/web/api/webapi.py` | 5/5 | Systematically updated all RF batch status checks throughout web API functions to match new naming convention |

</details>

## Confidence score: 4/5

- This PR is generally safe to merge as it's primarily a naming convention update with consistent changes across related files
- Score reflects the systematic nature of changes but potential risk if backend coordination is incomplete or if external dependencies rely on old status names
- Pay close attention to ensuring backend API alignment and verify that all status references have been updated consistently

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant webapi
    participant SimulationTask
    participant BatchTask
    participant Server
    
    User->>webapi: "run(simulation, task_name)"
    webapi->>webapi: "upload(simulation, task_name)"
    webapi->>SimulationTask: "create(task_type='RF')"
    SimulationTask->>Server: "POST /projects/{folder_id}/tasks"
    Server-->>SimulationTask: "return task with batchId/groupId"
    SimulationTask-->>webapi: "return task_id (batch_id)"
    
    webapi->>webapi: "start(task_id)"
    webapi->>webapi: "_is_modeler_batch(task_id)"
    webapi->>BatchTask: "new BatchTask(task_id)"
    webapi->>Server: "POST /terminal-component-modeler-split"
    Server-->>webapi: "split response with child tasks"
    
    webapi->>BatchTask: "check(solver_version, batch_type='RF_SWEEP')"
    BatchTask->>Server: "POST /projects/{batch_id}/batch-check"
    Server-->>BatchTask: "validation response"
    
    webapi->>BatchTask: "wait_for_validate(batch_type='RF_SWEEP')"
    BatchTask->>BatchTask: "detail(batch_type='RF_SWEEP')"
    BatchTask->>Server: "GET /tasks/{batch_id}/batch-detail"
    Server-->>BatchTask: "BatchDetail with status"
    
    alt status is validate_success or validate_warn
        webapi->>BatchTask: "submit(batch_type='RF_SWEEP')"
        BatchTask->>Server: "POST /projects/{batch_id}/batch-submit"
        Server-->>BatchTask: "submit confirmation"
    else status is blocked/error
        webapi->>webapi: "raise WebError with status reason"
    end
    
    webapi->>webapi: "monitor(task_id)"
    webapi->>webapi: "_monitor_modeler_batch(batch_id)"
    
    loop monitoring batch progress
        webapi->>BatchTask: "detail(batch_type='RF_SWEEP')"
        BatchTask->>Server: "GET /tasks/{batch_id}/batch-detail"
        Server-->>BatchTask: "BatchDetail with updated status"
        webapi->>webapi: "update progress bars for validate/run/postprocess"
        
        alt run completed but postprocess not triggered
            webapi->>BatchTask: "postprocess(batch_type='RF_SWEEP')"
            BatchTask->>Server: "POST /projects/{batch_id}/postprocess"
        end
        
        alt status is terminal error
            webapi->>webapi: "raise WebError"
        else status is success
            webapi->>webapi: "break monitoring loop"
        end
    end
    
    webapi->>webapi: "load(task_id, path)"
    webapi->>webapi: "download(task_id, path)"
    webapi->>BatchTask: "get_data_hdf5(remote_data_file_gz='cm_data.hdf5.gz')"
    BatchTask->>Server: "download batch results"
    Server-->>BatchTask: "simulation data"
    BatchTask-->>webapi: "downloaded file path"
    webapi-->>User: "SimulationDataType results"
```

<!-- /greptile_comment -->