### PR TITLE
Moving `get_geo_inds` to `Grid`

### DIFF
--- a/tests/test_components/test_grid.py
+++ b/tests/test_components/test_grid.py
@@ -341,3 +341,64 @@ def test_grid_auto_uniform():
 
     for b_uniform, b_auto in zip(bounds_uniform, bounds_auto):
         assert np.allclose(b_uniform, b_auto)
+
+
+def test_get_geo_inds_no_span():
+    g = make_grid()
+    # Full-domain box: spans all cells along each axis
+    geo_full = td.Box(center=(0, 0, 0), size=(2, 4, 6))
+
+    # Expected: expand discretize_inds by 2 and clip to Yee E-grid sizes
+    raw_inds = g.discretize_inds(geo_full.bounding_box, extend=False)
+    lengths = [len(arr) for arr in g.yee.E.x.to_list]  # [Nx, Ny, Nz] on E.x grid
+    expand = 2
+    expected = np.array(
+        [
+            [
+                max(raw_inds[i][0] - expand, 0),
+                min(raw_inds[i][1] + expand, lengths[i]),
+            ]
+            for i in range(3)
+        ]
+    )
+
+    inds = g._get_geo_inds(geo_full)
+    assert np.array_equal(inds, expected)
+
+
+def test_get_geo_inds_with_span():
+    g = make_grid()
+    geo_full = td.Box(center=(0, 0, 0), size=(2, 4, 6))
+
+    # span_inds are in the same index space as discretize_inds (boundaries index space)
+    # Choose a restricted span to intersect with the full-geometry indices
+    span_inds = np.array(
+        [
+            [1, 2],  # x boundaries indices (restrict to right cell)
+            [1, 3],  # y boundaries indices
+            [2, 5],  # z boundaries indices
+        ]
+    )
+
+    # Expected: intersect raw inds with span, then expand and clip
+    raw_inds = g.discretize_inds(geo_full.bounding_box, extend=False)
+    intersect = np.array(
+        [
+            [max(raw_inds[i][0], span_inds[i][0]), min(raw_inds[i][1], span_inds[i][1])]
+            for i in range(3)
+        ]
+    )
+    lengths = [len(arr) for arr in g.yee.E.x.to_list]
+    expand = 2
+    expected = np.array(
+        [
+            [
+                max(intersect[i][0] - expand, 0),
+                min(intersect[i][1] + expand, lengths[i]),
+            ]
+            for i in range(3)
+        ]
+    )
+
+    inds = g._get_geo_inds(geo_full, span_inds=span_inds)
+    assert np.array_equal(inds, expected)

--- a/tidy3d/components/grid/grid.py
+++ b/tidy3d/components/grid/grid.py
@@ -10,8 +10,8 @@ import pydantic.v1 as pd
 from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.data.data_array import DataArray, ScalarFieldDataArray, SpatialDataArray
 from tidy3d.components.data.utils import UnstructuredGridDataset, UnstructuredGridDatasetType
-from tidy3d.components.geometry.base import Box
-from tidy3d.components.types import ArrayFloat1D, Axis, Coordinate, InterpMethod
+from tidy3d.components.geometry.base import Box, Geometry
+from tidy3d.components.types import ArrayFloat1D, ArrayLike, Axis, Coordinate, InterpMethod
 from tidy3d.exceptions import SetupError
 
 # data type of one dimensional coordinate array.
@@ -711,3 +711,48 @@ class Grid(Tidy3dBaseModel):
             z=self.boundaries.z + vector[2],
         )
         return self.updated_copy(boundaries=boundaries)
