### PR TITLE
fix(rf): FXC-3994 simplify task and network naming scheme in TCM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unified run submission API: `web.run(...)` is now a container-aware wrapper that accepts a single simulation or arbitrarily nested containers (`list`, `tuple`, `dict` values) and returns results in the same shape.
 - `web.Batch(ComponentModeler)` and `web.Job(ComponentModeler)` native support
 - Simulation data of batch jobs are now automatically downloaded upon their individual completion in `Batch.run()`, avoiding waiting for the entire batch to reach completion.
+- Port names in `ModalComponentModeler` and `TerminalComponentModeler` can no longer include the `@` symbol.
 
 ### Fixed
 - Ensured the legacy `Env` proxy mirrors `config.web` profile switches and preserves API URL.

--- a/tests/test_plugins/smatrix/test_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_component_modeler.py
@@ -434,17 +434,9 @@ def test_get_task_name():
     task_name = ModalComponentModeler.get_task_name(port=port, mode_index=1)
     assert task_name == "port1@1"
 
-    # Test with format="PF"
-    task_name = ModalComponentModeler.get_task_name(port=port, format="PF")
+    # Test with mode_index unspecified
+    task_name = ModalComponentModeler.get_task_name(port=port)
     assert task_name == "port1@0"
-
-    # Test with format="RF"
-    task_name = ModalComponentModeler.get_task_name(port=port, format="RF")
-    assert task_name == "port1"
-
-    # Test with invalid format
-    with pytest.raises(ValueError):
-        ModalComponentModeler.get_task_name(port=port, format="invalid")
 
 
 def test_custom_source_time(monkeypatch):

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -1263,8 +1263,12 @@ def test_antenna_parameters(monkeypatch, port_type):
     modeler_data = run_component_modeler(monkeypatch, modeler)
 
     # Make sure network index works for single mode / multimode cases
-    port_1_network_index = modeler.network_index(modeler.ports[0], 0)
-    port_2_network_index = modeler.network_index(modeler.ports[1], 0)
+    if port_type == "lumped":
+        port_1_network_index = modeler.network_index(modeler.ports[0])
+        port_2_network_index = modeler.network_index(modeler.ports[1])
+    else:
+        port_1_network_index = modeler.network_index(modeler.ports[0], 0)
+        port_2_network_index = modeler.network_index(modeler.ports[1], 0)
     _ = modeler_data.get_antenna_metrics_data({port_1_network_index: 1.0})
     _ = modeler_data.get_antenna_metrics_data({port_2_network_index: None})
     antenna_params = modeler_data.get_antenna_metrics_data()
@@ -1362,7 +1366,7 @@ def test_run_only_and_element_mappings(monkeypatch, tmp_path):
         port_types=(CoaxialLumpedPort, CoaxialLumpedPort), grid_spec=grid_spec
     )
     port0_idx = modeler.network_index(modeler.ports[0])
-    port1_idx = modeler.network_index(modeler.ports[1], 0)
+    port1_idx = modeler.network_index(modeler.ports[1])
     modeler_run1 = modeler.updated_copy(run_only=(port0_idx,))
 
     # Make sure the smatrix and impedance calculations work for reduced simulations
@@ -2239,8 +2243,66 @@ def test_wave_port_mode_index_with_modeler():
 
     # Verify network_dict only has entries for the selected modes
     network_indices = set(modeler.network_dict.keys())
-    assert "port1_0" in network_indices
-    assert "port1_2" in network_indices
-    assert "port1_1" not in network_indices
-    assert "port1_3" not in network_indices
+    assert "port1@0" in network_indices
+    assert "port1@2" in network_indices
+    assert "port1@1" not in network_indices
+    assert "port1@3" not in network_indices
     assert "lumped_port" in network_indices
