### PR TITLE
fix(rf): minor compatibility solver version fix SCEM-11170

### DIFF
--- a/tidy3d/plugins/smatrix/run.py
+++ b/tidy3d/plugins/smatrix/run.py
@@ -201,7 +201,24 @@ def _run_local(
 
         return compose_modeler_data_from_batch_data(modeler=modeler, batch_data=sim_data_map)
 
-    batch = create_batch(modeler=modeler)
+    # Filter kwargs to only include valid Batch parameters
+    batch_kwargs = {
+        k: v
+        for k, v in kwargs.items()
+        if k
+        in {
+            "solver_version",
+            "folder_name",
+            "verbose",
+            "callback_url",
+            "simulation_type",
+            "parent_tasks",
+            "num_workers",
+            "reduce_simulation",
+            "pay_type",
+        }
+    }
+    batch = create_batch(modeler=modeler, **batch_kwargs)
     priority = kwargs.get("priority")
     if priority is None:
         batch_data = batch.run(path_dir=path_dir)


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-21 16:10:58 UTC

### Greptile Summary

This PR modifies the `_run_local()` function in `tidy3d/plugins/smatrix/run.py` to forward `**kwargs` to the `create_batch()` call. This change enables solver version parameters and other configuration options to propagate from the top-level microwave/RF plugin functions down to the Batch constructor, addressing compatibility issues with solver version specification in RF simulations. The modification fits into the broader architecture where `_run_local()` serves as a thin wrapper around batch operations, and needs to pass through configuration that affects how individual simulations within the batch are executed.

### Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/smatrix/run.py | 2/5 | Added `**kwargs` forwarding to `create_batch()` call, but this creates a conflict where autograd-specific kwargs (`folder_name`, `simulation_type`, `path_dir`) will be incorrectly passed to Batch constructor |

</details>

### Confidence score: 2/5

- This PR has significant implementation issues that could cause runtime failures in the autograd code path
- Score reflects a logical flaw where kwargs intended for `_run_async()` are now being forwarded to `create_batch()`, which may not accept those parameters. Additionally, the `priority` parameter handling creates inconsistent patterns (extracted from kwargs but handled separately, while other kwargs are blindly forwarded)
- Pay close attention to tidy3d/plugins/smatrix/run.py - the kwargs forwarding logic needs refinement to filter which parameters go to `create_batch()` versus `batch.run()`, and the interaction with the autograd code path (lines 193-198) needs testing to ensure `folder_name`, `simulation_type`, and `path_dir` don't break the Batch constructor

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant "_run_local"
    participant "web_ag"
    participant "_run_async"
    participant "create_batch"
    participant Batch
    participant "compose_modeler_data_from_batch_data"
    participant SimulationDataMap
    participant "compose_modeler_data"
    
    User->>_run_local: "Call with modeler, path_dir, kwargs"
    _run_local->>web_ag: "is_valid_for_autograd(sim) for each sim"
    
    alt Any sim valid for autograd
        web_ag-->>_run_local: "True"
        _run_local->>_run_async: "_run_async(simulations=sims, **kwargs)"
        _run_async-->>_run_local: "sim_data_map"
        _run_local->>compose_modeler_data_from_batch_data: "compose_modeler_data_from_batch_data(modeler, sim_data_map)"
    else No sim valid for autograd
        web_ag-->>_run_local: "False"
        _run_local->>create_batch: "create_batch(modeler, **kwargs)"
        create_batch->>Batch: "Batch(simulations=modeler.sim_dict, **kwargs)"
        Batch-->>create_batch: "batch"
        create_batch-->>_run_local: "batch"
        
        alt priority is None
            _run_local->>Batch: "batch.run(path_dir=path_dir)"
        else priority specified
            _run_local->>Batch: "batch.run(path_dir=path_dir, priority=priority)"
        end
        
        Batch-->>_run_local: "batch_data"
        _run_local->>compose_modeler_data_from_batch_data: "compose_modeler_data_from_batch_data(modeler, batch_data)"
    end
    
    compose_modeler_data_from_batch_data->>SimulationDataMap: "SimulationDataMap(keys, values)"
    SimulationDataMap-->>compose_modeler_data_from_batch_data: "port_simulation_data"
    compose_modeler_data_from_batch_data->>compose_modeler_data: "compose_modeler_data(modeler, port_simulation_data)"
    
    alt ModalComponentModeler
        compose_modeler_data->>compose_modeler_data: "ModalComponentModelerData(modeler, indexed_sim_data)"
    else TerminalComponentModeler
        compose_modeler_data->>compose_modeler_data: "TerminalComponentModelerData(modeler, indexed_sim_data)"
    end
    
    compose_modeler_data-->>compose_modeler_data_from_batch_data: "modeler_data"
    compose_modeler_data_from_batch_data-->>_run_local: "modeler_data"
    _run_local-->>User: "ComponentModelerDataType"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->