### PR TITLE
feat(tidy3d): FXC-3958-mypy-implement-type-defs-in-config-material-li…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -319,6 +319,9 @@ python_files = "*.py"
 python_version = "3.10"
 files = [
   "tidy3d/web",
+  "tidy3d/config",
+  "tidy3d/material_library",
+  "tidy3d/components/geometry"
 ]
 ignore_missing_imports = true
 follow_imports = "skip"

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 import functools
 import pathlib
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from os import PathLike
-from typing import Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 import autograd.numpy as np
 import pydantic.v1 as pydantic
 import shapely
 import xarray as xr
+from numpy._typing import ArrayLike, NDArray
+from typing_extensions import Self
 
 try:
     from matplotlib import patches
@@ -74,6 +77,11 @@ from tidy3d.exceptions import (
 from tidy3d.log import log
 from tidy3d.packaging import verify_packages_import
 
+if TYPE_CHECKING:
+    from gdstk import Cell
+    from matplotlib.backend_bases import Event
+    from matplotlib.patches import FancyArrowPatch
+
 POLY_GRID_SIZE = 1e-12
 POLY_TOLERANCE_RATIO = 1e-12
 POLY_DISTANCE_TOLERANCE = 8e-12
@@ -98,13 +106,11 @@ class Geometry(Tidy3dBaseModel, ABC):
     """Abstract base class, defines where something exists in space."""
 
     @cached_property
-    def plot_params(self):
+    def plot_params(self) -> PlotParams:
         """Default parameters for plotting a Geometry object."""
         return plot_params_geometry
 
-    def inside(
-        self, x: np.ndarray[float], y: np.ndarray[float], z: np.ndarray[float]
-    ) -> np.ndarray[bool]:
+    def inside(self, x: NDArray[float], y: NDArray[float], z: NDArray[float]) -> NDArray[bool]:
         """For input arrays ``x``, ``y``, ``z`` of arbitrary but identical shape, return an array
         with the same shape which is ``True`` for every point in zip(x, y, z) that is inside the
         volume of the :class:`Geometry`, and ``False`` otherwise.
@@ -124,7 +130,7 @@ class Geometry(Tidy3dBaseModel, ABC):
             ``True`` for every point that is inside the geometry.
         """
 
-        def point_inside(x: float, y: float, z: float):
+        def point_inside(x: float, y: float, z: float) -> bool:
             """Returns ``True`` if a single point ``(x, y, z)`` is inside."""
             shapes_intersect = self.intersections_plane(z=z)
             loc = self.make_shapely_point(x, y)
@@ -166,7 +172,7 @@ class Geometry(Tidy3dBaseModel, ABC):
         return shapely.Point(minx, miny)
 
     def _inds_inside_bounds(
-        self, x: np.ndarray[float], y: np.ndarray[float], z: np.ndarray[float]
+        self, x: NDArray[float], y: NDArray[float], z: NDArray[float]
     ) -> tuple[slice, slice, slice]:
         """Return slices into the sorted input arrays that are inside the geometry bounds.
 
@@ -193,8 +199,8 @@ class Geometry(Tidy3dBaseModel, ABC):
         return tuple(inds_in)
 
     def inside_meshgrid(
-        self, x: np.ndarray[float], y: np.ndarray[float], z: np.ndarray[float]
-    ) -> np.ndarray[bool]:
+        self, x: NDArray[float], y: NDArray[float], z: NDArray[float]
+    ) -> NDArray[bool]:
         """Perform ``self.inside`` on a set of sorted 1D coordinates. Applies meshgrid to the
         supplied coordinates before checking inside.
 
@@ -296,7 +302,7 @@ class Geometry(Tidy3dBaseModel, ABC):
         return plane.intersections_with(self)
 
     def intersects(
-        self, other, strict_inequality: tuple[bool, bool, bool] = [False, False, False]
+        self, other: Geometry, strict_inequality: tuple[bool, bool, bool] = [False, False, False]
     ) -> bool:
         """Returns ``True`` if two :class:`Geometry` have intersecting `.bounds`.
 
@@ -434,7 +440,7 @@ class Geometry(Tidy3dBaseModel, ABC):
         return bounds_union(bounds1, bounds2)
 
     @cached_property
-    def bounding_box(self):
+    def bounding_box(self) -> Box:
         """Returns :class:`Box` representation of the bounding box of a :class:`Geometry`.
 
         Returns
@@ -585,7 +591,9 @@ class Geometry(Tidy3dBaseModel, ABC):
         return ax
 
     @staticmethod
-    def _do_not_intersect(bounds_a, bounds_b, shape_a, shape_b):
+    def _do_not_intersect(
+        bounds_a: float, bounds_b: float, shape_a: Shapely, shape_b: Shapely
+    ) -> bool:
         """Check whether two shapes intersect."""
 
         # do a bounding box check to see if any intersection to do anything about
@@ -708,7 +716,7 @@ class Geometry(Tidy3dBaseModel, ABC):
         return ax
 
     @staticmethod
-    def _evaluate_inf(array):
+    def _evaluate_inf(array: ArrayLike) -> NDArray[np.floating]:
         """Processes values and evaluates any infs into large (signed) numbers."""
         array = get_static(np.array(array))
         return np.where(np.isinf(array), np.sign(array) * LARGE_NUMBER, array)
@@ -884,7 +892,7 @@ class Geometry(Tidy3dBaseModel, ABC):
 
         return points_new
 
-    def volume(self, bounds: Bound = None):
+    def volume(self, bounds: Bound = None) -> float:
         """Returns object's volume with optional bounds.
 
         Parameters
@@ -907,7 +915,7 @@ class Geometry(Tidy3dBaseModel, ABC):
     def _volume(self, bounds: Bound) -> float:
         """Returns object's volume within given bounds."""
 
-    def surface_area(self, bounds: Bound = None):
+    def surface_area(self, bounds: Bound = None) -> float:
         """Returns object's surface area with optional bounds.
 
         Parameters
@@ -1157,7 +1165,7 @@ class Geometry(Tidy3dBaseModel, ABC):
     @staticmethod
     @verify_packages_import(["gdstk"])
     def load_gds_vertices_gdstk(
-        gds_cell,
+        gds_cell: Cell,
         gds_layer: int,
         gds_dtype: Optional[int] = None,
         gds_scale: pydantic.PositiveFloat = 1.0,
@@ -1209,7 +1217,7 @@ class Geometry(Tidy3dBaseModel, ABC):
     @staticmethod
     @verify_packages_import(["gdstk"])
     def from_gds(
-        gds_cell,
+        gds_cell: Cell,
         axis: Axis,
         slab_bounds: tuple[float, float],
         gds_layer: int,
@@ -1373,7 +1381,7 @@ class Geometry(Tidy3dBaseModel, ABC):
     @verify_packages_import(["gdstk"])
     def to_gds(
         self,
-        cell,
+        cell: Cell,
         x: Optional[float] = None,
         y: Optional[float] = None,
         z: Optional[float] = None,
@@ -1468,65 +1476,65 @@ class Geometry(Tidy3dBaseModel, ABC):
             return (self.geometry_a, self.geometry_b)
         return (self,)
 
-    def __add__(self, other):
+    def __add__(self, other: Union[int, Geometry]) -> Union[Self, GeometryGroup]:
         """Union of geometries"""
         # This allows the user to write sum(geometries...) with the default start=0
         if isinstance(other, int):
             return self
         if not isinstance(other, Geometry):
-            return NotImplemented
+            return NotImplemented  # type: ignore[return-value]
         return GeometryGroup(geometries=self._as_union() + other._as_union())
 
-    def __radd__(self, other):
+    def __radd__(self, other: Union[int, Geometry]) -> Union[Self, GeometryGroup]:
         """Union of geometries"""
         # This allows the user to write sum(geometries...) with the default start=0
         if isinstance(other, int):
             return self
         if not isinstance(other, Geometry):
-            return NotImplemented
+            return NotImplemented  # type: ignore[return-value]
         return GeometryGroup(geometries=other._as_union() + self._as_union())
 
-    def __or__(self, other):
+    def __or__(self, other: Geometry) -> GeometryGroup:
         """Union of geometries"""
         if not isinstance(other, Geometry):
             return NotImplemented
         return GeometryGroup(geometries=self._as_union() + other._as_union())
 
-    def __mul__(self, other):
+    def __mul__(self, other: Geometry) -> ClipOperation:
         """Intersection of geometries"""
         if not isinstance(other, Geometry):
             return NotImplemented
         return ClipOperation(operation="intersection", geometry_a=self, geometry_b=other)
 
-    def __and__(self, other):
+    def __and__(self, other: Geometry) -> ClipOperation:
         """Intersection of geometries"""
         if not isinstance(other, Geometry):
             return NotImplemented
         return ClipOperation(operation="intersection", geometry_a=self, geometry_b=other)
 
-    def __sub__(self, other):
+    def __sub__(self, other: Geometry) -> ClipOperation:
         """Difference of geometries"""
         if not isinstance(other, Geometry):
-            return NotImplemented
+            return NotImplemented  # type: ignore[return-value]
         return ClipOperation(operation="difference", geometry_a=self, geometry_b=other)
 
-    def __xor__(self, other):
+    def __xor__(self, other: Geometry) -> ClipOperation:
         """Symmetric difference of geometries"""
         if not isinstance(other, Geometry):
             return NotImplemented
         return ClipOperation(operation="symmetric_difference", geometry_a=self, geometry_b=other)
 
-    def __pos__(self):
+    def __pos__(self) -> Self:
         """No op"""
         return self
 
-    def __neg__(self):
+    def __neg__(self) -> ClipOperation:
         """Opposite of a geometry"""
         return ClipOperation(
             operation="difference", geometry_a=Box(size=(inf, inf, inf)), geometry_b=self
         )
 
-    def __invert__(self):
+    def __invert__(self) -> ClipOperation:
         """Opposite of a geometry"""
         return ClipOperation(
             operation="difference", geometry_a=Box(size=(inf, inf, inf)), geometry_b=self
@@ -1547,7 +1555,7 @@ class Centered(Geometry, ABC):
     )
 
     @pydantic.validator("center", always=True)
-    def _center_not_inf(cls, val):
+    def _center_not_inf(cls, val: tuple[float, float, float]) -> tuple[float, float, float]:
         """Make sure center is not infinitiy."""
         if any(np.isinf(v) for v in val):
             raise ValidationError("center can not contain td.inf terms.")
@@ -1589,7 +1597,7 @@ class SimplePlaneIntersection(Geometry, ABC):
             # Apply transformation in the plane by removing row and column
             to_2D_in_plane = np.delete(np.delete(to_2D, 2, 0), axis, 1)
 
-            def transform(p_array):
+            def transform(p_array: NDArray) -> NDArray:
                 return np.dot(
                     np.hstack((p_array, np.ones((p_array.shape[0], 1)))), to_2D_in_plane.T
                 )[:, :2]
@@ -1699,7 +1707,7 @@ class Planar(SimplePlaneIntersection, Geometry, ABC):
 
     def intersections_plane(
         self, x: Optional[float] = None, y: Optional[float] = None, z: Optional[float] = None
-    ):
+    ) -> list[Shapely]:
         """Returns shapely geometry at plane specified by one non None value of x,y,z.
 
         Parameters
@@ -1743,7 +1751,7 @@ class Planar(SimplePlaneIntersection, Geometry, ABC):
         """
 
     @abstractmethod
-    def _intersections_side(self, position: float, axis: Axis) -> list:
+    def _intersections_side(self, position: float, axis: Axis) -> list[Shapely]:
         """Find shapely geometries intersecting planar geometry with axis orthogonal to plane.
 
         Parameters
@@ -1820,13 +1828,13 @@ class Circular(Geometry):
     )
 
     @pydantic.validator("radius", always=True)
