### PR TITLE
FXC-3275 - Adding gaussian monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking Changes
 - Added `structure_priority_mode` for `TerminalComponentModeler` and default to `"conductor"` to ensure metal structures override dielectrics regardless of structure order, preventing order-dependent results in RF simulations.
 - 1D lumped elements (with zero lateral extent) are no longer allowed. Use a small finite lateral extent (e.g., `1e-6`) instead.
+- Added `GaussianOverlapMonitor` and `AstigmaticGaussianOverlapMonitor` for decomposing electromagnetic fields onto Gaussian beam profiles.
+- Added `GaussianPort` and `AstigmaticGaussianPort` for S-matrix calculations using Gaussian beam sources and overlap monitors.
 
 ### Changed
 - `ModeSortSpec.sort_key` is now required with a default of `"n_eff"` (previously optional with `None` default). `ModeSortSpec.sort_order` is now optional with a default of `None`, which automatically selects the natural order based on `sort_key` and `sort_reference`: ascending when a reference is provided (closest first), otherwise descending for `n_eff` and polarization fractions (higher values first), ascending for `k_eff` and `mode_area` (lower values first).
@@ -56,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added validation to `DCVoltageSource` that warns when duplicate voltage values are detected in the `voltage` array, including treating `0` and `-0` as the same value.
 
 ### Changed
+- **Breaking**: Changed the interpretation of `waist_distance` and `waist_distances` for backward-propagating Gaussian beams (`GaussianBeam`, `AstigmaticGaussianBeam`, `GaussianBeamProfile`, `AstigmaticGaussianBeamProfile`). Previously, the waist position was interpreted relative to the directed propagation axis, meaning switching `direction` from `+` to `-` would also flip the waist position in the global reference frame. Now, the waist position is defined consistently for both directions: a positive `waist_distance` always places the beam waist behind the source/monitor plane (toward the negative normal axis), regardless of propagation direction. This ensures reciprocity between Gaussian sources and overlap monitors used in port-based S-matrix calculations. Users with existing simulations using backward-propagating Gaussian beams with non-zero waist distances may need to adjust their values.
 - For `HeatChargeSimulation` objects, the `plot` function now adds the simulation boundary conditions.
 
 ### Fixed

--- a/schemas/Simulation.json
+++ b/schemas/Simulation.json
@@ -821,6 +821,248 @@
       ],
       "type": "object"
     },
+    "AstigmaticGaussianOverlapMonitor": {
+      "additionalProperties": false,
+      "properties": {
+        "angle_phi": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "angle_theta": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "apodization": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ApodizationSpec"
+            }
+          ],
+          "default": {
+            "attrs": {},
+            "end": null,
+            "start": null,
+            "type": "ApodizationSpec",
+            "width": null
+          }
+        },
+        "attrs": {
+          "default": {},
+          "type": "object"
+        },
+        "center": {
+          "anyOf": [
+            {
+              "items": [
+                {
+                  "anyOf": [
+                    {
+                      "type": "autograd.tracer.Box"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "autograd.tracer.Box"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "autograd.tracer.Box"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                }
+              ],
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array"
+            },
+            {
+              "type": "autograd.tracer.Box"
+            }
+          ],
+          "default": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        "colocate": {
+          "default": true,
+          "type": "boolean"
+        },
+        "conjugated_dot_product": {
+          "default": true,
+          "type": "boolean"
+        },
+        "freqs": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "type": "ArrayLike"
+            }
+          ]
+        },
+        "interval_space": {
+          "default": [
+            1,
+            1,
+            1
+          ],
+          "items": [
+            {
+              "enum": [
+                1
+              ],
+              "type": "integer"
+            },
+            {
+              "enum": [
+                1
+              ],
+              "type": "integer"
+            },
+            {
+              "enum": [
+                1
+              ],
+              "type": "integer"
+            }
+          ],
+          "maxItems": 3,
+          "minItems": 3,
+          "type": "array"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "pol_angle": {
+          "default": 0,
+          "type": "number"
+        },
+        "size": {
+          "anyOf": [
+            {
+              "items": [
+                {
+                  "anyOf": [
+                    {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "autograd.tracer.Box"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "autograd.tracer.Box"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "autograd.tracer.Box"
+                    }
+                  ]
+                }
+              ],
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array"
+            },
+            {
+              "type": "autograd.tracer.Box"
+            }
+          ]
+        },
+        "store_fields_direction": {
+          "enum": [
+            "+",
+            "-"
+          ],
+          "type": "string"
+        },
+        "type": {
+          "default": "AstigmaticGaussianOverlapMonitor",
+          "enum": [
+            "AstigmaticGaussianOverlapMonitor"
+          ],
+          "type": "string"
+        },
+        "waist_distances": {
+          "default": [
+            0.0,
+            0.0
+          ],
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        "waist_sizes": {
+          "default": [
+            1.0,
+            1.0
+          ],
+          "items": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        }
+      },
+      "required": [
+        "freqs",
+        "name",
+        "size"
+      ],
+      "type": "object"
+    },
     "AugerRecombination": {
       "additionalProperties": false,
       "properties": {
@@ -8491,6 +8733,221 @@
         "concentration",
         "ref_con",
         "width"
+      ],
+      "type": "object"
+    },
+    "GaussianOverlapMonitor": {
+      "additionalProperties": false,
+      "properties": {
+        "angle_phi": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "angle_theta": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "apodization": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ApodizationSpec"
+            }
+          ],
+          "default": {
+            "attrs": {},
+            "end": null,
+            "start": null,
+            "type": "ApodizationSpec",
+            "width": null
+          }
+        },
+        "attrs": {
+          "default": {},
+          "type": "object"
+        },
+        "center": {
+          "anyOf": [
+            {
+              "items": [
+                {
+                  "anyOf": [
+                    {
+                      "type": "autograd.tracer.Box"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "autograd.tracer.Box"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "autograd.tracer.Box"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                }
+              ],
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array"
+            },
+            {
+              "type": "autograd.tracer.Box"
+            }
+          ],
+          "default": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        "colocate": {
+          "default": true,
+          "type": "boolean"
+        },
+        "conjugated_dot_product": {
+          "default": true,
+          "type": "boolean"
+        },
+        "freqs": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "type": "ArrayLike"
+            }
+          ]
+        },
+        "interval_space": {
+          "default": [
+            1,
+            1,
+            1
+          ],
+          "items": [
+            {
+              "enum": [
+                1
+              ],
+              "type": "integer"
+            },
+            {
+              "enum": [
+                1
+              ],
+              "type": "integer"
+            },
+            {
+              "enum": [
+                1
+              ],
+              "type": "integer"
+            }
+          ],
+          "maxItems": 3,
+          "minItems": 3,
+          "type": "array"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "pol_angle": {
+          "default": 0,
+          "type": "number"
+        },
+        "size": {
+          "anyOf": [
+            {
+              "items": [
+                {
+                  "anyOf": [
+                    {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "autograd.tracer.Box"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "autograd.tracer.Box"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "autograd.tracer.Box"
+                    }
+                  ]
+                }
+              ],
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array"
+            },
+            {
+              "type": "autograd.tracer.Box"
+            }
+          ]
+        },
+        "store_fields_direction": {
+          "enum": [
+            "+",
+            "-"
+          ],
+          "type": "string"
+        },
+        "type": {
+          "default": "GaussianOverlapMonitor",
+          "enum": [
+            "GaussianOverlapMonitor"
+          ],
+          "type": "string"
+        },
+        "waist_distance": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "waist_radius": {
+          "default": 1.0,
+          "exclusiveMinimum": 0,
+          "type": "number"
+        }
+      },
+      "required": [
+        "freqs",
+        "name",
+        "size"
       ],
       "type": "object"
     },
