### PR TITLE
Allow nonlinearity with custom medium (FXC-3548)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for `.lydrc` files for design rule checking in the `klayout` plugin.
 - Added a Gaussian inverse design filter option with autograd gradients and complete padding mode coverage.
 - Added support for argument passing to DRC file when running checks with `DRCRunner.run(..., drc_args={key: value})` in klayout plugin.
+- Added support for `nonlinear_spec` in `CustomMedium` and `CustomDispersiveMedium`.
 
 ### Breaking Changes
 - Edge singularity correction at PEC and lossy metal edges defaults to `True`.

--- a/tidy3d/components/nonlinear.py
+++ b/tidy3d/components/nonlinear.py
@@ -27,19 +27,25 @@ class NonlinearModel(ABC, Tidy3dBaseModel):
 
     def _validate_medium_type(self, medium: AbstractMedium) -> None:
         """Check that the model is compatible with the medium."""
-        from .medium import AbstractCustomMedium, DispersiveMedium, Medium
+        from .medium import (
+            AbstractCustomMedium,
+            CustomDispersiveMedium,
+            CustomMedium,
+            DispersiveMedium,
+            Medium,
+        )
 
-        if isinstance(medium, AbstractCustomMedium):
-            raise ValidationError(
-                f"'NonlinearModel' of class '{type(self).__name__}' is not currently supported "
-                f"for medium class '{type(medium).__name__}'."
-            )
         if medium.is_time_modulated:
             raise ValidationError(
                 f"'NonlinearModel' of class '{type(self).__name__}' is not currently supported "
                 f"for time-modulated medium class '{type(medium).__name__}'."
             )
-        if not isinstance(medium, (Medium, DispersiveMedium)):
+        if isinstance(medium, AbstractCustomMedium) and not medium.is_isotropic:
+            raise ValidationError(
+                f"'NonlinearModel' of class '{type(self).__name__}' is not currently supported "
+                f"for anisotropic medium class '{type(medium).__name__}'."
+            )
+        if not isinstance(medium, (Medium, DispersiveMedium, CustomMedium, CustomDispersiveMedium)):
             raise ValidationError(
                 f"'NonlinearModel' of class '{type(self).__name__}' is not currently supported "
                 f"for medium class '{type(medium).__name__}'."


### PR DESCRIPTION
This PR allows `nonlinear_spec` to be applied to `CustomMedium` and `CustomDispersiveMedium`. Anisotropic media are still not supported, and the nonlinearity cannot vary spatially.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-05 19:15:49 UTC

<h3>Greptile Summary</h3>


This PR extends nonlinearity support to `CustomMedium` and `CustomDispersiveMedium` classes. The implementation correctly validates that anisotropic media are rejected by checking the `is_isotropic` property before the type check.

**Key changes:**
- Reordered validation checks to check `is_time_modulated` first, then `is_isotropic`, and finally the type check
- Added `CustomMedium` and `CustomDispersiveMedium` to the list of allowed medium types in the `isinstance` check
- Updated imports to include the new custom medium types
- Updated error messages to be more specific about what is being rejected

**Issues found:**
- Missing CHANGELOG entry (per custom rule **a109c62a-aa8c-4cc4-b515-0ad947c47929**)

**Note:** The previous comment about missing anisotropic validation has been addressed - the code properly checks `medium.is_isotropic` before allowing custom media.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk, pending CHANGELOG entry addition
- The implementation is correct and properly validates media constraints. The validation logic is clear: it checks time-modulation first, then isotropy, and finally the type. Both `CustomMedium` and `CustomDispersiveMedium` have the `is_isotropic` property, so the check will correctly reject anisotropic custom media. The only issue is a missing CHANGELOG entry, which is a documentation concern rather than a code quality issue.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/nonlinear.py | 4/5 | Enabled nonlinearity support for `CustomMedium` and `CustomDispersiveMedium` by reordering validation checks and updating allowed types. The validation properly checks `is_isotropic` before type checking. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant NonlinearSpec
    participant NonlinearModel
    participant Medium
    
    User->>NonlinearSpec: Create NonlinearSpec with models
    User->>Medium: Create CustomMedium/CustomDispersiveMedium with nonlinear_spec
    NonlinearSpec->>NonlinearModel: Validate medium compatibility
    NonlinearModel->>Medium: Check is_time_modulated property
    alt is_time_modulated == True
        NonlinearModel-->>User: Raise ValidationError (time-modulated not supported)
    end
    NonlinearModel->>Medium: Check is_isotropic property
    alt is_isotropic == False
        NonlinearModel-->>User: Raise ValidationError (anisotropic not supported)
    end
    NonlinearModel->>Medium: Check medium type
    alt not in (Medium, DispersiveMedium, CustomMedium, CustomDispersiveMedium)
        NonlinearModel-->>User: Raise ValidationError (unsupported medium type)
    end
    NonlinearModel-->>NonlinearSpec: Validation passed
    NonlinearSpec-->>User: Medium with nonlinearity created successfully
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->