### PR TITLE
FXC-3724 support multimodal waveports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support of `os.PathLike` objects as paths like `pathlib.Path` alongside `str` paths in all path-related functions.
 - Added configurable local simulation result caching with checksum validation, eviction limits, and per-call overrides across `web.run`, `web.load`, and job workflows.
 - Added `DirectivityMonitorSpec` for automated creation and configuration of directivity radiation monitors in `TerminalComponentModeler`.
+- Added multimode support to `WavePort` in the smatrix plugin, allowing multiple modes to be analyzed per port.
+
+### Breaking Changes
+**Note: These breaking changes only affect the microwave and smatrix plugins.**
+- Renamed path integral classes for improved consistency. Please see our migration guide for details on updating your code.
+  - `VoltageIntegralAxisAligned` → `AxisAlignedVoltageIntegral`
+  - `CurrentIntegralAxisAligned` → `AxisAlignedCurrentIntegral`
+  - `CustomPathIntegral2D` → `Custom2DPathIntegral`
+  - `CustomVoltageIntegral2D` → `Custom2DVoltageIntegral`
+  - `CustomCurrentIntegral2D` → `Custom2DCurrentIntegral`
+  - Path integral and impedance calculator classes have been refactored and moved from the microwave plugin into Tidy3D components. They are now publicly exported via the top-level package `__init__.py`.
+- `WavePort` has been refactored to use `MicrowaveModeSpec`. The fields `voltage_integral`, and `current_integral` have been removed. Impedance specifications are now defined in `MicrowaveModeSpec.impedance_specs`. Please see our migration guide for details on updating your code.
 
 ### Changed
 - Improved performance of antenna metrics calculation by utilizing cached wave amplitude calculations instead of recomputing wave amplitudes for each port excitation in the `TerminalComponentModelerData`.
@@ -35,13 +47,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allowing for more geometries in a ClipOperation geometry.
 - Improved the speed of computing `Box` shape derivatives when used inside a `GeometryGroup`.
 - All RF and microwave specific components now inherit from `MicrowaveBaseModel`.
-- **[BREAKING]** Renamed path integral classes in `tidy3d.plugins.microwave` for improved consistency. Please see our migration guide for details on updating your code.
-  - `VoltageIntegralAxisAligned` → `AxisAlignedVoltageIntegral`
-  - `CurrentIntegralAxisAligned` → `AxisAlignedCurrentIntegral`
-  - `CustomPathIntegral2D` → `Custom2DPathIntegral`
-  - `CustomVoltageIntegral2D` → `Custom2DVoltageIntegral`
-  - `CustomCurrentIntegral2D` → `Custom2DCurrentIntegral`
-  - Path integral and impedance calculator classes have been refactored and moved from `tidy3d.plugins.microwave` to `tidy3d.components.microwave`. They are now publicly exported via the top-level package `__init__.py`, so you can import them directly, e.g. `from tidy3d import ImpedanceCalculator, AxisAlignedVoltageIntegral, AxisAlignedCurrentIntegral, Custom2DVoltageIntegral, Custom2DCurrentIntegral, Custom2DPathIntegral`.
 - `DirectivityMonitor` now forces `far_field_approx` to `True`, which was previously configurable.
 - Unified run submission API: `web.run(...)` is now a container-aware wrapper that accepts a single simulation or arbitrarily nested containers (`list`, `tuple`, `dict` values) and returns results in the same shape.
 - `web.Batch(ComponentModeler)` and `web.Job(ComponentModeler)` native support

--- a/docs/api/microwave/microwave_migration.rst
+++ b/docs/api/microwave/microwave_migration.rst
@@ -1,18 +1,27 @@
 .. _microwave_migration:
 
-v2.10 Refactor Migration
--------------------------
+v2.10 Refactor Migration Guide
+-------------------------------
 
-In version ``v2.10.0``, microwave plugin path integral classes were renamed for improved consistency and clarity. Additionally, these classes (and the impedance calculator) were refactored out of the plugin and moved into ``tidy3d.components.microwave`` and re-exported at the top-level package for convenience. This guide helps you update your scripts to use the new class names and imports.
+In version ``v2.10.0``, the microwave and RF simulation capabilities underwent significant refactoring to improve consistency, clarity, and functionality. This guide covers two major sets of breaking changes:
 
-Key Changes
-~~~~~~~~~~~
+1. **Path Integral Class Renames** - Classes were renamed for consistency
+2. **WavePort API Changes** - WavePort was refactored to support multiple modes with cleaner impedance specification
+
+This guide helps you update your scripts to work with v2.10+.
+
+1. Path Integral Class Renames
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Path integral classes were renamed for improved consistency and clarity. Additionally, these classes (and the impedance calculator) were refactored out of the plugin and re-exported at the top-level package for convenience.
+
+**Key changes:**
 
 *   **Renamed Classes**: Path integral classes have been renamed to follow a consistent naming pattern.
 *   **New Import Path (simplified)**: The path integral classes and impedance calculator are now exported at the top level. Prefer importing directly from ``tidy3d`` (e.g., ``from tidy3d import AxisAlignedVoltageIntegral, ImpedanceCalculator``). Existing plugin imports continue to work for backwards compatibility where applicable.
 
 Class Name Changes
-~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^
 
 The following classes have been renamed for consistency:
 
@@ -31,7 +40,7 @@ The following classes have been renamed for consistency:
 *   ``CustomPathIntegral2D`` → ``Custom2DPathIntegral``
 
 Migration Examples
-~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^
 
 **Before (v2.9.x):**
 
@@ -76,7 +85,7 @@ Migration Examples
     )
 
 Custom 2D Path Integrals
-~~~~~~~~~~~~~~~~~~~~~~~~~
+""""""""""""""""""""""""
 
 **Before:**
 
@@ -125,6 +134,317 @@ Custom 2D Path Integrals
     )
 
 Summary
-~~~~~~~
+^^^^^^^
 
 All functionality remains the same—only class names and preferred import paths have changed. Update your imports to the top level (``from tidy3d import ...``) and class names according to the table above, and your code will work with v2.10. For impedance calculations, import ``ImpedanceCalculator`` directly via ``from tidy3d import ImpedanceCalculator``.
