### PR TITLE
MultiGaussian pulse and more accurate frequency range

### DIFF
--- a/docs/api/sources.rst
+++ b/docs/api/sources.rst
@@ -33,6 +33,7 @@ Source Time Dependence
    :template: module.rst
 
    tidy3d.GaussianPulse
+   tidy3d.MultiGaussianPulse
    tidy3d.ContinuousWave
    tidy3d.SourceTime
    tidy3d.CustomSourceTime

--- a/schemas/ModeSimulation.json
+++ b/schemas/ModeSimulation.json
@@ -1903,7 +1903,7 @@
           "type": "object"
         },
         "freq0": {
-          "exclusiveMinimum": 0,
+          "minimum": 0,
           "type": "number"
         },
         "fwidth": {
@@ -3508,7 +3508,7 @@
           "type": "object"
         },
         "freq0": {
-          "exclusiveMinimum": 0,
+          "minimum": 0,
           "type": "number"
         },
         "fwidth": {
@@ -4322,7 +4322,7 @@
           "type": "object"
         },
         "freq0": {
-          "exclusiveMinimum": 0,
+          "minimum": 0,
           "type": "number"
         },
         "fwidth": {
@@ -6959,7 +6959,8 @@
             "mapping": {
               "ContinuousWave": "#/definitions/ContinuousWave",
               "CustomSourceTime": "#/definitions/CustomSourceTime",
-              "GaussianPulse": "#/definitions/GaussianPulse"
+              "GaussianPulse": "#/definitions/GaussianPulse",
+              "MultiGaussianPulse": "#/definitions/MultiGaussianPulse"
             },
             "propertyName": "type"
           },
@@ -6972,6 +6973,9 @@
             },
             {
               "$ref": "#/definitions/GaussianPulse"
+            },
+            {
+              "$ref": "#/definitions/MultiGaussianPulse"
             }
           ]
         },
@@ -7123,6 +7127,41 @@
           "type": "string"
         }
       },
+      "type": "object"
+    },
+    "MultiGaussianPulse": {
+      "additionalProperties": false,
+      "properties": {
+        "amplitude": {
+          "default": 1.0,
+          "minimum": 0,
+          "type": "number"
+        },
+        "attrs": {
+          "default": {},
+          "type": "object"
+        },
+        "phase": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "pulses": {
+          "items": {
+            "$ref": "#/definitions/GaussianPulse"
+          },
+          "type": "array"
+        },
+        "type": {
+          "default": "MultiGaussianPulse",
+          "enum": [
+            "MultiGaussianPulse"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "pulses"
+      ],
       "type": "object"
     },
     "MultiPhysicsMedium": {

--- a/schemas/Simulation.json
+++ b/schemas/Simulation.json
@@ -750,7 +750,8 @@
             "mapping": {
               "ContinuousWave": "#/definitions/ContinuousWave",
               "CustomSourceTime": "#/definitions/CustomSourceTime",
-              "GaussianPulse": "#/definitions/GaussianPulse"
+              "GaussianPulse": "#/definitions/GaussianPulse",
+              "MultiGaussianPulse": "#/definitions/MultiGaussianPulse"
             },
             "propertyName": "type"
           },
@@ -763,6 +764,9 @@
             },
             {
               "$ref": "#/definitions/GaussianPulse"
+            },
+            {
+              "$ref": "#/definitions/MultiGaussianPulse"
             }
           ]
         },
@@ -2280,7 +2284,7 @@
           "type": "object"
         },
         "freq0": {
-          "exclusiveMinimum": 0,
+          "minimum": 0,
           "type": "number"
         },
         "fwidth": {
@@ -2802,7 +2806,8 @@
             "mapping": {
               "ContinuousWave": "#/definitions/ContinuousWave",
               "CustomSourceTime": "#/definitions/CustomSourceTime",
-              "GaussianPulse": "#/definitions/GaussianPulse"
+              "GaussianPulse": "#/definitions/GaussianPulse",
+              "MultiGaussianPulse": "#/definitions/MultiGaussianPulse"
             },
             "propertyName": "type"
           },
@@ -2815,6 +2820,9 @@
             },
             {
               "$ref": "#/definitions/GaussianPulse"
+            },
+            {
+              "$ref": "#/definitions/MultiGaussianPulse"
             }
           ]
         },
@@ -3325,7 +3333,8 @@
             "mapping": {
               "ContinuousWave": "#/definitions/ContinuousWave",
               "CustomSourceTime": "#/definitions/CustomSourceTime",
-              "GaussianPulse": "#/definitions/GaussianPulse"
+              "GaussianPulse": "#/definitions/GaussianPulse",
+              "MultiGaussianPulse": "#/definitions/MultiGaussianPulse"
             },
             "propertyName": "type"
           },
@@ -3338,6 +3347,9 @@
             },
             {
               "$ref": "#/definitions/GaussianPulse"
+            },
+            {
+              "$ref": "#/definitions/MultiGaussianPulse"
             }
           ]
         },
@@ -4191,7 +4203,7 @@
           "type": "object"
         },
         "freq0": {
-          "exclusiveMinimum": 0,
+          "minimum": 0,
           "type": "number"
         },
         "fwidth": {
@@ -7472,7 +7484,8 @@
             "mapping": {
               "ContinuousWave": "#/definitions/ContinuousWave",
               "CustomSourceTime": "#/definitions/CustomSourceTime",
-              "GaussianPulse": "#/definitions/GaussianPulse"
+              "GaussianPulse": "#/definitions/GaussianPulse",
+              "MultiGaussianPulse": "#/definitions/MultiGaussianPulse"
             },
             "propertyName": "type"
           },
@@ -7485,6 +7498,9 @@
             },
             {
               "$ref": "#/definitions/GaussianPulse"
+            },
+            {
+              "$ref": "#/definitions/MultiGaussianPulse"
             }
           ]
         },
@@ -7660,7 +7676,7 @@
           "type": "object"
         },
         "freq0": {
-          "exclusiveMinimum": 0,
+          "minimum": 0,
           "type": "number"
         },
         "fwidth": {
@@ -10443,7 +10459,8 @@
             "mapping": {
               "ContinuousWave": "#/definitions/ContinuousWave",
               "CustomSourceTime": "#/definitions/CustomSourceTime",
-              "GaussianPulse": "#/definitions/GaussianPulse"
+              "GaussianPulse": "#/definitions/GaussianPulse",
+              "MultiGaussianPulse": "#/definitions/MultiGaussianPulse"
             },
             "propertyName": "type"
           },
@@ -10456,6 +10473,9 @@
             },
             {
               "$ref": "#/definitions/GaussianPulse"
+            },
+            {
+              "$ref": "#/definitions/MultiGaussianPulse"
             }
           ]
         },
@@ -10607,6 +10627,41 @@
           "type": "string"
         }
       },
+      "type": "object"
+    },
+    "MultiGaussianPulse": {
+      "additionalProperties": false,
+      "properties": {
+        "amplitude": {
+          "default": 1.0,
+          "minimum": 0,
+          "type": "number"
+        },
+        "attrs": {
+          "default": {},
+          "type": "object"
+        },
+        "phase": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "pulses": {
+          "items": {
+            "$ref": "#/definitions/GaussianPulse"
+          },
+          "type": "array"
+        },
+        "type": {
+          "default": "MultiGaussianPulse",
+          "enum": [
+            "MultiGaussianPulse"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "pulses"
+      ],
       "type": "object"
     },
     "MultiPhysicsMedium": {
@@ -12001,7 +12056,8 @@
             "mapping": {
               "ContinuousWave": "#/definitions/ContinuousWave",
               "CustomSourceTime": "#/definitions/CustomSourceTime",
-              "GaussianPulse": "#/definitions/GaussianPulse"
+              "GaussianPulse": "#/definitions/GaussianPulse",
+              "MultiGaussianPulse": "#/definitions/MultiGaussianPulse"
             },
             "propertyName": "type"
           },
@@ -12014,6 +12070,9 @@
             },
             {
               "$ref": "#/definitions/GaussianPulse"
+            },
+            {
+              "$ref": "#/definitions/MultiGaussianPulse"
             }
           ]
         },
@@ -12145,7 +12204,8 @@
             "mapping": {
               "ContinuousWave": "#/definitions/ContinuousWave",
               "CustomSourceTime": "#/definitions/CustomSourceTime",
-              "GaussianPulse": "#/definitions/GaussianPulse"
+              "GaussianPulse": "#/definitions/GaussianPulse",
+              "MultiGaussianPulse": "#/definitions/MultiGaussianPulse"
             },
             "propertyName": "type"
           },
