### PR TITLE
Component equality check refactor

### DIFF
--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -887,7 +887,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
                     return False
 
                 # convert tuple to dict to use this recursive function
-                if isinstance(val1, tuple) or isinstance(val2, tuple):
+                if isinstance(val1, tuple) and isinstance(val2, tuple):
                     val1 = dict(zip(range(len(val1)), val1))
                     val2 = dict(zip(range(len(val2)), val2))
 


### PR DESCRIPTION
This caused a validator error when comparing two semiconductor media since the `N_d` and `N_a` values can be both a float and a tuple (so when one medium had `N_d` a float and the other - a tuple, it was erroring).

<!-- greptile_comment -->

## Greptile Summary

This PR adds a type check to the component equality comparison function in `tidy3d/components/base.py`. The change addresses a specific bug where comparing two semiconductor media objects would fail with validator errors when they had different types for the same field (e.g., one having `N_d` as a float and another as a tuple).

The fix introduces an early type check using `type(val1) is not type(val2)` that returns `False` immediately if the types don't match, preventing the comparison from proceeding to validation steps that would cause errors. This change integrates well with the existing equality comparison logic in the base component system, which is fundamental to how Tidy3D objects are compared throughout the codebase.

The modification follows sound equality semantics - objects with different types for the same field should be considered unequal. This is a defensive programming approach that prevents downstream validation errors while maintaining logical correctness.

## Important Files Changed

<details>
<summary>Files Modified</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/components/base.py` | 4/5 | Added early type check in equality comparison to prevent validator errors when comparing objects with different field types |

</details>

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it addresses a specific bug with a targeted fix
- Score reflects a simple, well-reasoned change that follows good defensive programming practices and prevents error conditions
- No files require special attention as the change is localized and straightforward

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant Component1 as "Tidy3dBaseModel (Component 1)"
    participant Component2 as "Tidy3dBaseModel (Component 2)"
    participant EqualityCheck as "__eq__ method"
    participant CheckEqual as "check_equal function"

    User->>Component1: "component1 == component2"
    Component1->>EqualityCheck: "Call __eq__(other)"
    EqualityCheck->>CheckEqual: "check_equal(self.dict(), other.dict())"
    
    CheckEqual->>CheckEqual: "Compare dictionary keys"
    alt Keys are different
        CheckEqual-->>EqualityCheck: "Return False"
    else Keys are same
        loop For each key-value pair
            CheckEqual->>CheckEqual: "Get val1 = dict1[key], val2 = dict2[key]"
            CheckEqual->>CheckEqual: "val1 = get_static(val1), val2 = get_static(val2)"
            CheckEqual->>CheckEqual: "Check type(val1) is not type(val2)"
            alt Types are different
                CheckEqual-->>EqualityCheck: "Return False"
            else Types are same
                CheckEqual->>CheckEqual: "Check if either value is None (XOR)"
                alt One is None, other is not
                    CheckEqual-->>EqualityCheck: "Return False"
                else Both None or both not None
                    alt Values are tuples
                        CheckEqual->>CheckEqual: "Convert tuples to dicts and recurse"
                    else Values are dicts
                        CheckEqual->>CheckEqual: "Recurse with dictionaries"
                    else Values are numpy arrays
                        CheckEqual->>CheckEqual: "Use np.array_equal()"
                    else Other types
                        CheckEqual->>CheckEqual: "Use == comparison"
                    end
                end
            end
        end
        CheckEqual-->>EqualityCheck: "Return True if all comparisons passed"
    end
    
    EqualityCheck-->>Component1: "Return equality result"
    Component1-->>User: "Return boolean result"
```

<!-- /greptile_comment -->