### PR TITLE
chore: temp disable release autorun (FXC-3947)

### DIFF
--- a/.github/workflows/tidy3d-python-client-release.yml
+++ b/.github/workflows/tidy3d-python-client-release.yml
@@ -1,9 +1,7 @@
 name: "public/tidy3d/python-client-release"
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
I'm testing the new [autorelease](https://github.com/flexcompute/tidy3d/pull/2951) and need to disable this