### PR TITLE
Fixing generation rate validator

### DIFF
--- a/tidy3d/components/tcad/generation_recombination.py
+++ b/tidy3d/components/tcad/generation_recombination.py
@@ -207,7 +207,7 @@ class DistributedGeneration(Tidy3dBaseModel):
 
         zero_dims = [d for d in ["x", "y", "z"] if len(rate.coords[d]) <= 1]
 
-        if len(zero_dims) >= 1:
+        if len(zero_dims) > 1:
             raise ValueError("SpatialDataArray must be at least 2D.")
 
         return values


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-11 11:31:47 UTC

This PR fixes a critical bug in the validation logic for the `DistributedGeneration` class within Tidy3D's TCAD component. The issue was in the validator for `SpatialDataArray` dimensions, where the condition `len(zero_dims) >= 1` was incorrectly rejecting valid 2D arrays.

The change corrects the logic by modifying the condition to `len(zero_dims) > 1`, which properly allows arrays that are at least 2D. In the context of Tidy3D's spatial data handling, a `SpatialDataArray` represents 3D spatial data with x, y, and z coordinates, but it's common and valid to have one dimension collapsed (length <= 1) to represent 2D data - for example, a 2D array in the x-y plane with z having length 1.

This fix ensures that the validator only rejects arrays with 2 or more collapsed dimensions (which would be 1D or 0D), while properly accepting arrays with exactly one collapsed dimension that are effectively 2D. This aligns with the intended behavior of the generation rate modeling in Tidy3D's TCAD simulation capabilities, where 2D spatial distributions are frequently used.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/components/tcad/generation_recombination.py` | 5/5 | Fixed critical validation bug by changing condition from `>= 1` to `> 1` to properly allow 2D SpatialDataArrays |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it fixes a clear logical error in validation logic
- Score reflects a straightforward bug fix with obvious correctness and no complex side effects
- No files require special attention as the change is isolated and well-understood

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant DistributedGeneration
    participant Validator as "check_spatialdataarray_dimensions"
    participant SpatialDataArray as "rate: SpatialDataArray"

    User->>DistributedGeneration: "Create DistributedGeneration(rate=spatial_data)"
    DistributedGeneration->>Validator: "Validate rate dimensions"
    Validator->>SpatialDataArray: "Get coordinates for x, y, z"
    SpatialDataArray-->>Validator: "Return coords dict"
    Validator->>Validator: "Check dimensions: len(coords[d]) <= 1 for each axis"
    Validator->>Validator: "Count zero_dims (dimensions with <= 1 coordinate)"
    alt More than 1 zero dimension
        Validator-->>DistributedGeneration: "Raise ValueError: SpatialDataArray must be at least 2D"
        DistributedGeneration-->>User: "Validation error"
    else Valid (at most 1 zero dimension)
        Validator-->>DistributedGeneration: "Validation passed"
        DistributedGeneration-->>User: "DistributedGeneration instance created"
    end
```

<!-- /greptile_comment -->