### PR TITLE
FXC-3796-small updates to diffraction monitor data

### DIFF
--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -13,7 +13,6 @@ import autograd.numpy as np
 import pydantic.v1 as pd
 import xarray as xr
 from pandas import DataFrame
-from xarray.core.types import Self
 
 from tidy3d.components.base import cached_property, skip_if_fields_missing
 from tidy3d.components.base_sim.data.monitor_data import AbstractMonitorData
@@ -102,6 +101,8 @@ SHIFT_VALUE_ADJ_FLD_SRC = 1e-5
 AXIAL_RATIO_CAP = 100
 # At this sampling rate, the computed area of a sphere is within ~1% of the true value.
 MIN_ANGULAR_SAMPLES_SPHERE = 10
+# Threshold for cos(theta) to avoid unphysically large amplitudes near grazing angles
+COS_THETA_THRESH = 1e-5
 
 
 class MonitorData(AbstractMonitorData, ABC):
@@ -2776,8 +2777,10 @@ class AbstractFieldProjectionData(MonitorData):
         if not np.all(index_k == 0):
             raise SetupError("Can't compute RCS for a lossy background medium.")
 
-        k = self.k[None, None, None, ...]
-        eta = self.eta[None, None, None, ...]
+        n_leading = max(0, len(self.dims) - 1)
+        expand_idx = (None,) * n_leading + (Ellipsis,)
+        k = self.k[expand_idx]
+        eta = self.eta[expand_idx]
 
         if self.is_2d_simulation:
             constant = k**2 / (16 * np.pi * eta)
@@ -3307,6 +3310,17 @@ class DiffractionData(AbstractFieldProjectionData):
         to x, P(S) corresponds to ``Ex``(``Ez``) polarization for monitor normal to y, and P(S)
         corresponds to ``Ex``(``Ey``) polarization for monitor normal to z.
 
+    Note
+    ----
+
+        The power amplitudes per polarization and diffraction order, and correspondingly the power
+        per diffraction order, correspond to the power carried by each diffraction order in the
+        monitor normal direction. They are not to be confused with power carried by plane waves
+        in the propagation direction of each diffraction order, which can be obtained from the
+        spherical-coordinate fields which are also stored. The power definition is such that the
+        grating efficiency is the recorded power over the input source power, and the direct sum
+        over the power in all orders should equal the total power flowing through the monitor.
+
 
     Example
     -------
@@ -3473,10 +3487,10 @@ class DiffractionData(AbstractFieldProjectionData):
         """Complex power amplitude in each order for 's' and 'p' polarizations, normalized so that
         the power carried by the wave of that order and polarization equals ``abs(amps)^2``.
         """
+        # use a small threshold to avoid blow-up near grazing angles
         cos_theta = np.cos(np.nan_to_num(self.angles[0]))
-
-        # will set amplitudes to 0 for glancing or negative angles
-        cos_theta[cos_theta <= 0] = np.inf
+        # set amplitudes to 0 for angles with cos(theta) <= COS_THETA_THRESH (glancing or negative)
+        cos_theta[cos_theta <= COS_THETA_THRESH] = np.inf
 
         norm = 1.0 / np.sqrt(2.0 * self.eta) / np.sqrt(cos_theta)
         amp_theta = self.Etheta.values * norm
@@ -3491,9 +3505,14 @@ class DiffractionData(AbstractFieldProjectionData):
         return DataArray(np.stack([amp_phi, amp_theta], axis=3), coords=coords)
 
     @property
-    def power(self) -> Self:
+    def power(self) -> DataArray:
         """Total power in each order, summed over both polarizations."""
         return (np.abs(self.amps) ** 2).sum(dim="polarization")
