### PR TITLE
FXC-3800 fix: improve validation 'run_only' field in component modelers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added current integral specification classes: `AxisAlignedCurrentIntegralSpec`, `CompositeCurrentIntegralSpec`, and `Custom2DCurrentIntegralSpec`.
 - `sort_spec` in `ModeSpec` allows for fine-grained filtering and sorting of modes. This also deprecates `filter_pol`. The equivalent usage for example to `filter_pol="te"` is `sort_spec=ModeSortSpec(filter_key="TE_polarization", filter_reference=0.5)`. `ModeSpec.track_freq` has also been deprecated and moved to `ModeSortSpec.track_freq`.
 - Added `custom_source_time` parameter to `ComponentModeler` classes (`ModalComponentModeler` and `TerminalComponentModeler`), allowing specification of custom source time dependence.
+- Validation for `run_only` field in component modelers to catch duplicate or invalid matrix indices early with clear error messages.
 
 ### Changed
 - Improved performance of antenna metrics calculation by utilizing cached wave amplitude calculations instead of recomputing wave amplitudes for each port excitation in the `TerminalComponentModelerData`.

--- a/tests/test_plugins/smatrix/test_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_component_modeler.py
@@ -479,3 +479,31 @@ def test_custom_source_time(monkeypatch):
     ):
         custom_source = td.GaussianPulse(freq0=td.C_0, fwidth=1e12)
         modeler = make_component_modeler(custom_source_time=custom_source)
+
+
+def test_validate_run_only_uniqueness_modal():
+    """Test that run_only validator rejects duplicate entries for ModalComponentModeler."""
+    modeler = make_component_modeler()
+
+    # Get valid matrix indices (port_name, mode_index)
+    port0_idx = (modeler.ports[0].name, 0)
+    port1_idx = (modeler.ports[1].name, 0)
+
+    # Test with duplicate entries - should raise ValidationError
+    with pytest.raises(pydantic.ValidationError, match="duplicate entries"):
+        modeler.updated_copy(run_only=(port0_idx, port0_idx, port1_idx))
+
+
+def test_validate_run_only_membership_modal():
+    """Test that run_only validator rejects invalid indices for ModalComponentModeler."""
+    modeler = make_component_modeler()
+
+    # Test with invalid port name
+    with pytest.raises(pydantic.ValidationError, match="not present in"):
+        modeler.updated_copy(run_only=(("invalid_port", 0),))
+
+    # Test with invalid mode index
+    port0_name = modeler.ports[0].name
+    invalid_mode = modeler.ports[0].mode_spec.num_modes + 1
+    with pytest.raises(pydantic.ValidationError, match="not present in"):
+        modeler.updated_copy(run_only=((port0_name, invalid_mode),))

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -1804,3 +1804,49 @@ def test_custom_source_time(monkeypatch, tmp_path):
         for source in sim.sources:
             assert source.source_time.freq0 == custom_source.freq0
             assert source.source_time.fwidth == custom_source.fwidth
+
+
+def test_validate_run_only_uniqueness():
+    """Test that run_only validator rejects duplicate entries for TerminalComponentModeler."""
+    modeler = make_component_modeler(planar_pec=True)
+
+    # Get valid network indices
+    port0_idx = modeler.network_index(modeler.ports[0])
+    port1_idx = modeler.network_index(modeler.ports[1])
+
+    # Test with duplicate entries - should raise ValidationError
+    with pytest.raises(pd.ValidationError, match="duplicate entries"):
+        modeler.updated_copy(run_only=(port0_idx, port0_idx, port1_idx))
+
+
+def test_validate_run_only_membership():
+    """Test that run_only validator rejects invalid indices for TerminalComponentModeler."""
+    modeler = make_component_modeler(planar_pec=True)
+
+    # Test with invalid index - should raise ValidationError
+    with pytest.raises(pd.ValidationError, match="not present in"):
+        modeler.updated_copy(run_only=("invalid_port_name",))
+
+    # Test with partially invalid indices
+    port0_idx = modeler.network_index(modeler.ports[0])
+    with pytest.raises(pd.ValidationError, match="not present in"):
+        modeler.updated_copy(run_only=(port0_idx, "invalid_port"))
+
+
+def test_validate_run_only_with_wave_ports():
+    """Test run_only validation with WavePorts in TerminalComponentModeler."""
+    z_grid = td.UniformGrid(dl=1 * 1e3)
+    xy_grid = td.UniformGrid(dl=0.1 * 1e3)
+    grid_spec = td.GridSpec(grid_x=xy_grid, grid_y=xy_grid, grid_z=z_grid)
+    modeler = make_coaxial_component_modeler(port_types=(WavePort, WavePort), grid_spec=grid_spec)
+
+    port0_idx = modeler.network_index(modeler.ports[0])
+    port1_idx = modeler.network_index(modeler.ports[1])
+
+    # Valid case
+    modeler_updated = modeler.updated_copy(run_only=(port0_idx,))
+    assert modeler_updated.run_only == (port0_idx,)
+
+    # Invalid case
+    with pytest.raises(pd.ValidationError, match="not present in"):
+        modeler.updated_copy(run_only=("nonexistent_wave_port",))

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -133,6 +133,35 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
             )
         return element_mappings
 
