### PR TITLE
Update to component modeler task names to include mode index

### DIFF
--- a/tests/test_plugins/smatrix/test_run_functions.py
+++ b/tests/test_plugins/smatrix/test_run_functions.py
@@ -4,6 +4,7 @@ import json
 import os
 from unittest.mock import MagicMock
 
+import pydantic.v1 as pd
 import pytest
 
 import tidy3d
@@ -21,7 +22,6 @@ from tidy3d.plugins.smatrix.run import (
     compose_modeler,
     compose_modeler_data,
     compose_simulation_data_index,
-    compose_terminal_component_modeler_data,
     create_batch,
     run,
 )
@@ -54,36 +54,6 @@ def test_compose_simulation_data_index_empty_map():
     assert isinstance(result, SimulationDataMap)
     assert len(result.keys()) == 0
     assert len(result.values()) == 0
-
-
-def test_compose_terminal_component_modeler_data(monkeypatch):
-    # Mock compose_simulation_data_index
-    dummy_sim_data_map = SimulationDataMap(
-        keys=("port1", "port2"),
-        values=(
-            SimulationData(
-                simulation=make_terminal_component_modeler(planar_pec=True).simulation, data=()
-            ),
-            SimulationData(
-                simulation=make_terminal_component_modeler(planar_pec=True).simulation, data=()
-            ),
-        ),
-    )
-    monkeypatch.setattr(
-        "tidy3d.plugins.smatrix.run.compose_simulation_data_index", lambda x: dummy_sim_data_map
-    )
-
-    # Create a dummy TerminalComponentModeler
-    dummy_modeler = make_terminal_component_modeler(planar_pec=True)
-
-    # Call the function under test
-    port_task_map = {"port1": "task1", "port2": "task2"}
-    result = compose_terminal_component_modeler_data(dummy_modeler, port_task_map)
-
-    # Assertions
-    assert isinstance(result, TerminalComponentModelerData)
-    assert result.modeler == dummy_modeler
-    assert result.data == dummy_sim_data_map
 
 
 def test_create_batch(monkeypatch, tmp_path):
@@ -165,3 +135,22 @@ def test_compose_modeler_data_unsupported_type():
 
     with pytest.raises(TypeError, match="Unsupported modeler type: UnsupportedModeler"):
         compose_modeler_data(unsupported_modeler, dummy_sim_data_map)
+
+
+def test_compose_modeler_data_keys_mismatch():
+    dummy_sim_data_map = SimulationDataMap(
+        keys=("1", "2"),
+        values=(
+            SimulationData(
+                simulation=make_terminal_component_modeler(planar_pec=True).simulation, data=()
+            ),
+            SimulationData(
+                simulation=make_terminal_component_modeler(planar_pec=True).simulation, data=()
+            ),
+        ),
+    )
+
+    with pytest.raises(pd.ValidationError, match="do not match data keys"):
+        TerminalComponentModelerData(
+            modeler=make_terminal_component_modeler(planar_pec=True), data=dummy_sim_data_map
+        )

--- a/tests/test_plugins/smatrix/test_run_functions.py
+++ b/tests/test_plugins/smatrix/test_run_functions.py
@@ -21,7 +21,6 @@ from tidy3d.plugins.smatrix.data.terminal import TerminalComponentModelerData
 from tidy3d.plugins.smatrix.run import (
     compose_modeler,
     compose_modeler_data,
-    compose_simulation_data_index,
     create_batch,
     run,
 )
@@ -46,14 +45,6 @@ def test_compose_modeler_unsupported_type(tmp_path, monkeypatch):
     # Expect a TypeError when calling compose_modeler with the unsupported type
     with pytest.raises(TypeError, match="Unsupported modeler type: str"):
         compose_modeler(modeler_file=str(modeler_file))
-
-
-def test_compose_simulation_data_index_empty_map():
-    port_task_map = {}
-    result = compose_simulation_data_index(port_task_map)
-    assert isinstance(result, SimulationDataMap)
-    assert len(result.keys()) == 0
-    assert len(result.values()) == 0
 
 
 def test_create_batch(monkeypatch, tmp_path):

