### PR TITLE
Update batch status names

### DIFF
--- a/tidy3d/web/api/mode.py
+++ b/tidy3d/web/api/mode.py
@@ -490,7 +490,7 @@ class ModeSolverTask(ResourceLifecycle, Submittable, extra=pydantic.Extra.allow)
         http.delete(f"tidy3d/tasks/{self.task_id}")
 
     def abort(self):
-        """Abort the mode solver and its corresponding task from the server."""
+        """aborting the mode solver and its corresponding task from the server."""
         return http.put(
             "tidy3d/tasks/abort", json={"taskType": "MODE_SOLVER", "taskId": self.solver_id}
         )

--- a/tidy3d/web/api/mode.py
+++ b/tidy3d/web/api/mode.py
@@ -490,7 +490,7 @@ class ModeSolverTask(ResourceLifecycle, Submittable, extra=pydantic.Extra.allow)
         http.delete(f"tidy3d/tasks/{self.task_id}")
 
     def abort(self):
-        """aborting the mode solver and its corresponding task from the server."""
+        """Abort the mode solver and its corresponding task from the server."""
         return http.put(
             "tidy3d/tasks/abort", json={"taskType": "MODE_SOLVER", "taskId": self.solver_id}
         )

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -497,7 +497,7 @@ def start(
         batch = BatchTask(task_id)
         check_resp = batch.check(solver_version=solver_version, batch_type="RF_SWEEP")
         detail = batch.wait_for_validate(batch_type="RF_SWEEP")
-        status = detail.status
+        status = detail.totalStatus
         if status not in ("validate_success", "validate_warn"):
             # Surface server-provided reason if available
             reason = None
@@ -822,7 +822,7 @@ def download(
                 resp = BatchTask(task_id).detail(batch_type="RF_SWEEP")
                 total = resp.totalTask or 0
                 post_succ = resp.postprocessSuccess or 0
-                status = resp.status
+                status = resp.totalStatus
                 if status in {"error", "diverged", "blocked", "aborted", "aborting"}:
                     raise WebError(
                         f"Batch task {task_id} failed during postprocess: {status}"
@@ -1062,7 +1062,7 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
             postprocess_triggered = False
             while True:
                 detail = _batch_detail(batch_id)
-                status = detail.status
+                status = detail.totalStatus
                 total = detail.totalTask or 0
                 v = detail.validateSuccess or 0
                 r = detail.runSuccess or 0
@@ -1123,7 +1123,7 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
         postprocess_triggered = False
         while True:
             d = _batch_detail(batch_id)
-            s = d.status
+            s = d.totalStatus
             total = d.totalTask or 0
             p = d.postprocessSuccess or 0
             r = d.runSuccess or 0

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -498,7 +498,7 @@ def start(
         check_resp = batch.check(solver_version=solver_version, batch_type="RF_SWEEP")
         detail = batch.wait_for_validate(batch_type="RF_SWEEP")
         status = detail.status
-        if status not in ("Validate_Success", "Validate_Warn"):
+        if status not in ("validate_success", "validate_warn"):
             # Surface server-provided reason if available
             reason = None
             try:
@@ -773,7 +773,7 @@ def monitor(task_id: TaskId, verbose: bool = True) -> None:
 
 @wait_for_connection
 def abort(task_id: TaskId) -> TaskInfo:
-    """Abort a running task without deleting it."""
+    """aborting a running task without deleting it."""
     task = SimulationTask(taskId=task_id)
     task.abort()
     return get_info(task_id)
@@ -823,7 +823,7 @@ def download(
                 total = resp.totalTask or 0
                 post_succ = resp.postprocessSuccess or 0
                 status = resp.status
-                if status in {"Run_Failed", "Run_Diverged", "Blocked", "Aborted", "Abort"}:
+                if status in {"error", "diverged", "blocked", "aborted", "aborting"}:
                     raise WebError(
                         f"Batch task {task_id} failed during postprocess: {status}"
                     ) from None
@@ -989,19 +989,19 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
     console = get_logging_console() if verbose else None
 
     def _status_to_stage(status: str) -> tuple[str, int]:
-        if status in ("Created",):
-            return ("Created", 0)
-        if status in ("Preprocess",):
-            return ("Preprocess", 1)
-        if status in ("Validating",):
-            return ("Validating", 2)
-        if status in ("Validate_Success", "Validate_Warn"):
+        if status in ("draft",):
+            return ("draft", 0)
+        if status in ("preprocess",):
+            return ("preprocess", 1)
+        if status in ("validating",):
+            return ("validating", 2)
+        if status in ("validate_success", "validate_warn"):
             return ("Validate", 3)
-        if status in ("Running",):
-            return ("Running", 4)
-        if status in ("Postprocess",):
-            return ("Postprocess", 5)
-        if status in ("Run_Success",):
+        if status in ("running",):
+            return ("running", 4)
+        if status in ("postprocess",):
+            return ("postprocess", 5)
+        if status in ("run_success",):
             return ("Success", 6)
         return (status, 6)
 
@@ -1025,23 +1025,23 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
         with Progress(*progress_columns, console=console, transient=False) as progress:
             p_validate = progress.add_task("Validate", total=1.0)
             p_run = progress.add_task("Run", total=1.0)
-            p_post = progress.add_task("Postprocess", total=1.0)
+            p_post = progress.add_task("postprocess", total=1.0)
 
             task_bars = {}
             total_task = detail.totalTask or 0
             if total_task and total_task <= max_detail_tasks:
                 run_statuses = [
-                    "Created",
-                    "Preprocess",
-                    "Validating",
+                    "draft",
+                    "preprocess",
+                    "validating",
                     "Validate",
-                    "Running",
-                    "Postprocess",
+                    "running",
+                    "postprocess",
                     "Success",
                 ]
                 for t in detail.tasks or []:
                     tname = t.taskName or t.taskId
-                    status = t.status or "Created"
+                    status = t.status or "draft"
                     _, idx = _status_to_stage(status)
                     pbar = progress.add_task(
                         f"{tname}",
@@ -1051,12 +1051,12 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
                     task_bars[tname] = pbar
 
             terminal_errors = {
-                "Validate_Failed",
-                "Run_Failed",
-                "Run_Diverged",
-                "Blocked",
-                "Abort",
-                "Aborted",
+                "validate_fail",
+                "error",
+                "diverged",
+                "blocked",
+                "aborting",
+                "aborted",
             }
 
             postprocess_triggered = False
@@ -1085,14 +1085,14 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
                 if task_bars:
                     for t in detail.tasks or []:
                         tname = t.taskName or t.taskId
-                        status = t.status or "Created"
+                        status = t.status or "draft"
                         _, idx = _status_to_stage(status)
                         pbar = task_bars.get(tname)
                         if pbar is not None:
                             progress.update(pbar, completed=min(idx, 6), refresh=False)
 
                 # If run succeeded but postprocess not yet complete, trigger it and keep waiting
-                if status in ("Run_Success", "Postprocess") or r >= total:
+                if status in ("run_success", "postprocess") or r >= total:
                     if not postprocess_triggered:
                         # Kick off postprocess once
                         try:
@@ -1113,12 +1113,12 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
                 time.sleep(REFRESH_TIME)
     else:
         terminal_errors = {
-            "Validate_Failed",
-            "Run_Failed",
-            "Run_Diverged",
-            "Blocked",
-            "Abort",
-            "Aborted",
+            "validate_fail",
+            "error",
+            "diverged",
+            "blocked",
+            "aborting",
+            "aborted",
         }
         postprocess_triggered = False
         while True:
@@ -1127,7 +1127,7 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
             total = d.totalTask or 0
             p = d.postprocessSuccess or 0
             r = d.runSuccess or 0
-            if (s in ("Run_Success", "Postprocess") or r >= total) and total:
+            if (s in ("run_success", "postprocess") or r >= total) and total:
                 if p < total and not postprocess_triggered:
                     try:
                         BatchTask(batch_id).postprocess(batch_type="RF_SWEEP")

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -1025,7 +1025,7 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
         with Progress(*progress_columns, console=console, transient=False) as progress:
             p_validate = progress.add_task("Validate", total=1.0)
             p_run = progress.add_task("Run", total=1.0)
-            p_post = progress.add_task("postprocess", total=1.0)
+            p_post = progress.add_task("Postprocess", total=1.0)
 
             task_bars = {}
             total_task = detail.totalTask or 0
@@ -1067,10 +1067,11 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
                 v = detail.validateSuccess or 0
                 r = detail.runSuccess or 0
                 p = detail.postprocessSuccess or 0
+                postprocess_success = detail.postprocessStatus or None
 
                 progress.update(p_validate, completed=(v / total) if total else 0.0)
                 progress.update(p_run, completed=(r / total) if total else 0.0)
-                progress.update(p_post, completed=(p / total) if total else 0.0)
+                progress.update(p_post, completed=p if total else 0.0)
 
                 block = detail.taskBlockInfo
                 if block is not None:
@@ -1085,8 +1086,8 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
                 if task_bars:
                     for t in detail.tasks or []:
                         tname = t.taskName or t.taskId
-                        status = t.status or "draft"
-                        _, idx = _status_to_stage(status)
+                        task_status = t.status or "draft"
+                        _, idx = _status_to_stage(task_status)
                         pbar = task_bars.get(tname)
                         if pbar is not None:
                             progress.update(pbar, completed=min(idx, 6), refresh=False)
@@ -1102,9 +1103,9 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
                             pass
                         postprocess_triggered = True
 
-                if status in ("success",):
-                    console.log("Completed modeler run.")
-                    break
+                    if p:
+                        console.log("Successful component modeler run.")
+                        break
 
                 if status in terminal_errors:
                     raise WebError(f"Batch {batch_id} terminated: {status}")
@@ -1127,15 +1128,19 @@ def _monitor_modeler_batch(batch_id: str, verbose: bool = True, max_detail_tasks
             total = d.totalTask or 0
             p = d.postprocessSuccess or 0
             r = d.runSuccess or 0
-            if (s in ("run_success", "postprocess") or r >= total) and total:
+            postprocess_success = d.postprocessStatus or None
+            if s in ("run_success", "postprocess") or r >= total:
                 if p < total and not postprocess_triggered:
                     try:
                         BatchTask(batch_id).postprocess(batch_type="RF_SWEEP")
                     except Exception:
                         pass
                     postprocess_triggered = True
-                if p >= total:
+
+                if postprocess_success == "success":
+                    console.log("Successful component modeler run.")
                     break
+
             if s in terminal_errors:
                 raise WebError(f"Batch {batch_id} terminated: {s}")
             time.sleep(REFRESH_TIME)

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -773,7 +773,7 @@ def monitor(task_id: TaskId, verbose: bool = True) -> None:
 
 @wait_for_connection
 def abort(task_id: TaskId) -> TaskInfo:
-    """aborting a running task without deleting it."""
+    """Abort a running task without deleting it."""
     task = SimulationTask(taskId=task_id)
     task.abort()
     return get_info(task_id)

--- a/tidy3d/web/core/task_core.py
+++ b/tidy3d/web/core/task_core.py
@@ -713,7 +713,7 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
         )
 
     def abort(self):
-        """Abort current task from server."""
+        """aborting current task from server."""
         if not self.task_id:
             raise ValueError("Task id not found.")
         return http.put(
@@ -839,9 +839,9 @@ class BatchTask:
         while True:
             d = self.detail(batch_type=batch_type)
             status = d.status
-            if status in ("Validate_Success", "Validate_Warn", "Validate_Failed"):
+            if status in ("validate_success", "validate_warn", "validate_fail"):
                 return d
-            if status in ("Blocked", "Abort", "Aborted"):
+            if status in ("blocked", "aborting", "aborted"):
                 return d
             if timeout is not None and (datetime.now().timestamp() - start) > timeout:
                 return d
@@ -853,12 +853,12 @@ class BatchTask:
             d = self.detail(batch_type=batch_type)
             status = d.status
             if status in (
-                "Run_Success",
-                "Run_Failed",
-                "Run_Diverged",
-                "Blocked",
-                "Abort",
-                "Aborted",
+                "run_success",
+                "run_failed",
+                "diverged",
+                "blocked",
+                "aborting",
+                "aborted",
             ):
                 return d
             if timeout is not None and (datetime.now().timestamp() - start) > timeout:

--- a/tidy3d/web/core/task_core.py
+++ b/tidy3d/web/core/task_core.py
@@ -838,7 +838,7 @@ class BatchTask:
         start = datetime.now().timestamp()
         while True:
             d = self.detail(batch_type=batch_type)
-            status = d.status
+            status = d.totalStatus
             if status in ("validate_success", "validate_warn", "validate_fail"):
                 return d
             if status in ("blocked", "aborting", "aborted"):
@@ -851,7 +851,7 @@ class BatchTask:
         start = datetime.now().timestamp()
         while True:
             d = self.detail(batch_type=batch_type)
-            status = d.status
+            status = d.totalStatus
             if status in (
                 "run_success",
                 "run_failed",

--- a/tidy3d/web/core/task_core.py
+++ b/tidy3d/web/core/task_core.py
@@ -713,7 +713,7 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
         )
 
     def abort(self):
-        """aborting current task from server."""
+        """Aborting current task from server."""
         if not self.task_id:
             raise ValueError("Task id not found.")
         return http.put(

--- a/tidy3d/web/core/task_info.py
+++ b/tidy3d/web/core/task_info.py
@@ -232,6 +232,7 @@ class BatchDetail(TaskBase):
     totalStatus: BatchStatus = None
     totalTask: int = 0
     preprocessSuccess: int = 0
+    postprocessStatus: TaskStatus = None
     validateSuccess: int = 0
     runSuccess: int = 0
     postprocessSuccess: int = 0

--- a/tidy3d/web/core/task_info.py
+++ b/tidy3d/web/core/task_info.py
@@ -173,21 +173,20 @@ class RunInfo(TaskBase):
 
 
 class BatchStatus(str, Enum):
-    Created = "Created"
-    Preprocess = "Preprocess"
-    Validating = "Validating"
-    Validate_Success = "Validate_Success"
-    Validate_Warn = "Validate_Warn"
-    Validate_Failed = "Validate_Failed"
-    Blocked = "Blocked"
-    Running = "Running"
-    Aborting = "Aborting"
-    Run_Success = "Run_Success"
-    Postprocess = "Postprocess"
-    Run_Failed = "Run_Failed"
-    Run_Diverged = "Run_Diverged"
-    Abort = "Abort"
-    Aborted = "Aborted"
+    draft = "draft"
+    preprocess = "preprocess"
+    validating = "validating"
+    validate_success = "validate_success"
+    validate_warn = "validate_warn"
+    validate_fail = "validate_fail"
+    blocked = "blocked"
+    running = "running"
+    aborting = "aborting"
+    run_success = "run_success"
+    postprocess = "postprocess"
+    run_failed = "run_failed"
+    diverged = "diverged"
+    aborted = "aborted"
 
 
 class BatchTaskBlockInfo(TaskBlockInfo):

--- a/tidy3d/web/core/task_info.py
+++ b/tidy3d/web/core/task_info.py
@@ -196,6 +196,7 @@ class BatchTaskBlockInfo(TaskBlockInfo):
     taskBlockMsg: str = None
     taskBlockType: str = None
     blockStatus: str = None
+    taskStatus: str = None
 
 
 class BatchMember(TaskBase):
@@ -227,7 +228,8 @@ class BatchDetail(TaskBase):
     optimizationId: str = None
     groupId: str = None
     name: str = None
-    status: BatchStatus = None
+    status: str = None
+    totalStatus: BatchStatus = None
     totalTask: int = 0
     preprocessSuccess: int = 0
     validateSuccess: int = 0


### PR DESCRIPTION
Waiting till ready in the backend

<!-- greptile_comment -->

## Greptile Summary

This PR updates the batch status naming convention across the Tidy3D web API components to align with backend changes. The primary change involves transitioning from PascalCase/underscore status names (like `Validate_Success`, `Run_Failed`) to lowercase snake_case format (`validate_success`, `run_failed`). 

The changes span three key files:
- **`webapi.py`**: Updates status checking logic throughout the RF component modeler functionality, switches from `detail.status` to `detail.totalStatus` field, and fixes a postprocess progress calculation bug
- **`task_core.py`**: Modifies wait functions to use the new status field (`d.totalStatus`) and updated status names
- **`task_info.py`**: Completely refactors the `BatchStatus` enum values and adds new status fields (`totalStatus`, `postprocessStatus`, `taskStatus`)

The backend API appears to have evolved to provide more granular status information, distinguishing between individual task status and overall batch status. This change ensures the client code properly communicates with the updated backend by using the correct field names and status values. Additionally, the PR includes a bug fix in postprocess progress tracking where the calculation was incorrectly using division instead of raw success counts.

## Important Files Changed

<details>
<summary>Click to expand</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/web/core/task_info.py` | 2/5 | Major breaking changes to BatchStatus enum values and data model structure |
| `tidy3d/web/api/webapi.py` | 4/5 | Updates status checking logic and fixes postprocess calculation bug |
| `tidy3d/web/core/task_core.py` | 4/5 | Updates status field references and naming in wait functions |

</details>

## Confidence score: 3/5

- This PR introduces significant breaking changes to the batch status API that could impact existing code relying on the old enum values
- Score reflects concerns about the scope of breaking changes, particularly in `task_info.py` where the entire status enum is restructured
- Pay close attention to `tidy3d/web/core/task_info.py` which contains the most disruptive changes to the data model

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant webapi
    participant BatchTask
    participant Server
    participant _monitor_modeler_batch
    
    User->>webapi: "start(task_id)"
    webapi->>webapi: "_is_modeler_batch(task_id)"
    
    alt is modeler batch
        webapi->>Server: "POST tidy3d/projects/terminal-component-modeler-split"
        Server-->>webapi: "split response with child task info"
        webapi->>BatchTask: "check(solver_version, batch_type='RF_SWEEP')"
        BatchTask->>Server: "POST batch-check endpoint"
        Server-->>BatchTask: "check response"
        webapi->>BatchTask: "wait_for_validate(batch_type='RF_SWEEP')"
        loop validation waiting
            BatchTask->>Server: "GET batch-detail"
            Server-->>BatchTask: "detail with totalStatus"
            note over BatchTask: "Check status: validate_success, validate_warn, etc."
        end
        
        alt validation successful
            webapi->>BatchTask: "submit(solver_version, batch_type='RF_SWEEP')"
            BatchTask->>Server: "POST batch-submit"
        else validation failed  
            webapi->>User: "raise WebError with status reason"
        end
    else regular task
        webapi->>Server: "POST tidy3d/tasks/{task_id}/submit"
    end
    
    User->>webapi: "monitor(task_id)"
    
    alt is modeler batch
        webapi->>_monitor_modeler_batch: "_monitor_modeler_batch(task_id)"
        loop monitoring progress
            _monitor_modeler_batch->>BatchTask: "detail(batch_type='RF_SWEEP')"
            BatchTask->>Server: "GET batch-detail"
            Server-->>BatchTask: "BatchDetail with updated status names"
            _monitor_modeler_batch->>_monitor_modeler_batch: "_status_to_stage(status)"
            note over _monitor_modeler_batch: "Map new status names to stages:<br/>draft->0, preprocess->1, validating->2,<br/>validate_success/validate_warn->3,<br/>running->4, postprocess->5, run_success->6"
            
            alt run completed but postprocess needed
                _monitor_modeler_batch->>BatchTask: "postprocess(batch_type='RF_SWEEP')"
                BatchTask->>Server: "POST postprocess endpoint"
            end
        end
    else regular task
        loop monitoring
            webapi->>Server: "GET task status"
            Server-->>webapi: "status update"
        end
    end
```

<!-- /greptile_comment -->