### PR TITLE
replace infinite source width in dummy adjoint source time to avoid runtime warning for overflow error

### DIFF
--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -26,7 +26,6 @@ from tidy3d.components.source.utils import SourceType
 from tidy3d.components.structure import Structure
 from tidy3d.components.types import Ax, Axis, ColormapType, FieldVal, PlotScale, annotate_type
 from tidy3d.components.viz import add_ax_if_none, equal_aspect
-from tidy3d.constants import C_0, inf
 from tidy3d.exceptions import DataError, FileError, SetupError, Tidy3dKeyError
 from tidy3d.log import log
 
@@ -1175,7 +1174,16 @@ class SimulationData(AbstractYeeGridSimulationData):
 
         adj_srcs_process_fwidth = self._adjoint_src_width_single(adj_srcs)
 
-        tmp_src_time = GaussianPulse(freq0=C_0, fwidth=inf)
+        min_freq_tmp_src = np.maximum(
+            0, np.min([src.source_time.freq0 - src.source_time.fwidth for src in adj_srcs])
+        )
+        max_freq_tmp_src = np.max(
+            [src.source_time.freq0 + src.source_time.fwidth for src in adj_srcs]
+        )
+        tmp_src_f0 = 0.5 * (min_freq_tmp_src + max_freq_tmp_src)
+        tmp_src_fwidth = max_freq_tmp_src - min_freq_tmp_src
+
+        tmp_src_time = GaussianPulse(freq0=tmp_src_f0, fwidth=tmp_src_fwidth)
         for src in adj_srcs_process_fwidth:
             tmp_src = src.updated_copy(source_time=tmp_src_time)
             tmp_src_hash = tmp_src._hash_self()


### PR DESCRIPTION
Recently, a change was made that started causing the runtime warnings to pop up when making the adjoint source dummy source_time for hashing. The warnings look like the one pasted below. The fix is to not use a consistent, but finite width source that covers all the frequencies necessary (if not, validators will fail for some sources like custom field source).

<img width="915" height="58" alt="Screenshot 2025-10-13 at 10 59 12 AM" src="https://github.com/user-attachments/assets/47aa393c-6b78-4e64-b7a4-c0490a68ea71" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-13 15:01:59 UTC

### Greptile Summary

This PR fixes runtime overflow warnings in the adjoint source hashing logic by replacing infinite frequency width with computed finite bounds. The change modifies the dummy adjoint source creation in `tidy3d/components/data/sim_data.py` to calculate appropriate frequency bounds based on existing adjoint sources rather than using `fwidth=inf`. The fix determines `min_freq_tmp_src` and `max_freq_tmp_src` from the frequency ranges of all adjoint sources, then sets the temporary source's center frequency and width to cover this range. This maintains the original hashing functionality while eliminating numerical overflow warnings that were being triggered during calculations with infinite values.

### Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/components/data/sim_data.py` | 4/5 | Replaces infinite source width with computed finite frequency bounds in dummy adjoint source creation |

</details>

### Confidence score: 4/5

- This PR is safe to merge with minimal risk as it addresses a specific runtime warning without changing core functionality
- Score reflects a targeted fix that maintains existing behavior while solving numerical overflow issues; no major algorithmic changes or breaking modifications
- Pay close attention to the frequency bound calculations to ensure they properly cover all necessary frequency ranges for different source types

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant SimulationData
    participant AdjointSource
    participant GaussianPulse

    User->>SimulationData: "_adjoint_src_width_broadband(adj_srcs)"
    SimulationData->>SimulationData: "extract frequencies from adj_srcs"
    SimulationData->>SimulationData: "calculate middle_f0 = 0.5 * (max + min)"
    SimulationData->>SimulationData: "calculate decay_by_f0_fwidth = middle_f0 / NUM_ADJOINT_FWIDTH_TO_ZERO"
    SimulationData->>SimulationData: "calculate fwidth_to_min_f0 = (middle_f0 - min_f0) / NUM_ADJOINT_FWIDTH_TO_FMIN"
    SimulationData->>SimulationData: "check if fwidth_to_min_f0 > decay_by_f0_fwidth and log warning if needed"
    SimulationData->>SimulationData: "adj_src_fwidth = max(decay_by_f0_fwidth, fwidth_to_min_f0)"
    SimulationData-->>User: "return (middle_f0, adj_src_fwidth)"

    User->>SimulationData: "_make_broadband_source(adj_srcs)"
    SimulationData->>SimulationData: "_adjoint_src_width_broadband(adj_srcs)"
    SimulationData->>SimulationData: "get source_index from normalize_index"
    SimulationData->>GaussianPulse: "updated_copy(amplitude=1.0, phase=0.0)"
    GaussianPulse-->>SimulationData: "src_time_base"
    SimulationData->>GaussianPulse: "updated_copy(freq0=adj_src_f0, fwidth=adj_src_fwidth)"
    GaussianPulse-->>SimulationData: "updated source_time"
    SimulationData->>AdjointSource: "updated_copy(source_time=updated_source_time)"
    AdjointSource-->>SimulationData: "src_broadband"
    SimulationData-->>User: "return src_broadband"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->