### PR TITLE
Damiano/fix charge doc

### DIFF
--- a/docs/api/charge/output_data.rst
+++ b/docs/api/charge/output_data.rst
@@ -28,7 +28,7 @@ Monitor Data
    tidy3d.SteadyElectricFieldData
    tidy3d.SteadyCurrentDensityData
 
-Monitor Data
+Device Data
 ^^^^^^^^^^^^
 
 .. autosummary::

--- a/docs/api/charge/output_data.rst
+++ b/docs/api/charge/output_data.rst
@@ -28,3 +28,11 @@ Monitor Data
    tidy3d.SteadyElectricFieldData
    tidy3d.SteadyCurrentDensityData
 
+Monitor Data
+^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.DeviceCharacteristics

--- a/docs/api/heat/boundary_conditions.rst
+++ b/docs/api/heat/boundary_conditions.rst
@@ -38,3 +38,12 @@ Placement
    tidy3d.MediumMediumInterface
    tidy3d.StructureSimulationBoundary
    tidy3d.SimulationBoundary
+
+Coefficient Models
+^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.VerticalNaturalConvectionCoeffModel

--- a/docs/api/mediums.rst
+++ b/docs/api/mediums.rst
@@ -404,7 +404,7 @@ Multiphysics Medium
 .. autosummary::
    :toctree: _autosummary/
 
-   tidy3d.components.material.multi_physics.MultiPhysicsMedium
+   tidy3d.MultiPhysicsMedium
 
 This section is still under construction. 
 

--- a/docs/api/mediums.rst
+++ b/docs/api/mediums.rst
@@ -139,6 +139,7 @@ Anisotropic
    :template: module.rst
 
    tidy3d.AnisotropicMedium
+   tidy3d.AnisotropicMediumFromMedium2D
    tidy3d.FullyAnisotropicMedium
    tidy3d.Medium2D
 

--- a/docs/api/mesh/output_data.rst
+++ b/docs/api/mesh/output_data.rst
@@ -45,3 +45,6 @@ Individual Datasets
    tidy3d.PointDataArray
    tidy3d.CellDataArray
    tidy3d.IndexedDataArray
+   tidy3d.IndexedVoltageDataArray
+   tidy3d.IndexedTimeDataArray
+   tidy3d.IndexedFieldVoltageDataArray

--- a/docs/api/output_data.rst
+++ b/docs/api/output_data.rst
@@ -87,3 +87,4 @@ List of Dataset Types
    tidy3d.DiffractionDataArray
    tidy3d.DirectivityDataArray
    tidy3d.AxialRatioDataArray
+   tidy3d.SteadyVoltageDataArray

--- a/tidy3d/components/base_sim/simulation.py
+++ b/tidy3d/components/base_sim/simulation.py
@@ -128,8 +128,8 @@ class AbstractSimulation(Box, ABC):
         title="Structure Priority Setting",
         description="This field only affects structures of `priority=None`. "
         "If `equal`, the priority of those structures is set to 0; if `conductor`, "
-        "the priority of structures made of :class:`~tidy3d.LossyMetalMedium` is set to 90, "
-        ":class:`~tidy3d.PECMedium` to 100, and others to 0.",
+        "the priority of structures made of :class:`LossyMetalMedium` is set to 90, "
+        ":class:`PECMedium` to 100, and others to 0.",
     )
 
     """ Validating setup """

--- a/tidy3d/components/base_sim/simulation.py
+++ b/tidy3d/components/base_sim/simulation.py
@@ -128,8 +128,8 @@ class AbstractSimulation(Box, ABC):
         title="Structure Priority Setting",
         description="This field only affects structures of `priority=None`. "
         "If `equal`, the priority of those structures is set to 0; if `conductor`, "
-        "the priority of structures made of `LossyMetalMedium` is set to 90, "
-        "`PECMedium` to 100, and others to 0.",
+        "the priority of structures made of :class:`~tidy3d.LossyMetalMedium` is set to 90, "
+        ":class:`~tidy3d.PECMedium` to 100, and others to 0.",
     )
 
     """ Validating setup """

--- a/tidy3d/components/material/tcad/charge.py
+++ b/tidy3d/components/material/tcad/charge.py
@@ -33,7 +33,7 @@ class AbstractChargeMedium(AbstractMedium):
     def charge(self):
         """
         This means that a charge medium has been defined inherently within this solver medium.
-        This provides interconnection with the `MultiPhysicsMedium` higher-dimensional classes.
+        This provides interconnection with the :class:`MultiPhysicsMedium` higher-dimensional classes.
         """
         return self
 
