### PR TITLE
FXC-3903: tidy3d CLI Cache Helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validation for `run_only` field in component modelers to catch duplicate or invalid matrix indices early with clear error messages.
 - Introduced a profile-based configuration manager with TOML persistence and runtime overrides exposed via `tidy3d.config`.
 - Added support of `os.PathLike` objects as paths like `pathlib.Path` alongside `str` paths in all path-related functions.
-- Added configurable local simulation result caching with checksum validation, eviction limits, and per-call overrides across `web.run`, `web.load`, and job workflows.
+- Added local simulation result caching to avoid rerunning identical simulations. Enable and configure it through `td.config.local_cache` (size limits, cache directory). Use CLI commands `tidy3d cache {info, list, clear}` to inspect or clear the cache.
 - Added `DirectivityMonitorSpec` for automated creation and configuration of directivity radiation monitors in `TerminalComponentModeler`.
 - Added multimode support to `WavePort` in the smatrix plugin, allowing multiple modes to be analyzed per port.
 

--- a/tests/test_web/test_local_cache.py
+++ b/tests/test_web/test_local_cache.py
@@ -13,6 +13,7 @@ import autograd as ag
 import pytest
 import xarray as xr
 from autograd.core import defvjp
+from click.testing import CliRunner
 from rich.console import Console
 
 import tidy3d as td
@@ -37,6 +38,7 @@ from tidy3d.web.cache import (
     get_cache_entry_dir,
     resolve_local_cache,
 )
+from tidy3d.web.cli.app import tidy3d_cli
 from tidy3d.web.core.task_core import BatchTask
 
 common.CONNECTION_RETRY_TIME = 0.1
@@ -724,6 +726,49 @@ def _test_env_var_overrides(monkeypatch, tmp_path):
     manager._reload()
 
 
+def _test_cache_cli_commands(monkeypatch, tmp_path_factory, basic_simulation):
+    runner = CliRunner()
+    cache_dir = tmp_path_factory.mktemp("cli_cache")
+    artifact_dir = tmp_path_factory.mktemp("cli_cache_artifact")
+
+    monkeypatch.setattr(config.local_cache, "enabled", True)
+    monkeypatch.setattr(config.local_cache, "directory", cache_dir)
+    monkeypatch.setattr(config.local_cache, "max_entries", 3)
+    monkeypatch.setattr(config.local_cache, "max_size_gb", 2.5)
+
+    cache = resolve_local_cache(use_cache=True)
+    cache.clear()
+
+    artifact = artifact_dir / CACHE_ARTIFACT_NAME
+    artifact.write_text("payload_cli")
+    cache.store_result(
+        _FakeStubData(basic_simulation), f"{MOCK_TASK_ID}-cli", str(artifact), "FDTD"
+    )
+
+    info_result = runner.invoke(tidy3d_cli, ["cache", "info"])
+    assert info_result.exit_code == 0
+    assert "Enabled: yes" in info_result.output
+    assert "Entries: 1" in info_result.output
+    assert "Max entries: 3" in info_result.output
+    assert "Max size: 2.50 GB" in info_result.output
+
+    list_result = runner.invoke(tidy3d_cli, ["cache", "list"])
+    assert list_result.exit_code == 0
+    out = list_result.output
+    assert "Cache Entry #1" in out
+    assert "Workflow type: FDTD" in out
+    assert "File size:" in out
+
+    clear_result = runner.invoke(tidy3d_cli, ["cache", "clear"])
+    assert clear_result.exit_code == 0
+    assert "Local cache cleared." in clear_result.output
+    assert len(cache) == 0
+
+    list_after = runner.invoke(tidy3d_cli, ["cache", "list"])
+    assert list_after.exit_code == 0
+    assert "Cache is empty." in list_after.output
+
+
 def test_cache_sequential(
     monkeypatch, tmp_path, tmp_path_factory, basic_simulation, fake_data, request
 ):
