### PR TITLE
fix(tidy3d): FXC-4026-parsing-error-in-klayout-drc-results-loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved type hints for `Tidy3dBaseModel`, so that all derived classes will have more accurate return types.
 - More robust method for suppressing RF license warnings during tests.
 - Fixed frequency sampling of `TransmissionLineDataset` within `MicrowaveModeData` when using group index calculation.
+- Fixed DRC parsing for quoted categories in klayout plugin.
 
 ### Removed
 - Removed deprecated `use_complex_fields` parameter from `TwoPhotonAbsorption` and `KerrNonlinearity`. Parameters `beta` and `n2` are now real-valued only, as is `n0` if specified.

--- a/tests/test_plugins/klayout/drc/drc_results_clean.lyrdb
+++ b/tests/test_plugins/klayout/drc/drc_results_clean.lyrdb
@@ -13,6 +13,12 @@
    <categories>
    </categories>
   </category>
+  <category>
+   <name>'quoted category'</name>
+   <description>test if quoted categories are parsed correctly</description>
+   <categories>
+   </categories>
+  </category>
  </categories>
  <cells>
   <cell>

--- a/tests/test_plugins/klayout/drc/test_drc.py
+++ b/tests/test_plugins/klayout/drc/test_drc.py
@@ -326,9 +326,9 @@ class TestDRCResults:
         return DRCResults.load(filepath / "drc_results.lyrdb")
 
     @pytest.fixture(scope="class")
-    def drc_results_widthonly_clean(self):
+    def drc_results_clean(self):
         """Load the DRC results"""
-        return DRCResults.load(filepath / "drc_results_widthonly_clean.lyrdb")
+        return DRCResults.load(filepath / "drc_results_clean.lyrdb")
 
     def test_result_file_load(self, tmp_path):
         """Test that result file loading works"""
@@ -347,10 +347,10 @@ class TestDRCResults:
         with pytest.raises(ET.ParseError):
             DRCResults.load(tmp_path / "bad_resultsfile.lyrdb")
 
-    def test_is_drc_clean(self, drc_results, drc_results_widthonly_clean):
+    def test_is_drc_clean(self, drc_results, drc_results_clean):
         """Test DRCResults.is_clean"""
         assert not drc_results.is_clean
-        assert drc_results_widthonly_clean.is_clean
+        assert drc_results_clean.is_clean
 
     def test_count_drc_violations(self, drc_results):
         """Test that counting violations works"""

--- a/tidy3d/plugins/klayout/drc/results.py
+++ b/tidy3d/plugins/klayout/drc/results.py
@@ -350,13 +350,22 @@ def violations_from_file(resultsfile: Union[str, Path]) -> dict[str, DRCViolatio
     # Initialize violations dict with all the categories
     violations = {}
     for category in xmltree.getroot().findall(".//categories/category/name"):
-        violations[category.text] = DRCViolation(category=category.text, markers=())
+        category_name = category.text
+        if category_name is None:
+            raise FileError("Encountered DRC category without a name in results file.")
+        category_name = category_name.strip().strip("'\"")
+        violations[category_name] = DRCViolation(category=category_name, markers=())
 
     # Parse markers
     for item in xmltree.getroot().findall(".//item"):
-        category = item.find("category").text
+        category_el = item.find("category")
+        if category_el is None or category_el.text is None:
+            raise FileError("Encountered DRC item without a category in results file.")
+        category = category_el.text.strip().strip("'\"")
         value = item.find("values/value").text
         marker = parse_violation_value(value)
+        if category not in violations:
+            violations[category] = DRCViolation(category=category, markers=())
         violations[category] = DRCViolation(
             category=category,
             markers=(*violations[category].markers, marker),


### PR DESCRIPTION
Description:
DRCResults.load crashed when .lyrdb categories were wrapped in quotes (e.g. 'ABC.123'). The parser failed to match pre-defined keys, raising KeyError in violations_from_file.

Fix:
Trimmed quotes/whitespace and create categories on demand in results.py (lines 350–372) to handle inconsistent category formatting gracefully.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-06 16:20:27 UTC

<h3>Greptile Summary</h3>


Fixed `DRCResults.load()` crash when KLayout DRC result files contain category names wrapped in quotes (e.g., `'ABC.123'`). The parser now strips quotes and whitespace from category names and creates categories dynamically if they're referenced by violations but weren't pre-defined in the categories section.

**Key changes:**
- Enhanced `violations_from_file()` in `results.py:350-372` to strip quotes/whitespace from category names using `.strip().strip('\'"')`
- Added on-demand category creation when parsing violation items to handle inconsistent XML formatting
- Added proper null checks with informative error messages for missing category names or elements
- Renamed test fixture from `drc_results_widthonly_clean` to `drc_results_clean` for clarity
- Added test case with quoted category name (`'quoted category'`) to verify the fix

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with low risk - it fixes a specific parsing bug with appropriate error handling
- The fix is well-targeted and handles the edge case properly. Added test coverage for quoted categories. The string strip operations are safe and handle both single and double quotes correctly. Minor deduction for not testing double-quoted categories explicitly, though the logic handles them.
- No files require special attention - the changes are straightforward bug fixes with appropriate test coverage

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/klayout/drc/results.py | 4/5 | Fixed parsing of quoted category names in KLayout DRC results by stripping quotes and whitespace, and creating categories on-demand if missing |
| tests/test_plugins/klayout/drc/drc_results_clean.lyrdb | 5/5 | Added test category with quoted name (`'quoted category'`) to verify parser handles quoted categories correctly |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant DRCResults
    participant violations_from_file
    participant ET as XML Parser
    participant FileSystem

    User->>DRCResults: load(resultsfile)
    DRCResults->>violations_from_file: violations_from_file(resultsfile)
    violations_from_file->>FileSystem: Read .lyrdb file
    FileSystem-->>violations_from_file: XML content
    violations_from_file->>ET: parse(resultsfile)
    ET-->>violations_from_file: xmltree
    
    Note over violations_from_file: Initialize violations dict
    violations_from_file->>ET: findall(".//categories/category/name")
    ET-->>violations_from_file: category elements
    
    loop For each category
        violations_from_file->>violations_from_file: Strip quotes/whitespace<br/>category_name.strip().strip('\'"')
        violations_from_file->>violations_from_file: Create DRCViolation(category, markers=())
    end
    
    Note over violations_from_file: Parse violation markers
    violations_from_file->>ET: findall(".//item")
    ET-->>violations_from_file: item elements
    
    loop For each item
        violations_from_file->>violations_from_file: Extract category from item
        violations_from_file->>violations_from_file: Strip quotes/whitespace
        violations_from_file->>violations_from_file: Check if category exists
        alt Category not in violations
            violations_from_file->>violations_from_file: Create category on-demand
        end
        violations_from_file->>violations_from_file: Append marker to category
    end
    
    violations_from_file-->>DRCResults: violations dict
    DRCResults-->>User: DRCResults instance
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->