### PR TITLE
More efficient mesh refinement in LayerRefinementSpec for interior-disjoint structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for `tidy3d-extras`, an optional plugin that enables more accurate local mode solving via subpixel averaging.
 
 ### Changed
+- `LayerRefinementSpec` defaults to assuming structures made of different materials are interior-disjoint for more efficient mesh generation.
 
 ### Fixed
 

--- a/schemas/EMESimulation.json
+++ b/schemas/EMESimulation.json
@@ -5850,6 +5850,10 @@
           "minimum": 0,
           "type": "integer"
         },
+        "interior_disjoint_geometries": {
+          "default": true,
+          "type": "boolean"
+        },
         "min_steps_along_axis": {
           "exclusiveMinimum": 0,
           "type": "number"

--- a/schemas/ModeSimulation.json
+++ b/schemas/ModeSimulation.json
@@ -5081,6 +5081,10 @@
           "minimum": 0,
           "type": "integer"
         },
+        "interior_disjoint_geometries": {
+          "default": true,
+          "type": "boolean"
+        },
         "min_steps_along_axis": {
           "exclusiveMinimum": 0,
           "type": "number"

--- a/schemas/Simulation.json
+++ b/schemas/Simulation.json
@@ -8565,6 +8565,10 @@
           "minimum": 0,
           "type": "integer"
         },
+        "interior_disjoint_geometries": {
+          "default": true,
+          "type": "boolean"
+        },
         "min_steps_along_axis": {
           "exclusiveMinimum": 0,
           "type": "number"

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -8873,6 +8873,10 @@
           "minimum": 0,
           "type": "integer"
         },
+        "interior_disjoint_geometries": {
+          "default": true,
+          "type": "boolean"
+        },
         "min_steps_along_axis": {
           "exclusiveMinimum": 0,
           "type": "number"

--- a/tests/test_components/test_layerrefinement.py
+++ b/tests/test_components/test_layerrefinement.py
@@ -288,6 +288,62 @@ def test_grid_spec_with_layers():
     )
 
 
+def test_grid_spec_with_layers_interior_disjoint():
+    """Test the application of layer_specs with interior_disjoint assumption to GridSpec."""
+
+    thickness = 1e-3
+    lumped_elements = []
+    # a PEC thin layer structure
+    box1 = td.Box(size=(thickness, 2, 2))
+    box2 = td.Box(center=(0, -1, 0), size=(thickness, 1, 1))
+    pec_str = td.Structure(geometry=box1 - box2, medium=td.PEC)
+    # a dielectric that overlaps with PEC structure, hence breaking interior-disjoint assumption
+    die_str = td.Structure(
+        geometry=td.Box(size=(thickness, 0.5, 0.5)),
+        medium=td.Medium(),
+    )
+    # layer spec assuming interior disjoint geometries
+    layer_disjoint = LayerRefinementSpec.from_structures(
+        [
+            pec_str,
+        ],
+        interior_disjoint_geometries=True,
+    )
+    # layer spec for general geometries
+    layer_general = layer_disjoint.updated_copy(interior_disjoint_geometries=False)
+
+    sim = td.Simulation(
+        size=(4, 4, 4),
+        grid_spec=td.GridSpec.auto(
+            min_steps_per_wvl=11, wavelength=1, layer_refinement_specs=[layer_disjoint]
+        ),
+        boundary_spec=td.BoundarySpec.pml(),
+        structures=[pec_str],
+        run_time=1e-12,
+    )
+    sim_general = sim.updated_copy(
+        grid_spec=sim.grid_spec.updated_copy(layer_refinement_specs=[layer_general])
+    )
+
+    # for simulations with interior-disjoint geometries, same corner finder results for both layer settings
+    def is_equal_snapping_points(plist1, plist2):
+        if len(plist1) != len(plist2):
+            return False
+        for p1, p2 in zip(plist1, plist2):
+            if p1 != p2:
+                return False
+        return True
+
+    assert is_equal_snapping_points(
+        sim.internal_snapping_points, sim_general.internal_snapping_points
+    )
+
+    # for simulations with overlapping geometries, assuming interior-disjoint misses some corners in this simulation
+    sim = sim.updated_copy(structures=[pec_str, die_str])
+    sim_general = sim_general.updated_copy(structures=[pec_str, die_str])
+    assert len(sim_general.internal_snapping_points) > len(sim.internal_snapping_points)
+
+
 @pytest.mark.parametrize("gap_meshing_iters", [0, 1])
 def test_corner_refinement_outside_domain(gap_meshing_iters):
     """Test the behavior of corner refinement if corners are outside the simulation domain."""
