### PR TITLE
chore: improve error message for tidy3d-extras

### DIFF
--- a/tidy3d/packaging.py
+++ b/tidy3d/packaging.py
@@ -216,7 +216,8 @@ def supports_local_subpixel(fn):
                         tidy3d_extras["use_local_subpixel"] = False
                         raise Tidy3dImportError(
                             "The package 'tidy3d-extras' did not initialize correctly, "
-                            "likely due to an invalid API key."
+                            "likely due to an invalid API key. To suppress this error, "
+                            "you can set 'config.use_local_subpixel=False'."
                         )
 
                     if version != __version__:


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-08 19:08:35 UTC

<h3>Summary</h3>
This PR improves the error message handling for the 'tidy3d-extras' package initialization failure in the `tidy3d/packaging.py` file. The change enhances user experience by providing a clear workaround when the extras package fails to initialize, typically due to an invalid API key.

The modification adds helpful guidance to the existing `Tidy3dImportError` exception, instructing users that they can suppress the error by setting `config.use_local_subpixel=False`. This allows users to continue using the main tidy3d package even when the extras functionality is unavailable, preventing them from being blocked by initialization issues they may not need to resolve.

This change integrates well with the existing error handling patterns in the codebase and follows good UX principles by providing both problem identification and a concrete solution path for users.
<h3>Important Files Changed</h3>

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/packaging.py | 5/5 | Enhanced error message for tidy3d-extras initialization failure with user guidance |

</details>
<h3>Confidence score: 5/5</h3>

- This PR is safe to merge with minimal risk as it only improves an error message without changing functionality
- Score reflects the simple nature of the change and clear improvement to user experience
- No files require special attention as this is a straightforward error message enhancement

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant "Decorated Function" as DF
    participant "supports_local_subpixel" as SLS
    participant Config
    participant "tidy3d_extras" as Extras
    participant Logger

    User->>DF: "Call decorated function"
    DF->>SLS: "Check local subpixel support"
    SLS->>Config: "Check config.use_local_subpixel"
    
    alt config.use_local_subpixel is False
        Config-->>SLS: "False"
        SLS->>Extras: "Set use_local_subpixel = False"
        SLS->>Extras: "Set mod = None"
    else config.use_local_subpixel is True/None
        Config-->>SLS: "True/None"
        
        alt tidy3d_extras mod is None
            SLS->>Extras: "Try import tidy3d_extras"
            
            alt Import fails
                Extras-->>SLS: "ImportError"
                SLS->>Extras: "Set mod = None"
                SLS->>Extras: "Set use_local_subpixel = False"
                
                alt config.use_local_subpixel is True
                    SLS-->>User: "Raise Tidy3dImportError with installation instructions"
                end
            else Import succeeds
                Extras-->>SLS: "tidy3d_extras_mod"
                SLS->>Extras: "Check __version__"
                
                alt version is None
                    SLS->>Extras: "Set mod = None"
                    SLS->>Extras: "Set use_local_subpixel = False"
                    SLS-->>User: "Raise Tidy3dImportError about API key"
                else version exists
                    alt version != __version__
                        SLS->>Logger: "Log version mismatch warning"
                    end
                    
                    SLS->>Extras: "Check extension._features()"
                    SLS->>Extras: "Set mod = tidy3d_extras_mod"
                    SLS->>Extras: "Set use_local_subpixel based on features"
                end
            end
        end
    end
    
    SLS->>DF: "Return control"
    DF->>User: "Execute original function"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->