+
+2. WavePort API Changes for Multimodal Support
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``WavePort`` class was refactored to support multiple modes and to provide cleaner integration with the microwave mode solver. This required several breaking changes to the API.
+
+Overview of Breaking Changes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The WavePort refactor introduces the following breaking changes:
+
+*   **Removed fields**: ``voltage_integral`` and ``current_integral`` fields are removed from ``WavePort``
+*   **Impedance specification moved**: Voltage and current path integrals are now specified via ``MicrowaveModeSpec.impedance_specs`` instead of directly on the port
+*   **ModeSpec type changed**: ``mode_spec`` field now requires ``MicrowaveModeSpec`` instead of generic ``ModeSpec``
+*   **Method renamed**: ``compute_port_impedance()`` renamed to ``get_port_impedance()`` with new signature
+*   **Return shapes changed**: ``compute_voltage()`` and ``compute_current()`` now return data with a ``mode_index`` dimension
+*   **Deprecated field**: ``mode_index`` field is deprecated (still works but triggers warning)
+
+Removed Fields
+^^^^^^^^^^^^^^
+
+The following fields have been **removed** from ``WavePort``:
+
+*   ``voltage_integral: Optional[VoltageIntegralType]`` - Path integral for voltage calculation
+*   ``current_integral: Optional[CurrentIntegralType]`` - Path integral for current calculation
+
+Deprecated Fields
+^^^^^^^^^^^^^^^^^
+
+*   ``mode_index: Optional[int]`` - **Deprecated** field that previously specified which single mode to use (default was 0 in v2.9). Still works for backward compatibility but triggers a deprecation warning. Will be removed in a future version. **Migration**: For backwards compatible code, omit this field entirely. For forward compatible code, use ``mode_selection`` instead if you need to select specific modes.
+
+New MicrowaveModeSpec Integration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``mode_spec`` field now requires a ``MicrowaveModeSpec`` (instead of the generic ``ModeSpec``). This new class includes:
+
+*   ``impedance_specs``: Defines how to compute voltage, current, and characteristic impedance for each mode
+
+Migration Examples
+^^^^^^^^^^^^^^^^^^
+
+Single-Mode WavePort
+""""""""""""""""""""
+
+**Before (v2.9.x):**
+
+.. code-block:: python
+
+    import tidy3d as td
+    from tidy3d.plugins.smatrix import WavePort
+
+    # Define path integrals
+    voltage_path = td.AxisAlignedVoltageIntegralSpec(
+        center=(0, 0, 0),
+        size=(1.0, 0, 0),
+        sign="+",
+    )
+
+    current_path = td.Custom2DCurrentIntegralSpec.from_circular_path(
+        center=(0, 0, 0),
+        radius=0.5,
+        num_points=21,
+        normal_axis=2,
+        clockwise=False
+    )
+
+    # Create WavePort - path integrals attached directly to port
+    port = WavePort(
+        center=(0, 0, -5),
+        size=(2, 2, 0),
+        direction="+",
+        mode_spec=td.ModeSpec(num_modes=1),  # Generic ModeSpec
+        mode_index=0,  # Which mode to excite
+        voltage_integral=voltage_path,  # Attached to port
+        current_integral=current_path,  # Attached to port
+        name="port1"
+    )
+
+**After (v2.10+):**
+
+.. code-block:: python
+
+    import tidy3d as td
+    from tidy3d.plugins.smatrix import WavePort
+
+    # Define path integrals (same as before)
+    voltage_path = td.AxisAlignedVoltageIntegralSpec(
+        center=(0, 0, 0),
+        size=(1.0, 0, 0),
+        sign="+",
+    )
+
+    current_path = td.Custom2DCurrentIntegralSpec.from_circular_path(
+        center=(0, 0, 0),
+        radius=0.5,
+        num_points=21,
+        normal_axis=2,
+        clockwise=False
+    )
+
+    # Create WavePort - path integrals now in MicrowaveModeSpec
+    port = WavePort(
+        center=(0, 0, -5),
+        size=(2, 2, 0),
+        direction="+",
+        mode_spec=td.MicrowaveModeSpec(  # Use MicrowaveModeSpec
+            num_modes=1,
+            impedance_specs=td.CustomImpedanceSpec(
+                voltage_spec=voltage_path,  # Moved to impedance_specs
+                current_spec=current_path
+            )
+        ),
+        name="port1"
+        # Note: mode_index, voltage_integral, current_integral removed
+    )
+
+    # Mode selection now happens at source creation
+    source_time = td.GaussianPulse(freq0=10e9, fwidth=1e9)
+    source = port.to_source(source_time, mode_index=0)  # Mode selected here
+
+Multi-Mode WavePort (New Feature!)
+"""""""""""""""""""""""""""""""""""
+
+The new API enables WavePorts to support multiple modes simultaneously:
+
+.. code-block:: python
+
+    import tidy3d as td
+    from tidy3d.plugins.smatrix import WavePort
+
+    # Create a 3-mode WavePort
+    port = WavePort(
+        center=(0, 0, -5),
+        size=(4, 4, 0),
+        direction="+",
+        mode_spec=td.MicrowaveModeSpec(
+            num_modes=3,  # Solve for 3 modes
+            impedance_specs=td.AutoImpedanceSpec()  # Auto-compute impedance for all modes
+        ),
+        name="multimode_port"
+    )
+
+    # Create sources for different modes
+    source_time = td.GaussianPulse(freq0=10e9, fwidth=1e9)
+    source_mode0 = port.to_source(source_time, mode_index=0)  # Excite mode 0
+    source_mode1 = port.to_source(source_time, mode_index=1)  # Excite mode 1
+    source_mode2 = port.to_source(source_time, mode_index=2)  # Excite mode 2
+
+Per-Mode Impedance Specifications
+""""""""""""""""""""""""""""""""""
+
+For advanced use cases, you can specify different impedance calculation methods for each mode:
+
+.. code-block:: python
+
+    # Define custom specs for mode 0, auto for modes 1 and 2
+    port = WavePort(
+        center=(0, 0, -5),
+        size=(4, 4, 0),
+        direction="+",
+        mode_spec=td.MicrowaveModeSpec(
+            num_modes=3,
+            impedance_specs=(
+                td.CustomImpedanceSpec(
+                    voltage_spec=custom_voltage_path,
+                    current_spec=custom_current_path
+                ),  # Mode 0 uses custom specs
+                td.AutoImpedanceSpec(),  # Mode 1 uses auto
+                td.AutoImpedanceSpec(),  # Mode 2 uses auto
+            )
+        ),
+        name="mixed_impedance_port"
+    )
+
+Method Changes
+^^^^^^^^^^^^^^
+
+``compute_port_impedance()`` → ``get_port_impedance()``
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+The method for retrieving port impedance has been renamed and now requires a ``mode_index`` parameter:
+
+**Before (v2.9.x):**
+
+.. code-block:: python
+
+    # Get impedance - implicitly used port.mode_index
+    Z0 = port.compute_port_impedance(sim_data)
+
+**After (v2.10+):**
+
+.. code-block:: python
+
+    # Get impedance for mode 0
+    Z0_mode0 = port.get_port_impedance(sim_data, mode_index=0)
+
+    # Get impedance for mode 1 (multimodal port)
+    Z0_mode1 = port.get_port_impedance(sim_data, mode_index=1)
+
+Voltage and Current Computation Shape Changes
+""""""""""""""""""""""""""""""""""""""""""""""
+
+For multimodal ports, ``compute_voltage()`` and ``compute_current()`` now return data for **all modes** with a ``mode_index`` dimension:
+
+**Before (v2.9.x):**
+
+.. code-block:: python
+
+    # Returns shape: (n_freqs,) - single mode only
+    voltage = port.compute_voltage(sim_data)
+    current = port.compute_current(sim_data)
+
+**After (v2.10+):**
+
+.. code-block:: python
+
+    # For single-mode port: Returns shape: (n_freqs, 1)
+    # For multi-mode port: Returns shape: (n_freqs, n_modes)
+    voltage = port.compute_voltage(sim_data)
+    current = port.compute_current(sim_data)
+
+    # Select specific mode using xarray selection
+    voltage_mode0 = voltage.sel(mode_index=0)
+    voltage_mode1 = voltage.sel(mode_index=1)
+
+Using AutoImpedanceSpec for Simplified Setup
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For most cases, you can use ``AutoImpedanceSpec`` which automatically computes voltage, current, and impedance from the electromagnetic fields:
+
+.. code-block:: python
+
+    # Simplest form - let Tidy3D auto-compute everything
+    port = WavePort(
+        center=(0, 0, -5),
+        size=(2, 2, 0),
+        direction="+",
+        mode_spec=td.MicrowaveModeSpec(
+            num_modes=2,
+            impedance_specs=td.AutoImpedanceSpec()  # Works for all modes
+        ),
+        name="simple_port"
+    )
+
+Breaking Changes Summary
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following table summarizes all breaking changes to the ``WavePort`` API:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 30 40
+
+   * - Change
+     - Old (v2.9.x)
+     - New (v2.10+)
+   * - Port field: mode_index
+     - Required ``int`` (default: 0)
+     - **Deprecated** ``Optional[int]``. Omit this field.
+   * - Port field: mode_selection
+     - Did not exist
+     - **NEW** ``Optional[tuple[int, ...]]`` to select specific modes (default: ``None`` = all modes)
+   * - Port field: voltage_integral
+     - ``voltage_integral=path``
+     - Removed. Use ``mode_spec.impedance_specs``
+   * - Port field: current_integral
+     - ``current_integral=path``
+     - Removed. Use ``mode_spec.impedance_specs``
+   * - mode_spec type
+     - ``ModeSpec``
+     - ``MicrowaveModeSpec``
+   * - Impedance method
+     - ``compute_port_impedance(sim_data)``
+     - ``get_port_impedance(sim_data, mode_index)``
+   * - Monitor type
+     - Returns ``ModeMonitor``
+     - Returns ``MicrowaveModeMonitor``
+   * - Voltage/current shape
+     - ``(n_freqs,)``
+     - ``(n_freqs, n_modes)`` - added mode_index dimension
+   * - Multimodal support
+     - Not supported
+     - Fully supported via ``mode_spec.num_modes``
+
+Benefits of the New API
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The refactored API provides several advantages:
+
+*   **Multimodal ports**: Support for multiple modes enables more accurate modeling of multimode waveguides and transmission lines
+*   **Cleaner separation of concerns**: Mode selection happens at excitation time, not port definition time
+*   **Type safety**: ``MicrowaveModeSpec`` and ``MicrowaveModeMonitor`` make RF-specific behavior explicit
+*   **Flexibility**: Per-mode impedance specifications allow fine-grained control
+*   **Consistency**: Aligns with the general pattern of ``ModeSource`` where ``mode_index`` is a source parameter
+
+Backward Compatibility
+^^^^^^^^^^^^^^^^^^^^^^
+
+There is **no backward compatibility** for WavePort instantiation with the old field names (``voltage_integral``, ``current_integral``). Attempting to use these fields will result in a Pydantic validation error.
+
+The ``mode_index`` field is **deprecated** but still functional for backward compatibility:
+
+*   In v2.9: Required ``int`` field (default: 0) specifying which single mode to use
+*   In v2.10+: Optional ``int`` field (still accepts single integer only) but triggers a deprecation warning
+*   **Migration**: Simply omit the ``mode_index`` field from your WavePort definitions
+
+The new ``mode_selection`` field replaces ``mode_index`` for selecting modes:
+
+*   ``mode_selection: Optional[tuple[int, ...]]`` - New field that accepts a tuple of mode indices (e.g., ``(0, 2)`` to use modes 0 and 2)
+*   When ``None`` (default), all modes from ``mode_spec.num_modes`` are used
+*   **Note**: ``mode_index`` accepts only a single ``int``, while ``mode_selection`` accepts a tuple for multiple modes

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -1085,138 +1085,6 @@
       ],
       "type": "object"
     },
-    "AxisAlignedCurrentIntegral": {
-      "additionalProperties": false,
-      "properties": {
-        "attrs": {
-          "default": {},
-          "type": "object"
-        },
-        "center": {
-          "anyOf": [
-            {
-              "items": [
-                {
-                  "anyOf": [
-                    {
-                      "type": "autograd.tracer.Box"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ]
-                },
-                {
-                  "anyOf": [
-                    {
-                      "type": "autograd.tracer.Box"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ]
-                },
-                {
-                  "anyOf": [
-                    {
-                      "type": "autograd.tracer.Box"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ]
-                }
-              ],
-              "maxItems": 3,
-              "minItems": 3,
-              "type": "array"
-            },
-            {
-              "type": "autograd.tracer.Box"
-            }
-          ],
-          "default": [
-            0.0,
-            0.0,
-            0.0
-          ]
-        },
-        "extrapolate_to_endpoints": {
-          "default": false,
-          "type": "boolean"
-        },
-        "sign": {
-          "enum": [
-            "+",
-            "-"
-          ],
-          "type": "string"
-        },
-        "size": {
-          "anyOf": [
-            {
-              "items": [
-                {
-                  "anyOf": [
-                    {
-                      "minimum": 0,
-                      "type": "number"
-                    },
-                    {
-                      "type": "autograd.tracer.Box"
-                    }
-                  ]
-                },
-                {
-                  "anyOf": [
-                    {
-                      "minimum": 0,
-                      "type": "number"
-                    },
-                    {
-                      "type": "autograd.tracer.Box"
-                    }
-                  ]
-                },
-                {
-                  "anyOf": [
-                    {
-                      "minimum": 0,
-                      "type": "number"
-                    },
-                    {
-                      "type": "autograd.tracer.Box"
-                    }
-                  ]
-                }
-              ],
-              "maxItems": 3,
-              "minItems": 3,
-              "type": "array"
-            },
-            {
-              "type": "autograd.tracer.Box"
-            }
-          ]
-        },
-        "snap_contour_to_grid": {
-          "default": false,
-          "type": "boolean"
-        },
-        "type": {
-          "default": "AxisAlignedCurrentIntegral",
-          "enum": [
-            "AxisAlignedCurrentIntegral"
-          ],
-          "type": "string"
-        }
-      },
-      "required": [
-        "sign",
-        "size"
-      ],
-      "type": "object"
-    },
     "AxisAlignedCurrentIntegralSpec": {
       "additionalProperties": false,
       "properties": {
@@ -1339,138 +1207,6 @@
           "default": "AxisAlignedCurrentIntegralSpec",
           "enum": [
             "AxisAlignedCurrentIntegralSpec"
-          ],
-          "type": "string"
-        }
-      },
-      "required": [
-        "sign",
-        "size"
-      ],
-      "type": "object"
-    },
-    "AxisAlignedVoltageIntegral": {
-      "additionalProperties": false,
-      "properties": {
-        "attrs": {
-          "default": {},
-          "type": "object"
-        },
-        "center": {
-          "anyOf": [
-            {
-              "items": [
-                {
-                  "anyOf": [
-                    {
-                      "type": "autograd.tracer.Box"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ]
-                },
-                {
-                  "anyOf": [
-                    {
-                      "type": "autograd.tracer.Box"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ]
-                },
-                {
-                  "anyOf": [
-                    {
-                      "type": "autograd.tracer.Box"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ]
-                }
-              ],
-              "maxItems": 3,
-              "minItems": 3,
-              "type": "array"
-            },
-            {
-              "type": "autograd.tracer.Box"
-            }
-          ],
-          "default": [
-            0.0,
-            0.0,
-            0.0
-          ]
-        },
-        "extrapolate_to_endpoints": {
-          "default": false,
-          "type": "boolean"
-        },
-        "sign": {
-          "enum": [
-            "+",
-            "-"
-          ],
-          "type": "string"
-        },
-        "size": {
-          "anyOf": [
-            {
-              "items": [
-                {
-                  "anyOf": [
-                    {
-                      "minimum": 0,
-                      "type": "number"
-                    },
-                    {
-                      "type": "autograd.tracer.Box"
-                    }
-                  ]
-                },
-                {
-                  "anyOf": [
-                    {
-                      "minimum": 0,
-                      "type": "number"
-                    },
-                    {
-                      "type": "autograd.tracer.Box"
-                    }
-                  ]
-                },
-                {
-                  "anyOf": [
-                    {
-                      "minimum": 0,
-                      "type": "number"
-                    },
-                    {
-                      "type": "autograd.tracer.Box"
-                    }
-                  ]
-                }
-              ],
-              "maxItems": 3,
-              "minItems": 3,
-              "type": "array"
-            },
-            {
-              "type": "autograd.tracer.Box"
-            }
-          ]
-        },
-        "snap_path_to_grid": {
-          "default": false,
-          "type": "boolean"
-        },
-        "type": {
-          "default": "AxisAlignedVoltageIntegral",
-          "enum": [
-            "AxisAlignedVoltageIntegral"
           ],
           "type": "string"
         }
@@ -2771,47 +2507,6 @@
       ],
       "type": "object"
     },
-    "CompositeCurrentIntegral": {
-      "additionalProperties": false,
-      "properties": {
-        "attrs": {
-          "default": {},
-          "type": "object"
-        },
-        "path_specs": {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/AxisAlignedCurrentIntegralSpec"
-              },
-              {
-                "$ref": "#/definitions/Custom2DCurrentIntegralSpec"
-              }
-            ]
-          },
-          "type": "array"
-        },
-        "sum_spec": {
-          "enum": [
-            "split",
-            "sum"
-          ],
-          "type": "string"
-        },
-        "type": {
-          "default": "CompositeCurrentIntegral",
-          "enum": [
-            "CompositeCurrentIntegral"
-          ],
-          "type": "string"
-        }
-      },
-      "required": [
-        "path_specs",
-        "sum_spec"
-      ],
-      "type": "object"
-    },
     "CompositeCurrentIntegralSpec": {
       "additionalProperties": false,
       "properties": {
@@ -3189,42 +2884,6 @@
       },
       "type": "object"
     },
-    "Custom2DCurrentIntegral": {
-      "additionalProperties": false,
-      "properties": {
-        "attrs": {
-          "default": {},
-          "type": "object"
-        },
-        "axis": {
-          "enum": [
-            0,
-            1,
-            2
-          ],
-          "type": "integer"
-        },
-        "position": {
-          "type": "number"
-        },
-        "type": {
-          "default": "Custom2DCurrentIntegral",
-          "enum": [
-            "Custom2DCurrentIntegral"
-          ],
-          "type": "string"
-        },
-        "vertices": {
-          "type": "ArrayLike"
-        }
-      },
-      "required": [
-        "axis",
-        "position",
-        "vertices"
-      ],
-      "type": "object"
-    },
     "Custom2DCurrentIntegralSpec": {
       "additionalProperties": false,
       "properties": {
@@ -3247,42 +2906,6 @@
           "default": "Custom2DCurrentIntegralSpec",
           "enum": [
             "Custom2DCurrentIntegralSpec"
-          ],
-          "type": "string"
-        },
-        "vertices": {
-          "type": "ArrayLike"
-        }
-      },
-      "required": [
-        "axis",
-        "position",
-        "vertices"
-      ],
-      "type": "object"
-    },
-    "Custom2DVoltageIntegral": {
-      "additionalProperties": false,
-      "properties": {
-        "attrs": {
-          "default": {},
-          "type": "object"
-        },
-        "axis": {
-          "enum": [
-            0,
-            1,
-            2
-          ],
-          "type": "integer"
-        },
-        "position": {
-          "type": "number"
-        },
-        "type": {
-          "default": "Custom2DVoltageIntegral",
-          "enum": [
-            "Custom2DVoltageIntegral"
           ],
           "type": "string"
         },
@@ -18074,19 +17697,6 @@
           "default": false,
           "type": "boolean"
         },
-        "current_integral": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/AxisAlignedCurrentIntegral"
-            },
-            {
-              "$ref": "#/definitions/CompositeCurrentIntegral"
-            },
-            {
-              "$ref": "#/definitions/Custom2DCurrentIntegral"
-            }
-          ]
-        },
         "direction": {
           "enum": [
             "+",
@@ -18111,46 +17721,21 @@
           }
         },
         "mode_index": {
-          "default": 0,
           "minimum": 0,
           "type": "integer"
+        },
+        "mode_selection": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
         },
         "mode_spec": {
           "allOf": [
             {
-              "$ref": "#/definitions/ModeSpec"
+              "$ref": "#/definitions/MicrowaveModeSpec"
             }
-          ],
-          "default": {
-            "angle_phi": 0.0,
-            "angle_rotation": false,
-            "angle_theta": 0.0,
-            "attrs": {},
-            "bend_axis": null,
-            "bend_radius": null,
-            "filter_pol": null,
-            "group_index_step": false,
-            "num_modes": 1,
-            "num_pml": [
-              0,
-              0
-            ],
-            "precision": "double",
-            "sort_spec": {
-              "attrs": {},
-              "filter_key": null,
-              "filter_order": "over",
-              "filter_reference": 0.0,
-              "sort_key": null,
-              "sort_order": "ascending",
-              "sort_reference": null,
-              "track_freq": "central",
-              "type": "ModeSortSpec"
-            },
-            "target_neff": null,
-            "track_freq": null,
-            "type": "ModeSpec"
-          }
+          ]
         },
         "name": {
           "minLength": 1,
@@ -18214,16 +17799,6 @@
             "WavePort"
           ],
           "type": "string"
-        },
-        "voltage_integral": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/AxisAlignedVoltageIntegral"
-            },
-            {
-              "$ref": "#/definitions/Custom2DVoltageIntegral"
-            }
-          ]
         }
       },
       "required": [

--- a/tests/test_components/test_microwave.py
+++ b/tests/test_components/test_microwave.py
@@ -572,6 +572,49 @@ def test_composite_current_integral_validation():
         path_spec.updated_copy(path_specs=[voltage_spec])
 
 
+def test_composite_current_integral_bounds():
+    """Test that CompositeCurrentIntegralSpec correctly computes overall bounding box."""
+
+    # Single axis-aligned spec
+    spec1 = td.AxisAlignedCurrentIntegralSpec(center=(0, 0, 0), size=(2, 2, 0), sign="+")
+    composite1 = td.CompositeCurrentIntegralSpec(path_specs=(spec1,), sum_spec="sum")
+    expected_bounds1 = ((-1.0, -1.0, 0.0), (1.0, 1.0, 0.0))
+    assert composite1.bounds == expected_bounds1
+
+    # Two disjoint axis-aligned specs
+    spec2 = td.AxisAlignedCurrentIntegralSpec(center=(5, 5, 0), size=(2, 2, 0), sign="+")
+    composite2 = td.CompositeCurrentIntegralSpec(path_specs=(spec1, spec2), sum_spec="sum")
+    # Should span from (-1, -1, 0) to (6, 6, 0)
+    expected_bounds2 = ((-1.0, -1.0, 0.0), (6.0, 6.0, 0.0))
+    assert composite2.bounds == expected_bounds2
+
+    # Custom 2D spec
+    vertices = np.array([[0, 0], [2, 0], [2, 1], [0, 1], [0, 0]])
+    spec3 = td.Custom2DCurrentIntegralSpec(axis=2, position=0, vertices=vertices)
+    composite3 = td.CompositeCurrentIntegralSpec(path_specs=(spec3,), sum_spec="sum")
+    expected_bounds3 = ((0.0, 0.0, 0.0), (2.0, 1.0, 0.0))
+    assert composite3.bounds == expected_bounds3
+
+    # Mixed spec types (axis-aligned + custom 2D)
+    spec4 = td.AxisAlignedCurrentIntegralSpec(center=(-3, -3, 0), size=(1, 1, 0), sign="-")
+    composite4 = td.CompositeCurrentIntegralSpec(path_specs=(spec3, spec4), sum_spec="split")
+    # Custom spec: (0, 0, 0) to (2, 1, 0)
+    # Axis-aligned spec: (-3.5, -3.5, 0) to (-2.5, -2.5, 0)
+    # Overall: (-3.5, -3.5, 0) to (2, 1, 0)
+    expected_bounds4 = ((-3.5, -3.5, 0.0), (2.0, 1.0, 0.0))
+    assert composite4.bounds == expected_bounds4
+
+    # Overlapping specs
+    spec5 = td.AxisAlignedCurrentIntegralSpec(center=(1, 1, 0), size=(4, 4, 0), sign="+")
+    spec6 = td.AxisAlignedCurrentIntegralSpec(center=(2, 2, 0), size=(2, 2, 0), sign="+")
+    composite5 = td.CompositeCurrentIntegralSpec(path_specs=(spec5, spec6), sum_spec="sum")
+    # spec5: (-1, -1, 0) to (3, 3, 0)
+    # spec6: (1, 1, 0) to (3, 3, 0)
+    # Overall: (-1, -1, 0) to (3, 3, 0)
+    expected_bounds5 = ((-1.0, -1.0, 0.0), (3.0, 3.0, 0.0))
+    assert composite5.bounds == expected_bounds5
+
+
 def test_path_integral_creation():
     """Check that path integrals are correctly constructed from path specifications."""
 

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -3787,8 +3787,8 @@ def test_structures_per_medium(monkeypatch):
         )
 
 
-def test_validate_microwave_mode_spec_generation():
-    """Test that auto generation of path specs is correctly validated for currently unsupported structures."""
+def test_validate_microwave_mode_spec():
+    """Test that auto generation ande user supplied path specs are correctly validated."""
     freq0 = 10e9
     mm = 1e3
     run_time_spec = td.RunTimeSpec(quality_factor=3.0)
@@ -3840,3 +3840,24 @@ def test_validate_microwave_mode_spec_generation():
     # check that validation error is caught
     with pytest.raises(SetupError):
         sim._validate_microwave_mode_specs()
+
+    # Custom current spec is too large for mode plane
+    custom_spec = td.CustomImpedanceSpec(
+        current_spec=td.Custom2DCurrentIntegralSpec.from_circular_path(
+            center=(0, 0, 0), radius=10 * mm, num_points=21, normal_axis=0, clockwise=True
+        )
+    )
+    mode_spec = td.MicrowaveModeSpec(
+        num_modes=2,
+        target_neff=1.8,
+        impedance_specs=(custom_spec, td.AutoImpedanceSpec()),
+    )
+
+    mode_mon = mode_mon.updated_copy(
+        path="mode_spec/", impedance_specs=(custom_spec, td.AutoImpedanceSpec())
+    )
+    # check that validation error is in the MicrowaveModeSpec
+    with pytest.raises(SetupError):
+        sim = sim.updated_copy(
+            monitors=[mode_mon],
+        )

--- a/tests/test_plugins/smatrix/terminal_component_modeler_def.py
+++ b/tests/test_plugins/smatrix/terminal_component_modeler_def.py
@@ -5,7 +5,6 @@ from typing import Optional, Union
 import numpy as np
 
 import tidy3d as td
-import tidy3d.plugins.microwave as mw
 from tidy3d.plugins.smatrix import (
     CoaxialLumpedPort,
     LumpedPort,
@@ -286,24 +285,30 @@ def make_coaxial_component_modeler(
             voltage_center[0] += mean_radius
             voltage_size = [Router - Rinner, 0, 0]
 
-            voltage_integral = None
+            voltage_spec = None
             if use_voltage:
-                voltage_integral = td.AxisAlignedVoltageIntegral(
+                voltage_spec = td.AxisAlignedVoltageIntegralSpec(
                     center=voltage_center,
                     size=voltage_size,
                     extrapolate_to_endpoints=True,
                     snap_path_to_grid=True,
                     sign="+",
                 )
-            current_integral = None
+            current_spec = None
             if use_current:
-                current_integral = td.Custom2DCurrentIntegral.from_circular_path(
+                current_spec = td.Custom2DCurrentIntegralSpec.from_circular_path(
                     center=center,
                     radius=mean_radius,
                     num_points=41,
                     normal_axis=2,
                     clockwise=direction != "+",
                 )
+            mw_mode_spec = td.MicrowaveModeSpec(
+                num_modes=1,
+                impedance_specs=(
+                    td.CustomImpedanceSpec(voltage_spec=voltage_spec, current_spec=current_spec),
+                ),
+            )
             port_cells = None
             if port_refinement:
                 port_cells = 5
@@ -312,10 +317,7 @@ def make_coaxial_component_modeler(
                 size=[2 * Router, 2 * Router, 0],
                 direction=direction,
                 name="wave" + name,
-                mode_spec=td.ModeSpec(num_modes=1),
-                mode_index=0,
-                voltage_integral=voltage_integral,
-                current_integral=current_integral,
+                mode_spec=mw_mode_spec,
                 num_grid_cells=port_cells,
             )
         return port
@@ -416,19 +418,25 @@ def make_differential_stripline_modeler():
         z=td.Boundary.pml(),
     )
 
-    # Define port specification
-    wave_port_mode_spec = td.ModeSpec(num_modes=1, target_neff=np.sqrt(eps))
-
     # Define current and voltage integrals
-    current_integral = mw.AxisAlignedCurrentIntegral(
+    current_spec = td.AxisAlignedCurrentIntegralSpec(
         center=((se + w) / 2, 0, -waveport_z / 2), size=(2 * w, 3 * t, 0), sign="+"
     )
-    voltage_integral = mw.AxisAlignedVoltageIntegral(
+    voltage_spec = td.AxisAlignedVoltageIntegralSpec(
         center=(0, 0, -waveport_z / 2),
         size=(se, 0, 0),
         extrapolate_to_endpoints=True,
         snap_path_to_grid=True,
         sign="+",
+    )
+
+    # Define port specification
+    wave_port_mode_spec = td.MicrowaveModeSpec(
+        num_modes=1,
+        target_neff=np.sqrt(eps),
+        impedance_specs=td.CustomImpedanceSpec(
+            voltage_spec=voltage_spec, current_spec=current_spec
+        ),
     )
 
     # Define wave ports
@@ -438,18 +446,14 @@ def make_differential_stripline_modeler():
         mode_spec=wave_port_mode_spec,
         direction="+",
         name="WP1",
-        mode_index=0,
-        current_integral=current_integral,
-        voltage_integral=voltage_integral,
     )
     WP2 = WP1.updated_copy(
         name="WP2",
         center=(0, 0, waveport_z / 2),
         direction="-",
-        current_integral=current_integral.updated_copy(
-            center=((se + w) / 2, 0, waveport_z / 2), sign="-"
+        mode_spec=wave_port_mode_spec.updated_copy(
+            path="impedance_specs", current_spec=current_spec.updated_copy(sign="-")
         ),
-        voltage_integral=voltage_integral.updated_copy(center=(0, 0, waveport_z / 2)),
     )
 
     # define fimulation

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -51,7 +51,9 @@ def run_component_modeler(
     )
     modeler_data = TerminalComponentModelerData(modeler=modeler, data=port_data)
     monkeypatch.setattr(
-        td.plugins.smatrix.utils, "port_array_inv", lambda matrix: np.eye(len(modeler.ports))
+        td.plugins.smatrix.utils,
+        "port_array_inv",
+        lambda matrix: np.eye(len(modeler.matrix_indices_monitor)),
     )
     monkeypatch.setattr(
         td.plugins.smatrix.utils,
@@ -770,10 +772,10 @@ def test_run_coaxial_component_modeler_with_wave_ports(
 
     shape_one_port = (len(modeler.freqs), len(modeler.ports))
     shape_both_ports = (len(modeler.freqs),)
-    for port_in in modeler.ports:
-        for port_out in modeler.ports:
-            coords_in = {"port_in": port_in.name}
-            coords_out = {"port_out": port_out.name}
+    for port_in in modeler.network_dict.keys():
+        for port_out in modeler.network_dict.keys():
+            coords_in = {"port_in": port_in}
+            coords_out = {"port_out": port_out}
 
             assert np.all(s_matrix.sel(**coords_in).values.shape == shape_one_port), (
                 "source index not present in S matrix"
@@ -783,16 +785,16 @@ def test_run_coaxial_component_modeler_with_wave_ports(
             ), "monitor index not present in S matrix"
 
     # Another run with more modes in the mode spec
-    mode_spec = td.ModeSpec(num_modes=2)
-    modeler = modeler.updated_copy(path="ports/0/", mode_spec=mode_spec)
+    mode_spec = td.MicrowaveModeSpec(num_modes=2)
+    modeler: TerminalComponentModeler = modeler.updated_copy(path="ports/0/", mode_spec=mode_spec)
     s_matrix = get_terminal_port_data_array(monkeypatch, modeler)
 
-    shape_one_port = (len(modeler.freqs), len(modeler.ports))
+    shape_one_port = (len(modeler.freqs), len(modeler.matrix_indices_monitor))
     shape_both_ports = (len(modeler.freqs),)
-    for port_in in modeler.ports:
-        for port_out in modeler.ports:
-            coords_in = {"port_in": port_in.name}
-            coords_out = {"port_out": port_out.name}
+    for port_in in modeler.network_dict.keys():
+        for port_out in modeler.network_dict.keys():
+            coords_in = {"port_in": port_in}
+            coords_out = {"port_out": port_out}
 
             assert np.all(s_matrix.sel(**coords_in).values.shape == shape_one_port), (
                 "source index not present in S matrix"
@@ -814,10 +816,10 @@ def test_run_mixed_component_modeler_with_wave_ports(monkeypatch, tmp_path):
 
     shape_one_port = (len(modeler.freqs), len(modeler.ports))
     shape_both_ports = (len(modeler.freqs),)
-    for port_in in modeler.ports:
-        for port_out in modeler.ports:
-            coords_in = {"port_in": port_in.name}
-            coords_out = {"port_out": port_out.name}
+    for port_in in modeler.network_dict.keys():
+        for port_out in modeler.network_dict.keys():
+            coords_in = {"port_in": port_in}
+            coords_out = {"port_out": port_out}
 
             assert np.all(s_matrix.sel(**coords_in).values.shape == shape_one_port), (
                 "source index not present in S matrix"
@@ -832,7 +834,7 @@ def test_wave_port_path_integral_validation():
     size_port = [2, 2, 0]
     center_port = [0, 0, -10]
 
-    voltage_path = td.AxisAlignedVoltageIntegral(
+    voltage_path = td.AxisAlignedVoltageIntegralSpec(
         center=(0.5, 0, -10),
         size=(1.0, 0, 0),
         extrapolate_to_endpoints=True,
@@ -840,83 +842,115 @@ def test_wave_port_path_integral_validation():
         sign="+",
     )
 
-    custom_current_path = td.Custom2DCurrentIntegral.from_circular_path(
+    custom_current_path = td.Custom2DCurrentIntegralSpec.from_circular_path(
         center=center_port, radius=0.5, num_points=21, normal_axis=2, clockwise=False
     )
 
-    mode_spec = td.ModeSpec(num_modes=1, target_neff=1.8)
-
-    _ = WavePort(
-        center=center_port,
-        size=size_port,
-        name="wave_port_1",
-        mode_spec=mode_spec,
-        direction="+",
-        voltage_integral=voltage_path,
-        current_integral=None,
+    mw_mode_spec = td.MicrowaveModeSpec(
+        num_modes=1,
+        target_neff=1.8,
+        impedance_specs=(td.CustomImpedanceSpec(voltage_spec=voltage_path, current_spec=None),),
     )
 
     _ = WavePort(
         center=center_port,
         size=size_port,
         name="wave_port_1",
-        mode_spec=mode_spec,
+        mode_spec=mw_mode_spec,
         direction="+",
-        voltage_integral=None,
-        current_integral=custom_current_path,
+    )
+
+    mw_mode_spec = td.MicrowaveModeSpec(
+        num_modes=1,
+        target_neff=1.8,
+        impedance_specs=(
+            td.CustomImpedanceSpec(voltage_spec=None, current_spec=custom_current_path),
+        ),
+    )
+
+    _ = WavePort(
+        center=center_port,
+        size=size_port,
+        name="wave_port_1",
+        mode_spec=mw_mode_spec,
+        direction="+",
     )
 
     with pytest.raises(pd.ValidationError):
+        mw_mode_spec = td.MicrowaveModeSpec(
+            num_modes=1,
+            target_neff=1.8,
+            impedance_specs=(td.CustomImpedanceSpec(voltage_spec=None, current_spec=None),),
+        )
         _ = WavePort(
             center=center_port,
             size=size_port,
             name="wave_port_1",
-            mode_spec=mode_spec,
+            mode_spec=mw_mode_spec,
             direction="+",
-            voltage_integral=None,
-            current_integral=None,
         )
 
     voltage_path = voltage_path.updated_copy(size=(4, 0, 0))
     with pytest.raises(pd.ValidationError):
+        mode_spec = td.MicrowaveModeSpec(
+            num_modes=1,
+            target_neff=1.8,
+            impedance_specs=(td.CustomImpedanceSpec(voltage_spec=voltage_path, current_spec=None),),
+        )
         _ = WavePort(
             center=center_port,
             size=size_port,
             name="wave_port_1",
             mode_spec=mode_spec,
             direction="+",
-            voltage_integral=voltage_path,
-            current_integral=None,
         )
 
-    custom_current_path = td.Custom2DCurrentIntegral.from_circular_path(
+    custom_current_path = td.Custom2DCurrentIntegralSpec.from_circular_path(
         center=center_port, radius=3, num_points=21, normal_axis=2, clockwise=False
     )
+
     with pytest.raises(pd.ValidationError):
+        mode_spec = td.MicrowaveModeSpec(
+            num_modes=1,
+            target_neff=1.8,
+            impedance_specs=(
+                td.CustomImpedanceSpec(voltage_spec=None, current_spec=custom_current_path),
+            ),
+        )
         _ = WavePort(
             center=center_port,
             size=size_port,
             name="wave_port_1",
             mode_spec=mode_spec,
             direction="+",
-            voltage_integral=None,
-            current_integral=custom_current_path,
         )
 
     # Test integral path only slightly larger than port bounds
+    voltage_path_large = td.AxisAlignedVoltageIntegralSpec(
+        size=(0, 0, 70.000000298023424),
+        center=(0, 10000, 70.000000298023424),
+        extrapolate_to_endpoints=True,
+        snap_path_to_grid=True,
+        sign="+",
+    )
+    mw_mode_spec = td.MicrowaveModeSpec(
+        num_modes=1,
+        target_neff=1.8,
+        impedance_specs=(
+            td.CustomImpedanceSpec(voltage_spec=voltage_path_large, current_spec=None),
+        ),
+    )
     wave_port = WavePort(
         center=(0, 10000, 115.00000022351743),
         size=(500, 0, 160.00000000000003),
         name="wave_port_1",
-        mode_spec=mode_spec,
+        mode_spec=mw_mode_spec,
         direction="+",
-        voltage_integral=voltage_path.updated_copy(
-            size=(0, 0, 70.000000298023424), center=(0, 10000, 70.000000298023424)
-        ),
-        current_integral=None,
     )
     # Make sure validation would have failed if a strict comparison was used
-    assert wave_port.bounds[0][2] > wave_port.voltage_integral.bounds[0][2]
+    # Note: Need to access the voltage spec from the mode spec now
+    voltage_spec = wave_port.mode_spec.impedance_specs[0].voltage_spec
+    assert wave_port.bounds[0][2] > voltage_spec.bounds[0][2]
 
 
 def test_wave_port_grid_validation(tmp_path):
@@ -924,7 +958,7 @@ def test_wave_port_grid_validation(tmp_path):
     size_port = [2, 2, 0]
     center_port = [0, 0, -10]
 
-    voltage_path = td.AxisAlignedVoltageIntegral(
+    voltage_path = td.AxisAlignedVoltageIntegralSpec(
         center=(0.5, 0, -10),
         size=(1.0, 0, 0),
         extrapolate_to_endpoints=True,
@@ -932,23 +966,27 @@ def test_wave_port_grid_validation(tmp_path):
         sign="+",
     )
 
-    current_path = td.AxisAlignedCurrentIntegral(
+    current_path = td.AxisAlignedCurrentIntegralSpec(
         center=(0.5, 0, -10),
         size=(0.25, 0.5, 0),
         snap_contour_to_grid=True,
         sign="+",
     )
 
-    mode_spec = td.ModeSpec(num_modes=1, target_neff=1.8)
+    mw_mode_spec = td.MicrowaveModeSpec(
+        num_modes=1,
+        target_neff=1.8,
+        impedance_specs=(
+            td.CustomImpedanceSpec(voltage_spec=voltage_path, current_spec=current_path),
+        ),
+    )
 
     _ = WavePort(
         center=center_port,
         size=size_port,
         name="wave_port_1",
-        mode_spec=mode_spec,
+        mode_spec=mw_mode_spec,
         direction="+",
-        voltage_integral=voltage_path,
-        current_integral=current_path,
         num_grid_cells=None,
     )
 
@@ -957,10 +995,8 @@ def test_wave_port_grid_validation(tmp_path):
             center=center_port,
             size=size_port,
             name="wave_port_1",
-            mode_spec=mode_spec,
+            mode_spec=mw_mode_spec,
             direction="+",
-            voltage_integral=voltage_path,
-            current_integral=current_path,
             num_grid_cells=2,
         )
 
@@ -992,19 +1028,21 @@ def test_port_source_snapped_to_PML(tmp_path):
     """
     modeler = make_component_modeler(planar_pec=True)
     port_pos = 5e4