@@ -573,6 +629,7 @@ def test_gap_meshing():
                     corner_finder=None,
                     gap_meshing_iters=2,
                     dl_min_from_gap_width=True,
+                    interior_disjoint_geometries=False,
                 )
             ],
             min_steps_per_wvl=10,

--- a/tidy3d/components/geometry/utils.py
+++ b/tidy3d/components/geometry/utils.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from enum import Enum
 from math import isclose
 from typing import Any, Optional, Union
 
 import numpy as np
 import pydantic
+import shapely
 
 from tidy3d.components.autograd.utils import get_static
 from tidy3d.components.base import Tidy3dBaseModel
@@ -45,6 +47,7 @@ def merging_geometries_on_plane(
     geometries: list[GeometryType],
     plane: Box,
     property_list: list[Any],
+    interior_disjoint_geometries: bool = False,
 ) -> list[tuple[Any, Shapely]]:
     """Compute list of shapes on plane. Overlaps are removed or merged depending on
     provided property_list.
@@ -57,6 +60,8 @@ def merging_geometries_on_plane(
         Plane specification.
     property_list : List = None
         Property value for each structure.
+    interior_disjoint_geometries: bool = False
+        If ``True``, geometries of different properties on the plane must not be overlapping.
 
     Returns
     -------
@@ -77,6 +82,20 @@ def merging_geometries_on_plane(
         # Append each of them and their property information to the list of shapes
         for shape in shapes_plane:
             shapes.append((prop, shape, shape.bounds))
+
+    if interior_disjoint_geometries:
+        # No need to consider overlapping. We simply group shapes by property, and union_all
+        # shapes of the same property.
+        shapes_by_prop = defaultdict(list)
+        for prop, shape, _ in shapes:
+            shapes_by_prop[prop].append(shape)
+        # union shapes of same property
+        results = []
+        for prop, shapes in shapes_by_prop.items():
+            unionized = shapely.union_all(shapes).buffer(0).normalize()
+            if not unionized.is_empty:
+                results.append((prop, unionized))
+        return results
 
     background_shapes = []
     for prop, shape, bounds in shapes:

--- a/tidy3d/components/grid/corner_finder.py
+++ b/tidy3d/components/grid/corner_finder.py
@@ -85,6 +85,7 @@ class CornerFinderSpec(Tidy3dBaseModel):
         structure_list: list[Structure],
         center: tuple[float, float] = [0, 0, 0],
         size: tuple[float, float, float] = [inf, inf, inf],
+        interior_disjoint_geometries: bool = False,
     ) -> list[tuple[Any, Shapely]]:
         """On a 2D plane specified by axis = `normal_axis` and coordinate `coord`, merge geometries made of PEC.
 
@@ -100,6 +101,8 @@ class CornerFinderSpec(Tidy3dBaseModel):
             Center of the 2D plane (coordinate along ``axis`` is ignored)
         size : Tuple[float, float, float] = [inf, inf, inf]
             Size of the 2D plane (size along ``axis`` is ignored)
+        interior_disjoint_geometries: bool = False
+            If ``True``, geometries on the plane must not be overlapping.
 
         Returns
         -------
@@ -123,7 +126,9 @@ class CornerFinderSpec(Tidy3dBaseModel):
             PEC if (mat.is_pec or isinstance(mat, LossyMetalMedium)) else mat for mat in medium_list
         ]
         # merge geometries
-        merged_geos = merging_geometries_on_plane(geometry_list, plane, medium_list)
+        merged_geos = merging_geometries_on_plane(
+            geometry_list, plane, medium_list, interior_disjoint_geometries
+        )
 
         return merged_geos
 
