### PR TITLE
refc: backwards-compatible componentmodeler run() and autograd-support

### DIFF
--- a/docs/api/plugins/smatrix_migration.rst
+++ b/docs/api/plugins/smatrix_migration.rst
@@ -133,15 +133,6 @@ To ease the transition, we provide utilities that mimic the old workflow.
           modeler=my_modeler, batch_data=batch_data
       )
 
-- **Legacy run command**:
-  The `run` command from the old API is available as a legacy helper.
-
-  .. code-block:: python
-
-     from tidy3d.plugins.smatrix.run import run
-
-     modeler_data = run(my_modeler)
-
 
 API Reference
 ~~~~~~~~~~~~~
@@ -158,7 +149,6 @@ For more details, see the API documentation for the new classes and functions:
    tidy3d.plugins.smatrix.TerminalComponentModelerData
    tidy3d.SimulationMap
    tidy3d.SimulationDataMap
-   tidy3d.plugins.smatrix.run.run
    tidy3d.plugins.smatrix.run.create_batch
    tidy3d.plugins.smatrix.run.compose_modeler_data_from_batch_data
    tidy3d.plugins.smatrix.run.compose_modeler_data

--- a/tests/test_plugins/smatrix/test_component_modeler_autograd.py
+++ b/tests/test_plugins/smatrix/test_component_modeler_autograd.py
@@ -232,6 +232,35 @@ def test_component_modeler_autograd_tracing(patch_web_autograd_emulator, tmp_pat
     assert not np.isclose(g, 0.0)
 
 
+def test_component_modeler_autograd_error_with_element_mappings(
+    patch_web_autograd_emulator, tmp_path
+):
+    """Verify that we get the expected error when running a component modeler with `element_mappings` in autograd."""
+    td.config.logging_level = "ERROR"
+    td.config.log_suppression = True
+
+    def objective(scale: float) -> float:
+        modeler = build_modal_modeler(scale)
+        # set up symmetry (port names only; directions are handled internally)
+        left = ("p1", 0)
+        right = ("p2", 0)
+
+        element_mappings = [
+            ((left, right), (right, left), 1.0),
+        ]
+
+        modeler_with_mappings = modeler.updated_copy(element_mappings=element_mappings)
+        s = modeler_with_mappings.run(
+            path_dir=str(tmp_path),
+            verbose=False,
+            local_gradient=True,
+        )
+        return anp.real(anp.sum(s.data))
+
+    g = ag.grad(objective)(1.0)
+    assert np.isfinite(g)
+
+
 def test_component_modeler_autograd_tracing_modeler_run(patch_web_autograd_emulator, tmp_path):
     td.config.logging_level = "ERROR"
     td.config.log_suppression = True

--- a/tests/test_plugins/smatrix/test_component_modeler_autograd.py
+++ b/tests/test_plugins/smatrix/test_component_modeler_autograd.py
@@ -12,7 +12,7 @@ from tidy3d.plugins.smatrix.component_modelers.terminal import TerminalComponent
 from tidy3d.plugins.smatrix.data.data_array import TerminalPortDataArray
 from tidy3d.plugins.smatrix.ports.modal import Port as ModalPort
 from tidy3d.plugins.smatrix.ports.rectangular_lumped import LumpedPort as RectLumpedPort
-from tidy3d.plugins.smatrix.run import run as smatrix_run
+from tidy3d.web import run
 from tidy3d.web.api.autograd import autograd as web_ag
 
 
@@ -216,9 +216,10 @@ def test_component_modeler_autograd_tracing(patch_web_autograd_emulator, tmp_pat
 
     def objective(scale: float) -> float:
         modeler = build_modal_modeler(scale)
-        modeler_data = smatrix_run(
+        modeler_data = run(
             modeler,
-            path_dir=str(tmp_path),
+            task_name="cm_modal_autograd",
+            path=str(tmp_path / "cm_data.hdf5"),
             verbose=False,
             local_gradient=True,
         )
@@ -237,12 +238,11 @@ def test_component_modeler_autograd_tracing_modeler_run(patch_web_autograd_emula
 
     def objective(scale: float) -> float:
         modeler = build_modal_modeler(scale)
-        modeler_data = modeler.run(
+        s = modeler.run(
             path_dir=str(tmp_path),
             verbose=False,
             local_gradient=True,
         )
-        s = modeler_data.smatrix()
         return anp.real(anp.sum(s.data))
 
     g = ag.grad(objective)(1.0)
@@ -306,9 +306,10 @@ def test_terminal_component_modeler_autograd_tracing_stubbed(
 
     def objective(scale: float) -> float:
         modeler = build_terminal_modeler(scale)
-        modeler_data = smatrix_run(
+        modeler_data = run(
             modeler,
-            path_dir=str(tmp_path),
+            task_name="cm_terminal_autograd",
+            path=str(tmp_path / "cm_data.hdf5"),
             verbose=False,
             local_gradient=True,
         )
@@ -368,12 +369,12 @@ def test_terminal_component_modeler_autograd_tracing_modeler_run_stubbed(
 
     def objective(scale: float) -> float:
         modeler = build_terminal_modeler(scale)
-        modeler_data = modeler.run(
+        s = modeler.run(
             path_dir=str(tmp_path),
             verbose=False,
             local_gradient=True,
         )
-        s_vals = modeler_data.smatrix().data.data
+        s_vals = s.data.data
         return anp.real(anp.sum(s_vals))
 
     g = ag.grad(objective)(1.0)

--- a/tests/test_plugins/smatrix/test_run_functions.py
+++ b/tests/test_plugins/smatrix/test_run_functions.py
@@ -18,10 +18,10 @@ from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.plugins.smatrix.data.terminal import TerminalComponentModelerData
 from tidy3d.plugins.smatrix.run import (
+    _run_local,
     compose_modeler,
     compose_modeler_data,
     create_batch,
-    run,
 )
 
 
@@ -98,7 +98,7 @@ def test_run_function(monkeypatch):
     dummy_modeler = make_modal_component_modeler()
 
     # Call the function under test
-    result = run(modeler=dummy_modeler, path_dir="./temp_dir")
+    result = _run_local(modeler=dummy_modeler, path_dir="./temp_dir")
 
     # Assertions
     tidy3d.plugins.smatrix.run.create_batch.assert_called_once_with(modeler=dummy_modeler)

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -227,7 +227,8 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
     ):
         log.warning(
             "'ComponentModeler.run()' is deprecated and will be removed in a future release. "
-            "Use 'web.run(modeler)' instead.",
+            "Use web.run(modeler) instead. 'web.run' returns a 'ComponentModelerData' object; "
+            "get the scattering matrix via 'data.smatrix()'.",
             log_once=True,
         )
         from tidy3d.plugins.smatrix.run import _run_local

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -225,14 +225,14 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
         local_gradient: bool = False,
         max_num_adjoint_per_fwd: int = MAX_NUM_ADJOINT_PER_FWD,
     ):
-        """Run the component modeler and return modeler data.
+        log.warning(
+            "'ComponentModeler.run()' is deprecated and will be removed in a future release. "
+            "Use 'web.run(modeler)' instead.",
+            log_once=True,
+        )
+        from tidy3d.plugins.smatrix.run import _run_local
 
-        Delegates to `tidy3d.plugins.smatrix.run.run`, which selects between
-        an autograd-compatible path and the standard Batch path.
-        """
-        from tidy3d.plugins.smatrix.run import run
-
-        return run(
+        data = _run_local(
             self,
             path_dir=path_dir,
             folder_name=folder_name,
@@ -244,6 +244,7 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
             local_gradient=local_gradient,
             max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
         )
+        return data.smatrix()
 
 
 AbstractComponentModeler.update_forward_refs()

--- a/tidy3d/plugins/smatrix/run.py
+++ b/tidy3d/plugins/smatrix/run.py
@@ -4,6 +4,7 @@ import json
 
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.data.index import SimulationDataMap
+from tidy3d.log import log
 from tidy3d.plugins.smatrix.component_modelers.modal import ModalComponentModeler
 from tidy3d.plugins.smatrix.component_modelers.terminal import TerminalComponentModeler
 from tidy3d.plugins.smatrix.component_modelers.types import ComponentModelerType
@@ -179,15 +180,24 @@ def _run_local(
     # autograd path if any sim is valid for autograd
     from tidy3d.web.api.autograd import autograd as web_ag
 
-    sims = getattr(modeler, "sim_dict", None) or {}
+    sims = modeler.sim_dict
     if any(web_ag.is_valid_for_autograd(sim) for sim in sims.values()):
+        if len(modeler.element_mappings) > 0:
+            log.warning(
+                "Element mappings are used to populate S-matrix values, but autograd gradients "
+                "are computed only for simulated elements. Gradients for mapped elements are not "
+                "included. For optimization with autograd, prefer enforcing symmetry in geometry/"
+                "objective functions and use 'run_only' to select unique sources.",
+                log_once=True,
+            )
+
         from tidy3d.web.api.autograd.autograd import _run_async
 
         kwargs.setdefault("folder_name", "default")
         kwargs.setdefault("simulation_type", "tidy3d_autograd_async")
         kwargs.setdefault("path_dir", path_dir)
 
-        sim_data_map = _run_async(simulations=modeler.sim_dict, **kwargs)
+        sim_data_map = _run_async(simulations=sims, **kwargs)
 
         return compose_modeler_data_from_batch_data(modeler=modeler, batch_data=sim_data_map)
 

--- a/tidy3d/plugins/smatrix/run.py
+++ b/tidy3d/plugins/smatrix/run.py
@@ -148,25 +148,10 @@ def create_batch(
     return batch
 
 
-def _is_autograd_valid(modeler: ComponentModelerType) -> bool:
-    """Return True if any underlying simulation is valid for autograd."""
-    from tidy3d.web.api.autograd import autograd as web_ag
-
-    try:
-        sims = modeler.sim_dict
-    except AttributeError:
-        return False
-    if not sims:
-        return False
-
-    for sim in sims.values():
-        if web_ag.is_valid_for_autograd(sim):
-            return True
-    return False
-
-
-def run(
-    modeler: ComponentModelerType, path_dir: str = DEFAULT_DATA_DIR, **kwargs
+def _run_local(
+    modeler: ComponentModelerType,
+    path_dir: str = DEFAULT_DATA_DIR,
+    **kwargs,
 ) -> ComponentModelerDataType:
     """Execute the full simulation workflow for a given component modeler.
 
@@ -191,7 +176,11 @@ def run(
         S-parameter extraction and analysis.
     """
 
-    if _is_autograd_valid(modeler):
+    # autograd path if any sim is valid for autograd
+    from tidy3d.web.api.autograd import autograd as web_ag
+
+    sims = getattr(modeler, "sim_dict", None) or {}
+    if any(web_ag.is_valid_for_autograd(sim) for sim in sims.values()):
         from tidy3d.web.api.autograd.autograd import _run_async
 
         kwargs.setdefault("folder_name", "default")

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -23,6 +23,7 @@ from tidy3d.components.autograd.constants import (
 from tidy3d.components.autograd.derivative_utils import DerivativeInfo
 from tidy3d.components.data.data_array import DataArray
 from tidy3d.components.grid.grid_spec import GridSpec
+from tidy3d.components.types.workflow import WorkflowDataType, WorkflowType
 from tidy3d.exceptions import AdjointError
 from tidy3d.web.api.asynchronous import DEFAULT_DATA_DIR
 from tidy3d.web.api.asynchronous import run_async as run_async_webapi
@@ -94,7 +95,7 @@ def is_valid_for_autograd_async(simulations: dict[str, td.Simulation]) -> bool:
 
 
 def run(
-    simulation: typing.Any,
+    simulation: WorkflowType,
     task_name: str,
     folder_name: str = "default",
     path: str = "simulation_data.hdf5",
@@ -111,14 +112,14 @@ def run(
     reduce_simulation: typing.Literal["auto", True, False] = "auto",
     pay_type: typing.Union[PayType, str] = PayType.AUTO,
     priority: typing.Optional[int] = None,
-) -> td.SimulationData:
+) -> WorkflowDataType:
     """
     Submits a :class:`.Simulation` to server, starts running, monitors progress, downloads,
     and loads results as a :class:`.WorkflowDataType` object.
 
     Parameters
     ----------
-    simulation : Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`]
+    simulation : Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`, :class:`.ModalComponentModeler`, :class:`.TerminalComponentModeler`]
         Simulation to upload to server.
     task_name : str
         Name of task.
@@ -154,8 +155,8 @@ def run(
         Task priority for vGPU queue (1=lowest, 10=highest).
     Returns
     -------
-    Union[:class:`.SimulationData`, :class:`.HeatSimulationData`, :class:`.EMESimulationData`]
-        Object containing solver results for the supplied simulation.
+    Union[:class:`.SimulationData`, :class:`.HeatSimulationData`, :class:`.EMESimulationData`, :class:`.ModalComponentModelerData`, :class:`.TerminalComponentModelerData`]
+        Object containing solver results for the supplied input.
 
     Notes
     -----
@@ -203,10 +204,7 @@ def run(
     from tidy3d.plugins.smatrix.component_modelers.types import ComponentModelerType
 
     if isinstance(simulation, typing.get_args(ComponentModelerType)):
-        sims = getattr(simulation, "sim_dict", None)
-        if local_gradient or (
-            isinstance(sims, dict) and any(is_valid_for_autograd(s) for s in sims.values())
-        ):
+        if any(is_valid_for_autograd(s) for s in simulation.sim_dict.values()):
             from tidy3d.plugins.smatrix import run as smatrix_run
 
             path_dir = dirname(path) or "."

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -94,7 +94,7 @@ def is_valid_for_autograd_async(simulations: dict[str, td.Simulation]) -> bool:
 
 
 def run(
-    simulation: td.Simulation,
+    simulation: typing.Any,
     task_name: str,
     folder_name: str = "default",
     path: str = "simulation_data.hdf5",
@@ -198,6 +198,30 @@ def run(
     """
     if priority is not None and (priority < 1 or priority > 10):
         raise ValueError("Priority must be between '1' and '10' if specified.")
+
+    # component modeler path: route autograd-valid modelers to local run
+    from tidy3d.plugins.smatrix.component_modelers.types import ComponentModelerType
+
+    if isinstance(simulation, typing.get_args(ComponentModelerType)):
+        sims = getattr(simulation, "sim_dict", None)
+        if local_gradient or (
+            isinstance(sims, dict) and any(is_valid_for_autograd(s) for s in sims.values())
+        ):
+            from tidy3d.plugins.smatrix import run as smatrix_run
+
+            path_dir = dirname(path) or "."
+            return smatrix_run._run_local(
+                simulation,
+                path_dir=path_dir,
+                folder_name=folder_name,
+                callback_url=callback_url,
+                verbose=verbose,
+                solver_version=solver_version,
+                pay_type=pay_type,
+                priority=priority,
+                local_gradient=local_gradient,
+                max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
+            )
 
     if isinstance(simulation, td.Simulation) and is_valid_for_autograd(simulation):
         return _run(


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-10 08:44:14 UTC

This PR implements backwards-compatible component modeler `run()` functionality with autograd support. The changes consolidate the component modeler execution path under the unified `tidy3d.web.run()` API while maintaining backwards compatibility for existing code.

The core changes involve three main areas:

1. **API Consolidation**: The autograd `run()` function in `tidy3d/web/api/autograd/autograd.py` is modified to accept `ComponentModeler` objects by broadening the simulation parameter type from `td.Simulation` to `typing.Any`. This enables the function to handle both regular simulations and component modelers through a unified interface.

2. **Component Modeler Routing**: New routing logic detects `ComponentModeler` instances and routes them to the appropriate smatrix local run function when they contain autograd-valid simulations or when `local_gradient` is enabled. This leverages the existing smatrix infrastructure while enabling autograd capabilities.

3. **Documentation Cleanup**: The migration documentation is updated to remove references to deprecated legacy functionality, specifically removing the "legacy run command" section that documented `tidy3d.plugins.smatrix.run.run`. This aligns the documentation with the deprecation of the legacy helper function.

The integration fits well with the existing codebase architecture by reusing established patterns for type checking and routing to different execution paths. The changes maintain the existing `td.Simulation` autograd path unchanged, ensuring no breaking changes for current users while extending functionality to component modelers. The test updates demonstrate that the new API works correctly, with `modeler.run()` now returning smatrix data directly instead of requiring an additional `smatrix()` call.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `docs/api/plugins/smatrix_migration.rst` | 5/5 | Removes deprecated legacy run command documentation to align with API modernization |
| `tests/test_plugins/smatrix/test_component_modeler_autograd.py` | 4/5 | Updates tests to use new web.run() API and validates autograd functionality with component modelers |
| `tidy3d/web/api/autograd/autograd.py` | 4/5 | Adds component modeler support to autograd run function with type broadening and routing logic |

</details>

## Confidence score: 4/5

- This PR is generally safe to merge with some attention needed for the type system changes
- Score reflects solid architectural design but introduces runtime type checking instead of compile-time validation
- Pay close attention to the autograd.py file for potential type safety implications

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
```

<!-- /greptile_comment -->