### PR TITLE
fix(config): sync legacy env proxy with manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Edge singularity correction at PEC and lossy metal edges defaults to `True`.
 
 ### Fixed
+- Ensured the legacy `Env` proxy mirrors `config.web` profile switches and preserves API URL.
 - More robust `Sellmeier` and `Debye` material model, and prevent very large pole parameters in `PoleResidue` material model.
 - Bug in `WavePort` when more than one mode is requested in the `ModeSpec`.
 - Solver error for named 2D materials with inhomogeneous substrates.

--- a/tests/config/test_legacy_env.py
+++ b/tests/config/test_legacy_env.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import os
+import ssl
+
+from tidy3d.config import Env, get_manager, reload_config
+from tidy3d.config import config as config_wrapper
+
+
+def test_env_tracks_profile_switch(config_manager):
+    """Regression: Env should mirror manager profile switches."""
+
+    del config_manager  # ensure fixture runs, avoid lint for unused variable
+    try:
+        config_wrapper.switch_profile("dev")
+        assert config_wrapper.profile == "dev"
+        assert Env.current.name == "dev"
+        assert str(Env.current.web_api_endpoint) == str(config_wrapper.web.api_endpoint)
+    finally:
+        reload_config(profile="default")
+
+
+def test_env_pending_overrides_apply_on_activation(mock_config_dir, config_manager):
+    """Queued overrides should land once the corresponding profile is activated."""
+
+    del mock_config_dir
+    manager = config_manager
+    try:
+        config_wrapper.switch_profile("default")
+        assert manager.profile == "default"
+
+        Env.dev.enable_caching = False
+        Env.dev.ssl_version = ssl.TLSVersion.TLSv1_2
+
+        # Pending overrides should not touch the active profile yet.
+        default_web = manager.get_section("web")
+        assert default_web.enable_caching is True
+        assert default_web.ssl_version is None
+
+        Env.dev.active()
+        current_manager = get_manager()
+        assert current_manager.profile == "dev"
+        dev_web = current_manager.get_section("web")
+        assert dev_web.enable_caching is False
+        assert dev_web.ssl_version == ssl.TLSVersion.TLSv1_2
+        assert Env.current.enable_caching is False
+        assert Env.current.ssl_version == ssl.TLSVersion.TLSv1_2
+    finally:
+        reload_config(profile="default")
+
+
+def test_env_vars_follow_profile_switch(mock_config_dir, monkeypatch, config_manager):
+    """Environment variables applied via Env should restore previous values on switch."""
+
+    del mock_config_dir
+    del config_manager  # ensure fixture executes without lint complaints
+    try:
+        config_wrapper.switch_profile("default")
+        monkeypatch.setenv("TIDY3D_TEST_VAR", "previous")
+
+        Env.default.env_vars = {"TIDY3D_TEST_VAR": "applied"}
+        assert os.environ["TIDY3D_TEST_VAR"] == "applied"
+
+        Env.dev.env_vars = {}
+        Env.dev.active()
+        assert os.environ["TIDY3D_TEST_VAR"] == "previous"
+
+        Env.default.active()
+        assert os.environ["TIDY3D_TEST_VAR"] == "applied"
+    finally:
+        reload_config(profile="default")

--- a/tests/config/test_web_config.py
+++ b/tests/config/test_web_config.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from tidy3d.config.sections import WebConfig
+
+
+def test_build_api_url_joins_paths():
+    web = WebConfig(api_endpoint="https://example.com/api")
+    assert web.build_api_url("v1/tasks") == "https://example.com/api/v1/tasks"
+
+
+def test_build_api_url_strips_leading_slashes():
+    web = WebConfig(api_endpoint="https://example.com/api/")
+    assert web.build_api_url("/v1/tasks") == "https://example.com/api/v1/tasks"
+
+
+def test_build_api_url_returns_base_for_empty_path():
+    web = WebConfig(api_endpoint="https://example.com/api")
+    assert web.build_api_url("") == "https://example.com/api"
+
+
+def test_build_api_url_without_base_returns_path():
+    web = WebConfig.model_construct(api_endpoint="")
+    assert web.build_api_url("/v1/tasks") == "v1/tasks"