--- a/tidy3d/plugins/smatrix/data/base.py
+++ b/tidy3d/plugins/smatrix/data/base.py
@@ -1,0 +1,54 @@
+"""Data structures for post-processing modal component simulations to calculate S-matrices."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import pydantic.v1 as pd
+
+from tidy3d.components.base import Tidy3dBaseModel
+from tidy3d.components.data.data_array import DataArray
+from tidy3d.components.data.index import SimulationDataMap
+from tidy3d.plugins.smatrix.component_modelers.base import AbstractComponentModeler
+
+
+class AbstractComponentModelerData(ABC, Tidy3dBaseModel):
+    """A data container for the results of a :class:`.AbstractComponentModeler` run.
+
+    This class stores the original modeler and the simulation data obtained
+    from running the simulations it defines. It also provides a method to
+    compute the S-matrix from the simulation data.
+    """
+
+    modeler: AbstractComponentModeler = pd.Field(
+        ...,
+        title="Component modeler",
+        description="The original :class:`AbstractComponentModeler` object that defines the "
+        "simulation setup and from which this data was generated.",
+    )
+
+    data: SimulationDataMap = pd.Field(
+        ...,
+        title="SimulationDataMap",
+        description="A mapping from task names to :class:`.SimulationData` objects, "
+        "containing the results of each simulation run.",
+    )
+
+    log: str = pd.Field(
+        None,
+        title="Modeler Post-process Log",
+        description="A string containing the log information from the modeler post-processing run.",
+    )
+
+    @abstractmethod
+    def smatrix(self) -> DataArray:
+        """Computes and returns the scattering matrix (S-matrix)."""
+
+    @pd.validator("data")
+    def keys_match_modeler(cls, val, values):
+        modeler = values.get("modeler")
+        if modeler.sim_dict.keys() != val.keys():
+            raise ValueError(
+                f"Modeler keys {modeler.sim_dict.keys()} do not match data keys {val.keys()}."
+            )
+        return val

--- a/tidy3d/plugins/smatrix/data/base.py
+++ b/tidy3d/plugins/smatrix/data/base.py
@@ -47,8 +47,9 @@ class AbstractComponentModelerData(ABC, Tidy3dBaseModel):
     @pd.validator("data")
     def keys_match_modeler(cls, val, values):
         modeler = values.get("modeler")
-        if modeler.sim_dict.keys() != val.keys():
-            raise ValueError(
-                f"Modeler keys {modeler.sim_dict.keys()} do not match data keys {val.keys()}."
-            )
+        modeler_keys = tuple(modeler.sim_dict.keys())
+        data_keys = tuple(val.keys())
+        print(modeler_keys, data_keys)
+        if modeler_keys != data_keys:
+            raise ValueError(f"Modeler keys {modeler_keys} do not match data keys {data_keys}.")
         return val

--- a/tidy3d/plugins/smatrix/data/base.py
+++ b/tidy3d/plugins/smatrix/data/base.py
@@ -49,7 +49,6 @@ class AbstractComponentModelerData(ABC, Tidy3dBaseModel):
         modeler = values.get("modeler")
         modeler_keys = tuple(modeler.sim_dict.keys())
         data_keys = tuple(val.keys())
-        print(modeler_keys, data_keys)
         if modeler_keys != data_keys:
             raise ValueError(f"Modeler keys {modeler_keys} do not match data keys {data_keys}.")
         return val

--- a/tidy3d/plugins/smatrix/data/modal.py
+++ b/tidy3d/plugins/smatrix/data/modal.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 import pydantic.v1 as pd
 
-from tidy3d.components.base import Tidy3dBaseModel
-from tidy3d.components.data.index import SimulationDataMap
 from tidy3d.plugins.smatrix.component_modelers.modal import ModalComponentModeler
+from tidy3d.plugins.smatrix.data.base import AbstractComponentModelerData
 from tidy3d.plugins.smatrix.data.data_array import ModalPortDataArray
 
 
-class ModalComponentModelerData(Tidy3dBaseModel):
+class ModalComponentModelerData(AbstractComponentModelerData):
     """A data container for the results of a :class:`.ModalComponentModeler` run.
 
     This class stores the original modeler and the simulation data obtained
@@ -23,18 +22,6 @@ class ModalComponentModelerData(Tidy3dBaseModel):
         title="ModalComponentModeler",
         description="The original :class:`ModalComponentModeler` object that defines the simulation setup "
         "and from which this data was generated.",
