### PR TITLE
feat(design): add runtime priority control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a Gaussian inverse design filter option with autograd gradients and complete padding mode coverage.
 - Added support for argument passing to DRC file when running checks with `DRCRunner.run(..., drc_args={key: value})` in klayout plugin.
 - Added support for `nonlinear_spec` in `CustomMedium` and `CustomDispersiveMedium`.
+- `tidy3d.plugins.design.DesignSpace.run(..., fn_post=...)` now accepts a `priority` keyword to propagate vGPU queue priority to all automatically batched simulations.
 
 ### Breaking Changes
 - Edge singularity correction at PEC and lossy metal edges defaults to `True`.

--- a/tests/test_plugins/test_design.py
+++ b/tests/test_plugins/test_design.py
@@ -463,6 +463,22 @@ def test_sweep(sweep_method, monkeypatch):
     assert float_label in sweep_results_df, "didn't assign column header properly for float"
 
 
+def test_priority_forwarded_to_batch(monkeypatch):
+    captured_priority = {}
+
+    def run_with_priority(batch, path_dir: Optional[str] = None, priority: Optional[int] = None):
+        captured_priority["value"] = priority
+        return emulated_batch_run(batch, path_dir=path_dir)
+
+    monkeypatch.setattr(web.Batch, "run", run_with_priority)
+
+    design_space = init_design_space(sweep_method=tdd.MethodGrid())
+
+    design_space.run(scs_pre, scs_post, verbose=False, priority=7)
+
+    assert captured_priority["value"] == 7
+
+
 def emulated_estimate_cost_return(self, verbose=True):
     return 0.5
 

