### PR TITLE
ci: zizmor in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,4 +18,10 @@ repos:
         stages: [commit-msg]
         verbose: true
         entry: bash -c 'commitlint --edit || exit 0'
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    # Zizmor version.
+    rev: v1.15.2
+    hooks:
+      - id: zizmor
+        stages: [pre-commit]
 


### PR DESCRIPTION
As suggested by @daquinteroflex, the pre-commit config now uses zizmor without a requirement on poetry

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-20 12:57:03 UTC

### Greptile Summary

This PR adds zizmor, a security auditing tool for GitHub Actions workflows, to the pre-commit configuration. Zizmor will run automatically on commits to catch potential security issues in CI/CD workflows before they reach the repository. The tool is added via the `zizmor-pre-commit` repository at version v1.15.2, requiring no changes to existing dependencies or Poetry configuration. This enhances the repository's existing quality gates (Ruff for linting, Commitlint for commit messages) by adding security-focused checks for GitHub Actions workflows defined in `.github/workflows/`.

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `.pre-commit-config.yaml` | 3/5 | Adds zizmor security linter hook to pre-commit configuration for auditing GitHub Actions workflows |

</details>

### Confidence score: 3/5

- This PR is likely safe to merge but requires verification of the external hook repository
- Score reflects uncertainty about the `zizmor-pre-commit` repository URL - the official zizmor project repository should be verified as `https://github.com/zizmorcore/zizmor-pre-commit` may not be the correct/official source (the main zizmor project is at `https://github.com/woodruffw/zizmor`)
- Verify the repository URL and that v1.15.2 is a valid tag before merging; if the repository URL is incorrect, the pre-commit hook will fail for all developers

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Developer
    participant "Git (pre-commit)" as Git
    participant "Ruff Linter" as Ruff
    participant "Ruff Formatter" as Format
    participant "Commitlint" as Commit
    participant "Zizmor" as Zizmor

    Developer->>Git: "git commit"
    
    Note over Git: pre-commit stage
    Git->>Ruff: "Run ruff-check --fix"
    Ruff-->>Git: "Linting results"
    
    Git->>Format: "Run ruff-format"
    Format-->>Git: "Formatting results"
    
    Note over Git: commit-msg stage
    Git->>Commit: "Run commitlint (non-blocking)"
    Commit-->>Git: "Validation results (exit 0)"
    
    Git->>Zizmor: "Run zizmor linter"
    Zizmor-->>Git: "Security analysis results"
    
    Git-->>Developer: "Commit success/failure"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->