### PR TITLE
Make task names optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - New `MediumMonitor` that returns both permittivity and permeability profiles.
+- Task names are now optional when using `run(sim)` or `Job`. When running multiple jobs (via `run_async` or `Batch`), you can also provide simulations as a list without specifying task names. The previous dictionary-based format with explicit task names is still supported.
+
 ### Changed
 
 ### Fixed

--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -860,7 +860,8 @@ def test_autograd_objective(use_emulated_run, structure_key, monitor_key):
 
 
 @pytest.mark.parametrize("structure_key, monitor_key", args)
-def test_autograd_async(use_emulated_run, structure_key, monitor_key):
+@pytest.mark.parametrize("use_task_names", [True, False])
+def test_autograd_async(use_emulated_run, structure_key, monitor_key, use_task_names):
     """Test an objective function through tidy3d autograd."""
 
     fn_dict = get_functions(structure_key, monitor_key)
@@ -870,7 +871,10 @@ def test_autograd_async(use_emulated_run, structure_key, monitor_key):
     task_names = {"test_a", "adjoint", "_test"}
 
     def objective(*args):
-        sims = {task_name: make_sim(*args) for task_name in task_names}
+        if use_task_names:
+            sims = {task_name: make_sim(*args) for task_name in task_names}
+        else:
+            sims = [make_sim(*args)] * len(task_names)
         batch_data = run_async(sims, verbose=False)
         value = 0.0
         for _, sim_data in batch_data.items():

--- a/tests/test_web/test_tidy3d_stub.py
+++ b/tests/test_web/test_tidy3d_stub.py
@@ -15,6 +15,7 @@ from tidy3d.components.source.current import PointDipole
 from tidy3d.components.source.time import GaussianPulse
 from tidy3d.web.api.tidy3d_stub import Tidy3dStub, Tidy3dStubData
 from tidy3d.web.core.environment import Env, EnvironmentConfig
