### PR TITLE
feat(tidy3d): FXC-3982-support-lydrc-in-klayout-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added configurable local simulation result caching with checksum validation, eviction limits, and per-call overrides across `web.run`, `web.load`, and job workflows.
 - Added `DirectivityMonitorSpec` for automated creation and configuration of directivity radiation monitors in `TerminalComponentModeler`.
 - Added multimode support to `WavePort` in the smatrix plugin, allowing multiple modes to be analyzed per port.
+- Added support for `.lydrc` files for design rule checking in the `klayout` plugin.
 
 ### Breaking Changes
 - Edge singularity correction at PEC and lossy metal edges defaults to `True`.

--- a/tests/test_plugins/klayout/drc/test_drc.py
+++ b/tests/test_plugins/klayout/drc/test_drc.py
@@ -54,6 +54,25 @@ class TestDRCRunner:
         """
 
     @staticmethod
+    def wrap_drc_to_lydrc(body: str):
+        """Return the XML-wrapped .lydrc runset content."""
+        xml = f"""\
+        <?xml version="1.0" encoding="utf-8"?>
+        <klayout-macro>
+        <description>Test DRC runset</description>
+        <version/>
+        <category>drc</category>
+        <prolog/>
+        <epilog/>
+        <text>
+        {body}
+        </text>
+        </klayout-macro>
+        """
+
+        return xml
+
+    @staticmethod
     @pytest.fixture(scope="class")
     def bad_drcrunset_content_source():
         """The content of a DRC file with a bad source declaration"""
@@ -147,15 +166,26 @@ class TestDRCRunner:
         )
 
     @pytest.mark.parametrize("verbose", [True, False])
+    @pytest.mark.parametrize("drc_file_suffix", [".drc", ".lydrc"])
     def test_valid_run_on_gds(
-        self, monkeypatch, tmp_path, verbose, geom, geom_to_gds_kwargs, good_drcrunset_content
+        self,
+        monkeypatch,
+        tmp_path,
+        verbose,
+        geom,
+        geom_to_gds_kwargs,
+        good_drcrunset_content,
+        drc_file_suffix,
     ):
         """Test that no error is raised when runs on a gds are valid"""
         geom.to_gds_file(tmp_path / "test.gds", **geom_to_gds_kwargs)
-        self.write_drcrunset(tmp_path, "good_drcfile.drc", good_drcrunset_content)
+        drc_content = good_drcrunset_content
+        if drc_file_suffix == ".lydrc":
+            drc_content = TestDRCRunner.wrap_drc_to_lydrc(drc_content)
+        self.write_drcrunset(tmp_path, f"good_drcfile{drc_file_suffix}", drc_content)
         self.run(
             monkeypatch=monkeypatch,
-            drc_runsetfile=tmp_path / "good_drcfile.drc",
+            drc_runsetfile=tmp_path / f"good_drcfile{drc_file_suffix}",
             verbose=verbose,
             source=tmp_path / "test.gds",
             td_object_gds_savefile=tmp_path / "test.gds",
@@ -163,6 +193,7 @@ class TestDRCRunner:
         )
 
     @pytest.mark.parametrize("verbose", [True, False])
+    @pytest.mark.parametrize("drc_file_suffix", [".drc", ".lydrc"])
     @pytest.mark.parametrize(
         "td_object, obj_to_gds_kwargs",
         [
@@ -180,12 +211,16 @@ class TestDRCRunner:
         td_object,
         obj_to_gds_kwargs,
         good_drcrunset_content,
+        drc_file_suffix,
     ):
         """Test that no error is raised when runs on a Geometry, Structure, or Simulation are valid"""
-        self.write_drcrunset(tmp_path, "good_drcfile.drc", good_drcrunset_content)
+        drc_content = good_drcrunset_content
+        if drc_file_suffix == ".lydrc":
+            drc_content = TestDRCRunner.wrap_drc_to_lydrc(drc_content)
+        self.write_drcrunset(tmp_path, f"good_drcfile{drc_file_suffix}", drc_content)
         self.run(
             monkeypatch=monkeypatch,
-            drc_runsetfile=tmp_path / "good_drcfile.drc",
+            drc_runsetfile=tmp_path / f"good_drcfile{drc_file_suffix}",
             verbose=verbose,
             source=request.getfixturevalue(td_object),
             td_object_gds_savefile=tmp_path / "test.gds",
@@ -196,18 +231,27 @@ class TestDRCRunner:
     @pytest.mark.parametrize(
         "bad_drcrunset_content", ["bad_drcrunset_content_source", "bad_drcrunset_content_report"]
     )
+    @pytest.mark.parametrize("drc_file_suffix", [".drc", ".lydrc"])
     def test_check_drcfile_format_invalid(
-        self, request, monkeypatch, tmp_path, geom, geom_to_gds_kwargs, bad_drcrunset_content
+        self,
+        request,
+        monkeypatch,
+        tmp_path,
+        geom,
+        geom_to_gds_kwargs,
+        bad_drcrunset_content,
+        drc_file_suffix,
     ):
         """Tests that ValidationError is raised when the drc file content is invalid"""
         geom.to_gds_file(tmp_path / "test.gds", **geom_to_gds_kwargs)
-        self.write_drcrunset(
-            tmp_path, "bad_drcrunset.drc", request.getfixturevalue(bad_drcrunset_content)
-        )
+        drc_content = request.getfixturevalue(bad_drcrunset_content)
+        if drc_file_suffix == ".lydrc":
+            drc_content = TestDRCRunner.wrap_drc_to_lydrc(drc_content)
+        self.write_drcrunset(tmp_path, f"bad_drcrunset{drc_file_suffix}", drc_content)
         with pytest.raises(pd.ValidationError) as e:
             self.run(
                 monkeypatch=monkeypatch,
-                drc_runsetfile=tmp_path / "bad_drcrunset.drc",
+                drc_runsetfile=tmp_path / f"bad_drcrunset{drc_file_suffix}",
                 verbose=True,
                 source=tmp_path / "test.gds",
                 td_object_gds_savefile=None,

--- a/tidy3d/plugins/klayout/drc/drc.py
+++ b/tidy3d/plugins/klayout/drc/drc.py
@@ -24,6 +24,8 @@ from tidy3d.plugins.klayout.drc.defaults import (
 from tidy3d.plugins.klayout.drc.results import DRCResults
 from tidy3d.plugins.klayout.util import check_installation
 
+SUPPORTED_DRC_SUFFIXES: frozenset[str] = frozenset({".drc", ".lydrc"})
+
 
 class DRCConfig(Tidy3dBaseModel):
     """Configuration for KLayout DRC."""
@@ -54,9 +56,11 @@ class DRCConfig(Tidy3dBaseModel):
 
     @validator("drc_runset")
     def _validate_drc_runset_filetype(cls, v: pd.FilePath) -> pd.FilePath:
-        """Check DRC runset filetype is ``.drc``."""
-        if v.suffix != ".drc":
-            raise ValidationError(f"DRC runset file '{v}' must end with '.drc'.")
+        """Check DRC runset filetype is ``.drc`` or ``.lydrc``."""
+        if v.suffix not in SUPPORTED_DRC_SUFFIXES:
+            raise ValidationError(
+                f"DRC runset file '{v}' must end with one of {', '.join(SUPPORTED_DRC_SUFFIXES)}."
+            )
         return v
 
     @validator("drc_runset")


### PR DESCRIPTION
Currently, we only support .drc files for the DRC Runner in the DRC Config in the klayout plugin. This PR simply allows also “lydrc” suffixes in the validator.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-05 11:18:46 UTC

<h3>Greptile Summary</h3>


Extended KLayout DRC plugin to support `.lydrc` file format in addition to `.drc` files. `.lydrc` files are XML-wrapped DRC runsets that KLayout can process.

## Key Changes

- Added `SUPPORTED_DRC_SUFFIXES` constant containing both `.drc` and `.lydrc` suffixes
- Updated `_validate_drc_runset_filetype` validator to accept both file types
- Improved validation error message to list all supported suffixes
- The existing regex-based format validation correctly handles both plain `.drc` and XML-wrapped `.lydrc` content

## Test Coverage

- Added `wrap_drc_to_lydrc` helper method to generate XML-wrapped content
- Parametrized existing tests with `drc_file_suffix` to test both `.drc` and `.lydrc` formats
- All validation, GDS processing, and Tidy3D object tests now cover both formats

## Issues Found

- Validator docstring still mentions only `.drc` format (needs update)
- Missing CHANGELOG entry for this user-facing feature addition

<h3>Confidence Score: 4/5</h3>


- Safe to merge with minor documentation updates needed
- The implementation is simple and correct - adding `.lydrc` to the supported suffixes set and updating the validator. The regex patterns work correctly for both formats since they search for the DRC commands in the file content regardless of XML wrapping. Comprehensive test coverage added. Score is 4 (not 5) due to outdated docstring and missing CHANGELOG entry per repository guidelines.
- `tidy3d/plugins/klayout/drc/drc.py` needs docstring update on line 59, and CHANGELOG.md needs an entry

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/klayout/drc/drc.py | 4/5 | Added `.lydrc` support to DRC validator by updating constant and validation logic; docstring needs update |
| tests/test_plugins/klayout/drc/test_drc.py | 5/5 | Added comprehensive test coverage for `.lydrc` format with XML wrapper helper and parametrized tests |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant DRCRunner
    participant DRCConfig
    participant Validator
    participant KLayout

    User->>DRCRunner: run(source, drc_runset)
    DRCRunner->>DRCConfig: create config
    DRCConfig->>Validator: _validate_drc_runset_filetype(path)
    
    alt file suffix is .drc or .lydrc
        Validator-->>DRCConfig: valid
    else file suffix is other
        Validator-->>DRCConfig: ValidationError
    end
    
    DRCConfig->>Validator: _validate_drc_runset_format(path)
    Validator->>Validator: read file content
    
    alt content matches patterns
        Validator-->>DRCConfig: valid
    else content invalid
        Validator-->>DRCConfig: ValidationError
    end
    
    DRCConfig-->>DRCRunner: validated config
    DRCRunner->>KLayout: execute DRC with runset
    KLayout-->>DRCRunner: results
    DRCRunner-->>User: DRCResults
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->