### PR TITLE
fix(web): restore legacy environment exports

### DIFF
--- a/tests/config/test_legacy_env.py
+++ b/tests/config/test_legacy_env.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import ssl
+import warnings
 
 from tidy3d.config import Env, get_manager, reload_config
 from tidy3d.config import config as config_wrapper
@@ -69,3 +70,25 @@ def test_env_vars_follow_profile_switch(mock_config_dir, monkeypatch, config_man
         assert os.environ["TIDY3D_TEST_VAR"] == "applied"
     finally:
         reload_config(profile="default")
+
+
+def test_web_core_environment_reexports():
+    """Legacy `tidy3d.web.core.environment` exports remain available via config shim."""
+
+    import tidy3d.web as web
+    from tidy3d.config import Env as ConfigEnv
+
+    environment = web.core.environment
+    assert environment.Env is ConfigEnv
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        dev = environment.dev
+        uat = environment.uat
+
+    assert dev is ConfigEnv.dev
+    assert uat is ConfigEnv.uat
+    assert len(caught) == 2
+    assert "tidy3d.web.core.environment.dev" in str(caught[0].message)
+    assert "tidy3d.web.core.environment.uat" in str(caught[1].message)
+    assert "2.12" in str(caught[0].message)

--- a/tidy3d/config/__init__.py
+++ b/tidy3d/config/__init__.py
@@ -34,9 +34,11 @@ def _create_manager() -> ConfigManager:
 
 
 _base_manager = _create_manager()
+# TODO(FXC-3827): Drop LegacyConfigWrapper once legacy accessors are removed in Tidy3D 2.12.
 _config_wrapper = LegacyConfigWrapper(_base_manager)
 config = _config_wrapper
 
+# TODO(FXC-3827): Remove legacy Env exports after deprecation window (planned 2.12).
 Environment = LegacyEnvironment
 EnvironmentConfig = LegacyEnvironmentConfig
 Env = LegacyEnvironment(_base_manager)

--- a/tidy3d/config/legacy.py
+++ b/tidy3d/config/legacy.py
@@ -16,6 +16,7 @@ import toml
 
 from tidy3d.log import log
 
+# TODO(FXC-3827): Remove LegacyConfigWrapper/Environment shims and related helpers in Tidy3D 2.12.
 from .manager import ConfigManager, normalize_profile_name
 from .profiles import BUILTIN_PROFILES
 
@@ -26,6 +27,7 @@ def _warn_env_deprecated() -> None:
     log.warning(message, log_once=True)
 
 
+# TODO(FXC-3827): Delete LegacyConfigWrapper once legacy attribute access is dropped.
 class LegacyConfigWrapper:
     """Provide attribute-level compatibility with the legacy config module."""
 
@@ -144,6 +146,7 @@ class LegacyConfigWrapper:
         return self._manager.format()
 
 
+# TODO(FXC-3827): Delete LegacyEnvironmentConfig once profile-based Env shim is removed.
 class LegacyEnvironmentConfig:
     """Backward compatible environment config wrapper that proxies ConfigManager."""
 
@@ -318,6 +321,7 @@ class LegacyEnvironmentConfig:
         return self._web_section().get(key)
 
 
+# TODO(FXC-3827): Delete LegacyEnvironment after deprecating `tidy3d.config.Env`.
 class LegacyEnvironment:
     """Legacy Env wrapper that maps to profiles."""
 

--- a/tidy3d/web/core/__init__.py
+++ b/tidy3d/web/core/__init__.py
@@ -1,1 +1,8 @@
 """Tidy3d core package imports"""
+
+from __future__ import annotations
+
+# TODO(FXC-3827): Drop this import once the legacy shim is removed in Tidy3D 2.12.
+from . import environment
+
+__all__ = ["environment"]

--- a/tidy3d/web/core/environment.py
+++ b/tidy3d/web/core/environment.py
@@ -2,6 +2,41 @@
 
 from __future__ import annotations
 
+# TODO(FXC-3827): Remove this module-level legacy shim in Tidy3D 2.12.
+import warnings
+from typing import Any
+
 from tidy3d.config import Env, Environment, EnvironmentConfig
 
-__all__ = ["Env", "Environment", "EnvironmentConfig"]
+__all__ = [  # noqa: F822
+    "Env",
+    "Environment",
+    "EnvironmentConfig",
+    "dev",
+    "nexus",
+    "pre",
+    "prod",
+    "uat",
+]
+
+_LEGACY_ENV_NAMES = {"dev", "uat", "pre", "prod", "nexus"}
+_DEPRECATION_MESSAGE = (
+    "'tidy3d.web.core.environment.{name}' is deprecated and will be removed in "
+    "Tidy3D 2.12. Transition to 'tidy3d.config.Env.{name}' or "
+    "'tidy3d.config.config.switch_profile(...)'."
+)
+
+
+def _get_legacy_env(name: str) -> Any:
+    warnings.warn(_DEPRECATION_MESSAGE.format(name=name), DeprecationWarning, stacklevel=2)
+    return getattr(Env, name)
+
+
+def __getattr__(name: str) -> Any:
+    if name in _LEGACY_ENV_NAMES:
+        return _get_legacy_env(name)
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(__all__))

