### PR TITLE
docs(rf): FXC-3695 add documentation for the new (and moved) microwave components from mode impedance feature

### DIFF
--- a/docs/api/microwave/component_modeler.rst
+++ b/docs/api/microwave/component_modeler.rst
@@ -7,13 +7,13 @@ TerminalComponentModeler
    :toctree: ../_autosummary/
    :template: module.rst
 
-   tidy3d.plugins.smatrix.TerminalComponentModeler
-   tidy3d.plugins.smatrix.TerminalComponentModelerData
-   tidy3d.plugins.smatrix.MicrowaveSMatrixData
-   tidy3d.plugins.smatrix.TerminalPortDataArray
-   tidy3d.plugins.smatrix.PortDataArray
+   tidy3d.rf.TerminalComponentModeler
+   tidy3d.rf.TerminalComponentModelerData
+   tidy3d.rf.MicrowaveSMatrixData
+   tidy3d.rf.TerminalPortDataArray
+   tidy3d.rf.PortDataArray
 
-The :class:`.TerminalComponentModeler` is the core simulation object for 3D RF/microwave simulations in Tidy3D. Its primary function is to simulate the system over ``N`` number of ports and ``M`` number of frequency points, with the end result being a ``MxNxN`` S-parameter matrix.
+The :class:`~tidy3d.rf.TerminalComponentModeler` is the core simulation object for 3D RF/microwave simulations in Tidy3D. Its primary function is to simulate the system over ``N`` number of ports and ``M`` number of frequency points, with the end result being a ``MxNxN`` S-parameter matrix.
 
 .. code-block:: python
 
@@ -24,45 +24,52 @@ The :class:`.TerminalComponentModeler` is the core simulation object for 3D RF/m
        ...
    )
 
-The key parts of a :class:`.TerminalComponentModeler` are:
+The key parts of a :class:`~tidy3d.rf.TerminalComponentModeler` are:
 
-* The :class:`.Simulation` field defines the underlying Tidy3D `Simulation object <../simulation.html>`_. This base :class:`.Simulation` object contains information about the simulation domain such as structures, boundary conditions, grid specifications, and monitors. Note that sources should not be included in the base simulation, but rather in the ``ports`` field instead.
-* The ``ports`` field defines the list of source excitations. These are commonly of type :class:`LumpedPort` or :class:`.WavePort`. The number of ports determines the number of batch jobs in the :class:`.TerminalComponentModeler` and the dimensionality of the S-parameter matrix.
+* The :class:`~tidy3d.Simulation` field defines the underlying Tidy3D `Simulation object <../simulation.html>`_. This base :class:`~tidy3d.Simulation` object contains information about the simulation domain such as structures, boundary conditions, grid specifications, and monitors. Note that sources should not be included in the base simulation, but rather in the ``ports`` field instead.
+* The ``ports`` field defines the list of source excitations. These are commonly of type :class:`~tidy3d.rf.LumpedPort` or :class:`~tidy3d.rf.WavePort`. The number of ports determines the number of batch jobs in the :class:`~tidy3d.rf.TerminalComponentModeler` and the dimensionality of the S-parameter matrix. **Note:** Port names cannot contain the '@' symbol (reserved for internal indexing).
 * The ``freqs`` field defines the list of frequency points for the simulation.
 
-More information and explanation for additional fields can be found in the documentation page for the :class:`.TerminalComponentModeler`. In order to submit the simulation, use ``tidy3d.web.upload()``, ``tidy3d.web.start()``, ``tidy3d.web.monitor()``, and ``tidy3d.web.load()``.
+More information and explanation for additional fields can be found in the documentation page for the :class:`~tidy3d.rf.TerminalComponentModeler`.
+
+Workflow
+~~~~~~~~
+
+In order to submit the simulation, use ``web.upload()``, ``web.start()``, ``web.monitor()``, and ``web.load()``.
 
 .. code-block:: python
+   import tidy3d.web as web
 
    # Upload simulation and get cost estimate
-   my_task_id = tidy3d.web.upload(my_tcm, task_name='my_task_name')
+   my_task_id = web.upload(my_tcm, task_name='my_task_name')
 
    # Run simulation
-   tidy3d.web.start(my_task_id)
+   web.start(my_task_id)
 
    # Monitor simulation
-   tidy3d.web.monitor(my_task_id)
+   web.monitor(my_task_id)
 
    # Load results after completion
-   my_tcm_data = tidy3d.web.load(my_task_id)
+   my_tcm_data = web.load(my_task_id)
 
    
-Alternatively, use the ``tidy3d.web.run()`` method to perform all of the above in one single step.
+Alternatively, use the ``web.run()`` method to perform all of the above in one single step.
 
 
 .. code-block:: python
+   import tidy3d.web as web
 
    # Upload, run simulation, and download data
-   my_tcm_data = tidy3d.web.run(my_tcm, task_name='my_task_name', path='my/local/download/path')
+   my_tcm_data = web.run(my_tcm, task_name='my_task_name', path='my/local/download/path')
 
-To get the S-matrix from the results, use the ``smatrix()`` method of the :class:`.TerminalComponentModelerData` object.
+To get the S-matrix from the results, use the ``smatrix()`` method of the :class:`~tidy3d.rf.TerminalComponentModelerData` object.
 
 .. code-block:: python
 
    # Get S-matrix from results
    my_s_matrix = my_tcm_data.smatrix()
 
-The S-matrix is stored as a :class:`.MicrowaveSMatrixData` whose ``data`` property contains a :class:`.TerminalPortDataArray` instance. To obtain a specific ``S_ij`` value, use the ``port_in`` and ``port_out`` coordinates with the corresponding port name. To obtain a specific frequency, use the ``f`` coordinate.
+The S-matrix is stored as a :class:`~tidy3d.rf.MicrowaveSMatrixData` whose ``data`` property contains a :class:`~tidy3d.rf.TerminalPortDataArray` instance. To obtain a specific ``S_ij`` value, use the ``port_in`` and ``port_out`` coordinates with the corresponding port name. To obtain a specific frequency, use the ``f`` coordinate.
 
 .. code-block:: python
 
@@ -71,19 +78,7 @@ The S-matrix is stored as a :class:`.MicrowaveSMatrixData` whose ``data`` proper
 
 .. note::
 
-   At this moment, Tidy3D uses the physics phase convention :math:`e^{-i\omega t}`. Other RF simulation software and texts may use the electrical engineering convention :math:`e^{i\omega t}`. This affects the calculated S-parameters and impedance values. To convert between the two, simply use the complex conjugation operation, e.g. ``np.conjugate()``.
-
-To access simulation data for a given port excitation, use the ``data`` attribute of the :class:`.TerminalComponentModelerData`.
-
-.. code-block:: python
-
-   # Get simulation data for a given port "my_port"
-   sim_data = my_tcm_data.data["my_port"]
-
-   # Get monitor data from a given monitor "my_monitor"
-   my_monitor_data = sim_data["my_monitor"]
-
-The ``data`` attribute holds the simulation data in a dictionary with the respective port name as keys. The data for each monitor can then be accessed from the simulation data object using the monitor name as the dictionary key.
+   At this moment, Tidy3D uses the physics phase convention :math:`e^{-i\omega t}`. Other RF simulation software and texts may use the electrical engineering convention :math:`e^{i\omega t}`. This affects the sign of the imaginary part of calculated S-parameters and impedance values. To convert between the two, simply use the complex conjugation operation, e.g. ``np.conjugate()``.
 
 .. seealso::
 
@@ -97,7 +92,7 @@ The ``data`` attribute holds the simulation data in a dictionary with the respec
    + `Performing visualization of simulation data <../../notebooks/VizData.html>`_
    + `Advanced monitor data manipulation and visualization <../../notebooks/XarrayTutorial.html>`_
 
-   Please refer to the following example models to see the :class:`.TerminalComponentModeler` in action:
+   Please refer to the following example models to see the :class:`~tidy3d.rf.TerminalComponentModeler` in action:
 
    + `Differential stripline benchmark <../../notebooks/DifferentialStripline.html>`_
    + `Edge feed patch antenna benchmark <../../notebooks/EdgeFeedPatchAntennaBenchmark.html>`_