@@ -17272,6 +17729,7 @@
       "items": {
         "discriminator": {
           "mapping": {
+            "AstigmaticGaussianOverlapMonitor": "#/definitions/AstigmaticGaussianOverlapMonitor",
             "AuxFieldTimeMonitor": "#/definitions/AuxFieldTimeMonitor",
             "DiffractionMonitor": "#/definitions/DiffractionMonitor",
             "DirectivityMonitor": "#/definitions/DirectivityMonitor",
@@ -17282,6 +17740,7 @@
             "FieldTimeMonitor": "#/definitions/FieldTimeMonitor",
             "FluxMonitor": "#/definitions/FluxMonitor",
             "FluxTimeMonitor": "#/definitions/FluxTimeMonitor",
+            "GaussianOverlapMonitor": "#/definitions/GaussianOverlapMonitor",
             "MediumMonitor": "#/definitions/MediumMonitor",
             "MicrowaveModeMonitor": "#/definitions/MicrowaveModeMonitor",
             "MicrowaveModeSolverMonitor": "#/definitions/MicrowaveModeSolverMonitor",
@@ -17292,6 +17751,9 @@
           "propertyName": "type"
         },
         "oneOf": [
+          {
+            "$ref": "#/definitions/AstigmaticGaussianOverlapMonitor"
+          },
           {
             "$ref": "#/definitions/AuxFieldTimeMonitor"
           },
@@ -17321,6 +17783,9 @@
           },
           {
             "$ref": "#/definitions/FluxTimeMonitor"
+          },
+          {
+            "$ref": "#/definitions/GaussianOverlapMonitor"
           },
           {
             "$ref": "#/definitions/MediumMonitor"

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -821,6 +821,248 @@
       ],
       "type": "object"
     },
+    "AstigmaticGaussianOverlapMonitor": {
+      "additionalProperties": false,
+      "properties": {
+        "angle_phi": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "angle_theta": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "apodization": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ApodizationSpec"
+            }
+          ],
+          "default": {
+            "attrs": {},
+            "end": null,
+            "start": null,
+            "type": "ApodizationSpec",
+            "width": null
+          }
+        },
+        "attrs": {
+          "default": {},
+          "type": "object"
+        },
+        "center": {
+          "anyOf": [
+            {
+              "items": [
+                {
+                  "anyOf": [
+                    {
+                      "type": "autograd.tracer.Box"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "autograd.tracer.Box"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "autograd.tracer.Box"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                }
+              ],
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array"
+            },
+            {
+              "type": "autograd.tracer.Box"
+            }
+          ],
+          "default": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        "colocate": {
+          "default": true,
+          "type": "boolean"
+        },
+        "conjugated_dot_product": {
+          "default": true,
+          "type": "boolean"
+        },
+        "freqs": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "type": "ArrayLike"
+            }
+          ]
+        },
+        "interval_space": {
+          "default": [
+            1,
+            1,
+            1
+          ],
+          "items": [
+            {
+              "enum": [
+                1
+              ],
+              "type": "integer"
+            },
+            {
+              "enum": [
+                1
+              ],
+              "type": "integer"
+            },
+            {
+              "enum": [
+                1
+              ],
+              "type": "integer"
+            }
+          ],
+          "maxItems": 3,
+          "minItems": 3,
+          "type": "array"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "pol_angle": {
+          "default": 0,
+          "type": "number"
+        },
+        "size": {
+          "anyOf": [
+            {
+              "items": [
+                {
+                  "anyOf": [
+                    {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "autograd.tracer.Box"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "autograd.tracer.Box"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "autograd.tracer.Box"
+                    }
+                  ]
+                }
+              ],
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array"
+            },
+            {
+              "type": "autograd.tracer.Box"
+            }
+          ]
+        },
+        "store_fields_direction": {
+          "enum": [
+            "+",
+            "-"
+          ],
+          "type": "string"
+        },
+        "type": {
+          "default": "AstigmaticGaussianOverlapMonitor",
+          "enum": [
+            "AstigmaticGaussianOverlapMonitor"
+          ],
+          "type": "string"
+        },
+        "waist_distances": {
+          "default": [
+            0.0,
+            0.0
+          ],
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        "waist_sizes": {
+          "default": [
+            1.0,
+            1.0
+          ],
+          "items": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        }
+      },
+      "required": [
+        "freqs",
+        "name",
+        "size"
+      ],
+      "type": "object"
+    },
     "AugerRecombination": {
       "additionalProperties": false,
       "properties": {
@@ -8661,6 +8903,221 @@
       ],
       "type": "object"
     },
