### PR TITLE
More robust Sellmeier and Debye; validate PoleResidue parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Improved performance of antenna metrics calculation by utilizing cached wave amplitude calculations instead of recomputing wave amplitudes for each port excitation in the `TerminalComponentModelerData`.
 
+### Fixed
+- More robust `Sellmeier` and `Debye` material model, and prevent very large pole parameters in `PoleResidue` material model.
+
+
 ## [v2.10.0rc2] - 2025-10-01
 
 ### Added

--- a/tests/test_components/test_custom.py
+++ b/tests/test_components/test_custom.py
@@ -72,12 +72,14 @@ def make_custom_current_source():
     return td.CustomCurrentSource(size=SIZE, source_time=ST, current_dataset=current_dataset)
 
 
-def make_spatial_data(value=0, dx=0, unstructured=False, seed=None, uniform=False):
+def make_spatial_data(
+    value=0, dx=0, unstructured=False, seed=None, uniform=False, random_magnitude=1
+):
     """Makes a spatial data array."""
     if uniform:
         data = value * np.ones((Nx, Ny, Nz))
     else:
-        data = np.random.random((Nx, Ny, Nz)) + value
+        data = np.random.random((Nx, Ny, Nz)) * random_magnitude + value
     arr = td.SpatialDataArray(data, coords={"x": X + dx, "y": Y, "z": Z})
     if unstructured:
         method = "direct" if uniform else "linear"
@@ -777,11 +779,11 @@ def test_custom_pole_residue(unstructured):
 def test_custom_sellmeier(unstructured):
     """Custom Sellmeier medium."""
     seed = 897245
-    b1 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
-    c1 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
+    b1 = make_spatial_data(value=0.1, unstructured=unstructured, seed=seed)
+    c1 = make_spatial_data(value=0.1, unstructured=unstructured, seed=seed)
 
-    b2 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
-    c2 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
+    b2 = make_spatial_data(value=0.1, unstructured=unstructured, seed=seed)
+    c2 = make_spatial_data(value=0.1, unstructured=unstructured, seed=seed)
 
     # complex b
     with pytest.raises(pydantic.ValidationError):
@@ -814,6 +816,13 @@ def test_custom_sellmeier(unstructured):
     with pytest.raises(pydantic.ValidationError):
         btmp = make_spatial_data(value=0, dx=1, unstructured=(not unstructured), seed=seed)
         mat = CustomSellmeier(coeffs=((b1, c2), (btmp, c2)))
+
+    # some of C is close to 0
+    with pytest.raises(pydantic.ValidationError):
+        ctmp = make_spatial_data(
+            value=0, unstructured=unstructured, seed=seed, random_magnitude=1e-7
+        )
+        mat = CustomSellmeier(coeffs=((b1, c1), (b2, ctmp)))
 
     mat = CustomSellmeier(coeffs=((b1, c1), (b2, c2)))
     verify_custom_dispersive_medium_methods(mat, ["coeffs"])
@@ -931,10 +940,10 @@ def test_custom_debye(unstructured):
     eps_inf = make_spatial_data(value=1, unstructured=unstructured, seed=seed)
 
     eps1 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
-    tau1 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
+    tau1 = make_spatial_data(value=0.1, unstructured=unstructured, seed=seed)
 
     eps2 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
-    tau2 = make_spatial_data(value=0, unstructured=unstructured, seed=seed)
+    tau2 = make_spatial_data(value=0.1, unstructured=unstructured, seed=seed)
 
     # complex eps
     with pytest.raises(pydantic.ValidationError):
@@ -951,6 +960,12 @@ def test_custom_debye(unstructured):
         tautmp = make_spatial_data(value=-0.5, unstructured=unstructured, seed=seed)
         mat = CustomDebye(eps_inf=eps_inf, coeffs=((eps1, tau1), (eps2, tautmp)))
 
+    # some of tau is close to 0
+    with pytest.raises(pydantic.ValidationError):
+        tautmp = make_spatial_data(
+            value=0, unstructured=unstructured, seed=seed, random_magnitude=1e-38
+        )
+        mat = CustomDebye(eps_inf=eps_inf, coeffs=((eps1, tau1), (eps2, tautmp)))
     # inconsistent coords
     with pytest.raises(pydantic.ValidationError):
         epstmp = make_spatial_data(value=0, dx=1, unstructured=unstructured, seed=seed)

--- a/tests/test_components/test_medium.py
+++ b/tests/test_components/test_medium.py
@@ -62,6 +62,15 @@ def test_medium():
         _ = td.Medium(conductivity=-1.0)
 
 
+def test_validate_largest_pole_parameters():
+    # error for large pole parameters
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.PoleResidue(poles=[((-1e50 + 2j), (1 + 3j))])
+
+    with pytest.raises(pydantic.ValidationError):
+        _ = td.PoleResidue(poles=[((-1 + 2j), (1e50 + 3j))])
+
+
 def test_medium_conversions():
     n = 4.0
     k = 1.0