--- a/docs/api/microwave/impedance_calculator.rst
+++ b/docs/api/microwave/impedance_calculator.rst
@@ -1,0 +1,165 @@
+.. _impedance_calculator:
+
+Impedance Calculator
+--------------------
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.ImpedanceCalculator
+
+The :class:`~tidy3d.ImpedanceCalculator` computes characteristic impedance from electromagnetic field data using voltage and current path integrals. It supports three calculation methods depending on which integrals are provided:
+
+* **V and I method**: :math:`Z_0 = V / I` (when both voltage and current integrals are provided)
+* **P and V method**: :math:`Z_0 = |V|^2 / (2P^*)` (when only voltage integral is provided)
+* **P and I method**: :math:`Z_0 = 2P / |I|^2` (when only current integral is provided)
+
+where :math:`P = \frac{V I^*}{2}` is the complex power flow through the cross-section.
+
+**Basic Usage**
+
+.. code-block:: python
+
+   import tidy3d as td
+
+   # Define voltage integration path
+   voltage_integral = td.AxisAlignedVoltageIntegral(
+       center=(0, 0, 0),
+       size=(0, 0, 2),  # Vertical line
+       sign="+",
+       extrapolate_to_endpoints=True,
+       snap_path_to_grid=True
+   )
+
+   # Define current integration contour
+   current_integral = td.AxisAlignedCurrentIntegral(
+       center=(0, 0, 0),
+       size=(4, 2, 0),  # Rectangular loop
+       sign="+",
+       snap_contour_to_grid=True
+   )
+
+   # Create impedance calculator
+   # Note: The impedance calculator can also accept "None" for either the "voltage_integral" or the "current_integral",
+   # which determines the method for computing the impedance. This alternative method is detailed below.
+   Z_calculator = td.ImpedanceCalculator(
+       voltage_integral=voltage_integral,
+       current_integral=current_integral
+   )
+
+   # Compute impedance from mode data
+   mode_data = # ... obtain from ModeSimulation or ModeSolver
+   impedance = Z_calculator.compute_impedance(mode_data)
+
+**Using with Mode Solver Data**
+
+The impedance calculator is commonly used with mode solver results to determine the characteristic impedance of transmission line modes:
+
+.. code-block:: python
+
+   import tidy3d.web as web
+
+   # Run mode simulation
+   mode_sim = td.ModeSimulation(
+       size=(10, 10, 0),
+       grid_spec=td.GridSpec.auto(wavelength=0.3),
+       structures=[...],
+       monitors=[mode_monitor],
+       freqs=[1e9, 2e9, 3e9]
+   )
+
+   mode_sim_data = web.run(mode_sim, task_name='mode_solver')
+   # Calculate impedance for each mode
+   Z0 = Z_calculator.compute_impedance(mode_sim_data.modes)
+
+**Obtaining Voltage and Current**
+
+You can also retrieve the voltage and current values along with impedance:
+
+.. code-block:: python
+
+   # Get impedance, voltage, and current
+   Z, V, I = Z_calculator.compute_impedance(
+       mode_data,
+       return_voltage_and_current=True
+   )
+
+   print(f"Impedance: {Z} Ω")
+   print(f"Voltage: {V} V")
+   print(f"Current: {I} A")
+
+**Single Integral Calculation**
+
+When only voltage or current integral is specified, the complex power flow is automatically used:
+
+.. code-block:: python
+
+   # Calculator with only voltage integral
+   Z_calc_V = td.ImpedanceCalculator(
+       voltage_integral=voltage_integral,
+       current_integral=None
+   )
+
+   # Computes: Z = V^2 / (2*P)
+   Z_from_V = Z_calc_V.compute_impedance(mode_data)
+
+   # Calculator with only current integral
+   Z_calc_I = td.ImpedanceCalculator(
+       voltage_integral=None,
+       current_integral=current_integral
+   )
+
+   # Computes: Z = 2*P / I^2
+   Z_from_I = Z_calc_I.compute_impedance(mode_data)
+
+.. note::
+
+   For detailed information on path integral classes (voltage integrals, current integrals, composite integrals, custom paths, etc.), see :ref:`path_integrals`.
+
+**Field Data Compatibility**
+
+The impedance calculator and path integral classes work with various types of field data:
+
+* :class:`~tidy3d.ModeSolverData`: Mode field profiles from 2D mode solver
+* :class:`~tidy3d.FieldData`: Frequency-domain field data from monitors
+* :class:`~tidy3d.FieldTimeData`: Time-domain field data from monitors
+* :class:`~tidy3d.MicrowaveModeSolverData`: Microwave mode solver data (includes pre-computed integrals)
+
+.. code-block:: python
+
+   # Works with different data types
+   Z_from_mode = Z_calculator.compute_impedance(mode_solver_data)
+   Z_from_monitor = Z_calculator.compute_impedance(field_monitor_data)
+   Z_from_time = Z_calculator.compute_impedance(field_time_data)
+
+**Phase Convention**
+
+.. note::
+
+   Tidy3D uses the physics phase convention :math:`e^{-i\omega t}`. Some RF simulation software and textbooks use the electrical engineering convention :math:`e^{i\omega t}`. This affects calculated S-parameters and impedance values.
+
+   To convert between conventions, use complex conjugation:
+
+   .. code-block:: python
+
+      import numpy as np
+
+      # Convert from physics to engineering convention
+      Z_engineering = np.conjugate(Z_physics)
+
+      # Convert from engineering to physics convention
+      Z_physics = np.conjugate(Z_engineering)
+
+.. seealso::
+
+   Related documentation:
+
+   + :ref:`path_integrals`
+   + :ref:`microwave_mode_solver`
+
+   Tutorials and examples:
+
+   + `Computing the characteristic impedance of transmission lines <../../notebooks/CharacteristicImpedanceCalculator.html>`_
+
+~~~~

--- a/docs/api/microwave/index.rst
+++ b/docs/api/microwave/index.rst
@@ -1,12 +1,26 @@
 Microwave & RF |:satellite:|
 ==============================
 
+.. toctree::
+    :hidden:
+
+    component_modeler
+    material
+    rf_material_library
+    path_integrals
+    impedance_calculator
+    mode_solver
+    ports/lumped
+    ports/wave
+    radiation_scattering
+    output_data
+
 Overview
 --------
 
 .. warning::
 
-   RF simulations will be subject to new license requirements in the future.
+   RF simulations and functionality will require new license requirements in an upcoming release. All RF-specific classes are now available within the sub-package 'tidy3d.rf'.
 
 .. warning::
 
@@ -22,9 +36,13 @@ The following sections discuss:
 * `RF Materials Models`_: Typical material types in microwave/RF simulation
 * `RF Materials Library`_: The RF material library contains various dispersive models for real-world RF materials.
 * `Layer-based Grid Refinement`_: Automated grid refinement strategy for planar structures (e.g. printed circuit boards)
+* `Path Integrals`_: Tools for computing voltage and current from electromagnetic fields
+* `Impedance Calculator`_: Post-processing tool for impedance calculation from electromagnetic fields
+* `RF Mode Analysis`_: Performing RF-specific mode analysis, like computing the characteristic impedance of transmission line modes
 * `Lumped Port & Elements`_: Lumped excitations and circuit elements
 * `Wave Port`_: Port excitation based on modal fields
 * `Radiation & Scattering`_: Useful features for antenna and scattering problems
+* `RF Output Data`_: Data containers for microwave simulation results
 
 .. seealso::
 
@@ -38,6 +56,10 @@ The following sections discuss:
 .. include:: /api/microwave/material.rst
 .. include:: /api/microwave/rf_material_library.rst
 .. include:: /api/discretization/layer.rst
+.. include:: /api/microwave/path_integrals.rst
+.. include:: /api/microwave/impedance_calculator.rst
+.. include:: /api/microwave/mode_solver.rst
 .. include:: /api/microwave/ports/lumped.rst
 .. include:: /api/microwave/ports/wave.rst
 .. include:: /api/microwave/radiation_scattering.rst
+.. include:: /api/microwave/output_data.rst

--- a/docs/api/microwave/material.rst
+++ b/docs/api/microwave/material.rst
@@ -9,12 +9,12 @@ RF Materials Models
 
    tidy3d.PECMedium
    tidy3d.PMCMedium
-   tidy3d.LossyMetalMedium
-   tidy3d.SurfaceImpedanceFitterParam
-   tidy3d.HammerstadSurfaceRoughness
-   tidy3d.HuraySurfaceRoughness
+   tidy3d.rf.LossyMetalMedium
+   tidy3d.rf.SurfaceImpedanceFitterParam
+   tidy3d.rf.HammerstadSurfaceRoughness
+   tidy3d.rf.HuraySurfaceRoughness
 
-The :class:`.PECMedium` and :class:`.LossyMetalMedium` classes can be used to model metallic materials.
+The :class:`~tidy3d.PECMedium` and :class:`~tidy3d.rf.LossyMetalMedium` classes can be used to model metallic materials.
 
 .. code-block:: python
 
@@ -24,11 +24,11 @@ The :class:`.PECMedium` and :class:`.LossyMetalMedium` classes can be used to mo
    # lossy metal (conductivity in S/um)
    my_lossy_metal = LossyMetalMedium(conductivity=58, freq_range=(1e9, 10e9))
 
-Note that the unit of ``conductivity`` is ``S/um`` and the unit of ``freq_range`` is ``Hz``. The :class:`.LossyMetalMedium` class implements the surface impedance boundary condition (SIBC). It can accept surface roughness specifications using the Hammerstad or Huray models. Please refer to their respective documentation pages for details. Edge singularity correction is also available but turned off by default at this time.
+Note that the unit of ``conductivity`` is ``S/um`` and the unit of ``freq_range`` is ``Hz``. The :class:`~tidy3d.rf.LossyMetalMedium` class implements the surface impedance boundary condition (SIBC). It can accept surface roughness specifications using the Hammerstad or Huray models. Please refer to their respective documentation pages for details. Edge singularity correction is also available but turned off by default at this time.
 
 .. note::
 
