### PR TITLE
Fixing component modeler validator

### DIFF
--- a/tests/test_plugins/smatrix/test_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_component_modeler.py
@@ -390,13 +390,13 @@ def test_mapping_with_run_only():
     element_mappings are provided."""
     ports = make_ports()
 
-    EXCLUDE_INDEX = ("right_bot", 0)
+    EXCLUDE_INDEX = ["right_bot", 0]
     element_mappings = []
     run_only = []
     # add a mapping to each element in the row of EXCLUDE_INDEX
     for port in ports:
         for mode_index in range(port.mode_spec.num_modes):
-            row_index = (port.name, mode_index)
+            row_index = [port.name, mode_index]
             run_only.append(row_index)
             if row_index != EXCLUDE_INDEX:
                 mapping = ((row_index, row_index), (row_index, EXCLUDE_INDEX), +1)
@@ -408,7 +408,7 @@ def test_mapping_with_run_only():
 
     # Will pass, since run_only covers all source indices in element_mapping
     _ = make_component_modeler(element_mappings=element_mappings, run_only=run_only)
-
     run_only.remove(EXCLUDE_INDEX)
-    with pytest.raises(pydantic.ValidationError):
+    with pytest.raises(pydantic.ValidationError) as exc_info:
         _ = make_component_modeler(element_mappings=element_mappings, run_only=run_only)
+    assert "not present" in str(exc_info.value)

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -125,14 +125,24 @@ class AbstractComponentModeler(ABC, Generic[IndexType, ElementType], Tidy3dBaseM
         if run_only is None:
             return element_mappings
 
-        valid_set = set(run_only)
+        def list2tuple(item):
+            if isinstance(item, list):
+                return tuple(item)
+            return item
+
+        run_only_cleaned = []
+        for item in run_only:
+            run_only_cleaned.append(list2tuple(item))
+
+        valid_set = set(run_only_cleaned)
         invalid_indices = set()
         for mapping in element_mappings:
             input_element = mapping[0]
             output_element = mapping[1]
             for source_index in [input_element[1], output_element[1]]:
-                if source_index not in valid_set:
-                    invalid_indices.add(source_index)
+                source_index_cleaned = list2tuple(source_index)
+                if source_index_cleaned not in valid_set:
+                    invalid_indices.add(source_index_cleaned)
         if invalid_indices:
             raise SetupError(
                 f"'element_mappings' references source index(es) {invalid_indices} "


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-08 14:41:13 UTC

This PR fixes a validator issue in the component modeler's element mappings validation logic. The core problem was a type inconsistency where the validator was attempting to compare lists and tuples directly, causing validation failures even when the data was logically equivalent.

The fix introduces a `list2tuple` helper function in the base component modeler class that normalizes both `run_only` items and source indices from `element_mappings` to tuples before performing comparisons. This ensures consistent type handling throughout the validation process.

The changes also update the corresponding test case to use lists instead of tuples for matrix indices, aligning with the expected input format for the validator. An assertion was added to verify that the validation error message contains the expected "not present" text, ensuring the validator continues to work correctly after the fix.

This modification integrates well with the existing codebase by maintaining backward compatibility while fixing the type comparison issue. The component modeler functionality remains unchanged from a user perspective, but the internal validation logic is now more robust when handling mixed data types.

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/plugins/smatrix/component_modelers/base.py` | 4/5 | Adds `list2tuple` helper function to fix type inconsistency in element mappings validator |
| `tests/test_plugins/smatrix/test_component_modeler.py` | 4/5 | Updates test case to use lists instead of tuples and adds validation assertion |

</details>

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it addresses a specific validation bug without changing core functionality
- Score reflects a straightforward fix to a type comparison issue with appropriate test coverage updates
- Pay close attention to `tidy3d/plugins/smatrix/component_modelers/base.py` to ensure the helper function handles edge cases correctly

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant ModalComponentModeler
    participant Validator
    participant SetupError

    User->>ModalComponentModeler: "make_component_modeler(element_mappings, run_only)"
    ModalComponentModeler->>Validator: "_validate_element_mappings(element_mappings, values)"
    Validator->>Validator: "extract run_only from values"
    
    alt run_only is None
        Validator->>ModalComponentModeler: "return element_mappings (no validation)"
    else run_only is provided
        Validator->>Validator: "clean run_only items (convert lists to tuples)"
        Validator->>Validator: "create valid_set from run_only"
        
        loop for each mapping in element_mappings
            Validator->>Validator: "extract input_element and output_element"
            Validator->>Validator: "get source indices from elements"
            
            loop for each source_index
                Validator->>Validator: "clean source_index (convert list to tuple)"
                
                alt source_index not in valid_set
                    Validator->>Validator: "add to invalid_indices"
                end
            end
        end
        
        alt invalid_indices found
            Validator->>SetupError: "create error with invalid indices"
            SetupError->>User: "raise SetupError with message"
        else all indices valid
            Validator->>ModalComponentModeler: "return validated element_mappings"
            ModalComponentModeler->>User: "return created modeler instance"
        end
    end
```

<!-- /greptile_comment -->