### PR TITLE
hotfix: correct reversed color mapping for colorbar

### DIFF
--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -1450,7 +1450,10 @@ class Scene(Tidy3dBaseModel):
             if norm is not None:
                 # Use the same normalization as the colorbar for consistency
                 color = norm(eps_medium)
-                if reverse:
+                # TODO: This is a hack to ensure color consistency with the colorbar.
+                # It should be removed once we establish a proper color mapping where
+                # eps_min maps to 0 and eps_max maps to 1 for 'reverse=False'.
+                if not reverse:
                     color = 1 - color
                 color = min(1, max(color, 0))  # clip in case of custom eps limits
             else:


### PR DESCRIPTION
Temporary fix. I believe that we must use a consistent mapping where `eps_min` maps to 0 and `eps_max` maps to 1. In this way, we won't have issues introducing different scales. This is a temporary fix.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-13 16:58:07 UTC

### Greptile Summary

This PR fixes a critical bug in the permittivity visualization color mapping system within `tidy3d/components/scene.py`. The core issue was that the color mapping logic was inverted - when `reverse=False` (the default behavior), high permittivity values were displayed as light colors when they should appear dark. The fix changes the condition from `if reverse:` to `if not reverse:` on line 1456, ensuring that when reverse is False, the color value gets inverted (`color = 1 - color`). This establishes the correct mapping where `eps_min` corresponds to 0 (white) and `eps_max` corresponds to 1 (black), creating proper visual consistency between structure colors and the colorbar. The developer has acknowledged this as a temporary solution while working toward a more comprehensive color mapping system.

### Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/scene.py | 4/5 | Fixed reversed color mapping logic for permittivity visualization by inverting the reverse condition |

</details>

### Confidence score: 4/5

- This PR addresses a clear visualization bug with a targeted fix that should resolve the color mapping inconsistency
- Score reflects that while the fix appears correct, it's explicitly marked as temporary and the logic change affects visualization behavior that could have edge cases
- Pay close attention to tidy3d/components/scene.py to ensure the color inversion logic works correctly across different permittivity ranges and reverse settings

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Scene
    participant PlotParams
    participant Matplotlib as "Matplotlib/Colorbar"
    participant Medium
    
    User->>Scene: "plot_eps() or plot_structures_eps()"
    Scene->>Scene: "_get_plot_lims()"
    Scene->>Scene: "plot_structures_property()"
    Scene->>Scene: "_get_structures_2dbox()"
    
    loop "For each medium-shape pair"
        Scene->>Medium: "_eps_plot(frequency, eps_component)"
        Medium-->>Scene: "eps_medium value"
        Scene->>Scene: "_get_structure_eps_plot_params()"
        
        alt "norm is provided (new consistent mapping)"
            Scene->>Scene: "color = norm(eps_medium)"
            alt "reverse is False"
                Scene->>Scene: "color = 1 - color (temporary fix)"
            end
        else "fallback to linear mapping"
            Scene->>Scene: "eps_fraction = (eps_medium - eps_min) / delta_eps_max"
            alt "reverse is True"
                Scene->>Scene: "color = eps_fraction"
            else "reverse is False"
                Scene->>Scene: "color = 1 - eps_fraction"
            end
        end
        
        Scene->>PlotParams: "copy(update={'facecolor': str(color)})"
        Scene->>Scene: "plot_shape(shape, plot_params, ax)"
    end
    
    alt "cbar is True"
        Scene->>Scene: "_add_cbar_eps()"
        Scene->>Matplotlib: "add colorbar with consistent mapping"
    end
    
    Scene-->>User: "Ax (matplotlib axes with plot)"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->