@@ -12158,6 +12218,9 @@
             },
             {
               "$ref": "#/definitions/GaussianPulse"
+            },
+            {
+              "$ref": "#/definitions/MultiGaussianPulse"
             }
           ]
         },
@@ -13942,7 +14005,8 @@
             "mapping": {
               "ContinuousWave": "#/definitions/ContinuousWave",
               "CustomSourceTime": "#/definitions/CustomSourceTime",
-              "GaussianPulse": "#/definitions/GaussianPulse"
+              "GaussianPulse": "#/definitions/GaussianPulse",
+              "MultiGaussianPulse": "#/definitions/MultiGaussianPulse"
             },
             "propertyName": "type"
           },
@@ -13955,6 +14019,9 @@
             },
             {
               "$ref": "#/definitions/GaussianPulse"
+            },
+            {
+              "$ref": "#/definitions/MultiGaussianPulse"
             }
           ]
         },
@@ -14593,7 +14660,8 @@
             "mapping": {
               "ContinuousWave": "#/definitions/ContinuousWave",
               "CustomSourceTime": "#/definitions/CustomSourceTime",
-              "GaussianPulse": "#/definitions/GaussianPulse"
+              "GaussianPulse": "#/definitions/GaussianPulse",
+              "MultiGaussianPulse": "#/definitions/MultiGaussianPulse"
             },
             "propertyName": "type"
           },
@@ -14606,6 +14674,9 @@
             },
             {
               "$ref": "#/definitions/GaussianPulse"
+            },
+            {
+              "$ref": "#/definitions/MultiGaussianPulse"
             }
           ]
         },

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -750,7 +750,8 @@
             "mapping": {
               "ContinuousWave": "#/definitions/ContinuousWave",
               "CustomSourceTime": "#/definitions/CustomSourceTime",
-              "GaussianPulse": "#/definitions/GaussianPulse"
+              "GaussianPulse": "#/definitions/GaussianPulse",
+              "MultiGaussianPulse": "#/definitions/MultiGaussianPulse"
             },
             "propertyName": "type"
           },
@@ -763,6 +764,9 @@
             },
             {
               "$ref": "#/definitions/GaussianPulse"
+            },
+            {
+              "$ref": "#/definitions/MultiGaussianPulse"
             }
           ]
         },
@@ -2384,7 +2388,7 @@
           "type": "object"
         },
         "freq0": {
-          "exclusiveMinimum": 0,
+          "minimum": 0,
           "type": "number"
         },
         "fwidth": {
@@ -3074,7 +3078,8 @@
             "mapping": {
               "ContinuousWave": "#/definitions/ContinuousWave",
               "CustomSourceTime": "#/definitions/CustomSourceTime",
-              "GaussianPulse": "#/definitions/GaussianPulse"
+              "GaussianPulse": "#/definitions/GaussianPulse",
+              "MultiGaussianPulse": "#/definitions/MultiGaussianPulse"
             },
             "propertyName": "type"
           },
@@ -3087,6 +3092,9 @@
             },
             {
               "$ref": "#/definitions/GaussianPulse"
+            },
+            {
+              "$ref": "#/definitions/MultiGaussianPulse"
             }
           ]
         },
@@ -3597,7 +3605,8 @@
             "mapping": {
               "ContinuousWave": "#/definitions/ContinuousWave",
               "CustomSourceTime": "#/definitions/CustomSourceTime",
-              "GaussianPulse": "#/definitions/GaussianPulse"
+              "GaussianPulse": "#/definitions/GaussianPulse",
+              "MultiGaussianPulse": "#/definitions/MultiGaussianPulse"
             },
             "propertyName": "type"
           },
@@ -3610,6 +3619,9 @@
             },
             {
               "$ref": "#/definitions/GaussianPulse"
+            },
+            {
+              "$ref": "#/definitions/MultiGaussianPulse"
             }
           ]
         },
@@ -4463,7 +4475,7 @@
           "type": "object"
         },
         "freq0": {
-          "exclusiveMinimum": 0,
+          "minimum": 0,
           "type": "number"
         },
         "fwidth": {
@@ -7780,7 +7792,8 @@
             "mapping": {
               "ContinuousWave": "#/definitions/ContinuousWave",
               "CustomSourceTime": "#/definitions/CustomSourceTime",
-              "GaussianPulse": "#/definitions/GaussianPulse"
+              "GaussianPulse": "#/definitions/GaussianPulse",
+              "MultiGaussianPulse": "#/definitions/MultiGaussianPulse"
             },
             "propertyName": "type"
           },
@@ -7793,6 +7806,9 @@
             },
             {
               "$ref": "#/definitions/GaussianPulse"
+            },
+            {
+              "$ref": "#/definitions/MultiGaussianPulse"
             }
           ]
         },
@@ -7968,7 +7984,7 @@
           "type": "object"
         },
         "freq0": {
-          "exclusiveMinimum": 0,
+          "minimum": 0,
           "type": "number"
         },
         "fwidth": {
@@ -10926,7 +10942,8 @@
             "mapping": {
               "ContinuousWave": "#/definitions/ContinuousWave",
               "CustomSourceTime": "#/definitions/CustomSourceTime",
-              "GaussianPulse": "#/definitions/GaussianPulse"
+              "GaussianPulse": "#/definitions/GaussianPulse",
+              "MultiGaussianPulse": "#/definitions/MultiGaussianPulse"
             },
             "propertyName": "type"
           },
@@ -10939,6 +10956,9 @@
             },
             {
               "$ref": "#/definitions/GaussianPulse"
+            },
+            {
+              "$ref": "#/definitions/MultiGaussianPulse"
             }
           ]
         },
@@ -11090,6 +11110,41 @@
           "type": "string"
         }
       },
+      "type": "object"
+    },
+    "MultiGaussianPulse": {
+      "additionalProperties": false,
+      "properties": {
+        "amplitude": {
+          "default": 1.0,
+          "minimum": 0,
+          "type": "number"
+        },
+        "attrs": {
+          "default": {},
+          "type": "object"
+        },
+        "phase": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "pulses": {
+          "items": {
+            "$ref": "#/definitions/GaussianPulse"
+          },
+          "type": "array"
+        },
+        "type": {
+          "default": "MultiGaussianPulse",
+          "enum": [
+            "MultiGaussianPulse"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "pulses"
+      ],
       "type": "object"
     },
     "MultiPhysicsMedium": {
@@ -12484,7 +12539,8 @@
             "mapping": {
               "ContinuousWave": "#/definitions/ContinuousWave",
               "CustomSourceTime": "#/definitions/CustomSourceTime",
-              "GaussianPulse": "#/definitions/GaussianPulse"
+              "GaussianPulse": "#/definitions/GaussianPulse",
+              "MultiGaussianPulse": "#/definitions/MultiGaussianPulse"
             },
             "propertyName": "type"
           },
@@ -12497,6 +12553,9 @@
             },
             {
               "$ref": "#/definitions/GaussianPulse"
+            },
+            {
+              "$ref": "#/definitions/MultiGaussianPulse"
             }
           ]
         },
@@ -12628,7 +12687,8 @@
             "mapping": {
               "ContinuousWave": "#/definitions/ContinuousWave",
               "CustomSourceTime": "#/definitions/CustomSourceTime",
-              "GaussianPulse": "#/definitions/GaussianPulse"
+              "GaussianPulse": "#/definitions/GaussianPulse",
+              "MultiGaussianPulse": "#/definitions/MultiGaussianPulse"
             },
             "propertyName": "type"
           },
@@ -12641,6 +12701,9 @@
             },
             {
               "$ref": "#/definitions/GaussianPulse"
+            },
+            {
+              "$ref": "#/definitions/MultiGaussianPulse"
             }
           ]
         },
@@ -15148,7 +15211,8 @@
             "mapping": {
               "ContinuousWave": "#/definitions/ContinuousWave",
               "CustomSourceTime": "#/definitions/CustomSourceTime",
-              "GaussianPulse": "#/definitions/GaussianPulse"
+              "GaussianPulse": "#/definitions/GaussianPulse",
+              "MultiGaussianPulse": "#/definitions/MultiGaussianPulse"
             },
             "propertyName": "type"
           },