@@ -296,7 +296,7 @@ class SemiconductorMedium(AbstractChargeMedium):
 
     delta_E_g: BandGapNarrowingModelType = pd.Field(
         None,
-        title=r"$\Delta E_g$ Bandgap narrowing model.",
+        title=":math:'\\Delta E_g' Bandgap narrowing model.",
         description="Bandgap narrowing model.",
     )
 

--- a/tidy3d/components/material/tcad/charge.py
+++ b/tidy3d/components/material/tcad/charge.py
@@ -77,7 +77,7 @@ class ChargeConductorMedium(AbstractChargeMedium):
     conductivity: pd.PositiveFloat = pd.Field(
         ...,
         title="Electric conductivity",
-        description=f"Electric conductivity of material in units of {CONDUCTIVITY}.",
+        description="Electric conductivity of material.",
         units=CONDUCTIVITY,
     )
 
@@ -296,20 +296,24 @@ class SemiconductorMedium(AbstractChargeMedium):
 
     delta_E_g: BandGapNarrowingModelType = pd.Field(
         None,
-        title=":math:'\\Delta E_g' Bandgap narrowing model.",
+        title=":math:`\\Delta E_g` Bandgap narrowing model.",
         description="Bandgap narrowing model.",
     )
 
     N_a: Union[pd.NonNegativeFloat, SpatialDataArray, tuple[DopingBoxType, ...]] = pd.Field(
         0,
         title="Doping: Acceptor concentration",
-        description="Units of 1/cm^3",
+        description="Concentration of acceptor atoms, which create mobile holes, resulting in p-type material. "
+        "Can be specified as a single float for uniform doping, a :class:`SpatialDataArray` for a custom profile, "
+        "or a tuple of geometric shapes to define specific doped regions.",
         units="1/cm^3",
     )
 
     N_d: Union[pd.NonNegativeFloat, SpatialDataArray, tuple[DopingBoxType, ...]] = pd.Field(
         0,
         title="Doping: Donor concentration",
-        description="Units of 1/cm^3",
+        description="Concentration of donor atoms, which create mobile electrons, resulting in n-type material. "
+        "Can be specified as a single float for uniform doping, a :class:`SpatialDataArray` for a custom profile, "
+        "or a tuple of geometric shapes to define specific doped regions.",
         units="1/cm^3",
     )

