### PR TITLE
Add tidy3d-extras install option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - New `MediumMonitor` that returns both permittivity and permeability profiles.
 - Task names are now optional when using `run(sim)` or `Job`. When running multiple jobs (via `run_async` or `Batch`), you can also provide simulations as a list without specifying task names. The previous dictionary-based format with explicit task names is still supported.
+- Added support for `tidy3d-extras`, an optional plugin that enables more accurate local mode solving via subpixel averaging.
 
 ### Changed
 

--- a/docs/extras/index.rst
+++ b/docs/extras/index.rst
@@ -1,0 +1,76 @@
+Extras Plugin |:gift:|
+======================
+.. currentmodule:: tidy3d-extras
+
+``tidy3d-extras`` is an optional plugin for Tidy3D providing additional, more advanced local functionality. This additional functionality includes a more accurate local mode solver with subpixel averaging.
+
+
+Installation
+------------
+
+Simply go to `tidy3d.simulation.cloud <https://tidy3d.simulation.cloud/>`__ and sign up for an account.
+From there, just load our `web GUI <https://tidy3d.simulation.cloud/folders>`__ (no installation required) or continue with the next steps for the Python interface.
+
+``tidy3d-extras`` is a python module that can be easily installed via ``pip``.
+The version must match the version of Tidy3D, so the preferred command
+for installation is::
+
+   pip install "tidy3d[extras]"
+
+This command will install ``tidy3d-extras`` and its dependencies in the current environment.
+
+.. important::
+
+   ``tidy3d-extras`` is **not compatible with Conda environments**.
+   Please use a standard Python virtual environment (e.g., ``venv`` or ``virtualenv``) for installation.
+
+A Tidy3D API key is required to authenticate ``tidy3d-extras`` users.
+If you don't have one already configured, you can `get a free API key <https://tidy3d.simulation.cloud/account?tab=apikey>`__ and configure it with the following command::
+
+   tidy3d configure
+
+On **Windows**, it is easier to use ``pipx`` to find the path to the configuration tool::
+
+   pip install pipx
+   pipx run tidy3d configure
+
+More information about the installation and configuration of Tidy3D can be found `here <https://docs.flexcompute.com/projects/tidy3d/en/latest/install.html>`__.
+
+You can verify that the ``tidy3d-extras`` installation worked by running the following command to print the installed version::
+
+   python -c 'import tidy3d_extras as tde; print(tde.__version__)'
+
+
+Usage
+-----
+
+Currently, ``tidy3d-extras`` provides the following features:
+
+- Local subpixel-averaged permittivity. This is what one would obtain
+  with a ``PermittivityMonitor`` in an FDTD ``Simulation``.
+- More accurate local mode solver with subpixel averaging.
+
+By default, these features are automatically enabled if the ``tidy3d-extras``
+package is installed. Thus to obtain subpixel-averaged permittivity, you can
+use functions like ``Simulation.epsilon``. And the more accurate mode solver
+with subpixel averaging is used whenever the mode solver is run locally.
+
+Sometimes, you may want to change this behavior, for example to speed up
+permittivity computation. In this case, you can temporarily disable these
+features by setting the config variable::
+
+   tidy3d.config.use_local_subpixel = False
+
+This can also be set to ``True`` to ensure that subpixel averaging is used.
+You can check whether local subpixel averaging is turned on::
+
+   tidy3d.packaging.tidy3d_extras["use_local_subpixel"]
+
+Licenses
+--------
+
+.. toctree::
+   :maxdepth: 2
+
+   license
+   third_party_licenses

