### PR TITLE
hotfix: correct reversed color mapping for colorbar

### DIFF
--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -1450,7 +1450,10 @@ class Scene(Tidy3dBaseModel):
             if norm is not None:
                 # Use the same normalization as the colorbar for consistency
                 color = norm(eps_medium)
-                if reverse:
+                # TODO: This is a hack to ensure color consistency with the colorbar.
+                # It should be removed once we establish a proper color mapping where
+                # eps_min maps to 0 and eps_max maps to 1 for 'reverse=False'.
+                if not reverse:
                     color = 1 - color
                 color = min(1, max(color, 0))  # clip in case of custom eps limits
             else:


### PR DESCRIPTION
Temporary fix. I believe that we must use a consistent mapping where `eps_min` maps to 0 and `eps_max` maps to 1. In this way, we won't have issues introducing different scales. This is a temporary fix. I will create a Jira ticket to track this.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-13 19:03:58 UTC

### Greptile Summary

This hotfix addresses a color mapping inconsistency in the permittivity visualization system within the scene module. The change corrects a reversed color assignment where structure colors didn't match the associated colorbar when `reverse=False` (the default setting). The fix inverts the condition on line 1456 from `if reverse:` to `if not reverse:`, ensuring that color values are properly inverted (1 - color) to align with user expectations from the colorbar display.

This is explicitly marked as a temporary solution with a TODO comment explaining the need for a comprehensive color mapping system where `eps_min` consistently maps to 0 and `eps_max` maps to 1. The change maintains backward compatibility while fixing the immediate visualization bug that users encounter when viewing structure permittivity plots.

### Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/components/scene.py` | 4/5 | Fixed reversed color mapping condition for permittivity visualization colorbar consistency |

</details>

### Confidence score: 4/5

- This PR is safe to merge with minimal risk as it fixes a clear visualization bug with a simple logic correction
- Score reflects the straightforward nature of the fix and clear documentation of the issue, though points deducted for being explicitly temporary code
- Pay attention to the TODO comment indicating this is a temporary hack that should be replaced with proper color mapping architecture

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Scene
    participant Medium
    participant PlotUtils
    participant Matplotlib

    User->>Scene: "plot_structures_eps(..., reverse=False/True)"
    Scene->>Scene: "_get_structure_eps_plot_params(medium, freq, eps_min, eps_max, reverse, norm)"
    Scene->>Medium: "_eps_plot(frequency=freq, eps_component=eps_component)"
    Medium-->>Scene: "eps_medium value"
    
    alt norm is not None
        Scene->>Scene: "color = norm(eps_medium)"
        alt reverse is False
            Scene->>Scene: "color = 1 - color"
        end
        Scene->>Scene: "color = min(1, max(color, 0))"
    else fallback to linear mapping
        Scene->>Scene: "delta_eps = eps_medium - eps_min"
        Scene->>Scene: "delta_eps_max = eps_max - eps_min + 1e-5"
        Scene->>Scene: "eps_fraction = delta_eps / delta_eps_max"
        alt reverse is True
            Scene->>Scene: "color = eps_fraction"
        else reverse is False
            Scene->>Scene: "color = 1 - eps_fraction"
        end
        Scene->>Scene: "color = min(1, max(color, 0))"
    end
    
    Scene->>PlotUtils: "plot_params.copy(update={'facecolor': str(color)})"
    PlotUtils-->>Scene: "updated plot parameters"
    Scene-->>User: "plot parameters with corrected color mapping"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->