### PR TITLE
fix(CM): long validation error

### DIFF
--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -63,6 +63,25 @@ SOLVER_NAME = {
     "VOLUME_MESH": "VolumeMesher",
 }
 
+TERMINAL_ERRORS = {
+    "validate_fail",
+    "error",
+    "diverged",
+    "blocked",
+    "aborting",
+    "aborted",
+}
+
+RUN_STATUSES = [
+    "draft",
+    "preprocess",
+    "validating",
+    "validate",
+    "running",
+    "postprocess",
+    "success",
+]
+
 
 def _get_url(task_id: str) -> str:
     """Get the URL for a task on our server."""
@@ -1070,21 +1089,13 @@ def _monitor_modeler_batch(
 
     # Non-verbose path: poll without progress bars then return
     if not verbose:
-        terminal_errors = {
-            "validate_fail",
-            "error",
-            "diverged",
-            "blocked",
-            "aborting",
-            "aborted",
-        }
         # Run phase
         while True:
             d = _batch_detail(batch_id)
             s = d.totalStatus.value
             total = d.totalTask or 0
             r = d.runSuccess or 0
-            if s in terminal_errors:
+            if s in TERMINAL_ERRORS:
                 raise WebError(f"Batch {batch_id} terminated: {s}")
             if total and r >= total:
                 break
@@ -1096,7 +1107,7 @@ def _monitor_modeler_batch(
             postprocess_status = d.postprocessStatus
             if postprocess_status == "success":
                 break
-            elif postprocess_status in terminal_errors:
+            elif postprocess_status in TERMINAL_ERRORS:
                 raise WebError(
                     f"Batch {batch_id} terminated. Please contact customer support and provide this Component Modeler batch ID: '{batch_id}'"
                 )
@@ -1110,20 +1121,9 @@ def _monitor_modeler_batch(
         TimeElapsedColumn(),
     )
     with Progress(*progress_columns, console=console, transient=False) as progress:
-        terminal_errors = {"validate_fail", "error", "diverged", "blocked", "aborting", "aborted"}
-
         # Phase: Run (aggregate + per-task)
         p_run = progress.add_task("Run Total", total=1.0)
         task_bars: dict[str, int] = {}
-        run_statuses = [
-            "draft",
-            "preprocess",
-            "validating",
-            "validate",
-            "running",
-            "postprocess",
-            "success",
-        ]
 
         while True:
             detail = _batch_detail(batch_id)
@@ -1140,8 +1140,8 @@ def _monitor_modeler_batch(
                         _, idx = _status_to_stage(tstatus)
                         pbar = progress.add_task(
                             f"  {name}",
-                            total=len(run_statuses) - 1,
-                            completed=min(idx, len(run_statuses) - 1),
+                            total=len(RUN_STATUSES) - 1,
+                            completed=min(idx, len(RUN_STATUSES) - 1),
                         )
                         task_bars[name] = pbar
 
@@ -1174,7 +1174,7 @@ def _monitor_modeler_batch(
 
             if total and r >= total:
                 break
-            if status in terminal_errors:
+            if status in TERMINAL_ERRORS:
                 raise WebError(f"Batch {batch_id} terminated: {status}")
             progress.refresh()
             time.sleep(REFRESH_TIME)
@@ -1195,7 +1195,7 @@ def _monitor_modeler_batch(
                 progress.update(p_post, completed=0.33)
             elif postprocess_status == "running":
                 progress.update(p_post, completed=0.55)
-            elif postprocess_status in terminal_errors:
+            elif postprocess_status in TERMINAL_ERRORS:
                 raise WebError(
                     f"Batch {batch_id} terminated. Please contact customer support and provide this Component Modeler batch ID: '{batch_id}'"
                 )
@@ -1355,22 +1355,40 @@ def estimate_cost(
     console = get_logging_console() if verbose else None
 
     if _is_modeler_batch(task_id):
-        status = _batch_detail(task_id).totalStatus.value
+        d = _batch_detail(task_id)
+        status = d.totalStatus.value
 
         # Wait for a termination status
         while status not in ["validate_success", "success", "error", "failed"]:
             time.sleep(REFRESH_TIME)
-            status = _batch_detail(task_id).totalStatus.value
+            d = _batch_detail(task_id)
+            status = d.totalStatus.value
 
-        if status in ["validate_success", "success"]:
-            est_flex_unit = _batch_detail(task_id).estFlexUnit
-            if verbose:
-                console.log(
-                    f"Maximum FlexCredit cost: {est_flex_unit:1.3f}. Minimum cost depends on "
-                    "task execution details. Use 'web.real_cost(task_id)' to get the billed FlexCredit "
-                    "cost after a simulation run."
-                )
-            return est_flex_unit
+            if status in ["validate_success", "success"]:
+                est_flex_unit = _batch_detail(task_id).estFlexUnit
+                if verbose:
+                    console.log(
+                        f"Maximum FlexCredit cost: {est_flex_unit:1.3f}. Minimum cost depends on "
+                        "task execution details. Use 'web.real_cost(task_id)' to get the billed FlexCredit "
+                        "cost after a simulation run."
+                    )
+                return est_flex_unit
+            elif status in TERMINAL_ERRORS:
+                log.error(f"The ComponentModeler '{task_id}' has failed: {status}")
+
+                if status == "validate_fail":
+                    assert d.validateErrors is not None
+                    for key, error in d.validateErrors.items():
+                        # I don't like this ideally but would like to control the endpoint to make this better
+                        error_dict = json.loads(error)
+                        validation_error = error_dict["validation_error"]
+                        log.error(
+                            f"Subtask '{key}' has failed to validate:"
+                            f" \n {validation_error} \n "
+                            f"Fix your component modeler configuration. "
+                            f"Generate subtask simulations locally using `ComponentModelerType.sim_dict`."
+                        )
+                break
     else:
         task = SimulationTask.get(task_id)
 

--- a/tidy3d/web/core/task_info.py
+++ b/tidy3d/web/core/task_info.py
@@ -316,3 +316,4 @@ class BatchDetail(TaskBase):
     totalCheckMillis: int = None
     message: str = None
     tasks: list[BatchMember] = []
+    validateErrors: dict = None


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-09-24 14:40:31 UTC

<h3>Summary</h3>

This PR improves error handling for ComponentModeler validation failures by adding detailed error reporting and extracting hardcoded constants to module level.

- Extracted `terminal_errors` and `run_statuses` constants to module level to eliminate code duplication
- Added `validateErrors` field to `BatchDetail` class to capture validation error details  
- Enhanced `estimate_cost` function to provide detailed logging for validation failures, parsing JSON error responses and showing specific subtask failures
- Improved maintainability by removing duplicate constant definitions across multiple functions

The changes focus on better user experience when validation fails, providing more actionable error messages instead of generic failure notifications.

<h3>Confidence Score: 3/5</h3>

- This PR has a critical control flow bug that prevents proper error handling
- Score reflects a serious logical error in the control flow where status checking happens inside the waiting loop instead of after it, which breaks the intended error handling behavior. The code refactoring and new features are good, but the control flow bug needs to be fixed.
- tidy3d/web/api/webapi.py requires immediate attention due to incorrect control flow in estimate_cost function

<h3>Important Files Changed</h3>



File Analysis



| Filename | &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;  Score &nbsp;&nbsp;&nbsp;&nbsp; &nbsp; | Overview |
|----------|-------|----------|
| tidy3d/web/api/webapi.py | 4/5 | Extracted hardcoded constants to module level and improved error handling for validation failures with detailed logging |
| tidy3d/web/core/task_info.py | 5/5 | Added validateErrors field to BatchDetail class to support detailed error reporting |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant estimate_cost
    participant _batch_detail
    participant Logger as log
    
    Client->>estimate_cost: estimate_cost(task_id, verbose)
    estimate_cost->>_batch_detail: get batch details
    _batch_detail-->>estimate_cost: BatchDetail with status
    
    loop Wait for termination status
        estimate_cost->>_batch_detail: poll for status update
        _batch_detail-->>estimate_cost: updated status
    end
    
    alt status in ["validate_success", "success"]
        estimate_cost->>Client: return est_flex_unit
    else status in terminal_errors
        estimate_cost->>Logger: log.error(failure message)
        
        alt status == "validate_fail"
            estimate_cost->>_batch_detail: get validateErrors
            _batch_detail-->>estimate_cost: validateErrors dict
            
            loop for each validation error
                estimate_cost->>estimate_cost: parse JSON error
                estimate_cost->>Logger: log.error(detailed validation error)
            end
        end
        
        estimate_cost->>estimate_cost: break from loop
    end
```

<!-- /greptile_comment -->