@@ -133,6 +138,7 @@ class CornerFinderSpec(Tidy3dBaseModel):
         coord: float,
         structure_list: list[Structure],
         ravel: bool,
+        interior_disjoint_geometries: bool = False,
     ) -> tuple[ArrayFloat2D, ArrayFloat1D]:
         """On a 2D plane specified by axis = `normal_axis` and coordinate `coord`, find out corners of merged
         geometries made of PEC.
@@ -148,6 +154,8 @@ class CornerFinderSpec(Tidy3dBaseModel):
             List of structures present in simulation.
         ravel : bool
             Whether to put the resulting corners in a single list or per polygon.
+        interior_disjoint_geometries: bool = False
+            If ``True``, geometries made of different materials on the plane must not be overlapping.
 
         Returns
         -------
@@ -157,7 +165,10 @@ class CornerFinderSpec(Tidy3dBaseModel):
 
         # merge geometries
         merged_geos = self._merged_pec_on_plane(
-            normal_axis=normal_axis, coord=coord, structure_list=structure_list
+            normal_axis=normal_axis,
+            coord=coord,
+            structure_list=structure_list,
+            interior_disjoint_geometries=interior_disjoint_geometries,
         )
 
         # corner finder
@@ -183,11 +194,14 @@ class CornerFinderSpec(Tidy3dBaseModel):
                     )
                     corner_list.append(corners_xy)
                     convexity_list.append(corners_convexity)
+        return self._ravel_corners_and_convexity(ravel, corner_list, convexity_list)
 
+    def _ravel_corners_and_convexity(
+        self, ravel: bool, corner_list, convexity_list
+    ) -> tuple[ArrayFloat2D, ArrayFloat1D]:
+        """Whether to put the resulting corners in a single list or per polygon."""
         if ravel and len(corner_list) > 0:
-            corner_list = np.concatenate(corner_list)
-            convexity_list = np.concatenate(convexity_list)
-
+            return np.concatenate(corner_list), np.concatenate(convexity_list)
         return corner_list, convexity_list
 
     def corners(
@@ -195,6 +209,7 @@ class CornerFinderSpec(Tidy3dBaseModel):
         normal_axis: Axis,
         coord: float,
         structure_list: list[Structure],
+        interior_disjoint_geometries: bool = False,
     ) -> ArrayFloat2D:
         """On a 2D plane specified by axis = `normal_axis` and coordinate `coord`, find out corners of merged
         geometries made of `medium`.
@@ -208,7 +223,8 @@ class CornerFinderSpec(Tidy3dBaseModel):
             Position of plane along the normal axis.
         structure_list : List[Structure]
             List of structures present in simulation.
-
+        interior_disjoint_geometries: bool = False
+            If ``True``, geometries made of different materials on the plane must not be overlapping.
         Returns
         -------
         ArrayFloat2D
@@ -216,7 +232,11 @@ class CornerFinderSpec(Tidy3dBaseModel):
         """
 
         corner_list, _ = self._corners_and_convexity(
-            normal_axis=normal_axis, coord=coord, structure_list=structure_list, ravel=True
+            normal_axis=normal_axis,
+            coord=coord,
+            structure_list=structure_list,
+            ravel=True,
+            interior_disjoint_geometries=interior_disjoint_geometries,
         )
         return corner_list
 

--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -16,6 +16,7 @@ from tidy3d.components.source.utils import SourceType
 from tidy3d.components.structure import MeshOverrideStructure, Structure, StructureType
 from tidy3d.components.types import (
     TYPE_TAG_STR,
+    ArrayFloat1D,
     ArrayFloat2D,
     Axis,
     Coordinate,
@@ -1078,6 +1079,14 @@ class LayerRefinementSpec(Box):
         "This only applies if ``dl_min`` in ``AutoGrid`` specification is not set.",
     )
 
+    interior_disjoint_geometries: bool = pd.Field(
+        True,
+        title="Geometries Are Interior-Disjoint",
+        description="If ``True``, geometries made of different materials on the plane must not be overlapping. "
+        "This can speed up the performance "
+        "of corner finder when there are many structures crossing the plane.",
+    )
+
     @pd.validator("axis", always=True)
     @skip_if_fields_missing(["size"])
     def _finite_size_along_axis(cls, val, values):
@@ -1100,6 +1109,7 @@ class LayerRefinementSpec(Box):
         refinement_inside_sim_only: bool = True,
         gap_meshing_iters: pd.NonNegativeInt = 1,
         dl_min_from_gap_width: bool = True,
+        **kwargs,
     ):
         """Constructs a :class:`LayerRefinementSpec` that is unbounded in inplane dimensions from bounds along
         layer thickness dimension.