--- a/docs/extras/license.rst
+++ b/docs/extras/license.rst
@@ -1,0 +1,121 @@
+Software License Agreement
+==========================
+
+THIS AGREEMENT GOVERNS YOUR (“LICENSEE”) ACQUISITION AND USE OF THE FLEXCOMPUTE, INC (HEREAFTER “LICENSOR”) TIDY3D-EXTRAS SOFTWARE (THE “SOFTWARE”).
+IF YOU ARE ENTERING INTO THIS AGREEMENT ON BEHALF OF A COMPANY OR OTHER LEGAL ENTITY, YOU REPRESENT THAT YOU HAVE THE AUTHORITY TO BIND SUCH ENTITY AND ITS AFFILIATES TO THESE TERMS AND CONDITIONS, IN WHICH CASE THE TERM “LICENSEE” SHALL REFER TO YOU AND/OR SUCH ENTITY AND ITS AFFILIATES. IF YOU DO NOT HAVE SUCH AUTHORITY, OR IF YOU DO NOT AGREE WITH THESE TERMS AND CONDITIONS, YOU MUST NOT ACCEPT THIS AGREEMENT AND MAY NOT USE THE SOFTWARE.
+LICENSEE’S USE OF THE SOFTWARE CONSTITUTES LICENSEE’S AGREEMENT TO THESE TERMS. IT IS EFFECTIVE BETWEEN LICENSEE AND LICENSOR AS OF THE DATE LICENSEE FIRST USES THE SOFTWARE (THE “EFFECTIVE DATE”).
+
+NOW, THEREFORE, in consideration of the mutual covenants, terms, and conditions set forth herein, and for other good and valuable consideration, the receipt and sufficiency of which are hereby acknowledged, Licensor and Licensee agree as follows:
+
+1. Definitions
+--------------
+
+(a) **"Authorized User"** means an employee or contractor of Licensee who Licensee permits to access and use the Software and/or Documentation pursuant to Licensee's license hereunder.
+
+(b) **"Documentation"** means Licensor's user manuals, handbooks, and installation guides relating to the Software provided by Licensor to Licensee at https://docs.flexcompute.com/projects/tidy3d/en/latest/extras/.
+
+(c) **"Software"** means the python module which includes compiled C++ source code in object code format and python scripts, including any updates provided to Licensee by Licensor pursuant to this Agreement.
+
+(d) **"Third-Party Products"** means any third-party products described in Exhibit A provided with or incorporated into the Software, including any open source software.
+
+(e) **"Updates"** means any updates, bug fixes, patches, or other error corrections to the Software that Licensor generally makes available free of charge to all licensees of the Software.
+
+2. License
+----------
+
+(a) License Grant. Subject to and conditioned on Licensee's compliance with the terms and conditions of this Agreement, Licensor hereby grants Licensee a non-exclusive, non-sublicensable, terminable, limited license to use the Software solely for Licensee's internal business purposes during the Term.
+
+(b) Use Restrictions. Licensee shall not use the Software for any purposes beyond the scope of the license granted in this Agreement. Without limiting the foregoing and except as otherwise expressly set forth in this Agreement or other fully executed writing among the parties, Licensee shall not at any time, directly or indirectly: (i) modify, adapt, or create derivative works of the Software, in whole or in part; (ii) rent, lease, lend, sell, sublicense, assign, distribute, publish, transfer, or otherwise make available the Software as part of any other software created or distributed by Licensee; (iii) reverse engineer, disassemble, decompile, decode, adapt, or otherwise attempt to derive or gain access to the source code, in whole or in part, of that portion of the Software delivered in object code format; (iv) remove any proprietary notices from the Software; or (v) use the Software in any manner or for any purpose that infringes, misappropriates, or otherwise violates any intellectual property right or other right of any person, or that violates any applicable law.
+
+(c) Reservation of Rights. Licensor reserves all rights not expressly granted to Licensee in this Agreement. Except for the limited rights and licenses expressly granted under this Agreement, nothing in this Agreement grants, by implication, waiver, estoppel, or otherwise, to Licensee or any third party any intellectual property rights or other right, title, or interest in or to the Software.
+
+3. Licensee Responsibilities
+----------------------------
+
+(a) General. Licensee is responsible and liable for all uses of the Software resulting from access provided by Licensee, directly or indirectly, whether such access or use is permitted by or in violation of this Agreement. Without limiting the generality of the foregoing, Licensee is responsible for all acts and omissions of Authorized Users, and any act or omission by an Authorized User that would constitute a breach of this Agreement if taken by Licensee will be deemed a breach of this Agreement by Licensee. Licensee shall take reasonable efforts to make all Authorized Users aware of this Agreement's provisions as applicable to such Authorized User's use of the Software, and shall cause Authorized Users to comply with such provisions.
+
+(b) Third-Party Products. Licensor may distribute certain Third-Party Products with the Software. For purposes of this Agreement, such Third-Party Products are subject to their own license terms and the applicable flow-through provisions referred to in Exhibit A. If Licensee does not agree to abide by the applicable terms for such Third-Party Product, then Licensee should not install or use such Third-Party Products. The Software also contains certain open source software identified on Exhibit A. Licensee understands and acknowledges that such open source software is not licensed to Licensee pursuant to the provisions of this Agreement and that this Agreement may not be construed to grant any such right and/or license. Licensee shall have only such rights and/or licenses, if any, to use the open source software as set forth in the licenses referenced in Exhibit A.
+
+4. Support
+----------
+
+This Agreement does not entitle Licensee to any support for the Software.
+
+5. Fees and Payment
+-------------------
+
+(a) Fees. Licensee may choose to purchase access to certain additional functionality within the Software in which case Licensee shall pay Licensor the fees ("Fees") set forth in the applicable ordering form presented by Licensor. If Licensee fails to make any payment when due, in addition to all other remedies that may be available: (i) Licensor may charge interest on the past due amount at the rate of 1.5% per month calculated daily and compounded monthly or, if lower, the highest rate permitted under applicable law; (ii) Licensee shall reimburse Licensor for all costs incurred by Licensor in collecting any late payments or interest, including attorneys' fees, court costs, and collection agency fees; and (iii) if such failure continues for five (5) days following written notice thereof, Licensor may prohibit access to those portions of the Software requiring payment by Licensor until all past due amounts and interest thereon have been paid, without incurring any obligation or liability to Licensee or any other person by reason of such prohibition of access to the Software.
+
+(b) Taxes. All Fees and other amounts payable by Licensee under this Agreement are exclusive of taxes and similar assessments. Licensee is responsible for all sales, use, and excise taxes, and any other similar taxes, duties, and charges of any kind imposed by any federal, state, or local governmental or regulatory authority on any amounts payable by Licensee hereunder, other than any taxes imposed on Licensor's income.
+
+(c) Auditing Rights and Required Records. Licensee agrees to maintain complete and accurate records in accordance with generally accepted accounting principles during the Term and for a period of two (2) years after the termination or expiration of this Agreement with respect to matters necessary for accurately determining amounts due hereunder. Licensor may, at its own expense, on reasonable prior notice, periodically inspect and audit Licensee's records with respect to matters covered by this Agreement. Such inspection and auditing rights will extend throughout the Term of this Agreement and continue for a period of two (2) years after the termination or expiration of this Agreement. If Licensor’s audit reveals underpayment by Licensee, Licensee will promptly pay Licensor’s invoice reflecting the amounts due because of such underpayment.
+
+6. Intellectual Property Ownership; Feedback
+--------------------------------------------
+
+(a) Licensee acknowledges that, as between Licensee and Licensor, Licensor owns all right, title, and interest, including all intellectual property rights, in and to the Software and Documentation.
+
+(b) Feedback. If Licensee or any of its employees or contractors sends or transmits any communications or materials to Licensor by mail, email, telephone, or otherwise, suggesting or recommending changes to the Software or Documentation, including without limitation, new features or functionality relating thereto, or any comments, questions, suggestions, or the like ("Feedback"), Licensor is free to use such Feedback irrespective of any other obligation or limitation between the Parties governing such Feedback. Licensee hereby assigns to Licensor on Licensee's behalf, and on behalf of its employees, contractors and/or agents, all right, title, and interest in, and Licensor is free to use, without any attribution or compensation to any party, any ideas, know-how, concepts, techniques, or other intellectual property rights contained in the Feedback, for any purpose whatsoever, although Licensor is not required to use any Feedback.
+
+7. Warranty Disclaimer
+----------------------
+
+THE SOFTWARE AND DOCUMENTATION ARE PROVIDED "AS IS" AND LICENSOR HEREBY DISCLAIMS ALL WARRANTIES, WHETHER EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE. LICENSOR SPECIFICALLY DISCLAIMS ALL IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT, AND ALL WARRANTIES ARISING FROM COURSE OF DEALING, USAGE, OR TRADE PRACTICE. LICENSOR MAKES NO WARRANTY OF ANY KIND THAT THE SOFTWARE AND DOCUMENTATION, OR ANY PRODUCTS OR RESULTS OF THE USE THEREOF, WILL MEET LICENSEE'S OR ANY OTHER PERSON'S REQUIREMENTS, OPERATE WITHOUT INTERRUPTION, ACHIEVE ANY INTENDED RESULT, BE COMPATIBLE OR WORK WITH ANY SOFTWARE, SYSTEM OR OTHER SERVICES, OR BE SECURE, ACCURATE, COMPLETE, FREE OF HARMFUL CODE, OR ERROR FREE.
+
+8. Indemnification
+------------------
+
+Licensee Indemnification. Licensee shall indemnify, hold harmless, and, at Licensor's option, defend Licensor from and against any Losses resulting from any Third-Party Claim based on Licensee's, or any Authorized User's: (i) negligence or willful misconduct; or (ii) use of the Software or Documentation in a manner not authorized or contemplated by this Agreement; (iii) use of the Software in combination with data, software, hardware, equipment, or technology not provided by Licensor or authorized by Licensor in writing; (iv) modifications to the Software not made by Licensor; or (v) use of any version other than the most current version of the Software or Documentation delivered to Licensee, provided that Licensee may not settle any Third-Party Claim against Licensor unless such settlement completely and forever releases Licensor from all liability with respect to such Third-Party Claim or unless Licensor consents to such settlement, and further provided that Licensor will have the right, at its option, to defend itself against any such Third-Party Claim or to participate in the defense thereof by counsel of its own choice.
+
+9. Limitations of Liability
+---------------------------
+
+
+IN NO EVENT WILL LICENSOR BE LIABLE UNDER OR IN CONNECTION WITH THIS AGREEMENT UNDER ANY LEGAL OR EQUITABLE THEORY, INCLUDING BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), STRICT LIABILITY, AND OTHERWISE, FOR ANY: (A) CONSEQUENTIAL, INCIDENTAL, INDIRECT, EXEMPLARY, SPECIAL, ENHANCED, OR PUNITIVE DAMAGES; (B) INCREASED COSTS, DIMINUTION IN VALUE OR LOST BUSINESS, PRODUCTION, REVENUES, OR PROFITS; (C) LOSS OF GOODWILL OR REPUTATION; (D) USE, INABILITY TO USE, LOSS, INTERRUPTION, DELAY OR RECOVERY OF ANY DATA, OR BREACH OF DATA OR SYSTEM SECURITY; OR (E) COST OF REPLACEMENT GOODS OR SERVICES, IN EACH CASE REGARDLESS OF WHETHER LICENSOR WAS ADVISED OF THE POSSIBILITY OF SUCH LOSSES OR DAMAGES OR SUCH LOSSES OR DAMAGES WERE OTHERWISE FORESEEABLE. IN NO EVENT WILL LICENSOR'S AGGREGATE LIABILITY ARISING OUT OF OR RELATED TO THIS AGREEMENT UNDER ANY LEGAL OR EQUITABLE THEORY, INCLUDING BREACH OF CONTRACT, TORT (INCLUDING NEGLIGENCE), STRICT LIABILITY, AND OTHERWISE EXCEED ONE HUNDRED DOLLARS ($100).
+
+10. Term and Termination
+------------------------
+
+(a) Term. The term of this Agreement begins on the Effective Date and, unless terminated earlier pursuant to any of the Agreement's express provisions, will continue in effect for so long as Licensee (including any Authorized User) possesses, uses, or controls the Software (the "Term").
+
+(b) Termination. In addition to any other express termination right set forth in this Agreement:
+
+    (i) If Licensee is exclusively using that portion of the Software available without payment of Fees, Licensor may terminate this agreement for any reason, or no reason by written notice to Licensee.
+
+    (ii) Licensor may terminate this Agreement, effective on written notice to Licensee, at any time for any reason, or for no reason if Licensee: (A) fails to pay any amount when due hereunder, and such failure continues more than five (5) days after Licensor's delivery of written notice thereof; or (B) breaches any of its obligations under Section 2(b);
+
+    (iii) either Party may terminate this Agreement, effective on written notice to the other Party, if the other Party materially breaches this Agreement, and such breach: (A) is incapable of cure; or (B) being capable of cure, remains uncured thirty (30) days after the non-breaching Party provides the breaching Party with written notice of such breach; or
+
+    (iv) either Party may terminate this Agreement, effective immediately upon written notice to the other Party, if the other Party: (A) becomes insolvent or is generally unable to pay, or fails to pay, its debts as they become due; (B) files or has filed against it, a petition for voluntary or involuntary bankruptcy or otherwise becomes subject, voluntarily or involuntarily, to any proceeding under any domestic or foreign bankruptcy or insolvency law; (C) makes or seeks to make a general assignment for the benefit of its creditors; or (D) applies for or has appointed a receiver, trustee, custodian, or similar agent appointed by order of any court of competent jurisdiction to take charge of or sell any material portion of its property or business.
+
+(c) Effect of Expiration or Termination. Upon expiration or earlier termination of this Agreement, the license granted hereunder will also terminate and Licensee shall cease using and delete, destroy, or return all copies of the Software and Documentation and certify in writing to the Licensor that the Software and Documentation has been deleted or destroyed. No expiration or termination will affect Licensee's obligation to pay all Fees that may have become due before such expiration or termination, or entitle Licensee to any refund.
+
+(d) Survival. This Section 10(d) and 1, 5, 6, 7, 8, 9, and 11 survive any termination or expiration of this Agreement. No other provisions of this Agreement survive the expiration or earlier termination of this Agreement.
+
+11. Miscellaneous
+-----------------
+
+(a) Entire Agreement. This Agreement, together with any other documents incorporated herein by reference and all related Exhibits, constitutes the sole and entire agreement of the Parties with respect to the subject matter of this Agreement and supersedes all prior and contemporaneous understandings, agreements, and representations and warranties, both written and oral, with respect to such subject matter. In the event of any inconsistency between the statements made in the body of this Agreement, the related Exhibits, and any other documents incorporated herein by reference, the following order of precedence governs: (a) first, this Agreement, excluding its Exhibits; (b) second, the Exhibits to this Agreement as of the Effective Date; and (c) third, any other documents incorporated herein by reference.
+
+(b) Notices. All notices, requests, consents, claims, demands, waivers, and other communications hereunder (each, a "Notice") must be in writing and addressed to the Parties at the addresses each provide in the regular course of business, or to such other address that may be designated by the Party giving Notice from time to time in accordance with this Section. All Notices must be delivered by personal delivery, nationally recognized overnight courier (with all fees pre-paid), email (with confirmation of transmission or similar method to confirm receipt), in the case of Licensor’s notice to Licensee, through notice provided on Licensor’s website or through Licensee’s account with Licensor, or certified or registered mail (in each case, return receipt requested, postage pre-paid). Except as otherwise provided in this Agreement, a Notice is effective only: (i) upon receipt by the receiving Party (or, in the case of Licensor, posting or notifying Licensee pursuant to this Section), and (ii) if the Party giving the Notice has complied with the requirements of this Section.
+
+(c) Force Majeure. In no event shall Licensor be liable to Licensee, or be deemed to have breached this Agreement, for any failure or delay in performing its obligations under this Agreement, if and to the extent such failure or delay is caused by any circumstances beyond Licensor's reasonable control, including but not limited to: (i) acts of God; (ii) flood, fire, earthquake, pandemic, epidemic, or explosion; (iii) war, invasion, hostilities (whether war is declared or not), terrorist threats or acts, riot or other civil unrest; (iv) government order, law, or actions; (v) embargoes or blockades in effect on or after the date of this Agreement; (vi) national or regional emergency; (vii) strikes, labor stoppages or slowdowns, or other industrial disturbances; and (viii) shortage of adequate power or transportation facilities.
+
+(d) Amendment and Modification; Waiver. Licensor may amend these terms in its sole discretion by providing notice to Licensee, and notwithstanding Section 11(b), such notice may be given by Licensor by posting a new version of this license on Licensor’s website or including these terms within the digital files downloaded by Licensee. No waiver by any Party of any of the provisions hereof will be effective unless explicitly set forth in writing and signed by the Party so waiving. Except as otherwise set forth in this Agreement, (i) no failure to exercise, or delay in exercising, any rights, remedy, power, or privilege arising from this Agreement will operate or be construed as a waiver thereof, and (ii) no single or partial exercise of any right, remedy, power, or privilege hereunder will preclude any other or further exercise thereof or the exercise of any other right, remedy, power, or privilege.
+
+(e) Severability. If any provision of this Agreement is invalid, illegal, or unenforceable in any jurisdiction, such invalidity, illegality, or unenforceability will not affect any other term or provision of this Agreement or invalidate or render unenforceable such term or provision in any other jurisdiction. Upon such determination that any term or other provision is invalid, illegal, or unenforceable, the Parties hereto shall negotiate in good faith to modify this Agreement so as to effect the original intent of the Parties as closely as possible in a mutually acceptable manner in order that the transactions contemplated hereby be consummated as originally contemplated to the greatest extent possible.
+
+(f) Governing Law; Submission to Jurisdiction. This Agreement is governed by and construed in accordance with the internal laws of the State of Delaware without giving effect to any choice or conflict of law provision or rule that would require or permit the application of the laws of any jurisdiction other than those of the State of Delaware. Any legal suit, action, or proceeding arising out of or related to this Agreement or the licenses granted hereunder will be instituted exclusively in the federal courts of the United States or the courts of the State of Delaware, and each Party irrevocably submits to the [exclusive] jurisdiction of such courts in any such suit, action, or proceeding.
+
+(g) Assignment. Licensee may not assign or transfer any of its rights or delegate any of its obligations hereunder, in each case whether voluntarily, involuntarily, by operation of law or otherwise, without the prior written consent of Licensor. Any purported assignment, transfer, or delegation in violation of this Section is null and void. No assignment, transfer, or delegation will relieve the assigning or delegating Party of any of its obligations hereunder. This Agreement is binding upon and inures to the benefit of the Parties hereto and their respective permitted successors and assigns.
+
+(h) Export Regulation. The Software may be subject to US export control laws, including the Export Control Reform Act and its associated regulations. Licensee shall not, directly or indirectly, export, re-export, or release the Software to, or make the Software accessible from, any jurisdiction or country to which export, re-export, or release is prohibited by law, rule, or regulation. Licensee shall comply with all applicable federal laws, regulations, and rules, and complete all required undertakings (including obtaining any necessary export license or other governmental approval), prior to exporting, re-exporting, releasing, or otherwise making the Software available outside the US.
+
+(i) Equitable Relief. Each Party acknowledges and agrees that a breach or threatened breach by Licensee of any of its obligations under Section 2(b), would cause Licensor irreparable harm for which monetary damages would not be an adequate remedy and agrees that, in the event of such breach or threatened breach, Licensor will be entitled to equitable relief, including a restraining order, an injunction, specific performance, and any other relief that may be available from any court, without any requirement to post a bond or other security, or to prove actual damages or that monetary damages are not an adequate remedy. Such remedies are not exclusive and are in addition to all other remedies that may be available at law, in equity, or otherwise.
+
+EXHIBIT A
+---------
+
+Capitalized terms used but not defined in this Exhibit A have the meaning given to those terms in the Agreement.
+
+For a list of Third Party Products included in the Software please refer to the documents found here: https://docs.flexcompute.com/projects/tidy3d/en/latest/extras/.

