### PR TITLE
Relax threshold angle to avoid false positive corner detection in STL file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added multimode support to `WavePort` in the smatrix plugin, allowing multiple modes to be analyzed per port.
 
 ### Breaking Changes
+- Edge singularity correction at PEC and lossy metal edges defaults to `True`.
+- `angle_threshold` in `CornerFinderSpec` now defaults to `pi/4`.
 **Note: These breaking changes only affect the microwave and smatrix plugins.**
 - Renamed path integral classes for improved consistency. Please see our migration guide for details on updating your code.
   - `VoltageIntegralAxisAligned` → `AxisAlignedVoltageIntegral`
@@ -51,7 +53,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unified run submission API: `web.run(...)` is now a container-aware wrapper that accepts a single simulation or arbitrarily nested containers (`list`, `tuple`, `dict` values) and returns results in the same shape.
 - `web.Batch(ComponentModeler)` and `web.Job(ComponentModeler)` native support
 - Simulation data of batch jobs are now automatically downloaded upon their individual completion in `Batch.run()`, avoiding waiting for the entire batch to reach completion.
-- Edge singularity correction at PEC and lossy metal edges defaults to `True`.
 
 ### Fixed
 - Ensured the legacy `Env` proxy mirrors `config.web` profile switches and preserves API URL.

--- a/schemas/EMESimulation.json
+++ b/schemas/EMESimulation.json
@@ -2316,7 +2316,7 @@
       "additionalProperties": false,
       "properties": {
         "angle_threshold": {
-          "default": 0.3141592653589793,
+          "default": 0.7853981633974483,
           "exclusiveMaximum": 3.141592653589793,
           "minimum": 0,
           "type": "number"
@@ -6361,7 +6361,7 @@
             }
           ],
           "default": {
-            "angle_threshold": 0.3141592653589793,
+            "angle_threshold": 0.7853981633974483,
             "attrs": {},
             "concave_resolution": null,
             "convex_resolution": null,

--- a/schemas/ModeSimulation.json
+++ b/schemas/ModeSimulation.json
@@ -2359,7 +2359,7 @@
       "additionalProperties": false,
       "properties": {
         "angle_threshold": {
-          "default": 0.3141592653589793,
+          "default": 0.7853981633974483,
           "exclusiveMaximum": 3.141592653589793,
           "minimum": 0,
           "type": "number"
@@ -5574,7 +5574,7 @@
             }
           ],
           "default": {
-            "angle_threshold": 0.3141592653589793,
+            "angle_threshold": 0.7853981633974483,
             "attrs": {},
             "concave_resolution": null,
             "convex_resolution": null,

--- a/schemas/Simulation.json
+++ b/schemas/Simulation.json
@@ -2736,7 +2736,7 @@
       "additionalProperties": false,
       "properties": {
         "angle_threshold": {
-          "default": 0.3141592653589793,
+          "default": 0.7853981633974483,
           "exclusiveMaximum": 3.141592653589793,
           "minimum": 0,
           "type": "number"
@@ -9061,7 +9061,7 @@
             }
           ],
           "default": {
-            "angle_threshold": 0.3141592653589793,
+            "angle_threshold": 0.7853981633974483,
             "attrs": {},
             "concave_resolution": null,
             "convex_resolution": null,

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -2840,7 +2840,7 @@
       "additionalProperties": false,
       "properties": {
         "angle_threshold": {
-          "default": 0.3141592653589793,
+          "default": 0.7853981633974483,
           "exclusiveMaximum": 3.141592653589793,
           "minimum": 0,
           "type": "number"
@@ -9228,7 +9228,7 @@
             }
           ],
           "default": {
-            "angle_threshold": 0.3141592653589793,
+            "angle_threshold": 0.7853981633974483,
             "attrs": {},
             "concave_resolution": null,
             "convex_resolution": null,

--- a/tidy3d/components/grid/corner_finder.py
+++ b/tidy3d/components/grid/corner_finder.py
@@ -15,7 +15,7 @@ from tidy3d.components.structure import Structure
 from tidy3d.components.types import ArrayFloat1D, ArrayFloat2D, Axis, Shapely
 from tidy3d.constants import inf
 
-CORNER_ANGLE_THRESOLD = 0.1 * np.pi
+CORNER_ANGLE_THRESOLD = 0.25 * np.pi
 
 
 class CornerFinderSpec(Tidy3dBaseModel):


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-30 23:56:51 UTC

<h3>Greptile Summary</h3>


This PR increases the default `angle_threshold` in `CornerFinderSpec` from 0.1π to 0.25π (π/4) to reduce false positive corner detection when processing STL files.

**Key changes:**
- Updated `CORNER_ANGLE_THRESOLD` constant from `0.1 * np.pi` to `0.25 * np.pi` in `tidy3d/components/grid/corner_finder.py:18`
- Updated all JSON schemas (Simulation, EMESimulation, ModeSimulation, TerminalComponentModeler) to reflect the new default value
- Added breaking change entry in CHANGELOG.md noting that `angle_threshold` in `CornerFinderSpec` now defaults to pi/4
- Properly categorized this as a breaking change affecting the microwave and smatrix plugins

**Technical context:**
The angle threshold determines when a vertex qualifies as a corner. A vertex is considered a corner if the angle spanned by its two edges is larger than π minus the threshold value. The previous threshold of 0.1π (18°) was too sensitive, causing false positives when detecting corners in STL files. The new threshold of 0.25π (45°) is more conservative and will only detect vertices as corners when the angle deviation from straight is more pronounced.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no significant concerns
- The change is straightforward and well-implemented. It updates a single constant and ensures all related schema files are synchronized. The change is properly documented as a breaking change in the CHANGELOG. All modifications are consistent across files, and the new default value (pi/4) is reasonable for corner detection in geometric processing.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/grid/corner_finder.py | 5/5 | Changed default angle threshold constant from 0.1π to 0.25π (line 18) to reduce false positive corner detection |
| CHANGELOG.md | 4/5 | Added breaking change entry for angle_threshold default change to pi/4, moved from wrong section |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CornerFinderSpec
    participant LayerRefinementSpec
    participant GridSpec
    participant Simulation
    
    User->>CornerFinderSpec: Create with default angle_threshold
    Note over CornerFinderSpec: angle_threshold = 0.25π (NEW)<br/>previously 0.1π
    
    User->>LayerRefinementSpec: Configure with corner_finder
    LayerRefinementSpec->>CornerFinderSpec: Use corner detection
    
    User->>Simulation: Create with layer_refinement_specs
    Simulation->>GridSpec: Generate grid with layer specs
    GridSpec->>LayerRefinementSpec: Apply layer refinement
    LayerRefinementSpec->>CornerFinderSpec: Find corners on 2D plane
    
    CornerFinderSpec->>CornerFinderSpec: _filter_collinear_vertices()
    Note over CornerFinderSpec: Filter vertices where<br/>angle <= π - angle_threshold<br/>(now π - 0.25π = 0.75π)
    
    CornerFinderSpec-->>LayerRefinementSpec: Return corner coordinates
    LayerRefinementSpec-->>GridSpec: Apply corner-based refinement
    GridSpec-->>Simulation: Generate refined grid
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->