+
+
+def test_get_task_name():
+    """Test get_task_name with RF ports."""
+
+    # First make sure ports cannot have @ in their name
+    with pytest.raises(pd.ValidationError):
+        lumped_port = LumpedPort(
+            center=(0, 0, 0),
+            size=(1, 0, 0.5),
+            voltage_axis=0,
+            name="lumped1@0",
+        )
+
+    lumped_port = LumpedPort(
+        center=(0, 0, 0),
+        size=(1, 0, 0.5),
+        voltage_axis=0,
+        name="lumped1",
+    )
+
+    # Test with lumped port (no mode_index) - should work
+    task_name = TerminalComponentModeler.get_task_name(port=lumped_port)
+    assert task_name == "lumped1"
+
+    # Test with lumped port and mode_index - should raise ValueError
+    with pytest.raises(ValueError, match="mode_index.*should not be specified.*lumped port"):
+        TerminalComponentModeler.get_task_name(port=lumped_port, mode_index=0)
+
+    # Test with CoaxialLumpedPort as well
+    coax_port = CoaxialLumpedPort(
+        center=(0, 0, 0),
+        outer_diameter=2.0,
+        inner_diameter=0.5,
+        normal_axis=2,
+        direction="+",
+        name="coax1",
+    )
+
+    # Test with coaxial lumped port (no mode_index) - should work
+    task_name = TerminalComponentModeler.get_task_name(port=coax_port)
+    assert task_name == "coax1"
+
+    # Test with coaxial lumped port and mode_index - should raise ValueError
+    with pytest.raises(ValueError, match="mode_index.*should not be specified.*lumped port"):
+        TerminalComponentModeler.get_task_name(port=coax_port, mode_index=1)
+
+    wave_port = WavePort(
+        center=(0, 0, 0),
+        size=(4, 4, 0),
+        direction="+",
+        name="wave",
+        mode_selection=(1, 2),
+        mode_spec=td.MicrowaveModeSpec(num_modes=3),
+    )
+    # Test with wave port (no mode_index) - should work
+    task_name = TerminalComponentModeler.get_task_name(port=wave_port)
+    assert task_name == "wave@1"

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -23,7 +23,7 @@ from tidy3d.constants import HERTZ
 from tidy3d.exceptions import SetupError, Tidy3dKeyError
 from tidy3d.log import log
 from tidy3d.plugins.smatrix.ports.modal import Port
-from tidy3d.plugins.smatrix.ports.types import TerminalPortType
+from tidy3d.plugins.smatrix.ports.types import LumpedPortType, PortType, TerminalPortType
 from tidy3d.plugins.smatrix.ports.wave import WavePort
 from tidy3d.plugins.smatrix.types import Element, MatrixIndex, NetworkElement, NetworkIndex
 
@@ -182,27 +182,20 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
         return val
 
     @staticmethod
-    def get_task_name(
-        port: Port, mode_index: Optional[int] = None, format: Optional[TaskNameFormat] = "RF"
-    ) -> str:
+    def get_task_name(port: PortType, mode_index: Optional[int] = None) -> str:
         """Generates a standardized task name from a port object.
 
         This method creates a unique string identifier for a simulation task based on
-        a port. The naming convention can be controlled by specifying a mode index
-        directly, which takes precedence, or by selecting a predefined format.
+        a port and, if applicable, a specified mode index.
 
         Parameters
         ----------
-        port : Port
+        port : PortType
             The port object from which to derive the base name.
         mode_index : Optional[int], optional
-            If provided, this index is appended to the port name (e.g., 'port_1@1'),
-            overriding the `format` argument. Defaults to None.
-        format : TaskNameFormat, optional
-            Specifies the naming convention to use when `mode_index` is not provided.
-            - "RF": Returns the plain port name (e.g., "port_1").
-            - "PF": Appends a zero index to the name (e.g., "port_1@0").
-            Defaults to "RF".
+            If provided, this index is appended
+            to the port name (e.g., 'port_1@1'). Defaults to `None`, in which case the first
+            mode is chosen by default.
 
         Returns
         -------
@@ -212,19 +205,26 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
         Raises
         ------
         ValueError
-            If an invalid `format` string is provided.
+            If `mode_index` is specified for a lumped port.
         """
-        if mode_index is not None:
-            return f"{port.name}@{mode_index}"
-        if format == "PF":
-            port_name = f"{port.name}@0"
-        elif format == "RF":
-            port_name = f"{port.name}"
+
+        if isinstance(port, LumpedPortType):
+            if mode_index is not None:
+                raise ValueError(
+                    "'mode_index' should not be specified for a lumped port, "
+                    f"but was passed with value '{mode_index}'."
+                )
+            return f"{port.name}"
+        elif isinstance(port, WavePort):
+            # WavePorts default to first mode index
+            if mode_index is not None:
+                return f"{port.name}@{mode_index}"
+            return f"{port.name}@{port._mode_indices[0]}"
         else:
-            raise ValueError(
-                f"Format '{format}' invalid for port-name task creation. Must be defined in {TaskNameFormat}"
-            )
-        return port_name
+            # Modal ports default to 0
+            if mode_index is not None:
+                return f"{port.name}@{mode_index}"
+            return f"{port.name}@0"
 
     def get_port_by_name(self, port_name: str) -> Port:
         """Get the port from the name."""

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -37,7 +37,7 @@ from tidy3d.plugins.smatrix.data.data_array import PortDataArray
 from tidy3d.plugins.smatrix.ports.base_lumped import AbstractLumpedPort
 from tidy3d.plugins.smatrix.ports.coaxial_lumped import CoaxialLumpedPort
 from tidy3d.plugins.smatrix.ports.rectangular_lumped import LumpedPort
-from tidy3d.plugins.smatrix.ports.types import LumpedPortType, TerminalPortType
+from tidy3d.plugins.smatrix.ports.types import TerminalPortType
 from tidy3d.plugins.smatrix.ports.wave import WavePort
 from tidy3d.plugins.smatrix.types import NetworkElement, NetworkIndex, SParamDef
 
@@ -321,9 +321,7 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         NetworkIndex
             A unique string that is used to identify the row/column of the scattering matrix.
         """
-        if isinstance(port, LumpedPortType):
-            return f"{port.name}"
-        return f"{port.name}_{mode_index}"
+        return TerminalComponentModeler.get_task_name(port=port, mode_index=mode_index)
 
     @cached_property
     def network_dict(self) -> dict[NetworkIndex, tuple[TerminalPortType, int]]:

--- a/tidy3d/plugins/smatrix/ports/base.py
+++ b/tidy3d/plugins/smatrix/ports/base.py
@@ -1,0 +1,28 @@
+"""Abstract base class for all ports in the component and terminal component modelers."""
+
+from __future__ import annotations
+
+from abc import ABC
+
+import pydantic.v1 as pd
+
+from tidy3d.components.base import Tidy3dBaseModel
+from tidy3d.exceptions import SetupError
+
+
+class AbstractBasePort(Tidy3dBaseModel, ABC):
+    """Abstract base class representing a port excitation of a component."""
+
+    name: str = pd.Field(
+        ...,
+        title="Name",
+        description="Unique name for the port.",
+        min_length=1,
+    )
+
+    @pd.validator("name")
+    def _valid_port_name(cls, val):
+        """Make sure port name does not include the '@' symbol, so that task names will always be unique."""
+        if "@" in val:
+            raise SetupError(f"Port names must not include the '@' symbol. Name given was '{val}'.")
+        return val

--- a/tidy3d/plugins/smatrix/ports/base_terminal.py
+++ b/tidy3d/plugins/smatrix/ports/base_terminal.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import Optional, Union
-
-import pydantic.v1 as pd
 
 from tidy3d.components.base import cached_property
 from tidy3d.components.data.data_array import FreqDataArray
@@ -17,20 +15,14 @@ from tidy3d.components.source.base import Source
 from tidy3d.components.source.time import GaussianPulse
 from tidy3d.components.types import FreqArray
 from tidy3d.log import log
+from tidy3d.plugins.smatrix.ports.base import AbstractBasePort
 
 
-class AbstractTerminalPort(MicrowaveBaseModel, ABC):
+class AbstractTerminalPort(AbstractBasePort, MicrowaveBaseModel):
     """Class representing a single terminal-based port. All terminal ports must provide methods
     for computing voltage and current. These quantities represent the voltage between the
     terminals, and the current flowing from one terminal into the other.
     """
-
-    name: str = pd.Field(
-        ...,
-        title="Name",
-        description="Unique name for the port.",
-        min_length=1,
-    )
 
     @cached_property
     @abstractmethod

--- a/tidy3d/plugins/smatrix/ports/modal.py
+++ b/tidy3d/plugins/smatrix/ports/modal.py
@@ -8,6 +8,7 @@ from tidy3d.components.data.data_array import DataArray
 from tidy3d.components.geometry.base import Box
 from tidy3d.components.mode_spec import ModeSpec
 from tidy3d.components.types import Direction
+from tidy3d.plugins.smatrix.ports.base import AbstractBasePort
 
 
 class ModalPortDataArray(DataArray):
@@ -36,7 +37,7 @@ class ModalPortDataArray(DataArray):
     _data_attrs = {"long_name": "modal port matrix element"}
 
 
-class Port(Box):
+class Port(AbstractBasePort, Box):
     """Specifies a port for S-matrix calculation.
 
     A port defines a location and a set of modes for which the S-matrix
