### PR TITLE
Strengthen tidy3d-extras packaging test

### DIFF
--- a/tests/test_components/test_mode.py
+++ b/tests/test_components/test_mode.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import importlib
+
 import numpy as np
 import pydantic.v1 as pydantic
 import pytest
@@ -185,7 +187,8 @@ def test_mode_sim():
         _ = sim.plot_grid_mode_plane(ax=AX)
         _ = sim.plot_pml_mode_plane(ax=AX)
         _ = sim.reduced_simulation_copy
-    if td.packaging.tidy3d_extras["use_local_subpixel"]:
+    has_tidy3d_extras = importlib.util.find_spec("tidy3d_extras") is not None
+    if has_tidy3d_extras:
         _ = sim.run_local()
     else:
         with pytest.raises(SetupError):

--- a/tidy3d/packaging.py
+++ b/tidy3d/packaging.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import functools
 from importlib import import_module
+from importlib.util import find_spec
 from typing import Literal
 
 import numpy as np
@@ -194,26 +195,32 @@ def supports_local_subpixel(fn):
         else:
             # first try to import the module
             if tidy3d_extras["mod"] is None:
-                try:
-                    import tidy3d_extras as tidy3d_extras_mod
+                tidy3d_extras["use_local_subpixel"] = False
+                module_exists = find_spec("tidy3d_extras") is not None
+                if config.use_local_subpixel is True and not module_exists:
+                    raise Tidy3dImportError(
+                        "The package 'tidy3d-extras' is required for this "
+                        "operation when 'config.use_local_subpixel' is 'True'. "
+                        "Please install the 'tidy3d-extras' package using, for "
+                        "example, 'pip install tidy3d[extras]'."
+                    )
 
-                except ImportError as exc:
-                    tidy3d_extras["mod"] = None
-                    tidy3d_extras["use_local_subpixel"] = False
-                    if config.use_local_subpixel is True:
+                if module_exists:
+                    try:
+                        import tidy3d_extras as tidy3d_extras_mod
+
+                    except ImportError as exc:
+                        # this should not happen; if the API key is invalid,
+                        # the package should still import but the version will be None
                         raise Tidy3dImportError(
-                            "The package 'tidy3d-extras' is required for this "
-                            "operation when 'config.use_local_subpixel' is 'True'. "
-                            "Please install the 'tidy3d-extras' package using, for "
-                            "example, 'pip install tidy3d[extras]'."
+                            "The package 'tidy3d-extras' did not initialize correctly. "
+                            "To suppress this error, you can set "
+                            "'config.use_local_subpixel=False'."
                         ) from exc
 
-                else:
                     version = tidy3d_extras_mod.__version__
 
                     if version is None:
-                        tidy3d_extras["mod"] = None
-                        tidy3d_extras["use_local_subpixel"] = False
                         raise Tidy3dImportError(
                             "The package 'tidy3d-extras' did not initialize correctly, "
                             "likely due to an invalid API key. To suppress this error, "
@@ -245,8 +252,9 @@ def disable_local_subpixel(fn):
     def _fn(*args, **kwargs):
         use_local_subpixel = config.use_local_subpixel
         config.use_local_subpixel = False
-        result = fn(*args, **kwargs)
-        config.use_local_subpixel = use_local_subpixel
-        return result
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            config.use_local_subpixel = use_local_subpixel
 
     return _fn


### PR DESCRIPTION
Some minor improvements to packaging:

- `disable_local_subpixel` should restore the config even if the function it wraps errors
- check if the module exists before trying to import it, to discriminate between different types of import errors
- a bit better error messages

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-10 17:41:16 UTC

### Greptile Summary

This PR strengthens the packaging system for the optional `tidy3d-extras` dependency by improving error handling and module detection logic. The changes refactor the `supports_local_subpixel` decorator in `tidy3d/packaging.py` to use `find_spec()` for more robust module existence checking before attempting imports, providing clearer error differentiation between "module not found" vs "module failed to initialize". The `disable_local_subpixel` decorator is also enhanced with proper try/finally blocks to ensure configuration state is always restored even when exceptions occur.

Additionally, a new test function `test_tidy3d_extras()` is added to `tests/test_components/test_packaging.py` that validates the packaging behavior for both scenarios when tidy3d-extras is available and when it's not. This test ensures that the `@supports_local_subpixel` decorator correctly detects the module, loads features, and sets appropriate flags. The changes improve the reliability of Tidy3D's optional dependency handling, which is critical for a library that extends core functionality through optional packages.

### Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/packaging.py | 4/5 | Refactored module detection logic using find_spec() and improved error handling with try/finally blocks |
| tests/test_components/test_packaging.py | 4/5 | Added comprehensive test for tidy3d-extras packaging functionality and module detection |

</details>

### Confidence score: 4/5

- This PR improves robustness of optional dependency handling with minimal risk of breaking existing functionality
- Score reflects solid improvements to error handling and testing coverage, but complexity in module loading logic requires careful review
- Pay close attention to the refactored `supports_local_subpixel` decorator logic in `tidy3d/packaging.py`

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant test_tidy3d_extras
    participant importlib
    participant supports_local_subpixel
    participant get_eps
    participant tidy3d_extras_global
    participant config
    participant tidy3d_extras_mod

    User->>test_tidy3d_extras: "Run test_tidy3d_extras()"
    test_tidy3d_extras->>importlib: "find_spec('tidy3d_extras')"
    importlib-->>test_tidy3d_extras: "spec or None"
    test_tidy3d_extras->>test_tidy3d_extras: "has_tidy3d_extras = spec is not None"
    test_tidy3d_extras->>get_eps: "@supports_local_subpixel decorated call"
    
    supports_local_subpixel->>config: "Check config.use_local_subpixel"
    
    alt config.use_local_subpixel is False
        supports_local_subpixel->>tidy3d_extras_global: "Set use_local_subpixel = False"
        supports_local_subpixel->>tidy3d_extras_global: "Set mod = None"
    else config.use_local_subpixel is not False and mod is None
        supports_local_subpixel->>tidy3d_extras_global: "Set use_local_subpixel = False"
        supports_local_subpixel->>importlib: "find_spec('tidy3d_extras')"
        importlib-->>supports_local_subpixel: "spec or None"
        
        alt module exists
            supports_local_subpixel->>tidy3d_extras_mod: "import tidy3d_extras"
            tidy3d_extras_mod-->>supports_local_subpixel: "tidy3d_extras_mod"
            supports_local_subpixel->>tidy3d_extras_mod: "Check __version__"
            supports_local_subpixel->>tidy3d_extras_mod: "extension._features()"
            tidy3d_extras_mod-->>supports_local_subpixel: "features list"
            supports_local_subpixel->>tidy3d_extras_global: "Set mod = tidy3d_extras_mod"
            supports_local_subpixel->>tidy3d_extras_global: "Set use_local_subpixel = 'local_subpixel' in features"
        end
    end
    
    supports_local_subpixel->>get_eps: "Call original function"
    
    alt has_tidy3d_extras is True
        get_eps->>tidy3d_extras_global: "Assert mod is not None"
        get_eps->>tidy3d_extras_global: "Get mod.extension._features()"
        get_eps->>get_eps: "Assert use_local_subpixel == ('local_subpixel' in features)"
    else has_tidy3d_extras is False
        get_eps->>tidy3d_extras_global: "Assert use_local_subpixel is False"
        get_eps->>tidy3d_extras_global: "Assert mod is None"
    end
    
    get_eps-->>test_tidy3d_extras: "Function execution complete"
    test_tidy3d_extras-->>User: "Test complete"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->