### PR TITLE
feat(microwave): tidy3d_microwave and BroadbandPulse feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added current integral specification classes: `AxisAlignedCurrentIntegralSpec`, `CompositeCurrentIntegralSpec`, and `Custom2DCurrentIntegralSpec`.
 - `sort_spec` in `ModeSpec` allows for fine-grained filtering and sorting of modes. This also deprecates `filter_pol`. The equivalent usage for example to `filter_pol="te"` is `sort_spec=ModeSortSpec(filter_key="TE_polarization", filter_reference=0.5)`. `ModeSpec.track_freq` has also been deprecated and moved to `ModeSortSpec.track_freq`.
 - Added `custom_source_time` parameter to `ComponentModeler` classes (`ModalComponentModeler` and `TerminalComponentModeler`), allowing specification of custom source time dependence.
+- Added `tidy3d-microwave` package for enabling advanced microwave device simulation features.
+- Introduced `BroadbandPulse` for exciting simulations across a wide frequency spectrum.
 
 ### Changed
 - Improved performance of antenna metrics calculation by utilizing cached wave amplitude calculations instead of recomputing wave amplitudes for each port excitation in the `TerminalComponentModelerData`.

--- a/docs/api/sources.rst
+++ b/docs/api/sources.rst
@@ -34,6 +34,7 @@ Source Time Dependence
 
    tidy3d.GaussianPulse
    tidy3d.ContinuousWave
+   tidy3d.BroadbandPulse
    tidy3d.SourceTime
    tidy3d.CustomSourceTime
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ devsim = { version = "*", optional = true }
 cma = { version = "*", optional = true }
 openpyxl = { version = "*", optional = true }
 # tidy3d-extras = { version = "2.10.0rc3", optional = true }
