### PR TITLE
add nexus s3 config

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -25,6 +25,7 @@ API |:computer:|
     logging
     utilities
     submit_simulations
+    nexus_config
     mesh/index
     heat/index
     charge/index
@@ -55,6 +56,7 @@ API |:computer:|
 .. include:: /api/scene.rst
 .. include:: /api/logging.rst
 .. include:: /api/submit_simulations.rst
+.. include:: /api/nexus_config.rst
 .. include:: /api/mesh/index.rst
 .. include:: /api/heat/index.rst
 .. include:: /api/charge/index.rst

--- a/docs/api/nexus_config.rst
+++ b/docs/api/nexus_config.rst
@@ -1,0 +1,151 @@
+.. currentmodule:: tidy3d
+
+Nexus Environment Configuration
+================================
+
+Overview
+--------
+
+The Nexus environment enables Tidy3D to connect to custom on-premises or private cloud deployments for enterprise customers.
+
+.. note::
+   This feature is for enterprise customers with custom Tidy3D deployments. Most users should use the standard API key setup with the default production environment.
+
+Quick Start
+-----------
+
+**Simple setup** using the convenience option:
+
+.. code-block:: bash
+
+   tidy3d configure --apikey YOUR_KEY \
+     --nexus-url http://your-server
+
+This automatically sets:
+
+- API endpoint: ``http://your-server:5000``
+- Website endpoint: ``http://your-server/tidy3d``
+- S3 endpoint: ``http://your-server:9000``
+
+**Advanced setup** with individual endpoints:
+
+.. code-block:: bash
+
+   tidy3d configure --apikey YOUR_KEY \
+     --api-endpoint http://your-server:5000 \
+     --website-endpoint http://your-server/tidy3d
+
+Or configure only Nexus endpoints (preserves existing API key):
+
+.. code-block:: bash
+
+   tidy3d configure --nexus-url http://your-server
+
+Configuration
+-------------
+
+Command Syntax
+~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   tidy3d configure [--apikey <key>] [--nexus-url <url> | --api-endpoint <url> --website-endpoint <url>] [OPTIONS]
+
+**Options:**
+
+* ``--apikey <key>``: API key (prompts if not provided and no Nexus options given)
+* ``--nexus-url <url>``: Nexus base URL (convenience option that automatically sets all endpoints)
+* ``--api-endpoint <url>``: Nexus API server URL (overridden by ``--nexus-url``)
+* ``--website-endpoint <url>``: Nexus web interface URL (overridden by ``--nexus-url``)
+* ``--s3-region <region>``: S3 region (default: us-east-1)
+* ``--s3-endpoint <url>``: S3 storage URL (overridden by ``--nexus-url``)
+* ``--ssl-verify`` / ``--no-ssl-verify``: SSL verification (default: disabled)
+* ``--enable-caching`` / ``--no-caching``: Result caching (default: disabled)
+
+Examples
+~~~~~~~~
+
+.. code-block:: bash
+
+   # Simple configuration using nexus-url (recommended)
+   tidy3d configure --apikey XXX \
+     --nexus-url http://ec2-instance.compute.amazonaws.com
+
+   # Configure individual endpoints
+   tidy3d configure --apikey XXX \
+     --api-endpoint http://api.company.com:5000 \
+     --website-endpoint http://tidy3d.company.com
+
+   # Add Nexus to existing configuration
+   tidy3d configure --nexus-url http://api.company.com
+
+   # With all options
+   tidy3d configure --apikey XXX \
+     --api-endpoint https://api.company.com \
+     --website-endpoint https://tidy3d.company.com \
+     --s3-region eu-west-1 \
+     --s3-endpoint http://s3.company.com:9000 \
+     --ssl-verify \
+     --enable-caching
+
+Configuration File
+~~~~~~~~~~~~~~~~~~
+
+Settings are stored in ``~/.tidy3d/config`` (Windows: ``C:\Users\username\.tidy3d\config``):
+
+.. code-block:: toml
+
+   apikey = "your-api-key"
+   web_api_endpoint = "http://your-server:5000"
+   website_endpoint = "http://your-server/tidy3d"
+   s3_region = "us-east-1"
+   s3_endpoint = "http://127.0.0.1:9000"
+   ssl_verify = false
+   enable_caching = false
+
+Python Usage
+------------
+
+No code changes required. Tidy3D automatically uses the configured endpoints:
+
+.. code-block:: python
+
+   import tidy3d as td
+   import tidy3d.web as web
+   
+   sim = td.Simulation(...)
+   sim_data = web.run(sim, task_name="my_sim")
+
+
+Removing Configuration
+----------------------
+
+Delete the entire file and reconfigure:
+
+.. code-block:: bash
+
+   rm ~/.tidy3d/config
+   tidy3d configure --apikey=YOUR_API_KEY
+
+Troubleshooting
+---------------
+
+**Verify configuration:**
+
+.. code-block:: python
+
+   from tidy3d.web.core.environment import Env
+   print(Env.current.name, Env.current.web_api_endpoint)
+
+**Test connectivity:**
+
+.. code-block:: bash
+
+   curl http://your-api-endpoint:5000/health
+   export TIDY3D_ENV=prod && python -c "import tidy3d.web as web; web.test()"
+
+See Also
+--------
+
+* :doc:`submit_simulations` - Submitting and managing simulations
+* :doc:`../install` - Installation and API key setup

