### PR TITLE
fix(validation): relax the number of geometries in ClipOperation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Improved performance of antenna metrics calculation by utilizing cached wave amplitude calculations instead of recomputing wave amplitudes for each port excitation in the `TerminalComponentModelerData`.
 - Changed hashing method in `Tidy3dBaseModel` from sha256 to md5.
+- Allowing for more geometries in a ClipOperation geometry.
 
 ### Fixed
 - More robust `Sellmeier` and `Debye` material model, and prevent very large pole parameters in `PoleResidue` material model.

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -83,7 +83,7 @@ from .viz import (
 MAX_NUM_MEDIUMS = 65530
 
 # maximum geometry count in a single structure
-MAX_GEOMETRY_COUNT = 100
+MAX_GEOMETRY_COUNT = 5000
 
 # warn and error out if the same medium is present in too many structures
 WARN_STRUCTURES_PER_MEDIUM = 200


### PR DESCRIPTION
This PR is to unblock some tests. Backend improvement will be worked on soon.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-13 19:04:51 UTC

### Greptile Summary

This PR relaxes validation constraints for geometric operations by increasing the maximum allowed geometry count in a single structure from 100 to 5000. The change affects the `MAX_GEOMETRY_COUNT` constant in `scene.py` and is intended to support more complex ClipOperations that contain numerous geometric components. This modification unblocks failing tests that were hitting the previous geometric complexity limit. The change is properly documented in the CHANGELOG.md under the "Changed" category, indicating it's a modification to existing validation behavior rather than a bug fix. The PR serves as a temporary workaround while backend performance improvements are being developed to handle complex geometries more efficiently.

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `CHANGELOG.md` | 5/5 | Added changelog entry documenting the relaxation of geometry limits for ClipOperation |
| `tidy3d/components/scene.py` | 4/5| Increased MAX_GEOMETRY_COUNT constant from 100 to 5000 to allow more complex geometric structures |

</details>

### Confidence score: 4/5

- This PR is safe to merge with minimal risk as it only relaxes validation constraints to enable previously blocked functionality
- Score reflects the temporary nature of the change and potential performance implications of allowing 50x more geometries without corresponding backend improvements
- Pay close attention to `tidy3d/components/scene.py` to ensure the increased limit doesn't introduce performance issues in production

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Scene
    participant Validator
    participant Structure
    participant Medium
    participant GeometryGroup
    participant ClipOperation
    participant Logger

    User->>Scene: Create Scene with structures
    Scene->>Validator: Validate structures count
    
    alt Too many structures
        Validator->>Logger: Log warning about structures per medium
        alt Exceeds maximum
            Validator->>Scene: Raise SetupError
        end
    end

    Scene->>Validator: Validate number of geometries
    loop For each structure
        Validator->>Structure: Get geometry
        Structure->>GeometryGroup: Flatten groups if needed
        GeometryGroup->>ClipOperation: Count geometries
        alt Too many geometries
            Validator->>Scene: Raise SetupError
        end
    end

    Scene->>Scene: Create cached properties
    Scene->>Structure: Sort structures by priority
    Scene->>Scene: Build medium map
    
    User->>Scene: Call plot method
    Scene->>Scene: Get plot limits from bounds
    Scene->>Scene: Get structures for 2D box
    loop For each structure
        Scene->>Structure: Get geometry intersections
        Scene->>Medium: Get plotting parameters
        Scene->>Scene: Plot shape with medium
    end
    Scene->>Scene: Return matplotlib axes
```

<!-- greptile_other_comments_section -->

<details><summary><h4>Context used (3)</h4></summary>

- Rule from `dashboard` - Update the CHANGELOG.md file when making changes that affect user-facing functionality or fix bugs. ([source](https://app.greptile.com/review/custom-context?memory=a109c62a-aa8c-4cc4-b515-0ad947c47929))
- Rule from `dashboard` - Use changelog categories correctly: "Fixed" for bug fixes, "Changed" for modifications to existing f... ([source](https://app.greptile.com/review/custom-context?memory=17997812-233f-4a81-bee2-4d7666605061))
- Rule from `dashboard` - Add new constants to the existing constants.py file rather than defining them locally. Be careful wi... ([source](https://app.greptile.com/review/custom-context?memory=7347050d-a368-42db-9353-efafc8348176))
</details>


<!-- /greptile_comment -->