-    voltage_path = td.AxisAlignedVoltageIntegral(
+    voltage_path = td.AxisAlignedVoltageIntegralSpec(
         center=(port_pos, 0, 0),
         size=(0, 1e3, 0),
         sign="+",
+    )
+    mw_mode_spec = td.MicrowaveModeSpec(
+        num_modes=1,
+        impedance_specs=(td.CustomImpedanceSpec(voltage_spec=voltage_path, current_spec=None),),
     )
     port = WavePort(
         center=(port_pos, 0, 0),
         size=(0, 1e3, 1e3),
         name="wave_port",
-        mode_spec=td.ModeSpec(num_modes=1),
+        mode_spec=mw_mode_spec,
         direction="-",
-        voltage_integral=voltage_path,
-        current_integral=None,
     )
     modeler = modeler.updated_copy(ports=[port])
 
@@ -1019,20 +1057,23 @@ def test_port_source_snapped_to_PML(tmp_path):
 
     # also validate the negative side
     voltage_path = voltage_path.updated_copy(center=(-port_pos, 0, 0))
-    port = port.updated_copy(direction="+", center=(-port_pos, 0, 0), voltage_integral=voltage_path)
+    mw_mode_spec = td.MicrowaveModeSpec(
+        num_modes=1,
+        impedance_specs=(td.CustomImpedanceSpec(voltage_spec=voltage_path, current_spec=None),),
+    )
+    port = WavePort(
+        center=(-port_pos, 0, 0),
+        size=(0, 1e3, 1e3),
+        name="wave_port",
+        mode_spec=mw_mode_spec,
+        direction="+",
+    )
     modeler = modeler.updated_copy(ports=[port])
     with pytest.raises(SetupError):
         modeler.sim_dict
 
     with pytest.raises(SetupError):
         modeler._shift_value_signed(port)
-
-
-def test_wave_port_validate_current_integral(tmp_path):
-    """Checks that the current integral direction validator runs correctly."""
-    modeler = make_coaxial_component_modeler(port_types=(WavePort, WavePort))
-    with pytest.raises(pd.ValidationError):
-        _ = modeler.updated_copy(direction="-", path="ports/0/")
 
 
 def test_port_impedance_check():
@@ -1064,10 +1105,11 @@ def test_antenna_helpers(monkeypatch, tmp_path):
         theta=theta,
         phi=phi,
     )
