### PR TITLE
docstring improvements, broken test fix, and small refactor

### DIFF
--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -1016,10 +1016,10 @@ def test_antenna_helpers(monkeypatch, tmp_path):
     # Test monitor data normalization with different amplitude types
     a_array = FreqDataArray(np.ones(len(modeler.freqs)), {"f": modeler.freqs})
     normalized_data_array = modeler_data._monitor_data_at_port_amplitude(
-        modeler.ports[0], sim_data, rad_mon_data, a_array
+        modeler.ports[0], radiation_monitor.name, a_array
     )
     normalized_data_const = modeler_data._monitor_data_at_port_amplitude(
-        modeler.ports[0], sim_data, rad_mon_data, 1.0
+        modeler.ports[0], radiation_monitor.name, 1.0
     )
     assert isinstance(normalized_data_array, td.DirectivityData)
     assert isinstance(normalized_data_const, td.DirectivityData)
@@ -1277,7 +1277,7 @@ def test_internal_construct_smatrix_with_port_vi(monkeypatch):
     monkeypatch.setattr(
         tidy3d.plugins.smatrix.analysis.terminal,
         "compute_port_VI",
-        staticmethod(mock_compute_port_vi),
+        mock_compute_port_vi,
     )
     monkeypatch.setattr(
         tidy3d.plugins.smatrix.analysis.terminal, "port_reference_impedances", mock_port_impedances

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -1500,6 +1500,46 @@ class ImpedanceFreqModeDataArray(ImpedanceArray, FreqModeDataArray):
     __slots__ = ()
 
 
+def _make_base_result_data_array(result: DataArray) -> IntegralResultTypes:
+    """Helper for creating the proper base result type."""
+    cls = FreqDataArray
+    if "t" in result.coords:
+        cls = TimeDataArray
+    if "f" in result.coords and "mode_index" in result.coords:
+        cls = FreqModeDataArray
+    return cls.assign_data_attrs(cls(data=result.data, coords=result.coords))
+
+
+def _make_voltage_data_array(result: DataArray) -> VoltageIntegralResultTypes:
+    """Helper for creating the proper voltage array type."""
+    cls = VoltageFreqDataArray
+    if "t" in result.coords:
+        cls = VoltageTimeDataArray
+    if "f" in result.coords and "mode_index" in result.coords:
+        cls = VoltageFreqModeDataArray
+    return cls.assign_data_attrs(cls(data=result.data, coords=result.coords))
+
+
+def _make_current_data_array(result: DataArray) -> CurrentIntegralResultTypes:
+    """Helper for creating the proper current array type."""
+    cls = CurrentFreqDataArray
+    if "t" in result.coords:
+        cls = CurrentTimeDataArray
+    if "f" in result.coords and "mode_index" in result.coords:
+        cls = CurrentFreqModeDataArray
+    return cls.assign_data_attrs(cls(data=result.data, coords=result.coords))
+
+
+def _make_impedance_data_array(result: DataArray) -> ImpedanceResultTypes:
+    """Helper for creating the proper impedance array type."""
+    cls = ImpedanceFreqDataArray
+    if "t" in result.coords:
+        cls = ImpedanceTimeDataArray
+    if "f" in result.coords and "mode_index" in result.coords:
+        cls = ImpedanceFreqModeDataArray
+    return cls.assign_data_attrs(cls(data=result.data, coords=result.coords))
+
+
 DATA_ARRAY_TYPES = [
     SpatialDataArray,
     ScalarFieldDataArray,

--- a/tidy3d/plugins/microwave/custom_path_integrals.py
+++ b/tidy3d/plugins/microwave/custom_path_integrals.py
@@ -23,6 +23,9 @@ from .path_integrals import (
     IntegralResultTypes,
     MonitorDataTypes,
     VoltageIntegralResultTypes,
+    _make_base_result_data_array,
+    _make_current_data_array,
+    _make_voltage_data_array,
 )
 from .viz import (
     ARROW_CURRENT,
@@ -88,10 +91,6 @@ class CustomPathIntegral2D(AbstractAxesRH):
         :class:`.IntegralResultTypes`
             Result of integral over remaining dimensions (frequency, time, mode indices).
         """
-
-        from tidy3d.plugins.smatrix.utils import (
-            _make_base_result_data_array,
-        )
 
         (dim1, dim2, dim3) = self.local_dims
 
@@ -260,9 +259,6 @@ class CustomVoltageIntegral2D(CustomPathIntegral2D):
         :class:`.VoltageIntegralResultTypes`
             Result of voltage computation over remaining dimensions (frequency, time, mode indices).
         """
-        from tidy3d.plugins.smatrix.utils import (
-            _make_voltage_data_array,
-        )
 
         AxisAlignedPathIntegral._check_monitor_data_supported(em_field=em_field)
         voltage = -1.0 * self.compute_integral(field="E", em_field=em_field)
@@ -336,9 +332,6 @@ class CustomCurrentIntegral2D(CustomPathIntegral2D):
         :class:`.CurrentIntegralResultTypes`
             Result of current computation over remaining dimensions (frequency, time, mode indices).
         """
-        from tidy3d.plugins.smatrix.utils import (
-            _make_current_data_array,
-        )
 
         AxisAlignedPathIntegral._check_monitor_data_supported(em_field=em_field)
         current = self.compute_integral(field="H", em_field=em_field)

--- a/tidy3d/plugins/microwave/impedance_calculator.py
+++ b/tidy3d/plugins/microwave/impedance_calculator.py
@@ -8,7 +8,7 @@ import numpy as np
 import pydantic.v1 as pd
 
 from tidy3d.components.base import Tidy3dBaseModel
-from tidy3d.components.data.data_array import ImpedanceResultTypes
+from tidy3d.components.data.data_array import ImpedanceResultTypes, _make_impedance_data_array
 from tidy3d.components.data.monitor_data import FieldTimeData
 from tidy3d.components.monitor import ModeMonitor, ModeSolverMonitor
 from tidy3d.exceptions import ValidationError
@@ -57,7 +57,6 @@ class ImpedanceCalculator(Tidy3dBaseModel):
         :class:`.ImpedanceResultTypes`
             Result of impedance computation over remaining dimensions (frequency, time, mode indices).
         """
-        from tidy3d.plugins.smatrix.utils import _make_impedance_data_array
 
         AxisAlignedPathIntegral._check_monitor_data_supported(em_field=em_field)
 

--- a/tidy3d/plugins/microwave/path_integrals.py
+++ b/tidy3d/plugins/microwave/path_integrals.py
@@ -16,6 +16,9 @@ from tidy3d.components.data.data_array import (
     ScalarFieldTimeDataArray,
     ScalarModeFieldDataArray,
     VoltageIntegralResultTypes,
+    _make_base_result_data_array,
+    _make_current_data_array,
+    _make_voltage_data_array,
 )
 from tidy3d.components.data.monitor_data import FieldData, FieldTimeData, ModeData, ModeSolverData
 from tidy3d.components.geometry.base import Box, Geometry
@@ -101,9 +104,6 @@ class AxisAlignedPathIntegral(AbstractAxesRH, Box):
 
     def compute_integral(self, scalar_field: EMScalarFieldType) -> IntegralResultTypes:
         """Computes the defined integral given the input ``scalar_field``."""
-        from tidy3d.plugins.smatrix.utils import (
-            _make_base_result_data_array,
-        )
 
         if not scalar_field.does_cover(self.bounds, fp_eps, np.finfo(np.float32).smallest_normal):
             raise DataError("Scalar field does not cover the integration domain.")
@@ -218,9 +218,6 @@ class VoltageIntegralAxisAligned(AxisAlignedPathIntegral):
 
     def compute_voltage(self, em_field: MonitorDataTypes) -> VoltageIntegralResultTypes:
         """Compute voltage along path defined by a line."""
-        from tidy3d.plugins.smatrix.utils import (
-            _make_voltage_data_array,
-        )
 
         self._check_monitor_data_supported(em_field=em_field)
         e_component = "xyz"[self.main_axis]
@@ -371,9 +368,6 @@ class CurrentIntegralAxisAligned(AbstractAxesRH, Box):
 
     def compute_current(self, em_field: MonitorDataTypes) -> CurrentIntegralResultTypes:
         """Compute current flowing in loop defined by the outer edge of a rectangle."""
-        from tidy3d.plugins.smatrix.utils import (
-            _make_current_data_array,
-        )
 
         AxisAlignedPathIntegral._check_monitor_data_supported(em_field=em_field)
         ax1 = self.remaining_axes[0]

--- a/tidy3d/plugins/smatrix/analysis/antenna.py
+++ b/tidy3d/plugins/smatrix/analysis/antenna.py
@@ -11,28 +11,6 @@ from tidy3d.plugins.smatrix.analysis.terminal import (
 from tidy3d.plugins.smatrix.data.data_array import PortDataArray
 from tidy3d.plugins.smatrix.data.terminal import TerminalComponentModelerData
 
-# def _monitor_data_at_port_amplitude(
-#         modeler_data: TerminalComponentModelerData,
-#         port: TerminalPortType,
-#         sim_data: SimulationData,
-#         monitor_data: MonitorData,
-#         a_port: Union[FreqDataArray, complex],
-# ) -> MonitorData:
-#     """Normalize the monitor data to a desired complex amplitude of a port,
-#     represented by ``a_port``, where :math:`\\frac{1}{2}|a|^2` is the power
-#     incident from the port into the system.
-#     """
-#     a_raw, _ = compute_power_wave_amplitudes_at_each_port(
-#         modeler_data=modeler_data, port_reference_impedances=modeler_data.port_reference_impedances, sim_data=sim_data
-#     )
-#     a_raw_port = a_raw.sel(port=modeler_data.modeler.network_index(port))
-#     if not isinstance(a_port, FreqDataArray):
-#         freqs = list(monitor_data.monitor.freqs)
-#         array_vals = a_port * np.ones(len(freqs))
-#         a_port = FreqDataArray(array_vals, coords={"f": freqs})
-#     scale_array = a_port / a_raw_port
-#     return monitor_data.scale_fields_by_freq_array(scale_array, method="nearest")
-
 
 def get_antenna_metrics_data(
     terminal_component_modeler_data: TerminalComponentModelerData,
@@ -99,7 +77,7 @@ def get_antenna_metrics_data(
         sim_data_port = terminal_component_modeler_data.data[
             terminal_component_modeler_data.modeler.get_task_name(port)
         ]
-        radiation_data = sim_data_port[rad_mon.name]
+
         a, b = compute_wave_amplitudes_at_each_port(
             modeler=terminal_component_modeler_data.modeler,
             port_reference_impedances=terminal_component_modeler_data.port_reference_impedances,
@@ -118,7 +96,7 @@ def get_antenna_metrics_data(
         else:
             scaled_directivity_data = (
                 terminal_component_modeler_data._monitor_data_at_port_amplitude(
-                    port, sim_data_port, radiation_data, amplitude
+                    port, rad_mon.name, amplitude
                 )
             )
             scale_factor = amplitude / a_raw

--- a/tidy3d/plugins/smatrix/analysis/terminal.py
+++ b/tidy3d/plugins/smatrix/analysis/terminal.py
@@ -48,19 +48,25 @@ def terminal_construct_smatrix(
     S-matrix is computed more efficiently by scaling the 'b' matrix. This
     is also necessary when only a subset of ports are excited.
 
-    Args:
-        modeler_data: Data object containing the modeler definition and the raw
-            results from each port simulation run.
-        assume_ideal_excitation: If ``True``, assumes that exciting one port
-            does not produce incident waves at other ports. This simplifies the
-            S-matrix calculation and is required if not all ports are excited.
-        s_param_def: The definition of S-parameters to use, determining whether
-            "pseudo waves" or "power waves" are calculated.
+    Parameters
+    ----------
+    modeler_data : TerminalComponentModelerData
+        Data object containing the modeler definition and the raw
+        results from each port simulation run.
+    assume_ideal_excitation : bool, optional
+        If ``True``, assumes that exciting one port
+        does not produce incident waves at other ports. This simplifies the
+        S-matrix calculation and is required if not all ports are excited.
+        By default False.
+    s_param_def : SParamDef, optional
+        The definition of S-parameters to use, determining whether
+        "pseudo waves" or "power waves" are calculated. By default "pseudo".
 
-    Returns:
-        TerminalPortDataArray
-            The computed S-matrix as a ``TerminalPortDataArray`` with dimensions
-            for frequency, output port, and input port.
+    Returns
+    -------
+    TerminalPortDataArray
+        The computed S-matrix as a ``TerminalPortDataArray`` with dimensions
+        for frequency, output port, and input port.
     """
     monitor_indices = list(modeler_data.modeler.matrix_indices_monitor)
     source_indices = list(modeler_data.modeler.matrix_indices_source)
@@ -128,14 +134,17 @@ def port_reference_impedances(modeler_data: TerminalComponentModelerData) -> Por
     modal properties, while for other types like :class:`.LumpedPort`, the
     impedance is a user-defined constant value.
 
-    Args:
-        modeler_data: Data object containing the modeler definition and the raw
-            simulation data needed for :class:`.WavePort` impedance calculations.
+    Parameters
+    ----------
+    modeler_data : TerminalComponentModelerData
+        Data object containing the modeler definition and the raw
+        simulation data needed for :class:`.WavePort` impedance calculations.
 
-    Returns:
-        PortDataArray
-            A ``PortDataArray`` containing the complex impedance for each port at each
-            frequency.
+    Returns
+    -------
+    PortDataArray
+        A ``PortDataArray`` containing the complex impedance for each port at each
+        frequency.
     """
     values = np.zeros(
         (len(modeler_data.modeler.freqs), len(modeler_data.modeler.matrix_indices_monitor)),

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -1,4 +1,4 @@
-"""Tool for generating an S matrix automatically from a Tidy3d simulation and lumped port definitions."""
+"""Tool for generating an S matrix automatically from a Tidy3d simulation and terminal port definitions."""
 
 from __future__ import annotations
 

--- a/tidy3d/plugins/smatrix/data/modal.py
+++ b/tidy3d/plugins/smatrix/data/modal.py
@@ -1,4 +1,4 @@
-"""Tool for generating an S matrix automatically from a Tidy3d simulation and lumped port definitions."""
+"""Data structures for post-processing modal component simulations to calculate S-matrices."""
 
 from __future__ import annotations
 

--- a/tidy3d/plugins/smatrix/data/terminal.py
+++ b/tidy3d/plugins/smatrix/data/terminal.py
@@ -1,4 +1,4 @@
-"""Tool for generating an S matrix automatically from a Tidy3d simulation and lumped port definitions."""
+"""Data structures for post-processing terminal component simulations to calculate S-matrices."""
 
 from __future__ import annotations
 
@@ -144,16 +144,17 @@ class TerminalComponentModelerData(Tidy3dBaseModel):
     def _monitor_data_at_port_amplitude(
         self,
         port: TerminalPortType,
-        sim_data: SimulationData,
-        monitor_data: MonitorData,
+        monitor_name: str,
         a_port: Union[FreqDataArray, complex],
     ) -> MonitorData:
         """Normalize the monitor data to a desired complex amplitude of a port,
         represented by ``a_port``, where :math:`\\frac{1}{2}|a|^2` is the power
         incident from the port into the system.
         """
+        sim_data_port = self.data[self.modeler.get_task_name(port)]
+        monitor_data = sim_data_port[monitor_name]
         a_raw, _ = self.compute_power_wave_amplitudes_at_each_port(
-            self.port_reference_impedances, sim_data=sim_data
+            self.port_reference_impedances, sim_data=sim_data_port
         )
         a_raw_port = a_raw.sel(port=self.modeler.network_index(port))
         if not isinstance(a_port, FreqDataArray):

--- a/tidy3d/plugins/smatrix/network.py
+++ b/tidy3d/plugins/smatrix/network.py
@@ -1,5 +1,3 @@
-"""Tool for generating an S matrix automatically from a Tidy3d simulation and lumped port definitions."""
-
 from __future__ import annotations
 
 from typing import Literal

--- a/tidy3d/plugins/smatrix/ports/types.py
+++ b/tidy3d/plugins/smatrix/ports/types.py
@@ -2,6 +2,12 @@ from __future__ import annotations
 
 from typing import Union
 
+from tidy3d.components.data.data_array import (
+    CurrentFreqDataArray,
+    CurrentFreqModeDataArray,
+    VoltageFreqDataArray,
+    VoltageFreqModeDataArray,
+)
 from tidy3d.plugins.smatrix.ports.coaxial_lumped import CoaxialLumpedPort
 from tidy3d.plugins.smatrix.ports.rectangular_lumped import LumpedPort
 from tidy3d.plugins.smatrix.ports.wave import WavePort
@@ -9,3 +15,5 @@ from tidy3d.plugins.smatrix.ports.wave import WavePort
 LumpedPortType = Union[LumpedPort, CoaxialLumpedPort]
 TerminalPortType = Union[LumpedPortType, WavePort]
 PortReferenceType = Union[str, TerminalPortType]  # TODO Debate this
+PortVoltageType = Union[VoltageFreqDataArray, VoltageFreqModeDataArray]
+PortCurrentType = Union[CurrentFreqDataArray, CurrentFreqModeDataArray]

--- a/tidy3d/plugins/smatrix/ports/wave.py
+++ b/tidy3d/plugins/smatrix/ports/wave.py
@@ -1,4 +1,4 @@
-"""Class and custom data array for representing a scattering matrix wave port."""
+"""Class for representing a scattering matrix wave port."""
 
 from __future__ import annotations
 

--- a/tidy3d/plugins/smatrix/utils.py
+++ b/tidy3d/plugins/smatrix/utils.py
@@ -1,3 +1,10 @@
+"""Utility functions for S-matrix calculations and conversions.
+
+This module provides helper functions for scattering matrix computations,
+impedance conversions, and wave amplitude calculations in electromagnetic
+simulations.
+"""
+
 from __future__ import annotations
 
 from typing import Union
@@ -5,34 +12,35 @@ from typing import Union
 import numpy as np
 
 from tidy3d.components.data.data_array import (
-    CurrentFreqDataArray,
-    CurrentFreqModeDataArray,
-    CurrentIntegralResultTypes,
-    CurrentTimeDataArray,
     DataArray,
     FreqDataArray,
-    FreqModeDataArray,
-    ImpedanceFreqDataArray,
-    ImpedanceFreqModeDataArray,
-    ImpedanceResultTypes,
-    ImpedanceTimeDataArray,
-    IntegralResultTypes,
-    TimeDataArray,
-    VoltageFreqDataArray,
-    VoltageFreqModeDataArray,
-    VoltageIntegralResultTypes,
-    VoltageTimeDataArray,
 )
 from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.types import ArrayFloat1D
 from tidy3d.exceptions import Tidy3dError
 from tidy3d.plugins.smatrix.data.data_array import PortDataArray, TerminalPortDataArray
 from tidy3d.plugins.smatrix.network import SParamDef
-from tidy3d.plugins.smatrix.ports.types import LumpedPortType, TerminalPortType
+from tidy3d.plugins.smatrix.ports.types import (
+    LumpedPortType,
+    PortCurrentType,
+    PortVoltageType,
+    TerminalPortType,
+)
 
 
 def port_array_inv(matrix: DataArray):
-    """Helper to invert a port matrix."""
+    """Helper to invert a port matrix.
+
+    Parameters
+    ----------
+    matrix : DataArray
+        The matrix to invert.
+
+    Returns
+    -------
+    np.ndarray
+        The inverted matrix.
+    """
     return np.linalg.inv(matrix)
 
 
@@ -41,11 +49,16 @@ def ab_to_s(
 ) -> TerminalPortDataArray:
     """Get the scattering matrix given the wave amplitude matrices.
 
-    Args:
-        a_matrix: Matrix of incident power wave amplitudes.
-        b_matrix: Matrix of reflected power wave amplitudes.
+    Parameters
+    ----------
+    a_matrix : TerminalPortDataArray
+        Matrix of incident power wave amplitudes.
+    b_matrix : TerminalPortDataArray
+        Matrix of reflected power wave amplitudes.
 
-    Returns:
+    Returns
+    -------
+    TerminalPortDataArray
         The computed scattering (S) matrix.
     """
     validate_square_matrix(a_matrix, "ab_to_s")
@@ -70,12 +83,16 @@ def check_port_impedance_sign(Z_numpy: np.ndarray):
     part of its impedance does not change across all frequencies. A sign change
     can indicate an unphysical result or numerical instability.
 
-    Args:
-        Z_numpy: NumPy array of impedance values with shape (num_freqs, num_ports).
+    Parameters
+    ----------
+    Z_numpy : np.ndarray
+        NumPy array of impedance values with shape (num_freqs, num_ports).
 
-    Raises:
-        Tidy3dError: If an inconsistent sign of the real part of the impedance
-            is detected for any port.
+    Raises
+    ------
+    Tidy3dError
+        If an inconsistent sign of the real part of the impedance
+        is detected for any port.
     """
     for port_idx in range(Z_numpy.shape[1]):
         port_Z = Z_numpy[:, port_idx]
@@ -96,10 +113,16 @@ def compute_F(Z_numpy: ArrayFloat1D, s_param_def: SParamDef = "pseudo"):
     with differing port impedances. Its diagonal elements are defined as
     :math:`F_{kk} = 1 / (2 * \sqrt{Re(Z_k)})`.
 
-    Args:
-        Z_numpy: NumPy array of complex port impedances.
+    Parameters
+    ----------
+    Z_numpy : ArrayFloat1D
+        NumPy array of complex port impedances.
+    s_param_def : SParamDef, optional
+        The type of wave amplitudes, by default "pseudo".
 
-    Returns:
+    Returns
+    -------
+    ArrayFloat1D
         NumPy array containing the computed F values.
     """
     # Defined in [2] after equation 4.67
@@ -111,7 +134,7 @@ def compute_F(Z_numpy: ArrayFloat1D, s_param_def: SParamDef = "pseudo"):
 
 def compute_port_VI(
     port_out: TerminalPortType, sim_data: SimulationData
-) -> tuple[FreqDataArray, FreqDataArray]:
+) -> tuple[PortVoltageType, PortCurrentType]:
     """Compute the port voltages and currents.
 
     Parameters
@@ -123,7 +146,7 @@ def compute_port_VI(
 
     Returns
     -------
-    tuple[FreqDataArray, FreqDataArray]
+    tuple[PortVoltageType, PortCurrentType]
         Voltage and current values at the port as frequency arrays.
     """
     voltage = port_out.compute_voltage(sim_data)
@@ -190,8 +213,7 @@ def s_to_z(
     reference: Union[complex, PortDataArray],
     s_param_def: SParamDef = "pseudo",
 ) -> DataArray:
-    """
-    Get the impedance matrix given the scattering matrix and a reference impedance.
+    """Get the impedance matrix given the scattering matrix and a reference impedance.
 
     This function converts an S-matrix to a Z-matrix. It handles both a single
     uniform reference impedance and generalized per-port reference impedances.
@@ -202,9 +224,15 @@ def s_to_z(
         Scattering matrix computed using either the pseudo or power wave formulation.
     reference : Union[complex, :class:`.PortDataArray`]
         The reference impedance used at each port.
-    s_param_def : SParamDef
+    s_param_def : SParamDef, optional
         The type of wave amplitudes used for computing the scattering matrix, either pseudo waves
         defined by Equation 53 and Equation 54 in [1] or power waves defined by Equation 4.67 in [2].
+        By default "pseudo".
+
+    Returns
+    -------
+    DataArray
+        The computed impedance (Z) matrix.
     """
     validate_square_matrix(s_matrix, "s_to_z")
     # Ensure dimensions are ordered properly
@@ -252,7 +280,7 @@ def validate_square_matrix(matrix: TerminalPortDataArray, method_name: str) -> N
 
     Raises
     ------
-    DataError
+    Tidy3dError
         If the matrix is not square (unequal input/output dimensions).
     """
     n_out = len(matrix.port_out)
@@ -264,43 +292,3 @@ def validate_square_matrix(matrix: TerminalPortDataArray, method_name: str) -> N
             "was run with only a subset of port excitations. Please ensure that the `run_only` field in "
             "the 'TerminalComponentModeler' is not being used."
         )
-
-
-def _make_base_result_data_array(result: DataArray) -> IntegralResultTypes:
-    """Helper for creating the proper base result type."""
-    cls = FreqDataArray
-    if "t" in result.coords:
-        cls = TimeDataArray
-    if "f" in result.coords and "mode_index" in result.coords:
-        cls = FreqModeDataArray
-    return cls.assign_data_attrs(cls(data=result.data, coords=result.coords))
-
-
-def _make_voltage_data_array(result: DataArray) -> CurrentIntegralResultTypes:
-    """Helper for creating the proper voltage array type."""
-    cls = CurrentFreqDataArray
-    if "t" in result.coords:
-        cls = CurrentTimeDataArray
-    if "f" in result.coords and "mode_index" in result.coords:
-        cls = CurrentFreqModeDataArray
-    return cls.assign_data_attrs(cls(data=result.data, coords=result.coords))
-
-
-def _make_current_data_array(result: DataArray) -> VoltageIntegralResultTypes:
-    """Helper for creating the proper current array type."""
-    cls = VoltageFreqDataArray
-    if "t" in result.coords:
-        cls = VoltageTimeDataArray
-    if "f" in result.coords and "mode_index" in result.coords:
-        cls = VoltageFreqModeDataArray
-    return cls.assign_data_attrs(cls(data=result.data, coords=result.coords))
-
-
-def _make_impedance_data_array(result: DataArray) -> ImpedanceResultTypes:
-    """Helper for creating the proper impedance array type."""
-    cls = ImpedanceFreqDataArray
-    if "t" in result.coords:
-        cls = ImpedanceTimeDataArray
-    if "f" in result.coords and "mode_index" in result.coords:
-        cls = ImpedanceFreqModeDataArray
-    return cls.assign_data_attrs(cls(data=result.data, coords=result.coords))


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR implements a focused refactoring of the S-matrix plugin with three main objectives: improving docstring accuracy, fixing broken tests, and consolidating utility functions. The changes restructure the S-matrix module architecture by moving the `ModalComponentModeler` class to a dedicated `component_modelers/modal.py` file while keeping only the data container (`ModalComponentModelerData`) in the original location. Several utility functions for creating DataArray objects (`_make_base_result_data_array`, `_make_voltage_data_array`, `_make_current_data_array`, `_make_impedance_data_array`) have been relocated from the S-matrix utils module to the core `tidy3d.components.data.data_array` module, making them available to the broader codebase.

The refactoring improves API design by simplifying method signatures - notably the `_monitor_data_at_port_amplitude` method now accepts only a monitor name string instead of requiring callers to pass pre-computed simulation and monitor data objects. This change reduces coupling and improves encapsulation by moving data retrieval logic inside the method itself. New type aliases (`PortVoltageType`, `PortCurrentType`) have been added to improve type safety for voltage and current data arrays in S-matrix calculations. Import statements have been cleaned up throughout the affected modules, removing unused imports and consolidating helper function imports at the module level rather than within individual methods.

## Important Files Changed

<details>
<summary>Click to expand file changes</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/plugins/smatrix/data/modal.py` | 4/5 | Major restructuring removing ~300 lines of ModalComponentModeler class, leaving only data container |
| `tidy3d/plugins/smatrix/component_modelers/terminal.py` | 5/5 | Minor docstring update from 'lumped port definitions' to 'terminal port definitions' |
| `tidy3d/plugins/smatrix/network.py` | 4/5 | Complete removal of module docstring, now contains only type definitions |
| `tidy3d/plugins/smatrix/ports/wave.py` | 5/5 | Docstring cleanup removing mention of 'custom data array' |
| `tests/test_plugins/smatrix/test_terminal_component_modeler.py` | 4/5 | Critical test fixes updating method signatures and removing staticmethod wrapper |
| `tidy3d/plugins/microwave/custom_path_integrals.py` | 5/5 | Import refactoring moving utility functions from local to module-level imports |
| `tidy3d/plugins/smatrix/utils.py` | 4/5 | Major cleanup removing unused imports, functions, and switching to NumPy docstring style |
| `tidy3d/plugins/smatrix/analysis/antenna.py` | 4/5 | Method signature update and removal of 25 lines of commented-out code |
| `tidy3d/components/data/data_array.py` | 4/5 | Addition of four helper functions for creating DataArray subtypes based on coordinates |
| `tidy3d/plugins/smatrix/data/terminal.py` | 4/5 | API improvement changing method signature to accept monitor name instead of data objects |
| `tidy3d/plugins/smatrix/ports/types.py` | 5/5 | Addition of new type aliases for voltage and current data arrays |
| `tidy3d/plugins/microwave/impedance_calculator.py` | 5/5 | Import refactoring moving helper function to more logical module location |
| `tidy3d/plugins/microwave/path_integrals.py` | 4/5 | Import consolidation moving helper functions to module level |

</details>

## Confidence score: 4/5

- This PR is safe to merge with moderate confidence as it primarily involves refactoring and documentation improvements
- Score reflects good architectural improvements but complexity of changes across multiple interconnected modules
- Pay close attention to test files and the data array helper function implementations

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant TerminalComponentModeler
    participant Simulation
    participant PortDataArray
    participant SMatrix
    participant AntennaMetrics

    User->>TerminalComponentModeler: create modeler with ports
    TerminalComponentModeler->>Simulation: generate sim_dict for each port
    User->>TerminalComponentModeler: run_component_modeler()
    
    loop For each port excitation
        TerminalComponentModeler->>Simulation: run simulation with source
        Simulation-->>TerminalComponentModeler: return simulation data
    end
    
    TerminalComponentModeler->>PortDataArray: compute port voltages and currents
    TerminalComponentModeler->>PortDataArray: compute power wave amplitudes
    TerminalComponentModeler->>SMatrix: construct S-matrix from wave amplitudes
    
    User->>TerminalComponentModeler: smatrix()
    TerminalComponentModeler-->>User: return MicrowaveSMatrixData
    
    User->>TerminalComponentModeler: get_antenna_metrics_data()
    TerminalComponentModeler->>AntennaMetrics: compute radiation efficiency
    TerminalComponentModeler->>AntennaMetrics: compute gain and directivity
    TerminalComponentModeler-->>User: return AntennaMetricsData
```

<!-- /greptile_comment -->