### PR TITLE
remove unused api

### DIFF
--- a/tests/test_web/test_tidy3d_task.py
+++ b/tests/test_web/test_tidy3d_task.py
@@ -376,16 +376,3 @@ def test_get_log(monkeypatch, set_api_key, tmp_path):
     task.get_log(LOG_FNAME)
     with open(LOG_FNAME) as f:
         assert f.read() == "0.3,5.7"
-
-
-@responses.activate
-def test_get_running_tasks(set_api_key):
-    responses.add(
-        responses.GET,
-        f"{Env.current.web_api_endpoint}/tidy3d/py/tasks",
-        json={"data": [{"taskId": "1234", "status": "queued"}]},
-        status=200,
-    )
-
-    tasks = SimulationTask.get_running_tasks()
-    assert len(tasks) == 1

--- a/tidy3d/web/core/task_core.py
+++ b/tidy3d/web/core/task_core.py
@@ -296,20 +296,6 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
         task = SimulationTask(**resp) if resp else None
         return task
 
-    @classmethod
-    def get_running_tasks(cls) -> list[SimulationTask]:
-        """Get a list of running tasks from the server"
-
-        Returns
-        -------
-        List[:class:`.SimulationTask`]
-            :class:`.SimulationTask` object containing info about status,
-             size, credits of task and others.
-        """
-        resp = http.get("tidy3d/py/tasks")
-        if not resp:
-            return []
-        return parse_obj_as(list[SimulationTask], resp)
 
     def delete(self, versions: bool = False):
         """Delete current task from server.


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-23 02:18:43 UTC

<h3>Greptile Summary</h3>


This PR removes the unused `get_running_tasks()` classmethod from the `SimulationTask` class in `tidy3d/web/core/task_core.py` and its corresponding test in `tests/test_web/test_tidy3d_task.py`. The method provided a global query to fetch all running tasks from the server. This functionality has been superseded by the folder-scoped `Folder.list_tasks()` method (also present in `task_core.py`), which provides similar capabilities but scoped to specific folders. The removal is part of API cleanup and simplification, aligning the codebase toward folder-scoped task queries rather than global task queries.

**PR Description Notes:**
- The PR description is empty; a brief explanation of the change would improve clarity for reviewers and future maintainers.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/web/core/task_core.py | 4/5 | Removes unused `get_running_tasks()` classmethod from `SimulationTask` |
| tests/test_web/test_tidy3d_task.py | 5/5 | Removes test for the now-deleted `get_running_tasks()` method |

<h3>Confidence score: 4/5</h3>


- This PR is generally safe to merge but requires verification that no external code depends on the removed method.
- Score reflects a clean removal with appropriate test cleanup, but uncertainty about external dependencies and the absence of a changelog entry documenting this breaking change (rule violations: b72c7231-b258-4d03-aed2-51a50a9fe757, a109c62a-aa8c-4cc4-b515-0ad947c47929).
- Pay close attention to `tidy3d/web/core/task_core.py` to ensure no other internal code paths depend on `get_running_tasks()`, and verify that a CHANGELOG entry is added under "Changed" or "Removed" to document this breaking API change.

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant SimulationTask
    participant Folder
    participant HTTP as http_util
    participant API as Web API Endpoint
    participant S3 as S3 Storage

    User->>Folder: list()
    Folder->>HTTP: get("tidy3d/projects")
    HTTP->>API: GET /tidy3d/projects
    API-->>HTTP: projects data
    HTTP-->>Folder: response
    Folder-->>User: List[Folder]

    User->>Folder: get(folder_name, create=True)
    Folder->>HTTP: get("tidy3d/project", params)
    HTTP->>API: GET /tidy3d/project?projectName=...
    API-->>HTTP: folder data
    HTTP-->>Folder: response
    Folder-->>User: Folder

    User->>SimulationTask: create(task_type, task_name, folder_name)
    SimulationTask->>Folder: get(folder_name, create=True)
    Folder-->>SimulationTask: Folder
    SimulationTask->>HTTP: post("tidy3d/projects/{folder_id}/tasks", payload)
    HTTP->>API: POST /tidy3d/projects/{folder_id}/tasks
    API-->>HTTP: task data
    HTTP-->>SimulationTask: response
    SimulationTask-->>User: SimulationTask

    User->>SimulationTask: upload_simulation(stub, verbose)
    SimulationTask->>SimulationTask: to_hdf5_gz(temp_file)
    SimulationTask->>S3: upload_file(task_id, file, remote_file)
    S3-->>SimulationTask: upload complete
    SimulationTask-->>User: void

    User->>SimulationTask: submit(pay_type, solver_version)
    SimulationTask->>HTTP: post("tidy3d/tasks/{task_id}/submit", params)
    HTTP->>API: POST /tidy3d/tasks/{task_id}/submit
    API-->>HTTP: submission confirmation
    HTTP-->>SimulationTask: response
    SimulationTask-->>User: void

    User->>SimulationTask: estimate_cost(solver_version)
    SimulationTask->>HTTP: post("tidy3d/tasks/{task_id}/metadata", params)
    HTTP->>API: POST /tidy3d/tasks/{task_id}/metadata
    API-->>HTTP: cost estimate
    HTTP-->>SimulationTask: {"flexUnit": cost}
    SimulationTask-->>User: cost data

    User->>SimulationTask: get_sim_data_hdf5(to_file, verbose)
    SimulationTask->>S3: download_gz_file(task_id, remote_file, to_file)
    S3-->>SimulationTask: file data
    SimulationTask-->>User: Path

    User->>SimulationTask: get_log(to_file, verbose)
    SimulationTask->>S3: download_file(task_id, log_file, to_file)
    S3-->>SimulationTask: log data
    SimulationTask-->>User: Path

    User->>SimulationTask: delete(versions=False)
    SimulationTask->>HTTP: get("tidy3d/tasks/{task_id}")
    HTTP->>API: GET /tidy3d/tasks/{task_id}
    API-->>HTTP: task details
    HTTP-->>SimulationTask: task details
    SimulationTask->>HTTP: delete("tidy3d/group/{group_id}/versions", json)
    HTTP->>API: DELETE /tidy3d/group/{group_id}/versions
    API-->>HTTP: deletion confirmation
    HTTP-->>SimulationTask: response
    SimulationTask-->>User: void
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Require a changelog entry for any PR that is not purely an internal refactor. ([source](https://app.greptile.com/review/custom-context?memory=b72c7231-b258-4d03-aed2-51a50a9fe757))
- Rule from `dashboard` - Update the CHANGELOG.md file when making changes that affect user-facing functionality or fix bugs. ([source](https://app.greptile.com/review/custom-context?memory=a109c62a-aa8c-4cc4-b515-0ad947c47929))

<!-- /greptile_comment -->