-   When modeling lossy metals, always be sure to check the skin depth --- if the skin depth is significant compared to the geometry size, then :class:`.LossyMetalMedium` may be not accurate. In that case, use a regular dispersive medium instead.
+   When modeling lossy metals, always be sure to check the skin depth --- if the skin depth is significant compared to the geometry size, then :class:`~tidy3d.rf.LossyMetalMedium` may be not accurate. In that case, use a regular dispersive medium instead.
 
 
 .. autosummary::
@@ -38,7 +38,7 @@ Note that the unit of ``conductivity`` is ``S/um`` and the unit of ``freq_range`
    tidy3d.Medium
    tidy3d.plugins.dispersion.FastDispersionFitter
 
-To model lossless dielectrics, use the regular :class:`.Medium`.
+To model lossless dielectrics, use the regular :class:`~tidy3d.Medium`.
 
 .. code-block:: python
 

--- a/docs/api/microwave/microwave_migration.rst
+++ b/docs/api/microwave/microwave_migration.rst
@@ -1,12 +1,13 @@
 .. _microwave_migration:
 
-v2.10 Refactor Migration Guide
+v2.10 RF Refactor Migration Guide
 -------------------------------
 
-In version ``v2.10.0``, the microwave and RF simulation capabilities underwent significant refactoring to improve consistency, clarity, and functionality. This guide covers two major sets of breaking changes:
+In version ``v2.10.0``, the microwave and RF simulation capabilities underwent significant refactoring to improve consistency, clarity, and functionality. This guide covers three major sets of breaking changes:
 
 1. **Path Integral Class Renames** - Classes were renamed for consistency
 2. **WavePort API Changes** - WavePort was refactored to support multiple modes with cleaner impedance specification
+3. **Component Modeler Refactor** - ComponentModeler classes were refactored for improved web support
 
 This guide helps you update your scripts to work with v2.10+.
 
@@ -18,7 +19,7 @@ Path integral classes were renamed for improved consistency and clarity. Additio
 **Key changes:**
 
 *   **Renamed Classes**: Path integral classes have been renamed to follow a consistent naming pattern.
-*   **New Import Path (simplified)**: The path integral classes and impedance calculator are now exported at the top level. Prefer importing directly from ``tidy3d`` (e.g., ``from tidy3d import AxisAlignedVoltageIntegral, ImpedanceCalculator``). Existing plugin imports continue to work for backwards compatibility where applicable.
+*   **New Import Path (simplified)**: The path integral classes and impedance calculator are now exported at the 'tidy3d.rf' sub-package . Prefer importing directly from ``tidy3d.rf`` (e.g., ``from tidy3d.rf import AxisAlignedVoltageIntegral, ImpedanceCalculator``). Existing plugin imports continue to work for backwards compatibility where applicable.
 
 Class Name Changes
 ^^^^^^^^^^^^^^^^^^
@@ -67,7 +68,7 @@ Migration Examples
 
 .. code-block:: python
 
-    from tidy3d import (
+    from tidy3d.rf import (
         AxisAlignedVoltageIntegral,
         AxisAlignedCurrentIntegral,
     )
@@ -114,7 +115,7 @@ Custom 2D Path Integrals
 
 .. code-block:: python
 
-    from tidy3d import (
+    from tidy3d.rf import (
         Custom2DVoltageIntegral,
         Custom2DCurrentIntegral,
     )
@@ -136,7 +137,7 @@ Custom 2D Path Integrals
 Summary
 ^^^^^^^
 
-All functionality remains the same—only class names and preferred import paths have changed. Update your imports to the top level (``from tidy3d import ...``) and class names according to the table above, and your code will work with v2.10. For impedance calculations, import ``ImpedanceCalculator`` directly via ``from tidy3d import ImpedanceCalculator``.
+All functionality remains the same—only class names and preferred import paths have changed. Update your imports to the top level (``from tidy3d.rf import ...``) and class names according to the table above, and your code will work with v2.10.
 
 2. WavePort API Changes for Multimodal Support
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -185,17 +186,14 @@ Single-Mode WavePort
 
 .. code-block:: python
 
-    import tidy3d as td
-    from tidy3d.plugins.smatrix import WavePort
-
     # Define path integrals
-    voltage_path = td.AxisAlignedVoltageIntegralSpec(
+    voltage_path = AxisAlignedVoltageIntegralSpec(
         center=(0, 0, 0),
         size=(1.0, 0, 0),
         sign="+",
     )
 
-    current_path = td.Custom2DCurrentIntegralSpec.from_circular_path(
+    current_path = Custom2DCurrentIntegralSpec.from_circular_path(
         center=(0, 0, 0),
         radius=0.5,
         num_points=21,
@@ -208,7 +206,7 @@ Single-Mode WavePort
         center=(0, 0, -5),
         size=(2, 2, 0),
         direction="+",
-        mode_spec=td.ModeSpec(num_modes=1),  # Generic ModeSpec
+        mode_spec=ModeSpec(num_modes=1),  # Generic ModeSpec
         mode_index=0,  # Which mode to excite
         voltage_integral=voltage_path,  # Attached to port
         current_integral=current_path,  # Attached to port
@@ -219,17 +217,14 @@ Single-Mode WavePort
 
 .. code-block:: python
 
-    import tidy3d as td
-    from tidy3d.plugins.smatrix import WavePort
-
     # Define path integrals (same as before)
-    voltage_path = td.AxisAlignedVoltageIntegralSpec(
+    voltage_path = AxisAlignedVoltageIntegralSpec(
         center=(0, 0, 0),
         size=(1.0, 0, 0),
         sign="+",
     )
 
-    current_path = td.Custom2DCurrentIntegralSpec.from_circular_path(
+    current_path = Custom2DCurrentIntegralSpec.from_circular_path(
         center=(0, 0, 0),
         radius=0.5,
         num_points=21,
@@ -242,9 +237,9 @@ Single-Mode WavePort
         center=(0, 0, -5),
         size=(2, 2, 0),
         direction="+",
-        mode_spec=td.MicrowaveModeSpec(  # Use MicrowaveModeSpec
+        mode_spec=MicrowaveModeSpec(  # Use MicrowaveModeSpec
             num_modes=1,
-            impedance_specs=td.CustomImpedanceSpec(
+            impedance_specs=CustomImpedanceSpec(
                 voltage_spec=voltage_path,  # Moved to impedance_specs
                 current_spec=current_path
             )
@@ -254,7 +249,7 @@ Single-Mode WavePort
     )
 
     # Mode selection now happens at source creation
-    source_time = td.GaussianPulse(freq0=10e9, fwidth=1e9)
+    source_time = GaussianPulse(freq0=10e9, fwidth=1e9)
     source = port.to_source(source_time, mode_index=0)  # Mode selected here
 
 Multi-Mode WavePort (New Feature!)
@@ -264,23 +259,20 @@ The new API enables WavePorts to support multiple modes simultaneously:
 
 .. code-block:: python
 
-    import tidy3d as td
-    from tidy3d.plugins.smatrix import WavePort
-
     # Create a 3-mode WavePort
     port = WavePort(
         center=(0, 0, -5),
         size=(4, 4, 0),
         direction="+",
-        mode_spec=td.MicrowaveModeSpec(
+        mode_spec=MicrowaveModeSpec(
             num_modes=3,  # Solve for 3 modes
-            impedance_specs=td.AutoImpedanceSpec()  # Auto-compute impedance for all modes
+            impedance_specs=AutoImpedanceSpec()  # Auto-compute impedance for all modes
         ),
         name="multimode_port"
     )
 
     # Create sources for different modes
-    source_time = td.GaussianPulse(freq0=10e9, fwidth=1e9)
+    source_time = GaussianPulse(freq0=10e9, fwidth=1e9)
     source_mode0 = port.to_source(source_time, mode_index=0)  # Excite mode 0
     source_mode1 = port.to_source(source_time, mode_index=1)  # Excite mode 1
     source_mode2 = port.to_source(source_time, mode_index=2)  # Excite mode 2
@@ -297,15 +289,15 @@ For advanced use cases, you can specify different impedance calculation methods 
         center=(0, 0, -5),
         size=(4, 4, 0),
         direction="+",
-        mode_spec=td.MicrowaveModeSpec(
+        mode_spec=MicrowaveModeSpec(
             num_modes=3,
             impedance_specs=(
-                td.CustomImpedanceSpec(
+                CustomImpedanceSpec(
                     voltage_spec=custom_voltage_path,
                     current_spec=custom_current_path
                 ),  # Mode 0 uses custom specs
-                td.AutoImpedanceSpec(),  # Mode 1 uses auto
-                td.AutoImpedanceSpec(),  # Mode 2 uses auto
+                AutoImpedanceSpec(),  # Mode 1 uses auto
+                AutoImpedanceSpec(),  # Mode 2 uses auto
             )
         ),
         name="mixed_impedance_port"
@@ -374,9 +366,9 @@ For most cases, you can use ``AutoImpedanceSpec`` which automatically computes v
         center=(0, 0, -5),
         size=(2, 2, 0),
         direction="+",
-        mode_spec=td.MicrowaveModeSpec(
+        mode_spec=MicrowaveModeSpec(
             num_modes=2,
-            impedance_specs=td.AutoImpedanceSpec()  # Works for all modes
+            impedance_specs=AutoImpedanceSpec()  # Works for all modes
         ),
         name="simple_port"
     )
@@ -448,3 +440,15 @@ The new ``mode_selection`` field replaces ``mode_index`` for selecting modes:
 *   ``mode_selection: Optional[tuple[int, ...]]`` - New field that accepts a tuple of mode indices (e.g., ``(0, 2)`` to use modes 0 and 2)
 *   When ``None`` (default), all modes from ``mode_spec.num_modes`` are used
 *   **Note**: ``mode_index`` accepts only a single ``int``, while ``mode_selection`` accepts a tuple for multiple modes
+
+3. Component Modeler Refactor
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``smatrix`` plugin classes (``ComponentModeler``, ``TerminalComponentModeler``, etc.) were refactored to improve web and GUI support for RF capabilities. This section helps you update your scripts to the new, more robust API.
+
+.. note::
+
+   This content is also available as a standalone guide: :ref:`smatrix_migration`
+
+.. include:: /api/plugins/smatrix_migration.rst
+   :start-line: 12

--- a/docs/api/microwave/mode_solver.rst
+++ b/docs/api/microwave/mode_solver.rst
@@ -1,0 +1,168 @@
+.. _microwave_mode_solver:
+
+RF Mode Analysis
+----------------
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.rf.MicrowaveModeSpec
+   tidy3d.rf.AutoImpedanceSpec
+   tidy3d.rf.CustomImpedanceSpec
+   tidy3d.rf.MicrowaveModeMonitor
+   tidy3d.rf.MicrowaveModeSolverMonitor
+   tidy3d.ModeSimulation
+
+The :class:`~tidy3d.rf.MicrowaveModeSpec` extends the standard :class:`~tidy3d.ModeSpec` to include automatic characteristic impedance calculation for transmission line modes. This is particularly useful for microwave and RF applications where the characteristic impedance :math:`Z_0` is a critical parameter.
+
+Unlike the standard :class:`~tidy3d.ModeSpec`, :class:`~tidy3d.rf.MicrowaveModeSpec` includes an ``impedance_specs`` field that defines how voltage and current path integrals are computed for each mode. These integrals are then used to calculate the characteristic impedance of the transmission line.
+
+.. code-block:: python
+
+   # Create a microwave mode specification with automatic impedance calculation
+   mode_spec = MicrowaveModeSpec(
+       num_modes=2,
+       target_neff=1.5,
+       impedance_specs=AutoImpedanceSpec()  # Automatic path integral setup
+   )
+
+   # Use in a microwave mode monitor
+   monitor = MicrowaveModeMonitor(
+       center=(0, 0, 0),
+       size=(2, 2, 0),
+       freqs=[1e9, 2e9, 3e9],
+       mode_spec=mode_spec,
+       name='mode_monitor'
+   )
+
+**Automatic Impedance Calculation**
+
+The :class:`~tidy3d.rf.AutoImpedanceSpec` automatically determines appropriate voltage and current integration paths based on the mode field distribution. This is the recommended approach for most use cases, as it eliminates the need to manually define integration paths.
+
+.. code-block:: python
+
+   # Using automatic impedance specification (recommended)
+   mode_spec_auto = MicrowaveModeSpec(
+       num_modes=1,
+       impedance_specs=AutoImpedanceSpec()
+   )
+
+**Custom Impedance Calculation**
+
+For more control over the impedance calculation, you can specify custom voltage and current integration paths using :class:`~tidy3d.rf.CustomImpedanceSpec`. This allows you to define exactly where and how the voltage and current are computed.
+
+.. code-block:: python
+
+   # Define custom voltage path (line integral)
+   voltage_spec = AxisAlignedVoltageIntegralSpec(
+       center=(0, 0, 0),
+       size=(0, 0, 1),  # Vertical line
+       sign="+"
+   )
+
+   # Define custom current path (contour integral)
+   current_spec = AxisAlignedCurrentIntegralSpec(
+       center=(0, 0, 0),
+       size=(2, 1, 0),  # Rectangular loop
+       sign="+"
+   )
+
+   # Create custom impedance specification
+   custom_impedance = CustomImpedanceSpec(
+       voltage_spec=voltage_spec,
+       current_spec=current_spec
+   )
+
+   # Use in mode specification
+   mode_spec_custom = MicrowaveModeSpec(
+       num_modes=1,
+       impedance_specs=custom_impedance
+   )
+
+**Multiple Modes**
+
+When solving for multiple modes, you can provide different impedance specifications for each mode:
+
+.. code-block:: python
+
+   # Different impedance specs for each mode
+   mode_spec_multi = MicrowaveModeSpec(
+       num_modes=2,
+       impedance_specs=(
+           AutoImpedanceSpec(),  # Auto for first mode
+           custom_impedance,         # Custom for second mode
+       )
+   )
+
+   # Or use a single spec for all modes (will be duplicated)
+   mode_spec_shared = MicrowaveModeSpec(
+       num_modes=2,
+       impedance_specs=AutoImpedanceSpec()  # Applied to both modes
+   )
+
+**Mode Solver Monitors**
+
+There are two types of monitors for microwave mode analysis:
+
+* :class:`~tidy3d.rf.MicrowaveModeMonitor`: Records mode amplitudes and transmission line parameters (voltage, current, impedance) on a monitor plane during a full 3D FDTD simulation.
+* :class:`~tidy3d.rf.MicrowaveModeSolverMonitor`: Stores the complete 2D mode field profiles along with transmission line parameters from a standalone mode solver calculation.
+
+.. code-block:: python
+
+   # Monitor for mode amplitudes in full simulation
+   mode_monitor = MicrowaveModeMonitor(
+       center=(0, 0, 0),
+       size=(2, 2, 0),
+       freqs=[1e9, 2e9],
+       mode_spec=mode_spec,
+       name='mode_monitor'
+   )
+
+   # Monitor for mode field profiles (mode solver only)
+   mode_solver_monitor = MicrowaveModeSolverMonitor(
+       center=(0, 0, 0),
+       size=(2, 2, 0),
+       freqs=[1e9, 2e9],
+       mode_spec=mode_spec,
+       name='mode_solver_monitor'
+   )
+
+**Mode Simulation**
+
+For standalone mode solving (without a full 3D FDTD simulation), use :class:`~tidy3d.ModeSimulation`:
+
+.. code-block:: python
+
+   import tidy3d.web as web
+
+   # Create a mode simulation for transmission line analysis
+   mode_sim = ModeSimulation(
+       size=(10, 10, 0),
+       grid_spec=GridSpec.auto(wavelength=0.3),
+       structures=[...],  # Your transmission line structures
+       mode_spec=mode_spec,  # MicrowaveModeSpec defining impedance calculation
+       freqs=[1e9, 2e9, 3e9],
+   )
+
+   # Run the mode simulation
+   mode_sim_data = web.run(mode_sim, task_name='mode_analysis')
+
+   # Access impedance results from the modes
+   Z0 = mode_sim_data.modes.transmission_line_data.Z0
+
+.. seealso::
+
+   For more information on path integral specifications, see:
+
+   + :ref:`path_integrals`
+   + :ref:`impedance_calculator`
+   + :ref:`wave_port`
+
+   For practical examples:
+
+   + `Computing the characteristic impedance of transmission lines <../../notebooks/CharacteristicImpedanceCalculator.html>`_
+   + `Differential stripline benchmark <../../notebooks/DifferentialStripline.html>`_
+   + `Edge-mounted SMA to co-planar waveguide transition <../../notebooks/SMAEdgeMount.html>`_
+
+~~~~

--- a/docs/api/microwave/output_data.rst
+++ b/docs/api/microwave/output_data.rst
@@ -1,0 +1,85 @@
+.. currentmodule:: tidy3d
+
+RF Output Data
+--------------
+
+Monitor Data
+~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.rf.MicrowaveModeData
+   tidy3d.rf.MicrowaveModeSolverData
+   tidy3d.rf.DirectivityData
+   tidy3d.rf.AntennaMetricsData
+
+- **MicrowaveModeData**: Mode amplitudes with transmission line parameters (Z0, voltage, current) and propagation characteristics (γ, α, β).
+- **MicrowaveModeSolverData**: Complete 2D mode field profiles with transmission line parameters and mode classification.
+- **DirectivityData**: Far-field radiation patterns including directivity and radiated power.
+- **AntennaMetricsData**: Antenna figures of merit including gain, radiation efficiency, reflection efficiency, and realized gain.
+
+**Base Classes**
+
+.. currentmodule:: tidy3d.components.microwave.data.monitor_data
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   MicrowaveModeDataBase
+
+.. currentmodule:: tidy3d
+
+.. note::
+   :class:`~tidy3d.components.microwave.data.monitor_data.MicrowaveModeDataBase` is a base class providing shared properties and methods for microwave mode data.
+   The base class documentation is provided to help users discover inherited properties.
+
+
+Datasets and Data Arrays
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Datasets**
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.components.microwave.data.dataset.TransmissionLineDataset
+
+**Data Arrays**
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.components.data.data_array.VoltageTimeDataArray
+   tidy3d.components.data.data_array.VoltageFreqDataArray
+   tidy3d.components.data.data_array.VoltageFreqModeDataArray
+   tidy3d.components.data.data_array.CurrentTimeDataArray
+   tidy3d.components.data.data_array.CurrentFreqDataArray
+   tidy3d.components.data.data_array.CurrentFreqModeDataArray
+   tidy3d.components.data.data_array.ImpedanceTimeDataArray
+   tidy3d.components.data.data_array.ImpedanceFreqDataArray
+   tidy3d.components.data.data_array.ImpedanceFreqModeDataArray
+   tidy3d.components.microwave.data.data_array.PropagationConstantArray
+   tidy3d.components.microwave.data.data_array.PhaseConstantArray
+   tidy3d.components.microwave.data.data_array.AttenuationConstantArray
+   tidy3d.components.microwave.data.data_array.PhaseVelocityArray
+   tidy3d.components.microwave.data.data_array.GroupVelocityArray
+
+~~~~
+
+.. seealso::
+
+   Related documentation:
+
+   + `Output Data <../output_data.html>`_ - General information on working with output data in Tidy3D
+
+   For general information on working with monitor data:
+
+   + `Performing visualization of simulation data <../../notebooks/VizData.html>`_
+   + `Advanced monitor data manipulation and visualization <../../notebooks/XarrayTutorial.html>`_
+
+~~~~

--- a/docs/api/microwave/path_integrals.rst
+++ b/docs/api/microwave/path_integrals.rst
@@ -1,0 +1,241 @@
+.. _path_integrals:
+
+Path Integrals
+--------------
+
+Path integrals compute voltage and current from electromagnetic field data by integrating electric and magnetic fields along specified paths. These are essential for characterizing transmission lines and computing characteristic impedance.
+
+.. note::
+
+   For information on how path integrals are used to calculate characteristic impedance in transmission line mode analysis, see :ref:`microwave_mode_solver`. For the corresponding specification classes (``*Spec``) used in :class:`~tidy3d.MicrowaveModeSpec`, see the end of this page.
+
+Voltage Path Integrals
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.rf.AxisAlignedVoltageIntegral
+   tidy3d.rf.Custom2DVoltageIntegral
+
+Voltage path integrals compute voltage by integrating the electric field :math:`\mathbf{E}` along a line path:
+
+.. math::
+
+   V = -\int_{\text{path}} \mathbf{E} \cdot d\mathbf{l}
+
+**AxisAlignedVoltageIntegral**
+
+Integrates along an axis-aligned path, suitable for transmission lines with dominant electric field directions.
+
+.. code-block:: python
+
+   import tidy3d.web as web
+
+   # Create voltage path integral
+   voltage_integral = AxisAlignedVoltageIntegral(
+       center=(0, 0, 0),
+       size=(0, 0, 2.0),  # Line from (0,0,-1) to (0,0,1)
+       sign="+",
+       extrapolate_to_endpoints=True,  # Extrapolate field to path endpoints
+       snap_path_to_grid=True          # Snap path to simulation grid
+   )
+
+   # Compute voltage from mode data
+   mode_data = web.run(mode_solver, task_name='mode_solver')
+   voltage = voltage_integral.compute_voltage(mode_data)
+
+   print(f"Voltage: {voltage.values} V")
+
+The ``sign`` parameter determines integration direction: ``"+"`` integrates toward positive axis, ``"-"`` toward negative.
+
+**Custom2DVoltageIntegral**
+
+Integrates along an arbitrary 2D path for non-standard geometries.
+
+.. code-block:: python
+
+   import numpy as np
+
+   # Define custom path vertices in 2D plane
+   vertices = np.array([
+       [0, 0],    # Start point
+       [0, 1],    # Intermediate point
+       [1, 1],    # End point
+   ])
+
+   # Create custom voltage integral
+   custom_voltage = Custom2DVoltageIntegral(
+       axis=2,         # Normal axis (z)
+       position=0.0,   # Position along z-axis
+       vertices=vertices
+   )
+
+   # Compute voltage
+   voltage = custom_voltage.compute_voltage(mode_data)
+
+The path follows the vertices in order, integrating :math:`\mathbf{E} \cdot d\mathbf{l}` along each segment.
+
+Current Path Integrals
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.rf.AxisAlignedCurrentIntegral
+   tidy3d.rf.Custom2DCurrentIntegral
+   tidy3d.rf.CompositeCurrentIntegral
+
+Current path integrals compute current using Ampère's circuital law by integrating the magnetic field :math:`\mathbf{H}` around a closed contour:
+
+.. math::
+
+   I = \oint_{\text{contour}} \mathbf{H} \cdot d\mathbf{l}
+
+**AxisAlignedCurrentIntegral**
+
+Integrates around an axis-aligned rectangular loop, the most common approach for transmission lines.
+
+.. code-block:: python
+
+   # Create current path integral
+   current_integral = AxisAlignedCurrentIntegral(
+       center=(0, 0, 0),
+       size=(3, 2, 0),  # Loop dimensions in xy-plane
+       sign="+",
+       snap_contour_to_grid=True  # Snap contour to grid for accuracy
+   )
+
+   # Compute current from mode data
+   current = current_integral.compute_current(mode_data)
+
+   print(f"Current: {current.values} A")
+
+The rectangular loop is automatically constructed as four line segments. The ``sign`` parameter determines circulation direction and should match the power flow direction.
+
+**Custom2DCurrentIntegral**
+
+Integrates around an arbitrary closed 2D contour for non-standard geometries.
+
+.. code-block:: python
+
+   # Define closed contour (counterclockwise for positive current)
+   vertices = np.array([
+       [0, 0],
+       [2, 0],
+       [2, 1],
+       [0, 1],
+       [0, 0],  # Close the loop
+   ])
+
+   # Create custom current integral
+   custom_current = Custom2DCurrentIntegral(
+       axis=2,         # Normal axis
+       position=0.0,   # Position along normal axis
+       vertices=vertices
+   )
+
+   # Compute current
+   current = custom_current.compute_current(mode_data)
+
+For positive current in the positive ``axis`` direction, order vertices counterclockwise when viewed from the positive axis.
+
+**CompositeCurrentIntegral**
+
+Combines multiple current paths for complex geometries like differential lines.
+
+.. code-block:: python
+
+   # Define two separate current paths
+   path_1 = AxisAlignedCurrentIntegral(
+       center=(-2, 0, 0),
+       size=(1, 1, 0),
+       sign="+"
+   )
+
+   path_2 = AxisAlignedCurrentIntegral(
+       center=(2, 0, 0),
+       size=(1, 1, 0),
+       sign="+"
+   )
+
+   # Combine paths
+   composite_current = CompositeCurrentIntegral(
+       path_specs=(path_1, path_2),
+       sum_spec="sum"  # "sum" adds currents, "split" keeps them separate
+   )
+
+   # Compute combined current
+   current = composite_current.compute_current(mode_data)
+
+The ``sum_spec`` parameter controls combination:
+
+* ``"sum"``: Adds all currents together
+* ``"split"``: Returns maximum of phase-separated contributions (useful for identifying dominant current directions)
+
+Usage with ImpedanceCalculator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Path integrals are commonly used with :class:`~tidy3d.ImpedanceCalculator` to compute characteristic impedance:
+
+.. code-block:: python
+
+   # Create impedance calculator from voltage and current integrals
+   Z_calculator = ImpedanceCalculator(
+       voltage_integral=voltage_integral,
+       current_integral=current_integral
+   )
+
+   # Compute impedance: Z = V / I
+   Z0 = Z_calculator.compute_impedance(mode_data)
+
+   # Or get voltage, current, and impedance together
+   Z, V, I = Z_calculator.compute_impedance(
+       mode_data,
+       return_voltage_and_current=True
+   )
+
+See :ref:`impedance_calculator` for more details.
+
+Additional Information
+~~~~~~~~~~~~~~~~~~~~~~
+
+**Best Practices**
+
+* For voltage integrals, the path should follow electric field lines between conductors
+* For current integrals, the contour should enclose the current-carrying region
+* Use ``snap_path_to_grid=True`` and ``snap_contour_to_grid=True`` for improved accuracy
+* Use ``extrapolate_to_endpoints=True`` for voltage paths to better capture fields at conductor boundaries
+* Ensure the ``sign`` parameter matches the desired power flow direction
+
+**Path Integral Specification Classes**
+
+The classes documented above (``*Integral``) are **execution classes** that perform actual computations on field data. For use in :class:`~tidy3d.MicrowaveModeSpec` impedance specifications, corresponding **specification classes** (``*Spec``) exist:
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.rf.AxisAlignedVoltageIntegralSpec
+   tidy3d.rf.Custom2DVoltageIntegralSpec
+   tidy3d.rf.AxisAlignedCurrentIntegralSpec
+   tidy3d.rf.Custom2DCurrentIntegralSpec
+   tidy3d.rf.CompositeCurrentIntegralSpec
+
+These specification classes have the same parameters but are used for configuration (in :class:`~tidy3d.CustomImpedanceSpec`) rather than direct computation. See :ref:`microwave_mode_solver` for their usage in mode analysis.
+
+.. seealso::
+
+   **Related documentation:**
+
+   + :ref:`microwave_mode_solver` - Using path integrals for characteristic impedance calculation
+   + :ref:`impedance_calculator` - ImpedanceCalculator class for post-processing
+
+   **Practical examples:**
+
+   + `Computing the characteristic impedance of transmission lines <../../notebooks/CharacteristicImpedanceCalculator.html>`_
+   + `Differential stripline benchmark <../../notebooks/DifferentialStripline.html>`_
+
+~~~~

--- a/docs/api/microwave/ports/lumped.rst
+++ b/docs/api/microwave/ports/lumped.rst
@@ -7,8 +7,8 @@ Lumped Port & Elements
    :toctree: ../_autosummary/
    :template: module.rst
 
-   tidy3d.plugins.smatrix.LumpedPort
-   tidy3d.plugins.smatrix.CoaxialLumpedPort
+   tidy3d.rf.LumpedPort
+   tidy3d.rf.CoaxialLumpedPort
 
 The :class:`LumpedPort` feature represents a planar, uniform current excitation with a fixed impedance termination.
 
@@ -27,7 +27,7 @@ The :class:`LumpedPort` can be 1D (line) or 2D (plane). For 2D, only axis-aligne
 
 .. note::
 
-   Lumped ports and elements are fundamentally approximations and thus should only be used when the port/element size is much smaller than the wavelength of interest (typically ``lambda/10``). For more accurate results, especially when the port is adjacent to an intentional waveguide or transmission line, consider using the :class:`.WavePort` excitation instead.
+   Lumped ports and elements are fundamentally approximations and thus should only be used when the port/element size is much smaller than the wavelength of interest (typically ``lambda/10``). For more accurate results, especially when the port is adjacent to an intentional waveguide or transmission line, consider using the :class:`~tidy3d.rf.WavePort` excitation instead.
 
 The ``CoaxialLumpedPort`` represents an analytical coaxial field source.
 
@@ -52,11 +52,11 @@ The ``CoaxialLumpedPort`` represents an analytical coaxial field source.
    :toctree: ../_autosummary/
    :template: module.rst
 
-   tidy3d.LumpedResistor
-   tidy3d.CoaxialLumpedResistor
-   tidy3d.LinearLumpedElement
-   tidy3d.RLCNetwork
-   tidy3d.AdmittanceNetwork
+   tidy3d.rf.LumpedResistor
+   tidy3d.rf.CoaxialLumpedResistor
+   tidy3d.rf.LinearLumpedElement
+   tidy3d.rf.RLCNetwork
+   tidy3d.rf.AdmittanceNetwork
 
 For a simple resistive lumped element, use ``LumpedResistor``.
 
@@ -82,7 +82,7 @@ For more complicated RLC networks, use the general ``LinearLumpedElement`` class
        network=RLCNetwork(resistance=50, inductance=1e-9)  # RLC network
    )
 
-All lumped elements should be added to the ``lumped_elements`` field of the base :class:`.Simulation` instance.
+All lumped elements should be added to the ``lumped_elements`` field of the base :class:`~tidy3d.Simulation` instance.
 
 .. code-block:: python
 

--- a/docs/api/microwave/ports/wave.rst
+++ b/docs/api/microwave/ports/wave.rst
@@ -7,10 +7,11 @@ Wave Port
    :toctree: ../_autosummary/
    :template: module.rst
 
-   tidy3d.plugins.smatrix.WavePort
-   tidy3d.ModeSpec
+   tidy3d.rf.WavePort
 
-The :class:`.WavePort` represents a modal source port. The port mode is first calculated in the 2D mode solver, then injected into the 3D simulation. The :class:`.WavePort` is also automatically terminated with a modal absorbing boundary :class:`.ModeABCBoundary` that perfectly absorbs the outgoing mode. Any non-matching modes are subject to PEC reflection.
+The :class:`~tidy3d.rf.WavePort` represents a modal source port for RF and microwave simulations. The port mode is first calculated in the 2D mode solver with automatic characteristic impedance calculation, then injected into the 3D simulation. The :class:`~tidy3d.rf.WavePort` is also automatically terminated with a modal absorbing boundary :class:`~tidy3d.ModeABCBoundary` that perfectly absorbs the outgoing mode. Any non-matching modes are subject to PEC reflection.
+
+**Basic Usage**
 
 .. code-block:: python
 
@@ -19,18 +20,67 @@ The :class:`.WavePort` represents a modal source port. The port mode is first ca
        size=(port_width, port_height, 0),
        name='My Wave Port 1',
        direction='+',  # direction of signal
-       mode_spec=ModeSpec(target_neff=1.5),  # specification for mode solver
-       current_integral=my_current_integral,  # current integration curve for port impedance calculation
+       mode_spec=MicrowaveModeSpec(
+           num_modes=1,
+           target_neff=1.5,
+           impedance_specs=AutoImpedanceSpec()  # automatic impedance calculation
+       ),
    )
 
-Most fields are self explanatory. Some additional notes:
+Key parameters:
 
-* ``mode_spec`` is used to specify the effective index search value for the mode solver
-* ``current_integral`` and/or ``voltage_integral`` are used to specify the integration paths for port impedance calculation. If only one of the two is specified, then the port power is also used (automatically determined).
+* ``mode_spec`` uses :class:`~tidy3d.rf.MicrowaveModeSpec` to specify mode solver settings and impedance calculation
+* ``impedance_specs`` within :class:`~tidy3d.rf.MicrowaveModeSpec` defines how voltage, current, and characteristic impedance are computed. Use :class:`~tidy3d.rf.AutoImpedanceSpec` for automatic calculation (recommended) or :class:`~tidy3d.rf.CustomImpedanceSpec` for manual control.
 
-If it is desired to only solve for the 2D port mode, one can use the ``to_mode_solver()`` convenience method to generate a :class:`.ModeSolver` simulation object.
+
+**Multimode WavePort Support**
+
+WavePorts can support multiple modes simultaneously. This is useful for multimode waveguides and transmission lines.
 
 .. code-block:: python
+
+   # Create a WavePort that solves for 3 modes
+   multimode_port = WavePort(
+       center=(0, 0, 0),
+       size=(4, 4, 0),
+       direction='+',
+       mode_spec=MicrowaveModeSpec(
+           num_modes=3,  # solve for 3 modes
+           impedance_specs=AutoImpedanceSpec()  # applied to all modes
+       ),
+       name='multimode_port'
+   )
+
+When creating sources from a multimode port, specify which mode to excite:
+
+.. code-block:: python
+
+   source_time = GaussianPulse(freq0=10e9, fwidth=1e9)
+
+   # Create sources for different modes
+   source_mode0 = multimode_port.to_source(source_time, mode_index=0)
+   source_mode1 = multimode_port.to_source(source_time, mode_index=1)
+   source_mode2 = multimode_port.to_source(source_time, mode_index=2)
+
+You can also specify different impedance calculations for each mode:
+
+.. code-block:: python
+
+   mode_spec = MicrowaveModeSpec(
+       num_modes=2,
+       impedance_specs=(
+           CustomImpedanceSpec(...),  # custom for mode 0
+           AutoImpedanceSpec(),       # auto for mode 1
+       )
+   )
+
+**Mode Solver**
+
+If you need to solve for the 2D port mode without running a full 3D simulation, use the ``to_mode_solver()`` convenience method:
+
+.. code-block:: python
+
+   import tidy3d.web as web
 
    # Define a mode solver from the wave port
    my_mode_solver = my_wave_port_1.to_mode_solver(
@@ -41,61 +91,42 @@ If it is desired to only solve for the 2D port mode, one can use the ``to_mode_s
    # Execute mode solver
    my_mode_data = web.run(my_mode_solver, task_name='mode solver')
 
+The resulting ``my_mode_data`` will be :class:`~tidy3d.rf.MicrowaveModeSolverData` containing mode fields and transmission line parameters (characteristic impedance, voltage/current coefficients).
 
-.. autosummary::
-   :toctree: ../_autosummary/
-   :template: module.rst
+**Accessing Transmission Line Data**
 
-   tidy3d.plugins.microwave.AxisAlignedVoltageIntegral
-   tidy3d.plugins.microwave.AxisAlignedCurrentIntegral
-   tidy3d.plugins.microwave.Custom2DVoltageIntegral
-   tidy3d.plugins.microwave.Custom2DCurrentIntegral
-   tidy3d.plugins.microwave.AxisAlignedPathIntegral
-   tidy3d.plugins.microwave.Custom2DPathIntegral
-   tidy3d.plugins.microwave.ImpedanceCalculator
-
-The classes above are used to define the voltage/current integration paths for impedance calculation.
+After running a simulation with :class:`~tidy3d.rf.WavePort`, you can access the transmission line characteristics from the mode data:
 
 .. code-block:: python
 
-   # Define voltage integration line
-   my_voltage_integral = AxisAlignedVoltageIntegral(
-       center=(0,0,0),  # center of integration line
-       size=(5, 0, 0),  # length of integration line
-       sign='+',  # sign of integral
-   )
+   # Get mode data from TerminalComponentModeler results
+   mode_data = tcm_data.data['port1']['mode_monitor']
 
-   # Define current integration loop
-   my_current_integral = AxisAlignedCurrentIntegral(
-       center=(0,0,0),  # center of integration loop
-       size=(20, 20, 0),  # size of integration loop
-       sign='+', # sign of integral (should match wave port direction)
-   )
+   # Access characteristic impedance for each mode
+   Z0_mode0 = mode_data.transmission_line_data.Z0.sel(mode_index=0)
 
-In addition to being used in the :class:`.WavePort` definition, the current/voltage integration objects can also be applied to arbitrary EM field data (2D and 3D). This is most commonly used in conjunction with the ``ImpedanceCalculator`` to calculate the line impedance of a 2D mode.
+   # Get voltage and current coefficients
+   voltage_coeff = mode_data.transmission_line_data.voltage_coeffs.sel(mode_index=0)
+   current_coeff = mode_data.transmission_line_data.current_coeffs.sel(mode_index=0)
+
+Alternatively, use the port's ``get_port_impedance()`` method:
 
 .. code-block:: python
 
-   # Define impedance calculator
-   my_Z_calculator = ImpedanceCalculator(
-       voltage_integral = my_voltage_integral,
-       current_integral = my_current_integral,
-   )
-
-   # Calculate impedance of 2D mode
-   Z_mode = my_Z_calculator.compute_impedance(my_mode_data)
-
-As before, only one of the two integration paths (voltage or current) are strictly necessary. This determines the convention used to calculate the impedance (PI, PV, or VI).
+   # Get impedance directly from port
+   Z0 = my_wave_port_1.get_port_impedance(mode_data, mode_index=0)
 
 .. seealso::
 
-   For more information, please see the following articles:
+   **Related Documentation:**
 
-   + `Computing the characteristic impedance of transmission lines <../../notebooks/CharacteristicImpedanceCalculator.html>`_
+   + :ref:`microwave_mode_solver` - MicrowaveModeSpec and transmission line mode analysis
+   + :ref:`microwave_migration` - Migration guide for API changes
 
-   Example applications:
+   **Tutorials and Examples:**
 
    + `Differential stripline benchmark <../../notebooks/DifferentialStripline.html>`_
-
+   + `Coplanar waveguide RF photonics <../../notebooks/CPWRFPhotonics1.html>`_
+   + `Through silicon via <../../notebooks/ThroughSiliconVia.html>`_
 
 ~~~~

--- a/docs/api/microwave/radiation_scattering.rst
+++ b/docs/api/microwave/radiation_scattering.rst
@@ -7,13 +7,12 @@ Radiation & Scattering
    :toctree: ../_autosummary/
    :template: module.rst
 
-   tidy3d.DirectivityMonitor
-   tidy3d.plugins.smatrix.DirectivityMonitorSpec
-   tidy3d.plugins.microwave.RectangularAntennaArrayCalculator
-   tidy3d.plugins.microwave.LobeMeasurer
-   tidy3d.AntennaMetricsData
+   tidy3d.rf.DirectivityMonitor
+   tidy3d.rf.DirectivityMonitorSpec
+   tidy3d.rf.RectangularAntennaArrayCalculator
+   tidy3d.rf.LobeMeasurer
 
-When modeling antennas or scattering problems, it is vital to analyze the radiated far-field. For such applications, the :class:`.DirectivityMonitor` should be used.
+When modeling antennas or scattering problems, it is vital to analyze the radiated far-field. For such applications, the :class:`~tidy3d.rf.DirectivityMonitor` should be used.
 
 .. code-block:: python
 
@@ -33,16 +32,16 @@ When modeling antennas or scattering problems, it is vital to analyze the radiat
        name='My radiation monitor',
    )
 
-The :class:`.DirectivityMonitor` should completely surround the structure of interest.
+The :class:`~tidy3d.rf.DirectivityMonitor` should completely surround the structure of interest.
 
-Alternatively, a :class:`.DirectivityMonitorSpec` can be used to create a specification for automatic generation of a :class:`.DirectivityMonitor` in the :class:`.TerminalComponentModeler`.
+Alternatively, a :class:`~tidy3d.rf.DirectivityMonitorSpec` can be used to create a specification for automatic generation of a :class:`~tidy3d.rf.DirectivityMonitor` in the :class:`~tidy3d.rf.TerminalComponentModeler`.
 
 .. code-block:: python
 
    # Define directivity monitor spec
    my_directivity_monitor_spec = DirectivityMonitorSpec()
 
-Once the monitor or monitor spec is defined, it should be added to the ``radiation_monitors`` option of the :class:`.TerminalComponentModeler`.
+Once the monitor or monitor spec is defined, it should be added to the ``radiation_monitors`` option of the :class:`~tidy3d.rf.TerminalComponentModeler`.
 
 .. code-block:: python
 
@@ -52,7 +51,7 @@ Once the monitor or monitor spec is defined, it should be added to the ``radiati
        radiation_monitors=[my_directivity_monitor, my_directivity_monitor_spec],
    )
 
-Once the simulation is completed, the ``get_antenna_metrics_data()`` method of the :class:`.TerminalComponentModelerData` object is used to obtain the radiation metrics.
+Once the simulation is completed, the ``get_antenna_metrics_data()`` method of the :class:`~tidy3d.rf.TerminalComponentModelerData` object is used to obtain the radiation metrics.
 
 .. code-block:: python
 
@@ -74,7 +73,7 @@ Once the simulation is completed, the ``get_antenna_metrics_data()`` method of t
 
 Each metric is in the form of an ``xarray.DataArray`` object that can be used for plotting, export, and further analysis. For examples of how these datasets can be manipulated, please refer to the notebooks in the "See also" section below.
 
-The :class:`.LobeMeasurer` utility class can be used to analyze radiation pattern lobes.
+The :class:`~tidy3d.rf.LobeMeasurer` utility class can be used to analyze radiation pattern lobes.
 
 .. code-block:: python
 

--- a/docs/api/microwave/rf_material_library.rst
+++ b/docs/api/microwave/rf_material_library.rst
@@ -7,7 +7,7 @@ RF Materials Library
 
 The RF material library is a dictionary containing various dispersive models for real-world RF materials. To use the materials in the library, import it first by:
 
->>> from tidy3d.plugins.microwave import rf_material_library
+>>> from tidy3d.rf import rf_material_library
 
 The key of the dictionary is the abbreviated material name.
 

--- a/docs/api/plugins/microwave.rst
+++ b/docs/api/plugins/microwave.rst
@@ -5,7 +5,7 @@ Microwave
 
 .. warning::
 
-    RF simulations are subject to new license requirements in the future. These components are within the RF scope.
+    RF simulations and functionality will require new license requirements in an upcoming release. All RF-specific classes are now available within the sub-package 'tidy3d.rf'. These classes are included.
 
 
 .. autosummary::

--- a/docs/api/plugins/smatrix.rst
+++ b/docs/api/plugins/smatrix.rst
@@ -3,6 +3,20 @@
 S-Matrix Component Modelers Plugin
 ----------------------------------
 
+This plugin provides component modelers for computing S-parameters (scattering parameters) for both **photonics** and **RF/microwave** applications. The plugin supports:
+
+* **Photonics**: Modal component modelers for photonic devices (waveguides, splitters, filters, etc.)
+* **RF/Microwave**: Terminal component modelers for microwave circuits and antennas (available in :class:`tidy3d.rf` subpackage)
+
+.. warning::
+
+   Breaking changes were introduced in ``v2.10.0``, please see the :ref:`smatrix_migration` guide for help migrating your code.
+
+Photonics Component Modelers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For photonics applications, use the **ModalComponentModeler** which computes modal S-parameters based on mode overlap integrals.
+
 .. autosummary::
    :toctree: ../_autosummary/
    :template: module.rst
@@ -12,19 +26,34 @@ S-Matrix Component Modelers Plugin
    tidy3d.plugins.smatrix.Port
    tidy3d.plugins.smatrix.ModalPortDataArray
 
-.. seealso::
-   
-   For classes related to microwave/RF modeling, please refer to the main `Microwave and RF <../microwave/index.html>`_ page. 
+RF/Microwave Component Modelers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+For RF and microwave applications, use the **TerminalComponentModeler** (available in ``tidy3d.rf``) which computes terminal-based S-parameters.
 
 .. warning::
 
-   RF simulations will be subject to new license requirements in the future.
+   RF simulations will require new license requirements in an upcoming release. All RF-specific classes are available in the ``tidy3d.rf`` subpackage.
 
-.. include:: /api/microwave/component_modeler.rst
-.. include:: /api/microwave/material.rst
-.. include:: /api/microwave/ports/lumped.rst
-.. include:: /api/microwave/ports/wave.rst
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.rf.TerminalComponentModeler
+   tidy3d.rf.TerminalComponentModelerData
+   tidy3d.rf.LumpedPort
+   tidy3d.rf.CoaxialLumpedPort
+   tidy3d.rf.WavePort
+   tidy3d.rf.MicrowaveSMatrixData
+   tidy3d.rf.TerminalPortDataArray
+   tidy3d.rf.PortDataArray
+
+.. seealso::
+   For complete RF/microwave documentation, see:
+
+      * `RF Simulation Workflow <../microwave/component_modeler.html>`_ - Main RF simulation workflow
+      * `Microwave & RF Documentation <../microwave/index.html>`_ - Comprehensive RF features
+
 .. include:: /api/plugins/smatrix_migration.rst
 
 Further Details

--- a/docs/api/plugins/smatrix_migration.rst
+++ b/docs/api/plugins/smatrix_migration.rst
@@ -5,6 +5,10 @@ v2.10 Refactor Migration
 
 In version ``v2.10.0rc1``, ``smatrix`` plugin classes were refactored to improve web and GUI support for RF capabilities. This guide helps you update your scripts to the new, more robust API.
 
+.. seealso::
+
+   This guide is also included as part of the comprehensive :ref:`microwave_migration` guide, which covers all v2.10 RF/microwave breaking changes.
+
 Key Changes
 ~~~~~~~~~~~
 
@@ -40,10 +44,11 @@ The new workflow is more explicit and aligns with the general ``tidy3d`` API.
 .. code-block:: python
 
     import tidy3d.web as web
-    import tidy3d.plugins.smatrix as sm
+    # Rf classes now found in tidy3d.rf
+    import tidy3d.rf as rf
 
     # Modeler class is now immutable and cleaner
-    tcm = sm.TerminalComponentModeler(
+    tcm = rf.TerminalComponentModeler(
         simulation=sim,
         ports=[LP1, LP2],
         freqs=my_freqs,
@@ -81,8 +86,8 @@ Data Handling
 
 The new API introduces immutable data containers for simulation results, ensuring that your data is more predictable and easier to manage.
 
-*   :class:`.TerminalComponentModeler` returns a :class:`.TerminalComponentModelerData` object.
-*   ``ModalComponentModeler`` returns a ``ModalComponentModelerData`` object.
+*   :class:`tidy3d.rf.TerminalComponentModeler` returns a :class:`tidy3d.rf.TerminalComponentModelerData` object.
+*   :class:`.ModalComponentModeler` returns a :class:`.ModalComponentModelerData` object.
 
 These data objects contain the S-matrix, port impedance, and other relevant results.
 
@@ -145,8 +150,8 @@ For more details, see the API documentation for the new classes and functions:
 
    tidy3d.plugins.smatrix.ModalComponentModeler
    tidy3d.plugins.smatrix.ModalComponentModelerData
-   tidy3d.plugins.smatrix.TerminalComponentModeler
-   tidy3d.plugins.smatrix.TerminalComponentModelerData
+   tidy3d.rf.TerminalComponentModeler
+   tidy3d.rf.TerminalComponentModelerData
    tidy3d.SimulationMap
    tidy3d.SimulationDataMap
    tidy3d.plugins.smatrix.run.create_batch

--- a/tidy3d/components/microwave/data/data_array.py
+++ b/tidy3d/components/microwave/data/data_array.py
@@ -5,25 +5,39 @@ from tidy3d.constants import NEPERPERMETER, PERMETER, RADPERMETER, VELOCITY_SI
 
 
 class PropagationConstantArray(FreqModeDataArray):
+    """Data array for the complex propagation constant :math:`\\gamma = -\\alpha + j\\beta` with units of 1/m.
+
+    In the physics convention where time-harmonic fields evolve with :math:`e^{-j\\omega t}`, a wave
+    propagating in the +z direction varies as :math:`E(z) = E_0 e^{\\gamma z} = E_0 e^{-\\alpha z} e^{j\\beta z}`.
+    """
+
     __slots__ = ()
     _data_attrs = {"units": PERMETER, "long_name": "propagation constant"}
 
 
 class PhaseConstantArray(FreqModeDataArray):
+    """Data array for the phase constant :math:`\\beta = \\text{Im}(\\gamma)` with units of rad/m."""
+
     __slots__ = ()
     _data_attrs = {"units": RADPERMETER, "long_name": "phase constant"}
 
 
 class AttenuationConstantArray(FreqModeDataArray):
+    """Data array for the attenuation constant :math:`\\alpha = -\\text{Re}(\\gamma)` with units of Nepers/m."""
+
     __slots__ = ()
     _data_attrs = {"units": NEPERPERMETER, "long_name": "attenuation constant"}
 
 
 class PhaseVelocityArray(FreqModeDataArray):
+    """Data array for the phase velocity :math:`v_p = c/n_{\\mathrm{eff}}` with units of m/s."""
+
     __slots__ = ()
     _data_attrs = {"units": VELOCITY_SI, "long_name": "phase velocity"}
 
 
 class GroupVelocityArray(FreqModeDataArray):
+    """Data array for the group velocity :math:`v_g = c/n_{\\mathrm{group}}` with units of m/s."""
+
     __slots__ = ()
     _data_attrs = {"units": VELOCITY_SI, "long_name": "group velocity"}


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds comprehensive documentation for the new RF/microwave mode impedance calculation features introduced in v2.10.0. The documentation covers four major new areas:

- **Path Integrals**: New documentation for voltage and current path integral classes used to compute transmission line characteristics from electromagnetic field data
- **Impedance Calculator**: Post-processing tool for computing characteristic impedance using three different calculation methods (V/I, V²/2P, 2P/I²)
- **RF Mode Analysis**: Documentation for `MicrowaveModeSpec`, `MicrowaveModeMonitor`, and `MicrowaveModeSolverMonitor` that enable automatic impedance calculation during mode solving
- **RF Output Data**: Complete reference for new data containers including `MicrowaveModeData`, `MicrowaveModeSolverData`, and associated data arrays

The documentation includes extensive code examples, mathematical formulas, best practices, and cross-references. Minor updates were also made to existing documentation (component modeler, wave port) to integrate with the new features.

**Issues Found:**
- One undefined variable (`num_modes`) in code example at `impedance_calculator.rst:73`

<h3>Confidence Score: 4/5</h3>


- This documentation PR is safe to merge with one minor fix needed
- The documentation is comprehensive, well-structured, and properly formatted with correct RST syntax. The Python code file is clean with proper docstrings. One code example contains an undefined variable that will confuse users and needs to be fixed before merge. Otherwise the documentation follows established patterns and integrates well with existing docs.
- Fix the undefined variable in `docs/api/microwave/impedance_calculator.rst:73`

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| docs/api/microwave/impedance_calculator.rst | 4/5 | New comprehensive documentation for ImpedanceCalculator with usage examples and undefined variable in code example |
| docs/api/microwave/mode_solver.rst | 5/5 | New comprehensive documentation for MicrowaveModeSpec and RF mode analysis with clear examples |
| docs/api/microwave/output_data.rst | 5/5 | New documentation for RF output data classes, datasets, and data arrays with proper organization |
| docs/api/microwave/path_integrals.rst | 5/5 | New comprehensive documentation for voltage and current path integrals with detailed usage examples |
| tidy3d/components/microwave/data/data_array.py | 5/5 | Clean data array classes for microwave propagation constants with proper docstrings and units |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Docs as Documentation
    participant API as Tidy3D API
    participant Solver as Mode Solver
    participant Calc as ImpedanceCalculator

    User->>Docs: Read microwave RF docs
    
    Note over Docs: New documentation sections added:<br/>- Path Integrals<br/>- Impedance Calculator<br/>- RF Mode Analysis<br/>- Output Data
    
    User->>API: Create MicrowaveModeSpec with impedance_specs
    API->>API: Configure voltage/current integrals
    
    User->>API: Create WavePort or MicrowaveModeMonitor
    API->>API: Attach MicrowaveModeSpec
    
    User->>Solver: Run ModeSimulation or ModeSolver
    Solver->>Solver: Solve for mode fields
    Solver->>Calc: Compute voltage/current via path integrals
    Calc->>Calc: Calculate Z0 = V/I or Z0 = V²/2P or Z0 = 2P/I²
    Solver-->>User: Return MicrowaveModeSolverData with transmission line params
    
    User->>API: Access Z0, voltage, current from results
    API-->>User: Return transmission line characteristics
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->