+    @pd.validator("run_only", always=True)
+    @skip_if_fields_missing(["ports"])
+    def _validate_run_only(cls, val, values):
+        """Validate that run_only entries are unique and exist in matrix_indices_monitor."""
+        if val is None:
+            return val
+
+        # Check uniqueness
+        if len(val) != len(set(val)):
+            duplicates = [idx for idx in set(val) if val.count(idx) > 1]
+            raise SetupError(
+                f"'run_only' contains duplicate entries: {duplicates}. "
+                "Each index must appear only once."
+            )
+
+        # Check membership - use the helper method to get valid indices
+        ports = values["ports"]
+
+        valid_indices = set(cls._construct_matrix_indices_monitor(ports))
+        invalid_indices = [idx for idx in val if idx not in valid_indices]
+
+        if invalid_indices:
+            raise SetupError(
+                f"'run_only' contains indices {invalid_indices} that are not present in "
+                f"'matrix_indices_monitor'. Valid indices are: {sorted(valid_indices)}"
+            )
+
+        return val
+
     _freqs_not_empty = validate_freqs_not_empty()
     _freqs_lower_bound = validate_freqs_min()
     _freqs_unique = validate_freqs_unique()
@@ -205,6 +234,25 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
         if len(ports) == 0:
             raise Tidy3dKeyError(f'Port "{port_name}" not found.')
         return ports[0]
+
+    @staticmethod
+    @abstractmethod
+    def _construct_matrix_indices_monitor(ports: tuple) -> tuple[IndexType, ...]:
+        """Construct matrix indices for monitoring from ports.
+
+        This helper method is used by both the matrix_indices_monitor property
+        and the run_only validator to ensure consistency.
+
+        Parameters
+        ----------
+        ports : tuple
+            Tuple of port objects.
+
+        Returns
+        -------
+        tuple[IndexType, ...]
+            Tuple of matrix indices for monitoring.
+        """
 
     @property
     @abstractmethod

--- a/tidy3d/plugins/smatrix/component_modelers/modal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/modal.py
@@ -87,6 +87,26 @@ class ModalComponentModeler(AbstractComponentModeler):
             sim_dict[task_name] = sim_copy
         return SimulationMap(keys=tuple(sim_dict.keys()), values=tuple(sim_dict.values()))
 
+    @staticmethod
+    def _construct_matrix_indices_monitor(ports: tuple[Port, ...]) -> tuple[MatrixIndex, ...]:
+        """Construct matrix indices for monitoring from modal ports.
+
+        Parameters
+        ----------
+        ports : tuple[Port, ...]
+            Tuple of Port objects.
+
+        Returns
+        -------
+        tuple[MatrixIndex, ...]
+            Tuple of (port_name, mode_index) pairs.
+        """
+        matrix_indices = []
+        for port in ports:
+            for mode_index in range(port.mode_spec.num_modes):
+                matrix_indices.append((port.name, mode_index))
+        return tuple(matrix_indices)
+
     @cached_property
     def matrix_indices_monitor(self) -> tuple[MatrixIndex, ...]:
         """Returns a tuple of all possible matrix indices for monitoring.
@@ -98,11 +118,7 @@ class ModalComponentModeler(AbstractComponentModeler):
         Tuple[MatrixIndex, ...]
             A tuple of all possible matrix indices for the monitoring ports.
         """
-        matrix_indices = []
-        for port in self.ports:
-            for mode_index in range(port.mode_spec.num_modes):
-                matrix_indices.append((port.name, mode_index))
-        return tuple(matrix_indices)
+        return self._construct_matrix_indices_monitor(self.ports)
 
     @cached_property
     def matrix_indices_source(self) -> tuple[MatrixIndex, ...]:

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -256,16 +256,34 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
             network_dict[key] = (port, mode_index)
         return network_dict
 
