### PR TITLE
test: isolate numerical autograd artifacts

### DIFF
--- a/tests/test_components/autograd/numerical/conftest.py
+++ b/tests/test_components/autograd/numerical/conftest.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+ARTIFACT_ENV_VAR = "TIDY3D_NUMERICAL_ARTIFACT_DIR"
+DEFAULT_RELATIVE_DIR = Path("tests/tmp/autograd_numerical")
+
+
+def _sanitize_segment(value: str) -> str:
+    sanitized = re.sub(r"[^\w.-]+", "_", value)
+    sanitized = sanitized.strip("_")
+    return sanitized or "case"
+
+
+def _resolve_artifact_root() -> Path:
+    env_value = os.environ.get(ARTIFACT_ENV_VAR)
+    if env_value:
+        root = Path(env_value).expanduser()
+    else:
+        repo_root = Path(__file__).resolve().parents[4]
+        root = repo_root / DEFAULT_RELATIVE_DIR
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+@pytest.fixture(scope="session")
+def numerical_artifact_root() -> Path:
+    return _resolve_artifact_root()
+
+
+@pytest.fixture
+def numerical_case_dir(request, numerical_artifact_root: Path) -> Path:
+    safe_nodeid = _sanitize_segment(request.node.nodeid.replace(os.sep, "_"))
+    case_dir = numerical_artifact_root / safe_nodeid
+    case_dir.mkdir(parents=True, exist_ok=True)
+    return case_dir

--- a/tests/test_components/autograd/numerical/test_autograd_box_polyslab_numerical.py
+++ b/tests/test_components/autograd/numerical/test_autograd_box_polyslab_numerical.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
 import autograd.numpy as anp
 import numpy as np
@@ -38,6 +39,12 @@ else:
 
 if SHOW_PRINT_STATEMENTS:
     sys.stdout = sys.stderr
+
+
+def case_identifier(is_3d: bool, infinite_dim_2d: int | None, shift_box_center: bool) -> str:
+    geometry_tag = "3d" if is_3d else f"2d_infinite_dim_{infinite_dim_2d}"
+    shift_tag = "shifted" if shift_box_center else "centered"
+    return f"box_polyslab_{geometry_tag}_{shift_tag}"
 
 
 def dimension_permutation(infinite_dim: int) -> tuple[int, int]:
@@ -191,11 +198,13 @@ def run_parameter_simulations(
     tag: str,
     base_sim: td.Simulation,
     fom,
-    tmp_path,
+    artifact_dir: Path,
     *,
     local_gradient: bool,
 ):
     simulation_dict = {}
+    output_dir = artifact_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     for idx, param_values in enumerate(parameter_sets):
         geometry = make_geometry(param_values, box_center)
