### PR TITLE
chore: running the design plugin using local pipelines

### DIFF
--- a/tidy3d/plugins/design/design.py
+++ b/tidy3d/plugins/design/design.py
@@ -24,6 +24,13 @@ from .method import (
 from .parameter import ParameterAny, ParameterInt, ParameterType
 from .result import Result
 
+try:
+    from tidy3d_pipeline.run import run_batch
+
+    TIDY3D_LOCAL_RUN = True
+except ImportError:
+    TIDY3D_LOCAL_RUN = False
+
 
 class DesignSpace(Tidy3dBaseModel):
     """Manages all exploration of a parameter space within specified parameters using a supplied search method.
@@ -387,16 +394,23 @@ class DesignSpace(Tidy3dBaseModel):
             console.log(f"Running {run_statement}")
 
         # Running simulations and batches
-        sims_out = Batch(
+        batch_named_sims = Batch(
             simulations=named_sims,
             folder_name=self.folder_name,
             simulation_type="tidy3d_design",
             verbose=False,  # Using a custom output instead of Batch.monitor updates
-        ).run(path_dir=self.path_dir)
+        )
+        if TIDY3D_LOCAL_RUN:
+            sims_out = run_batch(batch_named_sims, path_dir=self.path_dir)
+        else:
+            sims_out = batch_named_sims.run(path_dir=self.path_dir)
 
         batch_results = {}
         for batch_key, batch in batches.items():
-            batch_out = batch.run(path_dir=self.path_dir)
+            if TIDY3D_LOCAL_RUN:
+                batch_out = run_batch(batch, path_dir=self.path_dir)
+            else:
+                batch_out = batch.run(path_dir=self.path_dir)
             batch_results[batch_key] = batch_out
 
         def _return_to_dict(return_dict: dict, key: str, return_obj: Any) -> None:
@@ -502,6 +516,9 @@ class DesignSpace(Tidy3dBaseModel):
             Estimated maximum cost for the ``DesignSpace.run``.
 
         """
+        if TIDY3D_LOCAL_RUN:
+            return 0.0
+
         # Get output fn_pre for paramters at the lowest span / default
         arg_dict = {}
         for param in self.parameters:


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-20 12:37:36 UTC

### Greptile Summary

This PR adds optional local execution support to the design plugin by conditionally importing `run_batch` from an external `tidy3d_pipeline` package. When the package is available, simulations run locally via `run_batch()` instead of the cloud-based `Batch.run()` method. A global `TIDY3D_LOCAL_RUN` flag controls branching throughout the execution flow, and cost estimation returns 0.0 for local runs since no FlexCredits are consumed. The implementation follows a graceful degradation pattern—if `tidy3d_pipeline` is not installed, the existing cloud workflow remains unchanged.

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/design/design.py | 3/5 | Added conditional import of `tidy3d_pipeline.run_batch`, branching logic for local vs cloud execution in `_find_and_map`, and cost bypass in `estimate_cost()` |

</details>

### Confidence score: 3/5

- This PR introduces a reasonable fallback pattern but relies on undocumented external package behavior that could silently break
- Score reflects tight coupling to `tidy3d_pipeline` interface without validation, bypassing cost estimation entirely for local runs, and lack of testing or documentation for the new execution path
- Pay close attention to tidy3d/plugins/design/design.py: verify `run_batch()` signature compatibility, ensure error handling is robust when local execution fails, and confirm the 0.0 cost return won't break downstream cost aggregation logic

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant DesignSpace
    participant Method
    participant Pre_Post_Handler
    participant fn_pre
    participant Batch
    participant run_batch
    participant fn_post

    User->>DesignSpace: "run(fn_pre, fn_post)"
    DesignSpace->>DesignSpace: "get_logging_console()"
    DesignSpace->>DesignSpace: "_get_evaluate_fn_pre_post(fn_pre, fn_post, _fn_mid, console)"
    DesignSpace->>Pre_Post_Handler: "create handler instance"
    DesignSpace->>Method: "_run(run_fn=handler.fn_combined, parameters, console)"
    
    loop For each parameter set
        Method->>Pre_Post_Handler: "fn_combined(args_list)"
        
        loop For each arg in args_list
            Pre_Post_Handler->>fn_pre: "fn_pre(**arg_list)"
            fn_pre-->>Pre_Post_Handler: "Simulation/Batch/list/dict"
        end
        
        Pre_Post_Handler->>DesignSpace: "_fn_mid(sim_dict, sim_counter, console)"
        DesignSpace->>DesignSpace: "create Batch from named_sims"
        
        alt TIDY3D_LOCAL_RUN is True
            DesignSpace->>run_batch: "run_batch(batch_named_sims, path_dir)"
            run_batch-->>DesignSpace: "BatchData"
        else TIDY3D_LOCAL_RUN is False
            DesignSpace->>Batch: "batch.run(path_dir)"
            Batch-->>DesignSpace: "BatchData"
        end
        
        DesignSpace->>DesignSpace: "process SimulationData and task metadata"
        DesignSpace-->>Pre_Post_Handler: "processed data, task_names, task_paths, sim_counter"
        
        loop For each data value
            Pre_Post_Handler->>fn_post: "fn_post(val)"
            fn_post-->>Pre_Post_Handler: "post_out result"
        end
        
        Pre_Post_Handler-->>Method: "post_out results"
    end
    
    Method-->>DesignSpace: "fn_args, fn_values, aux_values, opt_output"
    DesignSpace->>DesignSpace: "get_fn_source(fn_pre)"
    DesignSpace->>DesignSpace: "_package_run_results()"
    DesignSpace-->>User: "Result"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->