### PR TITLE
docs(charge): Fix rendering and missing dataclasses

### DIFF
--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -2108,7 +2108,7 @@ class GridSpec(Tidy3dBaseModel):
     wavelength: float = pd.Field(
         None,
         title="Free-space wavelength",
-        description="Free-space wavelength for automatic nonuniform grid. It can be 'None' "
+        description="Free-space wavelength for automatic nonuniform grid. It can be ``None`` "
         "if there is at least one source in the simulation, in which case it is defined by "
         "the source central frequency. "
         "Note: it only takes effect when at least one of the three dimensions "

--- a/tidy3d/components/material/tcad/charge.py
+++ b/tidy3d/components/material/tcad/charge.py
@@ -14,11 +14,7 @@ from tidy3d.components.tcad.types import (
     MobilityModelType,
     RecombinationModelType,
 )
-from tidy3d.constants import (
-    CONDUCTIVITY,
-    ELECTRON_VOLT,
-    PERMITTIVITY,
-)
+from tidy3d.constants import CONDUCTIVITY, ELECTRON_VOLT, PERCMCUBE, PERMITTIVITY
 
 
 class AbstractChargeMedium(AbstractMedium):
@@ -47,7 +43,7 @@ class AbstractChargeMedium(AbstractMedium):
 class ChargeInsulatorMedium(AbstractChargeMedium):
     """
     Insulating medium. Conduction simulations will not solve for electric
-    potential in a structure that has a medium with this 'charge'.
+    potential in a structure that has a medium with this ``charge``.
 
     Example
     -------
@@ -258,21 +254,21 @@ class SemiconductorMedium(AbstractChargeMedium):
     N_c: pd.PositiveFloat = pd.Field(
         ...,
         title="Effective density of electron states",
-        description=r"$N_c$ Effective density of states in the conduction band.",
-        units="cm^(-3)",
+        description=":math:`N_c` Effective density of states in the conduction band.",
+        units=PERCMCUBE,
     )
 
     N_v: pd.PositiveFloat = pd.Field(
         ...,
         title="Effective density of hole states",
-        description=r"$N_v$ Effective density of states in the valence band.",
-        units="cm^(-3)",
+        description=":math:`N_v` Effective density of states in the valence band.",
+        units=PERCMCUBE,
     )
 
     E_g: pd.PositiveFloat = pd.Field(
         ...,
         title="Band-gap energy",
-        description="Band-gap energy",
+        description=":math:`E_g` Band-gap energy",
         units=ELECTRON_VOLT,
     )
 
@@ -296,8 +292,9 @@ class SemiconductorMedium(AbstractChargeMedium):
 
     delta_E_g: BandGapNarrowingModelType = pd.Field(
         None,
-        title=":math:`\\Delta E_g` Bandgap narrowing model.",
-        description="Bandgap narrowing model.",
+        title="Bandgap narrowing model.",
+        description=":math:`\\Delta E_g` Bandgap narrowing model.",
+        units=ELECTRON_VOLT,
     )
 
     N_a: Union[pd.NonNegativeFloat, SpatialDataArray, tuple[DopingBoxType, ...]] = pd.Field(
@@ -306,7 +303,7 @@ class SemiconductorMedium(AbstractChargeMedium):
         description="Concentration of acceptor impurities, which create mobile holes, resulting in p-type material. "
         "Can be specified as a single float for uniform doping, a :class:`SpatialDataArray` for a custom profile, "
         "or a tuple of geometric shapes to define specific doped regions.",
-        units="1/cm^3",
+        units=PERCMCUBE,
     )
 
     N_d: Union[pd.NonNegativeFloat, SpatialDataArray, tuple[DopingBoxType, ...]] = pd.Field(
@@ -315,5 +312,5 @@ class SemiconductorMedium(AbstractChargeMedium):
         description="Concentration of donor impurities, which create mobile electrons, resulting in n-type material. "
         "Can be specified as a single float for uniform doping, a :class:`SpatialDataArray` for a custom profile, "
         "or a tuple of geometric shapes to define specific doped regions.",
-        units="1/cm^3",
+        units=PERCMCUBE,
     )

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -315,17 +315,17 @@ class NonlinearSusceptibility(NonlinearModel):
     chi3: float = pd.Field(
         0,
         title="Chi3",
-        description="Chi3 nonlinear susceptibility.",
+        description=":math:`\\chi_3` nonlinear susceptibility.",
         units=f"{MICROMETER}^2 / {VOLT}^2",
     )
 
     numiters: pd.PositiveInt = pd.Field(
         None,
         title="Number of iterations",
-        description="Deprecated. The old usage 'nonlinear_spec=model' with 'model.numiters' "
+        description="Deprecated. The old usage ``nonlinear_spec=model`` with ``model.numiters`` "
         "is deprecated and will be removed in a future release. The new usage is "
-        r"'nonlinear_spec=NonlinearSpec(models=\[model], num_iters=num_iters)'. Under the new "
-        "usage, this parameter is ignored, and 'NonlinearSpec.num_iters' is used instead.",
+        "``nonlinear_spec=NonlinearSpec(models=[model], num_iters=num_iters)``. Under the new "
+        "usage, this parameter is ignored, and ``NonlinearSpec.num_iters`` is used instead.",
     )
 
     @pd.validator("numiters", always=True)
@@ -762,7 +762,7 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
         title="Allow gain medium",
         description="Allow the medium to be active. Caution: "
         "simulations with a gain medium are unstable, and are likely to diverge."
-        "Simulations where 'allow_gain' is set to 'True' will still be charged even if "
+        "Simulations where ``allow_gain`` is set to ``True`` will still be charged even if "
         "diverged. Monitor data up to the divergence point will still be returned and can be "
         "useful in some cases.",
     )
@@ -6080,7 +6080,7 @@ class LossyMetalMedium(Medium):
         title="Allow gain medium",
         description="Allow the medium to be active. Caution: "
         "simulations with a gain medium are unstable, and are likely to diverge."
-        "Simulations where 'allow_gain' is set to 'True' will still be charged even if "
+        "Simulations where ``allow_gain`` is set to ``True`` will still be charged even if "
         "diverged. Monitor data up to the divergence point will still be returned and can be "
         "useful in some cases.",
     )
@@ -6866,8 +6866,8 @@ class CustomAnisotropicMedium(AbstractCustomMedium, AnisotropicMedium):
     interp_method: Optional[InterpMethod] = pd.Field(
         None,
         title="Interpolation method",
-        description="When the value is 'None', each component will follow its own "
-        "interpolation method. When the value is other than 'None', the interpolation "
+        description="When the value is ``None`` each component will follow its own "
+        "interpolation method. When the value is other than ``None`` the interpolation "
         "method specified by this field will override the one in each component.",
     )
 

--- a/tidy3d/components/spice/sources/dc.py
+++ b/tidy3d/components/spice/sources/dc.py
@@ -52,7 +52,7 @@ class DCVoltageSource(Tidy3dBaseModel):
     voltage: ArrayFloat1D = pd.Field(
         ...,
         title="Voltage",
-        description="DC voltage usually used as source in 'VoltageBC' boundary conditions.",
+        description="DC voltage usually used as source in :class:`VoltageBC` boundary conditions.",
         units=VOLT,
     )
 
@@ -81,7 +81,7 @@ class DCCurrentSource(Tidy3dBaseModel):
     name: Optional[str]
     current: pd.FiniteFloat = pd.Field(
         title="Current",
-        description="DC current usually used as source in 'CurrentBC' boundary conditions.",
+        description="DC current usually used as source in :class:`CurrentBC` boundary conditions.",
         units=AMP,
     )
 

--- a/tidy3d/components/tcad/bandgap.py
+++ b/tidy3d/components/tcad/bandgap.py
@@ -39,21 +39,21 @@ class SlotboomBandGapNarrowing(Tidy3dBaseModel):
 
     v1: pd.PositiveFloat = pd.Field(
         ...,
-        title=r"$V_{1,bgn}$ parameter",
-        description=r"$V_{1,bgn}$ parameter",
+        title=":math:`V_{1,bgn}` parameter",
+        description=":math:`V_{1,bgn}` parameter",
         units=VOLT,
     )
 
     n2: pd.PositiveFloat = pd.Field(
         ...,
-        title=r"$N_{2,bgn}$ parameter",
-        description=r"$N_{2,bgn}$ parameter",
+        title=":math:`N_{2,bgn}` parameter",
+        description=":math:`N_{2,bgn}` parameter",
         units=PERCMCUBE,
     )
 
     c2: float = pd.Field(
-        title=r"$C_{2,bgn}$ parameter",
-        description=r"$C_{2,bgn}$ parameter",
+        title=":math:`C_{2,bgn}` parameter",
+        description=":math:`C_{2,bgn}` parameter",
     )
 
     min_N: pd.NonNegativeFloat = pd.Field(

--- a/tidy3d/components/tcad/data/monitor_data/abstract.py
+++ b/tidy3d/components/tcad/data/monitor_data/abstract.py
@@ -18,6 +18,7 @@ from tidy3d.components.tcad.types import (
     HeatChargeMonitorType,
 )
 from tidy3d.components.types import Coordinate, ScalarSymmetry, annotate_type
+from tidy3d.constants import MICROMETER
 from tidy3d.log import log
 
 FieldDataset = Union[
@@ -45,6 +46,7 @@ class HeatChargeMonitorData(AbstractMonitorData, ABC):
         (0, 0, 0),
         title="Symmetry Center",
         description="Symmetry center of the original simulation in x, y, and z.",
+        units=MICROMETER,
     )
 
     @abstractmethod

--- a/tidy3d/components/tcad/data/monitor_data/charge.py
+++ b/tidy3d/components/tcad/data/monitor_data/charge.py
@@ -380,8 +380,9 @@ class SteadyElectricFieldData(HeatChargeMonitorData):
     E: UnstructuredFieldType = pd.Field(
         None,
         title="Electric field",
-        description="Contains the computed electric field in :math:`V/\\mu m`.",
+        description="Contains the computed electric field.",
         discriminator=TYPE_TAG_STR,
+        units=":math:`V/\\mu m`",
     )
 
     @property
@@ -422,8 +423,9 @@ class SteadyCurrentDensityData(HeatChargeMonitorData):
     J: UnstructuredFieldType = pd.Field(
         None,
         title="Current density",
-        description="Contains the computed current density in :math:`A/\\mu m^2`.",
+        description="Contains the computed current density.",
         discriminator=TYPE_TAG_STR,
+        units=":math:`A/\\mu m^2`",
     )
 
     @property

--- a/tidy3d/components/tcad/doping.py
+++ b/tidy3d/components/tcad/doping.py
@@ -9,7 +9,7 @@ import pydantic.v1 as pd
 
 from tidy3d.components.base import cached_property
 from tidy3d.components.geometry.base import Box
-from tidy3d.constants import PERCMCUBE
+from tidy3d.constants import MICROMETER, PERCMCUBE
 from tidy3d.exceptions import SetupError
 
 
@@ -115,7 +115,7 @@ class ConstantDoping(AbstractDopingBox):
     concentration: pd.NonNegativeFloat = pd.Field(
         default=0,
         title="Doping concentration density.",
-        description="Doping concentration density in #/cm^3.",
+        description="Doping concentration density.",
         units=PERCMCUBE,
     )
 
@@ -189,11 +189,13 @@ class GaussianDoping(AbstractDopingBox):
         title="Reference concentration.",
         description="Reference concentration. This is the minimum concentration in the box "
         "and it is attained at the edges/faces of the box.",
+        units=PERCMCUBE,
     )
 
     concentration: pd.PositiveFloat = pd.Field(
         title="Concentration",
         description="The concentration at the center of the box.",
+        units=PERCMCUBE,
     )
 
     width: pd.PositiveFloat = pd.Field(
@@ -201,6 +203,7 @@ class GaussianDoping(AbstractDopingBox):
         description="Width of the gaussian. The concentration will transition from "
         "``concentration`` at the center of the box to ``ref_con`` at the edge/face "
         "of the box in a distance equal to ``width``. ",
+        units=MICROMETER,
     )
 
     source: str = pd.Field(
@@ -208,8 +211,8 @@ class GaussianDoping(AbstractDopingBox):
         title="Source face",
         description="Specifies the side of the box acting as the source, i.e., "
         "the face specified does not have a gaussian evolution normal to it, instead "
-        "the concentration is constant from this face. Accepted values for 'source' "
-        "are ['xmin', 'xmax', 'ymin', 'ymax', 'zmin', 'zmax']",
+        "the concentration is constant from this face. Accepted values for ``source`` "
+        "are [``xmin``, ``xmax``, ``ymin``, ``ymax``, ``zmin``, ``zmax``]",
     )
 
     @cached_property

--- a/tidy3d/components/tcad/generation_recombination.py
+++ b/tidy3d/components/tcad/generation_recombination.py
@@ -91,11 +91,17 @@ class AugerRecombination(Tidy3dBaseModel):
     """
 
     c_n: pd.PositiveFloat = pd.Field(
-        ..., title="Constant for electrons", description="Constant for electrons in cm^6/s"
+        ...,
+        title="Constant for electrons",
+        description="Constant for electrons.",
+        units="cm^6/s",
     )
 
     c_p: pd.PositiveFloat = pd.Field(
-        ..., title="Constant for holes", description="Constant for holes in cm^6/s"
+        ...,
+        title="Constant for holes",
+        description="Constant for holes.",
+        units="cm^6/s",
     )
 
 
@@ -122,8 +128,9 @@ class RadiativeRecombination(Tidy3dBaseModel):
 
     r_const: float = pd.Field(
         ...,
-        title="Radiation constant in cm^3/s",
-        description="Radiation constant in cm^3/s",
+        title="Radiation constant",
+        description="Radiation constant of the radiative recombination model.",
+        units="cm^3/s",
     )
 
 
@@ -193,8 +200,8 @@ class DistributedGeneration(Tidy3dBaseModel):
     rate: SpatialDataArray = pd.Field(
         ...,
         title="Generation rate",
-        description="Spatially varying generation rate in cm^-3 s^-1",
-        units="cm^-3 s^-1",
+        description="Spatially varying generation rate.",
+        units="1/(cm^3 s^1)",
     )
 
     @classmethod

--- a/tidy3d/components/tcad/mobility.py
+++ b/tidy3d/components/tcad/mobility.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pydantic.v1 as pd
 
 from tidy3d.components.base import Tidy3dBaseModel
+from tidy3d.constants import PERCMCUBE
 
 
 class ConstantMobilityModel(Tidy3dBaseModel):
@@ -116,14 +117,16 @@ class CaugheyThomasMobility(Tidy3dBaseModel):
     # mobilities
     mu_min: pd.PositiveFloat = pd.Field(
         ...,
-        title=r"$\mu_{min}$ Minimum electron mobility",
-        description="Minimum electron mobility at reference temperature (300K) in cm^2/V-s. ",
+        title="Minimum electron mobility",
+        description="Minimum electron mobility  :math:`\\mu_{\\text{min}}`  at reference temperature (300K).",
+        units="cm^2/V-s",
     )
 
     mu: pd.PositiveFloat = pd.Field(
         ...,
         title="Reference mobility",
-        description="Reference mobility at reference temperature (300K) in cm^2/V-s",
+        description="Reference mobility at reference temperature (300K).",
+        units="cm^2/V-s",
     )
 
     # thermal exponent for reference mobility
@@ -142,7 +145,8 @@ class CaugheyThomasMobility(Tidy3dBaseModel):
     ref_N: pd.PositiveFloat = pd.Field(
         ...,
         title="Reference doping",
-        description="Reference doping at reference temperature (300K) in #/cm^3.",
+        description="Reference doping at reference temperature (300K).",
+        units=PERCMCUBE,
     )
 
     # temperature exponent

--- a/tidy3d/components/tcad/source/heat.py
+++ b/tidy3d/components/tcad/source/heat.py
@@ -30,7 +30,7 @@ class HeatSource(StructureBasedHeatChargeSource):
 
 class UniformHeatSource(HeatSource):
     """Volumetric heat source. This class is deprecated. You can use
-    'HeatSource' instead.
+    :class:`HeatSource` instead.
 
     Example
     -------


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-17 22:25:14 UTC

This PR systematically improves documentation consistency across the TCAD (Technology Computer-Aided Design) and charge-related components of the Tidy3D framework. The primary focus is on standardizing how units and mathematical notation are presented in API documentation.

The changes implement several key improvements:

1. **Unit Specification Standardization**: The PR moves unit information from inline descriptions to dedicated `units` parameters in field definitions. For example, in mobility.py, the `ref_N` field now uses `units=PERCMCUBE` instead of embedding "1/cm^3" in the description text.

2. **Mathematical Notation Formatting**: Raw LaTeX syntax (`r"$...$"`) is converted to proper Sphinx math role notation (`:math:`...``) throughout multiple files. This ensures mathematical expressions render correctly in generated documentation.

3. **Code Reference Formatting**: Single quotes around code identifiers are replaced with double backticks (`` `code` ``) to follow reStructuredText conventions and enable proper syntax highlighting.

4. **Cross-Reference Links**: Plain text class references are converted to proper Sphinx cross-references using `:class:`ClassName`` syntax, making the documentation more navigable.

5. **Constant Usage**: Hardcoded unit strings are replaced with imported constants like `PERCMCUBE` and `MICROMETER` for better maintainability.

These changes affect multiple TCAD components including mobility models, doping profiles, bandgap narrowing, generation/recombination models, heat sources, monitor data classes, and DC sources. The modifications follow established documentation patterns already present in the codebase, particularly in classes like `TemperatureData` which demonstrate the preferred structure of separating units from descriptions.

The improvements enhance the professional appearance of the API documentation, improve navigability through proper cross-references, and create a more consistent developer experience across the charge simulation components.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/tcad/mobility.py | 5/5 | Standardized units specification and improved LaTeX formatting in mobility model documentation |
| tidy3d/components/grid/grid_spec.py | 5/5 | Minor documentation fix changing 'None' to proper backtick formatting |
| tidy3d/components/tcad/doping.py | 5/5 | Added missing units attributes and corrected docstring formatting for doping models |
| tidy3d/components/tcad/bandgap.py | 5/5 | Fixed mathematical notation by converting LaTeX to Sphinx math role syntax |
| tidy3d/components/material/tcad/charge.py | 5/5 | Comprehensive documentation fixes including unit constants and Sphinx math formatting |
| tidy3d/components/medium.py | 5/5 | Updated code references and mathematical notation formatting throughout medium definitions |
| tidy3d/components/tcad/source/heat.py | 5/5 | Converted plain text class reference to proper Sphinx cross-reference syntax |
| tidy3d/components/tcad/data/monitor_data/charge.py | 5/5 | Separated unit specifications from descriptions in electric field and current density data classes |
| tidy3d/components/spice/sources/dc.py | 5/5 | Fixed documentation by converting class references to proper cross-reference syntax |
| tidy3d/components/tcad/generation_recombination.py | 5/5 | Improved unit formatting and separated units from descriptions in generation/recombination models |

</details>

## Confidence score: 5/5

- This PR is extremely safe to merge with virtually no risk of introducing functional issues
- Score reflects that all changes are purely documentation improvements with no logic modifications
- No files require special attention as all changes follow established patterns and conventions

### Context used:
**Rule -** In changelogs, enclose code identifiers (class, function names) in backticks and use specific names rather than generic descriptions. ([link](https://app.greptile.com/review/custom-context?memory=0af1d6df-6cf7-4988-b3fc-f5f8ec5cae30))
**Rule -** Adhere to the established docstring format and use correct syntax (e.g., double backticks for code) to ensure proper rendering. ([link](https://app.greptile.com/review/custom-context?memory=2f1f3aa0-b672-45d8-9bd5-136bcc28ce16))

<!-- /greptile_comment -->