### PR TITLE
add discriminators to multiphysics medium to avoid sporadic benign error messages

### DIFF
--- a/schemas/EMESimulation.json
+++ b/schemas/EMESimulation.json
@@ -7489,7 +7489,15 @@
           "type": "object"
         },
         "charge": {
-          "anyOf": [
+          "discriminator": {
+            "mapping": {
+              "ChargeConductorMedium": "#/definitions/ChargeConductorMedium",
+              "ChargeInsulatorMedium": "#/definitions/ChargeInsulatorMedium",
+              "SemiconductorMedium": "#/definitions/SemiconductorMedium"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
             {
               "$ref": "#/definitions/ChargeConductorMedium"
             },
@@ -7502,7 +7510,16 @@
           ]
         },
         "heat": {
-          "anyOf": [
+          "discriminator": {
+            "mapping": {
+              "FluidMedium": "#/definitions/FluidMedium",
+              "FluidSpec": "#/definitions/FluidSpec",
+              "SolidMedium": "#/definitions/SolidMedium",
+              "SolidSpec": "#/definitions/SolidSpec"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
             {
               "$ref": "#/definitions/FluidMedium"
             },
@@ -7521,7 +7538,34 @@
           "type": "string"
         },
         "optical": {
-          "anyOf": [
+          "discriminator": {
+            "mapping": {
+              "AnisotropicMedium": "#/definitions/AnisotropicMedium",
+              "AnisotropicMediumFromMedium2D": "#/definitions/AnisotropicMediumFromMedium2D",
+              "CustomAnisotropicMedium": "#/definitions/CustomAnisotropicMedium",
+              "CustomDebye": "#/definitions/CustomDebye",
+              "CustomDrude": "#/definitions/CustomDrude",
+              "CustomLorentz": "#/definitions/CustomLorentz",
+              "CustomMedium": "#/definitions/CustomMedium",
+              "CustomPoleResidue": "#/definitions/CustomPoleResidue",
+              "CustomSellmeier": "#/definitions/CustomSellmeier",
+              "Debye": "#/definitions/Debye",
+              "Drude": "#/definitions/Drude",
+              "FullyAnisotropicMedium": "#/definitions/FullyAnisotropicMedium",
+              "Lorentz": "#/definitions/Lorentz",
+              "LossyMetalMedium": "#/definitions/LossyMetalMedium",
+              "Medium": "#/definitions/Medium",
+              "Medium2D": "#/definitions/Medium2D",
+              "PECMedium": "#/definitions/PECMedium",
+              "PMCMedium": "#/definitions/PMCMedium",
+              "PerturbationMedium": "#/definitions/PerturbationMedium",
+              "PerturbationPoleResidue": "#/definitions/PerturbationPoleResidue",
+              "PoleResidue": "#/definitions/PoleResidue",
+              "Sellmeier": "#/definitions/Sellmeier"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
             {
               "$ref": "#/definitions/AnisotropicMedium"
             },

--- a/schemas/HeatChargeSimulation.json
+++ b/schemas/HeatChargeSimulation.json
@@ -5143,7 +5143,15 @@
           "type": "object"
         },
         "charge": {
-          "anyOf": [
+          "discriminator": {
+            "mapping": {
+              "ChargeConductorMedium": "#/definitions/ChargeConductorMedium",
+              "ChargeInsulatorMedium": "#/definitions/ChargeInsulatorMedium",
+              "SemiconductorMedium": "#/definitions/SemiconductorMedium"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
             {
               "$ref": "#/definitions/ChargeConductorMedium"
             },
@@ -5156,7 +5164,16 @@
           ]
         },
         "heat": {
-          "anyOf": [
+          "discriminator": {
+            "mapping": {
+              "FluidMedium": "#/definitions/FluidMedium",
+              "FluidSpec": "#/definitions/FluidSpec",
+              "SolidMedium": "#/definitions/SolidMedium",
+              "SolidSpec": "#/definitions/SolidSpec"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
             {
               "$ref": "#/definitions/FluidMedium"
             },
@@ -5175,7 +5192,34 @@
           "type": "string"
         },
         "optical": {
-          "anyOf": [
+          "discriminator": {
+            "mapping": {
+              "AnisotropicMedium": "#/definitions/AnisotropicMedium",
+              "AnisotropicMediumFromMedium2D": "#/definitions/AnisotropicMediumFromMedium2D",
+              "CustomAnisotropicMedium": "#/definitions/CustomAnisotropicMedium",
+              "CustomDebye": "#/definitions/CustomDebye",
+              "CustomDrude": "#/definitions/CustomDrude",
+              "CustomLorentz": "#/definitions/CustomLorentz",
+              "CustomMedium": "#/definitions/CustomMedium",
+              "CustomPoleResidue": "#/definitions/CustomPoleResidue",
+              "CustomSellmeier": "#/definitions/CustomSellmeier",
+              "Debye": "#/definitions/Debye",
+              "Drude": "#/definitions/Drude",
+              "FullyAnisotropicMedium": "#/definitions/FullyAnisotropicMedium",
+              "Lorentz": "#/definitions/Lorentz",
+              "LossyMetalMedium": "#/definitions/LossyMetalMedium",
+              "Medium": "#/definitions/Medium",
+              "Medium2D": "#/definitions/Medium2D",
+              "PECMedium": "#/definitions/PECMedium",
+              "PMCMedium": "#/definitions/PMCMedium",
+              "PerturbationMedium": "#/definitions/PerturbationMedium",
+              "PerturbationPoleResidue": "#/definitions/PerturbationPoleResidue",
+              "PoleResidue": "#/definitions/PoleResidue",
+              "Sellmeier": "#/definitions/Sellmeier"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
             {
               "$ref": "#/definitions/AnisotropicMedium"
             },

--- a/schemas/HeatSimulation.json
+++ b/schemas/HeatSimulation.json
@@ -5143,7 +5143,15 @@
           "type": "object"
         },
         "charge": {
-          "anyOf": [
+          "discriminator": {
+            "mapping": {
+              "ChargeConductorMedium": "#/definitions/ChargeConductorMedium",
+              "ChargeInsulatorMedium": "#/definitions/ChargeInsulatorMedium",
+              "SemiconductorMedium": "#/definitions/SemiconductorMedium"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
             {
               "$ref": "#/definitions/ChargeConductorMedium"
             },
@@ -5156,7 +5164,16 @@
           ]
         },
         "heat": {
-          "anyOf": [
+          "discriminator": {
+            "mapping": {
+              "FluidMedium": "#/definitions/FluidMedium",
+              "FluidSpec": "#/definitions/FluidSpec",
+              "SolidMedium": "#/definitions/SolidMedium",
+              "SolidSpec": "#/definitions/SolidSpec"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
             {
               "$ref": "#/definitions/FluidMedium"
             },
@@ -5175,7 +5192,34 @@
           "type": "string"
         },
         "optical": {
-          "anyOf": [
+          "discriminator": {
+            "mapping": {
+              "AnisotropicMedium": "#/definitions/AnisotropicMedium",
+              "AnisotropicMediumFromMedium2D": "#/definitions/AnisotropicMediumFromMedium2D",
+              "CustomAnisotropicMedium": "#/definitions/CustomAnisotropicMedium",
+              "CustomDebye": "#/definitions/CustomDebye",
+              "CustomDrude": "#/definitions/CustomDrude",
+              "CustomLorentz": "#/definitions/CustomLorentz",
+              "CustomMedium": "#/definitions/CustomMedium",
+              "CustomPoleResidue": "#/definitions/CustomPoleResidue",
+              "CustomSellmeier": "#/definitions/CustomSellmeier",
+              "Debye": "#/definitions/Debye",
+              "Drude": "#/definitions/Drude",
+              "FullyAnisotropicMedium": "#/definitions/FullyAnisotropicMedium",
+              "Lorentz": "#/definitions/Lorentz",
+              "LossyMetalMedium": "#/definitions/LossyMetalMedium",
+              "Medium": "#/definitions/Medium",
+              "Medium2D": "#/definitions/Medium2D",
+              "PECMedium": "#/definitions/PECMedium",
+              "PMCMedium": "#/definitions/PMCMedium",
+              "PerturbationMedium": "#/definitions/PerturbationMedium",
+              "PerturbationPoleResidue": "#/definitions/PerturbationPoleResidue",
+              "PoleResidue": "#/definitions/PoleResidue",
+              "Sellmeier": "#/definitions/Sellmeier"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
             {
               "$ref": "#/definitions/AnisotropicMedium"
             },

--- a/schemas/ModeSimulation.json
+++ b/schemas/ModeSimulation.json
@@ -7133,7 +7133,15 @@
           "type": "object"
         },
         "charge": {
-          "anyOf": [
+          "discriminator": {
+            "mapping": {
+              "ChargeConductorMedium": "#/definitions/ChargeConductorMedium",
+              "ChargeInsulatorMedium": "#/definitions/ChargeInsulatorMedium",
+              "SemiconductorMedium": "#/definitions/SemiconductorMedium"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
             {
               "$ref": "#/definitions/ChargeConductorMedium"
             },
@@ -7146,7 +7154,16 @@
           ]
         },
         "heat": {
-          "anyOf": [
+          "discriminator": {
+            "mapping": {
+              "FluidMedium": "#/definitions/FluidMedium",
+              "FluidSpec": "#/definitions/FluidSpec",
+              "SolidMedium": "#/definitions/SolidMedium",
+              "SolidSpec": "#/definitions/SolidSpec"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
             {
               "$ref": "#/definitions/FluidMedium"
             },
@@ -7165,7 +7182,34 @@
           "type": "string"
         },
         "optical": {
-          "anyOf": [
+          "discriminator": {
+            "mapping": {
+              "AnisotropicMedium": "#/definitions/AnisotropicMedium",
+              "AnisotropicMediumFromMedium2D": "#/definitions/AnisotropicMediumFromMedium2D",
+              "CustomAnisotropicMedium": "#/definitions/CustomAnisotropicMedium",
+              "CustomDebye": "#/definitions/CustomDebye",
+              "CustomDrude": "#/definitions/CustomDrude",
+              "CustomLorentz": "#/definitions/CustomLorentz",
+              "CustomMedium": "#/definitions/CustomMedium",
+              "CustomPoleResidue": "#/definitions/CustomPoleResidue",
+              "CustomSellmeier": "#/definitions/CustomSellmeier",
+              "Debye": "#/definitions/Debye",
+              "Drude": "#/definitions/Drude",
+              "FullyAnisotropicMedium": "#/definitions/FullyAnisotropicMedium",
+              "Lorentz": "#/definitions/Lorentz",
+              "LossyMetalMedium": "#/definitions/LossyMetalMedium",
+              "Medium": "#/definitions/Medium",
+              "Medium2D": "#/definitions/Medium2D",
+              "PECMedium": "#/definitions/PECMedium",
+              "PMCMedium": "#/definitions/PMCMedium",
+              "PerturbationMedium": "#/definitions/PerturbationMedium",
+              "PerturbationPoleResidue": "#/definitions/PerturbationPoleResidue",
+              "PoleResidue": "#/definitions/PoleResidue",
+              "Sellmeier": "#/definitions/Sellmeier"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
             {
               "$ref": "#/definitions/AnisotropicMedium"
             },

--- a/schemas/Simulation.json
+++ b/schemas/Simulation.json
@@ -10617,7 +10617,15 @@
           "type": "object"
         },
         "charge": {
-          "anyOf": [
+          "discriminator": {
+            "mapping": {
+              "ChargeConductorMedium": "#/definitions/ChargeConductorMedium",
+              "ChargeInsulatorMedium": "#/definitions/ChargeInsulatorMedium",
+              "SemiconductorMedium": "#/definitions/SemiconductorMedium"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
             {
               "$ref": "#/definitions/ChargeConductorMedium"
             },
@@ -10630,7 +10638,16 @@
           ]
         },
         "heat": {
-          "anyOf": [
+          "discriminator": {
+            "mapping": {
+              "FluidMedium": "#/definitions/FluidMedium",
+              "FluidSpec": "#/definitions/FluidSpec",
+              "SolidMedium": "#/definitions/SolidMedium",
+              "SolidSpec": "#/definitions/SolidSpec"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
             {
               "$ref": "#/definitions/FluidMedium"
             },
@@ -10649,7 +10666,34 @@
           "type": "string"
         },
         "optical": {
-          "anyOf": [
+          "discriminator": {
+            "mapping": {
+              "AnisotropicMedium": "#/definitions/AnisotropicMedium",
+              "AnisotropicMediumFromMedium2D": "#/definitions/AnisotropicMediumFromMedium2D",
+              "CustomAnisotropicMedium": "#/definitions/CustomAnisotropicMedium",
+              "CustomDebye": "#/definitions/CustomDebye",
+              "CustomDrude": "#/definitions/CustomDrude",
+              "CustomLorentz": "#/definitions/CustomLorentz",
+              "CustomMedium": "#/definitions/CustomMedium",
+              "CustomPoleResidue": "#/definitions/CustomPoleResidue",
+              "CustomSellmeier": "#/definitions/CustomSellmeier",
+              "Debye": "#/definitions/Debye",
+              "Drude": "#/definitions/Drude",
+              "FullyAnisotropicMedium": "#/definitions/FullyAnisotropicMedium",
+              "Lorentz": "#/definitions/Lorentz",
+              "LossyMetalMedium": "#/definitions/LossyMetalMedium",
+              "Medium": "#/definitions/Medium",
+              "Medium2D": "#/definitions/Medium2D",
+              "PECMedium": "#/definitions/PECMedium",
+              "PMCMedium": "#/definitions/PMCMedium",
+              "PerturbationMedium": "#/definitions/PerturbationMedium",
+              "PerturbationPoleResidue": "#/definitions/PerturbationPoleResidue",
+              "PoleResidue": "#/definitions/PoleResidue",
+              "Sellmeier": "#/definitions/Sellmeier"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
             {
               "$ref": "#/definitions/AnisotropicMedium"
             },

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -11100,7 +11100,15 @@
           "type": "object"
         },
         "charge": {
-          "anyOf": [
+          "discriminator": {
+            "mapping": {
+              "ChargeConductorMedium": "#/definitions/ChargeConductorMedium",
+              "ChargeInsulatorMedium": "#/definitions/ChargeInsulatorMedium",
+              "SemiconductorMedium": "#/definitions/SemiconductorMedium"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
             {
               "$ref": "#/definitions/ChargeConductorMedium"
             },
@@ -11113,7 +11121,16 @@
           ]
         },
         "heat": {
-          "anyOf": [
+          "discriminator": {
+            "mapping": {
+              "FluidMedium": "#/definitions/FluidMedium",
+              "FluidSpec": "#/definitions/FluidSpec",
+              "SolidMedium": "#/definitions/SolidMedium",
+              "SolidSpec": "#/definitions/SolidSpec"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
             {
               "$ref": "#/definitions/FluidMedium"
             },
@@ -11132,7 +11149,34 @@
           "type": "string"
         },
         "optical": {
-          "anyOf": [
+          "discriminator": {
+            "mapping": {
+              "AnisotropicMedium": "#/definitions/AnisotropicMedium",
+              "AnisotropicMediumFromMedium2D": "#/definitions/AnisotropicMediumFromMedium2D",
+              "CustomAnisotropicMedium": "#/definitions/CustomAnisotropicMedium",
+              "CustomDebye": "#/definitions/CustomDebye",
+              "CustomDrude": "#/definitions/CustomDrude",
+              "CustomLorentz": "#/definitions/CustomLorentz",
+              "CustomMedium": "#/definitions/CustomMedium",
+              "CustomPoleResidue": "#/definitions/CustomPoleResidue",
+              "CustomSellmeier": "#/definitions/CustomSellmeier",
+              "Debye": "#/definitions/Debye",
+              "Drude": "#/definitions/Drude",
+              "FullyAnisotropicMedium": "#/definitions/FullyAnisotropicMedium",
+              "Lorentz": "#/definitions/Lorentz",
+              "LossyMetalMedium": "#/definitions/LossyMetalMedium",
+              "Medium": "#/definitions/Medium",
+              "Medium2D": "#/definitions/Medium2D",
+              "PECMedium": "#/definitions/PECMedium",
+              "PMCMedium": "#/definitions/PMCMedium",
+              "PerturbationMedium": "#/definitions/PerturbationMedium",
+              "PerturbationPoleResidue": "#/definitions/PerturbationPoleResidue",
+              "PoleResidue": "#/definitions/PoleResidue",
+              "Sellmeier": "#/definitions/Sellmeier"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
             {
               "$ref": "#/definitions/AnisotropicMedium"
             },

--- a/tidy3d/components/material/multi_physics.py
+++ b/tidy3d/components/material/multi_physics.py
@@ -10,6 +10,7 @@ from tidy3d.components.material.solver_types import (
     HeatMediumType,
     OpticalMediumType,
 )
+from tidy3d.components.types.base import TYPE_TAG_STR
 
 
 class MultiPhysicsMedium(Tidy3dBaseModel):
@@ -83,7 +84,10 @@ class MultiPhysicsMedium(Tidy3dBaseModel):
     name: Optional[str] = pd.Field(None, title="Name", description="Medium name")
 
     optical: Optional[OpticalMediumType] = pd.Field(
-        None, title="Optical properties", description="Specifies optical properties."
+        None,
+        title="Optical properties",
+        description="Specifies optical properties.",
+        discriminator=TYPE_TAG_STR,
     )
 
     # electrical: Optional[ElectricalMediumType] = pd.Field(
@@ -93,11 +97,17 @@ class MultiPhysicsMedium(Tidy3dBaseModel):
     # )
 
     heat: Optional[HeatMediumType] = pd.Field(
-        None, title="Heat properties", description="Specifies properties for Heat simulations."
+        None,
+        title="Heat properties",
+        description="Specifies properties for Heat simulations.",
+        discriminator=TYPE_TAG_STR,
     )
 
     charge: Optional[ChargeMediumType] = pd.Field(
-        None, title="Charge properties", description="Specifies properties for Charge simulations."
+        None,
+        title="Charge properties",
+        description="Specifies properties for Charge simulations.",
+        discriminator=TYPE_TAG_STR,
     )
 
     def __getattr__(self, name: str):


### PR DESCRIPTION
To avoid things like:
<img width="719" height="283" alt="image_720" src="https://github.com/user-attachments/assets/f0972079-7cfe-4d97-aa9b-c23008977c59" />

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-16 17:39:49 UTC

This PR addresses a serialization issue in the `MultiPhysicsMedium` class by adding discriminator parameters to three optional medium fields. The `MultiPhysicsMedium` class contains three optional fields (`optical`, `heat`, and `charge`) that use union types (`OpticalMediumType`, `HeatMediumType`, `ChargeMediumType`). Each of these union types can contain multiple different medium classes, which creates ambiguity for Pydantic during serialization and deserialization.

The change adds `discriminator=TYPE_TAG_STR` to each of the three fields. `TYPE_TAG_STR` is a constant that equals `'type'`, which corresponds to a field present in all `Tidy3dBaseModel` subclasses. This discriminator tells Pydantic to use the `type` field to identify which specific subclass should be used when serializing or deserializing union types.

This follows an established pattern in the Tidy3D codebase where `TYPE_TAG_STR` is used as a discriminator for union types, as implemented in the `annotate_type` function in `types/base.py`. The change is purely structural - no business logic is modified, only serialization metadata is added to improve type resolution and prevent confusing error messages.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/material/multi_physics.py | 5/5 | Added discriminator parameters to three optional medium fields to improve Pydantic serialization |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it only adds serialization metadata without changing any business logic
- Score reflects that this is a well-understood Pydantic pattern being applied consistently to resolve a known serialization issue
- No files require special attention as the change is straightforward and follows established codebase patterns

<!-- /greptile_comment -->