### PR TITLE
Disallow autograd with element_mappings for a ComponentModeler

### DIFF
--- a/tests/test_plugins/smatrix/test_component_modeler_autograd.py
+++ b/tests/test_plugins/smatrix/test_component_modeler_autograd.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import tidy3d as td
+from tidy3d.exceptions import AdjointError
 from tidy3d.plugins.smatrix.analysis import terminal as terminal_analysis
 from tidy3d.plugins.smatrix.component_modelers.modal import ModalComponentModeler
 from tidy3d.plugins.smatrix.component_modelers.terminal import TerminalComponentModeler
@@ -230,6 +231,37 @@ def test_component_modeler_autograd_tracing(patch_web_autograd_emulator, tmp_pat
     g = ag.grad(objective)(1.0)
     assert np.isfinite(g)
     assert not np.isclose(g, 0.0)
+
+
+def test_component_modeler_autograd_error_with_element_mappings(
+    patch_web_autograd_emulator, tmp_path
+):
+    """Verify that we get the expected error when running a component modeler with `element_mappings` in autograd."""
+    td.config.logging_level = "ERROR"
+    td.config.log_suppression = True
+
+    def objective(scale: float) -> float:
+        modeler = build_modal_modeler(scale)
+        # set up symmetry
+        left = ("p1_-", 0)
+        right = ("p2_+", 0)
+
+        element_mappings = [
+            ((left, right), (right, left), 1.0),
+        ]
+
+        modeler_with_mappings = modeler.updated_copy(element_mappings=element_mappings)
+        modeler_data = modeler_with_mappings.run(
+            path_dir=str(tmp_path),
+            verbose=False,
+            local_gradient=True,
+        )
+        s = modeler_data.smatrix()
+        return anp.real(anp.sum(s.data))
+
+    # verify that we get an exception for autograd with element_mappings
+    with pytest.raises(AdjointError, match="Element mappings are not supported with autograd."):
+        g = ag.grad(objective)(1.0)
 
 
 def test_component_modeler_autograd_tracing_modeler_run(patch_web_autograd_emulator, tmp_path):

--- a/tidy3d/plugins/smatrix/run.py
+++ b/tidy3d/plugins/smatrix/run.py
@@ -4,6 +4,7 @@ import json
 
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.data.index import SimulationDataMap
+from tidy3d.exceptions import AdjointError
 from tidy3d.plugins.smatrix.component_modelers.modal import ModalComponentModeler
 from tidy3d.plugins.smatrix.component_modelers.terminal import TerminalComponentModeler
 from tidy3d.plugins.smatrix.component_modelers.types import ComponentModelerType
@@ -181,6 +182,14 @@ def _run_local(
 
     sims = getattr(modeler, "sim_dict", None) or {}
     if any(web_ag.is_valid_for_autograd(sim) for sim in sims.values()):
+        if len(modeler.element_mappings) > 0:
+            raise AdjointError(
+                "Element mappings are not supported with autograd. We recommend "
+                "enforcing S-Matrix symmetry in the geometry creation and objective function and "
+                "running the unique simulations via the `run_only` specification in the component "
+                "modeler."
+            )
+
         from tidy3d.web.api.autograd.autograd import _run_async
 
         kwargs.setdefault("folder_name", "default")


### PR DESCRIPTION
This will require some changes once the component modeler run functions are switched around, but wanted to get this ready to go for when that happens.

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-09 19:55:23 UTC

This PR adds validation logic to prevent users from combining `element_mappings` with autograd functionality in `ComponentModeler` components. The change introduces an `AdjointError` when both features are used together, as they are technically incompatible.

The implementation consists of three coordinated changes:
1. **Core validation logic** in `tidy3d/plugins/smatrix/run.py` that checks if autograd is valid and element_mappings are present, raising an informative error with suggested alternatives
2. **Test coverage** in `tests/test_plugins/smatrix/test_component_modeler_autograd.py` to verify the error is properly raised with the expected message
3. **Documentation** in `CHANGELOG.md` recording this behavioral change

The incompatibility arises because element mappings create computational shortcuts that exploit S-matrix symmetries by skipping certain simulations, but autograd requires the full computation graph to be traceable for gradient computation. The error message guides users toward alternative approaches: enforcing symmetry in geometry creation and objective functions, and using `run_only` specifications to control which simulations execute.

This change fits into the broader ComponentModeler ecosystem by adding defensive programming that prevents silent failures or undefined behavior during gradient-based optimization workflows. The PR description mentions this is preparatory work for upcoming changes to component modeler run functions.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/plugins/smatrix/run.py` | 5/5 | Added validation logic to raise AdjointError when element_mappings are used with autograd |
| `tests/test_plugins/smatrix/test_component_modeler_autograd.py` | 5/5 | Added test to verify proper error handling when combining element_mappings with autograd |
| `CHANGELOG.md` | 5/5 | Added changelog entry documenting the new error for element_mappings with autograd |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it adds defensive validation without changing existing functionality
- Score reflects clear error handling, comprehensive test coverage, and proper documentation of the change
- No files require special attention as all changes are straightforward validation logic with appropriate tests

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant ComponentModeler
    participant run_function
    participant autograd_module
    participant AdjointError

    User->>ComponentModeler: "Create modeler with element_mappings"
    User->>run_function: "Call run() with modeler"
    run_function->>run_function: "_is_autograd_valid(modeler)"
    run_function->>autograd_module: "Check if simulations are valid for autograd"
    autograd_module-->>run_function: "Return True/False"
    
    alt autograd is valid
        run_function->>run_function: "Check len(modeler.element_mappings) > 0"
        alt element_mappings exist
            run_function->>AdjointError: "Raise AdjointError"
            AdjointError-->>User: "Element mappings are not supported with autograd"
        else no element_mappings
            run_function->>autograd_module: "_run_async(simulations=modeler.sim_dict)"
            autograd_module-->>run_function: "Return sim_data_map"
            run_function->>run_function: "compose_modeler_data_from_batch_data()"
            run_function-->>User: "Return ComponentModelerDataType"
        end
    else autograd not valid
        run_function->>run_function: "create_batch(modeler)"
        run_function->>run_function: "batch.run()"
        run_function->>run_function: "compose_modeler_data_from_batch_data()"
        run_function-->>User: "Return ComponentModelerDataType"
    end
```

<!-- /greptile_comment -->