### PR TITLE
fix: poetry CI not actually running in py 3.13

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -752,7 +752,7 @@ jobs:
       uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a  # v1.4.1
       with:
         version: 2.1.1
-        virtualenvs-create: true
+        virtualenvs-create: false
         virtualenvs-in-project: true
 
     - name: set-python-${{ matrix.python-version }}
@@ -791,6 +791,9 @@ jobs:
     - name: install-project
       shell: bash
       run: |
+        which python
+        python -m venv .venv/
+        python --version
         poetry --version
         python --version
         python -m venv .venv


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures remote test matrix (incl. Python `3.13`) uses the intended interpreter and environment.
> 
> - Set Poetry `virtualenvs-create: false` so it uses the pre-created `.venv`
> - In `remote-tests` job, explicitly create/activate `.venv` and print Python info before `poetry install`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47671d5e91af5d4e198fdeeebc11b6dbc70ad34d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed Poetry CI configuration to ensure Python 3.13 tests run in the correct virtual environment by setting `virtualenvs-create: false` and manually creating/activating `.venv` before Poetry installation.

- Changed Poetry config from `virtualenvs-create: true` to `false` so it uses the manually created venv
- Added explicit venv creation and activation steps with diagnostic output (`which python`, `python --version`)
- Ensures the test matrix correctly uses Python 3.13 interpreter instead of falling back to a different version

**Issues found:**
- Duplicate `python -m venv .venv` commands (lines 795 and 799)
- Duplicate `python --version` commands (lines 796 and 798)  
- Diagnostic commands run before venv activation, so they show the wrong Python version - should run after activation to verify correct environment

<h3>Confidence Score: 3/5</h3>

- This PR addresses a real CI issue but has implementation flaws that reduce effectiveness
- The core fix (virtualenvs-create: false) is correct, but duplicate commands and misplaced diagnostics indicate the changes weren't thoroughly tested. The diagnostic commands run before venv activation, so they won't show if the correct Python is being used.
- The workflow file needs cleanup to remove duplicates and reorder diagnostic commands after venv activation

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/tidy3d-python-client-tests.yml | Changes Poetry virtualenv configuration to use pre-created .venv, but has duplicate commands and diagnostic commands run before venv activation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant Poetry as Poetry
    participant System as System Python
    participant Venv as .venv

    Note over GHA,Venv: Remote Tests Job Setup
    
    GHA->>Poetry: Install Poetry v2.1.1
    Note over Poetry: virtualenvs-create: false<br/>virtualenvs-in-project: true
    
    GHA->>System: Setup Python ${{ matrix.python-version }}
    Note over System: Python 3.10, 3.11, 3.12, or 3.13
    
    GHA->>System: which python (before venv)
    System-->>GHA: Shows system Python path
    
    GHA->>Venv: python -m venv .venv/ (duplicate)
    GHA->>System: python --version (before venv)
    System-->>GHA: Shows system Python version
    
    GHA->>Venv: python -m venv .venv (duplicate)
    
    GHA->>Venv: Activate .venv
    Note over Venv: Source .venv/bin/activate<br/>or .venv/Scripts/activate
    
    Venv->>System: which python (after activation)
    System-->>Venv: Shows venv Python path
    
    GHA->>Poetry: poetry env use python
    Poetry->>Venv: Uses activated venv
    
    GHA->>Poetry: poetry install -E dev
    Poetry->>Venv: Installs packages in .venv
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->