### PR TITLE
remove internal absorbers in reduced_simulation_copy

### DIFF
--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -253,6 +253,8 @@ def check_ms_reduction(ms):
     assert np.allclose(grids_1d.z, grids_1d_red.z)
     modes_red = ms.solve()
     assert np.allclose(ms.data.n_eff.values, modes_red.n_eff.values)
+    assert len(ms_red.simulation.sources) == 0
+    assert len(ms_red.simulation.internal_absorbers) == 0
 
 
 def test_mode_solver_validation():

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -569,15 +569,7 @@ class ModeSolver(Tidy3dBaseModel):
         # # if self.mode_spec.bend_radius is None, use this instead
         #     solver_ref_data_straight = self._ref_data_straight(mode_solver_data=solver_ref_data)
 
-        try:
-            solver = self.reduced_simulation_copy
-        except Exception as e:
-            solver = self
-            log.warning(
-                "Mode solver reduced_simulation_copy failed. "
-                "Falling back to non-reduced simulation, which may be slower. "
-                f"Exception: {e!s}"
-            )
+        solver = self._reduced_simulation_copy_with_fallback
 
         # Compute the mode solution by rotating the reference data to the monitor plane
         rotated_mode_fields = self._mode_rotation(
@@ -1128,22 +1120,26 @@ class ModeSolver(Tidy3dBaseModel):
 
         return bend_center
 
-    def _data_on_yee_grid(self) -> ModeSolverData:
-        """Solve for all modes, and construct data with fields on the Yee grid."""
-
+    @cached_property
+    def _reduced_simulation_copy_with_fallback(self) -> ModeSolver:
+        """Try to get a reduced simulation copy. If it fails, fall back to the non-reduced simulation."""
         # we try to do reduced simulation copy for efficiency
         # it should never fail -- if it does, this is likely due to an oversight
         # in the Simulation.subsection method. but falling back to non-reduced
         # simulation prevents unneeded errors in this case
         try:
-            solver = self.reduced_simulation_copy
+            return self.reduced_simulation_copy
         except Exception as e:
-            solver = self
             log.warning(
                 "Mode solver reduced_simulation_copy failed. "
                 "Falling back to non-reduced simulation, which may be slower. "
                 f"Exception: {e!s}"
             )
+            return self
+
+    def _data_on_yee_grid(self) -> ModeSolverData:
+        """Solve for all modes, and construct data with fields on the Yee grid."""
+        solver = self._reduced_simulation_copy_with_fallback
 
         _, _solver_coords = solver.plane.pop_axis(
             solver._solver_grid.boundaries.to_list, axis=solver.normal_axis
@@ -2609,6 +2605,7 @@ class ModeSolver(Tidy3dBaseModel):
             region=new_sim_box,
             monitors=[],
             sources=[],
+            internal_absorbers=[],
             warn_symmetry_expansion=False,  # we already warn upon mode solver creation
             grid_spec="identical",
             boundary_spec=new_bspec,


### PR DESCRIPTION
PEC frames can potentially be generated only for absorbers and mode sources. `ModeSolver.reduced_simulation_copy` removes sources, but not absorbers. While this doesn't seem to affect results, let's be consistent.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-09-25 07:00:28 UTC

<h3>Summary</h3>

This PR refactors the mode solver's simulation reduction logic and ensures internal absorbers are properly excluded from reduced simulations.

**Key changes:**
- Extracted the try-catch logic for reduced simulation copy into a `@cached_property` method `_reduced_simulation_copy_with_fallback`
- Added `internal_absorbers=[]` parameter to the `subsection()` call in `reduced_simulation_copy`
- Added test assertions to verify the reduced simulation has empty `sources` and `internal_absorbers`

The refactoring improves code organization by eliminating duplicate try-catch blocks and properly leverages caching for the fallback mechanism.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean refactoring that improves code organization, follows established patterns with @cached_property, includes appropriate test coverage, and maintains all existing functionality while ensuring internal absorbers are properly excluded from reduced simulations
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;  Score &nbsp;&nbsp;&nbsp;&nbsp; &nbsp; | Overview |
|----------|-------|----------|
| tidy3d/components/mode/mode_solver.py | 5/5 | Refactored exception handling into cached property and added internal_absorbers=[] to reduced simulation |
| tests/test_plugins/test_mode_solver.py | 5/5 | Added assertions to verify reduced simulation has empty sources and internal_absorbers |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant MS as ModeSolver
    participant RSCF as _reduced_simulation_copy_with_fallback
    participant RSC as reduced_simulation_copy
    participant Sim as Simulation
    participant Log as Logger

    Note over MS: solve() method calls
    MS->>RSCF: Get solver instance
    
    alt First call (cached_property)
        RSCF->>RSC: Try to get reduced simulation
        alt Success
            RSC->>Sim: subsection() with internal_absorbers=[]
            Sim-->>RSC: New reduced simulation
            RSC-->>RSCF: ModeSolver with reduced sim
        else Exception
            RSC-->>RSCF: Throws exception
            RSCF->>Log: Warning about fallback
            RSCF-->>RSCF: Return self (original)
        end
        RSCF-->>MS: Cached solver instance
    else Subsequent calls
        RSCF-->>MS: Return cached solver
    end
    
    MS->>MS: Continue with _data_on_yee_grid()
    
    Note over MS: Test verification
    MS->>Sim: Check sources length = 0
    MS->>Sim: Check internal_absorbers length = 0
```

<!-- /greptile_comment -->