### PR TITLE
Warn if different media have the same name

### DIFF
--- a/tests/test_components/test_scene.py
+++ b/tests/test_components/test_scene.py
@@ -47,7 +47,7 @@ def test_scene_init():
 
 
 def test_validate_components_none():
-    assert SCENE._validate_num_mediums(val=None) is None
+    assert SCENE._validate_mediums(val=None) is None
 
 
 def test_plot_eps():

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -1715,6 +1715,27 @@ def test_num_mediums(monkeypatch):
         )
 
 
+def test_unique_medium_names():
+    """Warn if non-unique medium names supplied."""
+
+    with AssertLogLevel("WARNING", contains_str="unique names"):
+        _ = td.Simulation(
+            size=(5, 5, 5),
+            structures=[
+                td.Structure(
+                    geometry=td.Box(size=(1, 1, 1)),
+                    medium=td.Medium(permittivity=2, name="medium1"),
+                ),
+                td.Structure(
+                    geometry=td.Box(size=(1, 1, 1), center=(1, 0, 0)),
+                    medium=td.Medium(permittivity=3, name="medium1"),
+                ),
+            ],
+            run_time=1e-12,
+            grid_spec=td.GridSpec.uniform(dl=0.02),
+        )
+
+
 def test_num_sources():
     """Make sure we error if too many sources supplied."""
 

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -138,8 +138,8 @@ class Scene(Tidy3dBaseModel):
     _unique_structure_names = assert_unique_names("structures")
 
     @pd.validator("structures", always=True)
-    def _validate_num_mediums(cls, val):
-        """Error if too many mediums present."""
+    def _validate_mediums(cls, val):
+        """Error if too many mediums present. Warn if different mediums have the same name."""
 
         if val is None:
             return val
@@ -149,6 +149,14 @@ class Scene(Tidy3dBaseModel):
             raise SetupError(
                 f"Tidy3D only supports {MAX_NUM_MEDIUMS} distinct mediums."
                 f"{len(mediums)} were supplied."
+            )
+
+        medium_names = [medium.name for medium in mediums if medium.name is not None]
+        if len(medium_names) != len(set(medium_names)):
+            log.warning(
+                "Different mediums with the same name were detected. "
+                "This may error in future Tidy3D versions, and using unique names for distinct "
+                "media is recommended."
             )
 
         return val


### PR DESCRIPTION
This was based on a discussion that GUI uses names for media more heavily than python does, and non-unique names are a bit problematic.

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-11 15:29:09 UTC

This PR adds validation logic to warn users when different media (mediums) in a simulation have the same name. The change addresses a specific integration issue where GUI tools rely more heavily on medium names than the Python API does, potentially causing confusion when different media share identical names.

The implementation modifies the `_validate_num_mediums` method in `tidy3d/components/scene.py`, renaming it to `_validate_mediums` and expanding its functionality. The new validation preserves the existing check for the maximum number of mediums while adding a name uniqueness check. When duplicate names are detected among different media, the system emits a warning message recommending unique names for distinct media.

The validation is implemented as a warning rather than an error, which is appropriate since medium names are optional in the Python API. This preserves backward compatibility while providing helpful guidance to users, especially those who work with both the Python API and GUI tools. The change runs whenever structures are set or validated through the `@pd.validator` decorator, ensuring timely feedback.

A corresponding test was added in `tests/test_components/test_simulation.py` to verify the warning behavior. The test creates a simulation with two structures containing different media (permittivity=2 and permittivity=3) that both use the name 'medium1', and validates that the expected warning is generated.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/scene.py | 5/5 | Renamed and expanded `_validate_num_mediums` to `_validate_mediums`, adding duplicate medium name detection with warning |
| tests/test_components/test_simulation.py | 5/5 | Added `test_unique_medium_names()` to verify warning behavior for duplicate medium names |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk
- Score reflects simple, well-tested validation logic that only adds warnings without breaking existing functionality
- No files require special attention

<!-- /greptile_comment -->