### PR TITLE
refactor: simplify autograd padding indices

### DIFF
--- a/tidy3d/plugins/autograd/functions.py
+++ b/tidy3d/plugins/autograd/functions.py
@@ -66,24 +66,15 @@ def _get_pad_indices(
     if n == 0:
         return numpy_module.zeros(total_pad, dtype=int)
 
-    idx = numpy_module.arange(-pad_width[0], n + pad_width[1])
-
+    pad_left, pad_right = pad_width
     if mode == "constant":
-        return idx
-    if mode == "edge":
-        return numpy_module.clip(idx, 0, n - 1)
-    if mode == "reflect":
-        period = 2 * n - 2 if n > 1 else 1
-        idx = numpy_module.mod(idx, period)
-        return numpy_module.where(idx >= n, period - idx, idx)
-    if mode == "symmetric":
-        period = 2 * n if n > 1 else 1
-        idx = numpy_module.mod(idx, period)
-        return numpy_module.where(idx >= n, period - idx - 1, idx)
-    if mode == "wrap":
-        return numpy_module.mod(idx, n)
+        return numpy_module.arange(-pad_left, n + pad_right)
 
-    raise ValueError(f"Unsupported padding mode: {mode}")
+    try:
+        indices = onp.pad(onp.arange(n), (pad_left, pad_right), mode=mode)
+    except ValueError as error:
+        raise ValueError(f"Unsupported padding mode: {mode}") from error
+    return numpy_module.asarray(indices, dtype=int)
 
 
 def pad(


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-06 10:08:29 UTC

<h3>Greptile Summary</h3>


Refactored `_get_pad_indices` function to delegate padding logic to NumPy's built-in `pad` function instead of manually implementing each mode (edge, reflect, symmetric, wrap). This simplification reduces code complexity from ~15 lines of mode-specific logic to a single delegation call with proper error handling.

**Key changes:**
- Removed manual index computation for edge, reflect, symmetric, and wrap modes
- Added delegation to `onp.pad(onp.arange(n), pad_width, mode=mode)` to generate indices
- Preserved constant mode behavior (unchanged)
- Improved error handling with try/catch block for unsupported modes
- Maintained compatibility by converting result back to appropriate numpy module (autograd.numpy when needed)

The refactoring maintains identical behavior while improving maintainability and leveraging well-tested NumPy functionality.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it's a clean refactoring that simplifies code without changing behavior
- The refactoring delegates to NumPy's well-tested `pad` function instead of reimplementing padding logic, reducing code complexity while maintaining identical behavior. Comprehensive test coverage exists for all padding modes, and the change properly handles error cases.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/autograd/functions.py | 5/5 | Simplified `_get_pad_indices` by delegating to NumPy's pad function instead of manual mode implementations - improves maintainability without changing behavior |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant pad
    participant _get_pad_indices
    participant numpy_pad as onp.pad
    
    Caller->>pad: array, pad_width, mode
    alt mode == "constant"
        pad->>pad: Use np.pad directly
    else other modes
        pad->>_get_pad_indices: n, pad_width, mode, numpy_module
        alt mode == "constant"
            _get_pad_indices->>_get_pad_indices: Return arange indices
        else other modes (edge, reflect, symmetric, wrap)
            _get_pad_indices->>numpy_pad: arange(n), pad_width, mode
            numpy_pad-->>_get_pad_indices: padded indices
            _get_pad_indices->>_get_pad_indices: Convert to numpy_module
        end
        _get_pad_indices-->>pad: indices
        pad->>pad: Index array using indices
    end
    pad-->>Caller: padded array
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->