### PR TITLE
FXC-2053 Convenience functions for lumped port model setup

### DIFF
--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -298,6 +298,20 @@ def test_box_from_bounds():
     assert b.center == (0, 0, 0)
 
 
+def test_box_padded_copy():
+    """Test that padding layers are added along box boundaries."""
+    box = td.Box(size=(3, 2, 4))
+    padded_box = box.padded_copy(x=(4, 10), y=(1, 2))
+    assert np.allclose(np.array(padded_box.size), np.array([17, 5, 4]))
+    assert np.allclose(np.array(padded_box.center), np.array([3, 0.5, 0]))
+
+    # ensure errors are raised if padding  format is invalid.
+    with pytest.raises(ValueError):
+        padded_box = box.padded_copy(x=(1, -2), z=(-2, 0))
+    with pytest.raises(ValueError):
+        padded_box = box.padded_copy(x=(1))
+
+
 def test_polyslab_center_axis():
     """Test the handling of center_axis in a polyslab having (-td.inf, td.inf) bounds."""
     ps = POLYSLAB.copy(update={"slab_bounds": (-td.inf, td.inf)})

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -3861,3 +3861,49 @@ def test_validate_microwave_mode_spec():
         sim = sim.updated_copy(
             monitors=[mode_mon],
         )
+
+
+def test_padded_copy():
+    """Test that padding layers are added along simulation boundaries."""
+    grid_spec = td.GridSpec.auto(wavelength=1.0)
+
+    sim = td.Simulation(
+        size=(5, 5, 5),
+        grid_spec=grid_spec,
+        structures=[
+            td.Structure(geometry=td.Box(size=(10, 13, 7)), medium=td.Medium(permittivity=2.0))
+        ],
+        lumped_elements=[],
+        run_time=1e-12,
+    )
+
+    padded_sim = sim.padded_copy(x=(4, 10), y=(1, 2))
+    assert np.allclose(np.array(padded_sim.size), np.array([19, 8, 5]))
+    assert np.allclose(np.array(padded_sim.center), np.array([3, 0.5, 0]))
+
+    with pytest.raises(ValueError):
+        padded_sim = sim.padded_copy(x=(1, -2), z=(-2, 0))
+    with pytest.raises(ValueError):
+        padded_sim = sim.padded_copy(x=(1))
+
+
+def test_uniformly_padded_copy():
+    """Test that padding layers are uniformly added along simulation boundaries."""
+    grid_spec = td.GridSpec.auto(wavelength=1.0)
+
+    sim = td.Simulation(
+        size=(5, 5, 5),
+        grid_spec=grid_spec,
+        structures=[
+            td.Structure(geometry=td.Box(size=(3, 2, 4)), medium=td.Medium(permittivity=2.0))
+        ],
+        lumped_elements=[],
+        run_time=1e-12,
+    )
+
+    padded_sim = sim.uniformly_padded_copy(padding=5)
+    assert np.allclose(np.array(padded_sim.size), np.array([15, 15, 15]))
+    assert np.allclose(np.array(padded_sim.center), np.array([0, 0, 0]))
+
+    with pytest.raises(ValueError):
+        padded_sim = sim.uniformly_padded_copy(padding=-1)

