### PR TITLE
refactor(RF)!: edge singularity correction defaults to True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unified run submission API: `web.run(...)` is now a container-aware wrapper that accepts a single simulation or arbitrarily nested containers (`list`, `tuple`, `dict` values) and returns results in the same shape.
 - `web.Batch(ComponentModeler)` and `web.Job(ComponentModeler)` native support
 - Simulation data of batch jobs are now automatically downloaded upon their individual completion in `Batch.run()`, avoiding waiting for the entire batch to reach completion.
+- Edge singularity correction at PEC and lossy metal edges defaults to `True`.
 
 ### Fixed
 - More robust `Sellmeier` and `Debye` material model, and prevent very large pole parameters in `PoleResidue` material model.

--- a/schemas/EMESimulation.json
+++ b/schemas/EMESimulation.json
@@ -8768,7 +8768,7 @@
           "type": "object"
         },
         "edge_singularity_correction": {
-          "default": false,
+          "default": true,
           "type": "boolean"
         },
         "timestep_reduction": {
@@ -11246,7 +11246,7 @@
         "lossy_metal": {
           "default": {
             "attrs": {},
-            "edge_singularity_correction": false,
+            "edge_singularity_correction": true,
             "timestep_reduction": 0.0,
             "type": "SurfaceImpedance"
           },
@@ -11294,7 +11294,7 @@
         "pec": {
           "default": {
             "attrs": {},
-            "edge_singularity_correction": false,
+            "edge_singularity_correction": true,
             "timestep_reduction": 0.3,
             "type": "PECConformal"
           },
@@ -11357,7 +11357,7 @@
           "type": "object"
         },
         "edge_singularity_correction": {
-          "default": false,
+          "default": true,
           "type": "boolean"
         },
         "timestep_reduction": {
@@ -12507,7 +12507,7 @@
         },
         "lossy_metal": {
           "attrs": {},
-          "edge_singularity_correction": false,
+          "edge_singularity_correction": true,
           "timestep_reduction": 0.0,
           "type": "SurfaceImpedance"
         },
@@ -12517,7 +12517,7 @@
         },
         "pec": {
           "attrs": {},
-          "edge_singularity_correction": false,
+          "edge_singularity_correction": true,
           "timestep_reduction": 0.3,
           "type": "PECConformal"
         },

--- a/schemas/ModeSimulation.json
+++ b/schemas/ModeSimulation.json
@@ -8422,7 +8422,7 @@
           "type": "object"
         },
         "edge_singularity_correction": {
-          "default": false,
+          "default": true,
           "type": "boolean"
         },
         "timestep_reduction": {
@@ -10922,7 +10922,7 @@
         "lossy_metal": {
           "default": {
             "attrs": {},
-            "edge_singularity_correction": false,
+            "edge_singularity_correction": true,
             "timestep_reduction": 0.0,
             "type": "SurfaceImpedance"
           },
@@ -10970,7 +10970,7 @@
         "pec": {
           "default": {
             "attrs": {},
-            "edge_singularity_correction": false,
+            "edge_singularity_correction": true,
             "timestep_reduction": 0.3,
             "type": "PECConformal"
           },
@@ -11033,7 +11033,7 @@
           "type": "object"
         },
         "edge_singularity_correction": {
-          "default": false,
+          "default": true,
           "type": "boolean"
         },
         "timestep_reduction": {
@@ -12297,7 +12297,7 @@
         },
         "lossy_metal": {
           "attrs": {},
-          "edge_singularity_correction": false,
+          "edge_singularity_correction": true,
           "timestep_reduction": 0.0,
           "type": "SurfaceImpedance"
         },
@@ -12307,7 +12307,7 @@
         },
         "pec": {
           "attrs": {},
-          "edge_singularity_correction": false,
+          "edge_singularity_correction": true,
           "timestep_reduction": 0.3,
           "type": "PECConformal"
         },

--- a/schemas/Simulation.json
+++ b/schemas/Simulation.json
@@ -12388,7 +12388,7 @@
           "type": "object"
         },
         "edge_singularity_correction": {
-          "default": false,
+          "default": true,
           "type": "boolean"
         },
         "timestep_reduction": {
@@ -15248,7 +15248,7 @@
         "lossy_metal": {
           "default": {
             "attrs": {},
-            "edge_singularity_correction": false,
+            "edge_singularity_correction": true,
             "timestep_reduction": 0.0,
             "type": "SurfaceImpedance"
           },
@@ -15296,7 +15296,7 @@
         "pec": {
           "default": {
             "attrs": {},
-            "edge_singularity_correction": false,
+            "edge_singularity_correction": true,
             "timestep_reduction": 0.3,
             "type": "PECConformal"
           },
@@ -15359,7 +15359,7 @@
           "type": "object"
         },
         "edge_singularity_correction": {
-          "default": false,
+          "default": true,
           "type": "boolean"
         },
         "timestep_reduction": {
@@ -17016,7 +17016,7 @@
         },
         "lossy_metal": {
           "attrs": {},
-          "edge_singularity_correction": false,
+          "edge_singularity_correction": true,
           "timestep_reduction": 0.0,
           "type": "SurfaceImpedance"
         },
@@ -17026,7 +17026,7 @@
         },
         "pec": {
           "attrs": {},
-          "edge_singularity_correction": false,
+          "edge_singularity_correction": true,
           "timestep_reduction": 0.3,
           "type": "PECConformal"
         },

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -13082,7 +13082,7 @@
           "type": "object"
         },
         "edge_singularity_correction": {
-          "default": false,
+          "default": true,
           "type": "boolean"
         },
         "timestep_reduction": {
@@ -15928,7 +15928,7 @@
             },
             "lossy_metal": {
               "attrs": {},
-              "edge_singularity_correction": false,
+              "edge_singularity_correction": true,
               "timestep_reduction": 0.0,
               "type": "SurfaceImpedance"
             },