-    def _radius_not_inf(cls, val):
+    def _radius_not_inf(cls, val: float) -> float:
         """Make sure center is not infinitiy."""
         if np.isinf(val):
             raise ValidationError("radius can not be td.inf.")
         return val
 
-    def _intersect_dist(self, position, z0) -> float:
+    def _intersect_dist(self, position: float, z0: float) -> float:
         """Distance between points on circle at z=position where center of circle at z=z0.
 
         Parameters
@@ -1867,7 +1875,7 @@ class Box(SimplePlaneIntersection, Centered):
     )
 
     @classmethod
-    def from_bounds(cls, rmin: Coordinate, rmax: Coordinate, **kwargs: Any):
+    def from_bounds(cls, rmin: Coordinate, rmax: Coordinate, **kwargs: Any) -> Self:
         """Constructs a :class:`Box` from minimum and maximum coordinate bounds
 
         Parameters
@@ -1896,7 +1904,7 @@ class Box(SimplePlaneIntersection, Centered):
         return self.size.index(0.0)
 
     @classmethod
-    def surfaces(cls, size: Size, center: Coordinate, **kwargs: Any):
+    def surfaces(cls, size: Size, center: Coordinate, **kwargs: Any) -> list[Self]:
         """Returns a list of 6 :class:`Box` instances corresponding to each surface of a 3D volume.
         The output surfaces are stored in the order [x-, x+, y-, y+, z-, z+], where x, y, and z
         denote which axis is perpendicular to that surface, while "-" and "+" denote the direction
@@ -1961,7 +1969,7 @@ class Box(SimplePlaneIntersection, Centered):
         del_idx = [[2 * i, 2 * i + 1] for i in del_idx]
         del_idx = [item for sublist in del_idx for item in sublist]
 
-        def del_items(items, indices):
+        def del_items(items: Iterable, indices: int) -> list:
             """Delete list items at indices."""
             return [i for j, i in enumerate(items) if j not in indices]
 
@@ -1984,7 +1992,7 @@ class Box(SimplePlaneIntersection, Centered):
         return surfaces
 
     @classmethod
-    def surfaces_with_exclusion(cls, size: Size, center: Coordinate, **kwargs: Any):
+    def surfaces_with_exclusion(cls, size: Size, center: Coordinate, **kwargs: Any) -> list[Self]:
         """Returns a list of 6 :class:`Box` instances corresponding to each surface of a 3D volume.
         The output surfaces are stored in the order [x-, x+, y-, y+, z-, z+], where x, y, and z
         denote which axis is perpendicular to that surface, while "-" and "+" denote the direction
@@ -2066,7 +2074,7 @@ class Box(SimplePlaneIntersection, Centered):
 
     def intersections_plane(
         self, x: Optional[float] = None, y: Optional[float] = None, z: Optional[float] = None
-    ):
+    ) -> list[Shapely]:
         """Returns shapely geometry at plane specified by one non None value of x,y,z.
 
         Parameters
@@ -2105,9 +2113,7 @@ class Box(SimplePlaneIntersection, Centered):
 
         return [self.make_shapely_box(minx, miny, maxx, maxy)]
 
-    def inside(
-        self, x: np.ndarray[float], y: np.ndarray[float], z: np.ndarray[float]
-    ) -> np.ndarray[bool]:
+    def inside(self, x: NDArray[float], y: NDArray[float], z: NDArray[float]) -> NDArray[bool]:
         """For input arrays ``x``, ``y``, ``z`` of arbitrary but identical shape, return an array
         with the same shape which is ``True`` for every point in zip(x, y, z) that is inside the
         volume of the :class:`Geometry`, and ``False`` otherwise.
@@ -2134,7 +2140,7 @@ class Box(SimplePlaneIntersection, Centered):
         dist_z = np.abs(z - z0)
         return (dist_x <= Lx / 2) * (dist_y <= Ly / 2) * (dist_z <= Lz / 2)
 
-    def intersections_with(self, other):
+    def intersections_with(self, other: Shapely) -> list[Shapely]:
         """Returns list of shapely geometries representing the intersections of the geometry with
         this 2D box.
 
@@ -2205,7 +2211,7 @@ class Box(SimplePlaneIntersection, Centered):
 
         rmin, rmax = self.bounds
 
-        def bound_array(arrs, idx):
+        def bound_array(arrs: ArrayLike, idx: int) -> NDArray:
             return np.array([(a[idx] if a is not None else 0) for a in arrs])
 
         # parse padding sizes for simulation
@@ -2233,7 +2239,7 @@ class Box(SimplePlaneIntersection, Centered):
         return (coord_min, coord_max)
 
     @cached_property
-    def geometry(self):
+    def geometry(self) -> Box:
         """:class:`Box` representation of self (used for subclasses of Box).
 
         Returns
@@ -2365,8 +2371,14 @@ class Box(SimplePlaneIntersection, Centered):
         return ax
 
     @staticmethod
-    def _arrow_shape_cb(arrow, pos, direction, sign, bend_radius):
-        def _cb(event) -> None:
+    def _arrow_shape_cb(
+        arrow: FancyArrowPatch,
+        pos: tuple[float, float],
+        direction: ArrayLike,
+        sign: float,
+        bend_radius: float | None,
+    ) -> Callable[[Event], None]:
+        def _cb(event: Event) -> None:
             # We only want to set the shape once, so we disconnect ourselves
             event.canvas.mpl_disconnect(arrow.set_shape_cb[0])
 
