### PR TITLE
Fix doping

### DIFF
--- a/tidy3d/components/tcad/doping.py
+++ b/tidy3d/components/tcad/doping.py
@@ -190,7 +190,8 @@ class GaussianDoping(AbstractDopingBox):
 
         indices_in_box, X, Y, Z = self._get_indices_in_box(coords=coords, meshgrid=meshgrid)
 
-        x_contrib = np.ones(X.shape)
+        x_contrib = np.zeros(X.shape)
+        x_contrib[indices_in_box] = 1.0
         if self.source != "xmin":
             x0 = self.bounds[0][0]
             indices = np.logical_and(x0 <= X, x0 + self.width >= X)
@@ -215,7 +216,8 @@ class GaussianDoping(AbstractDopingBox):
                 / self.sigma
             )
 
-        y_contrib = np.ones(X.shape)
+        y_contrib = np.zeros(X.shape)
+        y_contrib[indices_in_box] = 1.0
         if self.source != "ymin":
             y0 = self.bounds[0][1]
             indices = np.logical_and(y0 <= Y, y0 + self.width >= Y)
@@ -240,7 +242,8 @@ class GaussianDoping(AbstractDopingBox):
                 / self.sigma
             )
 
-        z_contrib = np.ones(X.shape)
+        z_contrib = np.zeros(X.shape)
+        z_contrib[indices_in_box] = 1.0
         if self.source != "zmin":
             z0 = self.bounds[0][2]
             indices = np.logical_and(z0 <= Z, z0 + self.width >= Z)


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-09-25 15:26:32 UTC

<h3>Summary</h3>

Fixed a critical bug in the `GaussianDoping._get_contrib` method where contribution arrays were incorrectly initialized with `np.ones()` instead of `np.zeros()`. This caused doping contributions to be applied to all grid points rather than only those within the specified doping box boundaries.

**Key Changes:**
- Changed initialization of `x_contrib`, `y_contrib`, and `z_contrib` from `np.ones(X.shape)` to `np.zeros(X.shape)`  
- Added explicit setting of contribution to `1.0` only for indices within the doping box (`indices_in_box`)
- Ensures proper spatial localization of gaussian doping profiles

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects a straightforward bug fix with clear logic improvement. The change corrects a fundamental initialization error and follows established patterns in the codebase. No breaking changes or complex logic introduced.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;  Score &nbsp;&nbsp;&nbsp;&nbsp; &nbsp; | Overview |
|----------|-------|----------|
| tidy3d/components/tcad/doping.py | 5/5 | Fixed critical bug where gaussian doping contribution was incorrectly applied to all grid points instead of only points within the doping box |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant GaussianDoping
    participant AbstractDopingBox
    
    Client->>GaussianDoping: _get_contrib(coords, meshgrid)
    GaussianDoping->>AbstractDopingBox: _get_indices_in_box(coords, meshgrid)
    AbstractDopingBox-->>GaussianDoping: indices_in_box, X, Y, Z
    
    Note over GaussianDoping: Initialize contribution arrays
    GaussianDoping->>GaussianDoping: x_contrib = np.zeros(X.shape)
    GaussianDoping->>GaussianDoping: x_contrib[indices_in_box] = 1.0
    
    Note over GaussianDoping: Apply Gaussian profile for x-direction
    alt self.source != "xmin"
        GaussianDoping->>GaussianDoping: Calculate gaussian decay from x0
        GaussianDoping->>GaussianDoping: x_contrib[indices] = exp(-(X-x0-width)²/(2σ²))
    end
    
    alt self.source != "xmax"  
        GaussianDoping->>GaussianDoping: Calculate gaussian decay from x1
        GaussianDoping->>GaussianDoping: x_contrib[indices] = exp(-(X-x1+width)²/(2σ²))
    end
    
    Note over GaussianDoping: Similar process for y and z directions
    GaussianDoping->>GaussianDoping: y_contrib = np.zeros(X.shape)
    GaussianDoping->>GaussianDoping: y_contrib[indices_in_box] = 1.0
    GaussianDoping->>GaussianDoping: Apply gaussian profile for y-direction
    
    GaussianDoping->>GaussianDoping: z_contrib = np.zeros(X.shape)  
    GaussianDoping->>GaussianDoping: z_contrib[indices_in_box] = 1.0
    GaussianDoping->>GaussianDoping: Apply gaussian profile for z-direction
    
    Note over GaussianDoping: Combine all contributions
    GaussianDoping->>GaussianDoping: total_contrib = x_contrib * y_contrib * z_contrib * concentration
    
    GaussianDoping-->>Client: total_contrib.squeeze()
```

<!-- /greptile_comment -->