### PR TITLE
perf: cache traced field conversion

### DIFF
--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -231,6 +231,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         copy_on_model_validation = "none"
 
     _cached_properties = pydantic.PrivateAttr({})
+    _has_tracers: Optional[bool] = pydantic.PrivateAttr(default=None)
 
     @pydantic.root_validator(skip_on_failure=True)
     def _special_characters_not_in_name(cls, values):
@@ -283,6 +284,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         # cached property is cleared automatically when validation is on, but it
         # needs to be manually cleared when validation is off
         new_copy._cached_properties = {}
+        new_copy._has_tracers = None
         return new_copy
 
     def updated_copy(
@@ -1054,7 +1056,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         return json_string
 
     def _strip_traced_fields(
-        self, starting_path: tuple[str] = (), include_untraced_data_arrays: bool = False
+        self, starting_path: tuple[str, ...] = (), include_untraced_data_arrays: bool = False
     ) -> AutogradFieldMap:
         """Extract a dictionary mapping paths in the model to the data traced by ``autograd``.
 
@@ -1072,6 +1074,10 @@ class Tidy3dBaseModel(pydantic.BaseModel):
             mapping of traced fields used by ``autograd``
 
         """
+
+        path = tuple(starting_path)
+        if self._has_tracers is False and not include_untraced_data_arrays:
+            return dict_ag()
 
         field_mapping = {}
 
@@ -1100,14 +1106,20 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         self_dict = self.dict()
 
         # if an include_only string was provided, only look at that subset of the dict
-        if starting_path:
-            for key in starting_path:
+        if path:
+            for key in path:
                 self_dict = self_dict[key]
 
-        handle_value(self_dict, path=starting_path)
+        handle_value(self_dict, path=path)
 
-        # convert the resulting field_mapping to an autograd-traced dictionary
-        return dict_ag(field_mapping)
+        if field_mapping:
+            if not include_untraced_data_arrays:
+                self._has_tracers = True
+            return dict_ag(field_mapping)
+
+        if not include_untraced_data_arrays and not path:
+            self._has_tracers = False
+        return dict_ag()
 
     def _insert_traced_fields(self, field_mapping: AutogradFieldMap) -> Self:
         """Recursively insert a map of paths to autograd-traced fields into a copy of this obj."""
@@ -1157,18 +1169,24 @@ class Tidy3dBaseModel(pydantic.BaseModel):
     def to_static(self) -> Self:
         """Version of object with all autograd-traced fields removed."""
 
+        if self._has_tracers is False:
+            return self
+
         # get dictionary of all traced fields
         field_mapping = self._strip_traced_fields()
 
         # shortcut to just return self if no tracers found, for performance
         if not field_mapping:
+            self._has_tracers = False
             return self
 
         # convert all fields to static values
         field_mapping_static = {key: get_static(val) for key, val in field_mapping.items()}
 
         # insert the static values into a copy of self
-        return self._insert_traced_fields(field_mapping_static)
+        static_self = self._insert_traced_fields(field_mapping_static)
+        static_self._has_tracers = False
+        return static_self
 
     @classmethod
     def add_type_field(cls) -> None:


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-07 12:55:45 UTC

<h3>Greptile Summary</h3>


Adds `_has_tracers` cache to optimize tracer field conversion by short-circuiting when objects have no autograd tracers.

**Major changes:**
- Added `_has_tracers` private attribute to cache tracer presence status
- Modified `_strip_traced_fields()` to set cache and return early when no tracers exist
- Updated `to_static()` to leverage cache for performance
- Fixed type hint for `starting_path` parameter (`tuple[str, ...]` instead of `tuple[str]`)
- Cache is properly invalidated in `copy()` method

**Critical issue found:**
- The `_has_tracers` cache is object-level but `_strip_traced_fields()` accepts a `starting_path` parameter to check only a subset of the object
- Early return at line 1079 incorrectly uses the global cache even when checking a specific path
- This can cause incorrect results: if full object has no tracers but a specific path does (or vice versa), the cached value will give wrong results for path-specific queries

<h3>Confidence Score: 1/5</h3>


- This PR contains a critical logic bug that will cause incorrect behavior when checking for tracers in specific paths
- The caching mechanism has a fundamental design flaw where an object-level cache is used for path-specific queries. This will definitely cause incorrect results in production when `_strip_traced_fields()` is called with different `starting_path` values, which happens in the autograd workflow (e.g., `starting_path=("structures",)` and `starting_path=("data",)`). The bug is deterministic and will affect correctness of autograd operations.
- The caching logic in `tidy3d/components/base.py` needs to be redesigned to either track cache per-path or avoid caching for path-specific queries

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/base.py | 1/5 | adds `_has_tracers` cache for performance but has critical logic bug where object-level cache is used incorrectly for path-specific queries, causing incorrect results when different `starting_path` values are used |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant BaseModel as Tidy3dBaseModel
    participant Cache as _has_tracers cache
    
    Note over Client,Cache: Scenario 1: Initial check with no path
    Client->>BaseModel: to_static()
    BaseModel->>BaseModel: _strip_traced_fields()
    BaseModel->>BaseModel: handle_value() recursively
    alt No tracers found
        BaseModel->>Cache: _has_tracers = False
        BaseModel->>Client: return self (early exit)
    else Tracers found
        BaseModel->>Cache: _has_tracers = True
        BaseModel->>BaseModel: get_static() on fields
        BaseModel->>BaseModel: _insert_traced_fields()
        BaseModel->>Cache: static_self._has_tracers = False
        BaseModel->>Client: return static_self
    end
    
    Note over Client,Cache: Scenario 2: Check with starting_path
    Client->>BaseModel: _strip_traced_fields(starting_path=("structures",))
    alt _has_tracers is False
        Note over BaseModel,Cache: BUG: Returns early even though<br/>cache is for full object, not this path
        BaseModel->>Client: return dict_ag() (incorrect!)
    else _has_tracers is None or True
        BaseModel->>BaseModel: self.dict()[starting_path]
        BaseModel->>BaseModel: handle_value() on subset
        alt Field mapping found
            BaseModel->>Cache: _has_tracers = True (incorrect for path-specific!)
            BaseModel->>Client: return dict_ag(field_mapping)
        else No mapping
            Note over BaseModel,Cache: Cache not updated for path-specific check
            BaseModel->>Client: return dict_ag()
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->