### PR TITLE
fix(packaging): restore tidy3d-extras messaging

### DIFF
--- a/tidy3d/packaging.py
+++ b/tidy3d/packaging.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import functools
 from importlib import import_module
+from importlib.util import find_spec
 from typing import Any, Literal
 
 import numpy as np
@@ -185,7 +186,7 @@ def get_numpy_major_version(module=np):
 
 def supports_local_subpixel(fn):
     """When decorating a method, checks that 'tidy3d-extras' is available,
-    conditioned on 'config.use_local_subpixel'."""
+    conditioned on 'config.simulation.use_local_subpixel'."""
 
     @functools.wraps(fn)
     def _fn(*args: Any, **kwargs: Any):
@@ -195,23 +196,32 @@ def supports_local_subpixel(fn):
             tidy3d_extras["use_local_subpixel"] = False
             tidy3d_extras["mod"] = None
         else:
-            # first try to import the module
             if tidy3d_extras["mod"] is None:
-                try:
-                    import tidy3d_extras as tidy3d_extras_mod
+                tidy3d_extras["use_local_subpixel"] = False
+                tidy3d_extras["mod"] = None
+                module_exists = find_spec("tidy3d_extras") is not None
 
-                except ImportError as exc:
-                    tidy3d_extras["mod"] = None
-                    tidy3d_extras["use_local_subpixel"] = False
-                    if preference is True:
+                if preference is True and not module_exists:
+                    raise Tidy3dImportError(
+                        "The package 'tidy3d-extras' is required for this "
+                        "operation when 'config.simulation.use_local_subpixel' is 'True'. "
+                        "Please install the 'tidy3d-extras' package using, for "
+                        "example, 'pip install tidy3d[extras]'."
+                    )
+
+                if module_exists:
+                    try:
+                        import tidy3d_extras as tidy3d_extras_mod
+
+                    except ImportError as exc:
+                        tidy3d_extras["mod"] = None
+                        tidy3d_extras["use_local_subpixel"] = False
                         raise Tidy3dImportError(
-                            "The package 'tidy3d-extras' is required for this "
-                            "operation when 'config.use_local_subpixel' is 'True'. "
-                            "Please install the 'tidy3d-extras' package using, for "
-                            "example, 'pip install tidy3d[extras]'."
+                            "The package 'tidy3d-extras' did not initialize correctly. "
+                            "To suppress this error, you can set "
+                            "'config.simulation.use_local_subpixel=False'."
                         ) from exc
 
-                else:
                     version = tidy3d_extras_mod.__version__
 
                     if version is None:
@@ -219,7 +229,8 @@ def supports_local_subpixel(fn):
                         tidy3d_extras["use_local_subpixel"] = False
                         raise Tidy3dImportError(
                             "The package 'tidy3d-extras' did not initialize correctly, "
-                            "likely due to an invalid API key."
+                            "likely due to an invalid API key. To suppress this error, "
+                            "you can set 'config.simulation.use_local_subpixel=False'."
                         )
 
                     if version != __version__:


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-07 09:54:16 UTC

<h3>Greptile Summary</h3>


This PR restores critical state management assignments that were removed in a previous commit, ensuring proper error handling when `tidy3d-extras` fails to initialize.

**Key Changes:**
- Restored `tidy3d_extras["mod"] = None` and `tidy3d_extras["use_local_subpixel"] = False` assignments in error paths to prevent inconsistent state
- Updated all config path references from `config.use_local_subpixel` to `config.simulation.use_local_subpixel` throughout error messages
- Added an `else` clause to re-check features when the module is already cached, ensuring the feature flag stays current
- Updated the docstring to reflect the correct config path
- Added type hints (`Any`) to decorator function signatures for consistency

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- This is a straightforward bug fix that restores proper state management for error handling paths. The changes are well-contained, restore previously working behavior, and align with existing test coverage. The state assignments prevent inconsistent cached state when errors occur, which is critical for correct decorator behavior.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/packaging.py | 5/5 | Restored state assignments for tidy3d-extras handling and updated config path references from `config.use_local_subpixel` to `config.simulation.use_local_subpixel` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant DecoratedFunction
    participant supports_local_subpixel
    participant config
    participant find_spec
    participant tidy3d_extras_mod

    User->>DecoratedFunction: call function
    DecoratedFunction->>supports_local_subpixel: execute decorator
    supports_local_subpixel->>config: check simulation.use_local_subpixel
    
    alt preference is False
        supports_local_subpixel->>supports_local_subpixel: reset tidy3d_extras state
    else preference is True/None
        alt tidy3d_extras["mod"] is None
            supports_local_subpixel->>supports_local_subpixel: reset state
            supports_local_subpixel->>find_spec: check if tidy3d_extras exists
            
            alt preference is True AND module not found
                supports_local_subpixel-->>User: raise Tidy3dImportError
            else module exists
                supports_local_subpixel->>tidy3d_extras_mod: import tidy3d_extras
                
                alt import fails
                    supports_local_subpixel->>supports_local_subpixel: reset state
                    supports_local_subpixel-->>User: raise Tidy3dImportError
                else import succeeds
                    supports_local_subpixel->>tidy3d_extras_mod: check __version__
                    
                    alt version is None
                        supports_local_subpixel->>supports_local_subpixel: reset state
                        supports_local_subpixel-->>User: raise Tidy3dImportError (invalid API key)
                    else version mismatch
                        supports_local_subpixel->>User: log warning
                        supports_local_subpixel->>tidy3d_extras_mod: check features
                        supports_local_subpixel->>supports_local_subpixel: cache module and features
                    else version matches
                        supports_local_subpixel->>tidy3d_extras_mod: check features
                        supports_local_subpixel->>supports_local_subpixel: cache module and features
                    end
                end
            end
        else tidy3d_extras["mod"] exists
            supports_local_subpixel->>tidy3d_extras_mod: re-check features
            supports_local_subpixel->>supports_local_subpixel: update use_local_subpixel flag
        end
    end
    
    supports_local_subpixel->>DecoratedFunction: execute original function
    DecoratedFunction->>User: return result
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->