### PR TITLE
fix(rf): fix frequency sampling in MicrowaveModeData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug in `TerminalComponentModelerData.get_antenna_metrics_data()` where `WavePort` mode indices were not properly handled. Improved docstrings and type hints to make the usage clearer.
 - Improved type hints for `Tidy3dBaseModel`, so that all derived classes will have more accurate return types.
 - More robust method for suppressing RF license warnings during tests.
+- Fixed frequency sampling of `TransmissionLineDataset` within `MicrowaveModeData` when using group index calculation.
 
 ### Removed
 - Removed deprecated `use_complex_fields` parameter from `TwoPhotonAbsorption` and `KerrNonlinearity`. Parameters `beta` and `n2` are now real-valued only, as is `n0` if specified.

--- a/tests/test_components/test_microwave.py
+++ b/tests/test_components/test_microwave.py
@@ -1156,6 +1156,88 @@ def test_mode_solver_with_microwave_mode_spec():
     )
 
 
+def test_mode_solver_with_microwave_group_index():
+    """Test that group_index calculation with MicrowaveModeSpec correctly filters frequencies."""
+
+    width = 1.0 * mm
+    height = 0.5 * mm
+    metal_thickness = 0.1 * mm
+
+    stripline_sim = make_mw_sim(
+        transmission_line_type="stripline",
+        width=width,
+        height=height,
+        metal_thickness=metal_thickness,
+    )
+    dl = 0.05 * mm
+    stripline_sim = stripline_sim.updated_copy(grid_spec=td.GridSpec.uniform(dl=dl))
+
+    plane = td.Box(center=(0, 0, 0), size=(0, 10 * width, 2 * height + metal_thickness))
+    num_modes = 1
+
+    # Define original frequencies that we want in the final result
+    original_freqs = [1e9, 5e9, 10e9]
+
+    # Create custom impedance spec (AutoImpedanceSpec won't work with local mode solver)
+    custom_spec = td.CustomImpedanceSpec(
+        voltage_spec=None,
+        current_spec=td.AxisAlignedCurrentIntegralSpec(
+            size=(0, width + dl, metal_thickness + dl), sign="+"
+        ),
+    )
+
+    # Enable group_index calculation
+    mode_spec = td.MicrowaveModeSpec(
+        num_modes=num_modes,
+        target_neff=2.2,
+        impedance_specs=custom_spec,
+        group_index_step=True,  # This will expand frequencies to triplets
+    )
+
+    mms = ModeSolver(
+        simulation=stripline_sim,
+        plane=plane,
+        mode_spec=mode_spec,
+        colocate=False,
+        freqs=original_freqs,
+    )
+
+    # Get the mode solver data
+    mms_data: td.MicrowaveModeSolverData = mms.data
+
+    # Verify that group index was calculated
+    assert mms_data.n_group is not None, "Group index should be calculated"
+
+    # Verify that transmission line data exists
+    assert mms_data.transmission_line_data is not None, "Transmission line data should exist"
+
+    # Verify that the frequencies in transmission_line_data match the original frequencies
+    # (not the expanded triplet used internally for group index calculation)
+    tl_freqs_Z0 = mms_data.transmission_line_data.Z0.coords["f"].values
+    tl_freqs_voltage = mms_data.transmission_line_data.voltage_coeffs.coords["f"].values
+    tl_freqs_current = mms_data.transmission_line_data.current_coeffs.coords["f"].values
+
+    assert len(tl_freqs_Z0) == len(original_freqs), (
+        f"Z0 should have {len(original_freqs)} frequencies, got {len(tl_freqs_Z0)}"
+    )
+    assert len(tl_freqs_voltage) == len(original_freqs), (
+        f"voltage_coeffs should have {len(original_freqs)} frequencies, got {len(tl_freqs_voltage)}"
+    )
+    assert len(tl_freqs_current) == len(original_freqs), (
+        f"current_coeffs should have {len(original_freqs)} frequencies, got {len(tl_freqs_current)}"
+    )
+
+    assert np.allclose(tl_freqs_Z0, original_freqs), (
+        f"Z0 frequencies {tl_freqs_Z0} should match original {original_freqs}"
+    )
+    assert np.allclose(tl_freqs_voltage, original_freqs), (
+        f"voltage_coeffs frequencies {tl_freqs_voltage} should match original {original_freqs}"
+    )
+    assert np.allclose(tl_freqs_current, original_freqs), (
+        f"current_coeffs frequencies {tl_freqs_current} should match original {original_freqs}"
+    )
+
+
 @pytest.mark.parametrize("axis", [0, 1, 2])
 def test_voltage_integral_axes(axis):
     """Check AxisAlignedVoltageIntegral runs."""

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -1890,6 +1890,24 @@ class ModeData(ModeSolverDataset, ElectromagneticFieldData):
 
         return pairs, values
 
+    def _group_index_freq_slices(self) -> tuple[slice, slice, slice]:
+        """Get frequency slices for group index numerical differentiation.
+
+        Group index calculation uses three-point finite differences, requiring
+        backward, center, and forward frequency points organized as triplets.
+
+        Returns
+        -------
+        tuple[slice, slice, slice]
+            Slices for (backward, center, forward) frequencies from the frequency array.
+        """
+        freqs = self.n_complex.coords["f"].values
+        num_freqs = freqs.size
+        back = slice(0, num_freqs, 3)
+        center = slice(1, num_freqs, 3)
+        fwd = slice(2, num_freqs, 3)
+        return back, center, fwd
+
     def _group_index_post_process(self, frequency_step: float) -> ModeData:
         """Calculate group index and remove added frequencies used only for this calculation.
 
@@ -1904,12 +1922,8 @@ class ModeData(ModeSolverDataset, ElectromagneticFieldData):
             Filtered data with calculated group index.
         """
 