@@ -209,9 +218,11 @@ def run_parameter_simulations(
 
     if len(simulation_dict) == 1:
         key, sim = next(iter(simulation_dict.items()))
+        result_path = output_dir / f"{key}.hdf5"
         sim_data = web.run(
             sim,
             task_name=key,
+            path=str(result_path),
             local_gradient=local_gradient,
             verbose=VERBOSE,
         )
@@ -219,6 +230,7 @@ def run_parameter_simulations(
 
     sim_data_map = web.run_async(
         simulation_dict,
+        path_dir=str(output_dir),
         local_gradient=local_gradient,
         verbose=VERBOSE,
     )
@@ -232,10 +244,13 @@ def make_objective(
     tag: str,
     base_sim: td.Simulation,
     fom,
-    tmp_path,
+    case_dir: Path,
     *,
     local_gradient: bool,
 ):
+    artifact_dir = case_dir / tag
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
     def objective(parameters):
         results = run_parameter_simulations(
             parameters,
@@ -244,7 +259,7 @@ def make_objective(
             tag,
             base_sim,
             fom,
-            tmp_path,
+            artifact_dir,
             local_gradient=local_gradient,
         )
 
@@ -304,7 +319,9 @@ def squeeze_dimension(array: np.ndarray, is_3d: bool, infinite_dim: int | None) 
     ],
 )
 @pytest.mark.parametrize("shift_box_center", (True, False))
-def test_box_and_polyslab_gradients_match(is_3d, infinite_dim_2d, shift_box_center, tmp_path):
+def test_box_and_polyslab_gradients_match(
+    is_3d, infinite_dim_2d, shift_box_center, numerical_case_dir
+):
     """Test that the box and polyslab gradients match for rectangular slab geometries. Allow
     comparison as well to finite difference values."""
 
@@ -330,13 +347,17 @@ def test_box_and_polyslab_gradients_match(is_3d, infinite_dim_2d, shift_box_cent
             box_center[infinite_dim_2d] = 0.5 * INFINITE_DIM_SIZE_UM
             box_center[final_dim_2d] = 0.5 * PERIODS_UM[0]
 
+    case_id = case_identifier(is_3d, None if is_3d else infinite_dim_2d, shift_box_center)
+    case_dir = numerical_case_dir / case_id
+    case_dir.mkdir(parents=True, exist_ok=True)
+
     box_objective = make_objective(
         make_box_geometry,
         box_center,
         "box",
         base_sim,
         fom,
-        tmp_path,
+        case_dir,
         local_gradient=LOCAL_GRADIENT,
     )
     polyslab_objective = make_objective(
@@ -345,7 +366,7 @@ def test_box_and_polyslab_gradients_match(is_3d, infinite_dim_2d, shift_box_cent
         "polyslab",
         base_sim,
         fom,
-        tmp_path,
+        case_dir,
         local_gradient=LOCAL_GRADIENT,
     )
 
@@ -355,7 +376,7 @@ def test_box_and_polyslab_gradients_match(is_3d, infinite_dim_2d, shift_box_cent
         "box_fd",
         base_sim,
         fom,
-        tmp_path,
+        case_dir,
         local_gradient=False,
     )
     polyslab_objective_fd = make_objective(
@@ -364,7 +385,7 @@ def test_box_and_polyslab_gradients_match(is_3d, infinite_dim_2d, shift_box_cent
         "polyslab_fd",
         base_sim,
         fom,
-        tmp_path,
+        case_dir,
         local_gradient=False,
     )
 
@@ -396,10 +417,10 @@ def test_box_and_polyslab_gradients_match(is_3d, infinite_dim_2d, shift_box_cent
     }
 
     if SAVE_OUTPUT_DATA:
-        np.savez(
-            f"test_diff_init_{'3' if is_3d else '2'}d_infinite_dim_{infinite_dim_2d}.npz",
-            **test_data,
+        npz_path = case_dir / (
+            f"test_diff_init_{'3' if is_3d else '2'}d_infinite_dim_{infinite_dim_2d}.npz"
         )
+        np.savez(npz_path, **test_data)
 
     def angled_overlap_deg(v1, v2):
         norm_v1 = np.linalg.norm(v1)

--- a/tests/test_components/autograd/numerical/test_autograd_conductivity_numerical.py
+++ b/tests/test_components/autograd/numerical/test_autograd_conductivity_numerical.py
@@ -37,7 +37,7 @@ SAVE_FD_LOC = 0
 SAVE_ADJ_LOC = 1
 LOCAL_GRADIENT = True
 VERBOSE = False
-NUMERICAL_RESULTS_DATA_DIR = "./numerical_conductivity_test/"
+NUMERICAL_RESULTS_SUBDIR = "numerical_conductivity_test"
 SHOW_PRINT_STATEMENTS = False
 
 RMS_THRESHOLD = 0.6
@@ -325,17 +325,9 @@ for idx in range(len(mesh_wvls_um)):
 
 
 @pytest.mark.numerical
-@pytest.mark.parametrize(
-    "conductivity_data_test_parameters, dir_name",
-    zip(
-        conductivity_data_test_parameters,
-        ([NUMERICAL_RESULTS_DATA_DIR] if SAVE_FD_ADJ_DATA else [None])
-        * len(conductivity_data_test_parameters),
-    ),
-    indirect=["dir_name"],
-)
+@pytest.mark.parametrize("conductivity_data_test_parameters", conductivity_data_test_parameters)
 def test_finite_difference_conductivity_data(
-    conductivity_data_test_parameters, rng, tmp_path, create_directory
+    conductivity_data_test_parameters, rng, numerical_case_dir
 ):
     """Test autograd conductivity gradients by comparing to numerical finite difference.
 
@@ -356,17 +348,14 @@ def test_finite_difference_conductivity_data(
         Test parameters including wavelengths, monitor configuration, etc.
     rng : numpy.random.Generator
         Random number generator for creating perturbation patterns
-    tmp_path : pathlib.Path
-        Temporary directory for simulation files
-    create_directory : fixture
-        Pytest fixture for creating directories
+    numerical_case_dir : pathlib.Path
+        Case-specific artifact directory for simulation and result files
     """
 
     # Create directory for plots if plotting is enabled
+    results_dir = numerical_case_dir / NUMERICAL_RESULTS_SUBDIR
     if PLOT_FD_ADJ_COMPARISON or SAVE_FD_ADJ_DATA:
-        import os
-
-        os.makedirs(NUMERICAL_RESULTS_DATA_DIR, exist_ok=True)
+        results_dir.mkdir(parents=True, exist_ok=True)
 
     num_tests = 0
     for monitor_size_wvl in monitor_sizes_3d_wvl:
@@ -414,8 +403,8 @@ def test_finite_difference_conductivity_data(
 
     eval_fns, eval_fn_names = make_eval_fns(monitor_size_wvl)
 
-    sim_path_dir = tmp_path / f"test{test_number}"
-    sim_path_dir.mkdir()
+    sim_path_dir = numerical_case_dir / "simulations" / f"test{test_number}"
+    sim_path_dir.mkdir(parents=True, exist_ok=True)
 
     objective = create_objective_function(
         block,
@@ -494,10 +483,20 @@ def test_finite_difference_conductivity_data(
     print("-" * 20)
     print("\n" * 3)
 
-    assert rms_error < RMS_THRESHOLD * fd_mag, "RMS error magnitude too large"
-
     test_results[SAVE_FD_LOC, :] = fd_grad
     test_results[SAVE_ADJ_LOC, :] = pattern_dot_adj_gradient
+
+    save_idx = test_number + 1
+    save_path = None
+    if SAVE_FD_ADJ_DATA:
+        results_dir.mkdir(parents=True, exist_ok=True)
+        save_path = results_dir / f"results_{save_idx}.npy"
+
+    try:
+        assert rms_error < RMS_THRESHOLD * fd_mag, "RMS error magnitude too large"
+    finally:
+        if save_path is not None:
+            np.save(save_path, test_results)
 
     test_number += 1
 
@@ -512,12 +511,9 @@ def test_finite_difference_conductivity_data(
         plt.grid(True, alpha=0.3)
 
         # Save the plot
-        plot_filename = f"{NUMERICAL_RESULTS_DATA_DIR}/gradient_comparison_test_{test_number}_{eval_fn_name}.png"
+        plot_filename = results_dir / (f"gradient_comparison_test_{test_number}_{eval_fn_name}.png")
         plt.savefig(plot_filename, dpi=150, bbox_inches="tight")
         print(f"Plot saved to: {plot_filename}")
 
         plt.show()
         plt.close()
-
-    if SAVE_FD_ADJ_DATA:
-        np.save(f"{NUMERICAL_RESULTS_DATA_DIR}/results_{test_number}.npy", test_results)

--- a/tests/test_components/autograd/numerical/test_autograd_mode_polyslab_numerical.py
+++ b/tests/test_components/autograd/numerical/test_autograd_mode_polyslab_numerical.py
@@ -20,7 +20,7 @@ SAVE_FD_LOC = 0
 SAVE_ADJ_LOC = 1
 LOCAL_GRADIENT = True
 VERBOSE = False
-NUMERICAL_RESULTS_DATA_DIR = "./numerical_mode_polyslab_test/"
+NUMERICAL_RESULTS_SUBDIR = "numerical_mode_polyslab_test"
 SHOW_PRINT_STATEMENTS = False
 
 NUM_MODE_MONITOR_FREQUENCIES = 4
@@ -301,18 +301,8 @@ for idx in range(len(mesh_wvls_um)):
 
 
 @pytest.mark.numerical
-@pytest.mark.parametrize(
-    "mode_data_test_parameters, dir_name",
-    zip(
-        mode_data_test_parameters,
-        ([NUMERICAL_RESULTS_DATA_DIR] if SAVE_FD_ADJ_DATA else [None])
-        * len(mode_data_test_parameters),
-    ),
-    indirect=["dir_name"],
-)
-def test_finite_difference_mode_data_polyslab(
-    mode_data_test_parameters, rng, tmp_path, create_directory
-):
+@pytest.mark.parametrize("mode_data_test_parameters", mode_data_test_parameters)
+def test_finite_difference_mode_data_polyslab(mode_data_test_parameters, rng, numerical_case_dir):
     """Test a variety of autograd permittivity gradients for ModeData in combination with polyslab by"""
     """comparing them to numerical finite difference."""
 
@@ -351,8 +341,8 @@ def test_finite_difference_mode_data_polyslab(
         size=(np.inf, np.inf, MODE_LAYER_HEIGHT_WVL * mesh_wvl_um + mesh_wvl_um),
     )
 
-    sim_path_dir = tmp_path / f"test{test_number}"
-    sim_path_dir.mkdir()
+    sim_path_dir = numerical_case_dir / "simulations" / f"test{test_number}"
+    sim_path_dir.mkdir(parents=True, exist_ok=True)
 
     # Weights for creating a random objective function over multiple frequencies by
     # summing their contributions by random weights. This helps verify gradient errors
@@ -471,10 +461,21 @@ def test_finite_difference_mode_data_polyslab(
     print("-" * 20)
     print("\n" * 3)
 
-    assert rms_error < RMS_THRESHOLD * fd_mag, "RMS error magnitude too large"
-
     test_results[SAVE_FD_LOC, :] = fd_grad
     test_results[SAVE_ADJ_LOC, :] = pattern_dot_adj_gradient
+
+    save_idx = test_number + 1
+    save_path = None
+    if SAVE_FD_ADJ_DATA:
+        results_dir = numerical_case_dir / NUMERICAL_RESULTS_SUBDIR
+        results_dir.mkdir(parents=True, exist_ok=True)
+        save_path = results_dir / f"results_{save_idx}.npy"
+
+    try:
+        assert rms_error < RMS_THRESHOLD * fd_mag, "RMS error magnitude too large"
+    finally:
+        if save_path is not None:
+            np.save(save_path, test_results)
 
     test_number += 1
 
@@ -487,6 +488,3 @@ def test_finite_difference_mode_data_polyslab(
         plt.ylabel("Gradient value")
         plt.legend()
         plt.show()
-
-    if SAVE_FD_ADJ_DATA:
-        np.save(f"{NUMERICAL_RESULTS_DATA_DIR}/results_{test_number}.npy", test_results)

--- a/tests/test_components/autograd/numerical/test_autograd_numerical.py
+++ b/tests/test_components/autograd/numerical/test_autograd_numerical.py
@@ -20,7 +20,7 @@ SAVE_FD_LOC = 0
 SAVE_ADJ_LOC = 1
 LOCAL_GRADIENT = False
 VERBOSE = False
-NUMERICAL_RESULTS_DATA_DIR = "./numerical_field_test/"
+NUMERICAL_RESULTS_SUBDIR = "numerical_field_test"
 SHOW_PRINT_STATEMENTS = False
 
 RMS_THRESHOLD = 0.25
@@ -218,16 +218,8 @@ for idx in range(len(mesh_wvls_um)):
 
 
 @pytest.mark.numerical
-@pytest.mark.parametrize(
-    "field_data_test_parameters, dir_name",
-    zip(
-        field_data_test_parameters,
-        ([NUMERICAL_RESULTS_DATA_DIR] if SAVE_FD_ADJ_DATA else [None])
-        * len(field_data_test_parameters),
-    ),
-    indirect=["dir_name"],
-)
-def test_finite_difference_field_data(field_data_test_parameters, rng, tmp_path, create_directory):
+@pytest.mark.parametrize("field_data_test_parameters", field_data_test_parameters)
+def test_finite_difference_field_data(field_data_test_parameters, rng, numerical_case_dir):
     """Test a variety of autograd permittivity gradients for FieldData by"""
     """comparing them to numerical finite difference."""
 
@@ -274,8 +266,8 @@ def test_finite_difference_field_data(field_data_test_parameters, rng, tmp_path,
 
     eval_fns, eval_fn_names = make_eval_fns(monitor_size_wvl)
 
-    sim_path_dir = tmp_path / f"test{test_number}"
-    sim_path_dir.mkdir()
+    sim_path_dir = numerical_case_dir / "simulations" / f"test{test_number}"
+    sim_path_dir.mkdir(parents=True, exist_ok=True)
 
     objective = create_objective_function(
         block,
@@ -349,10 +341,21 @@ def test_finite_difference_field_data(field_data_test_parameters, rng, tmp_path,
     print("-" * 20)
     print("\n" * 3)
 
-    assert rms_error < RMS_THRESHOLD * fd_mag, "RMS error magnitude too large"
-
     test_results[SAVE_FD_LOC, :] = fd_grad
     test_results[SAVE_ADJ_LOC, :] = pattern_dot_adj_gradient
+
+    save_idx = test_number + 1
+    save_path = None
+    if SAVE_FD_ADJ_DATA:
+        results_dir = numerical_case_dir / NUMERICAL_RESULTS_SUBDIR
+        results_dir.mkdir(parents=True, exist_ok=True)
+        save_path = results_dir / f"results_{save_idx}.npy"
+
+    try:
+        assert rms_error < RMS_THRESHOLD * fd_mag, "RMS error magnitude too large"
+    finally:
+        if save_path is not None:
+            np.save(save_path, test_results)
 
     test_number += 1
 
@@ -365,6 +368,3 @@ def test_finite_difference_field_data(field_data_test_parameters, rng, tmp_path,
         plt.ylabel("Gradient value")
         plt.legend()
         plt.show()
-
-    if SAVE_FD_ADJ_DATA:
-        np.save(f"{NUMERICAL_RESULTS_DATA_DIR}/results_{test_number}.npy", test_results)

--- a/tests/test_components/autograd/numerical/test_autograd_periodic_numerical.py
+++ b/tests/test_components/autograd/numerical/test_autograd_periodic_numerical.py
@@ -20,7 +20,7 @@ SAVE_FD_LOC = 0
 SAVE_ADJ_LOC = 1
 LOCAL_GRADIENT = False
 VERBOSE = False
-NUMERICAL_RESULTS_DATA_DIR = "./numerical_periodic_test/"
+NUMERICAL_RESULTS_SUBDIR = "numerical_periodic_test"
 SHOW_PRINT_STATEMENTS = False
 
 RMS_THRESHOLD = 0.25
@@ -265,18 +265,8 @@ for idx in range(len(mesh_wvls_um)):
 
 
 @pytest.mark.numerical
-@pytest.mark.parametrize(
-    "periodic_test_parameters, dir_name",
-    zip(
-        periodic_test_parameters,
-        ([NUMERICAL_RESULTS_DATA_DIR] if SAVE_FD_ADJ_DATA else [None])
-        * len(periodic_test_parameters),
-    ),
-    indirect=["dir_name"],
-)
-def test_finite_difference_diffraction_data(
-    periodic_test_parameters, rng, tmp_path, create_directory
-):
+@pytest.mark.parametrize("periodic_test_parameters", periodic_test_parameters)
+def test_finite_difference_diffraction_data(periodic_test_parameters, rng, numerical_case_dir):
     """Test a variety of autograd permittivity gradients for DiffractionData by"""
     """comparing them to numerical finite difference."""
 
@@ -331,8 +321,8 @@ def test_finite_difference_diffraction_data(
         orders_x=order_x, orders_y=order_y, polarization=polarization
     )
 
-    sim_path_dir = tmp_path / f"test{test_number}"
-    sim_path_dir.mkdir()
+    sim_path_dir = numerical_case_dir / "simulations" / f"test{test_number}"
+    sim_path_dir.mkdir(parents=True, exist_ok=True)
 
     objective = create_objective_function(
         block,
@@ -410,10 +400,21 @@ def test_finite_difference_diffraction_data(
     print("-" * 20)
     print("\n" * 3)
 
-    assert rms_error < RMS_THRESHOLD * fd_mag, "RMS error magnitude too large"
-
     test_results[SAVE_FD_LOC, :] = fd_grad
     test_results[SAVE_ADJ_LOC, :] = pattern_dot_adj_gradient
+
+    save_idx = test_number + 1
+    save_path = None
+    if SAVE_FD_ADJ_DATA:
+        results_dir = numerical_case_dir / NUMERICAL_RESULTS_SUBDIR
+        results_dir.mkdir(parents=True, exist_ok=True)
+        save_path = results_dir / f"results_{save_idx}.npy"
+
+    try:
+        assert rms_error < RMS_THRESHOLD * fd_mag, "RMS error magnitude too large"
+    finally:
+        if save_path is not None:
+            np.save(save_path, test_results)
 
     test_number += 1
 
@@ -425,6 +426,3 @@ def test_finite_difference_diffraction_data(
         plt.xlabel("Sample number")
         plt.ylabel("Gradient value")
         plt.show()
-
-    if SAVE_FD_ADJ_DATA:
-        np.save(f"{NUMERICAL_RESULTS_DATA_DIR}/results_{test_number}.npy", test_results)

--- a/tests/test_components/autograd/numerical/test_autograd_polyslab_sidewall_numerical.py
+++ b/tests/test_components/autograd/numerical/test_autograd_polyslab_sidewall_numerical.py
@@ -74,7 +74,7 @@ def _build_sim(theta_deg: float, axis: int, reference_plane: str) -> td.Simulati
 def _objective(theta_deg: float, axis: int, reference_plane: str, case_dir, verbose: bool) -> float:
     sim = _build_sim(theta_deg, axis=axis, reference_plane=reference_plane)
     task_name = f"obj_axis{axis}_ref{reference_plane}_t{float(theta_deg):+0.3f}"
-    out_path = case_dir / "objective.hdf5"
+    out_path = case_dir / f"{task_name}.hdf5"
     data = web.run(
         sim,
         task_name=task_name,
@@ -89,13 +89,16 @@ def _objective(theta_deg: float, axis: int, reference_plane: str, case_dir, verb
 @pytest.mark.parametrize("axis", AXES)
 @pytest.mark.parametrize("reference_plane", REF_PLANES)
 @pytest.mark.parametrize("theta0_deg", THETAS_DEG)
-def test_autograd_polyslab_sidewall_vs_fd(axis, reference_plane, theta0_deg, tmp_path):
+def test_autograd_polyslab_sidewall_vs_fd(axis, reference_plane, theta0_deg, numerical_case_dir):
     """Adjoint dJ/dtheta matches centered FD for PolySlab.sidewall_angle across axes/ref planes."""
 
     verbose = False
 
     # objective and adjoint grad
-    obj_fun = lambda tdeg: _objective(tdeg, axis, reference_plane, tmp_path, verbose)
+    objective_dir = numerical_case_dir / "objective"
+    objective_dir.mkdir(parents=True, exist_ok=True)
+
+    obj_fun = lambda tdeg: _objective(tdeg, axis, reference_plane, objective_dir, verbose)
     obj, grad_adj = value_and_grad(obj_fun)(anp.array(theta0_deg))
 
     # centered finite difference
@@ -104,9 +107,12 @@ def test_autograd_polyslab_sidewall_vs_fd(axis, reference_plane, theta0_deg, tmp
         f"plus_{uid}": _build_sim(theta0_deg + H, axis=axis, reference_plane=reference_plane),
         f"minus_{uid}": _build_sim(theta0_deg - H, axis=axis, reference_plane=reference_plane),
     }
+    fd_dir = numerical_case_dir / "finite_difference"
+    fd_dir.mkdir(parents=True, exist_ok=True)
+
     datas = web.run_async(
         sims,
-        path_dir=str(tmp_path),
+        path_dir=str(fd_dir),
         local_gradient=True,
         verbose=verbose,
     )

--- a/tests/test_components/autograd/numerical/test_autograd_symmetry_numerical.py
+++ b/tests/test_components/autograd/numerical/test_autograd_symmetry_numerical.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import operator
 import sys
+from pathlib import Path
 
 import autograd as ag
 import matplotlib.pylab as plt
@@ -19,7 +20,6 @@ SAVE_FD_LOC = 0
 SAVE_ADJ_LOC = 1
 LOCAL_GRADIENT = False
 VERBOSE = False
-NUMERICAL_RESULTS_DATA_DIR = "./numerical_symmetry_test/"
 SHOW_PRINT_STATEMENTS = True
 
 RMS_THRESHOLD = 0.25
@@ -127,6 +127,9 @@ def make_base_sim(
 
 
 def create_objective_functions(geometry, create_sim_base, eval_fn, sim_path_dir):
+    sim_path_dir = Path(sim_path_dir)
+    sim_path_dir.mkdir(parents=True, exist_ok=True)
+
     def objective_(perm_array, symmetry):
         sim_base = create_sim_base(symmetry)
 
@@ -137,9 +140,13 @@ def create_objective_functions(geometry, create_sim_base, eval_fn, sim_path_dir)
 
         sim_with_block = sim_base.updated_copy(structures=(*sim_base.structures, block_structure))
 
+        symmetry_tag = "_".join(str(val) for val in symmetry)
+        result_path = sim_path_dir / f"symmetry_{symmetry_tag}.hdf5"
+
         sim_data = web.run(
             sim_with_block,
             task_name="symmetry_field_testing",
+            path=str(result_path),
             local_gradient=LOCAL_GRADIENT,
             verbose=VERBOSE,
         )
@@ -221,18 +228,8 @@ for idx in range(len(mesh_wvls_um)):
 
 
 @pytest.mark.numerical
-@pytest.mark.parametrize(
-    "field_symmetry_test_parameters, dir_name",
-    zip(
-        field_symmetry_test_parameters,
-        ([NUMERICAL_RESULTS_DATA_DIR] if SAVE_FD_ADJ_DATA else [None])
-        * len(field_symmetry_test_parameters),
-    ),
-    indirect=["dir_name"],
-)
-def test_adjoint_difference_symmetry(
-    field_symmetry_test_parameters, rng, tmp_path, create_directory
-):
+@pytest.mark.parametrize("field_symmetry_test_parameters", field_symmetry_test_parameters)
+def test_adjoint_difference_symmetry(field_symmetry_test_parameters, rng, numerical_case_dir):
     """Test the gradient is not affected by symmetry when using field sources."""
 
     num_tests = 0
@@ -278,8 +275,8 @@ def test_adjoint_difference_symmetry(
 
     eval_fns, eval_fn_names = make_eval_fns(monitor_size_wvl)
 
-    sim_path_dir = tmp_path / f"test{test_number}"
-    sim_path_dir.mkdir()
+    sim_path_dir = numerical_case_dir / "simulations" / f"test{test_number}"
+    sim_path_dir.mkdir(parents=True, exist_ok=True)
 
     objective_no_symmetry, objective_x_symmetry, objective_y_symmetry, objective_xy_symmetry = (
         create_objective_functions(


### PR DESCRIPTION
While running the numerical autograd tests I kept hitting `BlockingIOError/OSError` because multiple parametrized cases were writing to the same `simulation_data.hdf5` and `test_diff_init_*.npz` files. This PR adds a shared `numerical_case_dir` fixture so every test run writes its HDF5/NPZ artifacts into an isolated per-case folder (under `tests/tmp/autograd_numerical` or the env-specified path), and updates all numerical tests to use it. The collisions disappear and the saved diagnostics are now easy to inspect post-run.

Also fixes a bug where tests with failing assertions wouldn't write artifacts (npz), which are arguably the most important ones to keep :smile: 

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR solves `BlockingIOError`/`OSError` issues in numerical autograd tests by introducing per-test-case artifact isolation. Previously, parametrized test cases wrote to the same `simulation_data.hdf5` and `test_diff_init_*.npz` files, causing race conditions.

**Key changes:**
- Added `conftest.py` with `numerical_case_dir` fixture that creates isolated directories per test case based on `request.node.nodeid`
- Replaced `tmp_path` and deprecated `create_directory`/`dir_name` fixtures with `numerical_case_dir` across all 7 test files
- Updated all `web.run()` and `web.run_async()` calls to use case-specific paths via `path=` or `path_dir=` parameters
- Changed hardcoded directory constants (e.g., `NUMERICAL_RESULTS_DATA_DIR`) to subdirectory names (e.g., `NUMERICAL_RESULTS_SUBDIR`)
- Added environment variable `TIDY3D_NUMERICAL_ARTIFACT_DIR` for custom artifact root paths

**Impact:**
- Eliminates file collision issues in parallel test execution
- Makes test artifacts easy to inspect post-run with clear per-case organization
- Maintains backward compatibility with optional environment-based path override

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are well-contained to test infrastructure, solve a real concurrency issue, and follow pytest best practices. Only one minor style issue found (unnecessary parentheses). All path handling uses pathlib properly, and the fixture design is clean with appropriate scopes.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tests/test_components/autograd/numerical/conftest.py | 5/5 | New fixture file providing `numerical_case_dir` for isolated test artifacts - implementation is clean and well-structured |
| tests/test_components/autograd/numerical/test_autograd_box_polyslab_numerical.py | 5/5 | Updated to use `numerical_case_dir` fixture, properly isolates HDF5/NPZ artifacts per test case |
| tests/test_components/autograd/numerical/test_autograd_conductivity_numerical.py | 4/5 | Updated to use `numerical_case_dir` fixture, removes old directory fixtures, minor style issue with unnecessary parentheses |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Test Function
    participant Fixture as numerical_case_dir Fixture
    participant Root as numerical_artifact_root
    participant FS as File System
    participant Web as web.run/run_async
    
    Test->>Fixture: Request numerical_case_dir
    Fixture->>Root: Get artifact root (session scope)
    Root->>FS: Check TIDY3D_NUMERICAL_ARTIFACT_DIR env
    alt env var set
        FS-->>Root: Custom path
    else env var not set
        FS-->>Root: tests/tmp/autograd_numerical
    end
    Root->>FS: mkdir(parents=True, exist_ok=True)
    Fixture->>FS: Create case-specific dir from request.node.nodeid
    FS-->>Fixture: Return isolated case directory
    Fixture-->>Test: Path to isolated directory
    
    Test->>Test: Create subdirectories (simulations/, objective/, etc.)
    Test->>Web: Run simulations with path/path_dir
    Web->>FS: Write simulation_data.hdf5 to case dir
    Web-->>Test: Return simulation data
    Test->>FS: Write test_diff_*.npz to case dir
    
    Note over Test,FS: Each parametrized test case<br/>writes to its own directory,<br/>preventing BlockingIOError
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->