### PR TITLE
docs(extras, FXC-3847): decorative emoji change

### DIFF
--- a/docs/extras/index.rst
+++ b/docs/extras/index.rst
@@ -1,5 +1,5 @@
-Extras Plugin |:gift:|
-======================
+Extras Plugin |:sparkles:|
+==========================
 .. currentmodule:: tidy3d-extras
 
 ``tidy3d-extras`` is an optional plugin for Tidy3D providing additional, more advanced local functionality. This additional functionality includes a more accurate local mode solver with subpixel averaging.


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-27 11:51:46 UTC

<h3>Greptile Summary</h3>


Updated the decorative emoji in the Extras Plugin documentation title from |:gift:| to |:sparkles:|.

- Simple cosmetic change to the RST documentation header
- No functional impact on code or documentation content
- No changelog entry included (per custom rule **b72c7231-b258-4d03-aed2-51a50a9fe757**, a changelog entry is required for PRs that are not purely internal refactors)

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The change is purely cosmetic, modifying only a decorative emoji in documentation. There are no code changes, logic modifications, or functional impacts. The RST syntax is correct.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| docs/extras/index.rst | 5/5 | Changed decorative emoji from gift to sparkles in page title |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Doc as docs/extras/index.rst
    participant Reader as Documentation Reader
    
    Dev->>Doc: Update emoji |:gift:| → |:sparkles:|
    Doc->>Doc: RST header underline adjusted
    Reader->>Doc: View documentation
    Doc->>Reader: Display "Extras Plugin ✨"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->