### PR TITLE
fix: raise error when _finalized simulation fails

### DIFF
--- a/tests/test_components/test_source_frames.py
+++ b/tests/test_components/test_source_frames.py
@@ -68,5 +68,5 @@ def test_source_absorber_frames():
             )
         ],
     )
-    with pytest.raises(pydantic.ValidationError):
-        _ = bad_sim._finalized
+    with pytest.raises(td.exceptions.Tidy3dError):
+        _ = bad_sim._validate_finalized()

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -2227,11 +2227,11 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
 
         try:
             _ = self._finalized
-        except Exception:
-            log.error(
+        except Exception as e:
+            raise Tidy3dError(
                 "Simulation fails after requested mode source PEC frames are added. "
                 "Please inspect '._finalized'."
-            )
+            ) from e
 
 
 class Simulation(AbstractYeeGridSimulation):


### PR DESCRIPTION
forgot that `log.error()` doesn't raise an actual error

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-20 23:29:22 UTC

### Greptile Summary

This PR fixes a critical bug in simulation validation where `log.error()` was incorrectly assumed to raise an exception. The `_validate_finalized()` method in `Simulation` now properly captures and re-raises exceptions after logging, ensuring that validation failures when adding mode source PEC frames are surfaced to users rather than silently ignored. The corresponding test was updated to call `_validate_finalized()` explicitly instead of accessing the `_finalized` property directly, ensuring the validation logic is properly exercised. This change aligns with the codebase's error handling pattern where validation failures must raise exceptions, not just log messages, particularly important for pre-upload validation that prevents invalid simulations from being submitted.

### Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/simulation.py | 5/5 | Fixed `_validate_finalized()` to properly capture and re-raise exceptions after logging, ensuring validation errors are not silently ignored |
| tests/test_components/test_source_frames.py | 4/5 | Updated test to call `_validate_finalized()` method instead of accessing `_finalized` property; inconsistency remains on line 42 where `_finalized` is still accessed directly |

</details>

### Confidence score: 4/5

- This PR fixes a critical validation bug with minimal risk, though one test inconsistency remains unaddressed
- Score reflects the correct fix to the core issue but potential incompleteness in test coverage (line 42 in test file still accesses `_finalized` directly without validation, which may or may not be intentional)
- Pay close attention to tests/test_components/test_source_frames.py line 42 to determine if the direct `_finalized` access should also be updated to `_validate_finalized()`

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as test_source_absorber_frames
    participant Simulation as Simulation
    participant Log as log
    participant Exception as ValidationError

    Note over Test: Create bad_sim with conflicting<br/>mode source frame and projection monitor
    
    Test->>Simulation: bad_sim._validate_finalized()
    activate Simulation
    
    Simulation->>Simulation: try: _ = self._finalized
    activate Simulation
    
    Note over Simulation: Validation fails due to<br/>incompatible components
    
    Simulation->>Exception: Exception raised
    deactivate Simulation
    
    Simulation->>Log: log.error("Simulation fails after<br/>requested mode source PEC frames<br/>are added. Please inspect '._finalized'.")
    
    Simulation->>Exception: raise e
    deactivate Simulation
    
    Exception-->>Test: ValidationError raised
    
    Note over Test: pytest.raises(ValidationError)<br/>assertion passes
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Use `log.error` instead of `assert` statements for error handling in production code. ([source](https://app.greptile.com/review/custom-context?memory=708d3d0c-2078-4d4f-a710-1416e9aca32f))

<!-- /greptile_comment -->