@@ -1157,6 +1167,7 @@ class LayerRefinementSpec(Box):
             refinement_inside_sim_only=refinement_inside_sim_only,
             gap_meshing_iters=gap_meshing_iters,
             dl_min_from_gap_width=dl_min_from_gap_width,
+            **kwargs,
         )
 
     @classmethod
@@ -1174,6 +1185,7 @@ class LayerRefinementSpec(Box):
         refinement_inside_sim_only: bool = True,
         gap_meshing_iters: pd.NonNegativeInt = 1,
         dl_min_from_gap_width: bool = True,
+        **kwargs,
     ):
         """Constructs a :class:`LayerRefinementSpec` from minimum and maximum coordinate bounds.
 
@@ -1233,6 +1245,7 @@ class LayerRefinementSpec(Box):
             refinement_inside_sim_only=refinement_inside_sim_only,
             gap_meshing_iters=gap_meshing_iters,
             dl_min_from_gap_width=dl_min_from_gap_width,
+            **kwargs,
         )
 
     @classmethod
@@ -1249,6 +1262,7 @@ class LayerRefinementSpec(Box):
         refinement_inside_sim_only: bool = True,
         gap_meshing_iters: pd.NonNegativeInt = 1,
         dl_min_from_gap_width: bool = True,
+        **kwargs,
     ):
         """Constructs a :class:`LayerRefinementSpec` from the bounding box of a list of structures.
 
@@ -1305,6 +1319,7 @@ class LayerRefinementSpec(Box):
             refinement_inside_sim_only=refinement_inside_sim_only,
             gap_meshing_iters=gap_meshing_iters,
             dl_min_from_gap_width=dl_min_from_gap_width,
+            **kwargs,
         )
 
     @cached_property
@@ -1387,20 +1402,27 @@ class LayerRefinementSpec(Box):
 
         return dl_min
 
-    def generate_snapping_points(self, structure_list: list[Structure]) -> list[CoordinateOptional]:
+    def generate_snapping_points(
+        self, structure_list: list[Structure], cached_corners_and_convexity=None
+    ) -> list[CoordinateOptional]:
         """generate snapping points for mesh refinement."""
         snapping_points = self._snapping_points_along_axis
         if self.corner_snapping:
-            snapping_points += self._corners(structure_list)
+            snapping_points += self._corners(structure_list, cached_corners_and_convexity)
         return snapping_points
 
     def generate_override_structures(
-        self, grid_size_in_vacuum: float, structure_list: list[Structure]
+        self,
+        grid_size_in_vacuum: float,
+        structure_list: list[Structure],
+        cached_corners_and_convexity=None,
     ) -> list[MeshOverrideStructure]:
         """Generate mesh override structures for mesh refinement."""
         return self._override_structures_along_axis(
             grid_size_in_vacuum
-        ) + self._override_structures_inplane(structure_list, grid_size_in_vacuum)
+        ) + self._override_structures_inplane(
+            structure_list, grid_size_in_vacuum, cached_corners_and_convexity
+        )
 
     def _inplane_inside(self, point: ArrayFloat2D) -> bool:
         """On the inplane cross section, whether the point is inside the layer.
@@ -1423,7 +1445,7 @@ class LayerRefinementSpec(Box):
 
     def _corners_and_convexity_2d(
         self, structure_list: list[Structure], ravel: bool
-    ) -> list[CoordinateOptional]:
+    ) -> tuple[list[ArrayFloat2D], list[ArrayFloat1D]]:
         """Raw inplane corners and their convexity."""
         if self.corner_finder is None:
             return [], []
@@ -1433,7 +1455,11 @@ class LayerRefinementSpec(Box):
         if self._is_inplane_bounded:
             structures_intersect = [s for s in structure_list if self.intersects(s.geometry)]
         inplane_points, convexity = self.corner_finder._corners_and_convexity(
-            self.axis, self.center_axis, structures_intersect, ravel
+            self.axis,
+            self.center_axis,
+            structures_intersect,
+            ravel,
+            self.interior_disjoint_geometries,
         )
 
         # filter corners outside the inplane bounds
@@ -1490,11 +1516,21 @@ class LayerRefinementSpec(Box):
 
         return dl_min
 
-    def _corners(self, structure_list: list[Structure]) -> list[CoordinateOptional]:
+    def _corners(
+        self, structure_list: list[Structure], cached_corners_and_convexity=None
+    ) -> list[CoordinateOptional]:
         """Inplane corners in 3D coordinate."""
-        inplane_points, _ = self._corners_and_convexity_2d(
-            structure_list=structure_list, ravel=True
-        )
+        if self.corner_finder is None:
+            return []
+        if cached_corners_and_convexity is None:
+            inplane_points, _ = self._corners_and_convexity_2d(
+                structure_list=structure_list, ravel=True
+            )
+        else:
+            inplane_points, convexity = cached_corners_and_convexity
+            inplane_points, _ = self.corner_finder._ravel_corners_and_convexity(
+                ravel=True, corner_list=inplane_points, convexity_list=convexity
+            )
 
         # convert 2d points to 3d
         return [
@@ -1528,7 +1564,10 @@ class LayerRefinementSpec(Box):
         ]
 
     def _override_structures_inplane(
-        self, structure_list: list[Structure], grid_size_in_vacuum: float
+        self,
+        structure_list: list[Structure],
+        grid_size_in_vacuum: float,
+        cached_corners_and_convexity=None,
     ) -> list[MeshOverrideStructure]:
         """Inplane mesh override structures for refining mesh around corners."""
         if self.corner_refinement is None:
@@ -1538,7 +1577,7 @@ class LayerRefinementSpec(Box):
             self.corner_refinement.override_structure(
                 corner, grid_size_in_vacuum, self.refinement_inside_sim_only
             )
-            for corner in self._corners(structure_list)
+            for corner in self._corners(structure_list, cached_corners_and_convexity)
         ]
 
     def _override_structures_along_axis(
@@ -2018,6 +2057,7 @@ class LayerRefinementSpec(Box):
             structure_list=structures,
             center=center,
             size=restricted_size,
+            interior_disjoint_geometries=self.interior_disjoint_geometries,
         )
 
         # find intersections of pec polygons with grid lines
@@ -2236,7 +2276,10 @@ class GridSpec(Tidy3dBaseModel):
         return override_used
 
     def internal_snapping_points(
-        self, structures: list[Structure], lumped_elements: list[LumpedElementType]
+        self,
+        structures: list[Structure],
+        lumped_elements: list[LumpedElementType],
+        cached_corners_and_convexity=None,
     ) -> list[CoordinateOptional]:
         """Internal snapping points. So far, internal snapping points are generated by
         `layer_refinement_specs` and lumped element.
@@ -2247,6 +2290,8 @@ class GridSpec(Tidy3dBaseModel):
             List of physical structures.
         lumped_elements : List[LumpedElementType]
             List of lumped elements.
+        cached_corners_and_convexity : Optional[list[CachedCornersAndConvexity]]
+            Cached corners and convexity data.
 
         Returns
         -------
@@ -2261,8 +2306,14 @@ class GridSpec(Tidy3dBaseModel):
         snapping_points = []
         # 1) from layer refinement spec
         if self.layer_refinement_used:
-            for layer_spec in self.layer_refinement_specs:
-                snapping_points += layer_spec.generate_snapping_points(list(structures))
+            for ind, layer_spec in enumerate(self.layer_refinement_specs):
+                if cached_corners_and_convexity is not None:
+                    cached_data = cached_corners_and_convexity[ind]
+                else:
+                    cached_data = None
+                snapping_points += layer_spec.generate_snapping_points(
+                    list(structures), cached_data
+                )
         # ) from lumped_elements
         for lumped_element in lumped_elements:
             snapping_points += lumped_element.to_snapping_points()
