### PR TITLE
Move mesh size validator to `post_init_validator`

### DIFF
--- a/tidy3d/components/tcad/simulation/heat_charge.py
+++ b/tidy3d/components/tcad/simulation/heat_charge.py
@@ -320,6 +320,12 @@ class HeatChargeSimulation(AbstractSimulation):
         "specify Charge simulations or transient Heat simulations.",
     )
 
+    def _post_init_validators(self):
+        """Call validators taking ``self`` that get run after init."""
+
+        # Charge mesh size validator
+        self._estimate_charge_mesh_size()
+
     @pd.validator("structures", always=True)
     def check_unsupported_geometries(cls, val):
         """Error if structures contain unsupported yet geometries."""
@@ -930,23 +936,25 @@ class HeatChargeSimulation(AbstractSimulation):
 
         return values
 
-    @pd.root_validator(skip_on_failure=True)
-    def estimate_charge_mesh_size(cls, values):
+    def _estimate_charge_mesh_size(self):
         """Make an estimate of the mesh size and raise a warning if too big.
         NOTE: this is a very rough estimate. The back-end will actually stop
         execution based on actual node-count."""
 
-        if TCADAnalysisTypes.CHARGE not in cls._check_simulation_types(values=values):
-            return values
+        if TCADAnalysisTypes.CHARGE not in self._get_simulation_types():
+            return
 
         # let's raise a warning if the estimate is larger than 2M nodes
         max_nodes = 2e6
         nodes_estimate = 0
 
-        structures = values["structures"]
-        grid_spec = values["grid_spec"]
+        structures = self.structures
+        grid_spec = self.grid_spec
 
         non_refined_structures = grid_spec.non_refined_structures
+
+        sim_center = self.center
+        sim_size = self.size
 
         if isinstance(grid_spec, UniformUnstructuredGrid):
             dl_min = grid_spec.dl
@@ -957,7 +965,11 @@ class HeatChargeSimulation(AbstractSimulation):
 
         for struct in structures:
             name = struct.name
-            bounds = struct.geometry.bounds
+            bounds = np.array(struct.geometry.bounds)
+            for dim in range(3):
+                bounds[0, dim] = max(bounds[0, dim], sim_center[dim] - sim_size[dim] / 2)
+                bounds[1, dim] = min(bounds[1, dim], sim_center[dim] + sim_size[dim] / 2)
+
             dl = dl_min
             if name in non_refined_structures:
                 dl = dl_max
@@ -980,7 +992,6 @@ class HeatChargeSimulation(AbstractSimulation):
                 "the pipeline will be stopped. If this happens the grid specification "
                 "may need to be modified."
             )
-        return values
 
     @pd.root_validator(skip_on_failure=True)
     def check_transient_heat(cls, values):


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-16 08:26:03 UTC

This PR moves the charge mesh size estimation validator from a `@pd.root_validator` to a `_post_init_validators` method in the `HeatChargeSimulation` class. The primary change refactors the `estimate_charge_mesh_size` method from a class method that accepts a `values` dictionary to an instance method that uses `self` attributes directly.

The key improvement is the addition of bounds clipping logic that constrains structure bounds to the simulation domain before calculating mesh estimates. This provides more accurate mesh size estimation by only considering the portions of structures that actually lie within the simulation domain boundaries. The validator continues to warn users when the estimated mesh size exceeds 2 million nodes, helping prevent simulations that may fail due to memory constraints.

This change fits into the broader TCAD (Technology Computer-Aided Design) simulation framework within tidy3d, specifically for heat and charge simulations. The timing change from root validator (runs during pydantic validation) to post-init validator (runs after object initialization) allows access to fully computed simulation properties like bounds, enabling more precise mesh estimation calculations.

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/tcad/simulation/heat_charge.py | 4/5 | Refactored charge mesh size validator from root validator to post-init validator with improved bounds clipping logic |

</details>

## Confidence score: 4/5

- This PR is safe to merge with minimal risk of breaking existing functionality
- Score reflects a well-structured refactoring that improves validator accuracy without changing core behavior
- Pay attention to the bounds clipping logic to ensure it correctly handles edge cases with infinite bounds

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant HeatChargeSimulation
    participant Validator
    participant Logger

    User->>HeatChargeSimulation: "Initialize simulation with parameters"
    HeatChargeSimulation->>HeatChargeSimulation: "_post_init_validators()"
    HeatChargeSimulation->>HeatChargeSimulation: "estimate_charge_mesh_size()"
    HeatChargeSimulation->>HeatChargeSimulation: "_get_simulation_types()"
    
    alt Charge simulation detected
        HeatChargeSimulation->>HeatChargeSimulation: "Calculate nodes estimate"
        HeatChargeSimulation->>HeatChargeSimulation: "Loop through structures"
        HeatChargeSimulation->>HeatChargeSimulation: "Calculate mesh size based on grid_spec"
        
        alt Mesh size exceeds limit
            HeatChargeSimulation->>Logger: "log.warning() - mesh too large"
            Logger-->>User: "Warning about mesh size"
        end
    end
    
    HeatChargeSimulation-->>User: "Return initialized simulation"
```

<!-- /greptile_comment -->