@@ -15161,6 +15225,9 @@
             },
             {
               "$ref": "#/definitions/GaussianPulse"
+            },
+            {
+              "$ref": "#/definitions/MultiGaussianPulse"
             }
           ]
         },
@@ -15799,7 +15866,8 @@
             "mapping": {
               "ContinuousWave": "#/definitions/ContinuousWave",
               "CustomSourceTime": "#/definitions/CustomSourceTime",
-              "GaussianPulse": "#/definitions/GaussianPulse"
+              "GaussianPulse": "#/definitions/GaussianPulse",
+              "MultiGaussianPulse": "#/definitions/MultiGaussianPulse"
             },
             "propertyName": "type"
           },
@@ -15812,6 +15880,9 @@
             },
             {
               "$ref": "#/definitions/GaussianPulse"
+            },
+            {
+              "$ref": "#/definitions/MultiGaussianPulse"
             }
           ]
         },

--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -2499,7 +2499,7 @@ def test_background_medium():
 
 class TestTidyArrayBox:
     def test_is_tidy_box(self):
-        da = DataArray(tracer_arr, dims=map(str, range(tracer_arr.ndim)))
+        da = DataArray(tracer_arr, dims=tuple(map(str, range(tracer_arr.ndim))))
         assert is_tidy_box(da.data)
 
     def test_real(self):

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -21,6 +21,7 @@ from tidy3d.plugins.mode import ModeSolver
 from ..utils import (
     SIM_FULL,
     AssertLogLevel,
+    AssertLogStr,
     cartesian_to_unstructured,
     run_emulated,
 )
@@ -257,8 +258,12 @@ def test_sim_bounds(shift_amount, log_level):
             center = shift_amount * amp * sign
             if np.sum(center) < 1e-12:
                 continue
-            with AssertLogLevel(log_level):
-                place_box(tuple(center))
+            if log_level is None:
+                with AssertLogStr("WARNING", excludes_str="outside of the simulation domain"):
+                    place_box(tuple(center))
+            else:
+                with AssertLogStr("WARNING", contains_str="outside of the simulation domain"):
+                    place_box(tuple(center))
 
 
 def test_sim_size():
@@ -1593,7 +1598,7 @@ def test_warn_lumped_elements_outside_sim_bounds():
         resistance=50,
         name="resistor_inside",
     )
-    with AssertLogLevel("INFO"):
+    with AssertLogStr("WARNING", excludes_str="not completely inside"):
         sim_good = td.Simulation(
             size=sim_size,
             center=sim_center,
@@ -1612,7 +1617,7 @@ def test_warn_lumped_elements_outside_sim_bounds():
         resistance=50,
         name="resistor_touching",
     )
-    with AssertLogLevel("INFO"):
+    with AssertLogStr("WARNING", excludes_str="not completely inside"):
         sim_good = td.Simulation(
             size=sim_size,
             center=sim_center,
@@ -1631,7 +1636,7 @@ def test_warn_lumped_elements_outside_sim_bounds():
         resistance=50,
         name="resistor_outside",
     )
-    with AssertLogLevel("WARNING"):
+    with AssertLogStr("WARNING", contains_str="not completely inside"):
         sim_bad = sim_good.updated_copy(lumped_elements=[resistor_out])
     assert len(sim_bad.volumetric_structures) == 0
 
@@ -1643,7 +1648,7 @@ def test_warn_lumped_elements_outside_sim_bounds():
         resistance=50,
         name="resistor_edge",
     )
-    with AssertLogLevel("WARNING"):
+    with AssertLogStr("WARNING", contains_str="not completely inside"):
         sim_bad = sim_good.updated_copy(lumped_elements=[resistor_edge])
     assert len(sim_bad.volumetric_structures) == 0
 

--- a/tests/test_components/test_source.py
+++ b/tests/test_components/test_source.py
@@ -133,6 +133,11 @@ def test_gaussian_from_frequency_range():
     g2 = td.GaussianPulse.from_frequency_range(fmin=fmin, fmax=fmax)
     assert g2.remove_dc_component
 
+    with AssertLogLevel("WARNING", contains_str="not sufficiently large"):
+        g_small = td.GaussianPulse.from_frequency_range(
+            fmin=fmin, fmax=60e9, remove_dc_component=True
+        )
+
     # 1) broadband: assert enough amplitude at fmin and fmax
     time = np.linspace(0, 5 / fmin, 10001)
     freqs = np.linspace(fmin, fmax, 101)
@@ -148,6 +153,36 @@ def test_gaussian_from_frequency_range():
     g = td.GaussianPulse.from_frequency_range(fmin=fmin, fmax=fmax)
     assert abs(g.fwidth - bandwidth) / bandwidth < 1e-4
     assert abs(g.freq0 - fmin) / fmin < 1e-4
+
+
+def test_gaussian_frequency_sigma_range():
+    sigma = 4
+    # derivative Gaussian
+    g = td.GaussianPulse.from_frequency_range(fmin=1e9, fmax=10e9, remove_dc_component=True)
+    f_range = g.frequency_range_sigma(sigma=sigma)
+    peak_amp = np.abs(g.amp_freq(g.peak_frequency))
+    amp = np.array([np.abs(g.amp_freq(f)) for f in f_range])
+    assert f_range[1] > f_range[0]
+    assert np.allclose(amp / peak_amp, np.exp(-(sigma**2) / 2))
+
+    # pure Gaussian
+    g = td.GaussianPulse.from_frequency_range(fmin=1e9, fmax=10e9, remove_dc_component=False)
+    assert np.allclose(g.frequency_range(num_fwidth=sigma), g.frequency_range_sigma(sigma=sigma))
+
+
+def test_multigaussian_from_frequency_range():
+    min_amp = 0.3
+    fmin = 0.1e9
+    fmax = 160e9
+    g = td.MultiGaussianPulse.from_frequency_range(fmin=fmin, fmax=fmax, min_rel_amp=min_amp)
+
+    # sample a few frequency grids to check
+    freqs = np.linspace(fmin, fmax, 1001)
+    amps = np.abs(g.amp_freq(freqs))
+    rel_amp = amps / np.max(amps)
+    assert np.all(rel_amp > min_amp * 0.5)  # it's a soft bound
+    # fwidth is merged, so should be quite large
+    assert g._fwidth > 0.1 * (fmax - fmin)
 
 
 def test_frequency_source_width():
@@ -357,7 +392,7 @@ def test_pol_arrow():
 def test_broadband_source():
     g = td.GaussianPulse(freq0=1e12, fwidth=0.1e12)
     mode_spec = td.ModeSpec(num_modes=2)
-    fmin, fmax = g.frequency_range(num_fwidth=CHEB_GRID_WIDTH)
+    fmin, fmax = g.frequency_range_sigma(sigma=CHEB_GRID_WIDTH)
     fdiff = (fmax - fmin) / 2
     fmean = (fmax + fmin) / 2
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1580,6 +1580,59 @@ def assert_log_level(
             )
 
 
+def assert_str_in_log(
+    records: list[tuple[int, str]],
+    log_level_test: str,
+    excludes_str: Optional[str] = None,
+    contains_str: Optional[str] = None,
+) -> None:
+    """Testing tool: Raises error if `excludes_str` appears , or `contains_str` doesn't appear at the test log level.
+    Unlike ``assert_log_level``, we don't raise error if the ``log_level_test`` is not present in the records.
+
+    Parameters
+    ----------
+    records : List[Tuple[int, str]]
+        List of (log_level: int, message: str) holding all of the captured logs.
+    log_level_test: str
+        String version of the log level for checking string (all uppercase).
+    excludes_str : str = None
+        If specified, errors if found in any of the log messages that are at level
+        ``log_level_test``.
+    contains_str : str = None
+        If specified, errors if not found in any of the log messages that are at level
+        ``log_level_test``.
+
+    Returns
+    -------
+        None
+    """
+
+    import sys
+
+    sys.stderr.write(str(records) + "\n")
+
+    # do nothing for None log level
+    if log_level_test is None:
+        return
+
+    log_level_test_int = _get_level_int(log_level_test)
+    contains_str_found = False
+    for log in records:
+        log_level, log_message = log
+        if log_level == log_level_test_int:
+            if excludes_str is not None and excludes_str in log_message:
+                raise AssertionError(
+                    f"Log record at level '{log_level_test}' contained '{excludes_str}'."
+                )
+            if contains_str is not None and contains_str in log_message:
+                contains_str_found = True
+
+    if contains_str and not contains_str_found:
+        raise AssertionError(
+            f"Log record at level '{log_level_test}' did not contain '{contains_str}'."
+        )
+
+
 class AssertLogLevelHandler:
     """Log handler used to store log records during assertion."""
 