+
+    def _get_geo_inds(self, geo: Geometry, span_inds: ArrayLike = None, expand_inds: int = 2):
+        """
+        Get ``geo_inds`` based on a geometry's bounding box, enlarged by ``expand_inds``.
+        If ``span_inds`` is supplied, take the intersection of ``span_inds`` and ``geo``'s bounding
+        box before the enlargement.
+
+        Parameters
+        ----------
+        geo : Geometry
+            The geometry whose bounding box is used to determine grid indices.
+        span_inds : ArrayLike, optional
+            Optional indices to restrict the region; the union with the geometry's bounding box is taken.
+        expand_inds : int, default=2
+            Number of grid cells to expand the region on each side.
+
+        Returns
+        -------
+        List[Tuple[int, int]]
+            The (start, stop) indexes of the cells for interpolation.
+        """
+        # only interpolate inside the bounding box
+        geo_inds = self.discretize_inds(geo.bounding_box, extend=False)
+        if span_inds is not None:
+            geo_inds = np.array(
+                [
+                    [lower, upper]
+                    for lower, upper in zip(
+                        [max(geo_inds[i][0], span_inds[i][0]) for i in range(3)],
+                        [min(geo_inds[i][1], span_inds[i][1]) for i in range(3)],
+                    )
+                ]
+            )
+
+        # expand `geo_inds` if requested
+        num_xyz = [len(xyz) for xyz in self.yee.E.x.to_list]
+        return np.array(
+            [
+                [lower, upper]
+                for lower, upper in zip(
+                    [max(geo_inds[i][0] - expand_inds, 0) for i in range(3)],
+                    [min(geo_inds[i][1] + expand_inds, num_xyz[i]) for i in range(3)],
+                )
+            ]
+        )


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-02 09:10:05 UTC

This PR moves the `_get_geo_inds` method to the `Grid` class, which computes grid indices for a geometry's bounding box with optional expansion and span restriction. The new method is added to `tidy3d/components/grid/grid.py` and provides a centralized way to determine which grid cells are relevant for a given geometry in the FDTD simulation framework.

The `_get_geo_inds` method takes a `Geometry` object and optional parameters for span indices restriction and expansion amount. It works by:
1. Computing discretization indices for the geometry's bounding box using `self.discretize_inds()`
2. Optionally taking the union with provided `span_inds` to restrict the region
3. Expanding the indices by a configurable number of grid cells (default 2) on each side
4. Clipping the expanded indices to stay within the Yee E-grid boundaries

This architectural improvement consolidates geometry-to-grid mapping logic within the `Grid` class itself, making it more accessible and reusable across different components that need to map geometric objects to discrete grid indices. The underscore prefix indicates this is intended as an internal helper method. The functionality is commonly needed for operations like material assignment, field monitoring, and spatial interpolations in electromagnetic simulations.

Corresponding test functions were added to `tests/test_components/test_grid.py` to validate both the basic expansion behavior and the more complex case with span indices restriction.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/grid/grid.py | 4/5 | Adds new `_get_geo_inds` method to Grid class for computing geometry-based grid indices with expansion and optional span restriction |
| tests/test_components/test_grid.py | 4/5 | Adds comprehensive tests for the new `_get_geo_inds` method covering both basic and span-restricted scenarios |

</details>

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it adds new functionality without modifying existing behavior
- Score reflects well-structured code with proper testing, though there's a potential issue with nested attribute access that should be verified
- Pay close attention to the grid attribute access pattern in line 749 of grid.py (`self.yee.E.x.to_list`)

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant Grid
    participant Geometry
    participant YeeGrid
    
    User->>Grid: "_get_geo_inds(geo, span_inds=None, expand_inds=2)"
    Grid->>Geometry: "geo.bounding_box"
    Geometry-->>Grid: "bounding box coordinates"
    Grid->>Grid: "discretize_inds(bounding_box, extend=False)"
    Grid-->>Grid: "raw geo_inds"
    
    alt span_inds provided
        Grid->>Grid: "intersect geo_inds with span_inds"
        Grid-->>Grid: "updated geo_inds"
    end
    
    Grid->>YeeGrid: "self.yee.E.x.to_list"
    YeeGrid-->>Grid: "grid dimensions [Nx, Ny, Nz]"
    Grid->>Grid: "expand geo_inds by expand_inds and clip to grid bounds"
    Grid-->>User: "final geo_inds array"
```

<!-- /greptile_comment -->