### PR TITLE
SCRF-1630-Modeler validation and sim_dict performance improvements

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -262,7 +262,7 @@ jobs:
           BRANCH_NAME="${STEPS_EXTRACT_BRANCH_NAME_OUTPUTS_BRANCH_NAME}"
           echo $BRANCH_NAME
           # Allow only Jira keys from known projects, even if the branch has an author prefix
-          ALLOWED_JIRA_PROJECTS=("FXC" "SCEM")
+          ALLOWED_JIRA_PROJECTS=("FXC" "SCEM" "SCRF")
           JIRA_PROJECT_PATTERN=$(IFS='|'; echo "${ALLOWED_JIRA_PROJECTS[*]}")
           JIRA_PATTERN="(${JIRA_PROJECT_PATTERN})-[0-9]+"
 

--- a/tests/test_plugins/test_array_factor.py
+++ b/tests/test_plugins/test_array_factor.py
@@ -363,16 +363,15 @@ def make_antenna_sim():
         remove_dc_component=False,  # Include DC component for more accuracy at low frequencies
     )
 
-    sim_unit = list(modeler.sim_dict.values())[0]
-
-    return sim_unit
+    return modeler
 
 
 def test_rectangular_array_calculator_array_make_antenna_array():
     """Test automatic antenna array creation."""
     freq0 = 10e9
     wavelength0 = td.C_0 / 10e9
-    sim_unit = make_antenna_sim()
+    modeler = make_antenna_sim()
+    sim_unit = list(modeler.sim_dict.values())[0]
     array_calculator = mw.RectangularAntennaArrayCalculator(
         array_size=(1, 2, 3),
         spacings=(0.5 * wavelength0, 0.6 * wavelength0, 0.4 * wavelength0),
@@ -437,8 +436,9 @@ def test_rectangular_array_calculator_array_make_antenna_array():
     assert len(sim_array.sources) == 6
 
     # check that override_structures are duplicated
-    assert len(sim_unit.grid_spec.override_structures) == 2
-    assert len(sim_array.grid_spec.override_structures) == 7
+    # assert len(sim_unit.grid_spec.override_structures) == 2
+    # assert len(sim_array.grid_spec.override_structures) == 7
+    assert sim_unit.grid.boundaries == modeler.base_sim.grid.boundaries
 
     # check that phase shifts are applied correctly
     phases_expected = array_calculator._antenna_phases
@@ -674,7 +674,8 @@ def test_rectangular_array_calculator_simulation_data_from_array_factor():
         phase_shifts=(np.pi / 3, np.pi / 4, np.pi / 5),
     )
 
-    sim_unit = make_antenna_sim()
+    modeler = make_antenna_sim()
+    sim_unit = list(modeler.sim_dict.values())[0]
 
     monitor = sim_unit.monitors[0]
     monitor_directivity = sim_unit.monitors[2]

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -223,7 +223,7 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
 
     @property
     def _sim_with_sources(self) -> Simulation:
-        """Instance of :class:`.Simulation` with all sources and absorbers added for each port, for troubleshooting."""
+        """Instance of :class:`.Simulation` with all sources and absorbers added for each port, for plotting."""
 
         sources = [port.to_source(self._source_time) for port in self.ports]
         absorbers = [
@@ -231,7 +231,9 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
             for port in self.ports
             if isinstance(port, WavePort) and port.absorber
         ]
-        return self.simulation.updated_copy(sources=sources, internal_absorbers=absorbers)
+        return self.simulation.updated_copy(
+            sources=sources, internal_absorbers=absorbers, validate=False
+        )
 
     @equal_aspect
     @add_ax_if_none
@@ -382,17 +384,16 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
     def sim_dict(self) -> SimulationMap:
         """Generate all the :class:`.Simulation` objects for the port parameter calculation."""
 
+        # Check base simulation for grid size at ports
+        TerminalComponentModeler._check_grid_size_at_ports(self.base_sim, self._lumped_ports)
+        TerminalComponentModeler._check_grid_size_at_wave_ports(self.base_sim, self._wave_ports)
+
         sim_dict = {}
         # Now, create simulations with wave port sources and mode solver monitors for computing port modes
         for network_index in self.matrix_indices_run_sim:
             task_name, sim_with_src = self._add_source_to_sim(network_index)
             # update simulation
             sim_dict[task_name] = sim_with_src
-
-        # Check final simulations for grid size at ports
-        for _, sim in sim_dict.items():
-            TerminalComponentModeler._check_grid_size_at_ports(sim, self._lumped_ports)
-            TerminalComponentModeler._check_grid_size_at_wave_ports(sim, self._wave_ports)
 
         return SimulationMap(keys=tuple(sim_dict.keys()), values=tuple(sim_dict.values()))
 