-    )
-
-    data: SimulationDataMap = pd.Field(
-        ...,
-        title="SimulationDataMap",
-        description="A mapping from task names to :class:`.SimulationData` objects, containing the results of each simulation run.",
-    )
-
-    log: str = pd.Field(
-        None,
-        title="Modeler Post-process Log",
-        description="A string containing the log information from the modeler post-processing run.",
     )
 
     def smatrix(self) -> ModalPortDataArray:

--- a/tidy3d/plugins/smatrix/data/terminal.py
+++ b/tidy3d/plugins/smatrix/data/terminal.py
@@ -14,8 +14,8 @@ from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.microwave.data.monitor_data import AntennaMetricsData
 from tidy3d.log import log
 from tidy3d.plugins.smatrix.component_modelers.terminal import TerminalComponentModeler
+from tidy3d.plugins.smatrix.data.base import AbstractComponentModelerData
 from tidy3d.plugins.smatrix.data.data_array import PortDataArray, TerminalPortDataArray
-from tidy3d.plugins.smatrix.data.modal import SimulationDataMap
 from tidy3d.plugins.smatrix.network import SParamDef
 from tidy3d.plugins.smatrix.ports.types import TerminalPortType
 from tidy3d.plugins.smatrix.utils import (
@@ -51,7 +51,7 @@ class MicrowaveSMatrixData(Tidy3dBaseModel):
     )
 
 
