### PR TITLE
chore: improve error message for tidy3d-extras

### DIFF
--- a/tidy3d/packaging.py
+++ b/tidy3d/packaging.py
@@ -216,7 +216,8 @@ def supports_local_subpixel(fn):
                         tidy3d_extras["use_local_subpixel"] = False
                         raise Tidy3dImportError(
                             "The package 'tidy3d-extras' did not initialize correctly, "
-                            "likely due to an invalid API key."
+                            "likely due to an invalid API key. To suppress this error, "
+                            "you can set 'config.use_local_subpixel=False'."
                         )
 
                     if version != __version__:


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-08 19:12:31 UTC

<h3>Summary</h3>
This PR improves the user experience by enhancing an error message in the `tidy3d/packaging.py` file. The change specifically targets the error handling for the 'tidy3d-extras' package initialization failure, which typically occurs when there's an invalid API key.

The modification adds helpful guidance to the existing error message by informing users that they can suppress this error by setting `config.use_local_subpixel=False`. This change aligns well with the existing codebase pattern where the `supports_local_subpixel` decorator already checks this configuration flag and gracefully handles cases when it's disabled.

The change integrates seamlessly with the Tidy3D framework's configuration system and error handling patterns. The `use_local_subpixel` configuration option appears to be an established mechanism for controlling whether the extras package functionality is required, making this error message enhancement both contextually appropriate and actionable for users.
<h3>Important Files Changed</h3>

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/packaging.py | 5/5 | Enhanced error message for tidy3d-extras initialization failure to include actionable guidance |

</details>
<h3>Confidence score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects simple, well-targeted user experience improvement with clear benefit and no code complexity
- No files require special attention

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant "Decorated Function" as Function
    participant "supports_local_subpixel" as Decorator
    participant Config
    participant "tidy3d_extras module" as ExtrasModule
    participant Logger

    User->>Function: "Call function with use_local_subpixel enabled"
    Function->>Decorator: "Check local subpixel support"
    
    alt config.use_local_subpixel is False
        Decorator->>Config: "Check use_local_subpixel setting"
        Config-->>Decorator: "False"
        Decorator->>Decorator: "Set tidy3d_extras['use_local_subpixel'] = False"
        Decorator->>Decorator: "Set tidy3d_extras['mod'] = None"
        Decorator->>Function: "Continue execution"
    else config.use_local_subpixel is True/None
        Decorator->>Config: "Check use_local_subpixel setting"
        Config-->>Decorator: "True/None"
        
        alt tidy3d_extras['mod'] is None
            Decorator->>ExtrasModule: "import tidy3d_extras"
            
            alt Import fails
                ExtrasModule-->>Decorator: "ImportError"
                Decorator->>Decorator: "Set tidy3d_extras['mod'] = None"
                Decorator->>Decorator: "Set tidy3d_extras['use_local_subpixel'] = False"
                
                alt config.use_local_subpixel is explicitly True
                    Decorator->>User: "Raise Tidy3dImportError with installation instructions"
                end
            else Import succeeds
                ExtrasModule-->>Decorator: "Module imported successfully"
                Decorator->>ExtrasModule: "Check __version__"
                
                alt version is None
                    ExtrasModule-->>Decorator: "None version"
                    Decorator->>Decorator: "Set tidy3d_extras['mod'] = None"
                    Decorator->>Decorator: "Set tidy3d_extras['use_local_subpixel'] = False"
                    Decorator->>User: "Raise Tidy3dImportError about invalid API key"
                else version exists
                    ExtrasModule-->>Decorator: "Valid version"
                    
                    alt version != __version__
                        Decorator->>Logger: "Log version mismatch warning"
                    end
                    
                    Decorator->>ExtrasModule: "Get extension._features()"
                    ExtrasModule-->>Decorator: "Return features list"
                    Decorator->>Decorator: "Set tidy3d_extras['mod'] = module"
                    Decorator->>Decorator: "Set use_local_subpixel based on 'local_subpixel' in features"
                end
            end
        end
        
        Decorator->>Function: "Continue execution with local subpixel support"
    end
    
    Function-->>User: "Return function result"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->