--- a/tests/test_web/test_cli.py
+++ b/tests/test_web/test_cli.py
@@ -1,17 +1,295 @@
+"""Tests for CLI commands including nexus configuration."""
+
 from __future__ import annotations
 
+import os
+from unittest.mock import patch
 
-def test_tidy3d_cli():
-    pass
-    # if os.path.exists(CONFIG_FILE):
-    #     shutil.move(CONFIG_FILE, f"{CONFIG_FILE}.bak")
-    #
-    # runner = CliRunner()
-    # result = runner.invoke(tidy3d_cli, ["configure"], input="apikey")
-    #
-    # # assert result.exit_code == 0
-    # if os.path.exists(CONFIG_FILE):
-    #     os.remove(CONFIG_FILE)
-    #
-    # if os.path.exists(f"{CONFIG_FILE}.bak"):
-    #     shutil.move(f"{CONFIG_FILE}.bak", CONFIG_FILE)
+import pytest
+import toml
+from click.testing import CliRunner
+
+from tidy3d.web.cli import tidy3d_cli
+from tidy3d.web.cli.app import configure_fn
+from tidy3d.web.core.environment import Environment
+
+
+@pytest.fixture
+def runner():
+    """Fixture for invoking command-line interfaces."""
+    return CliRunner()
+
+
+@pytest.fixture
+def temp_config_dir(tmp_path, monkeypatch):
+    """Create a temporary config directory."""
+    config_dir = tmp_path / ".tidy3d"
+    config_dir.mkdir()
+    config_file = config_dir / "config"
+
+    # Patch the CONFIG_FILE and TIDY3D_DIR at module level
+    monkeypatch.setattr("tidy3d.web.cli.app.CONFIG_FILE", str(config_file))
+    monkeypatch.setattr("tidy3d.web.cli.app.TIDY3D_DIR", str(config_dir))
+
+    return tmp_path, config_file
+
+
+# CLI Command Tests
+
+
+def test_nexus_command_minimal(runner, temp_config_dir):
+    """Test configure with nexus endpoints."""
+    tmp_path, config_file = temp_config_dir
+
+    result = runner.invoke(
+        tidy3d_cli,
+        [
+            "configure",
+            "--api-endpoint",
+            "http://test-api:5000",
+            "--website-endpoint",
+            "http://test-website/tidy3d",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Nexus environment configured successfully" in result.output
+
+    config = toml.loads(config_file.read_text())
+    assert config["web_api_endpoint"] == "http://test-api:5000"
+    assert config["website_endpoint"] == "http://test-website/tidy3d"
+
+
+def test_nexus_command_full_options(runner, temp_config_dir):
+    """Test configure with all nexus options."""
+    tmp_path, config_file = temp_config_dir
+
+    result = runner.invoke(
+        tidy3d_cli,
+        [
+            "configure",
+            "--api-endpoint",
+            "http://api:5000",
+            "--website-endpoint",
+            "http://web/tidy3d",
+            "--s3-region",
+            "eu-west-1",
+            "--s3-endpoint",
+            "http://s3:9000",
+            "--ssl-verify",
+            "--enable-caching",
+        ],
+    )
+
+    assert result.exit_code == 0
+
+    config = toml.loads(config_file.read_text())
+    assert config["s3_region"] == "eu-west-1"
+    assert config["s3_endpoint"] == "http://s3:9000"
+    assert config["ssl_verify"] is True
+    assert config["enable_caching"] is True
+
+
+def test_nexus_command_preserves_apikey(runner, temp_config_dir):
+    """Test that configure with nexus options preserves existing API key."""
+    tmp_path, config_file = temp_config_dir
+    config_file.write_text('apikey = "existing-key-123"\n')
+
+    result = runner.invoke(
+        tidy3d_cli,
+        [
+            "configure",
+            "--api-endpoint",
+            "http://api:5000",
+            "--website-endpoint",
+            "http://web/tidy3d",
+        ],
+    )
+
+    assert result.exit_code == 0
+
+    config = toml.loads(config_file.read_text())
+    assert config["apikey"] == "existing-key-123"
+    assert config["web_api_endpoint"] == "http://api:5000"
+
+
+def test_nexus_command_help(runner):
+    """Test configure command help shows nexus options."""
+    result = runner.invoke(tidy3d_cli, ["configure", "--help"])
+
+    assert result.exit_code == 0
+    assert "--api-endpoint" in result.output
+    assert "--website-endpoint" in result.output
+    assert "--s3-region" in result.output
+
+
+# configure_nexus_fn Tests
+
+
+def test_configure_nexus_creates_config(temp_config_dir):
+    """Test that configure_fn creates config file with nexus settings."""
+    tmp_path, config_file = temp_config_dir
+
+    configure_fn(
+        apikey=None,
+        api_endpoint="http://test:5000",
+        website_endpoint="http://test/web",
+        s3_region="us-west-2",
+        s3_endpoint="http://s3:9000",
+        ssl_verify=True,
+        enable_caching=False,
+    )
+
+    assert config_file.exists()
+    config = toml.loads(config_file.read_text())
+    assert config["web_api_endpoint"] == "http://test:5000"
+    assert config["s3_region"] == "us-west-2"
+
+
+def test_configure_nexus_updates_existing(temp_config_dir):
+    """Test that configure_fn updates existing config."""
+    tmp_path, config_file = temp_config_dir
+    config_file.write_text('apikey = "key123"\nold_field = "old"\n')
+
+    configure_fn(
+        apikey=None,
+        api_endpoint="http://new:5000",
+        website_endpoint="http://new/web",
+        s3_region="us-east-1",
+        s3_endpoint="http://127.0.0.1:9000",
+        ssl_verify=False,
+        enable_caching=False,
+    )
+
+    config = toml.loads(config_file.read_text())
+    assert config["apikey"] == "key123"
+    assert config["web_api_endpoint"] == "http://new:5000"
+
+
+# Environment Loading Tests
+
+
+def test_load_custom_env_from_config(temp_config_dir):
+    """Test _load_custom_env_from_config method."""
+    tmp_path, config_file = temp_config_dir
+
+    config_content = """
+web_api_endpoint = "http://customer:5000"
+website_endpoint = "http://customer/tidy3d"
+s3_region = "eu-west-1"
+s3_endpoint = "http://customer-s3:9000"
+ssl_verify = true
+enable_caching = true
+"""
+    config_file.write_text(config_content)
+
+    with patch.dict(os.environ, {"TIDY3D_BASE_DIR": str(tmp_path)}):
+        env = Environment()
+        custom_env = env._load_custom_env_from_config()
+
+    assert custom_env is not None
+    assert custom_env.name == "nexus_custom"
+    assert custom_env.web_api_endpoint == "http://customer:5000"
+    assert custom_env.s3_region == "eu-west-1"
+    assert custom_env.env_vars["AWS_ENDPOINT_URL_S3"] == "http://customer-s3:9000"
+
+
+def test_load_custom_env_no_config(temp_config_dir):
+    """Test _load_custom_env_from_config returns None when no config."""
+    tmp_path, config_file = temp_config_dir
+
+    if config_file.exists():
+        config_file.unlink()
+
+    with patch.dict(os.environ, {"TIDY3D_BASE_DIR": str(tmp_path)}):
+        env = Environment()
+        custom_env = env._load_custom_env_from_config()
+
+    assert custom_env is None
+
+
+def test_load_custom_env_missing_endpoints(temp_config_dir):
+    """Test _load_custom_env_from_config returns None if endpoints missing."""
+    tmp_path, config_file = temp_config_dir
+    config_file.write_text('web_api_endpoint = "http://test:5000"\n')
+
+    with patch.dict(os.environ, {"TIDY3D_BASE_DIR": str(tmp_path)}):
+        env = Environment()
+        custom_env = env._load_custom_env_from_config()
+
+    assert custom_env is None
+
+
+def test_environment_uses_custom_config(temp_config_dir):
+    """Test Environment initialization uses custom config."""
+    tmp_path, config_file = temp_config_dir
+
+    config_content = """
+web_api_endpoint = "http://custom:5000"
+website_endpoint = "http://custom/web"
+"""
+    config_file.write_text(config_content)
+
+    with patch.dict(os.environ, {"TIDY3D_BASE_DIR": str(tmp_path)}, clear=False):
+        if "TIDY3D_ENV" in os.environ:
+            del os.environ["TIDY3D_ENV"]
+        env = Environment()
+
+    assert env.current.name == "nexus_custom"
+    assert env.current.web_api_endpoint == "http://custom:5000"
+
+
+def test_tidy3d_env_overrides_custom_config(temp_config_dir):
+    """Test that TIDY3D_ENV environment variable overrides custom config."""
+    tmp_path, config_file = temp_config_dir
+
+    config_content = """
+web_api_endpoint = "http://custom:5000"
+website_endpoint = "http://custom/web"
+"""
+    config_file.write_text(config_content)
+
+    with patch.dict(os.environ, {"TIDY3D_BASE_DIR": str(tmp_path), "TIDY3D_ENV": "prod"}):
+        env = Environment()
+
+    # Should use prod, not custom config
+    assert env.current.name == "prod"
+    assert "https://tidy3d-api.simulation.cloud" in env.current.web_api_endpoint
+
+
+def test_environment_defaults_to_prod(temp_config_dir):
+    """Test Environment defaults to prod when no config or env var."""
+    tmp_path, config_file = temp_config_dir
+
+    if config_file.exists():
+        config_file.unlink()
+
+    with patch.dict(os.environ, {"TIDY3D_BASE_DIR": str(tmp_path)}, clear=False):
+        if "TIDY3D_ENV" in os.environ:
+            del os.environ["TIDY3D_ENV"]
+        env = Environment()
+
+    assert env.current.name == "prod"
+
+
+# Backward Compatibility Tests
+
+
+def test_configure_command_unchanged(runner):
+    """Test that configure command help works."""
+    result = runner.invoke(tidy3d_cli, ["configure", "--help"])
+
+    assert result.exit_code == 0
+    assert "--apikey" in result.output
+
+
+def test_existing_config_without_nexus_fields(temp_config_dir):
+    """Test that existing config files without nexus fields work normally."""
+    tmp_path, config_file = temp_config_dir
+    config_file.write_text('apikey = "test-key"\n')
+
+    with patch.dict(os.environ, {"TIDY3D_BASE_DIR": str(tmp_path)}):
+        env = Environment()
+
+    # Should default to prod since no custom endpoints
+    assert env.current.name == "prod"

--- a/tidy3d/web/cli/app.py
+++ b/tidy3d/web/cli/app.py
@@ -48,70 +48,191 @@ def tidy3d_cli():
 
 @click.command()
 @click.option("--apikey", prompt=False)
-def configure(apikey):
-    """Click command to configure the api key.
+@click.option("--nexus-url", help="Nexus base URL (automatically sets api/website/s3 endpoints)")
+@click.option("--api-endpoint", help="Nexus API endpoint URL (e.g., http://server:5000)")
+@click.option("--website-endpoint", help="Nexus website endpoint URL (e.g., http://server/tidy3d)")
+@click.option("--s3-region", help="S3 region (default: us-east-1)")
+@click.option("--s3-endpoint", help="S3 endpoint URL (default: http://127.0.0.1:9000)")
+@click.option("--ssl-verify/--no-ssl-verify", default=None, help="Enable/disable SSL verification")
+@click.option("--enable-caching/--no-caching", default=None, help="Enable/disable caching")
+def configure(
+    apikey,
+    nexus_url,
+    api_endpoint,
+    website_endpoint,
+    s3_region,
+    s3_endpoint,
+    ssl_verify,
+    enable_caching,
+):
+    """Configure API key and optionally Nexus environment settings.
 
     Parameters
     ----------
     apikey : str
-        User input api key.
+        User API key
+    nexus_url : str
+        Nexus base URL (automatically derives api/website/s3 endpoints)
+    api_endpoint : str
+        Nexus API endpoint URL
+    website_endpoint : str
+        Nexus website endpoint URL
+    s3_region : str
+        AWS S3 region
+    s3_endpoint : str
+        S3 endpoint URL
+    ssl_verify : bool
+        Whether to verify SSL certificates
+    enable_caching : bool
+        Whether to enable result caching
     """
-    configure_fn(apikey)
+    configure_fn(
+        apikey,
+        nexus_url,
+        api_endpoint,
+        website_endpoint,
+        s3_region,
+        s3_endpoint,
+        ssl_verify,
+        enable_caching,
+    )
 
 
-def configure_fn(apikey: str) -> None:
-    """Python function that tries to set configuration based on a provided API key.
+def configure_fn(
+    apikey: str | None,
+    nexus_url: str | None = None,
+    api_endpoint: str | None = None,
+    website_endpoint: str | None = None,
+    s3_region: str | None = None,
+    s3_endpoint: str | None = None,
+    ssl_verify: bool | None = None,
+    enable_caching: bool | None = None,
+) -> None:
+    """Configure API key and optionally Nexus environment settings.
 
     Parameters
     ----------
     apikey : str
-        User input api key.
+        User API key
+    nexus_url : str
+        Nexus base URL (automatically derives api/website/s3 endpoints)
+    api_endpoint : str
+        Nexus API endpoint URL
+    website_endpoint : str
+        Nexus website endpoint URL
+    s3_region : str
+        AWS S3 region
+    s3_endpoint : str
+        S3 endpoint URL
+    ssl_verify : bool
+        Whether to verify SSL certificates
+    enable_caching : bool
+        Whether to enable result caching
     """
+    # If nexus_url is provided, derive endpoints from it automatically on default config
+    if nexus_url:
+        api_endpoint = f"{nexus_url}/tidy3d-api"
+        website_endpoint = f"{nexus_url}/tidy3d"
+        s3_endpoint = f"{nexus_url}:9000"
 
-    def auth(req):
-        """Enrich auth information to request.
-        Parameters
-        ----------
-        req : requests.Request
-            the request needs to add headers for auth.
-        Returns
-        -------
-        requests.Request
-            Enriched request.
-        """
-        req.headers[HEADER_APIKEY] = apikey
-        return req
+    # Check if any Nexus options are provided
+    has_nexus_config = any(
+        [api_endpoint, website_endpoint, s3_region, s3_endpoint, ssl_verify, enable_caching]
+    )
 
-    if os.path.exists(CREDENTIAL_FILE):
-        with open(CREDENTIAL_FILE, encoding="utf-8") as fp:
-            auth_json = json.load(fp)
-        email = auth_json["email"]
-        password = auth_json["password"]
-        if email and password:
-            if migrate():
-                click.echo("Migrate successfully. auth.json is renamed to auth.json.bak.")
-                return
-
-    if not apikey:
-        current_apikey = get_description()
-        message = f"Current API key: [{current_apikey}]\n" if current_apikey else ""
-        apikey = click.prompt(f"{message}Please enter your api key", type=str)
-
-    try:
-        resp = requests.get(
-            f"{Env.current.web_api_endpoint}/apikey", auth=auth, verify=Env.current.ssl_verify
-        )
-    except (requests.exceptions.SSLError, ssl.SSLError):
-        resp = requests.get(f"{Env.current.web_api_endpoint}/apikey", auth=auth, verify=False)
-
-    if resp.status_code == 200:
-        click.echo("Configured successfully.")
-        with open(CONFIG_FILE, "w+", encoding="utf-8") as config_file:
-            toml_config = toml.loads(config_file.read())
-            toml_config.update({KEY_APIKEY: apikey})
-            config_file.write(toml.dumps(toml_config))
+    # Read or create config
+    if os.path.exists(CONFIG_FILE):
+        with open(CONFIG_FILE, encoding="utf-8") as f:
+            toml_config = toml.loads(f.read())
     else:
-        click.echo("API key is invalid.")
+        toml_config = {}
+
+    previous_apikey = toml_config.get("apikey")
+    if apikey:
+        apikey = apikey
+        toml_config["apikey"] = apikey
+    elif previous_apikey:
+        apikey = previous_apikey
+        click.echo(f"Using API key set in config file: {apikey}")
+
+    # Handle Nexus configuration
+    if has_nexus_config:
+        # Validate that both endpoints are provided if any endpoint is specified
+        if (api_endpoint or website_endpoint) and not (api_endpoint and website_endpoint):
+            click.echo(
+                "Error: Both --api-endpoint and --website-endpoint must be provided together."
+            )
+            return
+
+        if api_endpoint and website_endpoint:
+            toml_config.update(
+                {
+                    "web_api_endpoint": api_endpoint,
+                    "website_endpoint": website_endpoint,
+                }
+            )
+
+        if s3_region is not None:
+            toml_config["s3_region"] = s3_region
+        if s3_endpoint is not None:
+            toml_config["s3_endpoint"] = s3_endpoint
+        if ssl_verify is not None:
+            toml_config["ssl_verify"] = ssl_verify
+        if enable_caching is not None:
+            toml_config["enable_caching"] = enable_caching
+
+        click.echo(
+            f"Using Nexus environment configuration...\nCustom API endpoint at: {api_endpoint}"
+        )
+
+    # Handle API key configuration
+    if apikey:
+
+        def auth(req):
+            """Enrich auth information to request."""
+            req.headers[HEADER_APIKEY] = apikey
+            return req
+
+        if os.path.exists(CREDENTIAL_FILE):
+            with open(CREDENTIAL_FILE, encoding="utf-8") as fp:
+                auth_json = json.load(fp)
+            email = auth_json["email"]
+            password = auth_json["password"]
+            if email and password:
+                if migrate():
+                    click.echo("Migrate successfully. auth.json is renamed to auth.json.bak.")
+                    return
+
+        if not apikey:
+            current_apikey = get_description()
+            message = f"Current API key: [{current_apikey}]\n" if current_apikey else ""
+            apikey = click.prompt(f"{message}Please enter your api key", type=str)
+
+        # Determine which endpoint to validate against
+        validation_endpoint = api_endpoint if api_endpoint else Env.current.web_api_endpoint
+        validation_ssl_verify = ssl_verify if ssl_verify is not None else Env.current.ssl_verify
+
+        try:
+            resp = requests.get(
+                f"{validation_endpoint}/apikey",
+                auth=auth,
+                verify=validation_ssl_verify,
+            )
+        except (requests.exceptions.SSLError, ssl.SSLError):
+            resp = requests.get(f"{validation_endpoint}/apikey", auth=auth, verify=False)
+
+        if resp.status_code == 200:
+            toml_config.update({KEY_APIKEY: apikey})
+            click.echo("API key configured successfully.")
+        else:
+            click.echo(
+                f"ERROR: API key '{apikey}' is invalid. Checked against endpoint: {validation_endpoint}"
+            )
+            return
+
+    # Write config file
+    with open(CONFIG_FILE, "w", encoding="utf-8") as config_file:
+        config_file.write(toml.dumps(toml_config))
 
 
 @click.command()

--- a/tidy3d/web/core/environment.py
+++ b/tidy3d/web/core/environment.py
@@ -6,6 +6,7 @@ import os
 import ssl
 from typing import Optional
 
+import toml
 from pydantic.v1 import BaseSettings, Field
 
 from .core_config import get_logger
@@ -104,24 +105,99 @@ class Environment:
         "nexus": nexus,
     }
 
+    def _load_custom_env_from_config(self) -> Optional[EnvironmentConfig]:
+        """Load custom environment config from ~/.tidy3d/config file.
+
+        Reads all nexus-related configuration from the config file and
+        creates a dynamic EnvironmentConfig if web_api_endpoint and
+        website_endpoint are present.
+
+        Returns
+        -------
+        Optional[EnvironmentConfig]
+            Custom environment config if endpoints are configured, None otherwise.
+        """
+        # Determine config file path (same logic as cli.constants)
+        from os.path import expanduser
+
+        tidy3d_base_dir = os.getenv("TIDY3D_BASE_DIR", expanduser("~"))
+        if os.access(tidy3d_base_dir, os.W_OK):
+            config_file = f"{tidy3d_base_dir}/.tidy3d/config"
+        else:
+            config_file = "/tmp/.tidy3d/config"
+
+        if not os.path.exists(config_file):
+            return None
+
+        try:
+            with open(config_file, encoding="utf-8") as f:
+                config = toml.loads(f.read())
+
+            web_api = config.get("web_api_endpoint")
+            website = config.get("website_endpoint")
+
+            # Only create custom env if BOTH required endpoints are present
+            if not (web_api and website):
+                return None
+
+            log = get_logger()
+            log.info(f"Using custom nexus environment from config: {web_api}")
+
+            # Get optional settings with defaults matching the hardcoded nexus
+            s3_region = config.get("s3_region", "us-east-1")
+            s3_endpoint = config.get("s3_endpoint", "http://127.0.0.1:9000")
+            ssl_verify = config.get("ssl_verify", False)
+            enable_caching = config.get("enable_caching", False)
+
+            # Create dynamic environment matching nexus structure
+            return EnvironmentConfig(
+                name="nexus_custom",
+                web_api_endpoint=web_api,
+                website_endpoint=website,
+                s3_region=s3_region,
+                ssl_verify=ssl_verify,
+                enable_caching=enable_caching,
+                env_vars={"AWS_ENDPOINT_URL_S3": s3_endpoint},
+            )
+
+        except Exception as e:
+            log = get_logger()
+            log.warning(f"Failed to load custom nexus config: {e}")
+            return None
+
     def __init__(self):
         log = get_logger()
         """Initialize the environment."""
         self._previous_env_vars = {}
+
+        # 1. Try to load custom environment from config file
+        custom_env = self._load_custom_env_from_config()
+
+        # 2. Check for explicit TIDY3D_ENV setting
         env_key = os.environ.get("TIDY3D_ENV")
         env_key = env_key.lower() if env_key else env_key
-        log.info(f"env_key is {env_key}")
-        if not env_key:
-            self._current = prod
-        elif env_key in self.env_map:
-            self._current = self.env_map[env_key]
+
+        # 3. Determine which environment to use (precedence order)
+        if env_key:
+            log.info(f"TIDY3D_ENV is {env_key}")
+            if env_key in self.env_map:
+                self._current = self.env_map[env_key]
+            else:
+                log.warning(
+                    f"The value '{env_key}' for the environment variable TIDY3D_ENV is not supported. "
+                    f"Using prod as default."
+                )
+                self._current = prod
+        elif custom_env:
+            # Config file has custom endpoints and assumes TIDY3D_ENV=nexus
+            log.info("Using custom nexus environment from config file")
+            os.environ["TIDY3D_ENV"] = "nexus"
+            self._current = custom_env
         else:
-            log.warning(
-                f"The value '{env_key}' for the environment variable TIDY3D_ENV is not supported. "
-                f"Using prod as default."
-            )
+            # Default to prod
             self._current = prod
 
+        # Set up environment variables if needed
         if self._current.env_vars:
             for key, value in self._current.env_vars.items():
                 self._previous_env_vars[key] = os.environ.get(key)

--- a/tidy3d/web/core/http_util.py
+++ b/tidy3d/web/core/http_util.py
@@ -184,9 +184,17 @@ class HttpSessionManager:
     def get(self, path: str, json=None, params=None):
         """Get the resource."""
         self.reinit()
-        return self.session.get(
+        get = self.session.get(
             url=Env.current.get_real_url(path), auth=api_key_auth, json=json, params=params
         )
+        # try:
+        #     print("pre")
+        #     print(get)
+        #     print(get.text)
+        #     print("after")
+        # except Exception as e:
+        #     raise e
+        return get
 
     @http_interceptor
     def post(self, path: str, json=None):

--- a/tidy3d/web/core/s3utils.py
+++ b/tidy3d/web/core/s3utils.py
@@ -62,14 +62,25 @@ class _S3STSToken(BaseModel):
     def get_client(self) -> boto3.client:
         """Get the boto client for this token."""
 
-        return boto3.client(
-            "s3",
-            region_name=Env.current.s3_region,
-            aws_access_key_id=self.user_credential.access_key_id,
-            aws_secret_access_key=self.user_credential.secret_access_key,
-            aws_session_token=self.user_credential.session_token,
-            verify=Env.current.ssl_verify,
-        )
+        if Env.nexus.name == "nexus":
+            return boto3.client(
+                "s3",
+                endpoint_url=Env.current.env_vars.get("AWS_ENDPOINT_URL_S3"),
+                region_name=Env.current.s3_region,
+                aws_access_key_id=self.user_credential.access_key_id,
+                aws_secret_access_key=self.user_credential.secret_access_key,
+                aws_session_token=self.user_credential.session_token,
+                verify=Env.current.ssl_verify,
+            )
+        else:
+            return boto3.client(
+                "s3",
+                region_name=Env.current.s3_region,
+                aws_access_key_id=self.user_credential.access_key_id,
+                aws_secret_access_key=self.user_credential.secret_access_key,
+                aws_session_token=self.user_credential.session_token,
+                verify=Env.current.ssl_verify,
+            )
 
     def is_expired(self) -> bool:
         """True if token is expired."""


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-28 04:01:59 UTC

<h3>Greptile Summary</h3>


Added conditional S3 endpoint configuration to support nexus environment with custom S3-compatible storage (e.g., MinIO). When the nexus environment is active, the boto3 S3 client now uses a custom endpoint URL from environment variables.

- Introduced environment-based branching in `get_client()` method to configure S3 endpoint
- Custom endpoint sourced from `Env.current.env_vars["AWS_ENDPOINT_URL_S3"]` for nexus
- Maintains backward compatibility for standard AWS environments (dev, uat, prod)

<h3>Confidence Score: 3/5</h3>


- Safe to merge with minor fix needed for custom nexus configurations
- The implementation correctly adds S3 endpoint configuration for nexus, but has a critical logic bug: it checks `Env.nexus.name` (the hardcoded nexus object) instead of `Env.current.name`, which means custom nexus environments loaded from config files (with name "nexus_custom") won't trigger the conditional branch
- tidy3d/web/core/s3utils.py requires attention for the environment check logic

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/web/core/s3utils.py | 3/5 | Added conditional S3 endpoint configuration for nexus environment, but logic checks wrong environment object and doesn't support custom nexus configs |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App
    participant GetClient
    participant BotoLib

    App->>GetClient: call get_client
    GetClient->>GetClient: check environment type
    GetClient->>BotoLib: create S3 client
    BotoLib-->>GetClient: return client
    GetClient-->>App: return client
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->