### PR TITLE
chore: run ruff only at the pre-commit stage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,9 @@ repos:
     hooks:
      - id: ruff-check
        args: [ --fix ]
+       stages: [pre-commit]
      - id: ruff-format
+       stages: [pre-commit]
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.22.0
     hooks:


### PR DESCRIPTION
Note sure if this affected anyone else, but I was getting duplicate ruff checks in the pre-commit hook.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-15 20:49:00 UTC

### Greptile Summary

This PR addresses a pre-commit configuration issue where ruff code quality checks were running multiple times. The change restricts both `ruff-check` and `ruff-format` hooks to only execute during the pre-commit stage by adding `stages: [pre-commit]` to both hooks in `.pre-commit-config.yaml`. This follows the same pattern already used by the commitlint hook and prevents the duplicate execution that was causing the issue described in the PR. The change is minimal and targeted, affecting only the pre-commit hook configuration without impacting the actual code quality checks or formatting behavior.

PR Description Notes:
- Minor typo: "Note sure" should be "Not sure"

### Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| .pre-commit-config.yaml | 5/5 | Added stage restrictions to ruff hooks to prevent duplicate execution |

</details>

### Confidence score: 5/5

- This PR is safe to merge with minimal risk
- Score reflects a simple, well-understood configuration change that follows established patterns and resolves a known issue without affecting functionality
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->