-        freqs = self.n_complex.coords["f"].values
-        num_freqs = freqs.size
-        back = slice(0, num_freqs, 3)
-        center = slice(1, num_freqs, 3)
-        fwd = slice(2, num_freqs, 3)
-        freqs = freqs[center]
+        back, center, fwd = self._group_index_freq_slices()
+        freqs = self.n_complex.coords["f"].values[center]
 
         # calculate group index
         n_center = self.n_eff.isel(f=center).values

--- a/tidy3d/components/microwave/data/monitor_data.py
+++ b/tidy3d/components/microwave/data/monitor_data.py
@@ -281,6 +281,30 @@ class MicrowaveModeData(ModeData, MicrowaveBaseModel):
             super_info["Im(Z0)"] = self.transmission_line_data.Z0.imag
         return super_info
 
+    def _group_index_post_process(self, frequency_step: float) -> ModeData:
+        """Calculate group index and remove added frequencies used only for this calculation.
+
+        Parameters
+        ----------
+        frequency_step: float
+            Fractional frequency step used to calculate the group index.
+
+        Returns
+        -------
+        :class:`.ModeData`
+            Filtered data with calculated group index.
+        """
+        super_data = super()._group_index_post_process(frequency_step)
+        if self.transmission_line_data is not None:
+            _, center_inds, _ = self._group_index_freq_slices()
+            update_dict = {
+                "Z0": self.transmission_line_data.Z0.isel(f=center_inds),
+                "voltage_coeffs": self.transmission_line_data.voltage_coeffs.isel(f=center_inds),
+                "current_coeffs": self.transmission_line_data.current_coeffs.isel(f=center_inds),
+            }
+            super_data = super_data.updated_copy(**update_dict, path="transmission_line_data")
+        return super_data
+
 
 class MicrowaveModeSolverData(ModeSolverData, MicrowaveModeData):
     """


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-31 16:22:57 UTC

<h3>Greptile Summary</h3>


Fixes frequency sampling in `MicrowaveModeData` when group index calculation is enabled. Group index calculation requires triplet frequencies (backward, center, forward) for numerical differentiation, but the `TransmissionLineDataset` was incorrectly retaining all triplet frequencies instead of filtering back to the original center frequencies.

**Key Changes:**
- Extracted `_group_index_freq_slices()` helper method in `ModeData` to centralize frequency slice logic
- Overrode `_group_index_post_process()` in `MicrowaveModeData` to filter `transmission_line_data` frequencies
- Added comprehensive test `test_mode_solver_with_microwave_group_index()` to verify frequency filtering

**Issues Found:**
- Missing `None` check for `transmission_line_data` before accessing attributes (could cause `AttributeError`)
- Minor grammar issue in CHANGELOG entry ("to when" → "when")

<h3>Confidence Score: 3/5</h3>


- This PR fixes a valid bug but has a critical logic error that could cause runtime failures
- The fix correctly addresses the frequency sampling issue by filtering transmission line data to match the original frequencies after group index calculation. However, the implementation in `_group_index_post_process()` accesses `transmission_line_data` attributes without checking if it's `None` first (it's declared as `Optional[TransmissionLineDataset]`), which will cause an `AttributeError` in cases where transmission line data is not populated
- Pay close attention to `tidy3d/components/microwave/data/monitor_data.py` - the `_group_index_post_process()` method needs a None check before accessing `transmission_line_data`

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| CHANGELOG.md | 4/5 | Added changelog entry with minor grammar issue |
| tidy3d/components/data/monitor_data.py | 5/5 | Extracted frequency slice logic into reusable helper method |
| tidy3d/components/microwave/data/monitor_data.py | 3/5 | Overrides group index post-processing to filter transmission line frequencies, but lacks None check |
| tests/test_components/test_microwave.py | 5/5 | Comprehensive test validates frequency filtering in transmission line data during group index calculation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant MS as ModeSolver
    participant MSD as MicrowaveModeSolverData
    participant MMD as MicrowaveModeData
    participant MD as ModeData
    
    MS->>MS: _get_data_with_group_index()
    Note over MS: Expands frequencies to triplets<br/>(back, center, forward) for<br/>numerical differentiation
    MS->>MS: _freqs_for_group_index()
    Note over MS: Creates [f1*(1-δ), f1, f1*(1+δ),<br/>f2*(1-δ), f2, f2*(1+δ), ...]
    MS->>MSD: Solve with expanded frequencies
    Note over MSD: data_raw contains triplet frequencies<br/>in transmission_line_data
    MS->>MMD: _group_index_post_process(frequency_step)
    MMD->>MD: super()._group_index_post_process()
    MD->>MD: _group_index_freq_slices()
    Note over MD: Returns (back, center, fwd) slices<br/>slice(0, n, 3), slice(1, n, 3), slice(2, n, 3)
    MD->>MD: Calculate n_group from triplets
    MD->>MD: Filter frequencies to center values
    MD-->>MMD: Returns filtered ModeData
    MMD->>MMD: _group_index_freq_slices()
    Note over MMD: Reuse same frequency slices
    MMD->>MMD: Filter transmission_line_data
    Note over MMD: Z0.isel(f=center_inds)<br/>voltage_coeffs.isel(f=center_inds)<br/>current_coeffs.isel(f=center_inds)
    MMD->>MMD: updated_copy(**update_dict)
    MMD-->>MS: Returns MicrowaveModeData<br/>with original frequencies only
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->