-    modeler = modeler.updated_copy(radiation_monitors=[radiation_monitor])
+    modeler: TerminalComponentModeler = modeler.updated_copy(radiation_monitors=[radiation_monitor])
 
     # Run simulation to get data
     modeler_data = run_component_modeler(monkeypatch, modeler)
+    port_0_index = modeler.network_index(modeler.ports[0])
     sim_data = modeler_data.data[modeler_data.modeler.get_task_name(modeler.ports[0])]
     rad_mon_data = sim_data[radiation_monitor.name]
 
@@ -1081,10 +1123,10 @@ def test_antenna_helpers(monkeypatch, tmp_path):
     a_array = FreqDataArray(np.ones(len(modeler.freqs)), {"f": modeler.freqs})
     a_array_raw = 2.0 * a_array
     normalized_data_array = modeler_data._monitor_data_at_port_amplitude(
-        modeler.ports[0], radiation_monitor.name, a_array, a_array_raw
+        port_0_index, radiation_monitor.name, a_array, a_array_raw
     )
     normalized_data_const = modeler_data._monitor_data_at_port_amplitude(
-        modeler.ports[0], radiation_monitor.name, 1.0, a_array_raw
+        port_0_index, radiation_monitor.name, 1.0, a_array_raw
     )
     assert isinstance(normalized_data_array, td.DirectivityData)
     assert isinstance(normalized_data_const, td.DirectivityData)
@@ -1136,7 +1178,7 @@ def test_antenna_parameters(monkeypatch, port_type):
     modeler_data = run_component_modeler(monkeypatch, modeler)
 
     # Make sure network index works for single mode / multimode cases
-    port_1_network_index = modeler.network_index(modeler.ports[0])
+    port_1_network_index = modeler.network_index(modeler.ports[0], 0)
     port_2_network_index = modeler.network_index(modeler.ports[1], 0)
     _ = modeler_data.get_antenna_metrics_data({port_1_network_index: 1.0})
     _ = modeler_data.get_antenna_metrics_data({port_2_network_index: None})
@@ -1235,7 +1277,7 @@ def test_run_only_and_element_mappings(monkeypatch, tmp_path):
         port_types=(CoaxialLumpedPort, CoaxialLumpedPort), grid_spec=grid_spec
     )
     port0_idx = modeler.network_index(modeler.ports[0])
-    port1_idx = modeler.network_index(modeler.ports[1])
+    port1_idx = modeler.network_index(modeler.ports[1], 0)
     modeler_run1 = modeler.updated_copy(run_only=(port0_idx,))
 
     # Make sure the smatrix and impedance calculations work for reduced simulations
@@ -1398,7 +1440,7 @@ def test_wave_port_to_absorber(tmp_path):
     absorber = sim.internal_absorbers[0]
 
     assert absorber.boundary_spec.mode_spec == modeler.ports[0].mode_spec