--- a/tidy3d/components/material/tcad/charge.py
+++ b/tidy3d/components/material/tcad/charge.py
@@ -303,7 +303,7 @@ class SemiconductorMedium(AbstractChargeMedium):
     N_a: Union[pd.NonNegativeFloat, SpatialDataArray, tuple[DopingBoxType, ...]] = pd.Field(
         0,
         title="Doping: Acceptor concentration",
-        description="Concentration of acceptor atoms, which create mobile holes, resulting in p-type material. "
+        description="Concentration of acceptor impurities, which create mobile holes, resulting in p-type material. "
         "Can be specified as a single float for uniform doping, a :class:`SpatialDataArray` for a custom profile, "
         "or a tuple of geometric shapes to define specific doped regions.",
         units="1/cm^3",
@@ -312,7 +312,7 @@ class SemiconductorMedium(AbstractChargeMedium):
     N_d: Union[pd.NonNegativeFloat, SpatialDataArray, tuple[DopingBoxType, ...]] = pd.Field(
         0,
         title="Doping: Donor concentration",
-        description="Concentration of donor atoms, which create mobile electrons, resulting in n-type material. "
+        description="Concentration of donor impurities, which create mobile electrons, resulting in n-type material. "
         "Can be specified as a single float for uniform doping, a :class:`SpatialDataArray` for a custom profile, "
         "or a tuple of geometric shapes to define specific doped regions.",
         units="1/cm^3",

--- a/tidy3d/components/material/tcad/heat.py
+++ b/tidy3d/components/material/tcad/heat.py
@@ -47,25 +47,15 @@ class AbstractHeatMedium(ABC, Tidy3dBaseModel):
 
 class FluidMedium(AbstractHeatMedium):
     """Fluid medium. Heat simulations will not solve for temperature
-    in a structure that has a medium with this 'heat_spec'.
+    in a structure that has a medium with this ``heat_spec``.
 
+
+    Notes
+    --------
     The full set of parameters is primarily intended for calculations involving natural
     convection, where they are used to determine the heat transfer coefficient.
     In the current version, these specific properties may not be utilized for
     other boundary condition types.
-
-    Attributes
-    ----------
-    thermal_conductivity : float, optional
-        Thermal conductivity ($k$) of the fluid in $W/(\\mu m \\cdot K)$.
-    viscosity : float, optional
-        Dynamic viscosity ($\\mu$) of the fluid in $kg/(\\mu m \\cdot s)$.
-    specific_heat : float, optional
-        Specific heat ($c_p$) of the fluid in $\\mu m^2/(s^2 \\cdot K)$.
-    density : float, optional
-        Density ($\rho$) of the fluid in $kg/\\mu m^3$.
-    expansivity : float, optional
-        Thermal expansion coefficient ($\beta$) of the fluid in $1/K$.
 
     Examples
     --------

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -862,10 +862,10 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
     heat_spec: Optional[ThermalSpecType] = pd.Field(
         None,
         title="Heat Specification",
-        description="DEPRECATED: Use `td.MultiPhysicsMedium`. Specification of the medium heat properties. They are "
-        "used for solving the heat equation via the ``HeatSimulation`` interface. Such simulations can be"
+        description="DEPRECATED: Use :class:`MultiPhysicsMedium`. Specification of the medium heat properties. They are "
+        "used for solving the heat equation via the :class:`HeatSimulation` interface. Such simulations can be"
         "used for investigating the influence of heat propagation on the properties of optical systems. "
-        "Once the temperature distribution in the system is found using ``HeatSimulation`` object, "
+        "Once the temperature distribution in the system is found using :class:`HeatSimulation` object, "
         "``Simulation.perturbed_mediums_copy()`` can be used to convert mediums with perturbation "
         "models defined into spatially dependent custom mediums. "
         "Otherwise, the ``heat_spec`` does not directly affect the running of an optical "

--- a/tidy3d/components/parameter_perturbation.py
+++ b/tidy3d/components/parameter_perturbation.py
@@ -605,8 +605,8 @@ class LinearChargePerturbation(ChargePerturbation):
 
         .. math::
 
-            \\Delta X (T) = \\text{electron\\_coeff} \\times (N_e - \\text{electron\\_ref})
-            + \\text{hole\\_coeff} \\times (N_h - \\text{hole\\_ref}),
+            \\Delta X (T) = \\text{electron_coeff} \\times (N_e - \\text{electron_ref})
+            + \\text{hole_coeff} \\times (N_h - \\text{hole_ref}),
 
         where ``electron_coeff`` and ``hole_coeff`` are the parameter's sensitivities to electron and
         hole densities, while ``electron_ref`` and ``hole_ref`` are reference electron and hole density

--- a/tidy3d/components/tcad/bandgap.py
+++ b/tidy3d/components/tcad/bandgap.py
@@ -60,6 +60,6 @@ class SlotboomBandGapNarrowing(Tidy3dBaseModel):
         ...,
         title="Minimum total doping",
         description="Bandgap narrowing is applied at location where total doping "
-        "is higher than 'min_N'.",
+        "is higher than ``min_N``.",
         units=PERCMCUBE,
     )

--- a/tidy3d/components/tcad/boundary/heat.py
+++ b/tidy3d/components/tcad/boundary/heat.py
@@ -30,7 +30,7 @@ class TemperatureBC(HeatChargeBC):
 
     temperature: pd.PositiveFloat = pd.Field(
         title="Temperature",
-        description=f"Temperature value in units of {KELVIN}.",
+        description="Temperature value.",
         units=KELVIN,
     )
 
@@ -55,19 +55,26 @@ class VerticalNaturalConvectionCoeffModel(Tidy3dBaseModel):
     """
     Specification for natural convection from a vertical plate.
 
+    Notes
+    -----
+
     This class calculates the heat transfer coefficient (h) based on fluid
     properties and an expected temperature difference, then provides these
-    values as 'base' and 'exponent' for a generalized heat flux equation
-    q = base * (T_surf - T_fluid)^exponent + base * (T_surf - T_fluid).
+    values as  :math:`\\text{base_l}`,  :math:`\\text{base_nl}`, and  :math:`\\text{exponent}`  for a generalized heat flux equation
+
+    .. math::
+
+        q = \\text{base_nl} * (T_\\text{surf} - T_\\text{fluid})^\\text{exponent} + \\text{base}_{l} * (T_\\text{surf}- T_\\text{fluid}).
+
     """
 
     medium: FluidMedium = pd.Field(
         default=None,
         title="Interface medium",
         description=(
-            "The `FluidMedium` used for the heat transfer coefficient calculation. "
+            "The :class:`FluidMedium` used for the heat transfer coefficient calculation. "
             "If `None`, the fluid is automatically deduced from the interface, which can be defined"
-            "by either a `MediumMediumInterface` or a `StructureStructureInterface`."
+            "by either a :class:`MediumMediumInterface` or a :class:`StructureStructureInterface`."
         ),
     )
 

--- a/tidy3d/components/tcad/boundary/heat.py
+++ b/tidy3d/components/tcad/boundary/heat.py
@@ -46,7 +46,7 @@ class HeatFluxBC(HeatChargeBC):
 
     flux: float = pd.Field(
         title="Heat Flux",
-        description=f"Heat flux value in units of {HEAT_FLUX}.",
+        description="Heat flux value.",
         units=HEAT_FLUX,
     )
 
@@ -158,12 +158,12 @@ class ConvectionBC(HeatChargeBC):
 
     ambient_temperature: pd.PositiveFloat = pd.Field(
         title="Ambient Temperature",
-        description=f"Ambient temperature value in units of {KELVIN}.",
+        description="Ambient temperature.",
         units=KELVIN,
     )
 
     transfer_coeff: Union[pd.NonNegativeFloat, VerticalNaturalConvectionCoeffModel] = pd.Field(
         title="Heat Transfer Coefficient",
-        description=f"Heat flux value in units of {HEAT_TRANSFER_COEFF}.",
+        description="Heat transfer coefficient value.",
         units=HEAT_TRANSFER_COEFF,
     )

--- a/tidy3d/components/tcad/data/monitor_data/charge.py
+++ b/tidy3d/components/tcad/data/monitor_data/charge.py
@@ -295,13 +295,13 @@ class SteadyCapacitanceData(HeatChargeMonitorData):
 
     Notes
     -----
-        The small signal-capacitance of electrons  :math:`C_n`  and holes  :math:`C_p`  is computed from the charge due to
-         electrons :math:`Q_n` and holes :math:`Q_p` at an applied voltage :math:`V` at a voltage difference
-        :math:`\\Delta V` between two simulations.
 
-        .. math::
+    The small signal-capacitance of electrons  :math:`C_n`  and holes  :math:`C_p`  is computed from the charge due to electrons :math:`Q_n` and holes :math:`Q_p` at an applied voltage :math:`V` at a voltage difference
+    :math:`\\Delta V` between two simulations.
 
-            C_{n,p} = \\frac{Q_{n,p}(V + \\Delta V) - Q_{n,p}(V)}{\\Delta V}
+    .. math::
+
+        C_{n,p} = \\frac{Q_{n,p}(V + \\Delta V) - Q_{n,p}(V)}{\\Delta V}
 
 
     This is only computed when a voltage source with more than two sources is included within the simulation and determines the :math:`\\Delta V`.

--- a/tidy3d/components/tcad/data/monitor_data/charge.py
+++ b/tidy3d/components/tcad/data/monitor_data/charge.py
@@ -361,7 +361,7 @@ class SteadyElectricFieldData(HeatChargeMonitorData):
     E: UnstructuredFieldType = pd.Field(
         None,
         title="Electric field",
-        description=r"Contains the computed electric field in :math:`V/\\mu m`.",
+        description="Contains the computed electric field in :math:`V/\\mu m`.",
         discriminator=TYPE_TAG_STR,
     )
 
@@ -403,7 +403,7 @@ class SteadyCurrentDensityData(HeatChargeMonitorData):
     J: UnstructuredFieldType = pd.Field(
         None,
         title="Current density",
-        description=r"Contains the computed current density in :math:`A/\\mu m^2`.",
+        description="Contains the computed current density in :math:`A/\\mu m^2`.",
         discriminator=TYPE_TAG_STR,
     )
 

--- a/tidy3d/components/tcad/data/monitor_data/charge.py
+++ b/tidy3d/components/tcad/data/monitor_data/charge.py
@@ -164,7 +164,7 @@ class SteadyEnergyBandData(HeatChargeMonitorData):
     Ev: UnstructuredFieldType = pd.Field(
         None,
         title="Valence band series",
-        description="Contains the computed energy of the top of the valence band :math:`E_c`.",
+        description="Contains the computed energy of the top of the valence band :math:`E_v`.",
         discriminator=TYPE_TAG_STR,
     )
 

--- a/tidy3d/components/tcad/data/monitor_data/charge.py
+++ b/tidy3d/components/tcad/data/monitor_data/charge.py
@@ -120,13 +120,32 @@ class SteadyEnergyBandData(HeatChargeMonitorData):
     Notes
     -----
 
-        This data contains the energy bands data:
-        Ec -> Energy of the bottom of the conduction band, [eV]
-        Ev -> Energy of the top of the valence band, [eV]
-        Ei -> Intrinsic Fermi level, [eV]
-        Efn -> Quasi-Fermi level for electrons, [eV]
-        Efp -> Quasi-Fermi level for holes, [eV]
-        as defined in the  ``monitor``.
+    This data contains the energy bands data [eV]:
+
+     .. list-table::
+       :widths: 25 25 75
+       :header-rows: 1
+
+       * - Symbol
+         - Parameter Name
+         - Description
+       * - :math:`E_c`
+         - ``Ec``
+         - Energy of the bottom of the conduction band
+       * - :math:`E_v`
+         - ``Ev``
+         - Energy of the top of the valence band
+       * - :math:`E_i`
+         - ``Ei``
+         - Intrinsic Fermi level
+       * - :math:`E_{fn}`
+         - ``Efn``
+         - Quasi-Fermi level for electrons
+       * - :math:`E_{fp}`
+         - ``Efp``
+         - Quasi-Fermi level for holes
+
+    as defined in the  ``monitor``.
     """
 
     monitor: SteadyEnergyBandMonitor = pd.Field(
@@ -138,35 +157,35 @@ class SteadyEnergyBandData(HeatChargeMonitorData):
     Ec: UnstructuredFieldType = pd.Field(
         None,
         title="Conduction band series",
-        description=r"Contains the computed energy of the bottom of the conduction band $Ec$.",
+        description="Contains the computed energy of the bottom of the conduction band :math:`E_c`.",
         discriminator=TYPE_TAG_STR,
     )
 
     Ev: UnstructuredFieldType = pd.Field(
         None,
         title="Valence band series",
-        description=r"Contains the computed energy of the top of the valence band $Ec$.",
+        description="Contains the computed energy of the top of the valence band :math:`E_c`.",
         discriminator=TYPE_TAG_STR,
     )
 
     Ei: UnstructuredFieldType = pd.Field(
         None,
         title="Intrinsic Fermi level series",
-        description=r"Contains the computed intrinsic Fermi level for the material $Ei$.",
+        description="Contains the computed intrinsic Fermi level for the material :math:`E_i`.",
         discriminator=TYPE_TAG_STR,
     )
 
     Efn: UnstructuredFieldType = pd.Field(
         None,
         title="Electron's quasi-Fermi level series",
-        description=r"Contains the computed quasi-Fermi level for electrons $Efn$.",
+        description="Contains the computed quasi-Fermi level for electrons :math:`E_{fn}`.",
         discriminator=TYPE_TAG_STR,
     )
 
     Efp: UnstructuredFieldType = pd.Field(
         None,
         title="Hole's quasi-Fermi level series",
-        description=r"Contains the computed quasi-Fermi level for holes $Efp$.",
+        description="Contains the computed quasi-Fermi level for holes :math:`E_{fp}`.",
         discriminator=TYPE_TAG_STR,
     )
 
@@ -276,7 +295,7 @@ class SteadyCapacitanceData(HeatChargeMonitorData):
 
     Notes
     -----
-        The small signal-capacitance of electrons :math:`C_n` and holes  :math:`C_p`  is computed from the charge due to
+        The small signal-capacitance of electrons  :math:`C_n`  and holes  :math:`C_p`  is computed from the charge due to
          electrons :math:`Q_n` and holes :math:`Q_p` at an applied voltage :math:`V` at a voltage difference
         :math:`\\Delta V` between two simulations.
 
@@ -297,14 +316,14 @@ class SteadyCapacitanceData(HeatChargeMonitorData):
     hole_capacitance: SteadyVoltageDataArray = pd.Field(
         None,
         title="Hole capacitance",
-        description=r"Small signal capacitance ($\frac{dQ_p}{dV}$) associated to the monitor.",
+        description="Small signal capacitance :math:`(\\frac{dQ_p}{dV})` associated to the monitor.",
     )
     # C_p = hole_capacitance
 
     electron_capacitance: SteadyVoltageDataArray = pd.Field(
         None,
         title="Electron capacitance",
-        description=r"Small signal capacitance ($\frac{dQn}{dV}$) associated to the monitor.",
+        description="Small signal capacitance :math:`(\\frac{dQn}{dV})` associated to the monitor.",
     )
     # C_n = electron_capacitance
 

--- a/tidy3d/components/tcad/data/monitor_data/charge.py
+++ b/tidy3d/components/tcad/data/monitor_data/charge.py
@@ -77,7 +77,7 @@ class SteadyFreeCarrierData(HeatChargeMonitorData):
     electrons: UnstructuredFieldType = pd.Field(
         None,
         title="Electrons series",
-        description=r"Contains the computed electrons concentration $n$.",
+        description=r"Contains the computed electrons concentration :math:`n`.",
         discriminator=TYPE_TAG_STR,
     )
     # n = electrons
@@ -85,7 +85,7 @@ class SteadyFreeCarrierData(HeatChargeMonitorData):
     holes: UnstructuredFieldType = pd.Field(
         None,
         title="Holes series",
-        description=r"Contains the computed holes concentration $p$.",
+        description=r"Contains the computed holes concentration :math:`p`.",
         discriminator=TYPE_TAG_STR,
     )
     # p = holes

--- a/tidy3d/components/tcad/data/sim_data.py
+++ b/tidy3d/components/tcad/data/sim_data.py
@@ -255,8 +255,7 @@ class HeatChargeSimulationData(AbstractHeatChargeSimulationData):
     device_characteristics: Optional[DeviceCharacteristics] = pd.Field(
         None,
         title="Device characteristics",
-        description="Data characterizing the device :class:`DeviceCharacteristics`. Current characteristics include: "
-        "'steady_dc_hole_capacitance', 'steady_dc_electron_capacitance', and 'steady_dc_current_voltage'.",
+        description="Data characterizing the device :class:`DeviceCharacteristics`.",
     )
 
     @equal_aspect
@@ -464,7 +463,7 @@ class HeatSimulationData(HeatChargeSimulationData):
 
     Warning
     -------
-        :class`HeatSimulationData` is DEPRECATED.
+        :class:`HeatSimulationData` is DEPRECATED.
         Consider using :class:`HeatChargeSimulationData` instead.
     """
 

--- a/tidy3d/components/tcad/data/sim_data.py
+++ b/tidy3d/components/tcad/data/sim_data.py
@@ -255,8 +255,8 @@ class HeatChargeSimulationData(AbstractHeatChargeSimulationData):
     device_characteristics: Optional[DeviceCharacteristics] = pd.Field(
         None,
         title="Device characteristics",
-        description="Data characterizing the device :class:`.DeviceCharacteristics`. Current characteristics include: "
-        "'steady_dc_hole_capacitance', 'steady_dc_electron_capacitance', and 'steady_dc_current_voltage'",
+        description="Data characterizing the device :class:`DeviceCharacteristics`. Current characteristics include: "
+        "'steady_dc_hole_capacitance', 'steady_dc_electron_capacitance', and 'steady_dc_current_voltage'.",
     )
 
     @equal_aspect

--- a/tidy3d/components/tcad/data/sim_data.py
+++ b/tidy3d/components/tcad/data/sim_data.py
@@ -80,7 +80,7 @@ class DeviceCharacteristics(Tidy3dBaseModel):
         None,
         title="Small signal resistance",
         description="Steady DC computation of the small signal resistance. This is computed "
-        "as the derivative of the current-voltage relation, delta(V)/delta(I) and the result "
+        "as the derivative of the current-voltage relation :math:`\\frac{\\Delta V}{\\Delta I}`, and the result "
         "is given in Ohms. Note that in 2D the resistance is given in :math:`\\Omega \\mu`.",
     )
 

--- a/tidy3d/components/tcad/data/sim_data.py
+++ b/tidy3d/components/tcad/data/sim_data.py
@@ -255,7 +255,7 @@ class HeatChargeSimulationData(AbstractHeatChargeSimulationData):
     device_characteristics: Optional[DeviceCharacteristics] = pd.Field(
         None,
         title="Device characteristics",
-        description="Data characterizing the device. Current characteristics include: "
+        description="Data characterizing the device :class:`.DeviceCharacteristics`. Current characteristics include: "
         "'steady_dc_hole_capacitance', 'steady_dc_electron_capacitance', and 'steady_dc_current_voltage'",
     )
 

--- a/tidy3d/components/tcad/doping.py
+++ b/tidy3d/components/tcad/doping.py
@@ -98,7 +98,7 @@ class AbstractDopingBox(Box):
 
 class ConstantDoping(AbstractDopingBox):
     """
-    Sets constant doping :math:`N` in the specified box with a :parameter`size` and :parameter:`concentration`.
+    Sets constant doping :math:`N` in the specified box with a :py:attr:`~.Box.size` and :py:attr:`concentration`.
 
     For translationally invariant behavior in one dimension, the box must have infinite size in the
     homogenous (invariant) direction.
@@ -148,13 +148,13 @@ class GaussianDoping(AbstractDopingBox):
     -----
     The Gaussian doping concentration :math:`N` is defined in the following manner:
 
-    - :math:`N=N_{\\text{max}}` at locations more than :math:``width`` um away from the sides of the box.
+    - :math:`N=N_{\\text{max}}` at locations more than :math:`\\text{width}` um away from the sides of the box.
     - :math:`N=N_{\\text{ref}}` at location on the box sides.
-    - a Gaussian variation between :math:`N_{\\text{max}}` and  :math:`N_{\\text{ref}}`  at locations less than ``width``
+    - a Gaussian variation between :math:`N_{\\text{max}}` and  :math:`N_{\\text{ref}}`  at locations less than :math:`\\text{width}`
     um away from the sides.
 
     By definition, all sides of the box will have concentration :math:`N_{\\text{ref}}` (except the side specified
-    as source) and the center of the box (``width`` away from the box sides) will have a concentration
+    as source) and the center of the box (:math:`\\text{width}` away from the box sides) will have a concentration
     :math:`N_{\\text{max}}`.
 
     .. math::

--- a/tidy3d/components/tcad/doping.py
+++ b/tidy3d/components/tcad/doping.py
@@ -200,7 +200,7 @@ class GaussianDoping(AbstractDopingBox):
         title="Width of the gaussian.",
         description="Width of the gaussian. The concentration will transition from "
         "``concentration`` at the center of the box to ``ref_con`` at the edge/face "
-        "of the box in a distance equal to 'width'. ",
+        "of the box in a distance equal to ``width``. ",
     )
 
     source: str = pd.Field(

--- a/tidy3d/components/tcad/doping.py
+++ b/tidy3d/components/tcad/doping.py
@@ -98,9 +98,7 @@ class AbstractDopingBox(Box):
 
 class ConstantDoping(AbstractDopingBox):
     """
-    Sets constant doping :math:`N` in the specified box with a :py:attr:`~.Box.size` and :py:attr:`concentration`.
-
-    For translationally invariant behavior in one dimension, the box must have infinite size in the
+    Sets constant doping :math:`N` in the specified box with a :py:attr:`~.Box.size` and :py:attr:`concentration`. For translationally invariant behavior in one dimension, the box must have infinite size in the
     homogenous (invariant) direction.
 
     Example
@@ -139,9 +137,7 @@ class ConstantDoping(AbstractDopingBox):
 
 
 class GaussianDoping(AbstractDopingBox):
-    """Sets a gaussian doping in the specified box.
-
-    For translationally invariant behavior in one dimension, the box must have infinite size in the
+    """Sets a gaussian doping in the specified box. For translationally invariant behavior in one dimension, the box must have infinite size in the
     homogenous (invariant) direction.
 
     Notes
@@ -203,7 +199,7 @@ class GaussianDoping(AbstractDopingBox):
     width: pd.PositiveFloat = pd.Field(
         title="Width of the gaussian.",
         description="Width of the gaussian. The concentration will transition from "
-        "'concentration' at the center of the box to 'ref_con' at the edge/face "
+        "``concentration`` at the center of the box to ``ref_con`` at the edge/face "
         "of the box in a distance equal to 'width'. ",
     )
 

--- a/tidy3d/components/tcad/simulation/heat_charge.py
+++ b/tidy3d/components/tcad/simulation/heat_charge.py
@@ -166,7 +166,7 @@ class HeatChargeSimulation(AbstractSimulation):
                with defined heat properties.
            * - ``Conduction``
              - The electrical conduction equation is solved with
-               specified boundary conditions such as ``SteadyVoltageBC``, ``SteadyCurrentBC``, ...
+               specified boundary conditions such as :class:`VoltageBC`, :class:`CurrentBC`, ...
            * - ``Charge``
              - Drift-diffusion equations are solved for structures containing
                a defined :class:`SemiconductorMedium`. Insulators with a

--- a/tidy3d/components/tcad/source/coupled.py
+++ b/tidy3d/components/tcad/source/coupled.py
@@ -11,7 +11,7 @@ class HeatFromElectricSource(GlobalHeatChargeSource):
     Notes
     -----
 
-        If a :class`HeatFromElectricSource` is specified as a source, appropriate boundary
+        If a :class:`HeatFromElectricSource` is specified as a source, appropriate boundary
         conditions for an electric simulation must be provided, since such a simulation
         will be executed before the heat simulation can run.
 

--- a/tidy3d/components/tcad/source/heat.py
+++ b/tidy3d/components/tcad/source/heat.py
@@ -23,7 +23,7 @@ class HeatSource(StructureBasedHeatChargeSource):
 
     rate: Union[float, SpatialDataArray] = pd.Field(
         title="Volumetric Heat Rate",
-        description="Volumetric rate of heating or cooling (if negative)",
+        description="Volumetric rate of heating or cooling (if negative).",
         units=VOLUMETRIC_HEAT_RATE,
     )
 

--- a/tidy3d/components/tcad/source/heat.py
+++ b/tidy3d/components/tcad/source/heat.py
@@ -23,8 +23,7 @@ class HeatSource(StructureBasedHeatChargeSource):
 
     rate: Union[float, SpatialDataArray] = pd.Field(
         title="Volumetric Heat Rate",
-        description="Volumetric rate of heating or cooling (if negative) in units of "
-        f"{VOLUMETRIC_HEAT_RATE}.",
+        description="Volumetric rate of heating or cooling (if negative)",
         units=VOLUMETRIC_HEAT_RATE,
     )
 


### PR DESCRIPTION
A couple of Charge doc fixes. I am going to add more soon.

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-15 15:43:52 UTC

This review covers only the changes made since the last review, not the entire PR. This pull request implements comprehensive documentation improvements across the Tidy3D charge simulation framework, focusing on fixing Sphinx documentation formatting issues and ensuring proper rendering of mathematical expressions and cross-references.

The changes standardize mathematical notation by converting LaTeX dollar sign syntax (`$n$`, `$p$`) to proper reStructuredText `:math:` directive syntax (`:math:`n``, `:math:`p``) throughout charge monitor data docstrings. Additionally, numerous Sphinx cross-reference issues are corrected, replacing malformed references with proper `:class:` directive syntax to enable clickable links in the generated HTML documentation.

The PR enhances API documentation completeness by adding missing classes to various documentation sections, including `DeviceCharacteristics` in the charge output data API reference, `VerticalNaturalConvectionCoeffModel` in heat boundary conditions, and several indexed data array classes in mesh output data. Field descriptions are also simplified by removing redundant unit information that's already captured in dedicated 'units' parameters.

These modifications integrate seamlessly with the existing Tidy3D codebase by following established documentation patterns and Sphinx formatting conventions. The changes ensure consistent rendering across all charge simulation components while maintaining backward compatibility since no functional code is modified.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|-----------|
| tidy3d/components/parameter_perturbation.py | 5/5 | Fixed LaTeX math formatting by removing escaped backslashes in parameter names |
| tidy3d/components/tcad/source/coupled.py | 5/5 | Fixed malformed Sphinx class reference by adding missing backtick |
| tidy3d/components/tcad/boundary/heat.py | 5/5 | Enhanced thermal boundary condition documentation with proper math notation and cross-references |
| tidy3d/components/tcad/bandgap.py | 5/5 | Changed single quotes to double backticks for proper code formatting in docstring |
| tidy3d/components/material/tcad/charge.py | 5/5 | Fixed Sphinx cross-references and enhanced doping parameter descriptions |
| tidy3d/components/base_sim/simulation.py | 5/5 | Converted plain text class names to proper Sphinx cross-references |
| tidy3d/components/tcad/data/monitor_data/charge.py | 5/5 | Converted LaTeX dollar syntax to reStructuredText math directive throughout |
| docs/api/mediums.rst | 5/5 | Updated MultiPhysicsMedium reference to use public API import path |
| tidy3d/components/tcad/simulation/heat_charge.py | 5/5 | Fixed Sphinx cross-references and corrected class names in docstring |
| tidy3d/components/medium.py | 5/5 | Converted markdown-style backticks to proper Sphinx class directives |
| tidy3d/components/tcad/doping.py | 5/5 | Condensed docstrings and standardized quote usage for code identifiers |
| tidy3d/components/material/tcad/heat.py | 4/5 | Restructured FluidMedium docstring with better organization and formatting |
| tidy3d/components/tcad/data/sim_data.py | 5/5 | Fixed mathematical notation and Sphinx class references in simulation data |
| docs/api/heat/boundary_conditions.rst | 5/5 | Added VerticalNaturalConvectionCoeffModel to coefficient models documentation |
| docs/api/charge/output_data.rst | 3/5 | Added DeviceCharacteristics documentation but has duplicate section header issue |
| docs/api/output_data.rst | 5/5 | Added SteadyVoltageDataArray to dataset types documentation |
| tidy3d/components/tcad/source/heat.py | 5/5 | Simplified description by removing redundant unit information |
| docs/api/mesh/output_data.rst | 3/5 | Added indexed data array classes but unclear if placement is appropriate |

</details>

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as all changes are documentation-only improvements that don't affect any functional code
- Score reflects high confidence in the formatting fixes with minor structural documentation issues that need attention
- Pay close attention to docs/api/charge/output_data.rst which has a duplicate section header that should be renamed to avoid rendering conflicts

### Context used:
**Rule -** Adhere to the established docstring format and use correct syntax (e.g., double backticks for code) to ensure proper rendering. ([link](https://app.greptile.com/review/custom-context?memory=2f1f3aa0-b672-45d8-9bd5-136bcc28ce16))

<!-- /greptile_comment -->