### PR TITLE
Fix: Bug in WavePort when requesting more than one mode in the ModeSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - More robust `Sellmeier` and `Debye` material model, and prevent very large pole parameters in `PoleResidue` material model.
-
+- Bug in `WavePort` when more than one mode is requested in the `ModeSpec`.
 
 ## [v2.10.0rc2] - 2025-10-01
 

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -780,6 +780,25 @@ def test_run_coaxial_component_modeler_with_wave_ports(
                 s_matrix.sel(**coords_in).sel(**coords_out).values.shape == shape_both_ports
             ), "monitor index not present in S matrix"
 
+    # Another run with more modes in the mode spec
+    mode_spec = td.ModeSpec(num_modes=2)
+    modeler = modeler.updated_copy(path="ports/0/", mode_spec=mode_spec)
+    s_matrix = get_terminal_port_data_array(monkeypatch, modeler)
+
+    shape_one_port = (len(modeler.freqs), len(modeler.ports))
+    shape_both_ports = (len(modeler.freqs),)
+    for port_in in modeler.ports:
+        for port_out in modeler.ports:
+            coords_in = {"port_in": port_in.name}
+            coords_out = {"port_out": port_out.name}
+
+            assert np.all(s_matrix.sel(**coords_in).values.shape == shape_one_port), (
+                "source index not present in S matrix"
+            )
+            assert np.all(
+                s_matrix.sel(**coords_in).sel(**coords_out).values.shape == shape_both_ports
+            ), "monitor index not present in S matrix"
+
 
 def test_run_mixed_component_modeler_with_wave_ports(monkeypatch, tmp_path):
     """Checks the terminal component modeler will allow mixed ports."""

--- a/tidy3d/plugins/smatrix/ports/wave.py
+++ b/tidy3d/plugins/smatrix/ports/wave.py
@@ -103,8 +103,6 @@ class WavePort(AbstractTerminalPort, Box):
         to the total port voltage.
         """
         flux_sign = 1 if self.direction == "+" else -1
-
-        mode_data = mode_data._isel(mode_index=[self.mode_index])
         if self.voltage_integral is None:
             flux_sign = 1 if mode_data.monitor.store_fields_direction == "+" else -1
             current_coeffs = self.current_integral.compute_current(mode_data)
@@ -118,7 +116,6 @@ class WavePort(AbstractTerminalPort, Box):
         to the total port current.
         """
         flux_sign = 1 if self.direction == "+" else -1
-        mode_data = mode_data._isel(mode_index=[self.mode_index])
         if self.current_integral is None:
             flux_sign = 1 if mode_data.monitor.store_fields_direction == "+" else -1
             voltage_coeffs = self.voltage_integral.compute_voltage(mode_data)
@@ -221,20 +218,20 @@ class WavePort(AbstractTerminalPort, Box):
 
     def compute_voltage(self, sim_data: SimulationData) -> FreqDataArray:
         """Helper to compute voltage across the port."""
-        mode_data = sim_data[self._mode_monitor_name]
+        mode_data = sim_data[self._mode_monitor_name]._isel(mode_index=[self.mode_index])
         voltage_coeffs = self._mode_voltage_coefficients(mode_data)
         amps = mode_data.amps
-        fwd_amps = amps.sel(direction="+").squeeze()
-        bwd_amps = amps.sel(direction="-").squeeze()
+        fwd_amps = amps.sel(direction="+", mode_index=self.mode_index).squeeze()
+        bwd_amps = amps.sel(direction="-", mode_index=self.mode_index).squeeze()
         return voltage_coeffs * (fwd_amps + bwd_amps)
 
     def compute_current(self, sim_data: SimulationData) -> FreqDataArray:
         """Helper to compute current flowing through the port."""
-        mode_data = sim_data[self._mode_monitor_name]
+        mode_data = sim_data[self._mode_monitor_name]._isel(mode_index=[self.mode_index])
         current_coeffs = self._mode_current_coefficients(mode_data)
         amps = mode_data.amps
-        fwd_amps = amps.sel(direction="+").squeeze()
-        bwd_amps = amps.sel(direction="-").squeeze()
+        fwd_amps = amps.sel(direction="+", mode_index=self.mode_index).squeeze()
+        bwd_amps = amps.sel(direction="-", mode_index=self.mode_index).squeeze()
         # In ModeData, fwd_amps and bwd_amps are not relative to
         # the direction fields are stored
         sign = 1.0


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-01 20:35:07 UTC

<h3>Summary</h3>
This PR fixes a critical bug in the `WavePort` class that occurred when users requested more than one mode in the `ModeSpec` during S-parameter calculations. The issue was in the mode selection logic within the wave port implementation.

