### PR TITLE
FXC-3547-Adding mode sorting to ModeSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `CustomImpedanceSpec` for user-defined voltage and current path specifications in impedance calculations.
 - Added voltage integral specification classes: `AxisAlignedVoltageIntegralSpec` and `Custom2DVoltageIntegralSpec`.
 - Added current integral specification classes: `AxisAlignedCurrentIntegralSpec`, `CompositeCurrentIntegralSpec`, and `Custom2DCurrentIntegralSpec`.
+- `sort_spec` in `ModeSpec` allows for fine-grained filtering and sorting of modes. This also deprecates `filter_pol`. The equivalent usage for example to `filter_pol="te"` is `sort_spec=ModeSortSpec(filter_key="TE_polarization", filter_reference=0.5)`. `ModeSpec.track_freq` has also been deprecated and moved to `ModeSortSpec.track_freq`.
 
 ### Changed
 - Improved performance of antenna metrics calculation by utilizing cached wave amplitude calculations instead of recomputing wave amplitudes for each port excitation in the `TerminalComponentModelerData`.

--- a/schemas/EMESimulation.json
+++ b/schemas/EMESimulation.json
@@ -5265,6 +5265,24 @@
           ],
           "type": "string"
         },
+        "sort_spec": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ModeSortSpec"
+            }
+          ],
+          "default": {
+            "attrs": {},
+            "filter_key": null,
+            "filter_order": "over",
+            "filter_reference": 0.0,
+            "sort_key": null,
+            "sort_order": "ascending",
+            "sort_reference": null,
+            "track_freq": "central",
+            "type": "ModeSortSpec"
+          }
+        },
         "target_neff": {
           "exclusiveMinimum": 0,
           "type": "number"
@@ -7989,12 +8007,29 @@
           ],
           "type": "string"
         },
+        "sort_spec": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ModeSortSpec"
+            }
+          ],
+          "default": {
+            "attrs": {},
+            "filter_key": null,
+            "filter_order": "over",
+            "filter_reference": 0.0,
+            "sort_key": null,
+            "sort_order": "ascending",
+            "sort_reference": null,
+            "track_freq": "central",
+            "type": "ModeSortSpec"
+          }
+        },
         "target_neff": {
           "exclusiveMinimum": 0,
           "type": "number"
         },
         "track_freq": {
-          "default": "central",
           "enum": [
             "central",
             "highest",
@@ -8051,8 +8086,19 @@
               0
             ],
             "precision": "double",
+            "sort_spec": {
+              "attrs": {},
+              "filter_key": null,
+              "filter_order": "over",
+              "filter_reference": 0.0,
+              "sort_key": null,
+              "sort_order": "ascending",
+              "sort_reference": null,
+              "track_freq": "central",
+              "type": "ModeSortSpec"
+            },
             "target_neff": null,
-            "track_freq": "central",
+            "track_freq": null,
             "type": "ModeSpec"
           },
           "discriminator": {
@@ -8266,8 +8312,19 @@
               0
             ],
             "precision": "double",
+            "sort_spec": {
+              "attrs": {},
+              "filter_key": null,
+              "filter_order": "over",
+              "filter_reference": 0.0,
+              "sort_key": null,
+              "sort_order": "ascending",
+              "sort_reference": null,
+              "track_freq": "central",
+              "type": "ModeSortSpec"
+            },
             "target_neff": null,
-            "track_freq": "central",
+            "track_freq": null,
             "type": "ModeSpec"
           }
         },
@@ -8342,6 +8399,79 @@
         "name",
         "size"
       ],
+      "type": "object"
+    },
+    "ModeSortSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "attrs": {
+          "default": {},
+          "type": "object"
+        },
+        "filter_key": {
+          "enum": [
+            "TE_fraction",
+            "TM_fraction",
+            "k_eff",
+            "mode_area",
+            "n_eff",
+            "wg_TE_fraction",
+            "wg_TM_fraction"
+          ],
+          "type": "string"
+        },
+        "filter_order": {
+          "default": "over",
+          "enum": [
+            "over",
+            "under"
+          ],
+          "type": "string"
+        },
+        "filter_reference": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "sort_key": {
+          "enum": [
+            "TE_fraction",
+            "TM_fraction",
+            "k_eff",
+            "mode_area",
+            "n_eff",
+            "wg_TE_fraction",
+            "wg_TM_fraction"
+          ],
+          "type": "string"
+        },
+        "sort_order": {
+          "default": "ascending",
+          "enum": [
+            "ascending",
+            "descending"
+          ],
+          "type": "string"
+        },
+        "sort_reference": {
+          "type": "number"
+        },
+        "track_freq": {
+          "default": "central",
+          "enum": [
+            "central",
+            "highest",
+            "lowest"
+          ],
+          "type": "string"
+        },
+        "type": {
+          "default": "ModeSortSpec",
+          "enum": [
+            "ModeSortSpec"
+          ],
+          "type": "string"
+        }
+      },
       "type": "object"
     },
     "ModeSpec": {
@@ -8425,12 +8555,29 @@
           ],
           "type": "string"
         },
+        "sort_spec": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ModeSortSpec"
+            }
+          ],
+          "default": {
+            "attrs": {},
+            "filter_key": null,
+            "filter_order": "over",
+            "filter_reference": 0.0,
+            "sort_key": null,
+            "sort_order": "ascending",
+            "sort_reference": null,
+            "track_freq": "central",
+            "type": "ModeSortSpec"
+          }
+        },
         "target_neff": {
           "exclusiveMinimum": 0,
           "type": "number"
         },
         "track_freq": {
-          "default": "central",
           "enum": [
             "central",
             "highest",

--- a/schemas/ModeSimulation.json
+++ b/schemas/ModeSimulation.json
@@ -7220,12 +7220,29 @@
           ],
           "type": "string"
         },
+        "sort_spec": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ModeSortSpec"
+            }
+          ],
+          "default": {
+            "attrs": {},
+            "filter_key": null,
+            "filter_order": "over",
+            "filter_reference": 0.0,
+            "sort_key": null,
+            "sort_order": "ascending",
+            "sort_reference": null,
+            "track_freq": "central",
+            "type": "ModeSortSpec"
+          }
+        },
         "target_neff": {
           "exclusiveMinimum": 0,
           "type": "number"
         },
         "track_freq": {
-          "default": "central",
           "enum": [
             "central",
             "highest",
@@ -7282,8 +7299,19 @@
               0
             ],
             "precision": "double",
+            "sort_spec": {
+              "attrs": {},
+              "filter_key": null,
+              "filter_order": "over",
+              "filter_reference": 0.0,
+              "sort_key": null,
+              "sort_order": "ascending",
+              "sort_reference": null,
+              "track_freq": "central",
+              "type": "ModeSortSpec"
+            },
             "target_neff": null,
-            "track_freq": "central",
+            "track_freq": null,
             "type": "ModeSpec"
           },
           "discriminator": {
@@ -7467,8 +7495,19 @@
               0
             ],
             "precision": "double",
+            "sort_spec": {
+              "attrs": {},
+              "filter_key": null,
+              "filter_order": "over",
+              "filter_reference": 0.0,
+              "sort_key": null,
+              "sort_order": "ascending",
+              "sort_reference": null,
+              "track_freq": "central",
+              "type": "ModeSortSpec"
+            },
             "target_neff": null,
-            "track_freq": "central",
+            "track_freq": null,
             "type": "ModeSpec"
           }
         },
@@ -7717,8 +7756,19 @@
               0
             ],
             "precision": "double",
+            "sort_spec": {
+              "attrs": {},
+              "filter_key": null,
+              "filter_order": "over",
+              "filter_reference": 0.0,
+              "sort_key": null,
+              "sort_order": "ascending",
+              "sort_reference": null,
+              "track_freq": "central",
+              "type": "ModeSortSpec"
+            },
             "target_neff": null,
-            "track_freq": "central",
+            "track_freq": null,
             "type": "ModeSpec"
           }
         },
@@ -7793,6 +7843,79 @@
         "name",
         "size"
       ],
