### PR TITLE
feat(source_time): broadband pulse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `DirectivityMonitorSpec` for automated creation and configuration of directivity radiation monitors in `TerminalComponentModeler`.
 - Added multimode support to `WavePort` in the smatrix plugin, allowing multiple modes to be analyzed per port.
 - Added support for `.lydrc` files for design rule checking in the `klayout` plugin.
+- Introduced `BroadbandPulse` for exciting simulations across a wide frequency spectrum.
 
 ### Breaking Changes
 - Edge singularity correction at PEC and lossy metal edges defaults to `True`.

--- a/docs/api/sources.rst
+++ b/docs/api/sources.rst
@@ -34,6 +34,7 @@ Source Time Dependence
 
    tidy3d.GaussianPulse
    tidy3d.ContinuousWave
+   tidy3d.BroadbandPulse
    tidy3d.SourceTime
    tidy3d.CustomSourceTime
 

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -411,6 +411,7 @@ from .components.source.frame import (
 
 # sources
 from .components.source.time import (
+    BroadbandPulse,
     ContinuousWave,
     CustomSourceTime,
     GaussianPulse,
@@ -516,6 +517,7 @@ __all__ = [
     "Box",
     "BroadbandModeABCFitterParam",
     "BroadbandModeABCSpec",
+    "BroadbandPulse",
     "CaugheyThomasMobility",
     "CellDataArray",
     "ChargeConductorMedium",

--- a/tidy3d/components/source/time.py
+++ b/tidy3d/components/source/time.py
@@ -21,6 +21,7 @@ from tidy3d.components.viz import add_ax_if_none
 from tidy3d.constants import HERTZ
 from tidy3d.exceptions import ValidationError
 from tidy3d.log import log
+from tidy3d.packaging import requires_tidy3d_extras_feature, tidy3d_microwave
 
 # how many units of ``twidth`` from the ``offset`` until a gaussian pulse is considered "off"
 END_TIME_FACTOR_GAUSSIAN = 10
@@ -605,4 +606,67 @@ class CustomSourceTime(Pulse):
         return np.max(t_non_zero)
 
 
-SourceTimeType = Union[GaussianPulse, ContinuousWave, CustomSourceTime]
+class BroadbandPulse(SourceTime):
+    """A source time injecting significant energy in the entire custom frequency range."""
+
+    freq_range: FreqBound = pydantic.Field(
+        ...,
+        title="Frequency Range",
+        description="Frequency range where the pulse should have significant energy.",
+        units=HERTZ,
+    )
+    minimum_amplitude: float = pydantic.Field(
+        0.3,
+        title="Minimum Amplitude",
+        description="Minimum amplitude of the pulse relative to the peak amplitude in the frequency range.",
+        gt=0.05,
+        lt=0.5,
+    )
+    offset: float = pydantic.Field(
+        5.0,
+        title="Offset",
+        description="Time delay of the maximum value of the "
+        "pulse in units of 1 / (``2pi * fwidth``).",
+        ge=2.5,
+    )
+
+    @cached_property
+    @requires_tidy3d_extras_feature("BroadbandPulse")
+    def _source(self):
+        """Implementation of broadband pulse."""
+        return tidy3d_microwave["mod"].BroadbandPulse(
+            fmin=self.freq_range[0],
+            fmax=self.freq_range[1],
+            minRelAmp=self.minimum_amplitude,
+            amp=self.amplitude,
+            phase=self.phase,
+            offset=self.offset,
+        )
+
+    def end_time(self) -> float:
+        """Time after which the source is effectively turned off / close to zero amplitude."""
+        return self._source.end_time(END_TIME_FACTOR_GAUSSIAN)
+
+    def amp_time(self, time: float) -> complex:
+        """Complex-valued source amplitude as a function of time."""
+        return self._source.amp_time(time)
+
+    def amp_freq(self, freq: float) -> complex:
+        """Complex-valued source amplitude as a function of frequency."""
+        return self._source.amp_freq(freq)
+
+    def frequency_range_sigma(self, sigma: float = DEFAULT_SIGMA) -> FreqBound:
+        """Frequency range where the source amplitude is within ``exp(-sigma**2/2)`` of the peak amplitude."""
+        return self._source.frequency_range(sigma)
+
+    def frequency_range(self, num_fwidth: float = DEFAULT_SIGMA) -> FreqBound:
+        """Frequency range where the source amplitude is within ``exp(-sigma**2/2)`` of the peak amplitude."""
+        return self.frequency_range_sigma(num_fwidth)
+
+    @cached_property
+    def _freq0(self) -> float:
+        """Central frequency from frequency range."""
+        return np.mean(self.freq_range)
+
+
+SourceTimeType = Union[GaussianPulse, ContinuousWave, CustomSourceTime, BroadbandPulse]

--- a/tidy3d/packaging.py
+++ b/tidy3d/packaging.py
@@ -183,6 +183,75 @@ def get_numpy_major_version(module=np):
     return major_version
 
 
+def _check_tidy3d_extras_available():
+    """Helper function to check if 'tidy3d-extras' is available and version matched.
+
+    Raises
+    ------
+    Tidy3dImportError
+        If tidy3d-extras is not available or not properly initialized.
+    """
+    if tidy3d_extras["mod"] is None:
+        try:
+            import tidy3d_extras as tidy3d_extras_mod
+
+        except ImportError as exc:
+            tidy3d_extras["mod"] = None
+            raise Tidy3dImportError(
+                "The package 'tidy3d-extras' is required for this "
+                "operation. Please install the 'tidy3d-extras' package using, for "
+                "example, 'pip install tidy3d[extras]'."
+            ) from exc
+
+        else:
+            version = tidy3d_extras_mod.__version__
+
+            if version is None:
+                tidy3d_extras["mod"] = None
+                raise Tidy3dImportError(
+                    "The package 'tidy3d-extras' did not initialize correctly, "
+                    "likely due to an invalid API key."
+                )
+
+            if version != __version__:
+                log.warning(
+                    "The package 'tidy3d-extras' is required for this "
+                    "operation. The version of 'tidy3d-extras' should match "
+                    "the version of 'tidy3d'. You can install the correct "
+                    "version using 'pip install tidy3d[extras]'."
+                )
+
+            tidy3d_extras["mod"] = tidy3d_extras_mod
+
+
+def requires_tidy3d_extras_feature(feature_name: str):
+    """When decorating a method, requires that a specific feature is available in 'tidy3d-extras'.
+
+    Parameters
+    ----------
+    feature_name : str
+        The name of the feature to check for.
+    """
+
+    def decorator(fn):
+        @functools.wraps(fn)
+        def _fn(*args: Any, **kwargs: Any):
+            _check_tidy3d_extras_available()
+
+            features = tidy3d_extras["mod"].extension._features()
+            if feature_name not in features:
+                raise Tidy3dImportError(
+                    f"The feature '{feature_name}' is not available with your license. "
+                    "Please contact Tidy3D support, or upgrade your license."
+                )
+
+            return fn(*args, **kwargs)
+
+        return _fn
+
+    return decorator
+
+
 def supports_local_subpixel(fn):
     """When decorating a method, checks that 'tidy3d-extras' is available,
     conditioned on 'config.use_local_subpixel'."""
@@ -193,47 +262,14 @@ def supports_local_subpixel(fn):
 
         if preference is False:
             tidy3d_extras["use_local_subpixel"] = False
-            tidy3d_extras["mod"] = None
         else:
-            # first try to import the module
-            if tidy3d_extras["mod"] is None:
-                try:
-                    import tidy3d_extras as tidy3d_extras_mod
-
-                except ImportError as exc:
-                    tidy3d_extras["mod"] = None
-                    tidy3d_extras["use_local_subpixel"] = False
-                    if preference is True:
-                        raise Tidy3dImportError(
-                            "The package 'tidy3d-extras' is required for this "
-                            "operation when 'config.use_local_subpixel' is 'True'. "
-                            "Please install the 'tidy3d-extras' package using, for "
-                            "example, 'pip install tidy3d[extras]'."
-                        ) from exc
-
-                else:
-                    version = tidy3d_extras_mod.__version__
-
-                    if version is None:
-                        tidy3d_extras["mod"] = None
-                        tidy3d_extras["use_local_subpixel"] = False
-                        raise Tidy3dImportError(
-                            "The package 'tidy3d-extras' did not initialize correctly, "
-                            "likely due to an invalid API key."
-                        )
-
-                    if version != __version__:
-                        log.warning(
-                            "The package 'tidy3d-extras' is required for this "
-                            "operation. The version of 'tidy3d-extras' should match "
-                            "the version of 'tidy3d'. You can install the correct "
-                            "version using 'pip install tidy3d[extras]'."
-                        )
-
-                    features = tidy3d_extras_mod.extension._features()
-
-                    tidy3d_extras["mod"] = tidy3d_extras_mod
-                    tidy3d_extras["use_local_subpixel"] = "local_subpixel" in features
+            try:
+                _check_tidy3d_extras_available()
+            except Tidy3dImportError as exc:
+                tidy3d_extras["use_local_subpixel"] = False
+                raise Tidy3dImportError(
+                    f"Failed to load 'tidy3d-extras' for local subpixel support. {exc!s}"
+                ) from exc
             else:
                 features = tidy3d_extras["mod"].extension._features()
                 tidy3d_extras["use_local_subpixel"] = "local_subpixel" in features


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-05 18:53:41 UTC

<h3>Greptile Summary</h3>


This PR introduces `BroadbandPulse`, a new source time dependence class for exciting simulations across a wide frequency spectrum. The implementation wraps functionality from the `tidy3d-extras` package using a new license-gated decorator pattern.

## Key Changes
- Added `BroadbandPulse` class in `tidy3d/components/source/time.py` that delegates to `tidy3d-extras` implementation
- Implemented `requires_tidy3d_extras_feature` decorator in `packaging.py` for feature-level license checking
- Refactored `supports_local_subpixel` to use shared `_check_tidy3d_extras_available()` helper
- Updated exports in `__init__.py` and API documentation
- Added changelog entry under "Added" section

## Critical Issues Found
- **Missing `tidy3d_microwave` dictionary**: Line 24 imports `tidy3d_microwave` from `packaging.py`, but this dictionary is never defined (unlike `tidy3d_extras` which exists). This will cause an immediate `NameError` on import.
- **Missing input validation**: `BroadbandPulse.freq_range` lacks validation to ensure `freq_range[0] < freq_range[1]` and both values are positive, unlike similar patterns in `GaussianPulse.from_frequency_range`.

<h3>Confidence Score: 0/5</h3>


- This PR cannot be merged - it will cause immediate import failures in production
- Critical blocking issue: `tidy3d_microwave` is imported but never defined, causing a `NameError` that breaks all imports of `tidy3d.components.source.time`. Additionally, missing validation for `freq_range` could allow invalid parameters. The refactoring in `packaging.py` is good, but the missing dictionary definition makes the entire feature non-functional.
- `tidy3d/components/source/time.py` has critical import error and `tidy3d/packaging.py` is missing the `tidy3d_microwave` dictionary definition

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/source/time.py | 1/5 | Added BroadbandPulse class wrapping tidy3d-extras feature. Critical: missing tidy3d_microwave dict definition causes import error. Missing freq_range validation. |
| tidy3d/packaging.py | 3/5 | Added `requires_tidy3d_extras_feature` decorator and refactored `supports_local_subpixel` to use shared helper. Good refactoring but missing `tidy3d_microwave` dict needed by source/time.py. |
| CHANGELOG.md | 5/5 | Added changelog entry for `BroadbandPulse` in Added section. Clear and follows conventions. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant BroadbandPulse
    participant packaging
    participant tidy3d_extras
    
    User->>BroadbandPulse: Create BroadbandPulse(freq_range, minimum_amplitude, offset)
    BroadbandPulse->>BroadbandPulse: Store parameters
    
    User->>BroadbandPulse: Access _source property
    BroadbandPulse->>packaging: @requires_tidy3d_extras_feature("BroadbandPulse")
    packaging->>packaging: _check_tidy3d_extras_available()
    
    alt tidy3d_extras not loaded
        packaging->>tidy3d_extras: import tidy3d_extras
        tidy3d_extras-->>packaging: module loaded
        packaging->>packaging: Store in tidy3d_extras["mod"]
    end
    
    packaging->>tidy3d_extras: Check extension._features()
    tidy3d_extras-->>packaging: Return available features
    
    alt BroadbandPulse not in features
        packaging-->>User: Raise Tidy3dImportError
    else Feature available
        packaging->>BroadbandPulse: Continue execution
        BroadbandPulse->>tidy3d_extras: tidy3d_microwave["mod"].BroadbandPulse(...)
        Note over BroadbandPulse,tidy3d_extras: ❌ CRITICAL: tidy3d_microwave undefined
        tidy3d_extras-->>BroadbandPulse: Return wrapped implementation
        BroadbandPulse-->>User: Return _source object
    end
    
    User->>BroadbandPulse: Call amp_time(time)
    BroadbandPulse->>BroadbandPulse: _source.amp_time(time)
    BroadbandPulse-->>User: Return amplitude
    
    User->>BroadbandPulse: Call frequency_range()
    BroadbandPulse->>BroadbandPulse: _source.frequency_range(sigma)
    BroadbandPulse-->>User: Return frequency bounds
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->