### PR TITLE
fix: correct precommit stages  (BUG-0000)

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -239,7 +239,7 @@ jobs:
   lint-commit-messages:
     needs: determine-test-scope
     runs-on: ubuntu-latest
-    if: needs.determine-test-scope.outputs.pr_review_tests == 'true'
+    if: needs.determine-test-scope.outputs.code_quality_tests == 'true'
     name: lint-commit-messages
     steps:
       - name: Check out source code
@@ -624,7 +624,7 @@ jobs:
           exit 1
 
       - name: check-commit-message-linting
-        if: ${{ github.event_name == 'merge_group' && needs.lint-commit-messages.result != 'success' }}
+        if: ${{  needs.determine-test-scope.outputs.code_quality_tests == 'true' && needs.lint-commit-messages.result != 'success' }}
         run: |
           echo "❌ Commit message linting failed."
           exit 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+minimum_pre_commit_version: '4.0.0'
 default_install_hook_types:
   - pre-commit
   - commit-msg

--- a/poetry.lock
+++ b/poetry.lock
@@ -7476,4 +7476,4 @@ vtk = ["vtk"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.14"
-content-hash = "591568dd5f68370208830b200214d40918ff9e5a85b8c17a44c86a15b867e3b2"
+content-hash = "aad3732ef864215deb85363c3ac75b49169c67241a85c3adde7ac9270093a203"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dill = { version = "*", optional = true }
 ipython = { version = "*", optional = true }
 memory_profiler = { version = "*", optional = true }
 psutil = { version = "*", optional = true }
-pre-commit = { version = "*", optional = true }
+pre-commit = { version = ">=4.*", optional = true }
 pylint = { version = "*", optional = true }
 pytest = { version = ">=8.1", optional = true }
 pytest-timeout = { version = "*", optional = true }


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-16 12:57:19 UTC

### Greptile Summary

This PR fixes pre-commit hook stage configuration issues by adding explicit stage definitions and enforcing a minimum version requirement. The changes ensure that linting hooks (ruff-check, ruff-format) only run during the pre-commit stage and commit message validation (commitlint) only runs during the commit-msg stage. To support this configuration, the pre-commit dependency in pyproject.toml is updated from accepting any version to requiring version 4.0 or higher, which is necessary for the stage configuration syntax to work properly.

These changes address timing issues where hooks might have been running at inappropriate stages or not executing when expected, improving the development workflow reliability.

### Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| .pre-commit-config.yaml | 4/5 | Added minimum version requirement and explicit stage definitions for all hooks |
| pyproject.toml | 5/5 | Updated pre-commit dependency version constraint from "*" to ">=4.*" |

</details>

### Confidence score:4/5

- This PR is safe to merge with minimal risk as it only affects development tooling configuration
- Score reflects the straightforward nature of pre-commit configuration fixes with proper version constraints, though the explicit stage definitions need verification
- Pay close attention to .pre-commit-config.yaml to ensure the stage definitions work correctly across different git workflows

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant PreCommit as "Pre-commit"
    participant Ruff as "Ruff Linter/Formatter"
    participant CommitLint as "CommitLint"
    participant Git as "Git"

    User->>Git: "git commit"
    Git->>PreCommit: "trigger pre-commit hooks"
    
    PreCommit->>Ruff: "run ruff-check --fix"
    Ruff-->>PreCommit: "linting results"
    
    PreCommit->>Ruff: "run ruff-format"
    Ruff-->>PreCommit: "formatting results"
    
    alt Pre-commit hooks pass
        PreCommit-->>Git: "hooks passed"
        Git->>CommitLint: "trigger commit-msg hook"
        CommitLint-->>Git: "validate commit message"
        
        alt Commit message valid
            Git-->>User: "commit successful"
        else Commit message invalid
            Git-->>User: "commit failed - invalid message"
        end
    else Pre-commit hooks fail
        PreCommit-->>User: "commit failed - fix issues"
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->