--- a/docs/extras/third_party_licenses.rst
+++ b/docs/extras/third_party_licenses.rst
@@ -1,0 +1,826 @@
+Third-Party Licenses
+====================
+
+
+json
+----
+
+`json <https://github.com/nlohmann/json>`_
+
+::
+
+    MIT License
+
+    Copyright (c) 2013-2022 Niels Lohmann
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+tomlplusplus
+------------
+
+`toml++ <https://github.com/marzer/tomlplusplus>`_
+
+::
+
+    MIT License
+
+    Copyright (c) Mark Gillard <mark.gillard@outlook.com.au>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+
+ZLIB
+----
+
+`ZLIB <https://www.zlib.net/>`_
+
+::
+
+    Copyright (C) 1995-2024 Jean-loup Gailly and Mark Adler
+
+    This software is provided 'as-is', without any express or implied warranty.
+    In no event will the authors be held liable for any damages arising from
+    the use of this software.
+
+    Permission is granted to anyone to use this software for any purpose,
+    including commercial applications, and to alter it and redistribute it
+    freely, subject to the following restrictions:
+
+    1. The origin of this software must not be misrepresented; you must not
+       claim that you wrote the original software. If you use this software in
+       a product, an acknowledgment in the product documentation would be
+       appreciated but is not required.
+    2. Altered source versions must be plainly marked as such, and must not be
+       misrepresented as being the original software.
+    3. This notice may not be removed or altered from any source distribution.
+
+    Jean-loup Gailly        Mark Adler
+    jloup@gzip.org          madler@alumni.caltech.edu
+
+CDT
+---
+
+`CDT <https://artem-ogre.github.io/CDT/>`_
+
+::
+
+    Mozilla Public License
+
+    Version 2.0
+
+    1. Definitions
+
+    1.1. “Contributor”
+
+    means each individual or legal entity that creates, contributes to the
+    creation of, or owns Covered Software.
+
+    1.2. “Contributor Version”
+
+    means the combination of the Contributions of others (if any) used by a
+    Contributor and that particular Contributor’s Contribution.
+
+    1.3. “Contribution”
+
+    means Covered Software of a particular Contributor.
+
+    1.4. “Covered Software”
+
+    means Source Code Form to which the initial Contributor has attached the
+    notice in Exhibit A, the Executable Form of such Source Code Form, and
+    Modifications of such Source Code Form, in each case including portions
+    thereof.
+
+    1.5. “Incompatible With Secondary Licenses”
+
+    means
+
+    that the initial Contributor has attached the notice described in Exhibit B
+    to the Covered Software; or
+
+    that the Covered Software was made available under the terms of version 1.1
+    or earlier of the License, but not also under the terms of a Secondary
+    License.
+
+    1.6. “Executable Form”
+
+    means any form of the work other than Source Code Form.
+
+    1.7. “Larger Work”
+
+    means a work that combines Covered Software with other material, in a
+    separate file or files, that is not Covered Software.
+
+    1.8. “License”
+
+    means this document.
+
+    1.9. “Licensable”
+
+    means having the right to grant, to the maximum extent possible, whether at
+    the time of the initial grant or subsequently, any and all of the rights
+    conveyed by this License.
+
+    1.10. “Modifications”
+
+    means any of the following:
+
+    any file in Source Code Form that results from an addition to, deletion
+    from, or modification of the contents of Covered Software; or
+
+    any new file in Source Code Form that contains any Covered Software.
+
+    1.11. “Patent Claims” of a Contributor
+
+    means any patent claim(s), including without limitation, method, process,
+    and apparatus claims, in any patent Licensable by such Contributor that
+    would be infringed, but for the grant of the License, by the making, using,
+    selling, offering for sale, having made, import, or transfer of either its
+    Contributions or its Contributor Version.
+
+    1.12. “Secondary License”
+
+    means either the GNU General Public License, Version 2.0, the GNU Lesser
+    General Public License, Version 2.1, the GNU Affero General Public License,
+    Version 3.0, or any later versions of those licenses.
+
+    1.13. “Source Code Form”
+
+    means the form of the work preferred for making modifications.
+
+    1.14. “You” (or “Your”)
+
+    means an individual or a legal entity exercising rights under this License.
+    For legal entities, “You” includes any entity that controls, is controlled
+    by, or is under common control with You. For purposes of this definition,
+    “control” means (a) the power, direct or indirect, to cause the direction
+    or management of such entity, whether by contract or otherwise, or (b)
+    ownership of more than fifty percent (50%) of the outstanding shares or
+    beneficial ownership of such entity.
+
+    2. License Grants and Conditions
+
+    2.1. Grants
+
+    Each Contributor hereby grants You a world-wide, royalty-free,
+    non-exclusive license:
+
+    under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available, modify,
+    display, perform, distribute, and otherwise exploit its Contributions,
+    either on an unmodified basis, with Modifications, or as part of a Larger
+    Work; and
+
+    under Patent Claims of such Contributor to make, use, sell, offer for sale,
+    have made, import, and otherwise transfer either its Contributions or its
+    Contributor Version.
+
+    2.2. Effective Date
+
+    The licenses granted in Section 2.1 with respect to any Contribution become
+    effective for each Contribution on the date the Contributor first
+    distributes such Contribution.
+
+    2.3. Limitations on Grant Scope
+
+    The licenses granted in this Section 2 are the only rights granted under
+    this License. No additional rights or licenses will be implied from the
+    distribution or licensing of Covered Software under this License.
+    Notwithstanding Section 2.1(b) above, no patent license is granted by a
+    Contributor:
+
+    for any code that a Contributor has removed from Covered Software; or
+
+    for infringements caused by: (i) Your and any other third party’s
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+    under Patent Claims infringed by Covered Software in the absence of its
+    Contributions.
+
+    This License does not grant any rights in the trademarks, service marks, or
+    logos of any Contributor (except as may be necessary to comply with the
+    notice requirements in Section 3.4).
+
+    2.4. Subsequent Licenses
+
+    No Contributor makes additional grants as a result of Your choice to
+    distribute the Covered Software under a subsequent version of this License
+    (see Section 10.2) or under the terms of a Secondary License (if permitted
+    under the terms of Section 3.3).
+
+    2.5. Representation
+
+    Each Contributor represents that the Contributor believes its Contributions
+    are its original creation(s) or it has sufficient rights to grant the
+    rights to its Contributions conveyed by this License.
+
+    2.6. Fair Use
+
+    This License is not intended to limit any rights You have under applicable
+    copyright doctrines of fair use, fair dealing, or other equivalents.
+
+    2.7. Conditions
+
+    Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+    Section 2.1.
+
+    3. Responsibilities
+
+    3.1. Distribution of Source Form
+
+    All distribution of Covered Software in Source Code Form, including any
+    Modifications that You create or to which You contribute, must be under the
+    terms of this License. You must inform recipients that the Source Code Form
+    of the Covered Software is governed by the terms of this License, and how
+    they can obtain a copy of this License. You may not attempt to alter or
+    restrict the recipients’ rights in the Source Code Form.
+
+    3.2. Distribution of Executable Form
+
+    If You distribute Covered Software in Executable Form then:
+
+    such Covered Software must also be made available in Source Code Form, as
+    described in Section 3.1, and You must inform recipients of the Executable
+    Form how they can obtain a copy of such Source Code Form by reasonable
+    means in a timely manner, at a charge no more than the cost of distribution
+    to the recipient; and
+
+    You may distribute such Executable Form under the terms of this License, or
+    sublicense it under different terms, provided that the license for the
+    Executable Form does not attempt to limit or alter the recipients’ rights
+    in the Source Code Form under this License.
+
+    3.3. Distribution of a Larger Work
+
+    You may create and distribute a Larger Work under terms of Your choice,
+    provided that You also comply with the requirements of this License for the
+    Covered Software. If the Larger Work is a combination of Covered Software
+    with a work governed by one or more Secondary Licenses, and the Covered
+    Software is not Incompatible With Secondary Licenses, this License permits
+    You to additionally distribute such Covered Software under the terms of
+    such Secondary License(s), so that the recipient of the Larger Work may, at
+    their option, further distribute the Covered Software under the terms of
+    either this License or such Secondary License(s).
+
+    3.4. Notices
+
+    You may not remove or alter the substance of any license notices (including
+    copyright notices, patent notices, disclaimers of warranty, or limitations
+    of liability) contained within the Source Code Form of the Covered
+    Software, except that You may alter any license notices to the extent
+    required to remedy known factual inaccuracies.
+
+    3.5. Application of Additional Terms
+
+    You may choose to offer, and to charge a fee for, warranty, support,
+    indemnity or liability obligations to one or more recipients of Covered
+    Software. However, You may do so only on Your own behalf, and not on behalf
+    of any Contributor. You must make it absolutely clear that any such
+    warranty, support, indemnity, or liability obligation is offered by You
+    alone, and You hereby agree to indemnify every Contributor for any
+    liability incurred by such Contributor as a result of warranty, support,
+    indemnity or liability terms You offer. You may include additional
+    disclaimers of warranty and limitations of liability specific to any
+    jurisdiction.
+
+    4. Inability to Comply Due to Statute or Regulation
+
+    If it is impossible for You to comply with any of the terms of this License
+    with respect to some or all of the Covered Software due to statute,
+    judicial order, or regulation then You must: (a) comply with the terms of
+    this License to the maximum extent possible; and (b) describe the
+    limitations and the code they affect. Such description must be placed in a
+    text file included with all distributions of the Covered Software under
+    this License. Except to the extent prohibited by statute or regulation,
+    such description must be sufficiently detailed for a recipient of ordinary
+    skill to be able to understand it.
+
+    5. Termination
+
+    5.1. The rights granted under this License will terminate automatically if
+    You fail to comply with any of its terms. However, if You become compliant,
+    then the rights granted under this License from a particular Contributor
+    are reinstated (a) provisionally, unless and until such Contributor
+    explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+    if such Contributor fails to notify You of the non-compliance by some
+    reasonable means prior to 60 days after You have come back into compliance.
+    Moreover, Your grants from a particular Contributor are reinstated on an
+    ongoing basis if such Contributor notifies You of the non-compliance by
+    some reasonable means, this is the first time You have received notice of
+    non-compliance with this License from such Contributor, and You become
+    compliant prior to 30 days after Your receipt of the notice.
+
+    5.2. If You initiate litigation against any entity by asserting a patent
+    infringement claim (excluding declaratory judgment actions, counter-claims,
+    and cross-claims) alleging that a Contributor Version directly or
+    indirectly infringes any patent, then the rights granted to You by any and
+    all Contributors for the Covered Software under Section 2.1 of this License
+    shall terminate.
+
+    5.3. In the event of termination under Sections 5.1 or 5.2 above, all end
+    user license agreements (excluding distributors and resellers) which have
+    been validly granted by You or Your distributors under this License prior
+    to termination shall survive termination.
+
+    6. Disclaimer of Warranty
+
+    Covered Software is provided under this License on an “as is” basis,
+    without warranty of any kind, either expressed, implied, or statutory,
+    including, without limitation, warranties that the Covered Software is free
+    of defects, merchantable, fit for a particular purpose or non-infringing.
+    The entire risk as to the quality and performance of the Covered Software
+    is with You. Should any Covered Software prove defective in any respect,
+    You (not any Contributor) assume the cost of any necessary servicing,
+    repair, or correction. This disclaimer of warranty constitutes an essential
+    part of this License. No use of any Covered Software is authorized under
+    this License except under this disclaimer.
+
+    7. Limitation of Liability
+
+    Under no circumstances and under no legal theory, whether tort (including
+    negligence), contract, or otherwise, shall any Contributor, or anyone who
+    distributes Covered Software as permitted above, be liable to You for any
+    direct, indirect, special, incidental, or consequential damages of any
+    character including, without limitation, damages for lost profits, loss of
+    goodwill, work stoppage, computer failure or malfunction, or any and all
+    other commercial damages or losses, even if such party shall have been
+    informed of the possibility of such damages. This limitation of liability
+    shall not apply to liability for death or personal injury resulting from
+    such party’s negligence to the extent applicable law prohibits such
+    limitation. Some jurisdictions do not allow the exclusion or limitation of
+    incidental or consequential damages, so this exclusion and limitation may
+    not apply to You.
+
+    8. Litigation
+
+    Any litigation relating to this License may be brought only in the courts
+    of a jurisdiction where the defendant maintains its principal place of
+    business and such litigation shall be governed by laws of that
+    jurisdiction, without reference to its conflict-of-law provisions. Nothing
+    in this Section shall prevent a party’s ability to bring cross-claims or
+    counter-claims.
+
+    9. Miscellaneous
+
+    This License represents the complete agreement concerning the subject
+    matter hereof. If any provision of this License is held to be
+    unenforceable, such provision shall be reformed only to the extent
+    necessary to make it enforceable. Any law or regulation which provides that
+    the language of a contract shall be construed against the drafter shall not
+    be used to construe this License against a Contributor.
+
+    10. Versions of the License
+
+    10.1. New Versions
+
+    Mozilla Foundation is the license steward. Except as provided in Section
+    10.3, no one other than the license steward has the right to modify or
+    publish new versions of this License. Each version will be given a
+    distinguishing version number.
+
+    10.2. Effect of New Versions
+
+    You may distribute the Covered Software under the terms of the version of
+    the License under which You originally received the Covered Software, or
+    under the terms of any subsequent version published by the license steward.
+
+    10.3. Modified Versions
+
+    If you create software not governed by this License, and you want to create
+    a new license for such software, you may create and use a modified version
+    of this License if you rename the license and remove any references to the
+    name of the license steward (except to note that such modified license
+    differs from this License).
+
+    10.4. Distributing Source Code Form that is Incompatible With Secondary
+    Licenses
+
+    If You choose to distribute Source Code Form that is Incompatible With
+    Secondary Licenses under the terms of this version of the License, the
+    notice described in Exhibit B of this License must be attached.
+
+    Exhibit A - Source Code Form License Notice This Source Code Form is
+    subject to the terms of the Mozilla Public License, v. 2.0. If a copy of
+    the MPL was not distributed with this file, You can obtain one at
+    https://mozilla.org/MPL/2.0/.
+
+    If it is not possible or desirable to put the notice in a particular file,
+    then You may include the notice in a location (such as a LICENSE file in a
+    relevant directory) where a recipient would be likely to look for such a
+    notice.
+
+    You may add additional accurate notices of copyright ownership.
+
+    Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+    This Source Code Form is “Incompatible With Secondary Licenses”, as defined
+    by the Mozilla Public License, v. 2.0.
+
+OpenSSL
+-------
+
+`OpenSSL <https://www.openssl.org/>`_
+
+::
+
+    Apache License
+    Version 2.0, January 2004
+    https://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction, and
+      distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by the
+      copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all other
+      entities that control, are controlled by, or are under common control
+      with that entity. For the purposes of this definition, "control" means
+      (i) the power, direct or indirect, to cause the direction or management
+      of such entity, whether by contract or otherwise, or (ii) ownership of
+      fifty percent (50%) or more of the outstanding shares, or (iii)
+      beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity exercising
+      permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation source,
+      and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but not
+      limited to compiled object code, generated documentation, and
+      conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or Object
+      form, made available under the License, as indicated by a copyright
+      notice that is included in or attached to the work (an example is
+      provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including the original
+      version of the Work and any modifications or additions to that Work or
+      Derivative Works thereof, that is intentionally submitted to Licensor
+      for inclusion in the Work by the copyright owner or by an individual or
+      Legal Entity authorized to submit on behalf of the copyright owner. For
+      the purposes of this definition, "submitted" means any form of
+      electronic, verbal, or written communication sent to the Licensor or its
+      representatives, including but not limited to communication on
+      electronic mailing lists, source code control systems, and issue
+      tracking systems that are managed by, or on behalf of, the Licensor for
+      the purpose of discussing and improving the Work, but excluding
+      communication that is conspicuously marked or otherwise designated in
+      writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity on
+      behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of this
+      License, each Contributor hereby grants to You a perpetual, worldwide,
+      non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+      reproduce, prepare Derivative Works of, publicly display, publicly
+      perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of this
+      License, each Contributor hereby grants to You a perpetual, worldwide,
+      non-exclusive, no-charge, royalty-free, irrevocable (except as stated in
+      this section) patent license to make, have made, use, offer to sell,
+      sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable by
+      such Contributor that are necessarily infringed by their Contribution(s)
+      alone or by combination of their Contribution(s) with the Work to which
+      such Contribution(s) was submitted. If You institute patent litigation
+      against any entity (including a cross-claim or counterclaim in a
+      lawsuit) alleging that the Work or a Contribution incorporated within
+      the Work constitutes direct or contributory patent infringement, then
+      any patent licenses granted to You under this License for that Work
+      shall terminate as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the Work or
+      Derivative Works thereof in any medium, with or without modifications,
+      and in Source or Object form, provided that You meet the following
+      conditions:
+
+      (a) You must give any other recipients of the Work or Derivative Works a
+      copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices stating
+      that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works that You
+      distribute, all copyright, patent, trademark, and attribution notices
+      from the Source form of the Work, excluding those notices that do not
+      pertain to any part of the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+      distribution, then any Derivative Works that You distribute must include
+      a readable copy of the attribution notices contained within such NOTICE
+      file, excluding those notices that do not pertain to any part of the
+      Derivative Works, in at least one of the following places: within a
+      NOTICE text file distributed as part of the Derivative Works; within the
+      Source form or documentation, if provided along with the Derivative
+      Works; or, within a display generated by the Derivative Works, if and
+      wherever such third-party notices normally appear. The contents of the
+      NOTICE file are for informational purposes only and do not modify the
+      License. You may add Your own attribution notices within Derivative
+      Works that You distribute, alongside or as an addendum to the NOTICE
+      text from the Work, provided that such additional attribution notices
+      cannot be construed as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and may
+      provide additional or different license terms and conditions for use,
+      reproduction, or distribution of Your modifications, or for any such
+      Derivative Works as a whole, provided Your use, reproduction, and
+      distribution of the Work otherwise complies with the conditions stated
+      in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise, any
+      Contribution intentionally submitted for inclusion in the Work by You to
+      the Licensor shall be under the terms and conditions of this License,
+      without any additional terms or conditions. Notwithstanding the above,
+      nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed with
+      Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or agreed to
+      in writing, Licensor provides the Work (and each Contributor provides
+      its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+      OF ANY KIND, either express or implied, including, without limitation,
+      any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR
+      PURPOSE. You are solely responsible for determining the appropriateness
+      of using or redistributing the Work and assume any risks associated with
+      Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory, whether
+      in tort (including negligence), contract, or otherwise, unless required
+      by applicable law (such as deliberate and grossly negligent acts) or
+      agreed to in writing, shall any Contributor be liable to You for
+      damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the Work
+      (including but not limited to damages for loss of goodwill, work
+      stoppage, computer failure or malfunction, or any and all other
+      commercial damages or losses), even if such Contributor has been advised
+      of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing the
+      Work or Derivative Works thereof, You may choose to offer, and charge a
+      fee for, acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However, in
+      accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf of any
+      other Contributor, and only if You agree to indemnify, defend, and hold
+      each Contributor harmless for any liability incurred by, or claims
+      asserted against, such Contributor by reason of your accepting any such
+      warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+gl3w
+----
+
+`gl3w <https://github.com/skaslev/gl3w>`_
+
+::
+
+    This is free and unencumbered software released into the public domain.
+
+    Anyone is free to copy, modify, publish, use, compile, sell, or
+    distribute this software, either in source code form or as a compiled
+    binary, for any purpose, commercial or non-commercial, and by any
+    means.
+
+    In jurisdictions that recognize copyright laws, the author or authors
+    of this software dedicate any and all copyright interest in the
+    software to the public domain. We make this dedication for the benefit
+    of the public at large and to the detriment of our heirs and
+    successors. We intend this dedication to be an overt act of
+    relinquishment in perpetuity of all present and future rights to this
+    software under copyright law.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+    OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+    ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+    OTHER DEALINGS IN THE SOFTWARE.
+
+HDF5
+----
+
+`HDF5 <https://github.com/HDFGroup/hdf5>`_
+
+::
+
+    Copyright Notice and License Terms for
+    HDF5 (Hierarchical Data Format 5) Software Library and Utilities
+    -----------------------------------------------------------------------------
+
+    HDF5 (Hierarchical Data Format 5) Software Library and Utilities
+    Copyright 2006 by The HDF Group.
+
+    NCSA HDF5 (Hierarchical Data Format 5) Software Library and Utilities
+    Copyright 1998-2006 by The Board of Trustees of the University of Illinois.
+
+    All rights reserved.
+
+    This software library and utilities is covered by the 3-clause BSD License.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted for any purpose (including commercial purposes)
+    provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+      this list of conditions, and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions, and the following disclaimer in the documentation
+      and/or materials provided with the distribution.
+
+    3. Neither the name of The HDF Group, the name of the University, nor the
+      name of any Contributor may be used to endorse or promote products derived
+      from this software without specific prior written permission from
+      The HDF Group, the University, or the Contributor, respectively.
+
+    DISCLAIMER:
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+    THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+    OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+    TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+    For further details, please refer to the full license text available
+    at https://opensource.org/licenses/bsd-3-clause
+
+    You are under no obligation whatsoever to provide any bug fixes, patches, or
+    upgrades to the features, functionality or performance of the source code
+    ("Enhancements") to anyone; however, if you choose to make your Enhancements
+    available either publicly, or directly to The HDF Group, without imposing a
+    separate written license agreement for such Enhancements, then you hereby
+    grant the following license: a non-exclusive, royalty-free perpetual license
+    to install, use, modify, prepare derivative works, incorporate into other
+    computer software, distribute, and sublicense such enhancements or derivative
+    works thereof, in binary and source code form.
+
+    -----------------------------------------------------------------------------
+    -----------------------------------------------------------------------------
+
+    Contributors:   National Center for Supercomputing Applications (NCSA) at
+    the University of Illinois, Fortner Software, Unidata Program Center
+    (netCDF), The Independent JPEG Group (JPEG), Jean-loup Gailly and Mark Adler
+    (gzip), and Digital Equipment Corporation (DEC).
+
+    -----------------------------------------------------------------------------
+
+    Portions of HDF5 were developed with support from the Lawrence Berkeley
+    National Laboratory (LBNL) and the United States Department of Energy
+    under Prime Contract No. DE-AC02-05CH11231.
+
+    -----------------------------------------------------------------------------
+
+    Portions of HDF5 were developed with support from Lawrence Livermore
+    National Laboratory and the United States Department of Energy under
+    Prime Contract No. DE-AC52-07NA27344.
+
+    -----------------------------------------------------------------------------
+
+    Portions of HDF5 were developed with support from the University of
+    California, Lawrence Livermore National Laboratory (UC LLNL).
+    The following statement applies to those portions of the product and must
+    be retained in any redistribution of source code, binaries, documentation,
+    and/or accompanying materials:
+
+      This work was partially produced at the University of California,
+      Lawrence Livermore National Laboratory (UC LLNL) under contract
+      no. W-7405-ENG-48 (Contract 48) between the U.S. Department of Energy
+      (DOE) and The Regents of the University of California (University)
+      for the operation of UC LLNL.
+
+      DISCLAIMER:
+      THIS WORK WAS PREPARED AS AN ACCOUNT OF WORK SPONSORED BY AN AGENCY OF
+      THE UNITED STATES GOVERNMENT. NEITHER THE UNITED STATES GOVERNMENT NOR
+      THE UNIVERSITY OF CALIFORNIA NOR ANY OF THEIR EMPLOYEES, MAKES ANY
+      WARRANTY, EXPRESS OR IMPLIED, OR ASSUMES ANY LIABILITY OR RESPONSIBILITY
+      FOR THE ACCURACY, COMPLETENESS, OR USEFULNESS OF ANY INFORMATION,
+      APPARATUS, PRODUCT, OR PROCESS DISCLOSED, OR REPRESENTS THAT ITS USE
+      WOULD NOT INFRINGE PRIVATELY- OWNED RIGHTS. REFERENCE HEREIN TO ANY
+      SPECIFIC COMMERCIAL PRODUCTS, PROCESS, OR SERVICE BY TRADE NAME,
+      TRADEMARK, MANUFACTURER, OR OTHERWISE, DOES NOT NECESSARILY CONSTITUTE
+      OR IMPLY ITS ENDORSEMENT, RECOMMENDATION, OR FAVORING BY THE UNITED
+      STATES GOVERNMENT OR THE UNIVERSITY OF CALIFORNIA. THE VIEWS AND
+      OPINIONS OF AUTHORS EXPRESSED HEREIN DO NOT NECESSARILY STATE OR REFLECT
+      THOSE OF THE UNITED STATES GOVERNMENT OR THE UNIVERSITY OF CALIFORNIA,
+      AND SHALL NOT BE USED FOR ADVERTISING OR PRODUCT ENDORSEMENT PURPOSES.
+   
+    -----------------------------------------------------------------------------
+
+GCC Runtime Libraries
+---------------------
+
+`GCC Runtime Libraries <https://gcc.gnu.org/>`_
+
+::
+
+    This product includes portions of the GNU Compiler Collection (GCC) runtime libraries:
+
+    - GNU C++ Standard Library (`libstdc++`)
+    - GNU Compiler Support Library (`libgcc_s`)
+    - GNU OpenMP Runtime (`libgomp`)
+
+    These libraries are licensed under the **GNU General Public License, version 3 (GPLv3)** with the **GCC Runtime Library Exception**.
+
+    The GCC Runtime Library Exception permits linking these libraries with independent modules to produce an executable, without requiring the executable itself to be licensed under the GPL. As a result, you may use and redistribute this product without disclosing your own source code, provided you retain this notice and comply with the licenses of the included libraries.
+
+    **License References:**
+    - [GNU General Public License v3 (GPLv3)](https://www.gnu.org/licenses/gpl-3.0.html)
+    - [GCC Runtime Library Exception 3.1](https://www.gnu.org/licenses/gcc-exception-3.1.html)
+
+    **Source Code:**  
+    The original source code for these libraries is available from the [GCC project](https://gcc.gnu.org/).
+
+    These runtime libraries have been included in binary form as permitted by their licenses. No modifications have been made.
+
+LLVM Runtime Libraries
+----------------------
+
+`LLVM Runtime Libraries <https://llvm.org/>`_
+
+::
+
+    This product includes the following runtime libraries from the LLVM project:
+
+    - `libc++` (C++ Standard Library)
+    - `compiler-rt` (Low-level compiler support, e.g., builtins)
+    - `libomp` (OpenMP Runtime Library)
+
+    These libraries are licensed under the **Apache License, Version 2.0** with the **LLVM Exceptions**.
+
+    The LLVM Exception to the Apache 2.0 License permits static or dynamic linking of these libraries into proprietary applications without imposing the license on the proprietary portions of the application.
+
+    **License References:**
+    - [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+    - [LLVM License with Exception](https://llvm.org/docs/DeveloperPolicy.html#license)
+
+    **Source Code:**
+    The original source code is available from the [LLVM project](https://github.com/llvm/llvm-project).
+
+    These libraries are included in binary form with no modifications.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -255,6 +255,7 @@ Contents
   api/index
   GUI <https://tidy3d.simulation.cloud/>
   Photonforge <https://docs.flexcompute.com/projects/photonforge/en/latest/>
+  extras/index
   development/index
   changelog
   About our Solver <https://www.flexcompute.com/tidy3d/solver/>

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -219,6 +219,24 @@ Multiple dependency groups can be installed simultaneously:
 
     pip install "tidy3d[design,trimesh]"
 
+Extras Plugin
+----------------------
+
+An optional plugin providing additional local functionality,
+including a more accurate local mode solver:
+
+.. code-block:: bash
+
+    pip install "tidy3d[extras]"
+
+An API key is needed to use the extras plugin.
+For more information on the extras plugin, see `Extras Plugin <./extras/index.html>`_.
+
+.. important::
+
+   ``tidy3d-extras`` is **not compatible with Conda environments**.
+   Please use a standard Python virtual environment (e.g., ``venv`` or ``virtualenv``) for installation.
+
 Developer Installation
 ----------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ sphinxemoji = { version = "*", optional = true }
 devsim = { version = "*", optional = true }
 cma = { version = "*", optional = true }
 openpyxl = { version = "*", optional = true }
+# tidy3d-extras = { version = "2.10.0rc1", optional = true }
 
 [tool.poetry.extras]
 dev = [
@@ -178,7 +179,7 @@ dev = [
   'devsim',
   'cma',
   'diff-cover',
-  "openpyxl"
+  "openpyxl",
 ]
 docs = [
   "jupyter",
@@ -220,6 +221,7 @@ heatcharge = ["trimesh", "vtk", "devsim"]
 adjoint = ["jaxlib", "jax"]
 pytorch = ["torch"]
 design = ["bayesian-optimization", "pygad", "pyswarms"]
+# extras = ["tidy3d-extras"]
 
 [tool.poetry.scripts]
 tidy3d = "tidy3d.web.cli:tidy3d_cli"
@@ -228,15 +230,18 @@ tidy3d = "tidy3d.web.cli:tidy3d_cli"
 name = "pypi"
 priority = "primary"
 
+
 [[tool.poetry.source]]
 name = "jaxsource"
 url = "https://storage.googleapis.com/jax-releases/jax_releases.html"
 priority = "supplemental"
 
+
 [[tool.poetry.source]]
 name = "torch-cpu"
 url = "https://download.pytorch.org/whl/cpu"
 priority = "explicit"
+
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ from autograd.test_util import check_grads
 from autograd.wrap_util import unary_to_nary
 
 import tidy3d as td
-from tidy3d.config import config
 from tidy3d.log import DEFAULT_LEVEL, set_logging_console, set_logging_level
 
 
@@ -96,15 +95,6 @@ def mpl_config_interactive():
     mpl.use("TkAgg")
     yield
     mpl.use(original_backend)
-
-
-@pytest.fixture(autouse=True)
-def disable_local_subpixel():
-    """Disable local subpixel for the unit tests."""
-    use_local_subpixel = config.use_local_subpixel
-    config.use_local_subpixel = False
-    yield
-    config.use_local_subpixel = use_local_subpixel
 
 
 @pytest.fixture

--- a/tests/test_components/test_mode.py
+++ b/tests/test_components/test_mode.py
@@ -185,7 +185,12 @@ def test_mode_sim():
         _ = sim.plot_grid_mode_plane(ax=AX)
         _ = sim.plot_pml_mode_plane(ax=AX)
         _ = sim.reduced_simulation_copy
-    _ = sim.run_local()
+    if td.packaging.tidy3d_extras["use_local_subpixel"]:
+        _ = sim.run_local()
+    else:
+        with pytest.raises(SetupError):
+            _ = sim.run_local()
+        _ = sim.updated_copy(monitors=[]).run_local()
     _ = sim._mode_solver.sim_data
 
     assert sim.plane == sim.geometry

--- a/tests/test_components/test_packaging.py
+++ b/tests/test_components/test_packaging.py
@@ -79,8 +79,13 @@ def test_tidy3d_extras():
 
     @supports_local_subpixel
     def get_eps():
-        assert tidy3d_extras["use_local_subpixel"] is False
-        assert tidy3d_extras["mod"] is None
+        if has_tidy3d_extras:
+            assert tidy3d_extras["mod"] is not None
+            features = tidy3d_extras["mod"].extension._features()
+            assert tidy3d_extras["use_local_subpixel"] == ("local_subpixel" in features)
+        else:
+            assert tidy3d_extras["use_local_subpixel"] is False
+            assert tidy3d_extras["mod"] is None
 
     get_eps()
 

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -2169,6 +2169,7 @@ def test_tfsf_structures_grid():
 @pytest.mark.parametrize(
     "size, num_struct, log_level", [(1, 1, None), (50, 1, "WARNING"), (1, 11, "WARNING")]
 )
+@td.packaging.disable_local_subpixel
 def test_warn_large_epsilon(monkeypatch, size, num_struct, log_level):
     """Make sure we get a warning if the epsilon grid is too large."""
 

--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -592,6 +592,7 @@ def test_mode_solver_unstructured_custom_medium(nx, cond_factor, interp, tol, tm
     assert error_up < tol
 
 
+@td.packaging.disable_local_subpixel
 def test_mode_solver_straight_vs_angled():
     """Compare results for a straight and angled nominally identical waveguides.
     Note: results do not match perfectly because of the numerical grid.
@@ -826,6 +827,7 @@ def test_mode_solver_2D():
 
 @pytest.mark.parametrize("local", [True, False])
 @responses.activate
+@td.packaging.disable_local_subpixel
 def test_group_index(mock_remote_api, local, tmp_path):
     """Test group index and dispersion calculation"""
 
@@ -920,6 +922,7 @@ def test_pml_params():
     assert np.allclose(sf_f[N - n_pml :] / sf_f[N - n_pml], target_profile)
 
 
+@td.packaging.disable_local_subpixel
 def test_mode_solver_nan_pol_fraction():
     """Test mode solver when eigensolver returns 0 for some modes."""
     wg = td.Structure(geometry=td.Box(size=(0.5, 100, 0.22)), medium=td.Medium(permittivity=12))

--- a/tests/test_plugins/test_waveguide.py
+++ b/tests/test_plugins/test_waveguide.py
@@ -191,6 +191,7 @@ def test_rectangular_dielectric_coupled():
     assert np.allclose(wg.n_eff.values, [2.4453077, 2.2707212, 1.8694501, 1.5907708], atol=1e-1)
 
 
+@td.packaging.disable_local_subpixel
 def test_layered_clad():
     wg = waveguide.RectangularDielectric(
         wavelength=1.55,

--- a/tidy3d/components/mode/simulation.py
+++ b/tidy3d/components/mode/simulation.py
@@ -29,6 +29,7 @@ from tidy3d.components.types import TYPE_TAG_STR, Ax, Direction, EMField, FreqAr
 from tidy3d.constants import C_0
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
+from tidy3d.packaging import supports_local_subpixel, tidy3d_extras
 
 from .mode_solver import ModeSolver
 
@@ -249,8 +250,27 @@ class ModeSimulation(AbstractYeeGridSimulation):
         kwargs = {key: getattr(self, key) for key in MODE_SIM_MODE_SOLVER_SHARED_ATTRS}
         return ModeSolver(simulation=self._as_fdtd_sim, **kwargs)
 
+    @supports_local_subpixel
     def run_local(self):
         """Run locally."""
+
+        if tidy3d_extras["use_local_subpixel"]:
+            subpixel_sim = tidy3d_extras["mod"].SubpixelModeSimulation.from_mode_simulation(self)
+            return subpixel_sim.run_local()
+
+        for mnt in self.monitors:
+            if isinstance(mnt, PermittivityMonitor):
+                raise SetupError(
+                    "The package 'tidy3d-extras' is required "
+                    "for accurate local 'PermittivityMonitor' handling. "
+                    "Please install this package using, for example, "
+                    "'pip install tidy3d[extras]', and ensure "
+                    "'config.use_local_subpixel' is not 'False'. "
+                    "Alternatively, 'ModeSimulation.epsilon' may be "
+                    "used to obtain the non-subpixel-averaged "
+                    "permittivity."
+                )
+
         from .data.sim_data import ModeSimulationData
 
         # repeat the calculation every time, in case use_local_subpixel changed

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -22,7 +22,7 @@ import xarray as xr
 from tidy3d.constants import C_0, SECOND, fp_eps, inf
 from tidy3d.exceptions import SetupError, Tidy3dError, Tidy3dImportError, ValidationError
 from tidy3d.log import log
-from tidy3d.packaging import supports_local_subpixel, tidy3d_extras
+from tidy3d.packaging import disable_local_subpixel, supports_local_subpixel, tidy3d_extras
 from tidy3d.updater import Updater
 
 from .base import cached_property, skip_if_fields_missing
@@ -4533,6 +4533,7 @@ class Simulation(AbstractYeeGridSimulation):
                 "data, use hdf5 format instead."
             )
 
+    @disable_local_subpixel
     def _validate_tfsf_structure_intersections(self) -> None:
         """Error if the 4 sidewalls of a TFSF box don't all intersect the same structures.
         This validator may need to compute permittivities on the grid, so it is called

--- a/tidy3d/config.py
+++ b/tidy3d/config.py
@@ -38,10 +38,9 @@ class Tidy3dConfig(pd.BaseModel):
     )
 
     use_local_subpixel: Optional[bool] = pd.Field(
-        False,
+        None,
         title="Whether to use local subpixel averaging. If 'None', local subpixel "
-        "averaging will be used if 'tidy3d-extras' is installed and not used otherwise. "
-        "NOTE: This feature is not yet supported.",
+        "averaging will be used if 'tidy3d-extras' is installed and not used otherwise.",
     )
 
     @pd.validator("logging_level", pre=True, always=True)

--- a/tidy3d/packaging.py
+++ b/tidy3d/packaging.py
@@ -14,6 +14,8 @@ import numpy as np
 
 from .config import config
 from .exceptions import Tidy3dImportError
+from .log import log
+from .version import __version__
 
 vtk = {
     "mod": None,
@@ -23,7 +25,7 @@ vtk = {
     "numpy_to_vtk": None,
 }
 
-tidy3d_extras = {"mod": None, "use_local_subpixel": False}
+tidy3d_extras = {"mod": None, "use_local_subpixel": None}
 
 
 def check_import(module_name: str) -> bool:
@@ -195,11 +197,7 @@ def supports_local_subpixel(fn):
                 try:
                     import tidy3d_extras as tidy3d_extras_mod
 
-                    _ = tidy3d_extras_mod.__version__
-
-                    tidy3d_extras["mod"] = tidy3d_extras_mod
-                    tidy3d_extras["use_local_subpixel"] = True
-                except (ImportError, AttributeError) as exc:
+                except ImportError as exc:
                     tidy3d_extras["mod"] = None
                     tidy3d_extras["use_local_subpixel"] = False
                     if config.use_local_subpixel is True:
@@ -207,10 +205,47 @@ def supports_local_subpixel(fn):
                             "The package 'tidy3d-extras' is required for this "
                             "operation when 'config.use_local_subpixel' is 'True'. "
                             "Please install the 'tidy3d-extras' package using, for "
-                            "example, 'pip install tidy3d-extras'. NOTE: This "
-                            "feature is not yet supported."
+                            "example, 'pip install tidy3d[extras]'."
                         ) from exc
 
+                else:
+                    version = tidy3d_extras_mod.__version__
+
+                    if version is None:
+                        tidy3d_extras["mod"] = None
+                        tidy3d_extras["use_local_subpixel"] = False
+                        raise Tidy3dImportError(
+                            "The package 'tidy3d-extras' did not initialize correctly, "
+                            "likely due to an invalid API key."
+                        )
+
+                    if version != __version__:
+                        log.warning(
+                            "The package 'tidy3d-extras' is required for this "
+                            "operation. The version of 'tidy3d-extras' should match "
+                            "the version of 'tidy3d'. You can install the correct "
+                            "version using 'pip install tidy3d[extras]'."
+                        )
+
+                    features = tidy3d_extras_mod.extension._features()
+
+                    tidy3d_extras["mod"] = tidy3d_extras_mod
+                    tidy3d_extras["use_local_subpixel"] = "local_subpixel" in features
+
         return fn(*args, **kwargs)
+
+    return _fn
+
+
+def disable_local_subpixel(fn):
+    """When decorating a method, temporarily disables local subpixel."""
+
+    @functools.wraps(fn)
+    def _fn(*args, **kwargs):
+        use_local_subpixel = config.use_local_subpixel
+        config.use_local_subpixel = False
+        result = fn(*args, **kwargs)
+        config.use_local_subpixel = use_local_subpixel
+        return result
 
     return _fn


### PR DESCRIPTION
This PR prepares the frontend for tidy3d-extras release, including adding some documentation.

Summary of changes:

- Add docs and license info for tidy3d-extras
- Add install option `tidy3d[extras]` with version pinned to match
- Default to `use_local_subpixel=None`, so it is automatic
- Disable local subpixel in some tests and validators that assume it is not present


TODO:

- [x] Changelog entry
- [x] Add some user workflow considerations to docs

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-11 22:26:29 UTC

This PR introduces support for `tidy3d-extras`, an optional plugin that provides enhanced local functionality including more accurate mode solving via subpixel averaging. The key changes include:

**Core Integration**: The PR adds `tidy3d-extras` as an optional dependency in `pyproject.toml` with exact version pinning (`=2.10.0rc1`) to ensure compatibility. Users can now install it via `pip install "tidy3d[extras]"`.

**Automatic Detection**: The configuration system is updated to default `use_local_subpixel=None` instead of `False`, enabling automatic detection of tidy3d-extras availability. The `packaging.py` module now includes sophisticated version checking, feature detection via `extension._features()`, and graceful fallback when the extras package is unavailable.

**Test Infrastructure**: Several test functions receive the new `@disable_local_subpixel` decorator to ensure consistent behavior regardless of whether tidy3d-extras is installed. The global test fixture that previously disabled local subpixel for all tests has been removed, allowing tests to run with the actual default behavior users experience.

**Documentation and Licensing**: New documentation files explain installation, usage, and licensing for tidy3d-extras. The extras package uses a proprietary commercial license (unlike the main package's LGPL), suggesting a freemium model where basic functionality is free but additional features may require payment.

**Validation Updates**: The TFSF structure intersection validator now uses the `@disable_local_subpixel` decorator since this validation needs to compute permittivities on the grid consistently.

The changes maintain backward compatibility while seamlessly integrating enhanced capabilities when the extras package is available, addressing the previous reviewer's question about auto-detection - the system now automatically detects and uses tidy3d-extras when present.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/config.py` | 4/5 | Changes default `use_local_subpixel` from `False` to `None` for automatic detection |
| `tidy3d/packaging.py` | 4/5 | Adds comprehensive tidy3d-extras integration with version checking and feature detection |
| `pyproject.toml` | 5/5 | Adds optional `tidy3d-extras` dependency with exact version pinning |
| `tests/conftest.py` | 4/5 | Removes global fixture that disabled local subpixel for all tests |
| `tidy3d/components/simulation.py` | 5/5 | Adds `@disable_local_subpixel` decorator to TFSF validation method |
| `tests/test_plugins/test_mode_solver.py` | 4/5 | Adds `@disable_local_subpixel` decorators to three test functions |
| `tests/test_components/test_packaging.py` | 4/5 | Updates test to handle both scenarios when tidy3d-extras is available/unavailable |
| `tests/test_components/test_simulation.py` | 4/5 | Adds `@disable_local_subpixel` decorator to epsilon warning test |
| `tests/test_plugins/test_waveguide.py` | 5/5 | Adds `@disable_local_subpixel` decorator to layered cladding test |
| `docs/index.rst` | 5/5 | Adds link to tidy3d-extras documentation in main docs index |
| `docs/extras/index.rst` | 4/5 | New documentation introducing tidy3d-extras with installation and usage |
| `docs/extras/license.rst` | 4/5 | Comprehensive commercial license agreement for tidy3d-extras |
| `docs/extras/third_party_licenses.rst` | 5/5 | Third-party license attributions for dependencies in tidy3d-extras |
| `CHANGELOG.md` | 5/5 | Adds changelog entry documenting the new tidy3d-extras support |

</details>

## Confidence score: 4/5

- This PR introduces significant architectural changes but maintains backward compatibility and includes comprehensive testing
- Score reflects the complexity of automatic detection logic and the need for careful version synchronization between packages
- Pay close attention to `tidy3d/packaging.py` and `tidy3d/config.py` for the automatic detection implementation

### Context used:
**Rule -** Require a changelog entry for any PR that is not purely an internal refactor. ([link](https://app.greptile.com/review/custom-context?memory=b72c7231-b258-4d03-aed2-51a50a9fe757))
**Rule -** Write changelog entries to be clear and descriptive from a user's perspective, focusing on the added capability or user-facing impact. ([link](https://app.greptile.com/review/custom-context?memory=66e7d342-0019-4d74-a4fb-81567fea2f3c))
**Rule -** Use changelog categories correctly: "Fixed" for bug fixes, "Changed" for modifications to existing functionality, and "Added" for new features. ([link](https://app.greptile.com/review/custom-context?memory=17997812-233f-4a81-bee2-4d7666605061))
**Rule -** In changelogs, enclose code identifiers (class, function names) in backticks and use specific names rather than generic descriptions. ([link](https://app.greptile.com/review/custom-context?memory=0af1d6df-6cf7-4988-b3fc-f5f8ec5cae30))

<!-- /greptile_comment -->