### PR TITLE
Autograd support for component modelers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `TerminalComponentModelerData`, `ComponentModelerData`, `MicrowaveSMatrixData`, and introduced multiple DataArrays for modeler workflow data structures.
 - Added autograd support for dispersive material models: `Sellmeier`, `Drude`, `Lorentz`, `Debye` and their custom medium variants.
 - Added check and exception for NaN data in the adjoint pipeline to raise issue to user before adjoint source creation failure.
+- Added autograd support for `TerminalComponentModeler` and `ModalComponentModeler`.
 
 ### Changed
 - Validate mode solver object for large number of grid points on the modal plane.

--- a/tests/test_plugins/smatrix/test_component_modeler_autograd.py
+++ b/tests/test_plugins/smatrix/test_component_modeler_autograd.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import autograd as ag
+import autograd.numpy as anp
+import numpy as np
+import pytest
+
+import tidy3d as td
+from tidy3d.plugins.smatrix.analysis import terminal as terminal_analysis
+from tidy3d.plugins.smatrix.component_modelers.modal import ModalComponentModeler
+from tidy3d.plugins.smatrix.component_modelers.terminal import TerminalComponentModeler
+from tidy3d.plugins.smatrix.data.data_array import TerminalPortDataArray
+from tidy3d.plugins.smatrix.ports.modal import Port as ModalPort
+from tidy3d.plugins.smatrix.ports.rectangular_lumped import LumpedPort as RectLumpedPort
+from tidy3d.plugins.smatrix.run import run as smatrix_run
+from tidy3d.web.api.autograd import autograd as web_ag
+
+
+def _run_emulated_minimal(simulation: td.Simulation, path=None, **kwargs) -> td.SimulationData:
+    """Very small offline emulator used by autograd tests.
+
+    - Supports ModeMonitor (amps + n_complex)
+    - Supports FieldMonitor (Ex, Ey, Ez, Hx, Hy, Hz)
+    - Supports PermittivityMonitor (eps_xx, eps_yy, eps_zz)
+    """
+
+    rng = np.random.default_rng(42)
+
+    def _coords_for_monitor(sim: td.Simulation, mnt: td.Monitor):
+        grid = sim.discretize_monitor(mnt)
+        bounds = grid.boundaries.dict()
+
+        def centers(arr):
+            arr = np.asarray(arr)
+            if arr.size < 2:
+                return arr
+            return 0.5 * (arr[:-1] + arr[1:])
+
+        xyz = {}
+        for ax, dim in enumerate("xyz"):
+            if mnt.size[ax] == 0:
+                xyz[dim] = [mnt.center[ax]]
+            else:
+                arr = np.asarray(bounds[dim])
+                if arr.size < 2:
+                    xyz[dim] = [mnt.center[ax]]
+                else:
+                    xyz[dim] = centers(arr)
+
+        # ensure at least two points along any nonzero-size axis to avoid empty-grid interpolation
+        for ax, dim in enumerate("xyz"):
+            if mnt.size[ax] != 0 and len(xyz[dim]) < 2:
+                c = float(mnt.center[ax])
+                half = float(mnt.size[ax]) / 2.0
+                if half == 0:
+                    half = 1e-6
+                eps = max(half * 1e-3, 1e-6)
+                xyz[dim] = [c - eps, c + eps]
+        return xyz, grid
+
+    data_items = []
+
+    for mnt in simulation.monitors:
+        if isinstance(mnt, td.ModeMonitor):
+            f = list(mnt.freqs)
+            mode_index = np.arange(mnt.mode_spec.num_modes)
+            directions = np.array(["+", "-"])
+
+            amps_vals = (1 + 0.1j) * rng.random((len(directions), len(f), len(mode_index)))
+            n_vals = (1 + 0.05j) * rng.random((len(f), len(mode_index)))
+
+            amps = td.ModeAmpsDataArray(
+                amps_vals,
+                coords={"direction": directions, "f": f, "mode_index": mode_index},
+            )
+            n_complex = td.ModeIndexDataArray(n_vals, coords={"f": f, "mode_index": mode_index})
+
+            data_items.append(td.ModeData(monitor=mnt, amps=amps, n_complex=n_complex))
+
+        elif isinstance(mnt, td.FieldMonitor):
+            xyz, grid = _coords_for_monitor(simulation, mnt)
+            f = list(mnt.freqs)
+            shape = (len(xyz["x"]), len(xyz["y"]), len(xyz["z"]), len(f))
+
+            def cfield(shape=shape, xyz=xyz, f=f, rng=rng):
+                vals = (1 + 0.2j) * rng.random(shape)
+                return td.ScalarFieldDataArray(vals, coords={**xyz, "f": f})
+
+            data_items.append(
+                td.FieldData(
+                    monitor=mnt,
+                    grid_expanded=grid,
+                    Ex=cfield(),
+                    Ey=cfield(),
+                    Ez=cfield(),
+                    Hx=cfield(),
+                    Hy=cfield(),
+                    Hz=cfield(),
+                    symmetry=(0, 0, 0),
+                    symmetry_center=simulation.center,
+                )
+            )
+
+        elif isinstance(mnt, td.PermittivityMonitor):
+            xyz, grid = _coords_for_monitor(simulation, mnt)
+            f = list(mnt.freqs)
+            shape = (len(xyz["x"]), len(xyz["y"]), len(xyz["z"]), len(f))
+
+            def rfield(shape=shape, xyz=xyz, f=f, rng=rng):
+                vals = rng.random(shape)
+                return td.ScalarFieldDataArray(vals, coords={**xyz, "f": f})
+
+            data_items.append(
+                td.PermittivityData(
+                    monitor=mnt,
+                    grid_expanded=grid,
+                    eps_xx=rfield(),
+                    eps_yy=rfield(),
+                    eps_zz=rfield(),
+                )
+            )
+
+    return td.SimulationData(simulation=simulation, data=tuple(data_items))
+
+
+def _emulated_run_async_tidy3d(simulations, **kwargs):
+    """Batch wrapper around the minimal emulator."""
+    sim_data_map = {}
+    for task_name, sim in simulations.items():
+        sim_data_map[task_name] = _run_emulated_minimal(sim)
+
+    class _BatchLike(dict):
+        def __getitem__(self, key):
+            return sim_data_map[key]
+
+    return _BatchLike(sim_data_map), {}
+
+
+@pytest.fixture
+def patch_web_autograd_emulator(monkeypatch):
+    """Patch web autograd internals to use the local minimal emulator."""
+
+    monkeypatch.setattr(web_ag, "_run_async_tidy3d", _emulated_run_async_tidy3d)
+    yield
+
+
+def _build_base_sim(scale: float) -> td.Simulation:
+    """Shared base Simulation for modal and terminal modelers."""
+    return td.Simulation(
+        size=(4.0, 4.0, 4.0),
+        run_time=1e-13,
+        grid_spec=td.GridSpec.uniform(dl=0.2),
+        boundary_spec=td.BoundarySpec.pml(x=True, y=True, z=True),
+        structures=[
+            td.Structure(
+                geometry=td.Box(size=(1.0 + scale, 1.0, 1.0), center=(0.0, 0.0, 0.0)),
+                medium=td.Medium(permittivity=2.0 + 0.1 * scale),
+            )
+        ],
+        sources=[],
+        monitors=[],
+    )
+
+
+def build_modal_modeler(scale: float) -> ModalComponentModeler:
+    sim = _build_base_sim(scale)
+
+    # two modal ports on +/- z sides
+    port_size = (2.0, 2.0, 0.0)
+    p1 = ModalPort(
+        center=(0.0, 0.0, -1.5),
+        size=port_size,
+        direction="+",
+        mode_spec=td.ModeSpec(num_modes=1),
+        name="p1",
+    )
+    p2 = ModalPort(
+        center=(0.0, 0.0, 1.5),
+        size=port_size,
+        direction="-",
+        mode_spec=td.ModeSpec(num_modes=1),
+        name="p2",
+    )
+
+    freqs = [2.0e14]
+    return ModalComponentModeler(simulation=sim, ports=(p1, p2), freqs=freqs)
+
+
+def build_terminal_modeler(scale: float) -> TerminalComponentModeler:
+    sim = _build_base_sim(scale)
+
+    # two lumped ports on +/- z sides; injection axis is z
+    port_size = (1.0, 1.0, 0.0)
+    p1 = RectLumpedPort(
+        center=(0.0, 0.0, -1.5),
+        size=port_size,
+        voltage_axis=1,
+        name="lp1",
+        impedance=50.0,
+    )
+    p2 = RectLumpedPort(
+        center=(0.0, 0.0, 1.5),
+        size=port_size,
+        voltage_axis=1,
+        name="lp2",
+        impedance=50.0,
+    )
+
+    freqs = [2.0e14]
+    return TerminalComponentModeler(simulation=sim, ports=(p1, p2), freqs=freqs)
+
+
+def test_component_modeler_autograd_tracing(patch_web_autograd_emulator, tmp_path):
+    td.config.logging_level = "ERROR"
+    td.config.log_suppression = True
+
+    def objective(scale: float) -> float:
+        modeler = build_modal_modeler(scale)
+        modeler_data = smatrix_run(
+            modeler,
+            path_dir=str(tmp_path),
+            verbose=False,
+            local_gradient=True,
+        )
+        s = modeler_data.smatrix()  # ModalPortDataArray
+        return anp.real(anp.sum(s.data))
+
+    # verify that gradients propagate without error
+    g = ag.grad(objective)(1.0)
+    assert np.isfinite(g)
+    assert not np.isclose(g, 0.0)
+
+
+def test_component_modeler_autograd_tracing_modeler_run(patch_web_autograd_emulator, tmp_path):
+    td.config.logging_level = "ERROR"
+    td.config.log_suppression = True
+
+    def objective(scale: float) -> float:
+        modeler = build_modal_modeler(scale)
+        modeler_data = modeler.run(
+            path_dir=str(tmp_path),
+            verbose=False,
+            local_gradient=True,
+        )
+        s = modeler_data.smatrix()
+        return anp.real(anp.sum(s.data))
+
+    g = ag.grad(objective)(1.0)
+    assert np.isfinite(g)
+    assert not np.isclose(g, 0.0)
+
+
+def test_terminal_component_modeler_autograd_tracing_stubbed(
+    patch_web_autograd_emulator, monkeypatch, tmp_path
+):
+    """Autograd plumbing test for TerminalComponentModeler using a minimal S-matrix stub.
+
+    This test verifies that web.run autograd integration (forward/adjoint batching and result
+    composition) works for terminal modelers when terminal_construct_smatrix is replaced with a
+    simple function of FieldData. The full terminal analysis relies on voltage/current integrals
+    with interpolation and Yee-grid snapping, which are not autograd-compatible; hence the use of
+    a stub to keep the test fast and robust.
+    """
+
+    td.config.logging_level = "ERROR"
+    td.config.log_suppression = True
+
+    # Minimal stub: reduce first available FieldData per port over space (keep f), place on diagonal
+    def _fake_terminal_construct_smatrix(
+        modeler_data, assume_ideal_excitation=False, s_param_def="pseudo"
+    ):
+        ports = list(modeler_data.modeler.network_dict.keys())
+        freqs = list(modeler_data.modeler.freqs)
+        f_len = len(freqs)
+        n = len(ports)
+
+        diag_vals = []
+        for p in ports:
+            sim_data = modeler_data.data[p]
+            vals_f = None
+            for d in sim_data.data:
+                if isinstance(d, td.FieldData):
+                    arr = next(iter(d.field_components.values()))
+                    val_comp = arr.sum(dim=[c for c in arr.dims if c != "f"]).astype(complex)
+                    if "f" not in val_comp.dims:
+                        val_comp = td.FreqDataArray(
+                            np.ones((f_len,), dtype=complex), coords={"f": freqs}
+                        )
+                    vals_f = val_comp
+                    break
+            if vals_f is None:
+                vals_f = td.FreqDataArray(np.ones((f_len,), dtype=complex), coords={"f": freqs})
+            diag_vals.append(vals_f)
+
+        data = anp.zeros((f_len, n, n), dtype=complex)
+        for i, s in enumerate(diag_vals):
+            Ei = np.zeros((n, n))
+            Ei[i, i] = 1.0
+            data = data + anp.einsum("f,ij->fij", s.values, Ei)
+
+        return TerminalPortDataArray(data, coords={"f": freqs, "port_out": ports, "port_in": ports})
+
+    monkeypatch.setattr(
+        terminal_analysis, "terminal_construct_smatrix", _fake_terminal_construct_smatrix
+    )
+
+    def objective(scale: float) -> float:
+        modeler = build_terminal_modeler(scale)
+        modeler_data = smatrix_run(
+            modeler,
+            path_dir=str(tmp_path),
+            verbose=False,
+            local_gradient=True,
+        )
+        s_vals = modeler_data.smatrix().data.data
+        return anp.real(anp.sum(s_vals))
+
+    g = ag.grad(objective)(1.0)
+    assert np.isfinite(g)
+    assert not np.isclose(g, 0.0)
+
+
+def test_terminal_component_modeler_autograd_tracing_modeler_run_stubbed(
+    patch_web_autograd_emulator, monkeypatch, tmp_path
+):
+    """Same as terminal autograd test, but running via modeler.run()."""
+
+    td.config.logging_level = "ERROR"
+    td.config.log_suppression = True
+
+    def _fake_terminal_construct_smatrix(
+        modeler_data, assume_ideal_excitation=False, s_param_def="pseudo"
+    ):
+        ports = list(modeler_data.modeler.network_dict.keys())
+        freqs = list(modeler_data.modeler.freqs)
+        f_len = len(freqs)
+        n = len(ports)
+
+        diag_vals = []
+        for p in ports:
+            sim_data = modeler_data.data[p]
+            vals_f = None
+            for d in sim_data.data:
+                if isinstance(d, td.FieldData):
+                    arr = next(iter(d.field_components.values()))
+                    val_comp = arr.sum(dim=[c for c in arr.dims if c != "f"]).astype(complex)
+                    if "f" not in val_comp.dims:
+                        val_comp = td.FreqDataArray(
+                            np.ones((f_len,), dtype=complex), coords={"f": freqs}
+                        )
+                    vals_f = val_comp
+                    break
+            if vals_f is None:
+                vals_f = td.FreqDataArray(np.ones((f_len,), dtype=complex), coords={"f": freqs})
+            diag_vals.append(vals_f)
+
+        data = anp.zeros((f_len, n, n), dtype=complex)
+        for i, s in enumerate(diag_vals):
+            Ei = np.zeros((n, n))
+            Ei[i, i] = 1.0
+            data = data + anp.einsum("f,ij->fij", s.values, Ei)
+
+        return TerminalPortDataArray(data, coords={"f": freqs, "port_out": ports, "port_in": ports})
+
+    monkeypatch.setattr(
+        terminal_analysis, "terminal_construct_smatrix", _fake_terminal_construct_smatrix
+    )
+
+    def objective(scale: float) -> float:
+        modeler = build_terminal_modeler(scale)
+        modeler_data = modeler.run(
+            path_dir=str(tmp_path),
+            verbose=False,
+            local_gradient=True,
+        )
+        s_vals = modeler_data.smatrix().data.data
+        return anp.real(anp.sum(s_vals))
+
+    g = ag.grad(objective)(1.0)
+    assert np.isfinite(g)
+    assert not np.isclose(g, 0.0)

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Generic, Optional, TypeVar, Union, get_args
+from typing import TYPE_CHECKING, Generic, Optional, TypeVar, Union, get_args
 
 import pydantic.v1 as pd
 
