### PR TITLE
Fix collision between removing nearly parallel intersections and remo…

### DIFF
--- a/tests/test_components/test_layerrefinement.py
+++ b/tests/test_components/test_layerrefinement.py
@@ -870,3 +870,55 @@ def test_gap_meshing_skip_small_gap():
         run_time=1e-9,
     )
     assert sim.grid_info["min_grid_size"] > 20
+
+
+def test_gap_meshing_tiny_nearly_parallel():
+    """Test that tiny and nearly parallel features are handled properly. That is,
+    even though they are ignored, they are still taken into account when removing
+    reentry features."""
+
+    sim_size = (1, 1, 1)
+
+    diff = td.Structure(
+        geometry=td.PolySlab(
+            slab_bounds=[-0.2, 0.2],
+            axis=1,
+            vertices=[
+                (-0.43, -0.43),
+                (0.4, -0.35),
+                (0 - 1e-14, 0.05 - 1e-4),
+                (0 + 1e-14, 0.05 + 1e-4),
+                (-0.35, 0.4),
+            ],
+        ),
+        medium=td.PECMedium(),
+    )
+
+    sim = td.Simulation(
+        size=sim_size,
+        boundary_spec=td.BoundarySpec(
+            x=td.Boundary.periodic(),
+            y=td.Boundary.periodic(),
+            z=td.Boundary.periodic(),
+        ),
+        structures=[diff],
+        grid_spec=td.GridSpec.auto(
+            layer_refinement_specs=[
+                td.LayerRefinementSpec(
+                    axis=1,
+                    size=(td.inf, 0.2, td.inf),
+                    corner_finder=None,
+                    gap_meshing_iters=1,
+                    dl_min_from_gap_width=True,
+                )
+            ],
+            min_steps_per_wvl=7,
+            wavelength=1,
+        ),
+        run_time=1e-15,
+    )
+    # _, ax = plt.subplots(1, 1, figsize=(10, 10))
+    # sim.plot(y=0, ax=ax)
+    # sim.plot_grid(y=0, ax=ax)
+    # plt.show()
+    assert sim.grid_info["min_grid_size"] > 0.05

--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -1606,6 +1606,9 @@ class LayerRefinementSpec(Box):
         cells_ij = []
         # relative displacements of intersection from the bottom of the cell along y axis
         cells_dy = []
+        # whether intersections are valid: if polygon segment is almost parallel to
+        # a grid line, we mark those intersection as invalid
+        cells_valid = []
 
         # for each polygon vertex find the index of the first grid line on the right
         grid_lines_on_right = np.argmax(grid_x_coords[:, None] >= poly_vertices[None, :, 0], axis=0)
@@ -1631,12 +1634,15 @@ class LayerRefinementSpec(Box):
                 continue
 
             # intersects one grid line but almost parallel to it
-            if np.abs(ind_end - ind_beg) == 1 and np.abs(
-                v_beg[0] - v_end[0]
-            ) < 2 * GAP_MESHING_TOL * np.abs(
-                grid_x_coords[ind_beg - 1] - grid_x_coords[ind_end - 1]
-            ):
-                continue
+            not_nearly_parallel = True
+            if np.abs(ind_end - ind_beg) == 1:
+                delta_x = np.abs(v_beg[0] - v_end[0])
+                delta_y = np.abs(v_beg[1] - v_end[1])
+                grid_size_x = np.abs(grid_x_coords[ind_beg - 1] - grid_x_coords[ind_end - 1])
+                # we discard segments that are substantially vertical with respect to both grid step size
+                # and its own vertical size (so that we don't discard tiny pieces of curved boundaries)
+                if delta_x < 2 * GAP_MESHING_TOL * min(grid_size_x, delta_y):
+                    not_nearly_parallel = False
 
             # sort vertices in ascending order to make treatmeant unifrom
             reverse = False
@@ -1686,10 +1692,12 @@ class LayerRefinementSpec(Box):
             # record info
             cells_ij.append(np.transpose([cell_is, cell_js]))
             cells_dy.append(dy)
+            cells_valid.append(not_nearly_parallel * np.ones_like(dy))
 
         if len(cells_ij) > 0:
             cells_ij = np.concatenate(cells_ij)
             cells_dy = np.concatenate(cells_dy)
+            cells_valid = np.concatenate(cells_valid)
 
             # Filter from re-entering subcell features. That is, we discard any consecutive
             # intersections if they are crossing the same edge. This happens, for example,
@@ -1709,6 +1717,7 @@ class LayerRefinementSpec(Box):
             # an intersection point is not a part of a "re-entering subcell feature"
             # if it doesn't cross the same edges as its neighbors
             valid = np.logical_and(fwd_diff != 0, bwd_diff != 0)
+            valid = np.logical_and(valid, cells_valid)
 
             cells_dy = cells_dy[valid]
             cells_ij = cells_ij[valid]


