### PR TITLE
fix: Update rf smatrix logic flow

### DIFF
--- a/tidy3d/plugins/smatrix/data/terminal.py
+++ b/tidy3d/plugins/smatrix/data/terminal.py
@@ -101,8 +101,8 @@ class TerminalComponentModelerData(Tidy3dBaseModel):
 
     def smatrix(
         self,
-        assume_ideal_excitation: bool = False,
-        s_param_def: SParamDef = "pseudo",
+        assume_ideal_excitation: Optional[bool] = None,
+        s_param_def: Optional[SParamDef] = None,
     ) -> MicrowaveSMatrixData:
         """Computes and returns the S-matrix and port reference impedances.
 
@@ -110,9 +110,11 @@ class TerminalComponentModelerData(Tidy3dBaseModel):
         ----------
         assume_ideal_excitation: If ``True``, assumes that exciting one port
             does not produce incident waves at other ports. This simplifies the
-            S-matrix calculation and is required if not all ports are excited.
+            S-matrix calculation and is required if not all ports are excited. If not
+            provided, ``modeler.assume_ideal_excitation`` is used.
         s_param_def: The definition of S-parameters to use, determining whether
-            "pseudo waves" or "power waves" are calculated.
+            "pseudo waves" or "power waves" are calculated. If not provided,
+            ``modeler.s_param_def`` is used.
 
         Returns
         -------
@@ -123,13 +125,15 @@ class TerminalComponentModelerData(Tidy3dBaseModel):
 
         terminal_port_data = terminal_construct_smatrix(
             modeler_data=self,
-            assume_ideal_excitation=assume_ideal_excitation,
-            s_param_def=s_param_def,
+            assume_ideal_excitation=assume_ideal_excitation
+            if (assume_ideal_excitation is not None)
+            else self.modeler.assume_ideal_excitation,
+            s_param_def=s_param_def if (s_param_def is not None) else self.modeler.s_param_def,
         )
         smatrix_data = MicrowaveSMatrixData(
             data=terminal_port_data,
             port_reference_impedances=self.port_reference_impedances,
-            s_param_def=s_param_def,
+            s_param_def=s_param_def if (s_param_def is not None) else self.modeler.s_param_def,
         )
         return smatrix_data
 


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-03 13:38:53 UTC

This PR improves the API consistency of the S-matrix functionality in the `TerminalComponentModeler` by modifying how default parameters are handled in the `smatrix()` method. Previously, the method had hardcoded default values (`assume_ideal_excitation=False` and `s_param_def="pseudo"`) that would override the modeler's configuration settings. Now, these parameters default to `None` and fall back to the modeler's own configuration when not explicitly provided.

The change affects the `TerminalComponentModelerData.smatrix()` method in `tidy3d/plugins/smatrix/data/terminal.py`. When users call `smatrix()` without specifying these parameters, the method will now respect the `assume_ideal_excitation` and `s_param_def` values that were set during modeler initialization, creating a more intuitive configuration inheritance pattern.

This modification aligns with common software design principles where child operations should respect parent configuration by default while still allowing method-level overrides. The implementation uses conditional logic to check if parameters are `None` and falls back to `self.modeler.assume_ideal_excitation` and `self.modeler.s_param_def` accordingly.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/smatrix/data/terminal.py | 3/5 | Modified parameter defaults in `smatrix()` method to use optional parameters with fallback logic to modeler configuration |

</details>

## Confidence score: 3/5

- This PR introduces a potentially breaking change that could affect existing user code that relied on the previous default behavior
- Score reflects concern about backward compatibility despite the logical improvement in API design
- Pay close attention to `tidy3d/plugins/smatrix/data/terminal.py` and ensure proper testing of the fallback logic

<!-- /greptile_comment -->