### PR TITLE
RF task-name updates

### DIFF
--- a/tests/test_plugins/smatrix/test_run_functions.py
+++ b/tests/test_plugins/smatrix/test_run_functions.py
@@ -4,6 +4,7 @@ import json
 import os
 from unittest.mock import MagicMock
 
+import pydantic.v1 as pd
 import pytest
 
 import tidy3d
@@ -20,8 +21,6 @@ from tidy3d.plugins.smatrix.data.terminal import TerminalComponentModelerData
 from tidy3d.plugins.smatrix.run import (
     compose_modeler,
     compose_modeler_data,
-    compose_simulation_data_index,
-    compose_terminal_component_modeler_data,
     create_batch,
     run,
 )
@@ -46,44 +45,6 @@ def test_compose_modeler_unsupported_type(tmp_path, monkeypatch):
     # Expect a TypeError when calling compose_modeler with the unsupported type
     with pytest.raises(TypeError, match="Unsupported modeler type: str"):
         compose_modeler(modeler_file=str(modeler_file))
-
-
-def test_compose_simulation_data_index_empty_map():
-    port_task_map = {}
-    result = compose_simulation_data_index(port_task_map)
-    assert isinstance(result, SimulationDataMap)
-    assert len(result.keys()) == 0
-    assert len(result.values()) == 0
-
-
-def test_compose_terminal_component_modeler_data(monkeypatch):
-    # Mock compose_simulation_data_index
-    dummy_sim_data_map = SimulationDataMap(
-        keys=("port1", "port2"),
-        values=(
-            SimulationData(
-                simulation=make_terminal_component_modeler(planar_pec=True).simulation, data=()
-            ),
-            SimulationData(
-                simulation=make_terminal_component_modeler(planar_pec=True).simulation, data=()
-            ),
-        ),
-    )
-    monkeypatch.setattr(
-        "tidy3d.plugins.smatrix.run.compose_simulation_data_index", lambda x: dummy_sim_data_map
-    )
-
-    # Create a dummy TerminalComponentModeler
-    dummy_modeler = make_terminal_component_modeler(planar_pec=True)
-
-    # Call the function under test
-    port_task_map = {"port1": "task1", "port2": "task2"}
-    result = compose_terminal_component_modeler_data(dummy_modeler, port_task_map)
-
-    # Assertions
-    assert isinstance(result, TerminalComponentModelerData)
-    assert result.modeler == dummy_modeler
-    assert result.data == dummy_sim_data_map
 
 
 def test_create_batch(monkeypatch, tmp_path):
@@ -165,3 +126,22 @@ def test_compose_modeler_data_unsupported_type():
 
     with pytest.raises(TypeError, match="Unsupported modeler type: UnsupportedModeler"):
         compose_modeler_data(unsupported_modeler, dummy_sim_data_map)
