### PR TITLE
Check TemperatureMonitor is unstructured in Charge

### DIFF
--- a/tidy3d/components/tcad/simulation/heat_charge.py
+++ b/tidy3d/components/tcad/simulation/heat_charge.py
@@ -662,12 +662,10 @@ class HeatChargeSimulation(AbstractSimulation):
                     "but none have been defined."
                 )
 
-            # NOTE: SteadyPotentialMonitor and SteadyFreeCarrierMonitor are only supported
-            # for unstructured = True
+            # NOTE: in Charge we're only supporting unstructured monitors.
+            # only Temperature and Potential monitors can be structured.
             for mnt in monitors:
-                if isinstance(mnt, SteadyPotentialMonitor) or isinstance(
-                    mnt, SteadyFreeCarrierMonitor
-                ):
+                if isinstance(mnt, SteadyPotentialMonitor) or isinstance(mnt, TemperatureMonitor):
                     if not mnt.unstructured:
                         log.warning(
                             "Currently, Charge simulations support only unstructured monitors. Please set "


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-01 16:14:14 UTC

<h3>Summary</h3>
This PR corrects the monitor validation logic in Charge simulations within the TCAD module. The change modifies which monitor types require `unstructured=True` in the validation routine.

Specifically, the validation now checks `SteadyPotentialMonitor` and `TemperatureMonitor` instead of the previous combination of `SteadyPotentialMonitor` and `SteadyFreeCarrierMonitor`. This means:
- `TemperatureMonitor` must now be unstructured in Charge simulations
- `SteadyFreeCarrierMonitor` can now be structured (unstructured=False)
- `SteadyPotentialMonitor` continues to require unstructured=True

The change aligns the code implementation with the existing comment that states "only Temperature and Potential monitors can be structured". Previously, the code was inconsistent with this documentation, incorrectly treating `SteadyFreeCarrierMonitor` as requiring unstructured configuration while not enforcing this requirement for `TemperatureMonitor`.

This validation occurs in the `HeatChargeSimulation` class and affects how users configure monitors in multi-physics simulations that combine heat transfer and charge transport physics. The change ensures proper computational backend compatibility for different monitor types in the TCAD charge simulation framework.

## Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/tcad/simulation/heat_charge.py | 4/5 | Fixed monitor validation logic to correctly check TemperatureMonitor instead of SteadyFreeCarrierMonitor for unstructured requirement |

</details>

## Confidence score: 4/5

- This PR is safe to merge with minimal risk as it fixes a validation inconsistency
- Score reflects a straightforward logic correction that aligns code with documented behavior
- No files require special attention beyond the single modified validation routine

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant HeatChargeSimulation
    participant Validators
    participant GridSpec
    participant Structures
    participant Monitors
    participant BoundarySpec
    participant Sources

    User->>HeatChargeSimulation: "Create simulation instance"
    HeatChargeSimulation->>Validators: "_post_init_validators()"
    Validators->>HeatChargeSimulation: "_estimate_charge_mesh_size()"
    
    User->>HeatChargeSimulation: "Validate structures"
    HeatChargeSimulation->>Validators: "check_unsupported_geometries()"
    Validators->>Structures: "Check geometry dimensions"
    Structures-->>Validators: "Return validation result"
    Validators-->>HeatChargeSimulation: "Validation complete"
    
    User->>HeatChargeSimulation: "Validate monitors"
    HeatChargeSimulation->>Validators: "_monitors_cross_solids()"
    Validators->>HeatChargeSimulation: "_check_cross_solids()"
    HeatChargeSimulation->>Structures: "Check intersecting media"
    Structures-->>HeatChargeSimulation: "Return intersection data"
    HeatChargeSimulation-->>Validators: "Return validation result"
    Validators-->>HeatChargeSimulation: "Monitor validation complete"
    
    User->>HeatChargeSimulation: "Check charge simulation setup"
    HeatChargeSimulation->>Validators: "check_charge_simulation()"
    Validators->>HeatChargeSimulation: "_check_simulation_types()"
    HeatChargeSimulation->>BoundarySpec: "Check voltage BCs"
    BoundarySpec-->>HeatChargeSimulation: "Return BC count"
    HeatChargeSimulation->>Monitors: "Check charge monitors"
    Monitors-->>HeatChargeSimulation: "Return monitor types"
    HeatChargeSimulation-->>Validators: "Return simulation type validation"
    Validators-->>HeatChargeSimulation: "Charge validation complete"
    
    User->>HeatChargeSimulation: "Plot simulation properties"
    HeatChargeSimulation->>HeatChargeSimulation: "plot_property()"
    HeatChargeSimulation->>Sources: "plot_sources()"
    HeatChargeSimulation->>Monitors: "plot_monitors()"
    HeatChargeSimulation->>BoundarySpec: "plot_boundaries()"
    BoundarySpec->>HeatChargeSimulation: "_construct_heat_charge_boundaries()"
    HeatChargeSimulation-->>User: "Return plotted axes"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->