--- a/tests/test_plugins/smatrix/terminal_component_modeler_def.py
+++ b/tests/test_plugins/smatrix/terminal_component_modeler_def.py
@@ -700,3 +700,48 @@ def make_patch_antenna_modeler(padding: tuple[float, float, float] = (0.25, 0.25
     )
 
     return modeler
+
+
+def make_basic_filter_terminals():
+    # Frequency
+    (f_min, f_max) = (0.1e9, 8e9)
+
+    # Materials
+    med_Cu = td.LossyMetalMedium(conductivity=60, frequency_range=(f_min, f_max))
+
+    # Geometry and Structure
+    mm = 1000  # Conversion mm to micron
+    H = 0.8 * mm  # Substrate thickness
+    T = 0.035 * mm  # Metal thickness
+    WL = 0.5 * mm
+    WC = 4 * mm
+    LC = 5.3 * mm
+    LL1 = 5.8 * mm
+    LL2 = 1.2 * mm
+    LL3 = 11.1 * mm
+    Lsub = LL1 + WL + LL3
+    Wsub = 2 * (LC + WL + LL2)
+
+    geom_C = td.Box.from_bounds(rmin=(-WC / 2, 0, 0), rmax=(WC / 2, LC, T))
+    geom_L2 = td.Box.from_bounds(rmin=(-WL / 2, -LL2 - WL, 0), rmax=(WL / 2, 0, T))
+    geom_L1 = td.Box.from_bounds(rmin=(-WL / 2 - LL1, -LL2 - WL, 0), rmax=(-WL / 2, -LL2, T))
+    geom_L3 = td.Box.from_bounds(rmin=(WL / 2, -LL2 - WL, 0), rmax=(WL / 2 + LL3, -LL2, T))
+
+    geom_resonator_basic = td.GeometryGroup(geometries=[geom_C, geom_L1, geom_L2, geom_L3])
+
+    x0, y0, z0 = geom_resonator_basic.bounding_box.center  # center (x,y) with circuit
+    geom_gnd = td.Box(center=(x0, y0, -H - T / 2), size=(Lsub, Wsub, T))
+
+    str_gnd = td.Structure(geometry=geom_gnd, medium=med_Cu)
+    str_resonator_basic = td.Structure(geometry=geom_resonator_basic, medium=med_Cu)
+
+    # add second signal trace to test lateral_coord
+    geom_sign = td.Box.from_bounds(
+        rmin=(-WL / 2 - LL1, -2 * LL2 - WL, 0), rmax=(WL / 2 + LL3, -2 * LL2, T)
+    )
+    geom_resonator_modified = td.GeometryGroup(
+        geometries=[geom_C, geom_L1, geom_L2, geom_L3, geom_sign]
+    )
+    str_resonator_modified = td.Structure(geometry=geom_resonator_modified, medium=med_Cu)
+
+    return (str_gnd, str_resonator_basic, str_resonator_modified)

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -14,7 +14,7 @@ import tidy3d.plugins.smatrix.utils
 from tidy3d import SimulationDataMap
 from tidy3d.components.boundary import BroadbandModeABCSpec
 from tidy3d.components.data.data_array import FreqDataArray
-from tidy3d.exceptions import SetupError, Tidy3dError, Tidy3dKeyError
+from tidy3d.exceptions import SetupError, Tidy3dError, Tidy3dKeyError, ValidationError
 from tidy3d.plugins.smatrix import (
     CoaxialLumpedPort,
     LumpedPort,
@@ -31,6 +31,7 @@ from tidy3d.plugins.smatrix.utils import s_to_z, validate_square_matrix
 
 from ...utils import run_emulated
 from .terminal_component_modeler_def import (
+    make_basic_filter_terminals,
     make_coaxial_component_modeler,
     make_component_modeler,
     make_differential_stripline_modeler,
@@ -557,6 +558,90 @@ def test_coarse_grid_at_port(monkeypatch, tmp_path):
 def test_validate_port_voltage_axis():
     with pytest.raises(pd.ValidationError):
         LumpedPort(center=(0, 0, 0), size=(0, 1, 2), voltage_axis=0, impedance=50)
+
+
+def test_lumped_port_from_structures():
+    """Test automatic lumped port setup between two terminal structures."""
+
+    # set up terminals of a basic filter
+    (str_gnd, str_resonator_basic, str_resonator_modified) = make_basic_filter_terminals()
+
+    # Geometry and Structure
+    mm = 1000  # Conversion mm to micron
+    WL = 0.5 * mm
+    LL1 = 5.8 * mm
+    LL2 = 1.2 * mm
+
+    # define basic parameters for automatic lumped port setup (except for signal terminal)
+    lp_options = {
+        "ground_terminal": str_gnd,
+        "lateral_coord": -1450,
+        "voltage_axis": 2,
+        "impedance": 50,
+    }
+
+    # ensure that value error is triggered if signal and ground terminals are not specified
+    with pytest.raises(ValueError):
+        LP0 = LumpedPort.from_structures(x=-WL / 2 - LL1, name="LP1", **lp_options)
+
+    # make sure the Lumped port is set correctly
+    lp_options["signal_terminal"] = str_resonator_basic
+    LP1 = LumpedPort.from_structures(x=-WL / 2 - LL1, name="LP1", **lp_options)
+    assert LP1.voltage_axis == lp_options["voltage_axis"]
+    assert np.isclose(LP1.impedance, lp_options["impedance"])
+
+    # make sure that `port_width` does not cause port geometry exceed overlap of terminals
+    lp_options["port_width"] = 1000
+    with pytest.raises(ValueError):
+        LP2 = LumpedPort.from_structures(x=-WL / 2 - LL1, name="LP1", **lp_options)
+
+    lp_options["port_width"] = WL / 3
+    LP2 = LumpedPort.from_structures(x=-WL / 2 - LL1, name="LP2", **lp_options)
+    assert np.isclose(LP2.size[1], WL / 3)
+
+    # specify lateral coordinate to select appropriate signal terminal to resolve ambiguity
+    lp_options["signal_terminal"] = str_resonator_modified
+    lp_options["lateral_coord"] = -2 * LL2 - WL / 2
+    lp_options["port_width"] = None
+    LP3 = LumpedPort.from_structures(x=-WL / 2 - LL1, name="LP3", **lp_options)
+    assert np.isclose(LP3.center[1], -2 * LL2 - WL / 2)
+
+    # test that an error is raised when port plane does not intersect any signal terminals
+    with pytest.raises(ValueError):
+        LP3 = LumpedPort.from_structures(y=8 * mm, name="LP3", **lp_options)
+
+    # ensure that error is raised
+    with pytest.raises(ValueError):
+        lp_options["voltage_axis"] = 0
+        LP3 = LumpedPort.from_structures(x=-WL / 2 - LL1, name="LP3", **lp_options)
+
+    # test port width with lateral coords
+    lp_options["port_width"] = WL / 3
+    lp_options["voltage_axis"] = 2
+    LP4 = LumpedPort.from_structures(x=-WL / 2 - LL1, name="LP4", **lp_options)
+    assert np.isclose(LP4.size[1], lp_options["port_width"])
+
+    # test port width with lateral coords
+    lp_options["lateral_coord"] = None
+    with pytest.raises(ValidationError):
+        LP5 = LumpedPort.from_structures(x=-WL / 2 - LL1, name="LP5", **lp_options)
+
+    lp_options["lateral_coord"] = 10 * WL
+    with pytest.raises(ValidationError):
+        LP6 = LumpedPort.from_structures(x=-WL / 2 - LL1, name="LP6", **lp_options)
+
+    # ensure that validation error is raised when specified port width exceeds terminal overlap in lateral direction.
+    lp_options["port_width"] = 4 * WL
+    lp_options["lateral_coord"] = -2 * LL2 - WL / 2
+    with pytest.raises(ValueError):
+        LP6 = LumpedPort.from_structures(x=-WL / 2 - LL1, name="LP6", **lp_options)
+
+    # ensure that validation error is raised when terminal medium is not PEC or lossy metal
+    str_gnd_new = str_gnd.updated_copy(medium=td.Medium(conductivity=1e2))
+    lp_options["lateral_coord"] = -2 * LL2 - WL / 2
+    lp_options["ground_terminal"] = str_gnd_new
+    with pytest.raises(ValidationError):
+        LP7 = LumpedPort.from_structures(x=-WL / 2 - LL1, name="LP7", **lp_options)
 
 
 @pytest.mark.parametrize("snap_center", [None, 0.1])

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -2170,6 +2170,53 @@ class Box(SimplePlaneIntersection, Centered):
         shapely_box = Geometry.evaluate_inf_shape(shapely_box)
         return [Geometry.evaluate_inf_shape(shape) & shapely_box for shape in shapes_plane]
 
+    def padded_copy(
+        self,
+        x: Optional[tuple[pydantic.NonNegativeFloat, pydantic.NonNegativeFloat]] = None,
+        y: Optional[tuple[pydantic.NonNegativeFloat, pydantic.NonNegativeFloat]] = None,
+        z: Optional[tuple[pydantic.NonNegativeFloat, pydantic.NonNegativeFloat]] = None,
+    ) -> Box:
+        """Created a padded copy of a :class:`Box` instance.
+
+        Parameters
+        ----------
+        x : Optional[tuple[pydantic.NonNegativeFloat, pydantic.NonNegativeFloat]] = None
+            Padding sizes at the left and right boundaries of the box along x-axis.
+        y : Optional[tuple[pydantic.NonNegativeFloat, pydantic.NonNegativeFloat]] = None
+            Padding sizes at the left and right boundaries of the box along y-axis.
+        z : Optional[tuple[pydantic.NonNegativeFloat, pydantic.NonNegativeFloat]] = None
+            Padding sizes at the left and right boundaries of the box along z-axis.
+
+        Returns
+        -------
+        Box
+            Padded instance of :class:`Box`.
+        """
+
+        # Validate that padding values are non-negative
+        for axis_name, axis_padding in zip(("x", "y", "z"), (x, y, z)):
+            if axis_padding is not None:
+                if not isinstance(axis_padding, (tuple, list)) or len(axis_padding) != 2:
+                    raise ValueError(f"Padding for {axis_name}-axis must be a tuple of two values.")
+                if any(p < 0 for p in axis_padding):
+                    raise ValueError(
+                        f"Padding values for {axis_name}-axis must be non-negative. Got {axis_padding}."
+                    )
+
+        rmin, rmax = self.bounds
+
+        def bound_array(arrs, idx):
+            return np.array([(a[idx] if a is not None else 0) for a in arrs])
+
+        # parse padding sizes for simulation
+        drmin = bound_array((x, y, z), 0)
+        drmax = bound_array((x, y, z), 1)
+
+        rmin = np.array(rmin) - drmin
+        rmax = np.array(rmax) + drmax
+
+        return Box.from_bounds(rmin=rmin, rmax=rmax)
+
     @cached_property
     def bounds(self) -> Bound:
         """Returns bounding box min and max coordinates.

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -5816,3 +5816,50 @@ class Simulation(AbstractYeeGridSimulation):
         )
 
     _boundaries_for_zero_dims = validate_boundaries_for_zero_dims()
+
+    def padded_copy(
+        self,
+        x: Optional[tuple[pydantic.NonNegativeFloat, pydantic.NonNegativeFloat]] = None,
+        y: Optional[tuple[pydantic.NonNegativeFloat, pydantic.NonNegativeFloat]] = None,
+        z: Optional[tuple[pydantic.NonNegativeFloat, pydantic.NonNegativeFloat]] = None,
+    ) -> Simulation:
+        """Created a copy of simulation with padded simulation domain.
+
+        Parameters
+        ----------
+        x : Optional[tuple[pydantic.NonNegativeFloat, pydantic.NonNegativeFloat]] = None
+            Padding sizes at the left and right boundaries of the simulation along x-axis.
+        y : Optional[tuple[pydantic.NonNegativeFloat, pydantic.NonNegativeFloat]] = None
+            Padding sizes at the left and right boundaries of the simulation along y-axis.
+        z : Optional[tuple[pydantic.NonNegativeFloat, pydantic.NonNegativeFloat]] = None
+            Padding sizes at the left and right boundaries of the simulation along z-axis.
+
+        Returns
+        -------
+        Simulation
+            Simulation with padded simulation domain.
+        """
+        # get simulation bounding box and pad it
+        box = Box(center=self.center, size=self.size)
+        padded_box = box.padded_copy(x, y, z)
+
+        return self.updated_copy(size=padded_box.size, center=padded_box.center)
+
+    def uniformly_padded_copy(self, padding: pydantic.NonNegativeFloat) -> Simulation:
+        """Create copy of simulation with uniformly padded simulation domain.
+
+        Parameters
+        ----------
+        padding : pydantic.NonNegativeFloat
+            Padding size applied uniformly at all simulation boundaries.
+
+        Returns
+        -------
+        Simulation
+            Simulation with uniformly padded simulation domain.
+        """
+        if padding < 0:
+            raise ValueError(f"Padding must be non-negative. Got {padding}.")
+
+        padding_tuple = (padding, padding)
+        return self.padded_copy(x=padding_tuple, y=padding_tuple, z=padding_tuple)

--- a/tidy3d/plugins/smatrix/ports/rectangular_lumped.py
+++ b/tidy3d/plugins/smatrix/ports/rectangular_lumped.py
@@ -6,11 +6,13 @@ from typing import Optional
 
 import numpy as np
 import pydantic.v1 as pd
+from shapely import union_all
+from shapely.geometry.base import BaseMultipartGeometry
 
 from tidy3d.components.base import cached_property
 from tidy3d.components.data.data_array import FreqDataArray
 from tidy3d.components.data.sim_data import SimulationData
-from tidy3d.components.geometry.base import Box
+from tidy3d.components.geometry.base import Box, Geometry
 from tidy3d.components.geometry.utils import (
     SnapBehavior,
     SnapLocation,
@@ -20,11 +22,13 @@ from tidy3d.components.geometry.utils import (
 from tidy3d.components.geometry.utils_2d import increment_float
 from tidy3d.components.grid.grid import Grid, YeeGrid
 from tidy3d.components.lumped_element import LinearLumpedElement, LumpedResistor, RLCNetwork
+from tidy3d.components.medium import LossyMetalMedium, PECMedium
 from tidy3d.components.microwave.path_integrals.integrals.current import AxisAlignedCurrentIntegral
 from tidy3d.components.microwave.path_integrals.integrals.voltage import AxisAlignedVoltageIntegral
 from tidy3d.components.monitor import FieldMonitor
 from tidy3d.components.source.current import UniformCurrentSource
 from tidy3d.components.source.time import GaussianPulse
+from tidy3d.components.structure import Structure
 from tidy3d.components.types import Axis, FreqArray, LumpDistType
 from tidy3d.components.validators import assert_line_or_plane
 from tidy3d.exceptions import SetupError, ValidationError
@@ -296,3 +300,236 @@ class LumpedPort(AbstractLumpedPort, Box):
         snap_spec = SnappingSpec(location=snap_location, behavior=snap_behavior)
         current_box = snap_box_to_grid(grid, current_box, snap_spec)
         return current_box
+
+    @classmethod
+    def from_structures(
+        cls,
+        x: Optional[float] = None,
+        y: Optional[float] = None,
+        z: Optional[float] = None,
+        ground_terminal: Structure | None = None,
+        signal_terminal: Structure | None = None,
+        voltage_axis: Axis = None,
+        lateral_coord: Optional[float] = None,
+        port_width: Optional[float] = None,
+        **kwargs,
+    ) -> LumpedPort:
+        """
+        Auto-generate lumped port based on provided structures and plane coordinates.
+
+        Parameters
+        ----------
+        x : float = None
+            Position of plane in x direction, only one of x,y,z can be specified to define plane.
+        y : float = None
+            Position of plane in x direction, only one of x,y,z can be specified to define plane.
+        z : float = None
+            Position of plane in x direction, only one of x,y,z can be specified to define plane.
+        ground_terminal : Structure = None
+            Structure representing ground terminal.
+        signal_terminal : Structure = None
+            Structure representing signal terminal.
+        voltage_axis : Axis = None
+            Direction of lumped port voltage.
+        lateral_coord : Optional[float] = None
+            Coordinate along lateral axis.
+        port_width: float = None
+            Lateral Width of lumped port.
+        **kwargs:
+            Other LumpedPort parameters.
+
+        Returns
+        -------
+        LumpedPorts
+            Lumped Port defined between ground and signal terminals.
+
+        Notes
+        -----
+        - The lateral axis refers to the axis perpendicular to the voltage_axis within the port plane
+        - lateral_coord has two purposes:
+            (a) if ground/signal has multiple 2D shapes intersecting the port plane, the shape chosen to create the port is the one that intersects lateral_coord.
+            (b) if port_width is also specified, lateral_coord is used as the center position of the port along that axis.
+        - If port_width is not specified, port width is automatically chosen based on 2D bounds of the in-plane ground/signal shapes.
+        """
+
+        # Parse normal axis and coordinate
+        normal_axis, normal_coord = Geometry.parse_xyz_kwargs(x=x, y=y, z=z)
+
+        # make sure voltage axis was specified
+        if voltage_axis is None:
+            raise ValueError(
+                "No voltage axis was provided. Please make sure a valid voltage axis is specified."
+            )
+
+        # make sure normal is orthogonal to voltage axis
+        if normal_axis == voltage_axis:
+            xyz_string = "xyz"
+            raise ValueError(
+                "Voltage axis must lie in the plane of the Lumped Port. \n"
+                f"The provided voltage axis for the Lumped port is: {xyz_string[voltage_axis]}. \n"
+                f"The inferred axis normal to the Lumped Port is: {xyz_string[normal_axis]}"
+            )
+
+        # get lateral axis (defined as axis within  Lumped Port's plane orthogonal to voltage axis)
+        lateral_axis = 3 - normal_axis - voltage_axis
+
+        if ground_terminal is None or signal_terminal is None:
+            raise ValueError(
+                "Signal and ground terminals are required. Please check that both are specified."
+            )
+
+        # form a list of allowed terminal materials
+        ALLOWED_TERMINAL_MEDIA = (LossyMetalMedium, PECMedium)
+
+        # make sure that terminals are made of PEC or lossy metal
+        for name, terminal in (("ground", ground_terminal), ("signal", signal_terminal)):
+            if not isinstance(terminal.medium, ALLOWED_TERMINAL_MEDIA):
+                raise ValidationError(
+                    f"Invalid {name} terminal medium: expected either 'PEC' or 'LossyMetalMedium'. "
+                    f"Got: '{terminal.medium}'."
+                )
+
+        # 2D ground and signal shapes and axes
+        grounds_2d = ground_terminal.geometry.intersections_plane(x=x, y=y, z=z)
+        signals_2d = signal_terminal.geometry.intersections_plane(x=x, y=y, z=z)
+
+        _, coords_2d = Geometry.pop_axis((0, 1, 2), normal_axis)
+        lateral_axis_2d = coords_2d.index(lateral_axis)
+        voltage_axis_2d = 1 - lateral_axis_2d
+
+        # Check: structures intersects plane
+        if len(grounds_2d) == 0:
+            raise ValueError("Ground structure does not intersect Lumped Port plane.")
+        if len(signals_2d) == 0:
+            raise ValueError("Signal structure does not intersect Lumped Port plane.")
+
+        # Get 2 element list with index 0 = ground shape and index 1 = signal shape
+        shape_list = []
+
+        # loop over polygons / contours of terminals cut by a Lumped Port plane
+        for name, shapes in [("Ground", grounds_2d), ("Signal", signals_2d)]:
+            sel_shape = None
+
+            # If lateral_coord is specified, pick ground/signal shape based on intersection
+            if lateral_coord is not None:
+                # constract a line along voltage axis in the lumped port plane going throung the lateral coordinate
+                if voltage_axis_2d == 0:
+                    line = Geometry.make_shapely_box(-np.inf, lateral_coord, np.inf, lateral_coord)
+                else:
+                    line = Geometry.make_shapely_box(lateral_coord, -np.inf, lateral_coord, np.inf)
+
+                # collect all geometries in shapes that intersect the line
+                intersected_shapes = [s for s in shapes if s.intersects(line)]
+
+                if not intersected_shapes:
+                    raise ValidationError(
+                        f"{name} terminal was not detected at the specified lateral coordinate {lateral_coord}. "
+                        f"Please, make sure provided coordinate corresponds to a valid terminal location."
+                    )
+                # merge all loops of the terminal to one geometry
+                sel_shape = union_all(intersected_shapes)
+            else:
+                # combine all shapely geometries and check if result is a polygon
+                sel_shape = union_all(shapes)
+
+            # Check Lumped Port plane intersects a terminal
+            if sel_shape.is_empty:
+                raise ValidationError(
+                    f"{name} terminal is not intersecting the lumped port plane or lateral coordinate."
+                    "Please make sure the lumped port plane and/or terminals are specified correctly."
+                )
+            if isinstance(sel_shape, BaseMultipartGeometry):
+                coord_msg = (
+                    f"at lateral coordinate {lateral_coord}" if lateral_coord is not None else ""
+                )
+                coord_hint = (
+                    "Please define the port manually."
+                    if lateral_coord is not None
+                    else "Please specify a lateral coordinate to select the correct conductor."
+                )
+                raise ValidationError(
+                    f"Automatic lumped port setup failed: more than one {name.lower()} terminal conductor "
+                    f"intersects the lumped port plane {coord_msg}. {coord_hint}"
+                )
+            shape_list.append(sel_shape)
+
+        # Get 2d shapes
+        ground_2d, signal_2d = shape_list
+
+        # ensure that signal and ground terminals do not intersect
+        if ground_2d.intersects(signal_2d):
+            raise ValidationError(
+                "Ground intersects signal in the specified plane."
+                "Please make sure that ground and signal terminals do not overlap."
+            )
+
+        # get terminals' bounds
+        ground_bounds = np.array(ground_2d.bounds).reshape(2, 2).T
+        signal_bounds = np.array(signal_2d.bounds).reshape(2, 2).T
+
+        def intervals_overlap(a, b):
+            """Return True if [a_min, a_max] and [b_min, b_max] overlap."""
+            a_min, a_max = a
+            b_min, b_max = b
+            return not (a_max < b_min or a_min > b_max)
+
+        # ensure that terminal bounding boxes don't overlap along voltage axis
+        if intervals_overlap(ground_bounds[voltage_axis_2d], signal_bounds[voltage_axis_2d]):
+            raise ValidationError(
+                "Auto-generation of lumped port failed because ground and signal terminals have overlapping bounds along voltage axis. "
+                "Please define lumped port manually."
+            )
+        # ensure that terminal bounding boxes overlap in lateral direction
+        if not intervals_overlap(ground_bounds[lateral_axis_2d], signal_bounds[lateral_axis_2d]):
+            raise ValidationError(
+                "Auto-generation of lumped port failed because ground and signal terminals "
+                "don't have overlapping bounds along lateral axis. "
+                "Please define lumped port manually."
+            )
+
+        # reshape and combine bounds of the signal and ground cuts; rows correspond to axes
+        bounds = np.hstack((ground_bounds, signal_bounds))
+
+        # for each axis extract port bounds
+        new_bounds = np.sort(bounds, axis=1)[:, 1:3]
+        vmin, vmax = new_bounds[voltage_axis_2d, :]
+        lmin, lmax = new_bounds[lateral_axis_2d, :]
+
+        if port_width is not None:
+            if lateral_coord is not None:
+                # If port_width and lateral_coord are specified, set based on those instead
+                lmin_new, lmax_new = (
+                    lateral_coord - port_width / 2,
+                    lateral_coord + port_width / 2,
+                )
+            else:
+                # If only port_width is specified, set based on bounds
+                lcenter = (lmin + lmax) / 2
+                lmin_new, lmax_new = (lcenter - port_width / 2, lcenter + port_width / 2)
+                # make sure that port_width does not exceed width of terminal overlap along lateral axis.
+
+            if lmin_new < lmin or lmax_new > lmax:
+                raise ValueError(
+                    "Specified port region extends beyond the overlap between the signal and ground terminals. "
+                    "Please apply appropriate 'port_width' and 'lateral_coord', or set them to 'None' to allow for automatic assignment."
+                )
+            # update port limits along lateral axis
+            lmin, lmax = lmin_new, lmax_new
+
+        # WARNING: This currently does not check if edges of lumped port touches ground/signal.
+        #          This can happen if ground/signal does not overlap along lateral_axis
+        #          It is up to the user to provide sensible geometry choices for ground/signal to avoid this
+
+        # allocate memory for lumped port bounds
+        rmin = np.zeros(3)
+        rmax = np.zeros(3)
+
+        # construct lumped port bounds
+        rmin[voltage_axis], rmax[voltage_axis] = (vmin, vmax)
+        rmin[lateral_axis], rmax[lateral_axis] = (lmin, lmax)
+        rmin[normal_axis], rmax[normal_axis] = (normal_coord, normal_coord)
+
+        kwargs["voltage_axis"] = voltage_axis
+        lumped_port = LumpedPort.from_bounds(rmin=tuple(rmin), rmax=tuple(rmax), **kwargs)
+
+        return lumped_port


### PR DESCRIPTION
This PR introduces the first two automation utilities described in the corresponding Jira ticket aimed at simplifying model setup for lumped port simulations.

**Added functions**:

`LumpedPort.from_structures()` – Creates a lumped port by specifying a port plane (e.g. x = -L) together with the signal and ground structures. This helps automate port definition and reduce repetitive setup steps.

`Simulation.padded_copy()` – Adds padding layers automatically along simulation boundaries. Follows a similar specification style to BoundarySpec, supporting both uniform and side-specific padding.

`Simulation.uniformly_padded_copy()` - Applies padding uniformly along all simulation boundaries.

**Motivation**:
These utilities streamline the setup process for common notebook workflows involving lumped ports and improve consistency across examples.