The root cause was that mode selection was happening too early in the calculation pipeline - specifically in the `_mode_voltage_coefficients` and `_mode_current_coefficients` methods. This premature filtering prevented other parts of the code from accessing the full mode data needed for proper multi-mode calculations.

The fix relocates the mode selection from the coefficient calculation methods to the final voltage/current computation methods (`compute_voltage` and `compute_current`). Additionally, explicit `mode_index` selection is added when extracting forward and backward amplitudes. This architectural change ensures that:

1. Coefficient calculations receive complete mode data, enabling proper multi-mode operation
2. Final port-specific calculations still use only the requested mode
3. Amplitude extraction explicitly selects the correct mode rather than relying on implicit selection

The changes integrate seamlessly with the existing S-matrix calculation infrastructure in the microwave plugin, maintaining backward compatibility while fixing the multi-mode scenario. A comprehensive test case has been added to prevent regression, and the fix is properly documented in the changelog.

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/smatrix/ports/wave.py | 4/5 | Fixes mode selection bug by moving mode filtering from coefficient methods to final computation methods |
| tests/test_plugins/smatrix/test_terminal_component_modeler.py | 5/5 | Adds regression test to validate S-matrix shape with multiple modes requested |
| CHANGELOG.md | 5/5 | Documents the bug fix in the unreleased section following proper changelog conventions |

</details>

## Confidence score: 4/5

- This PR addresses a specific bug with a targeted fix that maintains existing functionality while resolving the multi-mode issue
- Score reflects the architectural nature of moving mode selection logic, which requires careful validation but appears well-implemented
- Pay close attention to tidy3d/plugins/smatrix/ports/wave.py to ensure the mode selection timing doesn't introduce edge cases

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant TerminalComponentModeler as TCM
    participant WavePort
    participant ModeMonitor
    participant ModeSource
    participant Simulation
    participant ModeData
    participant ImpedanceCalculator as ImpCalc

    User->>TCM: "Create modeler with WavePort(mode_spec=ModeSpec(num_modes>1))"
    TCM->>WavePort: "Initialize with multi-mode ModeSpec"
    WavePort->>WavePort: "Store mode_spec and mode_index"
    
    User->>TCM: "Generate simulation dictionary"
    TCM->>WavePort: "to_source(source_time)"
    WavePort->>ModeSource: "Create source with mode_spec and mode_index"
    ModeSource-->>WavePort: "Return configured source"
    WavePort-->>TCM: "Return source"
    
    TCM->>WavePort: "to_monitors(freqs)"
    WavePort->>ModeMonitor: "Create monitor with full mode_spec"
    Note over ModeMonitor: BUG: Monitor requests all modes<br/>but only mode_index is used later
    ModeMonitor-->>WavePort: "Return monitor"
    WavePort-->>TCM: "Return [monitor]"
    
    TCM->>Simulation: "Create simulation with sources and monitors"
    Simulation-->>TCM: "Return configured simulation"
    
    User->>TCM: "Run simulation"
    TCM->>Simulation: "Execute FDTD simulation"
    Simulation->>ModeData: "Compute mode amplitudes for all modes"
    ModeData-->>Simulation: "Return multi-mode data"
    Simulation-->>TCM: "Return SimulationData"
    
    TCM->>WavePort: "compute_voltage(sim_data)"
    WavePort->>ModeData: "_isel(mode_index=[self.mode_index])"
    Note over ModeData: Filter to specific mode only
    ModeData-->>WavePort: "Return single mode data"
    WavePort->>WavePort: "_mode_voltage_coefficients(mode_data)"
    WavePort->>WavePort: "Calculate voltage from amplitudes"
    WavePort-->>TCM: "Return voltage array"
    
    TCM->>WavePort: "compute_current(sim_data)"
    WavePort->>ModeData: "_isel(mode_index=[self.mode_index])"
    ModeData-->>WavePort: "Return single mode data"
    WavePort->>WavePort: "_mode_current_coefficients(mode_data)"
    WavePort->>WavePort: "Calculate current from amplitudes"
    WavePort-->>TCM: "Return current array"
    
    TCM->>WavePort: "compute_port_impedance(sim_data)"
    WavePort->>ModeData: "_isel(mode_index=[self.mode_index])"
    ModeData-->>WavePort: "Return single mode data"
    WavePort->>ImpCalc: "compute_impedance(mode_data)"
    ImpCalc-->>WavePort: "Return impedance array"
    WavePort-->>TCM: "Return port impedance"
    
    TCM->>TCM: "Construct S-parameter matrix"
    TCM-->>User: "Return TerminalComponentModelerData"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->