### PR TITLE
Prevent small bandwidth sources from popping up in terminal component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adaptive minimum spacing for `PolySlab` integration is now wavelength relative and a minimum discretization is set for computing gradients for cylinders.
 - The `TerminalComponentModeler` defaults to the pseudo wave definition of scattering parameters. The new field `s_param_def` can be used to switch between either pseudo or power wave definitions.
 - Restructured the smatrix plugin with backwards-incompatible changes for a more robust architecture. Notably, `ComponentModeler` has been renamed to `ModalComponentModeler` and internal web API methods have been removed. Please see our migration guide for details on updating your workflows.
+- Prevent small bandwidth sources from being created in `TerminalComponentModeler` when modeler frequencies are close together.
 
 ### Fixed
 - Fixed missing amplitude factor and handling of negative normal direction case when making adjoint sources from `DiffractionMonitor`.

--- a/tests/test_components/test_source.py
+++ b/tests/test_components/test_source.py
@@ -15,6 +15,7 @@ from ..utils import AssertLogLevel
 
 ST = td.GaussianPulse(freq0=2e14, fwidth=1e14)
 S = td.PointDipole(source_time=ST, polarization="Ex")
+FWIDTH_FRAC = 0.1
 
 
 ATOL = 1e-8
@@ -106,6 +107,18 @@ def test_gaussian_from_frequency_range():
     # error with fmin >= fmax
     with pytest.raises(ValueError):
         _ = td.GaussianPulse.from_frequency_range(fmin=1e10, fmax=0.9e10)
+    # error with minimum_source_bandwidth negative or 0
+    with pytest.raises(ValueError):
+        _ = td.GaussianPulse.from_frequency_range(
+            fmin=9e10, fmax=11e10, minimum_source_bandwidth=0.0
+        )
+        _ = td.GaussianPulse.from_frequency_range(
+            fmin=9e10, fmax=11e10, minimum_source_bandwidth=-1.0
+        )
+        # error with minimum_source_bandwidth greater than 1
+        _ = td.GaussianPulse.from_frequency_range(
+            fmin=9e10, fmax=11e10, minimum_source_bandwidth=1.0
+        )
 
     fmin = 1e9
     fmax = 20e9
@@ -135,6 +148,41 @@ def test_gaussian_from_frequency_range():
     g = td.GaussianPulse.from_frequency_range(fmin=fmin, fmax=fmax)
     assert abs(g.fwidth - bandwidth) / bandwidth < 1e-4
     assert abs(g.freq0 - fmin) / fmin < 1e-4
+
+
+def test_frequency_source_width():
+    """Ensure the source bandwidth has a lower bound regardless of the input frequencies."""
+
+    middle_freq = 1e10
+    fmin_large_bw = middle_freq * (1 - 2 * FWIDTH_FRAC)
+    fmax_large_bw = middle_freq * (1 + 2 * FWIDTH_FRAC)
+    fmin, fmax = td.GaussianPulse._minimum_source_bandwidth(
+        fmin=fmin_large_bw, fmax=fmax_large_bw, minimum_source_bandwidth=FWIDTH_FRAC
+    )
+
+    assert np.isclose(fmin, fmin_large_bw), (
+        "Expected no change in bandwidth (fmin unexpectedly changed)."
+    )
+
+    assert np.isclose(fmax, fmax_large_bw), (
+        "Expected no change in bandwidth (fmax unexpectedly changed)."
+    )
+
+    fmin_small_bw = middle_freq * (1 - 0.1 * FWIDTH_FRAC)
+    fmax_small_bw = middle_freq * (1 + 0.1 * FWIDTH_FRAC)
+    fmin, fmax = td.GaussianPulse._minimum_source_bandwidth(
+        fmin=fmin_small_bw, fmax=fmax_small_bw, minimum_source_bandwidth=FWIDTH_FRAC
+    )
+    fmin_expected = middle_freq * (1 - 0.5 * FWIDTH_FRAC)
+    fmax_expected = middle_freq * (1 + 0.5 * FWIDTH_FRAC)
+
+    assert np.isclose(fmin, fmin_expected), (
+        "Expected increase in bandwidth (fmin unexpected value)."
+    )
+
+    assert np.isclose(fmax, fmax_expected), (
+        "Expected increase in bandwidth (fmax unexpected value)."
+    )
 
 
 def test_dipole():

