### PR TITLE
docs: introduce ModeSimulation

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -20,6 +20,7 @@ API |:computer:|
     utilities
     configuration
     mesh/index
+    mode/index
     heat/index
     charge/index
     eme/index

--- a/docs/api/mode.rst
+++ b/docs/api/mode.rst
@@ -1,12 +1,1 @@
-.. currentmodule:: tidy3d
-
-Mode Specifications
-===================
-
-.. autosummary::
-   :toctree: _autosummary/
-   :template: module.rst
-
-   tidy3d.ModeSpec
-   tidy3d.ModeSortSpec
-   tidy3d.ModeInterpSpec
+.. include:: /api/mode/index.rst

--- a/docs/api/mode/deprecated.rst
+++ b/docs/api/mode/deprecated.rst
@@ -1,0 +1,15 @@
+.. currentmodule:: tidy3d
+
+Deprecated
+----------
+
+.. deprecated::
+   ``tidy3d.plugins.mode.ModeSolver`` is will be deprecated in a future version. Please use :class:`tidy3d.ModeSimulation` instead starting from version 2.10.0.
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.plugins.mode.ModeSolver
+   tidy3d.plugins.mode.ModeSolverData
+

--- a/docs/api/mode/index.rst
+++ b/docs/api/mode/index.rst
@@ -1,0 +1,16 @@
+Mode |:record_button:|
+======================
+
+.. toctree::
+    :hidden:
+
+    simulation
+    specification
+    output_data
+    deprecated
+
+
+.. include:: /api/mode/simulation.rst
+.. include:: /api/mode/specification.rst
+.. include:: /api/mode/output_data.rst
+.. include:: /api/mode/deprecated.rst

--- a/docs/api/mode/output_data.rst
+++ b/docs/api/mode/output_data.rst
@@ -1,0 +1,33 @@
+.. currentmodule:: tidy3d
+
+Output Data
+-----------
+
+Simulation Data
+^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.ModeSimulationData
+
+
+Monitor Data
+^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.ModeSolverData
+
+
+Datasets
+^^^^^^^^
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.ModeSolverDataset

--- a/docs/api/mode/simulation.rst
+++ b/docs/api/mode/simulation.rst
@@ -1,0 +1,10 @@
+.. currentmodule:: tidy3d
+
+Mode Simulation
+===============
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.ModeSimulation

--- a/docs/api/mode/specification.rst
+++ b/docs/api/mode/specification.rst
@@ -1,0 +1,13 @@
+.. currentmodule:: tidy3d
+
+Mode Specifications
+===================
+
+.. autosummary::
+   :toctree: ../_autosummary/
+   :template: module.rst
+
+   tidy3d.ModeSpec
+   tidy3d.ModeSortSpec
+   tidy3d.ModeInterpSpec
+

--- a/docs/api/simulation.rst
+++ b/docs/api/simulation.rst
@@ -40,7 +40,7 @@ Other Simulation Types
    :toctree: _autosummary/
    :template: module.rst
 
-   tidy3d.plugins.mode.ModeSolver
+   tidy3d.ModeSimulation
    tidy3d.EMESimulation
    tidy3d.HeatSimulation
    tidy3d.HeatChargeSimulation


### PR DESCRIPTION
Hi @e-g-melo, we had a conversation about this and thought the best approach is simply to deprecate in the docs for the rc3 release and then update the notebooks separately for 2.10

- [ ] rerouting from /api/mode -> /api/mode/index

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR restructures the mode documentation to introduce `ModeSimulation` as the primary interface, deprecating `ModeSolver`. The changes organize mode-related documentation into a new subdirectory structure with separate files for simulation, specifications, output data, and deprecated components.

**Key changes:**
- Created new `docs/api/mode/` directory with organized sections for simulation, specification, output data, and deprecated classes
- Updated `docs/api/simulation.rst` to reference `ModeSimulation` instead of the deprecated `ModeSolver`
- Converted `docs/api/mode.rst` to a redirect file that includes the new index for backward compatibility
- Added deprecation notice for `ModeSolver` and `ModeSolverData` in favor of `ModeSimulation`

**Issues found:**
- Missing version number in the `.. deprecated::` directive in `deprecated.rst` (line 6)
- Missing newlines at end of files in several RST files (style issue)

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor documentation fixes recommended
- The documentation restructuring is well-organized and maintains backward compatibility. The main issue is a missing version number in the deprecation directive which is required for proper RST rendering. The missing newlines at EOF are minor style issues that don't affect functionality.
- Pay attention to `docs/api/mode/deprecated.rst` - the deprecated directive needs a version number to render correctly

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| docs/api/mode/index.rst | 4/5 | New mode section index that organizes simulation, specification, output data, and deprecated content; missing newline at EOF |
| docs/api/mode/deprecated.rst | 3/5 | Deprecation notice for `ModeSolver` in favor of `ModeSimulation`; missing version number in deprecated directive |
| docs/api/simulation.rst | 5/5 | Updated reference from deprecated `ModeSolver` to new `ModeSimulation` in the "Other Simulation Types" section |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant DocsIndex as docs/api/index.rst
    participant ModeEntry as docs/api/mode.rst
    participant ModeIndex as docs/api/mode/index.rst
    participant Simulation as mode/simulation.rst
    participant Specification as mode/specification.rst
    participant OutputData as mode/output_data.rst
    participant Deprecated as mode/deprecated.rst
    
    User->>DocsIndex: Navigate to API docs
    DocsIndex->>ModeEntry: Reference mode section
    ModeEntry->>ModeIndex: Include mode/index.rst
    
    Note over ModeIndex: New structured organization
    
    ModeIndex->>Simulation: Include ModeSimulation docs
    ModeIndex->>Specification: Include ModeSpec classes
    ModeIndex->>OutputData: Include data output classes
    ModeIndex->>Deprecated: Include ModeSolver deprecation
    
    Note over Deprecated: ModeSolver → ModeSimulation
    Note over Simulation: New primary interface
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->