### PR TITLE
adjoint: add exception for NaN data in adjoint pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `SimulationMap` and `SimulationDataMap` immutable dictionary-like containers for managing collections of simulations and results.
 - Added `TerminalComponentModelerData`, `ComponentModelerData`, `MicrowaveSMatrixData`, and introduced multiple DataArrays for modeler workflow data structures.
 - Added autograd support for dispersive material models: `Sellmeier`, `Drude`, `Lorentz`, `Debye` and their custom medium variants.
+- Added check and exception for NaN data in the adjoint pipeline to raise issue to user before adjoint source creation failure.
 
 ### Changed
 - Validate mode solver object for large number of grid points on the modal plane.

--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -2813,3 +2813,24 @@ def test_custom_medium_conductivity_only_gradient(rng, use_emulated_run, tmp_pat
     val, grad = ag.value_and_grad(objective)(params0)
 
     assert anp.all(grad != 0.0), "some gradients are 0 for conductivity-only test"
+
+
+@pytest.mark.parametrize("structure_key, monitor_key", args)
+def test_vjp_nan(use_emulated_run, structure_key, monitor_key):
+    """Test vjp data that has nan in it is flagged as an error."""
+
+    fn_dict = get_functions(structure_key, monitor_key)
+    make_sim = fn_dict["sim"]
+    postprocess = fn_dict["postprocess"]
+
+    def objective(*args):
+        """Objective function."""
+        sim = make_sim(*args)
+        if PLOT_SIM:
+            plot_sim(sim, plot_eps=True)
+        data = run(sim, task_name="autograd_test", verbose=False)
+        value = (postprocess(data) + float("nan")) ** 2
+        return value
+
+    with pytest.raises(AdjointError, match="aN values detected for data field"):
+        grad = ag.grad(objective)(params0)

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -912,6 +912,14 @@ def setup_adj(
         k: get_static(v) for k, v in data_fields_vjp.items() if not np.allclose(v, 0)
     }
 
+    for k, v in data_fields_vjp.items():
+        if np.any(np.isnan(v)):
+            raise AdjointError(
+                f"NaN values detected for data field {k} in the adjoint pipeline. This may be "
+                f"due to NaN values in the simulation data or the computed value of your "
+                f"objective function."
+            )
+
     # if all entries are zero, there is no adjoint sim to run
     if not data_fields_vjp:
         return []


### PR DESCRIPTION
Adds NaN check for vjp data before adjoint simulations get created

<!-- greptile_comment -->

## Greptile Summary

This PR adds robust NaN detection and error handling to the adjoint optimization pipeline in Tidy3D's autograd system. The core change introduces a validation check in the `setup_adj` function within `tidy3d/web/api/autograd/autograd.py` that scans Vector-Jacobian Product (VJP) data for NaN values before adjoint simulations are created.

The implementation strategically places the NaN check after filtering out zero gradient values but before creating adjoint simulations. When NaN values are detected, the system raises an `AdjointError` with a clear, informative message that helps users identify whether the issue stems from simulation data corruption or problems in their objective function computations.

This change integrates seamlessly with Tidy3D's existing adjoint optimization workflow, which is used extensively for inverse design applications. The adjoint method computes gradients by running backward simulations, and NaN values in the VJP data can cause these backward simulations to fail or produce invalid gradients silently. By catching these issues early, the system prevents downstream failures and provides actionable feedback to users.

The PR includes comprehensive test coverage through a new parameterized test `test_vjp_nan` that deliberately introduces NaN values into objective functions and verifies proper error handling across different structure and monitor combinations. The change is also properly documented in the changelog, following the project's documentation standards.

## Important Files Changed

<details>
<summary>Files Changed</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/web/api/autograd/autograd.py` | 5/5 | Added NaN detection check in adjoint pipeline setup to prevent downstream failures |
| `tests/test_components/test_autograd.py` | 4/5 | Added comprehensive test coverage for NaN detection functionality |
| `CHANGELOG.md` | 5/5 | Documented the new NaN validation feature for users |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk of breaking existing functionality
- Score reflects well-designed defensive programming with proper error handling, comprehensive testing, and clear documentation
- No files require special attention as all changes follow established patterns and best practices

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant AutogradAPI as "tidy3d.web.run"
    participant RunPrimitive as "_run_primitive"
    participant ForwardSim as "Forward Simulation"
    participant PostProcessAdj as "postprocess_adj" 
    participant VJPFunction as "VJP Function"
    participant AdjointSim as "Adjoint Simulation"
    participant ErrorCheck as "NaN Check"

    User->>AutogradAPI: run(simulation, task_name, ...)
    AutogradAPI->>AutogradAPI: is_valid_for_autograd(simulation)
    AutogradAPI->>RunPrimitive: _run_primitive(traced_fields, ...)
    RunPrimitive->>ForwardSim: Execute forward simulation
    ForwardSim-->>RunPrimitive: Return simulation data
    RunPrimitive->>RunPrimitive: postprocess_fwd() - cache forward data
    RunPrimitive-->>AutogradAPI: Return traced field data

    Note over User,AdjointSim: When gradients are computed (backward pass)

    AutogradAPI->>VJPFunction: Execute VJP function
    VJPFunction->>ErrorCheck: Check vjp data for NaN values
    
    alt NaN values detected
        ErrorCheck-->>VJPFunction: Raise AdjointError
        VJPFunction-->>User: "NaN values detected in the adjoint pipeline"
    else No NaN values
        ErrorCheck-->>VJPFunction: Data valid, continue
        VJPFunction->>VJPFunction: setup_adj() - create adjoint simulations
        VJPFunction->>AdjointSim: Run adjoint simulation(s)
        AdjointSim-->>VJPFunction: Return adjoint data
        VJPFunction->>PostProcessAdj: postprocess_adj(adjoint_data, ...)
        PostProcessAdj-->>VJPFunction: Return gradients
        VJPFunction-->>AutogradAPI: Return VJP gradients
    end

    AutogradAPI-->>User: Return simulation data with gradients
```

### Context used:
**Rule -** Do not use markdown formatting in exception or warning messages; use single quotes to highlight variable names and code. ([link](https://app.greptile.com/review/custom-context?memory=9b45957a-2d0d-4c24-a5d3-eef6f721cbfd))
**Rule -** Use changelog categories correctly: "Fixed" for bug fixes, "Changed" for modifications to existing functionality, and "Added" for new features. ([link](https://app.greptile.com/review/custom-context?memory=17997812-233f-4a81-bee2-4d7666605061))
**Rule -** In changelogs, enclose code identifiers (class, function names) in backticks and use specific names rather than generic descriptions. ([link](https://app.greptile.com/review/custom-context?memory=0af1d6df-6cf7-4988-b3fc-f5f8ec5cae30))
**Rule -** Prefer pytest.mark.parametrize over manual for loops to define and run distinct test cases, reducing code duplication. ([link](https://app.greptile.com/review/custom-context?memory=b75eacba-78e6-4ee4-b8d5-a0961c4a1dd3))
**Rule -** Assert the direct outcome of an operation rather than a side effect (like a log message) when possible. ([link](https://app.greptile.com/review/custom-context?memory=82bf390c-5e3e-49d3-8311-2467151aa6af))

<!-- /greptile_comment -->