--- a/tidy3d/plugins/design/README.md
+++ b/tidy3d/plugins/design/README.md
@@ -95,6 +95,10 @@ With the design parameters and our method defined, we can combine everything int
 design_space = tdd.DesignSpace(parameters=[param_n, param_r], method=method)
 ```
 
+Execution-time options such as vGPU queue priority are supplied when calling `run`. For example,
+`design_space.run(fn_pre, fn_post, priority=7)` forwards that priority to every automatically batched
+simulation (only available when both `fn` and `fn_post` are provided).
+
 ## Results
 
 The `DesignSpace.run()` function returns a `Result` object, which is basically a dataset containing the function inputs, outputs, source code, and any task ID information corresponding to each data point.

--- a/tidy3d/plugins/design/design.py
+++ b/tidy3d/plugins/design/design.py
@@ -144,7 +144,13 @@ class DesignSpace(Tidy3dBaseModel):
         except (TypeError, OSError):
             return None
 
-    def run(self, fn: Callable, fn_post: Optional[Callable] = None, verbose: bool = True) -> Result:
+    def run(
+        self,
+        fn: Callable,
+        fn_post: Optional[Callable] = None,
+        verbose: bool = True,
+        priority: Optional[int] = None,
+    ) -> Result:
         """Explore a parameter space with a supplied method using the user supplied function.
         Supplied functions are used to evaluate the design space and are called within the method.
         For optimization methods these functions act as the fitness function. A single function can be
@@ -209,6 +215,11 @@ class DesignSpace(Tidy3dBaseModel):
         verbose : bool = True
             Toggle the output of statements stored in the logging console.
 
+        priority : int = None
+            Optional vGPU queue priority (1 = lowest, 10 = highest) applied to simulations run via
+            ``fn`` / ``fn_post``. Ignored when ``fn_post`` is not provided because no automatic
+            batching occurs in that mode.
+
         Returns
         -------
         :class:`Result`
@@ -216,19 +227,31 @@ class DesignSpace(Tidy3dBaseModel):
             Can be converted to ``pandas.DataFrame`` with ``.to_dataframe()``.
         """
 
+        if priority is not None and (priority < 1 or priority > 10):
+            raise ValueError("'priority' must be between 1 and 10 (inclusive).")
+
         # Get the console
         # Method.run checks for console is None instead of being passed console and verbose
         console = get_logging_console() if verbose else None
 
         # Run based on how many functions the user provides
         if fn_post is None:
+            if priority is not None:
+                log.warning(
+                    "'priority' has no effect unless both fn and fn_post are provided;"
+                    " please split your function to allow automatic batching.",
+                    log_once=True,
+                )
             fn_args, fn_values, aux_values, opt_output = self.run_single(fn, console)
             sim_names = None
             sim_paths = None
 
         else:
             fn_args, fn_values, aux_values, opt_output, sim_names, sim_paths = self.run_pre_post(
-                fn_pre=fn, fn_post=fn_post, console=console
+                fn_pre=fn,
+                fn_post=fn_post,
+                console=console,
+                priority=priority,
             )
 
             if len(sim_names) == 0:
@@ -252,12 +275,20 @@ class DesignSpace(Tidy3dBaseModel):
         evaluate_fn = self._get_evaluate_fn_single(fn=fn)
         return self.method._run(run_fn=evaluate_fn, parameters=self.parameters, console=console)
 
-    def run_pre_post(self, fn_pre: Callable, fn_post: Callable, console: Console) -> tuple(
-        list[dict], list[dict], list[Any]
-    ):
+    def run_pre_post(
+        self,
+        fn_pre: Callable,
+        fn_post: Callable,
+        console: Console,
+        priority: Optional[int] = None,
+    ) -> tuple(list[dict], list[dict], list[Any]):
         """Run a function with Tidy3D implicitly called in between."""
         handler = self._get_evaluate_fn_pre_post(
-            fn_pre=fn_pre, fn_post=fn_post, fn_mid=self._fn_mid, console=console
+            fn_pre=fn_pre,
+            fn_post=fn_post,
+            fn_mid=self._fn_mid,
+            console=console,
+            priority=priority,
         )
         fn_args, fn_values, aux_values, opt_output = self.method._run(
             run_fn=handler.fn_combined, parameters=self.parameters, console=console
@@ -276,16 +307,22 @@ class DesignSpace(Tidy3dBaseModel):
         return evaluate
 
     def _get_evaluate_fn_pre_post(
-        self, fn_pre: Callable, fn_post: Callable, fn_mid: Callable, console: Console
+        self,
+        fn_pre: Callable,
+        fn_post: Callable,
+        fn_mid: Callable,
+        console: Console,
+        priority: Optional[int],
     ):
         """Get function that tries to use batch processing on a set of arguments."""
 
         class Pre_Post_Handler:
-            def __init__(self, console) -> None:
+            def __init__(self, console, priority) -> None:
                 self.sim_counter = 0
                 self.sim_names = []
                 self.sim_paths = []
                 self.console = console
+                self.priority = priority
 
             def fn_combined(self, args_list: list[dict[str, Any]]) -> list[Any]:
                 """Compute fn_pre and fn_post functions and capture other outputs."""
@@ -300,7 +337,10 @@ class DesignSpace(Tidy3dBaseModel):
                     )
 
                 data, task_names, task_paths, sim_counter = fn_mid(
-                    sim_dict, self.sim_counter, self.console
+                    sim_dict,
+                    self.sim_counter,
+                    self.console,
+                    self.priority,
                 )
                 self.sim_names.extend(task_names)
                 self.sim_paths.extend(task_paths)
@@ -308,18 +348,26 @@ class DesignSpace(Tidy3dBaseModel):
                 post_out = [fn_post(val) for val in data.values()]
                 return post_out
 
-        handler = Pre_Post_Handler(console)
+        handler = Pre_Post_Handler(console, priority)
 
         return handler
 
     @staticmethod
-    def _run_batch(batch: Batch, path_dir: str) -> BatchData:
+    def _run_batch(
+        batch: Batch,
+        path_dir: str,
+        priority: Optional[int] = None,
+    ) -> BatchData:
         """Run a batch and return the BatchData."""
-        batch_out = batch.run(path_dir=path_dir)
+        batch_out = batch.run(path_dir=path_dir, priority=priority)
         return batch_out
 
     def _fn_mid(
-        self, pre_out: dict[int, Any], sim_counter: int, console: Console
+        self,
+        pre_out: dict[int, Any],
+        sim_counter: int,
+        console: Console,
+        priority: Optional[int],
     ) -> Union[dict[int, Any], BatchData]:
         """A function of the output of ``fn_pre`` that gives the input to ``fn_post``."""
 
@@ -399,11 +447,11 @@ class DesignSpace(Tidy3dBaseModel):
             simulation_type="tidy3d_design",
             verbose=False,  # Using a custom output instead of Batch.monitor updates
         )
-        sims_out = self._run_batch(batch, path_dir=self.path_dir)
+        sims_out = self._run_batch(batch, path_dir=self.path_dir, priority=priority)
 
         batch_results = {}
         for batch_key, batch in batches.items():
-            batch_out = self._run_batch(batch, path_dir=self.path_dir)
+            batch_out = self._run_batch(batch, path_dir=self.path_dir, priority=priority)
             batch_results[batch_key] = batch_out
 
         def _return_to_dict(return_dict: dict, key: str, return_obj: Any) -> None:
@@ -468,6 +516,7 @@ class DesignSpace(Tidy3dBaseModel):
             Union[SimulationData, list[SimulationData], dict[str, SimulationData]], Any
         ],
         path_dir: str = ".",
+        priority: Optional[int] = None,
         **batch_kwargs: Any,
     ) -> Result:
         """
@@ -485,7 +534,7 @@ class DesignSpace(Tidy3dBaseModel):
             )
 
         new_self = self.updated_copy(path_dir=path_dir)
-        result = new_self.run(fn=fn_pre, fn_post=fn_post)
+        result = new_self.run(fn=fn_pre, fn_post=fn_post, priority=priority)
 
         return result
 


### PR DESCRIPTION
Intentionally keeping `priority` outside of model fields because those affect caching. We need a better way to handle runtime arguments, but for now I want to avoid polluting more model fields with them.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds runtime priority control to `DesignSpace.run()` for managing vGPU queue priority when automatically batching simulations. The `priority` parameter (1-10) is threaded through the execution path and forwarded to `Batch.run()` calls.

**Key changes:**
- Added optional `priority` parameter to `run()`, `run_pre_post()`, `_fn_mid()`, `_run_batch()`, and `run_batch()` methods
- Priority validation ensures values are between 1-10 (inclusive)
- Warning issued when `priority` is set but `fn_post` is not provided (since batching only occurs with both functions)
- Priority stored in `Pre_Post_Handler` and passed to all batch execution calls
- Updated documentation and changelog with clear user-facing descriptions

**Implementation notes:**
- Author intentionally kept `priority` outside model fields to avoid affecting caching behavior
- Design cleanly separates runtime parameters from model state

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk - straightforward parameter threading with proper validation and documentation.
- The implementation correctly threads the priority parameter through the call chain, includes appropriate validation and user warnings, and has test coverage for the happy path. Minor style inconsistency in validation logic compared to other parts of the codebase, and missing edge case tests (invalid priority values), but these are non-critical.
- No files require special attention - all changes are straightforward parameter additions

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/design/design.py | 4/5 | Added `priority` parameter threading through `run()`, `run_pre_post()`, `_fn_mid()`, and `_run_batch()` to propagate vGPU queue priority to batch operations. Includes validation and warning for single-function mode. Minor style inconsistency in validation logic. |
| tests/test_plugins/test_design.py | 5/5 | Added test to verify priority parameter is correctly forwarded to Batch.run() using monkeypatch. Test covers happy path but missing edge case validation tests. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant DesignSpace
    participant Pre_Post_Handler
    participant _fn_mid
    participant Batch
    
    User->>DesignSpace: run(fn, fn_post, priority=7)
    DesignSpace->>DesignSpace: validate priority (1-10)
    alt fn_post is None
        DesignSpace->>DesignSpace: log warning about priority
        DesignSpace->>DesignSpace: run_single(fn)
    else fn_post provided
        DesignSpace->>DesignSpace: run_pre_post(fn, fn_post, priority)
        DesignSpace->>Pre_Post_Handler: create handler with priority
        Pre_Post_Handler->>Pre_Post_Handler: fn_combined(args_list)
        Pre_Post_Handler->>Pre_Post_Handler: call fn_pre for each arg
        Pre_Post_Handler->>_fn_mid: call with sim_dict and priority
        _fn_mid->>_fn_mid: extract Simulations and Batches
        _fn_mid->>Batch: create Batch from simulations
        _fn_mid->>DesignSpace: _run_batch(batch, priority)
        DesignSpace->>Batch: run(path_dir, priority=7)
        Batch-->>DesignSpace: BatchData
        _fn_mid-->>Pre_Post_Handler: BatchData with task info
        Pre_Post_Handler->>Pre_Post_Handler: call fn_post with data
        Pre_Post_Handler-->>DesignSpace: results
    end
    DesignSpace-->>User: Result
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->