### PR TITLE
fix validation of run_only and element_mappings in the smatrix plugin

### DIFF
--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -16246,8 +16246,32 @@
       "default": [],
       "items": {
         "items": [
-          {},
-          {},
+          {
+            "items": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "maxItems": 2,
+            "minItems": 2,
+            "type": "array"
+          },
+          {
+            "items": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "maxItems": 2,
+            "minItems": 2,
+            "type": "array"
+          },
           {
             "anyOf": [
               {
@@ -16323,7 +16347,9 @@
       "type": "boolean"
     },
     "run_only": {
-      "items": {},
+      "items": {
+        "type": "string"
+      },
       "type": "array"
     },
     "s_param_def": {

--- a/tests/test_plugins/smatrix/test_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_component_modeler.py
@@ -315,6 +315,11 @@ def test_component_modeler_run_only(monkeypatch):
     s_matrix.loc[coords_in_run_only] = 0
     assert np.all(s_matrix.values == 0.0)
 
+    # make sure lists are correctly converted into tuples
+    run_only = [list(ONLY_SOURCE)]
+    modeler = modeler.updated_copy(run_only=run_only)
+    assert ONLY_SOURCE in modeler.matrix_indices_run_sim
+
 
 def _test_mappings(element_mappings, s_matrix):
     """Makes sure the mappings are reflected in a given S matrix."""
@@ -390,13 +395,14 @@ def test_mapping_with_run_only():
     element_mappings are provided."""
     ports = make_ports()
 
-    EXCLUDE_INDEX = ("right_bot", 0)
+    EXCLUDE_INDEX = ["right_bot", 0]
     element_mappings = []
     run_only = []
     # add a mapping to each element in the row of EXCLUDE_INDEX
     for port in ports:
         for mode_index in range(port.mode_spec.num_modes):
-            row_index = (port.name, mode_index)
+            # Test that providing a list is properly handled
+            row_index = [port.name, mode_index]
             run_only.append(row_index)
             if row_index != EXCLUDE_INDEX:
                 mapping = ((row_index, row_index), (row_index, EXCLUDE_INDEX), +1)

--- a/tidy3d/plugins/smatrix/analysis/terminal.py
+++ b/tidy3d/plugins/smatrix/analysis/terminal.py
@@ -20,8 +20,8 @@ from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.plugins.smatrix.component_modelers.terminal import TerminalComponentModeler
 from tidy3d.plugins.smatrix.data.data_array import PortDataArray, TerminalPortDataArray
 from tidy3d.plugins.smatrix.data.terminal import TerminalComponentModelerData
-from tidy3d.plugins.smatrix.network import SParamDef
 from tidy3d.plugins.smatrix.ports.wave import WavePort
+from tidy3d.plugins.smatrix.types import SParamDef
 from tidy3d.plugins.smatrix.utils import (
     ab_to_s,
     check_port_impedance_sign,

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Generic, Optional, TypeVar, Union, get_args
+from typing import TYPE_CHECKING, Optional, Union, get_args
 
 import pydantic.v1 as pd
 
@@ -24,6 +24,7 @@ from tidy3d.log import log
 from tidy3d.plugins.smatrix.ports.modal import Port
 from tidy3d.plugins.smatrix.ports.types import TerminalPortType
 from tidy3d.plugins.smatrix.ports.wave import WavePort
+from tidy3d.plugins.smatrix.types import Element, MatrixIndex, NetworkElement, NetworkIndex
 
 if TYPE_CHECKING:
     from tidy3d.web.core.types import PayType
@@ -32,18 +33,18 @@ if TYPE_CHECKING:
 FWIDTH_FRAC = 1.0 / 10
 DEFAULT_DATA_DIR = "."
 
-# Generic type variables for matrix indices and elements
-IndexType = TypeVar("IndexType")
-ElementType = TypeVar("ElementType")
+IndexType = Union[MatrixIndex, NetworkIndex]
+ElementType = Union[Element, NetworkElement]
 
 
-class AbstractComponentModeler(ABC, Generic[IndexType, ElementType], Tidy3dBaseModel):
+class AbstractComponentModeler(ABC, Tidy3dBaseModel):
     """Tool for modeling devices and computing port parameters."""
 
     name: str = pd.Field(
         "",
         title="Name",
     )
+
     simulation: Simulation = pd.Field(
         ...,
         title="Simulation",

--- a/tidy3d/plugins/smatrix/component_modelers/modal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/modal.py
@@ -13,17 +13,15 @@ from tidy3d.components.index import SimulationMap
 from tidy3d.components.monitor import ModeMonitor
 from tidy3d.components.source.field import ModeSource
 from tidy3d.components.source.time import GaussianPulse
-from tidy3d.components.types import Ax
+from tidy3d.components.types import Ax, Complex
 from tidy3d.components.viz import add_ax_if_none, equal_aspect
 from tidy3d.plugins.smatrix.ports.modal import Port
+from tidy3d.plugins.smatrix.types import Element, MatrixIndex
 
 from .base import FWIDTH_FRAC, AbstractComponentModeler
 
-MatrixIndex = tuple[str, pd.NonNegativeInt]  # the 'i' in S_ij
-Element = tuple[MatrixIndex, MatrixIndex]  # the 'ij' in S_ij
 
-
-class ModalComponentModeler(AbstractComponentModeler[MatrixIndex, Element]):
+class ModalComponentModeler(AbstractComponentModeler):
     """A tool for modeling devices and computing scattering matrix elements.
 
     This class orchestrates the process of running multiple simulations to
@@ -41,6 +39,24 @@ class ModalComponentModeler(AbstractComponentModeler[MatrixIndex, Element]):
         title="Ports",
         description="Collection of ports describing the scattering matrix elements. "
         "For each input mode, one simulation will be run with a modal source.",
+    )
+
+    run_only: Optional[tuple[MatrixIndex, ...]] = pd.Field(
+        None,
+        title="Run Only",
+        description="Set of matrix indices that define the simulations to run. "
+        "If ``None``, simulations will be run for all indices in the scattering matrix. "
+        "If a tuple is given, simulations will be run only for the given matrix indices.",
+    )
+
+    element_mappings: tuple[tuple[Element, Element, Complex], ...] = pd.Field(
+        (),
+        title="Element Mappings",
+        description="Tuple of S matrix element mappings, each described by a tuple of "
+        "(input_element, output_element, coefficient), where the coefficient is the "
+        "element_mapping coefficient describing the relationship between the input and output "
+        "matrix element. If all elements of a given column of the scattering matrix are defined "
+        "by ``element_mappings``, the simulation corresponding to this column is skipped automatically.",
     )
 
     @cached_property
@@ -87,6 +103,17 @@ class ModalComponentModeler(AbstractComponentModeler[MatrixIndex, Element]):
             for mode_index in range(port.mode_spec.num_modes):
                 matrix_indices.append((port.name, mode_index))
         return tuple(matrix_indices)
+
+    @cached_property
+    def matrix_indices_source(self) -> tuple[MatrixIndex, ...]:
+        """Tuple of all the source matrix indices, which may be less than the total number of
+        ports."""
+        return super().matrix_indices_source
+
+    @cached_property
+    def matrix_indices_run_sim(self) -> tuple[MatrixIndex, ...]:
+        """Tuple of all the matrix indices that will be used to run simulations."""
+        return super().matrix_indices_run_sim
 
     @cached_property
     def port_names(self) -> tuple[list[str], list[str]]:

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -14,7 +14,7 @@ from tidy3d.components.index import SimulationMap
 from tidy3d.components.monitor import DirectivityMonitor
 from tidy3d.components.simulation import Simulation
 from tidy3d.components.source.time import GaussianPulse
-from tidy3d.components.types import Ax
+from tidy3d.components.types import Ax, Complex
 from tidy3d.components.viz import add_ax_if_none, equal_aspect
 from tidy3d.constants import C_0, OHM
 from tidy3d.exceptions import SetupError, Tidy3dKeyError, ValidationError
@@ -24,15 +24,15 @@ from tidy3d.plugins.smatrix.component_modelers.base import (
     AbstractComponentModeler,
 )
 from tidy3d.plugins.smatrix.data.data_array import PortDataArray
-from tidy3d.plugins.smatrix.network import NetworkElement, NetworkIndex, SParamDef
 from tidy3d.plugins.smatrix.ports.base_lumped import AbstractLumpedPort
 from tidy3d.plugins.smatrix.ports.coaxial_lumped import CoaxialLumpedPort
 from tidy3d.plugins.smatrix.ports.rectangular_lumped import LumpedPort
 from tidy3d.plugins.smatrix.ports.types import TerminalPortType
 from tidy3d.plugins.smatrix.ports.wave import WavePort
+from tidy3d.plugins.smatrix.types import NetworkElement, NetworkIndex, SParamDef
 
 
-class TerminalComponentModeler(AbstractComponentModeler[NetworkIndex, NetworkElement]):
+class TerminalComponentModeler(AbstractComponentModeler):
     """
     Tool for modeling two-terminal multiport devices and computing port parameters
     with lumped and wave ports.
@@ -55,6 +55,24 @@ class TerminalComponentModeler(AbstractComponentModeler[NetworkIndex, NetworkEle
         title="Terminal Ports",
         description="Collection of lumped and wave ports associated with the network. "
         "For each port, one simulation will be run with a source that is associated with the port.",
+    )
+
+    run_only: Optional[tuple[NetworkIndex, ...]] = pd.Field(
+        None,
+        title="Run Only",
+        description="Set of matrix indices that define the simulations to run. "
+        "If ``None``, simulations will be run for all indices in the scattering matrix. "
+        "If a tuple is given, simulations will be run only for the given matrix indices.",
+    )
+
+    element_mappings: tuple[tuple[NetworkElement, NetworkElement, Complex], ...] = pd.Field(
+        (),
+        title="Element Mappings",
+        description="Tuple of S matrix element mappings, each described by a tuple of "
+        "(input_element, output_element, coefficient), where the coefficient is the "
+        "element_mapping coefficient describing the relationship between the input and output "
+        "matrix element. If all elements of a given column of the scattering matrix are defined "
+        "by ``element_mappings``, the simulation corresponding to this column is skipped automatically.",
     )
 
     radiation_monitors: tuple[DirectivityMonitor, ...] = pd.Field(
@@ -222,6 +240,17 @@ class TerminalComponentModeler(AbstractComponentModeler[NetworkIndex, NetworkEle
             else:
                 matrix_indices.append(self.network_index(port))
         return tuple(matrix_indices)
+
+    @cached_property
+    def matrix_indices_source(self) -> tuple[NetworkIndex, ...]:
+        """Tuple of all the source matrix indices, which may be less than the total number of
+        ports."""
+        return super().matrix_indices_source
+
+    @cached_property
+    def matrix_indices_run_sim(self) -> tuple[NetworkIndex, ...]:
+        """Tuple of all the matrix indices that will be used to run simulations."""
+        return super().matrix_indices_run_sim
 
     @cached_property
     def sim_dict(self) -> SimulationMap:

--- a/tidy3d/plugins/smatrix/data/terminal.py
+++ b/tidy3d/plugins/smatrix/data/terminal.py
@@ -16,8 +16,8 @@ from tidy3d.log import log
 from tidy3d.plugins.smatrix.component_modelers.terminal import TerminalComponentModeler
 from tidy3d.plugins.smatrix.data.base import AbstractComponentModelerData
 from tidy3d.plugins.smatrix.data.data_array import PortDataArray, TerminalPortDataArray
-from tidy3d.plugins.smatrix.network import SParamDef
 from tidy3d.plugins.smatrix.ports.types import TerminalPortType
+from tidy3d.plugins.smatrix.types import SParamDef
 from tidy3d.plugins.smatrix.utils import (
     ab_to_s,
     check_port_impedance_sign,

--- a/tidy3d/plugins/smatrix/network.py
+++ b/tidy3d/plugins/smatrix/network.py
@@ -1,9 +1,0 @@
-from __future__ import annotations
-
-from typing import Literal
-
-NetworkIndex = str  # the 'i' in S_ij
-NetworkElement = tuple[NetworkIndex, NetworkIndex]  # the 'ij' in S_ij
-
-# The definition of wave amplitudes used to construct scattering matrix
-SParamDef = Literal["pseudo", "power"]

--- a/tidy3d/plugins/smatrix/types.py
+++ b/tidy3d/plugins/smatrix/types.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import pydantic.v1 as pd
+
+# S matrix indices and entries for the ModalComponentModeler
+MatrixIndex = tuple[str, pd.NonNegativeInt]  # the 'i' in S_ij
+Element = tuple[MatrixIndex, MatrixIndex]  # the 'ij' in S_ij
+# S matrix indices and entries for the TerminalComponentModeler
+NetworkIndex = str  # the 'i' in S_ij
+NetworkElement = tuple[NetworkIndex, NetworkIndex]  # the 'ij' in S_ij
+
+# The definition of wave amplitudes used to construct the scattering matrix
+# in the TerminalComponentModeler
+SParamDef = Literal["pseudo", "power"]

--- a/tidy3d/plugins/smatrix/utils.py
+++ b/tidy3d/plugins/smatrix/utils.py
@@ -19,13 +19,13 @@ from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.types import ArrayFloat1D
 from tidy3d.exceptions import Tidy3dError
 from tidy3d.plugins.smatrix.data.data_array import PortDataArray, TerminalPortDataArray
-from tidy3d.plugins.smatrix.network import SParamDef
 from tidy3d.plugins.smatrix.ports.types import (
     LumpedPortType,
     PortCurrentType,
     PortVoltageType,
     TerminalPortType,
 )
+from tidy3d.plugins.smatrix.types import SParamDef
 
 
 def port_array_inv(matrix: DataArray):


### PR DESCRIPTION
Refactoring the component modelers a bit to ensure validation is working properly. Also these changes improve the documentation as well, since the generic types don't look nice

<img width="737" height="189" alt="image" src="https://github.com/user-attachments/assets/4d9bccb4-0bde-4b9b-97c6-9554e0d37b24" />

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-08 17:54:42 UTC

This PR refactors the smatrix plugin component modelers to fix validation issues with `run_only` and `element_mappings` fields while improving documentation readability. The key changes involve:

1. **Type System Restructure**: Replaced generic type variables (`IndexType`, `ElementType`) with concrete Union types in the base component modeler, eliminating the need for `Generic` inheritance

2. **New Types Module**: Created a dedicated `tidy3d/plugins/smatrix/types.py` file to centralize all type definitions (`MatrixIndex`, `Element`, `NetworkIndex`, `NetworkElement`, `SParamDef`) that were previously scattered across different modules

3. **Import Reorganization**: Updated import statements across multiple files to reference the new types module instead of importing from `network.py`

4. **Enhanced Validation**: Added a new `_validate_element_mappings` method to ensure that source indices referenced in `element_mappings` exist in the `run_only` list when specified

5. **Explicit Field Definitions**: The `TerminalComponentModeler` now explicitly defines `run_only` and `element_mappings` fields with concrete types instead of inheriting generic versions

The refactoring addresses pydantic validation failures that occurred with generic types while maintaining the same functionality. The changes follow good software engineering practices by separating type definitions from implementation logic, which also improves auto-generated documentation rendering since generic types don't display nicely in docs.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/plugins/smatrix/component_modelers/base.py` | 4/5 | Replaced generic types with concrete Union types and added validation for element_mappings |
| `tidy3d/plugins/smatrix/types.py` | 5/5 | New file consolidating all smatrix type definitions in one location |
| `tidy3d/plugins/smatrix/component_modelers/terminal.py` | 3/5 | Refactored to remove generic inheritance and explicitly define fields with cached properties |
| `tidy3d/plugins/smatrix/network.py` | 4/5 | Emptied file as part of type consolidation effort |
| `tidy3d/plugins/smatrix/data/terminal.py` | 5/5 | Updated import to use new types module location |
| `tidy3d/plugins/smatrix/utils.py` | 5/5 | Updated import to use new types module location |
| `tidy3d/plugins/smatrix/analysis/terminal.py` | 5/5 | Updated import to use new types module location |
| `tests/test_plugins/smatrix/test_component_modeler.py` | 5/5 | Updated test to use list format for matrix indices to verify validation flexibility |

</details>

## Confidence score: 3/5

- This PR requires careful review due to significant architectural changes in the validation system and type definitions
- Score reflects concerns about the redundant cached property implementations and potential field validation issues in TerminalComponentModeler
- Pay close attention to `tidy3d/plugins/smatrix/component_modelers/terminal.py` for potential issues with field inheritance and validation

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant ModalComponentModeler
    participant AbstractComponentModeler
    participant Validator
    participant SimulationMap
    participant BatchRunner
    
    User->>ModalComponentModeler: "create modeler with ports, run_only, element_mappings"
    ModalComponentModeler->>AbstractComponentModeler: "inherit validation logic"
    AbstractComponentModeler->>Validator: "validate element_mappings against run_only"
    
    alt element_mappings references invalid source indices
        Validator-->>User: "raise SetupError - invalid source indices"
    else validation passes
        Validator->>ModalComponentModeler: "validation complete"
    end
    
    User->>ModalComponentModeler: "call matrix_indices_run_sim property"
    ModalComponentModeler->>AbstractComponentModeler: "compute run simulation indices"
    
    alt no element_mappings
        AbstractComponentModeler->>ModalComponentModeler: "return matrix_indices_source"
    else has element_mappings
        AbstractComponentModeler->>AbstractComponentModeler: "filter out fully mapped columns"
        AbstractComponentModeler->>ModalComponentModeler: "return filtered indices"
    end
    
    User->>ModalComponentModeler: "access sim_dict property"
    ModalComponentModeler->>ModalComponentModeler: "iterate over matrix_indices_run_sim"
    ModalComponentModeler->>SimulationMap: "create simulation for each source index"
    SimulationMap->>ModalComponentModeler: "return simulation dictionary"
    
    User->>ModalComponentModeler: "call run() method"
    ModalComponentModeler->>BatchRunner: "delegate to smatrix.run"
    BatchRunner->>BatchRunner: "execute simulations in parallel"
    BatchRunner->>ModalComponentModeler: "return ModalComponentModelerData"
    ModalComponentModeler->>User: "return results with S-matrix data"
```

<!-- /greptile_comment -->