### PR TITLE
fix(ci): handle reviews in branch name lint

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -211,11 +211,16 @@ jobs:
     name: lint-branch-name
     env:
       PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_BRANCH: ${{ github.event.pull_request.head.ref }}
     steps:
       - name: extract-branch-name
         id: extract-branch-name
         run: |
           BRANCH_NAME="${GITHUB_HEAD_REF}"
+          if [[ -z "$BRANCH_NAME" && -n "$PR_BRANCH" ]]; then
+            BRANCH_NAME="$PR_BRANCH"
+            echo "(fallback) Using PR head branch name: $BRANCH_NAME"
+          fi
           if [[ -z "$BRANCH_NAME" ]]; then
             BRANCH_NAME="${GITHUB_REF_NAME:-${GITHUB_REF#refs/heads/}}"
             echo "(fallback) Using ref-derived branch name: $BRANCH_NAME"


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-20 13:32:38 UTC

### Greptile Summary

This PR fixes a bug in the GitHub Actions workflow where branch name linting fails during `pull_request_review` events. The workflow file `.github/workflows/tidy3d-python-client-tests.yml` is updated to add a fallback mechanism that extracts the branch name from `github.event.pull_request.head.ref` when `GITHUB_HEAD_REF` is not populated (which occurs during review submissions). The change introduces the `PR_BRANCH` environment variable and checks it before falling back to the existing ref-derived method, ensuring the `lint-branch-name` job can correctly validate branch naming conventions across all trigger types (pull requests, reviews, pushes) while maintaining the existing fallback chain for backward compatibility.

---

### Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `.github/workflows/tidy3d-python-client-tests.yml` | 5/5 | Added fallback to extract branch name from PR head ref during review events when GITHUB_HEAD_REF is empty |

</details>

---

### Confidence score: 5/5

- This PR is safe to merge with minimal risk
- Score reflects a targeted bug fix that addresses a specific GitHub Actions environment variable behavior without modifying any production code or logic
- No files require special attention

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant GitHub
    participant DetermineScope as "determine-test-scope"
    participant Lint as "lint"
    participant Zizmor as "zizmor"
    participant BranchLint as "lint-branch-name"
    participant CommitLint as "lint-commit-messages"
    participant SchemaVerify as "verify-schema-change"
    participant LocalTests as "local-tests"
    participant RemoteTests as "remote-tests"
    participant PRRequirements as "pr-requirements-pass"

    User->>GitHub: Pull Request Event (opened/reopened/synchronize/ready_for_review/edited)
    GitHub->>DetermineScope: Trigger workflow
    DetermineScope->>GitHub: Check PR approval status via API
    GitHub-->>DetermineScope: Return reviews and approval state
    DetermineScope->>DetermineScope: Determine test scope based on event type
    DetermineScope-->>GitHub: Output test flags (code_quality_tests, pr_review_tests, local_tests, remote_tests)
    
    alt code_quality_tests == true
        GitHub->>Lint: Run linting checks
        Lint->>Lint: Run ruff format & check
        Lint-->>GitHub: Lint results
        
        GitHub->>Zizmor: Run zizmor security analysis
        Zizmor->>Zizmor: Analyze workflows and generate SARIF
        Zizmor->>GitHub: Upload SARIF results
        Zizmor-->>GitHub: Zizmor results
        
        GitHub->>CommitLint: Run commit message linting
        CommitLint->>CommitLint: Check commit messages with commitlint
        CommitLint-->>GitHub: Commit lint results
        
        GitHub->>SchemaVerify: Verify schema changes
        SchemaVerify->>SchemaVerify: Install dependencies and regenerate schemas
        SchemaVerify->>SchemaVerify: Run schema diff against base branch
        SchemaVerify->>SchemaVerify: Verify allowed changes
        SchemaVerify-->>GitHub: Schema verification results
    end
    
    alt pr_review_tests == true
        GitHub->>BranchLint: Run branch name linting
        BranchLint->>BranchLint: Extract branch name
        BranchLint->>BranchLint: Enforce Jira key or exempt prefix
        BranchLint-->>GitHub: Branch lint results
    end
    
    alt local_tests == true
        GitHub->>LocalTests: Run local tests
        LocalTests->>LocalTests: Install project with uv
        LocalTests->>LocalTests: Run pytest with coverage
        LocalTests->>LocalTests: Generate diff coverage report
        LocalTests->>GitHub: Post coverage comment to PR
        LocalTests-->>GitHub: Local test results
    end
    
    alt remote_tests == true
        GitHub->>RemoteTests: Run remote tests (multi-platform)
        RemoteTests->>RemoteTests: Install project with poetry
        RemoteTests->>RemoteTests: Run doctests and pytest with coverage
        RemoteTests-->>GitHub: Remote test results
    end
    
    GitHub->>PRRequirements: Check all required jobs
    PRRequirements->>PRRequirements: Validate lint result
    PRRequirements->>PRRequirements: Validate schema verification result
    PRRequirements->>PRRequirements: Validate local tests result
    PRRequirements->>PRRequirements: Validate remote tests result
    PRRequirements->>PRRequirements: Validate commit message linting result
    PRRequirements->>PRRequirements: Validate branch name linting result
    PRRequirements->>PRRequirements: Validate zizmor result
    PRRequirements-->>GitHub: Final workflow status
    GitHub-->>User: Workflow completion notification
    
    alt Pull Request Review Event (submitted)
        User->>GitHub: Submit PR review
        GitHub->>DetermineScope: Trigger workflow
        Note over DetermineScope: If review is approved, enables remote tests
        DetermineScope-->>GitHub: Output test flags
        Note over GitHub: Same test execution flow as above
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->