### PR TITLE
fix: pass path_dir correctly to batch run

### DIFF
--- a/tests/test_plugins/smatrix/test_run_functions.py
+++ b/tests/test_plugins/smatrix/test_run_functions.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 from unittest.mock import MagicMock
 
 import pydantic.v1 as pd
@@ -57,11 +56,10 @@ def test_create_batch(monkeypatch, tmp_path):
     dummy_modeler = make_modal_component_modeler()
 
     # Test with default arguments
-    result_batch = create_batch(modeler=dummy_modeler, path_dir=str(tmp_path))
+    result_batch = create_batch(modeler=dummy_modeler)
     mock_batch_class.assert_called_once_with(
         simulations=dummy_modeler.sim_dict,
     )
-    mock_batch_instance.to_file.assert_called_once_with(os.path.join(str(tmp_path), "batch.hdf5"))
     assert result_batch == mock_batch_instance
 
     # Reset mocks for next test
@@ -69,11 +67,8 @@ def test_create_batch(monkeypatch, tmp_path):
     mock_batch_instance.to_file.reset_mock()
 
     # Test with parent_batch_id and group_id
-    file_name = "custom_batch.hdf5"
     result_batch = create_batch(
         modeler=dummy_modeler,
-        path_dir=str(tmp_path),
-        file_name=file_name,
         some_kwarg="value",
     )
 
@@ -81,7 +76,6 @@ def test_create_batch(monkeypatch, tmp_path):
         simulations=dummy_modeler.sim_dict,
         some_kwarg="value",
     )
-    mock_batch_instance.to_file.assert_called_once_with(os.path.join(str(tmp_path), file_name))
     assert result_batch == mock_batch_instance
 
 
@@ -107,10 +101,8 @@ def test_run_function(monkeypatch):
     result = run(modeler=dummy_modeler, path_dir="./temp_dir")
 
     # Assertions
-    tidy3d.plugins.smatrix.run.create_batch.assert_called_once_with(
-        modeler=dummy_modeler, path_dir="./temp_dir"
-    )
-    mock_batch_instance.run.assert_called_once_with()
+    tidy3d.plugins.smatrix.run.create_batch.assert_called_once_with(modeler=dummy_modeler)
+    mock_batch_instance.run.assert_called_once_with(path_dir="./temp_dir")
     tidy3d.plugins.smatrix.run.compose_modeler_data_from_batch_data.assert_called_once_with(
         modeler=dummy_modeler, batch_data=mock_batch_data
     )

