### PR TITLE
fix pec frame lengths

### DIFF
--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -5645,16 +5645,12 @@ class Simulation(AbstractYeeGridSimulation):
         if isinstance(obj, ModeSource):
             axis = obj.injection_axis
             length = obj.frame.length
+            if direction == "+":
+                span_inds[axis][1] += length - 1
+            else:
+                span_inds[axis][0] -= length - 1
         else:
             axis = obj.size.index(0.0)
-            length = 1
-
-        if direction == "+":
-            span_inds[axis][1] += length - 1
-            span_inds[axis][0] -= 1
-        else:
-            span_inds[axis][1] += 1
-            span_inds[axis][0] -= length - 1
 
         box_bounds = [
             [


### PR DESCRIPTION
`span_inds = np.array(self.grid.discretize_inds(obj))` by itself gives frame of length 1 already

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-08 21:40:39 UTC

This PR fixes a bug in the PEC (Perfect Electric Conductor) frame length calculation for mode sources in the Tidy3D electromagnetic simulation framework. The issue was that the code was double-counting frame dimensions when discretizing objects on the computational grid.

The problem occurred in the `_get_pec_objects` method where `self.grid.discretize_inds(obj)` already returns grid indices that create a frame of length 1, but the original code was then adding/subtracting additional frame length on top of that base frame. This resulted in PEC frames being larger than intended.

The fix reorganizes the logic to:
1. Use the base frame from `discretize_inds()` for `InternalAbsorber` objects (which only need a single-cell frame)
2. Apply frame length adjustments only to `ModeSource` objects, but subtract 1 from the adjustment to account for the base frame already provided
3. Move the frame length adjustment logic inside the `ModeSource` conditional block to prevent it from affecting other object types

This change ensures that PEC frames have the correct dimensions as specified by the design, with `ModeSource` objects respecting their configurable `frame.length` parameter and `InternalAbsorber` objects using the appropriate single-cell frame.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/simulation.py | 4/5 | Fixed double-counting bug in PEC frame length calculation by moving frame adjustment logic inside ModeSource conditional |

</details>

## Confidence score: 4/5

- This PR is safe to merge with low risk as it fixes a clear bug in frame dimension calculation
- Score reflects a straightforward bug fix that addresses double-counting in frame length calculations
- Pay close attention to tidy3d/components/simulation.py to ensure the frame length logic works correctly for all object types

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant Simulation
    participant Grid
    participant PECFrame

    User->>Simulation: Create simulation with ModeSource + PECFrame
    Simulation->>Simulation: _make_pec_frame(mode_source)
    Simulation->>Grid: discretize_inds(mode_source)
    Grid-->>Simulation: span_inds (already length 1)
    
    Note over Simulation: Bug fix: span_inds already gives length 1
    Note over Simulation: Old code: span_inds[axis][1] += length
    Note over Simulation: New code: span_inds[axis][1] += length - 1
    
    Simulation->>Simulation: Calculate box_bounds from corrected span_inds
    Simulation->>PECFrame: Create Structure with PECMedium
    PECFrame-->>Simulation: PEC frame structure
    Simulation-->>User: Simulation with correctly sized PEC frame
```

<!-- /greptile_comment -->