### PR TITLE
Warn/error if too many structures are of the same medium

### DIFF
--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -2146,19 +2146,19 @@ def test_tfsf_structures_grid():
 
 
 @pytest.mark.parametrize(
-    "size, num_struct, log_level", [(1, 1, None), (50, 1, "WARNING"), (1, 11000, "WARNING")]
+    "size, num_struct, log_level", [(1, 1, None), (50, 1, "WARNING"), (1, 11, "WARNING")]
 )
-def test_warn_large_epsilon(size, num_struct, log_level):
+def test_warn_large_epsilon(monkeypatch, size, num_struct, log_level):
     """Make sure we get a warning if the epsilon grid is too large."""
 
+    monkeypatch.setattr(simulation, "NUM_STRUCTURES_WARN_EPSILON", 10)
     structures = [
         td.Structure(
             geometry=td.Box(center=(0, 0, 0), size=(0.1, 0.1, 0.1)),
-            medium=td.Medium(permittivity=1.0),
+            medium=td.Medium(permittivity=eps),
         )
-        for _ in range(num_struct)
+        for eps in np.linspace(1, 2, num_struct)
     ]
-
     sim = td.Simulation(
         size=(size, size, size),
         grid_spec=td.GridSpec.uniform(dl=0.1),
@@ -3715,3 +3715,44 @@ def test_messages_contain_object_names():
     monitor = td.FieldMonitor(name=name, center=(-1.0, 0, 0), size=(0.5, 0, 1), freqs=[100e14])
     with pytest.raises(pydantic.ValidationError, match=name) as e:
         _ = sim.updated_copy(monitors=[monitor])
+
+
+def test_structures_per_medium(monkeypatch):
+    """Test if structures that share the same medium warn or error appropriately."""
+    import tidy3d.components.scene as scene
+
+    # Set low thresholds to keep the test fast; ensure len(structures) > MAX to avoid early return
+    monkeypatch.setattr(scene, "WARN_STRUCTURES_PER_MEDIUM", 2)
+    monkeypatch.setattr(scene, "MAX_STRUCTURES_PER_MEDIUM", 4)
+
+    shared_med = td.Medium(permittivity=2.0)
+    # 3 share the same medium -> triggers warning (> WARN), but <= MAX per-medium
+    same_medium_structs = [
+        td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=shared_med) for _ in range(3)
+    ]
+    # Add two with different mediums so total structures > MAX but error should not be triggered
+    other_structs = [
+        td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=td.Medium(permittivity=3.0)),
+        td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=td.Medium(permittivity=4.0)),
+    ]
+    structs = same_medium_structs + other_structs  # total = 5 > MAX = 4
+
+    with AssertLogLevel("WARNING", contains_str="use the same medium"):
+        _ = td.Simulation(
+            size=(10, 10, 10),
+            run_time=1e-12,
+            grid_spec=td.GridSpec.uniform(dl=0.02),
+            structures=structs,
+        )
+
+    # Now test error
+    monkeypatch.setattr(scene, "MAX_STRUCTURES_PER_MEDIUM", 3, raising=False)
+    structs = [td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=shared_med) for _ in range(4)]
+
+    with pytest.raises(pydantic.ValidationError, match="use the same medium"):
+        _ = td.Simulation(
+            size=(10, 10, 10),
+            run_time=1e-12,
+            grid_spec=td.GridSpec.uniform(dl=0.02),
+            structures=structs,
+        )

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -212,7 +212,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         "operation of Tidy3D as it is not used internally. "
         "Note that, unlike regular Tidy3D fields, ``attrs`` are mutable. "
         "For example, the following is allowed for setting an ``attr`` ``obj.attrs['foo'] = bar``. "
-        "Also note that `Tidy3D`` will raise a ``TypeError`` if ``attrs`` contain objects "
+        "Also note that Tidy3D will raise a ``TypeError`` if ``attrs`` contain objects "
         "that can not be serialized. One can check if ``attrs`` are serializable "
         "by calling ``obj.json()``.",
     )

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -79,6 +79,10 @@ MAX_NUM_MEDIUMS = 65530
 # maximum geometry count in a single structure
 MAX_GEOMETRY_COUNT = 100
 