-class TerminalComponentModelerData(Tidy3dBaseModel):
+class TerminalComponentModelerData(AbstractComponentModelerData):
     """
     Data associated with a :class:`TerminalComponentModeler` simulation run.
 
@@ -85,18 +85,6 @@ class TerminalComponentModelerData(Tidy3dBaseModel):
         title="TerminalComponentModeler",
         description="The original :class:`TerminalComponentModeler` object that defines the simulation setup "
         "and from which this data was generated.",
-    )
-
-    data: SimulationDataMap = pd.Field(
-        ...,
-        title="Port-Simulation Data Map",
-        description="A read-only dictionary that maps simulation data to each microwave port name",
-    )
-
-    log: str = pd.Field(
-        None,
-        title="Solver Log",
-        description="A string containing the log information from the simulation run.",
     )
 
     def smatrix(

--- a/tidy3d/plugins/smatrix/run.py
+++ b/tidy3d/plugins/smatrix/run.py
@@ -18,66 +18,6 @@ from tidy3d.web import Batch, BatchData
 DEFAULT_DATA_DIR = "."
 
 
-def compose_simulation_data_index(port_task_map: dict[str, str]) -> SimulationDataMap:
-    port_data_dict = {}
-    for _, _ in port_task_map.items():
-        pass
-        # FIXME: get simulationdata for each port
-        # port_data_dict[port] = sim_data_i
-
-    return SimulationDataMap(
-        keys=tuple(port_data_dict.keys()), values=tuple(port_data_dict.values())
-    )
-
-
-def compose_terminal_component_modeler_data(
-    modeler: TerminalComponentModeler, port_task_map: dict[str, str]
-) -> TerminalComponentModelerData:
-    """Assemble `TerminalComponentModelerData` from simulation results.
-
-    This function maps the simulation data from a completed batch run back to the
-    ports of the terminal component modeler.
-
-    Parameters
-    ----------
-    modeler : TerminalComponentModeler
-        The `TerminalComponentModeler` used to generate the simulations.
-    port_task_map : dict[str, str]
-        A dictionary mapping port names to their corresponding task identifiers.
-
-    Returns
-    -------
-    TerminalComponentModelerData
-        An object containing the results mapped to their respective ports.
-    """
-    port_simulation_data = compose_simulation_data_index(port_task_map)
-    return TerminalComponentModelerData(modeler=modeler, data=port_simulation_data)
-
-
-def compose_modal_component_modeler_data(
-    modeler: ModalComponentModeler, port_task_map: dict[str, str]
-) -> ModalComponentModelerData:
-    """Assemble `ModalComponentModelerData` from simulation results.
-
-    This function maps the simulation data from a completed batch run back to the
-    ports of the component modeler.
-
-    Parameters
-    ----------
-    modeler : ModalComponentModeler
-        The `ModalComponentModeler` used to generate the simulations.
-    port_task_map : dict[str, str]
-        A dictionary mapping port names to their corresponding task identifiers.
-
-    Returns
-    -------
-    ModalComponentModelerData
-        An object containing the results mapped to their respective ports.
-    """
-    port_simulation_data = compose_simulation_data_index(port_task_map)
-    return ModalComponentModelerData(modeler=modeler, data=port_simulation_data)
-
-
 def compose_modeler(
     modeler_file: str,
 ) -> ComponentModelerType:

--- a/tidy3d/plugins/smatrix/run.py
+++ b/tidy3d/plugins/smatrix/run.py
@@ -122,14 +122,7 @@ def compose_modeler_data_from_batch_data(
     port_simulation_data = SimulationDataMap(
         keys=tuple(batch_data.keys()), values=tuple(batch_data.values())
     )
-    if isinstance(modeler, ModalComponentModeler):
-        modeler_data = ModalComponentModelerData(modeler=modeler, data=port_simulation_data)
-    elif isinstance(modeler, TerminalComponentModeler):
-        modeler_data = TerminalComponentModelerData(modeler=modeler, data=port_simulation_data)
-    else:
-        raise TypeError(f"Unsupported modeler type: {type(modeler)}")
-
-    return modeler_data
+    return compose_modeler_data(modeler=modeler, indexed_sim_data=port_simulation_data)
 
 
 def create_batch(

--- a/tidy3d/plugins/smatrix/run.py
+++ b/tidy3d/plugins/smatrix/run.py
@@ -4,12 +4,13 @@ import json
 import os
 
 from tidy3d.components.base import Tidy3dBaseModel
+from tidy3d.components.data.index import SimulationDataMap
 from tidy3d.plugins.smatrix.component_modelers.modal import ModalComponentModeler
 from tidy3d.plugins.smatrix.component_modelers.terminal import TerminalComponentModeler
 from tidy3d.plugins.smatrix.component_modelers.types import (
     ComponentModelerType,
 )
-from tidy3d.plugins.smatrix.data.modal import ModalComponentModelerData, SimulationDataMap
+from tidy3d.plugins.smatrix.data.modal import ModalComponentModelerData
 from tidy3d.plugins.smatrix.data.terminal import TerminalComponentModelerData
 from tidy3d.plugins.smatrix.data.types import ComponentModelerDataType
 from tidy3d.web import Batch, BatchData
@@ -150,72 +151,6 @@ def compose_modeler_data(
     return modeler_data
 
 
-def compose_terminal_modeler_data_from_batch_data(
-    modeler: TerminalComponentModeler,
-    batch_data: BatchData,
-) -> TerminalComponentModelerData:
-    """Assemble `TerminalComponentModelerData` from simulation batch results.
-
-    This function maps the simulation data from a completed `BatchData` object
-    back to the ports of the `TerminalComponentModeler`.
-
-    Parameters
-    ----------
-    modeler : TerminalComponentModeler
-        The `TerminalComponentModeler` used to generate the simulations.
-    batch_data : BatchData
-        The results obtained from running the simulation `Batch`.
-
-    Returns
-    -------
-    TerminalComponentModelerData
-        An object containing the results mapped to their respective ports.
-    """
-    # Build keys to match the actual task names used in sim_dict (may include mode_index for WavePort)
-    task_names: list[str] = []
-    data_list = []
-    for source_index in modeler.matrix_indices_run_sim:
-        port, mode_index = modeler.network_dict[source_index]
-        task_name = modeler.get_task_name(port=port, mode_index=mode_index)
-        task_names.append(task_name)
-        data_list.append(batch_data[task_name])
-    port_simulation_data = SimulationDataMap(keys=tuple(task_names), values=tuple(data_list))
-    return TerminalComponentModelerData(modeler=modeler, data=port_simulation_data)
-
-
-def compose_modal_modeler_data_from_batch_data(
-    modeler: ModalComponentModeler,
-    batch_data: BatchData,
-) -> ModalComponentModelerData:
-    """Assemble `ModalComponentModelerData` from simulation batch results.
-
-    This function maps the simulation data from a completed `BatchData` object
-    back to the ports of the `ModalComponentModeler`.
-
-    Parameters
-    ----------
-    modeler : ModalComponentModeler
-        The `ModalComponentModeler` used to generate the simulations.
-    batch_data : BatchData, optional
-        The results obtained from running the simulation `Batch`.
-
-    Returns
-    -------
-    ModalComponentModelerData
-        An object containing the results mapped to their respective ports.
-    """
-    # Use exact task names for each (port, mode_index) that was run
-    task_names: list[str] = []
-    data_list = []
-    for port_name, mode_index in modeler.matrix_indices_run_sim:
-        port = modeler.get_port_by_name(port_name=port_name)
-        task_name = modeler.get_task_name(port=port, mode_index=mode_index)
-        task_names.append(task_name)
-        data_list.append(batch_data[task_name])
-    port_simulation_data = SimulationDataMap(keys=tuple(task_names), values=tuple(data_list))
-    return ModalComponentModelerData(modeler=modeler, data=port_simulation_data)
-
-
 def compose_modeler_data_from_batch_data(
     modeler: ComponentModelerType,
     batch_data: BatchData,
@@ -244,14 +179,13 @@ def compose_modeler_data_from_batch_data(
     TypeError
         If the provided `modeler` is not a recognized type.
     """
