### PR TITLE
chore: run ruff only at the pre-commit stage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,9 @@ repos:
     hooks:
      - id: ruff-check
        args: [ --fix ]
+       stages: [pre-commit]
      - id: ruff-format
+       stages: [pre-commit]
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.22.0
     hooks:


### PR DESCRIPTION
Note sure if this affected anyone else, but I was getting duplicate ruff checks in the pre-commit hook.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-15 20:53:26 UTC

### Greptile Summary

This PR fixes a pre-commit configuration issue causing duplicate ruff checks. The change adds explicit `stages: [pre-commit]` configuration to both the `ruff-check` and `ruff-format` hooks in the `.pre-commit-config.yaml` file. Previously, these hooks were running at multiple git hook stages (pre-commit and commit-msg) because the default install hook types include both stages. This duplication was creating an inefficient workflow where the same linting and formatting operations were executed twice. The fix ensures ruff only runs during the pre-commit stage, which is the intended behavior for code quality checks in this repository's workflow.

### Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|--------|----------|
| .pre-commit-config.yaml | 5/5 | Added explicit stage configuration to prevent duplicate ruff hook execution |

</details>

### Confidence score: 5/5

- This PR is safe to merge with minimal risk
- Score reflects a simple, well-targeted fix that addresses a specific workflow inefficiency without affecting code functionality
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->