### PR TITLE
fix broken tests for the TCM and improve docstrings

### DIFF
--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -57,10 +57,20 @@ def run_component_modeler(
         lambda Z_numpy, s_param_def: 1.0 / (2.0 * np.sqrt(np.abs(Z_numpy) + 1e-4)),
     )
     monkeypatch.setattr(
-        td.plugins.smatrix.utils,
+        td.plugins.smatrix.analysis.terminal,
         "check_port_impedance_sign",
         lambda Z_numpy: np.ndarray([]),
     )
+    # monkeypatch.setattr(
+    #     TerminalComponentModelerData,
+    #     "compute_F",
+    #     lambda Z_numpy, s_param_def: 1.0 / (2.0 * np.sqrt(np.abs(Z_numpy) + 1e-4)),
+    # )
+    # monkeypatch.setattr(
+    #     TerminalComponentModelerData,
+    #     "check_port_impedance_sign",
+    #     lambda Z_numpy: np.ndarray([]),
+    # )
 
     return modeler_data
 

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -61,16 +61,6 @@ def run_component_modeler(
         "check_port_impedance_sign",
         lambda Z_numpy: np.ndarray([]),
     )
-    # monkeypatch.setattr(
-    #     TerminalComponentModelerData,
-    #     "compute_F",
-    #     lambda Z_numpy, s_param_def: 1.0 / (2.0 * np.sqrt(np.abs(Z_numpy) + 1e-4)),
-    # )
-    # monkeypatch.setattr(
-    #     TerminalComponentModelerData,
-    #     "check_port_impedance_sign",
-    #     lambda Z_numpy: np.ndarray([]),
-    # )
 
     return modeler_data
 

--- a/tidy3d/plugins/smatrix/analysis/terminal.py
+++ b/tidy3d/plugins/smatrix/analysis/terminal.py
@@ -1,3 +1,17 @@
+"""Terminal component modeler analysis functions.
+
+This module contains functions for constructing S-matrices and computing wave amplitudes
+for terminal-based component modeling in electromagnetic simulations.
+
+References
+----------
+.. [1]  R. B. Marks and D. F. Williams, "A general waveguide circuit theory,"
+        J. Res. Natl. Inst. Stand. Technol., vol. 97, pp. 533, 1992.
+
+.. [2]  D. M. Pozar, Microwave Engineering, 4th ed. Hoboken, NJ, USA:
+        John Wiley & Sons, 2012.
+"""
+
 from __future__ import annotations
 
 import numpy as np
