### PR TITLE
fix(rf, FXC-3797): error message of preprocess modeler

### DIFF
--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -198,7 +198,7 @@ def _upload_component_modeler_subtasks(
     }
 
     if verbose:
-        console.log("Starting Modeler and Subtasks Validation...")
+        console.log("Starting modeler and subtasks validation...")
 
     initial_resp = http.post(split_path, payload)
     split_job_detail = AsyncJobDetail(**initial_resp)
@@ -234,8 +234,10 @@ def _upload_component_modeler_subtasks(
                 time.sleep(RUN_REFRESH_TIME)
 
             if split_job_detail.status in ERROR_STATES:
-                msg = split_job_detail.message or "An unknown error occurred."
-                final_error = WebError(f"Component modeler split job failed: {msg}")
+                msg = split_job_detail.result or "An unknown error occurred."
+                final_error = WebError(
+                    f"Component modeler split job failed ({split_job_detail.status}): {msg}"
+                )
 
             if not final_error:
                 description = "Validating"
@@ -278,8 +280,10 @@ def _upload_component_modeler_subtasks(
 
         # Check for split job failure.
         if split_job_detail.status in ERROR_STATES:
-            msg = split_job_detail.message or "An unknown error occurred."
-            final_error = WebError(f"Component modeler split job failed: {msg}")
+            msg = split_job_detail.result or "An unknown error occurred."
+            final_error = WebError(
+                f"Component modeler split job failed ({split_job_detail.status}): {msg}"
+            )
 
         # If split succeeded, poll for validation completion.
         if not final_error:


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-22 15:12:38 UTC

### Greptile Summary

This PR fixes error message handling in the Component Modeler preprocessing workflow within `tidy3d/web/api/webapi.py`. The changes correct a critical bug where error details were being retrieved from the wrong field (`message` instead of `result`) when split job preprocessing fails. The error messages are enhanced to include status information (e.g., "failed", "error") for improved debugging context. Additionally, a console log message is updated to use lowercase capitalization, aligning with the codebase's established logging conventions. These changes ensure that users receive accurate and informative error messages when Component Modeler preprocessing encounters issues, improving the overall debugging experience for the web API component of Tidy3D.

### Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|-----------|
| tidy3d/web/api/webapi.py | 5/5 | Fixed error message retrieval field from `message` to `result`, added status information to error messages, and corrected console log capitalization |

</details>

### Confidence score: 5/5

- This PR is safe to merge with minimal risk
- Score reflects a straightforward bug fix with clear improvements to error handling, no complex logic changes, and consistent application across both verbose and non-verbose code paths
- No files require special attention

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant upload
    participant SimulationTask
    participant _upload_component_modeler_subtasks
    participant http
    participant Server
    participant _batch_detail_error
    participant BatchTask

    User->>upload: "upload(simulation, task_name, ...)"
    upload->>SimulationTask: "create(task_type='RF', ...)"
    SimulationTask->>Server: "POST create task"
    Server-->>SimulationTask: "task with batch_id"
    SimulationTask-->>upload: "task object"
    
    upload->>_upload_component_modeler_subtasks: "resource_id, verbose, solver_version"
    
    _upload_component_modeler_subtasks->>http: "POST tidy3d/async-biz/component-modeler-split"
    http-->>_upload_component_modeler_subtasks: "AsyncJobDetail"
    
    loop Poll split job status
        _upload_component_modeler_subtasks->>http: "GET monitor_split_path"
        http-->>_upload_component_modeler_subtasks: "AsyncJobDetail with progress"
    end
    
    alt Split job succeeds
        _upload_component_modeler_subtasks->>BatchTask: "check(solver_version, batch_type='RF_SWEEP')"
        BatchTask->>Server: "POST validation request"
        
        loop Poll validation status
            _upload_component_modeler_subtasks->>BatchTask: "detail(batch_type='RF_SWEEP')"
            BatchTask->>Server: "GET batch details"
            Server-->>BatchTask: "BatchDetail"
            BatchTask-->>_upload_component_modeler_subtasks: "BatchDetail"
        end
        
        alt Validation fails
            _upload_component_modeler_subtasks->>_batch_detail_error: "resource_id"
            _batch_detail_error->>BatchTask: "detail(batch_type='RF_SWEEP')"
            BatchTask->>Server: "GET batch details"
            Server-->>BatchTask: "BatchDetail with validateErrors"
            BatchTask-->>_batch_detail_error: "BatchDetail"
            
            loop Parse validation errors
                _batch_detail_error->>_batch_detail_error: "json.loads(error_str)"
                _batch_detail_error->>_batch_detail_error: "extract validation_error"
            end
            
            _batch_detail_error-->>_upload_component_modeler_subtasks: "WebError with details"
            _upload_component_modeler_subtasks-->>upload: "WebError"
            upload-->>User: "raise WebError"
        else Validation succeeds
            _upload_component_modeler_subtasks-->>upload: "None (success)"
        end
    else Split job fails
        _upload_component_modeler_subtasks-->>upload: "WebError"
        upload-->>User: "raise WebError"
    end
    
    upload->>upload: "estimate_cost(resource_id, ...)"
    upload-->>User: "return resource_id"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Use single quotes around class names like 'WavePort' in error messages and warnings. Use double back... ([source](https://app.greptile.com/review/custom-context?memory=9fe45587-ca43-4a13-b2de-6011420299be))

<!-- /greptile_comment -->