+    "GaussianOverlapMonitor": {
+      "additionalProperties": false,
+      "properties": {
+        "angle_phi": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "angle_theta": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "apodization": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ApodizationSpec"
+            }
+          ],
+          "default": {
+            "attrs": {},
+            "end": null,
+            "start": null,
+            "type": "ApodizationSpec",
+            "width": null
+          }
+        },
+        "attrs": {
+          "default": {},
+          "type": "object"
+        },
+        "center": {
+          "anyOf": [
+            {
+              "items": [
+                {
+                  "anyOf": [
+                    {
+                      "type": "autograd.tracer.Box"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "autograd.tracer.Box"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "autograd.tracer.Box"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                }
+              ],
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array"
+            },
+            {
+              "type": "autograd.tracer.Box"
+            }
+          ],
+          "default": [
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        "colocate": {
+          "default": true,
+          "type": "boolean"
+        },
+        "conjugated_dot_product": {
+          "default": true,
+          "type": "boolean"
+        },
+        "freqs": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "type": "ArrayLike"
+            }
+          ]
+        },
+        "interval_space": {
+          "default": [
+            1,
+            1,
+            1
+          ],
+          "items": [
+            {
+              "enum": [
+                1
+              ],
+              "type": "integer"
+            },
+            {
+              "enum": [
+                1
+              ],
+              "type": "integer"
+            },
+            {
+              "enum": [
+                1
+              ],
+              "type": "integer"
+            }
+          ],
+          "maxItems": 3,
+          "minItems": 3,
+          "type": "array"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "pol_angle": {
+          "default": 0,
+          "type": "number"
+        },
+        "size": {
+          "anyOf": [
+            {
+              "items": [
+                {
+                  "anyOf": [
+                    {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "autograd.tracer.Box"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "autograd.tracer.Box"
+                    }
+                  ]
+                },
+                {
+                  "anyOf": [
+                    {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "autograd.tracer.Box"
+                    }
+                  ]
+                }
+              ],
+              "maxItems": 3,
+              "minItems": 3,
+              "type": "array"
+            },
+            {
+              "type": "autograd.tracer.Box"
+            }
+          ]
+        },
+        "store_fields_direction": {
+          "enum": [
+            "+",
+            "-"
+          ],
+          "type": "string"
+        },
+        "type": {
+          "default": "GaussianOverlapMonitor",
+          "enum": [
+            "GaussianOverlapMonitor"
+          ],
+          "type": "string"
+        },
+        "waist_distance": {
+          "default": 0.0,
+          "type": "number"
+        },
+        "waist_radius": {
+          "default": 1.0,
+          "exclusiveMinimum": 0,
+          "type": "number"
+        }
+      },
+      "required": [
+        "freqs",
+        "name",
+        "size"
+      ],
+      "type": "object"
+    },
     "GaussianPulse": {
       "additionalProperties": false,
       "properties": {
@@ -15883,6 +16340,7 @@
           "items": {
             "discriminator": {
               "mapping": {
+                "AstigmaticGaussianOverlapMonitor": "#/definitions/AstigmaticGaussianOverlapMonitor",
                 "AuxFieldTimeMonitor": "#/definitions/AuxFieldTimeMonitor",
                 "DiffractionMonitor": "#/definitions/DiffractionMonitor",
                 "DirectivityMonitor": "#/definitions/DirectivityMonitor",
@@ -15893,6 +16351,7 @@
                 "FieldTimeMonitor": "#/definitions/FieldTimeMonitor",
                 "FluxMonitor": "#/definitions/FluxMonitor",
                 "FluxTimeMonitor": "#/definitions/FluxTimeMonitor",
+                "GaussianOverlapMonitor": "#/definitions/GaussianOverlapMonitor",
                 "MediumMonitor": "#/definitions/MediumMonitor",
                 "MicrowaveModeMonitor": "#/definitions/MicrowaveModeMonitor",
                 "MicrowaveModeSolverMonitor": "#/definitions/MicrowaveModeSolverMonitor",
@@ -15903,6 +16362,9 @@
               "propertyName": "type"
             },
             "oneOf": [
+              {
+                "$ref": "#/definitions/AstigmaticGaussianOverlapMonitor"
+              },
               {
                 "$ref": "#/definitions/AuxFieldTimeMonitor"
               },
@@ -15932,6 +16394,9 @@
               },
               {
                 "$ref": "#/definitions/FluxTimeMonitor"
+              },
+              {
+                "$ref": "#/definitions/GaussianOverlapMonitor"
               },
               {
                 "$ref": "#/definitions/MediumMonitor"

--- a/tests/test_components/test_monitor.py
+++ b/tests/test_components/test_monitor.py
@@ -344,6 +344,14 @@ def test_diffraction_validators():
 FREQS = np.array([1, 2, 3]) * 1e12
 
 
+def test_gaussian_overlap_monitors_basic():
+    g = td.GaussianOverlapMonitor(size=(1, 1, 0), name="g", freqs=FREQS)
+    a = td.AstigmaticGaussianOverlapMonitor(size=(1, 1, 0), name="a", freqs=FREQS)
+    for m in (g, a):
+        s = m.storage_size(num_cells=10, tmesh=[0.0, 1.0])
+        assert isinstance(s, int) and s > 0
+
+
 def test_monitor():
     size = (1, 2, 3)
     center = (1, 2, 3)
@@ -381,10 +389,14 @@ def test_monitor():
     m10 = td.PermittivityMonitor(size=size, center=center, freqs=FREQS, name="perm")
     m11 = td.AuxFieldTimeMonitor(size=size, center=center, name="aux_field_time", fields=("Nfx",))
     m12 = td.MediumMonitor(size=size, center=center, freqs=FREQS, name="mat")
+    m13 = td.GaussianOverlapMonitor(size=(1, 1, 0), center=center, freqs=FREQS, name="gauss")
+    m14 = td.AstigmaticGaussianOverlapMonitor(
+        size=(1, 1, 0), center=center, freqs=FREQS, name="astigauss"
+    )
 
     tmesh = np.linspace(0, 1, 10)
 
-    for m in [m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m12]:
+    for m in [m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14]:
         m.storage_size(num_cells=100, tmesh=tmesh)
 
     for m in [m2, m4]:

--- a/tests/test_data/test_monitor_data.py
+++ b/tests/test_data/test_monitor_data.py
@@ -18,6 +18,7 @@ from tidy3d.components.data.monitor_data import (
     DiffractionData,
     DirectivityData,
     FieldData,
+    FieldOverlapData,
     FieldTimeData,
     FluxData,
     FluxTimeData,
@@ -267,6 +268,16 @@ def make_mode_data():
     return ModeData(monitor=MODE_MONITOR, amps=AMPS.copy(), n_complex=N_COMPLEX.copy())
 
 
+def make_field_overlap_data():
+    monitor = td.GaussianOverlapMonitor(
+        size=(0, 2, 2),
+        freqs=[1e14, 1.1e14],
+        name="gaussian_overlap_monitor",
+        store_fields_direction="+",
+    )
+    return FieldOverlapData(monitor=monitor, amps=AMPS)
+
+
 def make_flux_data():
     return FluxData(monitor=FLUX_MONITOR, flux=FLUX.copy())
 
@@ -472,6 +483,11 @@ def test_mode_data():
     _ = data.n_complex
     _ = data.n_eff
     _ = data.k_eff
+
+
+def test_overlap_data():
+    data = make_field_overlap_data()
+    _ = data.amps
 
 
 def test_flux_data():

--- a/tests/test_plugins/smatrix/test_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_component_modeler.py
@@ -9,7 +9,13 @@ import pytest
 import tidy3d as td
 from tidy3d import SimulationDataMap
 from tidy3d.exceptions import SetupError, Tidy3dKeyError
-from tidy3d.plugins.smatrix import ModalComponentModeler, ModalComponentModelerData, Port
+from tidy3d.plugins.smatrix import (
+    AstigmaticGaussianPort,
+    GaussianPort,
+    ModalComponentModeler,
+    ModalComponentModelerData,
+    Port,
+)
 from tidy3d.web.api.container import Batch
 
 from ...utils import AssertLogStr, run_emulated
@@ -144,6 +150,7 @@ def make_coupler():
 
 def make_ports():
     sim = make_coupler()
+
     # source
     src_pos = sim.size[0] / 2 - straight_wg_length / 2
 
@@ -179,7 +186,28 @@ def make_ports():
         name="left_bot",
     )
 
-    return [port_right_top, port_right_bot, port_left_top, port_left_bot]
+    # Gaussian ports on top and bottom
+    port_z_bot = AstigmaticGaussianPort(
+        center=[0, 0, wg_height + 0.1],
+        size=(10, 10, 0),
+        direction="-",
+        name="z_top",
+        angle_theta=0.0,
+        angle_phi=0.0,
+        pol_angle=0.0,
+    )
+
+    port_z_top = GaussianPort(
+        center=[0, 0, -0.1],
+        size=(10, 10, 0),
+        direction="+",
+        name="z_bot",
+        angle_theta=0.0,
+        angle_phi=0.0,
+        pol_angle=0.0,
+    )
+
+    return [port_right_top, port_right_bot, port_left_top, port_left_bot, port_z_bot, port_z_top]
 
 
 def make_component_modeler(**kwargs):
@@ -283,13 +311,12 @@ def test_run_component_modeler(monkeypatch):
     s_matrix = modeler_data.smatrix()
 
     for port_in in modeler.ports:
-        for mode_index_in in range(port_in.mode_spec.num_modes):
+        for mode_index_in in range(port_in.num_modes):
             for port_out in modeler.ports:
-                for mode_index_out in range(port_out.mode_spec.num_modes):
+                for mode_index_out in range(port_out.num_modes):
                     coords_in = {"port_in": port_in.name, "mode_index_in": mode_index_in}
                     coords_out = {"port_out": port_out.name, "mode_index_out": mode_index_out}
-
-                    assert np.all(s_matrix.sel(**coords_in) != 0), (
+                    assert np.all(s_matrix.sel(**coords_in).sel(mode_index_out=0) != 0), (
                         "source index not present in S matrix"
                     )
                     assert np.all(s_matrix.sel(**coords_in).sel(**coords_out) != 0), (
@@ -309,7 +336,7 @@ def test_component_modeler_run_only(monkeypatch):
     coords_in_run_only = {"port_in": port_run_only, "mode_index_in": mode_index_run_only}
 
     # make sure the run only mappings are non-zero
-    assert np.all(s_matrix.sel(**coords_in_run_only) != 0)
+    assert np.all(s_matrix.sel(**coords_in_run_only).sel(mode_index_out=0) != 0)
 
     # make sure if we zero out the run_only mappings, everythging is zero
     s_matrix.loc[coords_in_run_only] = 0
@@ -370,7 +397,7 @@ def test_mapping_exclusion(monkeypatch):
 
     # add a mapping to each element in the row of EXCLUDE_INDEX
     for port in ports:
-        for mode_index in range(port.mode_spec.num_modes):
+        for mode_index in range(port.num_modes):
             row_index = (port.name, mode_index)
             if row_index != EXCLUDE_INDEX:
                 mapping = ((row_index, row_index), (row_index, EXCLUDE_INDEX), +1)
@@ -400,7 +427,7 @@ def test_mapping_with_run_only():
     run_only = []
     # add a mapping to each element in the row of EXCLUDE_INDEX
     for port in ports:
-        for mode_index in range(port.mode_spec.num_modes):
+        for mode_index in range(port.num_modes):
             # Test that providing a list is properly handled
             row_index = [port.name, mode_index]
             run_only.append(row_index)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1412,6 +1412,25 @@ def run_emulated(simulation: td.Simulation, path=None, **kwargs) -> td.Simulatio
             **field_cmps,
         )
 
+    def make_gaussian_overlap_data(
+        monitor: td.GaussianOverlapMonitor | td.AstigmaticGaussianOverlapMonitor,
+    ) -> td.FieldOverlapData:
+        """Random FieldOverlapData from a GaussianOverlapMonitor or AstigmaticGaussianOverlapMonitor."""
+        grid = simulation.discretize_monitor(monitor)
+        coords_amps = {
+            "direction": ["+", "-"],
+            "f": list(monitor.freqs),
+            "mode_index": [0],  # singleton for Gaussian ports
+        }
+        amps = make_data(coords=coords_amps, data_array_type=td.ModeAmpsDataArray, is_complex=True)
+        return td.FieldOverlapData(
+            monitor=monitor,
+            amps=amps,
+            symmetry=(0, 0, 0),
+            symmetry_center=simulation.center,
+            grid_expanded=grid,
+        )
+
     def make_flux_data(monitor: td.FluxMonitor) -> td.FluxData:
         """make a random ModeData from a ModeMonitor."""
 
@@ -1597,6 +1616,8 @@ def run_emulated(simulation: td.Simulation, path=None, **kwargs) -> td.Simulatio
         td.FieldProjectionKSpaceMonitor: make_field_projection_kspace_data,
         td.AuxFieldTimeMonitor: make_aux_field_time_data,
         td.FluxTimeMonitor: make_flux_time_data,
+        td.GaussianOverlapMonitor: make_gaussian_overlap_data,
+        td.AstigmaticGaussianOverlapMonitor: make_gaussian_overlap_data,
     }
 
     data = [MONITOR_MAKER_MAP[type(mnt)](mnt) for mnt in simulation.monitors]

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -226,6 +226,7 @@ from .components.data.monitor_data import (
     DiffractionData,
     DirectivityData,
     FieldData,
+    FieldOverlapData,
     FieldProjectionAngleData,
     FieldProjectionCartesianData,
     FieldProjectionKSpaceData,
@@ -355,6 +356,7 @@ from .components.mode_spec import (
 
 # monitors
 from .components.monitor import (
+    AstigmaticGaussianOverlapMonitor,
     AuxFieldTimeMonitor,
     DiffractionMonitor,
     DirectivityMonitor,
@@ -366,6 +368,7 @@ from .components.monitor import (
     FieldTimeMonitor,
     FluxMonitor,
     FluxTimeMonitor,
+    GaussianOverlapMonitor,
     MediumMonitor,
     ModeMonitor,
     ModeSolverMonitor,
@@ -518,6 +521,7 @@ __all__ = [
     "ApodizationSpec",
     "AstigmaticGaussianBeam",
     "AstigmaticGaussianBeamProfile",
+    "AstigmaticGaussianOverlapMonitor",
     "AugerRecombination",
     "AutoGrid",
     "AutoImpedanceSpec",
@@ -636,6 +640,7 @@ __all__ = [
     "FieldDataset",
     "FieldGrid",
     "FieldMonitor",
+    "FieldOverlapData",
     "FieldProjectionAngleData",
     "FieldProjectionAngleDataArray",
     "FieldProjectionAngleMonitor",
@@ -667,6 +672,7 @@ __all__ = [
     "GaussianBeam",
     "GaussianBeamProfile",
     "GaussianDoping",
+    "GaussianOverlapMonitor",
     "GaussianPulse",
     "Geometry",
     "GeometryGroup",

--- a/tidy3d/components/beam.py
+++ b/tidy3d/components/beam.py
@@ -205,7 +205,6 @@ class BeamProfile(Box):
                 field_vals[2, :] *= -1
             else:
                 field_vals[:2, :] *= -1
-
         # Rotate the fields back to the original propagation axes
         field_vals = self._inverse_rotate_field_vals_z(field_vals, background_n)
 
@@ -371,11 +370,11 @@ class GaussianBeamProfile(BeamProfile):
         0.0,
         title="Waist Distance",
         description="Distance from the beam waist along the propagation direction. "
-        "A positive value means the waist is positioned behind the beam, considering the propagation direction. "
-        "For example, for a beam propagating in the ``+`` direction, a positive value of ``beam_distance`` "
-        "means the beam waist is positioned in the ``-`` direction (behind the beam). "
-        "A negative value means the beam waist is in the ``+`` direction (in front of the beam). "
-        "For an angled beam, the distance is defined along the rotated propagation direction.",
+        "A positive value places the waist behind the beam plane (toward the negative normal axis). "
+        "A negative value places the waist in front of the beam plane (toward the positive normal axis). "
+        "This definition is independent of the ``direction`` parameter, ensuring consistent waist "
+        "positioning for both forward- and backward-propagating beams. "
+        "For an angled beam, the distance is measured along the rotated propagation direction.",
         units=MICROMETER,
     )
     _backward_waist_warning = warn_backward_waist_distance("waist_distance")
@@ -392,6 +391,8 @@ class GaussianBeamProfile(BeamProfile):
         """
 
         w_0, z_0 = self.waist_radius, self.waist_distance
+        if self.direction == "-":
+            z_0 = -z_0
         z_r = w_0**2 * k0 / 2  # shape k0
         w_z = w_0 * np.sqrt(1 + ((z + z_0) / z_r) ** 2)  # shape (Np, Nk0)
         # inv_r_z shape (Np, Nk0)
@@ -441,10 +442,9 @@ class AstigmaticGaussianBeamProfile(BeamProfile):
         title="Waist distances",
         description="Distance to the beam waist along the propagation direction "
         "for the waist sizes in the local x and y directions. "
-        "When ``direction`` is ``+`` and ``waist_distances`` are positive, the waist "
-        "is on the ``-`` side (behind) the beam plane. When ``direction`` is ``+`` and "
-        "``waist_distances`` are negative, the waist is on the ``+`` side (in front) of "
-        "the beam plane.",
+        "Positive values place the waist behind the beam plane (toward the negative normal axis); "
+        "negative values place the waist in front of the beam plane. "
+        "This definition is independent of the ``direction`` parameter.",
         units=MICROMETER,
     )
     _backward_waist_warning = warn_backward_waist_distance("waist_distances")
@@ -461,6 +461,8 @@ class AstigmaticGaussianBeamProfile(BeamProfile):
         """
 
         w_xy, z_xy = self.waist_sizes, self.waist_distances  # shape (2, )
+        if self.direction == "-":
+            z_xy = [-z_i for z_i in z_xy]
         z_r = [w**2 * k0 / 2 for w in w_xy]  # shape (2, Nk0)
         w_z, w_0, inv_r_z, psi_g = [], [], [], []  # final shape (2, Np, Nk0) after loop below
         for w, z_i, z_ri in zip(w_xy, z_xy, z_r):

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -21,6 +21,7 @@ from tidy3d.components.grid.grid import Coords, Grid
 from tidy3d.components.medium import Medium, MediumType
 from tidy3d.components.mode_spec import ModeSortSpec, ModeSpec
 from tidy3d.components.monitor import (
+    AstigmaticGaussianOverlapMonitor,
     AuxFieldTimeMonitor,
     DiffractionMonitor,
     DirectivityMonitor,
@@ -32,6 +33,7 @@ from tidy3d.components.monitor import (
     FieldTimeMonitor,
     FluxMonitor,
     FluxTimeMonitor,
+    GaussianOverlapMonitor,
     MediumMonitor,
     ModeMonitor,
     ModeSolverMonitor,
@@ -1733,7 +1735,63 @@ class MediumData(MediumDataset, AbstractFieldData):
     )
 
 
-class ModeData(ModeSolverDataset, ElectromagneticFieldData):
+class AbstractOverlapData(ElectromagneticFieldData):
+    amps: ModeAmpsDataArray = pd.Field(
+        ...,
+        title="Amplitudes",
+        description="Complex-valued amplitudes of the overlap decomposition.",
+    )
+
+    def normalize(self, source_spectrum_fn) -> AbstractOverlapData:
+        """Return copy of self after normalization is applied using source spectrum function."""
+        if self.amps is None:
+            return self.copy()
+        source_freq_amps = source_spectrum_fn(self.amps.f)[None, :, None]
+        new_amps = (self.amps / source_freq_amps).astype(self.amps.dtype)
+        return self.copy(update={"amps": new_amps})
+
+    @property
+    def time_reversed_copy(self) -> AbstractOverlapData:
+        """Make a copy of the data with direction-reversed fields. In lossy or gyrotropic systems,
+        the time-reversed fields will not be the same as the backward-propagating modes.
+        Note: this only reverses the store fields, any other stored quantities are untouched.
+        """
+        mnt = self.monitor
+
+        if not mnt.store_fields_direction:
+            return self.copy()
+
+        # Time reversal
+        new_data = {}
+        for comp, field in self.field_components.items():
+            if comp[0] == "H":
+                new_data[comp] = -np.conj(field)
+            else:
+                new_data[comp] = np.conj(field)
+
+        # switch direction in the monitor
+        new_dir = "+" if mnt.store_fields_direction == "-" else "-"
+        update_dict = {"store_fields_direction": new_dir}
+        if hasattr(mnt, "direction"):
+            update_dict["direction"] = new_dir
+        new_data["monitor"] = mnt.updated_copy(**update_dict)
+        return self.copy(update=new_data)
+
+
+class FieldOverlapData(AbstractOverlapData):
+    monitor: Union[GaussianOverlapMonitor, AstigmaticGaussianOverlapMonitor] = pd.Field(
+        ..., title="Monitor", description="Monitor associated with the data."
+    )
+
+    def _make_adjoint_sources(
+        self, dataset_names: list[str], fwidth: float
+    ) -> list[Union[CustomCurrentSource, PointDipole]]:
+        """Converts a :class:`.FieldData` to a list of adjoint current or point sources."""
+
+        raise NotImplementedError("Could not formulate adjoint source for overlap monitor output.")
+
+
+class ModeData(ModeSolverDataset, AbstractOverlapData):
     """
     Data associated with a :class:`.ModeMonitor`: modal amplitudes, propagation indices and mode profiles.
 
@@ -1773,11 +1831,7 @@ class ModeData(ModeSolverDataset, ElectromagneticFieldData):
     """
 
     monitor: ModeMonitor = pd.Field(
-        ..., title="Monitor", description="Mode monitor associated with the data."
-    )
-
-    amps: ModeAmpsDataArray = pd.Field(
-        ..., title="Amplitudes", description="Complex-valued amplitudes associated with the mode."
+        ..., title="Monitor", description="Monitor associated with the data."
     )
 
     eps_spec: list[EpsSpecType] = pd.Field(
@@ -1798,12 +1852,6 @@ class ModeData(ModeSolverDataset, ElectromagneticFieldData):
                     "eps_spec must be provided at the same frequencies as mode solver data."
                 )
         return val
-
-    def normalize(self, source_spectrum_fn) -> ModeData:
-        """Return copy of self after normalization is applied using source spectrum function."""
-        source_freq_amps = source_spectrum_fn(self.amps.f)[None, :, None]
-        new_amps = (self.amps / source_freq_amps).astype(self.amps.dtype)
-        return self.copy(update={"amps": new_amps})
 
     def overlap_sort(
         self,
@@ -2091,25 +2139,6 @@ class ModeData(ModeSolverDataset, ElectromagneticFieldData):
         update_dict["monitor"] = self.monitor.updated_copy(freqs=freqs)
 
         return self.copy(update=update_dict)
-
-    @property
-    def time_reversed_copy(self) -> FieldData:
-        """Make a copy of the data with direction-reversed fields. In lossy or gyrotropic systems,
-        the time-reversed fields will not be the same as the backward-propagating modes."""
-
-        # Time reversal
-        new_data = {}
-        for comp, field in self.field_components.items():
-            if comp[0] == "H":
-                new_data[comp] = -np.conj(field)
-            else:
-                new_data[comp] = np.conj(field)
-
-        # switch direction in the monitor
-        mnt = self.monitor
-        new_dir = "+" if mnt.store_fields_direction == "-" else "-"
-        new_data["monitor"] = mnt.updated_copy(store_fields_direction=new_dir)
-        return self.copy(update=new_data)
 
     def _colocated_propagation_axes_field(self, field_name: Literal["E", "H"]) -> DataArray:
         """Collect a field DataArray containing all 3 field components and rotate from frame
@@ -2737,10 +2766,6 @@ class ModeSolverData(ModeData):
         "interpolating in frequency.",
     )
 
-    def normalize(self, source_spectrum_fn: Callable[[float], complex]) -> ModeSolverData:
-        """Return copy of self after normalization is applied using source spectrum function."""
-        return self.copy()
-
     def _normalize_modes(self):
         """Normalize modes. Note: this modifies ``self`` in-place."""
         scaling = np.sqrt(np.abs(self.flux))
@@ -2958,25 +2983,6 @@ class ModeSolverData(ModeData):
             assume_sorted=True,
         )
         return interpolated_data
-
-    @property
-    def time_reversed_copy(self) -> FieldData:
-        """Make a copy of the data with direction-reversed fields. In lossy or gyrotropic systems,
-        the time-reversed fields will not be the same as the backward-propagating modes."""
-
-        # Time reversal
-        new_data = {}
-        for comp, field in self.field_components.items():
-            if comp[0] == "H":
-                new_data[comp] = -np.conj(field)
-            else:
-                new_data[comp] = np.conj(field)
-
-        # switch direction in the monitor
-        mnt = self.monitor
-        new_dir = "+" if mnt.store_fields_direction == "-" else "-"
-        new_data["monitor"] = mnt.updated_copy(direction=new_dir, store_fields_direction=new_dir)
-        return self.copy(update=new_data)
 
     def _check_fields_stored(self, components: list[str]) -> None:
         """Check that all requested field components are stored in the data."""

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -337,8 +337,88 @@ class PlanarMonitor(Monitor, ABC):
         return self.size.index(0.0)
 
 
-class AbstractModeMonitor(PlanarMonitor, FreqMonitor):
+class AbstractOverlapMonitor(PlanarMonitor, FreqMonitor):
+    """:class:`Monitor` that projects fields onto a specified basis and stores overlap amplitudes.
+
+    This base is shared by ModeMonitor and Gaussian-overlap monitors.
+    """
+
+    store_fields_direction: Direction = pydantic.Field(
+        None,
+        title="Store Fields",
+        description="Propagation direction for the field profiles stored from overlap calculation.",
+    )
+
+    colocate: bool = pydantic.Field(
+        True,
+        title="Colocate Fields",
+        description="Toggle whether fields should be colocated to grid cell boundaries (i.e. primal grid nodes).",
+    )
+
+    conjugated_dot_product: bool = pydantic.Field(
+        True,
+        title="Conjugated Dot Product",
+        description="Use conjugated or non-conjugated dot product for overlap/decomposition.",
+    )
+
+    _draw_overlap_arrows: bool = True
+    """Whether to draw arrows in AbstractOverlapMonitor.plot(). Subclasses override to False."""
+
+    def plot(
+        self,
+        x: Optional[float] = None,
+        y: Optional[float] = None,
+        z: Optional[float] = None,
+        ax: Ax = None,
+        **patch_kwargs,
+    ) -> Ax:
+        """Plot this overlap monitor with an arrow indicating propagation direction."""
+        ax = super().plot(x=x, y=y, z=z, ax=ax, **patch_kwargs)
+
+        if not self._draw_overlap_arrows:
+            return ax
+
+        kwargs_alpha = patch_kwargs.get("alpha")
+        arrow_alpha = ARROW_ALPHA if kwargs_alpha is None else kwargs_alpha
+
+        ax = self._plot_arrow(
+            x=x,
+            y=y,
+            z=z,
+            ax=ax,
+            direction=self._dir_arrow,
+            bend_radius=None,
+            bend_axis=None,
+            color=ARROW_COLOR_MONITOR,
+            alpha=arrow_alpha,
+            both_dirs=True,
+        )
+        return ax
+
+    @cached_property
+    def _dir_arrow(self) -> tuple[float, float, float]:
+        """Monitor direction normal vector in cartesian coordinates."""
+        theta, phi = self._angles
+        dx = np.cos(phi) * np.sin(theta)
+        dy = np.sin(phi) * np.sin(theta)
+        dz = np.cos(theta)
+        return self.unpop_axis(dz, (dx, dy), axis=self.normal_axis)
+
+    @property
+    def _angles(self) -> tuple[float, float]:
+        """Angle tuple (theta, phi) in radians. Children override to supply values."""
+        return (0.0, 0.0)
+
+    def _storage_size_solver(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
+        """Default size of intermediate data; store all fields on plane for overlap."""
+        num_sample = len(getattr(self, "freqs", [0]))
+        return BYTES_COMPLEX * num_cells * num_sample * 6
+
+
+class AbstractModeMonitor(AbstractOverlapMonitor):
     """:class:`Monitor` that records mode-related data."""
+
+    _draw_overlap_arrows: bool = False  # AbstractModeMonitor.plot() draws its own arrows
 
     mode_spec: ModeSpec = pydantic.Field(
         ModeSpec(),
@@ -401,12 +481,8 @@ class AbstractModeMonitor(PlanarMonitor, FreqMonitor):
         return ax
 
     @cached_property
-    def _dir_arrow(self) -> tuple[float, float, float]:
-        """Source direction normal vector in cartesian coordinates."""
-        dx = np.cos(self.mode_spec.angle_phi) * np.sin(self.mode_spec.angle_theta)
-        dy = np.sin(self.mode_spec.angle_phi) * np.sin(self.mode_spec.angle_theta)
-        dz = np.cos(self.mode_spec.angle_theta)
-        return self.unpop_axis(dz, (dx, dy), axis=self.normal_axis)
+    def _angles(self) -> tuple[float, float]:
+        return (self.mode_spec.angle_theta, self.mode_spec.angle_phi)
 
     @cached_property
     def _bend_axis(self) -> Axis:
@@ -445,6 +521,136 @@ class AbstractModeMonitor(PlanarMonitor, FreqMonitor):
         if self.mode_spec.precision == "double":
             return 2 * bytes_single
         return bytes_single
+
+
+class AbstractGaussianOverlapMonitor(AbstractOverlapMonitor):
+    """:class:`Monitor` that records amplitudes from decomposition onto a Gaussian-like beam.
+
+    Common fields and behavior shared by GaussianOverlapMonitor and
+    AstigmaticGaussianOverlapMonitor.
+    """
+
+    angle_theta: float = pydantic.Field(
+        0.0,
+        title="Polar Angle",
+        description="Polar angle of propagation direction.",
+        units=RADIAN,
+    )
+
+    angle_phi: float = pydantic.Field(
+        0.0,
+        title="Azimuth Angle",
+        description="Azimuth angle of propagation direction.",
+        units=RADIAN,
+    )
+
+    pol_angle: float = pydantic.Field(
+        0,
+        title="Polarization Angle",
+        description="Specifies the angle between the electric field polarization of the "
+        "source and the plane defined by the injection axis and the propagation axis (rad). "
+        "``pol_angle=0`` (default) specifies P polarization, "
+        "while ``pol_angle=np.pi/2`` specifies S polarization. "
+        "At normal incidence when S and P are undefined, ``pol_angle=0`` defines: "
+        "- ``Ey`` polarization for propagation along ``x``."
+        "- ``Ex`` polarization for propagation along ``y``."
+        "- ``Ex`` polarization for propagation along ``z``.",
+        units=RADIAN,
+    )
+
+    @property
+    def _angles(self) -> tuple[float, float]:
+        return (self.angle_theta, self.angle_phi)
+
+    def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
+        """Size of monitor storage given the number of points after discretization."""
+        # store complex amplitudes for +/- directions
+        num_dirs = 2
+        return BYTES_COMPLEX * len(self.freqs) * num_dirs
+
+
+class GaussianOverlapMonitor(AbstractGaussianOverlapMonitor):
+    """:class:`Monitor` that records amplitudes from decomposition onto a Gaussian beam.
+
+    Example
+    -------
+    >>> gauss = GaussianOverlapMonitor(
+    ...     size=(0, 3, 3),
+    ...     freqs=[2e14],
+    ...     pol_angle=np.pi / 2,
+    ...     waist_radius=1.0,
+    ...     name="gaussian_monitor",
+    ... )
+
+    Notes
+    --------
+        If one wants the focus 'in front' of the monitor, a negative value of ``waist_distance``
+        is needed. See also :class:`.GaussianBeam`.
+    """
+
+    waist_radius: pydantic.PositiveFloat = pydantic.Field(
+        1.0,
+        title="Waist Radius",
+        description="Radius of the beam at the waist.",
+        units=MICROMETER,
+    )
+
+    waist_distance: float = pydantic.Field(
+        0.0,
+        title="Waist Distance",
+        description="Distance from the beam waist along the propagation direction. "
+        "A positive value places the waist behind the monitor plane (toward the negative normal axis). "
+        "A negative value places the waist in front of the monitor plane. "
+        "For an angled beam, the distance is measured along the rotated propagation direction.",
+        units=MICROMETER,
+    )
+
+
+class AstigmaticGaussianOverlapMonitor(AbstractGaussianOverlapMonitor):
+    """:class:`Monitor` that records amplitudes from decomposition onto an astigmatic Gaussian beam.
+
+    The simple astigmatic Gaussian distribution allows
+    both an elliptical intensity profile and different waist locations for the two principal axes
+    of the ellipse. When equal waist sizes and equal waist distances are specified in the two
+    directions, this monitor becomes equivalent to :class:`GaussianOverlapMonitor`.
+
+    Notes
+    -----
+
+        This class implements the simple astigmatic Gaussian beam described in _`[1]`.
+
+        **References**:
+
+        .. [1] Kochkina et al., Applied Optics, vol. 52, issue 24, 2013.
+
+    Example
+    -------
+    >>> gauss = AstigmaticGaussianOverlapMonitor(
+    ...     size=(0,3,3),
+    ...     pol_angle=np.pi / 2,
+    ...     waist_sizes=(1.0, 2.0),
+    ...     waist_distances = (3.0, 4.0),
+    ...     freqs=[2e14],
+    ...     name="astigmatic_gaussian_monitor",
+    ... )
+    """
+
+    waist_sizes: tuple[pydantic.PositiveFloat, pydantic.PositiveFloat] = pydantic.Field(
+        (1.0, 1.0),
+        title="Waist sizes",
+        description="Size of the beam at the waist in the local x and y directions.",
+        units=MICROMETER,
+    )
+
+    waist_distances: tuple[float, float] = pydantic.Field(
+        (0.0, 0.0),
+        title="Waist distances",
+        description="Distance to the beam waist along the propagation direction "
+        "for the waist sizes in the local x and y directions. "
+        "Positive values place the waist behind the monitor plane (toward the negative normal axis); "
+        "negative values place the waist in front of the monitor plane.",
+        units=MICROMETER,
+    )
 
 
 class FieldMonitor(AbstractFieldMonitor, FreqMonitor):

--- a/tidy3d/components/source/field.py
+++ b/tidy3d/components/source/field.py
@@ -558,13 +558,7 @@ class GaussianBeam(AngledFieldSource, PlanarSource, BroadbandSource):
     ...     direction='+',
     ...     waist_radius=1.0)
 
-    Notes
-    --------
-    If one wants the focus 'in front' of the source, a negative value of ``waist_distance`` is needed.
 
-    .. image:: ../../_static/img/beam_waist.png
-        :width: 30%
-        :align: center
 
     See Also
     --------
@@ -584,11 +578,11 @@ class GaussianBeam(AngledFieldSource, PlanarSource, BroadbandSource):
         0.0,
         title="Waist Distance",
         description="Distance from the beam waist along the propagation direction. "
-        "A positive value means the waist is positioned behind the source, considering the propagation direction. "
-        "For example, for a beam propagating in the ``+`` direction, a positive value of ``beam_distance`` "
-        "means the beam waist is positioned in the ``-`` direction (behind the source). "
-        "A negative value means the beam waist is in the ``+`` direction (in front of the source). "
-        "For an angled source, the distance is defined along the rotated propagation direction.",
+        "A positive value places the waist behind the source plane (toward the negative normal axis). "
+        "A negative value places the waist in front of the source plane (toward the positive normal axis). "
+        "This definition is independent of the ``direction`` parameter, ensuring consistent waist "
+        "positioning for both forward- and backward-propagating beams. "
+        "For an angled source, the distance is measured along the rotated propagation direction.",
         units=MICROMETER,
     )
 
@@ -646,10 +640,9 @@ class AstigmaticGaussianBeam(AngledFieldSource, PlanarSource, BroadbandSource):
         title="Waist distances",
         description="Distance to the beam waist along the propagation direction "
         "for the waist sizes in the local x and y directions. "
-        "When ``direction`` is ``+`` and ``waist_distances`` are positive, the waist "
-        "is on the ``-`` side (behind) the source plane. When ``direction`` is ``+`` and "
-        "``waist_distances`` are negative, the waist is on the ``+`` side (in front) of "
-        "the source plane.",
+        "Positive values place the waist behind the source plane (toward the negative normal axis); "
+        "negative values place the waist in front of the source plane. "
+        "This definition is independent of the ``direction`` parameter.",
         units=MICROMETER,
     )
 

--- a/tidy3d/components/types/monitor.py
+++ b/tidy3d/components/types/monitor.py
@@ -6,6 +6,7 @@ from typing import Union
 
 from tidy3d.components.microwave.monitor import MicrowaveModeMonitor, MicrowaveModeSolverMonitor
 from tidy3d.components.monitor import (
+    AstigmaticGaussianOverlapMonitor,
     AuxFieldTimeMonitor,
     DiffractionMonitor,
     DirectivityMonitor,
@@ -16,6 +17,7 @@ from tidy3d.components.monitor import (
     FieldTimeMonitor,
     FluxMonitor,
     FluxTimeMonitor,
+    GaussianOverlapMonitor,
     MediumMonitor,
     ModeMonitor,
     ModeSolverMonitor,
@@ -40,4 +42,6 @@ MonitorType = Union[
     DirectivityMonitor,
     MicrowaveModeMonitor,
     MicrowaveModeSolverMonitor,
+    GaussianOverlapMonitor,
+    AstigmaticGaussianOverlapMonitor,
 ]

--- a/tidy3d/components/types/monitor_data.py
+++ b/tidy3d/components/types/monitor_data.py
@@ -9,6 +9,7 @@ from tidy3d.components.data.monitor_data import (
     DiffractionData,
     DirectivityData,
     FieldData,
+    FieldOverlapData,
     FieldProjectionAngleData,
     FieldProjectionCartesianData,
     FieldProjectionKSpaceData,
@@ -40,6 +41,7 @@ MonitorDataTypes = (
     FieldProjectionAngleData,
     DiffractionData,
     DirectivityData,
+    FieldOverlapData,
     MicrowaveModeData,
     MicrowaveModeSolverData,
 )

--- a/tidy3d/components/validators.py
+++ b/tidy3d/components/validators.py
@@ -307,11 +307,11 @@ def warn_if_dataset_none(field_name: str):
 
 
 def warn_backward_waist_distance(field_name: str):
-    """Warn if a backward-propagating beam uses a non-zero waist distance."""
+    """Warn about changed waist distance behavior for backward-propagating beams."""
 
     @pydantic.root_validator(allow_reuse=True)
     def _warn_backward_nonzero(cls, values):
-        """Emit deprecation warning for backward propagation with non-zero waist."""
+        """Emit warning about changed waist distance interpretation."""
         direction = values.get("direction")
         if direction != "-":
             return values
@@ -319,12 +319,14 @@ def warn_backward_waist_distance(field_name: str):
         waist_array = np.atleast_1d(waist_value)
         if not np.all(np.isclose(waist_array, 0.0)):
             log.warning(
-                f"Behavior of {cls.__name__} with direction '-' and non-zero '{field_name}' will "
-                "change in version 2.11 to be consistent with upcoming beam overlap monitors and "
-                "ports. Currently, the waist distance is interpreted w.r.t. the directed "
-                "propagation axis, so switching 'direction' also switches the position of the "
-                "waist in the global reference frame. In the future, the waist position will be "
-                "defined such that it is the same for backward- and forward-propagating beams.",
+                f"Starting in version 2.11, the behavior of {cls.__name__} with direction '-' "
+                f"and non-zero '{field_name}' has changed. The waist position is now defined "
+                "consistently for both forward- and backward-propagating beams: a positive "
+                f"'{field_name}' always places the beam waist behind the source/monitor plane "
+                "(toward the negative normal axis). This ensures reciprocity between Gaussian "
+                "sources and overlap monitors used for port-based S-matrix calculations. "
+                "If your simulation relied on the previous behavior (where the waist position "
+                "flipped with direction), you may need to adjust your waist distance values.",
             )
         return values
 

--- a/tidy3d/plugins/smatrix/__init__.py
+++ b/tidy3d/plugins/smatrix/__init__.py
@@ -26,7 +26,7 @@ from tidy3d.plugins.smatrix.data.terminal import (
 )
 from tidy3d.plugins.smatrix.data.types import ComponentModelerDataType
 from tidy3d.plugins.smatrix.ports.coaxial_lumped import CoaxialLumpedPort
-from tidy3d.plugins.smatrix.ports.modal import Port
+from tidy3d.plugins.smatrix.ports.modal import AstigmaticGaussianPort, GaussianPort, Port
 from tidy3d.plugins.smatrix.ports.rectangular_lumped import LumpedPort
 from tidy3d.plugins.smatrix.ports.wave import WavePort
 
@@ -42,11 +42,13 @@ ComponentModeler = ModalComponentModeler
 
 __all__ = [
     "AbstractComponentModeler",
+    "AstigmaticGaussianPort",
     "CoaxialLumpedPort",
     "ComponentModeler",
     "ComponentModelerDataType",
     "ComponentModelerType",
     "DirectivityMonitorSpec",
+    "GaussianPort",
     "LumpedPort",
     "MicrowaveSMatrixData",
     "ModalComponentModeler",

--- a/tidy3d/plugins/smatrix/analysis/modal.py
+++ b/tidy3d/plugins/smatrix/analysis/modal.py
@@ -14,7 +14,8 @@ def modal_construct_smatrix(modeler_data: ModalComponentModelerData) -> ModalPor
     """Constructs the S-matrix from the data of a :class:`.ModalComponentModeler`.
 
     This function post-processes the :class:`.SimulationData` from a series of
-    simulations to compute the scattering matrix (S-matrix).
+    simulations to compute the scattering matrix (S-matrix). Supports both modal
+    ports (ModeMonitor/ModeData) and Gaussian ports (GaussianOverlapMonitor/FieldOverlapData).
 
     Parameters
     ----------
@@ -65,11 +66,17 @@ def modal_construct_smatrix(modeler_data: ModalComponentModelerData) -> ModalPor
             port_name_out, mode_index_out = row_index
             port_out = modeler_data.modeler.get_port_by_name(port_name=port_name_out)
 
-            # directly compute the element
-            mode_amps_data = sim_data[port_out.name].copy().amps
+            # Read overlap amplitudes from either ModeData or FieldOverlapData.
+            # Both expose '.amps' over coords ('direction', 'f', 'mode_index').
+            overlap_amps = sim_data[port_out.name].copy().amps
+
+            # Outgoing direction at the output port: flip the "input" convention.
             dir_out = "-" if port_out.direction == "+" else "+"
-            amp = mode_amps_data.sel(f=coords["f"], direction=dir_out, mode_index=mode_index_out)
+            amp = overlap_amps.sel(f=coords["f"], direction=dir_out, mode_index=mode_index_out)
+
+            # Normalization provided by modeler (handles both modal and gaussian runs).
             source_norm = modeler_data.modeler._normalization_factor(port_in, sim_data)
+
             s_matrix_elements = np.array(amp.data) / np.array(source_norm)
             coords_set = {
                 "port_in": port_name_in,

--- a/tidy3d/plugins/smatrix/component_modelers/modal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/modal.py
@@ -10,12 +10,19 @@ import pydantic.v1 as pd
 from tidy3d.components.base import cached_property
 from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.index import SimulationMap
-from tidy3d.components.monitor import ModeMonitor
-from tidy3d.components.source.field import ModeSource
+from tidy3d.components.monitor import AbstractOverlapMonitor
+from tidy3d.components.source.field import DirectionalSource
 from tidy3d.components.source.time import GaussianPulse
 from tidy3d.components.types import Ax, Complex
 from tidy3d.components.viz import add_ax_if_none, equal_aspect
-from tidy3d.plugins.smatrix.ports.modal import Port
+from tidy3d.constants import GLANCING_CUTOFF
+from tidy3d.exceptions import SetupError
+from tidy3d.plugins.smatrix.ports.modal import (
+    AbstractGaussianPort,
+    GaussianPort,
+    ModalPortType,
+    Port,
+)
 from tidy3d.plugins.smatrix.types import Element, MatrixIndex
 
 from .base import FWIDTH_FRAC, AbstractComponentModeler
@@ -28,7 +35,7 @@ class ModalComponentModeler(AbstractComponentModeler):
     -----
         This class orchestrates the process of running multiple simulations to
         derive the scattering matrix (S-matrix) of a component. It uses modal
-        sources and monitors defined by a set of ports.
+        or Gaussian sources and monitors defined by a set of ports.
 
     See Also
     --------
@@ -36,7 +43,7 @@ class ModalComponentModeler(AbstractComponentModeler):
         * `Computing the scattering matrix of a device <../../notebooks/SMatrix.html>`_
     """
 
-    ports: tuple[Port, ...] = pd.Field(
+    ports: tuple[ModalPortType, ...] = pd.Field(
         (),
         title="Ports",
         description="Collection of ports describing the scattering matrix elements. "
@@ -95,7 +102,9 @@ class ModalComponentModeler(AbstractComponentModeler):
         return SimulationMap(keys=tuple(sim_dict.keys()), values=tuple(sim_dict.values()))
 
     @staticmethod
-    def _construct_matrix_indices_monitor(ports: tuple[Port, ...]) -> tuple[MatrixIndex, ...]:
+    def _construct_matrix_indices_monitor(
+        ports: tuple[ModalPortType, ...],
+    ) -> tuple[MatrixIndex, ...]:
         """Construct matrix indices for monitoring from modal ports.
 
         Parameters
@@ -110,7 +119,7 @@ class ModalComponentModeler(AbstractComponentModeler):
         """
         matrix_indices = []
         for port in ports:
-            for mode_index in range(port.mode_spec.num_modes):
+            for mode_index in range(port.num_modes):
                 matrix_indices.append((port.name, mode_index))
         return tuple(matrix_indices)
 
@@ -162,70 +171,35 @@ class ModalComponentModeler(AbstractComponentModeler):
 
         return port_names_out, port_names_in
 
-    def to_monitor(self, port: Port) -> ModeMonitor:
-        """Creates a mode monitor from a given port.
-
-        This monitor is used to measure the mode amplitudes at the port.
-
-        Parameters
-        ----------
-        port : Port
-            The port to convert into a monitor.
-
-        Returns
-        -------
-        ModeMonitor
-            A :class:`.ModeMonitor` configured to match the port's
-            properties.
-        """
-        return ModeMonitor(
-            center=port.center,
-            size=port.size,
-            freqs=self.freqs,
-            mode_spec=port.mode_spec,
-            name=port.name,
-        )
+    def to_monitor(self, port: ModalPortType) -> AbstractOverlapMonitor:
+        """Creates an overlap monitor from a given port (modal or gaussian)."""
+        return port.to_monitor(freqs=self.freqs)
 
     def to_source(
-        self, port: Port, mode_index: int, num_freqs: int = 1, **kwargs: Any
-    ) -> list[ModeSource]:
-        """Creates a mode source from a given port.
-
-        This source is used to excite a specific mode at the port.
-
-        Parameters
-        ----------
-        port : Port
-            The port to convert into a source.
-        mode_index : int
-            The index of the mode to excite.
-        num_freqs : int, optional
-            The number of frequency points for the source, by default 1.
-
-        Returns
-        -------
-        List[ModeSource]
-            A list containing a single :class:`.ModeSource` configured to
-            excite the specified mode at the port.
-        """
-        freq0 = np.mean(self.freqs)
-        fdiff = max(self.freqs) - min(self.freqs)
+        self, port: ModalPortType, mode_index: int, num_freqs: int = 1, **kwargs: Any
+    ) -> DirectionalSource:
+        """Creates a source from a given port (modal or gaussian)."""
+        freqs = self.freqs
+        freq0 = 0.5 * (max(freqs) + min(freqs))
+        fdiff = max(freqs) - min(freqs)
         fwidth = max(fdiff, freq0 * FWIDTH_FRAC)
-        return ModeSource(
-            center=port.center,
-            size=port.size,
-            source_time=self.custom_source_time
-            if self.custom_source_time is not None
-            else GaussianPulse(freq0=freq0, fwidth=fwidth),
-            mode_spec=port.mode_spec,
+        source_time = self.custom_source_time
+        if source_time is None:
+            source_time = GaussianPulse(
+                freq0=freq0,
+                fwidth=fwidth,
+                remove_dc_component=self.remove_dc_component,
+            )
+        return port.to_source(
+            freq0=freq0,
+            fwidth=fwidth,
             mode_index=mode_index,
-            direction=port.direction,
-            name=port.name,
             num_freqs=num_freqs,
+            source_time=source_time,
             **kwargs,
         )
 
-    def shift_port(self, port: Port) -> Port:
+    def shift_port(self, port: ModalPortType) -> ModalPortType:
         """Generates a new port shifted slightly in the normal direction.
 
         This is to ensure that the source is placed just inside the
@@ -244,8 +218,30 @@ class ModalComponentModeler(AbstractComponentModeler):
 
         shift_value = self._shift_value_signed(port=port)
         center_shifted = list(port.center)
-        center_shifted[port.size.index(0.0)] += shift_value
-        port_shifted = port.copy(update={"center": center_shifted})
+        normal_dim, plane_dims = port.pop_axis([0, 1, 2], port.size.index(0.0))
+        center_shifted[normal_dim] += shift_value
+        update = {}
+        if isinstance(port, AbstractGaussianPort):
+            theta = port.angle_theta
+            phi = port.angle_phi
+            cos_theta = np.cos(theta)
+            if np.abs(cos_theta) < GLANCING_CUTOFF:
+                raise SetupError(
+                    "Cannot shift Gaussian port at glancing incidence. "
+                    "Adjust angle_theta or use a different injection axis."
+                )
+            tan_theta = np.sin(theta) / cos_theta
+            center_shifted[plane_dims[0]] += shift_value * tan_theta * np.cos(phi)
+            center_shifted[plane_dims[1]] += shift_value * tan_theta * np.sin(phi)
+            if isinstance(port, GaussianPort):
+                waist_distance = port.waist_distance + shift_value / cos_theta
+                update["waist_distance"] = waist_distance
+            else:
+                waist_distances = list(port.waist_distances)
+                waist_distances[0] = waist_distances[0] + shift_value / cos_theta
+                waist_distances[1] = waist_distances[1] + shift_value / cos_theta
+                update["waist_distances"] = waist_distances
+        port_shifted = port.updated_copy(center=center_shifted, **update)
         return port_shifted
 
     @equal_aspect
@@ -281,8 +277,9 @@ class ModalComponentModeler(AbstractComponentModeler):
 
         plot_sources = []
         for port_source in self.ports:
-            mode_source_0 = self.to_source(port=port_source, mode_index=0)
-            plot_sources.append(mode_source_0)
+            # for plotting, use mode_index=0 (gaussian ignores it)
+            src0 = self.to_source(port=port_source, mode_index=0)
+            plot_sources.append(src0)
         sim_plot = self.simulation.copy(update={"sources": plot_sources})
         return sim_plot.plot(x=x, y=y, z=z, ax=ax)
 
@@ -322,8 +319,8 @@ class ModalComponentModeler(AbstractComponentModeler):
 
         plot_sources = []
         for port_source in self.ports:
-            mode_source_0 = self.to_source(port=port_source, mode_index=0)
-            plot_sources.append(mode_source_0)
+            src0 = self.to_source(port=port_source, mode_index=0)
+            plot_sources.append(src0)
         sim_plot = self.simulation.copy(update={"sources": plot_sources})
         return sim_plot.plot_eps(x=x, y=y, z=z, ax=ax, **kwargs)
 
@@ -346,8 +343,9 @@ class ModalComponentModeler(AbstractComponentModeler):
         """
 
         port_monitor_data = sim_data[port_source.name]
-        mode_index = sim_data.simulation.sources[0].mode_index
-
+        # some sources (GaussianBeam) don't have 'mode_index'; default to 0
+        src = sim_data.simulation.sources[0]
+        mode_index = getattr(src, "mode_index", 0)
         normalize_amps = port_monitor_data.amps.sel(
             f=np.array(self.freqs),
             direction=port_source.direction,

--- a/tidy3d/plugins/smatrix/ports/modal.py
+++ b/tidy3d/plugins/smatrix/ports/modal.py
@@ -2,12 +2,23 @@
 
 from __future__ import annotations
 
+from abc import ABC
+from typing import Any, Optional, Union
+
 import pydantic.v1 as pd
 
 from tidy3d.components.data.data_array import DataArray
 from tidy3d.components.geometry.base import Box
 from tidy3d.components.mode_spec import ModeSpec
+from tidy3d.components.monitor import (
+    AstigmaticGaussianOverlapMonitor,
+    GaussianOverlapMonitor,
+    ModeMonitor,
+)
+from tidy3d.components.source.field import AstigmaticGaussianBeam, GaussianBeam, ModeSource
+from tidy3d.components.source.time import GaussianPulse, SourceTimeType
 from tidy3d.components.types import Direction
+from tidy3d.constants import MICROMETER, RADIAN
 from tidy3d.plugins.smatrix.ports.base import AbstractBasePort
 
 
@@ -37,12 +48,12 @@ class ModalPortDataArray(DataArray):
     _data_attrs = {"long_name": "modal port matrix element"}
 
 
-class Port(AbstractBasePort, Box):
-    """Specifies a port for S-matrix calculation.
+class AbstractPort(AbstractBasePort, Box, ABC):
+    """Abstract base class for modal and Gaussian ports used in S-matrix calculations.
 
     Notes
     -----
-        A port defines a location and a set of modes for which the S-matrix
+        A port defines a location and a set of modes or Gaussian beams for which the S-matrix
         is calculated.
     """
 
@@ -51,8 +62,207 @@ class Port(AbstractBasePort, Box):
         title="Direction",
         description="'+' or '-', defining which direction is considered 'input'.",
     )
+
+    @property
+    def num_modes(self) -> int:
+        """Number of modes defined on this port."""
+        return 1
+
+
+class Port(AbstractPort):
+    """Specifies a modal port for S-matrix calculation."""
+
     mode_spec: ModeSpec = pd.Field(
         ModeSpec(),
         title="Mode Specification",
         description="Specifies how the mode solver will solve for the modes of the port.",
     )
+
+    def to_monitor(self, freqs: tuple[float, ...]) -> ModeMonitor:
+        """Create a ModeMonitor matching this modal port."""
+        return ModeMonitor(
+            center=self.center,
+            size=self.size,
+            freqs=freqs,
+            mode_spec=self.mode_spec,
+            name=self.name,
+        )
+
+    def to_source(
+        self,
+        freq0: float,
+        fwidth: float,
+        mode_index: int,
+        num_freqs: int = 1,
+        source_time: Optional[SourceTimeType] = None,
+        **kwargs: Any,
+    ) -> ModeSource:
+        """Create a ModeSource matching this modal port."""
+        if source_time is None:
+            source_time = GaussianPulse(freq0=freq0, fwidth=fwidth)
+        return ModeSource(
+            center=self.center,
+            size=self.size,
+            source_time=source_time,
+            mode_spec=self.mode_spec,
+            mode_index=mode_index,
+            direction=self.direction,
+            name=self.name,
+            num_freqs=num_freqs,
+            **kwargs,
+        )
+
+    @property
+    def num_modes(self) -> int:
+        """Number of modes defined on this port."""
+        return self.mode_spec.num_modes
+
+
+class AbstractGaussianPort(AbstractPort, ABC):
+    """Abstract base for Gaussian-like ports (Gaussian and AstigmaticGaussian)."""
+
+    angle_theta: float = pd.Field(
+        0.0,
+        title="Polar Angle",
+        description="Polar angle of the propagation axis from the injection axis.",
+        units=RADIAN,
+    )
+    angle_phi: float = pd.Field(
+        0.0,
+        title="Azimuth Angle",
+        description="Azimuth angle of the propagation axis in the plane orthogonal to the injection axis.",
+        units=RADIAN,
+    )
+    pol_angle: float = pd.Field(
+        0.0,
+        title="Polarization Angle",
+        description="Angle between E-field polarization and the plane defined by the injection axis and propagation axis. "
+        "0 => P polarization, pi/2 => S polarization.",
+        units=RADIAN,
+    )
+
+
+class GaussianPort(AbstractGaussianPort):
+    """Specifies a Gaussian port for S-matrix calculation."""
+
+    waist_radius: pd.PositiveFloat = pd.Field(
+        1.0,
+        title="Waist Radius",
+        description="Radius of the beam at the waist.",
+        units=MICROMETER,
+    )
+    waist_distance: float = pd.Field(
+        0.0,
+        title="Waist Distance",
+        description="Distance from the beam waist along the propagation direction. "
+        "A positive value places the waist behind the port plane (toward the negative normal axis). "
+        "A negative value places the waist in front of the port plane. "
+        "This definition is independent of the ``direction`` parameter.",
+        units=MICROMETER,
+    )
+
+    def to_monitor(self, freqs: tuple[float, ...]) -> GaussianOverlapMonitor:
+        """Create a GaussianOverlapMonitor matching this gaussian port."""
+        return GaussianOverlapMonitor(
+            center=self.center,
+            size=self.size,
+            freqs=freqs,
+            angle_theta=self.angle_theta,
+            angle_phi=self.angle_phi,
+            pol_angle=self.pol_angle,
+            waist_radius=self.waist_radius,
+            waist_distance=self.waist_distance,
+            name=self.name,
+        )
+
+    def to_source(
+        self,
+        freq0: float,
+        fwidth: float,
+        mode_index: int = 0,
+        num_freqs: int = 1,
+        source_time: Optional[SourceTimeType] = None,
+        **kwargs: Any,
+    ) -> GaussianBeam:
+        """Create a GaussianBeam matching this gaussian port. Ignores mode_index."""
+        if source_time is None:
+            source_time = GaussianPulse(freq0=freq0, fwidth=fwidth)
+        return GaussianBeam(
+            center=self.center,
+            size=self.size,
+            source_time=source_time,
+            angle_theta=self.angle_theta,
+            angle_phi=self.angle_phi,
+            pol_angle=self.pol_angle,
+            waist_radius=self.waist_radius,
+            waist_distance=self.waist_distance,
+            direction=self.direction,
+            name=self.name,
+            num_freqs=num_freqs,
+            **kwargs,
+        )
+
+
+class AstigmaticGaussianPort(AbstractGaussianPort):
+    """Specifies an astigmatic Gaussian port for S-matrix calculation."""
+
+    waist_sizes: tuple[pd.PositiveFloat, pd.PositiveFloat] = pd.Field(
+        (1.0, 1.0),
+        title="Waist sizes",
+        description="Size of the beam at the waist in the local x and y directions.",
+        units=MICROMETER,
+    )
+    waist_distances: tuple[float, float] = pd.Field(
+        (0.0, 0.0),
+        title="Waist distances",
+        description="Distance to the beam waist along the propagation direction "
+        "for the waist sizes in the local x and y directions. "
+        "Positive values place the waist behind the port plane (toward the negative normal axis); "
+        "negative values place the waist in front of the port plane. "
+        "This definition is independent of the ``direction`` parameter.",
+        units=MICROMETER,
+    )
+
+    def to_monitor(self, freqs: tuple[float, ...]) -> AstigmaticGaussianOverlapMonitor:
+        """Create an AstigmaticGaussianOverlapMonitor matching this port."""
+        return AstigmaticGaussianOverlapMonitor(
+            center=self.center,
+            size=self.size,
+            freqs=freqs,
+            angle_theta=self.angle_theta,
+            angle_phi=self.angle_phi,
+            pol_angle=self.pol_angle,
+            waist_sizes=self.waist_sizes,
+            waist_distances=self.waist_distances,
+            name=self.name,
+        )
+
+    def to_source(
+        self,
+        freq0: float,
+        fwidth: float,
+        mode_index: int = 0,
+        num_freqs: int = 1,
+        source_time: Optional[SourceTimeType] = None,
+        **kwargs: Any,
+    ) -> AstigmaticGaussianBeam:
+        """Create an AstigmaticGaussianBeam matching this port. Ignores mode_index."""
+        if source_time is None:
+            source_time = GaussianPulse(freq0=freq0, fwidth=fwidth)
+        return AstigmaticGaussianBeam(
+            center=self.center,
+            size=self.size,
+            source_time=source_time,
+            angle_theta=self.angle_theta,
+            angle_phi=self.angle_phi,
+            pol_angle=self.pol_angle,
+            waist_sizes=self.waist_sizes,
+            waist_distances=self.waist_distances,
+            direction=self.direction,
+            name=self.name,
+            num_freqs=num_freqs,
+            **kwargs,
+        )
+
+
+ModalPortType = Union[Port, GaussianPort, AstigmaticGaussianPort]


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-16 09:46:16 UTC

### Greptile Summary

This PR adds Gaussian overlap monitor functionality to the Tidy3D simulation system through FXC-3275. The implementation introduces two new monitor classes: `GaussianOverlapMonitor` for circular Gaussian beam overlap calculations and `AstigmaticGaussianOverlapMonitor` for elliptical beams with different waist parameters in each direction.

The change refactors the monitor class hierarchy by creating a new `AbstractOverlapMonitor` base class that contains shared functionality between existing mode monitors and the new Gaussian monitors. This includes fields for `store_fields_direction`, `colocate`, and `conjugated_dot_product`, which were moved from `AbstractModeMonitor` to enable code reuse. The Gaussian monitors add specialized fields for beam parameters including angles, polarization, and waist characteristics.

The implementation follows established patterns in the codebase with proper inheritance, documentation, and type safety. Test coverage is included for both monitor classes with basic functionality verification and integration into the comprehensive monitor test suite.

### Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `tidy3d/components/monitor.py` | 4/5 | Major refactoring adding AbstractOverlapMonitor base class and two new Gaussian overlap monitor implementations |
| `tidy3d/components/types/monitor.py` | 5/5 | Simple type additions registering the new monitor classes in the type system |
| `tests/test_components/test_monitor.py` | 5/5 | Basic test coverage for the new monitor classes with integration into existing test suite |

</details>

### Confidence score: 4/5

- This PR is safe to merge with good architectural design and proper testing
- Score reflects solid implementation following established patterns, but monitor hierarchy refactoring in critical simulation code requires careful validation
- Pay close attention to the monitor.py file to ensure the refactoring doesn't break existing mode monitor functionality

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Simulation as "Simulation"
    participant GaussianMonitor as "GaussianOverlapMonitor"
    participant AstigmaticGaussianMonitor as "AstigmaticGaussianOverlapMonitor"
    participant AbstractGaussianOverlapMonitor as "AbstractGaussianOverlapMonitor"
    participant FreqMonitor as "FreqMonitor"
    participant Solver as "FDTD Solver"

    User->>GaussianMonitor: "Create GaussianOverlapMonitor(size, freqs, waist_radius, waist_distance)"
    GaussianMonitor->>AbstractGaussianOverlapMonitor: "Inherit base functionality"
    AbstractGaussianOverlapMonitor->>FreqMonitor: "Inherit frequency domain processing"
    
    User->>AstigmaticGaussianMonitor: "Create AstigmaticGaussianOverlapMonitor(size, freqs, waist_sizes, waist_distances)"
    AstigmaticGaussianMonitor->>AbstractGaussianOverlapMonitor: "Inherit base functionality"
    
    User->>Simulation: "Add monitors to simulation"
    Simulation->>GaussianMonitor: "Validate monitor configuration"
    Simulation->>AstigmaticGaussianMonitor: "Validate monitor configuration"
    
    User->>Simulation: "Run simulation"
    Simulation->>Solver: "Initialize FDTD solver"
    Solver->>GaussianMonitor: "Record field data at frequencies"
    Solver->>AstigmaticGaussianMonitor: "Record field data at frequencies"
    
    GaussianMonitor->>AbstractGaussianOverlapMonitor: "Compute Gaussian beam overlap"
    AstigmaticGaussianMonitor->>AbstractGaussianOverlapMonitor: "Compute astigmatic Gaussian beam overlap"
    
    AbstractGaussianOverlapMonitor->>Solver: "Return complex amplitudes for +/- directions"
    Solver->>Simulation: "Store monitor data"
    Simulation->>User: "Return simulation results with Gaussian overlap data"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces Gaussian-beam field decomposition and integrates it into port-based S‑matrix flows.
> 
> - Adds `GaussianOverlapMonitor` and `AstigmaticGaussianOverlapMonitor` to compute overlaps onto (astigmatic) Gaussian beams; exports, schemas, and types updated
> - Refactors monitor hierarchy with new `AbstractOverlapMonitor` shared by mode and Gaussian overlap monitors; moves shared fields (`store_fields_direction`, `colocate`, `conjugated_dot_product`)
> - Adds `FieldOverlapData` for overlap amplitudes and normalization; updates data utils and tests
> - Adds `GaussianPort` and `AstigmaticGaussianPort`; `ModalComponentModeler` now accepts modal or Gaussian ports, constructs appropriate sources/monitors, and builds S‑matrices from overlap amps
> - Updates beam/gaussian waist semantics to be direction‑independent (backward propagation behavior changed) and adjusts warnings; monitor/source docs clarified
> - Test suite extended for new monitors/ports and S‑matrix paths; schemas (`Simulation.json`, `TerminalComponentModeler.json`) include new monitor types
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bb6f496bcfddfb47a1431e90d6caf68de69dbed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->