### PR TITLE
Change EME validation to only depend on transverse grids (FXC-3746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed frequency sampling of `TransmissionLineDataset` within `MicrowaveModeData` when using group index calculation.
 - Fixed DRC parsing for quoted categories in klayout plugin.
 - Removed mode solver warnings about evaluating permittivity of a `Medium2D`.
+- Maximum number of grid points in an EME simulation is now based solely on transverse grid points. Maximum number of EME cells is unchanged.
 
 ### Removed
 - Removed deprecated `use_complex_fields` parameter from `TwoPhotonAbsorption` and `KerrNonlinearity`. Parameters `beta` and `n2` are now real-valued only, as is `n0` if specified.

--- a/tests/test_components/test_eme.py
+++ b/tests/test_components/test_eme.py
@@ -412,16 +412,10 @@ def test_eme_simulation():
         _ = sim.updated_copy(monitors=[monitor])
 
     # test max sim size and freqs
-    sim_bad = sim.updated_copy(size=(1000, 1000, 1000))
+    sim_bad = sim.updated_copy(size=(150, 150, 3))
     with pytest.raises(SetupError):
         sim_bad.validate_pre_upload()
-    sim_bad = sim.updated_copy(size=(1000, 500, 3), monitors=[], store_port_modes=True)
-    with pytest.raises(SetupError):
-        sim_bad.validate_pre_upload()
-    sim_bad = sim.updated_copy(size=(1000, 500, 3), monitors=[], store_port_modes=False)
-    with pytest.raises(SetupError):
-        sim_bad.validate_pre_upload()
-    sim_bad = sim.updated_copy(size=(500, 500, 3), monitors=[])
+    sim_bad = sim.updated_copy(size=(50, 50, 3), monitors=[])
     with AssertLogLevel("WARNING", "slow-down"):
         sim_bad.validate_pre_upload()
 

--- a/tidy3d/components/eme/simulation.py
+++ b/tidy3d/components/eme/simulation.py
@@ -43,11 +43,11 @@ from .monitor import (
 from .sweep import EMEFreqSweep, EMELengthSweep, EMEModeSweep, EMEPeriodicitySweep, EMESweepSpecType
 
 # maximum numbers of simulation parameters
-MAX_GRID_CELLS = 20e9
 WARN_MONITOR_DATA_SIZE_GB = 10
 MAX_MONITOR_INTERNAL_DATA_SIZE_GB = 50
 MAX_SIMULATION_DATA_SIZE_GB = 50
 WARN_MODE_NUM_CELLS = 1e5
+MAX_MODE_NUM_CELLS = 5e6
 
 
 # eme specific simulation parameters
@@ -807,14 +807,6 @@ class EMESimulation(AbstractYeeGridSimulation):
 
     def _validate_size(self) -> None:
         """Ensures the simulation is within size limits before simulation is uploaded."""
-
-        num_comp_cells = self.num_cells / 2 ** (np.sum(np.abs(self.symmetry)))
-        if num_comp_cells > MAX_GRID_CELLS:
-            raise SetupError(
-                f"Simulation has {num_comp_cells:.2e} computational cells, "
-                f"a maximum of {MAX_GRID_CELLS:.2e} are allowed."
-            )
-
         num_freqs = len(self.freqs)
         if num_freqs > MAX_NUM_FREQS:
             raise SetupError(
@@ -876,6 +868,12 @@ class EMESimulation(AbstractYeeGridSimulation):
         def warn_mode_size(monitor: AbstractModeMonitor, msg_header: str, custom_loc: list) -> None:
             """Warn if a mode component has a large number of points."""
             num_cells = np.prod(self.discretize_monitor(monitor).num_cells)
+            if num_cells > MAX_MODE_NUM_CELLS:
+                raise SetupError(
+                    msg_header + f"has {num_cells:.2e} computational cells "
+                    "in the transverse directions, "
+                    f"a maximum of {MAX_MODE_NUM_CELLS:.2e} are allowed."
+                )
             if num_cells > WARN_MODE_NUM_CELLS:
                 consolidated_logger.warning(
                     msg_header + f"has a large number ({num_cells:1.2e}) of grid points. "


### PR DESCRIPTION
Previously, EME validated based on the total number of grid points in the simulation. It is better to only validate based on the transverse grid points in the mode solver monitors. The max number of EME cells is handled elsewhere.

I'm not too sure about the numbers, the max here seems pretty large but it's consistent with the current unit tests. Let me know if you have suggestions for more reasonable max number of transverse grid points which would still handle applications of interest.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-05 20:17:05 UTC

<h3>Greptile Summary</h3>


Refactored EME simulation validation to check transverse grid points in mode solver monitors rather than total simulation grid points.

**Key Changes:**
- Removed `MAX_GRID_CELLS` constant and validation check from `_validate_size()` method
- Added `MAX_MODE_NUM_CELLS` constant (2e8) 
- Enhanced `_validate_modes_size()` to raise `SetupError` when transverse grid points exceed `MAX_MODE_NUM_CELLS`
- Updated validation logic to check each mode monitor's transverse computational cells using `discretize_monitor()`
- Added changelog entry explaining the change

**Impact:**
This change makes the validation more targeted and appropriate for EME simulations, where the relevant constraint is the transverse grid resolution used for mode solving, not the total 3D simulation size.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it improves validation logic appropriately for EME simulations
- The change is well-targeted and correctly implements the intended validation improvement. The old validation checked total simulation grid cells which was overly restrictive for EME. The new validation properly checks transverse grid points in mode monitors, which is the actual constraint for EME mode solving. The constant value (2e8) is consistent with existing tests and appropriate for the use case.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| CHANGELOG.md | 5/5 | Added changelog entry for EME validation change - correctly categorized under Fixed section |
| tidy3d/components/eme/simulation.py | 5/5 | Refactored EME validation to check transverse grid points only instead of total simulation cells - implementation looks correct |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant EMESimulation
    participant validate_pre_upload
    participant _validate_size
    participant _validate_modes_size
    participant warn_mode_size
    
    User->>EMESimulation: Create simulation
    EMESimulation->>validate_pre_upload: Validate before upload
    validate_pre_upload->>_validate_size: Check frequency limits
    _validate_size-->>validate_pre_upload: OK
    validate_pre_upload->>_validate_modes_size: Check mode monitor sizes
    _validate_modes_size->>warn_mode_size: Check each monitor
    warn_mode_size->>EMESimulation: discretize_monitor(monitor)
    EMESimulation-->>warn_mode_size: Grid with num_cells
    warn_mode_size->>warn_mode_size: Calculate num_cells = prod(num_cells)
    alt num_cells > MAX_MODE_NUM_CELLS
        warn_mode_size-->>_validate_modes_size: Raise SetupError
        _validate_modes_size-->>validate_pre_upload: Error
        validate_pre_upload-->>User: Validation failed
    else num_cells > WARN_MODE_NUM_CELLS
        warn_mode_size-->>_validate_modes_size: Log warning
    else
        warn_mode_size-->>_validate_modes_size: OK
    end
    _validate_modes_size-->>validate_pre_upload: OK
    validate_pre_upload-->>User: Validation passed
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->