@@ -2625,7 +2637,7 @@ class Box(SimplePlaneIntersection, Centered):
 
     @staticmethod
     def _snap_coords_outside(
-        min_max_index: int, snap_coords_values: np.ndarray, coord_normal_face: float
+        min_max_index: int, snap_coords_values: NDArray, coord_normal_face: float
     ) -> float:
         """Snap interpolation coordinate for a PEC face integration to be just outside the surface boundary.
         This ensures we don't interpolate with fields that are zero inside of the PEC."""
@@ -2900,13 +2912,13 @@ class Transformed(Geometry):
     )
 
     @pydantic.validator("transform")
-    def _transform_is_invertible(cls, val):
+    def _transform_is_invertible(cls, val: MatrixReal4x4) -> MatrixReal4x4:
         # If the transform is not invertible, this will raise an error
         _ = np.linalg.inv(val)
         return val
 
     @pydantic.validator("geometry")
-    def _geometry_is_finite(cls, val):
+    def _geometry_is_finite(cls, val: GeometryType) -> GeometryType:
         if not np.isfinite(val.bounds).all():
             raise ValidationError(
                 "Transformations are only supported on geometries with finite dimensions. "
@@ -2916,7 +2928,7 @@ class Transformed(Geometry):
         return val
 
     @pydantic.root_validator(skip_on_failure=True)
-    def _apply_transforms(cls, values):
+    def _apply_transforms(cls, values: dict[str, Any]) -> dict[str, Any]:
         while isinstance(values["geometry"], Transformed):
             inner = values["geometry"]
             values["geometry"] = inner.geometry
@@ -2995,9 +3007,7 @@ class Transformed(Geometry):
             np.dot(to_2D, self.transform),
         )
 
-    def inside(
-        self, x: np.ndarray[float], y: np.ndarray[float], z: np.ndarray[float]
-    ) -> np.ndarray[bool]:
+    def inside(self, x: NDArray[float], y: NDArray[float], z: NDArray[float]) -> NDArray[bool]:
         """For input arrays ``x``, ``y``, ``z`` of arbitrary but identical shape, return an array
         with the same shape which is ``True`` for every point in zip(x, y, z) that is inside the
         volume of the :class:`Geometry`, and ``False`` otherwise.
@@ -3204,7 +3214,7 @@ class ClipOperation(Geometry):
     )
 
     @pydantic.validator("geometry_a", "geometry_b", always=True)
-    def _geometries_untraced(cls, val):
+    def _geometries_untraced(cls, val: GeometryType) -> GeometryType:
         """Make sure that ``ClipOperation`` geometries do not contain tracers."""
         traced = val._strip_traced_fields()
         if traced:
@@ -3365,9 +3375,7 @@ class ClipOperation(Geometry):
             )
         return result
 
-    def inside(
-        self, x: np.ndarray[float], y: np.ndarray[float], z: np.ndarray[float]
-    ) -> np.ndarray[bool]:
+    def inside(self, x: NDArray[float], y: NDArray[float], z: NDArray[float]) -> NDArray[bool]:
         """For input arrays ``x``, ``y``, ``z`` of arbitrary but identical shape, return an array
         with the same shape which is ``True`` for every point in zip(x, y, z) that is inside the
         volume of the :class:`Geometry`, and ``False`` otherwise.
@@ -3391,8 +3399,8 @@ class ClipOperation(Geometry):
         return self._bit_operation(inside_a, inside_b)
 
     def inside_meshgrid(
-        self, x: np.ndarray[float], y: np.ndarray[float], z: np.ndarray[float]
-    ) -> np.ndarray[bool]:
+        self, x: NDArray[float], y: NDArray[float], z: NDArray[float]
+    ) -> NDArray[bool]:
         """Faster way to check ``self.inside`` on a meshgrid. The input arrays are assumed sorted.
 
         Parameters
@@ -3469,7 +3477,9 @@ class GeometryGroup(Geometry):
     )
 
     @pydantic.validator("geometries", always=True)
-    def _geometries_not_empty(cls, val):
+    def _geometries_not_empty(
+        cls, val: tuple[annotate_type(GeometryType), ...]
+    ) -> tuple[annotate_type(GeometryType), ...]:
         """make sure geometries are not empty."""
         if not len(val) > 0:
             raise ValidationError("GeometryGroup.geometries must not be empty.")
@@ -3564,9 +3574,7 @@ class GeometryGroup(Geometry):
         """
         return any(geom.intersects_axis_position(axis, position) for geom in self.geometries)
 
-    def inside(
-        self, x: np.ndarray[float], y: np.ndarray[float], z: np.ndarray[float]
-    ) -> np.ndarray[bool]:
+    def inside(self, x: NDArray[float], y: NDArray[float], z: NDArray[float]) -> NDArray[bool]:
         """For input arrays ``x``, ``y``, ``z`` of arbitrary but identical shape, return an array
         with the same shape which is ``True`` for every point in zip(x, y, z) that is inside the
         volume of the :class:`Geometry`, and ``False`` otherwise.
@@ -3589,8 +3597,8 @@ class GeometryGroup(Geometry):
         return functools.reduce(lambda a, b: a | b, individual_insides)
 
     def inside_meshgrid(
-        self, x: np.ndarray[float], y: np.ndarray[float], z: np.ndarray[float]
-    ) -> np.ndarray[bool]:
+        self, x: NDArray[float], y: NDArray[float], z: NDArray[float]
+    ) -> NDArray[bool]:
         """Faster way to check ``self.inside`` on a meshgrid. The input arrays are assumed sorted.
 
         Parameters

--- a/tidy3d/components/geometry/mesh.py
+++ b/tidy3d/components/geometry/mesh.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Any, Callable, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union
 
 import numpy as np
 import pydantic.v1 as pydantic
@@ -20,6 +20,9 @@ from tidy3d.log import log
 from tidy3d.packaging import verify_packages_import
 
 from . import base
+
+if TYPE_CHECKING:
+    from trimesh import Trimesh
 
 AREA_SIZE_THRESHOLD = 1e-36
 
@@ -44,7 +47,7 @@ class TriangleMesh(base.Geometry, ABC):
 
     @pydantic.root_validator(pre=True)
     @verify_packages_import(["trimesh"])
