### PR TITLE
feat: automatic directivity monitors in terminal component modelers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduced a profile-based configuration manager with TOML persistence and runtime overrides exposed via `tidy3d.config`.
 - Added support of `os.PathLike` objects as paths like `pathlib.Path` alongside `str` paths in all path-related functions.
 - Added configurable local simulation result caching with checksum validation, eviction limits, and per-call overrides across `web.run`, `web.load`, and job workflows.
+- Added `DirectivityMonitorSpec` for automated creation and configuration of directivity radiation monitors in `TerminalComponentModeler`.
 
 ### Changed
 - Improved performance of antenna metrics calculation by utilizing cached wave amplitude calculations instead of recomputing wave amplitudes for each port excitation in the `TerminalComponentModelerData`.

--- a/docs/api/microwave/radiation_scattering.rst
+++ b/docs/api/microwave/radiation_scattering.rst
@@ -8,6 +8,7 @@ Radiation & Scattering
    :template: module.rst
 
    tidy3d.DirectivityMonitor
+   tidy3d.plugins.smatrix.DirectivityMonitorSpec
    tidy3d.plugins.microwave.RectangularAntennaArrayCalculator
    tidy3d.plugins.microwave.LobeMeasurer
    tidy3d.AntennaMetricsData
@@ -30,19 +31,25 @@ When modeling antennas or scattering problems, it is vital to analyze the radiat
        phi=my_phi,
        theta=my_theta,
        name='My radiation monitor',
-       far_field_approx=True,
    )
 
-The :class:`.DirectivityMonitor` should completely surround the structure of interest. The ``far_field_approx`` flag can be used to set whether the far-field approximation is used (default ``True``).
+The :class:`.DirectivityMonitor` should completely surround the structure of interest.
 
-Once the monitor is defined, it should be added to the ``radiation_monitors`` option of the :class:`.TerminalComponentModeler`.
+Alternatively, a :class:`.DirectivityMonitorSpec` can be used to create a specification for automatic generation of a :class:`.DirectivityMonitor` in the :class:`.TerminalComponentModeler`.
+
+.. code-block:: python
+
+   # Define directivity monitor spec
+   my_directivity_monitor_spec = DirectivityMonitorSpec()
+
+Once the monitor or monitor spec is defined, it should be added to the ``radiation_monitors`` option of the :class:`.TerminalComponentModeler`.
 
 .. code-block:: python
 
    # Add directivity monitor to simulation
    my_tcm = TerminalComponentModeler(
        ...,
-       radiation_monitors=[my_directivity_monitor],
+       radiation_monitors=[my_directivity_monitor, my_directivity_monitor_spec],
    )
 
 Once the simulation is completed, the ``get_antenna_metrics_data()`` method of the :class:`.TerminalComponentModelerData` object is used to obtain the radiation metrics.

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -6096,6 +6096,69 @@
       ],
       "type": "object"
     },
