### PR TITLE
fix(tidy3d): FXC-3885-cache-directory-sharding

### DIFF
--- a/tests/test_web/test_local_cache.py
+++ b/tests/test_web/test_local_cache.py
@@ -13,7 +13,7 @@ from tidy3d.web import Job, common, run_async
 from tidy3d.web.api import webapi as web
 from tidy3d.web.api.container import WebContainer
 from tidy3d.web.api.webapi import load_simulation_if_cached
-from tidy3d.web.cache import CACHE_ARTIFACT_NAME, clear, resolve_local_cache
+from tidy3d.web.cache import CACHE_ARTIFACT_NAME, clear, get_cache_entry_dir, resolve_local_cache
 
 common.CONNECTION_RETRY_TIME = 0.1
 
@@ -281,7 +281,7 @@ def _test_checksum_mismatch_triggers_refresh(monkeypatch, tmp_path, basic_simula
 
     cache = resolve_local_cache(use_cache=True)
     metadata = cache.list()[0]
-    corrupted_path = cache.root / metadata["cache_key"] / CACHE_ARTIFACT_NAME
+    corrupted_path = get_cache_entry_dir(cache.root, metadata["cache_key"]) / CACHE_ARTIFACT_NAME
     corrupted_path.write_text("corrupted")
 
     cache._fetch(metadata["cache_key"])

--- a/tidy3d/web/cache.py
+++ b/tidy3d/web/cache.py
@@ -31,6 +31,14 @@ TMP_BATCH_PREFIX = "tmp_batch"
 _CACHE: Optional[LocalCache] = None
 
 
+def get_cache_entry_dir(root: os.PathLike, key: str) -> Path:
+    """
+    Returns the cache directory for a given key.
+    A three-character prefix subdirectory is used to avoid hitting filesystem limits on the number of entries per folder.
+    """
+    return Path(root) / key[:3] / key
+
+
 @dataclass
 class CacheEntry:
     """Internal representation of a cache entry."""
@@ -41,7 +49,7 @@ class CacheEntry:
 
     @property
     def path(self) -> Path:
-        return self.root / self.key
+        return get_cache_entry_dir(self.root, self.key)
 
     @property
     def artifact_path(self) -> Path:
@@ -168,28 +176,14 @@ class LocalCache:
             with self._lock:
                 self._root.mkdir(parents=True, exist_ok=True)
                 self._ensure_limits(file_size)
-                final_dir = self._root / key
-                backup_dir: Optional[Path] = None
-
-                try:
-                    if final_dir.exists():
-                        backup_dir = final_dir.with_name(
-                            f"{final_dir.name}.bak.{_timestamp_suffix()}"
-                        )
-                        os.replace(final_dir, backup_dir)
-                    # move tmp_dir into place
-                    os.replace(tmp_dir, final_dir)
-                except Exception:
-                    # restore backup if needed
-                    if backup_dir and backup_dir.exists():
-                        os.replace(backup_dir, final_dir)
-                    raise
-                else:
-                    entry = CacheEntry(key=key, root=self._root, metadata=metadata)
-                    if backup_dir and backup_dir.exists():
-                        shutil.rmtree(backup_dir, ignore_errors=True)
-                    log.debug("Stored simulation cache entry '%s' (%d bytes).", key, file_size)
-                    return entry
+                final_dir = get_cache_entry_dir(self._root, key)
+                final_dir.parent.mkdir(parents=True, exist_ok=True)
+                if final_dir.exists():
+                    shutil.rmtree(final_dir)
+                os.replace(tmp_dir, final_dir)
+                entry = CacheEntry(key=key, root=self._root, metadata=metadata)
+                log.debug("Stored simulation cache entry '%s' (%d bytes).", key, file_size)
+                return entry
         finally:
             try:
                 if tmp_dir.exists():
@@ -242,20 +236,33 @@ class LocalCache:
             log.info(f"Simulation cache evicted entry '{entry.key}' to reclaim {size} bytes.")
 
     def _iter_entries(self) -> Iterable[CacheEntry]:
+        """Iterate over all cache entries, including those in prefix subdirectories."""
         if not self._root.exists():
             return []
+
         entries: list[CacheEntry] = []
-        for child in self._root.iterdir():
-            if child.name.startswith(TMP_PREFIX) or child.name.startswith(TMP_BATCH_PREFIX):
+
+        for prefix_dir in self._root.iterdir():
+            if not prefix_dir.is_dir() or prefix_dir.name.startswith(
+                (TMP_PREFIX, TMP_BATCH_PREFIX)
+            ):
                 continue
-            meta_path = child / CACHE_METADATA_NAME
-            if not meta_path.exists():
-                continue
-            try:
-                metadata = json.loads(meta_path.read_text(encoding="utf-8"))
-            except Exception:
-                metadata = {}
-            entries.append(CacheEntry(key=child.name, root=self._root, metadata=metadata))
+
+            for child in prefix_dir.iterdir():
+                if not child.is_dir():
+                    continue
+
+                meta_path = child / CACHE_METADATA_NAME
+                if not meta_path.exists():
+                    continue
+
+                try:
+                    metadata = json.loads(meta_path.read_text(encoding="utf-8"))
+                except Exception:
+                    metadata = {}
+
+                entries.append(CacheEntry(key=child.name, root=self._root, metadata=metadata))
+
         return entries
 
     def _load_entry(self, key: str) -> Optional[CacheEntry]:


### PR DESCRIPTION
**Previous State**
The local cache drops every artifact into a single directory. This could crash with filesystem limits.

**Fix**
This PR shard directories with 3-character-prefix of key.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-30 12:50:53 UTC

<h3>Greptile Summary</h3>


Implements cache directory sharding by organizing cache entries into 3-character prefix subdirectories (e.g., `root/{key[:3]}/{key}/`) to avoid filesystem limits on entries per directory.

**Key changes:**
- Added `get_cache_entry_dir()` helper function to compute sharded paths
- Updated `CacheEntry.path` to use sharded structure
- Modified `_store()` to create prefix subdirectories and simplified logic by removing backup/restore mechanism
- Rewrote `_iter_entries()` to traverse the two-level directory hierarchy

**Critical issues found:**
- **Backward compatibility broken**: `_iter_entries()` only looks for new-style entries in prefix subdirs. Existing cache entries stored directly under root (before this PR) will be invisible, never evicted, and waste disk space (tidy3d/web/cache.py:243)
- **Incorrect directory creation logic**: Creating `final_dir` at line 180 before using `os.replace()` at line 181 will cause the replace to fail if an entry already exists. The old backup/restore logic was removed but the directory creation wasn't updated properly (tidy3d/web/cache.py:180)
- **Missing test coverage**: No tests verify the sharding logic works correctly or handle backward compatibility (tests/test_web/test_local_cache.py:367)

<h3>Confidence Score: 1/5</h3>


- This PR has critical backward compatibility issues that will break existing cache functionality
- The implementation breaks backward compatibility by making old cache entries inaccessible, and has a logic bug that causes unnecessary operations. The `_iter_entries()` method only searches for entries in the new sharded structure, leaving old entries orphaned and preventing proper cache eviction.
- Pay close attention to tidy3d/web/cache.py - the `_iter_entries()` and `_store()` methods need fixes for backward compatibility and correct directory creation logic

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/web/cache.py | 1/5 | Implements cache directory sharding with 3-char prefixes, but has critical backward compatibility issue - old cache entries won't be found, and directory creation logic has unnecessary operations |
| tests/test_web/test_local_cache.py | 2/5 | Updated test to use `get_cache_entry_dir` helper, but missing tests for sharding logic and backward compatibility with old cache structure |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant LocalCache
    participant FileSystem
    
    Note over Client,FileSystem: Storing a cache entry (new sharded structure)
    Client->>LocalCache: _store(key, source_path, metadata)
    LocalCache->>LocalCache: get_cache_entry_dir(root, key)
    Note right of LocalCache: Returns root/key[:3]/key
    LocalCache->>FileSystem: mkdir(root/key[:3]/key, parents=True)
    Note right of FileSystem: Creates both prefix and key dirs
    LocalCache->>FileSystem: os.replace(tmp_dir, final_dir)
    Note right of FileSystem: Fails if final_dir exists and not empty!
    LocalCache->>Client: Returns CacheEntry
    
    Note over Client,FileSystem: Iterating cache entries (new logic)
    Client->>LocalCache: _iter_entries()
    LocalCache->>FileSystem: iterdir() on root
    FileSystem-->>LocalCache: Returns all dirs (prefixes + old entries)
    loop For each prefix_dir
        LocalCache->>FileSystem: Check if is_dir()
        alt Is directory
            LocalCache->>FileSystem: iterdir() on prefix_dir
            loop For each child
                LocalCache->>FileSystem: Check if child.is_dir()
                Note right of LocalCache: Old entries have files here,<br/>so they're skipped!
                LocalCache->>FileSystem: Read metadata.json
                LocalCache->>LocalCache: Create CacheEntry
            end
        end
    end
    LocalCache-->>Client: Returns only new-style entries
    Note right of LocalCache: Old entries are invisible!
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->