-    def _validate_trimesh_library(cls, values):
+    def _validate_trimesh_library(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Check if the trimesh package is imported as a validator."""
         return values
 
@@ -303,7 +306,7 @@ class TriangleMesh(base.Geometry, ABC):
     @verify_packages_import(["trimesh"])
     def _triangles_to_trimesh(
         cls, triangles: np.ndarray
-    ):  # -> TrimeshType: We need to get this out of the classes and into functional methods operating on a class (maybe still referenced to the class)
+    ) -> Trimesh:  # -> We need to get this out of the classes and into functional methods operating on a class (maybe still referenced to the class)
         """Convert an (N, 3, 3) numpy array of triangles to a ``trimesh.Trimesh``."""
         import trimesh
 
@@ -492,7 +495,7 @@ class TriangleMesh(base.Geometry, ABC):
     @verify_packages_import(["trimesh"])
     def trimesh(
         self,
-    ):  # -> TrimeshType: We need to get this out of the classes and into functional methods operating on a class (maybe still referenced to the class)
+    ) -> Trimesh:  # -> We need to get this out of the classes and into functional methods operating on a class (maybe still referenced to the class)
         """A ``trimesh.Trimesh`` object representing the custom surface mesh geometry."""
         return self._triangles_to_trimesh(self.triangles)
 

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import math
 from copy import copy
 from functools import lru_cache
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import autograd.numpy as np
 import pydantic.v1 as pydantic
 import shapely
 from autograd.tracer import getval, isbox
+from numpy._typing import NDArray
 from numpy.polynomial.legendre import leggauss as _leggauss
 
 from tidy3d.components.autograd import AutogradFieldMap, TracedVertices, get_static
@@ -37,6 +38,9 @@ from tidy3d.packaging import verify_packages_import
 
 from . import base, triangulation
 
+if TYPE_CHECKING:
+    from gdstk import Cell
+
 # sampling polygon along dilation for validating polygon to be
 # non self-intersecting during the entire dilation process
 _N_SAMPLE_POLYGON_INTERSECT = 5
@@ -53,7 +57,7 @@ _MIN_POLYGON_AREA = fp_eps
 
 
 @lru_cache(maxsize=128)
-def leggauss(n):
+def leggauss(n: int) -> tuple[NDArray, NDArray]:
     """Cached version of leggauss with dtype conversions."""
     g, w = _leggauss(n)
     return g.astype(config.adjoint.gradient_dtype_float, copy=False), w.astype(
@@ -102,7 +106,7 @@ class PolySlab(base.Planar):
         return shapely.Polygon(vertices)
 
     @pydantic.validator("slab_bounds", always=True)
-    def slab_bounds_order(cls, val):
+    def slab_bounds_order(cls, val: tuple[float, float]) -> tuple[float, float]:
         """Maximum position of the slab should be no smaller than its minimal position."""
         if val[1] < val[0]:
             raise SetupError(
@@ -113,7 +117,7 @@ class PolySlab(base.Planar):
         return val
 
     @pydantic.validator("vertices", always=True)
-    def correct_shape(cls, val):
+    def correct_shape(cls, val: ArrayFloat2D) -> ArrayFloat2D:
         """Makes sure vertices size is correct.
         Make sure no intersecting edges.
         """
@@ -140,7 +144,9 @@ class PolySlab(base.Planar):
 
     @pydantic.validator("vertices", always=True)
     @skip_if_fields_missing(["dilation"])
-    def no_complex_self_intersecting_polygon_at_reference_plane(cls, val, values):
+    def no_complex_self_intersecting_polygon_at_reference_plane(
+        cls, val: ArrayFloat2D, values: dict[str, Any]
+    ) -> ArrayFloat2D:
         """At the reference plane, check if the polygon is self-intersecting.
 
         There are two types of self-intersection that can occur during dilation:
@@ -190,7 +196,9 @@ class PolySlab(base.Planar):
 
     @pydantic.validator("vertices", always=True)
     @skip_if_fields_missing(["sidewall_angle", "dilation", "slab_bounds", "reference_plane"])
-    def no_self_intersecting_polygon_during_extrusion(cls, val, values):
+    def no_self_intersecting_polygon_during_extrusion(
+        cls, val: ArrayFloat2D, values: dict[str, Any]
+    ) -> ArrayFloat2D:
         """In this simple polyslab, we don't support self-intersecting polygons yet, meaning that
         any normal cross section of the PolySlab cannot be self-intersecting. This part checks
         if any self-interction will occur during extrusion with non-zero sidewall angle.
@@ -261,7 +269,7 @@ class PolySlab(base.Planar):
     @classmethod
     def from_gds(
         cls,
-        gds_cell,
+        gds_cell: Cell,
         axis: Axis,
         slab_bounds: tuple[float, float],
         gds_layer: int,
@@ -325,7 +333,7 @@ class PolySlab(base.Planar):
 
     @staticmethod
     def _load_gds_vertices(
-        gds_cell,
+        gds_cell: Cell,
         gds_layer: int,
         gds_dtype: Optional[int] = None,
         gds_scale: pydantic.PositiveFloat = 1.0,
@@ -411,7 +419,7 @@ class PolySlab(base.Planar):
         return zmax - zmin
 
     @cached_property
-    def reference_polygon(self) -> np.ndarray:
+    def reference_polygon(self) -> NDArray:
         """The polygon at the reference plane.
 
         Returns
@@ -426,7 +434,7 @@ class PolySlab(base.Planar):
         return self._heal_polygon(offset_vertices)
 
     @cached_property
-    def middle_polygon(self) -> np.ndarray:
+    def middle_polygon(self) -> NDArray:
         """The polygon at the middle.
 
         Returns
@@ -444,7 +452,7 @@ class PolySlab(base.Planar):
         return self.reference_polygon
 
     @cached_property
-    def base_polygon(self) -> np.ndarray:
+    def base_polygon(self) -> NDArray:
         """The polygon at the base, derived from the ``middle_polygon``.
 
         Returns
@@ -458,7 +466,7 @@ class PolySlab(base.Planar):
         return self._shift_vertices(self.middle_polygon, dist)[0]
 
     @cached_property
-    def top_polygon(self) -> np.ndarray:
+    def top_polygon(self) -> NDArray:
         """The polygon at the top, derived from the ``middle_polygon``.
 
         Returns
@@ -493,9 +501,7 @@ class PolySlab(base.Planar):
         """Is this ``PolySlab`` CCW-oriented?"""
         return PolySlab._area(self.vertices) > 0
 
-    def inside(
-        self, x: np.ndarray[float], y: np.ndarray[float], z: np.ndarray[float]
-    ) -> np.ndarray[bool]:
+    def inside(self, x: NDArray[float], y: NDArray[float], z: NDArray[float]) -> NDArray[bool]:
         """For input arrays ``x``, ``y``, ``z`` of arbitrary but identical shape, return an array
         with the same shape which is ``True`` for every point in zip(x, y, z) that is inside the
         volume of the :class:`Geometry`, and ``False`` otherwise.
@@ -549,10 +555,10 @@ class PolySlab(base.Planar):
             # slanted sidewall, offsetting vertices at each z
             else:
                 # a helper function for moving axis
-                def _move_axis(arr):
+                def _move_axis(arr: NDArray) -> NDArray:
                     return np.moveaxis(arr, source=self.axis, destination=-1)
 
-                def _move_axis_reverse(arr):
+                def _move_axis_reverse(arr: NDArray) -> NDArray:
                     return np.moveaxis(arr, source=-1, destination=self.axis)
 
                 inside_polygon_axis = _move_axis(inside_polygon)
@@ -635,7 +641,7 @@ class PolySlab(base.Planar):
         path, _ = section.to_2D(to_2D=to_2D)
         return path.polygons_full
 
-    def _intersections_normal(self, z: float):
+    def _intersections_normal(self, z: float) -> list[Shapely]:
         """Find shapely geometries intersecting planar geometry with axis normal to slab.
 
         Parameters
@@ -659,7 +665,7 @@ class PolySlab(base.Planar):
         vertices_z = self._shift_vertices(self.middle_polygon, dist)[0]
         return [self.make_shapely_polygon(vertices_z)]
 
-    def _intersections_side(self, position, axis) -> list:
+    def _intersections_side(self, position: float, axis: int) -> list[Shapely]:
         """Find shapely geometries intersecting planar geometry with axis orthogonal to slab.
 
         For slanted polyslab, the procedure is as follows,
@@ -766,7 +772,7 @@ class PolySlab(base.Planar):
         # in other cases, just return the original unmerged polygons
         return polys
 
-    def _find_intersecting_height(self, position: float, axis: int) -> np.ndarray:
+    def _find_intersecting_height(self, position: float, axis: int) -> NDArray:
         """Found a list of height where the plane will intersect with the vertices;
         For vertical sidewall, just return np.array([]).
         Assumes axis is handles so this function works on xy plane.
@@ -805,11 +811,11 @@ class PolySlab(base.Planar):
 
     def _find_intersecting_ys_angle_vertical(
         self,
-        vertices: np.ndarray,
+        vertices: NDArray,
         position: float,
         axis: int,
         exclude_on_vertices: bool = False,
-    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    ) -> tuple[NDArray, NDArray, NDArray]:
         """Finds pairs of forward and backwards vertices where polygon intersects position at axis,
         Find intersection point (in y) assuming straight line,and intersecting angle between plane
         and edges. (For unslanted polyslab).
@@ -888,8 +894,8 @@ class PolySlab(base.Planar):
         return ints_y_sort, ints_angle_sort
 
     def _find_intersecting_ys_angle_slant(
-        self, vertices: np.ndarray, position: float, axis: int
-    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        self, vertices: NDArray, position: float, axis: int
+    ) -> tuple[NDArray, NDArray, NDArray]:
         """Finds pairs of forward and backwards vertices where polygon intersects position at axis,
         Find intersection point (in y) assuming straight line,and intersecting angle between plane
         and edges. (For slanted polyslab)
@@ -1043,7 +1049,7 @@ class PolySlab(base.Planar):
         return -extrusion * self._tanq
 
     @staticmethod
-    def _area(vertices: np.ndarray) -> float:
+    def _area(vertices: NDArray) -> float:
         """Compute the signed polygon area (positive for CCW orientation).
 
         Parameters
@@ -1066,7 +1072,7 @@ class PolySlab(base.Planar):
         return np.sum(term1 - term2) * 0.5
 
     @staticmethod
-    def _perimeter(vertices: np.ndarray) -> float:
+    def _perimeter(vertices: NDArray) -> float:
         """Compute the polygon perimeter.
 
         Parameters
@@ -1090,7 +1096,7 @@ class PolySlab(base.Planar):
         return np.sum(dists)
 
     @staticmethod
-    def _orient(vertices: np.ndarray) -> np.ndarray:
+    def _orient(vertices: NDArray) -> NDArray:
         """Return a CCW-oriented polygon.
 
         Parameters
@@ -1106,7 +1112,7 @@ class PolySlab(base.Planar):
         return vertices if PolySlab._area(vertices) > 0 else vertices[::-1, :]
 
     @staticmethod
-    def _remove_duplicate_vertices(vertices: np.ndarray) -> np.ndarray:
+    def _remove_duplicate_vertices(vertices: NDArray) -> NDArray:
         """Remove redundant/identical nearest neighbour vertices.
 
         Parameters
@@ -1125,7 +1131,7 @@ class PolySlab(base.Planar):
         return vertices[~np.isclose(vertices_diff, 0, rtol=_IS_CLOSE_RTOL)]
 
     @staticmethod
-    def _proper_vertices(vertices: ArrayFloat2D) -> np.ndarray:
+    def _proper_vertices(vertices: ArrayFloat2D) -> NDArray:
         """convert vertices to np.array format,
         removing duplicate neighbouring vertices,
         and oriented in CCW direction.
@@ -1141,7 +1147,7 @@ class PolySlab(base.Planar):
 
     @staticmethod
     def _edge_events_detection(
-        proper_vertices: np.ndarray, dilation: float, ignore_at_dist: bool = True
+        proper_vertices: NDArray, dilation: float, ignore_at_dist: bool = True
     ) -> bool:
         """Detect any edge events within the offset distance ``dilation``.
         If ``ignore_at_dist=True``, the edge event at ``dist`` is ignored.
@@ -1198,7 +1204,7 @@ class PolySlab(base.Planar):
 
     @staticmethod
     def _neighbor_vertices_crossing_detection(
-        vertices: np.ndarray, dist: float, ignore_at_dist: bool = True
+        vertices: NDArray, dist: float, ignore_at_dist: bool = True
     ) -> float:
         """Detect if neighboring vertices will cross after a dilation distance dist.
 
@@ -1233,12 +1239,12 @@ class PolySlab(base.Planar):
         return None
 
     @staticmethod
-    def array_to_vertices(arr_vertices: np.ndarray) -> ArrayFloat2D:
+    def array_to_vertices(arr_vertices: NDArray) -> ArrayFloat2D:
         """Converts a numpy array of vertices to a list of tuples."""
         return list(arr_vertices)
 
     @staticmethod
-    def vertices_to_array(vertices_tuple: ArrayFloat2D) -> np.ndarray:
+    def vertices_to_array(vertices_tuple: ArrayFloat2D) -> NDArray:
         """Converts a list of tuples (vertices) to a numpy array."""
         return np.array(vertices_tuple)
 
@@ -1246,7 +1252,7 @@ class PolySlab(base.Planar):
     def interior_angle(self) -> ArrayFloat1D:
         """Angle formed inside polygon by two adjacent edges."""
 
-        def normalize(v):
+        def normalize(v: NDArray) -> NDArray:
             return v / np.linalg.norm(v, axis=0)
 
         vs_orig = self.reference_polygon.T
@@ -1266,8 +1272,8 @@ class PolySlab(base.Planar):
 
     @staticmethod
     def _shift_vertices(
-        vertices: np.ndarray, dist
-    ) -> tuple[np.ndarray, np.ndarray, tuple[np.ndarray, np.ndarray]]:
+        vertices: NDArray, dist: float
+    ) -> tuple[NDArray, NDArray, tuple[NDArray, NDArray]]:
         """Shifts the vertices of a polygon outward uniformly by distances
         `dists`.
 
@@ -1290,7 +1296,7 @@ class PolySlab(base.Planar):
         if math.isclose(getval(dist), 0):
             return vertices, np.zeros(vertices.shape[0], dtype=float), None
 
-        def rot90(v):
+        def rot90(v: tuple[NDArray, NDArray]) -> NDArray:
             """90 degree rotation of 2d vector
             vx -> vy
             vy -> -vx