@@ -2309,6 +2360,7 @@ class GridSpec(Tidy3dBaseModel):
         wavelength: pd.PositiveFloat,
         sim_size: tuple[float, 3],
         lumped_elements: list[LumpedElementType],
+        cached_corners_and_convexity=None,
     ) -> list[StructureType]:
         """Internal mesh override structures. So far, internal override structures are generated by
         `layer_refinement_specs` and lumped element.
@@ -2323,6 +2375,8 @@ class GridSpec(Tidy3dBaseModel):
             Simulation domain size.
         lumped_elements : List[LumpedElementType]
             List of lumped elements.
+        cached_corners_and_convexity : Optional[list[CachedCornersAndConvexity]]
+            Cached corners and convexity data.
 
         Returns
         -------
@@ -2337,9 +2391,15 @@ class GridSpec(Tidy3dBaseModel):
         override_structures = []
         # 1) from layer refinement spec
         if self.layer_refinement_used:
-            for layer_spec in self.layer_refinement_specs:
+            for ind, layer_spec in enumerate(self.layer_refinement_specs):
+                if cached_corners_and_convexity is not None:
+                    cached_data = cached_corners_and_convexity[ind]
+                else:
+                    cached_data = None
                 override_structures += layer_spec.generate_override_structures(
-                    self._min_vacuum_dl_in_autogrid(wavelength, sim_size), list(structures)
+                    self._min_vacuum_dl_in_autogrid(wavelength, sim_size),
+                    list(structures),
+                    cached_data,
                 )
         # 2) from lumped element
         for lumped_element in lumped_elements:

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -111,6 +111,8 @@ from .structure import MeshOverrideStructure, Structure
 from .subpixel_spec import SubpixelSpec
 from .types import (
     TYPE_TAG_STR,
+    ArrayFloat1D,
+    ArrayFloat2D,
     Ax,
     Axis,
     CoordinateOptional,
@@ -970,6 +972,20 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         return pml_thicknesses
 
     @cached_property
+    def _internal_layerfinement_corners_and_convexity_2d(
+        self,
+    ) -> list[tuple[list[ArrayFloat2D], list[ArrayFloat1D]]]:
+        """Internal inplane corners and their convexity for each layer_refinement_specs."""
+        cached_data = []
+        for layer in self.grid_spec.layer_refinement_specs:
+            cached_data.append(
+                layer._corners_and_convexity_2d(
+                    structure_list=self.scene.all_structures, ravel=False
+                )
+            )
+        return cached_data
+
+    @cached_property
     def internal_override_structures(self) -> list[MeshOverrideStructure]:
         """Internal mesh override structures. So far, internal override structures all come from `layer_refinement_specs`.
 
@@ -984,6 +1000,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
             wavelength,
             self.geometry.size,
             self.lumped_elements,
+            self._internal_layerfinement_corners_and_convexity_2d,
         )
 
     @cached_property
