### PR TITLE
chore: add codeowners (FXC-3880)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+.github/workflows/ @daquinteroflex
+tidy3d/components/autograd/ @yaugenst-flex @tylerflex @groberts-flex
+tidy3d/components/dispersion_fitter.py @caseyflex
+tidy3d/components/eme/ @caseyflex
+tidy3d/components/material/tcad/ @marc-flex
+tidy3d/components/microwave/ @dmarek-flex @weiliangjin2021
+tidy3d/components/nonlinear.py @caseyflex
+tidy3d/components/spice/ @marc-flex
+tidy3d/components/tcad/ @marc-flex
+tidy3d/config/ @yaugenst-flex
+tidy3d/plugins/autograd/ @yaugenst-flex
+tidy3d/plugins/expressions/ @yaugenst-flex
+tidy3d/plugins/klayout/ @bzhangflex
+tidy3d/plugins/microwave/ @dmarek-flex
+tidy3d/plugins/pytorch/ @yaugenst-flex
+tidy3d/web/cache.py @marcorudolphflex
+tidy3d/web/cli/cache.py @marcorudolphflex


### PR DESCRIPTION
Prompted by recent discussions I think it'd be good to establish this. Let's iterate on the list, I just put down the ones I think are quite clear (to me) currently.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-29 16:02:42 UTC

<h3>Greptile Summary</h3>


Adds a CODEOWNERS file to establish code ownership for key areas of the codebase. The file assigns ownership for configuration management, autograd components, dispersion fitting, EME simulation, and CI/CD workflows.

- `tidy3d/config/` → `@yaugenst-flex`
- `tidy3d/components/autograd/` → `@yaugenst-flex`, `@tylerflex`, `@groberts-flex`
- `tidy3d/components/dispersion_fitter.py` → `@caseyflex`
- `tidy3d/components/eme/` → `@caseyflex`
- `.github/workflows/` → `@daquinteroflex`

All paths referenced in the file exist, all GitHub usernames are valid contributors, and the ownership assignments align well with actual contribution history.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk - it only adds a configuration file
- The CODEOWNERS file is a simple GitHub configuration file that doesn't affect runtime code. All paths are valid, usernames exist, and ownership assignments are reasonable based on contribution history. No functional code changes.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/CODEOWNERS | 5/5 | Added CODEOWNERS file defining code ownership for config, autograd, dispersion fitter, EME, and workflows directories. All paths exist and owners align with contribution history. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub
    participant Owners as Code Owners
    
    Dev->>GH: Create PR affecting owned files
    GH->>GH: Parse .github/CODEOWNERS
    GH->>Owners: Request review from owners
    Note over GH,Owners: Auto-requests based on:<br/>config/ → yaugenst-flex<br/>autograd/ → yaugenst-flex, tylerflex, groberts-flex<br/>dispersion_fitter.py → caseyflex<br/>eme/ → caseyflex<br/>workflows/ → daquinteroflex
    Owners->>GH: Provide review
    GH->>Dev: Review feedback
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->