### PR DESCRIPTION
…ving small reentry features in gap meshing

The issue was caused by a collision between removing intersection from nearly parallel to grid lines PEC boundaries and removing small reentry features. For example, in the figure below the small (red) segment was considered parallel to grid lines due to a poor criterion (only comparing size along x to the cell size), and its intersection with grid lines was skipped, as the result this triple crossing, which should be removed by our reentry feature removal, was considered as a double crossing. Now the criterion for nearly parallel PEC boundaries is improved, and also we keep all intersection until after reentry feature removal

<img width="873" height="657" alt="Screenshot_20250902_164202" src="https://github.com/user-attachments/assets/ae1c1c15-76dc-4fa0-bb39-a6e059bc0ec7" />

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-02 23:46:41 UTC

This PR fixes a bug in the gap meshing algorithm where two filtering mechanisms were interfering with each other. The issue occurred when removing intersections from nearly parallel PEC boundaries collided with the removal of small reentry features, causing triple crossings to be incorrectly identified as double crossings.

The core problem was in the criterion used to detect nearly parallel segments. The original implementation only compared the segment's x-extent to the grid cell size, which was too crude and could incorrectly classify curved boundary segments as parallel to grid lines. When segments were deemed "nearly parallel," their intersections with grid lines were immediately discarded. However, this premature removal interfered with the reentry feature removal logic, which relies on properly identifying triple crossings.

The fix implements two key improvements:

1. **Enhanced nearly-parallel detection**: The new criterion considers both the grid spacing and the segment's own vertical extent (`delta_y`), using the formula `delta_x < 2 * GAP_MESHING_TOL * min(grid_size_x, delta_y)`. This provides a more sophisticated geometric assessment that reduces false positives.

2. **Deferred filtering architecture**: Instead of immediately discarding intersections from nearly-parallel segments, the algorithm now tracks their validity status and only applies the filter after reentry feature removal is complete. This ensures both filtering mechanisms can operate correctly on the complete dataset.

The changes are localized to the gap meshing logic in `grid_spec.py`, where the validity tracking system (`cells_valid`) is introduced to coordinate between the two filtering stages. A comprehensive regression test has been added to prevent this specific collision scenario from recurring.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/grid/grid_spec.py | 4/5 | Improved nearly-parallel boundary detection criterion and implemented deferred filtering to prevent collision with reentry feature removal |
| tests/test_components/test_layerrefinement.py | 5/5 | Added regression test for gap meshing collision between nearly parallel and reentry feature removal |

</details>

## Confidence score: 4/5

- This PR addresses a well-defined geometric algorithm bug with a targeted fix that improves robustness
- Score reflects the complexity of the meshing algorithm and the subtle interaction between filtering mechanisms
- The grid specification file requires careful attention due to its critical role in mesh generation

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant LayerRefinementSpec
    participant GapMesher
    participant CornerFinder
    participant GridBoundaryDetector
    participant ReentryFeatureRemover

    User->>LayerRefinementSpec: "_resolve_gaps(structures, grid, boundaries)"
    LayerRefinementSpec->>CornerFinder: "_merged_pec_on_plane(coord, axis, structures)"
    CornerFinder-->>LayerRefinementSpec: "merged_pec_geometries"
    
    LayerRefinementSpec->>GapMesher: "_process_slice(x, y, merged_geos, boundaries)"
    
    loop "For each PEC polygon"
        GapMesher->>GridBoundaryDetector: "_find_vertical_intersections(grid_coords, poly_vertices)"
        
        Note over GridBoundaryDetector: "Check if segment is nearly parallel to grid"
        GridBoundaryDetector->>GridBoundaryDetector: "Calculate delta_x vs grid_size_x and delta_y"
        
        alt "Segment is nearly parallel (improved criterion)"
            GridBoundaryDetector->>GridBoundaryDetector: "Mark intersection as invalid but keep for reentry removal"
        else "Segment crosses grid normally"
            GridBoundaryDetector->>GridBoundaryDetector: "Record valid intersection"
        end
        
        GridBoundaryDetector-->>GapMesher: "intersection_cells_and_positions"
    end
    
    GapMesher->>ReentryFeatureRemover: "Filter re-entering subcell features"
    
    Note over ReentryFeatureRemover: "Remove consecutive intersections on same edge"
    Note over ReentryFeatureRemover: "Now includes previously skipped nearly-parallel intersections"
    
    ReentryFeatureRemover-->>GapMesher: "filtered_intersections"
    
    GapMesher->>GapMesher: "_generate_horizontal_snapping_lines(intersections)"
    GapMesher-->>LayerRefinementSpec: "snapping_lines, min_gap_width"
    LayerRefinementSpec-->>User: "gap_resolved_snapping_points"
```

<!-- /greptile_comment -->