### PR TITLE
normalize_index adjoint fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Stricter validation for `bend_radius` in mode simulations, preventing the bend center from coinciding with the simulation boundary.
+- Prevent autograd adjoint simulations from reusing out-of-range `normalize_index` values by defaulting their normalization to the first adjoint source when needed.
 
 
 ## [v2.10.0rc1] - 2025-09-11

--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -1427,6 +1427,58 @@ def test_broadband_adjoint_src_width():
     )
 
 
+def test_autograd_multi_source_normalize_index(use_emulated_run):
+    """Gradient run with multi-source normalization does not raise and returns finite grads."""
+
+    freq0 = 2e14
+    fwidth = 5e13
+
+    source_time = td.GaussianPulse(freq0=freq0, fwidth=fwidth)
+    source0 = td.UniformCurrentSource(
+        size=(0, 0, 0),
+        center=(0.0, -0.2, 0.0),
+        polarization="Hx",
+        source_time=source_time,
+    )
+    source1 = source0.updated_copy(center=(0.0, 0.2, 0.0))
+
+    monitor = td.FieldMonitor(
+        size=(0, 0, 0),
+        center=(0.0, 0.0, 0.0),
+        freqs=[freq0],
+        fields=["Ex"],
+        name="field",
+    )
+
+    base_sim = td.Simulation(
+        size=(1.0, 1.0, 1.0),
+        run_time=8 / fwidth,
+        grid_spec=td.GridSpec.uniform(dl=0.1),
+        sources=[source0, source1],
+        monitors=[monitor],
+        normalize_index=1,
+    )
+
+    def objective(params):
+        eps = 2.0 + params[0]
+        structure = td.Structure(
+            geometry=td.Box(size=(0.5, 0.5, 0.5), center=(0.0, 0.0, 0.0)),
+            medium=td.Medium(permittivity=eps),
+        )
+
+        sim = base_sim.updated_copy(structures=[structure])
+        data = run(sim, task_name="normalize_index_clamp", verbose=False)
+        field = data["field"].Ex.sel(f=freq0).values
+        return anp.real(field).sum()
+
+    params = anp.array([0.1])
+    val, grad = ag.value_and_grad(objective)(params)
+
+    assert anp.isfinite(val)
+    assert grad.shape == params.shape
+    assert anp.all(anp.isfinite(grad))
+
+
 @pytest.mark.parametrize("colocate", [True, False])
 @pytest.mark.parametrize("objtype", ["flux", "intensity"])
 def test_interp_objectives(use_emulated_run, colocate, objtype):

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -1098,8 +1098,12 @@ class SimulationData(AbstractYeeGridSimulationData):
                 "post_norm": adjoint_source_info.post_norm,
             }
 
-            if not adjoint_source_info.normalize_sim:
-                sim_adj_update_dict["normalize_index"] = None
+            if adjoint_source_info.normalize_sim:
+                normalize_index_adj = 0
+            else:
+                normalize_index_adj = None
+
+            sim_adj_update_dict["normalize_index"] = normalize_index_adj
 
             if sim_original.sources and grid_spec_original.wavelength is None:
                 sim_adj_update_dict["grid_spec"] = grid_spec_adj


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-22 20:21:32 UTC

This PR fixes a critical bug in Tidy3D's autograd adjoint simulation functionality related to the `normalize_index` parameter handling. The core issue was that adjoint simulations could inappropriately reuse `normalize_index` values from forward simulations, potentially causing out-of-range errors or incorrect normalization behavior.

The fix implements explicit logic in `sim_data.py` that ensures `normalize_index` is always properly set based on the `normalize_sim` flag: when normalization is enabled (`normalize_sim=True`), it defaults to index 0 (the first adjoint source), and when disabled, it's set to `None`. This replaces the previous conditional logic that only handled the `False` case, leaving the `True` case potentially undefined.

The changes integrate well with Tidy3D's broader autograd ecosystem, which is used for inverse design workflows where gradient-based optimization requires reliable field normalization. The `normalize_index` parameter is particularly important in multi-source simulations where users need to specify which source serves as the normalization reference. This fix ensures that adjoint simulations maintain consistent and predictable normalization behavior, which is essential for accurate gradient computations in electromagnetic optimization problems.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/data/sim_data.py | 5/5 | Fixed normalize_index logic to explicitly set values based on normalize_sim flag |
| tests/test_components/autograd/test_autograd.py | 5/5 | Added regression test for multi-source normalize_index gradient computation |
| CHANGELOG.md | 5/5 | Documented the normalize_index bug fix for autograd adjoint simulations |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it addresses a specific bug with a targeted fix
- Score reflects a well-contained bug fix with appropriate test coverage and clear documentation
- No files require special attention as all changes are straightforward and well-tested

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant Simulation
    participant SimulationData
    participant AutogradPipeline
    participant AdjointSources
    
    User->>Simulation: Create simulation with normalize_index
    User->>AutogradPipeline: Run gradient computation
    
    AutogradPipeline->>SimulationData: Process forward simulation data
    SimulationData->>SimulationData: Check normalize_index bounds
    
    alt normalize_index out of range
        SimulationData->>AdjointSources: Default to first source (index 0)
        Note over SimulationData: Fix: Prevent reusing invalid normalize_index
        AdjointSources-->>SimulationData: Use safe normalization index
    else normalize_index valid
        SimulationData->>AdjointSources: Use original normalize_index
        AdjointSources-->>SimulationData: Use specified normalization index
    end
    
    SimulationData->>AutogradPipeline: Create adjoint sources with valid index
    AutogradPipeline->>User: Return gradient computation results
```

<!-- /greptile_comment -->