### PR TITLE
FXC-3904-Taking out DesignSpace._run_batch

### DIFF
--- a/tidy3d/plugins/design/design.py
+++ b/tidy3d/plugins/design/design.py
@@ -312,6 +312,12 @@ class DesignSpace(Tidy3dBaseModel):
 
         return handler
 
+    @staticmethod
+    def _run_batch(batch: Batch, path_dir: str) -> BatchData:
+        """Run a batch and return the BatchData."""
+        batch_out = batch.run(path_dir=path_dir)
+        return batch_out
+
     def _fn_mid(
         self, pre_out: dict[int, Any], sim_counter: int, console: Console
     ) -> Union[dict[int, Any], BatchData]:
@@ -387,16 +393,17 @@ class DesignSpace(Tidy3dBaseModel):
             console.log(f"Running {run_statement}")
 
         # Running simulations and batches
-        sims_out = Batch(
+        batch = Batch(
             simulations=named_sims,
             folder_name=self.folder_name,
             simulation_type="tidy3d_design",
             verbose=False,  # Using a custom output instead of Batch.monitor updates
-        ).run(path_dir=self.path_dir)
+        )
+        sims_out = self._run_batch(batch, path_dir=self.path_dir)
 
         batch_results = {}
         for batch_key, batch in batches.items():
-            batch_out = batch.run(path_dir=self.path_dir)
+            batch_out = self._run_batch(batch, path_dir=self.path_dir)
             batch_results[batch_key] = batch_out
 
         def _return_to_dict(return_dict: dict, key: str, return_obj: Any) -> None:


### PR DESCRIPTION
This supersedes #2909 and allows for the batch call to be easily monkeypatched on-prem.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-28 12:51:38 UTC

<h3>Greptile Summary</h3>


Refactors batch execution to enable on-prem deployment by extracting `Batch.run()` call into a static method `_run_batch`. This allows the execution logic to be easily monkeypatched in on-prem environments without modifying core logic.

**Key changes:**
- Added static method `DesignSpace._run_batch()` that wraps `batch.run(path_dir)`
- Updated two call sites in `_fn_mid()` to use `self._run_batch()` instead of calling `batch.run()` directly
- No changes to behavior in default cloud-based workflow
- Enables external packages to override batch execution by monkeypatching the static method

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk - it's a simple refactoring that extracts method calls for better extensibility
- Score reflects a clean, minimal refactoring with no logic changes. The new static method is a straightforward wrapper that maintains existing behavior while enabling extensibility. The only reason it's not a 5 is the lack of documentation explaining the monkeypatching use case, which could help future maintainers understand the design decision.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/design/design.py | 4/5 | Adds static method `_run_batch` to wrap `Batch.run()` call, enabling easy monkeypatching for on-prem deployment. Changes are minimal and maintain existing behavior. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant DesignSpace
    participant Method
    participant Pre_Post_Handler
    participant fn_pre
    participant _run_batch
    participant Batch
    participant fn_post

    User->>DesignSpace: run(fn_pre, fn_post)
    DesignSpace->>DesignSpace: get_logging_console()
    DesignSpace->>DesignSpace: _get_evaluate_fn_pre_post()
    DesignSpace->>Pre_Post_Handler: create handler instance
    DesignSpace->>Method: _run(run_fn=handler.fn_combined)
    
    loop For each parameter set
        Method->>Pre_Post_Handler: fn_combined(args_list)
        
        loop For each arg in args_list
            Pre_Post_Handler->>fn_pre: fn_pre(**arg_list)
            fn_pre-->>Pre_Post_Handler: Simulation/Batch/list/dict
        end
        
        Pre_Post_Handler->>DesignSpace: _fn_mid(sim_dict, sim_counter)
        DesignSpace->>DesignSpace: create Batch from named_sims
        
        Note over DesignSpace,_run_batch: NEW: Extracted to static method
        DesignSpace->>_run_batch: _run_batch(batch, path_dir)
        _run_batch->>Batch: batch.run(path_dir)
        Batch-->>_run_batch: BatchData
        _run_batch-->>DesignSpace: BatchData
        
        loop For each user batch
            DesignSpace->>_run_batch: _run_batch(batch, path_dir)
            _run_batch->>Batch: batch.run(path_dir)
            Batch-->>_run_batch: BatchData
            _run_batch-->>DesignSpace: BatchData
        end
        
        DesignSpace->>DesignSpace: process SimulationData and metadata
        DesignSpace-->>Pre_Post_Handler: data, task_names, task_paths
        
        loop For each data value
            Pre_Post_Handler->>fn_post: fn_post(val)
            fn_post-->>Pre_Post_Handler: post_out result
        end
        
        Pre_Post_Handler-->>Method: post_out results
    end
    
    Method-->>DesignSpace: fn_args, fn_values, aux_values, opt_output
    DesignSpace->>DesignSpace: _package_run_results()
    DesignSpace-->>User: Result
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->