### PR TITLE
patch: catch errors where `flex_unit` is None

### DIFF
--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -1464,10 +1464,10 @@ def real_cost(task_id: str, verbose=True) -> float | None:
     if _is_modeler_batch(task_id):
         status = _batch_detail(task_id).totalStatus.value
         flex_unit = _batch_detail(task_id).realFlexUnit or None
-        if status not in ["success", "run_success"]:
+        if (status not in ["success", "run_success"]) or (flex_unit is None):
             log.warning(
                 f"Billed FlexCredit for task '{task_id}' is not available. If the task has been "
-                "successfully run, it should be available shortly."
+                "successfully run, it should be available shortly. If this issue persists, contact customer support."
             )
         else:
             if verbose:
@@ -1476,6 +1476,7 @@ def real_cost(task_id: str, verbose=True) -> float | None:
                     "task execution details. Use 'web.real_cost(task_id)' to get the billed FlexCredit "
                     "cost after a simulation run."
                 )
+
         return flex_unit
     else:
         task_info = get_info(task_id)


### PR DESCRIPTION
I thought about something more comprehensive, but I really hope this issue is fixed on the backend rather than the python client

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-09-29 16:15:37 UTC

<h3>Summary</h3>

This PR addresses an issue where `flex_unit` could be `None`, causing potential problems in the cost reporting functionality. The main change adds a null check in the conditional logic and improves the warning message to suggest contacting customer support for persistent issues.

- Added explicit check for `flex_unit is None` in the batch processing path
- Enhanced warning message with additional guidance for users
- Fixed doctest markers to prevent test failures in autograd parametrizations

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The changes are defensive programming practices that handle edge cases properly. The main logic change adds a null check that prevents potential issues, and the doctest fixes are low-risk maintenance changes. Only minor style issue with extra blank lines.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;  Score &nbsp;&nbsp;&nbsp;&nbsp; &nbsp; | Overview |
|----------|-------|----------|
| tidy3d/plugins/autograd/invdes/parametrizations.py | 5/5 | Added doctest skip markers to prevent test failures, no functional changes |
| tidy3d/web/api/webapi.py | 4/5 | Added null check for flex_unit and improved warning message, with minor formatting changes |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant real_cost_function as real_cost()
    participant batch_detail as _batch_detail()
    participant log as Logger

    Client->>real_cost_function: real_cost(task_id)
    real_cost_function->>batch_detail: _batch_detail(task_id)
    batch_detail-->>real_cost_function: {totalStatus, realFlexUnit}
    
    alt status not in success states OR flex_unit is None
        real_cost_function->>log: warning("FlexCredit not available...")
    else status is success AND flex_unit is not None
        alt verbose=True
            real_cost_function->>log: info("Billed FlexCredit cost: {flex_unit}")
        end
    end
    
    real_cost_function-->>Client: return flex_unit
```

<!-- /greptile_comment -->