@@ -15938,7 +15938,7 @@
             },
             "pec": {
               "attrs": {},
-              "edge_singularity_correction": false,
+              "edge_singularity_correction": true,
               "timestep_reduction": 0.3,
               "type": "PECConformal"
             },
@@ -16684,7 +16684,7 @@
         "lossy_metal": {
           "default": {
             "attrs": {},
-            "edge_singularity_correction": false,
+            "edge_singularity_correction": true,
             "timestep_reduction": 0.0,
             "type": "SurfaceImpedance"
           },
@@ -16732,7 +16732,7 @@
         "pec": {
           "default": {
             "attrs": {},
-            "edge_singularity_correction": false,
+            "edge_singularity_correction": true,
             "timestep_reduction": 0.3,
             "type": "PECConformal"
           },
@@ -16795,7 +16795,7 @@
           "type": "object"
         },
         "edge_singularity_correction": {
-          "default": false,
+          "default": true,
           "type": "boolean"
         },
         "timestep_reduction": {

--- a/tidy3d/components/subpixel_spec.py
+++ b/tidy3d/components/subpixel_spec.py
@@ -121,7 +121,7 @@ class PECConformal(AbstractSubpixelAveragingMethod):
     )
 
     edge_singularity_correction: bool = pd.Field(
-        False,
+        True,
         title="Apply Singularity Model At Metal Edges",
         description="Apply field correction model at metallic edges where field singularity occurs. "
         "The edges should be straight, and aligned with the primal grids; and the wedge angle is either "


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-17 17:29:07 UTC

### Greptile Summary

This PR changes the default behavior for edge singularity correction in PEC (Perfect Electric Conductor) simulations from `False` to `True`. The change affects the `edge_singularity_correction` field in the `PECConformal` class, which controls whether field correction models are applied at metallic edges where field singularities occur. This correction is particularly important for straight edges aligned with primal grids having wedge angles of 0 or 90 degrees.

The change improves simulation accuracy by default, especially for RF and microwave applications where PEC boundaries are common. By enabling this correction by default, users will automatically get more physically accurate results without needing to understand the technical details of edge singularity handling. The change is properly documented in the CHANGELOG as a breaking change, acknowledging that it affects default behavior and may impact existing simulations that relied on the previous default.

### Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| CHANGELOG.md | 5/5 | Documents the breaking change for edge singularity correction defaulting to True |
| tidy3d/components/subpixel_spec.py | 5/5 | Changes default value of `edge_singularity_correction` from False to True in PECConformal class |

</details>

### Confidence score: 5/5

- This PR is safe to merge with minimal risk as it's a straightforward default value change with proper documentation
- Score reflects the simple nature of the change, clear documentation, and appropriate breaking change labeling
- No files require special attention - both changes are well-implemented and documented

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Simulation
    participant SubpixelSpec
    participant PECConformal
    participant Solver

    User->>Simulation: "Create simulation with PEC structures"
    Simulation->>SubpixelSpec: "Initialize default SubpixelSpec()"
    SubpixelSpec->>PECConformal: "Create PECConformal() for pec field"
    Note over PECConformal: edge_singularity_correction=True (new default)
    PECConformal->>SubpixelSpec: "Return PECConformal instance"
    SubpixelSpec->>Simulation: "Return configured SubpixelSpec"
    
    User->>Simulation: "Run simulation"
    Simulation->>Solver: "Submit with subpixel configurations"
    Solver->>PECConformal: "Apply edge singularity correction at metal edges"
    Note over Solver: Field correction model applied at metallic edges where singularity occurs
    Solver->>Simulation: "Return results with improved accuracy"
    Simulation->>User: "Simulation completed"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->