+    @staticmethod
+    def _construct_matrix_indices_monitor(
+        ports: tuple[TerminalPortType, ...],
+    ) -> tuple[NetworkIndex, ...]:
+        """Construct matrix indices for monitoring from terminal ports.
+
+        Parameters
+        ----------
+        ports : tuple[TerminalPortType, ...]
+            Tuple of terminal port objects (LumpedPort, CoaxialLumpedPort, or WavePort).
+
+        Returns
+        -------
+        tuple[NetworkIndex, ...]
+            Tuple of network index strings.
+        """
+        matrix_indices = []
+        for port in ports:
+            if isinstance(port, WavePort):
+                matrix_indices.append(TerminalComponentModeler.network_index(port, port.mode_index))
+            else:
+                matrix_indices.append(TerminalComponentModeler.network_index(port))
+        return tuple(matrix_indices)
+
     @cached_property
     def matrix_indices_monitor(self) -> tuple[NetworkIndex, ...]:
         """Tuple of all the possible matrix indices."""
-        matrix_indices = []
-        for port in self.ports:
-            if isinstance(port, WavePort):
-                matrix_indices.append(self.network_index(port, port.mode_index))
-            else:
-                matrix_indices.append(self.network_index(port))
-        return tuple(matrix_indices)
+        return self._construct_matrix_indices_monitor(self.ports)
 
     @cached_property
     def matrix_indices_source(self) -> tuple[NetworkIndex, ...]:


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-22 19:15:24 UTC

### Greptile Summary

This PR adds validation for the `run_only` field in component modelers by checking for duplicate entries and verifying that all specified indices correspond to valid port/mode combinations. The implementation extracts matrix indices construction logic into a new abstract static method `_construct_matrix_indices_monitor` in the base class, which is then implemented by both `ModalComponentModeler` and `TerminalComponentModeler`. A pydantic validator `_validate_run_only` in `AbstractComponentModeler` uses this method to validate user-provided `run_only` values during object construction, before cached properties are initialized. The refactoring maintains backward compatibility while enabling early error detection with clear error messages.

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/smatrix/component_modelers/base.py | 4/5 | Added `_validate_run_only` validator and abstract static method `_construct_matrix_indices_monitor` to enable validation of `run_only` field for duplicate and invalid indices |
| tidy3d/plugins/smatrix/component_modelers/modal.py | 5/5 | Extracted matrix indices construction into static method `_construct_matrix_indices_monitor` implementing base class abstract method, delegated from cached property |
| tidy3d/plugins/smatrix/component_modelers/terminal.py | 5/5 | Refactored `matrix_indices_monitor` to use new static method `_construct_matrix_indices_monitor` that handles both `LumpedPort` and `WavePort` types |
| tests/test_plugins/smatrix/test_component_modeler.py | 5/5 | Added two test functions validating `run_only` uniqueness and membership constraints for `ModalComponentModeler` |
| tests/test_plugins/smatrix/test_terminal_component_modeler.py | 5/5 | Added three comprehensive test functions covering `run_only` validation for duplicates, invalid indices, and `WavePort` compatibility in `TerminalComponentModeler` |
| CHANGELOG.md | 4/5 | Added changelog entry documenting new validation feature for `run_only` field under "Added" category |

</details>

### Confidence score: 4/5

- This PR is safe to merge with minimal risk as the validation logic is well-tested and maintains backward compatibility
- Score reflects solid implementation with comprehensive tests, though the changelog entry could be categorized as "Changed" rather than "Added" since it improves existing functionality, and there's minor concern about the interaction between `@staticmethod` and `@abstractmethod` decorators in the validation context
- Pay close attention to tidy3d/plugins/smatrix/component_modelers/base.py to verify the abstract static method is correctly accessible during pydantic validation

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant AbstractComponentModeler
    participant Validator
    participant HelperMethod
    
    User->>AbstractComponentModeler: Create/update modeler with run_only
    AbstractComponentModeler->>Validator: @pd.validator("run_only")
    
    alt run_only is None
        Validator->>AbstractComponentModeler: return val (skip validation)
    else run_only has value
        Validator->>Validator: Check for duplicates
        alt duplicates found
            Validator->>User: raise SetupError("duplicate entries")
        end
        
        Validator->>Validator: Get ports from values
        alt ports is None
            Validator->>AbstractComponentModeler: return val
        else ports exist
            Validator->>HelperMethod: _construct_matrix_indices_monitor(ports)
            HelperMethod->>Validator: return valid_indices set
            Validator->>Validator: Check membership of run_only indices
            alt invalid indices found
                Validator->>User: raise SetupError("not present in matrix_indices_monitor")
            else all indices valid
                Validator->>AbstractComponentModeler: return val
            end
        end
    end
    
    AbstractComponentModeler->>User: Validation complete
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Use changelog categories correctly: "Fixed" for bug fixes, "Changed" for modifications to existing f... ([source](https://app.greptile.com/review/custom-context?memory=17997812-233f-4a81-bee2-4d7666605061))

<!-- /greptile_comment -->