--- a/tidy3d/plugins/smatrix/run.py
+++ b/tidy3d/plugins/smatrix/run.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.data.index import SimulationDataMap
@@ -127,24 +126,14 @@ def compose_modeler_data_from_batch_data(
 
 def create_batch(
     modeler: ComponentModelerType,
-    path_dir: str = DEFAULT_DATA_DIR,
-    file_name: str = "batch.hdf5",
     **kwargs,
 ) -> Batch:
-    """Create a simulation Batch from a component modeler and save it to a file.
+    """Create a simulation Batch from a component modeler.
 
     Parameters
     ----------
     modeler : ComponentModelerType
         The component modeler that defines the set of simulations.
-    path_dir : str, optional
-        Directory where the batch file will be saved. Defaults to ".".
-    parent_batch_id : str, optional
-        Identifier for a parent batch, if this is a child batch.
-    group_id : str, optional
-        Identifier for grouping tasks within the batch.
-    file_name : str, optional
-        Name for the HDF5 file where the batch is stored. Defaults to "batch.hdf5".
     **kwargs
         Additional keyword arguments passed to the `Batch` constructor.
 
@@ -153,13 +142,11 @@ def create_batch(
     Batch
         The configured `Batch` object ready for execution.
     """
-    filepath = os.path.join(path_dir, file_name)
 
     batch = Batch(
         simulations=modeler.sim_dict,
         **kwargs,
     )
-    batch.to_file(filepath)
     return batch
 
 
@@ -188,7 +175,7 @@ def run(
         An object containing the processed simulation data, ready for
         S-parameter extraction and analysis.
     """
-    batch = create_batch(modeler=modeler, path_dir=path_dir, **kwargs)
-    batch_data = batch.run()
+    batch = create_batch(modeler=modeler, **kwargs)
+    batch_data = batch.run(path_dir=path_dir)
     modeler_data = compose_modeler_data_from_batch_data(modeler=modeler, batch_data=batch_data)
     return modeler_data

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -605,7 +605,7 @@ class Batch(WebContainer):
         >>> for task_name, sim_data in batch_data.items(): # doctest: +SKIP
         ...     # do something with data. # doctest: +SKIP
 
-        ``bach_data`` does not store all of the data objects in memory,
+        ``batch_data`` does not store all of the data objects in memory,
         rather it iterates over the task names and loads the corresponding
         data from file one by one. If no file exists for that task, it downloads it.
         """


### PR DESCRIPTION
I don't think we can easily support filenames other than `batch.hdf5 `at the moment.

It also seems like `batch.to_file()` is superfluous in `create_batch`, since the run command also saves it to file.

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-03 15:52:18 UTC

This PR fixes path handling issues in batch operations within the Tidy3D framework, specifically addressing how the `path_dir` parameter is passed through to batch run operations. The changes are part of a broader refactor to clean up the batch workflow and ensure consistent file path management.

The main changes include:
1. **Docstring typo fix**: Corrected 'bach_data' to 'batch_data' in the container.py docstring for better documentation clarity
2. **Standardized batch path handling**: Replaced manual path construction using `os.path.join()` with the standardized `Batch._batch_path(path_dir=path_dir)` method in the S-matrix plugin
3. **Fixed missing parameter**: Added the missing `path_dir` parameter to the `batch.run()` call to ensure batch files are saved in the correct directory
4. **Code cleanup**: Removed unused `os` import after switching to the standardized path method

These changes integrate with the existing batch management system by using established internal methods like `Batch._batch_path()` rather than ad-hoc path construction. The refactor enforces the use of 'batch.hdf5' as the standard filename across all batch operations, removing the flexibility for custom filenames but ensuring consistency. This addresses the issue mentioned in the PR description where `batch.to_file()` was being called redundantly since `batch.run()` also saves files.

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/web/api/container.py` | 5/5 | Simple docstring typo fix changing 'bach_data' to 'batch_data' |
| `tidy3d/plugins/smatrix/run.py` | 4/5 | Standardizes batch path handling and fixes missing path_dir parameter in batch.run() call |

</details>

## Confidence score: 4/5

- This PR is safe to merge with low risk as it primarily fixes path handling bugs and documentation
- Score reflects straightforward bug fixes with minimal complexity, though the path handling changes affect file I/O operations
- Pay close attention to `tidy3d/plugins/smatrix/run.py` to ensure the path handling changes work correctly with existing batch workflows

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant run
    participant create_batch
    participant Batch
    participant batch.run
    participant compose_modeler_data_from_batch_data
    participant compose_modeler_data
    participant ComponentModelerData

    User->>run: "run(modeler, path_dir, **kwargs)"
    run->>create_batch: "create_batch(modeler, path_dir, **kwargs)"
    create_batch->>Batch: "Batch(simulations=modeler.sim_dict, **kwargs)"
    Batch-->>create_batch: "batch object"
    create_batch->>Batch: "batch.to_file(filepath)"
    create_batch-->>run: "batch"
    run->>batch.run: "batch.run(path_dir=path_dir)"
    batch.run-->>run: "batch_data"
    run->>compose_modeler_data_from_batch_data: "compose_modeler_data_from_batch_data(modeler, batch_data)"
    compose_modeler_data_from_batch_data->>compose_modeler_data: "compose_modeler_data(modeler, port_simulation_data)"
    compose_modeler_data->>ComponentModelerData: "create data object"
    ComponentModelerData-->>compose_modeler_data: "modeler_data"
    compose_modeler_data-->>compose_modeler_data_from_batch_data: "modeler_data"
    compose_modeler_data_from_batch_data-->>run: "modeler_data"
    run-->>User: "modeler_data"
```

<!-- /greptile_comment -->