+from tidy3d.web.core.types import TaskType
 
 test_env = EnvironmentConfig(
     name="test",
@@ -119,3 +120,10 @@ def test_stub_data_postprocess_logs(tmp_path):
     file_path = os.path.join(tmp_path, "test_warnings.hdf5")
     sim_data.to_file(file_path)
     Tidy3dStubData.postprocess(file_path)
+
+
+def test_default_task_name():
+    sim = make_sim()
+    stub = Tidy3dStub(simulation=sim)
+    default_task_name = stub.get_default_task_name()
+    assert default_task_name.startswith(TaskType.FDTD.name.lower())

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -20,6 +20,7 @@ from tidy3d.components.monitor import FieldMonitor
 from tidy3d.components.source.current import PointDipole
 from tidy3d.components.source.time import GaussianPulse
 from tidy3d.exceptions import SetupError
+from tidy3d.web import common
 from tidy3d.web.api.asynchronous import run_async
 from tidy3d.web.api.container import Batch, Job
 from tidy3d.web.api.webapi import (
@@ -53,6 +54,7 @@ PROJECT_NAME = "default"
 FLEX_UNIT = 1.0
 EST_FLEX_UNIT = 11.11
 FILE_SIZE_GB = 4.0
+common.CONNECTION_RETRY_TIME = 0.1
 
 task_core_path = "tidy3d.web.core.task_core"
 api_path = "tidy3d.web.api.webapi"
@@ -132,12 +134,12 @@ def mock_upload(monkeypatch, set_api_key):
             matchers.json_params_matcher(
                 {
                     "taskType": TaskType.FDTD.name,
-                    "taskName": TASK_NAME,
                     "callbackUrl": None,
                     "simulationType": "tidy3d",
                     "parentTasks": None,
                     "fileType": "Gz",
-                }
+                },
+                strict_match=False,
             )
         ],
         json={
@@ -520,12 +522,13 @@ def test_get_tasks(set_api_key):
 
 
 @responses.activate
-def test_run(mock_webapi, monkeypatch, tmp_path):
+@pytest.mark.parametrize("task_name", [TASK_NAME, None])
+def test_run(mock_webapi, monkeypatch, tmp_path, task_name):
     sim = make_sim()
     monkeypatch.setattr(f"{api_path}.load", lambda *args, **kwargs: True)
     assert run(
         sim,
-        task_name=TASK_NAME,
+        task_name=task_name,
         folder_name=PROJECT_NAME,
         path=str(tmp_path / "web_test_tmp.json"),
     )
@@ -584,10 +587,11 @@ def test_abort_task(set_api_key):
 
 
 @responses.activate
-def test_job(mock_webapi, monkeypatch, tmp_path):
+@pytest.mark.parametrize("task_name", [TASK_NAME, None])
+def test_job(mock_webapi, monkeypatch, tmp_path, task_name):
     monkeypatch.setattr("tidy3d.web.api.container.Job.load", lambda *args, **kwargs: True)
     sim = make_sim()
-    j = Job(simulation=sim, task_name=TASK_NAME, folder_name=PROJECT_NAME)
+    j = Job(simulation=sim, task_name=task_name, folder_name=PROJECT_NAME)
 
     fname = str(tmp_path / "web_test_tmp.json")
 
@@ -610,11 +614,15 @@ def mock_job_status(monkeypatch):
 
 
 @responses.activate
-def test_batch(mock_webapi, mock_job_status, mock_load, tmp_path):
+@pytest.mark.parametrize("task_name", [TASK_NAME, None])
+def test_batch(mock_webapi, mock_job_status, mock_load, tmp_path, task_name):
     # monkeypatch.setattr("tidy3d.web.api.container.Batch.monitor", lambda self: time.sleep(0.1))
     # monkeypatch.setattr("tidy3d.web.api.container.Job.status", property(lambda self: "success"))
+    if task_name is None:
+        sims = [make_sim()]
+    else:
+        sims = {TASK_NAME: make_sim()}
 
-    sims = {TASK_NAME: make_sim()}
     b = Batch(simulations=sims, folder_name=PROJECT_NAME)
 
     fname = str(tmp_path / "batch.json")
@@ -696,9 +704,10 @@ def test_batch_run_saves_file_after_upload(mock_webapi, mock_job_status, tmp_pat
 
 
 @responses.activate
-def test_async(mock_webapi, mock_job_status):
+@pytest.mark.parametrize("task_name", [TASK_NAME, None])
+def test_async(mock_webapi, mock_job_status, task_name):
     # monkeypatch.setattr("tidy3d.web.api.container.Job.status", property(lambda self: "success"))
-    sims = {TASK_NAME: make_sim()}
+    sims = {TASK_NAME: make_sim()} if task_name else [make_sim()]
     _ = run_async(sims, folder_name=PROJECT_NAME)
 
 

--- a/tidy3d/web/api/asynchronous.py
+++ b/tidy3d/web/api/asynchronous.py
@@ -12,7 +12,7 @@ from .container import DEFAULT_DATA_DIR, Batch, BatchData
 
 
 def run_async(
-    simulations: dict[str, WorkflowType],
+    simulations: Union[dict[str, WorkflowType], tuple[WorkflowType], list[WorkflowType]],
     folder_name: str = "default",
     path_dir: str = DEFAULT_DATA_DIR,
     callback_url: Optional[str] = None,
@@ -32,8 +32,8 @@ def run_async(
 
     Parameters
     ----------
-    simulations : Dict[str, Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`]]
-        Mapping of task name to simulation.
+    simulations : Union[Dict[str, Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`]], tuple[Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`]], list[Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`]]]
+        Mapping of task name to simulation or list of simulations.
     folder_name : str = "default"
         Name of folder to store each task on web UI.
     path_dir : str

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -28,6 +28,7 @@ from tidy3d.exceptions import AdjointError
 from tidy3d.web.api.asynchronous import DEFAULT_DATA_DIR
 from tidy3d.web.api.asynchronous import run_async as run_async_webapi
 from tidy3d.web.api.container import DEFAULT_DATA_PATH, Batch, BatchData, Job
+from tidy3d.web.api.tidy3d_stub import Tidy3dStub
 from tidy3d.web.api.webapi import run as run_webapi
 from tidy3d.web.core.s3utils import download_file, upload_file
 from tidy3d.web.core.types import PayType
@@ -96,7 +97,7 @@ def is_valid_for_autograd_async(simulations: dict[str, td.Simulation]) -> bool:
 
 def run(
     simulation: WorkflowType,
-    task_name: str,
+    task_name: typing.Optional[str] = None,
     folder_name: str = "default",
     path: str = "simulation_data.hdf5",
     callback_url: typing.Optional[str] = None,
@@ -121,8 +122,8 @@ def run(
     ----------
     simulation : Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`, :class:`.ModalComponentModeler`, :class:`.TerminalComponentModeler`]
         Simulation to upload to server.
-    task_name : str
-        Name of task.
+    task_name : Optional[str] = None
+        Name of task. If not provided, a default name will be generated.
     folder_name : str = "default"
         Name of folder to store task on web UI.
     path : str = "simulation_data.hdf5"
@@ -200,6 +201,10 @@ def run(
     if priority is not None and (priority < 1 or priority > 10):
         raise ValueError("Priority must be between '1' and '10' if specified.")
 
+    if task_name is None:
+        stub = Tidy3dStub(simulation=simulation)
+        task_name = stub.get_default_task_name()
+
     # component modeler path: route autograd-valid modelers to local run
     from tidy3d.plugins.smatrix.component_modelers.types import ComponentModelerType
 
@@ -261,7 +266,7 @@ def run(
 
 
 def run_async(
-    simulations: dict[str, td.Simulation],
+    simulations: typing.Union[dict[str, td.Simulation], tuple[td.Simulation], list[td.Simulation]],
     folder_name: str = "default",
     path_dir: str = DEFAULT_DATA_DIR,
     callback_url: typing.Optional[str] = None,
@@ -283,8 +288,8 @@ def run_async(
 
     Parameters
     ----------
-    simulations : Dict[str, Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`]]
-        Mapping of task name to simulation.
+    simulations : Union[Dict[str, Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`]], tuple[Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`]], list[Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`]]]
+        Mapping of task name to simulation or list of simulations.
     folder_name : str = "default"
         Name of folder to store each task on web UI.
     path_dir : str
@@ -328,6 +333,13 @@ def run_async(
     # validate priority if specified
     if priority is not None and (priority < 1 or priority > 10):
         raise ValueError("Priority must be between '1' and '10' if specified.")
+
+    if isinstance(simulations, (tuple, list)):
+        sim_dict = {}
+        for i, sim in enumerate(simulations, 1):
+            task_name = Tidy3dStub(simulation=sim).get_default_task_name() + f"_{i}"
+            sim_dict[task_name] = sim
+        simulations = sim_dict
 
     if is_valid_for_autograd_async(simulations):
         return _run_async(

--- a/tidy3d/web/api/connect_util.py
+++ b/tidy3d/web/api/connect_util.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 from functools import wraps
+from typing import Optional
 
 from requests import ReadTimeout
 from requests.exceptions import ConnectionError as ConnErr
@@ -12,13 +13,14 @@ from urllib3.exceptions import NewConnectionError
 
 from tidy3d.exceptions import WebError
 from tidy3d.log import log
-from tidy3d.web.common import CONNECTION_RETRY_TIME, REFRESH_TIME
+from tidy3d.web import common
+from tidy3d.web.common import REFRESH_TIME
 
 
-def wait_for_connection(decorated_fn=None, wait_time_sec: float = CONNECTION_RETRY_TIME):
+def wait_for_connection(decorated_fn=None, wait_time_sec: Optional[float] = None):
     """Causes function to ignore connection errors and retry for ``wait_time_sec`` secs."""
 
-    def decorator(web_fn):
+    def decorator(web_fn, wait_time_sec=wait_time_sec):
         """Decorator returned by @wait_for_connection()"""
 
         @wraps(web_fn)
@@ -27,12 +29,14 @@ def wait_for_connection(decorated_fn=None, wait_time_sec: float = CONNECTION_RET
             time_start = time.time()
             warned_previously = False
 
-            while (time.time() - time_start) < wait_time_sec:
+            timeout = common.CONNECTION_RETRY_TIME if wait_time_sec is None else wait_time_sec
+
+            while (time.time() - time_start) < timeout:
                 try:
                     return web_fn(*args, **kwargs)
                 except (ConnErr, ConnectionError, NewConnectionError, ReadTimeout, JSONDecodeError):
                     if not warned_previously:
-                        log.warning(f"No connection: Retrying for {wait_time_sec} seconds.")
+                        log.warning(f"No connection: Retrying for {timeout} seconds.")
                         warned_previously = True
                     time.sleep(REFRESH_TIME)
 
@@ -41,7 +45,7 @@ def wait_for_connection(decorated_fn=None, wait_time_sec: float = CONNECTION_RET
         return web_fn_wrapped
 
     if decorated_fn:
-        return decorator(decorated_fn)
+        return decorator(decorated_fn, wait_time_sec=wait_time_sec)
 
     return decorator
 

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -8,7 +8,7 @@ import time
 from abc import ABC
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
-from typing import Literal, Optional
+from typing import Literal, Optional, Union
 
 import pydantic.v1 as pd
 from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn, TimeElapsedColumn
@@ -20,6 +20,7 @@ from tidy3d.components.types.workflow import WorkflowDataType, WorkflowType
 from tidy3d.exceptions import DataError
 from tidy3d.log import get_logging_console, log
 from tidy3d.web.api import webapi as web
+from tidy3d.web.api.tidy3d_stub import Tidy3dStub
 from tidy3d.web.core.constants import TaskId, TaskName
 from tidy3d.web.core.task_core import Folder
 from tidy3d.web.core.task_info import RunInfo, TaskInfo
@@ -151,7 +152,11 @@ class Job(WebContainer):
         discriminator="type",
     )
 
-    task_name: TaskName = pd.Field(..., title="Task Name", description="Unique name of the task.")
+    task_name: TaskName = pd.Field(
+        None,
+        title="Task Name",
+        description="Unique name of the task. Will be auto-generated if not provided.",
+    )
 
     folder_name: str = pd.Field(
         "default", title="Folder Name", description="Name of folder to store task on web UI."
@@ -421,6 +426,17 @@ class Job(WebContainer):
         if len(parent_dir) > 0 and not os.path.exists(parent_dir):
             os.makedirs(parent_dir, exist_ok=True)
 
+    @pd.root_validator(pre=True)
+    def set_task_name_if_none(cls, values):
+        """
+        Auto-assign a task_name if user did not provide one.
+        """
+        if values.get("task_name") is None:
+            sim = values.get("simulation")
+            stub = Tidy3dStub(simulation=sim)
+            values["task_name"] = stub.get_default_task_name()
+        return values
+
 
 class BatchData(Tidy3dBaseModel, Mapping):
     """
@@ -532,7 +548,9 @@ class Batch(WebContainer):
         * `Inverse taper edge coupler <../../notebooks/EdgeCoupler.html>`_
     """
 
-    simulations: dict[TaskName, annotate_type(WorkflowType)] = pd.Field(
+    simulations: Union[
+        dict[TaskName, annotate_type(WorkflowType)], tuple[annotate_type(WorkflowType)]
+    ] = pd.Field(
         ...,
         title="Simulations",
         description="Mapping of task names to Simulations to run as a batch.",
@@ -663,12 +681,21 @@ class Batch(WebContainer):
         if self.jobs_cached is not None:
             return self.jobs_cached
 
+        if isinstance(self.simulations, tuple):
+            simulations = {}
+            for i, sim in enumerate(self.simulations, 1):
+                stub = Tidy3dStub(simulation=sim)
+                task_name = stub.get_default_task_name() + f"_{i}"
+                simulations[task_name] = sim
+        else:
+            simulations = self.simulations
+
         # the type of job to upload (to generalize to subclasses)
         JobType = self._job_type
         self_dict = self.dict()
 
         jobs = {}
-        for task_name, simulation in self.simulations.items():
+        for task_name, simulation in simulations.items():
             job_kwargs = {}
 
             for key in JobType._upload_fields:

--- a/tidy3d/web/api/tidy3d_stub.py
+++ b/tidy3d/web/api/tidy3d_stub.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from typing import Callable, Optional
 
 import pydantic.v1 as pd
@@ -172,6 +173,27 @@ class Tidy3dStub(BaseModel, TaskStub):
             self.simulation.validate_pre_upload(source_required)
         elif isinstance(self.simulation, EMESimulation):
             self.simulation.validate_pre_upload()
+
+    def get_default_task_name(self) -> str:
+        """
+        Generate a default task name based on the simulation type and
+        the current date and time.
+
+        The name is composed of the simulation type and a human-readable timestamp in the format ``YYYY-MM-DD_HH-MM-SS``
+
+        Example
+        -------
+        >>> stub.get_default_task_name() # doctest: +SKIP
+        'fdtd_2025-09-16_14-30-55'
+
+        Returns
+        -------
+        str
+            Default task name, e.g. ``"fdtd_2025-09-16_14-30-55"``.
+        """
+        sim_type = self.get_type().lower()
+        timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        return f"{sim_type}_{timestamp}"
 
 
 class Tidy3dStubData(BaseModel, TaskStubData):

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -106,7 +106,7 @@ def _task_dict_to_url_bullet_list(data_dict: dict) -> str:
 @wait_for_connection
 def run(
     simulation: WorkflowType,
-    task_name: str,
+    task_name: Optional[str] = None,
     folder_name: str = "default",
     path: str = "simulation_data.hdf5",
     callback_url: Optional[str] = None,
@@ -129,8 +129,8 @@ def run(
     ----------
     simulation : Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`]
         Simulation to upload to server.
-    task_name : str
-        Name of task.
+    task_name : Optional[str] = None
+        Name of task. If not provided, a default name will be generated.
     folder_name : str = "default"
         Name of folder to store task on web UI.
     path : str = "simulation_data.hdf5"
@@ -233,7 +233,7 @@ def run(
 @wait_for_connection
 def upload(
     simulation: WorkflowType,
-    task_name: str,
+    task_name: Optional[str] = None,
     folder_name: str = "default",
     callback_url: Optional[str] = None,
     verbose: bool = True,
@@ -251,8 +251,8 @@ def upload(
     ----------
     simulation : Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`]
         Simulation to upload to server.
-    task_name : str
-        Name of task.
+    task_name : Optional[str]
+        Name of task. If not provided, a default name will be generated.
     folder_name : str
         Name of folder to store task on web UI
     callback_url : str = None
@@ -299,6 +299,9 @@ def upload(
     stub = Tidy3dStub(simulation=simulation)
     stub.validate_pre_upload(source_required=source_required)
     log.debug("Creating task.")
+
+    if task_name is None:
+        task_name = stub.get_default_task_name()
 
     task_type = stub.get_type()
     # Component modeler compatibility: map to RF task type


### PR DESCRIPTION
Relates to https://github.com/flexcompute/tidy3d/issues/2819

**Change**

task_name becomes optional in `run` and `run_async` as well as in `Job` and `Batch`.
In  `run_async` and `Batch`, a list of simulations instead of a dictionary can be provided.
Task name is generated with simulation type and timestamp like `fdtd_2025-09-16_14-30-55`, trailed with `"_{index}"` for batch jobs.

**Usage Example:**

```
sim_data = run(sim)
results = run_async([sim1, sim2, sim3])
```
(similar with `Job` or `Batch`)

Explicit task_names are still supported.

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-16 11:20:45 UTC

This PR implements a significant user experience improvement by making task names optional across the Tidy3D web API. The changes affect multiple core functions (`run`, `run_async`, `Job`, and `Batch`) to allow users to submit simulations without explicitly providing task names.

The implementation adds automatic task name generation using the format `{simulation_type}_{timestamp}` (e.g., `fdtd_2025-09-16_14-30-55`). For batch operations, an index suffix is appended (`_{index}`) to ensure uniqueness. The core functionality is implemented through a new `get_default_task_name()` method in the `Tidy3dStub` class that combines the simulation type (lowercased) with a human-readable timestamp.

Key API changes include:
- `run(simulation, task_name=None)` - task_name parameter becomes optional
- `run_async(simulations)` - now accepts either a dictionary (existing) or list of simulations (new)
- `Job` class - task_name field becomes optional
- `Batch` class - simulations field accepts either dictionary or list format

The changes maintain full backward compatibility - existing code using explicit task names continues to work unchanged. The implementation correctly handles the conversion from list format to the internal dictionary format required by the underlying job management system.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/web/api/tidy3d_stub.py` | 4/5 | Adds `get_default_task_name()` method that generates task names from simulation type and timestamp |
| `tidy3d/web/api/container.py` | 4/5 | Makes task_name optional in Job class and enables list input for Batch simulations with auto-naming |
| `tidy3d/web/api/webapi.py` | 4/5 | Makes task_name parameter optional in `run()` and `upload()` functions with default name generation |
| `tidy3d/web/api/asynchronous.py` | 4/5 | Enables `run_async()` to accept list of simulations instead of requiring dictionary format |
| `tidy3d/web/api/autograd/autograd.py` | 4/5 | Updates autograd-specific `run()` and `run_async()` functions to support optional task names |
| `tests/test_web/test_webapi.py` | 4/5 | Adds parametrized tests covering both explicit and auto-generated task name scenarios |
| `tests/test_web/test_tidy3d_stub.py` | 4/5 | Adds test for default task name generation functionality |
| `tests/test_components/autograd/test_autograd.py` | 5/5 | Extends autograd async test to cover both dictionary and list simulation formats |
| `CHANGELOG.md` | 5/5 | Documents the new optional task names feature with clear user-facing description |

</details>

## Confidence score: 4/5

- This PR is generally safe to merge with good backward compatibility, but has some potential edge cases around timing
- Score reflects solid implementation and comprehensive testing, but concerns about timestamp collision edge cases and missing validation
- Pay close attention to the task name generation logic in `tidy3d_stub.py` and batch conversion logic in `container.py`

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant run as web.run()
    participant Tidy3dStub
    participant upload as web.upload()
    participant Task as SimulationTask
    participant start as web.start()
    participant monitor as web.monitor()
    participant load as web.load()

    User->>run: run(simulation, task_name=None)
    
    alt task_name is None
        run->>Tidy3dStub: Tidy3dStub(simulation=simulation)
        Tidy3dStub->>Tidy3dStub: get_default_task_name()
        Note over Tidy3dStub: Generates name like "fdtd_2025-09-16_14-30-55"
        Tidy3dStub-->>run: generated_task_name
        run->>run: task_name = generated_task_name
    end
    
    run->>upload: upload(simulation, task_name, ...)
    upload->>Tidy3dStub: Tidy3dStub(simulation)
    upload->>Task: create(task_type, task_name, ...)
    Task-->>upload: task_id
    upload-->>run: task_id
    
    run->>start: start(task_id, ...)
    start->>Task: submit(task_id, ...)
    Task-->>start: success
    start-->>run: success
    
    run->>monitor: monitor(task_id, ...)
    monitor->>Task: get_status(task_id)
    loop Until completion
        Task-->>monitor: status
        alt status not complete
            monitor->>monitor: wait
        end
    end
    monitor-->>run: completed
    
    run->>load: load(task_id, ...)
    load->>Task: download and load data
    Task-->>load: simulation_data
    load-->>run: simulation_data
    
    run-->>User: simulation_data
```

<!-- /greptile_comment -->