@@ -1591,8 +1644,8 @@ class AssertLogLevelHandler:
 
 
 @dataclasses.dataclass
-class AssertLogLevel:
-    """Context manager to check log level for records logged within its context."""
+class AbstractAssertLog:
+    """Context manager to check logs."""
 
     log_level_expected: Union[str, None]
     contains_str: str = None
@@ -1613,11 +1666,34 @@ class AssertLogLevel:
         td.log.handlers["assert_log_level"] = self.handler
         return self
 
+
+@dataclasses.dataclass
+class AssertLogLevel(AbstractAssertLog):
+    """Context manager to check log level for records logged within its context."""
+
     def __exit__(self, exc_type, exc_value, traceback):
         # Check the records and clean up
         assert_log_level(
             records=self.records,
             log_level_expected=self.log_level_expected,
+            contains_str=self.contains_str,
+        )
+        # Remove handler
+        del td.log.handlers["assert_log_level"]
+
+
+@dataclasses.dataclass
+class AssertLogStr(AbstractAssertLog):
+    """Context manager to check if log contains certain strings at the test log level for records logged within its context."""
+
+    excludes_str: str = None
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # Check the records and clean up
+        assert_str_in_log(
+            records=self.records,
+            log_level_test=self.log_level_expected,
+            excludes_str=self.excludes_str,
             contains_str=self.contains_str,
         )
         # Remove handler

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -359,6 +359,7 @@ from .components.source.time import (
     ContinuousWave,
     CustomSourceTime,
     GaussianPulse,
+    MultiGaussianPulse,
     SourceTime,
 )
 
@@ -624,6 +625,7 @@ __all__ = [
     "ModeSpec",
     "ModulationSpec",
     "Monitor",
+    "MultiGaussianPulse",
     "MultiPhysicsMedium",
     "NedeljkovicSorefMashanovich",
     "NonlinearModel",

--- a/tidy3d/components/boundary.py
+++ b/tidy3d/components/boundary.py
@@ -311,7 +311,7 @@ class ModeABCBoundary(AbstractABCBoundary):
         """
 
         if freq_spec is None:
-            freq_spec = source.source_time.freq0
+            freq_spec = source.source_time._freq0
 
         return cls(
             plane=source.bounding_box,
@@ -528,7 +528,7 @@ class BlochBoundary(BoundaryEdge):
         if medium is None:
             medium = Medium(permittivity=1.0, name="free_space")
 
-        freq0 = source.source_time.freq0
+        freq0 = source.source_time._freq0
         eps_complex = medium.eps_model(freq0)
         kmag = np.real(freq0 * np.sqrt(eps_complex * EPSILON_0 * MU_0))
 

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -1144,7 +1144,7 @@ class SimulationData(AbstractYeeGridSimulationData):
         adj_srcs_process_fwidth = []
         for adj_src in adj_srcs:
             source_time = adj_src.source_time
-            freq0 = source_time.freq0
+            freq0 = source_time._freq0
 
             fwidth = np.minimum(freq0 / NUM_ADJOINT_FWIDTH_TO_ZERO, source_time.fwidth)
 
@@ -1171,16 +1171,16 @@ class SimulationData(AbstractYeeGridSimulationData):
 
         # Group sources by frequency or port, whichever gives fewer groups
         num_ports = len(hashes_to_src_times)
-        num_unique_freqs = len({src.source_time.freq0 for src in adj_srcs_process_fwidth})
+        num_unique_freqs = len({src.source_time._freq0 for src in adj_srcs_process_fwidth})
 
         log.info(f"Found {num_ports} spatial ports and {num_unique_freqs} unique frequencies.")
 
         adjoint_infos = []
         if num_unique_freqs <= num_ports:
             log.info("Grouping adjoint sources by frequency.")
-            unique_freqs = {src.source_time.freq0 for src in adj_srcs_process_fwidth}
+            unique_freqs = {src.source_time._freq0 for src in adj_srcs_process_fwidth}
             for freq0 in unique_freqs:
-                group = [src for src in adj_srcs_process_fwidth if src.source_time.freq0 == freq0]
+                group = [src for src in adj_srcs_process_fwidth if src.source_time._freq0 == freq0]
                 post_norm = xr.DataArray(data=np.array([1 + 0j]), coords={"f": [freq0]})
                 adjoint_infos.append(
                     AdjointSourceInfo(sources=group, post_norm=post_norm, normalize_sim=True)
@@ -1234,7 +1234,7 @@ class SimulationData(AbstractYeeGridSimulationData):
     def _adjoint_src_width_broadband(adj_srcs: list[SourceType]) -> float:
         """Find the adjoint source fwidth that sufficiently covers all adjoint frequencies."""
 
-        adj_srcs_f0 = [adj_src.source_time.freq0 for adj_src in adj_srcs]
+        adj_srcs_f0 = [adj_src.source_time._freq0 for adj_src in adj_srcs]
         middle_f0 = 0.5 * (np.max(adj_srcs_f0) + np.min(adj_srcs_f0))
         min_f0 = np.min(adj_srcs_f0)
 
@@ -1281,7 +1281,7 @@ class SimulationData(AbstractYeeGridSimulationData):
         amps_complex = []
         for src in adj_srcs:
             src_time = src.source_time
-            freqs.append(src_time.freq0)
+            freqs.append(src_time._freq0)
             amp_complex = src_time.amplitude * np.exp(1j * src_time.phase)
             amps_complex.append(amp_complex)
 

--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -2178,7 +2178,7 @@ class GridSpec(Tidy3dBaseModel):
             )
 
         # Use central frequency of sources, if any.
-        freqs = np.array([source.source_time.freq0 for source in sources])
+        freqs = np.array([source.source_time._freq0_for_mesher for source in sources])
 
         # multiple sources of different central frequencies
         if not np.all(np.isclose(freqs, freqs[0])):

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -814,7 +814,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
             bounds=self.simulation_bounds, x=x, y=y, z=z, hlim=hlim, vlim=vlim
         )
         if freq is None:
-            freq0s = [source.source_time.freq0 for source in self.sources]
+            freq0s = [source.source_time._freq0 for source in self.sources]
             if freq0s and all(math.isclose(freq0, freq0s[0]) for freq0 in freq0s):
                 freq = freq0s[0]
             else:
@@ -1982,7 +1982,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
 
         # some nonlinear materials depend on the central frequency
         # we update them with hardcoded freq0
-        freqs = np.array([source.source_time.freq0 for source in self.sources])
+        freqs = np.array([source.source_time._freq0 for source in self.sources])
         for i, structure in enumerate(new_structures):
             medium = structure.medium
             nonlinear_spec = medium.nonlinear_spec
@@ -3131,7 +3131,7 @@ class Simulation(AbstractYeeGridSimulation):
                     "Add at least one source or use parameter 'frequency' for 'ModeABCBoundary'.",
                 )
 
-            freq0s = [source.source_time.freq0 for source in sources]
+            freq0s = [source.source_time._freq0 for source in sources]
             if not all(math.isclose(freq0, freq0s[0]) for freq0 in freq0s):
                 log.warning(
                     "At least one 'ModeABCBoundary' does not specify frequency at which the absorbed mode must be evaluated. "
@@ -3261,7 +3261,7 @@ class Simulation(AbstractYeeGridSimulation):
                 struct_bound_min, struct_bound_max = structure.geometry.bounds
 
                 for source in sources:
-                    lambda0 = C_0 / source.source_time.freq0
+                    lambda0 = C_0 / source.source_time._freq0
 
                     zipped = zip(["x", "y", "z"], sim_bound_min, struct_bound_min, boundaries)
                     for axis, sim_val, struct_val, boundary in zipped:
@@ -3352,7 +3352,7 @@ class Simulation(AbstractYeeGridSimulation):
         if val is None:
             return val
 
-        source_ranges = [source.source_time.frequency_range() for source in values["sources"]]
+        source_ranges = [source.source_time.frequency_range_loose() for source in values["sources"]]
         if not source_ranges:
             # Commented out to eliminate this message from Mode real time log in GUI
             # TODO: Bring it back when it doesn't interfere with mode solver
@@ -3823,7 +3823,7 @@ class Simulation(AbstractYeeGridSimulation):
 
         with log as consolidated_logger:
             for source_index, source in enumerate(values.get("sources")):
-                freq0 = source.source_time.freq0
+                freq0 = source.source_time._freq0_for_mesher
 
                 for medium_index, medium in enumerate(mediums):
                     # min wavelength in PEC/PMC is meaningless and we'll get divide by inf errors
@@ -4260,7 +4260,7 @@ class Simulation(AbstractYeeGridSimulation):
     def _validate_nonlinear_specs(self) -> None:
         """Run :class:`.NonlinearSpec` validators that depend on knowing the central
         frequencies of the sources. Also print some warnings only once per unique medium."""
-        freqs = np.array([source.source_time.freq0 for source in self.sources])
+        freqs = np.array([source.source_time._freq0 for source in self.sources])
         for medium in self.scene.mediums:
             if medium.nonlinear_spec is not None:
                 for model in medium._nonlinear_models:
@@ -4423,7 +4423,7 @@ class Simulation(AbstractYeeGridSimulation):
                         center=source.center,
                         size=source.size,
                         name="tmp",
-                        freqs=[source.source_time.freq0],
+                        freqs=[source.source_time._freq0],
                         colocate=False,
                     )
                     msg_header = f"Mode source at sources[{src_ind}] "
@@ -4487,7 +4487,7 @@ class Simulation(AbstractYeeGridSimulation):
 
     def _validate_freq_monitors_freq_range(self) -> None:
         """Rise the error if any DFT monitors have frequencies outside of the simulation frequency range."""
-        source_ranges = [source.source_time.frequency_range() for source in self.sources]
+        source_ranges = [source.source_time.frequency_range_loose() for source in self.sources]
         if not source_ranges:
             return
 
@@ -4597,7 +4597,7 @@ class Simulation(AbstractYeeGridSimulation):
                 # side wall - the profiles must be the same along the injection axis, so we take
                 # a single "stripe" of epsilon as the reference and subtract it from all other
                 # stripes, which should result in zero if all the epsilon profiles are the same
-                freq0 = source.source_time.freq0
+                freq0 = source.source_time._freq0
                 _, plane_axs = source.pop_axis("xyz", axis=source.injection_axis)
                 ref_eps = self.epsilon(box=sidewall_surfaces[0], coord_key="centers", freq=freq0)
                 kwargs = {plane_axs[0]: 0, plane_axs[1]: 0}
@@ -4703,7 +4703,7 @@ class Simulation(AbstractYeeGridSimulation):
 
             # get the maximum refractive index evaluated over each of all the source central frequencies
             all_ref_inds = [
-                self.get_refractive_indices(src.source_time.freq0) for src in self.sources
+                self.get_refractive_indices(src.source_time._freq0) for src in self.sources
             ]
             avg_ref_inds = [np.mean(np.array(n)) for n in all_ref_inds]
             max_ref_ind = np.max(avg_ref_inds, initial=1)
@@ -5101,7 +5101,7 @@ class Simulation(AbstractYeeGridSimulation):
         Tuple[float, float]
             Minimum and maximum frequencies of the power spectrum of the sources.
         """
-        source_ranges = [source.source_time.frequency_range() for source in self.sources]
+        source_ranges = [source.source_time.frequency_range_sigma() for source in self.sources]
         freq_min = min((freq_range[0] for freq_range in source_ranges), default=0.0)
         freq_max = max((freq_range[1] for freq_range in source_ranges), default=0.0)
 
@@ -5334,7 +5334,7 @@ class Simulation(AbstractYeeGridSimulation):
                 "add sources before querying for the minimum material "
                 "wavelength."
             )
