### PR TITLE
hotfix: remove unneeded warning with Medium2D and mode solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More robust method for suppressing RF license warnings during tests.
 - Fixed frequency sampling of `TransmissionLineDataset` within `MicrowaveModeData` when using group index calculation.
 - Fixed DRC parsing for quoted categories in klayout plugin.
+- Removed mode solver warnings about evaluating permittivity of a `Medium2D`.
 
 ### Removed
 - Removed deprecated `use_complex_fields` parameter from `TwoPhotonAbsorption` and `KerrNonlinearity`. Parameters `beta` and `n2` are now real-valued only, as is `n0` if specified.

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -1914,7 +1914,7 @@ class ModeSolver(Tidy3dBaseModel):
     def _intersecting_media(self) -> list:
         """List of media (including simulation background) intersecting the mode plane."""
         total_structures = [self.simulation.scene.background_structure]
-        total_structures += list(self.simulation.structures)
+        total_structures += list(self.simulation.volumetric_structures)
         return self.simulation.scene.intersecting_media(self.plane, total_structures)
 
     @cached_property


### PR DESCRIPTION
Whenever a `Medium2D` and a `ModeSolver` are present, we get warnings `Evaluating the permittivity of a Medium2D is unphysical`. We should be checking the volumetric equivalent structure instead.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-06 16:49:01 UTC

<h3>Greptile Summary</h3>


Fixed spurious warnings when using `Medium2D` structures with `ModeSolver` by switching from `self.simulation.structures` to `self.simulation.volumetric_structures` in the `_intersecting_media` method.

- The `volumetric_structures` property automatically converts `Medium2D` structures to their 3D `AnisotropicMedium` equivalents
- This prevents the unphysical permittivity warning that was triggered when the mode solver accessed `Medium2D.eps_diagonal()` directly
- The fix is minimal (one-line change) and uses the existing infrastructure designed specifically for this conversion
- No test changes needed as this fixes a warning issue rather than functional behavior

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with low risk, pending a changelog entry
- The change is well-targeted and uses existing infrastructure (`volumetric_structures` property) that was designed specifically for converting Medium2D to 3D equivalents. The fix is minimal (one line) and directly addresses the root cause of spurious warnings. However, the PR is missing a changelog entry as required by project conventions for bug fixes, which is the only reason for not scoring 5/5.
- No files require special attention - the change is straightforward and correct

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/mode/mode_solver.py | 5/5 | Changed from `self.simulation.structures` to `self.simulation.volumetric_structures` in `_intersecting_media` method to use converted 3D equivalents of Medium2D structures, avoiding unphysical permittivity warnings |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant MS as ModeSolver
    participant Sim as Simulation
    participant Scene
    participant Medium2D
    participant VolumetricMedium as AnisotropicMedium

    Note over MS: _intersecting_media() called
    MS->>Sim: Get background_structure
    MS->>Sim: Get volumetric_structures
    Note over Sim: Returns structures with<br/>Medium2D converted to<br/>3D volumetric equivalents
    Sim->>Sim: _volumetric_structures_grid()
    loop For each structure
        alt Structure has Medium2D
            Sim->>Medium2D: volumetric_equivalent()
            Medium2D->>VolumetricMedium: Create AnisotropicMedium
            VolumetricMedium-->>Sim: Return 3D medium
            Note over Sim: Replace Medium2D structure<br/>with volumetric equivalent
        else Structure has 3D medium
            Note over Sim: Keep structure as is
        end
    end
    Sim-->>MS: Return volumetric_structures
    MS->>Scene: intersecting_media(plane, structures)
    Scene->>VolumetricMedium: Access permittivity
    Note over Scene: No warning since<br/>using physical 3D medium
    Scene-->>MS: Return intersecting media list
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->