--- a/tidy3d/config/legacy.py
+++ b/tidy3d/config/legacy.py
@@ -110,6 +110,18 @@ class LegacyConfigWrapper:
 
         self._manager = manager
 
+    def switch_profile(self, profile: str) -> None:
+        """Switch active profile and synchronize the legacy environment proxy."""
+
+        normalized = normalize_profile_name(profile)
+        self._manager.switch_profile(normalized)
+        try:
+            from tidy3d.config import Env as _legacy_env
+        except Exception:
+            _legacy_env = None
+        if _legacy_env is not None:
+            _legacy_env._sync_to_manager(apply_env=True)
+
     def __getattr__(self, name: str) -> Any:
         return getattr(self._manager, name)
 
@@ -133,7 +145,7 @@ class LegacyConfigWrapper:
 
 
 class LegacyEnvironmentConfig:
-    """Backward compatible environment config wrapper."""
+    """Backward compatible environment config wrapper that proxies ConfigManager."""
 
     def __init__(
         self,
@@ -151,35 +163,38 @@ class LegacyEnvironmentConfig:
     ) -> None:
         if name is None:
             raise ValueError("Environment name is required")
-        name = normalize_profile_name(name)
         self._manager = manager
-        self._name = name
+        self._name = normalize_profile_name(name)
         self._environment = environment
-        self._overrides: dict[str, Any] = {}
+        self._pending: dict[str, Any] = {}
         if web_api_endpoint is not None:
-            self._overrides["api_endpoint"] = web_api_endpoint
+            self._pending["api_endpoint"] = web_api_endpoint
         if website_endpoint is not None:
-            self._overrides["website_endpoint"] = website_endpoint
+            self._pending["website_endpoint"] = website_endpoint
         if s3_region is not None:
-            self._overrides["s3_region"] = s3_region
+            self._pending["s3_region"] = s3_region
         if ssl_verify is not None:
-            self._overrides["ssl_verify"] = ssl_verify
+            self._pending["ssl_verify"] = ssl_verify
         if enable_caching is not None:
-            self._overrides["enable_caching"] = enable_caching
+            self._pending["enable_caching"] = enable_caching
         if ssl_version is not None:
-            self._overrides["ssl_version"] = ssl_version
+            self._pending["ssl_version"] = ssl_version
         if env_vars is not None:
-            self._overrides["env_vars"] = dict(env_vars)
+            self._pending["env_vars"] = dict(env_vars)
+
+    def reset_manager(self, manager: ConfigManager) -> None:
+        self._manager = manager
 
     @property
     def manager(self) -> Optional[ConfigManager]:
-        return self._manager
+        if self._manager is not None:
+            return self._manager
+        if self._environment is not None:
+            return self._environment._manager
+        return None
 
     def active(self) -> None:
         _warn_env_deprecated()
-        if self._manager is not None and self._manager.profile != self._name:
-            self._manager.switch_profile(self._name)
-
         environment = self._environment
         if environment is None:
             from tidy3d.config import Env  # local import to avoid circular
@@ -217,17 +232,19 @@ class LegacyEnvironmentConfig:
         return bool(value)
 
     @enable_caching.setter
-    def enable_caching(self, value: bool) -> None:
-        self._overrides["enable_caching"] = value
-        if self._manager and self._manager.profile == self._name:
-            self._manager.update_section("web", enable_caching=value)
+    def enable_caching(self, value: Optional[bool]) -> None:
+        self._set_pending("enable_caching", value)
 
     @property
     def ssl_version(self):
         return self._value("ssl_version")
 
+    @ssl_version.setter
+    def ssl_version(self, value) -> None:
+        self._set_pending("ssl_version", value)
+
     @property
-    def env_vars(self):
+    def env_vars(self) -> dict[str, str]:
         value = self._value("env_vars")
         if value is None:
             return {}
@@ -235,7 +252,7 @@ class LegacyEnvironmentConfig:
 
     @env_vars.setter
     def env_vars(self, value: dict[str, str]) -> None:
-        self._overrides["env_vars"] = dict(value)
+        self._set_pending("env_vars", dict(value))
 
     @property
     def name(self) -> str:
@@ -245,29 +262,60 @@ class LegacyEnvironmentConfig:
     def name(self, value: str) -> None:
         self._name = normalize_profile_name(value)
 
-    def get_real_url(self, path: str) -> str:
-        endpoint = self.web_api_endpoint or ""
-        return "/".join([endpoint.rstrip("/"), path.lstrip("/")])
-
-    @property
-    def _web_section(self):
-        section = {}
-        if self._manager is not None:
-            if self._manager.profile == self._name:
-                source = self._manager.as_dict().get("web", {})
+    def copy_state_from(self, other: LegacyEnvironmentConfig) -> None:
+        if not isinstance(other, LegacyEnvironmentConfig):
+            raise TypeError("Expected LegacyEnvironmentConfig instance.")
+        for key, value in other._pending.items():
+            if key == "env_vars" and value is not None:
+                self._pending[key] = dict(value)
             else:
-                source = self._manager.preview_profile(self._name).get("web", {})
-            if isinstance(source, dict):
-                section.update(source)
-        for key, value in self._overrides.items():
-            if value is not None:
-                section[key] = value
-        return section
+                self._pending[key] = value
+
+    def get_real_url(self, path: str) -> str:
+        manager = self.manager
+        if manager is not None and manager.profile == self._name:
+            web_section = manager.get_section("web")
+            if hasattr(web_section, "build_api_url"):
+                return web_section.build_api_url(path)
+
+        endpoint = self.web_api_endpoint or ""
+        if not path:
+            return endpoint
+        return "/".join([endpoint.rstrip("/"), str(path).lstrip("/")])
+
+    def apply_pending_overrides(self) -> None:
+        manager = self.manager
+        if manager is None or manager.profile != self._name:
+            return
+        if not self._pending:
+            return
+        updates = dict(self._pending)
+        manager.update_section("web", **updates)
+        self._pending.clear()
+
+    def _set_pending(self, key: str, value: Any) -> None:
+        if key == "env_vars" and value is not None:
+            self._pending[key] = dict(value)
+        else:
+            self._pending[key] = value
+        self.apply_pending_overrides()
+
+    def _web_section(self) -> dict[str, Any]:
+        manager = self.manager
+        if manager is None:
+            return {}
+        profile = normalize_profile_name(self._name)
+        if manager.profile == profile:
+            section = manager.get_section("web")
+            return section.model_dump(mode="python", exclude_unset=False)
+        preview = manager.preview_profile(profile)
+        source = preview.get("web", {})
+        return dict(source) if isinstance(source, dict) else {}
 
     def _value(self, key: str) -> Any:
-        if key in self._overrides and self._overrides[key] is not None:
-            return self._overrides[key]
-        return self._web_section.get(key)
+        if key in self._pending:
+            return self._pending[key]
+        return self._web_section().get(key)
 
 
 class LegacyEnvironment:
@@ -275,63 +323,73 @@ class LegacyEnvironment:
 
     def __init__(self, manager: ConfigManager):
         self._previous_env_vars: dict[str, Optional[str]] = {}
+        self.env_map: dict[str, LegacyEnvironmentConfig] = {}
+        self._current: Optional[LegacyEnvironmentConfig] = None
+        self._manager: Optional[ConfigManager] = None
+        self._applied_profile: Optional[str] = None
         self.reset_manager(manager)
 
     def reset_manager(self, manager: ConfigManager) -> None:
         self._manager = manager
-        self.env_map: dict[str, LegacyEnvironmentConfig] = {}
+        self.env_map = {}
         for name in BUILTIN_PROFILES:
-            self.env_map[name] = LegacyEnvironmentConfig(manager, name, environment=self)
-
-        desired_env = os.getenv("TIDY3D_ENV")
-        if desired_env:
-            desired = normalize_profile_name(desired_env)
-        else:
-            desired = manager.profile
-
-        if desired == "default":
-            desired = "prod"
-
-        desired = normalize_profile_name(desired)
-
-        self._current = self.env_map.setdefault(
-            desired, LegacyEnvironmentConfig(manager, desired, environment=self)
-        )
-        self._apply_env_vars(self._current)
+            key = normalize_profile_name(name)
+            self.env_map[key] = LegacyEnvironmentConfig(manager, key, environment=self)
+        self._applied_profile = None
+        self._current = None
+        self._sync_to_manager(apply_env=True)
 
     @property
     def current(self) -> LegacyEnvironmentConfig:
+        self._sync_to_manager()
+        assert self._current is not None
         return self._current
 
     def set_current(self, env_config: LegacyEnvironmentConfig) -> None:
         _warn_env_deprecated()
         key = normalize_profile_name(env_config.name)
-        if env_config.manager is self._manager:
-            if self._manager.profile != key:
-                self._manager.switch_profile(key)
-            stored = self.env_map.setdefault(key, env_config)
-        else:
-            stored = env_config
-            stored.name = key
-            self.env_map[key] = stored
+        stored = self._get_config(key)
+        stored.copy_state_from(env_config)
+        if self._manager and self._manager.profile != key:
+            self._manager.switch_profile(key)
+        self._sync_to_manager(apply_env=True)
 
-        stored._environment = self
-        self._current = stored
-        self._apply_env_vars(stored)
-
-    def enable_caching(self, enable_caching: bool = True) -> None:
-        if self._current.manager is self._manager:
-            self._manager.update_section("web", enable_caching=enable_caching)
-        self._current.enable_caching = enable_caching
+    def enable_caching(self, enable_caching: Optional[bool] = True) -> None:
+        config = self.current
+        config.enable_caching = enable_caching
+        self._sync_to_manager()
 
     def set_ssl_version(self, ssl_version) -> None:
-        if self._current.manager is self._manager:
-            self._manager.update_section("web", ssl_version=ssl_version)
-        self._current._overrides["ssl_version"] = ssl_version
+        config = self.current
+        config.ssl_version = ssl_version
+        self._sync_to_manager()
 
     def __getattr__(self, name: str) -> LegacyEnvironmentConfig:
+        return self._get_config(name)
+
+    def _get_config(self, name: str) -> LegacyEnvironmentConfig:
         key = normalize_profile_name(name)
-        return self.env_map.setdefault(key, LegacyEnvironmentConfig(self._manager, key))
+        config = self.env_map.get(key)
+        if config is None:
+            config = LegacyEnvironmentConfig(self._manager, key, environment=self)
+            self.env_map[key] = config
+        else:
+            manager = self._manager
+            if manager is not None:
+                config.reset_manager(manager)
+            config._environment = self
+        return config
+
+    def _sync_to_manager(self, *, apply_env: bool = False) -> None:
+        if self._manager is None:
+            return
+        active = normalize_profile_name(self._manager.profile)
+        config = self._get_config(active)
+        config.apply_pending_overrides()
+        self._current = config
+        if apply_env or self._applied_profile != active:
+            self._apply_env_vars(config)
+            self._applied_profile = active
 
     def _apply_env_vars(self, config: LegacyEnvironmentConfig) -> None:
         self._restore_env_vars()

--- a/tidy3d/config/sections.py
+++ b/tidy3d/config/sections.py
@@ -375,6 +375,17 @@ class WebConfig(ConfigSection):
             normalized = normalized.rstrip("/")
         return normalized
 
+    def build_api_url(self, path: str) -> str:
+        """Join the configured API endpoint with a request path."""
+
+        base = str(self.api_endpoint or "")
+        path_str = str(path or "")
+        if not base:
+            return path_str.lstrip("/")
+        if not path_str:
+            return base
+        return "/".join([base.rstrip("/"), path_str.lstrip("/")])
+
 
 @register_handler("web")
 def apply_web(config: WebConfig) -> None:

--- a/tidy3d/plugins/dispersion/fit.py
+++ b/tidy3d/plugins/dispersion/fit.py
@@ -16,10 +16,10 @@ from tidy3d.components.base import Tidy3dBaseModel, cached_property, skip_if_fie
 from tidy3d.components.medium import AbstractMedium, PoleResidue
 from tidy3d.components.types import ArrayFloat1D, Ax
 from tidy3d.components.viz import add_ax_if_none
+from tidy3d.config import config
 from tidy3d.constants import C_0, HBAR, MICROMETER
 from tidy3d.exceptions import SetupError, ValidationError, WebError
 from tidy3d.log import get_logging_console, log
