### PR TITLE
Making sure fp_eps is float64

### DIFF
--- a/tidy3d/constants.py
+++ b/tidy3d/constants.py
@@ -64,7 +64,7 @@ dp_eps = np.finfo(np.float64).eps
 Double floating point precision.
 """
 
-fp_eps = np.finfo(np.float32).eps
+fp_eps = np.float64(np.finfo(np.float32).eps)
 """
 Floating point precision.
 """


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-05 13:12:57 UTC

This PR adds a temporary debugging print statement to the `tidy3d/constants.py` file. The change introduces `print(fp_eps)` on line 68, which will output the floating-point epsilon value every time the constants module is imported. Despite the PR title "Making sure fp_eps is float64", the actual implementation does not modify `fp_eps` to use `float64` precision - it still uses `np.float32` as defined on line 67. 

The constants module appears to be part of Tidy3D's core infrastructure for defining numerical precision parameters used throughout the electromagnetic simulation framework. The `fp_eps` constant likely represents the machine epsilon for floating-point comparisons and calculations. This debugging code suggests the developer was investigating the current value of `fp_eps`, possibly as part of a larger effort to upgrade the precision from `float32` to `float64`, but the change is incomplete.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/constants.py | 1/5 | Added temporary debugging print statement that outputs fp_eps value on module import |

</details>

## Confidence score: 1/5

- This PR is not safe to merge as it contains debugging code that should not be in production
- Score reflects the presence of temporary debugging code that will cause unwanted console output in production environments
- Pay close attention to tidy3d/constants.py as it contains debugging code that must be removed

### Context used:
**Rule -** Remove temporary debugging code (print() calls), commented-out code, and other workarounds before finalizing a pull request. ([link](https://app.greptile.com/review/custom-context?memory=f6a669d8-0060-4f11-9cac-10ac7ee749ea))

<!-- /greptile_comment -->