-    assert absorber.boundary_spec.mode_index == modeler.ports[0].mode_index
+    assert absorber.boundary_spec.mode_index == 0
     assert absorber.boundary_spec.plane == modeler.ports[0].geometry
     assert absorber.boundary_spec.freq_spec == BroadbandModeABCSpec(
         frequency_range=(np.min(modeler.freqs), np.max(modeler.freqs))
@@ -1571,6 +1613,20 @@ def test_S_parameter_deembedding(monkeypatch, tmp_path):
     assert not np.allclose(S_dmb.data.values, s_matrix.data.values)
     assert np.allclose(S_dmb.data.values, S_dmb_shortcut.data.values)
 
+    # Test multimodal version of de-embedding
+    old_custom_spec = modeler.ports[0].mode_spec.impedance_specs[0]
+    new_mode_spec = modeler.ports[0].mode_spec.updated_copy(
+        num_modes=2, impedance_specs=(old_custom_spec, old_custom_spec)
+    )
+    modeler = modeler.updated_copy(path="ports/0/", mode_spec=new_mode_spec)
+    modeler_data = run_component_modeler(monkeypatch, modeler)
+    s_matrix = modeler_data.smatrix()
+    # reuse previous port shifts
+    S_dmb = modeler_data.change_port_reference_planes(smatrix=s_matrix, port_shifts=port_shifts)
+    S_dmb_shortcut = modeler_data.smatrix_deembedded(port_shifts=port_shifts)
+    assert not np.allclose(S_dmb.data.values, s_matrix.data.values)
+    assert np.allclose(S_dmb.data.values, S_dmb_shortcut.data.values)
+
     # test if `.smatrix_deembedded()` raises a `ValueError` when at least one port to be shifted is not defined in TCM
     port_shifts_wrong = PortNameDataArray(data=[10, -10], coords={"port": ["wave_1", "LP_wave_2"]})
 
@@ -1674,10 +1730,8 @@ def test_wave_port_extrusion_coaxial():
     # move wave port plane so that is does not intersect any structures
     port_1_center_new = (638.4, 0.0, -51000)
 
-    # update voltage integral
-    voltage_int = port_1.voltage_integral.updated_copy(center=port_1_center_new)
     # update WavePort
-    port_1 = port_1.updated_copy(center=port_1_center_new, voltage_integral=voltage_int)
+    port_1 = port_1.updated_copy(center=port_1_center_new)
 
     # update component modeler
     tcm = tcm.updated_copy(ports=[port_1, port_2])
@@ -1758,14 +1812,8 @@ def test_wave_port_extrusion_differential_stripline():
     port_1 = port_1.updated_copy(extrude_structures=True)
     port_2 = port_2.updated_copy(extrude_structures=True)
 
-    # update current and voltage integrals
-    current_int = port_1.current_integral.updated_copy(center=port_1_center_new)
-    voltage_int = port_1.voltage_integral.updated_copy(center=port_1_center_new)
-
     # update WavePort
-    port_1 = port_1.updated_copy(
-        center=port_1_center_new, current_integral=current_int, voltage_integral=voltage_int
-    )
+    port_1 = port_1.updated_copy(center=port_1_center_new)
 
     # update component modeler
     tcm = tcm.updated_copy(ports=[port_1, port_2])
@@ -1842,8 +1890,8 @@ def test_validate_run_only_with_wave_ports():
     grid_spec = td.GridSpec(grid_x=xy_grid, grid_y=xy_grid, grid_z=z_grid)
     modeler = make_coaxial_component_modeler(port_types=(WavePort, WavePort), grid_spec=grid_spec)
 
-    port0_idx = modeler.network_index(modeler.ports[0])
-    port1_idx = modeler.network_index(modeler.ports[1])
+    port0_idx = modeler.network_index(modeler.ports[0], 0)
+    port1_idx = modeler.network_index(modeler.ports[1], 0)
 
     # Valid case
     modeler_updated = modeler.updated_copy(run_only=(port0_idx,))
@@ -1973,3 +2021,141 @@ def test_radiation_monitors_auto():
     assert isinstance(default_origin_monitor, td.DirectivityMonitor)
     # Default should be (0, 0, 0) as defined in the field
     assert default_origin_monitor.custom_origin == (0, 0, 0)
+
+
+def test_wave_port_mode_index_validation():
+    """Test that WavePort.mode_index is validated correctly."""
+    # Create mode_spec with 3 modes - don't specify impedance_specs to use defaults
+    mode_spec = td.MicrowaveModeSpec(num_modes=3)
+
+    # Valid: single mode
+    port = WavePort(
+        center=(0, 0, -10),
+        size=(0, 2, 2),
+        name="port1",
+        mode_spec=mode_spec,
+        direction="+",
+        mode_index=0,
+    )
+    assert port._mode_indices == (0,)
+
+    # Invalid: index greater than number of modes
+    with pytest.raises(pd.ValidationError):
+        WavePort(
+            center=(0, 0, -10),
+            size=(0, 2, 2),
+            name="port_neg",
+            mode_spec=mode_spec,
+            direction="+",
+            mode_index=4,
+        )
+
+    # Valid: multiple modes as tuple
+    port = WavePort(
+        center=(0, 0, -10),
+        size=(0, 2, 2),
+        name="port2",
+        mode_spec=mode_spec,
+        direction="+",
+        mode_selection=[0, 2],
+    )
+    assert port._mode_indices == (0, 2)
+
+    # Valid: None (use all modes)
+    port = WavePort(
+        center=(0, 0, -10),
+        size=(0, 2, 2),
+        name="port3",
+        mode_spec=mode_spec,
+        direction="+",
+        mode_selection=None,
+    )
+    assert port._mode_indices == (0, 1, 2)
+
+    # Invalid: negative index
+    with pytest.raises(pd.ValidationError, match="non-negative"):
+        WavePort(
+            center=(0, 0, -10),
+            size=(0, 2, 2),
+            name="port_neg",
+            mode_spec=mode_spec,
+            direction="+",
+            mode_selection=(-1,),
+        )
+
+    # Invalid: index >= num_modes
+    with pytest.raises(pd.ValidationError, match="mode_spec.num_modes"):
+        WavePort(
+            center=(0, 0, -10),
+            size=(0, 2, 2),
+            name="port_large",
+            mode_spec=mode_spec,
+            direction="+",
+            mode_selection=(3,),  # num_modes is 3, so valid range is 0-2
+        )
+
+    # Invalid: duplicate indices
+    with pytest.raises(pd.ValidationError, match="duplicate"):
+        WavePort(
+            center=(0, 0, -10),
+            size=(0, 2, 2),
+            name="port_dup",
+            mode_spec=mode_spec,
+            direction="+",
+            mode_selection=(0, 1, 0),
+        )
+
+
+def test_wave_port_mode_index_with_modeler():
+    """Test that WavePort.mode_index works correctly with TerminalComponentModeler."""
+    z_grid = td.UniformGrid(dl=1 * 1e3)
+    xy_grid = td.UniformGrid(dl=0.1 * 1e3)
+    grid_spec = td.GridSpec(grid_x=xy_grid, grid_y=xy_grid, grid_z=z_grid)
+
+    # Create mode_spec with 4 modes - use defaults
+    mode_spec = td.MicrowaveModeSpec(num_modes=4)
+
+    # Create port with mode_index selecting subset
+    port = WavePort(
+        center=(0, 0, -10),
+        size=(0, 2, 2),
+        name="port1",
+        mode_spec=mode_spec,
+        direction="+",
+        mode_selection=(0, 2),  # Only modes 0 and 2
+    )
+
+    # Verify the port has only the selected modes
+    assert port._mode_indices == (0, 2)
+
+    # Create a simple simulation to test with
+    sim = td.Simulation(
+        size=(10, 10, 10),
+        grid_spec=grid_spec,
+        run_time=1e-12,
+        structures=[],
+        boundary_spec=td.BoundarySpec.all_sides(boundary=td.PML()),
+    )
+
+    # Create a modeler with this port
+    lumped_port = LumpedPort(
+        center=(0, 0, 10),
+        size=(1, 1, 0),
+        voltage_axis=0,  # x-direction since port is in x-y plane
+        name="lumped_port",
+    )
+
+    modeler = TerminalComponentModeler(
+        simulation=sim,
+        ports=[port, lumped_port],
+        freqs=[2e9, 3e9],
+        element_mappings=(),
+    )
+
+    # Verify network_dict only has entries for the selected modes
+    network_indices = set(modeler.network_dict.keys())
+    assert "port1_0" in network_indices
+    assert "port1_2" in network_indices
+    assert "port1_1" not in network_indices
+    assert "port1_3" not in network_indices
+    assert "lumped_port" in network_indices

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,6 +14,12 @@ from autograd.tracer import new_box
 import tidy3d as td
 from tidy3d import ModeIndexDataArray
 from tidy3d.components.base import Tidy3dBaseModel
+from tidy3d.components.data.data_array import (
+    CurrentFreqModeDataArray,
+    ImpedanceFreqModeDataArray,
+    VoltageFreqModeDataArray,
+)
+from tidy3d.components.microwave.data.dataset import TransmissionLineDataset
 from tidy3d.log import _get_level_int
 from tidy3d.web import BatchData
 
@@ -1230,6 +1236,60 @@ def run_emulated(simulation: td.Simulation, path=None, **kwargs) -> td.Simulatio
             **field_cmps,
         )
 
+    def make_microwave_mode_solver_data(
+        monitor: td.MicrowaveModeSolverMonitor,
+    ) -> td.MicrowaveModeSolverData:
+        """make a random ModeSolverData from a MicrowaveModeSolverMonitor."""
+        field_cmps = {}
+        grid = simulation.discretize_monitor(monitor)
+        index_coords = {}
+        index_coords["f"] = list(monitor.freqs)
+        index_coords["mode_index"] = np.arange(monitor.mode_spec.num_modes)
+        index_data_shape = (len(index_coords["f"]), len(index_coords["mode_index"]))
+        index_data = ModeIndexDataArray(
+            (1 + 1j) * DATA_GEN_FN(index_data_shape), coords=index_coords
+        )
+        for field_name in ["Ex", "Ey", "Ez", "Hx", "Hy", "Hz"]:
+            coords = get_spatial_coords_dict(simulation, monitor, field_name)
+            coords["f"] = list(monitor.freqs)
+            coords["mode_index"] = index_coords["mode_index"]
+
+            field_cmps[field_name] = make_data(
+                coords=coords, data_array_type=td.ScalarModeFieldDataArray, is_complex=True
+            )
+
+        impedance_specs: tuple = monitor.mode_spec._impedance_specs_as_tuple
+        if len(impedance_specs) == 1:
+            impedance_specs = impedance_specs * monitor.mode_spec.num_modes
+        used_mode_inds = []
+        for mode_index, spec in enumerate(impedance_specs):
+            if spec is not None:
+                used_mode_inds.append(mode_index)
+        index_coords = {}
+        index_coords["f"] = list(monitor.freqs)
+        index_coords["mode_index"] = np.array(used_mode_inds)
+        index_data_shape = (len(index_coords["f"]), len(index_coords["mode_index"]))
+        Z0_data = ImpedanceFreqModeDataArray(
+            (1000 + 1j) * DATA_GEN_FN(index_data_shape), coords=index_coords
+        )
+        V_data = VoltageFreqModeDataArray(
+            (1000 + 1j) * DATA_GEN_FN(index_data_shape), coords=index_coords
+        )
+        I_data = CurrentFreqModeDataArray(
+            (1000 + 1j) * DATA_GEN_FN(index_data_shape), coords=index_coords
+        )
+        tl_data = TransmissionLineDataset(Z0=Z0_data, voltage_coeffs=V_data, current_coeffs=I_data)
+
+        return td.MicrowaveModeSolverData(
+            monitor=monitor,
+            symmetry=(0, 0, 0),
+            symmetry_center=simulation.center,
+            grid_expanded=grid,
+            n_complex=index_data,
+            transmission_line_data=tl_data,
+            **field_cmps,
+        )
+
     def make_eps_data(monitor: td.PermittivityMonitor) -> td.PermittivityData:
         """make a random PermittivityData from a PermittivityMonitor."""
         field_mnt = td.FieldMonitor(**monitor.dict(exclude={"type", "fields"}))
@@ -1289,11 +1349,66 @@ def run_emulated(simulation: td.Simulation, path=None, **kwargs) -> td.Simulatio
                 field_cmps[field_name] = make_data(
                     coords=coords, data_array_type=td.ScalarModeFieldDataArray, is_complex=True
                 )
+
         return td.ModeData(
             monitor=monitor,
             n_complex=n_complex,
             amps=amps,
             grid_expanded=simulation.discretize_monitor(monitor),
+            **field_cmps,
+        )
+
+    def make_microwave_mode_data(monitor: td.MicrowaveModeMonitor) -> td.MicrowaveModeData:
+        """Make a random microwave mode data"""
+        _ = np.arange(monitor.mode_spec.num_modes)
+        index_coords = {}
+        index_coords["f"] = list(monitor.freqs)
+        index_coords["mode_index"] = np.arange(monitor.mode_spec.num_modes)
+        n_complex = make_data(
+            coords=index_coords, data_array_type=td.ModeIndexDataArray, is_complex=True
+        )
+        coords_amps = {"direction": ["+", "-"]}
+        coords_amps.update(index_coords)
+        amps = make_data(coords=coords_amps, data_array_type=td.ModeAmpsDataArray, is_complex=True)
+        field_cmps = {}
+        if monitor.store_fields_direction is not None:
+            for field_name in ["Ex", "Ey", "Ez", "Hx", "Hy", "Hz"]:
+                coords = get_spatial_coords_dict(simulation, monitor, field_name)
+                coords["f"] = list(monitor.freqs)
+                coords["mode_index"] = index_coords["mode_index"]
+                field_cmps[field_name] = make_data(
+                    coords=coords, data_array_type=td.ScalarModeFieldDataArray, is_complex=True
+                )
+
+        impedance_specs: tuple = monitor.mode_spec._impedance_specs_as_tuple
+        if len(impedance_specs) == 1:
+            impedance_specs = impedance_specs * monitor.mode_spec.num_modes
+        used_mode_inds = []
+        for mode_index, spec in enumerate(impedance_specs):
+            if spec is not None:
+                used_mode_inds.append(mode_index)
+
+        index_coords = {}
+        index_coords["f"] = list(monitor.freqs)
+        index_coords["mode_index"] = np.array(used_mode_inds)
+        index_data_shape = (len(index_coords["f"]), len(index_coords["mode_index"]))
+        Z0_data = ImpedanceFreqModeDataArray(
+            (1000 + 1j) * DATA_GEN_FN(index_data_shape), coords=index_coords
+        )
+        V_data = VoltageFreqModeDataArray(
+            (1000 + 1j) * DATA_GEN_FN(index_data_shape), coords=index_coords
+        )
+        I_data = CurrentFreqModeDataArray(
+            (1000 + 1j) * DATA_GEN_FN(index_data_shape), coords=index_coords
+        )
+        tl_data = TransmissionLineDataset(Z0=Z0_data, voltage_coeffs=V_data, current_coeffs=I_data)
+
+        return td.MicrowaveModeData(
+            monitor=monitor,
+            n_complex=n_complex,
+            amps=amps,
+            grid_expanded=simulation.discretize_monitor(monitor),
+            transmission_line_data=tl_data,
             **field_cmps,
         )
 
@@ -1469,7 +1584,9 @@ def run_emulated(simulation: td.Simulation, path=None, **kwargs) -> td.Simulatio
         td.FieldMonitor: make_field_data,
         td.FieldTimeMonitor: make_field_time_data,
         td.ModeSolverMonitor: make_mode_solver_data,
+        td.MicrowaveModeSolverMonitor: make_microwave_mode_solver_data,
         td.ModeMonitor: make_mode_data,
+        td.MicrowaveModeMonitor: make_microwave_mode_data,
         td.PermittivityMonitor: make_eps_data,
         td.MediumMonitor: make_medium_data,
         td.DiffractionMonitor: make_diff_data,

--- a/tidy3d/components/microwave/mode_spec.py
+++ b/tidy3d/components/microwave/mode_spec.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
+import numpy as np
 import pydantic.v1 as pd
 
 from tidy3d.components.base import cached_property