-from tidy3d.web.core.environment import Env
 
 
 class DispersionFitter(Tidy3dBaseModel):
@@ -658,7 +658,7 @@ class DispersionFitter(Tidy3dBaseModel):
         :class:`DispersionFitter`
             A :class:`DispersionFitter` instance.
         """
-        resp = requests.get(url_file, verify=Env.current.ssl_verify)
+        resp = requests.get(url_file, verify=config.web.ssl_verify)
 
         try:
             resp.raise_for_status()

--- a/tidy3d/plugins/dispersion/web.py
+++ b/tidy3d/plugins/dispersion/web.py
@@ -13,10 +13,10 @@ from pydantic.v1 import Field, NonNegativeFloat, PositiveFloat, PositiveInt, val
 from tidy3d.components.base import Tidy3dBaseModel, skip_if_fields_missing
 from tidy3d.components.medium import PoleResidue
 from tidy3d.components.types import Undefined
+from tidy3d.config import config
 from tidy3d.constants import HERTZ, MICROMETER
 from tidy3d.exceptions import SetupError, Tidy3dError, WebError
 from tidy3d.log import log
-from tidy3d.web.core.environment import Env
 from tidy3d.web.core.http_util import get_headers
 
 from .fit import DispersionFitter
@@ -228,11 +228,12 @@ class FitterData(AdvancedFitterParam):
 
         _env = config_env
         if _env == "default":
-            _env = "dev" if "dev" in Env.current.web_api_endpoint else "prod"
+            endpoint = str(config.web.api_endpoint or "")
+            _env = "dev" if "dev" in endpoint else "prod"
         return URL_ENV[_env]
 
     @staticmethod
-    def _setup_server(url_server: str):
+    def _setup_server(url_server: str) -> tuple[dict[str, str], bool]:
         """set up web server access
 
         Parameters
@@ -241,18 +242,20 @@ class FitterData(AdvancedFitterParam):
             URL for the server
         """
 
+        ssl_verify = config.web.ssl_verify
         try:
             # test connection
-            resp = requests.get(f"{url_server}/health", verify=Env.current.ssl_verify)
+            resp = requests.get(f"{url_server}/health", verify=ssl_verify)
             resp.raise_for_status()
         except (requests.exceptions.SSLError, ssl.SSLError):
             log.info("Retrying with SSL verification disabled.")
-            Env.current.ssl_verify = False
-            resp = requests.get(f"{url_server}/health", verify=Env.current.ssl_verify)
+            ssl_verify = False
+            resp = requests.get(f"{url_server}/health", verify=ssl_verify)
+            resp.raise_for_status()
         except Exception as e:
             raise WebError("Connection to the server failed. Please try again.") from e
 
-        return get_headers()
+        return get_headers(), ssl_verify
 
     def run(self) -> tuple[PoleResidue, float]:
         """Execute the data fit using the stable fitter in the server.