+    "DirectivityMonitorSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "attrs": {
+          "default": {},
+          "type": "object"
+        },
+        "buffer": {
+          "default": 2,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "custom_origin": {
+          "default": [
+            0,
+            0,
+            0
+          ],
+          "items": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "maxItems": 3,
+          "minItems": 3,
+          "type": "array"
+        },
+        "freqs": {
+          "items": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "name": {
+          "type": "string"
+        },
+        "num_phi_points": {
+          "default": 200,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "num_theta_points": {
+          "default": 100,
+          "minimum": 0,
+          "type": "integer"
+        },
+        "type": {
+          "default": "DirectivityMonitorSpec",
+          "enum": [
+            "DirectivityMonitorSpec"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "DistributedGeneration": {
       "additionalProperties": false,
       "properties": {
@@ -18304,7 +18367,21 @@
     "radiation_monitors": {
       "default": [],
       "items": {
-        "$ref": "#/definitions/DirectivityMonitor"
+        "discriminator": {
+          "mapping": {
+            "DirectivityMonitor": "#/definitions/DirectivityMonitor",
+            "DirectivityMonitorSpec": "#/definitions/DirectivityMonitorSpec"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/definitions/DirectivityMonitor"
+          },
+          {
+            "$ref": "#/definitions/DirectivityMonitorSpec"
+          }
+        ]
       },
       "type": "array"
     },

--- a/tests/test_plugins/smatrix/terminal_component_modeler_def.py
+++ b/tests/test_plugins/smatrix/terminal_component_modeler_def.py
@@ -474,3 +474,225 @@ def make_differential_stripline_modeler():
     )
 
     return tcm
+
+
+def make_patch_antenna_simulation(padding: tuple[float, float, float] = (0.25, 0.25, 0.25)):
+    """Create a rectangular patch antenna simulation on a dielectric substrate.
+
+    Closely follows the patch antenna design from AntennaCharacteristics.ipynb,
+    based on: Sheen, D.M., Ali, S.M., Abouzahra, M.D. and Kong, J.A., 1990.
+    Application of the three-dimensional finite-difference time-domain method
+    to the analysis of planar microstrip circuits.
+
+    Parameters
+    ----------
+    padding : tuple[float, float, float]
+        Padding between substrate and simulation domain boundaries in x, y, z directions.
+
+    Returns
+    -------
+    td.Simulation
+        Patch antenna simulation object.
+    """
+    # Frequency setup for patch antenna (5-11 GHz range for resonances at 7.5 and 10 GHz)
+    freq_start_antenna = 5e9
+    freq_stop_antenna = 11e9
+    freq0 = (freq_start_antenna + freq_stop_antenna) / 2
+    wavelength0 = td.C_0 / freq0
+
+    # Metal thickness
+    th = 0.05 * mm
+
+    # Substrate parameters
+    sub_x = 23.34 * mm
+    sub_y = 40 * mm
+    sub_z = 0.794 * mm
+
+    # Patch parameters
+    patch_x = 12.45 * mm
+    patch_y = 16 * mm
+
+    # Feed line parameters
+    feed_x = 2.46 * mm
+    feed_y = 20 * mm
+    feed_offset = 2.09 * mm
+
+    # Materials
+    medium_sub = td.Medium(permittivity=2.2, name="Substrate")
+    medium_metal = td.PECMedium()
+
+    # Create structures for grid refinement calculation
+    ground_plane_temp = td.Structure(
+        geometry=td.Box(center=[0, 0, -(sub_z + th) / 2], size=[sub_x, sub_y, th]),
+        medium=medium_metal,
+        name="Ground",
+    )
+
+    feed_line_temp = td.Structure(
+        geometry=td.Box.from_bounds(
+            rmin=[-patch_x / 2 + feed_offset, -sub_y / 2, sub_z / 2],
+            rmax=[-patch_x / 2 + feed_offset + feed_x, -sub_y / 2 + feed_y, sub_z / 2 + th],
+        ),
+        medium=medium_metal,
+        name="Feed line",
+    )
+
+    patch_temp = td.Structure(
+        geometry=td.Box.from_bounds(
+            rmin=[-patch_x / 2, -sub_y / 2 + feed_y, sub_z / 2],
+            rmax=[patch_x / 2, -sub_y / 2 + feed_y + patch_y, sub_z / 2 + th],
+        ),
+        medium=medium_metal,
+        name="Patch",
+    )
+
+    # Create LayerRefinementSpec helper
+    def create_lr_spec(structures_list):
+        """Returns LayerRefinementSpec applied to the bounding box of the input structure list"""
+        lr_spec = td.LayerRefinementSpec.from_structures(
+            structures=structures_list,
+            axis=2,  # Layer normal is oriented along the z-axis
+            bounds_snapping="bounds",  # Snap grid lines to layer bounds in normal direction
+            bounds_refinement=td.GridRefinement(
+                dl=th, num_cells=2
+            ),  # cell size and num cells at layer boundaries in normal direction
+            corner_refinement=td.GridRefinement(
+                dl=0.2 * mm, num_cells=2
+            ),  # cell size and num cells around in-plane metal corners
+        )
+        return lr_spec
+
+    # Layer refinement for the ground layer
+    lr_spec_1 = create_lr_spec([ground_plane_temp])
+
+    # Layer refinement for the patch antenna layer
+    lr_spec_2 = create_lr_spec([feed_line_temp, patch_temp])
+
+    # Define overall grid specification
+    grid_spec = td.GridSpec.auto(
+        wavelength=wavelength0, min_steps_per_wvl=25, layer_refinement_specs=[lr_spec_1, lr_spec_2]
+    )
+
+    # Create substrate
+    substrate = td.Structure(
+        geometry=td.Box(center=[0, 0, 0], size=[sub_x, sub_y, sub_z]),
+        medium=medium_sub,
+        name="Substrate",
+    )
+
+    # Create ground plane
+    ground_plane = td.Structure(
+        geometry=td.Box(center=[0, 0, -(sub_z + th) / 2], size=[sub_x, sub_y, th]),
+        medium=medium_metal,
+        name="Ground",
+    )
+
+    # Create feed line
+    feed_line = td.Structure(
+        geometry=td.Box.from_bounds(
+            rmin=[-patch_x / 2 + feed_offset, -sub_y / 2, sub_z / 2],
+            rmax=[-patch_x / 2 + feed_offset + feed_x, -sub_y / 2 + feed_y, sub_z / 2 + th],
+        ),
+        medium=medium_metal,
+        name="Feed line",
+    )
+
+    # Create patch antenna
+    patch = td.Structure(
+        geometry=td.Box.from_bounds(
+            rmin=[-patch_x / 2, -sub_y / 2 + feed_y, sub_z / 2],
+            rmax=[patch_x / 2, -sub_y / 2 + feed_y + patch_y, sub_z / 2 + th],
+        ),
+        medium=medium_metal,
+        name="Patch",
+    )
+
+    # Structures list (dielectric first, then metal/PEC)
+    structures_list = [substrate, ground_plane, feed_line, patch]
+
+    # Padding distance
+    padding_um = td.C_0 / freq_start_antenna * np.array(padding)
+
+    # Simulation size
+    sim_x = sub_x + 2 * padding_um[0]
+    sim_y = sub_y + 2 * padding_um[1]
+    sim_z = sub_z + 2 * padding_um[2]
+
+    # Define PMLs on all sides
+    boundary_spec = td.BoundarySpec.pml(x=True, y=False, z=True)
+
+    # Create simulation object
+    sim = td.Simulation(
+        center=[0, 0, 0],
+        size=[sim_x, sim_y, sim_z],
+        structures=structures_list,
+        sources=[],
+        monitors=[],
+        boundary_spec=boundary_spec,
+        grid_spec=grid_spec,
+        run_time=5e-9,
+        shutoff=1e-4,
+        plot_length_units="mm",
+    )
+
+    return sim
+
+
+def make_patch_antenna_modeler(padding: tuple[float, float, float] = (0.25, 0.25, 0.25)):
+    """Create a TerminalComponentModeler for a rectangular patch antenna.
+
+    Closely follows the antenna setup from AntennaCharacteristics.ipynb.
+
+    Returns
+    -------
+    TerminalComponentModeler
+        Component modeler for the patch antenna.
+    """
+    # Frequency setup for patch antenna
+    freq_start_antenna = 5e9
+    freq_stop_antenna = 11e9
+
+    sim = make_patch_antenna_simulation(padding=padding)
+
+    # Patch antenna dimensions
+    patch_x = 12.45 * mm
+    feed_x = 2.46 * mm
+    feed_offset = 2.09 * mm
+    sub_z = 0.794 * mm
+    sub_y = 40 * mm
+
+    # Create lumped port excitation at feed line
+    port = LumpedPort(
+        name="lumped_port",
+        center=[-patch_x / 2 + feed_offset + feed_x / 2, -sub_y / 2, 0],
+        size=[feed_x, 0, sub_z],
+        voltage_axis=2,
+        impedance=50,
+    )
+
+    # Frequency sweep (201 points as in notebook)
+    freqs = np.linspace(freq_start_antenna, freq_stop_antenna, 201)
+
+    # Target frequencies for field monitor
+    freqs_target = [7.5e9, 10e9]
+
+    # Field monitor
+    monitor_field = td.FieldMonitor(
+        center=(0, 0, sub_z / 2),
+        size=(td.inf, td.inf, 0),
+        freqs=freqs_target,
+        name="field",
+    )
+
+    # Update simulation with field monitor
+    sim = sim.updated_copy(monitors=[monitor_field])
+
+    modeler = TerminalComponentModeler(
+        simulation=sim,
+        ports=[port],
+        freqs=freqs,
+        remove_dc_component=False,
+        radiation_monitors=[],
+    )
+
+    return modeler

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -24,6 +24,7 @@ from tidy3d.plugins.smatrix import (
     TerminalPortDataArray,
     WavePort,
 )
+from tidy3d.plugins.smatrix.component_modelers.terminal import AUTO_RADIATION_MONITOR_NAME
 from tidy3d.plugins.smatrix.data.data_array import PortNameDataArray
 from tidy3d.plugins.smatrix.ports.base_lumped import AbstractLumpedPort
 from tidy3d.plugins.smatrix.utils import s_to_z, validate_square_matrix
@@ -33,6 +34,7 @@ from .terminal_component_modeler_def import (
     make_coaxial_component_modeler,
     make_component_modeler,
     make_differential_stripline_modeler,
+    make_patch_antenna_modeler,
 )
 
 mm = 1e3
@@ -1850,3 +1852,124 @@ def test_validate_run_only_with_wave_ports():
     # Invalid case
     with pytest.raises(pd.ValidationError, match="not present in"):
         modeler.updated_copy(run_only=("nonexistent_wave_port",))
+
+
+def test_radiation_monitors_auto():
+    """Test DirectivityMonitorSpec with various configurations."""
+    from tidy3d.plugins.smatrix import DirectivityMonitorSpec
+
+    # Test 1: DirectivityMonitorSpec with default values
+    auto_spec = DirectivityMonitorSpec()
+    assert auto_spec.buffer == 2
+    assert auto_spec.num_theta_points == 100
+    assert auto_spec.num_phi_points == 200
+    assert auto_spec.name is None
+    assert auto_spec.freqs is None
+
+    # Test 2: DirectivityMonitorSpec with custom values
+    auto_spec_custom = DirectivityMonitorSpec(
+        name="custom_auto",
+        buffer=3,
+        num_theta_points=50,
+        num_phi_points=100,
+    )
+    assert auto_spec_custom.name == "custom_auto"
+    assert auto_spec_custom.buffer == 3
+    assert auto_spec_custom.num_theta_points == 50
+    assert auto_spec_custom.num_phi_points == 100
+
+    # Test 3: Default DirectivityMonitorSpec in modeler
+    tcm = make_patch_antenna_modeler(padding=(0.5, 0.5, 0.5))
+    tcm_with_auto = tcm.updated_copy(radiation_monitors=(auto_spec, auto_spec_custom))
+    sim = tcm_with_auto.sim_dict["lumped_port"]
+
+    assert len(sim.monitors) == 5
+
+    assert isinstance(sim.monitors[-2], td.DirectivityMonitor)
+    assert len(sim.monitors[-2].theta) == 100
+    assert len(sim.monitors[-2].phi) == 200
+    assert (sim.monitors[-2].freqs == tcm_with_auto.freqs).all()
+    assert sim.monitors[-2].name == f"{AUTO_RADIATION_MONITOR_NAME}_0"
+
+    assert isinstance(sim.monitors[-1], td.DirectivityMonitor)
+    assert len(sim.monitors[-1].theta) == auto_spec_custom.num_theta_points
+    assert len(sim.monitors[-1].phi) == auto_spec_custom.num_phi_points
+    assert (sim.monitors[-1].freqs == tcm_with_auto.freqs).all()
+    assert sim.monitors[-1].name == auto_spec_custom.name
+
+    # Test 4: Mixed DirectivityMonitor and DirectivityMonitorSpec
+    manual_monitor = td.DirectivityMonitor(
+        size=tuple(0.8 * np.array(tcm.simulation.size)),
+        center=tcm.simulation.center,
+        freqs=tcm.freqs[1:3],
+        name="manual_monitor",
+        theta=np.linspace(0, np.pi, 50),
+        phi=np.linspace(-np.pi, np.pi, 100),
+    )
+    tcm_mixed = tcm.updated_copy(
+        radiation_monitors=(
+            manual_monitor,
+            DirectivityMonitorSpec(name="auto_1", buffer=2),
+            DirectivityMonitorSpec(name="auto_2", buffer=3),
+        )
+    )
+    sim_mixed = tcm_mixed.sim_dict["lumped_port"]
+
+    # Check that all three monitors are present
+    monitor_names = {m.name for m in sim_mixed.monitors}
+    assert "manual_monitor" in monitor_names
+    assert "auto_1" in monitor_names
+    assert "auto_2" in monitor_names
+
+    # Test 5: Buffer distance validation - should raise error with insufficient padding
+    with pytest.raises(ValueError, match="Automatic construction of radiation monitors failed"):
+        tcm_small = make_patch_antenna_modeler(padding=(0.01, 0.01, 0.5))
+        tcm_small_with_auto = tcm_small.updated_copy(radiation_monitors=(DirectivityMonitorSpec(),))
+        _ = tcm_small_with_auto.sim_dict["lumped_port"]
+
+    # Test 6: Custom buffer parameter - smaller buffer should fail with tight padding
+    with pytest.raises(ValueError, match="Automatic construction of radiation monitors failed"):
+        tcm_tight = make_patch_antenna_modeler(padding=(0.05, 0.05, 0.5))
+        tcm_tight_with_auto = tcm_tight.updated_copy(
+            radiation_monitors=(DirectivityMonitorSpec(buffer=5),)  # Require 5 cells
+        )
+        _ = tcm_tight_with_auto.sim_dict["lumped_port"]
+
+    # Test 7: custom_origin propagation
+    # Test 7a: custom_origin with explicit coordinates
+    custom_origin_coords = (1.0, 2.0, 3.0)
+    spec_with_origin = DirectivityMonitorSpec(
+        name="with_custom_origin", custom_origin=custom_origin_coords
+    )
+    tcm_with_origin = tcm.updated_copy(radiation_monitors=(spec_with_origin,))
+    sim_with_origin = tcm_with_origin.sim_dict["lumped_port"]
+
+    # Find the generated DirectivityMonitor
+    origin_monitor = [m for m in sim_with_origin.monitors if m.name == "with_custom_origin"][0]
+    assert isinstance(origin_monitor, td.DirectivityMonitor)
+    assert origin_monitor.custom_origin == custom_origin_coords
+
+    # Test 7b: custom_origin with None (should be accepted and propagated)
+    spec_with_none_origin = DirectivityMonitorSpec(name="with_none_origin", custom_origin=None)
+    tcm_with_none_origin = tcm.updated_copy(radiation_monitors=(spec_with_none_origin,))
+    sim_with_none_origin = tcm_with_none_origin.sim_dict["lumped_port"]
+
+    # Find the generated DirectivityMonitor
+    none_origin_monitor = [
+        m for m in sim_with_none_origin.monitors if m.name == "with_none_origin"
+    ][0]
+    assert isinstance(none_origin_monitor, td.DirectivityMonitor)
+    assert none_origin_monitor.custom_origin is None
+
+    # Test 7c: default custom_origin (should use the default value from field definition)
+    spec_default_origin = DirectivityMonitorSpec(name="default_origin")
+    tcm_default_origin = tcm.updated_copy(radiation_monitors=(spec_default_origin,))
+    sim_default_origin = tcm_default_origin.sim_dict["lumped_port"]
+
+    # Find the generated DirectivityMonitor
+    default_origin_monitor = [m for m in sim_default_origin.monitors if m.name == "default_origin"][
+        0
+    ]
+    assert isinstance(default_origin_monitor, td.DirectivityMonitor)
+    # Default should be (0, 0, 0) as defined in the field
+    assert default_origin_monitor.custom_origin == (0, 0, 0)

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -915,7 +915,7 @@ class AbstractFieldProjectionMonitor(SurfaceIntegrationMonitor, FreqMonitor):
     and projects them to a given set of observation points.
     """
 
-    custom_origin: Coordinate = pydantic.Field(
+    custom_origin: Optional[Coordinate] = pydantic.Field(
         None,
         title="Local Origin",
         description="Local origin used for defining observation points. If ``None``, uses the "

--- a/tidy3d/plugins/smatrix/__init__.py
+++ b/tidy3d/plugins/smatrix/__init__.py
@@ -9,6 +9,7 @@ from tidy3d.plugins.smatrix.component_modelers.base import (
 )
 from tidy3d.plugins.smatrix.component_modelers.modal import ModalComponentModeler
 from tidy3d.plugins.smatrix.component_modelers.terminal import (
+    DirectivityMonitorSpec,
     ModelerLowFrequencySmoothingSpec,
     TerminalComponentModeler,
 )
@@ -45,6 +46,7 @@ __all__ = [
     "ComponentModeler",
     "ComponentModelerDataType",
     "ComponentModelerType",
+    "DirectivityMonitorSpec",
     "LumpedPort",
     "MicrowaveSMatrixData",
     "ModalComponentModeler",

--- a/tidy3d/plugins/smatrix/analysis/antenna.py
+++ b/tidy3d/plugins/smatrix/analysis/antenna.py
@@ -67,7 +67,7 @@ def get_antenna_metrics_data(
     # Get the radiation monitor, use first as default
     # if none specified
     if monitor_name is None:
-        rad_mon = terminal_component_modeler_data.modeler.radiation_monitors[0]
+        rad_mon = terminal_component_modeler_data.modeler._finalized_radiation_monitors[0]
     else:
         rad_mon = terminal_component_modeler_data.modeler.get_radiation_monitor_by_name(
             monitor_name

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -8,12 +8,14 @@ import numpy as np
 import pydantic.v1 as pd
 
 from tidy3d import ClipOperation, GeometryGroup, GridSpec, PolySlab
-from tidy3d.components.base import cached_property
+from tidy3d.components.base import cached_property, skip_if_fields_missing
 from tidy3d.components.boundary import BroadbandModeABCSpec
 from tidy3d.components.frequency_extrapolation import (
     AbstractLowFrequencySmoothingSpec,
     LowFrequencySmoothingSpec,
 )
+from tidy3d.components.geometry.base import Box
+from tidy3d.components.geometry.bound_ops import bounds_union
 from tidy3d.components.geometry.utils import _shift_object
 from tidy3d.components.geometry.utils_2d import snap_coordinate_to_grid
 from tidy3d.components.index import SimulationMap
@@ -21,9 +23,10 @@ from tidy3d.components.microwave.base import MicrowaveBaseModel
 from tidy3d.components.monitor import DirectivityMonitor, ModeMonitor
 from tidy3d.components.simulation import Simulation
 from tidy3d.components.source.time import GaussianPulse
-from tidy3d.components.types import Ax, Complex
+from tidy3d.components.types import Ax, Complex, Coordinate
+from tidy3d.components.types.base import annotate_type
 from tidy3d.components.viz import add_ax_if_none, equal_aspect
-from tidy3d.constants import C_0, OHM, fp_eps
+from tidy3d.constants import C_0, MICROMETER, OHM, fp_eps, inf
 from tidy3d.exceptions import SetupError, Tidy3dKeyError, ValidationError
 from tidy3d.log import log
 from tidy3d.plugins.smatrix.component_modelers.base import (
@@ -37,6 +40,79 @@ from tidy3d.plugins.smatrix.ports.rectangular_lumped import LumpedPort
 from tidy3d.plugins.smatrix.ports.types import TerminalPortType
 from tidy3d.plugins.smatrix.ports.wave import WavePort
 from tidy3d.plugins.smatrix.types import NetworkElement, NetworkIndex, SParamDef
+
+AUTO_RADIATION_MONITOR_NAME = "radiation"
+AUTO_RADIATION_MONITOR_BUFFER = 2
+AUTO_RADIATION_MONITOR_NUM_POINTS_THETA = 100
+AUTO_RADIATION_MONITOR_NUM_POINTS_PHI = 200
+
+
+class DirectivityMonitorSpec(MicrowaveBaseModel):
+    """
+    Specification for automatically generating a :class:`.DirectivityMonitor`.
+
+    When included in the :attr:`.TerminalComponentModeler.radiation_monitors` tuple,
+    a :class:`.DirectivityMonitor` will be automatically generated with the specified
+    parameters. This allows users to mix manual :class:`.DirectivityMonitor` objects
+    with automatically generated ones, each with customizable parameters.
+
+    Note
+    ----
+    The default origin (`custom_origin`) for defining observation points in the automatically
+    generated monitor is set to (0, 0, 0) in the global coordinate system.
+
+    Example
+    -------
+    >>> auto_monitor = DirectivityMonitorSpec(
+    ...     name="custom_auto",
+    ...     buffer=3,
+    ...     num_theta_points=50,
+    ...     num_phi_points=100
+    ... )
+    """
+
+    name: Optional[str] = pd.Field(
+        None,
+        title="Monitor Name",
+        description=f"Optional name for the auto-generated monitor. "
+        f"If not provided, defaults to '{AUTO_RADIATION_MONITOR_NAME}_' + index of the monitor in the list of radiation monitors.",
+    )
+
+    freqs: Optional[tuple[pd.NonNegativeInt, ...]] = pd.Field(
+        None,
+        title="Frequencies",
+        description="Frequencies to obtain fields at. If not provided, uses all frequencies "
+        "from the :class:`.TerminalComponentModeler`. Must be a subset of modeler frequencies if provided.",
+    )
+
+    buffer: pd.NonNegativeInt = pd.Field(
+        AUTO_RADIATION_MONITOR_BUFFER,
+        title="Buffer Distance",
+        description="Number of grid cells to maintain between monitor and PML/domain boundaries. "
+        f"Default: {AUTO_RADIATION_MONITOR_BUFFER} cells.",
+    )
+
+    num_theta_points: pd.NonNegativeInt = pd.Field(
+        AUTO_RADIATION_MONITOR_NUM_POINTS_THETA,
+        title="Elevation Angle Points",
+        description="Number of elevation angle (theta) sample points from 0 to π. "
+        f"Default: {AUTO_RADIATION_MONITOR_NUM_POINTS_THETA}.",
+    )
+
+    num_phi_points: pd.NonNegativeInt = pd.Field(
+        AUTO_RADIATION_MONITOR_NUM_POINTS_PHI,
+        title="Azimuthal Angle Points",
+        description="Number of azimuthal angle (phi) sample points from -π to π. "
+        f"Default: {AUTO_RADIATION_MONITOR_NUM_POINTS_PHI}.",
+    )
+
+    custom_origin: Optional[Coordinate] = pd.Field(
+        (0, 0, 0),
+        title="Local Origin",
+        description="Local origin used for defining observation points. If ``None``, uses the "
+        "monitor's center.",
+        units=MICROMETER,
+    )
 
 
 class ModelerLowFrequencySmoothingSpec(AbstractLowFrequencySmoothingSpec):
@@ -103,11 +179,15 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         "by ``element_mappings``, the simulation corresponding to this column is skipped automatically.",
     )
 
-    radiation_monitors: tuple[DirectivityMonitor, ...] = pd.Field(
+    radiation_monitors: tuple[
+        annotate_type(Union[DirectivityMonitor, DirectivityMonitorSpec]), ...
+    ] = pd.Field(
         (),
         title="Radiation Monitors",
         description="Facilitates the calculation of figures-of-merit for antennas. "
-        "These monitor will be included in every simulation and record the radiated fields. ",
+        "These monitors will be included in every simulation and record the radiated fields. "
+        "Users can specify a combination of :class:`.DirectivityMonitor` objects for manual placement and :class:`.DirectivityMonitorSpec` "
+        "objects for automatic generation.",
     )
 
     assume_ideal_excitation: bool = pd.Field(
@@ -315,9 +395,9 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         return SimulationMap(keys=tuple(sim_dict.keys()), values=tuple(sim_dict.values()))
 
     @cached_property
-    def base_sim(self) -> Simulation:
-        """The base simulation with all grid refinement options, port loads (if present), and monitors added,
-        which is only missing the source excitations.
+    def _base_sim_no_radiation_monitors(self) -> Simulation:
+        """The intermediate base simulation with all grid refinement options, port loads (if present), and monitors added,
+        which is only missing the source excitations and radiation monitors.
         """
         # internal mesh override and snapping points are automatically generated from lumped elements.
         lumped_resistors = [port.to_load() for port in self._lumped_ports]
@@ -352,9 +432,6 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         ]
 
         new_mnts = list(self.simulation.monitors) + field_monitors
-
-        if self.radiation_monitors is not None:
-            new_mnts = new_mnts + list(self.radiation_monitors)
 
         new_lumped_elements = list(self.simulation.lumped_elements) + [
             port.to_load(snap_center=snap_centers[port.name]) for port in self._lumped_ports
@@ -406,8 +483,213 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         # extrude port structures
         sim_wo_source = self._extrude_port_structures(sim=sim_wo_source)
 
-        # This is the new default simulation with all shared components added
         return sim_wo_source
+
+    @cached_property
+    def _finalized_radiation_monitors(self) -> tuple[DirectivityMonitor, ...]:
+        """
+        The tuple of DirectivityMonitor objects for the radiation monitors.
+
+        Expands any DirectivityMonitorSpec instances to actual DirectivityMonitor objects.
+        DirectivityMonitor objects are kept as-is.
+        """
+        base_sim = self._base_sim_no_radiation_monitors
+        finalized = []
+
+        for index, rad_mon in enumerate(self.radiation_monitors):
+            if isinstance(rad_mon, DirectivityMonitorSpec):
+                # Generate DirectivityMonitor from DirectivityMonitorSpec spec
+                if not rad_mon.name:
+                    mon_name = f"{AUTO_RADIATION_MONITOR_NAME}_{index}"
+                    rad_mon = rad_mon.updated_copy(name=mon_name)
+
+                try:
+                    generated = self._generate_radiation_monitor(
+                        simulation=base_sim, auto_spec=rad_mon
+                    )
+                    finalized.append(generated)
+                except ValueError as e:
+                    raise ValueError(
+                        "Automatic construction of radiation monitors failed. "
+                        "Please address the reason or provide a tuple of DirectivityMonitor "
+                        "objects to the 'radiation_monitors' parameter."
+                    ) from e
+            else:
+                # DirectivityMonitor - use as-is
+                finalized.append(rad_mon)
+
+        return tuple(finalized)
+
+    @cached_property
+    def base_sim(self) -> Simulation:
+        """The base simulation with all components added, including radiation monitors."""
+        base_sim_tmp = self._base_sim_no_radiation_monitors
+        mnts_with_radiation = list(base_sim_tmp.monitors) + list(self._finalized_radiation_monitors)
+        return base_sim_tmp.updated_copy(monitors=mnts_with_radiation)
+
+    def _generate_radiation_monitor(
+        self, simulation: Simulation, auto_spec: DirectivityMonitorSpec
+    ) -> DirectivityMonitor:
+        """
+        Generates a DirectivityMonitor object for the simulation.
+
+        The monitor is placed at a specified buffer distance from PML boundaries
+        (or domain boundaries if no PML). It samples the whole sphere with specified angular resolution.
+
+        The monitor is validated to ensure it is far enough from simulation structures.
+
+        Parameters
+        ----------
+        simulation : Simulation
+            The simulation for which to generate the monitor.
+        auto_spec : DirectivityMonitorSpec
+            Specification for auto-generation.
+
+        Returns
+        -------
+        DirectivityMonitor
+            The generated monitor configured to measure radiation in all directions.
+
+        Raises
+        ------
+        ValueError
+            If the monitor is not far enough from structures.
+        """
+
+        # Extract parameters from auto_spec
+        monitor_name = auto_spec.name
+        monitor_buffer = auto_spec.buffer
+        num_theta = auto_spec.num_theta_points
+        num_phi = auto_spec.num_phi_points
+        monitor_freqs = auto_spec.freqs or self.freqs
+
+        # Get PML thicknesses in all directions
+        pml_layers = simulation.num_pml_layers  # List of (minus, plus) layers for each axis
+        grid = simulation.grid
+        boundaries = grid.boundaries.to_list  # List of coordinate arrays for each axis
+        num_cells = grid.num_cells  # List of number of cells for each axis
+
+        # Calculate monitor span using the specified buffer distance
+        mnt_span = [
+            (minus_pml + monitor_buffer, num_cells_axis - plus_pml - monitor_buffer)
+            for (minus_pml, plus_pml), num_cells_axis in zip(pml_layers, num_cells)
+        ]
+
+        # Calculate monitor bounds
+        mnt_bounds = [
+            (coords[start_idx], coords[end_idx]) if sim_size_axis > 0 else (-inf, inf)
+            for (start_idx, end_idx), coords, sim_size_axis in zip(
+                mnt_span, boundaries, simulation.size
+            )
+        ]
+
+        mnt_bounds = np.transpose(mnt_bounds)
+
+        mnt_box = Box.from_bounds(mnt_bounds[0], mnt_bounds[1])
+
+        # Create angle arrays for full sphere sampling
+        # theta: elevation angle [0, pi]
+        # phi: azimuthal angle [-pi, pi]
+        theta = np.linspace(0, np.pi, num_theta)
+        phi = np.linspace(-np.pi, np.pi, num_phi)
+
+        # Create the monitor
+        monitor = DirectivityMonitor(
+            center=mnt_box.center,
+            size=mnt_box.size,
+            freqs=monitor_freqs,
+            name=monitor_name,
+            theta=theta,
+            phi=phi,
+            custom_origin=auto_spec.custom_origin,
+        )
+
+        # Validate that monitor is far enough from structures
+        self._validate_radiation_monitor_buffer(simulation, mnt_span, monitor_buffer)
+
+        return monitor
+
+    def _validate_radiation_monitor_buffer(
+        self, simulation: Simulation, mnt_span: list[tuple[int, int]], buffer: int
+    ) -> None:
+        """Validate that the radiation monitor is far enough from simulation structures.
+
+        Checks that each side of the monitor is at least AUTO_RADIATION_MONITOR_BUFFER cells
+        away from the union of all structures and lumped elements, using grid cell indices.
+
+        Parameters
+        ----------
+        simulation : Simulation
+            The simulation containing structures and lumped elements.
+        mnt_span : list[tuple[int, int]]
+            The span (start, stop) indices of the monitor in each axis.
+        buffer : int
+            The buffer distance to use.
+
+        Raises
+        ------
+        ValueError
+            If the monitor is not far enough from structures.
+        """
+        # Get finalized simulation to include all structures
+        finalized_sim = simulation._finalized
+
+        # Get all structures (including finalized ones)
+        structures = finalized_sim.structures
+
+        # Get lumped elements
+        lumped_elements = simulation.lumped_elements
+
+        # If no structures or lumped elements, validation passes
+        if not structures and not lumped_elements:
+            return
+
+        # Calculate union of bounding boxes for all structures and lumped elements
+        all_geoms = []
+
+        # Add structures
+        for struct in structures:
+            all_geoms.append(struct.geometry)
+
+        # Add lumped elements (they have geometry)
+        for elem in lumped_elements:
+            all_geoms.append(elem.to_geometry())
+
+        # Compute union of all bounds
+        if all_geoms:
+            union_bounds = all_geoms[0].bounds
+            for geom in all_geoms[1:]:
+                union_bounds = bounds_union(union_bounds, geom.bounds)
+
+            # Convert union bounds to Box and get grid cell indices
+            union_box = Box.from_bounds(union_bounds[0], union_bounds[1])
+            grid = simulation.grid
+            union_inds = grid.discretize_inds(union_box, extend=True)
+
+            # Check each axis
+            for axis in range(3):
+                mnt_start, mnt_end = mnt_span[axis]
+                union_start, union_end = union_inds[axis]
+
+                axis_name = "xyz"[axis]
+
+                # Check minus side: union should be at least BUFFER cells away from monitor start
+                buffer_minus = union_start - mnt_start
+                if buffer_minus < buffer:
+                    raise ValueError(
+                        f"Automatically generated radiation monitor is too close to structures on the negative {axis_name} side. "
+                        f"Buffer: {buffer_minus} cells, required: {buffer} cells. "
+                        f"Please increase simulation domain size."
+                    )
+
+                # Check plus side: union should be at least BUFFER cells away from monitor end
+                buffer_plus = mnt_end - union_end
+                if buffer_plus < buffer:
+                    raise ValueError(
+                        f"Automatically generated radiation monitor is too close to structures on the positive {axis_name} side. "
+                        f"Buffer: {buffer_plus} cells, required: {buffer} cells. "
+                        f"Please increase simulation domain size."
+                    )
 
     def _add_source_to_sim(self, source_index: NetworkIndex) -> tuple[str, Simulation]:
         """Adds the source corresponding to the ``source_index`` to the base simulation."""
@@ -457,16 +739,31 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         return val
 
     @pd.validator("radiation_monitors")
+    @skip_if_fields_missing(["freqs"])
     def _validate_radiation_monitors(cls, val, values):
-        freqs = set(values.get("freqs"))
-        for rad_mon in val:
-            mon_freqs = rad_mon.freqs
-            is_subset = freqs.issuperset(mon_freqs)
-            if not is_subset:
-                raise ValidationError(
-                    f"The frequencies in the radiation monitor '{rad_mon.name}' "
-                    f"must be equal to or a subset of the frequencies in the '{cls.__name__}'."
-                )
+        """Validate radiation monitors configuration.
+
+        Validates that:
+        - DirectivityMonitor frequencies are a subset of modeler frequencies
+        - DirectivityMonitorSpec frequencies (if provided) are a subset of modeler frequencies
+        """
+        modeler_freqs = set(values.get("freqs", []))
+
+        for index, rad_mon in enumerate(val):
+            # Only validate freqs if explicitly provided
+            # freqs are provided always in DirectivityMonitor
+            # in DirectivityMonitorSpec, freqs may be not provided,
+            # in this case, we use the modeler frequencies, so no validation is needed
+            if rad_mon.freqs is not None:
+                mon_freqs = set(rad_mon.freqs)
+                is_subset = modeler_freqs.issuperset(mon_freqs)
+                if not is_subset:
+                    mon_name = rad_mon.name or f"{AUTO_RADIATION_MONITOR_NAME}_{index}"
+                    raise ValidationError(
+                        f"The frequencies in the radiation monitor '{mon_name}' "
+                        f"must be equal to or a subset of the frequencies in the '{cls.__name__}'."
+                    )
+
         return val
 
     @staticmethod
@@ -532,7 +829,7 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         ``Tidy3dKeyError``
             If no monitor with the given name exists.
         """
-        for monitor in self.radiation_monitors:
+        for monitor in self._finalized_radiation_monitors:
             if monitor.name == monitor_name:
                 return monitor
         raise Tidy3dKeyError(f"No radiation monitor named '{monitor_name}'.")


### PR DESCRIPTION
Here's a working version for automatic generation of directivity monitors in terminal component modelers. It creates a directivity monitor 2 cells away from pml/domain boundaries, and also checks that it is at least 2 cells away from structures and lumped elements. Re-runs of a couple of cases using this feature:
- https://github.com/flexcompute/tidy3d-notebooks/blob/8d8dffc6e3653fe9921cb593bcacd76ea4f1c224/AntennaCharacteristics.ipynb
- https://github.com/flexcompute/tidy3d-notebooks/blob/8d8dffc6e3653fe9921cb593bcacd76ea4f1c224/EdgeFeedPatchAntennaBenchmark.ipynb

A bit unsure about the API. Currently, it works as
```
tcm = TerminalComponentModeler(..., radiation_monitors="auto")
```
but maybe a better way is to introduce some sort of `AutoDirectivityMonitor`
```
tcm = TerminalComponentModeler(..., radiation_monitors=[AutoDirectivityMonitor()])
```
where it is possible to adjust parameters `AutoDirectivityMonitor(freqs=..., num_theta_points=..., num_phi_points=..., name=..., buffer=...)`

what do you think?

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-17 04:49:09 UTC

### Greptile Summary

This PR introduces automatic directivity monitor generation for antenna calculations in terminal component modelers. The key feature allows users to specify `radiation_monitors="auto"` in `TerminalComponentModeler`, which automatically creates and positions a `DirectivityMonitor` for far-field radiation pattern analysis.

The implementation intelligently positions the monitor 2 grid cells away from PML/domain boundaries while ensuring adequate clearance from structures and lumped elements. The auto-generated monitor samples the full sphere with configurable angular resolution (100 theta points, 200 phi points by default) and includes comprehensive validation to prevent placement issues.

The change maintains backward compatibility - users can still provide custom `DirectivityMonitor` objects as before, or use the new "auto" convenience feature. The implementation uses proper separation of concerns with dedicated methods for monitor generation, validation, and simulation finalization. This feature significantly improves the usability of antenna modeling workflows by automating the complex geometry considerations typically required for proper monitor placement.

### Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/smatrix/component_modelers/terminal.py | 4/5 | Core implementation of automatic DirectivityMonitor generation with validation and placement logic |
| tests/test_plugins/smatrix/test_terminal_component_modeler.py | 5/5 | Added comprehensive tests for automatic radiation monitor creation and error handling |
| tests/test_plugins/smatrix/terminal_component_modeler_def.py | 5/5 | Added patch antenna test case functions to support automatic directivity monitor testing |
| tidy3d/plugins/smatrix/analysis/antenna.py | 4/5 | Updated to use finalized radiation monitors instead of raw monitors for consistency |

</details>

### Confidence score: 4/5

- This PR introduces a valuable feature that improves antenna modeling usability with well-structured implementation and comprehensive testing
- Score reflects one minor typo in error message ("sizet" instead of "size") and potential for future API considerations around customizable parameters
- The core implementation follows established patterns and includes proper validation, error handling, and backward compatibility

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant TerminalComponentModeler
    participant Simulation
    participant RadiationMonitorGenerator
    participant ValidationEngine

    User->>TerminalComponentModeler: "Create modeler with radiation_monitors='auto'"
    TerminalComponentModeler->>TerminalComponentModeler: "_finalized_radiation_monitors property accessed"
    TerminalComponentModeler->>RadiationMonitorGenerator: "_generate_radiation_monitor()"
    RadiationMonitorGenerator->>Simulation: "Get PML thicknesses from num_pml_layers"
    RadiationMonitorGenerator->>Simulation: "Get grid boundaries"
    RadiationMonitorGenerator->>RadiationMonitorGenerator: "Calculate monitor span with AUTO_RADIATION_MONITOR_BUFFER"
    RadiationMonitorGenerator->>RadiationMonitorGenerator: "Create Box.from_bounds()"
    RadiationMonitorGenerator->>RadiationMonitorGenerator: "Generate theta and phi arrays"
    RadiationMonitorGenerator->>RadiationMonitorGenerator: "Create DirectivityMonitor"
    RadiationMonitorGenerator->>ValidationEngine: "_validate_radiation_monitor_buffer()"
    ValidationEngine->>Simulation: "Get finalized structures"
    ValidationEngine->>ValidationEngine: "Calculate union of structure bounds"
    ValidationEngine->>ValidationEngine: "Check buffer distances"
    alt Buffer validation passes
        ValidationEngine-->>RadiationMonitorGenerator: "Validation successful"
        RadiationMonitorGenerator-->>TerminalComponentModeler: "Return DirectivityMonitor"
    else Buffer validation fails
        ValidationEngine->>ValidationEngine: "Raise ValueError"
        ValidationEngine-->>User: "ValueError: Monitor too close to structures"
    end
    TerminalComponentModeler->>TerminalComponentModeler: "Add monitor to base_sim"
    TerminalComponentModeler-->>User: "Return modeler with auto radiation monitor"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->