### PR TITLE
feat: abstract simulation support plot_3d too

### DIFF
--- a/tidy3d/components/base_sim/simulation.py
+++ b/tidy3d/components/base_sim/simulation.py
@@ -702,3 +702,15 @@ class AbstractSimulation(Box, ABC):
             medium=scene.medium,
             **kwargs,
         )
+
+    def plot_3d(self, width=800, height=800) -> None:
+        """Render 3D plot of ``AbstractSimulation`` (in jupyter notebook only).
+        Parameters
+        ----------
+        width : float = 800
+            width of the 3d view dom's size
+        height : float = 800
+            height of the 3d view dom's size
+
+        """
+        return self.scene.plot_3d(width=width, height=height)

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -2671,3 +2671,15 @@ class ModeSolver(Tidy3dBaseModel):
         self._cached_properties["data_raw"] = data
         self._cached_properties.pop("data", None)
         self._cached_properties.pop("sim_data", None)
+
+    def plot_3d(self, width=800, height=800) -> None:
+        """Render 3D plot of ``ModeSolver`` (in jupyter notebook only).
+        Parameters
+        ----------
+        width : float = 800
+            width of the 3d view dom's size
+        height : float = 800
+            height of the 3d view dom's size
+
+        """
+        return self.simulation.plot_3d(width=width, height=height)


### PR DESCRIPTION
https://flow360.atlassian.net/browse/SCEM-11073

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-09-29 06:58:54 UTC

<h3>Summary</h3>

This PR adds `plot_3d` support to both `AbstractSimulation` and `ModeSolver` classes by creating delegation methods that forward to the existing `plot_3d` functionality in the `Scene` class.

**Key Changes:**
- Added `plot_3d` method to `AbstractSimulation` that delegates to `self.scene.plot_3d()`
- Added `plot_3d` method to `ModeSolver` that delegates to `self.simulation.plot_3d()`
- Both methods accept `width` and `height` parameters with default values of 800

**Issues Found:**
- Docstring format doesn't follow the established convention (`name : type = default` format)
- Missing newline at end of file in `mode_solver.py`

The implementation follows a clean delegation pattern and maintains consistency with the existing codebase architecture.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor style corrections needed
- The changes are straightforward delegation methods with no complex logic or potential runtime errors. Only minor docstring formatting and file formatting issues were found.
- Both files need minor style corrections for docstring format and file endings

<h3>Important Files Changed</h3>



File Analysis



| Filename | &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;  Score &nbsp;&nbsp;&nbsp;&nbsp; &nbsp; | Overview |
|----------|-------|----------|
| tidy3d/components/base_sim/simulation.py | 4/5 | Added `plot_3d` method to `AbstractSimulation` that delegates to `scene.plot_3d` |
| tidy3d/components/mode/mode_solver.py | 4/5 | Added `plot_3d` method to `ModeSolver` that delegates to `simulation.plot_3d` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ModeSolver
    participant AbstractSimulation  
    participant Scene
    participant plot_scene_3d

    Note over User, plot_scene_3d: ModeSolver.plot_3d() call flow
    User->>ModeSolver: plot_3d(width, height)
    ModeSolver->>AbstractSimulation: simulation.plot_3d(width, height)
    AbstractSimulation->>Scene: scene.plot_3d(width, height) 
    Scene->>plot_scene_3d: plot_scene_3d(self, width, height)
    plot_scene_3d-->>User: 3D visualization rendered

    Note over User, plot_scene_3d: AbstractSimulation.plot_3d() direct call
    User->>AbstractSimulation: plot_3d(width, height)
    AbstractSimulation->>Scene: scene.plot_3d(width, height)
    Scene->>plot_scene_3d: plot_scene_3d(self, width, height)
    plot_scene_3d-->>User: 3D visualization rendered
```

<!-- /greptile_comment -->