### PR TITLE
fix: changelog for v2.10.0rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Stricter validation for `bend_radius` in mode simulations, preventing the bend center from coinciding with the simulation boundary.
 - Prevent autograd adjoint simulations from reusing out-of-range `normalize_index` values by defaulting their normalization to the first adjoint source when needed.
-- Subtasks validation propagation of `web.upload(ComponentModeler)` previously was not being propagated to users, and hung without response.
+- Subtasks validation errors from `web.upload(ComponentModeler)` previously were not being propagated to users, and hung without response.
 
 ## [v2.10.0rc1] - 2025-09-11
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-01 15:13:05 UTC

<h3>Summary</h3>
This pull request makes a minor grammatical fix to the changelog entry for v2.10.0rc2 in the CHANGELOG.md file. The change corrects awkward phrasing from "Subtasks validation propagation of" to "Subtasks validation errors from" and fixes verb agreement from "was" to "were" to match the plural subject "errors".

The fix improves the clarity and readability of the changelog entry that describes a bug fix where validation errors from `web.upload(ComponentModeler)` were not being properly propagated to users, causing operations to hang without response. This is purely a documentation improvement that aligns with the project's commitment to maintaining professional quality in user-facing documentation.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|--------|----------|
| CHANGELOG.md | 5/5 | Minor grammatical correction to changelog entry improving clarity and verb agreement |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it only contains a minor grammatical fix to documentation
- Score reflects the non-functional nature of the change - it's purely a documentation improvement with no code modifications
- No files require special attention as this is a straightforward grammar correction

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->