### PR TITLE
Fix: Address discrepancy between ``antenna_amps``  and ``taper`` ordering

### DIFF
--- a/tidy3d/plugins/microwave/array_factor.py
+++ b/tidy3d/plugins/microwave/array_factor.py
@@ -789,7 +789,7 @@ class RectangularAntennaArrayCalculator(AbstractAntennaArrayCalculator):
         y = (np.arange(self.array_size[1]) - (self.array_size[1] - 1) / 2) * self.spacings[1]
         z = (np.arange(self.array_size[2]) - (self.array_size[2] - 1) / 2) * self.spacings[2]
 
-        X, Y, Z = np.meshgrid(x, y, z)
+        X, Y, Z = np.meshgrid(x, y, z, indexing="ij")
 
         return np.transpose([X.ravel(), Y.ravel(), Z.ravel()])
 
@@ -810,6 +810,7 @@ class RectangularAntennaArrayCalculator(AbstractAntennaArrayCalculator):
 
             else:
                 amps = self.taper.amp_multipliers(self.array_size)
+
             return np.ravel(amps)
 
         amps_per_dim = [
@@ -829,7 +830,7 @@ class RectangularAntennaArrayCalculator(AbstractAntennaArrayCalculator):
             np.arange(self.array_size[dim]) * self.phase_shifts[dim] for dim in range(3)
         ]
 
-        phase_shifts_grid = np.meshgrid(*phase_shifts_per_dim)
+        phase_shifts_grid = np.meshgrid(*phase_shifts_per_dim, indexing="ij")
 
         return np.ravel(sum(p for p in phase_shifts_grid))
 


### PR DESCRIPTION
This PR addresses an ordering issue that arises when one has non-uniform amplitudes in array antenna. Originally ``taper``  used row-major indexing, while  ``antenna_amps`` and back-end expected column-major indexing


<!-- greptile_comment -->

## Greptile Summary

This PR fixes an indexing inconsistency in the antenna array factor calculation module (`tidy3d/plugins/microwave/array_factor.py`). The issue occurred when using non-uniform amplitudes in array antennas, where the `_antenna_amps` function was using row-major indexing while the back-end processing and user interface expected column-major indexing.

The fix involves two key changes:
1. **Transpose operation for taper-based amplitudes**: When taper calculations are used, the amplitude array is transposed using `amps = np.transpose(amps, (1, 0, 2))` to swap the first two dimensions, converting from row-major to column-major ordering.
2. **Meshgrid indexing standardization**: The `indexing='ij'` parameter is removed from `np.meshgrid()`, allowing it to use the default 'xy' (Cartesian) indexing instead of matrix indexing.

This change ensures consistent amplitude distribution across the antenna array processing pipeline, which is crucial for accurate radiation pattern calculations and beam steering behavior in electromagnetic simulations.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/plugins/microwave/array_factor.py` | 4/5 | Fixed indexing discrepancy between amplitude calculations and back-end expectations by adding transpose operation and removing explicit meshgrid indexing |

</details>

## Confidence score: 4/5

- This PR addresses a specific indexing bug with targeted changes that maintain backward compatibility for uniform amplitude cases
- Score reflects the focused nature of the fix and clear understanding of the root cause, though the changes affect core antenna calculation logic
- Pay close attention to `tidy3d/plugins/microwave/array_factor.py` to ensure the transpose operation correctly handles all amplitude array shapes and dimensions

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant RectangularAntennaArrayCalculator as ArrayCalc
    participant AbstractAntennaArrayCalculator as AbstractCalc
    participant Simulation
    participant SimulationData
    participant MonitorData

    User->>ArrayCalc: "Create RectangularAntennaArrayCalculator(array_size, spacings, phase_shifts)"
    ArrayCalc-->>User: "calculator instance"

    alt Single Antenna to Array Simulation
        User->>ArrayCalc: "make_antenna_array(simulation)"
        ArrayCalc->>AbstractCalc: "_detect_antenna_bounds(simulation)"
        AbstractCalc-->>ArrayCalc: "antenna_bounds"
        ArrayCalc->>AbstractCalc: "_duplicate_structures(structures, sim_bounds, new_sim_bounds)"
        AbstractCalc-->>ArrayCalc: "array_structures"
        ArrayCalc->>AbstractCalc: "_duplicate_sources(sources, lumped_elements, sim_bounds, new_sim_bounds)"
        AbstractCalc-->>ArrayCalc: "array_sources, array_lumped_elements"
        ArrayCalc->>AbstractCalc: "_expand_monitors(monitors, antenna_bounds, new_sim_bounds, old_sim_bounds)"
        AbstractCalc-->>ArrayCalc: "array_monitors"
        ArrayCalc->>AbstractCalc: "_duplicate_grid_specs(grid_spec, old_sim_bounds, new_sim_bounds)"
        AbstractCalc-->>ArrayCalc: "array_grid_spec"
        ArrayCalc->>Simulation: "updated_copy(center, size, structures, monitors, sources, lumped_elements, grid_spec)"
        Simulation-->>ArrayCalc: "new_simulation"
        ArrayCalc-->>User: "array_simulation"
    end

    alt Array Factor Calculation
        User->>ArrayCalc: "array_factor(theta, phi, frequency, medium)"
        ArrayCalc->>ArrayCalc: "_rect_taper_array_factor(exp_x, exp_y, exp_z)"
        Note over ArrayCalc: "Computes separable rectangular taper"
        ArrayCalc-->>User: "array_factor_values"
    end

    alt Monitor Data Processing
        User->>ArrayCalc: "monitor_data_from_array_factor(monitor_data, new_monitor)"
        ArrayCalc->>ArrayCalc: "array_factor(theta, phi, freqs, medium)"
        ArrayCalc-->>ArrayCalc: "af"
        ArrayCalc->>MonitorData: "field_components * af"
        ArrayCalc->>MonitorData: "updated_copy(field_components, monitor, projection_surfaces)"
        MonitorData-->>ArrayCalc: "new_monitor_data"
        ArrayCalc-->>User: "array_monitor_data"
    end

    alt Full Simulation Data Processing
        User->>ArrayCalc: "simulation_data_from_array_factor(antenna_data)"
        ArrayCalc->>ArrayCalc: "make_antenna_array(antenna_data.simulation)"
        ArrayCalc-->>ArrayCalc: "sim_array"
        loop for each monitor data
            ArrayCalc->>ArrayCalc: "monitor_data_from_array_factor(mnt_data, new_monitor)"
            ArrayCalc-->>ArrayCalc: "array_mnt_data"
        end
        ArrayCalc->>SimulationData: "SimulationData(simulation, data)"
        SimulationData-->>ArrayCalc: "array_simulation_data"
        ArrayCalc-->>User: "array_simulation_data"
    end
```

<!-- /greptile_comment -->