@@ -264,13 +267,13 @@ class FitterData(AdvancedFitterParam):
         """
 
         url_server = self._set_url("default")
-        headers = self._setup_server(url_server)
+        headers, ssl_verify = self._setup_server(url_server)
 
         resp = requests.post(
             f"{url_server}/dispersion/fit",
             headers=headers,
             data=self.json(),
-            verify=Env.current.ssl_verify,
+            verify=ssl_verify,
         )
 
         try:

--- a/tidy3d/web/api/mode.py
+++ b/tidy3d/web/api/mode.py
@@ -20,12 +20,12 @@ from tidy3d.components.data.monitor_data import ModeSolverData
 from tidy3d.components.eme.simulation import EMESimulation
 from tidy3d.components.medium import AbstractCustomMedium
 from tidy3d.components.simulation import Simulation
+from tidy3d.config import config
 from tidy3d.exceptions import SetupError, WebError
 from tidy3d.log import get_logging_console, log
 from tidy3d.plugins.mode.mode_solver import MODE_MONITOR_NAME, ModeSolver
 from tidy3d.version import __version__
 from tidy3d.web.core.core_config import get_logger_console
-from tidy3d.web.core.environment import Env
 from tidy3d.web.core.http_util import http
 from tidy3d.web.core.s3utils import download_file, download_gz_file, upload_file
 from tidy3d.web.core.task_core import Folder
@@ -480,10 +480,7 @@ class ModeSolverTask(ResourceLifecycle, Submittable, extra=pydantic.Extra.allow)
 
         http.post(
             f"{MODESOLVER_API}/{self.task_id}/{self.solver_id}/run",
-            {
-                "enableCaching": Env.current.enable_caching,
-                "payType": pay_type.value,
-            },
+            {"enableCaching": config.web.enable_caching, "payType": pay_type.value},
         )
 
     def delete(self) -> None:

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -16,6 +16,7 @@ from tidy3d.components.medium import AbstractCustomMedium
 from tidy3d.components.mode.mode_solver import ModeSolver
 from tidy3d.components.mode.simulation import ModeSimulation
 from tidy3d.components.types.workflow import WorkflowDataType, WorkflowType
+from tidy3d.config import config
 from tidy3d.exceptions import WebError
 from tidy3d.log import get_logging_console, log
 from tidy3d.plugins.smatrix.component_modelers.terminal import TerminalComponentModeler
@@ -38,7 +39,6 @@ from tidy3d.web.core.constants import (
     SIMULATION_DATA_HDF5_GZ,
     TaskId,
 )
-from tidy3d.web.core.environment import Env
 from tidy3d.web.core.exceptions import WebNotFoundError
 from tidy3d.web.core.http_util import get_version as _get_protocol_version
 from tidy3d.web.core.http_util import http
@@ -75,17 +75,24 @@ SOLVER_NAME = {
 
 def _get_url(task_id: str) -> str:
     """Get the URL for a task on our server."""
-    return f"{Env.current.website_endpoint}/workbench?taskId={task_id}"
+    return _build_website_url(f"workbench?taskId={task_id}")
 
 
 def _get_folder_url(folder_id: str) -> str:
     """Get the URL for a task folder on our server."""
-    return f"{Env.current.website_endpoint}/folders/{folder_id}"
+    return _build_website_url(f"folders/{folder_id}")
 
 
 def _get_url_rf(resource_id: str) -> str:
     """Get the RF GUI URL for a modeler/batch group."""
-    return f"{Env.current.website_endpoint}/rf?taskId={resource_id}"
+    return _build_website_url(f"rf?taskId={resource_id}")
+
+
+def _build_website_url(path: str) -> str:
+    base = str(config.web.website_endpoint or "")
+    if not path:
+        return base
+    return "/".join([base.rstrip("/"), str(path).lstrip("/")])
 
 
 def _is_modeler_batch(resource_id: str) -> bool:
@@ -757,7 +764,7 @@ def upload(
     task.validate_post_upload(parent_tasks=parent_tasks)
 
     # log the url for the task in the web UI
-    log.debug(f"{Env.current.website_endpoint}/folders/{task.folder_id}/tasks/{resource_id}")
+    log.debug(_build_website_url(f"folders/{task.folder_id}/tasks/{resource_id}"))
     return resource_id
 
 

--- a/tidy3d/web/cli/app.py
+++ b/tidy3d/web/cli/app.py
@@ -20,7 +20,6 @@ from tidy3d.config.loader import (
 )
 from tidy3d.web.cli.constants import TIDY3D_DIR
 from tidy3d.web.core.constants import HEADER_APIKEY
-from tidy3d.web.core.environment import Env
 
 from .develop.index import develop
 
@@ -95,12 +94,12 @@ def configure_fn(apikey: str) -> None:
         message = f"Current API key: [{current_apikey}]\n" if current_apikey else ""
         apikey = click.prompt(f"{message}Please enter your api key", type=str)
 
+    target_url = config.web.build_api_url("apikey")
+
     try:
-        resp = requests.get(
-            f"{Env.current.web_api_endpoint}/apikey", auth=auth, verify=Env.current.ssl_verify
-        )
+        resp = requests.get(target_url, auth=auth, verify=config.web.ssl_verify)
     except (requests.exceptions.SSLError, ssl.SSLError):
-        resp = requests.get(f"{Env.current.web_api_endpoint}/apikey", auth=auth, verify=False)
+        resp = requests.get(target_url, auth=auth, verify=False)
 
     if resp.status_code == 200:
         click.echo("Configured successfully.")

--- a/tidy3d/web/core/http_util.py
+++ b/tidy3d/web/core/http_util.py
@@ -27,7 +27,6 @@ from .constants import (
     SIMCLOUD_APIKEY,
 )
 from .core_config import get_logger
-from .environment import Env
 from .exceptions import WebError, WebNotFoundError
 
 JSONType: TypeAlias = dict[str, Any] | list[Any] | str | int
@@ -201,7 +200,7 @@ def http_interceptor(func: Callable[..., Any]) -> Callable[..., JSONType]:
 
 class TLSAdapter(HTTPAdapter):
     def init_poolmanager(self, *args: Any, **kwargs: Any) -> None:
-        context = create_urllib3_context(ssl_version=Env.current.ssl_version)
+        context = create_urllib3_context(ssl_version=config.web.ssl_version)
         kwargs["ssl_context"] = context
         return super().init_poolmanager(*args, **kwargs)
 
@@ -213,14 +212,14 @@ class HttpSessionManager:
         """Initialize the session."""
         self.session = session
         self._mounted_ssl_version = None
-        self._ensure_tls_adapter(Env.current.ssl_version)
-        self.session.verify = Env.current.ssl_verify
+        self._ensure_tls_adapter(config.web.ssl_version)
+        self.session.verify = config.web.ssl_verify
 
     def reinit(self) -> None:
         """Reinitialize the session."""
-        ssl_version = Env.current.ssl_version
+        ssl_version = config.web.ssl_version
         self._ensure_tls_adapter(ssl_version)
-        self.session.verify = Env.current.ssl_verify
+        self.session.verify = config.web.ssl_verify
 
     def _ensure_tls_adapter(self, ssl_version: str) -> None:
         if not ssl_version:
@@ -237,14 +236,14 @@ class HttpSessionManager:
         """Get the resource."""
         self.reinit()
         return self.session.get(
-            url=Env.current.get_real_url(path), auth=api_key_auth, json=json, params=params
+            url=config.web.build_api_url(path), auth=api_key_auth, json=json, params=params
         )
 
     @http_interceptor
     def post(self, path: str, json: JSONType = None) -> requests.Response:
         """Create the resource."""
         self.reinit()
-        return self.session.post(Env.current.get_real_url(path), json=json, auth=api_key_auth)
+        return self.session.post(config.web.build_api_url(path), json=json, auth=api_key_auth)
 
     @http_interceptor
     def put(
@@ -253,7 +252,7 @@ class HttpSessionManager:
         """Update the resource."""
         self.reinit()
         return self.session.put(
-            Env.current.get_real_url(path), json=json, auth=api_key_auth, files=files
+            config.web.build_api_url(path), json=json, auth=api_key_auth, files=files
         )
 
     @http_interceptor
@@ -263,7 +262,7 @@ class HttpSessionManager:
         """Delete the resource."""
         self.reinit()
         return self.session.delete(
-            Env.current.get_real_url(path), auth=api_key_auth, json=json, params=params
+            config.web.build_api_url(path), auth=api_key_auth, json=json, params=params
         )
 
 

--- a/tidy3d/web/core/s3utils.py
+++ b/tidy3d/web/core/s3utils.py
@@ -25,8 +25,9 @@ from rich.progress import (
     TransferSpeedColumn,
 )
 
+from tidy3d.config import config
+
 from .core_config import get_logger_console
-from .environment import Env
 from .exceptions import WebError
 from .file_util import extract_gzip_file
 from .http_util import http
@@ -66,11 +67,11 @@ class _S3STSToken(BaseModel):
 
         return boto3.client(
             "s3",
-            region_name=Env.current.s3_region,
+            region_name=config.web.s3_region,
             aws_access_key_id=self.user_credential.access_key_id,
             aws_secret_access_key=self.user_credential.secret_access_key,
             aws_session_token=self.user_credential.session_token,
-            verify=Env.current.ssl_verify,
+            verify=config.web.ssl_verify,
         )
 
     def is_expired(self) -> bool:

--- a/tidy3d/web/core/task_core.py
+++ b/tidy3d/web/core/task_core.py
@@ -15,6 +15,7 @@ from botocore.exceptions import ClientError
 from pydantic.v1 import Extra, Field, parse_obj_as
 
 import tidy3d as td
+from tidy3d.config import config
 from tidy3d.exceptions import ValidationError
 from tidy3d.web.common import REFRESH_TIME
 
@@ -27,7 +28,6 @@ from .constants import (
     SIMULATION_DATA_HDF5_GZ,
 )
 from .core_config import get_logger_console
-from .environment import Env
 from .exceptions import WebError, WebNotFoundError
 from .file_util import read_simulation_from_hdf5
 from .http_util import get_version as _get_protocol_version
@@ -478,7 +478,7 @@ class SimulationTask(ResourceLifecycle, Submittable, extra=Extra.allow):
                 "solverVersion": solver_version,
                 "workerGroup": worker_group,
                 "protocolVersion": protocol_version,
-                "enableCaching": Env.current.enable_caching,
+                "enableCaching": config.web.enable_caching,
                 "payType": pay_type.value,
                 "priority": priority,
             },


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-31 12:11:05 UTC

<h3>Greptile Summary</h3>


This PR fixes a synchronization issue between the legacy `Env` proxy and the new `ConfigManager` system, ensuring profile switches are properly reflected in the legacy API.

**Key Changes:**
- Added `LegacyConfigWrapper.switch_profile()` that calls `Env._sync_to_manager()` after profile switches to keep legacy code in sync
- Refactored `LegacyEnvironmentConfig` to use a `_pending` overrides system that applies changes when the profile becomes active
- Introduced `WebConfig.build_api_url()` helper method to centralize URL construction logic
- Migrated all production code from `Env.current` to `config.web` (8 files affected)
- Added comprehensive regression tests for profile switching, pending overrides, and environment variable restoration

**Technical Details:**
- The `_sync_to_manager()` method ensures `Env.current` always reflects the active profile
- Pending overrides queue changes to inactive profiles and apply them upon activation
- URL building is now centralized through `build_api_url()` instead of manual string concatenation
- Environment variables are properly restored when switching between profiles

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor considerations around global state mutation
- The refactoring is well-structured with comprehensive test coverage. The score reflects one global state mutation concern in the SSL verification fallback logic. All `Env.current` usages have been successfully migrated from production code, and the synchronization mechanism is properly implemented.
- Pay attention to `tidy3d/plugins/dispersion/web.py` which modifies global config state in an exception handler

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/config/legacy.py | 4/5 | Major refactor to sync legacy Env proxy with ConfigManager, added `_sync_to_manager()`, `_pending` overrides, and bidirectional sync logic |
| tidy3d/config/sections.py | 5/5 | Added `build_api_url()` helper to join API endpoint with request paths |
| tidy3d/web/core/http_util.py | 5/5 | Migrated from `Env.current` to `config.web` for all HTTP session configuration |
| tidy3d/plugins/dispersion/web.py | 4/5 | Migrated from `Env.current` to `config.web`, including SSL verification updates using `config.update_section()` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant config as config.switch_profile()
    participant ConfigManager
    participant LegacyEnv as Env (Legacy)
    participant LegacyConfig as LegacyEnvironmentConfig
    participant WebConfig
    
    User->>config: switch_profile("dev")
    config->>ConfigManager: switch_profile("dev")
    ConfigManager->>ConfigManager: Set active profile to "dev"
    config->>LegacyEnv: _sync_to_manager(apply_env=True)
    LegacyEnv->>LegacyEnv: Get active profile name
    LegacyEnv->>LegacyConfig: _get_config("dev")
    LegacyConfig-->>LegacyEnv: Return dev config
    LegacyEnv->>LegacyConfig: apply_pending_overrides()
    LegacyConfig->>ConfigManager: update_section("web", **pending)
    ConfigManager->>WebConfig: Apply pending overrides
    LegacyConfig->>LegacyConfig: Clear _pending dict
    LegacyEnv->>LegacyEnv: Set _current = dev config
    LegacyEnv->>LegacyEnv: _apply_env_vars(config)
    LegacyEnv->>LegacyEnv: Restore previous env vars
    LegacyEnv->>LegacyEnv: Apply new env vars from config
    LegacyEnv-->>config: Sync complete
    config-->>User: Profile switched, Env synced
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->