### PR TITLE
feat(tidy3d): FXC-3573 add mypy to CI

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -171,7 +171,33 @@ jobs:
         run: ruff format --check --diff
       - name: Run ruff check
         run: ruff check tidy3d
-  
+
+  mypy:
+    name: static-type-checks (mypy)
+    needs: determine-test-scope
+    if: needs.determine-test-scope.outputs.code_quality_tests == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: false
+          persist-credentials: false
+
+      - name: set-python-3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install mypy
+        run: |
+          python -m pip install --upgrade pip
+          pip install "mypy==1.13.0"
+
+      - name: Run mypy
+        run: |
+          mypy --config-file=pyproject.toml
+
   zizmor:
     name: Run zizmor 🌈
     runs-on: ubuntu-latest
@@ -637,6 +663,7 @@ jobs:
       - local-tests
       - remote-tests
       - lint
+      - mypy
       - verify-schema-change
       - lint-commit-messages
       - lint-branch-name
@@ -655,6 +682,12 @@ jobs:
         if: ${{ needs.lint.result != 'success' }}
         run: |
           echo "❌ Linting failed."
+          exit 1
+
+      - name: check-mypy-result
+        if: ${{ needs.determine-test-scope.outputs.code_quality_tests == 'true' && needs.mypy.result != 'success' }}
+        run: |
+          echo "❌ Mypy type checking failed."
           exit 1
           
       - name: check-schema-change-verification

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,6 @@ repos:
     hooks:
       - id: mypy
         name: mypy (type signatures)
-        files: ^tidy3d/web
+        pass_filenames: false
         args:
           - --config-file=pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -317,6 +317,9 @@ python_files = "*.py"
 
 [tool.mypy]
 python_version = "3.10"
+files = [
+  "tidy3d/web",
+]
 ignore_missing_imports = true
 follow_imports = "skip"
 disallow_untyped_defs = true


### PR DESCRIPTION
Add mypy checks to our CI pipeline.
Is done immediately after linting and uses the config from pyproject.toml.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-29 15:37:34 UTC

<h3>Greptile Summary</h3>


Adds mypy static type checking to the CI pipeline to enforce type safety in the `tidy3d/web` directory. The implementation is clean and well-integrated.

**Key Changes:**
- New `mypy` job in CI workflow that runs after the determine-test-scope job (only when `code_quality_tests == true`)
- Installs mypy version 1.13.0 and executes type checks using configuration from `pyproject.toml`
- Pre-commit hook updated from file-based filtering (`files: ^tidy3d/web`) to config-based filtering (`pass_filenames: false`)
- Added `files = ["tidy3d/web"]` configuration in `pyproject.toml` to specify the directory for type checking
- Mypy job properly integrated into `pr-requirements-pass` with a dedicated validation step that fails the pipeline if type checks fail

**Implementation Notes:**
- The mypy job uses Python 3.10, consistent with the project's mypy configuration
- The job correctly depends on `determine-test-scope` and only runs when code quality tests are enabled
- Both CI and pre-commit hook use the same configuration source (`pyproject.toml`), ensuring consistency

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - all changes are correctly implemented with proper CI integration
- Score of 5 reflects clean implementation: (1) mypy job is properly configured with hardcoded Python 3.10 version, (2) correctly integrated into pr-requirements-pass job dependencies with validation step, (3) pre-commit hook properly delegates file selection to config, (4) all three files work together cohesively
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/tidy3d-python-client-tests.yml | 5/5 | Adds mypy job to CI that installs mypy 1.13.0, runs type checks with config from pyproject.toml, properly integrated into pr-requirements-pass job with validation step |
| .pre-commit-config.yaml | 5/5 | Changes mypy hook from file-based filtering (`files: ^tidy3d/web`) to config-based filtering (`pass_filenames: false`), correctly delegating file selection to pyproject.toml |
| pyproject.toml | 5/5 | Adds `files = ["tidy3d/web"]` to mypy configuration to specify which directory to type check, properly configured to work with CI and pre-commit hook |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PR as Pull Request
    participant Scope as determine-test-scope
    participant Lint as lint job
    participant Mypy as mypy job
    participant Final as pr-requirements-pass

    PR->>Scope: Trigger workflow
    Scope->>Scope: Determine if code_quality_tests=true
    
    alt code_quality_tests == true
        Scope->>Lint: Run ruff linting
        Scope->>Mypy: Run mypy type checks
        
        Lint->>Lint: Check formatting and style
        Lint-->>Final: Report result
        
        Mypy->>Mypy: Checkout code
        Mypy->>Mypy: Setup Python 3.10
        Mypy->>Mypy: Install mypy==1.13.0
        Mypy->>Mypy: Run mypy --config-file=pyproject.toml
        Note over Mypy: Reads files from pyproject.toml<br/>(tidy3d/web directory)
        Mypy-->>Final: Report result
        
        Final->>Final: Check lint result
        Final->>Final: Check mypy result (if code_quality_tests)
        Final->>Final: Validate all required jobs
        Final-->>PR: Pass/Fail result
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->