-        freq_max = max(source.source_time.freq0 for source in self.sources)
+        freq_max = max(source.source_time._freq0_from_sigma for source in self.sources)
         wvl_min = C_0 / freq_max
 
         n_values = self.get_refractive_indices(freq_max)

--- a/tidy3d/components/source/base.py
+++ b/tidy3d/components/source/base.py
@@ -65,7 +65,7 @@ class Source(Box, AbstractSource, ABC):
     @pydantic.validator("source_time", always=True)
     def _freqs_lower_bound(cls, val):
         """Raise validation error if central frequency is too low."""
-        _assert_min_freq(val.freq0, msg_start="'source_time.freq0'")
+        _assert_min_freq(val._freq0_from_sigma, msg_start="'source_time.freq0'")
         return val
 
     def plot(

--- a/tidy3d/components/source/field.py
+++ b/tidy3d/components/source/field.py
@@ -104,7 +104,7 @@ class BroadbandSource(Source, ABC):
     @cached_property
     def frequency_grid(self) -> np.ndarray:
         """A Chebyshev grid used to approximate frequency dependence."""
-        freq_min, freq_max = self.source_time.frequency_range(num_fwidth=CHEB_GRID_WIDTH)
+        freq_min, freq_max = self.source_time.frequency_range_sigma(sigma=CHEB_GRID_WIDTH)
         return self._chebyshev_freq_grid(freq_min, freq_max)
 
     def _chebyshev_freq_grid(self, freq_min, freq_max):
@@ -514,11 +514,11 @@ class PlaneWave(AngledFieldSource, PlanarSource, BroadbandSource):
     @cached_property
     def frequency_grid(self) -> np.ndarray:
         """A Chebyshev grid used to approximate frequency dependence."""
-        freq_min, freq_max = self.source_time.frequency_range(num_fwidth=CHEB_GRID_WIDTH)
+        freq_min, freq_max = self.source_time.frequency_range_sigma(sigma=CHEB_GRID_WIDTH)
         if not self._is_fixed_angle:
             # For frequency-dependent angles (constat in-plane k), truncate minimum frequency at
             # the critical frequency of glancing incidence
-            f_crit = self.source_time.freq0 * np.sin(self.angle_theta)
+            f_crit = self.source_time._freq0 * np.sin(self.angle_theta)
             freq_min = max(freq_min, f_crit * CRITICAL_FREQUENCY_FACTOR)
         return self._chebyshev_freq_grid(freq_min, freq_max)
 
@@ -527,8 +527,8 @@ class PlaneWave(AngledFieldSource, PlanarSource, BroadbandSource):
         the source frequency range is entirely below ``f_crit * CRITICAL_FREQUENCY_FACTOR."""
         if self._is_fixed_angle or self.num_freqs == 1:
             return
-        freq_min, freq_max = self.source_time.frequency_range(num_fwidth=CHEB_GRID_WIDTH)
-        f_crit = self.source_time.freq0 * np.sin(self.angle_theta)
+        freq_min, freq_max = self.source_time.frequency_range_sigma(sigma=CHEB_GRID_WIDTH)
+        f_crit = self.source_time._freq0 * np.sin(self.angle_theta)
         if f_crit * CRITICAL_FREQUENCY_FACTOR > freq_max:
             raise SetupError(
                 "Broadband plane wave source defined with a bandwidth too close to the critical "

--- a/tidy3d/components/source/time.py
+++ b/tidy3d/components/source/time.py
@@ -7,7 +7,9 @@ from typing import Optional, Union
 
 import numpy as np
 import pydantic.v1 as pydantic
+from pyroots import Brentq
 
+from tidy3d.components.base import cached_property
 from tidy3d.components.data.data_array import TimeDataArray
 from tidy3d.components.data.dataset import TimeDataset
 from tidy3d.components.data.validators import validate_no_nans
@@ -17,9 +19,24 @@ from tidy3d.components.validators import warn_if_dataset_none
 from tidy3d.components.viz import add_ax_if_none
 from tidy3d.constants import HERTZ
 from tidy3d.exceptions import ValidationError
+from tidy3d.log import log
 
 # how many units of ``twidth`` from the ``offset`` until a gaussian pulse is considered "off"
 END_TIME_FACTOR_GAUSSIAN = 10
+
+# warn if source amplitude is too small at the endpoints of frequency range
+WARN_SOURCE_AMPLITUDE = 0.1
+# used in Brentq
+_ROOTS_TOL = 1e-10
+# threshold for applying actual central frequency if the approximate central frequency
+# differ by this threshold value.
+THRESHOLD_FOR_MESHER_ACTUAL_FREQ0 = 10
+# default min_rel_amp value
+DEFAULT_MIN_REL_AMP = 0.3
+# min_rel_amp tolerance
+TOLERANCE_REL_AMP = 0.2
+# maximal number of pulses in auto multiGaussian generation
+MAX_NUM_PULSES_AUTO_MULTIGAUSSIAN = 20
 
 
 class SourceTime(AbstractTimeDependence):
@@ -54,7 +71,7 @@ class SourceTime(AbstractTimeDependence):
             The supplied or created matplotlib axes.
         """
 
-        fmin, fmax = self.frequency_range()
+        fmin, fmax = self.frequency_range_sigma()
         return self.plot_spectrum_in_frequency_range(
             times, fmin, fmax, num_freqs=num_freqs, val=val, ax=ax
         )
@@ -63,15 +80,60 @@ class SourceTime(AbstractTimeDependence):
     def frequency_range(self, num_fwidth: float = 4.0) -> FreqBound:
         """Frequency range within plus/minus ``num_fwidth * fwidth`` of the central frequency."""
 
+    def frequency_range_sigma(self, sigma: float = 4.0) -> FreqBound:
+        """Frequency range where the source amplitude is within ``exp(-sigma**2/2)`` of the peak amplitude."""
+        return self.frequency_range(num_fwidth=sigma)
+
+    def frequency_range_loose(self, sigma: float = 4.0) -> FreqBound:
+        """A loose frequency range that is union of ``frequency_range`` and ``frequency_range_sigma``."""
+        f_range = self.frequency_range(num_fwidth=sigma)
+        f_sigma_range = self.frequency_range_sigma(sigma=sigma)
+        return min(f_range[0], f_sigma_range[0]), max(f_range[1], f_sigma_range[1])
+
     @abstractmethod
     def end_time(self) -> Optional[float]:
         """Time after which the source is effectively turned off / close to zero amplitude."""
+
+    @cached_property
+    @abstractmethod
+    def _freq0(self) -> float:
+        """Central frequency from input parameters such as Gaussian parameters, which might not be the
+        actual central frequency, e.g. when DC removal is applied.
+        """
+
+    @cached_property
+    def _freq0_from_sigma(self) -> float:
+        """Central of frequency range where the source amplitude is within ``exp(-1/2)`` of the peak amplitude."""
+        return np.mean(self.frequency_range_sigma(sigma=1))
+
+    @cached_property
+    def _freq0_for_mesher(self) -> float:
+        """For mesh generation, apply `_freq0` in most cases, unless it deviates from the actual central frequency
+        signficantly.
+        """
+        if (
+            np.isclose(self._freq0, 0)
+            or self._freq0 >= THRESHOLD_FOR_MESHER_ACTUAL_FREQ0 * self._freq0_from_sigma
+            or self._freq0_from_sigma >= THRESHOLD_FOR_MESHER_ACTUAL_FREQ0 * self._freq0
+        ):
+            return self._freq0_from_sigma
+        return self._freq0
+
+    @property
+    @abstractmethod
+    def _fwidth(self) -> float:
+        """Standard deviation of the frequency content of the pulse."""
+
+    @property
+    def twidth(self) -> float:
+        """Width of pulse in seconds."""
+        return 1.0 / (2 * np.pi * self._fwidth)
 
 
 class Pulse(SourceTime, ABC):
     """A source time that ramps up with some ``fwidth`` and oscillates at ``freq0``."""
 
-    freq0: pydantic.PositiveFloat = pydantic.Field(
+    freq0: pydantic.NonNegativeFloat = pydantic.Field(
         ..., title="Central Frequency", description="Central frequency of the pulse.", units=HERTZ
     )
     fwidth: pydantic.PositiveFloat = pydantic.Field(
@@ -89,10 +151,22 @@ class Pulse(SourceTime, ABC):
         ge=2.5,
     )
 
+    @cached_property
+    def _freq0(self) -> float:
+        """Central frequency from Gaussian parameters, which might not be the actual central frequency, e.g. when
+        DC removal is applied.
+        """
+        return self.freq0
+
     @property
-    def twidth(self) -> float:
-        """Width of pulse in seconds."""
-        return 1.0 / (2 * np.pi * self.fwidth)
+    def _fwidth(self) -> float:
+        """Standard deviation of the frequency content of the pulse."""
+        return self.fwidth
+
+    @property
+    def offset_time(self) -> float:
+        """Offset time in seconds."""
+        return self.offset * self.twidth
 
     def frequency_range(self, num_fwidth: float = 4.0) -> FreqBound:
         """Frequency range within 5 standard deviations of the central frequency.
@@ -130,15 +204,31 @@ class GaussianPulse(Pulse):
         "If ``True``, the Gaussian pulse is modified at low frequencies to zero out the "
         "DC component, which is usually desirable so that the fields will decay. However, "
         "for broadband simulations, it may be better to have non-vanishing source power "
-        "near zero frequency. Setting this to ``False`` results in an unmodified Gaussian "
-        "pulse spectrum which can have a nonzero DC component.",
+        "near zero frequency by setting this to ``False``, or apply a ``MultiGaussianPulse``.",
     )
+
+    @property
+    def peak_time(self) -> float:
+        """Peak time in seconds, defined by ``offset``."""
+        return self.offset * self.twidth
+
+    @property
+    def _peak_time_shift(self) -> float:
+        """In the case of DC removal, the time shift of the pulse peak position can be different from ``offset``."""
+        if self.remove_dc_component and self.fwidth > self.freq0:
+            return self.twidth * np.sqrt(1 - self.freq0**2 / self.fwidth**2)
+        return 0
+
+    @property
+    def offset_time(self) -> float:
+        """Offset time in seconds. Note that in the case of DC removal, the maximal value of pulse can be shifted."""
+        return self.peak_time + self._peak_time_shift
 
     def amp_time(self, time: float) -> complex:
         """Complex-valued source amplitude as a function of time."""
 
         omega0 = 2 * np.pi * self.freq0
-        time_shifted = time - self.offset * self.twidth
+        time_shifted = time - self.offset_time
 
         offset = np.exp(1j * self.phase)
         oscillation = np.exp(-1j * omega0 * time)
@@ -148,7 +238,9 @@ class GaussianPulse(Pulse):
 
         # subtract out DC component
         if self.remove_dc_component:
-            pulse_amp = pulse_amp * (1j + time_shifted / self.twidth**2 / omega0)
+            pulse_amp = pulse_amp * (1j * omega0 + time_shifted / self.twidth**2)
+            # normalize by peak frequency instead of omega0, as omega0 can be 0
+            pulse_amp /= 2 * np.pi * self.peak_frequency
         else:
             # 1j to make it agree in large omega0 limit
             pulse_amp = pulse_amp * 1j
@@ -162,7 +254,71 @@ class GaussianPulse(Pulse):
         # if not self.remove_dc_component:
         #     return None
 
-        return self.offset * self.twidth + END_TIME_FACTOR_GAUSSIAN * self.twidth
+        end_time = self.offset_time + END_TIME_FACTOR_GAUSSIAN * self.twidth
+
+        # for derivative Gaussian that contains two peaks, add time interval between them
+        if self.remove_dc_component and self.fwidth > self.freq0:
+            end_time += 2 * self._peak_time_shift
+        return end_time
+
+    def amp_freq(self, freq: float) -> complex:
+        """Complex-valued source spectrum in frequency domain."""
+        phase = np.exp(1j * self.phase + 1j * 2 * np.pi * (freq - self.freq0) * self.offset_time)
+        envelope = np.exp(-((freq - self.freq0) ** 2) / 2 / self.fwidth**2)
+        amp = 1j * self.amplitude / self.fwidth * phase * envelope
+        if not self.remove_dc_component:
+            return amp
+
+        # derivative of Gaussian when DC is removed
+        return freq * amp / (2 * np.pi * self.peak_frequency)
+
+    def _rel_amp_freq(self, freq: float) -> complex:
+        """Complex-valued source spectrum in frequency domain normalized by peak amplitude."""
+        return self.amp_freq(freq) / self._peak_freq_amp
+
+    @property
+    def peak_frequency(self) -> float:
+        """Frequency at which the source time dependence has its peak amplitude in the frequency domain."""
+        if not self.remove_dc_component:
+            return self.freq0
+        return 0.5 * (self.freq0 + np.sqrt(self.freq0**2 + 4 * self.fwidth**2))
+
+    @property
+    def _peak_freq_amp(self) -> complex:
+        """Peak amplitude in frequency domain"""
+        return self.amp_freq(self.peak_frequency)
+
+    @property
+    def _peak_time_amp(self) -> complex:
+        """Peak amplitude in time domain"""
+        return self.amp_time(self.peak_time)
+
+    def frequency_range_sigma(self, sigma: float = 4.0) -> FreqBound:
+        """Frequency range where the source amplitude is within ``exp(-sigma**2/2)`` of the peak amplitude."""
+        if not self.remove_dc_component:
+            return self.frequency_range(num_fwidth=sigma)
+
+        # With dc removed, we'll need to solve for the nonlinear equation to find the frequency range
+        def equation_for_sigma_frequency(freq):
+            """computes I / I_p - exp(-sigma)"""
+            return np.abs(self._rel_amp_freq(freq)) - np.exp(-(sigma**2) / 2)
+
+        root_scalar = Brentq(raise_on_fail=False, epsilon=_ROOTS_TOL)
+        fmin_data = root_scalar(equation_for_sigma_frequency, 0, self.peak_frequency)
+        fmax_data = root_scalar(
+            equation_for_sigma_frequency,
+            self.peak_frequency,
+            self.peak_frequency
+            + self.fwidth * (100 + 2 * sigma**2),  # "100" to make sure that it flips sign
+        )
+        fmin, fmax = fmin_data.x0, fmax_data.x0
+
+        # if unconverged, fall back to fwidth
+        if not (fmin_data.converged and fmax_data.converged and fmax > fmin):
+            return self.frequency_range(num_fwidth=sigma)
+
+        # converged
+        return fmin, fmax
 
     @property
     def amp_complex(self) -> complex:
@@ -206,12 +362,75 @@ class GaussianPulse(Pulse):
 
         return fmin, fmax
 
+    @staticmethod
+    def _validate_min_rel_amp(min_rel_amp: pydantic.PositiveFloat):
+        """Validate the range of lower bound for amplitude in the frequency range normalized by the peak amplitude."""
+        if min_rel_amp <= 0.05 or min_rel_amp >= 0.5:
+            raise ValidationError("'min_rel_amp' must be in the range (0.05, 0.5).")
+
+    @staticmethod
+    def _unmodulated_gaussian_fwidth_from_rel_amp(min_rel_amp) -> pydantic.PositiveFloat:
+        """Compute ``fwidth`` for an DC-removed unmodulated``GaussianPulse`` whose amplitude at ``freq=fmin``
+        relative to peak amplitude is `min_rel_amp`. Also returns upper frequency range ``fmax``. The returned
+        ``fwidth`` and ``fmax`` are normalized by ``fmin``.
+        """
+
+        def equation_for_fwidth(fwidth):
+            pulse = GaussianPulse(freq0=0, fwidth=fwidth, remove_dc_component=True)
+            return abs(pulse._rel_amp_freq(1)) - min_rel_amp
+
+        # solve for dimensionless fwidth
+        root_scalar = Brentq(raise_on_fail=True, epsilon=_ROOTS_TOL)
+        fwidth_data = root_scalar(equation_for_fwidth, 1, 100 / min_rel_amp)
+        # compute frequency range
+        fwidth = fwidth_data.x0
+        pulse = GaussianPulse(freq0=0, fwidth=fwidth, remove_dc_component=True)
+        sigma = np.sqrt(-2 * np.log(min_rel_amp))
+        return fwidth, pulse.frequency_range_sigma(sigma=sigma)[1]
+
+    @classmethod
+    def _from_min_frequency(
+        cls, fmin: pydantic.PositiveFloat, min_rel_amp: pydantic.PositiveFloat = 0.3
+    ) -> tuple[GaussianPulse, float]:
+        """Create a ``GaussianPulse`` with DC removed that maximizes frequency range starting from ``fmin`` where the minimal
+        amplitude in the frequency range normalized by the peak amplitude is ``min_rel_amp``.
+
+        Parameters
+        ----------
+        fmin : float
+            Lower bound of frequency of interest.
+        min_rel_amp : float
+            Lower bound of amplitude relative to the peak amplitude in the frequency range.
+
+        Returns
+        -------
+        tuple[GaussianPulse, float]
+            A ``GaussianPulse`` that maximizes the frequency range [fmin, fmax] where the minimal relative
+            amplitude is ``min_rel_amp``, and fmax.
+        """
+        cls._validate_min_rel_amp(min_rel_amp)
+
+        def equation_for_min_amp(fmax):
+            """computes |amp_freq(fmin)/peak_amp| - min_rel_amp"""
+            gaussian = cls.from_frequency_range(
+                fmin, fmax, disable_warning=True, remove_dc_component=True
+            )
+            return np.abs(gaussian._rel_amp_freq(fmin)) - min_rel_amp
+
+        root_scalar = Brentq(raise_on_fail=True, epsilon=_ROOTS_TOL)
+        # Heuristic bracketing interval that works for min_rel_amp in the range of (0.05, 0.5)
+        bracketing_interval_a = fmin * (1 + 1e-5)
+        bracketing_interval_b = fmin * 100 / min_rel_amp
+        fmax_data = root_scalar(equation_for_min_amp, bracketing_interval_a, bracketing_interval_b)
+        return cls.from_frequency_range(fmin, fmax_data.x0, remove_dc_component=True), fmax_data.x0
+
     @classmethod
     def from_frequency_range(
         cls,
         fmin: pydantic.PositiveFloat,
         fmax: pydantic.PositiveFloat,
         minimum_source_bandwidth: pydantic.PositiveFloat = None,
+        disable_warning: bool = False,
         **kwargs,
     ) -> GaussianPulse:
         """Create a ``GaussianPulse`` that maximizes its amplitude in the frequency range [fmin, fmax].
@@ -253,7 +472,148 @@ class GaussianPulse(Pulse):
         coeff = ((1 + log_ratio**2) ** 0.5 - 1) / 2.0
         freq0 = freq_center - coeff / log_ratio * freq_range
         fwidth = freq_range / log_ratio * coeff**0.5
-        return cls(freq0=freq0, fwidth=fwidth, **kwargs)
+        pulse = cls(freq0=freq0, fwidth=fwidth, **kwargs)
+        if not disable_warning and np.abs(pulse._rel_amp_freq(fmin)) < WARN_SOURCE_AMPLITUDE:
+            log.warning(
+                "Source amplitude is not sufficiently large throughout the specified frequency range, "
+                "which can result in inaccurate simulation results. Please either "
+                "decrease the frequency range, or apply 'MultiGaussianPulse.from_frequency_range' "
+                "for generating broadband source time profiles.",
+            )
+        return pulse
+
+
+class MultiGaussianPulse(SourceTime):
+    """Source time dependence that describes a sum of Gaussian pulses.
+
+    Example
+    -------
+    >>> pulse = MultiGaussianPulse(pulses=[GaussianPulse(freq0=200e12, fwidth=20e12)])
+    """
+
+    pulses: tuple[GaussianPulse, ...] = pydantic.Field(
+        ...,
+        title="Gaussian Pulses",
+        description="Source time response that is the sum of those Gaussian pulses.",
+    )
+
+    @property
+    def _fwidth(self) -> float:
+        """Standard deviation of the frequency content of the pulse."""
+        frequency_range = self.frequency_range_sigma(sigma=1.0)
+        return 0.5 * (frequency_range[1] - frequency_range[0])
+
+    def end_time(self) -> Optional[float]:
+        """Time after which the source is effectively turned off / close to zero amplitude."""
+        return max(s.end_time() for s in self.pulses)
+
+    def frequency_range(self, num_fwidth: float = 4.0) -> FreqBound:
+        """The union of `frequency_range` of each pulse."""
+        all_ranges = [s.frequency_range(num_fwidth) for s in self.pulses]
+        f_mins, f_maxs = zip(*all_ranges)
+        return min(f_mins), max(f_maxs)
+
+    def frequency_range_sigma(self, sigma: float = 4.0) -> FreqBound:
+        """Frequency range where the source amplitude is within ``exp(-sigma**2/2)`` of the peak amplitude."""
+        all_ranges = [s.frequency_range_sigma(sigma) for s in self.pulses]
+        f_mins, f_maxs = zip(*all_ranges)
+        return min(f_mins), max(f_maxs)
+
+    def amp_time(self, time: float) -> complex:
+        """Complex-valued source amplitude as a function of time."""
+        stacked_amp = np.stack([pulse.amp_time(time) for pulse in self.pulses])
+        return np.sum(stacked_amp, axis=0)
+
+    def amp_freq(self, freq: float) -> complex:
+        """Complex-valued source spectrum in frequency domain."""
+        stacked_amp = np.stack([pulse.amp_freq(freq) for pulse in self.pulses])
+        return np.sum(stacked_amp, axis=0)
+
+    @cached_property
+    def _freq0(self) -> float:
+        """Central frequency. Since it's missing from input parameters, let's apply the actual central frequency."""
+        return self._freq0_from_sigma
+
+    @staticmethod
+    def _pulses_adjustment(pulses: tuple[GaussianPulse, ...]) -> tuple[GaussianPulse, ...]:
+        """Adjust amplitude, phase, and offset time, so that all pulses roughly have equal amplitude and phase."""
+        # scale amplitude to the largest one
+        highest_amp = max(abs(p._peak_freq_amp) for p in pulses)
+        # scale offset time to the longest one
+        offset_time_longest = max(p.offset_time for p in pulses)
+        return (
+            p.updated_copy(
+                amplitude=highest_amp / abs(p._peak_freq_amp),
+                offset=(offset_time_longest - p._peak_time_shift) / p.twidth,
+                phase=2 * np.pi * p.freq0 * offset_time_longest,
+            )
+            for p in pulses
+        )
+
+    @classmethod
+    def from_frequency_range(
+        cls,
+        fmin: pydantic.PositiveFloat,
+        fmax: pydantic.PositiveFloat,
+        min_rel_amp: pydantic.PositiveFloat = 0.3,
+    ) -> MultiGaussianPulse:
+        """Create a :class:`.MultiGaussianPulse` that maximizes its amplitude in the frequency range [fmin, fmax],
+        whose minimal amplitude in the frequency range relative to the peak amplitude is roughly bounded
+        by ``min_rel_amp``. DC components are removed in those Gaussian pulses.
+
+        Parameters
+        ----------
+        fmin : float
+            Lower bound of frequency of interest.
+        fmax : float
+            Upper bound of frequency of interest.
+        min_rel_amp : float
+            A soft lower bound of amplitude relative to the peak amplitude in the frequency range [fmin, fmax].
+
+        Returns
+        -------
+        :class:`.MultiGaussianPulse`
+            A :class:`.MultiGaussianPulse` that maximizes its amplitude in the frequency range [fmin, fmax].
+        """
+        # validate that fmin and fmax must positive, and fmax > fmin
+        if fmin <= 0:
+            raise ValidationError("'fmin' must be positive.")
+        if fmax <= fmin:
+            raise ValidationError("'fmax' must be greater than 'fmin'.")
+        GaussianPulse._validate_min_rel_amp(min_rel_amp)
+
+        # fwidth, and frequency range to be applied to the pulse of lowest frequency for maximing
+        # fwidth
+        fwidth_rel, fmax_rel = GaussianPulse._unmodulated_gaussian_fwidth_from_rel_amp(min_rel_amp)
+        # iteration
+        pulses = []
+        fmax_compute = fmin
+        ind_pulse = 0
+        while fmax_compute < fmax:
+            # 1st pulse is most broadband
+            if ind_pulse == 0:
+                fmax_iter = fmax_compute * fmax_rel
+                pulse = GaussianPulse(freq0=0, fwidth=fmax_compute * fwidth_rel)
+            else:
+                pulse, fmax_iter = GaussianPulse._from_min_frequency(fmax_compute, min_rel_amp)
+
+            # reaching fmax
+            if fmax_iter > fmax or np.isclose(fmax_iter, fmax):
+                pulse = GaussianPulse.from_frequency_range(fmax_compute, fmax, disable_warning=True)
+                fmax_compute = fmax
+            else:
+                fmax_compute = fmax_iter
+            pulses.append(pulse)
+            ind_pulse += 1
+
+            # a few more stopping criteria: 1) amplitude at fmax is close to the threshold
+            if np.isclose(abs(pulse._rel_amp_freq(fmax)), min_rel_amp, rtol=TOLERANCE_REL_AMP):
+                break
+            # 2) number of pulses reaching the maximal
+            if ind_pulse > MAX_NUM_PULSES_AUTO_MULTIGAUSSIAN:
+                break
+
+        return cls(pulses=cls._pulses_adjustment(pulses))
 
 
 class ContinuousWave(Pulse):
@@ -275,7 +635,7 @@ class ContinuousWave(Pulse):
 
         twidth = 1.0 / (2 * np.pi * self.fwidth)
         omega0 = 2 * np.pi * self.freq0
-        time_shifted = time - self.offset * twidth
+        time_shifted = time - self.offset_time
 
         const = 1.0
         offset = np.exp(1j * self.phase)
@@ -404,9 +764,8 @@ class CustomSourceTime(Pulse):
         data_times = self.data_times
 
         # shift time
-        twidth = 1.0 / (2 * np.pi * self.fwidth)
-        max_time_shifted = run_time - self.offset * twidth
-        min_time_shifted = -self.offset * twidth
+        max_time_shifted = run_time - self.offset_time
+        min_time_shifted = -self.offset_time
 
         return (max_time_shifted < min(data_times)) | (min_time_shifted > max(data_times))
 
@@ -468,4 +827,4 @@ class CustomSourceTime(Pulse):
         return np.max(t_non_zero)
 
 
-SourceTimeType = Union[GaussianPulse, ContinuousWave, CustomSourceTime]
+SourceTimeType = Union[GaussianPulse, MultiGaussianPulse, ContinuousWave, CustomSourceTime]

--- a/tidy3d/plugins/adjoint/components/data/sim_data.py
+++ b/tidy3d/plugins/adjoint/components/data/sim_data.py
@@ -272,7 +272,7 @@ class JaxSimulationData(SimulationData, JaxObject):
                 for i, freq in enumerate(freqs):
                     freq = float(freq)
                     for source_index, source in enumerate(self.simulation.sources):
-                        if source.source_time.freq0 == freq and source.source_time.amplitude > 0:
+                        if source.source_time._freq0 == freq and source.source_time.amplitude > 0:
                             spectrum_fn = self.source_spectrum(source_index)
                             norm_factor_f[i] = complex(spectrum_fn([freq])[0])
 

--- a/tidy3d/plugins/smatrix/ports/coaxial_lumped.py
+++ b/tidy3d/plugins/smatrix/ports/coaxial_lumped.py
@@ -174,7 +174,7 @@ class CoaxialLumpedPort(AbstractLumpedPort, AbstractAxesRH):
             coord1: xs,
             coord2: ys,
             coord3: [center[self.injection_axis]],
-            "f": [source_time.freq0],
+            "f": [source_time._freq0],
         }
 
         kwargs = {


### PR DESCRIPTION
This PR addresses a few existing issues:

- source time's frequency_range is accurate for pure Gaussian. For derivative Gaussian, it will deviates significantly with broader bandwidth.
- Similary, `offset` is only accurate for pure Gaussian, and derivative Gaussian with `freq0>fwidth`, otherwise there can be two peaks in time, as illustrated in the figure below. In this case, `offset` refers to the position of the 1st peak in this PR.
<img width="415" height="342" alt="image" src="https://github.com/user-attachments/assets/efea7d28-ff77-49db-a53c-55572f788168" />


New features:

- MultiGaussian pulse is introduced, which is simply a tuple of Gaussian pulses. But it introduces lots of changes to the code (both frontend and solver), as it doesn't have `freq0` and `fwidth` fields.
- The important feature of MultiGaussian is its automatic generation from frequency range. The minimal amplitude of the pulse in frequency domain relative to the peak amplitude in the frequency range is roughly bounded by the user defined value. The number of Gaussians will increase with larger frequency range, and smaller lower bound.
- In the auto-generated MulitGaussian, we always remove DC component for each individual Gaussian pulse. This complicates the math, and `Brentq` solver is used in multiple places.

## Example
Let's define a source over a very broadband frequency range [0.1, 60] GHz, and source amplitude relative to the peak amplitude over this range should be above 30%. The code is as follows,
`source_time = td.MultiGaussianPulse.from_frequency_range(fmin=.1e9, fmax=60e9, min_rel_amp=0.3)`

The figure illustrates that the generated pulse contains 3 Gaussian pulses.
<img width="768" height="371" alt="image" src="https://github.com/user-attachments/assets/aa30dc66-2e11-479e-b8c2-a3924e3bda0e" />