--- a/tidy3d/components/source/time.py
+++ b/tidy3d/components/source/time.py
@@ -185,9 +185,34 @@ class GaussianPulse(Pulse):
         phase = np.angle(amp)
         return cls(amplitude=amplitude, phase=phase, **kwargs)
 
+    @staticmethod
+    def _minimum_source_bandwidth(
+        fmin: float, fmax: float, minimum_source_bandwidth: float
+    ) -> tuple[float, float]:
+        """Define a source bandwidth based on fmin and fmax, but enforce a minimum bandwidth."""
+        if minimum_source_bandwidth <= 0:
+            raise ValidationError("'minimum_source_bandwidth' must be positive")
+        if minimum_source_bandwidth >= 1:
+            raise ValidationError("'minimum_source_bandwidth' must less than or equal to 1")
+
+        f_difference = fmax - fmin
+        f_middle = 0.5 * (fmin + fmax)
+
+        full_width = minimum_source_bandwidth * f_middle
+        if f_difference < full_width:
+            half_width = 0.5 * full_width
+            fmin = f_middle - half_width
+            fmax = f_middle + half_width
+
+        return fmin, fmax
+
     @classmethod
     def from_frequency_range(
-        cls, fmin: pydantic.PositiveFloat, fmax: pydantic.PositiveFloat, **kwargs
+        cls,
+        fmin: pydantic.PositiveFloat,
+        fmax: pydantic.PositiveFloat,
+        minimum_source_bandwidth: pydantic.PositiveFloat = None,
+        **kwargs,
     ) -> GaussianPulse:
         """Create a ``GaussianPulse`` that maximizes its amplitude in the frequency range [fmin, fmax].
 
@@ -210,6 +235,9 @@ class GaussianPulse(Pulse):
             raise ValidationError("'fmin' must be positive.")
         if fmax <= fmin:
             raise ValidationError("'fmax' must be greater than 'fmin'.")
+
+        if minimum_source_bandwidth is not None:
+            fmin, fmax = cls._minimum_source_bandwidth(fmin, fmax, minimum_source_bandwidth)
 
         # frequency range and center
         freq_range = fmax - fmin

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -342,8 +342,14 @@ class TerminalComponentModeler(AbstractComponentModeler[NetworkIndex, NetworkEle
         if len(self.freqs) == 1:
             freq0 = self.freqs[0]
             return GaussianPulse(freq0=self.freqs[0], fwidth=freq0 * FWIDTH_FRAC)
+
+        # Using the minimum_source_bandwidth, ensure we don't create a pulse that is too narrowband
+        # when fmin and fmax are close together
         return GaussianPulse.from_frequency_range(
-            fmin=min(self.freqs), fmax=max(self.freqs), remove_dc_component=self.remove_dc_component
+            fmin=np.min(self.freqs),
+            fmax=np.max(self.freqs),
+            remove_dc_component=self.remove_dc_component,
+            minimum_source_bandwidth=FWIDTH_FRAC,
         )
 
     @pd.validator("simulation")


### PR DESCRIPTION
Right now, if there is more than one frequency in the modeler but those are all close together (which might happen for someone optimizing a narrow band of frequencies in the adjoint), then the bandwidth of the sources created can be very narrow leading to a very broad time pulse. This sets a minimum width for these sources.

<!-- greptile_comment -->

## Greptile Summary

This PR addresses a practical issue in the `TerminalComponentModeler` where users optimizing narrow frequency bands (common in adjoint optimization workflows) could inadvertently create sources with very narrow bandwidths, resulting in problematic broad time pulses. The core change introduces a `_minimal_source_bandwidth` method that enforces a minimum bandwidth threshold of 10% of the center frequency (`FWIDTH_FRAC = 1.0/10`) when the natural frequency range is insufficient.

The implementation modifies the `_source_time` property in `tidy3d/plugins/smatrix/component_modelers/terminal.py` to use this new method, ensuring that when multiple frequencies are closely spaced, the resulting Gaussian pulse remains well-conditioned for time-domain simulations. The solution maintains backward compatibility - existing use cases with sufficient bandwidth remain unchanged, while only narrow-band edge cases are affected.

This change fits into the broader Tidy3D ecosystem by improving the robustness of S-matrix component modeling, particularly for advanced optimization scenarios where users might work with tightly constrained frequency ranges. The fix prevents simulation convergence issues and unstable behavior that could occur with overly broad time pulses.

**PR Description Notes:**
- Minor typo: "int he" should be "in the"

## Important Files Changed

<details>
<summary>Files Modified</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `CHANGELOG.md` | 5/5 | Added changelog entry documenting the prevention of small bandwidth sources in `TerminalComponentModeler` |
| `tidy3d/plugins/smatrix/component_modelers/terminal.py` | 4/5 | Implemented `_minimal_source_bandwidth` method and modified `_source_time` property to enforce minimum bandwidth constraint |
| `tests/test_plugins/smatrix/test_terminal_component_modeler.py` | 5/5 | Added comprehensive test coverage for the new minimum bandwidth functionality |

</details>

## Confidence score: 4/5

- This PR addresses a specific edge case with a targeted solution that maintains backward compatibility
- Score reflects solid implementation with proper testing and documentation, though the core logic change affects critical source generation behavior
- Pay close attention to the `_minimal_source_bandwidth` method implementation and its integration with existing source time generation

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant TerminalComponentModeler
    participant _minimal_source_bandwidth
    participant GaussianPulse
    participant Simulation

    User->>TerminalComponentModeler: Create modeler with close frequencies
    TerminalComponentModeler->>TerminalComponentModeler: Initialize with freqs array
    
    Note over TerminalComponentModeler: During source time creation
    TerminalComponentModeler->>TerminalComponentModeler: Access _source_time property
    TerminalComponentModeler->>_minimal_source_bandwidth: Call with freqs array
    
    Note over _minimal_source_bandwidth: Check if bandwidth is too small
    _minimal_source_bandwidth->>_minimal_source_bandwidth: Calculate f_difference = fmax - fmin
    _minimal_source_bandwidth->>_minimal_source_bandwidth: Calculate f_middle = 0.5 * (fmin + fmax)
    
    alt Small bandwidth case
        _minimal_source_bandwidth->>_minimal_source_bandwidth: if f_difference < FWIDTH_FRAC * f_middle
        _minimal_source_bandwidth->>_minimal_source_bandwidth: Expand bandwidth to minimum
        _minimal_source_bandwidth->>_minimal_source_bandwidth: fmin = f_middle - 0.5 * FWIDTH_FRAC * f_middle
        _minimal_source_bandwidth->>_minimal_source_bandwidth: fmax = f_middle + 0.5 * FWIDTH_FRAC * f_middle
    else Large bandwidth case
        Note over _minimal_source_bandwidth: Use original fmin, fmax
    end
    
    _minimal_source_bandwidth-->>TerminalComponentModeler: Return (fmin, fmax)
    TerminalComponentModeler->>GaussianPulse: from_frequency_range(fmin, fmax)
    GaussianPulse-->>TerminalComponentModeler: Return GaussianPulse with adequate bandwidth
    
    Note over TerminalComponentModeler: Continue with simulation setup
    TerminalComponentModeler->>TerminalComponentModeler: Create sim_dict with sources
    TerminalComponentModeler->>Simulation: Add source with adequate bandwidth
    
    Note over User,Simulation: Prevents broad time pulses from narrow frequency ranges
```

<!-- /greptile_comment -->