### PR TITLE
ci: added jira key enforcement for pr

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -160,6 +160,54 @@ jobs:
       - name: Run ruff check
         run: ruff check tidy3d
   
+  lint-branch-name:
+    needs: determine-test-scope
+    runs-on: ubuntu-latest
+    name: lint-branch-name
+    env:
+      PR_TITLE: ${{ github.event.pull_request.title }}
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: extract-branch-name
+        id: extract-branch-name
+        run: |
+          BRANCH_NAME="${{ github.head_ref }}"
+          echo "Branch name: $BRANCH_NAME"
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: enforce-jira-key
+        id: enforce-jira-key
+        run: |
+          BRANCH_NAME="${{ steps.extract-branch-name.outputs.branch_name }}"
+          echo $BRANCH_NAME
+          JIRA_PATTERN='[A-Z]{2,}-[0-9]+'
+
+          # List of exempt prefixes (case-insensitive)
+          EXEMPT_PREFIXES=("chore" "hotfix" "daily-chore")
+          
+          # Convert branch name to lowercase for comparison
+          BRANCH_LOWER=$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]')
+
+          # Check if branch starts with any exempt prefix
+          for prefix in "${EXEMPT_PREFIXES[@]}"; do
+            if [[ "$BRANCH_LOWER" == $prefix* ]]; then
+              echo "ℹ️  Branch starts with '$prefix' - Jira key not required"
+              exit 0
+            fi
+          done
+
+          if [[ "$BRANCH_NAME" =~ $JIRA_PATTERN ]]; then
+              echo "✅ Jira key found in branch name: ${BASH_REMATCH[0]}"
+          else
+              echo "❌ No Jira key found in branch name, checking PR name as fallback"
+              if [[ "$PR_TITLE" =~ $JIRA_PATTERN ]]; then
+                echo "✅ Jira key found in PR-title: ${BASH_REMATCH[0]}"
+              else
+                echo "❌ No Jira key found in branch name and PR title"
+                exit 1
+              fi
+          fi
+
   lint-commit-messages:
     needs: determine-test-scope
     runs-on: ubuntu-latest
@@ -515,7 +563,7 @@ jobs:
       (( needs.determine-test-scope.outputs.pr_approval_state == 'true' ) && 
       ( needs.determine-test-scope.outputs.local_tests == 'true' ) || 
       ( needs.determine-test-scope.outputs.remote_tests == 'true' ))
-    needs: [local-tests, remote-tests, lint, verify-schema-change, lint-commit-messages]
+    needs: [local-tests, remote-tests, lint, verify-schema-change, lint-commit-messages, lint-branch-name]
     runs-on: ubuntu-latest
     steps:
       - name: check-passing-remote-tests
@@ -539,6 +587,9 @@ jobs:
             exit 1
           elif [[ github.event_name == 'merge_group' && "${{ needs.lint-commit-messages.result }}" != 'success' ]]; then
             echo "❌ Linting of commit messages failed or was skipped."
+            exit 1
+          elif [[ "${{ github.event_name }}" == 'pull_request' && "${{ needs.lint-branch-name.result }}" != 'success' ]]; then
+            echo "❌ Linting of branch name failed."
             exit 1
           fi
           echo "✅ All required test jobs passed!"


### PR DESCRIPTION
Added a new job to the github CI pipeline, which checks if the branch name contains a Jira key. Currently, this check runs only in the pull-request phase (I am not sure if this is correct or the check should also be applied in other stages).

The check can be overriden if the branch name starts with "hotfix" or "chore".

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-06 13:00:32 UTC

<h3>Summary</h3>
This PR adds a GitHub Actions workflow job that enforces Jira issue key requirements in branch names during pull requests. The implementation introduces a new `lint-branch-name` job that validates branch names contain a Jira key pattern (`[A-Z]{2,}-[0-9]+`) while allowing exemptions for branches starting with "hotfix" or "chore".