+# warn and error out if the same medium is present in too many structures
+WARN_STRUCTURES_PER_MEDIUM = 200
+MAX_STRUCTURES_PER_MEDIUM = 1_000
+
 
 class Scene(Tidy3dBaseModel):
     """Contains generic information about the geometry and medium properties common to all types of
@@ -173,6 +177,43 @@ class Scene(Tidy3dBaseModel):
                         f"flattened. A maximum of {MAX_GEOMETRY_COUNT} is supported due to "
                         f"preprocessing performance."
                     )
+
+        return val
+
+    @pd.validator("structures", always=True)
+    def _validate_structures_per_medium(cls, val):
+        """Error if too many structures share the same medium; suggest using GeometryGroup."""
+        if val is None:
+            return val
+
+        # if total structures are <= warn limit, the constraint cannot be violated.
+        if len(val) <= WARN_STRUCTURES_PER_MEDIUM:
+            return val
+
+        # Count structures per medium
+        counts = {}
+        get = counts.get
+        for structure in val:
+            key = structure.medium
+            new_count = get(key, 0) + 1
+            # Exit early to avoid slow counting if many structures present
+            if new_count > MAX_STRUCTURES_PER_MEDIUM:
+                raise SetupError(
+                    f"More than {MAX_STRUCTURES_PER_MEDIUM} structures use the same medium. "
+                    "For performance, use a 'GeometryGroup' or boolean operations to combine "
+                    "geometries that share a medium."
+                )
+            counts[key] = new_count
+
+        # Now check if we should warn
+        for count in counts.values():
+            if count > WARN_STRUCTURES_PER_MEDIUM:
+                log.warning(
+                    f"More than {WARN_STRUCTURES_PER_MEDIUM} structures use the same medium. "
+                    "For performance, use a 'GeometryGroup' or boolean operations to combine "
+                    "geometries that share a medium."
+                )
+                break
 
         return val
 


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-11 15:09:29 UTC

This PR introduces validation logic to prevent performance issues when too many structures share the same medium in Tidy3D simulations. The change adds two new constants: `WARN_STRUCTURES_PER_MEDIUM` (200) and `MAX_STRUCTURES_PER_MEDIUM` (1,000), along with a new validator method `_validate_structures_per_medium` in the Scene class.

The validator implements a two-tier approach: it issues a warning when more than 200 structures use the same medium and throws an error when the count exceeds 1,000. The implementation includes an early exit optimization to avoid expensive counting operations when the total number of structures is already below the warning threshold or when a medium's structure count exceeds the maximum limit during iteration.

This change addresses a known performance bottleneck in Tidy3D's preprocessing pipeline. When many structures share the same medium, the simulation setup becomes computationally expensive and memory-intensive. The validator guides users toward more efficient alternatives like `GeometryGroup` or boolean operations, which the framework can handle more efficiently than processing thousands of individual structures during meshing and material assignment.

The PR also includes comprehensive tests that use `monkeypatch` to override the default thresholds, ensuring the validation logic works correctly for both warning and error scenarios without requiring the creation of hundreds of actual structures.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/components/scene.py` | 4/5 | Adds validation constants and `_validate_structures_per_medium` method to warn/error when too many structures share the same medium |
| `tests/test_components/test_simulation.py` | 5/5 | Adds comprehensive test coverage for the new validation logic using monkeypatch to override thresholds |

</details>

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it adds helpful validation without changing core functionality
- Score reflects well-implemented validation logic with proper error handling and performance optimizations
- Pay close attention to the performance impact in production environments with large simulations

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant Simulation
    participant Scene
    participant Validator
    participant Logger

    User->>Simulation: "Create simulation with many structures sharing same medium"
    Simulation->>Scene: "_validate_structures_per_medium()"
    
    Scene->>Validator: "Check if structures count <= WARN_STRUCTURES_PER_MEDIUM"
    alt Total structures <= WARN_STRUCTURES_PER_MEDIUM
        Validator-->>Scene: "Return early - no validation needed"
        Scene-->>Simulation: "Validation passed"
        Simulation-->>User: "Simulation created successfully"
    else Total structures > WARN_STRUCTURES_PER_MEDIUM
        Scene->>Validator: "Count structures per medium"
        loop For each structure
            Validator->>Validator: "counts[structure.medium] += 1"
            alt count > MAX_STRUCTURES_PER_MEDIUM
                Validator->>Scene: "Raise SetupError"
                Scene->>User: "Error: More than 1000 structures use same medium"
            end
        end
        
        alt Any medium has > WARN_STRUCTURES_PER_MEDIUM structures
            Validator->>Logger: "log.warning() - suggest GeometryGroup"
            Logger-->>User: "Warning: Consider using GeometryGroup for performance"
        end
        
        Validator-->>Scene: "Validation complete"
        Scene-->>Simulation: "Validation passed with warnings"
        Simulation-->>User: "Simulation created with warnings"
    end
```

<!-- /greptile_comment -->