@@ -1298,10 +1304,10 @@ class PolySlab(base.Planar):
             vxs, vys = v
             return np.stack((-vys, vxs), axis=0)
 
-        def cross(u, v):
+        def cross(u: NDArray, v: NDArray) -> Any:
             return u[0] * v[1] - u[1] * v[0]
 
-        def normalize(v):
+        def normalize(v: NDArray) -> NDArray:
             return v / np.linalg.norm(v, axis=0)
 
         vs_orig = copy(vertices.T)
@@ -1334,8 +1340,8 @@ class PolySlab(base.Planar):
 
     @staticmethod
     def _edge_length_and_reduction_rate(
-        vertices: np.ndarray,
-    ) -> tuple[np.ndarray, np.ndarray]:
+        vertices: NDArray,
+    ) -> tuple[NDArray, NDArray]:
         """Edge length of reduction rate of each edge with unit offset length.
 
         Parameters
@@ -1362,7 +1368,7 @@ class PolySlab(base.Planar):
         return edge_length, edge_reduction
 
     @staticmethod
-    def _maximal_erosion(vertices: np.ndarray) -> float:
+    def _maximal_erosion(vertices: NDArray) -> float:
         """The erosion value that reduces the length of
         all edges to be non-positive.
         """
@@ -1371,7 +1377,7 @@ class PolySlab(base.Planar):
         return -np.min(edge_length[ind_nonzero] / edge_reduction[ind_nonzero])
 
     @staticmethod
-    def _heal_polygon(vertices: np.ndarray) -> np.ndarray:
+    def _heal_polygon(vertices: NDArray) -> NDArray:
         """heal a self-intersecting polygon."""
         shapely_poly = PolySlab.make_shapely_polygon(vertices)
         if shapely_poly.is_valid:
@@ -1507,7 +1513,9 @@ class PolySlab(base.Planar):
         return vjps
 
     # ---- Shared helpers for VJP surface integrations ----
-    def _z_slices(self, sim_min: np.ndarray, sim_max: np.ndarray, is_2d: bool, dx: float):
+    def _z_slices(
+        self, sim_min: NDArray, sim_max: NDArray, is_2d: bool, dx: float
+    ) -> tuple[NDArray, float, float, float]:
         """Compute z-slice centers and spacing within bounds.
 
         Returns (z_centers, dz, z0, z1). For 2D, returns single center and dz=1.
@@ -1530,7 +1538,7 @@ class PolySlab(base.Planar):
 
     @staticmethod
     def _clip_edge_to_bounds_t(
-        v0_3d: np.ndarray, v1_3d: np.ndarray, sim_min: np.ndarray, sim_max: np.ndarray
+        v0_3d: NDArray, v1_3d: NDArray, sim_min: NDArray, sim_max: NDArray
     ) -> Optional[tuple[float, float]]:
         """Parametric bounds [t0,t1] of segment within [sim_min, sim_max]."""
         t_start, t_end = 0.0, 1.0
@@ -1561,7 +1569,9 @@ class PolySlab(base.Planar):
         return (t_start, t_end)
 
     @staticmethod
-    def _adaptive_edge_samples(L: float, dx: float, t_start: float = 0.0, t_end: float = 1.0):
+    def _adaptive_edge_samples(
+        L: float, dx: float, t_start: float = 0.0, t_end: float = 1.0
+    ) -> tuple[NDArray, NDArray]:
         """Gauss samples and weights along [t_start,t_end] with adaptive count."""
         L_eff = L * max(0.0, t_end - t_start)
         n_uniform = max(1, int(np.ceil(L_eff / dx)))
@@ -1597,12 +1607,12 @@ class PolySlab(base.Planar):
 
     def _collect_sidewall_patches(
         self,
-        vertices: np.ndarray,
-        next_v: np.ndarray,
-        edges: np.ndarray,
+        vertices: NDArray,
+        next_v: NDArray,
+        edges: NDArray,
         basis: dict,
-        sim_min: np.ndarray,
-        sim_max: np.ndarray,
+        sim_min: NDArray,
+        sim_max: NDArray,
         is_2d: bool,
         dx: float,
     ) -> dict:
@@ -1814,8 +1824,8 @@ class PolySlab(base.Planar):
     def _compute_derivative_sidewall_angle(
         self,
         derivative_info: DerivativeInfo,
-        sim_min: np.ndarray,
-        sim_max: np.ndarray,
+        sim_min: NDArray,
+        sim_max: NDArray,
         is_2d: bool = False,
         interpolators: Optional[dict] = None,
     ) -> float:
@@ -1934,7 +1944,7 @@ class PolySlab(base.Planar):
     def compute_derivative_slab_bounds_line(
         self,
         derivative_info: DerivativeInfo,
-        extents: np.ndarray,
+        extents: NDArray,
         r1_min: float,
         r1_max: float,
         r2_min: float,
@@ -1999,7 +2009,7 @@ class PolySlab(base.Planar):
     def compute_derivative_slab_bounds_surface(
         self,
         derivative_info: DerivativeInfo,
-        extents: np.ndarray,
+        extents: NDArray,
         r1_min: float,
         r1_max: float,
         r2_min: float,
@@ -2089,11 +2099,11 @@ class PolySlab(base.Planar):
     def _compute_derivative_vertices(
         self,
         derivative_info: DerivativeInfo,
-        sim_min: np.ndarray,
-        sim_max: np.ndarray,
+        sim_min: NDArray,
+        sim_max: NDArray,
         is_2d: bool = False,
         interpolators: Optional[dict] = None,
-    ) -> np.ndarray:
+    ) -> NDArray:
         """VJP for the vertices of a ``PolySlab``.
 
         Uses shared sidewall patch collection and batched field evaluation.
@@ -2159,7 +2169,9 @@ class PolySlab(base.Planar):
         vjp_per_vertex = np.stack((v0x + v1x, v0y + v1y), axis=1)
         return vjp_per_vertex
 
-    def _edge_geometry_arrays(self, dtype: np.dtype = config.adjoint.gradient_dtype_float):
+    def _edge_geometry_arrays(
+        self, dtype: np.dtype = config.adjoint.gradient_dtype_float
+    ) -> tuple[NDArray, NDArray, NDArray, dict[str, NDArray]]:
         """Return (vertices, next_v, edges, basis) arrays for sidewall edge geometry."""
         vertices = np.asarray(self.vertices, dtype=dtype)
         next_v = np.roll(vertices, -1, axis=0)
@@ -2169,8 +2181,8 @@ class PolySlab(base.Planar):
 
     def edge_basis_vectors(
         self,
-        edges: np.ndarray,  # (N, 2)
-    ) -> dict[str, np.ndarray]:  # (N, 3)
+        edges: NDArray,  # (N, 2)
+    ) -> dict[str, NDArray]:  # (N, 3)
         """Normalized basis vectors for ``normal`` direction, ``slab`` tangent direction and ``edge``."""
 
         # ensure edges have consistent dtype
@@ -2207,7 +2219,7 @@ class PolySlab(base.Planar):
             "perp2": slabs_norm_xyz,
         }
 
-    def unpop_axis_vect(self, ax_coords: np.ndarray, plane_coords: np.ndarray) -> np.ndarray:
+    def unpop_axis_vect(self, ax_coords: NDArray, plane_coords: NDArray) -> NDArray:
         """Combine coordinate along axis with coordinates on the plane tangent to the axis.
 
         ax_coords.shape == [N]
@@ -2224,7 +2236,7 @@ class PolySlab(base.Planar):
 
         return arr_xyz
 
-    def pop_axis_vect(self, coord: np.ndarray) -> tuple[np.ndarray, tuple[np.ndarray, np.ndarray]]:
+    def pop_axis_vect(self, coord: NDArray) -> tuple[NDArray, tuple[NDArray, NDArray]]:
         """Combine coordinate along axis with coordinates on the plane tangent to the axis.
 
         coord.shape == [N, 3]
@@ -2237,7 +2249,7 @@ class PolySlab(base.Planar):
         return arr_axis, arrs_plane
 
     @staticmethod
-    def normalize_vect(arr: np.ndarray) -> np.ndarray:
+    def normalize_vect(arr: NDArray) -> NDArray:
         """normalize an array shaped (N, d) along the `d` axis and return (N, 1)."""
         norm = np.linalg.norm(arr, axis=-1, keepdims=True)
         norm = np.where(norm == 0, 1, norm)
@@ -2351,14 +2363,16 @@ class ComplexPolySlabBase(PolySlab):
     :class:`plugins.polyslab.ComplexPolySlab`."""
 
     @pydantic.validator("vertices", always=True)
-    def no_self_intersecting_polygon_during_extrusion(cls, val, values):
+    def no_self_intersecting_polygon_during_extrusion(
+        cls, val: ArrayFloat2D, values: dict[str, Any]
+    ) -> ArrayFloat2D:
         """Turn off the validation for this class."""
         return val
 
     @classmethod
     def from_gds(
         cls,
-        gds_cell,
+        gds_cell: Cell,
         axis: Axis,
         slab_bounds: tuple[float, float],
         gds_layer: int,

--- a/tidy3d/components/geometry/primitives.py
+++ b/tidy3d/components/geometry/primitives.py
@@ -9,6 +9,7 @@ import autograd.numpy as anp
 import numpy as np
 import pydantic.v1 as pydantic
 import shapely
+from shapely.geometry.base import BaseGeometry
 
 from tidy3d.components.autograd import AutogradFieldMap, TracedSize1D
 from tidy3d.components.autograd.derivative_utils import DerivativeInfo
@@ -112,7 +113,7 @@ class Sphere(base.Centered, base.Circular):
 
     def intersections_plane(
         self, x: Optional[float] = None, y: Optional[float] = None, z: Optional[float] = None
-    ):
+    ) -> list[BaseGeometry]:
         """Returns shapely geometry at plane specified by one non None value of x,y,z.
 
         Parameters
@@ -213,7 +214,9 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
 
     @pydantic.validator("length", always=True)
     @skip_if_fields_missing(["sidewall_angle", "reference_plane"])
-    def _only_middle_for_infinite_length_slanted_cylinder(cls, val, values):
+    def _only_middle_for_infinite_length_slanted_cylinder(
+        cls, val: float, values: dict[str, Any]
+    ) -> float:
         """For a slanted cylinder of infinite length, ``reference_plane`` can only
         be ``middle``; otherwise, the radius at ``center`` is either td.inf or 0.
         """
@@ -395,7 +398,7 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
         return vjps
 
     @property
-    def center_axis(self):
+    def center_axis(self) -> Any:
         """Gets the position of the center of the geometry in the out of plane dimension."""
         z0, _ = self.pop_axis(self.center, axis=self.axis)
         return z0
@@ -522,7 +525,7 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
         path, _ = section.to_2D(to_2D=to_2D)
         return path.polygons_full
 
-    def _intersections_normal(self, z: float):
+    def _intersections_normal(self, z: float) -> list[BaseGeometry]:
         """Find shapely geometries intersecting cylindrical geometry with axis normal to slab.
 
         Parameters
@@ -549,7 +552,7 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
         _, (x0, y0) = self.pop_axis(static_self.center, axis=self.axis)
         return [shapely.Point(x0, y0).buffer(radius_offset, quad_segs=_N_SHAPELY_QUAD_SEGS)]
 
-    def _intersections_side(self, position, axis):
+    def _intersections_side(self, position: float, axis: int) -> list[BaseGeometry]:
         """Find shapely geometries intersecting cylindrical geometry with axis orthogonal to length.
         When ``sidewall_angle`` is nonzero, so that it's in fact a conical frustum or cone, the
         cross section can contain hyperbolic curves. This is currently approximated by a polygon
@@ -767,7 +770,7 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
         """
         return min(self.radius_bottom, self.radius_top)
 
-    def _radius_z(self, z: float):
+    def _radius_z(self, z: float) -> float:
         """Compute the radius of the cross section at the position z.
 
         Parameters

--- a/tidy3d/components/geometry/utils.py
+++ b/tidy3d/components/geometry/utils.py
@@ -479,7 +479,7 @@ def get_closest_value(test: float, coords: np.ArrayLike, upper_bound_idx: int) -
     return lower_bound if dlower < dupper else upper_bound
 
 
-def snap_box_to_grid(grid: Grid, box: Box, snap_spec: SnappingSpec, rtol=fp_eps) -> Box:
+def snap_box_to_grid(grid: Grid, box: Box, snap_spec: SnappingSpec, rtol: float = fp_eps) -> Box:
     """Snaps a :class:`.Box` to the grid, so that the boundaries of the box are aligned with grid centers or boundaries.
     The way in which each dimension of the `box` is snapped to the grid is controlled by ``snap_spec``.
     """

--- a/tidy3d/components/geometry/utils_2d.py
+++ b/tidy3d/components/geometry/utils_2d.py
@@ -12,11 +12,11 @@ from tidy3d.components.geometry.polyslab import _MIN_POLYGON_AREA, PolySlab
 from tidy3d.components.grid.grid import Grid
 from tidy3d.components.scene import Scene
 from tidy3d.components.structure import Structure
-from tidy3d.components.types import Axis
+from tidy3d.components.types import Axis, Shapely
 from tidy3d.constants import fp_eps, inf
 
 
-def increment_float(val: float, sign) -> float:
+def increment_float(val: float, sign: int) -> float:
     """Applies a small positive or negative shift as though `val` is a 32bit float
     using numpy.nextafter, but additionally handles some corner cases.
     """
@@ -52,7 +52,7 @@ def get_bounds(geom: Geometry, axis: Axis) -> tuple[float, float]:
     return (geom.bounds[0][axis], geom.bounds[1][axis])
 
 
-def get_thickened_geom(geom: Geometry, axis: Axis):
+def get_thickened_geom(geom: Geometry, axis: Axis) -> Geometry:
     """Helper to return a slightly thickened version of a planar geometry."""
     center = get_bounds(geom, axis)[0]
     neg_thickness = increment_float(center, -1.0)
@@ -64,7 +64,7 @@ def get_neighbors(
     geom: Geometry,
     axis: Axis,
     structures: list[Structure],
-):
+) -> tuple[tuple[Structure, ...], tuple[Structure, ...], tuple[float, float]]:
     """Find the neighboring structures and return the tested positions above and below."""
     center = get_bounds(geom, axis)[0]
     check_delta = [
@@ -127,7 +127,7 @@ def subdivide(
         vertices = list(zip(xx, yy))
         return PolySlab(slab_bounds=(center, center), vertices=vertices, axis=axis)
 
-    def to_multipolygon(shapely_geometry) -> shapely.MultiPolygon:
+    def to_multipolygon(shapely_geometry: Shapely) -> shapely.MultiPolygon:
         return shapely.MultiPolygon(ClipOperation.to_polygon_list(shapely_geometry))
 
     axis = geom._normal_2dmaterial

--- a/tidy3d/config/legacy.py
+++ b/tidy3d/config/legacy.py
@@ -14,7 +14,7 @@ from typing import Any, Optional
 
 import toml
 
-from tidy3d.log import log
+from tidy3d.log import LogLevel, log
 
 # TODO(FXC-3827): Remove LegacyConfigWrapper/Environment shims and related helpers in Tidy3D 2.12.
 from .manager import ConfigManager, normalize_profile_name
@@ -36,11 +36,11 @@ class LegacyConfigWrapper:
         self._frozen = False  # retained for backwards compatibility tests
 
     @property
-    def logging_level(self):
+    def logging_level(self) -> LogLevel:
         return self._manager.get_section("logging").level
 
     @logging_level.setter
-    def logging_level(self, value):
+    def logging_level(self, value: LogLevel) -> None:
         from warnings import warn
 
         warn(
@@ -51,11 +51,11 @@ class LegacyConfigWrapper:
         self._manager.update_section("logging", level=value)
 
     @property
-    def log_suppression(self):
+    def log_suppression(self) -> bool:
         return self._manager.get_section("logging").suppression
 
     @log_suppression.setter
-    def log_suppression(self, value):
+    def log_suppression(self, value: bool) -> None:
         from warnings import warn
 
         warn(
@@ -66,11 +66,11 @@ class LegacyConfigWrapper:
         self._manager.update_section("logging", suppression=value)
 
     @property
-    def use_local_subpixel(self):
+    def use_local_subpixel(self) -> Optional[bool]:
         return self._manager.get_section("simulation").use_local_subpixel
 
     @use_local_subpixel.setter
-    def use_local_subpixel(self, value):
+    def use_local_subpixel(self, value: Optional[bool]) -> None:
         from warnings import warn
 
         warn(
@@ -81,11 +81,11 @@ class LegacyConfigWrapper:
         self._manager.update_section("simulation", use_local_subpixel=value)
 
     @property
-    def suppress_rf_license_warning(self):
+    def suppress_rf_license_warning(self) -> bool:
         return self._manager.get_section("microwave").suppress_rf_license_warning
 
     @suppress_rf_license_warning.setter
-    def suppress_rf_license_warning(self, value):
+    def suppress_rf_license_warning(self, value: bool) -> None:
         from warnings import warn
 
         warn(
@@ -97,14 +97,14 @@ class LegacyConfigWrapper:
         self._manager.update_section("microwave", suppress_rf_license_warning=value)
 
     @property
-    def frozen(self):
+    def frozen(self) -> bool:
         return self._frozen
 
     @frozen.setter
-    def frozen(self, value):
+    def frozen(self, value: bool) -> None:
         self._frozen = bool(value)
 
-    def save(self, include_defaults: bool = False):
+    def save(self, include_defaults: bool = False) -> None:
         self._manager.save(include_defaults=include_defaults)
 
     def reset_manager(self, manager: ConfigManager) -> None:
@@ -239,11 +239,11 @@ class LegacyEnvironmentConfig:
         self._set_pending("enable_caching", value)
 
     @property
-    def ssl_version(self):
+    def ssl_version(self) -> Optional[ssl.TLSVersion]:
         return self._value("ssl_version")
 
     @ssl_version.setter
-    def ssl_version(self, value) -> None:
+    def ssl_version(self, value: Optional[ssl.TLSVersion]) -> None:
         self._set_pending("ssl_version", value)
 
     @property
@@ -363,7 +363,7 @@ class LegacyEnvironment:
         config.enable_caching = enable_caching
         self._sync_to_manager()
 
-    def set_ssl_version(self, ssl_version) -> None:
+    def set_ssl_version(self, ssl_version: Optional[ssl.TLSVersion]) -> None:
         config = self.current
         config.ssl_version = ssl_version
         self._sync_to_manager()

--- a/tidy3d/config/manager.py
+++ b/tidy3d/config/manager.py
@@ -59,14 +59,14 @@ class SectionAccessor:
         model = self._manager._get_model(self._path)
         return f"SectionAccessor({self._path}={model!r})"
 
-    def __rich__(self):
+    def __rich__(self) -> Panel:
         model = self._manager._get_model(self._path)
         if model is None:
             return Panel(Text(f"Section '{self._path}' is unavailable", style="red"))
         data = _prepare_for_display(model.model_dump(exclude_unset=False))
         return _build_section_panel(self._path, data)
 
-    def dict(self, *args, **kwargs):
+    def dict(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
         model = self._manager._get_model(self._path)
         if model is None:
             return {}
@@ -135,7 +135,7 @@ class ConfigManager:
         return self._profile
 
     @property
-    def config_dir(self):
+    def config_dir(self) -> Path:
         return self._loader.config_dir
 
     @property
@@ -264,7 +264,7 @@ class ConfigManager:
             tree = deep_merge(tree, self._env_overrides)
         return deep_merge(self._default_tree(), tree)
 
-    def __rich__(self):
+    def __rich__(self) -> Panel:
         """Return a rich renderable representation of the full configuration."""
 
         return _build_config_panel(

--- a/tidy3d/material_library/material_library.py
+++ b/tidy3d/material_library/material_library.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import json
 from os import PathLike
-from typing import Union
+from typing import TYPE_CHECKING, Any, Union
 
 import pydantic.v1 as pd
+from rich.panel import Panel
+from rich.table import Table
 
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.material.multi_physics import MultiPhysicsMedium
@@ -36,6 +38,9 @@ from .util import (
     summarize_variant_item,
     summarize_variant_item_rich,
 )
+
+if TYPE_CHECKING:
+    from IPython.lib.pretty import RepresentationPrinter
 
 
 def export_matlib_to_file(fname: PathLike = "matlib.json") -> None:
@@ -87,13 +92,13 @@ class AbstractVariantItem(Tidy3dBaseModel):
     def summarize_mediums(self) -> dict[str, Union[PoleResidue, Medium2D, MultiPhysicsMedium]]:
         return {}
 
-    def __str__(self):
+    def __str__(self) -> str:
         return summarize_variant_item(self)
 
-    def __rich__(self):
+    def __rich__(self) -> Panel:
         return summarize_variant_item_rich(self)
 
-    def _repr_pretty_(self, p, cycle):
+    def _repr_pretty_(self, p: RepresentationPrinter, cycle: bool) -> None:
         return repr_pretty_with_rich(self, p, cycle)
 
 
@@ -126,7 +131,7 @@ class MaterialItem(Tidy3dBaseModel):
     )
 
     @pd.validator("default", always=True)
-    def _default_in_variants(cls, val, values):
+    def _default_in_variants(cls, val: str, values: dict[str, Any]) -> Any:
         """Make sure the default variant is already included in the ``variants``."""
         if val not in values["variants"]:
             raise SetupError(
@@ -135,12 +140,12 @@ class MaterialItem(Tidy3dBaseModel):
             )
         return val
 
-    def __getitem__(self, variant_name):
+    def __getitem__(self, variant_name: str) -> Union[PoleResidue, MultiPhysicsMedium]:
         """Helper function to easily access the medium of a variant"""
         return self.variants[variant_name].medium
 
     @property
-    def medium(self):
+    def medium(self) -> Union[PoleResidue, MultiPhysicsMedium]:
         """The default medium."""
         if self.name == "Silicon Dioxide":
             log.warning(
@@ -149,13 +154,13 @@ class MaterialItem(Tidy3dBaseModel):
             )
         return self.variants[self.default].medium
 
-    def __str__(self):
+    def __str__(self) -> str:
         return summarize_material_item(self)
 
-    def __rich__(self):
+    def __rich__(self) -> Panel:
         return summarize_material_item_rich(self)
 
-    def _repr_pretty_(self, p, cycle):
+    def _repr_pretty_(self, p: RepresentationPrinter, cycle: bool) -> None:
         return repr_pretty_with_rich(self, p, cycle)
 
 
@@ -236,7 +241,7 @@ class MaterialItemUniaxial(MaterialItem):
         "that maps from a key to the variant model.",
     )
 
-    def medium(self, optical_axis: Axis):
+    def medium(self, optical_axis: Axis) -> AnisotropicMedium:
         """The default medium."""
         return self.variants[self.default].medium(optical_axis)
 
@@ -2108,13 +2113,13 @@ cSi_MultiPhysics = VariantItem(
 
 
 class MaterialLibrary(dict):
-    def __str__(self):
+    def __str__(self) -> str:
         return summarize_material_library(self)
 
-    def __rich__(self):
+    def __rich__(self) -> Table:
         return summarize_material_library_rich(self)
 
-    def _repr_pretty_(self, p, cycle):
+    def _repr_pretty_(self, p: RepresentationPrinter, cycle: bool) -> None:
         return repr_pretty_with_rich(self, p, cycle)
 
 

--- a/tidy3d/material_library/parametric_materials.py
+++ b/tidy3d/material_library/parametric_materials.py
@@ -274,7 +274,7 @@ class Graphene(ParametricVariantItem2D):
         freqs: list[float],
         sigma: list[complex],
         indslist: list[tuple[int, int]],
-    ):
+    ) -> PoleResidue:
         """Fit the interband conductivity with a Pade approximation, as described in
 
         Stamatios Amanatiadis, Theodoros Zygiridis, Tadao Ohtani, Yasushi Kanai,

--- a/tidy3d/material_library/util.py
+++ b/tidy3d/material_library/util.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from io import StringIO
+from typing import TYPE_CHECKING, Union
 
 from rich.console import Console
 from rich.panel import Panel
@@ -8,12 +9,22 @@ from rich.table import Table
 from rich.text import Text
 from rich.tree import Tree
 
+from tidy3d import Medium2D, MultiPhysicsMedium, PoleResidue
 from tidy3d.components.viz import FLEXCOMPUTE_COLORS
+
+if TYPE_CHECKING:
+    from IPython.lib.pretty import RepresentationPrinter
+
+    from tidy3d.material_library.material_library import (
+        AbstractVariantItem,
+        MaterialItem,
+        MaterialLibrary,
+    )
 
 MAX_POLES_TO_DISPLAY = 3
 
 
-def summarize_material_library(matlib) -> str:
+def summarize_material_library(matlib: MaterialLibrary) -> str:
     """Return a user-friendly multiline string summarizing the entire material library."""
     lines = ["Material Library Summary:"]
     for key, mat_item in sorted(matlib.items()):
@@ -28,7 +39,7 @@ def summarize_material_library(matlib) -> str:
     return "\n".join(lines)
 
 
-def summarize_material_item(m) -> str:
+def summarize_material_item(m: MaterialItem) -> str:
     """
     Return a concise summary of a single MaterialItem instance:
     includes name, default variant, plus the list of all variants.
@@ -41,7 +52,7 @@ def summarize_material_item(m) -> str:
     return "\n".join(lines)
 
 
-def variant_name(v):
+def variant_name(v: AbstractVariantItem) -> str:
     """Retrieve variant name for display."""
     default_name = "Unnamed Variant"
     name = default_name
@@ -56,7 +67,7 @@ def variant_name(v):
     return name
 
 
-def summarize_medium(med) -> list[str]:
+def summarize_medium(med: Union[PoleResidue, Medium2D, MultiPhysicsMedium]) -> list[str]:
     """Returns relevant medium information for display."""
     lines = []
 
@@ -77,7 +88,7 @@ def summarize_medium(med) -> list[str]:
     return lines
 
 
-def summarize_variant_item(v) -> str:
+def summarize_variant_item(v: AbstractVariantItem) -> str:
     """
     Return a concise summary for a single VariantItem instance,
     highlighting references and main model parameters (e.g., eps_inf, # poles, freq. range).
@@ -109,7 +120,11 @@ def summarize_variant_item(v) -> str:
     return "\n".join(lines)
 
 
-def repr_pretty_with_rich(obj, p, cycle) -> None:
+def repr_pretty_with_rich(
+    obj: Union[AbstractVariantItem, MaterialItem, MaterialLibrary],
+    p: RepresentationPrinter,
+    cycle: bool,
+) -> None:
     """Enable _repr_pretty_ for jupyter notebooks to use the rich printing output."""
     if cycle:
         p.text("MaterialLibrary(...)")
@@ -121,7 +136,9 @@ def repr_pretty_with_rich(obj, p, cycle) -> None:
         p.text(sio.getvalue())
 
 
-def add_medium_details_to_tree(medium, medium_node: Tree) -> None:
+def add_medium_details_to_tree(
+    medium: Union[PoleResidue, Medium2D, MultiPhysicsMedium], medium_node: Tree
+) -> None:
     """Adds details of a medium dictionary to a Rich Tree node."""
 
     if hasattr(medium, "eps_inf"):
@@ -139,7 +156,7 @@ def add_medium_details_to_tree(medium, medium_node: Tree) -> None:
         medium_node.add(f"[bold]Freq. Range:[/bold] {medium.frequency_range}")
 
 
-def summarize_material_library_rich(matlib):
+def summarize_material_library_rich(matlib: MaterialLibrary) -> Table:
     """Returns a Rich Table summarizing the MaterialLibrary."""
 
     table = Table(
@@ -187,7 +204,7 @@ def summarize_material_library_rich(matlib):
     return table
 
 
-def summarize_material_item_rich(m):
+def summarize_material_item_rich(m: MaterialItem) -> Panel:
     """Returns a Rich Tree representation summarizing the MaterialItem."""
     tree_title = f"[bold {FLEXCOMPUTE_COLORS['brand_purple']}]Material Summary: {m.name}[/]"
     tree = Tree(tree_title)
@@ -207,7 +224,7 @@ def summarize_material_item_rich(m):
     return Panel(tree, border_style=f"{FLEXCOMPUTE_COLORS['brand_purple']}", expand=False)
 
 
-def summarize_variant_item_rich(v):
+def summarize_variant_item_rich(v: AbstractVariantItem) -> Panel:
     """Returns Rich renderables for displaying a VariantItem summary."""
 
     name = variant_name(v)


### PR DESCRIPTION
…brary-and-geometry

follow up of https://github.com/flexcompute/tidy3d/pull/2921

Here, all functions of the packages `tidy3d/config`, `tidy3d/material_library` and `tidy3d/components/geometry` were extended with typedefs for mypy.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-04 11:34:44 UTC

<h3>Greptile Summary</h3>


This PR adds comprehensive type annotations to three packages (`tidy3d/config`, `tidy3d/material_library`, and `tidy3d/components/geometry`) as a follow-up to PR #2921. The changes enable mypy type checking by adding these packages to the mypy configuration in `pyproject.toml`.

**Key changes:**
- Added return type annotations to properties, methods, and functions across all three packages
- Imported necessary types (`LogLevel`, `NDArray`, `Cell`, `Trimesh`, etc.) and used `TYPE_CHECKING` guards for forward references
- Added `typing.Self` for methods returning the same type
- Properly annotated complex types like `NDArray[float]` and `Union` types

**Issues found:**
- In `tidy3d/components/geometry/base.py`, the `__or__` method returns `GeometryGroup` but is annotated as returning `ClipOperation`

<h3>Confidence Score: 4/5</h3>


- This PR is mostly safe to merge with one type annotation fix needed
- The PR adds comprehensive type annotations across three packages, which improves code quality and enables static type checking. However, there is one incorrect return type annotation in the `__or__` method that needs to be corrected. The change is otherwise straightforward and low-risk, consisting primarily of adding type hints without changing logic.
- tidy3d/components/geometry/base.py requires attention for the incorrect return type annotation on the `__or__` method

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| pyproject.toml | 5/5 | Added new packages to mypy file list for type checking |
| tidy3d/material_library/material_library.py | 5/5 | Added type annotations and imported necessary types for IPython and rich |
| tidy3d/components/geometry/base.py | 3/5 | Added extensive type annotations to methods; incorrect return type on `__or__` method (returns GeometryGroup but annotated as ClipOperation) |
| tidy3d/components/geometry/polyslab.py | 5/5 | Added comprehensive type annotations to methods and functions |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant MyPy as MyPy Type Checker
    participant Config as tidy3d/config
    participant MatLib as tidy3d/material_library
    participant Geom as tidy3d/components/geometry
    
    Dev->>MyPy: Run mypy type checking
    MyPy->>Config: Check type annotations
    Config-->>MyPy: ✓ All types valid
    MyPy->>MatLib: Check type annotations
    MatLib-->>MyPy: ✓ All types valid
    MyPy->>Geom: Check type annotations
    Geom-->>MyPy: ⚠️ __or__ return type mismatch
    MyPy->>Dev: Report type errors
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->