### PR TITLE
Stricter validation for mode solver bend radius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Stricter validation for `bend_radius` in mode simulations, preventing the bend center from coinciding with the simulation boundary.
 
 
 ## [v2.10.0rc1] - 2025-09-11

--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -1171,6 +1171,14 @@ def test_mode_small_bend_radius_fail():
             mode_spec=td.ModeSpec(num_modes=1, bend_radius=1, bend_axis=0),
             simulation=simulation,
         )
+    # also error when bend radius is exactly aligned with simulation boundary
+    with pytest.raises(ValueError):
+        ms = ModeSolver(
+            plane=PLANE,
+            freqs=np.linspace(1e14, 2e14, 100),
+            mode_spec=td.ModeSpec(num_modes=1, bend_radius=1.5, bend_axis=0),
+            simulation=simulation,
+        )
     # should work for infinite mode plane
     ms = ModeSolver(
         plane=td.Box(center=(0, 0, 0), size=(td.inf, 0, td.inf)),

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -60,7 +60,7 @@ from tidy3d.components.validators import (
     validate_freqs_not_empty,
 )
 from tidy3d.components.viz import make_ax, plot_params_pml
-from tidy3d.constants import C_0
+from tidy3d.constants import C_0, fp_eps
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
 from tidy3d.packaging import supports_local_subpixel, tidy3d_extras
@@ -299,7 +299,7 @@ class ModeSolver(Tidy3dBaseModel):
         _, plane_axs = mode_plane.pop_axis([0, 1, 2], mode_plane.size.index(0.0))
         radial_ax = plane_axs[(mode_spec.bend_axis + 1) % 2]
 
-        if np.abs(mode_spec.bend_radius) < mode_plane.size[radial_ax] / 2:
+        if np.abs(mode_spec.bend_radius) <= mode_plane.size[radial_ax] / 2 + fp_eps:
             raise ValueError(
                 "Mode solver bend radius is smaller than half the mode plane size "
                 "along the radial axis, which can produce wrong results."


### PR DESCRIPTION
Some mode simulations errored when the bend center exactly aligned with the simulation boundary due to singular transformation. This PR fixes it by adding some buffer to the existing validator.

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-19 23:16:03 UTC

This PR addresses a specific edge case in the mode solver where simulations would fail due to singular transformation when the bend center exactly aligned with simulation boundaries. The fix implements stricter validation for the `bend_radius` parameter in mode simulations.

The core change modifies the validation logic in `mode_solver.py` by adding a small floating-point tolerance (`fp_eps`) to the comparison threshold and changing from a strict inequality (`<`) to a less-than-or-equal comparison (`<=`). This prevents numerical instabilities that occur when the bend radius is exactly half the mode plane size along the radial axis, which would cause the transformation matrix to become singular.

The validation now imports `fp_eps` from the constants module and checks if `np.abs(mode_spec.bend_radius) <= mode_plane.size[radial_ax] / 2 + fp_eps` instead of the previous `< mode_plane.size[radial_ax] / 2`. This change integrates well with Tidy3D's existing floating-point precision handling patterns found throughout the codebase, where `fp_eps` is used as a standard tolerance for numerical comparisons.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `CHANGELOG.md` | 5/5 | Added changelog entry documenting stricter bend_radius validation fix |
| `tidy3d/components/mode/mode_solver.py` | 5/5 | Modified bend radius validation to use floating-point tolerance preventing singular transformations |
| `tests/test_plugins/test_mode_solver.py` | 5/5 | Added test case to verify validation catches bend radius exactly equal to boundary alignment |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it addresses a specific numerical stability issue with a well-established solution
- Score reflects a targeted fix using standard floating-point tolerance practices already established in the codebase
- No files require special attention as all changes are straightforward and well-tested

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant ModeSolver
    participant ValidationHelper as "_validate_mode_plane_radius"
    participant ModeSpec
    
    User->>ModeSolver: "Create ModeSolver with bend_radius"
    Note over User,ModeSolver: mode_spec contains bend_radius > 0
    
    ModeSolver->>ModeSolver: "_post_init_validators()"
    ModeSolver->>ValidationHelper: "_validate_mode_plane_radius(mode_spec, plane, sim_geom)"
    
    ValidationHelper->>ModeSpec: "get mode_spec.bend_radius"
    ModeSpec-->>ValidationHelper: "bend_radius value"
    
    Note over ValidationHelper: Check if bend_radius > 0
    
    ValidationHelper->>ValidationHelper: "_mode_plane(plane, sim_geom)"
    Note over ValidationHelper: Calculate effective mode plane bounds
    
    ValidationHelper->>ValidationHelper: "Calculate radial_ax from plane and bend_axis"
    
    ValidationHelper->>ValidationHelper: "Check: abs(bend_radius) <= plane_size/2 + fp_eps"
    Note over ValidationHelper: Stricter validation:<br/>Previous: abs(bend_radius) <= plane_size/2<br/>Fixed: abs(bend_radius) <= plane_size/2 + fp_eps
    
    alt Validation Fails (bend center too close to boundary)
        ValidationHelper-->>ModeSolver: "ValueError: bend radius too small"
        ModeSolver-->>User: "ValidationError: bend center coincides with boundary"
    else Validation Passes
        ValidationHelper-->>ModeSolver: "Validation OK"
        ModeSolver-->>User: "ModeSolver created successfully"
    end
```

<!-- /greptile_comment -->