@@ -255,13 +264,15 @@ def test_medium_dispersion():
 def test_medium_dispersion_conversion():
     m_PR = td.PoleResidue(eps_inf=1.0, poles=[((-1 + 2j), (1 + 3j)), ((-2 + 4j), (1 + 5j))])
     m_SM = td.Sellmeier(coeffs=[(2, 3), (2, 4)])
+    m_SM_small_C = td.Sellmeier(coeffs=[(2, 3), (2, 1e-20)])
     m_LZ = td.Lorentz(eps_inf=1.0, coeffs=[(1, 3, 2), (2, 4, 1)])
     m_LZ2 = td.Lorentz(eps_inf=1.0, coeffs=[(1, 2, 3), (2, 1, 4)])
     m_DR = td.Drude(eps_inf=1.0, coeffs=[(1, 3), (2, 4)])
     m_DB = td.Debye(eps_inf=1.0, coeffs=[(1, 3), (2, 4)])
+    m_DB_small_tau = td.Debye(eps_inf=1.0, coeffs=[(1, 3), (2, 1e-50)])
 
     freqs = np.linspace(0.01, 1, 1001)
-    for medium in [m_PR, m_SM, m_DB, m_LZ, m_DR, m_LZ2]:  # , m_DB]:
+    for medium in [m_PR, m_SM, m_SM_small_C, m_DB, m_DB_small_tau, m_LZ, m_DR, m_LZ2]:  # , m_DB]:
         eps_model = medium.eps_model(freqs)
         eps_pr = medium.pole_residue.eps_model(freqs)
         np.testing.assert_allclose(eps_model, eps_pr)

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -24,6 +24,7 @@ from tidy3d.constants import (
     ETA_0,
     HBAR,
     HERTZ,
+    LARGEST_FP_NUMBER,
     MICROMETER,
     MU_0,
     PERMITTIVITY,
@@ -3367,6 +3368,18 @@ class PoleResidue(DispersiveMedium):
                 raise SetupError("For stable medium, 'Re(a_i)' must be non-positive.")
         return val
 
+    @pd.validator("poles", always=True)
+    def _poles_largest_value(cls, val):
+        """Assert pole parameters are not too large."""
+        for a, c in val:
+            if np.any(abs(_get_numpy_array(a)) > LARGEST_FP_NUMBER):
+                raise ValidationError(
+                    "The value of some 'a_i' is too large. They are unlikely to contribute to material dispersion."
+                )
+            if np.any(abs(_get_numpy_array(c)) > LARGEST_FP_NUMBER):
+                raise ValidationError("The value of some 'c_i' is too large.")
+        return val
+
     _validate_permittivity_modulation = DispersiveMedium._permittivity_modulation_validation()
     _validate_conductivity_modulation = DispersiveMedium._conductivity_modulation_validation()
 
@@ -4261,14 +4274,19 @@ class Sellmeier(DispersiveMedium):
     def _pole_residue_dict(self) -> dict:
         """Dict representation of Medium as a pole-residue model"""
         poles = []
+        eps_inf = _ones_like(self.coeffs[0][0])
         for B, C in self.coeffs:
-            beta = 2 * np.pi * C_0 / np.sqrt(C)
-            alpha = -0.5 * beta * B
-            a = 1j * beta
-            c = 1j * alpha
-            poles.append((a, c))
+            # for small C, it's equivalent to modifying eps_inf
+            if np.any(np.isclose(_get_numpy_array(C), 0)):
+                eps_inf += B
+            else:
+                beta = 2 * np.pi * C_0 / np.sqrt(C)
+                alpha = -0.5 * beta * B
+                a = 1j * beta
+                c = 1j * alpha
+                poles.append((a, c))
         return {
-            "eps_inf": 1,
+            "eps_inf": eps_inf,
             "poles": poles,
             "frequency_range": self.frequency_range,
             "name": self.name,
@@ -4436,6 +4454,18 @@ class CustomSellmeier(CustomDispersiveMedium, Sellmeier):
                     "To simulate a gain medium, please set 'allow_gain=True'. "
                     "Caution: simulations with a gain medium are unstable, "
                     "and are likely to diverge."
+                )
+        return val
+
+    @pd.validator("coeffs", always=True)
+    def _coeffs_C_all_near_zero_or_much_greater(cls, val):
+        """We restrict either all C~=0, or very different from 0."""
+        for _, C in val:
+            c_array_near_zero = np.isclose(_get_numpy_array(C), 0)
+            if np.any(c_array_near_zero) and not np.all(c_array_near_zero):
+                raise SetupError(
+                    "Coefficients 'C_i' are restricted to be "
+                    "either all near zero or much greater than 0."
                 )
         return val
 
@@ -5546,14 +5576,19 @@ class Debye(DispersiveMedium):
         """Dict representation of Medium as a pole-residue model."""
 
         poles = []
+        eps_inf = self.eps_inf
         for de, tau in self.coeffs:
-            a = -2 * np.pi / tau + 0j
-            c = -0.5 * de * a
+            # for |tau| close to 0, it's equivalent to modifying eps_inf
+            if np.any(abs(_get_numpy_array(tau)) < 1 / 2 / np.pi / LARGEST_FP_NUMBER):
+                eps_inf = eps_inf + de
+            else:
+                a = -2 * np.pi / tau + 0j
+                c = -0.5 * de * a
 
-            poles.append((a, c))
+                poles.append((a, c))
 
         return {
-            "eps_inf": self.eps_inf,
+            "eps_inf": eps_inf,
             "poles": poles,
             "frequency_range": self.frequency_range,
             "name": self.name,
@@ -5687,6 +5722,16 @@ class CustomDebye(CustomDispersiveMedium, Debye):
                 )
             if not CustomDispersiveMedium._validate_isreal_dataarray_tuple((de, tau)):
                 raise SetupError("All terms in 'coeffs' must be real.")
+        return val
+
+    @pd.validator("coeffs", always=True)
+    def _coeffs_tau_all_sufficient_positive(cls, val):
+        """We restrict either all tau is sufficently greater than 0."""
+        for _, tau in val:
+            if np.any(_get_numpy_array(tau) < 1 / 2 / np.pi / LARGEST_FP_NUMBER):
+                raise SetupError(
+                    "Coefficients 'tau_i' are restricted to be sufficiently greater than 0."
+                )
         return val
 
     def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:

--- a/tidy3d/constants.py
+++ b/tidy3d/constants.py
@@ -261,6 +261,11 @@ LARGE_NUMBER = 1e10
 Large number used for comparing infinity.
 """
 
+LARGEST_FP_NUMBER = 1e38
+"""
+Largest number used for single precision floating point number.
+"""
+
 inf = np.inf
 """
 Representation of infinity used within tidy3d.


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-09-27 19:07:10 UTC

<h3>Summary</h3>

This PR improves the robustness of material dispersion models by addressing edge cases in `Sellmeier`, `Debye`, and `PoleResidue` models. 

The key improvements include:
- **PoleResidue validation**: Added bounds checking to prevent excessively large pole parameters using the new `LARGEST_FP_NUMBER` constant
- **Sellmeier robustness**: When coefficient C ≈ 0, the contribution is now added to `eps_inf` instead of creating problematic poles
- **Debye robustness**: When tau is very small (< 1/(2π·LARGEST_FP_NUMBER)), the contribution is added to `eps_inf` to avoid numerical instability
- **Mixed parameter validation**: Added validators to prevent mixing zero/near-zero and normal values within coefficient arrays
- **Test updates**: Modified test coefficients from 0 to 0.1 to avoid the edge case behaviors being handled

The changes follow good engineering practices by gracefully handling numerical edge cases that could cause instability or precision issues in electromagnetic simulations.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge with one logic bug that should be fixed
- Score reflects solid robustness improvements and good validation logic, but reduced by one critical bug in the Debye model where eps_inf is incorrectly scoped within the loop
- tidy3d/components/medium.py requires attention due to the eps_inf scoping bug in the Debye model

<h3>Important Files Changed</h3>



File Analysis



| Filename | &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;  Score &nbsp;&nbsp;&nbsp;&nbsp; &nbsp; | Overview |
|----------|-------|----------|
| tidy3d/components/medium.py | 4/5 | Enhanced robustness for Sellmeier/Debye models and added PoleResidue validation, but has one logic bug in Debye implementation |
| tests/test_components/test_custom.py | 5/5 | Updated test values from 0 to 0.1 for tau and C coefficients to avoid edge case behaviors |
| tidy3d/constants.py | 5/5 | Added LARGEST_FP_NUMBER constant (1e38) for single precision floating point validation |
| CHANGELOG.md | 5/5 | Added clear changelog entry describing robustness improvements to material models |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as User/Application
    participant PR as PoleResidue
    participant SM as Sellmeier
    participant DB as Debye
    participant Val as Validators
    participant Const as Constants

    User->>PR: Create PoleResidue with poles
    PR->>Val: Validate causality (Re(a_i) ≤ 0)
    PR->>Const: Check LARGEST_FP_NUMBER
    PR->>Val: Validate pole magnitudes < LARGEST_FP_NUMBER
    Val-->>PR: Validation complete
    PR-->>User: PoleResidue created safely

    User->>SM: Create Sellmeier with coeffs (B, C)
    SM->>Val: Check if C ≈ 0
    alt C ≈ 0
        SM->>SM: Add B to eps_inf instead of creating pole
    else C >> 0
        SM->>SM: Create pole (a=jβ, c=jα)
    end
    SM->>Val: Validate mixed zero/non-zero C values
    Val-->>SM: Validation complete
    SM-->>User: Sellmeier created robustly

    User->>DB: Create Debye with coeffs (de, tau)
    DB->>Const: Check tau vs 1/(2π·LARGEST_FP_NUMBER)
    alt tau very small
        DB->>DB: Add de to eps_inf instead of creating pole
    else tau normal
        DB->>DB: Create pole (a=-2π/tau, c=-0.5·de·a)
    end
    DB->>Val: Validate mixed small/normal tau values
    Val-->>DB: Validation complete
    DB-->>User: Debye created robustly
```

<!-- /greptile_comment -->