+      "type": "object"
+    },
+    "ModeSortSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "attrs": {
+          "default": {},
+          "type": "object"
+        },
+        "filter_key": {
+          "enum": [
+            "TE_fraction",
+            "TM_fraction",
+            "k_eff",
+            "mode_area",
+            "n_eff",
+            "wg_TE_fraction",
+            "wg_TM_fraction"
+          ],
+          "type": "string"
+        },
+        "filter_order": {
+          "default": "over",
+          "enum": [
+            "over",
+            "under"
+          ],
+          "type": "string"
+        },
+        "filter_reference": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "sort_key": {
+          "enum": [
+            "TE_fraction",
+            "TM_fraction",
+            "k_eff",
+            "mode_area",
+            "n_eff",
+            "wg_TE_fraction",
+            "wg_TM_fraction"
+          ],
+          "type": "string"
+        },
+        "sort_order": {
+          "default": "ascending",
+          "enum": [
+            "ascending",
+            "descending"
+          ],
+          "type": "string"
+        },
+        "sort_reference": {
+          "type": "number"
+        },
+        "track_freq": {
+          "default": "central",
+          "enum": [
+            "central",
+            "highest",
+            "lowest"
+          ],
+          "type": "string"
+        },
+        "type": {
+          "default": "ModeSortSpec",
+          "enum": [
+            "ModeSortSpec"
+          ],
+          "type": "string"
+        }
+      },
       "type": "object"
     },
     "ModeSource": {
@@ -7886,8 +8009,19 @@
               0
             ],
             "precision": "double",
+            "sort_spec": {
+              "attrs": {},
+              "filter_key": null,
+              "filter_order": "over",
+              "filter_reference": 0.0,
+              "sort_key": null,
+              "sort_order": "ascending",
+              "sort_reference": null,
+              "track_freq": "central",
+              "type": "ModeSortSpec"
+            },
             "target_neff": null,
-            "track_freq": "central",
+            "track_freq": null,
             "type": "ModeSpec"
           },
           "discriminator": {
@@ -8079,12 +8213,29 @@
           ],
           "type": "string"
         },
+        "sort_spec": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ModeSortSpec"
+            }
+          ],
+          "default": {
+            "attrs": {},
+            "filter_key": null,
+            "filter_order": "over",
+            "filter_reference": 0.0,
+            "sort_key": null,
+            "sort_order": "ascending",
+            "sort_reference": null,
+            "track_freq": "central",
+            "type": "ModeSortSpec"
+          }
+        },
         "target_neff": {
           "exclusiveMinimum": 0,
           "type": "number"
         },
         "track_freq": {
-          "default": "central",
           "enum": [
             "central",
             "highest",

--- a/schemas/Simulation.json
+++ b/schemas/Simulation.json
@@ -11186,12 +11186,29 @@
           ],
           "type": "string"
         },
+        "sort_spec": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ModeSortSpec"
+            }
+          ],
+          "default": {
+            "attrs": {},
+            "filter_key": null,
+            "filter_order": "over",
+            "filter_reference": 0.0,
+            "sort_key": null,
+            "sort_order": "ascending",
+            "sort_reference": null,
+            "track_freq": "central",
+            "type": "ModeSortSpec"
+          }
+        },
         "target_neff": {
           "exclusiveMinimum": 0,
           "type": "number"
         },
         "track_freq": {
-          "default": "central",
           "enum": [
             "central",
             "highest",
@@ -11248,8 +11265,19 @@
               0
             ],
             "precision": "double",
+            "sort_spec": {
+              "attrs": {},
+              "filter_key": null,
+              "filter_order": "over",
+              "filter_reference": 0.0,
+              "sort_key": null,
+              "sort_order": "ascending",
+              "sort_reference": null,
+              "track_freq": "central",
+              "type": "ModeSortSpec"
+            },
             "target_neff": null,
-            "track_freq": "central",
+            "track_freq": null,
             "type": "ModeSpec"
           },
           "discriminator": {
@@ -11433,8 +11461,19 @@
               0
             ],
             "precision": "double",
+            "sort_spec": {
+              "attrs": {},
+              "filter_key": null,
+              "filter_order": "over",
+              "filter_reference": 0.0,
+              "sort_key": null,
+              "sort_order": "ascending",
+              "sort_reference": null,
+              "track_freq": "central",
+              "type": "ModeSortSpec"
+            },
             "target_neff": null,
-            "track_freq": "central",
+            "track_freq": null,
             "type": "ModeSpec"
           }
         },
@@ -11683,8 +11722,19 @@
               0
             ],
             "precision": "double",
+            "sort_spec": {
+              "attrs": {},
+              "filter_key": null,
+              "filter_order": "over",
+              "filter_reference": 0.0,
+              "sort_key": null,
+              "sort_order": "ascending",
+              "sort_reference": null,
+              "track_freq": "central",
+              "type": "ModeSortSpec"
+            },
             "target_neff": null,
-            "track_freq": "central",
+            "track_freq": null,
             "type": "ModeSpec"
           }
         },
@@ -11759,6 +11809,79 @@
         "name",
         "size"
       ],
+      "type": "object"
+    },
+    "ModeSortSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "attrs": {
+          "default": {},
+          "type": "object"
+        },
+        "filter_key": {
+          "enum": [
+            "TE_fraction",
+            "TM_fraction",
+            "k_eff",
+            "mode_area",
+            "n_eff",
+            "wg_TE_fraction",
+            "wg_TM_fraction"
+          ],
+          "type": "string"
+        },
+        "filter_order": {
+          "default": "over",
+          "enum": [
+            "over",
+            "under"
+          ],
+          "type": "string"
+        },
+        "filter_reference": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "sort_key": {
+          "enum": [
+            "TE_fraction",
+            "TM_fraction",
+            "k_eff",
+            "mode_area",
+            "n_eff",
+            "wg_TE_fraction",
+            "wg_TM_fraction"
+          ],
+          "type": "string"
+        },
+        "sort_order": {
+          "default": "ascending",
+          "enum": [
+            "ascending",
+            "descending"
+          ],
+          "type": "string"
+        },
+        "sort_reference": {
+          "type": "number"
+        },
+        "track_freq": {
+          "default": "central",
+          "enum": [
+            "central",
+            "highest",
+            "lowest"
+          ],
+          "type": "string"
+        },
+        "type": {
+          "default": "ModeSortSpec",
+          "enum": [
+            "ModeSortSpec"
+          ],
+          "type": "string"
+        }
+      },
       "type": "object"
     },
     "ModeSource": {
@@ -11852,8 +11975,19 @@
               0
             ],
             "precision": "double",
+            "sort_spec": {
+              "attrs": {},
+              "filter_key": null,
+              "filter_order": "over",
+              "filter_reference": 0.0,
+              "sort_key": null,
+              "sort_order": "ascending",
+              "sort_reference": null,
+              "track_freq": "central",
+              "type": "ModeSortSpec"
+            },
             "target_neff": null,
-            "track_freq": "central",
+            "track_freq": null,
             "type": "ModeSpec"
           },
           "discriminator": {
@@ -12045,12 +12179,29 @@
           ],
           "type": "string"
         },
+        "sort_spec": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ModeSortSpec"
+            }
+          ],
+          "default": {
+            "attrs": {},
+            "filter_key": null,
+            "filter_order": "over",
+            "filter_reference": 0.0,
+            "sort_key": null,
+            "sort_order": "ascending",
+            "sort_reference": null,
+            "track_freq": "central",
+            "type": "ModeSortSpec"
+          }
+        },
         "target_neff": {
           "exclusiveMinimum": 0,
           "type": "number"
         },
         "track_freq": {
-          "default": "central",
           "enum": [
             "central",
             "highest",

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -11842,12 +11842,29 @@
           ],
           "type": "string"
         },
+        "sort_spec": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ModeSortSpec"
+            }
+          ],
+          "default": {
+            "attrs": {},
+            "filter_key": null,
+            "filter_order": "over",
+            "filter_reference": 0.0,
+            "sort_key": null,
+            "sort_order": "ascending",
+            "sort_reference": null,
+            "track_freq": "central",
+            "type": "ModeSortSpec"
+          }
+        },
         "target_neff": {
           "exclusiveMinimum": 0,
           "type": "number"
         },
         "track_freq": {
-          "default": "central",
           "enum": [
             "central",
             "highest",
@@ -11904,8 +11921,19 @@
               0
             ],
             "precision": "double",
+            "sort_spec": {
+              "attrs": {},
+              "filter_key": null,
+              "filter_order": "over",
+              "filter_reference": 0.0,
+              "sort_key": null,
+              "sort_order": "ascending",
+              "sort_reference": null,
+              "track_freq": "central",
+              "type": "ModeSortSpec"
+            },
             "target_neff": null,
-            "track_freq": "central",
+            "track_freq": null,
             "type": "ModeSpec"
           },
           "discriminator": {
@@ -12089,8 +12117,19 @@
               0
             ],
             "precision": "double",
+            "sort_spec": {
+              "attrs": {},
+              "filter_key": null,
+              "filter_order": "over",
+              "filter_reference": 0.0,
+              "sort_key": null,
+              "sort_order": "ascending",
+              "sort_reference": null,
+              "track_freq": "central",
+              "type": "ModeSortSpec"
+            },
             "target_neff": null,
