### PR TITLE
Revert "Update batch web status names"

### DIFF
--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -498,7 +498,7 @@ def start(
         check_resp = batch.check(solver_version=solver_version, batch_type="RF_SWEEP")
         detail = batch.wait_for_validate(batch_type="RF_SWEEP")
         status = detail.status
-        if status not in ("validate_success", "validate_warn"):
+        if status not in ("Validate_Success", "Validate_Warn"):
             # Surface server-provided reason if available
             reason = None
             try:
@@ -823,7 +823,7 @@ def download(
                 total = resp.totalTask or 0
                 post_succ = resp.postprocessSuccess or 0
                 status = resp.status
-                if status in {"error", "diverged", "blocked", "aborted", "aborting"}:
+                if status in {"Run_Failed", "Run_Diverged", "Blocked", "Aborted", "Abort"}:
                     raise WebError(
                         f"Batch task {task_id} failed during postprocess: {status}"
                     ) from None
@@ -989,19 +989,19 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
     console = get_logging_console() if verbose else None
 
     def _status_to_stage(status: str) -> tuple[str, int]:
-        if status in ("draft",):
-            return ("draft", 0)
-        if status in ("preprocess",):
-            return ("preprocess", 1)
-        if status in ("validating",):
-            return ("validating", 2)
-        if status in ("validate_success", "validate_warn"):
+        if status in ("Created",):
+            return ("Created", 0)
+        if status in ("Preprocess",):
+            return ("Preprocess", 1)
+        if status in ("Validating",):
+            return ("Validating", 2)
+        if status in ("Validate_Success", "Validate_Warn"):
             return ("Validate", 3)
-        if status in ("running",):
-            return ("running", 4)
-        if status in ("postprocess",):
-            return ("postprocess", 5)
-        if status in ("run_success",):
+        if status in ("Running",):
+            return ("Running", 4)
+        if status in ("Postprocess",):
+            return ("Postprocess", 5)
+        if status in ("Run_Success",):
             return ("Success", 6)
         return (status, 6)
 
@@ -1025,23 +1025,23 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
         with Progress(*progress_columns, console=console, transient=False) as progress:
             p_validate = progress.add_task("Validate", total=1.0)
             p_run = progress.add_task("Run", total=1.0)
-            p_post = progress.add_task("postprocess", total=1.0)
+            p_post = progress.add_task("Postprocess", total=1.0)
 
             task_bars = {}
             total_task = detail.totalTask or 0
             if total_task and total_task <= max_detail_tasks:
                 run_statuses = [
-                    "draft",
-                    "preprocess",
-                    "validating",
+                    "Created",
+                    "Preprocess",
+                    "Validating",
                     "Validate",
-                    "running",
-                    "postprocess",
+                    "Running",
+                    "Postprocess",
                     "Success",
                 ]
                 for t in detail.tasks or []:
                     tname = t.taskName or t.taskId
-                    status = t.status or "draft"
+                    status = t.status or "Created"
                     _, idx = _status_to_stage(status)
                     pbar = progress.add_task(
                         f"{tname}",
@@ -1051,12 +1051,12 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
                     task_bars[tname] = pbar
 
             terminal_errors = {
-                "validate_fail",
-                "error",
-                "diverged",
-                "blocked",
-                "aborting",
-                "aborted",
+                "Validate_Failed",
+                "Run_Failed",
+                "Run_Diverged",
+                "Blocked",
+                "Abort",
+                "Aborted",
             }
 
             postprocess_triggered = False
@@ -1085,14 +1085,14 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
                 if task_bars:
                     for t in detail.tasks or []:
                         tname = t.taskName or t.taskId
-                        status = t.status or "draft"
+                        status = t.status or "Created"
                         _, idx = _status_to_stage(status)
                         pbar = task_bars.get(tname)
                         if pbar is not None:
                             progress.update(pbar, completed=min(idx, 6), refresh=False)
 
                 # If run succeeded but postprocess not yet complete, trigger it and keep waiting
-                if status in ("run_success", "postprocess") or r >= total:
+                if status in ("Run_Success", "Postprocess") or r >= total:
                     if not postprocess_triggered:
                         # Kick off postprocess once
                         try:
@@ -1113,12 +1113,12 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
                 time.sleep(REFRESH_TIME)
     else:
         terminal_errors = {
-            "validate_fail",
-            "error",
-            "diverged",
-            "blocked",
-            "aborting",
-            "aborted",
+            "Validate_Failed",
+            "Run_Failed",
+            "Run_Diverged",
+            "Blocked",
+            "Abort",
+            "Aborted",
         }
         postprocess_triggered = False
         while True:
@@ -1127,7 +1127,7 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
             total = d.totalTask or 0
             p = d.postprocessSuccess or 0
             r = d.runSuccess or 0
-            if (s in ("run_success", "postprocess") or r >= total) and total:
+            if (s in ("Run_Success", "Postprocess") or r >= total) and total:
                 if p < total and not postprocess_triggered:
                     try:
                         BatchTask(batch_id).postprocess(batch_type="RF_SWEEP")

--- a/tidy3d/web/core/task_core.py
+++ b/tidy3d/web/core/task_core.py
@@ -713,7 +713,7 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
         )
 
     def abort(self):
-        """Aborting current task from server."""
+        """Abort current task from server."""
         if not self.task_id:
             raise ValueError("Task id not found.")
         return http.put(
@@ -839,9 +839,9 @@ class BatchTask:
         while True:
             d = self.detail(batch_type=batch_type)
             status = d.status
-            if status in ("validate_success", "validate_warn", "validate_fail"):
+            if status in ("Validate_Success", "Validate_Warn", "Validate_Failed"):
                 return d
-            if status in ("blocked", "aborting", "aborted"):
+            if status in ("Blocked", "Abort", "Aborted"):
                 return d
             if timeout is not None and (datetime.now().timestamp() - start) > timeout:
                 return d
@@ -853,12 +853,12 @@ class BatchTask:
             d = self.detail(batch_type=batch_type)
             status = d.status
             if status in (
-                "run_success",
-                "run_failed",
-                "diverged",
-                "blocked",
-                "aborting",
-                "aborted",
+                "Run_Success",
+                "Run_Failed",
+                "Run_Diverged",
+                "Blocked",
+                "Abort",
+                "Aborted",
             ):
                 return d
             if timeout is not None and (datetime.now().timestamp() - start) > timeout:

--- a/tidy3d/web/core/task_info.py
+++ b/tidy3d/web/core/task_info.py
@@ -173,20 +173,21 @@ class RunInfo(TaskBase):
 
 
 class BatchStatus(str, Enum):
-    draft = "draft"
-    preprocess = "preprocess"
-    validating = "validating"
-    validate_success = "validate_success"
-    validate_warn = "validate_warn"
-    validate_fail = "validate_fail"
-    blocked = "blocked"
-    running = "running"
-    aborting = "aborting"
-    run_success = "run_success"
-    postprocess = "postprocess"
-    run_failed = "run_failed"
-    diverged = "diverged"
-    aborted = "aborted"
+    Created = "Created"
+    Preprocess = "Preprocess"
+    Validating = "Validating"
+    Validate_Success = "Validate_Success"
+    Validate_Warn = "Validate_Warn"
+    Validate_Failed = "Validate_Failed"
+    Blocked = "Blocked"
+    Running = "Running"
+    Aborting = "Aborting"
+    Run_Success = "Run_Success"
+    Postprocess = "Postprocess"
+    Run_Failed = "Run_Failed"
+    Run_Diverged = "Run_Diverged"
+    Abort = "Abort"
+    Aborted = "Aborted"
 
 
 class BatchTaskBlockInfo(TaskBlockInfo):


### PR DESCRIPTION
Reverts flexcompute/tidy3d#2756

<!-- greptile_comment -->

## Greptile Summary

This pull request reverts PR #2756, which had attempted to standardize batch web status names from mixed PascalCase/CamelCase format to snake_case format across the RF/component modeler API. The reversion affects three core files in the web API system:

**Key Changes Made:**
- **BatchStatus enum**: Reverts status values from snake_case back to mixed format (e.g., 'validate_success' → 'Validate_Success', 'run_failed' → 'Run_Failed')
- **Status checking logic**: Updates all status validation and monitoring code in `task_core.py` and `webapi.py` to use the original PascalCase/mixed format
- **API consistency**: Ensures client-side status checking matches the format returned by backend services

The changes span critical batch processing functionality including validation workflows (`wait_for_validate()`), execution monitoring (`wait_for_run()`), error detection, and postprocessing triggers. The reversion restores the original mixed naming convention where some statuses use PascalCase ('Created', 'Running') while others use underscore-separated format ('Validate_Success', 'Run_Failed').

This revert indicates that the backend RF/component modeler API was not updated to match the snake_case standardization, creating a mismatch between client expectations and server responses. The batch processing system requires exact string matching for status transitions, making this alignment critical for proper workflow execution.

## Important Files Changed

<details>
<summary>Files Changed</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/web/core/task_info.py` | 2/5 | Reverts BatchStatus enum from snake_case to mixed PascalCase/underscore format, potentially breaking if backend expects snake_case |
| `tidy3d/web/core/task_core.py` | 4/5 | Reverts status checking logic in validation and execution monitoring to match backend API format |
| `tidy3d/web/api/webapi.py` | 4/5 | Systematically updates status validation, error detection, and monitoring logic back to PascalCase format |

</details>

## Confidence score: 3/5

- This revert appears necessary to fix compatibility issues with backend API that still returns PascalCase status values
- Score reflects uncertainty about backend API state and potential for breaking changes if revert is incomplete
- Pay close attention to `tidy3d/web/core/task_info.py` where enum changes could cause runtime errors if backend format differs

<!-- /greptile_comment -->