+from tidy3d.components.autograd.constants import MAX_NUM_ADJOINT_PER_FWD
 from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.geometry.utils import _shift_value_signed
 from tidy3d.components.simulation import Simulation
@@ -23,6 +24,9 @@ from tidy3d.log import log
 from tidy3d.plugins.smatrix.ports.modal import Port
 from tidy3d.plugins.smatrix.ports.types import TerminalPortType
 from tidy3d.plugins.smatrix.ports.wave import WavePort
+
+if TYPE_CHECKING:
+    from tidy3d.web.core.types import PayType
 
 # fwidth of gaussian pulse in units of central frequency
 FWIDTH_FRAC = 1.0 / 10
@@ -206,6 +210,39 @@ class AbstractComponentModeler(ABC, Generic[IndexType, ElementType], Tidy3dBaseM
         )
 
     unique_port_names = assert_unique_names("ports")
+
+    def run(
+        self,
+        path_dir: str = DEFAULT_DATA_DIR,
+        *,
+        folder_name: str = "default",
+        callback_url: Optional[str] = None,
+        verbose: bool = True,
+        solver_version: Optional[str] = None,
+        pay_type: Union[PayType, str] = "AUTO",
+        priority: Optional[int] = None,
+        local_gradient: bool = False,
+        max_num_adjoint_per_fwd: int = MAX_NUM_ADJOINT_PER_FWD,
+    ):
+        """Run the component modeler and return modeler data.
+
+        Delegates to `tidy3d.plugins.smatrix.run.run`, which selects between
+        an autograd-compatible path and the standard Batch path.
+        """
+        from tidy3d.plugins.smatrix.run import run
+
+        return run(
+            self,
+            path_dir=path_dir,
+            folder_name=folder_name,
+            callback_url=callback_url,
+            verbose=verbose,
+            solver_version=solver_version,
+            pay_type=pay_type,
+            priority=priority,
+            local_gradient=local_gradient,
+            max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
+        )
 
 
 AbstractComponentModeler.update_forward_refs()