-            "track_freq": "central",
+            "track_freq": null,
             "type": "ModeSpec"
           }
         },
@@ -12339,8 +12378,19 @@
               0
             ],
             "precision": "double",
+            "sort_spec": {
+              "attrs": {},
+              "filter_key": null,
+              "filter_order": "over",
+              "filter_reference": 0.0,
+              "sort_key": null,
+              "sort_order": "ascending",
+              "sort_reference": null,
+              "track_freq": "central",
+              "type": "ModeSortSpec"
+            },
             "target_neff": null,
-            "track_freq": "central",
+            "track_freq": null,
             "type": "ModeSpec"
           }
         },
@@ -12415,6 +12465,79 @@
         "name",
         "size"
       ],
+      "type": "object"
+    },
+    "ModeSortSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "attrs": {
+          "default": {},
+          "type": "object"
+        },
+        "filter_key": {
+          "enum": [
+            "TE_fraction",
+            "TM_fraction",
+            "k_eff",
+            "mode_area",
+            "n_eff",
+            "wg_TE_fraction",
+            "wg_TM_fraction"
+          ],
+          "type": "string"
+        },
+        "filter_order": {
+          "default": "over",
+          "enum": [
+            "over",
+            "under"
+          ],
+          "type": "string"
+        },
+        "filter_reference": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "sort_key": {
+          "enum": [
+            "TE_fraction",
+            "TM_fraction",
+            "k_eff",
+            "mode_area",
+            "n_eff",
+            "wg_TE_fraction",
+            "wg_TM_fraction"
+          ],
+          "type": "string"
+        },
+        "sort_order": {
+          "default": "ascending",
+          "enum": [
+            "ascending",
+            "descending"
+          ],
+          "type": "string"
+        },
+        "sort_reference": {
+          "type": "number"
+        },
+        "track_freq": {
+          "default": "central",
+          "enum": [
+            "central",
+            "highest",
+            "lowest"
+          ],
+          "type": "string"
+        },
+        "type": {
+          "default": "ModeSortSpec",
+          "enum": [
+            "ModeSortSpec"
+          ],
+          "type": "string"
+        }
+      },
       "type": "object"
     },
     "ModeSource": {
@@ -12508,8 +12631,19 @@
               0
             ],
             "precision": "double",
+            "sort_spec": {
+              "attrs": {},
+              "filter_key": null,
+              "filter_order": "over",
+              "filter_reference": 0.0,
+              "sort_key": null,
+              "sort_order": "ascending",
+              "sort_reference": null,
+              "track_freq": "central",
+              "type": "ModeSortSpec"
+            },
             "target_neff": null,
-            "track_freq": "central",
+            "track_freq": null,
             "type": "ModeSpec"
           },
           "discriminator": {
@@ -12701,12 +12835,29 @@
           ],
           "type": "string"
         },
+        "sort_spec": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ModeSortSpec"
+            }
+          ],
+          "default": {
+            "attrs": {},
+            "filter_key": null,
+            "filter_order": "over",
+            "filter_reference": 0.0,
+            "sort_key": null,
+            "sort_order": "ascending",
+            "sort_reference": null,
+            "track_freq": "central",
+            "type": "ModeSortSpec"
+          }
+        },
         "target_neff": {
           "exclusiveMinimum": 0,
           "type": "number"
         },
         "track_freq": {
-          "default": "central",
           "enum": [
             "central",
             "highest",
@@ -17918,8 +18069,19 @@
               0
             ],
             "precision": "double",
+            "sort_spec": {
+              "attrs": {},
+              "filter_key": null,
+              "filter_order": "over",
+              "filter_reference": 0.0,
+              "sort_key": null,
+              "sort_order": "ascending",
+              "sort_reference": null,
+              "track_freq": "central",
+              "type": "ModeSortSpec"
+            },
             "target_neff": null,
-            "track_freq": "central",
+            "track_freq": null,
             "type": "ModeSpec"
           }
         },

--- a/tests/test_components/test_mode.py
+++ b/tests/test_components/test_mode.py
@@ -33,9 +33,9 @@ def test_modes():
     _ = td.ModeSpec(num_modes=2)
     _ = td.ModeSpec(num_modes=1, target_neff=1.0)
 
-    options = [None, "lowest", "highest", "central"]
-    for opt in options:
-        _ = td.ModeSpec(num_modes=3, track_freq=opt)
+    # Valid options now specified via ModeSortSpec.track_freq
+    for opt in ["lowest", "highest", "central"]:
+        _ = td.ModeSpec(num_modes=3, sort_spec=td.ModeSortSpec(track_freq=opt))
 
     with pytest.raises(pydantic.ValidationError):
         _ = td.ModeSpec(num_modes=3, track_freq="middle")
@@ -161,7 +161,9 @@ def test_validation_from_simulation():
 
 
 def get_mode_sim():
-    mode_spec = MODE_SPEC.updated_copy(filter_pol="tm")
+    mode_spec = MODE_SPEC.updated_copy(
+        sort_spec=td.ModeSortSpec(filter_key="TM_fraction", filter_reference=0.5)
+    )
     permittivity_monitor = td.PermittivityMonitor(
         size=(1, 1, 0), center=(0, 0, 0), name="eps", freqs=FS
     )
@@ -339,6 +341,12 @@ def test_mode_sim_data():
     sim_data = get_mode_sim_data()
     _ = sim_data.plot_field("Ey", ax=AX, mode_index=0, f=FS[0])
 
+    sort_spec = td.ModeSortSpec(sort_key="k_eff", track_freq=None)
+    sim_data_sorted = sim_data.sort_modes(sort_spec)
+    assert sim_data_sorted.simulation.mode_spec.sort_spec == sort_spec
+    assert sim_data_sorted.modes_raw.monitor.mode_spec.sort_spec == sort_spec
+    assert np.all(sim_data_sorted.modes_raw.k_eff.diff(dim="mode_index") >= 0)
+
 
 def test_plane_crosses_symmetry_plane_warning(monkeypatch):
     """Test that a warning is issued if the mode plane crosses a symmetry plane but the centers do not match."""
@@ -389,3 +397,19 @@ def test_plane_crosses_symmetry_plane_warning(monkeypatch):
             mode_spec=td.ModeSpec(),
             freqs=[td.C_0],
         )
+
+
+def test_track_freq_deprecation():
+    """Ensure using ModeSpec.track_freq emits a deprecation warning."""
+    from ..utils import AssertLogLevel
+
+    with AssertLogLevel("WARNING", contains_str="deprecated"):
+        _ = td.ModeSpec(num_modes=3, track_freq="central")
+
+    # Deprecated value still takes precedence (backwards compatibility)
+    ms = td.ModeSpec(num_modes=3, track_freq="lowest", sort_spec=td.ModeSortSpec())
+    assert ms._track_freq == "lowest"
+
+    # Tracking can be turned off in ModeSortSpec
+    ms = td.ModeSpec(num_modes=3, sort_spec=td.ModeSortSpec(track_freq=None))
+    assert ms._track_freq is None

--- a/tests/test_data/test_data_arrays.py
+++ b/tests/test_data/test_data_arrays.py
@@ -205,6 +205,11 @@ def make_mode_index_data_array():
     return td.ModeIndexDataArray(values, coords={"f": FS, "mode_index": MODE_INDICES})
 
 
