### PR TITLE
feat(tidy3d): FXC-3829-duplicate-convergence-checks-for-non-lazy-post…

### DIFF
--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -40,7 +40,7 @@ from tidy3d.web.core.types import PayType
 DEFAULT_NUM_WORKERS = 10
 DEFAULT_DATA_PATH = "simulation_data.hdf5"
 DEFAULT_DATA_DIR = "."
-BATCH_MONITOR_PROGRESS_REFRESH_TIME = 0.02
+BATCH_PROGRESS_REFRESH_TIME = 0.02
 
 BatchCategoryType = Literal[
     "tidy3d",
@@ -839,6 +839,9 @@ class Batch(WebContainer):
                         completed += 1
                         progress.update(pbar, completed=completed)
 
+                    progress.refresh()
+                    time.sleep(BATCH_PROGRESS_REFRESH_TIME)
+
     def get_info(self) -> dict[TaskName, TaskInfo]:
         """Get information about each task in the :class:`Batch`.
 
@@ -1070,7 +1073,7 @@ class Batch(WebContainer):
                             progress.update(pbar, description=desc, completed=pct)
 
                         progress.refresh()
-                        time.sleep(BATCH_MONITOR_PROGRESS_REFRESH_TIME)
+                        time.sleep(BATCH_PROGRESS_REFRESH_TIME)
 
                     # final render to terminal state for all bars
                     for task_name, job in self.jobs.items():

--- a/tidy3d/web/api/tidy3d_stub.py
+++ b/tidy3d/web/api/tidy3d_stub.py
@@ -308,8 +308,6 @@ class Tidy3dStubData(BaseModel, TaskStubData):
         stub_data = Tidy3dStubData.from_file(
             file_path, lazy=lazy, on_load=cls._check_convergence_and_warnings
         )
-        if not lazy:
-            cls._check_convergence_and_warnings(stub_data)
         return stub_data
 
     @staticmethod


### PR DESCRIPTION
…processing

currently, we observe duplicate log messages on warnings (and possibly multiple log downloads) on warnings when lazy is set to false, as we trigger it in “from_file” via the `on_load` and then again in `Tidy3dStubData.postprocess`

https://github.com/flexcompute/tidy3d/blob/7d63acee11a2079442552ffd7913495b84b40963/tidy3d/components/base.py#L408

https://github.com/flexcompute/tidy3d/blob/7d63acee11a2079442552ffd7913495b84b40963/tidy3d/web/api/tidy3d_stub.py#L312

I just removed the second call in postprocess.

As a little side-fix, I trigger a refresh on the upload progress bar in batches which was displayed as incomplete sometimes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-24 11:08:10 UTC

<h3>Greptile Summary</h3>


Fixes duplicate convergence check warnings when `lazy=False` and improves progress bar refresh behavior for batch uploads.

**Main Changes:**
- Removed redundant `_check_convergence_and_warnings()` call in `Tidy3dStubData.postprocess()` that was causing duplicate log messages when `lazy=False`. The convergence check is already triggered via the `on_load` callback in `from_file()` (line 407 in base.py), so the second call was unnecessary.
- Renamed constant from `BATCH_MONITOR_PROGRESS_REFRESH_TIME` to `BATCH_PROGRESS_REFRESH_TIME` for consistency
- Added `progress.refresh()` and sleep after upload completion in batch processing

**Issues Found:**
- The progress bar refresh fix in `container.py` has a logical issue: the refresh and sleep are placed outside the loop (lines 842-843), executing only once after all uploads complete, which won't resolve incomplete progress displays during uploads. They should be inside the loop.

<h3>Confidence Score: 3/5</h3>


- This PR is safe to merge with one logical issue that needs correction
- Score reflects correct fix for duplicate convergence checks but a logical error in the progress bar refresh placement that prevents it from achieving its stated goal
- Pay close attention to tidy3d/web/api/container.py lines 842-843 - the refresh logic is placed outside the loop

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/web/api/tidy3d_stub.py | 5/5 | Removed duplicate convergence check when lazy=False to prevent duplicate log messages |
| tidy3d/web/api/container.py | 4/5 | Renamed constant and added progress bar refresh after upload completion, potential issue with refresh placement |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Tidy3dStubData
    participant BaseModel
    participant LazyProxy
    participant ConvergenceCheck

    Note over Client,ConvergenceCheck: Postprocess with lazy=False (OLD BEHAVIOR)
    Client->>Tidy3dStubData: postprocess(file_path, lazy=False)
    Tidy3dStubData->>BaseModel: from_file(lazy=False, on_load=_check_convergence)
    BaseModel->>BaseModel: dict_from_file()
    BaseModel->>BaseModel: parse_obj()
    BaseModel->>ConvergenceCheck: on_load(_check_convergence) ✓ First call
    BaseModel-->>Tidy3dStubData: stub_data
    Note over Tidy3dStubData,ConvergenceCheck: OLD: Duplicate call here
    Tidy3dStubData->>ConvergenceCheck: _check_convergence(stub_data) ✗ REMOVED
    Tidy3dStubData-->>Client: stub_data

    Note over Client,ConvergenceCheck: Postprocess with lazy=True
    Client->>Tidy3dStubData: postprocess(file_path, lazy=True)
    Tidy3dStubData->>BaseModel: from_file(lazy=True, on_load=_check_convergence)
    BaseModel->>LazyProxy: create LazyProxy with on_load callback
    BaseModel-->>Tidy3dStubData: proxy
    Tidy3dStubData-->>Client: proxy (not yet loaded)
    Note over Client,LazyProxy: Later access triggers loading
    Client->>LazyProxy: access attribute
    LazyProxy->>LazyProxy: materialize data
    LazyProxy->>ConvergenceCheck: on_load(_check_convergence) ✓ Called on access
    LazyProxy-->>Client: data
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->