--- a/tidy3d/plugins/smatrix/run.py
+++ b/tidy3d/plugins/smatrix/run.py
@@ -6,9 +6,7 @@ from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.data.index import SimulationDataMap
 from tidy3d.plugins.smatrix.component_modelers.modal import ModalComponentModeler
 from tidy3d.plugins.smatrix.component_modelers.terminal import TerminalComponentModeler
-from tidy3d.plugins.smatrix.component_modelers.types import (
-    ComponentModelerType,
-)
+from tidy3d.plugins.smatrix.component_modelers.types import ComponentModelerType
 from tidy3d.plugins.smatrix.data.modal import ModalComponentModelerData
 from tidy3d.plugins.smatrix.data.terminal import TerminalComponentModelerData
 from tidy3d.plugins.smatrix.data.types import ComponentModelerDataType
@@ -150,6 +148,23 @@ def create_batch(
     return batch
 
 
+def _is_autograd_valid(modeler: ComponentModelerType) -> bool:
+    """Return True if any underlying simulation is valid for autograd."""
+    from tidy3d.web.api.autograd import autograd as web_ag
+
+    try:
+        sims = modeler.sim_dict
+    except AttributeError:
+        return False
+    if not sims:
+        return False
+
+    for sim in sims.values():
+        if web_ag.is_valid_for_autograd(sim):
+            return True
+    return False
+
+
 def run(
     modeler: ComponentModelerType, path_dir: str = DEFAULT_DATA_DIR, **kwargs
 ) -> ComponentModelerDataType:
@@ -175,7 +190,22 @@ def run(
         An object containing the processed simulation data, ready for
         S-parameter extraction and analysis.
     """
-    batch = create_batch(modeler=modeler, **kwargs)
-    batch_data = batch.run(path_dir=path_dir)
-    modeler_data = compose_modeler_data_from_batch_data(modeler=modeler, batch_data=batch_data)
-    return modeler_data
+
+    if _is_autograd_valid(modeler):
+        from tidy3d.web.api.autograd.autograd import _run_async
+
+        kwargs.setdefault("folder_name", "default")
+        kwargs.setdefault("simulation_type", "tidy3d_autograd_async")
+        kwargs.setdefault("path_dir", path_dir)
+
+        sim_data_map = _run_async(simulations=modeler.sim_dict, **kwargs)
+
+        return compose_modeler_data_from_batch_data(modeler=modeler, batch_data=sim_data_map)
+
+    batch = create_batch(modeler=modeler)
+    priority = kwargs.get("priority")
+    if priority is None:
+        batch_data = batch.run(path_dir=path_dir)
+    else:
+        batch_data = batch.run(path_dir=path_dir, priority=priority)
+    return compose_modeler_data_from_batch_data(modeler=modeler, batch_data=batch_data)

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -23,7 +23,6 @@ from tidy3d.components.autograd.constants import (
 from tidy3d.components.autograd.derivative_utils import DerivativeInfo
 from tidy3d.components.data.data_array import DataArray
 from tidy3d.components.grid.grid_spec import GridSpec
-from tidy3d.components.types.workflow import WorkflowDataType, WorkflowType
 from tidy3d.exceptions import AdjointError
 from tidy3d.web.api.asynchronous import DEFAULT_DATA_DIR
 from tidy3d.web.api.asynchronous import run_async as run_async_webapi
@@ -55,9 +54,7 @@ _INSPECT_ADJOINT_PLANE = td.Box(center=(0, 0, 0), size=(td.inf, td.inf, 0))
 
 
 def is_valid_for_autograd(simulation: td.Simulation) -> bool:
-    """Check whether a supplied simulation can use autograd run."""
-
-    # only support Simulations
+    """Check whether a supplied Simulation can use the autograd path."""
     if not isinstance(simulation, td.Simulation):
         return False
 
@@ -97,7 +94,7 @@ def is_valid_for_autograd_async(simulations: dict[str, td.Simulation]) -> bool:
 
 
 def run(
-    simulation: WorkflowType,
+    simulation: td.Simulation,
     task_name: str,
     folder_name: str = "default",
     path: str = "simulation_data.hdf5",
@@ -114,7 +111,7 @@ def run(
     reduce_simulation: typing.Literal["auto", True, False] = "auto",
     pay_type: typing.Union[PayType, str] = PayType.AUTO,
     priority: typing.Optional[int] = None,
-) -> WorkflowDataType:
+) -> td.SimulationData:
     """
     Submits a :class:`.Simulation` to server, starts running, monitors progress, downloads,
     and loads results as a :class:`.WorkflowDataType` object.
@@ -201,7 +198,8 @@ def run(
     """
     if priority is not None and (priority < 1 or priority > 10):
         raise ValueError("Priority must be between '1' and '10' if specified.")
-    if is_valid_for_autograd(simulation):
+
+    if isinstance(simulation, td.Simulation) and is_valid_for_autograd(simulation):
         return _run(
             simulation=simulation,
             task_name=task_name,
@@ -241,7 +239,7 @@ def run(
 
 
 def run_async(
-    simulations: dict[str, WorkflowType],
+    simulations: dict[str, td.Simulation],
     folder_name: str = "default",
     path_dir: str = DEFAULT_DATA_DIR,
     callback_url: typing.Optional[str] = None,

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -31,7 +31,15 @@ DEFAULT_DATA_PATH = "simulation_data.hdf5"
 DEFAULT_DATA_DIR = "."
 BATCH_MONITOR_PROGRESS_REFRESH_TIME = 0.02
 
-BatchCategoryType = Literal["tidy3d", "microwave", "tidy3d_design"]
+BatchCategoryType = Literal[
+    "tidy3d",
+    "microwave",
+    "tidy3d_design",
+    "tidy3d_autograd",
+    "tidy3d_autograd_async",
+    "autograd_fwd",
+    "autograd_bwd",
+]
 
 
 class WebContainer(Tidy3dBaseModel, ABC):


### PR DESCRIPTION
Most of the initial code here from @yaugenst-flex - I added/fixed up a few things to get it working with component modeler based optimizations for s params. I tested my patch antenna optimization for terminal component modeler and a modal example.

<!-- greptile_comment -->

## Greptile Summary

This pull request adds autograd (automatic differentiation) support for component modelers in Tidy3D, specifically enabling optimization workflows for `TerminalComponentModeler` and `ModalComponentModeler`. The changes extend the existing autograd infrastructure to handle these higher-level abstractions that manage multiple simulations for electromagnetic component modeling.

The core modification expands the web API's batch categorization system to recognize autograd simulation types, allowing proper routing of forward and backward (adjoint) simulations. The autograd module is enhanced to validate and execute component modelers by leveraging their internal simulation dictionaries through the existing batch execution infrastructure. When a component modeler contains autograd-compatible simulations, it routes through the new autograd pathway; otherwise, it falls back to the standard web API.

The implementation maintains full backward compatibility while adding sophisticated handling for composite simulation objects. Component modelers internally contain multiple simulations that need to be executed in batch and then reconstructed into appropriate data structures. The changes include validation logic to check underlying simulations for autograd compatibility and composition functions to properly reconstruct `ComponentModelerData` objects from batch execution results.

A comprehensive test suite validates the autograd integration using an offline emulator that generates realistic monitor data without requiring web API calls. The testing covers both modal and terminal component modelers, with the terminal modeler using stubbed S-matrix construction to bypass non-autograd-compatible voltage/current integral calculations.

## Important Files Changed

<details>
<summary>Click to expand</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/web/api/container.py` | 5/5 | Extended BatchCategoryType to include four new autograd simulation categories |
| `CHANGELOG.md` | 5/5 | Added changelog entry documenting autograd support for component modelers |
| `tidy3d/web/api/autograd/autograd.py` | 4/5 | Extended autograd infrastructure to handle component modelers with new validation and execution logic |
| `tests/test_plugins/smatrix/test_component_modeler_autograd.py` | 4/5 | Added comprehensive test suite with offline emulator for component modeler autograd functionality |

</details>

## Confidence score: 4/5

- This PR introduces significant new functionality but appears well-architected with proper fallback mechanisms
- Score reflects the complexity of autograd integration and potential for subtle edge cases in composite simulation handling
- Pay close attention to the autograd module changes and test coverage for component modeler workflows

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant web_run as web.run()
    participant autograd as autograd.py
    participant modeler as ComponentModeler
    participant batch as Batch Processing
    participant server as Tidy3D Server
    participant composer as Data Composer

    User->>web_run: web.run(component_modeler, ...)
    web_run->>autograd: is_valid_for_autograd(modeler)
    autograd->>modeler: Check for traced fields in sim_dict
    modeler-->>autograd: Returns True if autograd-compatible
    autograd-->>web_run: Valid for autograd

    web_run->>autograd: _run_component_modeler()
    autograd->>modeler: modeler.sim_dict
    modeler-->>autograd: Dictionary of simulations
    autograd->>autograd: _run_async(simulations_dict)
    
    autograd->>batch: Create batch from sim_dict
    batch->>server: Upload and run simulations
    server-->>batch: Return SimulationData results
    batch-->>autograd: sim_data_map

    autograd->>composer: _compose_modeler_data_from_sim_map()
    composer->>composer: Create SimulationDataMap
    alt ModalComponentModeler
        composer->>composer: Create ModalComponentModelerData
    else TerminalComponentModeler  
        composer->>composer: Create TerminalComponentModelerData
    end
    composer-->>autograd: ComponentModelerData
    autograd-->>web_run: Final modeler data
    web_run-->>User: ComponentModelerData with gradients
```

<!-- /greptile_comment -->