+
+
+def test_compose_modeler_data_keys_mismatch():
+    dummy_sim_data_map = SimulationDataMap(
+        keys=("1", "2"),
+        values=(
+            SimulationData(
+                simulation=make_terminal_component_modeler(planar_pec=True).simulation, data=()
+            ),
+            SimulationData(
+                simulation=make_terminal_component_modeler(planar_pec=True).simulation, data=()
+            ),
+        ),
+    )
+
+    with pytest.raises(pd.ValidationError, match="do not match data keys"):
+        TerminalComponentModelerData(
+            modeler=make_terminal_component_modeler(planar_pec=True), data=dummy_sim_data_map
+        )

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -144,7 +144,7 @@ class AbstractComponentModeler(ABC, Generic[IndexType, ElementType], Tidy3dBaseM
     def get_task_name(port: Port, mode_index: Optional[int] = None) -> str:
         """The name of a task, determined by the port of the source and mode index, if given."""
         if mode_index is not None:
-            return f"{port.name}_{mode_index}"
+            return f"{port.name}@{mode_index}"
         return f"{port.name}"
 
     def get_port_by_name(self, port_name: str) -> Port:

--- a/tidy3d/plugins/smatrix/data/base.py
+++ b/tidy3d/plugins/smatrix/data/base.py
@@ -1,0 +1,54 @@
+"""Data structures for post-processing modal component simulations to calculate S-matrices."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import pydantic.v1 as pd
+
+from tidy3d.components.base import Tidy3dBaseModel
+from tidy3d.components.data.data_array import DataArray
+from tidy3d.components.data.index import SimulationDataMap
+from tidy3d.plugins.smatrix.component_modelers.base import AbstractComponentModeler
+
+
+class AbstractComponentModelerData(ABC, Tidy3dBaseModel):
+    """A data container for the results of a :class:`.AbstractComponentModeler` run.
+
+    This class stores the original modeler and the simulation data obtained
+    from running the simulations it defines. It also provides a method to
+    compute the S-matrix from the simulation data.
+    """
+
+    modeler: AbstractComponentModeler = pd.Field(
+        ...,
+        title="Component modeler",
+        description="The original :class:`AbstractComponentModeler` object that defines the "
+        "simulation setup and from which this data was generated.",
+    )
+
+    data: SimulationDataMap = pd.Field(
+        ...,
+        title="SimulationDataMap",
+        description="A mapping from task names to :class:`.SimulationData` objects, "
+        "containing the results of each simulation run.",
+    )
+
+    log: str = pd.Field(
+        None,
+        title="Modeler Post-process Log",
+        description="A string containing the log information from the modeler post-processing run.",
+    )
+
+    @abstractmethod
+    def smatrix(self) -> DataArray:
+        """Computes and returns the scattering matrix (S-matrix)."""
+
+    @pd.validator("data")
+    def keys_match_modeler(cls, val, values):
+        modeler = values.get("modeler")
+        modeler_keys = tuple(modeler.sim_dict.keys())
+        data_keys = tuple(val.keys())
+        if modeler_keys != data_keys:
+            raise ValueError(f"Modeler keys {modeler_keys} do not match data keys {data_keys}.")
+        return val

--- a/tidy3d/plugins/smatrix/data/modal.py
+++ b/tidy3d/plugins/smatrix/data/modal.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 import pydantic.v1 as pd
 
-from tidy3d.components.base import Tidy3dBaseModel
-from tidy3d.components.data.index import SimulationDataMap
 from tidy3d.plugins.smatrix.component_modelers.modal import ModalComponentModeler
+from tidy3d.plugins.smatrix.data.base import AbstractComponentModelerData
 from tidy3d.plugins.smatrix.data.data_array import ModalPortDataArray
 
 
-class ModalComponentModelerData(Tidy3dBaseModel):
+class ModalComponentModelerData(AbstractComponentModelerData):
     """A data container for the results of a :class:`.ModalComponentModeler` run.
 
     This class stores the original modeler and the simulation data obtained
@@ -23,18 +22,6 @@ class ModalComponentModelerData(Tidy3dBaseModel):
         title="ModalComponentModeler",
         description="The original :class:`ModalComponentModeler` object that defines the simulation setup "
         "and from which this data was generated.",
-    )
-
-    data: SimulationDataMap = pd.Field(
-        ...,
-        title="SimulationDataMap",
-        description="A mapping from task names to :class:`.SimulationData` objects, containing the results of each simulation run.",
-    )
-
-    log: str = pd.Field(
-        None,
-        title="Modeler Post-process Log",
-        description="A string containing the log information from the modeler post-processing run.",
     )
 
     def smatrix(self) -> ModalPortDataArray:

--- a/tidy3d/plugins/smatrix/data/terminal.py
+++ b/tidy3d/plugins/smatrix/data/terminal.py
@@ -14,8 +14,8 @@ from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.microwave.data.monitor_data import AntennaMetricsData
 from tidy3d.log import log
 from tidy3d.plugins.smatrix.component_modelers.terminal import TerminalComponentModeler
+from tidy3d.plugins.smatrix.data.base import AbstractComponentModelerData
 from tidy3d.plugins.smatrix.data.data_array import PortDataArray, TerminalPortDataArray
-from tidy3d.plugins.smatrix.data.modal import SimulationDataMap
 from tidy3d.plugins.smatrix.network import SParamDef
 from tidy3d.plugins.smatrix.ports.types import TerminalPortType
 from tidy3d.plugins.smatrix.utils import (
@@ -51,7 +51,7 @@ class MicrowaveSMatrixData(Tidy3dBaseModel):
     )
 
 
