### PR TITLE
feat: fixed commitlint check in github actions

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -163,7 +163,7 @@ jobs:
   lint-commit-messages:
     needs: determine-test-scope
     runs-on: ubuntu-latest
-    name: veryify-commit-linting
+    name: lint-commit-messages
     steps:
       - name: Check out source code
         uses: actions/checkout@v4
@@ -534,10 +534,7 @@ jobs:
             exit 1 # Given remote-tests always run after a PR is approved
           elif [[ "${{ needs.local-tests.result }}" != 'success' ]]; then
             echo "❌ local-tests failed or were skipped."
-          elif [[ "${{ needs.determine-test-scope.outputs.pr_approval_state }}" == 'true' && github.event.pull_request ]]; then
-            echo "❌ PR requires approval."
-            exit 1
-          elif [[ github.event_name == 'merge_group' && "${{ needs.lint-commit-messages.result }}" != 'success' ]]; then
+          elif [[ "${{ github.event_name }}" == 'merge_group' && "${{ needs.lint-commit-messages.result }}" != 'success' ]]; then
             echo "❌ Linting of commit messages failed or was skipped."
             exit 1
           fi


### PR DESCRIPTION
fixed a bug in the commitlint check in github actions. The variable github.event_name was missing the ${{ }} around them to make it a proper string comparison. 

Another check has the same problem and therefore never run as well. I deleted the other check, because @yaugenst and I believe that this check is superficial anyways (in the past it definitely never ran because of this bug).

related to #2862.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-07 06:39:35 UTC

<h3>Summary</h3>
This PR fixes a critical bug in the GitHub Actions workflow for the Tidy3D Python client where commit message linting was never actually executing due to incorrect template syntax. The main issue was that `github.event_name` variables were used as bare strings instead of being properly wrapped in `${{ }}` brackets, causing string comparisons to always evaluate as false.

The changes update the workflow to properly check if the event is a merge_group before running commit message validation, rename a job for consistency (`check-commit-messages` → `lint-commit-messages`), remove a problematic approval check that was preventing execution, and add debugging output to provide visibility into workflow operation. This ensures that commit message linting now runs as intended during merge group events, aligning with the established pattern of validating commits before merges while avoiding disruption during regular PR development.

The fix addresses a longstanding issue where the commit linting functionality existed in the codebase but was silently failing, which could have led to inconsistent commit message standards over time.
<h3>Important Files Changed</h3>

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/tidy3d-python-client-tests.yml | 4/5 | Fixed critical GitHub Actions syntax bugs in commit message linting, renamed job for consistency, removed problematic checks, and added debugging output |

</details>
<h3>Confidence score: 4/5</h3>

- This PR is safe to merge with minimal risk as it fixes a clear syntax bug and improves workflow reliability
- Score reflects straightforward syntax fixes to GitHub Actions workflow with clear before/after behavior
- Pay close attention to the GitHub Actions workflow file to ensure the commit linting logic works as expected

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant GitHub
    participant DetermineScope as "determine-test-scope"
    participant Approval as "PR Approval Check"
    participant Lint as "lint"
    participant CommitLint as "lint-commit-messages" 
    participant SchemaVerify as "verify-schema-change"
    participant LocalTests as "local-tests"
    participant RemoteTests as "remote-tests"
    participant PRRequirements as "pr-requirements-pass"

    User->>GitHub: "Creates/Updates Pull Request"
    GitHub->>DetermineScope: "Trigger workflow"
    
    alt Pull Request Event
        DetermineScope->>Approval: "Check PR approval status"
        Approval->>DetermineScope: "Return approval state"
    end
    
    DetermineScope->>DetermineScope: "Determine test scope based on event/approval"
    DetermineScope->>GitHub: "Output local_tests and remote_tests flags"
    
    par Conditional Job Execution
        alt Local or Remote Tests Required
            GitHub->>Lint: "Run linting checks"
            Lint->>Lint: "Run ruff format and check"
            Lint->>GitHub: "Return lint results"
        end
        
        alt Merge Group Event
            GitHub->>CommitLint: "Check commit messages"
            CommitLint->>CommitLint: "Validate conventional commits format"
            CommitLint->>GitHub: "Return commit lint results"
        end
        
        alt Local or Remote Tests Required
            GitHub->>SchemaVerify: "Verify schema changes"
            SchemaVerify->>SchemaVerify: "Check schema consistency and versioning"
            SchemaVerify->>GitHub: "Return schema verification results"
        end
        
        alt Local Tests Required
            GitHub->>LocalTests: "Run local tests"
            LocalTests->>LocalTests: "Execute test suite with coverage"
            LocalTests->>GitHub: "Return local test results and coverage"
        end
        
        alt Remote Tests Required  
            GitHub->>RemoteTests: "Run remote tests"
            RemoteTests->>RemoteTests: "Execute tests across multiple platforms/versions"
            RemoteTests->>GitHub: "Return remote test results"
        end
    end
    
    GitHub->>PRRequirements: "Aggregate all job results"
    PRRequirements->>PRRequirements: "Validate all required jobs passed"
    PRRequirements->>GitHub: "Final PR status"
    GitHub->>User: "Workflow completion status"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->