+    port_simulation_data = SimulationDataMap(
+        keys=tuple(batch_data.keys()), values=tuple(batch_data.values())
+    )
     if isinstance(modeler, ModalComponentModeler):
-        modeler_data = compose_modal_modeler_data_from_batch_data(
-            modeler=modeler, batch_data=batch_data
-        )
+        modeler_data = ModalComponentModelerData(modeler=modeler, data=port_simulation_data)
     elif isinstance(modeler, TerminalComponentModeler):
-        modeler_data = compose_terminal_modeler_data_from_batch_data(
-            modeler=modeler, batch_data=batch_data
-        )
+        modeler_data = TerminalComponentModelerData(modeler=modeler, data=port_simulation_data)
     else:
         raise TypeError(f"Unsupported modeler type: {type(modeler)}")
 

--- a/tidy3d/plugins/smatrix/run.py
+++ b/tidy3d/plugins/smatrix/run.py
@@ -171,9 +171,15 @@ def compose_terminal_modeler_data_from_batch_data(
     TerminalComponentModelerData
         An object containing the results mapped to their respective ports.
     """
-    ports = [modeler.get_task_name(port=port_i) for port_i in modeler.ports]
-    data = [batch_data[modeler.get_task_name(port=port_i)] for port_i in modeler.ports]
-    port_simulation_data = SimulationDataMap(keys=tuple(ports), values=tuple(data))
+    # Build keys to match the actual task names used in sim_dict (may include mode_index for WavePort)
+    task_names: list[str] = []
+    data_list = []
+    for source_index in modeler.matrix_indices_run_sim:
+        port, mode_index = modeler.network_dict[source_index]
+        task_name = modeler.get_task_name(port=port, mode_index=mode_index)
+        task_names.append(task_name)
+        data_list.append(batch_data[task_name])
+    port_simulation_data = SimulationDataMap(keys=tuple(task_names), values=tuple(data_list))
     return TerminalComponentModelerData(modeler=modeler, data=port_simulation_data)
 
 
@@ -198,9 +204,15 @@ def compose_modal_modeler_data_from_batch_data(
     ModalComponentModelerData
         An object containing the results mapped to their respective ports.
     """
-    ports = [modeler.get_task_name(port=port_i) for port_i in modeler.ports]
-    data = [batch_data[modeler.get_task_name(port=port_i)] for port_i in modeler.ports]
-    port_simulation_data = SimulationDataMap(keys=tuple(ports), values=tuple(data))
+    # Use exact task names for each (port, mode_index) that was run
+    task_names: list[str] = []
+    data_list = []
+    for port_name, mode_index in modeler.matrix_indices_run_sim:
+        port = modeler.get_port_by_name(port_name=port_name)
+        task_name = modeler.get_task_name(port=port, mode_index=mode_index)
+        task_names.append(task_name)
+        data_list.append(batch_data[task_name])
+    port_simulation_data = SimulationDataMap(keys=tuple(task_names), values=tuple(data_list))
     return ModalComponentModelerData(modeler=modeler, data=port_simulation_data)
 
 

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -286,12 +286,7 @@ def upload(
     port_name_list = None
     if task_type in ("COMPONENT_MODELER", "TERMINAL_COMPONENT_MODELER"):
         task_type = "RF"
-        # Collect port names for modeler tasks if available
-        try:
-            sim_dict = getattr(simulation, "sim_dict", None)
-            port_name_list = sim_dict.keys() if sim_dict else None
-        except Exception:
-            port_name_list = None
+        port_name_list = tuple(simulation.sim_dict.keys())
 
     task = SimulationTask.create(
         task_type,


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-01 14:44:19 UTC

This PR fixes a critical bug in the S-matrix component modeling functionality where task name generation was inconsistent between simulation creation and data retrieval phases. The changes update two key functions: `compose_terminal_modeler_data_from_batch_data` and `compose_modal_modeler_data_from_batch_data` in the `tidy3d/plugins/smatrix/run.py` file.

The core issue was that these functions were generating incomplete task names that didn't account for mode indices when dealing with WavePort objects. The original implementation only iterated through `modeler.ports` and called `get_task_name(port=port_i)` without the `mode_index` parameter. However, the actual simulation dictionary creation uses both port and mode_index information, with task names potentially including `_{mode_index}` suffixes for WavePort objects.

The fix ensures consistency by using the exact same logic for task name generation in both phases:
- For `TerminalComponentModeler`: Uses `modeler.matrix_indices_run_sim` indices and maps them through `modeler.network_dict` to get the correct (port, mode_index) pairs
- For `ModalComponentModeler`: Directly uses the (port_name, mode_index) tuples from `modeler.matrix_indices_run_sim`

This change maintains the integrity of the component modeling workflow by ensuring that data retrieval operations can successfully locate simulation results using the correct task names that match those used during simulation creation.

## Important Files Changed

<details>
<summary>Files Changed</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/smatrix/run.py | 4/5 | Fixed critical bug in task name generation for S-matrix component modeling data retrieval functions |

</details>

## Confidence score: 4/5

- This PR addresses a critical bug that would cause KeyError exceptions in production, making it an important fix with clear benefits
- Score reflects the focused nature of the change and the clear problem-solution mapping, though the complexity of the S-matrix modeling system requires careful attention
- Pay close attention to the task name generation logic and ensure the fix covers all WavePort scenarios correctly

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant run
    participant create_batch
    participant Batch
    participant compose_modeler_data_from_batch_data
    participant compose_terminal_modeler_data_from_batch_data
    participant compose_modal_modeler_data_from_batch_data
    participant SimulationDataMap
    participant TerminalComponentModelerData
    participant ModalComponentModelerData

    User->>run: "run(modeler, path_dir)"
    run->>create_batch: "create_batch(modeler, path_dir)"
    create_batch->>Batch: "Batch(simulations=modeler.sim_dict, parent_tasks, group_ids)"
    Batch-->>create_batch: batch
    create_batch->>Batch: "batch.to_file(filepath)"
    create_batch-->>run: batch
    
    run->>Batch: "batch.run()"
    Batch-->>run: batch_data
    
    run->>compose_modeler_data_from_batch_data: "compose_modeler_data_from_batch_data(modeler, batch_data)"
    
    alt modeler is ModalComponentModeler
        compose_modeler_data_from_batch_data->>compose_modal_modeler_data_from_batch_data: "compose_modal_modeler_data_from_batch_data(modeler, batch_data)"
        compose_modal_modeler_data_from_batch_data->>SimulationDataMap: "SimulationDataMap(keys, values)"
        SimulationDataMap-->>compose_modal_modeler_data_from_batch_data: port_simulation_data
        compose_modal_modeler_data_from_batch_data->>ModalComponentModelerData: "ModalComponentModelerData(modeler, data)"
        ModalComponentModelerData-->>compose_modal_modeler_data_from_batch_data: modeler_data
        compose_modal_modeler_data_from_batch_data-->>compose_modeler_data_from_batch_data: modeler_data
    else modeler is TerminalComponentModeler
        compose_modeler_data_from_batch_data->>compose_terminal_modeler_data_from_batch_data: "compose_terminal_modeler_data_from_batch_data(modeler, batch_data)"
        compose_terminal_modeler_data_from_batch_data->>SimulationDataMap: "SimulationDataMap(keys, values)"
        SimulationDataMap-->>compose_terminal_modeler_data_from_batch_data: port_simulation_data
        compose_terminal_modeler_data_from_batch_data->>TerminalComponentModelerData: "TerminalComponentModelerData(modeler, data)"
        TerminalComponentModelerData-->>compose_terminal_modeler_data_from_batch_data: modeler_data
        compose_terminal_modeler_data_from_batch_data-->>compose_modeler_data_from_batch_data: modeler_data
    end
    
    compose_modeler_data_from_batch_data-->>run: modeler_data
    run-->>User: ComponentModelerDataType
```

<!-- /greptile_comment -->