### PR TITLE
chore(commitlint): allow breaking change flag without scope case

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,8 +1,23 @@
 {
+  "parserPreset": {
+    "parserOpts": {
+      "headerPattern": "^([^\\(\\s:!]+)(?:\\(([^)]+)\\))?(!)?: (.+)$",
+      "headerCorrespondence": [
+        "type",
+        "scope",
+        "breaking",
+        "subject"
+      ],
+      "noteKeywords": [
+        "BREAKING CHANGE",
+        "BREAKING CHANGES"
+      ]
+    }
+  },
   "rules": {
     "header-min-length": [2, "always", 12],
-    "header-max-length": [2, "always", 72],
-    "footer-max-line-length": [2, "always", 72],
+    "header-max-length": [2, "always", 120],
+    "footer-max-line-length": [2, "always", 120],
     "type-empty": [2, "never"],
     "type-enum": [2, "always", [
       "feat",
@@ -17,7 +32,7 @@
       "chore",
       "revert"
     ]],
-    "body-max-line-length": [2, "always", 72],
-    "scope-case": [2, "always", "lower-case"]
+    "body-max-line-length": [2, "always", 120],
+    "scope-case": [0]
   }
 }


### PR DESCRIPTION
See discussion in https://github.com/flexcompute/tidy3d/pull/2905

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-21 06:48:01 UTC

### Greptile Summary

This PR updates the commitlint configuration at the repository root to properly parse Conventional Commits breaking change syntax and accommodate the project's scope naming conventions. The changes add a custom parser preset with an explicit regex pattern that correctly captures the `!` breaking change marker (supporting both `type!: subject` and `type(scope)!: subject` formats) and maps it to a dedicated field. Additionally, the `scope-case` rule is disabled to allow non-lowercase scopes such as JIRA ticket IDs (e.g., `FXC-3760`) and PascalCase component names, which are common in the project's commit messages. Line length limits are also increased from 72 to 120 characters for more flexibility. These configuration-only changes integrate with the existing pre-commit hook workflow defined in `.pre-commit-config.yaml` for advisory commit message validation.

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `.commitlintrc.json` | 5/5 | Added custom `headerPattern` regex to capture breaking change `!` flag, disabled `scope-case` enforcement, and increased line length limits to 120 characters |

</details>

### Confidence score: 5/5

- This PR is safe to merge with minimal risk as it contains only configuration changes with no runtime impact on the codebase
- The regex pattern correctly handles all standard Conventional Commits breaking change formats, and disabling scope-case aligns with the repository's use of JIRA keys and PascalCase naming in commit scopes
- No files require special attention

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Developer
    participant Git
    participant PreCommit as Pre-commit Hook
    participant Commitlint
    participant Parser as Custom Parser Preset
    
    Developer->>Git: "git commit -m 'feat(FXC-3760)!: add feature'"
    Git->>PreCommit: Trigger pre-commit hooks
    PreCommit->>Commitlint: Validate commit message
    Commitlint->>Parser: Parse message with custom regex
    Note over Parser: Pattern: ^([^\\(\\s:!]+)(?:\\(([^)]+)\\))?(!)?: (.+)$
    Parser->>Parser: Extract fields:<br/>type="feat"<br/>scope="FXC-3760"<br/>breaking="!"<br/>subject="add feature"
    Parser-->>Commitlint: Return parsed components
    Commitlint->>Commitlint: Validate rules:<br/>- header length (12-120 chars)<br/>- type in enum<br/>- scope-case [0] (disabled)
    Commitlint-->>PreCommit: Validation passed
    PreCommit-->>Git: Hook successful
    Git-->>Developer: Commit accepted
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->