The job integrates seamlessly with the existing CI pipeline by adding itself to the workflow dependencies and failure conditions. It extracts the branch name from GitHub's context (`github.head_ref`), performs case-insensitive prefix checking for exemptions, and uses bash regex matching to validate the Jira pattern. The implementation only runs during pull request events (`github.event_name == 'pull_request'`), ensuring it doesn't interfere with merge operations or other workflow triggers.

This change supports development governance by ensuring all feature work can be traced back to specific Jira tickets, improving project management and change tracking capabilities. The exemption system acknowledges that emergency fixes and maintenance work may not always require formal ticket creation.

**PR Description Notes:**
- Contains a minor typo: "overriden" should be "overridden"
<h3>Important Files Changed</h3>

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `.github/workflows/tidy3d-python-client-tests.yml` | 4/5 | Added Jira key validation job for pull request branch names with hotfix/chore exemptions |

</details>
<h3>Confidence score: 4/5</h3>

- This PR is safe to merge with minimal risk as it only adds validation without breaking existing functionality
- Score reflects well-structured implementation with proper error handling and clear exemption logic
- Pay attention to the workflow integration points to ensure the job properly fails the CI when branch names don't comply

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant GitHub as "GitHub (PR Event)"
    participant CI as "CI Pipeline"
    participant BranchLinter as "Branch Name Linter"
    participant TestScope as "Test Scope Determiner"
    participant Lint as "Code Linter"
    participant Schema as "Schema Verifier"
    participant LocalTest as "Local Tests"
    participant RemoteTest as "Remote Tests"
    participant Requirements as "PR Requirements Check"

    User->>GitHub: "Create Pull Request"
    GitHub->>CI: "Trigger PR workflow"
    
    CI->>TestScope: "Determine test scope"
    TestScope->>TestScope: "Check approval state"
    TestScope->>TestScope: "Set local_tests and remote_tests flags"
    
    par Branch Name Check
        CI->>BranchLinter: "Check branch name for Jira key"
        BranchLinter->>BranchLinter: "Extract branch name"
        BranchLinter->>BranchLinter: "Check for exempt prefixes (hotfix, chore)"
        alt Branch has Jira key or exempt prefix
            BranchLinter->>CI: "✅ Branch name valid"
        else Branch missing Jira key
            BranchLinter->>CI: "❌ Branch name invalid"
        end
    and Code Linting
        CI->>Lint: "Run linting checks"
        Lint->>Lint: "Run ruff format and check"
        Lint->>CI: "Linting results"
    and Schema Verification
        CI->>Schema: "Verify schema changes"
        Schema->>Schema: "Regenerate schemas"
        Schema->>Schema: "Check if committed schemas match"
        Schema->>Schema: "Validate version for schema changes"
        Schema->>CI: "Schema verification results"
    and Local Tests
        alt local_tests == true
            CI->>LocalTest: "Run local tests"
            LocalTest->>LocalTest: "Install dependencies"
            LocalTest->>LocalTest: "Run pytest with coverage"
            LocalTest->>LocalTest: "Generate diff coverage report"
            LocalTest->>CI: "Local test results"
        end
    and Remote Tests
        alt remote_tests == true
            CI->>RemoteTest: "Run remote tests"
            RemoteTest->>RemoteTest: "Install project dependencies"
            RemoteTest->>RemoteTest: "Run doctests and full test suite"
            RemoteTest->>CI: "Remote test results"
        end
    end
    
    CI->>Requirements: "Check all job results"
    Requirements->>Requirements: "Validate lint, schema, tests, and branch name"
    
    alt All checks pass
        Requirements->>GitHub: "✅ PR requirements met"
        GitHub->>User: "PR ready for merge"
    else Any check fails
        Requirements->>GitHub: "❌ PR requirements not met"
        GitHub->>User: "Fix issues before merge"
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

Rule from `dashboard` - Do not use markdown formatting in exception or warning messages; use single quotes to highlight vari... ([source](https://app.greptile.com/review/custom-context?memory=9b45957a-2d0d-4c24-a5d3-eef6f721cbfd))

<!-- /greptile_comment -->