### PR TITLE
docs(fix): Fix angle spec documentation

### DIFF
--- a/docs/api/sources.rst
+++ b/docs/api/sources.rst
@@ -114,8 +114,8 @@ Plane Wave
    :template: module.rst
 
    tidy3d.PlaneWave
-   tidy3d.FixedInPlaneK
-   tidy3d.FixedAngle
+   tidy3d.FixedInPlaneKSpec
+   tidy3d.FixedAngleSpec
 
 The ``PlaneWave`` class represents an incident plane wave of a certain polarization and orientation. This is typically used in conjunction with periodic boundary conditions, e.g. in a unit cell simulation.
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-31 20:43:41 UTC

<h3>Greptile Summary</h3>


Fixed incorrect class names in the API documentation for plane wave sources.

- Changed `tidy3d.FixedInPlaneK` to `tidy3d.FixedInPlaneKSpec`
- Changed `tidy3d.FixedAngle` to `tidy3d.FixedAngleSpec`

The documentation previously referenced non-existent class names. The actual classes in the codebase are `FixedInPlaneKSpec` and `FixedAngleSpec`, both properly exported in `tidy3d/__init__.py`. This fix ensures the documentation correctly references the actual API, allowing Sphinx to properly generate documentation links.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- This is a straightforward documentation fix that corrects incorrect class names. The changes align perfectly with the actual class names in the codebase (`FixedInPlaneKSpec` and `FixedAngleSpec`), which are properly exported and available in the tidy3d namespace. No code logic is affected, only documentation references.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| docs/api/sources.rst | 5/5 | Fixed incorrect class names in documentation from `FixedInPlaneK` and `FixedAngle` to the correct `FixedInPlaneKSpec` and `FixedAngleSpec` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Docs as Documentation System
    participant Sphinx as Sphinx Builder
    participant API as API Reference

    Dev->>Docs: Update sources.rst with correct class names
    Note over Dev,Docs: FixedInPlaneK → FixedInPlaneKSpec<br/>FixedAngle → FixedAngleSpec
    Docs->>Sphinx: Process RST file
    Sphinx->>API: Generate API documentation
    API->>Sphinx: Import tidy3d.FixedInPlaneKSpec
    API->>Sphinx: Import tidy3d.FixedAngleSpec
    Sphinx-->>Dev: Documentation successfully built
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->