### PR TITLE
fix(ci): Relax branch-name lint to allow prefixes

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -216,6 +216,10 @@ jobs:
         id: extract-branch-name
         run: |
           BRANCH_NAME="${GITHUB_HEAD_REF}"
+          if [[ -z "$BRANCH_NAME" ]]; then
+            BRANCH_NAME="${GITHUB_REF_NAME:-${GITHUB_REF#refs/heads/}}"
+            echo "(fallback) Using ref-derived branch name: $BRANCH_NAME"
+          fi
           echo "Branch name: $BRANCH_NAME"
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
@@ -226,7 +230,10 @@ jobs:
         run: |
           BRANCH_NAME="${STEPS_EXTRACT_BRANCH_NAME_OUTPUTS_BRANCH_NAME}"
           echo $BRANCH_NAME
-          JIRA_PATTERN='[A-Z]{2,}-[0-9]+'
+          # Allow only Jira keys from known projects, even if the branch has an author prefix
+          ALLOWED_JIRA_PROJECTS=("FXC" "SCEM")
+          JIRA_PROJECT_PATTERN=$(IFS='|'; echo "${ALLOWED_JIRA_PROJECTS[*]}")
+          JIRA_PATTERN="(${JIRA_PROJECT_PATTERN})-[0-9]+"
 
           # List of exempt prefixes (case-insensitive)
           EXEMPT_PREFIXES=("chore" "hotfix" "daily-chore")
@@ -250,6 +257,7 @@ jobs:
                 echo "✅ Jira key found in PR-title: ${BASH_REMATCH[0]}"
               else
                 echo "❌ No Jira key found in branch name and PR title"
+                echo "ℹ️  Expected Jira key prefixes: ${ALLOWED_JIRA_PROJECTS[*]}"
                 exit 1
               fi
           fi
@@ -684,4 +692,3 @@ jobs:
       - name: all-checks-passed
         if: ${{ success() }}
         run: echo "✅ All required jobs passed!"
-


### PR DESCRIPTION
https://github.com/flexcompute/tidy3d/pull/2905 surfaced an issue where the branch name link was overly restrictive in allowing the Jira ticket ID to only appear at the start of the branch name. This PR addresses that by allowing the ID to appear anywhere in the branch name. As an additional guard, we check for specific project keys, as otherwise the regex would likely have too many false positives.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-20 07:46:25 UTC

### Greptile Summary

This PR relaxes the branch name validation rules in the CI workflow to allow Jira ticket IDs (like FXC-1234) to appear anywhere in branch names, not just at the beginning. Previously, developers had to name branches like `FXC-1234-feature-name`, which prevented common patterns like `username/FXC-1234-feature-name`. The change introduces an allowlist of known Jira project keys (FXC, SCEM) to prevent false positives from overly permissive matching. The validation logic now dynamically constructs a regex pattern from the allowed projects array and applies it to the entire branch name. If the branch name doesn't contain a Jira key, the existing fallback to check the PR title remains intact, ensuring compatibility with current workflows while adding flexibility for developer-prefixed branch names.

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/tidy3d-python-client-tests.yml | 5/5 | Relaxed Jira ticket ID validation to allow IDs anywhere in branch names (not just at start), added project key allowlist (FXC, SCEM) to preventfalse positives, and improved error messaging with guidance on expected prefixes |

</details>

### Confidence score: 5/5

- This PR is safe to merge with minimal risk
- The change is a straightforward regex pattern update with clear logic, maintains backward compatibility through existing exemptions and PR title fallback, and adds helpful error messaging; no breaking changes or complex logic introduced
- No files require special attention

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant GitHub
    participant DetermineScope as "determine-test-scope"
    participant Lint
    participant Zizmor
    participant BranchLint as "lint-branch-name"
    participant CommitLint as "lint-commit-messages"
    participant SchemaVerify as "verify-schema-change"
    participant LocalTests as "local-tests"
    participant RemoteTests as "remote-tests"
    participant FinalCheck as "pr-requirements-pass"

    User->>GitHub: Trigger workflow (PR/Review/Dispatch/Merge)
    GitHub->>DetermineScope: Start job
    DetermineScope->>GitHub: Check PR approval status
    GitHub-->>DetermineScope: Return approval state
    DetermineScope->>DetermineScope: Determine test scope based on event & approval
    DetermineScope-->>GitHub: Output test flags (code_quality, local, remote, pr_review)

    par Code Quality Tests (if enabled)
        DetermineScope->>Lint: Trigger linting
        Lint->>Lint: Run ruff format & check
        Lint-->>GitHub: Report result
        
        DetermineScope->>Zizmor: Trigger security analysis
        Zizmor->>Zizmor: Run zizmor workflow scan
        Zizmor->>GitHub: Upload SARIF results
        Zizmor-->>GitHub: Report result
        
        DetermineScope->>CommitLint: Trigger commit message lint
        CommitLint->>CommitLint: Validate conventional commits
        CommitLint-->>GitHub: Report result
        
        DetermineScope->>SchemaVerify: Trigger schema verification
        SchemaVerify->>SchemaVerify: Regenerate schemas & compare
        SchemaVerify->>SchemaVerify: Check schema diff vs base branch
        SchemaVerify->>SchemaVerify: Verify allowed changes for version
        SchemaVerify-->>GitHub: Report result
    end

    par PR Review Tests (if enabled)
        DetermineScope->>BranchLint: Trigger branch name lint
        BranchLint->>BranchLint: Extract branch name
        BranchLint->>BranchLint: Check for Jira key or exempt prefix
        BranchLint-->>GitHub: Report result
    end

    par Local Tests (if enabled)
        DetermineScope->>LocalTests: Trigger local tests
        LocalTests->>LocalTests: Install dependencies (Python 3.10, 3.13)
        LocalTests->>LocalTests: Run pytest with coverage
        LocalTests->>LocalTests: Generate diff-coverage report
        LocalTests->>GitHub: Post coverage comment to PR
        LocalTests-->>GitHub: Report result
    end

    par Remote Tests (if enabled)
        DetermineScope->>RemoteTests: Trigger remote tests
        RemoteTests->>RemoteTests: Install dependencies (Python 3.10-3.13, multi-OS)
        RemoteTests->>RemoteTests: Run doctests
        RemoteTests->>RemoteTests: Run pytest with coverage
        RemoteTests->>GitHub: Create coverage badge (if develop branch)
        RemoteTests-->>GitHub: Report result
    end

    GitHub->>FinalCheck: Trigger final validation
    FinalCheck->>FinalCheck: Check all required job results
    alt All checks passed
        FinalCheck-->>GitHub: ✅ Success
        GitHub-->>User: All required jobs passed
    else Any check failed
        FinalCheck-->>GitHub: ❌ Failure
        GitHub-->>User: One or more jobs failed
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->