-class TerminalComponentModelerData(Tidy3dBaseModel):
+class TerminalComponentModelerData(AbstractComponentModelerData):
     """
     Data associated with a :class:`TerminalComponentModeler` simulation run.
 
@@ -85,18 +85,6 @@ class TerminalComponentModelerData(Tidy3dBaseModel):
         title="TerminalComponentModeler",
         description="The original :class:`TerminalComponentModeler` object that defines the simulation setup "
         "and from which this data was generated.",
-    )
-
-    data: SimulationDataMap = pd.Field(
-        ...,
-        title="Port-Simulation Data Map",
-        description="A read-only dictionary that maps simulation data to each microwave port name",
-    )
-
-    log: str = pd.Field(
-        None,
-        title="Solver Log",
-        description="A string containing the log information from the simulation run.",
     )
 
     def smatrix(

--- a/tidy3d/plugins/smatrix/run.py
+++ b/tidy3d/plugins/smatrix/run.py
@@ -4,77 +4,18 @@ import json
 import os
 
 from tidy3d.components.base import Tidy3dBaseModel
+from tidy3d.components.data.index import SimulationDataMap
 from tidy3d.plugins.smatrix.component_modelers.modal import ModalComponentModeler
 from tidy3d.plugins.smatrix.component_modelers.terminal import TerminalComponentModeler
 from tidy3d.plugins.smatrix.component_modelers.types import (
     ComponentModelerType,
 )
-from tidy3d.plugins.smatrix.data.modal import ModalComponentModelerData, SimulationDataMap
+from tidy3d.plugins.smatrix.data.modal import ModalComponentModelerData
 from tidy3d.plugins.smatrix.data.terminal import TerminalComponentModelerData
 from tidy3d.plugins.smatrix.data.types import ComponentModelerDataType
 from tidy3d.web import Batch, BatchData
 
 DEFAULT_DATA_DIR = "."
-
-
-def compose_simulation_data_index(port_task_map: dict[str, str]) -> SimulationDataMap:
-    port_data_dict = {}
-    for _, _ in port_task_map.items():
-        pass
-        # FIXME: get simulationdata for each port
-        # port_data_dict[port] = sim_data_i
-
-    return SimulationDataMap(
-        keys=tuple(port_data_dict.keys()), values=tuple(port_data_dict.values())
-    )
-
-
-def compose_terminal_component_modeler_data(
-    modeler: TerminalComponentModeler, port_task_map: dict[str, str]
-) -> TerminalComponentModelerData:
-    """Assemble `TerminalComponentModelerData` from simulation results.
-
-    This function maps the simulation data from a completed batch run back to the
-    ports of the terminal component modeler.
-
-    Parameters
-    ----------
-    modeler : TerminalComponentModeler
-        The `TerminalComponentModeler` used to generate the simulations.
-    port_task_map : dict[str, str]
-        A dictionary mapping port names to their corresponding task identifiers.
-
-    Returns
-    -------
-    TerminalComponentModelerData
-        An object containing the results mapped to their respective ports.
-    """
-    port_simulation_data = compose_simulation_data_index(port_task_map)
-    return TerminalComponentModelerData(modeler=modeler, data=port_simulation_data)
-
-
-def compose_modal_component_modeler_data(
-    modeler: ModalComponentModeler, port_task_map: dict[str, str]
-) -> ModalComponentModelerData:
-    """Assemble `ModalComponentModelerData` from simulation results.
-
-    This function maps the simulation data from a completed batch run back to the
-    ports of the component modeler.
-
-    Parameters
-    ----------
-    modeler : ModalComponentModeler
-        The `ModalComponentModeler` used to generate the simulations.
-    port_task_map : dict[str, str]
-        A dictionary mapping port names to their corresponding task identifiers.
-
-    Returns
-    -------
-    ModalComponentModelerData
-        An object containing the results mapped to their respective ports.
-    """
-    port_simulation_data = compose_simulation_data_index(port_task_map)
-    return ModalComponentModelerData(modeler=modeler, data=port_simulation_data)
 
 
 def compose_modeler(
@@ -150,60 +91,6 @@ def compose_modeler_data(
     return modeler_data
 
 
-def compose_terminal_modeler_data_from_batch_data(
-    modeler: TerminalComponentModeler,
-    batch_data: BatchData,
-) -> TerminalComponentModelerData:
-    """Assemble `TerminalComponentModelerData` from simulation batch results.
-
-    This function maps the simulation data from a completed `BatchData` object
-    back to the ports of the `TerminalComponentModeler`.
-
-    Parameters
-    ----------
-    modeler : TerminalComponentModeler
-        The `TerminalComponentModeler` used to generate the simulations.
-    batch_data : BatchData
-        The results obtained from running the simulation `Batch`.
-
-    Returns
-    -------
-    TerminalComponentModelerData
-        An object containing the results mapped to their respective ports.
-    """
-    ports = [modeler.get_task_name(port=port_i) for port_i in modeler.ports]
-    data = [batch_data[modeler.get_task_name(port=port_i)] for port_i in modeler.ports]
-    port_simulation_data = SimulationDataMap(keys=tuple(ports), values=tuple(data))
-    return TerminalComponentModelerData(modeler=modeler, data=port_simulation_data)
-
-
-def compose_modal_modeler_data_from_batch_data(
-    modeler: ModalComponentModeler,
-    batch_data: BatchData,
-) -> ModalComponentModelerData:
-    """Assemble `ModalComponentModelerData` from simulation batch results.
-
-    This function maps the simulation data from a completed `BatchData` object
-    back to the ports of the `ModalComponentModeler`.
-
-    Parameters
-    ----------
-    modeler : ModalComponentModeler
-        The `ModalComponentModeler` used to generate the simulations.
-    batch_data : BatchData, optional
-        The results obtained from running the simulation `Batch`.
-
-    Returns
-    -------
-    ModalComponentModelerData
-        An object containing the results mapped to their respective ports.
-    """
-    ports = [modeler.get_task_name(port=port_i) for port_i in modeler.ports]
-    data = [batch_data[modeler.get_task_name(port=port_i)] for port_i in modeler.ports]
-    port_simulation_data = SimulationDataMap(keys=tuple(ports), values=tuple(data))
-    return ModalComponentModelerData(modeler=modeler, data=port_simulation_data)
-
-
 def compose_modeler_data_from_batch_data(
     modeler: ComponentModelerType,
     batch_data: BatchData,
@@ -232,18 +119,10 @@ def compose_modeler_data_from_batch_data(
     TypeError
         If the provided `modeler` is not a recognized type.
     """
