### PR TITLE
doc(fix): Fix angle spec documentation

### DIFF
--- a/docs/api/sources.rst
+++ b/docs/api/sources.rst
@@ -113,8 +113,8 @@ Plane Wave
    :template: module.rst
 
    tidy3d.PlaneWave
-   tidy3d.FixedInPlaneK
-   tidy3d.FixedAngle
+   tidy3d.FixedInPlaneKSpec
+   tidy3d.FixedAngleSpec
 
 The ``PlaneWave`` class represents an incident plane wave of a certain polarization and orientation. This is typically used in conjunction with periodic boundary conditions, e.g. in a unit cell simulation.
 


### PR DESCRIPTION
Hi Dario,
I just added the correct names since the documentation already references the example notebook.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-31 20:27:45 UTC

<h3>Greptile Summary</h3>


This PR corrects incorrect class names in the API documentation for plane wave sources. The documentation was referencing `FixedInPlaneK` and `FixedAngle`, but the actual class names in the codebase have always been `FixedInPlaneKSpec` and `FixedAngleSpec` (with the "Spec" suffix).

- Updated `tidy3d.FixedInPlaneK` → `tidy3d.FixedInPlaneKSpec`
- Updated `tidy3d.FixedAngle` → `tidy3d.FixedAngleSpec`

This is a documentation-only fix with no code changes. The correction ensures that users referencing the API documentation will find the correct class names that match the actual implementation.

<h3>Confidence Score: 5/5</h3>


- This PR is completely safe to merge with zero risk
- This is a trivial documentation fix correcting class names to match the actual implementation. No code changes were made, only RST documentation was updated. The change has been verified against the actual class definitions in the codebase.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| docs/api/sources.rst | 5/5 | Corrected class names from `FixedInPlaneK` and `FixedAngle` to `FixedInPlaneKSpec` and `FixedAngleSpec` to match actual implementation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Docs as docs/api/sources.rst
    participant User as User/Reader
    
    Dev->>Docs: Update FixedInPlaneK → FixedInPlaneKSpec
    Dev->>Docs: Update FixedAngle → FixedAngleSpec
    Note over Docs: RST documentation now references<br/>correct class names
    User->>Docs: Read PlaneWave documentation
    Docs->>User: Show correct class names:<br/>FixedInPlaneKSpec, FixedAngleSpec
    Note over User: Can now import classes with<br/>correct names from tidy3d
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->