--- a/tidy3d/web/environment.py
+++ b/tidy3d/web/environment.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+# TODO(FXC-3827): Remove this re-export once `tidy3d.web.environment` shim is retired in 2.12.
 from .core.environment import Env
 
 __all__ = ["Env"]


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-03 08:54:39 UTC

<h3>Greptile Summary</h3>


This PR restores backward compatibility for legacy environment exports from `tidy3d.web.core.environment`. Users who previously accessed environment instances like `dev`, `uat`, `prod`, `pre`, and `nexus` directly from this module will now have those exports available again, with appropriate deprecation warnings pointing them to the new config system.

**Key changes:**
- Added module-level `__getattr__` and `__dir__` to `tidy3d.web.core.environment` to dynamically provide legacy environment instances
- All legacy access now emits `DeprecationWarning` with clear migration path to `tidy3d.config.Env.{name}` or `tidy3d.config.config.switch_profile(...)`
- Added comprehensive test coverage verifying the legacy exports work correctly and emit proper deprecation warnings
- Added TODO comments throughout documenting the deprecation timeline (removal planned for Tidy3D 2.12)
- Made `web.core.environment` submodule explicitly available via `tidy3d.web.core.__init__.py`

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are straightforward backward compatibility shims that restore previously available functionality. The implementation uses standard Python module-level `__getattr__` patterns, includes proper deprecation warnings, has comprehensive test coverage, and doesn't modify any core logic. All changes are additive and well-documented with clear deprecation timelines.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/web/core/environment.py | 5/5 | Added `__getattr__` and `__dir__` to dynamically export legacy environment instances (`dev`, `uat`, etc.) with deprecation warnings |
| tidy3d/web/core/__init__.py | 5/5 | Added `environment` submodule import to expose legacy environment exports |
| tests/config/test_legacy_env.py | 5/5 | Added comprehensive test verifying legacy environment exports work with proper deprecation warnings |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant web.core.environment
    participant __getattr__
    participant tidy3d.config.Env
    participant LegacyEnvironment
    participant warnings

    User->>web.core.environment: import tidy3d.web.core.environment
    Note over web.core.environment: Module loads with Env, Environment, EnvironmentConfig
    
    User->>web.core.environment: access environment.dev
    web.core.environment->>__getattr__: __getattr__("dev")
    __getattr__->>__getattr__: check if "dev" in _LEGACY_ENV_NAMES
    __getattr__->>warnings: warn deprecation message
    __getattr__->>tidy3d.config.Env: getattr(Env, "dev")
    tidy3d.config.Env->>LegacyEnvironment: __getattr__("dev")
    LegacyEnvironment-->>tidy3d.config.Env: return LegacyEnvironmentConfig("dev")
    tidy3d.config.Env-->>__getattr__: return dev config
    __getattr__-->>User: return dev environment config

    User->>web.core.environment: access environment.uat
    web.core.environment->>__getattr__: __getattr__("uat")
    __getattr__->>warnings: warn deprecation message
    __getattr__->>tidy3d.config.Env: getattr(Env, "uat")
    tidy3d.config.Env->>LegacyEnvironment: __getattr__("uat")
    LegacyEnvironment-->>User: return uat environment config
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->