### PR TITLE
chore: improve error message for tidy3d-extras

### DIFF
--- a/tidy3d/packaging.py
+++ b/tidy3d/packaging.py
@@ -216,7 +216,8 @@ def supports_local_subpixel(fn):
                         tidy3d_extras["use_local_subpixel"] = False
                         raise Tidy3dImportError(
                             "The package 'tidy3d-extras' did not initialize correctly, "
-                            "likely due to an invalid API key."
+                            "likely due to an invalid API key. To suppress this error, "
+                            "you can set 'config.use_local_subpixel=False'."
                         )
 
                     if version != __version__:


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-08 19:17:32 UTC

<h3>Summary</h3>
This PR improves the error message displayed when the 'tidy3d-extras' package fails to initialize, typically due to authentication issues with an invalid API key. The change is focused on enhancing user experience by providing clear, actionable guidance.

The modification occurs in the `packaging.py` file within the `supports_local_subpixel` decorator context. When the extras package cannot be properly initialized, users previously received a generic error message indicating an API key issue but no clear resolution path. The enhanced error message now explicitly tells users they can suppress the error by setting `config.use_local_subpixel=False`, which allows them to continue using the main tidy3d functionality without the extras features.

This change fits naturally into the existing error handling infrastructure and maintains the same control flow - it simply extends the existing `Tidy3dImportError` with more helpful guidance. The improvement addresses a common user pain point where authentication failures would block usage even when the extras functionality wasn't strictly needed.
<h3>Important Files Changed</h3>

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/packaging.py | 5/5 | Enhanced error message to provide actionable guidance for tidy3d-extras initialization failures |

</details>
<h3>Confidence score: 5/5</h3>

- This PR is safe to merge with minimal risk as it only improves an error message without changing any logic or control flow
- Score reflects a simple, well-targeted improvement that enhances user experience without introducing any technical complexity or potential breaking changes
- No files require special attention as the change is straightforward and isolated to error messaging

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Function as "Decorated Function"
    participant Config as "config.use_local_subpixel"
    participant TidyExtras as "tidy3d_extras module"
    participant Logger as "log.warning"

    User->>Function: "Call function with @supports_local_subpixel decorator"
    Function->>Config: "Check config.use_local_subpixel value"
    
    alt config.use_local_subpixel is False
        Function->>TidyExtras: "Set use_local_subpixel = False, mod = None"
        Function->>User: "Execute original function"
    else config.use_local_subpixel is not False
        alt tidy3d_extras["mod"] is None
            Function->>TidyExtras: "Try to import tidy3d_extras"
            alt ImportError occurs
                TidyExtras->>Function: "ImportError exception"
                Function->>TidyExtras: "Set mod = None, use_local_subpixel = False"
                alt config.use_local_subpixel is True
                    Function->>User: "Raise Tidy3dImportError with improved message"
                else
                    Function->>User: "Continue execution"
                end
            else Import successful
                TidyExtras->>Function: "Return tidy3d_extras_mod"
                Function->>TidyExtras: "Check version"
                alt version is None
                    Function->>TidyExtras: "Set mod = None, use_local_subpixel = False"
                    Function->>User: "Raise Tidy3dImportError about API key"
                else version exists
                    alt version != __version__
                        Function->>Logger: "Log warning about version mismatch"
                    end
                    Function->>TidyExtras: "Check features"
                    TidyExtras->>Function: "Return features list"
                    Function->>TidyExtras: "Set mod and use_local_subpixel based on features"
                end
            end
        end
        Function->>User: "Execute original function"
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->