### PR TITLE
MediumMonitor in ModeSimulation

### DIFF
--- a/tidy3d/components/mode/simulation.py
+++ b/tidy3d/components/mode/simulation.py
@@ -259,10 +259,10 @@ class ModeSimulation(AbstractYeeGridSimulation):
             return subpixel_sim.run_local()
 
         for mnt in self.monitors:
-            if isinstance(mnt, PermittivityMonitor):
+            if isinstance(mnt, (PermittivityMonitor, MediumMonitor)):
                 raise SetupError(
                     "The package 'tidy3d-extras' is required "
-                    "for accurate local 'PermittivityMonitor' handling. "
+                    "for accurate local 'PermittivityMonitor' and 'MediumMonitor' handling. "
                     "Please install this package using, for example, "
                     "'pip install tidy3d[extras]', and ensure "
                     "'config.use_local_subpixel' is not 'False'. "


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-09-30 20:57:34 UTC

<h3>Summary</h3>
This pull request adds support for `MediumMonitor` in `ModeSimulation` by expanding the existing monitor handling logic that was previously only available for `PermittivityMonitor`. The change is implemented in the `run_local()` method within `tidy3d/components/mode/simulation.py`.

The core modification involves updating an `isinstance` check to include both `PermittivityMonitor` and `MediumMonitor`, ensuring that both monitor types receive the same subpixel handling treatment. This is critical because both monitors require accurate material property representation in mode solving, which depends on the 'tidy3d-extras' package for proper subpixel averaging capabilities.

The developer also introduced a new type alias `ModeSimulationMonitorType` that clearly defines which monitor types are supported in `ModeSimulation`, improving type safety and code documentation. The monitors field type annotation was updated accordingly to use this new alias. The error message was also updated to mention both monitor types, providing users with clear guidance when the required dependencies are missing.

This change follows the established pattern in the codebase for handling monitors that require special subpixel processing, maintaining consistency with existing validation logic and error handling approaches.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/mode/simulation.py | 5/5 | Added MediumMonitor support to ModeSimulation with proper type aliasing and consistent error handling |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it extends existing functionality without breaking changes
- Score reflects straightforward logic extension following established patterns with proper type safety improvements
- No files require special attention as the change is well-contained and follows existing code patterns

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ModeSimulation
    participant ModeSolver
    participant "tidy3d_extras"
    participant ModeSimulationData

    User->>ModeSimulation: "run_local()"
    ModeSimulation->>ModeSimulation: "Check if tidy3d_extras['use_local_subpixel'] is enabled"
    
    alt tidy3d_extras['use_local_subpixel'] is True
        ModeSimulation->>"tidy3d_extras": "SubpixelModeSimulation.from_mode_simulation(self)"
        "tidy3d_extras"-->>ModeSimulation: "Return subpixel_sim"
        ModeSimulation->>"tidy3d_extras": "subpixel_sim.run_local()"
        "tidy3d_extras"-->>User: "Return result"
    else tidy3d_extras['use_local_subpixel'] is False
        ModeSimulation->>ModeSimulation: "Check monitors for PermittivityMonitor or MediumMonitor"
        alt Contains PermittivityMonitor or MediumMonitor
            ModeSimulation-->>User: "Raise SetupError: tidy3d-extras package required"
        else No special monitors
            ModeSimulation->>ModeSimulation: "_invalidate_solver_cache()"
            ModeSimulation->>ModeSolver: "Access _mode_solver.data_raw"
            ModeSolver-->>ModeSimulation: "Return modes_raw data"
            ModeSimulation->>ModeSimulationData: "Create ModeSimulationData(simulation=self, modes_raw=modes_raw)"
            ModeSimulationData-->>User: "Return simulation data"
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->