+from tidy3d.components.geometry.base import Box
+from tidy3d.components.geometry.bound_ops import bounds_contains
 from tidy3d.components.microwave.base import MicrowaveBaseModel
 from tidy3d.components.microwave.path_integrals.specs.impedance import (
     AutoImpedanceSpec,
@@ -14,6 +17,8 @@ from tidy3d.components.microwave.path_integrals.specs.impedance import (
 )
 from tidy3d.components.mode_spec import AbstractModeSpec
 from tidy3d.components.types import annotate_type
+from tidy3d.constants import fp_eps
+from tidy3d.exceptions import SetupError
 
 
 class MicrowaveModeSpec(AbstractModeSpec, MicrowaveBaseModel):
@@ -86,8 +91,6 @@ class MicrowaveModeSpec(AbstractModeSpec, MicrowaveBaseModel):
 
         # Otherwise, check that the count matches
         if num_impedance_specs != num_modes:
-            from tidy3d.exceptions import SetupError
-
             raise SetupError(
                 f"Given {num_impedance_specs} impedance specifications in the 'MicrowaveModeSpec', "
                 f"but the number of modes requested is {num_modes}. Please ensure that the "
@@ -96,3 +99,44 @@ class MicrowaveModeSpec(AbstractModeSpec, MicrowaveBaseModel):
             )
 
         return val
+
+    def _check_path_integrals_within_box(self, box: Box):
+        """Raise SetupError if a ``CustomImpedanceSpec`` includes a path specification
+        defined outside a candidate box.
+        """
+        for impedance_ind, impedance_spec in enumerate(self._impedance_specs_as_tuple):
+            if isinstance(impedance_spec, AutoImpedanceSpec) or impedance_spec is None:
+                continue
+
+            # Check both voltage and current specs using the same logic
+            specs_to_check = [
+                (impedance_spec.voltage_spec, "voltage"),
+                (impedance_spec.current_spec, "current"),
+            ]
+
+            for spec, spec_type in specs_to_check:
+                if spec is None:
+                    continue
+
+                box_bounds = box.bounds
+                # If the box is a plane (one dimension is zero), we need to ignore
+                # the bounds check along the normal axis
+                if box.size.count(0.0) == 1:
+                    normal_axis = box._normal_axis
+                    # Convert tuple to list so we can modify it
+                    box_bounds = [list(box_bounds[0]), list(box_bounds[1])]
+                    # Set the bounds along normal axis to match the spec bounds
+                    box_bounds[0][normal_axis] = spec.bounds[0][normal_axis]
+                    box_bounds[1][normal_axis] = spec.bounds[1][normal_axis]
+                    # Convert back to tuple for bounds_contains
+                    box_bounds = (tuple(box_bounds[0]), tuple(box_bounds[1]))
+
+                if not bounds_contains(
+                    box_bounds, spec.bounds, fp_eps, np.finfo(np.float32).smallest_normal
+                ):
+                    raise SetupError(
+                        "A 'MicrowaveModeSpec' must be setup with all path specifications defined within "
+                        f"the bounds of the mode solving plane. The 'CustomImpedanceSpec' at index "
+                        f"'{impedance_ind}' was provided with a {spec_type} path specification with bounds "
+                        f"'{spec.bounds}', but the mode plane bounds are '{box.bounds}'."
+                    )

--- a/tidy3d/components/microwave/path_integrals/integrals/current.py
+++ b/tidy3d/components/microwave/path_integrals/integrals/current.py
@@ -208,13 +208,18 @@ class CompositeCurrentIntegral(CompositeCurrentIntegralSpec):
         current_out_phase = _make_current_data_array(current_out_phase)
 
         if self.sum_spec == "sum":
-            return current_in_phase + current_out_phase
+            current = current_in_phase + current_out_phase
+        else:
+            # For split mode, return the larger magnitude current
+            current = xr.where(
+                abs(current_in_phase) >= abs(current_out_phase), current_in_phase, current_out_phase
+            )
+            # Choose sign for current when using the split method.
+            # We prefer both V and I to be positive
+            current = xr.where(current.real >= 0.0, current, -current)
+            current = _make_current_data_array(current)
 
-        # For split mode, return the larger magnitude current
-        current = xr.where(
-            abs(current_in_phase) >= abs(current_out_phase), current_in_phase, current_out_phase
-        )
-        return _make_current_data_array(current)
+        return current
 
     def _check_phase_sign_consistency(
         self,

--- a/tidy3d/components/microwave/path_integrals/specs/current.py
+++ b/tidy3d/components/microwave/path_integrals/specs/current.py
@@ -9,6 +9,7 @@ import pydantic.v1 as pd
 
 from tidy3d.components.base import cached_property
 from tidy3d.components.geometry.base import Box, Geometry
+from tidy3d.components.geometry.bound_ops import bounds_union
 from tidy3d.components.microwave.base import MicrowaveBaseModel
 from tidy3d.components.microwave.path_integrals.specs.base import (
     AbstractAxesRH,
@@ -16,7 +17,7 @@ from tidy3d.components.microwave.path_integrals.specs.base import (
     Custom2DPathIntegralSpec,
 )
 from tidy3d.components.microwave.path_integrals.viz import ARROW_CURRENT, plot_params_current_path
-from tidy3d.components.types import Ax
+from tidy3d.components.types import Ax, Bound
 from tidy3d.components.types.base import Axis, Direction
 from tidy3d.components.validators import assert_plane
 from tidy3d.components.viz import add_ax_if_none
@@ -372,3 +373,24 @@ class CompositeCurrentIntegralSpec(MicrowaveBaseModel):
                 "'CompositeCurrentIntegralSpec.path_specs' must be a list of one or more current integrals. "
             )
         return val
+
+    @cached_property
+    def bounds(self) -> Bound:
+        """Return the overall bounding box of all path specifications.
+
+        Computed by taking the union of bounds from all path specs.
+
+        Returns
+        -------
+        Bound
+            Tuple of (rmin, rmax) where rmin and rmax are tuples of (x, y, z) coordinates
+            representing the minimum and maximum corners of the bounding box.
+        """
+        # Start with bounds of first path spec
+        overall_bounds = self.path_specs[0].bounds
+
+        # Union with bounds of remaining path specs
+        for path_spec in self.path_specs[1:]:
+            overall_bounds = bounds_union(overall_bounds, path_spec.bounds)
+
+        return overall_bounds

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -266,6 +266,8 @@ class ModeSolver(Tidy3dBaseModel):
         self._warn_thick_pml(simulation=self.simulation, plane=self.plane, mode_spec=self.mode_spec)
         self._validate_rotate_structures()
         self._validate_num_grid_points()
+        if self._has_microwave_mode_spec:
+            self._validate_microwave_mode_spec(mode_spec=self.mode_spec, plane=self.plane)
 
     @classmethod
     def _warn_thick_pml(
@@ -337,6 +339,11 @@ class ModeSolver(Tidy3dBaseModel):
                 "Too many grid points on the modal plane. Please reduce the modal plane size, apply a coarser grid, "
                 "or reduce the number of modes."
             )
+
+    @classmethod
+    def _validate_microwave_mode_spec(cls, mode_spec: MicrowaveModeSpec, plane: Box) -> None:
+        """Validate that the microwave mode spec is correctly setup."""
+        mode_spec._check_path_integrals_within_box(plane)
 
     @cached_property
     def normal_axis(self) -> Axis:

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -11,6 +11,8 @@ from typing import Any, Literal, Optional, Union, get_args
 
 import autograd.numpy as np
 
+from tidy3d.components.microwave.mode_spec import MicrowaveModeSpec
+
 from .types.monitor import MonitorType
 
 try:
@@ -74,7 +76,7 @@ from .medium import (
     MediumType3D,
     PECMedium,
 )
-from .microwave.mode_spec import MicrowaveModeSpec
+from .microwave.monitor import MicrowaveModeMonitor, MicrowaveModeSolverMonitor
 from .microwave.path_integrals.mode_plane_analyzer import ModePlaneAnalyzer
 from .monitor import (
     AbstractFieldProjectionMonitor,
@@ -4266,6 +4268,12 @@ class Simulation(AbstractYeeGridSimulation):
                 # we just pick one of the in-plane axes to test the roation
                 rotate_kwargs = {"angle": theta, "axis": axes[1]}
                 ModeSolver._make_rotated_structures(structs_in, translate_kwargs, rotate_kwargs)
+            # Validate microwave mode spec with mode solver setup
+            if isinstance(mode_obj.mode_spec, MicrowaveModeSpec):
+                ModeSolver._validate_microwave_mode_spec(
+                    mode_spec=mode_obj.mode_spec,
+                    plane=mode_obj.geometry,
+                )
 
         for imnt, monitor in enumerate(self.monitors):
             if isinstance(monitor, AbstractModeMonitor):
@@ -4687,13 +4695,10 @@ class Simulation(AbstractYeeGridSimulation):
         fail to instantiate.
         """
         for monitor in self.monitors:
-            if not isinstance(monitor, AbstractModeMonitor):
+            if not isinstance(monitor, (MicrowaveModeMonitor, MicrowaveModeSolverMonitor)):
                 continue
 
-            if (
-                isinstance(monitor.mode_spec, MicrowaveModeSpec)
-                and monitor.mode_spec._using_auto_current_spec
-            ):
+            if monitor.mode_spec._using_auto_current_spec:
                 mode_plane_analyzer = ModePlaneAnalyzer(
                     center=monitor.center, size=monitor.size, field_data_colocated=monitor.colocate
                 )
@@ -4706,7 +4711,7 @@ class Simulation(AbstractYeeGridSimulation):
                     )
                 except SetupError as e:
                     raise SetupError(
-                        f"Failed to setup auto impedance specification for monitor '{monitor.name}'"
+                        f"Failed to setup auto impedance specification for monitor '{monitor.name}'. {e!s}"
                     ) from e
 
     @cached_property

--- a/tidy3d/plugins/smatrix/analysis/antenna.py
+++ b/tidy3d/plugins/smatrix/analysis/antenna.py
@@ -7,7 +7,6 @@ import numpy as np
 from tidy3d.components.microwave.data.monitor_data import AntennaMetricsData
 from tidy3d.plugins.smatrix.data.data_array import PortDataArray
 from tidy3d.plugins.smatrix.data.terminal import TerminalComponentModelerData
-from tidy3d.plugins.smatrix.ports.wave import WavePort
 from tidy3d.plugins.smatrix.types import NetworkIndex
 
 
@@ -52,18 +51,8 @@ def get_antenna_metrics_data(
     """
     # Use the first port as default if none specified
     if port_amplitudes is None:
-        first_port = terminal_component_modeler_data.modeler.ports[0]
-        mode_index = None
-        if isinstance(first_port, WavePort):
-            mode_index = first_port.mode_index
-        port_amplitudes = {
-            terminal_component_modeler_data.modeler.network_index(first_port, mode_index): None
-        }
-    # Check port names, and create map from port to amplitude
-    port_dict = {}
-    for key in port_amplitudes.keys():
-        port, _ = terminal_component_modeler_data.modeler.network_dict[key]
-        port_dict[port] = port_amplitudes[key]
+        first_port_index = terminal_component_modeler_data.modeler.matrix_indices_source[0]
+        port_amplitudes = {first_port_index: None}
     # Get the radiation monitor, use first as default
     # if none specified
     if monitor_name is None:
@@ -87,9 +76,8 @@ def get_antenna_metrics_data(
     a_matrix, b_matrix = terminal_component_modeler_data.port_power_wave_matrices
     # Retrieve associated simulation data
     combined_directivity_data = None
-    for port, amplitude in port_dict.items():
-        port_in_index = terminal_component_modeler_data.modeler.network_index(port)
-        _, mode_index = terminal_component_modeler_data.modeler.network_dict[port_in_index]
+    for port_in_index, amplitude in port_amplitudes.items():
+        port, mode_index = terminal_component_modeler_data.modeler.network_dict[port_in_index]
         if amplitude is not None:
             if np.isclose(amplitude, 0.0):
                 continue
@@ -114,7 +102,7 @@ def get_antenna_metrics_data(
         else:
             scaled_directivity_data = (
                 terminal_component_modeler_data._monitor_data_at_port_amplitude(
-                    port, rad_mon.name, amplitude, a_raw
+                    port_in_index, rad_mon.name, amplitude, a_raw
                 )
             )
             scale_factor = amplitude / a_raw

--- a/tidy3d/plugins/smatrix/analysis/terminal.py
+++ b/tidy3d/plugins/smatrix/analysis/terminal.py
@@ -147,7 +147,7 @@ def port_reference_impedances(modeler_data: TerminalComponentModelerData) -> Por
         if isinstance(port, WavePort):
             # WavePorts have a port impedance calculated from its associated modal field distribution
             # and is frequency dependent.
-            data = port.compute_port_impedance(sim_data).data
+            data = port.get_port_impedance(sim_data, mode_index).data
             port_impedances = port_impedances._with_updated_data(data=data, coords=indexer)
         else:
             # LumpedPorts have a constant reference impedance
@@ -195,9 +195,17 @@ def _compute_port_voltages_currents(
     V_matrix = PortDataArray(values, coords=coords)
     I_matrix = V_matrix.copy(deep=True)
 
+    waveport_cache_results = (None, None, None)
     for network_index in network_indices:
         port, mode_index = modeler.network_dict[network_index]
-        V_out, I_out = compute_port_VI(port, sim_data)
+        if isinstance(port, WavePort):
+            if waveport_cache_results[0] is not port:
+                V_modes, I_modes = compute_port_VI(port, sim_data)
+                waveport_cache_results = (port, V_modes, I_modes)
+            V_out = waveport_cache_results[1].sel(mode_index=mode_index)
+            I_out = waveport_cache_results[2].sel(mode_index=mode_index)
+        else:
+            V_out, I_out = compute_port_VI(port, sim_data)
         indexer = {"port": network_index}
         V_matrix = V_matrix._with_updated_data(data=V_out.data, coords=indexer)
         I_matrix = I_matrix._with_updated_data(data=I_out.data, coords=indexer)

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -214,8 +214,6 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
         ValueError
             If an invalid `format` string is provided.
         """
-        if isinstance(port, WavePort) and mode_index is None:
-            mode_index = port.mode_index
         if mode_index is not None:
             return f"{port.name}@{mode_index}"
         if format == "PF":

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -37,7 +37,7 @@ from tidy3d.plugins.smatrix.data.data_array import PortDataArray
 from tidy3d.plugins.smatrix.ports.base_lumped import AbstractLumpedPort
 from tidy3d.plugins.smatrix.ports.coaxial_lumped import CoaxialLumpedPort
 from tidy3d.plugins.smatrix.ports.rectangular_lumped import LumpedPort
-from tidy3d.plugins.smatrix.ports.types import TerminalPortType
+from tidy3d.plugins.smatrix.ports.types import LumpedPortType, TerminalPortType
 from tidy3d.plugins.smatrix.ports.wave import WavePort
 from tidy3d.plugins.smatrix.types import NetworkElement, NetworkIndex, SParamDef
 
@@ -321,19 +321,22 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         NetworkIndex
             A unique string that is used to identify the row/column of the scattering matrix.
         """
-        # Currently the mode_index is ignored, but will be supported once multimodal WavePorts are enabled.
-        return f"{port.name}"
+        if isinstance(port, LumpedPortType):
+            return f"{port.name}"
+        return f"{port.name}_{mode_index}"
 
     @cached_property
     def network_dict(self) -> dict[NetworkIndex, tuple[TerminalPortType, int]]:
         """Dictionary associating each unique ``NetworkIndex`` to a port and mode index."""
         network_dict = {}
         for port in self.ports:
-            mode_index = None
             if isinstance(port, WavePort):
-                mode_index = port.mode_index
-            key = TerminalComponentModeler.network_index(port, mode_index)
-            network_dict[key] = (port, mode_index)
+                for mode_index in port._mode_indices:
+                    key = self.network_index(port, mode_index)
+                    network_dict[key] = (port, mode_index)
+            else:
+                key = self.network_index(port, None)
+                network_dict[key] = (port, None)
         return network_dict
 
     @staticmethod
@@ -355,7 +358,8 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         matrix_indices = []
         for port in ports:
             if isinstance(port, WavePort):
-                matrix_indices.append(TerminalComponentModeler.network_index(port, port.mode_index))
+                for mode_index in port._mode_indices:
+                    matrix_indices.append(TerminalComponentModeler.network_index(port, mode_index))
             else:
                 matrix_indices.append(TerminalComponentModeler.network_index(port))
         return tuple(matrix_indices)
@@ -697,7 +701,9 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         if isinstance(port, WavePort):
             # Source is placed just before the field monitor of the port
             mode_src_pos = port.center[port.injection_axis] + self._shift_value_signed(port)
-            port_source = port.to_source(self._source_time, snap_center=mode_src_pos)
+            port_source = port.to_source(
+                self._source_time, snap_center=mode_src_pos, mode_index=mode_index
+            )
         else:
             port_center_on_axis = port.center[port.injection_axis]
             new_port_center = snap_coordinate_to_grid(

--- a/tidy3d/plugins/smatrix/data/terminal.py
+++ b/tidy3d/plugins/smatrix/data/terminal.py
@@ -22,7 +22,7 @@ from tidy3d.plugins.smatrix.data.data_array import (
     PortNameDataArray,
     TerminalPortDataArray,
 )
-from tidy3d.plugins.smatrix.ports.types import LumpedPortType, TerminalPortType
+from tidy3d.plugins.smatrix.ports.types import LumpedPortType
 from tidy3d.plugins.smatrix.types import NetworkIndex, SParamDef
 from tidy3d.plugins.smatrix.utils import (
     ab_to_s,
@@ -179,9 +179,8 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
                     f"Please, make sure the port name is from the following list {port_names}"
                 )
 
-            # get index of a shifted port in port_names list
-            idx = port_names.index(shift_name)
-            port = ports[idx]
+            # get the port by the name
+            port = self.modeler.get_port_by_name(shift_name)
 
             # if de-embedding is requested for lumped port
             if isinstance(port, LumpedPortType):
@@ -192,14 +191,16 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
                 # alternatively we can send a warning and set `shifts_vector[index]` to 0.
                 # shifts_vector[index] = 0.0
             else:
-                shifts_vec[idx] = port_shifts.sel(port=shift_name).values
-                directions_vec[idx] = -1 if port.direction == "-" else 1
-                port_idxs.append(idx)
-
                 # Collect corresponding mode_data
                 mode_data = mode_map[port._mode_monitor_name]
-                n_complex = mode_data.n_complex.sel(mode_index=port.mode_index)
-                n_complex_new.append(np.squeeze(n_complex.data))
+                for mode_index in port._mode_indices:
+                    network_index = self.modeler.network_index(port, mode_index)
+                    idx = smatrix.data.indexes["port_in"].get_loc(network_index)
+                    shifts_vec[idx] = port_shifts.sel(port=shift_name).values
+                    directions_vec[idx] = -1 if port.direction == "-" else 1
+                    port_idxs.append(idx)
+                    n_complex = mode_data.n_complex.sel(mode_index=mode_index)
+                    n_complex_new.append(np.squeeze(n_complex.data))
 
         # flatten port shift vector
         shifts_vec = np.ravel(shifts_vec)
@@ -236,7 +237,7 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
 
     def _monitor_data_at_port_amplitude(
         self,
-        port: TerminalPortType,
+        port_index: NetworkIndex,
         monitor_name: str,
         a_port: Union[FreqDataArray, complex],
         a_raw_port: FreqDataArray,
@@ -249,7 +250,7 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
 
         Parameters
         ----------
-        port : TerminalPortType
+        port_index : NetworkIndex
             The port at which to normalize the amplitude.
         monitor_name : str
             Name of the monitor to normalize.
@@ -265,7 +266,8 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
         :class:`.MonitorData`
             Normalized monitor data scaled to the desired port amplitude.
         """
-        sim_data_port = self.data[self.modeler.get_task_name(port)]
+        port, mode_index = self.modeler.network_dict[port_index]
+        sim_data_port = self.data[self.modeler.get_task_name(port, mode_index)]
         monitor_data = sim_data_port[monitor_name]
         if not isinstance(a_port, FreqDataArray):
             freqs = list(monitor_data.monitor.freqs)

--- a/tidy3d/plugins/smatrix/ports/wave.py
+++ b/tidy3d/plugins/smatrix/ports/wave.py
@@ -4,34 +4,27 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-import numpy as np
 import pydantic.v1 as pd
 
 from tidy3d.components.base import cached_property, skip_if_fields_missing
 from tidy3d.components.boundary import ABCBoundary, InternalAbsorber, ModeABCBoundary
 from tidy3d.components.data.data_array import FreqDataArray, FreqModeDataArray
-from tidy3d.components.data.monitor_data import ModeData
 from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.geometry.base import Box
-from tidy3d.components.geometry.bound_ops import bounds_contains
 from tidy3d.components.grid.grid import Grid
-from tidy3d.components.microwave.impedance_calculator import (
-    CurrentIntegralType,
-    ImpedanceCalculator,
-    VoltageIntegralType,
-)
-from tidy3d.components.monitor import ModeMonitor
+from tidy3d.components.microwave.data.monitor_data import MicrowaveModeData
+from tidy3d.components.microwave.mode_spec import MicrowaveModeSpec
+from tidy3d.components.microwave.monitor import MicrowaveModeMonitor
 from tidy3d.components.simulation import Simulation
-from tidy3d.components.source.field import ModeSource, ModeSpec
+from tidy3d.components.source.field import ModeSource
 from tidy3d.components.source.frame import PECFrame
 from tidy3d.components.source.time import GaussianPulse
 from tidy3d.components.structure import MeshOverrideStructure
 from tidy3d.components.types import Axis, Direction, FreqArray
-from tidy3d.constants import fp_eps
-from tidy3d.exceptions import ValidationError
+from tidy3d.exceptions import SetupError, ValidationError
+from tidy3d.log import log
 from tidy3d.plugins.mode import ModeSolver
-
-from .base_terminal import AbstractTerminalPort
+from tidy3d.plugins.smatrix.ports.base_terminal import AbstractTerminalPort
 
 DEFAULT_WAVE_PORT_NUM_CELLS = 5
 MIN_WAVE_PORT_NUM_CELLS = 3
@@ -47,31 +40,11 @@ class WavePort(AbstractTerminalPort, Box):
         description="'+' or '-', defining which direction is considered 'input'.",
     )
 
-    mode_spec: ModeSpec = pd.Field(
-        ModeSpec(),
+    mode_spec: MicrowaveModeSpec = pd.Field(
+        default_factory=MicrowaveModeSpec._default_without_license_warning,
         title="Mode Specification",
-        description="Parameters to feed to mode solver which determine modes measured by monitor.",
-    )
-
-    mode_index: pd.NonNegativeInt = pd.Field(
-        0,
-        title="Mode Index",
-        description="Index into the collection of modes returned by mode solver. "
-        " Specifies which mode to inject using this source. "
-        "If larger than ``mode_spec.num_modes``, "
-        "``num_modes`` in the solver will be set to ``mode_index + 1``.",
-    )
-
-    voltage_integral: Optional[VoltageIntegralType] = pd.Field(
-        None,
-        title="Voltage Integral",
-        description="Definition of voltage integral used to compute voltage and the characteristic impedance.",
-    )
-
-    current_integral: Optional[CurrentIntegralType] = pd.Field(
-        None,
-        title="Current Integral",
-        description="Definition of current integral used to compute current and the characteristic impedance.",
+        description="Parameters to feed to mode solver which determine modes and how transmission line "
+        "quantities, e.g., charateristic impedance, are computed.",
     )
 
     num_grid_cells: Optional[int] = pd.Field(
@@ -108,31 +81,22 @@ class WavePort(AbstractTerminalPort, Box):
         description="Extrudes structures that intersect the wave port plane by a few grid cells when ``True``, improving mode injection accuracy.",
     )
 
-    def _mode_voltage_coefficients(self, mode_data: ModeData) -> FreqModeDataArray:
-        """Calculates scaling coefficients to convert mode amplitudes
-        to the total port voltage.
-        """
-        flux_sign = 1 if self.direction == "+" else -1
-        if self.voltage_integral is None:
-            flux_sign = 1 if mode_data.monitor.store_fields_direction == "+" else -1
-            current_coeffs = self.current_integral.compute_current(mode_data)
-            voltage_coeffs = 2 * flux_sign * mode_data.complex_flux / np.conj(current_coeffs)
-        else:
-            voltage_coeffs = self.voltage_integral.compute_voltage(mode_data)
-        return voltage_coeffs.squeeze()
+    mode_index: Optional[pd.NonNegativeInt] = pd.Field(
+        None,
+        title="Mode Index (deprecated)",
+        description="Index into the collection of modes returned by mode solver. "
+        "Specifies which mode to inject using this port. "
+        "Deprecated. Use the 'mode_selection' field instead.",
+    )
 
-    def _mode_current_coefficients(self, mode_data: ModeData) -> FreqModeDataArray:
-        """Calculates scaling coefficients to convert mode amplitudes
-        to the total port current.
-        """
-        flux_sign = 1 if self.direction == "+" else -1
-        if self.current_integral is None:
-            flux_sign = 1 if mode_data.monitor.store_fields_direction == "+" else -1
-            voltage_coeffs = self.voltage_integral.compute_voltage(mode_data)
-            current_coeffs = (2 * flux_sign * mode_data.complex_flux / voltage_coeffs).conj()
-        else:
-            current_coeffs = self.current_integral.compute_current(mode_data)
-        return current_coeffs.squeeze()
+    mode_selection: Optional[tuple[int, ...]] = pd.Field(
+        None,
+        title="Mode Selection",
+        description="Selects specific mode(s) to use from the mode solver. "
+        "Can be a single integer for one mode, or a tuple of integers for multiple modes. "
+        "If ``None`` (default), all modes from the ``mode_spec`` are used. "
+        "Indices must be non-negative and less than ``mode_spec.num_modes``.",
+    )
 
     @cached_property
     def injection_axis(self) -> Axis:
@@ -147,11 +111,25 @@ class WavePort(AbstractTerminalPort, Box):
 
     @cached_property
     def _mode_monitor_name(self) -> str:
-        """Return the name of the :class:`.ModeMonitor` associated with this port."""
+        """Return the name of the :class:`.MicrowaveModeMonitor` associated with this port."""
         return f"{self.name}_mode"
 
+    @cached_property
+    def _mode_indices(self) -> tuple[int, ...]:
+        """Mode indices that will be excited/monitored by this port."""
+        if self.mode_index is not None and self.mode_selection is None:
+            return (self.mode_index,)
+        if self.mode_selection is not None:
+            # User specified specific modes
+            return self.mode_selection
+        # Default: use all modes
+        return tuple(range(self.mode_spec.num_modes))
+
     def to_source(
-        self, source_time: GaussianPulse, snap_center: Optional[float] = None
+        self,
+        source_time: GaussianPulse,
+        snap_center: Optional[float] = None,
+        mode_index: int = 0,
     ) -> ModeSource:
         """Create a mode source from the wave port."""
         center = list(self.center)
@@ -162,7 +140,7 @@ class WavePort(AbstractTerminalPort, Box):
             size=self.size,
             source_time=source_time,
             mode_spec=self.mode_spec,
-            mode_index=self.mode_index,
+            mode_index=mode_index,
             direction=self.direction,
             name=self.name,
             frame=self.frame,
@@ -170,13 +148,13 @@ class WavePort(AbstractTerminalPort, Box):
 
     def to_monitors(
         self, freqs: FreqArray, snap_center: Optional[float] = None, grid: Grid = None
-    ) -> list[ModeMonitor]:
-        """The wave port uses a :class:`.ModeMonitor` to compute the characteristic impedance
+    ) -> list[MicrowaveModeMonitor]:
+        """The wave port uses a :class:`.MicrowaveModeMonitor` to compute the characteristic impedance
         and the port voltages and currents."""
         center = list(self.center)
         if snap_center:
             center[self.injection_axis] = snap_center
-        mode_mon = ModeMonitor(
+        mode_mon = MicrowaveModeMonitor(
             center=self.center,
             size=self.size,
             freqs=freqs,
@@ -210,9 +188,12 @@ class WavePort(AbstractTerminalPort, Box):
         if isinstance(self.absorber, (ABCBoundary, ModeABCBoundary)):
             boundary_spec = self.absorber
         else:
+            # TODO: ModeABCBoundary currently only accepts one mode, so
+            # we choose the first mode for now
+            mode_index = self._mode_indices[0]
             boundary_spec = ModeABCBoundary(
                 mode_spec=self.mode_spec,
-                mode_index=self.mode_index,
+                mode_index=mode_index,
                 plane=self.geometry,
                 freq_spec=freq_spec,
             )
@@ -228,20 +209,20 @@ class WavePort(AbstractTerminalPort, Box):
 
     def compute_voltage(self, sim_data: SimulationData) -> FreqDataArray:
         """Helper to compute voltage across the port."""
-        mode_data = sim_data[self._mode_monitor_name]._isel(mode_index=[self.mode_index])
-        voltage_coeffs = self._mode_voltage_coefficients(mode_data)
+        mode_data: MicrowaveModeData = sim_data[self._mode_monitor_name]
+        voltage_coeffs = mode_data.transmission_line_data.voltage_coeffs
         amps = mode_data.amps
-        fwd_amps = amps.sel(direction="+", mode_index=self.mode_index).squeeze()
-        bwd_amps = amps.sel(direction="-", mode_index=self.mode_index).squeeze()
+        fwd_amps = amps.sel(direction="+").squeeze()
+        bwd_amps = amps.sel(direction="-").squeeze()
         return voltage_coeffs * (fwd_amps + bwd_amps)
 
     def compute_current(self, sim_data: SimulationData) -> FreqDataArray:
         """Helper to compute current flowing through the port."""
-        mode_data = sim_data[self._mode_monitor_name]._isel(mode_index=[self.mode_index])
-        current_coeffs = self._mode_current_coefficients(mode_data)
+        mode_data: MicrowaveModeData = sim_data[self._mode_monitor_name]
+        current_coeffs = mode_data.transmission_line_data.current_coeffs
         amps = mode_data.amps
-        fwd_amps = amps.sel(direction="+", mode_index=self.mode_index).squeeze()
-        bwd_amps = amps.sel(direction="-", mode_index=self.mode_index).squeeze()
+        fwd_amps = amps.sel(direction="+").squeeze()
+        bwd_amps = amps.sel(direction="-").squeeze()
         # In ModeData, fwd_amps and bwd_amps are not relative to
         # the direction fields are stored
         sign = 1.0
@@ -249,23 +230,37 @@ class WavePort(AbstractTerminalPort, Box):
             sign = -1.0
         return sign * current_coeffs * (fwd_amps - bwd_amps)
 
-    def compute_port_impedance(
-        self, sim_mode_data: Union[SimulationData, ModeData]
+    def get_port_impedance(
+        self, sim_mode_data: Union[SimulationData, MicrowaveModeData], mode_index: int
     ) -> FreqModeDataArray:
-        """Helper to compute impedance of port. The port impedance is computed from the
-        transmission line mode, which should be TEM or at least quasi-TEM."""
-        impedance_calc = ImpedanceCalculator(
-            voltage_integral=self.voltage_integral, current_integral=self.current_integral
-        )
+        """Retrieve the characteristic impedance of the port for a specific mode.
+
+        The port impedance is computed from the transmission line mode characteristics,
+        which should ideally be TEM (Transverse Electromagnetic) or at least quasi-TEM.
+        The impedance is extracted from the transmission line data computed by the
+        mode solver.
+
+        Parameters
+        ----------
+        sim_mode_data : Union[:class:`.SimulationData`, :class:`.MicrowaveModeData`]
+            Simulation data containing the mode monitor results, or the mode data directly.
+            If :class:`.SimulationData` is provided, the mode data is extracted using the
+            port's mode monitor name.
+        mode_index : int
+            Index of the mode for which to compute the impedance. This selects a specific
+            mode from the mode spectrum computed by the mode solver.
+
+        Returns
+        -------
+        :class:`.FreqModeDataArray`
+            Frequency-dependent characteristic impedance Z0 for the specified mode.
+            The impedance is complex-valued and varies with frequency.
+        """
         if isinstance(sim_mode_data, SimulationData):
             mode_data = sim_mode_data[self._mode_monitor_name]
         else:
             mode_data = sim_mode_data
-
-        # Filter out unwanted modes to reduce impedance computation effort
-        mode_data = mode_data._isel(mode_index=[self.mode_index])
-        impedance_array = impedance_calc.compute_impedance(mode_data)
-        return impedance_array
+        return mode_data.transmission_line_data.Z0.sel(mode_index=[mode_index])
 
     def to_mesh_overrides(self) -> list[MeshOverrideStructure]:
         """Creates a list of :class:`.MeshOverrideStructure` for mesh refinement in the transverse
@@ -286,46 +281,53 @@ class WavePort(AbstractTerminalPort, Box):
             )
         ]
 
-    @pd.validator("voltage_integral", "current_integral")
+    @pd.validator("mode_spec", always=True)
     def _validate_path_integrals_within_port(cls, val, values):
-        """Raise ``ValidationError`` when the supplied path integrals are not within the port bounds."""
+        """Validate that the microwave mode spec contains path specs all within the port bounds."""
         center = values["center"]
         size = values["size"]
-        box = Box(center=center, size=size)
-        if val and not bounds_contains(
-            box.bounds, val.bounds, fp_eps, np.finfo(np.float32).smallest_normal
-        ):
-            raise ValidationError(
-                f"'{cls.__name__}' must be setup with all path integrals defined within the bounds "
-                f"of the port. Path bounds are '{val.bounds}', but port bounds are '{box.bounds}'."
-            )
+        self_plane = Box(size=size, center=center)
+        try:
+            val._check_path_integrals_within_box(self_plane)
+        except SetupError as e:
+            raise SetupError(
+                f"Failed to setup '{cls.__name__}' with the suppled 'MicrowaveModeSpec'. {e!s}"
+            ) from e
         return val
 
-    @pd.validator("current_integral", always=True)
-    @skip_if_fields_missing(["voltage_integral"])
-    def _check_voltage_or_current(cls, val, values):
-        """Raise validation error if both ``voltage_integral`` and ``current_integral``
-        were not provided."""
-        if values.get("voltage_integral") is None and val is None:
-            raise ValidationError(
-                "At least one of 'voltage_integral' or 'current_integral' must be provided."
-            )
-        return val
-
-    @pd.validator("current_integral", always=True)
-    def _validate_current_integral_sign(cls, val, values):
-        """
-        Validate that the sign of ``current_integral`` matches the port direction.
-        """
+    @skip_if_fields_missing(["mode_spec"])
+    @pd.validator("mode_selection", always=True)
+    def _validate_mode_selection(cls, val, values):
+        """Validate that mode_selection contains valid, unique indices within range."""
         if val is None:
             return val
 
-        direction = values.get("direction")
-        name = values.get("name")
-        if val.sign != direction:
+        indices = val
+
+        # Check for non-negative integers
+        if any(idx < 0 for idx in indices):
             raise ValidationError(
-                f"'current_integral' sign must match the '{name}' direction '{direction}'."
+                f"'mode_selection' must contain non-negative integers. Got: {indices}"
             )
+
+        # Check for duplicates
+        if len(indices) != len(set(indices)):
+            duplicates = [idx for idx in set(indices) if list(indices).count(idx) > 1]
+            raise ValidationError(
+                f"'mode_selection' contains duplicate entries: {duplicates}. "
+                "Each index must appear only once."
+            )
+
+        # Check that indices are within range of num_modes
+        mode_spec = values["mode_spec"]
+        num_modes = mode_spec.num_modes
+        invalid_indices = [idx for idx in indices if idx >= num_modes]
+        if invalid_indices:
+            raise ValidationError(
+                f"'mode_selection' contains indices {invalid_indices} that are >= "
+                f"'mode_spec.num_modes' ({num_modes}). Valid range is 0 to {num_modes - 1}."
+            )
+
         return val
 
     @pd.root_validator(pre=False)
@@ -339,3 +341,27 @@ class WavePort(AbstractTerminalPort, Box):
             )
 
         return values
+
+    @pd.validator("mode_index", always=True)
+    def _mode_index_deprecated(cls, val):
+        """Warn that 'mode_index' is deprecated in favor of 'mode_selection'."""
+        if val is not None:
+            log.warning(
+                "'mode_index' is deprecated and will be removed in future versions. "
+                "Please use 'mode_selection' instead."
+            )
+        return val
+
+    @skip_if_fields_missing(["mode_spec"])
+    @pd.validator("mode_index", always=True)
+    def _validate_mode_index(cls, val, values):
+        """Validate that mode_selection contains valid, unique indices within range."""
+        if val is None:
+            return val
+        num_modes = values["mode_spec"].num_modes
+        if val >= num_modes:
+            raise ValidationError(
+                f"'mode_index' is >= "
+                f"'mode_spec.num_modes' ({num_modes}). Valid range is 0 to {num_modes - 1}."
+            )
+        return val


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-16 20:12:05 UTC

### Greptile Summary

This PR implements multimodal waveport support in the S-matrix component modeler, enabling waveguide ports to handle multiple propagating modes simultaneously. The changes refactor the WavePort class to use `MicrowaveModeSpec` instead of manual impedance calculations, introduce a network indexing system that creates separate entries for each port-mode combination, and update the analysis pipeline to work with `NetworkIndex` identifiers rather than simple port references.

Key architectural changes include replacing the single `mode_index` field with a multimodal approach, switching from `TerminalPortType` to `NetworkIndex` for port identification, and implementing caching optimizations for voltage/current calculations to avoid redundant computations across modes of the same port. The refactoring leverages existing microwave components for transmission line calculations while maintaining backward compatibility with lumped ports.

### Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/plugins/smatrix/ports/wave.py` | 4/5| Major refactoring to support multimodal operation using MicrowaveModeSpec and removing manual impedance calculations |
| `tidy3d/plugins/smatrix/component_modelers/terminal.py` | 4/5 | Core network indexing changes to create separate entries for each port-mode combination |
| `tidy3d/plugins/smatrix/analysis/terminal.py` | 4/5 | Added caching optimization for voltage/current calculations and mode_index parameter support |
| `tidy3d/plugins/smatrix/data/terminal.py` | 4/5 | Updated method signature from TerminalPortType to NetworkIndex for multimodal support |
| `tidy3d/plugins/smatrix/component_modelers/base.py` | 5/5 | Removed automatic mode_index assignment to require explicit specification |
| `tidy3d/plugins/smatrix/analysis/antenna.py` | 4/5 | Refactored to use NetworkIndex-based processing instead of port-based iteration |
| `tests/test_plugins/smatrix/test_terminal_component_modeler.py` | 3/5 | Updated test suite with incomplete validation migration and duplicate code blocks |
| `tests/test_plugins/smatrix/terminal_component_modeler_def.py` | 4/5 | Updated WavePort configuration to use MicrowaveModeSpec with CustomImpedanceSpec |
| `tests/utils.py` | 4/5 | Added data generator functions for microwave monitor data with transmission line support |

</details>

### Confidence score: 3/5

- This PR requires careful review due to significant architectural changes affecting the S-matrix analysis pipeline
- Score reflects the comprehensive nature of the refactoring with multiple interdependent changes, incomplete test validation migration, and potential for runtime issues if network indexing logic has edge cases
- Pay close attention to test files with TODO comments and duplicate code blocks, and verify that all validation logic has been properly migrated to the new API

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant TerminalComponentModeler
    participant WavePort
    participant MicrowaveModeSpec
    participant Simulation
    participant TerminalComponentModelerData
    participant SMatrixCalculation

    User->>TerminalComponentModeler: "Create modeler with multimodal wave ports"
    TerminalComponentModeler->>WavePort: "Initialize with MicrowaveModeSpec"
    WavePort->>MicrowaveModeSpec: "Configure num_modes > 1"
    
    User->>TerminalComponentModeler: "Generate simulation dictionary"
    TerminalComponentModeler->>TerminalComponentModeler: "Build network_dict mapping"
    Note over TerminalComponentModeler: Maps each mode to unique NetworkIndex
    
    loop For each mode in each WavePort
        TerminalComponentModeler->>WavePort: "Create source for mode_index"
        WavePort->>Simulation: "Add ModeSource with specific mode"
        TerminalComponentModeler->>WavePort: "Create monitors for mode"
        WavePort->>Simulation: "Add MicrowaveModeMonitor"
    end
    
    User->>TerminalComponentModeler: "Run simulations"
    loop For each simulation task
        TerminalComponentModeler->>Simulation: "Execute FDTD simulation"
        Simulation->>TerminalComponentModelerData: "Return SimulationData"
    end
    
    User->>TerminalComponentModelerData: "Calculate S-matrix"
    TerminalComponentModelerData->>SMatrixCalculation: "Process multimodal data"
    
    loop For each port and mode combination
        SMatrixCalculation->>WavePort: "Compute voltage/current for mode"
        WavePort->>SMatrixCalculation: "Return modal V/I data"
        SMatrixCalculation->>SMatrixCalculation: "Convert to wave amplitudes"
    end
    
    SMatrixCalculation->>TerminalComponentModelerData: "Return complete S-matrix"
    TerminalComponentModelerData->>User: "Provide multimodal S-parameters"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->