@@ -52,10 +53,4 @@ class Port(Box):
         ModeSpec(),
         title="Mode Specification",
         description="Specifies how the mode solver will solve for the modes of the port.",
-    )
-    name: str = pd.Field(
-        ...,
-        title="Name",
-        description="Unique name for the port.",
-        min_length=1,
     )

--- a/tidy3d/plugins/smatrix/ports/types.py
+++ b/tidy3d/plugins/smatrix/ports/types.py
@@ -9,10 +9,12 @@ from tidy3d.components.data.data_array import (
     VoltageFreqModeDataArray,
 )
 from tidy3d.plugins.smatrix.ports.coaxial_lumped import CoaxialLumpedPort
+from tidy3d.plugins.smatrix.ports.modal import Port
 from tidy3d.plugins.smatrix.ports.rectangular_lumped import LumpedPort
 from tidy3d.plugins.smatrix.ports.wave import WavePort
 
 LumpedPortType = Union[LumpedPort, CoaxialLumpedPort]
 TerminalPortType = Union[LumpedPortType, WavePort]
+PortType = Union[Port, TerminalPortType]
 PortVoltageType = Union[VoltageFreqDataArray, VoltageFreqModeDataArray]
 PortCurrentType = Union[CurrentFreqDataArray, CurrentFreqModeDataArray]


### PR DESCRIPTION
Main change here is fixing a missed issue when adding the multimodal waveports last week (using _ instead of @). Now network_index will be identical to task name. But also tried to reduce code duplication and make things more explicit in the `get_task_name`.

I still want to keep `network_index` because it makes more sense to me when indexing into matrices, rather than task name. I don't want to break backwards compatibility by removing or renaming `get_task_name` either.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-05 16:59:42 UTC

<h3>Greptile Summary</h3>


This PR fixes an inconsistency in the network naming scheme for the Terminal Component Modeler (TCM). The main change is standardizing the separator between port names and mode indices from underscore (`_`) to `@` symbol for WavePorts, making `network_index` consistent with `task_name`.

**Key Changes:**
- Refactored `network_index()` in `terminal.py` to delegate to `get_task_name()` instead of duplicating logic, eliminating the underscore vs `@` inconsistency
- Enhanced `get_task_name()` in `base.py` to enforce stricter validation: RF format now requires `mode_index` for non-lumped ports and prohibits it for lumped ports
- Added `PortType` union type to support the broader type signature needed in `get_task_name()`
- Updated all tests to reflect the new `@` separator format (`port1@0` instead of `port1_0`)

**Issues Found:**
- Docstring for `get_task_name()` is outdated and doesn't accurately describe the new RF format behavior or document all ValueError cases

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor documentation improvements needed
- The logic changes are sound and well-tested, successfully fixing the naming inconsistency. Code duplication was eliminated through proper refactoring. However, the docstring for `get_task_name()` needs updating to accurately reflect the new behavior, which prevents a score of 5. All tests were updated correctly and error handling follows the style guide.
- The docstring in `tidy3d/plugins/smatrix/component_modelers/base.py` should be updated before merge

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/smatrix/component_modelers/base.py | 3/5 | Refactored `get_task_name` to enforce mode_index requirement for non-lumped ports in RF format; docstring needs updating to reflect new behavior |
| tidy3d/plugins/smatrix/component_modelers/terminal.py | 5/5 | Simplified `network_index` to delegate to `get_task_name`, eliminating code duplication and fixing underscore vs `@` inconsistency |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant TCM as TerminalComponentModeler
    participant Base as AbstractComponentModeler
    
    Note over TCM,Base: Old flow (underscore format)
    User->>TCM: network_index(waveport, mode=0)
    TCM->>TCM: isinstance check
    TCM-->>User: "port1_0"
    
    Note over TCM,Base: New flow (@ format)
    User->>TCM: network_index(waveport, mode=0)
    TCM->>Base: get_task_name(port, mode=0, format="RF")
    Base->>Base: Check if LumpedPortType
    Base->>Base: Check mode_index not None
    Base-->>TCM: "port1@0"
    TCM-->>User: "port1@0"
    
    Note over TCM,Base: Lumped port handling
    User->>TCM: network_index(lumped_port, None)
    TCM->>Base: get_task_name(port, None, format="RF")
    Base->>Base: Check if LumpedPortType
    Base->>Base: Validate no mode_index
    Base-->>TCM: "port1"
    TCM-->>User: "port1"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->