+# tidy3d-microwave = { version = "2.10.0rc3", optional = true }
 
 [tool.poetry.extras]
 dev = [
@@ -214,6 +215,7 @@ heatcharge = ["trimesh", "vtk", "devsim"]
 pytorch = ["torch"]
 design = ["bayesian-optimization", "pygad", "pyswarms"]
 # extras = ["tidy3d-extras"]
+# microwave = ["tidy3d-microwave"]
 
 [tool.poetry.scripts]
 tidy3d = "tidy3d.web.cli:tidy3d_cli"

--- a/tests/test_components/test_packaging.py
+++ b/tests/test_components/test_packaging.py
@@ -6,7 +6,9 @@ from tidy3d.packaging import (
     Tidy3dImportError,
     check_import,
     supports_local_subpixel,
+    supports_microwave,
     tidy3d_extras,
+    tidy3d_microwave,
     verify_packages_import,
 )
 
@@ -88,6 +90,25 @@ def test_tidy3d_extras():
             assert tidy3d_extras["mod"] is None
 
     get_eps()
+
+
+def test_tidy3d_microwave():
+    import importlib
+
+    has_tidy3d_microwave = importlib.util.find_spec("tidy3d_microwave") is not None
+    print(f"has_tidy3d_microwave = {has_tidy3d_microwave}")
+
+    if has_tidy3d_microwave:
+
+        @supports_microwave
+        def get_pulse():
+            assert tidy3d_microwave["mod"] is not None
+            pulse = tidy3d_microwave["mod"].BroadbandPulse(fmin=0.1, fmax=10)
+            _ = pulse.frequency_range(2)
+
+        get_pulse()
+    else:
+        assert tidy3d_microwave["mod"] is None
 
 
 if __name__ == "__main__":

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -405,6 +405,7 @@ from .components.source.frame import (
 
 # sources
 from .components.source.time import (
+    BroadbandPulse,
     ContinuousWave,
     CustomSourceTime,
     GaussianPulse,
@@ -510,6 +511,7 @@ __all__ = [
     "Box",
     "BroadbandModeABCFitterParam",
     "BroadbandModeABCSpec",
+    "BroadbandPulse",
     "CaugheyThomasMobility",
     "CellDataArray",
     "ChargeConductorMedium",

--- a/tidy3d/components/source/time.py
+++ b/tidy3d/components/source/time.py
@@ -21,6 +21,7 @@ from tidy3d.components.viz import add_ax_if_none
 from tidy3d.constants import HERTZ
 from tidy3d.exceptions import ValidationError
 from tidy3d.log import log
+from tidy3d.packaging import supports_microwave, tidy3d_microwave
 
 # how many units of ``twidth`` from the ``offset`` until a gaussian pulse is considered "off"
 END_TIME_FACTOR_GAUSSIAN = 10
@@ -605,4 +606,67 @@ class CustomSourceTime(Pulse):
         return np.max(t_non_zero)
 
 
-SourceTimeType = Union[GaussianPulse, ContinuousWave, CustomSourceTime]
+class BroadbandPulse(SourceTime):
+    """A source time injecting significant energy in the entire custom frequency range."""
+
+    freq_range: FreqBound = pydantic.Field(
+        ...,
+        title="Frequency Range",
+        description="Frequency range where the pulse should have significant energy.",
+        units=HERTZ,
+    )
+    minimum_amplitude: float = pydantic.Field(
+        0.3,
+        title="Minimum Amplitude",
+        description="Minimum amplitude of the pulse relative to the peak amplitude in the frequency range.",
+        gt=0.05,
+        lt=0.5,
+    )
+    offset: float = pydantic.Field(
+        5.0,
+        title="Offset",
+        description="Time delay of the maximum value of the "
+        "pulse in units of 1 / (``2pi * fwidth``).",
+        ge=2.5,
+    )
+
+    @cached_property
+    @supports_microwave
+    def _source(self):
+        """Implementation of broadband pulse."""
+        return tidy3d_microwave["mod"].BroadbandPulse(
+            fmin=self.freq_range[0],
+            fmax=self.freq_range[1],
+            minRelAmp=self.minimum_amplitude,
+            amp=self.amplitude,
+            phase=self.phase,
+            offset=self.offset,
+        )
+
+    def end_time(self) -> float:
+        """Time after which the source is effectively turned off / close to zero amplitude."""
+        return self._source.end_time(END_TIME_FACTOR_GAUSSIAN)
+
+    def amp_time(self, time: float) -> complex:
+        """Complex-valued source amplitude as a function of time."""
+        return self._source.amp_time(time)
+
+    def amp_freq(self, freq: float) -> complex:
+        """Complex-valued source amplitude as a function of frequency."""
+        return self._source.amp_freq(freq)
+
+    def frequency_range_sigma(self, sigma: float = DEFAULT_SIGMA) -> FreqBound:
+        """Frequency range where the source amplitude is within ``exp(-sigma**2/2)`` of the peak amplitude."""
+        return self._source.frequency_range(sigma)
+
+    def frequency_range(self, num_fwidth: float = DEFAULT_SIGMA) -> FreqBound:
+        """Frequency range where the source amplitude is within ``exp(-sigma**2/2)`` of the peak amplitude."""
+        return self.frequency_range_sigma(num_fwidth)
+
+    @cached_property
+    def _freq0(self) -> float:
+        """Central frequency from frequency range."""
+        return np.mean(self.freq_range)
+
+
+SourceTimeType = Union[GaussianPulse, ContinuousWave, CustomSourceTime, BroadbandPulse]

--- a/tidy3d/packaging.py
+++ b/tidy3d/packaging.py
@@ -28,6 +28,8 @@ vtk = {
 
 tidy3d_extras = {"mod": None, "use_local_subpixel": None}
 
+tidy3d_microwave = {"mod": None}
+
 
 def check_import(module_name: str) -> bool:
     """
@@ -256,5 +258,49 @@ def disable_local_subpixel(fn):
             return fn(*args, **kwargs)
         finally:
             config.use_local_subpixel = use_local_subpixel
+
+    return _fn
+
+
+def supports_microwave(fn):
+    """When decorating a method, checks that 'tidy3d-microwave' is available."""
+
+    @functools.wraps(fn)
+    def _fn(*args, **kwargs):
+        # first try to import the module
+        if tidy3d_microwave["mod"] is None:
+            try:
+                import tidy3d_microwave as tidy3d_microwave_mod
+
+            except ImportError as exc:
+                tidy3d_microwave["mod"] = None
+                raise Tidy3dImportError(
+                    "The package 'tidy3d-microwave' is required for this "
+                    "operation. "
+                    "Please install the 'tidy3d-microwave' package using, for "
+                    "example, 'pip install tidy3d[microwave]'."
+                ) from exc
+
+            else:
+                version = tidy3d_microwave_mod.__version__
+
+                if version is None:
+                    tidy3d_microwave["mod"] = None
+                    raise Tidy3dImportError(
+                        "The package 'tidy3d-microwave' did not initialize correctly, "
+                        "likely due to an invalid API key."
+                    )
+
+                if version != __version__:
+                    log.warning(
+                        "The package 'tidy3d-microwave' is required for this "
+                        "operation. The version of 'tidy3d-microwave' should match "
+                        "the version of 'tidy3d'. You can install the correct "
+                        "version using 'pip install tidy3d[microwave]'."
+                    )
+
+                tidy3d_microwave["mod"] = tidy3d_microwave_mod
+
+        return fn(*args, **kwargs)
 
     return _fn

--- a/tidy3d/plugins/smatrix/ports/wave.py
+++ b/tidy3d/plugins/smatrix/ports/wave.py
@@ -108,6 +108,11 @@ class WavePort(AbstractTerminalPort, Box):
         description="Extrudes structures that intersect the wave port plane by a few grid cells when ``True``, improving mode injection accuracy.",
     )
 
+    num_freqs: int = pd.Field(
+        1,
+        title="Number of frequencies",
+    )
+
     def _mode_voltage_coefficients(self, mode_data: ModeData) -> FreqModeDataArray:
         """Calculates scaling coefficients to convert mode amplitudes
         to the total port voltage.
@@ -166,6 +171,7 @@ class WavePort(AbstractTerminalPort, Box):
             direction=self.direction,
             name=self.name,
             frame=self.frame,
+            num_freqs=self.num_freqs,
         )
 
     def to_monitors(


### PR DESCRIPTION
- [ ] add tests

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-09 23:26:28 UTC

### Greptile Summary

This PR introduces support for the `tidy3d-microwave` plugin and adds a new `BroadbandPulse` source time class for microwave simulations. The changes implement a modular architecture that allows Tidy3D to conditionally support microwave-specific functionality through an optional external package.

The implementation follows the established pattern used for other optional dependencies like `tidy3d-extras`. Key components include: packaging infrastructure with a `@supports_microwave` decorator that handles import validation and version checking; a `BroadbandPulse` class that acts as a bridge between Tidy3D's source time interface and the microwave package's implementation; build configuration updates in `pyproject.toml`; API documentation additions; and basic integration tests.

The `BroadbandPulse` class enables users to create broadband excitation sources with guaranteed amplitude levels across specified frequency ranges, particularly useful for microwave simulation applications. The modular design ensures users can access this functionality by installing the optional `tidy3d[microwave]` package while keeping the core Tidy3D package lightweight.

**PR Description Notes:**
- The PR body only contains "- [ ] add tests" which suggests this is a work-in-progress checklist item

### Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `CHANGELOG.md` | 3/5 | Added changelog entries for tidy3d-microwave plugin and BroadbandPulse feature with minor spelling/grammar issues from previous reviews |
| `tidy3d/packaging.py` | 4/5 | Added microwave package support infrastructure with decorator and version checking following established patterns |
| `docs/api/sources.rst` | 5/5 | Added BroadbandPulse to source time dependencies documentation |
| `tidy3d/components/source/time.py` | 3/5 | Implemented BroadbandPulse class but contains magic numbers in validation constraints that need addressing |
| `tests/test_components/test_packaging.py` | 3/5 | Added basic integration tests but has limited coverage and unused variable issue from previous review |
| `pyproject.toml` | 5/5 | Added microwave extras group configuration following existing patterns |

</details>

### Confidence score: 3/5

- This PR introduces well-architected functionality but has implementation issues that need attention before merging
- Score reflects unresolved issues from previous reviews, limited test coverage, magic numbers in validation, and dependency on potentially unavailable external package
- Pay close attention to the BroadbandPulse implementation validation constraints and test coverage for error handling scenarios

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant BroadbandPulse as "BroadbandPulse"
    participant tidy3d_microwave as "tidy3d_microwave module"
    participant Packaging as "packaging.py"
    participant SourceImplementation as "tidy3d_microwave.BroadbandPulse"

    User->>BroadbandPulse: "Initialize BroadbandPulse(freq_range, minimum_amplitude, offset)"
    BroadbandPulse->>Packaging: "@supports_microwave decorator called"
    Packaging->>tidy3d_microwave: "Check if tidy3d_microwave module available"
    
    alt tidy3d_microwave available
        tidy3d_microwave-->>Packaging: "Module found and validated"
        Packaging-->>BroadbandPulse: "Proceed with initialization"
        BroadbandPulse->>SourceImplementation: "Create tidy3d_microwave.BroadbandPulse(fmin, fmax, minRelAmp, amp, phase, offset)"
        SourceImplementation-->>BroadbandPulse: "Return implementation instance"
        BroadbandPulse-->>User: "BroadbandPulse instance created"
    else tidy3d_microwave not available
        tidy3d_microwave-->>Packaging: "ImportError raised"
        Packaging-->>BroadbandPulse: "Tidy3dImportError: install tidy3d[microwave]"
        BroadbandPulse-->>User: "Error: Missing tidy3d-microwave package"
    end

    User->>BroadbandPulse: "Call amp_time(time)"
    BroadbandPulse->>SourceImplementation: "Delegate to _source.amp_time(time)"
    SourceImplementation-->>BroadbandPulse: "Return complex amplitude"
    BroadbandPulse-->>User: "Complex amplitude value"

    User->>BroadbandPulse: "Call amp_freq(freq)"
    BroadbandPulse->>SourceImplementation: "Delegate to _source.amp_freq(freq)"
    SourceImplementation-->>BroadbandPulse: "Return complex amplitude"
    BroadbandPulse-->>User: "Complex amplitude value"

    User->>BroadbandPulse: "Call end_time()"
    BroadbandPulse->>SourceImplementation: "Delegate to _source.end_time(END_TIME_FACTOR_GAUSSIAN)"
    SourceImplementation-->>BroadbandPulse: "Return end time"
    BroadbandPulse-->>User: "End time value"

    User->>BroadbandPulse: "Call frequency_range_sigma(sigma)"
    BroadbandPulse->>SourceImplementation: "Delegate to _source.frequency_range(sigma)"
    SourceImplementation-->>BroadbandPulse: "Return frequency bounds"
    BroadbandPulse-->>User: "Frequency range tuple"
```

<!-- greptile_other_comments_section -->

<details><summary><h4>Context used (3)</h4></summary>

- Rule from `dashboard` - Avoid hardcoding values ("magic numbers") that can be programmatically derived from data; use named ... ([source](https://app.greptile.com/review/custom-context?memory=6661caa7-319d-4caf-8111-723b32818d62))
- Rule from `dashboard` - In changelogs, enclose code identifiers (class, function names) in backticks and use specific names ... ([source](https://app.greptile.com/review/custom-context?memory=0af1d6df-6cf7-4988-b3fc-f5f8ec5cae30))
- Rule from `dashboard` - Require a changelog entry for any PR that is not purely an internal refactor. ([source](https://app.greptile.com/review/custom-context?memory=b72c7231-b258-4d03-aed2-51a50a9fe757))
</details>


<!-- /greptile_comment -->