### PR TITLE
propagate verbose argument to start function in webapi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restructured the smatrix plugin with backwards-incompatible changes for a more robust architecture. Notably, `ComponentModeler` has been renamed to `ModalComponentModeler` and internal web API methods have been removed. Please see our migration guide for details on updating your workflows.
 - Prevent small bandwidth sources from being created in `TerminalComponentModeler` when modeler frequencies are close together.
 - `Simulation.epsilon` now samples off-diagonal elements of fully tensorial permittivity at grid *boundaries*, to be consistent with the how these enter the FDTD simulation. This means that all off-diagonal components are now sampled at the same locations.
+- Propagate `verbose` to `start` function in web API.
 
 ### Fixed
 - Bug in `TerminalComponentModeler.get_antenna_metrics_data` when port amplitudes are set to zero.

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -215,6 +215,7 @@ def run(
     )
     start(
         task_id,
+        verbose=verbose,
         solver_version=solver_version,
         worker_group=worker_group,
         pay_type=pay_type,
@@ -473,6 +474,7 @@ def get_info(task_id: TaskId, verbose: bool = True) -> TaskInfo:
 @wait_for_connection
 def start(
     task_id: TaskId,
+    verbose: bool = True,
     solver_version: Optional[str] = None,
     worker_group: Optional[str] = None,
     pay_type: Union[PayType, str] = PayType.AUTO,
@@ -485,6 +487,8 @@ def start(
 
     task_id : str
         Unique identifier of task on server.  Returned by :meth:`upload`.
+    verbose : bool = True
+        If ``True``, will print log messages, otherwise, will run silently.
     solver_version: str = None
         target solver version.
     worker_group: str = None
@@ -499,7 +503,7 @@ def start(
     To monitor progress, can call :meth:`monitor` after starting simulation.
     """
 
-    console = get_logging_console()
+    console = get_logging_console() if verbose else None
 
     # Component modeler batch path: hide split/check/submit
     if _is_modeler_batch(task_id):
@@ -509,7 +513,8 @@ def start(
         status = detail.totalStatus
         status_str = status.value
         if status_str in ("validate_success", "validate_warn"):
-            console.log("Component modeler batch validation has been successful.")
+            if verbose:
+                console.log("Component modeler batch validation has been successful.")
         if status_str not in ("validate_success", "validate_warn"):
             raise WebError(f"Batch task {task_id} is blocked: {status_str}")
         # Submit batch to start runs after validation


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-17 16:31:00 UTC

This PR adds verbosity control to the `start` function in the Tidy3D web API by propagating the `verbose` parameter from the `run` function. The change ensures consistent behavior across the entire web API workflow - when users set `verbose=False` in the `run` function, the `start` function will now also operate silently instead of always producing console output.

The implementation is straightforward: the `start` function now accepts a `verbose` parameter (defaulting to `True` for backward compatibility) and conditionally creates console logging objects and outputs messages based on this flag. This change integrates well with the existing codebase pattern where other functions like `monitor` and `load` already respect the verbose setting from the `run` function.

The modification addresses an inconsistency in the web API where users could suppress output from most operations but the start phase would still produce console messages. This enhancement is particularly valuable for automated workflows, batch processing, and integration scenarios where minimal console output is desired.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `CHANGELOG.md` | 5/5 | Added changelog entry documenting the verbose parameter propagation to start function |
| `tidy3d/web/api/webapi.py` | 5/5 | Added verbose parameter to start function and implemented conditional logging behavior |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it only adds optional verbosity control without changing core functionality
- Score reflects simple, well-implemented changes that follow established patterns in the codebase and maintain backward compatibility
- No files require special attention as both changes are straightforward and properly implemented

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant webapi as "webapi.run()"
    participant upload_func as "upload()"
    participant start_func as "start()"
    participant monitor_func as "monitor()"
    participant load_func as "load()"
    participant SimulationTask
    participant Server

    User->>webapi: "run(simulation, task_name, verbose=True)"
    webapi->>upload_func: "upload(simulation, task_name, verbose=verbose)"
    upload_func->>SimulationTask: "create(task_type, task_name, folder_name)"
    SimulationTask->>Server: "POST /create_task"
    Server-->>SimulationTask: "task_id"
    SimulationTask-->>upload_func: "task object"
    upload_func->>SimulationTask: "upload_simulation()"
    SimulationTask->>Server: "PUT /upload_data"
    Server-->>SimulationTask: "upload confirmation"
    upload_func-->>webapi: "task_id"
    
    webapi->>start_func: "start(task_id, verbose=verbose)"
    start_func->>SimulationTask: "get(task_id)"
    SimulationTask->>Server: "GET /task_details"
    Server-->>SimulationTask: "task details"
    SimulationTask-->>start_func: "task object"
    start_func->>SimulationTask: "submit()"
    SimulationTask->>Server: "POST /start_simulation"
    Server-->>SimulationTask: "start confirmation"
    start_func-->>webapi: "completion"
    
    webapi->>monitor_func: "monitor(task_id, verbose=verbose)"
    loop "Monitor Progress"
        monitor_func->>SimulationTask: "get_running_info()"
        SimulationTask->>Server: "GET /run_status"
        Server-->>SimulationTask: "progress data"
        SimulationTask-->>monitor_func: "perc_done, field_decay"
    end
    monitor_func-->>webapi: "completion"
    
    webapi->>load_func: "load(task_id, path, verbose=verbose)"
    load_func->>SimulationTask: "get_sim_data_hdf5()"
    SimulationTask->>Server: "GET /download_results"
    Server-->>SimulationTask: "simulation data"
    SimulationTask-->>load_func: "downloaded file"
    load_func-->>webapi: "SimulationData"
    webapi-->>User: "SimulationData"
```

<!-- /greptile_comment -->