### PR TITLE
FXC-3004-container-aware-web-run-returning-lazy-results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `CustomCurrentIntegral2D` → `Custom2DCurrentIntegral`
   - Path integral and impedance calculator classes have been refactored and moved from `tidy3d.plugins.microwave` to `tidy3d.components.microwave`. They are now publicly exported via the top-level package `__init__.py`, so you can import them directly, e.g. `from tidy3d import ImpedanceCalculator, AxisAlignedVoltageIntegral, AxisAlignedCurrentIntegral, Custom2DVoltageIntegral, Custom2DCurrentIntegral, Custom2DPathIntegral`.
 - `DirectivityMonitor` now forces `far_field_approx` to `True`, which was previously configurable.
+- Unified run submission API: `web.run(...)` is now a container-aware wrapper that accepts a single simulation or arbitrarily nested containers (`list`, `tuple`, `dict` values) and returns results in the same shape.
+- `web.Batch(ComponentModeler)` and `web.Job(ComponentModeler)` native support
 
 ### Fixed
 - More robust `Sellmeier` and `Debye` material model, and prevent very large pole parameters in `PoleResidue` material model.

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -22,7 +23,9 @@ from tidy3d.components.source.time import GaussianPulse
 from tidy3d.exceptions import SetupError
 from tidy3d.web import common
 from tidy3d.web.api.asynchronous import run_async
