### PR TITLE
FXC-2087 Implement automatic structure extrusion for boundary waveports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added S-parameter de-embedding to `TerminalComponentModelerData`, enabling recalculation with shifted reference planes.
+- Added optional automatic extrusion of structures intersecting with a `WavePort` via the new `extrude_structures` field, ensuring mode sources, absorbers, and PEC frames are fully contained.
 - Added support for `tidy3d-extras`, an optional plugin that enables more accurate local mode solving via subpixel averaging.
 - Added support for `symlog` and `log` scale plotting in `Scene.plot_eps()` and `Scene.plot_structures_property()` methods. The `symlog` scale provides linear behavior near zero and logarithmic behavior elsewhere, while 'log' is a base 10 logarithmic scale.
 - Added `LowFrequencySmoothingSpec` and `ModelerLowFrequencySmoothingSpec` for automatic smoothing of mode monitor data at low frequencies where DFT sampling is insufficient.

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -17880,6 +17880,10 @@
           ],
           "type": "string"
         },
+        "extrude_structures": {
+          "default": false,
+          "type": "boolean"
+        },
         "frame": {
           "allOf": [
             {

--- a/tests/test_plugins/smatrix/terminal_component_modeler_def.py
+++ b/tests/test_plugins/smatrix/terminal_component_modeler_def.py
@@ -5,6 +5,7 @@ from typing import Optional, Union
 import numpy as np
 
 import tidy3d as td
+import tidy3d.plugins.microwave as mw
 from tidy3d.plugins.smatrix import (
     CoaxialLumpedPort,
     LumpedPort,
@@ -331,3 +332,145 @@ def make_coaxial_component_modeler(
     )
 
     return modeler
+
+
+def make_differential_stripline_modeler():
+    # Frequency range (Hz)
+    f_min, f_max = (1e9, 70e9)
+
+    # Frequency sample points
+    freqs = np.linspace(f_min, f_max, 101)
+
+    # Geometry
+    mil = 25.4  # conversion to mils to microns (default unit)
+    w = 3.2 * mil  # Signal strip width
+    t = 0.7 * mil  # Conductor thickness
+    h = 10.7 * mil  # Substrate thickness
+    se = 7 * mil  # gap between edge-coupled pair
+    L = 4000 * mil  # Line length
+    len_inf = 1e6  # Effective infinity
+
+    left_end = -L / 2
+    right_end = len_inf
+
+    len_z = right_end - left_end
+    cent_z = (left_end + right_end) / 2
+    waveport_z = L
+
+    # Material properties
+    eps = 4.4  # Relative permittivity, substrate
+
+    # define media
+    med_sub = td.Medium(permittivity=eps)
+    med_metal = td.PEC
+
+    left_strip_geometry = td.Box(center=(-(se + w) / 2, 0, 0), size=(w, t, L))
+    right_strip_geometry = td.Box(center=((se + w) / 2, 0, 0), size=(w, t, L))
+
+    # Substrate
+    str_sub = td.Structure(geometry=td.Box(center=(0, 0, 0), size=(len_inf, h, L)), medium=med_sub)
+
+    # disjoint signal strips
+    str_signal_strips = td.Structure(
+        geometry=td.GeometryGroup(geometries=[left_strip_geometry, right_strip_geometry]),
+        medium=med_metal,
+    )
+
+    # Top ground plane
+    str_gnd_top = td.Structure(
+        geometry=td.Box(center=(0, h / 2 + t / 2, 0), size=(len_inf, t, L)), medium=med_metal
+    )
+
+    # Bottom ground plane
+    str_gnd_bot = td.Structure(
+        geometry=td.Box(center=(0, -h / 2 - t / 2, 0), size=(len_inf, t, L)), medium=med_metal
+    )
+
+    # Create a LayerRefinementSpec from signal trace structures
+    lr_spec = td.LayerRefinementSpec.from_structures(
+        structures=[str_signal_strips],
+        axis=1,  # Layer normal is in y-direction
+        min_steps_along_axis=10,  # Min 10 grid cells along normal direction
+        refinement_inside_sim_only=False,  # Metal structures extend outside sim domain. Set 'False' to snap to corners outside sim.
+        bounds_snapping="bounds",  # snap grid to metal boundaries
+        corner_refinement=td.GridRefinement(
+            dl=t / 10, num_cells=2
+        ),  # snap to corners and apply added refinement
+    )
+
+    # Layer refinement for top and bottom ground planes
+    lr_spec2 = lr_spec.updated_copy(center=(0, h / 2 + t / 2, cent_z), size=(len_inf, t, len_z))
+    lr_spec3 = lr_spec.updated_copy(center=(0, -h / 2 - t / 2, cent_z), size=(len_inf, t, len_z))
+
+    # Define overall grid specification
+    grid_spec = td.GridSpec.auto(
+        wavelength=td.C_0 / f_max,
+        min_steps_per_wvl=30,
+        layer_refinement_specs=[lr_spec, lr_spec2, lr_spec3],
+    )
+
+    # boundary specs
+    boundary_spec = td.BoundarySpec(
+        x=td.Boundary.pml(),
+        y=td.Boundary.pec(),
+        z=td.Boundary.pml(),
+    )
+
+    # Define port specification
+    wave_port_mode_spec = td.ModeSpec(num_modes=1, target_neff=np.sqrt(eps))
+
+    # Define current and voltage integrals
+    current_integral = mw.AxisAlignedCurrentIntegral(
+        center=((se + w) / 2, 0, -waveport_z / 2), size=(2 * w, 3 * t, 0), sign="+"
+    )
+    voltage_integral = mw.AxisAlignedVoltageIntegral(
+        center=(0, 0, -waveport_z / 2),
+        size=(se, 0, 0),
+        extrapolate_to_endpoints=True,
+        snap_path_to_grid=True,
+        sign="+",
+    )
+
+    # Define wave ports
+    WP1 = WavePort(
+        center=(0, 0, -waveport_z / 2),
+        size=(len_inf, len_inf, 0),
+        mode_spec=wave_port_mode_spec,
+        direction="+",
+        name="WP1",
+        mode_index=0,
+        current_integral=current_integral,
+        voltage_integral=voltage_integral,
+    )
+    WP2 = WP1.updated_copy(
+        name="WP2",
+        center=(0, 0, waveport_z / 2),
+        direction="-",
+        current_integral=current_integral.updated_copy(
+            center=((se + w) / 2, 0, waveport_z / 2), sign="-"
+        ),
+        voltage_integral=voltage_integral.updated_copy(center=(0, 0, waveport_z / 2)),
+    )
+
+    # define fimulation
+    sim = td.Simulation(
+        size=(50 * mil, h + 2 * t, 1.05 * L),
+        center=(0, 0, 0),
+        grid_spec=grid_spec,
+        boundary_spec=boundary_spec,
+        structures=[str_sub, str_signal_strips, str_gnd_top, str_gnd_bot],
+        monitors=[],
+        run_time=2e-9,  # simulation run time in seconds
+        shutoff=1e-7,  # lower shutoff threshold for more accurate low frequency
+        plot_length_units="mm",
+        symmetry=(-1, 0, 0),  # odd symmetry in x-direction
+    )
+
+    # set up component modeler
+    tcm = TerminalComponentModeler(
+        simulation=sim,  # simulation, previously defined
+        ports=[WP1, WP2],  # wave ports, previously defined
+        freqs=freqs,  # S-parameter frequency points
+    )
+
+    return tcm

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -29,7 +29,11 @@ from tidy3d.plugins.smatrix.ports.base_lumped import AbstractLumpedPort
 from tidy3d.plugins.smatrix.utils import s_to_z, validate_square_matrix
 
 from ...utils import run_emulated
-from .terminal_component_modeler_def import make_coaxial_component_modeler, make_component_modeler
+from .terminal_component_modeler_def import (
+    make_coaxial_component_modeler,
+    make_component_modeler,
+    make_differential_stripline_modeler,
+)
 
 mm = 1e3
 
@@ -1595,3 +1599,182 @@ def test_S_parameter_deembedding(monkeypatch, tmp_path):
     S_dmb_shortcut = modeler_data_LP.smatrix_deembedded(port_shifts=port_shifts_LP)
     assert not np.allclose(S_dmb.data.values, s_matrix_LP.data.values)
     assert np.allclose(S_dmb_shortcut.data.values, S_dmb.data.values)
+
+
+def test_wave_port_extrusion_coaxial():
+    """Test extrusion of structures wave port absorber."""
+
+    # define a terminal component modeler
+    tcm = make_coaxial_component_modeler(
+        length=100000,
+        port_types=(WavePort, WavePort),
+    )
+
+    # update ports and set flag to extrude structures
+    ports = tcm.ports
+    port_1 = ports[0]
+    port_2 = ports[1]
+    port_1 = port_1.updated_copy(center=(0, 0, -50000), extrude_structures=True)
+
+    # test that structure extrusion requires an internal absorber (should raise ValidationError)
+    with pytest.raises(pd.ValidationError):
+        _ = port_2.updated_copy(center=(0, 0, 50000), extrude_structures=True, absorber=False)
+
+    # define a valid waveport
+    port_2 = port_2.updated_copy(center=(0, 0, 50000), extrude_structures=True)
+
+    # update component modeler
+    tcm = tcm.updated_copy(ports=[port_1, port_2])
+
+    # generate simulations from component modeler
+    sim = tcm.base_sim
+
+    # get injection axis that would be used to extrude structure
+    inj_axis = sim.internal_absorbers[0].size.index(0.0)
+
+    # get grid boundaries
+    bnd_coords = sim.grid.boundaries.to_list[inj_axis]
+
+    # get size of structures along injection axis directions
+    str_bnds = [
+        np.min(sim.structures[-4].geometry.geometries[0].slab_bounds),
+        np.max(sim.structures[-2].geometry.geometries[0].slab_bounds),
+    ]
+
+    pec_bnds = []
+
+    # infer placement of PEC plates beyond internal absorber
+    for absorber in sim.internal_absorbers:
+        absorber_cntr = absorber.center[inj_axis]
+        right_ind = np.searchsorted(bnd_coords, absorber_cntr, side="right")
+        left_ind = np.searchsorted(bnd_coords, absorber_cntr, side="left") - 1
+        pec_bnds.append(bnd_coords[right_ind + 1])
+        pec_bnds.append(bnd_coords[left_ind - 1])
+
+    # get range of coordinates along injection axis for PEC plates
+    pec_bnds = [np.min(pec_bnds), np.max(pec_bnds)]
+
+    # ensure that structures were extruded up to PEC plates
+    assert all(np.isclose(str_bnd, pec_bnd) for str_bnd, pec_bnd in zip(str_bnds, pec_bnds))
+
+    # generate a new TCM simulation to test edge case when wave port plane does not intersect any structures
+    tcm = make_coaxial_component_modeler(
+        length=100000, port_types=(WavePort, WavePort), use_current=False
+    )
+
+    # update ports and set flag to extrude structures
+    ports = tcm.ports
+    port_1 = ports[0]
+    port_2 = ports[1]
+    port_1 = port_1.updated_copy(center=(0, 0, -50000), extrude_structures=True)
+    port_2 = port_2.updated_copy(center=(0, 0, 50000), extrude_structures=True)
+
+    # move wave port plane so that is does not intersect any structures
+    port_1_center_new = (638.4, 0.0, -51000)
+
+    # update voltage integral
+    voltage_int = port_1.voltage_integral.updated_copy(center=port_1_center_new)
+    # update WavePort
+    port_1 = port_1.updated_copy(center=port_1_center_new, voltage_integral=voltage_int)
+
+    # update component modeler
+    tcm = tcm.updated_copy(ports=[port_1, port_2])
+
+    # make sure that
+    with pytest.raises(SetupError):
+        sim = tcm.base_sim
+
+
+def test_wave_port_extrusion_differential_stripline():
+    """Test extrusion of structures wave port absorber for differential stripline."""
+
+    tcm = make_differential_stripline_modeler()
+
+    # update ports and set flag to extrude structures
+    ports = tcm.ports
+    port_1 = ports[0]
+    port_2 = ports[1]
+    port_1 = port_1.updated_copy(extrude_structures=True)
+
+    # test that structure extrusion requires an internal absorber (should raise ValidationError)
+    with pytest.raises(pd.ValidationError):
+        _ = port_2.updated_copy(extrude_structures=True, absorber=False)
+
+    # define a valid waveport
+    port_2 = port_2.updated_copy(extrude_structures=True)
+
+    # update component modeler
+    tcm = tcm.updated_copy(ports=[port_1, port_2])
+
+    # generate simulations from component modeler
+    sim = tcm.base_sim
+
+    # get injection axis that would be used to extrude structure
+    inj_axis = sim.internal_absorbers[0].size.index(0.0)
+
+    # get grid boundaries
+    bnd_coords = sim.grid.boundaries.to_list[inj_axis]
+
+    # get size of structures along injection axis directions
+    str_bnds = [
+        np.min(sim.structures[-6].geometry.geometries[0].slab_bounds),
+        np.max(sim.structures[-1].geometry.geometries[0].slab_bounds),
+    ]
+
+    pec_bnds = []
+
+    # infer placement of PEC plates beyond internal absorber
+    for absorber in sim._shifted_internal_absorbers:
+        # get the PEC box with its face surfaces
+        (box, inj_axis, direction) = sim._pec_frame_box(absorber)
+        surfaces = box.surfaces(box.size, box.center)
+
+        # get extrusion coordinates and a cutting plane for inference of intersecting structures.
+        sign = 1 if direction == "+" else -1
+        cutting_plane = surfaces[2 * inj_axis + (1 if direction == "+" else 0)]
+
+        # get extrusion extent along injection axis
+        pec_bnds.append(cutting_plane.center[inj_axis])
+
+    # get range of coordinates along injection axis for PEC plates
+    pec_bnds = [np.min(pec_bnds), np.max(pec_bnds)]
+
+    # ensure that structures were extruded up to PEC plates
+    assert all(np.isclose(str_bnd, pec_bnd) for str_bnd, pec_bnd in zip(str_bnds, pec_bnds))
+
+    # test scenario when wave port extrusion is requested, but port plane does not intersect any structures
+    mil = 25.4
+    port_1_center_new = (0, 0, -2010 * mil)
+
+    # re-assemble a new component modeler
+    tcm = make_differential_stripline_modeler()
+
+    # update ports and set flag to extrude structures
+    ports = tcm.ports
+    port_1 = ports[0]
+    port_2 = ports[1]
+    port_1 = port_1.updated_copy(extrude_structures=True)
+    port_2 = port_2.updated_copy(extrude_structures=True)
+
+    # update current and voltage integrals
+    current_int = port_1.current_integral.updated_copy(center=port_1_center_new)
+    voltage_int = port_1.voltage_integral.updated_copy(center=port_1_center_new)
+
+    # update WavePort
+    port_1 = port_1.updated_copy(
+        center=port_1_center_new, current_integral=current_int, voltage_integral=voltage_int
+    )
+
+    # update component modeler
+    tcm = tcm.updated_copy(ports=[port_1, port_2])
+
+    # make sure that the error is triggered
+    with pytest.raises(SetupError):
+        sim = tcm.base_sim
+
+    # update component modeler
+    tcm = tcm.updated_copy(ports=[port_2, port_1])
+
+    # make sure that the error is triggered even when ports are reshuffled
+    with pytest.raises(SetupError):
+        sim = tcm.base_sim

--- a/tidy3d/components/geometry/utils.py
+++ b/tidy3d/components/geometry/utils.py
@@ -735,10 +735,11 @@ def _shift_value_signed(
             f"{name} position '{obj_position}' is outside of simulation bounds '({grid_boundaries[0]}, {grid_boundaries[-1]})' along dimension '{'xyz'[normal_axis]}'."
         )
     obj_index = obj_pos_gt_grid_bounds[-1]
-
     # shift the obj to the left
     signed_shift = shift if direction == "+" else -shift
     if signed_shift < 0:
+        if np.isclose(obj_position, grid_boundaries[obj_index + 1]):
+            obj_index += 1
         shifted_index = obj_index + signed_shift
         if shifted_index < 0 or grid_centers[shifted_index] <= bounds[0][normal_axis]:
             raise SetupError(

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -2151,29 +2151,9 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         the frame is added around the injection plane. For internal absorbers, a backing pec
         plate is also added on the non-absorbing side.
         """
-        span_inds = np.array(self.grid.discretize_inds(obj))
 
-        coords = self.grid.boundaries.to_list
-        direction = obj.direction
-        if isinstance(obj, ModeSource):
-            axis = obj.injection_axis
-            length = obj.frame.length
-            if direction == "+":
-                span_inds[axis][1] += length - 1
-            else:
-                span_inds[axis][0] -= length - 1
-        else:
-            axis = obj.size.index(0.0)
-
-        box_bounds = [
-            [
-                c[beg],
-                c[end],
-            ]
-            for c, (beg, end) in zip(coords, span_inds)
-        ]
-
-        box = Box.from_bounds(*np.transpose(box_bounds))
+        # get pec frame bounding box, object's axis and direction
+        (box, axis, direction) = self._pec_frame_box(obj)
 
         surfaces = Box.surfaces(box.size, box.center)
         if isinstance(obj, ModeSource):
@@ -2192,6 +2172,42 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         )
 
         return structure
+
+    def _pec_frame_box(
+        self, obj: Union[ModeSource, InternalAbsorber], expand: bool = False
+    ) -> tuple[Box, int, str]:
+        """Return pec bounding box, frame axis and object's direction"""
+
+        span_inds = np.array(self.grid.discretize_inds(obj))
+        coords = self.grid.boundaries.to_list
+        direction = obj.direction
+        if isinstance(obj, ModeSource):
+            axis = obj.injection_axis
+            length = obj.frame.length
+            if direction == "+":
+                span_inds[axis][1] += length - 1
+            else:
+                span_inds[axis][0] -= length - 1
+        else:
+            axis = obj.size.index(0.0)
+
+        # ensure that the pec frame is at least one cell larger than wave port plane
+        if expand:
+            for dim in range(3):
+                if dim != axis:
+                    grid_size = len(coords[dim])
+                    (beg, end) = span_inds[dim]
+                    span_inds[dim] = [np.maximum(0, beg - 1), np.minimum(grid_size - 1, end + 1)]
+
+        box_bounds = [
+            [
+                c[beg],
+                c[end],
+            ]
+            for c, (beg, end) in zip(coords, span_inds)
+        ]
+
+        return (Box.from_bounds(*np.transpose(box_bounds)), axis, direction)
 
     @cached_property
     def _modal_plane_frames(self) -> list[Structure]:

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -7,12 +7,14 @@ from typing import Optional, Union
 import numpy as np
 import pydantic.v1 as pd
 
+from tidy3d import ClipOperation, GeometryGroup, GridSpec, PolySlab
 from tidy3d.components.base import cached_property
 from tidy3d.components.boundary import BroadbandModeABCSpec
 from tidy3d.components.frequency_extrapolation import (
     AbstractLowFrequencySmoothingSpec,
     LowFrequencySmoothingSpec,
 )
+from tidy3d.components.geometry.utils import _shift_object
 from tidy3d.components.geometry.utils_2d import snap_coordinate_to_grid
 from tidy3d.components.index import SimulationMap
 from tidy3d.components.microwave.base import MicrowaveBaseModel
@@ -21,7 +23,7 @@ from tidy3d.components.simulation import Simulation
 from tidy3d.components.source.time import GaussianPulse
 from tidy3d.components.types import Ax, Complex
 from tidy3d.components.viz import add_ax_if_none, equal_aspect
-from tidy3d.constants import C_0, OHM
+from tidy3d.constants import C_0, OHM, fp_eps
 from tidy3d.exceptions import SetupError, Tidy3dKeyError, ValidationError
 from tidy3d.log import log
 from tidy3d.plugins.smatrix.component_modelers.base import (
@@ -284,6 +286,7 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         # Now, create simulations with wave port sources and mode solver monitors for computing port modes
         for network_index in self.matrix_indices_run_sim:
             task_name, sim_with_src = self._add_source_to_sim(network_index)
+            # update simulation
             sim_dict[task_name] = sim_with_src
 
         # Check final simulations for grid size at ports
@@ -379,8 +382,14 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
                 max_deviation=self.low_freq_smoothing.max_deviation,
             )
 
-        # This is the new default simulation will all shared components added
-        return sim_wo_source.copy(update=update_dict)
+        # update base simulation with updated set of shared components
+        sim_wo_source = sim_wo_source.copy(update=update_dict)
+
+        # extrude port structures
+        sim_wo_source = self._extrude_port_structures(sim=sim_wo_source)
+
+        # This is the new default simulation with all shared components added
+        return sim_wo_source
 
     def _add_source_to_sim(self, source_index: NetworkIndex) -> tuple[str, Simulation]:
         """Adds the source corresponding to the ``source_index`` to the base simulation."""
@@ -398,6 +407,7 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
                 self._source_time, snap_center=new_port_center, grid=self.base_sim.grid
             )
         task_name = self.get_task_name(port=port, mode_index=mode_index)
+
         return (task_name, self.base_sim.updated_copy(sources=[port_source]))
 
     @cached_property
@@ -506,6 +516,130 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
             if monitor.name == monitor_name:
                 return monitor
         raise Tidy3dKeyError(f"No radiation monitor named '{monitor_name}'.")
+
+    def _extrude_port_structures(self, sim: Simulation) -> Simulation:
+        """
+        Extrude structures intersecting a port plane when a wave port lies on a structure boundary.
+
+        This method checks wave ports with ``extrude_structures==True`` and automatically extends the boundary structures
+        to PEC plates associated with internal absorbers in the direction opposite to the mode source.
+        This ensures that mode sources and internal absorbers are fully contained within the extrusion.
+
+        Parameters
+        ----------
+        sim : Simulation
+            Simulation object containing mode sources, internal absorbers, and monitors,
+            after mesh overrides and snapping points are applied.
+
+        Returns
+        -------
+        Simulation
+            Updated simulation with extruded structures added to ``simulation.structures``.
+        """
+
+        # create list with extruded structures
+        new_structures = []
+        all_new_structures = []
+
+        # get all mode sources from TerminalComponentModeler that correspond to ports with ``extrude_structures`` flag set to ``True``.
+        for port in self.ports:
+            if isinstance(port, WavePort) and port.extrude_structures:
+                # compute snap_center and shift the internal absorber associated with the current port
+                snap_center = port.center[port.injection_axis] + self._shift_value_signed(port)
+                absorber = port.to_absorber(snap_center=snap_center)
+                shifted_absorber = _shift_object(
+                    obj=absorber,
+                    grid=sim.grid,
+                    bounds=sim.bounds,
+                    direction=absorber.direction,
+                    shift=absorber.grid_shift,
+                )
+
+                # get the PEC box with its face surfaces
+                (box, inj_axis, direction) = sim._pec_frame_box(shifted_absorber, expand=True)
+                surfaces = box.surfaces(box.size, box.center)
+
+                # get extrusion coordinates and a cutting plane for inference of intersecting structures.
+                sign = 1 if direction == "+" else -1
+                back_pec_plane = surfaces[2 * inj_axis + (1 if direction == "+" else 0)]
+
+                # get extrusion extent along injection axis
+                extrude_to = back_pec_plane.center[inj_axis]
+
+                # move cutting plane beyond the waveport plane along the `ModeSource` injection direction.
+                center = list(back_pec_plane.center)
+                center[inj_axis] = port.center[inj_axis] - sign * fp_eps * box.size[inj_axis]
+                cutting_plane = back_pec_plane.updated_copy(center=center)
+
+                # define extrusion bounds
+                extrusion_bounds = [cutting_plane.center[inj_axis], extrude_to][::sign]
+
+                # loop over structures and extrude those that intersect a waveport plane
+                for structure in sim.structures:
+                    # get geometries that intersect the plane on which the waveport is defined
+
+                    shapely_geom = cutting_plane.intersections_with(structure.geometry)
+
+                    polygon_list = []
+                    for geom in shapely_geom:
+                        polygon_list = polygon_list + ClipOperation.to_polygon_list(geom)
+
+                    new_geoms = []
+                    # loop over identified geometries and extrude them
+                    for polygon in polygon_list:
+                        # construct outer shell of an extruded geometry first
+                        exterior_vertices = np.array(polygon.exterior.coords)
+                        outer_shell = PolySlab(
+                            axis=inj_axis, slab_bounds=extrusion_bounds, vertices=exterior_vertices
+                        )
+
+                        # construct innner shells that represent holes
+                        hole_polyslabs = [
+                            PolySlab(
+                                axis=inj_axis,
+                                slab_bounds=extrusion_bounds,
+                                vertices=np.array(hole.coords),
+                            )
+                            for hole in polygon.interiors
+                        ]
+
+                        # construct final geometry by removing inner holes from outer shell
+                        if hole_polyslabs:
+                            holes = GeometryGroup(geometries=hole_polyslabs)
+                            extruded_slab_new = ClipOperation(
+                                operation="difference", geometry_a=outer_shell, geometry_b=holes
+                            )
+                        else:
+                            extruded_slab_new = outer_shell
+
+                        # append extruded geometry
+                        new_geoms.append(extruded_slab_new)
+                    if len(polygon_list) != 0:
+                        # update structure and add it to the list
+                        new_struct = structure.updated_copy(
+                            geometry=GeometryGroup(geometries=new_geoms)
+                        )
+                        new_structures.append(new_struct)
+
+                        # if current port does not intersect any structures raise error
+                if not new_structures:
+                    raise SetupError(
+                        f"The 'WavePort' '{port.name}' does not intersect any structures."
+                        f"Please ensure that it is located within or at the boundary of a structure."
+                    )
+
+                all_new_structures = all_new_structures + new_structures
+                new_structures = []
+
+        # if new structures are extruded (Lumped Port extrusion is ignored)
+        if all_new_structures:
+            # update structures in simulation while keeping the same grid
+            sim = sim.updated_copy(
+                grid_spec=GridSpec.from_grid(sim.grid),
+                structures=[*sim.structures, *all_new_structures],
+            )
+
+        return sim
 
 
 TerminalComponentModeler.update_forward_refs()

--- a/tidy3d/plugins/smatrix/ports/wave.py
+++ b/tidy3d/plugins/smatrix/ports/wave.py
@@ -91,15 +91,21 @@ class WavePort(AbstractTerminalPort, Box):
 
     frame: Optional[PECFrame] = pd.Field(
         DEFAULT_WAVE_PORT_FRAME,
-        title="Source Frame.",
+        title="Source Frame",
         description="Add a thin frame around the source during FDTD run for an improved injection.",
     )
 
     absorber: Union[bool, ABCBoundary, ModeABCBoundary] = pd.Field(
         True,
-        title="Absorber.",
+        title="Absorber",
         description="Place a mode absorber in the port. If ``True``, an automatically generated mode absorber is placed in the port. "
         "If :class:`.ABCBoundary` or :class:`.ModeABCBoundary`, a mode absorber is placed in the port with the specified boundary conditions.",
+    )
+
+    extrude_structures: bool = pd.Field(
+        False,
+        title="Extrude Structures",
+        description="Extrudes structures that intersect the wave port plane by a few grid cells when ``True``, improving mode injection accuracy.",
     )
 
     def _mode_voltage_coefficients(self, mode_data: ModeData) -> FreqModeDataArray:
@@ -321,3 +327,15 @@ class WavePort(AbstractTerminalPort, Box):
                 f"'current_integral' sign must match the '{name}' direction '{direction}'."
             )
         return val
+
+    @pd.root_validator(pre=False)
+    def _check_absorber_if_extruding_structures(cls, values):
+        """Raise validation error when ``extrude_structures`` is set to ``True``
+        while ``absorber`` is set to ``False``."""
+
+        if values.get("extrude_structures") and not values.get("absorber"):
+            raise ValidationError(
+                "Structure extrusion for a waveport requires an internal absorber. Set `absorber=True` to enable it."
+            )
+
+        return values


### PR DESCRIPTION
This PR adds automatic extrusion of structures intersecting waveports that are placed on boundaries. 

Key changes:
- Introduced the  field in  to mark ports for which material should be extruded.
- Implemented the extrusion logic in , ensuring mode sources, internal absorbers, and PEC frames are fully contained within the extruded structures.
- Extrusion occurs only when  is set to .

This improves simulation accuracy when waveports are located on structure boundaries and simplifies user workflow.

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-04 15:39:10 UTC

This PR implements automatic structure extrusion for waveports positioned on simulation boundaries. The main functionality adds a new `extrude_structures` boolean field to the `WavePort` class that, when set to `True`, triggers automatic extension of intersecting structures to ensure mode sources, internal absorbers, and PEC frames are fully contained within the material geometry.

The core implementation resides in the `TerminalComponentModeler` class with the addition of a new `_extrude_port_structures` method that performs the geometric operations. This method identifies structures intersecting the waveport plane and creates extended `PolySlab` geometries that stretch from the port location to cover all necessary simulation components. The extrusion logic handles complex geometries with holes using `ClipOperation` and integrates seamlessly into the existing simulation pipeline.

This feature addresses a common simulation accuracy issue where waveports placed directly on structure boundaries might not provide adequate material coverage for electromagnetic field calculations. By automating the extrusion process, the PR simplifies user workflow while ensuring proper containment of all port-related simulation elements.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/smatrix/component_modelers/terminal.py | 3/5 | Implements core extrusion logic with potential bounds checking issues |
| tidy3d/plugins/smatrix/ports/wave.py | 5/5 | Clean addition of extrude_structures boolean field with proper defaults |
| tests/test_plugins/smatrix/test_terminal_component_modeler.py | 4/5 | Comprehensive test validating extrusion functionality for coaxial geometry |
| CHANGELOG.md | 4/5 | Documents new feature with clear user-facing descriptions |

</details>

## Confidence score: 3/5

- This PR requires careful review due to potential runtime errors in the extrusion logic
- Score lowered due to unsafe array access without bounds checking and complex geometric operations that could fail
- Pay close attention to tidy3d/plugins/smatrix/component_modelers/terminal.py, specifically the `_extrude_port_structures` method

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant TerminalComponentModeler as TCM
    participant WavePort
    participant Simulation as Sim
    participant Structure
    participant GeometryGroup as GeoGroup
    participant PolySlab
    participant ClipOperation as ClipOp

    User->>WavePort: "Create WavePort with extrude_structures=True"
    User->>TCM: "Create TerminalComponentModeler with WavePort"
    
    User->>TCM: "Access sim_dict property"
    TCM->>TCM: "_add_source_to_sim(network_index)"
    TCM->>WavePort: "to_source(source_time, snap_center)"
    WavePort-->>TCM: "ModeSource"
    TCM->>Sim: "updated_copy(sources=[port_source])"
    Sim-->>TCM: "simulation with source"
    
    TCM->>TCM: "_extrude_port_structures(sim_with_src)"
    
    loop "For each WavePort with extrude_structures=True"
        TCM->>WavePort: "Check extrude_structures flag"
        WavePort-->>TCM: "True"
        
        TCM->>TCM: "Calculate mode source position and offset"
        TCM->>TCM: "Define extrusion bounding box"
        TCM->>TCM: "Get slice planes (left and right)"
        
        loop "For each structure in simulation"
            TCM->>Structure: "Get geometry intersections with slice planes"
            Structure-->>TCM: "Shapely polygons"
            
            loop "For each intersecting polygon"
                TCM->>PolySlab: "Create outer shell from exterior vertices"
                PolySlab-->>TCM: "Outer PolySlab"
                
                alt "Polygon has holes"
                    loop "For each hole"
                        TCM->>PolySlab: "Create hole PolySlab from interior vertices"
                        PolySlab-->>TCM: "Hole PolySlab"
                    end
                    TCM->>GeoGroup: "Create GeometryGroup(hole_polyslabs)"
                    GeoGroup-->>TCM: "Holes geometry group"
                    TCM->>ClipOp: "ClipOperation(difference, outer_shell, holes)"
                    ClipOp-->>TCM: "Extruded geometry with holes"
                else "No holes"
                    TCM->>TCM: "Use outer shell as extruded geometry"
                end
                
                TCM->>TCM: "Add extruded geometry to new_geoms list"
            end
            
            TCM->>TCM: "Add original structure geometry to new_geoms"
            TCM->>GeoGroup: "Create GeometryGroup(new_geoms)"
            GeoGroup-->>TCM: "Combined geometry group"
            TCM->>Structure: "Create new Structure with combined geometry"
            Structure-->>TCM: "Extended structure"
            TCM->>TCM: "Add to new_structures list"
        end
    end
    
    TCM->>Sim: "updated_copy(structures=new_structures)"
    Sim-->>TCM: "Simulation with extruded structures"
    TCM-->>User: "SimulationMap with extruded structures"
```

<!-- /greptile_comment -->