+
+    @property
+    def radar_cross_section(self) -> DataArray:
+        """Radar cross section in units of incident power."""
+        raise ValueError("RCS is not a well-defined quantity for diffraction data.")
 
     @property
     def fields_spherical(self) -> xr.Dataset:

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -1535,6 +1535,25 @@ class DiffractionMonitor(PlanarMonitor, FreqMonitor):
     """:class:`Monitor` that uses a 2D Fourier transform to compute the
     diffraction amplitudes and efficiency for allowed diffraction orders.
 
+    Note
+    ----
+
+        The diffraction data are separated into S and P polarizations. At normal incidence when
+        S and P are undefined, P(S) corresponds to ``Ey``(``Ez``) polarization for monitor normal
+        to x, P(S) corresponds to ``Ex``(``Ez``) polarization for monitor normal to y, and P(S)
+        corresponds to ``Ex``(``Ey``) polarization for monitor normal to z.
+
+    Note
+    ----
+
+        The power amplitudes per polarization and diffraction order, and correspondingly the power
+        per diffraction order, correspond to the power carried by each diffraction order in the
+        monitor normal direction. They are not to be confused with power carried by plane waves
+        in the propagation direction of each diffraction order, which can be obtained from the
+        spherical-coordinate fields which are also stored. The power definition is such that the
+        grating efficiency is the recorded power over the input source power, and the direct sum
+        over the power in all orders should equal the total power flowing through the monitor.
+
     Example
     -------
     >>> monitor = DiffractionMonitor(


### PR DESCRIPTION
While investigating [FXC-3796](https://flow360.atlassian.net/browse/FXC-3796) stumbled upon a few things that can be improved:

- The power amplitudes very close to grazing angles can become unphysically large because of the 1/cos(theta) normalization. Setting it to zero instead when cos(theta) < 1e-5 as it cannot be accurately computed anyway.
- Spent some time thinking about this normalization but it seems to me that it is the correct one. Added an explanation to the monitor data docstring and also in the monitor itself in case people do not see it in the data.
- Noticed that `radar_cross_section` was not working for DiffractionData so I made it work, but then I also realized that it doesn't make much sense for a grating, so instead I raise a ValueError. I kept the fix which avoids assuming a fixed number of dimensions as it's more robust anyway.

[FXC-3796]: https://flow360.atlassian.net/browse/FXC-3796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-27 13:27:05 UTC

<h3>Greptile Summary</h3>


This PR makes several improvements to diffraction monitor data handling:

- Fixed dynamic indexing in `radar_cross_section` calculation to handle variable dimensions instead of hardcoded 3D indexing
- Improved numerical stability by using a small threshold (`COS_THETA_TRESH = 1e-5`) instead of zero when filtering grazing angles
- Added explicit `radar_cross_section` override in `DiffractionData` that raises `ValueError`, since RCS is not well-defined for diffraction data
- Removed unused `Self` import from xarray and updated type hints to use `DataArray` directly
- Enhanced documentation with detailed notes explaining S/P polarization conventions at normal incidence and clarifying power definitions for diffraction orders

**Issues Found:**
- Typo in constant name: `COS_THETA_TRESH` should be `COS_THETA_THRESH` (missing second 'H')

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with a minor spelling fix
- The changes are well-thought-out improvements that fix real bugs (dynamic dimension handling for RCS, better grazing angle handling) and add helpful documentation. The only issue is a spelling typo in a constant name that needs correction to maintain code quality.
- tidy3d/components/data/monitor_data.py requires a spelling fix for the constant name

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/data/monitor_data.py | 3/5 | Fixed radar cross section indexing for variable dimensions, improved threshold handling for grazing angles, added RCS override for DiffractionData, and enhanced documentation. Contains typo in new constant name. |
| tidy3d/components/monitor.py | 5/5 | Added documentation notes explaining polarization convention at normal incidence and clarifying power definition for diffraction orders. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant DiffractionMonitor
    participant DiffractionData
    participant AbstractFieldProjectionData
    
    User->>DiffractionMonitor: Configure monitor with freqs
    Note over DiffractionMonitor: Documentation updated with<br/>polarization conventions
    
    User->>DiffractionData: Access diffraction results
    DiffractionData->>DiffractionData: compute angles()
    Note over DiffractionData: Returns theta, phi angles
    
    DiffractionData->>DiffractionData: amps property
    Note over DiffractionData: Apply COS_THETA_TRESH<br/>to filter grazing angles
    DiffractionData->>DiffractionData: Normalize with cos(theta)
    Note over DiffractionData: Set to inf if cos(theta) <= 1e-5
    
    DiffractionData->>DiffractionData: power property
    Note over DiffractionData: Sum |amps|^2 over polarizations
    
    User->>DiffractionData: radar_cross_section property
    DiffractionData-->>User: ValueError (not well-defined)
    
    User->>AbstractFieldProjectionData: radar_cross_section property
    AbstractFieldProjectionData->>AbstractFieldProjectionData: Calculate n_leading from dims
    Note over AbstractFieldProjectionData: Dynamic indexing fix:<br/>expand_idx based on len(dims)-1
    AbstractFieldProjectionData->>AbstractFieldProjectionData: Apply dynamic expansion to k, eta
    AbstractFieldProjectionData-->>User: RCS DataArray
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->