-from tidy3d.web.api.container import Batch, Job
+from tidy3d.web.api.container import Batch, Job, WebContainer
+from tidy3d.web.api.run import _collect_by_hash, run
+from tidy3d.web.api.tidy3d_stub import Tidy3dStubData
 from tidy3d.web.api.webapi import (
     abort,
     delete,
@@ -38,7 +41,6 @@ from tidy3d.web.api.webapi import (
     load_simulation,
     monitor,
     real_cost,
-    run,
     start,
     upload,
 )
@@ -55,6 +57,7 @@ FLEX_UNIT = 1.0
 EST_FLEX_UNIT = 11.11
 FILE_SIZE_GB = 4.0
 common.CONNECTION_RETRY_TIME = 0.1
+INVALID_TASK_ID = "INVALID_TASK_ID"
 
 task_core_path = "tidy3d.web.core.task_core"
 api_path = "tidy3d.web.api.webapi"
@@ -768,13 +771,95 @@ def test_main(mock_webapi, monkeypatch, mock_job_status, tmp_path):
 @responses.activate
 def test_load_invalid_task_raises(mock_webapi):
     """Ensure that load() raises TaskNotFoundError for a non-existent task ID."""
-    fake_id = "INVALID_TASK_ID"
 
     responses.add(
         responses.GET,
-        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{fake_id}/detail",
+        f"{Env.current.web_api_endpoint}/tidy3d/tasks/{INVALID_TASK_ID}/detail",
         json={"error": "Task not found"},
         status=404,
     )
     with pytest.raises(WebNotFoundError, match="Resource not found"):
-        load(fake_id)
+        load(INVALID_TASK_ID, replace_existing=True)
+
+
+def _fake_load_factory(tmp_root, taskid_to_sim: dict):
+    def _fake_load(task_id, path="simulation_data.hdf5", lazy=False, **kwargs):
+        abs_path = path if os.path.isabs(path) else os.path.join(tmp_root, path)
+        abs_path = os.path.normpath(abs_path)
+        os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+
+        sim_for_this = taskid_to_sim.get(task_id)
+
+        log = "- Time step    827 / time 4.13e-14s (  4 % done), field decay: 0.110e+00"
+        sim_data = SimulationData(simulation=sim_for_this, data=[], diverged=False, log=log)
+
+        sim_data.to_file(abs_path)
+        return Tidy3dStubData.postprocess(abs_path, lazy=lazy)
+
+    return _fake_load
+
+
+def apply_common_patches(
+    monkeypatch, tmp_root, *, api_path="tidy3d.web.api.webapi", path_to_sim=None, taskid_to_sim=None
+):
+    """Patch start/monitor/get_info/estimate_cost/upload/_check_folder/_modesolver_patch/load."""
+    monkeypatch.setattr(f"{api_path}.start", lambda *a, **k: True)
+    monkeypatch.setattr(f"{api_path}.monitor", lambda *a, **k: True)
+    monkeypatch.setattr(f"{api_path}.get_info", lambda *a, **k: SimpleNamespace(status="success"))
+    monkeypatch.setattr(f"{api_path}.estimate_cost", lambda *a, **k: 0.0)
+    monkeypatch.setattr(f"{api_path}.upload", lambda *a, **k: k["task_name"])
+    monkeypatch.setattr(WebContainer, "_check_folder", lambda *a, **k: True)
+    monkeypatch.setattr(f"{api_path}._modesolver_patch", lambda *_, **__: None, raising=False)
+    monkeypatch.setattr(
+        f"{api_path}.load",
+        _fake_load_factory(tmp_root=str(tmp_root), taskid_to_sim=taskid_to_sim),
+        raising=False,
+    )
+
+
+@responses.activate
+def test_run_with_flexible_containers_offline_lazy(monkeypatch, tmp_path):
+    sim1 = make_sim()
+    sim2 = sim1.updated_copy(run_time=sim1.run_time / 2)
+    sim_container = [sim1, {"sim": sim1, "sim2": sim2}, (sim1, [sim2])]
+
+    h2sim = _collect_by_hash(sim_container)
+    task_name = "T"
+    out_dir = tmp_path / "out"
+
+    taskid_to_sim = {f"{task_name}_{h}": s for h, s in h2sim.items()}
+
+    apply_common_patches(monkeypatch, tmp_path, taskid_to_sim=taskid_to_sim)
+
+    data = run(sim_container, task_name=task_name, folder_name="PROJECT", path=str(out_dir))
+
+    assert isinstance(data, list) and len(data) == 3
+
+    assert isinstance(data[0], SimulationData)
+    assert data[0].__class__.__name__ == "SimulationDataProxy"
+
+    assert isinstance(data[1], dict)
+    assert "sim2" in data[1]
+    assert isinstance(data[1]["sim2"], SimulationData)
+    assert data[1]["sim2"].__class__.__name__ == "SimulationDataProxy"
+
+    assert isinstance(data[2], tuple)
+    assert data[2][0].__class__.__name__ == "SimulationDataProxy"
+    assert isinstance(data[2][1], list)
+    assert data[2][1][0].__class__.__name__ == "SimulationDataProxy"
+
+    assert data[0].simulation == sim1
+    assert data[1]["sim2"].simulation == sim2
+
+
+@responses.activate
+def test_run_single_offline_eager(monkeypatch, tmp_path):
+    sim = make_sim()
+    single_file = str(tmp_path / "sim.hdf5")
+    task_name = "single"
+    apply_common_patches(monkeypatch, tmp_path, taskid_to_sim={task_name: sim})
+
+    sim_data = run(sim, task_name=task_name, path=single_file)
+
+    assert isinstance(sim_data, SimulationData)
+    assert sim_data.__class__.__name__ == "SimulationData"  # no proxy

--- a/tests/test_web/test_webapi_mode.py
+++ b/tests/test_web/test_webapi_mode.py
@@ -12,6 +12,7 @@ from tidy3d.components.data.dataset import ModeIndexDataArray
 from tidy3d.plugins.mode import ModeSolver
 from tidy3d.web.api.asynchronous import run_async
 from tidy3d.web.api.container import Batch, Job
+from tidy3d.web.api.run import run
 from tidy3d.web.api.webapi import (
     abort,
     download_json,
@@ -20,7 +21,6 @@ from tidy3d.web.api.webapi import (
     get_reduced_simulation,
     get_run_info,
     load_simulation,
-    run,
     upload,
 )
 from tidy3d.web.core.environment import Env

--- a/tidy3d/web/__init__.py
+++ b/tidy3d/web/__init__.py
@@ -13,8 +13,9 @@ core_config.set_config(log, get_logging_console(), __version__)
 
 # from .api.asynchronous import run_async # NOTE: we use autograd one now (see below)
 # autograd compatible wrappers for run and run_async
-from .api.autograd.autograd import run, run_async
+from .api.autograd.autograd import run_async
 from .api.container import Batch, BatchData, Job
+from .api.run import run
 from .api.webapi import (
     abort,
     account,
@@ -29,6 +30,7 @@ from .api.webapi import (
     load,
     load_simulation,
     monitor,
+    postprocess_start,
     real_cost,
     start,
     test,
@@ -59,6 +61,7 @@ __all__ = [
     "load",
     "load_simulation",
     "monitor",
+    "postprocess_start",
     "real_cost",
     "run",
     "run_async",

--- a/tidy3d/web/api/asynchronous.py
+++ b/tidy3d/web/api/asynchronous.py
@@ -24,6 +24,7 @@ def run_async(
     reduce_simulation: Literal["auto", True, False] = "auto",
     pay_type: Union[PayType, str] = PayType.AUTO,
     priority: Optional[int] = None,
+    lazy: bool = False,
 ) -> BatchData:
     """Submits a set of Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`] objects to server,
     starts running, monitors progress, downloads, and loads results as a :class:`.BatchData` object.
@@ -56,6 +57,10 @@ def run_async(
     priority: int = None
         Priority of the simulation in the Virtual GPU (vGPU) queue (1 = lowest, 10 = highest).
         It affects only simulations from vGPU licenses and does not impact simulations using FlexCredits.
+    lazy : bool = False
+        Whether to load the actual data (``lazy=False``) or return a proxy that loads
+        the data when accessed (``lazy=True``).
+
     Returns
     ------
     :class:`BatchData`
@@ -91,6 +96,7 @@ def run_async(
         parent_tasks=parent_tasks,
         reduce_simulation=reduce_simulation,
         pay_type=pay_type,
+        lazy=lazy,
     )
 
     batch_data = batch.run(path_dir=path_dir, priority=priority)

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -106,6 +106,7 @@ def run(
     reduce_simulation: typing.Literal["auto", True, False] = "auto",
     pay_type: typing.Union[PayType, str] = PayType.AUTO,
     priority: typing.Optional[int] = None,
+    lazy: bool = False,
 ) -> WorkflowDataType:
     """
     Submits a :class:`.Simulation` to server, starts running, monitors progress, downloads,
@@ -147,6 +148,10 @@ def run(
         Which method to pay for the simulation.
     priority: int = None
         Task priority for vGPU queue (1=lowest, 10=highest).
+    lazy : bool = False
+        Whether to load the actual data (``lazy=False``) or return a proxy that loads
+        the data when accessed (``lazy=True``).
+
     Returns
     -------
     Union[:class:`.SimulationData`, :class:`.HeatSimulationData`, :class:`.EMESimulationData`, :class:`.ModalComponentModelerData`, :class:`.TerminalComponentModelerData`]
@@ -237,6 +242,7 @@ def run(
             max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
             pay_type=pay_type,
             priority=priority,
+            lazy=lazy,
         )
 
     return run_webapi(
@@ -255,6 +261,7 @@ def run(
         reduce_simulation=reduce_simulation,
         pay_type=pay_type,
         priority=priority,
+        lazy=lazy,
     )
 
 
@@ -273,6 +280,7 @@ def run_async(
     reduce_simulation: typing.Literal["auto", True, False] = "auto",
     pay_type: typing.Union[PayType, str] = PayType.AUTO,
     priority: typing.Optional[int] = None,
+    lazy: bool = False,
 ) -> BatchData:
     """Submits a set of Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`] objects to server,
     starts running, monitors progress, downloads, and loads results as a :class:`.BatchData` object.
@@ -307,6 +315,9 @@ def run_async(
         Whether to reduce structures in the simulation to the simulation domain only. Note: currently only implemented for the mode solver.
     pay_type: typing.Union[PayType, str] = PayType.AUTO
         Specify the payment method.
+    lazy : bool = False
+        Whether to load the actual data (``lazy=False``) or return a proxy that loads
+        the data when accessed (``lazy=True``).
 
     Returns
     ------
@@ -349,6 +360,7 @@ def run_async(
             max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
             pay_type=pay_type,
             priority=priority,
+            lazy=lazy,
         )
 
     return run_async_webapi(
@@ -364,6 +376,7 @@ def run_async(
         reduce_simulation=reduce_simulation,
         pay_type=pay_type,
         priority=priority,
+        lazy=lazy,
     )
 
 

--- a/tidy3d/web/api/autograd/engine.py
+++ b/tidy3d/web/api/autograd/engine.py
@@ -10,7 +10,7 @@ from .io_utils import get_vjp_traced_fields, upload_sim_fields_keys
 
 def parse_run_kwargs(**run_kwargs):
     """Parse the ``run_kwargs`` to extract what should be passed to the ``Job``/``Batch`` init."""
-    job_fields = [*list(Job._upload_fields), "solver_version", "pay_type"]
+    job_fields = [*list(Job._upload_fields), "solver_version", "pay_type", "lazy"]
     job_init_kwargs = {k: v for k, v in run_kwargs.items() if k in job_fields}
     return job_init_kwargs
 

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -20,6 +20,16 @@ from tidy3d.components.types.workflow import WorkflowDataType, WorkflowType
 from tidy3d.exceptions import DataError
 from tidy3d.log import get_logging_console, log
 from tidy3d.web.api import webapi as web
+from tidy3d.web.api.states import (
+    COMPLETED_PERCENT,
+    COMPLETED_STATES,
+    END_STATES,
+    ERROR_STATES,
+    PRE_ERROR_STATES,
+    PRE_VALIDATE_STATES,
+    RUNNING_STATES,
+    STATE_PROGRESS_PERCENTAGE,
+)
 from tidy3d.web.api.tidy3d_stub import Tidy3dStub
 from tidy3d.web.core.constants import TaskId, TaskName
 from tidy3d.web.core.task_core import Folder
@@ -212,6 +222,12 @@ class Job(WebContainer):
         description="Specify the payment method.",
     )
 
+    lazy: bool = pd.Field(
+        False,
+        title="Lazy",
+        description="Whether to load the actual data (lazy=False) or return a proxy that loads the data when accessed (lazy=True).",
+    )
+
     _upload_fields = (
         "simulation",
         "task_name",
@@ -292,13 +308,30 @@ class Job(WebContainer):
         :class:`TaskInfo`
             :class:`TaskInfo` object containing info about status, size, credits of task and others.
         """
-
         return web.get_info(task_id=self.task_id)
 
     @property
     def status(self):
         """Return current status of :class:`Job`."""
-        return self.get_info().status
+        if web._is_modeler_batch(self.task_id):
+            detail = self.get_info()
+            status = detail.totalStatus.value
+            return status
+        else:
+            return self.get_info().status
+
+    @property
+    def postprocess_status(self):
+        """Return current postprocess status of :class:`Job` if it is a Component Modeler."""
+        if web._is_modeler_batch(self.task_id):
+            detail = self.get_info()
+            return detail.postprocessStatus
+        else:
+            log.warning(
+                f"Task ID '{self.task_id}' is not a modeler batch job. "
+                "'postprocess_start' is only applicable to Component Modelers"
+            )
+            return
 
     def start(self, priority: Optional[int] = None) -> None:
         """Start running a :class:`Job`.
@@ -369,7 +402,7 @@ class Job(WebContainer):
             Object containing simulation results.
         """
         self._check_path_dir(path=path)
-        data = web.load(task_id=self.task_id, path=path, verbose=self.verbose)
+        data = web.load(task_id=self.task_id, path=path, verbose=self.verbose, lazy=self.lazy)
         if isinstance(self.simulation, ModeSolver):
             self.simulation._patch_data(data=data)
         return data
@@ -412,6 +445,37 @@ class Job(WebContainer):
         the full ``run_time``. If early shut-off is triggered, the cost is adjusted proportionately.
         """
         return web.estimate_cost(self.task_id, verbose=verbose, solver_version=self.solver_version)
+
+    def postprocess_start(self, worker_group: Optional[str] = None, verbose: bool = True) -> None:
+        """
+        If the job is a modeler batch, checks if the run is complete and starts
+        the postprocess phase.
+
+        This function does not wait for postprocessing to finish and is only
+        applicable to Component Modeler batch jobs.
+
+        Parameters
+        ----------
+        worker_group : Optional[str] = None
+            The specific worker group to run the postprocessing task on.
+        verbose : bool = True
+            Whether to print info messages. This overrides the Job's 'verbose' setting for this call.
+        """
+        # First, confirm that the task is a modeler batch job.
+        if not web._is_modeler_batch(self.task_id):
+            # If not, inform the user and exit.
+            # This warning is important and should not be suppressed.
+            log.warning(
+                f"Task ID '{self.task_id}' is not a modeler batch job. "
+                "'postprocess_start' is only applicable to Component Modelers"
+            )
+            return
+
+        # If it is a modeler batch, call the dedicated function to start postprocessing.
+        # The verbosity is a combination of the job's setting and the method's parameter.
+        web.postprocess_start(
+            batch_id=self.task_id, verbose=(self.verbose and verbose), worker_group=worker_group
+        )
 
     @staticmethod
     def _check_path_dir(path: str) -> None:
@@ -477,13 +541,19 @@ class BatchData(Tidy3dBaseModel, Mapping):
         True, title="Verbose", description="Whether to print info messages and progressbars."
     )
 
+    lazy: bool = pd.Field(
+        False,
+        title="Lazy",
+        description="Whether to load the actual data (lazy=False) or return a proxy that loads the data when accessed (lazy=True).",
+    )
+
     def load_sim_data(self, task_name: str) -> WorkflowDataType:
         """Load a simulation data object from file by task name."""
         task_data_path = self.task_paths[task_name]
         task_id = self.task_ids[task_name]
         web.get_info(task_id)
 
-        return web.load(task_id=task_id, path=task_data_path, verbose=False)
+        return web.load(task_id=task_id, path=task_data_path, verbose=False, lazy=self.lazy)
 
     def __getitem__(self, task_name: TaskName) -> WorkflowDataType:
         """Get the simulation data object for a given ``task_name``."""
@@ -549,7 +619,7 @@ class Batch(WebContainer):
     """
 
     simulations: Union[
-        dict[TaskName, annotate_type(WorkflowType)], tuple[annotate_type(WorkflowType)]
+        dict[TaskName, annotate_type(WorkflowType)], tuple[annotate_type(WorkflowType), ...]
     ] = pd.Field(
         ...,
         title="Simulations",
@@ -621,6 +691,12 @@ class Batch(WebContainer):
         "so that ``jobs`` is written when ``Batch.to_file()`` and then the proper task is loaded "
         "from ``Batch.from_file()``. We recommend leaving unset as setting this field along with "
         "fields that were not used to create the task will cause errors.",
+    )
+
+    lazy: bool = pd.Field(
+        False,
+        title="Lazy",
+        description="Whether to load the actual data (lazy=False) or return a proxy that loads the data when accessed (lazy=True).",
     )
 
     _job_type = Job
@@ -818,8 +894,58 @@ class Batch(WebContainer):
             run_info_dict[task_name] = run_info
         return run_info_dict
 
+    def postprocess_start(self, worker_group: Optional[str] = None, verbose: bool = True) -> None:
+        """
+        Starts the postprocess phase for all applicable jobs within the batch.
+
+        This function iterates through each job in the batch and calls its
+        'postprocess_start' method. The check for whether a job is a
+        Component Modeler task is handled within the individual Job's method.
+
+        This function does not wait for postprocessing to finish.
+
+        Parameters
+        ----------
+        worker_group : Optional[str] = None
+            The specific worker group to run the postprocessing tasks on.
+        verbose : bool = True
+            Whether to print info messages.
+        """
+        if self.verbose and verbose:
+            console = get_logging_console()
+            console.log("Attempting to start postprocessing for jobs in the batch.")
+
+        for job in self.jobs.values():
+            job.postprocess_start(worker_group=worker_group, verbose=verbose)
+
     def monitor(self) -> None:
-        """Monitor progress of each of the running tasks."""
+        """
+        Monitor progress of each of the running tasks.
+
+        For Component Modeler jobs, this method will automatically trigger the
+        post-processing step as soon as the run phase is complete.
+        """
+
+        def check_continue_condition(job) -> bool:
+            """
+            Determines if a job still needs monitoring.
+            Returns True if monitoring should continue, False if the job is finished.
+            """
+            status = job.status
+            if not web._is_modeler_batch(job.task_id):
+                # For regular jobs, finish when the status is in an end state.
+                return status not in END_STATES
+
+            # For modeler jobs, the logic is more complex.
+            if status == "run_success":
+                condition = job.postprocess_status not in END_STATES
+                return condition
+
+            if status not in END_STATES:
+                return True  # Still running, definitely continue.
+
+            # If status is a final end state (e.g., 'success', 'error'), we are done.
+            return False
 
         def pbar_description(
             task_name: str, status: str, max_name_length: int, status_width: int
@@ -832,46 +958,24 @@ class Batch(WebContainer):
             # right-align status
             task_part = f"{task_name:<{max_name_length}}"
 
-            if "error" in status or "diverge" in status or "aborted" in status:
+            if status in ERROR_STATES:
                 status_part = f"→ [red]{status:<{status_width}}"
-            elif status == "success":
+            elif status in COMPLETED_STATES:
                 status_part = f"→ [green]{status:<{status_width}}"
-            elif status == "queued" or status == "queued_solver" or status == "aborting":
+            elif status in (PRE_ERROR_STATES | PRE_VALIDATE_STATES):
                 status_part = f"→ [yellow]{status:<{status_width}}"
-            elif status in ["preprocess", "postprocess", "running"]:
+            elif status in RUNNING_STATES:
                 status_part = f"→ [blue]{status:<{status_width}}"
             else:
                 status_part = f"→ {status:<{status_width}}"
 
             return f"{task_part} {status_part}"
 
-        run_statuses = [
-            "draft",
-            "queued",
-            "preprocess",
-            "queued_solver",
-            "running",
-            "postprocess",
-            "visualize",
-            "success",
-            "aborting",
-        ]
-        end_statuses = (
-            "success",
-            "error",
-            "errored",
-            "diverged",
-            "diverge",
-            "deleted",
-            "draft",
-            "aborted",
-        )
-
         max_task_name = max(len(task_name) for task_name in self.jobs.keys())
         max_name_length = min(30, max(max_task_name, 15))
-        status_width = max(
-            max(len(status) for status in run_statuses), max(len(status) for status in end_statuses)
-        )
+
+        # Keep track of modeler jobs that have had postprocessing started.
+        postprocess_started_tasks = set()
 
         if self.verbose:
             console = get_logging_console()
@@ -890,60 +994,79 @@ class Batch(WebContainer):
             )
 
             with Progress(*progress_columns, console=console, transient=False) as progress:
-                # create progress bars
+                # Create progress bars
                 pbar_tasks = {}
                 for task_name, job in self.jobs.items():
                     status = job.status
-                    description = pbar_description(task_name, status, max_name_length, status_width)
-                    completed = run_statuses.index(status) if status in run_statuses else 0
+                    description = pbar_description(task_name, status, max_name_length, 0)
+                    completed = STATE_PROGRESS_PERCENTAGE[status]
                     pbar = progress.add_task(
-                        description, total=len(run_statuses) - 1, completed=completed
+                        description, total=COMPLETED_PERCENT, completed=completed
                     )
                     pbar_tasks[task_name] = pbar
 
-                while any(job.status not in end_statuses for job in self.jobs.values()):
-                    updates = []
+                while any(check_continue_condition(job) for job in self.jobs.values()):
                     for task_name, job in self.jobs.items():
                         status = job.status
-                        if status in run_statuses:
-                            updates.append(
-                                (
-                                    pbar_tasks[task_name],
-                                    pbar_description(
-                                        task_name, status, max_name_length, status_width
-                                    ),
-                                    run_statuses.index(status),
-                                )
-                            )
+                        if (
+                            web._is_modeler_batch(job.task_id)
+                            and status == "run_success"
+                            and job.task_id not in postprocess_started_tasks
+                        ):
+                            job.postprocess_start(verbose=True)
+                            postprocess_started_tasks.add(job.task_id)
 
-                    for pbar, description, completed in updates:
-                        progress.update(
-                            pbar, description=description, completed=completed, refresh=False
-                        )
+                        # Update progress bar
+                        pbar = pbar_tasks[task_name]
+                        if status != "run_success":
+                            completed_percent = STATE_PROGRESS_PERCENTAGE[status]
+                        elif status == "run_success":
+                            postprocess_status = job.postprocess_status
+                            if postprocess_status in END_STATES:
+                                status = postprocess_status
+                                completed_percent = STATE_PROGRESS_PERCENTAGE[postprocess_status]
+                            else:
+                                status = "postprocess"
+                                completed_percent = STATE_PROGRESS_PERCENTAGE["postprocess"]
+                        description = pbar_description(task_name, status, max_name_length, 0)
+                        progress.update(pbar, description=description, completed=completed_percent)
 
                     progress.refresh()
                     time.sleep(BATCH_MONITOR_PROGRESS_REFRESH_TIME)
 
-                updates = []
+                # Final update to ensure all bars show their terminal state
                 for task_name, job in self.jobs.items():
-                    updates.append(
-                        (
-                            pbar_tasks[task_name],
-                            pbar_description(task_name, job.status, max_name_length, status_width),
-                            len(run_statuses) - 1,
-                        )
-                    )
+                    status = job.status
+                    if status != "run_success":
+                        completed_percent = STATE_PROGRESS_PERCENTAGE[status]
+                    elif status == "run_success":
+                        postprocess_status = job.postprocess_status
+                        if postprocess_status in END_STATES:
+                            status = postprocess_status
+                            completed_percent = STATE_PROGRESS_PERCENTAGE[postprocess_status]
+                        else:
+                            status = "postprocess"
+                            completed_percent = STATE_PROGRESS_PERCENTAGE["postprocess"]
+                    pbar = pbar_tasks[task_name]
+                    description = pbar_description(task_name, status, max_name_length, 0)
 
-                for pbar, description, completed in updates:
-                    progress.update(
-                        pbar, description=description, completed=completed, refresh=False
-                    )
+                    progress.update(pbar, description=description, completed=completed_percent)
 
                 progress.refresh()
                 console.log("Batch complete.")
 
         else:
-            while any(job.status not in end_statuses for job in self.jobs.values()):
+            # Non-verbose path
+            while any(check_continue_condition(job) for job in self.jobs.values()):
+                for job in self.jobs.values():
+                    # If a modeler job is done running, start its postprocessing once.
+                    if (
+                        web._is_modeler_batch(job.task_id)
+                        and job.status == "run_success"
+                        and job.task_id not in postprocess_started_tasks
+                    ):
+                        job.postprocess_start(verbose=False)
+                        postprocess_started_tasks.add(job.task_id)
                 time.sleep(web.REFRESH_TIME)
 
     @staticmethod
@@ -1087,7 +1210,9 @@ class Batch(WebContainer):
             task_paths[task_name] = self._job_data_path(task_id=job.task_id, path_dir=path_dir)
             task_ids[task_name] = self.jobs[task_name].task_id
 
-        data = BatchData(task_paths=task_paths, task_ids=task_ids, verbose=self.verbose)
+        data = BatchData(
+            task_paths=task_paths, task_ids=task_ids, verbose=self.verbose, lazy=self.lazy
+        )
 
         for task_name, job in self.jobs.items():
             if isinstance(job.simulation, ModeSolver):

--- a/tidy3d/web/api/run.py
+++ b/tidy3d/web/api/run.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import typing
+
+from tidy3d.components.autograd.constants import MAX_NUM_ADJOINT_PER_FWD
+from tidy3d.components.types.workflow import WorkflowDataType, WorkflowType
+from tidy3d.web.api.autograd.autograd import run as run_autograd
+from tidy3d.web.api.autograd.autograd import run_async
+from tidy3d.web.api.autograd.constants import LOCAL_GRADIENT
+from tidy3d.web.api.container import DEFAULT_DATA_DIR, DEFAULT_DATA_PATH
+from tidy3d.web.core.types import PayType
+
+RunInput: typing.TypeAlias = typing.Union[
+    WorkflowType,
+    list["RunInput"],
+    tuple["RunInput", ...],
+    dict[typing.Hashable, "RunInput"],
+]
+
+RunOutput: typing.TypeAlias = typing.Union[
+    WorkflowDataType,
+    list["RunOutput"],
+    tuple["RunOutput", ...],
+    dict[typing.Hashable, "RunOutput"],
+]
+
+
+def _collect_by_hash(
+    node: RunInput,
+    found: dict[str, WorkflowType] | None = None,
+) -> dict[str, WorkflowType]:
+    """Traverses the structure and collects all simulations into a `{hash: sim}` mapping.
+    The latest occurrence of the same hash overwrites the previous one — which is fine
+    since identical objects share the same hash."""
+    if found is None:
+        found = {}
+    if isinstance(node, WorkflowType):
+        found[str(hash(node))] = node
+        return found
+    if isinstance(node, (list, tuple)):
+        for v in node:
+            _collect_by_hash(v, found)
+        return found
+    if isinstance(node, dict):
+        if any(isinstance(k, WorkflowType) for k in node.keys()):
+            raise ValueError("Dict keys must not be simulations.")
+        for v in node.values():
+            _collect_by_hash(v, found)
+        return found
+    raise TypeError(f"Unsupported element in container: {type(node)!r}")
+
+
+def _reconstruct_by_hash(node: RunInput, h2data: dict[str, WorkflowDataType]) -> RunOutput:
+    """Replaces each leaf node (simulation) with its corresponding data object.
+
+    If a simulation appears multiple times in the input structure, the first
+    occurrence reuses the same object; subsequent occurrences receive a `.copy()`
+    to avoid shared-state side effects.
+    """
+    seen = set()
+
+    def _recur(n: RunInput) -> RunOutput:
+        if isinstance(n, WorkflowType):
+            h = str(hash(n))
+            data = h2data[h]
+            if h in seen:
+                return data.copy()
+            seen.add(h)
+            return data
+        if isinstance(n, tuple):
+            return tuple(_recur(v) for v in n)
+        if isinstance(n, list):
+            return [_recur(v) for v in n]
+        if isinstance(n, dict):
+            return {k: _recur(v) for k, v in n.items()}
+        raise TypeError(f"Unsupported element in reconstruction: {type(n)!r}")
+
+    return _recur(node)
+
+
+def run(
+    simulation: RunInput,
+    task_name: typing.Optional[str] = None,
+    folder_name: str = "default",
+    path: typing.Optional[str] = None,
+    callback_url: typing.Optional[str] = None,
+    verbose: bool = True,
+    progress_callback_upload: typing.Optional[typing.Callable[[float], None]] = None,
+    progress_callback_download: typing.Optional[typing.Callable[[float], None]] = None,
+    solver_version: typing.Optional[str] = None,
+    worker_group: typing.Optional[str] = None,
+    simulation_type: str = "tidy3d",
+    parent_tasks: typing.Optional[list[str]] = None,
+    local_gradient: bool = LOCAL_GRADIENT,
+    max_num_adjoint_per_fwd: int = MAX_NUM_ADJOINT_PER_FWD,
+    reduce_simulation: typing.Literal["auto", True, False] = "auto",
+    pay_type: typing.Union[PayType, str] = PayType.AUTO,
+    priority: typing.Optional[int] = None,
+    max_workers: typing.Optional[int] = None,
+    lazy: typing.Optional[bool] = None,
+) -> RunOutput:
+    """
+    Submit one or many simulations and return results in the same container shape.
+
+    This is a convenience wrapper around the autograd runners that accepts a single
+    :class:`WorkflowType` **or** an arbitrarily nested container of simulations
+    (`list`, `tuple`, or `dict` values). Internally, all simulations are collected,
+    deduplicated by object hash, executed either synchronously (single) or
+    asynchronously (batch), and the returned data objects are reassembled to mirror
+    the input structure.
+
+    **Path behavior**
+      - **Single simulation:** results are downloaded to ``f"{path}.hdf5"``.
+      - **Multiple simulations:** ``path`` is treated as a **directory**, and each
+        task will write its own results file inside that directory.
+
+    **Lazy loading**
+      - If ``lazy`` is *not* specified: single runs default to ``False`` (eager load);
+        batch runs default to ``True`` (proxy objects that load on first access).
+
+    Parameters
+    ----------
+    simulation : Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`] | list | tuple | dict
+        A simulation or a container whose leaves are simulations.
+        Supported containers are ``list``, ``tuple``, and ``dict`` (values only).
+        Dict **keys must not** be simulations.
+    task_name : Optional[str], default None
+        Optional name for a single run. Prefixed for multiple runs.
+    folder_name : str = "default"
+        Folder shown on the web UI.
+    path : Optional[str] = None
+        Output path. Interpreted as a file path for single simulations and a directory for multiple simulations.
+        Defaults are "simulation.hdf5" (single simulation) and the current directory (multiple simulations).
+    callback_url : Optional[str] = None
+        Optional HTTP PUT endpoint to receive completion events.
+    verbose : bool = True
+        If ``True``, print status and progress; otherwise run quietly.
+    progress_callback_upload : Optional[Callable[[float], None]] = None
+        Callback invoked with byte counts during upload (single-run path only).
+    progress_callback_download : Optional[Callable[[float], None]] = None
+        Callback invoked with byte counts during download (single-run path only).
+    solver_version : Optional[str] = None
+        Target solver version.
+    worker_group : Optional[str] = None
+        Worker group to target.
+    simulation_type : str = "tidy3d"
+        Simulation type label passed through to the runners.
+    parent_tasks : Optional[List[str]] = None
+        Parent task IDs, if any.
+    local_gradient : bool = ``LOCAL_GRADIENT``
+        Compute gradients locally (more downloads; useful for experimental features).
+    max_num_adjoint_per_fwd : int = ``MAX_NUM_ADJOINT_PER_FWD``
+        Maximum number of adjoint simulations allowed per forward run.
+    reduce_simulation : {"auto", True, False} = "auto"
+        Whether to reduce structures to the simulation domain (mode solver only).
+    pay_type : Union[PayType, str] = PayType.AUTO
+        Payment method selection.
+    priority : Optional[int] = None
+        Queue priority for vGPU (1 = lowest, 10 = highest).
+    max_workers : Optional[int] = None
+        Maximum parallel submissions for batch runs. ``None`` submits all at once.
+    lazy : Optional[bool] = None
+        Whether to load the actual data (``lazy=False``) or return a proxy that loads
+        the data when accessed (``lazy=True``).
+
+    Returns
+    -------
+    RunOutput
+        A data object (or nested container of data objects) matching the input
+        container shape. Leaves are instances of the corresponding
+        :class:`WorkflowDataType`.
+
+    Notes
+    -----
+    - Simulations are indexed by ``hash(sim)``. If the *same object* appears multiple
+      times in the input, it is executed once and its data is reused at all positions.
+      The *last* occurrence wins if duplicates with the same hash are encountered.
+    - For each simulation, a mode-solver compatibility patch is applied so that
+      the returned data exposes expected convenience attributes.
+    - ``progress_callback_*`` are only used in the single-run code path.
+
+    Raises
+    ------
+    ValueError
+        If no simulations are found in ``simulation``.
+    TypeError
+        If an unsupported container element is encountered, or if a dict key is a
+        simulation object.
+
+    Examples
+    --------
+        Single run (eager by default)::
+
+        .. code-block:: python
+
+            sim_data = run(sim, task_name="wg_bend", path="out/bend")
+            # writes: "out/bend.hdf5"
+
+        Batch run with nested structure (lazy by default)::
+
+        .. code-block:: python
+
+            sims = {
+                "coarse": [sim_a, sim_b],
+                "fine": sim_c,
+            }
+            data = run(sims, path="out/batch_dir", max_workers=4)
+
+            # 'data' mirrors 'sims' structure:
+            # data["coarse"][0] -> data for sim_a, etc.
+
+    See Also
+    --------
+    tidy3d.web.api.autograd.autograd.run
+        Underlying autograd single-run implementation.
+    tidy3d.web.api.autograd.autograd.run_async
+        Underlying autograd batch submission implementation.
+    """
+    h2sim: dict[str, WorkflowType] = _collect_by_hash(simulation)
+    if not h2sim:
+        raise ValueError("No simulation data found in simulation input.")
+
+    key_prefix = ""
+    if len(h2sim) == 1:
+        path = path if path is not None else DEFAULT_DATA_PATH
+        h, sim = next(iter(h2sim.items()))
+        data = {
+            h: run_autograd(
+                simulation=sim,
+                task_name=task_name,
+                folder_name=folder_name,
+                path=path,
+                callback_url=callback_url,
+                verbose=verbose,
+                progress_callback_upload=progress_callback_upload,
+                progress_callback_download=progress_callback_download,
+                solver_version=solver_version,
+                worker_group=worker_group,
+                simulation_type=simulation_type,
+                parent_tasks=parent_tasks,
+                local_gradient=local_gradient,
+                max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
+                reduce_simulation=reduce_simulation,
+                pay_type=pay_type,
+                priority=priority,
+                lazy=lazy if lazy is not None else False,
+            )
+        }
+    else:
+        key_prefix = f"{task_name}_" if task_name else ""
+        sims = {f"{key_prefix}{h}": s for h, s in h2sim.items()}
+        path = path if path is not None else DEFAULT_DATA_DIR
+        data = run_async(
+            simulations=sims,
+            folder_name=folder_name,
+            path_dir=path,
+            callback_url=callback_url,
+            num_workers=max_workers,
+            verbose=verbose,
+            simulation_type=simulation_type,
+            solver_version=solver_version,
+            parent_tasks=parent_tasks,
+            local_gradient=local_gradient,
+            max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
+            reduce_simulation=reduce_simulation,
+            pay_type=pay_type,
+            priority=priority,
+            lazy=lazy if lazy is not None else True,
+        )
+
+    h2data: dict[str, WorkflowDataType] = {}
+    for k, sim_data in data.items():
+        h = k[len(key_prefix) :] if key_prefix else k
+        h2data[h] = sim_data
+
+    return _reconstruct_by_hash(simulation, h2data)

--- a/tidy3d/web/api/states.py
+++ b/tidy3d/web/api/states.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+PRE_ERROR_STATES = {
+    "aborting",
+}
+
+ERROR_STATES = {
+    "validate_fail",
+    "error",
+    "errored",
+    "diverge",
+    "diverged",
+    "blocked",
+    "run_failed",
+    "aborted",
+    "deleted",
+}
+
+PRE_VALIDATE_STATES = {
+    "draft",
+    "queued",
+    "queued_solver",
+    "preprocess",
+    "validating",
+    "validate",
+}
+
+POST_RUN_STATES = {
+    "postprocess",
+    "run_success",
+}
+
+COMPLETED_STATES = {"visualize", "success", "completed", "processed"}
+
+END_STATES = ERROR_STATES | COMPLETED_STATES
+
+POST_VALIDATE_STATES = {
+    "validate_success",
+    "validate_warn",
+}
+
+RUNNING_STATES = (
+    PRE_VALIDATE_STATES | POST_VALIDATE_STATES | {"running"} | POST_RUN_STATES | COMPLETED_STATES
+)
+
+ALL_POST_VALIDATE_STATES = POST_VALIDATE_STATES | {"running"} | POST_RUN_STATES | COMPLETED_STATES
+
+VALID_PROGRESS_STATES = RUNNING_STATES | PRE_ERROR_STATES
+
+ALL_STATES = VALID_PROGRESS_STATES | ERROR_STATES
+
+
+PROGRESSION_ORDER = (
+    "draft",
+    "queued",
+    "queued_solver",
+    "preprocess",
+    "validating",
+    "validate",
+    "validate_success",
+    "validate_warn",
+    "running",
+    "postprocess",
+    "run_success",
+    "visualize",
+    "success",
+    "completed",
+)
+
+MAX_STEPS = len(PROGRESSION_ORDER) - 1
+COMPLETED_PERCENT = 100
+
+
+STATE_PROGRESS_PERCENTAGE = {
+    # --- Progression States ---
+    "draft": round((0 / MAX_STEPS) * COMPLETED_PERCENT),  # 0%
+    "queued": round((1 / MAX_STEPS) * COMPLETED_PERCENT),  # 8%
+    "queued_solver": round((2 / MAX_STEPS) * COMPLETED_PERCENT),  # 15%
+    "preprocess": round((3 / MAX_STEPS) * COMPLETED_PERCENT),  # 23%
+    "validating": round((4 / MAX_STEPS) * COMPLETED_PERCENT),  # 31%
+    "validate": round((5 / MAX_STEPS) * COMPLETED_PERCENT),  # 38%
+    "validate_success": round((6 / MAX_STEPS) * COMPLETED_PERCENT),  # 46%
+    "validate_warn": round((7 / MAX_STEPS) * COMPLETED_PERCENT),  # 54%
+    "running": round((8 / MAX_STEPS) * COMPLETED_PERCENT),  # 62%
+    "run_success": round((9 / MAX_STEPS) * COMPLETED_PERCENT),  # 69%
+    "postprocess": round((10 / MAX_STEPS) * COMPLETED_PERCENT),  # 77%
+    "visualize": round((11 / MAX_STEPS) * COMPLETED_PERCENT),  # 85%
+    "success": COMPLETED_PERCENT,  # 100%
+    "completed": COMPLETED_PERCENT,  # 100%
+    # --- Error States ---
+    # All error states map to 0%
+    "validate_fail": 0,
+    "error": 0,
+    "errored": 0,
+    "diverge": 0,
+    "diverged": 0,
+    "blocked": 0,
+    "run_failed": 0,
+    "aborted": 0,
+    "deleted": 0,
+}

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -18,6 +18,13 @@ from tidy3d.components.types.workflow import WorkflowDataType, WorkflowType
 from tidy3d.exceptions import WebError
 from tidy3d.log import get_logging_console, log
 from tidy3d.plugins.smatrix.component_modelers.terminal import TerminalComponentModeler
+from tidy3d.web.api.states import (
+    ALL_POST_VALIDATE_STATES,
+    END_STATES,
+    ERROR_STATES,
+    POST_VALIDATE_STATES,
+    STATE_PROGRESS_PERCENTAGE,
+)
 from tidy3d.web.core.account import Account
 from tidy3d.web.core.constants import (
     CM_DATA_HDF5_GZ,
@@ -33,7 +40,7 @@ from tidy3d.web.core.environment import Env
 from tidy3d.web.core.exceptions import WebNotFoundError
 from tidy3d.web.core.http_util import get_version as _get_protocol_version
 from tidy3d.web.core.http_util import http
-from tidy3d.web.core.task_core import BatchTask, Folder, SimulationTask
+from tidy3d.web.core.task_core import BatchDetail, BatchTask, Folder, SimulationTask
 from tidy3d.web.core.task_info import ChargeType, TaskInfo
 from tidy3d.web.core.types import PayType
 
@@ -62,25 +69,6 @@ SOLVER_NAME = {
     "HEAT_CHARGE": "HeatCharge",
     "VOLUME_MESH": "VolumeMesher",
 }
-
-TERMINAL_ERRORS = {
-    "validate_fail",
-    "error",
-    "diverged",
-    "blocked",
-    "aborting",
-    "aborted",
-}
-
-RUN_STATUSES = [
-    "draft",
-    "preprocess",
-    "validating",
-    "validate",
-    "running",
-    "postprocess",
-    "success",
-]
 
 
 def _get_url(task_id: str) -> str:
@@ -139,6 +127,7 @@ def run(
     reduce_simulation: Literal["auto", True, False] = "auto",
     pay_type: Union[PayType, str] = PayType.AUTO,
     priority: Optional[int] = None,
+    lazy: bool = False,
 ) -> WorkflowDataType:
     """
     Submits a :class:`.Simulation` to server, starts running, monitors progress, downloads,
@@ -176,6 +165,10 @@ def run(
     priority: int = None
         Priority of the simulation in the Virtual GPU (vGPU) queue (1 = lowest, 10 = highest).
         It affects only simulations from vGPU licenses and does not impact simulations using FlexCredits.
+    lazy : bool = False
+        Whether to load the actual data (``lazy=False``) or return a proxy that loads
+        the data when accessed (``lazy=True``).
+
     Returns
     -------
     Union[:class:`.SimulationData`, :class:`.HeatSimulationData`, :class:`.EMESimulationData`]
@@ -242,7 +235,11 @@ def run(
     )
     monitor(task_id, verbose=verbose)
     data = load(
-        task_id=task_id, path=path, verbose=verbose, progress_callback=progress_callback_download
+        task_id=task_id,
+        path=path,
+        verbose=verbose,
+        progress_callback=progress_callback_download,
+        lazy=lazy,
     )
     if isinstance(simulation, ModeSolver):
         simulation._patch_data(data=data)
@@ -473,24 +470,39 @@ def get_reduced_simulation(simulation, reduce_simulation):
 
 
 @wait_for_connection
-def get_info(task_id: TaskId, verbose: bool = True) -> TaskInfo:
-    """Return information about a task.
+def get_info(task_id: TaskId, verbose: bool = True) -> TaskInfo | BatchDetail:
+    """Return information about a simulation task or a modeler batch.
+
+    This function fetches details for a given task ID, automatically
+    distinguishing between a standard simulation task and a modeler batch.
 
     Parameters
     ----------
-    task_id : str
-        Unique identifier of task on server.  Returned by :meth:`upload`.
-    verbose : bool = True
-        If ``True``, will print progressbars and status, otherwise, will run silently.
+    task_id : TaskId
+        The unique identifier for the task or batch.
+    verbose : bool, optional
+        If ``True`` (default), display progress bars and status updates.
+        If ``False``, the function runs silently.
+
     Returns
     -------
-    :class:`TaskInfo`
-        Object containing information about status, size, credits of task.
+    TaskInfo | BatchDetail
+        A ``TaskInfo`` object for a standard simulation task, or a
+        ``BatchDetail`` object for a modeler batch.
+
+    Raises
+    ------
+    ValueError
+        If no task is found for the given ``task_id``.
     """
-    task = SimulationTask.get(task_id, verbose)
-    if not task:
-        raise ValueError("Task not found.")
-    return TaskInfo(**{"taskId": task.task_id, "taskType": task.task_type, **task.dict()})
+    if _is_modeler_batch(task_id):
+        batch = BatchTask(task_id)
+        return batch.detail(batch_type="RF_SWEEP")
+    else:
+        task = SimulationTask.get(task_id, verbose)
+        if not task:
+            raise ValueError("Task not found.")
+        return TaskInfo(**{"taskId": task.task_id, "taskType": task.task_type, **task.dict()})
 
 
 @wait_for_connection
@@ -534,15 +546,16 @@ def start(
         detail = batch.wait_for_validate(batch_type="RF_SWEEP")
         status = detail.totalStatus
         status_str = status.value
-        if status_str in ("validate_success", "validate_warn"):
-            if verbose:
-                console.log("Component modeler batch validation has been successful.")
-        if status_str not in ("validate_success", "validate_warn"):
+        if status_str in POST_VALIDATE_STATES:
+            pass
+        elif status_str not in POST_VALIDATE_STATES:
             raise WebError(f"Batch task {task_id} is blocked: {status_str}")
         # Submit batch to start runs after validation
         batch.submit(
             solver_version=solver_version, batch_type="RF_SWEEP", worker_group=worker_group
         )
+        if verbose:
+            console.log(f"Component Modeler '{task_id}' validation succeeded. Starting to solve...")
         return
 
     if priority is not None and (priority < 1 or priority > 10):
@@ -588,24 +601,41 @@ def get_status(task_id) -> str:
     task_id : str
         Unique identifier of task on server.  Returned by :meth:`upload`.
     """
-    task_info = get_info(task_id)
-    status = task_info.status
-    if status == "visualize":
-        return "success"
-    if status == "error":
-        try:
-            # Try to obtain the error message
-            task = SimulationTask(taskId=task_id)
-            with tempfile.NamedTemporaryFile(suffix=".json") as tmp_file:
-                task.get_error_json(to_file=tmp_file.name)
-                with open(tmp_file.name) as f:
-                    error_content = json.load(f)
-                    error_msg = error_content["msg"]
-        except Exception:
-            # If the error message could not be obtained, raise a generic error message
-            error_msg = "Error message could not be obtained, please contact customer support."
+    if _is_modeler_batch(task_id):
+        # split (modeler-specific)
+        batch = BatchTask(task_id)
+        detail = batch.detail(batch_type="RF_SWEEP")
+        status = detail.totalStatus
+        if status == "visualize":
+            return "success"
+        if status in ERROR_STATES:
+            try:
+                # TODO Try to obtain the error message
+                pass
+            except Exception:
+                # If the error message could not be obtained, raise a generic error message
+                error_msg = "Error message could not be obtained, please contact customer support."
 
-        raise WebError(f"Error running task {task_id}! {error_msg}")
+            raise WebError(f"Error running task {task_id}! {error_msg}")
+    else:
+        task_info = get_info(task_id)
+        status = task_info.status
+        if status == "visualize":
+            return "success"
+        if status in ERROR_STATES:
+            try:
+                # Try to obtain the error message
+                task = SimulationTask(taskId=task_id)
+                with tempfile.NamedTemporaryFile(suffix=".json") as tmp_file:
+                    task.get_error_json(to_file=tmp_file.name)
+                    with open(tmp_file.name) as f:
+                        error_content = json.load(f)
+                        error_msg = error_content["msg"]
+            except Exception:
+                # If the error message could not be obtained, raise a generic error message
+                error_msg = "Error message could not be obtained, please contact customer support."
+
+            raise WebError(f"Error running task {task_id}! {error_msg}")
     return status
 
 
@@ -647,8 +677,6 @@ def monitor(task_id: TaskId, verbose: bool = True, worker_group: Optional[str] =
 
     task_type = task_info.taskType
 
-    break_statuses = ("success", "error", "diverged", "deleted", "draft", "abort", "aborted")
-
     def get_estimated_cost() -> float:
         """Get estimated cost, if None, is not ready."""
         task_info = get_info(task_id)
@@ -672,7 +700,7 @@ def monitor(task_id: TaskId, verbose: bool = True, worker_group: Optional[str] =
     def monitor_preprocess() -> None:
         """Periodically check the status."""
         status = get_status(task_id)
-        while status not in break_statuses and status != "running":
+        while status not in END_STATES and status != "running":
             new_status = get_status(task_id)
             if new_status != status:
                 status = new_status
@@ -686,7 +714,7 @@ def monitor(task_id: TaskId, verbose: bool = True, worker_group: Optional[str] =
         console.log(f"status = {status}")
 
     # already done
-    if status in break_statuses:
+    if status in END_STATES:
         return
 
     # preprocessing
@@ -768,7 +796,7 @@ def monitor(task_id: TaskId, verbose: bool = True, worker_group: Optional[str] =
             console.log(f"status = {status}")
 
         with console.status(f"[bold green]Finishing '{task_name}'...", spinner="runner"):
-            while status not in break_statuses:
+            while status not in END_STATES:
                 new_status = get_status(task_id)
                 if new_status != status:
                     status = new_status
@@ -779,7 +807,7 @@ def monitor(task_id: TaskId, verbose: bool = True, worker_group: Optional[str] =
             url = _get_url(task_id)
             console.log(f"View simulation result at [blue underline][link={url}]'{url}'[/link].")
     else:
-        while get_status(task_id) not in break_statuses:
+        while get_status(task_id) not in END_STATES:
             time.sleep(REFRESH_TIME)
 
 
@@ -873,7 +901,7 @@ def download(
                 post_succ = resp.postprocessSuccess or 0
                 status = resp.totalStatus
                 status_str = status.value
-                if status_str in {"error", "diverged", "blocked", "aborted", "aborting"}:
+                if status_str in ERROR_STATES:
                     raise WebError(
                         f"Batch task {task_id} failed during postprocess: {status_str}"
                     ) from None
@@ -1028,9 +1056,12 @@ def load(
         Object containing simulation data.
     """
     # For component modeler batches, default to a clearer filename if the default was used.
-    if _is_modeler_batch(task_id) and os.path.basename(path) == "simulation_data.hdf5":
+    if _is_modeler_batch(task_id):
         base_dir = os.path.dirname(path) or "."
-        path = os.path.join(base_dir, "cm_data.hdf5")
+        if os.path.basename(path) == "simulation_data.hdf5":
+            path = os.path.join(base_dir, "cm_data.hdf5")
+        elif os.path.basename(path) == "simulation_data.hdf5.gz":
+            path = os.path.join(base_dir, "cm_data.hdf5.gz")
 
     if not os.path.exists(path) or replace_existing:
         download(task_id=task_id, path=path, verbose=verbose, progress_callback=progress_callback)
@@ -1057,7 +1088,7 @@ def _monitor_modeler_batch(
 
     def _status_to_stage(status: str) -> tuple[str, int]:
         s = (status or "").lower()
-        # Map a broader set of statuses to monotonic stages for progress bars
+        # Map a broader set of states to monotonic stages for progress bars
         if s in ("draft", "created"):
             return ("draft", 0)
         if s in ("queue", "queued"):
@@ -1074,7 +1105,7 @@ def _monitor_modeler_batch(
             return ("postprocess", 5)
         if s in ("run_success", "success"):
             return ("success", 6)
-        # Unknown statuses map to earliest stage to avoid showing 100% prematurely
+        # Unknown states map to earliest stage to avoid showing 100% prematurely
         return (s or "unknown", 0)
 
     detail = _batch_detail(batch_id)
@@ -1095,19 +1126,21 @@ def _monitor_modeler_batch(
             s = d.totalStatus.value
             total = d.totalTask or 0
             r = d.runSuccess or 0
-            if s in TERMINAL_ERRORS:
+            if s in ERROR_STATES:
                 raise WebError(f"Batch {batch_id} terminated: {s}")
-            if total and r >= total:
+            # Updated break condition for robustness
+            if s in ("run_success", "success") or (total and r >= total):
                 break
             time.sleep(REFRESH_TIME)
-        # Postprocess phase
-        BatchTask(batch_id).postprocess(batch_type="RF_SWEEP", worker_group=worker_group)
+
+        postprocess_start(batch_id, verbose=False, worker_group=worker_group)
+
         while True:
             d = _batch_detail(batch_id)
             postprocess_status = d.postprocessStatus
             if postprocess_status == "success":
                 break
-            elif postprocess_status in TERMINAL_ERRORS:
+            elif postprocess_status in ERROR_STATES:
                 raise WebError(
                     f"Batch {batch_id} terminated. Please contact customer support and provide this Component Modeler batch ID: '{batch_id}'"
                 )
@@ -1140,8 +1173,8 @@ def _monitor_modeler_batch(
                         _, idx = _status_to_stage(tstatus)
                         pbar = progress.add_task(
                             f"  {name}",
-                            total=len(RUN_STATUSES) - 1,
-                            completed=min(idx, len(RUN_STATUSES) - 1),
+                            total=1.0,
+                            completed=STATE_PROGRESS_PERCENTAGE[tstatus] / 100,
                         )
                         task_bars[name] = pbar
 
@@ -1168,19 +1201,24 @@ def _monitor_modeler_batch(
                         continue
                     tstatus = (t.status or "draft").lower()
                     _, idx = _status_to_stage(tstatus)
-                    completed = min(idx, 6)
                     desc = f"  {tname} [{tstatus or 'draft'}]"
-                    progress.update(pbar, completed=completed, description=desc, refresh=False)
+                    progress.update(
+                        pbar,
+                        completed=STATE_PROGRESS_PERCENTAGE[tstatus] / 100,
+                        description=desc,
+                        refresh=False,
+                    )
 
-            if total and r >= total:
+            # Updated break condition for robustness
+            if status in ("run_success", "success") or (total and r >= total):
                 break
-            if status in TERMINAL_ERRORS:
+            if status in ERROR_STATES:
                 raise WebError(f"Batch {batch_id} terminated: {status}")
             progress.refresh()
             time.sleep(REFRESH_TIME)
 
-        # Phase: Postprocess
-        BatchTask(batch_id).postprocess(batch_type="RF_SWEEP", worker_group=worker_group)
+        postprocess_start(batch_id, verbose=True, worker_group=worker_group)
+
         p_post = progress.add_task("Postprocess", total=1.0)
         while True:
             detail = _batch_detail(batch_id)
@@ -1195,7 +1233,7 @@ def _monitor_modeler_batch(
                 progress.update(p_post, completed=0.33)
             elif postprocess_status == "running":
                 progress.update(p_post, completed=0.55)
-            elif postprocess_status in TERMINAL_ERRORS:
+            elif postprocess_status in ERROR_STATES:
                 raise WebError(
                     f"Batch {batch_id} terminated. Please contact customer support and provide this Component Modeler batch ID: '{batch_id}'"
                 )
@@ -1358,37 +1396,34 @@ def estimate_cost(
         d = _batch_detail(task_id)
         status = d.totalStatus.value
 
-        # Wait for a termination status
-        while status not in ["validate_success", "success", "error", "failed"]:
-            time.sleep(REFRESH_TIME)
-            d = _batch_detail(task_id)
-            status = d.totalStatus.value
+        if status in ALL_POST_VALIDATE_STATES:
+            est_flex_unit = _batch_detail(task_id).estFlexUnit
+            if verbose:
+                console.log(
+                    f"Maximum FlexCredit cost: {est_flex_unit:1.3f}. Minimum cost depends on "
+                    "task execution details. Use 'web.real_cost(task_id)' to get the billed FlexCredit "
+                    "cost after a simulation run."
+                )
+            return est_flex_unit
 
-            if status in ["validate_success", "success"]:
-                est_flex_unit = _batch_detail(task_id).estFlexUnit
-                if verbose:
-                    console.log(
-                        f"Maximum FlexCredit cost: {est_flex_unit:1.3f}. Minimum cost depends on "
-                        "task execution details. Use 'web.real_cost(task_id)' to get the billed FlexCredit "
-                        "cost after a simulation run."
+        elif status in ERROR_STATES:
+            log.error(f"The ComponentModeler '{task_id}' has failed: {status}")
+
+            if status == "validate_fail":
+                assert d.validateErrors is not None
+                for key, error in d.validateErrors.items():
+                    # I don't like this ideally but would like to control the endpoint to make this better
+                    error_dict = json.loads(error)
+                    validation_error = error_dict["validation_error"]
+                    log.error(
+                        f"Subtask '{key}' has failed to validate:"
+                        f" \n {validation_error} \n "
+                        f"Fix your component modeler configuration. "
+                        f"Generate subtask simulations locally using `ComponentModelerType.sim_dict`."
                     )
-                return est_flex_unit
-            elif status in TERMINAL_ERRORS:
-                log.error(f"The ComponentModeler '{task_id}' has failed: {status}")
 
-                if status == "validate_fail":
-                    assert d.validateErrors is not None
-                    for key, error in d.validateErrors.items():
-                        # I don't like this ideally but would like to control the endpoint to make this better
-                        error_dict = json.loads(error)
-                        validation_error = error_dict["validation_error"]
-                        log.error(
-                            f"Subtask '{key}' has failed to validate:"
-                            f" \n {validation_error} \n "
-                            f"Fix your component modeler configuration. "
-                            f"Generate subtask simulations locally using `ComponentModelerType.sim_dict`."
-                        )
-                break
+        raise WebError("Could not get estimated cost!")
+
     else:
         task = SimulationTask.get(task_id)
 
@@ -1400,12 +1435,12 @@ def estimate_cost(
         status = task_info.metadataStatus
 
         # Wait for a termination status
-        while status not in ["processed", "success", "error", "failed"]:
+        while status not in ALL_POST_VALIDATE_STATES:
             time.sleep(REFRESH_TIME)
             task_info = get_info(task_id)
             status = task_info.metadataStatus
 
-        if status in ["processed", "success"]:
+        if status in ALL_POST_VALIDATE_STATES:
             if verbose:
                 console.log(
                     f"Estimated FlexCredit cost: {task_info.estFlexUnit:1.3f}. Minimum cost depends on "
@@ -1421,6 +1456,9 @@ def estimate_cost(
                         f"  {fc_post:1.3f} FlexCredit of the total cost from post-processing."
                     )
             return task_info.estFlexUnit
+
+        elif status in ERROR_STATES:
+            log.error(f"The task '{task_id}' has failed: {status}")
 
         # Something went wrong
         raise WebError("Could not get estimated cost!")
@@ -1572,6 +1610,49 @@ def account(verbose=True) -> Account:
         console.log(message)
 
     return account_info
+
+
+@wait_for_connection
+def postprocess_start(
+    batch_id: str,
+    verbose: bool = True,
+    worker_group: Optional[str] = None,
+) -> None:
+    """
+    Checks if a batch run is complete and starts the postprocess phase.
+
+    This function does not wait for postprocessing to finish.
+    """
+    console = get_logging_console() if verbose else None
+    if _is_modeler_batch(batch_id):
+        # Perform a single check on the run phase status
+        detail = _batch_detail(batch_id)
+        status = detail.totalStatus.value
+        total_tasks = detail.totalTask or 0
+        successful_runs = detail.runSuccess or 0
+
+        if status in ERROR_STATES:
+            raise WebError(f"Batch '{batch_id}' terminated with error status: {status}")
+
+        # Check if the run phase is complete before proceeding
+        is_run_complete = status in ("run_success", "success") or (
+            total_tasks > 0 and successful_runs >= total_tasks
+        )
+
+        if not is_run_complete:
+            if console:
+                console.log(
+                    f"Batch '{batch_id}' run phase is not yet complete (Status: {status}). "
+                    f"Cannot start postprocessing."
+                )
+            return  # Exit if the run is not done
+        BatchTask(batch_id).postprocess(batch_type="RF_SWEEP", worker_group=worker_group)
+        return
+    else:
+        raise WebError(
+            f"Batch ID '{batch_id}' is not a component modeler batch job. "
+            "'postprocess_start' is only applicable to those classes."
+        )
 
 
 @wait_for_connection

--- a/tidy3d/web/core/file_util.py
+++ b/tidy3d/web/core/file_util.py
@@ -42,10 +42,11 @@ def read_simulation_from_hdf5_gz(file_name: str) -> str:
     """read simulation str from hdf5.gz"""
 
     hdf5_file, hdf5_file_path = tempfile.mkstemp(".hdf5")
-    os.close(hdf5_file_path)
+    os.close(hdf5_file)
     try:
         extract_gzip_file(file_name, hdf5_file_path)
-        json_str = read_simulation_from_hdf5(file_name)
+        # Pass the uncompressed temporary file path to the reader
+        json_str = read_simulation_from_hdf5(hdf5_file_path)
     finally:
         os.unlink(hdf5_file_path)
     return json_str


### PR DESCRIPTION
**Goal**
Extend web.run (and only the surfaces that already wrap it - autograd entry points, CLI helpers, Job/Batch, run_async) so the API accepts arbitrary Python containers and returns SimulationData lazily in the same structure, relying on the lazy-load.

**Implementation**
- web.run now delegates to legacy run for single runs and to run_async for multiple runs
- input is parsed for simulation type objects, flattened into a dict with sim hashes as keys, used as batch in run_async and then rearranged into the input structure
- path is interpreted as dir for multiple runs and filename for single runs

**Open questions:**
If same simulation is submitted multiple times, the sim_data objects of these simulations are the same - should we make copies?

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-16 19:47:25 UTC

### Greptile Summary

This PR implements a major enhancement to the `web.run()` API, making it container-aware so it can accept arbitrary Python containers (lists, tuples, dictionaries) containing simulation objects and return results in the same nested structure. The implementation introduces a unified interface that maintains backward compatibility while adding powerful batch processing capabilities.

The core change is a new `tidy3d/web/api/run.py` module that serves as a container-aware wrapper. This wrapper intelligently delegates to the existing legacy `run` function for single simulations and to `run_async` for multiple simulations. The implementation uses hash-based deduplication to avoid running identical simulations multiple times, optimizing performance when the same simulation appears in different parts of the input structure.

A new `lazy` parameter has been added throughout the web API stack, allowing users to control whether simulation data is loaded immediately (eager) or deferred until first access (lazy). The lazy loading behavior defaults to `False` for single simulations (maintaining existing behavior) and `True` for batch runs (more efficient for large operations).

The changes extend across multiple layers including the main web interface, autograd entry points, container classes (Job, Batch, BatchData), and asynchronous operations. Path parameter interpretation has also been enhanced to treat paths as directories for multiple runs and filenames for single runs, providing intuitive behavior based on input type.

### Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/web/api/run.py` | 3/5 | New container-aware wrapper with hash-based deduplication but contains debugging print statements that must be removed |
| `tidy3d/web/api/container.py` | 4/5 | Added lazy loading support to Job, Batch, and BatchData classes with proper parameter propagation |
| `tests/test_web/test_webapi.py` | 4/5 | Added comprehensive tests for container-aware functionality with good coverage |
| `tidy3d/web/api/webapi.py` | 5/5 | Added lazy parameter to run function with proper documentation and implementation |
| `tidy3d/web/api/asynchronous.py` | 5/5 | Added lazy parameter support to run_async function with proper forwarding |
| `tidy3d/web/api/autograd/autograd.py` | 5/5 | Added lazy parameter support to autograd run functions maintaining compatibility |
| `tidy3d/web/api/autograd/engine.py` | 5/5 | Added lazy parameter to job_fields for autograd compatibility |
| `tidy3d/web/__init__.py` | 5/5 | Updated imports to use new container-aware run implementation |
| `tests/test_web/test_webapi_mode.py` | 5/5 | Updated imports to reflect new run module location |
| `CHANGELOG.md` | 5/5 | Added changelog entry documenting the new container-aware web.run API |
| `tidy3d/plugins/smatrix/run.py` |4/5 | Refactored to use new container-aware run_async API with proper separation of concerns |
| `tidy3d/packaging.py` | 5/5 | Minor cleanup of error message text for better user experience |

</details>

### Confidence score: 3/5

- This PR introduces significant functionality but contains debugging code that must be removed before merging
- Score reflects the presence of print statements and complex container traversal logic requiring careful review
- Pay close attention to `tidy3d/web/api/run.py` which contains debugging print statements that violate coding standards

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant run as "run()"
    participant _collect_by_hash as "_collect_by_hash()"
    participant run_autograd as "run_autograd()"
    participant run_async as "run_async()" 
    participant _reconstruct_by_hash as "_reconstruct_by_hash()"

    User->>run: "call run() with simulation container"
    run->>_collect_by_hash: "extract simulations by hash"
    _collect_by_hash-->>run: "return {hash: sim} mapping"
    
    alt Single simulation
        run->>run_autograd: "run single simulation"
        run_autograd-->>run: "return simulation data"
    else Multiple simulations
        run->>run_async: "run batch of simulations"  
        run_async-->>run: "return batch data dict"
    end
    
    run->>_reconstruct_by_hash: "rebuild container structure"
    _reconstruct_by_hash-->>run: "return structured results"
    run-->>User: "return results in original container shape"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Remove temporary debugging code (print() calls), commented-out code, and other workarounds before fi... ([source](https://app.greptile.com/review/custom-context?memory=f6a669d8-0060-4f11-9cac-10ac7ee749ea))

<!-- /greptile_comment -->