-    if isinstance(modeler, ModalComponentModeler):
-        modeler_data = compose_modal_modeler_data_from_batch_data(
-            modeler=modeler, batch_data=batch_data
-        )
-    elif isinstance(modeler, TerminalComponentModeler):
-        modeler_data = compose_terminal_modeler_data_from_batch_data(
-            modeler=modeler, batch_data=batch_data
-        )
-    else:
-        raise TypeError(f"Unsupported modeler type: {type(modeler)}")
-
-    return modeler_data
+    port_simulation_data = SimulationDataMap(
+        keys=tuple(batch_data.keys()), values=tuple(batch_data.values())
+    )
+    return compose_modeler_data(modeler=modeler, indexed_sim_data=port_simulation_data)
 
 
 def create_batch(

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -288,11 +288,8 @@ def upload(
         task_type = "RF"
         # Collect port names for modeler tasks if available
         try:
-            ports = getattr(simulation, "ports", None)
-            if ports is not None:
-                port_name_list = [
-                    getattr(p, "name", None) for p in ports if getattr(p, "name", None)
-                ]
+            sim_dict = getattr(simulation, "sim_dict", None)
+            port_name_list = sim_dict.keys() if sim_dict else None
         except Exception:
             port_name_list = None
 

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -286,12 +286,7 @@ def upload(
     port_name_list = None
     if task_type in ("COMPONENT_MODELER", "TERMINAL_COMPONENT_MODELER"):
         task_type = "RF"
-        # Collect port names for modeler tasks if available
-        try:
-            sim_dict = getattr(simulation, "sim_dict", None)
-            port_name_list = sim_dict.keys() if sim_dict else None
-        except Exception:
-            port_name_list = None
+        port_name_list = tuple(simulation.sim_dict.keys())
 
     task = SimulationTask.create(
         task_type,


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-02 17:32:27 UTC

This PR introduces changes to the task naming convention for RF component modelers in the Tidy3D simulation framework. The primary modification updates the separator used in task names from underscore (`_`) to at-sign (`@`) when combining port names with mode indices. Additionally, the PR refactors how port names are collected for RF task uploads, shifting from directly accessing port objects to extracting names from a simulation dictionary.

The core change occurs in the `get_task_name` static method within the base S-matrix component modeler class, where task names are now formatted as `{port.name}@{mode_index}` instead of `{port.name}_{mode_index}`. This naming convention change propagates throughout the RF simulation workflow, affecting how tasks are identified and managed.

Concurrently, the web API upload functionality has been updated to align with this architectural shift. Instead of iterating through port objects to extract names, the system now retrieves port names from the keys of a `sim_dict` attribute on the simulation object. This `sim_dict` appears to be a `SimulationMap` that contains pre-computed task names, suggesting a move toward more centralized task name management.

These changes represent part of a broader "RF task-name updates" initiative that aims to standardize and potentially improve the readability of task naming conventions in RF component modeling workflows. The modifications maintain functional compatibility while establishing a new naming paradigm that may better handle complex port names or provide clearer semantic meaning in task identification.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/smatrix/component_modelers/base.py | 4/5 | Updates task naming format from underscore to `@` symbol separator for port names and mode indices |
| tidy3d/web/api/webapi.py | 3/5 | Refactors port name collection to use simulation dictionary keys instead of direct port object access |

</details>

## Confidence score: 3/5

- This PR introduces a potentially breaking change to task naming conventions that could affect existing workflows and integrations
- Score reflects concerns about the `@` symbol choice which has special meaning in many contexts and could cause parsing or encoding issues
- Pay close attention to tidy3d/web/api/webapi.py where the logic assumes `sim_dict` exists and may fail if the attribute is missing

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant webapi
    participant ComponentModeler
    participant SimulationTask
    participant BatchTask
    participant Server

    User->>webapi: "run(simulation, task_name, folder_name)"
    webapi->>webapi: "upload(simulation, task_name, folder_name)"
    webapi->>ComponentModeler: "get task_type from simulation"
    ComponentModeler->>ComponentModeler: "get_task_name(port, mode_index)"
    ComponentModeler-->>webapi: "task_type = 'RF'"
    webapi->>SimulationTask: "create(task_type='RF', task_name, folder_name)"
    SimulationTask->>Server: "Create RF task on server"
    Server-->>SimulationTask: "task_id, batch_id"
    SimulationTask-->>webapi: "task_id"
    webapi->>webapi: "start(task_id)"
    webapi->>BatchTask: "is_batch(task_id, batch_type='RF_SWEEP')"
    BatchTask-->>webapi: "true"
    webapi->>Server: "POST split RF batch"
    Server-->>webapi: "child simulation subtasks"
    webapi->>BatchTask: "check(batch_type='RF_SWEEP')"
    BatchTask->>Server: "Validate RF batch"
    Server-->>BatchTask: "validation results"
    webapi->>BatchTask: "submit(batch_type='RF_SWEEP')"
    BatchTask->>Server: "Submit batch for execution"
    webapi->>webapi: "monitor(task_id)"
    webapi->>webapi: "_monitor_modeler_batch(task_id)"
    loop Monitoring Progress
        webapi->>BatchTask: "_batch_detail(batch_id)"
        BatchTask->>Server: "Get batch status"
        Server-->>BatchTask: "batch progress details"
        BatchTask-->>webapi: "status, progress"
        webapi->>User: "Display progress bars"
    end
    webapi->>BatchTask: "postprocess(batch_type='RF_SWEEP')"
    BatchTask->>Server: "Start postprocessing"
    loop Wait for Postprocess
        webapi->>BatchTask: "detail(batch_type='RF_SWEEP')"
        BatchTask-->>webapi: "postprocess status"
    end
    webapi->>webapi: "load(task_id)"
    webapi->>BatchTask: "get_data_hdf5()"
    BatchTask->>Server: "Download results"
    Server-->>BatchTask: "cm_data.hdf5"
    BatchTask-->>webapi: "simulation data"
    webapi-->>User: "WorkflowDataType results"
```

<!-- /greptile_comment -->