+def make_group_index_data_array():
+    values = (1 + 0.1j) * np.random.random((len(FS), len(MODE_INDICES)))
+    return td.GroupIndexDataArray(values, coords={"f": FS, "mode_index": MODE_INDICES})
+
+
 def make_far_field_data_array():
     values = (1 + 1j) * np.random.random((len(PD), len(THETAS), len(PHIS), len(FS)))
     return td.FieldProjectionAngleDataArray(

--- a/tests/test_data/test_monitor_data.py
+++ b/tests/test_data/test_monitor_data.py
@@ -50,6 +50,7 @@ from .test_data_arrays import (
     make_far_field_data_array,
     make_flux_data_array,
     make_flux_time_data_array,
+    make_group_index_data_array,
     make_mode_amps_data_array,
     make_mode_index_data_array,
     make_scalar_field_data_array,
@@ -61,6 +62,7 @@ from .test_data_arrays import (
 # data array instances
 AMPS = make_mode_amps_data_array()
 N_COMPLEX = make_mode_index_data_array()
+N_GROUP = make_group_index_data_array()
 FLUX = make_flux_data_array()
 FLUX_TIME = make_flux_time_data_array()
 GRID_CORRECTION = FreqModeDataArray(
@@ -179,6 +181,7 @@ def make_mode_solver_data_smooth(conjugated_dot_product: bool = True):
         symmetry_center=SIM_SYM.center,
         grid_expanded=SIM_SYM.discretize_monitor(MODE_MONITOR_WITH_FIELDS),
         n_complex=N_COMPLEX.copy(),
+        n_group=N_GROUP.copy(),
         grid_primal_correction=GRID_CORRECTION,
         grid_dual_correction=GRID_CORRECTION,
         amps=AMPS.copy(),
@@ -709,7 +712,6 @@ def test_mode_solver_data_sort(conjugated_dot_product):
     # make it unsorted
     num_modes = len(data.Ex.coords["mode_index"])
     num_freqs = len(data.Ex.coords["f"])
-    phases = 2 * np.pi * np.random.random((num_freqs, num_modes))
     unsorting = np.arange(num_modes) * np.ones((num_freqs, num_modes))
     unsorting = unsorting.astype(int)
     # we keep first, central, and last sorted
@@ -718,7 +720,11 @@ def test_mode_solver_data_sort(conjugated_dot_product):
             unsorting[freq_id, :] = np.random.permutation(unsorting[freq_id, :])
 
     # unsort using sorting tool
-    data_unsorted = data._reorder_modes(unsorting, phases, None)
+    data_unsorted = data._apply_mode_reorder(unsorting)
+    assert not np.allclose(data.n_complex, data_unsorted.n_complex)
+    assert not np.allclose(data.grid_dual_correction, data_unsorted.grid_dual_correction)
+    assert not np.allclose(data.grid_primal_correction, data_unsorted.grid_primal_correction)
+    assert not np.allclose(data.n_group, data_unsorted.n_group)
 
     # sort back using all starting frequencies
     overlap_thresh = 0.95
@@ -733,6 +739,7 @@ def test_mode_solver_data_sort(conjugated_dot_product):
         assert np.allclose(data.n_complex, data_sorted.n_complex)
         assert np.allclose(data.grid_dual_correction, data_sorted.grid_dual_correction)
         assert np.allclose(data.grid_primal_correction, data_sorted.grid_primal_correction)
+        assert np.allclose(data.n_group, data_sorted.n_group)
 
         # make sure neighboring frequencies are in phase
         data_1 = data._isel(f=[0])

--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import get_args
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pydantic.v1 as pydantic
@@ -12,6 +14,7 @@ from tidy3d import ScalarFieldDataArray
 from tidy3d.components.data.monitor_data import ModeSolverData
 from tidy3d.components.mode.derivatives import create_sfactor_b, create_sfactor_f
 from tidy3d.components.mode.solver import compute_modes
+from tidy3d.components.mode_spec import MODE_DATA_KEYS
 from tidy3d.exceptions import DataError, SetupError
 from tidy3d.plugins.mode import ModeSolver
 from tidy3d.plugins.mode.mode_solver import MODE_MONITOR_NAME
@@ -689,7 +692,7 @@ def test_mode_solver_angle_bend():
         bend_axis=0,
         angle_theta=np.pi / 3,
         angle_phi=np.pi,
-        track_freq="highest",
+        sort_spec=td.ModeSortSpec(track_freq="highest"),
     )
     # put plane entirely in the symmetry quadrant rather than sitting on its center
     plane = td.Box(center=(0, 0.5, 0), size=(1, 0, 1))
@@ -850,7 +853,7 @@ def test_group_index(mock_remote_api, local, tmp_path):
         num_modes=2,
         target_neff=3.0,
         precision="double" if local else "single",
-        track_freq="central",
+        sort_spec=td.ModeSortSpec(track_freq="central"),
     )
 
     if local:
@@ -1299,3 +1302,204 @@ def test_translated_dot():
 
     assert np.allclose(data2.outer_dot(data_translated), data2.outer_dot(data2), atol=atol)
     assert np.allclose(data_translated.outer_dot(data2), data2.outer_dot(data2), atol=atol)
+
+
+def test_mode_spec_filter_pol_sort_spec_exclusive():
+    """Ensure ModeSpec errors when both filter_pol and sort_spec are set."""
+    with pytest.raises(pydantic.ValidationError, match="simultaneously"):
+        _ = td.ModeSpec(num_modes=1, filter_pol="te", sort_spec=td.ModeSortSpec(sort_key="n_eff"))
+
+
+def test_modes_filter_sort():
+    """Test the filtering and sorting of modes."""
+    simulation = td.Simulation(
+        size=SIM_SIZE,
+        grid_spec=td.GridSpec(wavelength=1.0),
+        structures=[WAVEGUIDE],
+        run_time=1e-12,
+        symmetry=(0, 0, 1),
+        boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
+        sources=[SRC],
+    )
+    # turn off track_freq so sorting is exact at all freqs
+    mode_spec = td.ModeSpec(
+        num_modes=5,
+        target_neff=2.0,
+        sort_spec=td.ModeSortSpec(sort_key="n_eff", sort_order="ascending", track_freq=None),
+        num_pml=(10, 10),
+    )
+    ms = ModeSolver(
+        simulation=simulation,
+        plane=PLANE,
+        mode_spec=mode_spec,
+        freqs=[td.C_0 / 1.0, td.C_0 / 2.0],
+        direction="-",
+    )
+    modes = ms.solve()
+    n_eff = modes.n_eff
+    print(n_eff.diff(dim="mode_index"))
+    assert np.all(n_eff.diff(dim="mode_index") >= 0)
+
+    for key in get_args(MODE_DATA_KEYS):
+        print(key)
+        # Test ascending
+        sort_spec = td.ModeSortSpec(sort_key=key, sort_order="ascending", track_freq=None)
+        modes = modes.sort_modes(sort_spec)
+        metric = getattr(modes, key)
+        assert np.all(metric.diff(dim="mode_index") >= 0)
+
+        # Test descending
+        sort_spec = td.ModeSortSpec(sort_key=key, sort_order="descending", track_freq=None)
+        modes = modes.sort_modes(sort_spec)
+        metric = getattr(modes, key)
+        assert np.all(metric.diff(dim="mode_index") <= 0)
+
+        # Test descending with a large reference value should be the same as ascending
+        sort_spec = td.ModeSortSpec(
+            sort_key=key, sort_order="descending", sort_reference=100, track_freq=None
+        )
+        modes = modes.sort_modes(sort_spec)
+        metric = getattr(modes, key)
+        assert np.all(metric.diff(dim="mode_index") >= 0)
+
+    # Test filter + sort within groups using n_eff at first frequency
+    ms = ms.updated_copy(mode_spec=mode_spec)
+    metric = modes.n_eff.isel(f=0)
+    thresh = float(np.median(metric.values))
+
+    # Test filter by n_eff and sort by k_eff
+    sort_spec = td.ModeSortSpec(
+        filter_key="n_eff",
+        filter_reference=thresh,
+        filter_order="over",
+        sort_key="k_eff",
+        sort_order="ascending",
+        track_freq=None,
+    )
+    modes = modes.sort_modes(sort_spec)
+    for ifreq in range(len(ms.freqs)):
+        metric_filtered = modes.n_eff.isel(f=ifreq)
+        metric_sorted = modes.k_eff.isel(f=ifreq)
+        first_group_size = int(np.sum(metric_filtered.values >= thresh))
+        # first group satisfies filter
+        assert np.all(metric_filtered.isel(mode_index=slice(0, first_group_size)).values >= thresh)
+        # and is sorted ascending within the group
+        assert np.all(
+            metric_sorted.isel(mode_index=slice(0, first_group_size)).diff(dim="mode_index") >= 0
+        )
+        # second group satisfies filter
+        assert np.all(
+            metric_filtered.isel(mode_index=slice(first_group_size, None)).values < thresh
+        )
+        # and is also sorted ascending within the group
+        assert np.all(
+            metric_sorted.isel(mode_index=slice(first_group_size, None)).diff(dim="mode_index") >= 0
+        )
+
+    # Test filter only with filter_order="under", and no sorting defined
+    ms = ms.updated_copy(
+        mode_spec=mode_spec.updated_copy(
+            sort_spec=td.ModeSortSpec(
+                filter_key="TE_fraction",
+                filter_reference=0.5,
+                filter_order="under",
+            )
+        )
+    )
+    # need to solve again because so that the default sorting from the solver will apply, as
+    # the modes had been reordered previously, and sort_val is None
+    modes = ms.solve()
+    for ifreq in range(len(ms.freqs)):
+        metric_filtered = modes.TE_fraction.isel(f=ifreq)
+        metric_sorted = modes.n_eff.isel(f=ifreq)  # defaults to n_eff in descending order
+        first_group_size = int(np.sum(metric_filtered.values <= 0.5))
+
+        # print(metric_filtered.values)
+        # print(metric_sorted.values)
+
+        # first group satisfies filter
+        assert np.all(metric_filtered.isel(mode_index=slice(0, first_group_size)).values <= 0.5)
+        # and is sorted
+        assert np.all(
+            metric_sorted.isel(mode_index=slice(0, first_group_size)).diff(dim="mode_index") <= 0
+        )
+        # second group satisfies filter
+        assert np.all(metric_filtered.isel(mode_index=slice(first_group_size, None)).values > 0.5)
+        # and is also sorted
+        assert np.all(
+            metric_sorted.isel(mode_index=slice(first_group_size, None)).diff(dim="mode_index") <= 0
+        )
+
+    # Test that if we now reorder based on a track_freq, the original order is preserved at
+    # the track_freq, but not at the other one
+    sort_spec = td.ModeSortSpec(
+        sort_key="k_eff",
+        sort_order="ascending",
+        track_freq="lowest",
+    )
+    modes = modes.sort_modes(sort_spec=sort_spec)
+    assert np.all(np.diff(modes.k_eff.isel(f=0)) >= 0)
+    assert not np.all(np.diff(modes.k_eff.isel(f=-1)) >= 0)
+
+
+def test_sort_spec_track_freq():
+    """Test various ways to sort and track that should result in the same final modes."""
+    simulation = td.Simulation(
+        size=SIM_SIZE,
+        grid_spec=td.GridSpec(wavelength=1.0),
+        structures=[WAVEGUIDE],
+        run_time=1e-12,
+        symmetry=(0, 0, 1),
+        boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
+        sources=[SRC],
+    )
+    sort_spec = td.ModeSortSpec(sort_key="TE_fraction")
+    mode_spec = td.ModeSpec(
+        num_modes=5,
+        target_neff=2.0,
+        sort_spec=sort_spec.updated_copy(track_freq="lowest"),
+        num_pml=(10, 10),
+        group_index_step=True,
+    )
+    ms = ModeSolver(
+        simulation=simulation,
+        plane=PLANE,
+        mode_spec=mode_spec,
+        freqs=[td.C_0 / 0.5, td.C_0 / 1.0, td.C_0 / 2.0],
+        direction="-",
+    )
+    modes_lowest = ms.solve()
+
+    # TODO remove this when track_freq is removed
+    mode_spec = td.ModeSpec(
+        num_modes=5,
+        target_neff=2.0,
+        sort_spec=sort_spec,
+        track_freq="lowest",
+        num_pml=(10, 10),
+        group_index_step=True,
+    )
+    ms = ms.updated_copy(mode_spec=mode_spec)
+    modes_lowest_legacy = ms.solve()
+
+    assert modes_lowest == modes_lowest_legacy
+
+    mode_spec = td.ModeSpec(
+        num_modes=5,
+        target_neff=2.0,
+        sort_spec=sort_spec.updated_copy(track_freq=None),
+        num_pml=(10, 10),
+        group_index_step=True,
+    )
+    ms = ms.updated_copy(mode_spec=mode_spec)
+    modes_untracked = ms.solve()
+
+    assert not np.all(modes_lowest.n_eff == modes_untracked.n_eff)
+
+    modes_lowest_retracked = modes_untracked.overlap_sort(track_freq="lowest")
+
+    # The field modes come out with a different phase so the datas are not equivalent but we can
+    # check that everything matches
+    assert np.allclose(modes_lowest.Ex.abs, modes_lowest_retracked.Ex.abs)
+    assert np.all(modes_lowest.n_eff == modes_lowest_retracked.n_eff)
+    assert np.all(modes_lowest.n_group == modes_lowest_retracked.n_group)

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -191,6 +191,7 @@ from .components.data.data_array import (
     FieldProjectionKSpaceDataArray,
     FluxDataArray,
     FluxTimeDataArray,
+    GroupIndexDataArray,
     HeatDataArray,
     IndexedDataArray,
     IndexedFieldVoltageDataArray,
@@ -341,7 +342,7 @@ from .components.mode.data.sim_data import ModeSimulationData
 from .components.mode.simulation import ModeSimulation
 
 # modes
-from .components.mode_spec import ModeSpec
+from .components.mode_spec import ModeSortSpec, ModeSpec
 
 # monitors
 from .components.monitor import (
@@ -641,6 +642,7 @@ __all__ = [
     "GridRefinementRegion",
     "GridSpec",
     "GroundVoltage",
+    "GroupIndexDataArray",
     "HammerstadSurfaceRoughness",
     "HeatBoundarySpec",
     "HeatChargeBoundarySpec",
@@ -697,6 +699,7 @@ __all__ = [
     "ModeSolverData",
     "ModeSolverDataset",
     "ModeSolverMonitor",
+    "ModeSortSpec",
     "ModeSource",
     "ModeSpec",
     "ModulationSpec",

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -39,6 +39,16 @@ DEFAULT_TOLERANCE_CELL_FINDING = 1e-6
 class Dataset(Tidy3dBaseModel, ABC):
     """Abstract base class for objects that store collections of `:class:`.DataArray`s."""
 
+    @property
+    def data_arrs(self) -> dict:
+        """Returns a dictionary of all `:class:`.DataArray`s in the dataset."""
+        data_arrs = {}
+        for key in self.__fields__.keys():
+            data = getattr(self, key)
+            if isinstance(data, DataArray):
+                data_arrs[key] = data
+        return data_arrs
+
 
 class AbstractFieldDataset(Dataset, ABC):
     """Collection of scalar fields with some symmetry properties."""

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -18,6 +18,7 @@ from tidy3d.components.base import cached_property, skip_if_fields_missing
 from tidy3d.components.base_sim.data.monitor_data import AbstractMonitorData
 from tidy3d.components.grid.grid import Coords, Grid
 from tidy3d.components.medium import Medium, MediumType
+from tidy3d.components.mode_spec import ModeSortSpec
 from tidy3d.components.monitor import (
     AuxFieldTimeMonitor,
     DiffractionMonitor,
@@ -1679,6 +1680,12 @@ class ModeData(ModeSolverDataset, ElectromagneticFieldData):
         corresponds to physically the same mode at all frequencies. Modes with overlap values over
         ``overlap_thresh`` are considered matching and not rearranged.
 
+        Note
+        ----
+            The monitor associated to this data is updated so that the deprecated
+            ``monitor.mode_spec.track_freq`` is set to ``None``, while
+            ``monitor.mode_spec.sort_spec.track_freq`` is set to the provided ``track_freq``.
+
         Parameters
         ----------
         track_freq : Literal["central", "lowest", "highest"]
@@ -1758,13 +1765,24 @@ class ModeData(ModeSolverDataset, ElectromagneticFieldData):
                 data_template = data_to_sort
 
         # Rearrange modes using computed sorting values
-        mode_data_sorted = self._reorder_modes(
-            sorting=sorting,
-            phase=phase,
-            track_freq=track_freq,
+
+        # 1) Reorder using the shared implementation (creates a copy)
+        data_reordered = self._apply_mode_reorder(sorting)
+
+        # 2) Apply phase shifts to field components in-place (data_reordered is already a copy)
+        for field in data_reordered.field_components.values():
+            phase_fact = np.exp(-1j * phase[None, None, None, :, :]).astype(field.data.dtype)
+            field.values *= phase_fact
+
+        # 3) Update mode_spec: prefer sort_spec.track_freq; clear deprecated track_freq
+        mspec = data_reordered.monitor.mode_spec
+        sort_spec = mspec.sort_spec.updated_copy(track_freq=track_freq)
+        mspec_updated = mspec.updated_copy(sort_spec=sort_spec, track_freq=None, validate=False)
+        monitor_updated = data_reordered.monitor.updated_copy(
+            mode_spec=mspec_updated, validate=False
         )
 
-        return mode_data_sorted
+        return data_reordered.updated_copy(monitor=monitor_updated, deep=False, validate=False)
 
     def _isel(self, **isel_kwargs):
         """Wraps ``xarray.DataArray.isel`` for all data fields that are defined over frequency and
@@ -1850,49 +1868,6 @@ class ModeData(ModeSolverDataset, ElectromagneticFieldData):
             arr_abs[:, jmax] = -1
 
         return pairs, values
-
-    def _reorder_modes(
-        self,
-        sorting: Numpy,
-        phase: Numpy,
-        track_freq: TrackFreq,
-    ) -> ModeData:
-        """Rearrange modes for the i-th frequency according to sorting[i, :] and apply phase
-        shifts."""
-
-        num_freqs, _ = np.shape(sorting)
-
-        # Create new dict with rearranged field components
-        update_dict = {}
-        for field_name, field in self.field_components.items():
-            field_sorted = field.copy()
-
-            # Rearrange modes
-            for freq_id in range(num_freqs):
-                field_sorted.data[..., freq_id, :] = field_sorted.data[
-                    ..., freq_id, sorting[freq_id, :]
-                ]
-
-            # Apply phase shift
-            phase_fact = np.exp(-1j * phase[None, None, None, :, :]).astype(field_sorted.data.dtype)
-            field_sorted.data = field_sorted.data * phase_fact
-
-            update_dict[field_name] = field_sorted
-
-        # Rearrange data over f and mode_index
-        data_dict = dict(**self._grid_correction_dict, n_complex=self.n_complex)
-        for key, data in data_dict.items():
-            update_dict[key] = data.copy()
-            for freq_id in range(num_freqs):
-                update_dict[key].data[freq_id, :] = update_dict[key].data[
-                    freq_id, sorting[freq_id, :]
-                ]
-
-        # Update mode_spec in the monitor
-        mode_spec = self.monitor.mode_spec.copy(update={"track_freq": track_freq})
-        update_dict["monitor"] = self.monitor.copy(update={"mode_spec": mode_spec})
-
-        return self.copy(update=update_dict)
 
     def _group_index_post_process(self, frequency_step: float) -> ModeData:
         """Calculate group index and remove added frequencies used only for this calculation.
@@ -2080,6 +2055,26 @@ class ModeData(ModeSolverDataset, ElectromagneticFieldData):
         return xr.Dataset(data_vars={"te": te_frac, "tm": tm_frac})
 
     @property
+    def TE_fraction(self) -> xr.DataArray:
+        """Alias for ``pol_fraction.te``."""
+        return self.pol_fraction["te"]
+
+    @property
+    def TM_fraction(self) -> xr.DataArray:
+        """Alias for ``pol_fraction.tm``."""
+        return self.pol_fraction["tm"]
+
+    @property
+    def wg_TE_fraction(self) -> xr.DataArray:
+        """Alias for ``pol_fraction_waveguide.te``."""
+        return self.pol_fraction_waveguide["te"]
+
+    @property
+    def wg_TM_fraction(self) -> xr.DataArray:
+        """Alias for ``pol_fraction_waveguide.tm``."""
+        return self.pol_fraction_waveguide["tm"]
+
+    @property
     def modes_info(self) -> xr.Dataset:
         """Dataset collecting various properties of the stored modes."""
 
@@ -2104,9 +2099,9 @@ class ModeData(ModeSolverDataset, ElectromagneticFieldData):
 
         if len(self.field_components) == 6:
             info["mode area"] = self.mode_area
-            info[f"TE (E{self._tangential_dims[0]}) fraction"] = self.pol_fraction["te"]
-            info["wg TE fraction"] = self.pol_fraction_waveguide["te"]
-            info["wg TM fraction"] = self.pol_fraction_waveguide["tm"]
+            info[f"TE (E{self._tangential_dims[0]}) fraction"] = self.TE_fraction
+            info["wg TE fraction"] = self.wg_TE_fraction
+            info["wg TM fraction"] = self.wg_TM_fraction
 
         return xr.Dataset(data_vars=info)
 
@@ -2209,6 +2204,133 @@ class ModeData(ModeSolverDataset, ElectromagneticFieldData):
         )
 
         return src_adj
+
+    def _apply_mode_reorder(self, sort_inds_2d):
+        """Apply a mode reordering along mode_index for all frequency indices.
+
+        Parameters
+        ----------
+        sort_inds_2d : np.ndarray
+            Array of shape (num_freqs, num_modes) where each row is the
+            permutation to apply to the mode_index for that frequency.
+        """
+        num_freqs, num_modes = sort_inds_2d.shape
+        modify_data = {}
+        for key, data in self.data_arrs.items():
+            if "mode_index" not in data.dims or "f" not in data.dims:
+                continue
+            dims_orig = data.dims
+            f_coord = data.coords["f"]
+            slices = []
+            for ifreq in range(num_freqs):
+                sl = data.isel(f=ifreq, mode_index=sort_inds_2d[ifreq])
+                slices.append(sl.assign_coords(mode_index=np.arange(num_modes)))
+            # Concatenate along the 'f' dimension name and then restore original frequency coordinates
+            data = xr.concat(slices, dim="f").assign_coords(f=f_coord).transpose(*dims_orig)
+            modify_data[key] = data
+        return self.updated_copy(**modify_data)
+
+    def sort_modes(
+        self, sort_spec: Optional[ModeSortSpec] = None, track_freq: Optional[TrackFreq] = None
+    ) -> ModeSolverData:
+        """Sort modes per frequency according to ``sort_spec``.
+
+        The modes are first filtered if ``sort_spec.filter_key`` is provided. They are then sorted
+        within each filtered group according to ``sort_spec.sort_key``. if provided. Finally,
+        if a tracking frequency is also provided either in ``sort_spec`` or as a separate argument,
+        the tracking is applied . The tracking could reshuffle the filter/sort criteria at
+        frequencies away from the tracking frequency.
+
+        Parameters
+        ----------
+        sort_spec : Optional[:class:`.ModeSortSpec`]
+            Specification of how to sort the modes.
+        track_freq : Optional[Literal["central", "lowest", "highest"]]
+            Specifies that modes should be tracked across frequencies. Overrides
+            ``sort_spec.track_freq``, but the returned data will have
+            ``monitor.mode_spec.sort_spec.track_freq`` set to the provided value, while
+            ``self.monitor.mode_spec.track_freq`` will be set to ``None``.
+
+        Returns
+        -------
+        :class:`.ModeSolverData`
+            Copy of self with modes sorted according to ``sort_spec``.
+        """
+
+        # Return the original data if no new sorting / tracking required
+        if track_freq is None and sort_spec is None:
+            return self
+
+        num_freqs = self.n_eff["f"].size
+        num_modes = self.n_eff["mode_index"].size
+        all_inds = np.arange(num_modes)
+        identity = np.arange(num_modes)
+        sort_inds_2d = np.tile(identity, (num_freqs, 1))
+
+        # Helper to compute ordered indices within a subset
+        def _order_indices(indices, vals_all):
+            if indices.size == 0:
+                return indices
+            vals = vals_all.isel(mode_index=indices)
+            order = np.argsort(vals)
+            if sort_spec.sort_order == "descending":
+                order = order[::-1]
+            return indices[order]
+
+        # Precompute metrics if provided
+        filter_metric = None
+        sort_metric = None
+        if sort_spec.filter_key is not None:
+            filter_metric = getattr(self, sort_spec.filter_key)
+        if sort_spec.sort_key is not None:
+            sort_metric = getattr(self, sort_spec.sort_key)
+
+        for ifreq in range(num_freqs):
+            # Build groups according to filter if requested
+            if filter_metric is not None:
+                vals_filt = filter_metric.isel(f=ifreq).values
+                # Boolean mask for modes in the first group
+                if sort_spec.filter_order == "over":
+                    mask_first = vals_filt >= sort_spec.filter_reference
+                else:
+                    mask_first = vals_filt <= sort_spec.filter_reference
+                group1 = all_inds[mask_first]
+                group2 = all_inds[~mask_first]
+            else:
+                group1 = all_inds
+                group2 = np.array([], dtype=int)
+
+            # Sorting within each group if requested
+            if sort_metric is not None:
+                vals_sort = sort_metric.isel(f=ifreq)
+                if sort_spec.sort_reference is not None:
+                    vals_sort = np.abs(vals_sort - sort_spec.sort_reference)
+                g1 = _order_indices(group1, vals_sort)
+                g2 = _order_indices(group2, vals_sort)
+                sort_inds = np.concatenate([g1, g2])
+            else:
+                # only filtering applied, keep original ordering within groups
+                sort_inds = np.concatenate([group1, group2])
+
+            sort_inds_2d[ifreq, : len(sort_inds)] = sort_inds
+
+        # If all rows are identity, skip
+        if np.all(sort_inds_2d == np.tile(identity, (num_freqs, 1))):
+            data_sorted = self
+        else:
+            data_sorted = self._apply_mode_reorder(sort_inds_2d)  # this creates a copy
+            data_sorted = data_sorted.updated_copy(
+                path="monitor/mode_spec", sort_spec=sort_spec, deep=False, validate=False
+            )
+
+        # Sort modes across frequencies if requested.
+        # Note: after sorting, ``track_freq`` is set in ``sort_spec`` regardless of how it was
+        # provided. The deprecated ``mode_spec.track_freq`` is cleared.
+        track_freq = track_freq or sort_spec.track_freq
+        if track_freq and num_freqs > 1:
+            data_sorted = data_sorted.overlap_sort(track_freq)
+
+        return data_sorted
 
 
 class ModeSolverData(ModeData):
@@ -2988,7 +3110,7 @@ class FieldProjectionCartesianData(AbstractFieldProjectionData):
         return tangential_dims
 
     @property
-    def poynting(self) -> DataArray:
+    def poynting(self) -> ScalarFieldDataArray:
         """Time-averaged Poynting vector for field data associated to a Cartesian field projection monitor."""
         fc = self.fields_cartesian
         dim1, dim2 = self.tangential_dims

--- a/tidy3d/components/mode/data/sim_data.py
+++ b/tidy3d/components/mode/data/sim_data.py
@@ -10,6 +10,7 @@ from tidy3d.components.base import cached_property
 from tidy3d.components.data.monitor_data import MediumData, PermittivityData
 from tidy3d.components.data.sim_data import AbstractYeeGridSimulationData
 from tidy3d.components.mode.simulation import ModeSimulation
+from tidy3d.components.mode_spec import ModeSortSpec
 from tidy3d.components.types import TYPE_TAG_STR, Ax, PlotScale
 from tidy3d.components.types.monitor_data import ModeSolverDataType
 
@@ -102,4 +103,13 @@ class ModeSimulationData(AbstractYeeGridSimulationData):
             vmax=vmax,
             ax=ax,
             **sel_kwargs,
+        )
+
+    def sort_modes(self, sort_spec: ModeSortSpec) -> ModeSimulationData:
+        """Sort modes per frequency according to ``sort_spec``."""
+
+        modes_sorted = self.modes_raw.sort_modes(sort_spec=sort_spec)
+        data_sorted = self.updated_copy(modes_raw=modes_sorted)
+        return data_sorted.updated_copy(
+            path="simulation", mode_spec=modes_sorted.monitor.mode_spec, deep=False, validate=False
         )

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -547,12 +547,13 @@ class ModeSolver(Tidy3dBaseModel):
         self._normalize_modes(mode_solver_data=mode_solver_data)
 
         # filter polarization if requested
-        if self.mode_spec.filter_pol is not None:
-            self._filter_polarization(mode_solver_data=mode_solver_data)
+        mode_solver_data = self._filter_polarization(mode_solver_data=mode_solver_data)
 
-        # sort modes if requested
-        if self.mode_spec.track_freq and len(self.freqs) > 1:
-            mode_solver_data = mode_solver_data.overlap_sort(self.mode_spec.track_freq)
+        # filter and sort modes if requested by sort_spec
+        mode_solver_data = mode_solver_data.sort_modes(
+            sort_spec=self.mode_spec.sort_spec,
+            track_freq=self.mode_spec.track_freq,
+        )
 
         self._field_decay_warning(mode_solver_data.symmetry_expanded)
 
@@ -1352,11 +1353,20 @@ class ModeSolver(Tidy3dBaseModel):
         return mode_solver_data.updated_copy(**skip_components, validate=False)
 
     def _filter_polarization(self, mode_solver_data: ModeSolverData):
-        """Filter polarization. Note: this modifies ``mode_solver_data`` in-place."""
+        """Filter polarization."""
+        filter_pol = self.mode_spec.filter_pol
+        if filter_pol is None:
+            return mode_solver_data
+
+        num_freqs = len(self.freqs)
+        num_modes = self.mode_spec.num_modes
+        identity = np.arange(num_modes)
+        sort_inds_2d = np.tile(identity, (num_freqs, 1))
+
         pol_frac = mode_solver_data.pol_fraction
-        for ifreq in range(len(self.freqs)):
-            te_frac = pol_frac.te.isel(f=ifreq)
-            if self.mode_spec.filter_pol == "te":
+        for ifreq in range(num_freqs):
+            te_frac = pol_frac.te.isel(f=ifreq).values
+            if filter_pol == "te":
                 sort_inds = np.concatenate(
                     (
                         np.where(te_frac >= 0.5)[0],
@@ -1364,7 +1374,7 @@ class ModeSolver(Tidy3dBaseModel):
                         np.where(np.isnan(te_frac))[0],
                     )
                 )
-            elif self.mode_spec.filter_pol == "tm":
+            elif filter_pol == "tm":
                 sort_inds = np.concatenate(
                     (
                         np.where(te_frac <= 0.5)[0],
@@ -1372,13 +1382,13 @@ class ModeSolver(Tidy3dBaseModel):
                         np.where(np.isnan(te_frac))[0],
                     )
                 )
-            for data in [
-                *list(mode_solver_data.field_components.values()),
-                mode_solver_data.n_complex,
-                mode_solver_data.grid_primal_correction,
-                mode_solver_data.grid_dual_correction,
-            ]:
-                data.values[..., ifreq, :] = data.values[..., ifreq, sort_inds]
+            sort_inds_2d[ifreq, : len(sort_inds)] = sort_inds
+
+        # If no reordering needed across all frequencies, skip
+        if np.all(sort_inds_2d == np.tile(identity, (num_freqs, 1))):
+            return mode_solver_data
+
+        return mode_solver_data._apply_mode_reorder(sort_inds_2d)
 
     def _make_path_integrals(
         self,

--- a/tidy3d/components/mode_spec.py
+++ b/tidy3d/components/mode_spec.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC
 from math import isclose
-from typing import Literal, Union
+from typing import Literal, Optional, Union
 
 import numpy as np
 import pydantic.v1 as pd
@@ -17,6 +17,73 @@ from .base import Tidy3dBaseModel, skip_if_fields_missing
 from .types import Axis2D, TrackFreq
 
 GROUP_INDEX_STEP = 0.005
+MODE_DATA_KEYS = Literal[
+    "n_eff",
+    "k_eff",
+    "TE_fraction",
+    "TM_fraction",
+    "wg_TE_fraction",
+    "wg_TM_fraction",
+    "mode_area",
+]
+
+
+class ModeSortSpec(Tidy3dBaseModel):
+    """Specification for filtering and sorting modes within each frequency.
+
+    First, an optional filtering step splits the modes into two groups based on a threshold
+    applied to ``filter_key``: modes "over" or "under" ``filter_reference`` are placed first,
+    with the remaining modes placed next. Second, an optional sorting step orders modes within
+    each group according to ``sort_key``, optionally with respect to ``sort_reference`` and in
+    the specified ``sort_order``.
+    """
+
+    # Filtering stage
+    filter_key: Optional[MODE_DATA_KEYS] = pd.Field(
+        None,
+        title="Filtering key",
+        description="Quantity used to filter modes into two groups before sorting.",
+    )
+    filter_reference: float = pd.Field(
+        0.0,
+        title="Filtering reference",
+        description="Reference value used in the filtering stage.",
+    )
+    filter_order: Literal["over", "under"] = pd.Field(
+        "over",
+        title="Filtering order",
+        description="Select whether the first group contains values over or under the reference.",
+    )
+
+    # Sorting stage
+    sort_key: Optional[MODE_DATA_KEYS] = pd.Field(
+        None,
+        title="Sorting key",
+        description="Quantity used to sort modes within each filtered group. If ``None``, "
+        "sorting is by descending effective index.",
+    )
+    sort_reference: Optional[float] = pd.Field(
+        None,
+        title="Sorting reference",
+        description=(
+            "If provided, sorting is based on the absolute difference to this reference value."
+        ),
+    )
+    sort_order: Literal["ascending", "descending"] = pd.Field(
+        "ascending",
+        title="Sorting direction",
+        description="Sort order for the selected key or difference to reference value.",
+    )
+
+    # Frequency tracking - applied after sorting and filtering
+    track_freq: Optional[TrackFreq] = pd.Field(
+        "central",
+        title="Tracking base frequency",
+        description="If provided, enables cross-frequency mode tracking. Can be 'lowest', "
+        "'central', or 'highest', which refers to the frequency **index** in the list of "
+        "frequencies. The mode sorting would then be exact at the specified frequency, "
+        "while at other frequencies it can change depending on the mode tracking.",
+    )
 
 
 class AbstractModeSpec(Tidy3dBaseModel, ABC):
@@ -109,13 +176,10 @@ class AbstractModeSpec(Tidy3dBaseModel, ABC):
         "Note: currently only supported when 'angle_phi' is a multiple of 'np.pi'.",
     )
 
-    track_freq: Union[TrackFreq, None] = pd.Field(
-        "central",
-        title="Mode Tracking Frequency",
-        description="Parameter that turns on/off mode tracking based on their similarity. "
-        "Can take values ``'lowest'``, ``'central'``, or ``'highest'``, which correspond to "
-        "mode tracking based on the lowest, central, or highest frequency. "
-        "If ``None`` no mode tracking is performed.",
+    track_freq: Optional[TrackFreq] = pd.Field(
+        None,
+        title="Mode Tracking Frequency (deprecated)",
+        description="Deprecated. Use 'sort_spec.track_freq' instead.",
     )
 
     group_index_step: Union[pd.PositiveFloat, bool] = pd.Field(
@@ -125,6 +189,14 @@ class AbstractModeSpec(Tidy3dBaseModel, ABC):
         "set to a positive value, it sets the fractional frequency step used in the numerical "
         "differentiation of the effective index to compute the group index. If set to `True`, the "
         f"default of {GROUP_INDEX_STEP} is used.",
+    )
+
+    sort_spec: ModeSortSpec = pd.Field(
+        ModeSortSpec(),
+        title="Mode filtering and sorting specification",
+        description="Defines how to filter and sort modes within each frequency. If ``track_freq`` "
+        "is not ``None``, the sorting is only exact at the specified frequency, while at other "
+        "frequencies it can change depending on the mode tracking.",
     )
 
     @pd.validator("bend_axis", always=True)
@@ -173,10 +245,16 @@ class AbstractModeSpec(Tidy3dBaseModel, ABC):
     def check_precision(cls, values):
         """Verify critical ModeSpec settings for group index calculation."""
         if values["group_index_step"] > 0:
-            if values["track_freq"] is None:
+            # prefer explicit track_freq on ModeSpec, else fall back to sort_spec.track_freq
+            # TODO: can be replaced with self._track_freq in pydantic v2
+            tf = values.get("track_freq")
+            if tf is None:
+                sort_spec = values.get("sort_spec")
+                tf = None if sort_spec is None else sort_spec.track_freq
+            if tf is None:
                 log.warning(
                     "Group index calculation without mode tracking can lead to incorrect results "
-                    "around mode crossings. Consider setting 'track_freq' to 'central'."
+                    "around mode crossings. Consider setting 'sort_spec.track_freq' to 'central'."
                 )
 
             # multiply by 5 to be safe
@@ -199,6 +277,48 @@ class AbstractModeSpec(Tidy3dBaseModel, ABC):
                 "enabled."
             )
         return val
+
+    @pd.root_validator(skip_on_failure=True)
+    def _filter_pol_and_sort_spec_exclusive(cls, values):
+        """Ensure that 'filter_pol' and 'sort_spec' are not used together."""
+        sort_spec = values.get("sort_spec")
+        sort_or_filter = sort_spec.filter_key is not None or sort_spec.sort_key is not None
+        if values.get("filter_pol") is not None and sort_or_filter:
+            raise SetupError(
+                "'filter_pol' cannot be used simultaneously with sorting or filtering "
+                "defined in 'sort_spec'. Define the filtering in 'sort_spec' exclusively."
+            )
+        return values
+
+    @pd.validator("filter_pol", always=True)
+    def _filter_pol_deprecated(cls, val):
+        """Warn that 'filter_pol' is deprecated in favor of 'sort_spec'."""
+        if val is not None:
+            log.warning(
+                "'filter_pol' is deprecated and will be removed in future versions. "
+                "Please use 'sort_spec' instead."
+            )
+        return val
+
+    @pd.validator("track_freq", always=True)
+    def _track_freq_deprecated(cls, val):
+        """Warn that 'track_freq' on ModeSpec is deprecated in favor of 'sort_spec.track_freq'."""
+        if val is not None:
+            log.warning(
+                "'ModeSpec.track_freq' is deprecated and will be removed in future versions. "
+                "Please use 'sort_spec.track_freq' instead."
+            )
+        return val
+
+    @property
+    def _track_freq(self) -> Optional[TrackFreq]:
+        """Private resolver for tracking frequency: prefers ModeSpec.track_freq if set,
+        otherwise falls back to ModeSortSpec.track_freq."""
+        if self.track_freq is not None:
+            return self.track_freq
+        if self.sort_spec is not None:
+            return self.sort_spec.track_freq
+        return None
 
 
 class ModeSpec(AbstractModeSpec):


### PR DESCRIPTION
Addresses the new suggestion in #1391 to add more advanced ways to sort modes in the mode solver (and mode sources and monitors).

Probably we should still keep the issue open as I should also implement the FilterSpec as discussed in that issue.

@yuanshen-flexcompute does the current PR help with some of your use cases that made you bring it up though?

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-07 08:34:20 UTC

<h3>Summary</h3>
This PR adds advanced mode sorting functionality to the Tidy3D mode solver by introducing a new `ModeSortSpec` class and integrating it into the `ModeSpec` configuration. The implementation addresses user feedback from issue #1391 where users were spending significant time manually filtering and sorting modes after simulation.

The core addition is the `ModeSortSpec` class which allows users to sort modes by various physical properties including effective index (`n_eff`), loss coefficient (`k_eff`), TE polarization fraction (`TE_fraction`), waveguide TE/TM fractions (`wg_TE_fraction`, `wg_TM_fraction`), and mode area (`mode_area`). Users can specify sorting direction (ascending/descending) and optionally provide a reference value to sort by proximity to that value.

The implementation integrates seamlessly into the existing mode solver pipeline through a new `_sort_modes()` method that operates on `ModeSolverData` after polarization filtering but before frequency tracking. The sorting is applied per-frequency to handle cases where mode properties vary across the frequency spectrum. A mutual exclusivity validator ensures that the new `sort_spec` cannot be used simultaneously with the legacy `filter_pol` field to prevent conflicting behaviors.

To support the sorting functionality, three new property aliases were added to the `ModeData` class: `TE_fraction`, `wg_TE_fraction`, and `wg_TM_fraction`. These provide more convenient access to polarization fraction data and are used by the `modes_info` method for consistency. The `ModeSortSpec` class is properly exported through the main `__init__.py` file to make it available in the public API.
<h3>Important Files Changed</h3>

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/mode_spec.py | 4/5 | Adds new `ModeSortSpec` class and `sort_spec` field to `ModeSpec` with mutual exclusivity validation |
| tidy3d/components/mode/mode_solver.py | 4/5 | Implements core sorting logic with `_sort_modes()` method and helper functions for mode reordering |
| tidy3d/components/data/monitor_data.py | 5/5 | Adds convenience property aliases for polarization fractions used by sorting functionality |
| tidy3d/__init__.py | 5/5 | Exports new `ModeSortSpec` class to public API |
| tests/test_plugins/test_mode_solver.py | 4/5 | Adds comprehensive tests for mode sorting functionality and mutual exclusivity validation |

</details>
<h3>Confidence score: 4/5</h3>

- This PR is generally safe to merge with well-structured implementation and comprehensive testing
- Score reflects the complexity of the mode manipulation logic and integration with existing pipeline components
- Pay close attention to the mode solver implementation file and validator logic in the mode_spec file

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ModeSpec
    participant ModeSolver
    participant ModeSolverData
    participant sort_methods as _sort_modes & _apply_mode_reorder

    User->>ModeSpec: "Create ModeSpec with sort_spec"
    ModeSpec->>ModeSpec: "Validate sort_spec parameters"
    Note over ModeSpec: Check key is in SORT_KEYS<br/>Ensure filter_pol and sort_spec not both used

    User->>ModeSolver: "Create ModeSolver with ModeSpec"
    ModeSolver->>ModeSolver: "Initialize and validate"

    User->>ModeSolver: "Call solve() or data_raw"
    ModeSolver->>ModeSolver: "_data_on_yee_grid()"
    ModeSolver->>ModeSolver: "_colocate_data() if needed"
    ModeSolver->>ModeSolver: "_normalize_modes()"
    ModeSolver->>ModeSolver: "_filter_polarization()"
    ModeSolver->>sort_methods: "_sort_modes(mode_solver_data)"
    
    sort_methods->>ModeSolverData: "getattr(mode_solver_data, sort_spec.key)"
    Note over sort_methods: Get metric values (n_eff, k_eff, etc.)
    
    sort_methods->>sort_methods: "Apply reference_value if provided"
    Note over sort_methods: metric = abs(metric - reference_value)
    
    sort_methods->>sort_methods: "Loop over frequencies"
    loop For each frequency
        sort_methods->>sort_methods: "np.argsort(metric values)"
        sort_methods->>sort_methods: "Reverse if direction='descending'"
        sort_methods->>sort_methods: "_apply_mode_reorder(data, freq_idx, sort_inds)"
        sort_methods->>ModeSolverData: "Reorder field components and n_complex"
        Note over ModeSolverData: data.values[..., freq_idx, :] = data.values[..., freq_idx, sort_inds]
    end
    
    alt If track_freq is set and multiple frequencies
        ModeSolver->>ModeSolverData: "mode_solver_data.overlap_sort(track_freq)"
        Note over ModeSolverData: Apply frequency-based mode tracking
    end

    ModeSolver-->>User: "Return sorted ModeSolverData"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->