@@ -996,7 +1013,9 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
             List of snapping points coordinates.
         """
         return self.grid_spec.internal_snapping_points(
-            self.scene.all_structures, self.lumped_elements
+            self.scene.all_structures,
+            self.lumped_elements,
+            self._internal_layerfinement_corners_and_convexity_2d,
         )
 
     @equal_aspect


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-19 17:21:53 UTC

This PR introduces a significant performance optimization for mesh refinement in `LayerRefinementSpec` when dealing with interior-disjoint structures (non-overlapping geometries made of different materials). The core enhancement adds a new boolean field `interior_disjoint_geometries` to `LayerRefinementSpec` that defaults to `True`, enabling the mesh generation system to bypass expensive overlap detection and resolution logic when structures are known to be non-overlapping.

The optimization strategy operates on multiple levels:

**Geometry Processing Optimization**: The `merging_geometries_on_plane()` function in `tidy3d/components/geometry/utils.py` now includes a fast path that groups shapes by material property and uses `shapely.union_all()` for efficient union operations, avoiding complex intersection calculations.

**Computation Caching**: A new `@cached_property` called `_internal_layerfinement_corners_and_convexity_2d` is added to the simulation class to precompute expensive corner detection data once and reuse it across multiple mesh generation operations.

**Parameter Threading**: The optimization flag is systematically threaded through the entire corner finding pipeline, from `LayerRefinementSpec` through `corner_finder` methods to the low-level geometry processing functions.

This change specifically targets a common simulation scenario where different material regions (like metal and dielectric structures) are designed to be spatially separated. The optimization maintains backward compatibility by making cached parameters optional throughout the call chain and providing sensible defaults. The implementation fits well with the existing mesh generation architecture, leveraging established patterns like `@cached_property` decorators and extending existing method signatures with optional parameters.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `CHANGELOG.md` | 5/5 | Added documentation for the performance optimization feature |
| `tidy3d/components/simulation.py` | 3/5 | Introduced caching mechanism but contains method name typo and potential signature issues |
| `tidy3d/components/grid/corner_finder.py` | 4/5 | Added `interior_disjoint_geometries` parameter threading through corner finding pipeline |
| `tidy3d/components/grid/grid_spec.py` | 4/5 | Added new field to `LayerRefinementSpec` and threaded optimization parameter through mesh generation |
| `tidy3d/components/geometry/utils.py` | 1/5 | Contains critical bugs in optimized geometry processing that will cause runtime failures |
| `tests/test_components/test_layerrefinement.py` | 4/5 | Added comprehensive test coverage for the new optimization feature |

</details>

## Confidence score: 2/5

- This PR contains critical implementation bugs that will cause runtime failures when the optimization is enabled
- Score reflects serious issues in the core geometry processing logic and method signature inconsistencies
- Pay close attention to `tidy3d/components/geometry/utils.py` which has multiple bugs that will prevent the optimization from working

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant LayerRefinementSpec
    participant CornerFinderSpec
    participant merging_geometries_on_plane
    participant shapely
    participant Simulation

    User->>LayerRefinementSpec: Create with interior_disjoint_geometries=True
    User->>Simulation: Add LayerRefinementSpec to grid_spec
    Simulation->>Simulation: Access _internal_layerfinement_corners_and_convexity_2d (cached)
    
    loop For each layer refinement spec
        Simulation->>LayerRefinementSpec: Call _corners_and_convexity_2d()
        LayerRefinementSpec->>CornerFinderSpec: Call _corners_and_convexity()
        CornerFinderSpec->>CornerFinderSpec: Call _merged_pec_on_plane()
        CornerFinderSpec->>merging_geometries_on_plane: Call with interior_disjoint_geometries flag
        
        alt interior_disjoint_geometries is True
            Note over merging_geometries_on_plane: Fast optimization path
            merging_geometries_on_plane->>merging_geometries_on_plane: Group shapes by material property
            loop For each material property group
                merging_geometries_on_plane->>shapely: Call union_all() on shape group
                shapely-->>merging_geometries_on_plane: Return merged shapes
            end
        else interior_disjoint_geometries is False
            Note over merging_geometries_on_plane: Complex overlap processing
            loop For each shape pair
                merging_geometries_on_plane->>shapely: Check intersections and merge/subtract
                shapely-->>merging_geometries_on_plane: Return processed shapes
            end
        end
        
        merging_geometries_on_plane-->>CornerFinderSpec: Return list of merged shapes
        CornerFinderSpec->>CornerFinderSpec: Find corners from merged shapes
        CornerFinderSpec-->>LayerRefinementSpec: Return corner coordinates and convexity
        LayerRefinementSpec-->>Simulation: Cache and return corner data
    end
    
    Simulation->>LayerRefinementSpec: Generate override structures and snapping points
    LayerRefinementSpec-->>Simulation: Return optimized mesh refinement data
    Simulation-->>User: Complete simulation with optimized mesh
```

### Context used:
**Rule -** Keep docstrings and comments synchronized with code changes to ensure they are always accurate and not misleading. ([link](https://app.greptile.com/review/custom-context?memory=8947a127-e303-4dbf-b326-493579e5f047))

<!-- /greptile_comment -->