@@ -240,7 +254,7 @@ def compute_power_wave_amplitudes_at_each_port(
     """Compute the incident and reflected power wave amplitudes at each port.
 
     This is a convenience function that calls
-    :meth:`.compute_wave_amplitudes_at_each_port` with ``s_param_def="power"``.
+    :func:`.compute_wave_amplitudes_at_each_port` with ``s_param_def="power"``.
     The computed amplitudes have not been normalized.
 
     Parameters

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Generic, Optional, TypeVar, Union, get_args
 
-import numpy as np
 import pydantic.v1 as pd
 
 from tidy3d.components.base import Tidy3dBaseModel, cached_property
-from tidy3d.components.data.data_array import DataArray
 from tidy3d.components.geometry.utils import _shift_value_signed
 from tidy3d.components.simulation import Simulation
 from tidy3d.components.types import Complex, FreqArray
@@ -194,11 +192,6 @@ class AbstractComponentModeler(ABC, Generic[IndexType, ElementType], Tidy3dBaseM
                 source_indices_needed.append(col_index)
 
         return source_indices_needed
-
-    @staticmethod
-    def inv(matrix: DataArray):
-        """Helper to invert a port matrix."""
-        return np.linalg.inv(matrix)
 
     def _shift_value_signed(self, port: Union[Port, WavePort]) -> float:
         """How far (signed) to shift the source from the monitor."""

--- a/tidy3d/plugins/smatrix/data/terminal.py
+++ b/tidy3d/plugins/smatrix/data/terminal.py
@@ -47,7 +47,7 @@ class MicrowaveSMatrixData(Tidy3dBaseModel):
     s_param_def: SParamDef = pd.Field(
         "pseudo",
         title="Scattering Parameter Definition",
-        description="Whether to scattering parameters are defined using the 'pseudo' or 'power' wave definitions.",
+        description="Whether scattering parameters are defined using the 'pseudo' or 'power' wave definitions.",
     )
 
 
@@ -57,6 +57,17 @@ class TerminalComponentModelerData(Tidy3dBaseModel):
 
     This class serves as a data container for the results of a component modeler simulation,
     with the original simulation definition, and port simulation data, and the solver log.
+
+    Notes
+    -----
+
+    **References**
+
+    .. [1]  R. B. Marks and D. F. Williams, "A general waveguide circuit theory,"
+            J. Res. Natl. Inst. Stand. Technol., vol. 97, pp. 533, 1992.
+
+    .. [2]  D. M. Pozar, Microwave Engineering, 4th ed. Hoboken, NJ, USA:
+            John Wiley & Sons, 2012.
 
     See Also
     --------
@@ -93,8 +104,21 @@ class TerminalComponentModelerData(Tidy3dBaseModel):
         assume_ideal_excitation: bool = False,
         s_param_def: SParamDef = "pseudo",
     ) -> MicrowaveSMatrixData:
-        """Stores the computed S-matrix and reference impedances
-        for the terminal ports"""
+        """Computes and returns the S-matrix and port reference impedances.
+
+        Parameters
+        ----------
+        assume_ideal_excitation: If ``True``, assumes that exciting one port
+            does not produce incident waves at other ports. This simplifies the
+            S-matrix calculation and is required if not all ports are excited.
+        s_param_def: The definition of S-parameters to use, determining whether
+            "pseudo waves" or "power waves" are calculated.
+
+        Returns
+        -------
+        :class:`.MicrowaveSMatrixData`
+            Container with the computed S-parameters and the port reference impedances.
+        """
         from tidy3d.plugins.smatrix.analysis.terminal import terminal_construct_smatrix
 
         terminal_port_data = terminal_construct_smatrix(

--- a/tidy3d/plugins/smatrix/utils.py
+++ b/tidy3d/plugins/smatrix/utils.py
@@ -26,9 +26,6 @@ from tidy3d.components.data.data_array import (
 from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.types import ArrayFloat1D
 from tidy3d.exceptions import Tidy3dError
-from tidy3d.plugins.smatrix.component_modelers.base import (
-    AbstractComponentModeler,
-)
 from tidy3d.plugins.smatrix.data.data_array import PortDataArray, TerminalPortDataArray
 from tidy3d.plugins.smatrix.network import SParamDef
 from tidy3d.plugins.smatrix.ports.types import LumpedPortType, TerminalPortType
@@ -60,7 +57,7 @@ def ab_to_s(
     a_vals = s_matrix.copy(deep=True).values
     b_vals = b_matrix.copy(deep=True).values
 
-    s_vals = np.matmul(b_vals, AbstractComponentModeler.inv(a_vals))
+    s_vals = np.matmul(b_vals, port_array_inv(a_vals))
 
     s_matrix.data = s_vals
     return s_matrix


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This pull request improves the Terminal Component Modeler (TCM) system within the S-matrix plugin by fixing broken tests, enhancing documentation, and cleaning up code organization. The changes address test failures that occurred due to function relocations and improve the overall quality of the codebase.

The main technical changes include:

1. **Import consolidation**: The `SParamDef` type definition was moved from local definitions to a centralized `network` module, eliminating code duplication across multiple files.

2. **Function relocation handling**: The `check_port_impedance_sign` function was moved from `td.plugins.smatrix.utils` to `td.plugins.smatrix.analysis.terminal`, requiring updates to test monkeypatch targets.

3. **Code decoupling**: The matrix inversion functionality was refactored from a static method on `AbstractComponentModeler` to a standalone `port_array_inv()` utility function, reducing coupling between utility functions and class hierarchies.

4. **Dead code removal**: Unused imports and the now-redundant `inv` static method were removed from the base component modeler class.

5. **Documentation enhancements**: Comprehensive academic references were added to module and class docstrings, and minor documentation fixes were applied throughout.

These changes fit into the broader S-matrix plugin system, which handles scattering parameter analysis for electromagnetic simulations. The refactoring improves maintainability by reducing code duplication, fixing dependency issues, and providing better technical documentation with proper academic context for the implemented algorithms.

## Important Files Changed

<details>
<summary>File changes summary</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/plugins/smatrix/analysis/terminal.py` | 5/5 | Added comprehensive module documentation with academic references and fixed minor docstring issue |
| `tests/test_plugins/smatrix/test_terminal_component_modeler.py` | 4/5 | Fixed broken tests by updating monkeypatch locations and removing debug code |
| `tidy3d/plugins/smatrix/data/terminal.py` | 5/5 | Refactored imports to use centralized type definitions and improved documentation |
| `tidy3d/plugins/smatrix/utils.py` | 4/5 | Added helper function and cleaned up imports to decouple utility functions |
| `tidy3d/plugins/smatrix/component_modelers/base.py` | 5/5 | Removed unused code including dead imports and redundant static method |

</details>

## Confidence score: 4/5

- This PR is generally safe to merge with low risk of breaking existing functionality
- Score reflects solid refactoring changes with proper test fixes, though the monkeypatch updates indicate some structural changes that needed accommodation
- Pay close attention to the test file changes to ensure all monkeypatch targets are correctly updated

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant TerminalComponentModeler
    participant TerminalComponentModelerData
    participant AnalysisModule as terminal_construct_smatrix
    participant Utils as utils

    User->>TerminalComponentModeler: "Create modeler with ports and simulation"
    TerminalComponentModeler->>TerminalComponentModeler: "Generate sim_dict for each port excitation"
    
    User->>TerminalComponentModeler: "Run simulations"
    TerminalComponentModeler->>TerminalComponentModelerData: "Create data object with simulation results"
    
    User->>TerminalComponentModelerData: "smatrix(assume_ideal_excitation, s_param_def)"
    TerminalComponentModelerData->>AnalysisModule: "terminal_construct_smatrix(modeler_data, assume_ideal_excitation, s_param_def)"
    
    AnalysisModule->>AnalysisModule: "port_reference_impedances(modeler_data)"
    
    loop For each source simulation
        AnalysisModule->>AnalysisModule: "compute_wave_amplitudes_at_each_port(modeler, port_impedances, sim_data, s_param_def)"
        AnalysisModule->>Utils: "compute_port_VI(port, sim_data)"
        Utils-->>AnalysisModule: "Return voltage and current"
        AnalysisModule->>Utils: "compute_F(Z_numpy, s_param_def)"
        Utils-->>AnalysisModule: "Return F matrix"
        AnalysisModule->>Utils: "check_port_impedance_sign(Z_numpy)"
        AnalysisModule->>AnalysisModule: "Calculate a and b matrices"
    end
    
    alt If ideal excitation or partial excitation
        AnalysisModule->>AnalysisModule: "s_matrix = b_matrix / a_diag"
    else Full excitation matrix
        AnalysisModule->>Utils: "ab_to_s(a_matrix, b_matrix)"
        Utils-->>AnalysisModule: "Return S matrix"
    end
    
    AnalysisModule->>AnalysisModule: "Apply element_mappings if present"
    AnalysisModule-->>TerminalComponentModelerData: "Return TerminalPortDataArray"
    TerminalComponentModelerData-->>User: "Return MicrowaveSMatrixData with S-matrix and reference impedances"
```

<!-- /greptile_comment -->