### PR TITLE
fix: add missing classes in docs and fix formatting errors (FXC-4270)

### DIFF
--- a/docs/api/charge/mediums.rst
+++ b/docs/api/charge/mediums.rst
@@ -59,6 +59,28 @@ Bandgap
    tidy3d.SlotboomBandGapNarrowing
 
 
+Effective Density Of States (DOS)
+^^^^^^^^
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.ConstantEffectiveDOS
+   tidy3d.IsotropicEffectiveDOS
+   tidy3d.MultiValleyEffectiveDOS
+   tidy3d.DualValleyEffectiveDOS
+
+Energy Bandgap
+^^^^^^^^
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.ConstantEnergyBandGap
+   tidy3d.VarshniEnergyBandGap
+
 Charge Carrier Properties
 ------------------------------------
 

--- a/docs/api/spice.rst
+++ b/docs/api/spice.rst
@@ -27,4 +27,5 @@ Analysis
    tidy3d.AbstractSSACAnalysis
    tidy3d.SSACAnalysis
    tidy3d.IsothermalSSACAnalysis
+   tidy3d.SteadyChargeDCAnalysis
    tidy3d.ChargeToleranceSpec

--- a/tidy3d/components/spice/analysis/dc.py
+++ b/tidy3d/components/spice/analysis/dc.py
@@ -72,7 +72,7 @@ class SteadyChargeDCAnalysis(Tidy3dBaseModel):
     fermi_dirac: bool = pd.Field(
         False,
         title="Fermi-Dirac statistics",
-        description="Determines whether Fermi-Dirac statistics are used. When False, "
+        description="Determines whether Fermi-Dirac statistics are used. When ``False``, "
         "Boltzmann statistics will be used. This can provide more accurate results in situations "
         "where very high doping may lead the pseudo-Fermi energy level to approach "
         "either the conduction or valence energy bands.",

--- a/tidy3d/components/tcad/bandgap_energy.py
+++ b/tidy3d/components/tcad/bandgap_energy.py
@@ -25,9 +25,9 @@ class VarshniEnergyBandGap(Tidy3dBaseModel):
     -----
     The model implements the following formula:
 
-        .. math::
+    .. math::
 
-            E_g(T) = E_g(0) - \\frac{\\alpha T^2}{T + \\beta}$
+        E_g(T) = E_g(0) - \\frac{\\alpha T^2}{T + \\beta}
 
     Example
     -------

--- a/tidy3d/components/tcad/effective_DOS.py
+++ b/tidy3d/components/tcad/effective_DOS.py
@@ -6,7 +6,7 @@ import numpy as np
 import pydantic.v1 as pd
 
 from tidy3d.components.base import Tidy3dBaseModel
-from tidy3d.constants import HBAR, K_B, M_E_EV
+from tidy3d.constants import HBAR, K_B, M_E_EV, PERCMCUBE
 from tidy3d.exceptions import DataError
 
 um_3_to_cm_3 = 1e12  # conversion factor from micron^(-3) to cm^(-3)
@@ -33,7 +33,7 @@ class ConstantEffectiveDOS(EffectiveDOS):
     """Constant effective density of states model."""
 
     N: pd.PositiveFloat = pd.Field(
-        ..., title="Effective DOS", description="Effective density of states", units="cm^(-3)"
+        ..., title="Effective DOS", description="Effective density of states", units=PERCMCUBE
     )
 
     def calc_eff_dos(self, T: float):
@@ -44,11 +44,13 @@ class IsotropicEffectiveDOS(EffectiveDOS):
     """Effective density of states model that assumes single valley and isotropic effective mass.
     The model assumes the standard equation for the 3D semiconductor with parabolic energy dispersion:
 
+    Notes
+    -----
+
     .. math::
 
-        \\begin{equation}
-             \\mathbf{N_eff} = 2 * (\\frac{m_eff * m_e * k_B T}{2 \\pi \\hbar^2})^(3/2)
-        \\end{equation}
+        \\mathbf{N_eff} = 2 * (\\frac{m_eff * m_e * k_B T}{2 \\pi \\hbar^2})^(3/2)
+
     """
 
     m_eff: pd.PositiveFloat = pd.Field(
@@ -65,11 +67,13 @@ class MultiValleyEffectiveDOS(EffectiveDOS):
     """Effective density of states model that assumes multiple equivalent valleys and anisotropic effective mass.
     The model assumes the standard equation for the 3D semiconductor with parabolic energy dispersion:
 
+    Notes
+    -----
+
     .. math::
 
-        \\begin{equation}
-             \\mathbf{N_eff} = 2 * N_valley * (m_{eff_long} * m_{eff_trans} * m_{eff_trans})^(1/2) *(\\frac{m_e * k_B * T}{2 \\pi * \\hbar^2})^(3/2)
-        \\end{equation}
+       N_{\\text{eff}} = 2 N_{\\text{valley}} \\left( m_{\\text{eff,long}} m_{\\text{eff,trans}}^2 \\right)^{1/2} \\left( \\frac{m_e k_B T}{2 \\pi \\hbar^2} \\right)^{3/2}
+
     """
 
     m_eff_long: pd.PositiveFloat = pd.Field(
@@ -101,11 +105,13 @@ class DualValleyEffectiveDOS(EffectiveDOS):
     """Effective density of states model that assumes combination of light holes and heavy holes with isotropic effective masses.
     The model assumes the standard equation for the 3D semiconductor with parabolic energy dispersion:
 
+    Notes
+    -----
+
     .. math::
 
-        \\begin{equation}
-             \\mathbf{N_eff} = 2 * ( {\\frac{m_{eff_lh} * m_e * k_B * T}{2 \\pi \\hbar^2})^(3/2) + (\\frac{m_{eff_hh} * m_e * k_B * T}{2 \\pi \\hbar^2})^(3/2) )
-        \\end{equation}
+       N_{eff} = 2 \\left( \\frac{m_{\\text{eff, lh}} m_e k_B T}{2 \\pi \\hbar^2} \\right)^{3/2} + 2 \\left( \\frac{m_{\\text{eff, hh}} m_e k_B T}{2 \\pi \\hbar^2} \\right)^{3/2}
+
     """
 
     m_eff_lh: pd.PositiveFloat = pd.Field(


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-09-24 09:13:09 UTC

<h3>Summary</h3>

This PR addresses documentation completeness and formatting issues by adding missing class references and fixing various formatting errors.

Key changes include:
- Added missing "Effective Density Of States (DOS)" and "Energy Bandgap" sections in charge mediums documentation with proper class references
- Added missing `SteadyChargeDCAnalysis` class reference to the SPICE analysis documentation
- Fixed docstring formatting by properly formatting boolean values with backticks
- Improved LaTeX mathematical formula formatting by correcting math blocks and notation
- Fixed file endings and general formatting consistency

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This PR contains only documentation improvements with no code logic changes, making it completely safe to merge
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;  Score &nbsp;&nbsp;&nbsp;&nbsp; &nbsp; | Overview |
|----------|-------|----------|
| docs/api/charge/mediums.rst | 5/5 | Added missing Effective Density Of States (DOS) and Energy Bandgap sections with proper class references, and fixed missing newline at end of file |
| docs/api/spice.rst | 5/5 | Added missing SteadyChargeDCAnalysis class reference to the Analysis section |
| tidy3d/components/spice/analysis/dc.py | 5/5 | Fixed formatting in docstring by properly formatting 'False' with backticks for consistent documentation rendering |
| tidy3d/components/tcad/bandgap_energy.py | 5/5 | Fixed mathematical formula formatting by removing improper equation environment and correcting LaTeX markup |
| tidy3d/components/tcad/effective_DOS.py | 5/5 | Updated units constant usage and fixed mathematical formula formatting by restructuring math blocks and improving LaTeX notation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant RST as RST Docs
    participant PY as Python Files
    participant Sphinx as Documentation Builder
    
    Dev->>RST: Add missing class references
    Dev->>RST: Fix formatting errors
    Dev->>PY: Fix docstring formatting
    Dev->>PY: Improve LaTeX math notation
    RST->>Sphinx: Generate API documentation
    PY->>Sphinx: Extract docstrings for rendering
    Sphinx->>Dev: Complete documentation build
```

<!-- /greptile_comment -->