### PR TITLE
remove unused api

### DIFF
--- a/tests/test_web/test_tidy3d_task.py
+++ b/tests/test_web/test_tidy3d_task.py
@@ -376,16 +376,3 @@ def test_get_log(monkeypatch, set_api_key, tmp_path):
     task.get_log(LOG_FNAME)
     with open(LOG_FNAME) as f:
         assert f.read() == "0.3,5.7"
-
-
-@responses.activate
-def test_get_running_tasks(set_api_key):
-    responses.add(
-        responses.GET,
-        f"{Env.current.web_api_endpoint}/tidy3d/py/tasks",
-        json={"data": [{"taskId": "1234", "status": "queued"}]},
-        status=200,
-    )
-
-    tasks = SimulationTask.get_running_tasks()
-    assert len(tasks) == 1

--- a/tidy3d/web/core/task_core.py
+++ b/tidy3d/web/core/task_core.py
@@ -296,21 +296,6 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
         task = SimulationTask(**resp) if resp else None
         return task
 
-    @classmethod
-    def get_running_tasks(cls) -> list[SimulationTask]:
-        """Get a list of running tasks from the server"
-
-        Returns
-        -------
-        List[:class:`.SimulationTask`]
-            :class:`.SimulationTask` object containing info about status,
-             size, credits of task and others.
-        """
-        resp = http.get("tidy3d/py/tasks")
-        if not resp:
-            return []
-        return parse_obj_as(list[SimulationTask], resp)
-
     def delete(self, versions: bool = False):
         """Delete current task from server.
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-23 02:20:56 UTC

<h3>Greptile Summary</h3>


This PR removes the deprecated `SimulationTask.get_running_tasks()` class method and its associated test. The method previously queried the `/tidy3d/py/tasks` endpoint to retrieve all running tasks across the system. This functionality is redundant with the existing `Folder.list_tasks()` method, which provides scoped task retrieval within specific folders - the preferred pattern in the codebase. The removal includes both the implementation in `task_core.py` (14 lines) and its corresponding test in `test_tidy3d_task.py` (9 lines), maintaining consistency between production code and test suite.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|-------|-----------|
| tidy3d/web/core/task_core.py | 5/5 | Removed unused `get_running_tasks` classmethod and added minor whitespace formatting |
| tests/test_web/test_tidy3d_task.py | 5/5 | Removed test for the deleted `get_running_tasks` method |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are straightforward deletions of unused code with no side effects. Both the implementation and its test are removed together, maintaining test-code parity. No other parts of the codebase reference this method, and alternative functionality exists via `Folder.list_tasks()`.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->