@@ -746,3 +791,4 @@ def test_cache_sequential(
     _test_store_and_fetch_do_not_iterate(monkeypatch, tmp_path, basic_simulation)
     _test_mode_solver_caching(monkeypatch, tmp_path)
     _test_verbosity(monkeypatch, basic_simulation)
+    _test_cache_cli_commands(monkeypatch, tmp_path_factory, basic_simulation)

--- a/tidy3d/web/cache.py
+++ b/tidy3d/web/cache.py
@@ -842,8 +842,16 @@ def resolve_local_cache(use_cache: Optional[bool] = None) -> Optional[LocalCache
         return None
 
     if _CACHE is not None and _CACHE._root != Path(config.local_cache.directory):
-        log.debug(f"Clearing old cache directory {_CACHE._root}")
-        _CACHE.clear(hard=True)
+        old_root = _CACHE._root
+        new_root = Path(config.local_cache.directory)
+        log.debug(f"Moving cache directory from {old_root} → {new_root}")
+        try:
+            new_root.parent.mkdir(parents=True, exist_ok=True)
+            if old_root.exists():
+                shutil.move(old_root, new_root)
+        except Exception as e:
+            log.warning(f"Failed to move cache directory: {e}. Delete old cache.")
+            shutil.rmtree(old_root)
 
     _CACHE = LocalCache(
         directory=config.local_cache.directory,

--- a/tidy3d/web/cli/app.py
+++ b/tidy3d/web/cli/app.py
@@ -18,6 +18,7 @@ from tidy3d.config.loader import (
     legacy_config_directory,
     migrate_legacy_config,
 )
+from tidy3d.web.cli.cache import cache_group
 from tidy3d.web.cli.constants import TIDY3D_DIR
 from tidy3d.web.core.constants import HEADER_APIKEY
 
@@ -217,3 +218,4 @@ tidy3d_cli.add_command(configure)
 tidy3d_cli.add_command(convert)
 tidy3d_cli.add_command(develop)
 tidy3d_cli.add_command(config_group, name="config")
+tidy3d_cli.add_command(cache_group)

--- a/tidy3d/web/cli/cache.py
+++ b/tidy3d/web/cli/cache.py
@@ -1,0 +1,95 @@
+"""Cache-related CLI commands."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import click
+
+from tidy3d import config
+from tidy3d.web.cache import LocalCache, resolve_local_cache
+from tidy3d.web.cache import clear as clear_cache
+
+
+def _fmt_size(num_bytes: int) -> str:
+    """Format bytes into human-readable form."""
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if num_bytes < 1024.0 or unit == "TB":
+            return f"{num_bytes:.2f} {unit}"
+        num_bytes /= 1024.0
+    return f"{num_bytes:.2f} B"  # fallback, though unreachable
+
+
+def _get_cache(ensure: bool = True) -> Optional[LocalCache]:
+    """Resolve the local cache object, surfacing errors as ClickExceptions."""
+    try:
+        cache = resolve_local_cache(use_cache=True)
+    except Exception as exc:  # pragma: no cover - defensive guard
+        raise click.ClickException(f"Failed to access local cache: {exc}") from exc
+    if cache is None and ensure:
+        raise click.ClickException("Local cache is disabled in the current configuration.")
+    return cache
+
+
+@click.group(name="cache")
+def cache_group() -> None:
+    """Inspect or manage the local cache."""
+
+
+@cache_group.command()
+def info() -> None:
+    """Display current cache configuration and usage statistics."""
+
+    enabled = bool(config.local_cache.enabled)
+    directory = config.local_cache.directory
+    max_entries = config.local_cache.max_entries
+    max_size_gb = config.local_cache.max_size_gb
+
+    cache = _get_cache(ensure=False)
+    entries = 0
+    total_size = 0
+    if cache is not None:
+        stats = cache.sync_stats()
+        entries = stats.total_entries
+        total_size = stats.total_size
+
+    click.echo(f"Enabled: {'yes' if enabled else 'no'}")
+    click.echo(f"Directory: {directory}")
+    click.echo(f"Entries: {entries}")
+    click.echo(f"Total size: {_fmt_size(total_size)}")
+    click.echo("Max entries: " + (str(max_entries) if max_entries else "unlimited"))
+    click.echo(
+        "Max size: " + (f"{_fmt_size(max_size_gb * 1024**3)}" if max_size_gb else "unlimited")
+    )
+
+
+@cache_group.command(name="list")
+def list() -> None:
+    """List cached entries in a readable, separated format."""
+
+    cache = _get_cache()
+    entries = cache.list()
+    if not entries:
+        click.echo("Cache is empty.")
+        return
+
+    def fmt_key(key: str) -> str:
+        return key.replace("_", " ").capitalize()
+
+    for i, entry in enumerate(entries, start=1):
+        entry.pop("simulation_hash", None)
+        entry.pop("checksum", None)
+        entry["file_size"] = _fmt_size(entry["file_size"])
+
+        click.echo(f"\n=== Cache Entry #{i} ===")
+        for k, v in entry.items():
+            click.echo(f"{fmt_key(k)}: {v}")
+    click.echo("")
+
+
+@cache_group.command()
+def clear() -> None:
+    """Remove all cache contents."""
+
+    clear_cache()
+    click.echo("Local cache cleared.")


### PR DESCRIPTION
Implements cache CLI helpers:

- list: Shows cache entries
- info: Shows local cache config, no. of entries and total storage size 
- clear: clears cache

Sidefix: Move cache directory instead of deleting it on change.

Note: Branch was originally coming from this one (https://github.com/flexcompute/tidy3d/pull/2945) as the cache stats from there are used, this is why greptile comments are partially misleading.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-04 15:12:18 UTC

<h3>Greptile Summary</h3>


This PR implements CLI helpers for the local cache system, along with a major refactoring to improve performance by introducing a lightweight stats tracking mechanism.

**Key Changes:**
- Added three new CLI commands: `tidy3d cache info` (shows config and usage stats), `tidy3d cache list` (displays all cache entries), and `tidy3d cache clear` (removes all cached data)
- Introduced `CacheStats` and `CacheEntryMetadata` Pydantic models to replace loose dictionaries for better type safety
- Implemented `stats.json` file to track cache metadata (`last_used`, `total_size`, `total_entries`) without needing to iterate through all cache entries
- Replaced `threading.Lock` with `threading.RLock` and added `_with_lock()` context manager for cleaner lock management
- Optimized `__len__()` method to read from stats file instead of iterating all entries
- Added `sync_stats()` method to rebuild stats file from actual cache entries when inconsistencies are detected
- Improved eviction logic to work with stats dictionary instead of iterating entries, with proper handling of incoming entries during limit enforcement

**Issues Found:**
- One critical bug in error handling path (line 800 in `tidy3d/web/cache.py`) where `old_root._root` should be `old_root`

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge after fixing the critical syntax error on line 800
- The implementation is well-designed with comprehensive tests covering all new functionality. The stats tracking system is a smart optimization that avoids expensive directory iteration. However, there's one critical bug in the error handling path (line 800) where `old_root._root` should be `old_root`, which would cause an AttributeError if that code path is executed. The rest of the code is solid with proper locking, atomic operations, and thorough test coverage.
- Pay close attention to `tidy3d/web/cache.py` line 800 - the syntax error must be fixed before merging

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/web/cli/cache.py | 5/5 | New CLI commands for cache management (list, info, clear) - clean implementation with proper error handling |
| tidy3d/web/cli/app.py | 5/5 | Added import and registration for cache_group CLI command - minimal change |
| tidy3d/web/cache.py | 4/5 | Major refactoring: added CacheStats and CacheEntryMetadata models, stats tracking system, and performance optimizations. One potential issue with error reference in line 800. |
| tests/test_web/test_local_cache.py | 5/5 | Added comprehensive tests for stats tracking, sync, CLI commands, and performance optimizations - thorough coverage |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI as CLI Commands
    participant Cache as LocalCache
    participant Stats as CacheStats
    participant FS as File System

    Note over User,FS: Cache Info Command
    User->>CLI: tidy3d cache info
    CLI->>Cache: sync_stats()
    Cache->>FS: Read stats.json
    FS-->>Cache: Return stats data
    Cache->>Cache: _iter_entries() to rebuild if needed
    Cache->>FS: Write updated stats.json
    FS-->>Cache: Stats written
    Cache-->>CLI: Return CacheStats
    CLI-->>User: Display info (enabled, entries, size, limits)

    Note over User,FS: Cache List Command
    User->>CLI: tidy3d cache list
    CLI->>Cache: list()
    Cache->>Cache: _with_lock()
    Cache->>Cache: _iter_entries()
    Cache->>FS: Read metadata from each entry
    FS-->>Cache: Entry metadata
    Cache-->>CLI: Return list of entries
    CLI-->>User: Display formatted entries

    Note over User,FS: Store Result with Stats Tracking
    User->>Cache: store_result(data, task_id, path, type)
    Cache->>Cache: _with_lock()
    Cache->>Cache: _ensure_limits()
    Cache->>Stats: _load_stats()
    Stats-->>Cache: Current stats
    Cache->>Cache: Check if eviction needed
    alt Eviction Required
        Cache->>Cache: _evict() or _evict_by_size()
        Cache->>FS: Remove old entries
        Cache->>Stats: _record_remove_stats()
    end
    Cache->>FS: Copy artifact to temp location
    Cache->>Cache: Calculate checksum
    Cache->>FS: Write metadata.json
    Cache->>FS: Atomic rename to final location
    Cache->>Stats: _record_store_stats()
    Stats->>FS: Write updated stats.json
    Cache-->>User: Entry stored

    Note over User,FS: Fetch with Stats Update
    User->>Cache: try_fetch(simulation)
    Cache->>Cache: _with_lock()
    Cache->>Cache: build_cache_key()
    Cache->>Cache: _fetch(key)
    Cache->>FS: Load metadata
    Cache->>Cache: verify() checksum
    Cache->>Cache: _touch(entry)
    Cache->>Stats: _record_touch_stats()
    Stats->>FS: Update stats.json with new last_used
    Cache-->>User: Return CacheEntry

    Note over User,FS: Clear Cache
    User->>CLI: tidy3d cache clear
    CLI->>Cache: clear()
    Cache->>FS: Remove cache directory
    Cache->>FS: Write empty stats.json
    CLI-->>User: "Local cache cleared."
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->