@@ -414,7 +415,10 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
 
         # Make an initial simulation with new grid_spec to determine where LumpedPorts are snapped
         sim_wo_source = self.simulation.updated_copy(
-            grid_spec=grid_spec, lumped_elements=lumped_resistors
+            grid_spec=grid_spec,
+            lumped_elements=lumped_resistors,
+            validate=False,
+            deep=False,
         )
         snap_centers = {}
         for port in self._lumped_ports:
@@ -480,7 +484,11 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
             )
 
         # update base simulation with updated set of shared components
-        sim_wo_source = sim_wo_source.copy(update=update_dict)
+        sim_wo_source = sim_wo_source.updated_copy(
+            **update_dict,
+            validate=False,
+            deep=False,
+        )
 
         # extrude port structures
         sim_wo_source = self._extrude_port_structures(sim=sim_wo_source)
@@ -527,7 +535,10 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         """The base simulation with all components added, including radiation monitors."""
         base_sim_tmp = self._base_sim_no_radiation_monitors
         mnts_with_radiation = list(base_sim_tmp.monitors) + list(self._finalized_radiation_monitors)
-        return base_sim_tmp.updated_copy(monitors=mnts_with_radiation)
+        grid_spec = GridSpec.from_grid(base_sim_tmp.grid)
+        grid_spec.attrs["from_grid_spec"] = base_sim_tmp.grid_spec
+        # We skipped validations up to now, here we finally validate the base sim
+        return base_sim_tmp.updated_copy(monitors=mnts_with_radiation, grid_spec=grid_spec)
 
     def _generate_radiation_monitor(
         self, simulation: Simulation, auto_spec: DirectivityMonitorSpec
@@ -712,7 +723,10 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
             )
         task_name = self.get_task_name(port=port, mode_index=mode_index)
 
-        return (task_name, self.base_sim.updated_copy(sources=[port_source]))
+        return (
+            task_name,
+            self.base_sim.updated_copy(sources=[port_source], validate=False, deep=False),
+        )
 
     @cached_property
     def _source_time(self):
@@ -983,6 +997,8 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
             sim = sim.updated_copy(
                 grid_spec=GridSpec.from_grid(sim.grid),
                 structures=[*sim.structures, *all_new_structures],
+                validate=False,
+                deep=False,
             )
 
         return sim


### PR DESCRIPTION
Separated these updates in a standalone PR.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-11-10 18:14:34 UTC

<h3>Greptile Summary</h3>


This PR optimizes `TerminalComponentModeler` performance by deferring validation until necessary. The changes skip validation (`validate=False`) and deep copying (`deep=False`) during intermediate simulation construction steps, performing full validation only on the final `base_sim` object at line 540. Additionally, grid size validation was moved from checking every generated simulation in `sim_dict` to a single check of `base_sim` before simulation generation, reducing redundant checks.

Key changes:
- Updated `_sim_with_sources` docstring from "troubleshooting" to "plotting" for clarity
- Replaced deprecated `.copy(update=...)` method with `.updated_copy(**...)` 
- Added `validate=False` and `deep=False` flags to intermediate `updated_copy()` calls
- Moved grid size validation in `sim_dict()` to run once on `base_sim` instead of per-simulation
- Added explicit `GridSpec.from_grid()` call in `base_sim` property before final validation

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk - focused performance optimization with validation preserved where it matters
- The changes are well-structured optimizations that skip redundant validation steps during intermediate simulation construction while ensuring the final simulation is fully validated. The grid size checks are moved to run once instead of multiple times, which is more efficient. The only minor concern is lack of a CHANGELOG entry for this performance improvement.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/smatrix/component_modelers/terminal.py | 4/5 | Performance optimization: skip validation during intermediate simulation copies, validate only the final `base_sim`. Grid size validation moved earlier to check once instead of per-simulation. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant TCM as TerminalComponentModeler
    participant BaseSim as _base_sim_no_radiation_monitors
    participant FinalSim as base_sim
    participant SimDict as sim_dict
    
    User->>TCM: Create modeler
    TCM->>BaseSim: Build intermediate simulation
    Note over BaseSim: updated_copy(validate=False, deep=False)
    BaseSim-->>TCM: Simulation without validation
    
    TCM->>FinalSim: Add radiation monitors
    Note over FinalSim: GridSpec.from_grid() + validate=True
    FinalSim-->>TCM: Fully validated base_sim
    
    User->>TCM: Access sim_dict property
    TCM->>FinalSim: Check grid size (once)
    Note over FinalSim: _check_grid_size_at_ports()<br/>_check_grid_size_at_wave_ports()
    
    loop For each network_index
        TCM->>SimDict: Create simulation with source
        Note over SimDict: updated_copy(validate=False, deep=False)
        SimDict-->>TCM: Simulation copy (no validation)
    end
    
    TCM-->>User: SimulationMap with all simulations
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->