### PR TITLE
feat(tidy3d): FXC-3689 Per-Simulation Downloads During Batch Runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DirectivityMonitor` now forces `far_field_approx` to `True`, which was previously configurable.
 - Unified run submission API: `web.run(...)` is now a container-aware wrapper that accepts a single simulation or arbitrarily nested containers (`list`, `tuple`, `dict` values) and returns results in the same shape.
 - `web.Batch(ComponentModeler)` and `web.Job(ComponentModeler)` native support
+- Simulation data of batch jobs are now automatically downloaded upon their individual completion in `Batch.run()`, avoiding waiting for the entire batch to reach completion.
 
 ### Fixed
 - More robust `Sellmeier` and `Debye` material model, and prevent very large pole parameters in `PoleResidue` material model.

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+from concurrent.futures import Future
 from types import SimpleNamespace
 
 import numpy as np
@@ -25,7 +26,7 @@ from tidy3d.web import common
 from tidy3d.web.api.asynchronous import run_async
 from tidy3d.web.api.container import Batch, Job, WebContainer
 from tidy3d.web.api.run import _collect_by_hash, run
-from tidy3d.web.api.tidy3d_stub import Tidy3dStubData
+from tidy3d.web.api.tidy3d_stub import Tidy3dStubData, task_type_name_of
 from tidy3d.web.api.webapi import (
     abort,
     delete,
@@ -63,6 +64,24 @@ task_core_path = "tidy3d.web.core.task_core"
 api_path = "tidy3d.web.api.webapi"
 
 Env.dev.active()
+
+
+class ImmediateExecutor:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def submit(self, fn, *args, **kwargs):
+        future = Future()
+        try:
+            result = fn(*args, **kwargs)
+        except Exception as err:  # pragma: no cover - defensive
+            future.set_exception(err)
+        else:
+            future.set_result(result)
+        return future
+
+    def shutdown(self, wait=True):
+        pass
 
 
 def make_sim():
@@ -703,6 +722,106 @@ def test_batch_run_saves_file_after_upload(mock_webapi, mock_job_status, tmp_pat
         batch.run(path_dir=str(tmp_path))
 
 
+def test_batch_monitor_downloads_on_success(monkeypatch, tmp_path):
+    events = []
+
+    class FakeJob:
+        def __init__(self, task_id: str, statuses: list[str]):
+            self.task_id = task_id
+            self._statuses = statuses
+            self._idx = 0
+
+        @property
+        def status(self):
+            status = self._statuses[self._idx]
+            if self._idx < len(self._statuses) - 1:
+                self._idx += 1
+            events.append((self.task_id, "status", status))
+            return status
+
+        def download(self, path: str):
+            events.append((self.task_id, "download", path))
+
+    monkeypatch.setattr("tidy3d.web.api.container.ThreadPoolExecutor", ImmediateExecutor)
+    monkeypatch.setattr("tidy3d.web.api.container.time.sleep", lambda *_args, **_kwargs: None)
+
+    sims = {"task_a": make_sim(), "task_b": make_sim()}
+    batch = Batch(simulations=sims, folder_name=PROJECT_NAME, verbose=False)
+    batch._cached_properties = {}
+    fake_jobs = {
+        "task_a": FakeJob("task_a_id", ["running", "success", "success"]),
+        "task_b": FakeJob("task_b_id", ["running", "running", "success"]),
+    }
+    batch._cached_properties["jobs"] = fake_jobs
+
+    batch.monitor(download_on_success=True, path_dir=str(tmp_path))
+
+    downloads = [event for event in events if event[1] == "download"]
+    assert len(downloads) == 2
+    assert {event[0] for event in downloads} == {"task_a_id", "task_b_id"}
+
+    expected_paths = {
+        "task_a_id": os.path.join(str(tmp_path), "task_a_id.hdf5"),
+        "task_b_id": os.path.join(str(tmp_path), "task_b_id.hdf5"),
+    }
+
+    for task_id, _, path in downloads:
+        assert path == expected_paths[task_id]
+
+    job1_download_idx = next(
+        i
+        for i, event in enumerate(events)
+        if event == ("task_a_id", "download", expected_paths["task_a_id"])
+    )
+    job2_success_idx = next(
+        i for i, event in enumerate(events) if event == ("task_b_id", "status", "success")
+    )
+
+    assert job1_download_idx < job2_success_idx, "Download should start before other jobs finish"
+
+
+def test_batch_monitor_skips_existing_download(monkeypatch, tmp_path):
+    events = []
+
+    class FakeJob:
+        def __init__(self, task_id: str, statuses: list[str]):
+            self.task_id = task_id
+            self._statuses = statuses
+            self._idx = 0
+
+        @property
+        def status(self):
+            status = self._statuses[self._idx]
+            if self._idx < len(self._statuses) - 1:
+                self._idx += 1
+            events.append((self.task_id, "status", status))
+            return status
+
+        def download(self, path: str):
+            events.append((self.task_id, "download", path))
+
+    monkeypatch.setattr("tidy3d.web.api.container.ThreadPoolExecutor", ImmediateExecutor)
+    monkeypatch.setattr("tidy3d.web.api.container.time.sleep", lambda *_args, **_kwargs: None)
+
+    sims = {"task_a": make_sim(), "task_b": make_sim()}
+    batch = Batch(simulations=sims, folder_name=PROJECT_NAME, verbose=False)
+    batch._cached_properties = {}
+    fake_jobs = {
+        "task_a": FakeJob("task_a_id", ["success", "success"]),
+        "task_b": FakeJob("task_b_id", ["running", "success"]),
+    }
+    batch._cached_properties["jobs"] = fake_jobs
+
+    existing_path = os.path.join(str(tmp_path), "task_a_id.hdf5")
+    with open(existing_path, "w", encoding="utf8") as handle:
+        handle.write("cached")
+
+    batch.monitor(download_on_success=True, path_dir=str(tmp_path))
+
+    downloads = [event for event in events if event[1] == "download"]
+    assert downloads == [("task_b_id", "download", os.path.join(str(tmp_path), "task_b_id.hdf5"))]
+
+
 """ Async """
 
 
@@ -800,16 +919,30 @@ def _fake_load_factory(tmp_root, taskid_to_sim: dict):
 
 
 def apply_common_patches(
-    monkeypatch, tmp_root, *, api_path="tidy3d.web.api.webapi", path_to_sim=None, taskid_to_sim=None
+    monkeypatch,
+    tmp_root,
+    *,
+    api_path="tidy3d.web.api.webapi",
+    taskid_to_sim=None,
 ):
     """Patch start/monitor/get_info/estimate_cost/upload/_check_folder/_modesolver_patch/load."""
     monkeypatch.setattr(f"{api_path}.start", lambda *a, **k: True)
     monkeypatch.setattr(f"{api_path}.monitor", lambda *a, **k: True)
-    monkeypatch.setattr(f"{api_path}.get_info", lambda *a, **k: SimpleNamespace(status="success"))
+
+    # --- make get_info return also task type ---
+    def _fake_get_info(task_id: str, *_, **__):
+        sim = taskid_to_sim.get(task_id) if taskid_to_sim else None
+        task_type = task_type_name_of(sim) if sim is not None else None
+        return SimpleNamespace(status="success", taskType=task_type)
+
+    monkeypatch.setattr(f"{api_path}.get_info", _fake_get_info)
+
+    # other patches
     monkeypatch.setattr(f"{api_path}.estimate_cost", lambda *a, **k: 0.0)
     monkeypatch.setattr(f"{api_path}.upload", lambda *a, **k: k["task_name"])
     monkeypatch.setattr(WebContainer, "_check_folder", lambda *a, **k: True)
     monkeypatch.setattr(f"{api_path}._modesolver_patch", lambda *_, **__: None, raising=False)
+    monkeypatch.setattr(f"{api_path}.download", lambda *_, **__: None, raising=False)
     monkeypatch.setattr(
         f"{api_path}.load",
         _fake_load_factory(tmp_root=str(tmp_root), taskid_to_sim=taskid_to_sim),

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -742,8 +742,8 @@ class Batch(WebContainer):
             self.start()
         else:
             self.start(priority=priority)
-        self.monitor()
-        return self.load(path_dir=path_dir)
+        self.monitor(path_dir=path_dir, download_on_success=True)
+        return self.load(path_dir=path_dir, skip_download=True)
 
     @cached_property
     def jobs(self) -> dict[TaskName, Job]:
@@ -896,20 +896,11 @@ class Batch(WebContainer):
 
     def postprocess_start(self, worker_group: Optional[str] = None, verbose: bool = True) -> None:
         """
-        Starts the postprocess phase for all applicable jobs within the batch.
+        Start the postprocess phase for all applicable jobs in the batch.
 
-        This function iterates through each job in the batch and calls its
-        'postprocess_start' method. The check for whether a job is a
-        Component Modeler task is handled within the individual Job's method.
-
-        This function does not wait for postprocessing to finish.
-
-        Parameters
-        ----------
-        worker_group : Optional[str] = None
-            The specific worker group to run the postprocessing tasks on.
-        verbose : bool = True
-            Whether to print info messages.
+        This simply forwards to each Job's `postprocess_start(...)`. The Job decides
+        whether it's a Component Modeler task and whether it can/should start now.
+        This method does not wait for postprocessing to finish.
         """
         if self.verbose and verbose:
             console = get_logging_console()
@@ -918,44 +909,86 @@ class Batch(WebContainer):
         for job in self.jobs.values():
             job.postprocess_start(worker_group=worker_group, verbose=verbose)
 
-    def monitor(self) -> None:
+    def monitor(
+        self,
+        *,
+        download_on_success: bool = False,
+        path_dir: str = DEFAULT_DATA_DIR,
+        replace_existing: bool = False,
+        postprocess_worker_group: Optional[str] = None,
+    ) -> None:
         """
-        Monitor progress of each of the running tasks.
+        Monitor progress of each running task.
 
-        For Component Modeler jobs, this method will automatically trigger the
-        post-processing step as soon as the run phase is complete.
+        - For Component Modeler jobs, automatically triggers postprocessing once run finishes.
+        - Optionally downloads results as soon as a job reaches final success.
+        - Rich progress bars in verbose mode; quiet polling otherwise.
+
+
+        Parameters
+        ----------
+        download_on_success : bool = False
+            If ``True``, automatically start downloading the results for a job as soon as it reaches
+            ``success``.
+        path_dir : str = './'
+            Base directory where data will be downloaded, by default the current working directory.
+            Only used when ``download_on_success`` is ``True``.
+        replace_existing : bool = False
+            Downloads the data even if path exists (overwriting the existing). Only used when
+            ``download_on_success`` is ``True``.
         """
+        # ----- download scheduling ---------------------------------------------------
+        downloads_started: set[str] = set()
+        download_futures: dict[TaskId, concurrent.futures.Future] = {}
+        download_executor: Optional[ThreadPoolExecutor] = None
 
-        def check_continue_condition(job) -> bool:
-            """
-            Determines if a job still needs monitoring.
-            Returns True if monitoring should continue, False if the job is finished.
-            """
+        if download_on_success:
+            self._check_path_dir(path_dir=path_dir)
+            download_executor = ThreadPoolExecutor(max_workers=self.num_workers)
+
+        def _should_download(job) -> bool:
             status = job.status
             if not web._is_modeler_batch(job.task_id):
-                # For regular jobs, finish when the status is in an end state.
+                return status == "success"
+            if status == "success":
+                return True
+            return status == "run_success" and getattr(job, "postprocess_status", None) == "success"
+
+        def schedule_download(job) -> None:
+            if download_executor is None or not _should_download(job):
+                return
+            task_id = job.task_id
+            if task_id in downloads_started:
+                return
+
+            job_path_str = self._job_data_path(task_id=task_id, path_dir=path_dir)
+            if os.path.exists(job_path_str):
+                if not replace_existing:
+                    downloads_started.add(task_id)
+                    log.info(
+                        f"File '{job_path_str}' already exists. Skipping download "
+                        "(set `replace_existing=True` to overwrite)."
+                    )
+                    return
+                log.info(f"File '{job_path_str}' already exists. Overwriting.")
+
+            downloads_started.add(task_id)
+            download_futures[task_id] = download_executor.submit(job.download, job_path_str)
+
+        # ----- continue condition & status formatting -------------------------------
+        def check_continue_condition(job) -> bool:
+            status = job.status
+            if not web._is_modeler_batch(job.task_id):
                 return status not in END_STATES
-
-            # For modeler jobs, the logic is more complex.
             if status == "run_success":
-                condition = job.postprocess_status not in END_STATES
-                return condition
-
-            if status not in END_STATES:
-                return True  # Still running, definitely continue.
-
-            # If status is a final end state (e.g., 'success', 'error'), we are done.
-            return False
+                return job.postprocess_status not in END_STATES
+            return status not in END_STATES
 
         def pbar_description(
             task_name: str, status: str, max_name_length: int, status_width: int
         ) -> str:
-            """Make a progressbar description based on the status."""
-            # if task name too long, truncate and add ...
-            if len(task_name) > max_name_length - 3:  # -3 to leave room for ...
+            if len(task_name) > max_name_length - 3:
                 task_name = task_name[: (max_name_length - 3)] + "..."
-
-            # right-align status
             task_part = f"{task_name:<{max_name_length}}"
 
             if status in ERROR_STATES:
@@ -968,106 +1001,125 @@ class Batch(WebContainer):
                 status_part = f"→ [blue]{status:<{status_width}}"
             else:
                 status_part = f"→ {status:<{status_width}}"
-
             return f"{task_part} {status_part}"
 
         max_task_name = max(len(task_name) for task_name in self.jobs.keys())
         max_name_length = min(30, max(max_task_name, 15))
 
-        # Keep track of modeler jobs that have had postprocessing started.
-        postprocess_started_tasks = set()
+        # track which modeler jobs we've already kicked into postprocess
+        postprocess_started_tasks: set[str] = set()
 
-        if self.verbose:
-            console = get_logging_console()
+        try:
+            if self.verbose:
+                console = get_logging_console()
+                self.estimate_cost()
+                console.log(
+                    "Use 'Batch.real_cost()' to get the billed FlexCredit cost after completion."
+                )
 
-            self.estimate_cost()
-            console.log(
-                "Use 'Batch.real_cost()' to "
-                "get the billed FlexCredit cost after the Batch has completed."
-            )
+                progress_columns = (
+                    TextColumn("[progress.description]{task.description}"),
+                    BarColumn(bar_width=25),
+                    TaskProgressColumn(),
+                    TimeElapsedColumn(),
+                )
 
-            progress_columns = (
-                TextColumn("[progress.description]{task.description}"),
-                BarColumn(bar_width=25),
-                TaskProgressColumn(),
-                TimeElapsedColumn(),
-            )
-
-            with Progress(*progress_columns, console=console, transient=False) as progress:
-                # Create progress bars
-                pbar_tasks = {}
-                for task_name, job in self.jobs.items():
-                    status = job.status
-                    description = pbar_description(task_name, status, max_name_length, 0)
-                    completed = STATE_PROGRESS_PERCENTAGE[status]
-                    pbar = progress.add_task(
-                        description, total=COMPLETED_PERCENT, completed=completed
-                    )
-                    pbar_tasks[task_name] = pbar
-
-                while any(check_continue_condition(job) for job in self.jobs.values()):
+                with Progress(*progress_columns, console=console, transient=False) as progress:
+                    pbar_tasks: dict[str, int] = {}
                     for task_name, job in self.jobs.items():
+                        schedule_download(job)
                         status = job.status
-                        if (
-                            web._is_modeler_batch(job.task_id)
-                            and status == "run_success"
-                            and job.task_id not in postprocess_started_tasks
-                        ):
-                            job.postprocess_start(verbose=True)
-                            postprocess_started_tasks.add(job.task_id)
+                        completed = STATE_PROGRESS_PERCENTAGE.get(status, 0)
+                        desc = pbar_description(task_name, status, max_name_length, 0)
+                        pbar_tasks[task_name] = progress.add_task(
+                            desc, total=COMPLETED_PERCENT, completed=completed
+                        )
 
-                        # Update progress bar
-                        pbar = pbar_tasks[task_name]
-                        if status != "run_success":
-                            completed_percent = STATE_PROGRESS_PERCENTAGE[status]
-                        elif status == "run_success":
-                            postprocess_status = job.postprocess_status
-                            if postprocess_status in END_STATES:
-                                status = postprocess_status
-                                completed_percent = STATE_PROGRESS_PERCENTAGE[postprocess_status]
+                    while any(check_continue_condition(job) for job in self.jobs.values()):
+                        for task_name, job in self.jobs.items():
+                            status = job.status
+
+                            # auto-start postprocess for modeler jobs when run finishes
+                            if (
+                                web._is_modeler_batch(job.task_id)
+                                and status == "run_success"
+                                and job.task_id not in postprocess_started_tasks
+                            ):
+                                job.postprocess_start(
+                                    worker_group=postprocess_worker_group, verbose=True
+                                )
+                                postprocess_started_tasks.add(job.task_id)
+
+                            schedule_download(job)
+
+                            # choose display status & percent
+                            if status != "run_success":
+                                display_status = status
+                                pct = STATE_PROGRESS_PERCENTAGE.get(status, 0)
                             else:
-                                status = "postprocess"
-                                completed_percent = STATE_PROGRESS_PERCENTAGE["postprocess"]
-                        description = pbar_description(task_name, status, max_name_length, 0)
-                        progress.update(pbar, description=description, completed=completed_percent)
+                                post_st = getattr(job, "postprocess_status", None)
+                                if post_st in END_STATES:
+                                    display_status = post_st
+                                    pct = STATE_PROGRESS_PERCENTAGE.get(post_st, 0)
+                                else:
+                                    display_status = "postprocess"
+                                    pct = STATE_PROGRESS_PERCENTAGE.get("postprocess", 0)
+
+                            pbar = pbar_tasks[task_name]
+                            desc = pbar_description(task_name, display_status, max_name_length, 0)
+                            progress.update(pbar, description=desc, completed=pct)
+
+                        progress.refresh()
+                        time.sleep(BATCH_MONITOR_PROGRESS_REFRESH_TIME)
+
+                    # final render to terminal state for all bars
+                    for task_name, job in self.jobs.items():
+                        schedule_download(job)
+                        status = job.status
+                        if status != "run_success":
+                            display_status = status
+                            pct = STATE_PROGRESS_PERCENTAGE.get(status, COMPLETED_PERCENT)
+                        else:
+                            post_st = getattr(job, "postprocess_status", None)
+                            if post_st in END_STATES:
+                                display_status = post_st
+                                pct = STATE_PROGRESS_PERCENTAGE.get(post_st, COMPLETED_PERCENT)
+                            else:
+                                display_status = "postprocess"
+                                pct = STATE_PROGRESS_PERCENTAGE.get(
+                                    "postprocess", COMPLETED_PERCENT
+                                )
+
+                        pbar = pbar_tasks[task_name]
+                        desc = pbar_description(task_name, display_status, max_name_length, 0)
+                        progress.update(pbar, description=desc, completed=pct)
 
                     progress.refresh()
-                    time.sleep(BATCH_MONITOR_PROGRESS_REFRESH_TIME)
+                    console.log("Batch complete.")
+            else:
+                # quiet mode
+                while any(check_continue_condition(job) for job in self.jobs.values()):
+                    for job in self.jobs.values():
+                        if (
+                            web._is_modeler_batch(job.task_id)
+                            and job.status == "run_success"
+                            and job.task_id not in postprocess_started_tasks
+                        ):
+                            job.postprocess_start(
+                                worker_group=postprocess_worker_group, verbose=False
+                            )
+                            postprocess_started_tasks.add(job.task_id)
 
-                # Final update to ensure all bars show their terminal state
-                for task_name, job in self.jobs.items():
-                    status = job.status
-                    if status != "run_success":
-                        completed_percent = STATE_PROGRESS_PERCENTAGE[status]
-                    elif status == "run_success":
-                        postprocess_status = job.postprocess_status
-                        if postprocess_status in END_STATES:
-                            status = postprocess_status
-                            completed_percent = STATE_PROGRESS_PERCENTAGE[postprocess_status]
-                        else:
-                            status = "postprocess"
-                            completed_percent = STATE_PROGRESS_PERCENTAGE["postprocess"]
-                    pbar = pbar_tasks[task_name]
-                    description = pbar_description(task_name, status, max_name_length, 0)
+                        schedule_download(job)
 
-                    progress.update(pbar, description=description, completed=completed_percent)
-
-                progress.refresh()
-                console.log("Batch complete.")
-
-        else:
-            # Non-verbose path
-            while any(check_continue_condition(job) for job in self.jobs.values()):
-                for job in self.jobs.values():
-                    # If a modeler job is done running, start its postprocessing once.
-                    if (
-                        web._is_modeler_batch(job.task_id)
-                        and job.status == "run_success"
-                        and job.task_id not in postprocess_started_tasks
-                    ):
-                        job.postprocess_start(verbose=False)
-                        postprocess_started_tasks.add(job.task_id)
-                time.sleep(web.REFRESH_TIME)
+                    time.sleep(web.REFRESH_TIME)
+        finally:
+            if download_executor is not None:
+                try:
+                    for fut in concurrent.futures.as_completed(download_futures.values()):
+                        fut.result()
+                finally:
+                    download_executor.shutdown(wait=True)
 
     @staticmethod
     def _job_data_path(task_id: TaskId, path_dir: str = DEFAULT_DATA_DIR):
@@ -1176,7 +1228,12 @@ class Batch(WebContainer):
                         completed += 1
                         progress.update(pbar, completed=completed)
 
-    def load(self, path_dir: str = DEFAULT_DATA_DIR, replace_existing: bool = False) -> BatchData:
+    def load(
+        self,
+        path_dir: str = DEFAULT_DATA_DIR,
+        replace_existing: bool = False,
+        skip_download: bool = False,
+    ) -> BatchData:
         """Download results and load them into :class:`.BatchData` object.
 
         Parameters
@@ -1185,6 +1242,8 @@ class Batch(WebContainer):
             Base directory where data will be downloaded, by default current working directory.
         replace_existing : bool = False
             Downloads the data even if path exists (overwriting the existing).
+        skip_download : bool = False
+            Does not trigger download. Should be True if already downloaded.
 
         Returns
         ------
@@ -1218,8 +1277,8 @@ class Batch(WebContainer):
             if isinstance(job.simulation, ModeSolver):
                 job_data = data[task_name]
                 job.simulation._patch_data(data=job_data)
-
-        self.download(path_dir=path_dir, replace_existing=replace_existing)
+        if not skip_download:
+            self.download(path_dir=path_dir, replace_existing=replace_existing)
 
         return data
 

--- a/tidy3d/web/api/tidy3d_stub.py
+++ b/tidy3d/web/api/tidy3d_stub.py
@@ -49,6 +49,25 @@ from tidy3d.web.core.file_util import (
 from tidy3d.web.core.stub import TaskStub, TaskStubData
 from tidy3d.web.core.types import TaskType
 
+TYPE_MAP: dict[type, TaskType] = {
+    Simulation: TaskType.FDTD,
+    ModeSolver: TaskType.MODE_SOLVER,
+    HeatSimulation: TaskType.HEAT,
+    HeatChargeSimulation: TaskType.HEAT_CHARGE,
+    EMESimulation: TaskType.EME,
+    ModeSimulation: TaskType.MODE,
+    VolumeMesher: TaskType.VOLUME_MESH,
+    ModalComponentModeler: TaskType.COMPONENT_MODELER,
+    TerminalComponentModeler: TaskType.TERMINAL_COMPONENT_MODELER,
+}
+
+
+def task_type_name_of(simulation: WorkflowType) -> str:
+    for cls, ttype in TYPE_MAP.items():
+        if isinstance(simulation, cls):
+            return ttype.name
+    raise TypeError(f"Could not find task type for: {type(simulation).__name__}")
+
 
 class Tidy3dStub(BaseModel, TaskStub):
     simulation: WorkflowType = pd.Field(discriminator="type")
@@ -153,24 +172,7 @@ class Tidy3dStub(BaseModel, TaskStub):
         :class:`TaskType`
             An instance Type of the component class calling ``load``.
         """
-        if isinstance(self.simulation, Simulation):
-            return TaskType.FDTD.name
-        if isinstance(self.simulation, ModeSolver):
-            return TaskType.MODE_SOLVER.name
-        if isinstance(self.simulation, HeatSimulation):
-            return TaskType.HEAT.name
-        if isinstance(self.simulation, HeatChargeSimulation):
-            return TaskType.HEAT_CHARGE.name
-        if isinstance(self.simulation, EMESimulation):
-            return TaskType.EME.name
-        if isinstance(self.simulation, ModeSimulation):
-            return TaskType.MODE.name
-        elif isinstance(self.simulation, VolumeMesher):
-            return TaskType.VOLUME_MESH.name
-        elif isinstance(self.simulation, ModalComponentModeler):
-            return TaskType.COMPONENT_MODELER.name
-        elif isinstance(self.simulation, TerminalComponentModeler):
-            return TaskType.TERMINAL_COMPONENT_MODELER.name
+        return task_type_name_of(self.simulation)
 
     def validate_pre_upload(self, source_required) -> None:
         """Perform some pre-checks on instances of component"""


### PR DESCRIPTION
refers to https://github.com/flexcompute/tidy3d/issues/2893

**Previous State**
Batch.run() waits for every job to finish (`Batch.monitor()`) before calling `Batch.download()`, so even tasks that completed early don’t start transferring until the whole batch is done. This is a noticeable delay for large batches with many short simulations.

**Problem**
Users want each simulation’s results to begin downloading immediately after that simulation hits success, rather than waiting for the entire batch to complete.

**Solution**
Monitor-triggered downloads: Extend the `Batch.monitor()` loop to detect job transitions to success and queue `job.download()` right away via a shared executor given the kwarg `download_on_success`.
Download in `Batch.load()` is then skipped by having kwarg `skip_download` which is `False` as default for other callers.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-15 14:32:52 UTC

### Greptile Summary

This PR implements per-simulation downloads during batch runs to improve user experience by downloading completed simulations immediately rather than waiting for the entire batch to finish. The change extends the `Batch.monitor()` method with a `download_on_success` parameter that creates a ThreadPoolExecutor to handle concurrent downloads when individual jobs reach "success" status. The `Batch.run()` method is updated to use `monitor(download_on_success=True)` followed by `load(skip_download=True)` to avoid double-downloading. This addresses a performance bottleneck where users experienced unnecessary delays for large batches with many short simulations that completed at different times.

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| CHANGELOG.md | 5/5 | Added changelog entry documenting the new per-simulation download feature |
| tests/test_web/test_webapi.py | 5/5 | Added comprehensive tests for per-simulation downloads with proper mocking and timing verification |
| tidy3d/web/api/container.py | 4/5 | Implemented core feature with new parameters for monitor/load methods and download scheduling logic |

</details>

### Confidence score: 4/5

- This PR is safe to merge with minimal risk as it maintains backward compatibility through default parameters and proper error handling
- Score reflects well-implemented feature with comprehensive testing, though the complex threading logic in container.py requires attention to ensure proper resource cleanup
- Pay close attention to the download executor cleanup logic in the finally block and concurrent access patterns in the monitor method

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Batch as "Batch"
    participant Job as "Job"
    participant WebAPI as "webapi"
    participant Executor as "ThreadPoolExecutor"
    participant Progress as "Progress Bar"
    
    User->>+Batch: "run(path_dir)"
    Batch->>+Batch: "_check_path_dir(path_dir)"
    Batch-->>-Batch: "create dir if needed"
    Batch->>+Batch: "upload()"
    
    Note over Batch,Job: "Upload Phase"
    Batch->>+Executor: "ThreadPoolExecutor(max_workers)"
    loop "For each job"
        Batch->>+Job: "job.upload()"
        Job->>+WebAPI: "web.upload(**kwargs)"
        WebAPI-->>-Job: "task_id"
        Job-->>-Batch: "uploaded"
    end
    Batch->>+Progress: "create progress bar"
    Progress-->>-Batch: "show upload progress"
    Executor-->>-Batch: "all uploads complete"
    
    Batch->>+Batch: "to_file(batch_path)"
    Batch-->>-Batch: "save batch.hdf5 with task_ids"
    
    Note over Batch,Job: "Start Phase"
    Batch->>+Batch: "start(priority)"
    loop "For each job"
        Batch->>+Job: "job.start(priority)"
        Job->>+WebAPI: "web.start(task_id, priority)"
        WebAPI-->>-Job: "started"
        Job-->>-Batch: "started"
    end
    Batch-->>-Batch: "all jobs started"
    
    Note over Batch,Job: "Monitor Phase with Downloads"
    Batch->>+Batch: "monitor(download_on_success=True)"
    Batch->>+Executor: "download_executor = ThreadPoolExecutor()"
    
    loop "Until all jobs complete"
        loop "For each job"
            Batch->>+Job: "job.status"
            Job->>+WebAPI: "web.get_info(task_id)"
            WebAPI-->>-Job: "status info"
            Job-->>-Batch: "status"
            
            alt "status == 'success'"
                Batch->>+Executor: "submit download job"
                Executor->>+Job: "job.download(path)"
                Job->>+WebAPI: "web.download(task_id, path)"
                WebAPI-->>-Job: "download complete"
                Job-->>-Executor: "file saved"
                Executor-->>-Batch: "download future"
            end
        end
        Batch->>+Progress: "update progress bars"
        Progress-->>-Batch: "display updated status"
    end
    
    Executor-->>-Batch: "all downloads complete"
    Batch-->>-Batch: "monitoring complete"
    
    Note over Batch,User: "Load Phase"
    Batch->>+Batch: "load(path_dir, skip_download=True)"
    Batch->>+Batch: "create BatchData object"
    Batch-->>-Batch: "BatchData with task_paths"
    Batch-->>-User: "BatchData"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->