### PR TITLE
refactor: classmethods added and misc changes

### DIFF
--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -1368,8 +1368,8 @@ def test_too_many_traced_structures(monkeypatch, use_emulated_run):
     def make_sim(*args):
         structure = make_structures(*args)[structure_key]
         return SIM_BASE.updated_copy(
-            structures=(config.adjoint.max_traced_structures + 1) * (structure,), 
-            monitors=(monitor,)
+            structures=(config.adjoint.max_traced_structures + 1) * (structure,),
+            monitors=(monitor,),
         )
 
     def objective(*args):

--- a/tests/test_components/test_absorbers.py
+++ b/tests/test_components/test_absorbers.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import numpy as np
-from pydantic import ValidationError
 import pytest
+from pydantic import ValidationError
 
 import tidy3d as td
 from tidy3d.components.boundary import DEFAULT_BROADBAND_MODE_ABC_NUM_FREQS

--- a/tests/test_components/test_low_freq_smoothing.py
+++ b/tests/test_components/test_low_freq_smoothing.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from pydantic import ValidationError
-
 import pytest
+from pydantic import ValidationError
 
 import tidy3d as td
 

--- a/tests/test_components/test_map.py
+++ b/tests/test_components/test_map.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import collections.abc
 
-from pydantic import ValidationError
 import pytest
+from pydantic import ValidationError
 
 from tidy3d import SimulationMap
 

--- a/tests/test_components/test_source_frames.py
+++ b/tests/test_components/test_source_frames.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from pydantic import ValidationError
 import pytest
+from pydantic import ValidationError
 
 import tidy3d as td
 

--- a/tests/test_data/test_map_data.py
+++ b/tests/test_data/test_map_data.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import collections.abc
 
-from pydantic import ValidationError
 import pytest
+from pydantic import ValidationError
 
 from tidy3d import SimulationDataMap
 

--- a/tests/test_package/test_log.py
+++ b/tests/test_package/test_log.py
@@ -213,7 +213,6 @@ def test_logging_warning_capture():
 
     sim_dict["monitors"] = monitors
 
-    
     sim = td.Simulation.model_validate(sim_dict)
     print(sim.monitors_data_size)
     sim.validate_pre_upload()

--- a/tests/test_plugins/klayout/drc/test_drc.py
+++ b/tests/test_plugins/klayout/drc/test_drc.py
@@ -6,8 +6,8 @@ import os
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
-from pydantic import ValidationError
 import pytest
+from pydantic import ValidationError
 
 import tidy3d as td
 from tidy3d.exceptions import FileError

--- a/tests/test_plugins/smatrix/test_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_component_modeler.py
@@ -9,7 +9,6 @@ from pydantic import ValidationError
 import tidy3d as td
 from tidy3d import SimulationDataMap
 from tidy3d.exceptions import SetupError, Tidy3dKeyError
-from tidy3d.plugins.smatrix import Port
 from tidy3d.plugins.smatrix import ModalComponentModeler, ModalComponentModelerData, Port
 from tidy3d.web.api.container import Batch
 

--- a/tests/test_plugins/smatrix/test_run_functions.py
+++ b/tests/test_plugins/smatrix/test_run_functions.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock
 
-from pydantic import ValidationError
 import pytest
+from pydantic import ValidationError
 
 import tidy3d
 from tests.test_plugins.smatrix.terminal_component_modeler_def import (

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -1197,7 +1197,9 @@ def test_antenna_helpers(monkeypatch, tmp_path):
         theta=theta,
         phi=phi,
     )
-    modeler: TerminalComponentModeler = modeler.updated_copy(radiation_monitors=(radiation_monitor,))
+    modeler: TerminalComponentModeler = modeler.updated_copy(
+        radiation_monitors=(radiation_monitor,)
+    )
 
     # Run simulation to get data
     modeler_data = run_component_modeler(monkeypatch, modeler)

--- a/tests/test_web/test_webapi_extra.py
+++ b/tests/test_web/test_webapi_extra.py
@@ -59,7 +59,7 @@ def test_get_tasks_order_old(monkeypatch):
 
         def dict(self):
             return {"task_id": self.task_id, "created_at": self.created_at}
-        
+
         def model_dump(self):
             return self.dict()
 

--- a/tidy3d/components/autograd/field_map.py
+++ b/tidy3d/components/autograd/field_map.py
@@ -7,7 +7,12 @@ from typing import Any, Callable, Union
 
 from pydantic import Field
 
-from tidy3d.components.autograd.types import AutogradFieldMap, TracedArrayLike, TracedComplex, TracedFloat
+from tidy3d.components.autograd.types import (
+    AutogradFieldMap,
+    TracedArrayLike,
+    TracedComplex,
+    TracedFloat,
+)
 from tidy3d.components.base import Tidy3dBaseModel
 
 

--- a/tidy3d/components/autograd/utils.py
+++ b/tidy3d/components/autograd/utils.py
@@ -11,10 +11,10 @@ __all__ = [
     "asarray1d",
     "contains",
     "get_static",
+    "hasbox",
     "is_tidy_box",
     "pack_complex_vec",
     "split_list",
-    "hasbox",
 ]
 
 

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -15,7 +15,7 @@ from functools import total_ordering, wraps
 from math import ceil
 from os import PathLike
 from pathlib import Path
-from typing import Any, Callable, Literal, Literal, Optional, TypeVar, Union, get_args, get_origin
+from typing import Any, Callable, Literal, Optional, TypeVar, Union, get_args, get_origin
 
 import h5py
 import numpy as np
@@ -24,7 +24,6 @@ import xarray as xr
 import yaml
 from autograd.tracer import isbox
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator
-from typing_extensions import Self
 
 from tidy3d.compat import Self
 from tidy3d.exceptions import FileError
@@ -174,7 +173,8 @@ class Tidy3dBaseModel(BaseModel):
     _has_tracers: Optional[bool] = PrivateAttr(default=None)
 
     @field_validator("name", check_fields=False)
-    def _validate_name_no_special_characters(name):
+    @classmethod
+    def _validate_name_no_special_characters(cls, name):
         if name is None:
             return name
         for character in FORBID_SPECIAL_CHARACTERS:
@@ -1270,7 +1270,7 @@ class Tidy3dBaseModel(BaseModel):
         json_str = make_json_compatible(json_str)
 
         return hashlib.sha256(json_str.encode("utf-8")).hexdigest()
-    
+
     @cached_property_guarded(lambda self: self._attrs_digest())
     def _json_string(self) -> str:
         """Returns string representation of a :class:`Tidy3dBaseModel`.
@@ -1586,7 +1586,7 @@ class Tidy3dBaseModel(BaseModel):
         console.print(self)
         output = sio.getvalue()
         return output.rstrip("\n")
-    
+
 
 def _make_lazy_proxy(
     target_cls: type,
@@ -1675,4 +1675,3 @@ def _make_lazy_proxy(
 
     _LazyProxy.__name__ = proxy_name
     return _LazyProxy
-

--- a/tidy3d/components/base_sim/data/sim_data.py
+++ b/tidy3d/components/base_sim/data/sim_data.py
@@ -69,7 +69,8 @@ class AbstractSimulationData(Tidy3dBaseModel, ABC):
         return self
 
     @field_validator("data")
-    def validate_no_ambiguity(val):
+    @classmethod
+    def validate_no_ambiguity(cls, val):
         """Ensure all :class:`AbstractMonitorData` entries in ``.data`` correspond to different
         monitors in ``.simulation``.
         """

--- a/tidy3d/components/base_sim/simulation.py
+++ b/tidy3d/components/base_sim/simulation.py
@@ -136,6 +136,7 @@ class AbstractSimulation(Box, ABC):
     """ Validating setup """
 
     @model_validator(mode="before")
+    @classmethod
     def _update_simulation(cls, data):
         """Update the simulation if it is an earlier version."""
         # dummy upgrade of version number

--- a/tidy3d/components/bc_placement.py
+++ b/tidy3d/components/bc_placement.py
@@ -46,7 +46,8 @@ class StructureStructureInterface(AbstractBCPlacement):
     )
 
     @field_validator("structures")
-    def unique_names(val):
+    @classmethod
+    def unique_names(cls, val):
         """Error if the same structure is provided twice"""
         if val[0] == val[1]:
             raise SetupError(
@@ -69,7 +70,8 @@ class MediumMediumInterface(AbstractBCPlacement):
     )
 
     @field_validator("mediums")
-    def unique_names(val):
+    @classmethod
+    def unique_names(cls, val):
         """Error if the same structure is provided twice"""
         if val[0] == val[1]:
             raise SetupError("The same medium is provided twice in 'MediumMediumInterface'.")

--- a/tidy3d/components/boundary.py
+++ b/tidy3d/components/boundary.py
@@ -10,11 +10,12 @@ from pydantic import (
     Field,
     NonNegativeFloat,
     NonNegativeInt,
+    PositiveFloat,
     field_validator,
     model_validator,
-    PositiveFloat,
 )
 
+from tidy3d.compat import Self
 from tidy3d.components.validators import _assert_min_freq, assert_plane
 from tidy3d.components.viz import (
     ARROW_ALPHA,
@@ -22,7 +23,6 @@ from tidy3d.components.viz import (
     PlotParams,
     plot_params_absorber,
 )
-from tidy3d.compat import Self
 from tidy3d.constants import C_0, CONDUCTIVITY, EPSILON_0, HERTZ, MU_0, PML_SIGMA
 from tidy3d.exceptions import DataError, SetupError, ValidationError
 from tidy3d.log import log
@@ -132,7 +132,7 @@ class ABCBoundary(AbstractABCBoundary):
         units=CONDUCTIVITY,
     )
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def _conductivity_only_with_float_permittivity(self):
         """Validate that conductivity can be provided only with float permittivity."""
         if self.conductivity is not None and self.permittivity is None:
@@ -203,6 +203,7 @@ class BroadbandModeABCSpec(Tidy3dBaseModel):
     )
 
     @field_validator("frequency_range", mode="after")
+    @classmethod
     def validate_frequency_range(cls, val):
         """Validate that max frequency is greater than min frequency."""
         _assert_min_freq(val[0], "min frequency")

--- a/tidy3d/components/data/unstructured/base.py
+++ b/tidy3d/components/data/unstructured/base.py
@@ -93,7 +93,8 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
         return val
 
     @field_validator("points")
-    def points_right_indexing(val: PointDataArray) -> PointDataArray:
+    @classmethod
+    def points_right_indexing(cls, val: PointDataArray) -> PointDataArray:
         """Check that points are indexed corrrectly."""
         indices_expected = np.arange(len(val.data))
         indices_given = val.index.data
@@ -106,14 +107,16 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
         return val
 
     @field_validator("values")
-    def first_values_dim_is_index(val: IndexedDataArrayTypes) -> IndexedDataArrayTypes:
+    @classmethod
+    def first_values_dim_is_index(cls, val: IndexedDataArrayTypes) -> IndexedDataArrayTypes:
         """Check that the number of data values matches the number of grid points."""
         if val.dims[0] != "index":
             raise ValidationError("First dimension of array 'values' must be 'index'.")
         return val
 
     @field_validator("values")
-    def values_right_indexing(val: IndexedDataArrayTypes) -> IndexedDataArrayTypes:
+    @classmethod
+    def values_right_indexing(cls, val: IndexedDataArrayTypes) -> IndexedDataArrayTypes:
         """Check that data values are indexed correctly."""
         # currently support only simple ordered indexing of points, that is, 0, 1, 2, ...
         indices_expected = np.arange(len(val.index.data))
@@ -140,7 +143,8 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
         return self
 
     @field_validator("cells")
-    def match_cells_to_vtk_type(val: CellDataArray) -> CellDataArray:
+    @classmethod
+    def match_cells_to_vtk_type(cls, val: CellDataArray) -> CellDataArray:
         """Check that cell connections does not have duplicate points."""
         if vtk is None:
             return val
@@ -185,6 +189,7 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
         return self
 
     @field_validator("cells")
+    @classmethod
     def warn_degenerate_cells(cls, val: CellDataArray) -> CellDataArray:
         """Check that cell connections does not have duplicate points."""
         degenerate_cells = cls._find_degenerate_cells(val)
@@ -228,6 +233,7 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
         return data
 
     @model_validator(mode="before")
+    @classmethod
     def _add_default_coords(cls, data: dict) -> dict:
         def _add_default_coords(da: DataArray) -> DataArray:
             """Add 0..N-1 coordinates to any dimension that does not already have one.

--- a/tidy3d/components/dispersion_fitter.py
+++ b/tidy3d/components/dispersion_fitter.py
@@ -194,7 +194,8 @@ class AdvancedFastFitterParam(Tidy3dBaseModel):
     )
 
     @field_validator("loss_bounds")
-    def _max_loss_geq_min_loss(val):
+    @classmethod
+    def _max_loss_geq_min_loss(cls, val):
         """Must have max_loss >= min_loss."""
         if val[0] > val[1]:
             raise ValidationError(
@@ -203,7 +204,8 @@ class AdvancedFastFitterParam(Tidy3dBaseModel):
         return val
 
     @field_validator("weights")
-    def _weights_average_to_one(val):
+    @classmethod
+    def _weights_average_to_one(cls, val):
         """Weights must average to one."""
         if val is None:
             return None

--- a/tidy3d/components/eme/grid.py
+++ b/tidy3d/components/eme/grid.py
@@ -120,7 +120,8 @@ class EMEGridSpec(Tidy3dBaseModel, ABC):
     )
 
     @field_validator("num_reps")
-    def _validate_num_reps(val):
+    @classmethod
+    def _validate_num_reps(cls, val):
         """Check num_reps is not too large."""
         if val > MAX_NUM_REPS:
             raise SetupError(
@@ -696,7 +697,8 @@ class EMEGrid(Box):
     )
 
     @field_validator("mode_specs")
-    def _validate_size(val):
+    @classmethod
+    def _validate_size(cls, val):
         """Check grid size and num modes."""
         num_eme_cells = len(val)
         if num_eme_cells > MAX_NUM_EME_CELLS:

--- a/tidy3d/components/eme/simulation.py
+++ b/tidy3d/components/eme/simulation.py
@@ -282,20 +282,23 @@ class EMESimulation(AbstractYeeGridSimulation):
     _freqs_lower_bound = validate_freqs_min()
 
     @field_validator("grid_spec")
-    def _validate_auto_grid_wavelength(val):
+    @classmethod
+    def _validate_auto_grid_wavelength(cls, val):
         """Handle the case where grid_spec is auto and wavelength is not provided."""
         # this is handled instead post-init to ensure freqs is defined
         return val
 
     @field_validator("freqs")
-    def _validate_freqs(val):
+    @classmethod
+    def _validate_freqs(cls, val):
         """Freqs cannot contain duplicates."""
         if len(set(val)) != len(val):
             raise SetupError(f"'EMESimulation' 'freqs={val}' cannot contain duplicate frequencies.")
         return val
 
     @field_validator("structures")
-    def _validate_structures(val):
+    @classmethod
+    def _validate_structures(cls, val):
         """Validate and warn for certain medium types."""
         for ind, structure in enumerate(val):
             medium = structure.medium

--- a/tidy3d/components/eme/sweep.py
+++ b/tidy3d/components/eme/sweep.py
@@ -105,7 +105,8 @@ class EMEPeriodicitySweep(EMESweepSpec):
     )
 
     @field_validator("num_reps")
-    def _validate_num_reps(val):
+    @classmethod
+    def _validate_num_reps(cls, val):
         """Check num_reps is not too large."""
         for num_reps_dict in val:
             for value in num_reps_dict.values():

--- a/tidy3d/components/frequency_extrapolation.py
+++ b/tidy3d/components/frequency_extrapolation.py
@@ -75,6 +75,7 @@ class LowFrequencySmoothingSpec(AbstractLowFrequencySmoothingSpec):
     )
 
     @field_validator("monitors")
+    @classmethod
     def _validate_monitors(cls, val):
         """Validate the monitors list is not empty."""
         if not val:

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -1571,7 +1571,8 @@ class Centered(Geometry, ABC):
         return val
 
     @field_validator("center")
-    def _center_not_inf(val: tuple[float, float, float]) -> tuple[float, float, float]:
+    @classmethod
+    def _center_not_inf(cls, val: tuple[float, float, float]) -> tuple[float, float, float]:
         """Make sure center is not infinitiy."""
         if any(np.isinf(v) for v in val):
             raise ValidationError("center can not contain td.inf terms.")
@@ -1680,7 +1681,8 @@ class Planar(SimplePlaneIntersection, Geometry, ABC):
     )
 
     @field_validator("sidewall_angle")
-    def validate_angle(val) -> float:
+    @classmethod
+    def validate_angle(cls, val: float) -> float:
         lower_bound = -np.pi / 2
         upper_bound = np.pi / 2
         if (val <= lower_bound) or (val >= upper_bound):
@@ -1847,7 +1849,8 @@ class Circular(Geometry):
     )
 
     @field_validator("radius")
-    def _radius_not_inf(val: float) -> float:
+    @classmethod
+    def _radius_not_inf(cls, val: float) -> float:
         """Make sure center is not infinitiy."""
         if np.isinf(val):
             raise ValidationError("radius can not be 'td.inf'.")
@@ -2931,13 +2934,15 @@ class Transformed(Geometry):
     )
 
     @field_validator("transform")
-    def _transform_is_invertible(val: MatrixReal4x4) -> MatrixReal4x4:
+    @classmethod
+    def _transform_is_invertible(cls, val: MatrixReal4x4) -> MatrixReal4x4:
         # If the transform is not invertible, this will raise an error
         _ = np.linalg.inv(val)
         return val
 
     @field_validator("geometry")
-    def _geometry_is_finite(val: GeometryType) -> GeometryType:
+    @classmethod
+    def _geometry_is_finite(cls, val: GeometryType) -> GeometryType:
         if not np.isfinite(val.bounds).all():
             raise ValidationError(
                 "Transformations are only supported on geometries with finite dimensions. "
@@ -3230,7 +3235,8 @@ class ClipOperation(Geometry):
     )
 
     @field_validator("geometry_a", "geometry_b")
-    def _geometries_untraced(val: GeometryType) -> GeometryType:
+    @classmethod
+    def _geometries_untraced(cls, val: GeometryType) -> GeometryType:
         """Make sure that ``ClipOperation`` geometries do not contain tracers."""
         traced = val._strip_traced_fields()
         if traced:
@@ -3492,7 +3498,8 @@ class GeometryGroup(Geometry):
     )
 
     @field_validator("geometries")
-    def _geometries_not_empty(val: tuple[GeometryType, ...]) -> tuple[GeometryType, ...]:
+    @classmethod
+    def _geometries_not_empty(cls, val: tuple[GeometryType, ...]) -> tuple[GeometryType, ...]:
         """make sure geometries are not empty."""
         if not len(val) > 0:
             raise ValidationError("GeometryGroup.geometries must not be empty.")

--- a/tidy3d/components/geometry/mesh.py
+++ b/tidy3d/components/geometry/mesh.py
@@ -47,11 +47,13 @@ class TriangleMesh(base.Geometry, ABC):
 
     @model_validator(mode="before")
     @verify_packages_import(["trimesh"])
-    def _validate_trimesh_library(data: dict[str, Any]) -> dict[str, Any]:
+    @classmethod
+    def _validate_trimesh_library(cls, data: dict[str, Any]) -> dict[str, Any]:
         """Check if the trimesh package is imported as a validator."""
         return data
 
     @field_validator("mesh_dataset", mode="before")
+    @classmethod
     def _warn_if_none(cls, val: TriangleMeshDataset) -> TriangleMeshDataset:
         """Warn if the Dataset fails to load."""
         if isinstance(val, dict):
@@ -61,6 +63,7 @@ class TriangleMesh(base.Geometry, ABC):
         return val
 
     @field_validator("mesh_dataset")
+    @classmethod
     def _check_mesh(cls, val: TriangleMeshDataset) -> TriangleMeshDataset:
         """Check that the mesh is valid."""
         if val is None:

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -105,7 +105,8 @@ class PolySlab(base.Planar):
         return shapely.Polygon(vertices)
 
     @field_validator("slab_bounds")
-    def slab_bounds_order(val: tuple[float, float]) -> tuple[float, float]:
+    @classmethod
+    def slab_bounds_order(cls, val: tuple[float, float]) -> tuple[float, float]:
         """Maximum position of the slab should be no smaller than its minimal position."""
         if val[1] < val[0]:
             raise SetupError(

--- a/tidy3d/components/geometry/utils.py
+++ b/tidy3d/components/geometry/utils.py
@@ -9,8 +9,8 @@ from math import isclose
 from typing import Any, Optional, Union
 
 import numpy as np
-from pydantic import Field, NonNegativeInt
 import shapely
+from pydantic import Field, NonNegativeInt
 from shapely.geometry import (
     Polygon,
 )
@@ -449,9 +449,7 @@ class SnappingSpec(Tidy3dBaseModel):
         description="Describes how snapping positions will be chosen.",
     )
 
-    margin: Optional[
-        tuple[NonNegativeInt, NonNegativeInt, NonNegativeInt]
-    ] = Field(
+    margin: Optional[tuple[NonNegativeInt, NonNegativeInt, NonNegativeInt]] = Field(
         (0, 0, 0),
         title="Margin",
         description="Number of additional grid points to consider when expanding or contracting "

--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -22,7 +22,6 @@ from tidy3d.components.geometry.utils_2d import increment_float
 from tidy3d.components.lumped_element import LumpedElementType
 from tidy3d.components.source.utils import SourceType
 from tidy3d.components.structure import MeshOverrideStructure, Structure, StructureType
-from tidy3d.components.types.base import discriminated_union
 from tidy3d.components.types import (
     TYPE_TAG_STR,
     ArrayFloat1D,
@@ -34,6 +33,7 @@ from tidy3d.components.types import (
     Symmetry,
     Undefined,
 )
+from tidy3d.components.types.base import discriminated_union
 from tidy3d.constants import C_0, MICROMETER, dp_eps, fp_eps, inf
 from tidy3d.exceptions import SetupError
 from tidy3d.log import log
@@ -294,7 +294,8 @@ class UniformGrid(GridSpec1d):
     )
 
     @field_validator("dl")
-    def _validate_dl(val):
+    @classmethod
+    def _validate_dl(cls, val):
         """
         Ensure 'dl' is not too small.
         """
@@ -428,7 +429,8 @@ class CustomGridBoundaries(GridSpec1d):
         return min(np.diff(self.coords))
 
     @field_validator("coords")
-    def _validate_coords(val):
+    @classmethod
+    def _validate_coords(cls, val):
         """
         Ensure 'coords' is sorted and has at least 2 entries.
         """

--- a/tidy3d/components/lumped_element.py
+++ b/tidy3d/components/lumped_element.py
@@ -32,9 +32,9 @@ from .geometry.utils import (
     snap_point_to_grid,
 )
 from .geometry.utils_2d import increment_float
-from .microwave.base import MicrowaveBaseModel
 from .grid.grid import Grid
 from .medium import PEC2D, Debye, Drude, Lorentz, Medium, Medium2D, PoleResidue
+from .microwave.base import MicrowaveBaseModel
 from .microwave.formulas.circuit_parameters import (
     capacitance_colinear_cylindrical_wire_segments,
     capacitance_rectangular_sheets,
@@ -398,7 +398,8 @@ class CoaxialLumpedResistor(LumpedElement):
         ]
 
     @field_validator("center")
-    def _center_not_inf(val):
+    @classmethod
+    def _center_not_inf(cls, val):
         """Make sure center is not infinitiy."""
         if any(np.isinf(v) for v in val):
             raise ValidationError("'center' can not contain 'td.inf' terms.")

--- a/tidy3d/components/material/tcad/charge.py
+++ b/tidy3d/components/material/tcad/charge.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Union
-
 from typing import Optional, Union
 
 from pydantic import Field, NonNegativeFloat, PositiveFloat, field_validator
@@ -322,6 +320,7 @@ class SemiconductorMedium(AbstractChargeMedium):
 
     # DEPRECATION VALIDATORS
     @field_validator("N_c")
+    @classmethod
     def check_nc_uses_model(cls, val):
         """Issue deprecation warning if float is provided"""
         if isinstance(val, (float, int)):
@@ -333,6 +332,7 @@ class SemiconductorMedium(AbstractChargeMedium):
         return val
 
     @field_validator("N_v")
+    @classmethod
     def check_nv_uses_model(cls, val):
         """Issue deprecation warning if float is provided"""
         if isinstance(val, (float, int)):
@@ -344,6 +344,7 @@ class SemiconductorMedium(AbstractChargeMedium):
         return val
 
     @field_validator("E_g")
+    @classmethod
     def check_eg_uses_model(cls, val):
         """Issue deprecation warning if float is provided"""
         if isinstance(val, (float, int)):
@@ -355,6 +356,7 @@ class SemiconductorMedium(AbstractChargeMedium):
         return val
 
     @field_validator("N_d")
+    @classmethod
     def check_nd_uses_model(cls, val):
         """Issue deprecation warning if float is provided"""
         if isinstance(val, (float, int)):
@@ -366,6 +368,7 @@ class SemiconductorMedium(AbstractChargeMedium):
         return val
 
     @field_validator("N_a")
+    @classmethod
     def check_na_uses_model(cls, val):
         """Issue deprecation warning if float is provided"""
         if isinstance(val, (float, int)):

--- a/tidy3d/components/material/tcad/heat.py
+++ b/tidy3d/components/material/tcad/heat.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC
 from typing import Optional, Union
 
-from pydantic import Field, PositiveFloat, NonNegativeFloat
+from pydantic import Field, NonNegativeFloat, PositiveFloat
 
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.constants import (

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -71,6 +71,7 @@ from .dispersion_fitter import (
 )
 from .geometry.base import Geometry
 from .grid.grid import Coords, Grid
+from .material.tcad.heat import ThermalSpecType
 from .nonlinear import (  # noqa: F401
     KerrNonlinearity,
     NonlinearModel,
@@ -78,7 +79,6 @@ from .nonlinear import (  # noqa: F401
     NonlinearSusceptibility,
     TwoPhotonAbsorption,
 )
-from .material.tcad.heat import ThermalSpecType
 from .parameter_perturbation import (
     IndexPerturbation,
     ParameterPerturbation,
@@ -1176,7 +1176,8 @@ class PECMedium(AbstractMedium):
     """
 
     @field_validator("modulation_spec")
-    def _validate_modulation_spec(cls, val, info):
+    @classmethod
+    def _validate_modulation_spec(cls, val):
         """Check compatibility with modulation_spec."""
         if val is not None:
             raise ValidationError(
@@ -1222,7 +1223,8 @@ class PMCMedium(AbstractMedium):
     """
 
     @field_validator("modulation_spec")
-    def _validate_modulation_spec(cls, val, info):
+    @classmethod
+    def _validate_modulation_spec(cls, val):
         """Check compatibility with modulation_spec."""
         if val is not None:
             raise ValidationError(
@@ -1491,7 +1493,8 @@ class CustomIsotropicMedium(AbstractCustomMedium, Medium):
     _no_nans = validate_no_nans("permittivity", "conductivity")
 
     @field_validator("permittivity")
-    def _eps_inf_greater_no_less_than_one(val):
+    @classmethod
+    def _eps_inf_greater_no_less_than_one(cls, val):
         """Assert any eps_inf must be >=1"""
 
         if not CustomIsotropicMedium._validate_isreal_dataarray(val):
@@ -1671,6 +1674,7 @@ class CustomMedium(AbstractCustomMedium):
     _no_nans = validate_no_nans("eps_dataset", "permittivity", "conductivity")
 
     @model_validator(mode="before")
+    @classmethod
     def _warn_if_none(cls, data: dict) -> dict:
         """Warn if the data array fails to load, and return a vacuum medium."""
         fail_load = False
@@ -1747,7 +1751,8 @@ class CustomMedium(AbstractCustomMedium):
         return self
 
     @field_validator("eps_dataset")
-    def _eps_dataset_single_frequency(val):
+    @classmethod
+    def _eps_dataset_single_frequency(cls, val):
         """Assert only one frequency supplied."""
         if val is None:
             return val
@@ -1884,7 +1889,8 @@ class CustomMedium(AbstractCustomMedium):
         return self
 
     @field_validator("permittivity", "conductivity")
-    def _check_permittivity_conductivity_interpolate(val, info):
+    @classmethod
+    def _check_permittivity_conductivity_interpolate(cls, val, info):
         """Check that the custom medium 'SpatialDataArrays' can be interpolated."""
 
         if isinstance(val, SpatialDataArray):
@@ -2646,6 +2652,7 @@ class CustomDispersiveMedium(AbstractCustomMedium, DispersiveMedium, ABC):
         """
 
         @model_validator(mode="before")
+        @classmethod
         def _warn_if_none(cls, data: dict):
             is_not_loaded = AbstractCustomMedium._not_loaded
 
@@ -2781,7 +2788,8 @@ class PoleResidue(DispersiveMedium):
     )
 
     @field_validator("poles")
-    def _causality_validation(val):
+    @classmethod
+    def _causality_validation(cls, val):
         """Assert causal medium."""
         for a, _ in val:
             if np.any(np.real(_get_numpy_array(a)) > 0):
@@ -2789,6 +2797,7 @@ class PoleResidue(DispersiveMedium):
         return val
 
     @field_validator("poles")
+    @classmethod
     def _poles_largest_value(cls, val):
         """Assert pole parameters are not too large."""
         for a, c in val:
@@ -3372,7 +3381,8 @@ class CustomPoleResidue(CustomDispersiveMedium, PoleResidue):
     _warn_if_none = CustomDispersiveMedium._warn_if_data_none("poles")
 
     @field_validator("eps_inf")
-    def _eps_inf_positive(val):
+    @classmethod
+    def _eps_inf_positive(cls, val):
         """eps_inf must be positive"""
         if not CustomDispersiveMedium._validate_isreal_dataarray(val):
             raise SetupError("'eps_inf' must be real.")
@@ -3657,7 +3667,8 @@ class Sellmeier(DispersiveMedium):
         return self
 
     @field_validator("modulation_spec")
-    def _validate_permittivity_modulation(val):
+    @classmethod
+    def _validate_permittivity_modulation(cls, val):
         """Assert modulated permittivity cannot be <= 0."""
 
         if val is None or val.permittivity is None:
@@ -3842,7 +3853,8 @@ class CustomSellmeier(CustomDispersiveMedium, Sellmeier):
     _warn_if_none = CustomDispersiveMedium._warn_if_data_none("coeffs")
 
     @field_validator("coeffs")
-    def _correct_shape_and_sign(val):
+    @classmethod
+    def _correct_shape_and_sign(cls, val):
         """every term in coeffs must have the same shape, and B>=0 and C>0."""
         if len(val) == 0:
             return val
@@ -3874,6 +3886,7 @@ class CustomSellmeier(CustomDispersiveMedium, Sellmeier):
         return self
 
     @field_validator("coeffs")
+    @classmethod
     def _coeffs_C_all_near_zero_or_much_greater(cls, val):
         """We restrict either all C~=0, or very different from 0."""
         for _, C in val:
@@ -4114,6 +4127,7 @@ class Lorentz(DispersiveMedium):
     )
 
     @field_validator("coeffs")
+    @classmethod
     def _coeffs_unequal_f_delta(cls, val):
         """f**2 and delta**2 cannot be exactly the same."""
         for _, f, delta in val:
@@ -4356,7 +4370,8 @@ class CustomLorentz(CustomDispersiveMedium, Lorentz):
     _warn_if_none = CustomDispersiveMedium._warn_if_data_none("coeffs")
 
     @field_validator("eps_inf")
-    def _eps_inf_positive(val):
+    @classmethod
+    def _eps_inf_positive(cls, val):
         """eps_inf must be positive"""
         if not CustomDispersiveMedium._validate_isreal_dataarray(val):
             raise SetupError("'eps_inf' must be real.")
@@ -4365,6 +4380,7 @@ class CustomLorentz(CustomDispersiveMedium, Lorentz):
         return val
 
     @field_validator("coeffs")
+    @classmethod
     def _coeffs_unequal_f_delta(cls, val):
         """f and delta cannot be exactly the same.
         Not needed for now because we have a more strict
@@ -4391,7 +4407,8 @@ class CustomLorentz(CustomDispersiveMedium, Lorentz):
         return self
 
     @field_validator("coeffs")
-    def _coeffs_delta_all_smaller_or_larger_than_fi(val):
+    @classmethod
+    def _coeffs_delta_all_smaller_or_larger_than_fi(cls, val):
         """We restrict either all f**2>delta**2 or all f**2<delta**2 for now."""
         for _, f, delta in val:
             f2 = f**2
@@ -4756,7 +4773,8 @@ class CustomDrude(CustomDispersiveMedium, Drude):
     _warn_if_none = CustomDispersiveMedium._warn_if_data_none("coeffs")
 
     @field_validator("eps_inf")
-    def _eps_inf_positive(val):
+    @classmethod
+    def _eps_inf_positive(cls, val):
         """eps_inf must be positive"""
         if not CustomDispersiveMedium._validate_isreal_dataarray(val):
             raise SetupError("'eps_inf' must be real.")
@@ -5101,7 +5119,8 @@ class CustomDebye(CustomDispersiveMedium, Debye):
     _warn_if_none = CustomDispersiveMedium._warn_if_data_none("coeffs")
 
     @field_validator("eps_inf")
-    def _eps_inf_positive(val):
+    @classmethod
+    def _eps_inf_positive(cls, val):
         """eps_inf must be positive"""
         if not CustomDispersiveMedium._validate_isreal_dataarray(val):
             raise SetupError("'eps_inf' must be real.")
@@ -5126,6 +5145,7 @@ class CustomDebye(CustomDispersiveMedium, Debye):
         return self
 
     @field_validator("coeffs")
+    @classmethod
     def _coeffs_tau_all_sufficient_positive(cls, val):
         """We restrict either all tau is sufficently greater than 0."""
         for _, tau in val:
@@ -5570,7 +5590,8 @@ class LossyMetalMedium(Medium):
     )
 
     @field_validator("frequency_range")
-    def _validate_frequency_range(val):
+    @classmethod
+    def _validate_frequency_range(cls, val):
         """Validate that frequency range is finite and non-zero."""
         for freq in val:
             if not np.isfinite(freq):
@@ -6028,7 +6049,8 @@ class FullyAnisotropicMedium(AbstractMedium):
         return val
 
     @field_validator("permittivity")
-    def permittivity_spd_and_ge_one(val):
+    @classmethod
+    def permittivity_spd_and_ge_one(cls, val):
         """Check that provided permittivity tensor is symmetric positive definite
         with eigenvalues >= 1.
         """
@@ -6324,7 +6346,8 @@ class CustomAnisotropicMedium(AbstractCustomMedium, AnisotropicMedium):
     )
 
     @field_validator("xx", "yy", "zz")
-    def _isotropic_xx(val, info):
+    @classmethod
+    def _isotropic_xx(cls, val, info):
         """If it's `CustomMedium`, make sure it's isotropic."""
         if isinstance(val, CustomMedium) and not val.is_isotropic:
             raise SetupError(f"The {info.field_name}-component medium type is not isotropic.")

--- a/tidy3d/components/microwave/base.py
+++ b/tidy3d/components/microwave/base.py
@@ -13,6 +13,7 @@ class MicrowaveBaseModel(Tidy3dBaseModel):
     """Base model that all RF and microwave specific components inherit from."""
 
     @model_validator(mode="before")
+    @classmethod
     def _warn_rf_license(cls, values):
         from tidy3d.config import config
 

--- a/tidy3d/components/microwave/data/monitor_data.py
+++ b/tidy3d/components/microwave/data/monitor_data.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Optional
 
 import xarray as xr
-from pydantic import Field, model_validator
+from pydantic import Field
 
 from tidy3d.components.data.data_array import FieldProjectionAngleDataArray, FreqDataArray
 from tidy3d.components.data.monitor_data import DirectivityData, ModeData, ModeSolverData

--- a/tidy3d/components/microwave/path_integrals/mode_plane_analyzer.py
+++ b/tidy3d/components/microwave/path_integrals/mode_plane_analyzer.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from itertools import chain
 from math import isclose
 
-from pydantic import Field
 import shapely
+from pydantic import Field
 from shapely.geometry import LineString, Polygon
 
 from tidy3d.components.base import cached_property

--- a/tidy3d/components/microwave/path_integrals/specs/base.py
+++ b/tidy3d/components/microwave/path_integrals/specs/base.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 import numpy as np
-from pydantic import Field, field_validator
 import shapely
 import xarray as xr
+from pydantic import Field, field_validator
 from typing_extensions import Self
 
 from tidy3d.components.base import cached_property
@@ -224,6 +224,7 @@ class Custom2DPathIntegralSpec(AbstractAxesRH):
         return self.axis
 
     @field_validator("vertices")
+    @classmethod
     def _correct_shape(cls, val):
         """Makes sure vertices size is correct."""
         # overall shape of vertices

--- a/tidy3d/components/microwave/path_integrals/specs/current.py
+++ b/tidy3d/components/microwave/path_integrals/specs/current.py
@@ -362,6 +362,7 @@ class CompositeCurrentIntegralSpec(MicrowaveBaseModel):
         return ax
 
     @field_validator("path_specs")
+    @classmethod
     def _path_specs_not_empty(cls, val):
         """Makes sure at least one path spec has been supplied"""
         # overall shape of vertices

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -74,9 +74,9 @@ from tidy3d.components.types import (
     PlotScale,
     Symmetry,
 )
+from tidy3d.components.types.base import TYPE_TAG_STR, discriminated_union
 from tidy3d.components.types.mode_spec import ModeSpecType
 from tidy3d.components.types.monitor_data import ModeSolverDataType
-from tidy3d.components.types.base import TYPE_TAG_STR, discriminated_union
 from tidy3d.components.validators import (
     validate_freqs_min,
     validate_freqs_not_empty,
@@ -205,6 +205,7 @@ class ModeSolver(Tidy3dBaseModel):
     )
 
     @field_validator("simulation")
+    @classmethod
     def _convert_to_simulation(val):
         """Convert to regular Simulation if e.g. JaxSimulation given."""
         if hasattr(val, "to_simulation"):
@@ -216,6 +217,7 @@ class ModeSolver(Tidy3dBaseModel):
         return val
 
     @field_validator("plane")
+    @classmethod
     def is_plane(val):
         """Raise validation error if not planar."""
         if val.size.count(0.0) != 1:
@@ -271,7 +273,7 @@ class ModeSolver(Tidy3dBaseModel):
     def _validate_rotate_structures_after(self):
         self._validate_rotate_structures()
         return self
-    
+
     @model_validator(mode="after")
     def _validate_num_grid_points(self):
         """Upper bound of the product of the number of grid points and the number of modes. The bound is very loose: subspace
@@ -341,7 +343,6 @@ class ModeSolver(Tidy3dBaseModel):
         if np.abs(self.mode_spec.angle_theta) > 0 and self.mode_spec.angle_rotation:
             _ = self._rotate_structures
 
-    
     @staticmethod
     def _make_rotated_structures(
         structures: list[Structure], translate_kwargs: dict, rotate_kwargs: dict

--- a/tidy3d/components/mode/simulation.py
+++ b/tidy3d/components/mode/simulation.py
@@ -215,18 +215,21 @@ class ModeSimulation(AbstractYeeGridSimulation):
     )
 
     @field_validator("grid_spec")
-    def _validate_auto_grid_wavelength(val):
+    @classmethod
+    def _validate_auto_grid_wavelength(cls, val):
         # abstract override, logic is handled in post-init to ensure freqs is defined
         return val
 
     @field_validator("plane")
-    def _validate_planar(val):
+    @classmethod
+    def _validate_planar(cls, val):
         if val.size.count(0.0) != 1:
             raise ValidationError(f"'ModeSimulation.plane' must be planar, given 'size={val.size}'")
         return val
 
     @model_validator(mode="before")
-    def is_plane(data):
+    @classmethod
+    def is_plane(cls, data):
         """Raise validation error if not planar."""
         if hasattr(data, "get") and data.get("plane") is None:
             val = Box(size=data.get("size"), center=data.get("center"))

--- a/tidy3d/components/mode_spec.py
+++ b/tidy3d/components/mode_spec.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC
 from math import isclose
-from typing import Literal, Optional, Optional, Union
+from typing import Literal, Optional, Union
 
 import numpy as np
 from pydantic import (
@@ -212,14 +212,16 @@ class AbstractModeSpec(Tidy3dBaseModel, ABC):
     )
 
     @field_validator("group_index_step", mode="before")
-    def _validate_group_index_step_default(val):
+    @classmethod
+    def _validate_group_index_step_default(cls, val):
         """If ``True``, replace with default fractional step."""
         if val is True:
             return GROUP_INDEX_STEP
         return val
 
     @field_validator("group_index_step")
-    def _validate_group_index_step_size(val):
+    @classmethod
+    def _validate_group_index_step_size(cls, val):
         """Ensure group-index step is < 1."""
         if val is not False and val >= 1:
             raise ValidationError(
@@ -228,14 +230,16 @@ class AbstractModeSpec(Tidy3dBaseModel, ABC):
         return val
 
     @field_validator("bend_radius")
-    def _validate_bend_radius_not_zero(v):
+    @classmethod
+    def _validate_bend_radius_not_zero(cls, v):
         """`bend_radius` magnitude must be non-zero."""
         if v is not None and isclose(v, 0):
             raise SetupError("The magnitude of 'bend_radius' must be larger than 0.")
         return v
 
     @field_validator("angle_theta")
-    def _validate_angle_theta_glancing(val):
+    @classmethod
+    def _validate_angle_theta_glancing(cls, val):
         """Disallow incidence too close to glancing."""
         if abs(np.pi / 2 - val) < GLANCING_CUTOFF:
             raise SetupError(
@@ -259,7 +263,7 @@ class AbstractModeSpec(Tidy3dBaseModel, ABC):
                 "'angle_phi' must be a multiple of 'π/2' when 'angle_rotation' is enabled."
             )
         return self
-    
+
     @model_validator(mode="after")
     def check_precision(self):
         """Verify critical ModeSpec settings for group index calculation."""
@@ -295,6 +299,7 @@ class AbstractModeSpec(Tidy3dBaseModel, ABC):
         return self
 
     @field_validator("filter_pol")
+    @classmethod
     def _filter_pol_deprecated(cls, val):
         """Warn that 'filter_pol' is deprecated in favor of 'sort_spec'."""
         if val is not None:
@@ -305,6 +310,7 @@ class AbstractModeSpec(Tidy3dBaseModel, ABC):
         return val
 
     @field_validator("track_freq")
+    @classmethod
     def _track_freq_deprecated(cls, val):
         """Warn that 'track_freq' on ModeSpec is deprecated in favor of 'sort_spec.track_freq'."""
         if val is not None:

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -106,7 +106,8 @@ class FreqMonitor(Monitor, ABC):
     _freqs_lower_bound = validate_freqs_min()
 
     @field_validator("freqs")
-    def _warn_num_freqs(val, info):
+    @classmethod
+    def _warn_num_freqs(cls, val, info):
         """Warn if number of frequencies is too large."""
         if len(val) > WARN_NUM_FREQS:
             log.warning(
@@ -406,7 +407,8 @@ class AbstractModeMonitor(PlanarMonitor, FreqMonitor):
         return direction.index(1)
 
     @field_validator("mode_spec")
-    def _warn_num_modes(val, info):
+    @classmethod
+    def _warn_num_modes(cls, val, info):
         """Warn if number of modes is too large."""
         if val.num_modes > WARN_NUM_MODES:
             log.warning(
@@ -537,60 +539,6 @@ class AuxFieldTimeMonitor(AbstractAuxFieldMonitor, TimeMonitor):
         # stores 1 real number per grid cell, per time step, per field
         num_steps = self.num_steps(tmesh)
         return BYTES_REAL * num_steps * num_cells * len(self.fields)
-
-
-class AbstractMediumPropertyMonitor(FreqMonitor, ABC):
-    """:class:`Monitor` that records material properties in the frequency domain."""
-
-    colocate: Literal[False] = Field(
-        False,
-        title="Colocate Fields",
-        description="Colocation turned off, since colocated medium property values do not have a "
-        "physical meaning - they do not correspond to the subpixel-averaged ones.",
-    )
-
-    interval_space: tuple[PositiveInt, PositiveInt, PositiveInt] = Field(
-        (1, 1, 1),
-        title="Spatial Interval",
-        description="Number of grid step intervals between monitor recordings. If equal to 1, "
-        "there will be no downsampling. If greater than 1, the step will be applied, but the "
-        "first and last point of the monitor grid are always included.",
-    )
-
-    apodization: ApodizationSpec = Field(
-        default_factory=ApodizationSpec,
-        title="Apodization Specification",
-        description="This field is ignored in this monitor.",
-    )
-
-
-class MediumMonitor(AbstractMediumPropertyMonitor):
-    """:class:`Monitor` that records the diagonal components of the complex-valued relative
-    permittivity and permeability tensor in the frequency domain. The recorded data has the same shape as a
-    :class:`.FieldMonitor` of the same geometry: the permittivity and permeability values are saved at the
-    Yee grid locations, and can be interpolated to any point inside the monitor.
-
-    Notes
-    -----
-
-        If 2D materials are present, then the permittivity values correspond to the
-        volumetric equivalent of the 2D materials.
-
-        .. TODO add links to relevant areas
-
-    Example
-    -------
-    >>> monitor = MediumMonitor(
-    ...     center=(1,2,3),
-    ...     size=(2,2,2),
-    ...     freqs=[250e12, 300e12],
-    ...     name='medium_monitor')
-    """
-
-    def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
-        """Size of monitor storage given the number of points after discretization."""
-        # stores 6 complex number per grid cell, per frequency
-        return BYTES_COMPLEX * num_cells * len(self.freqs) * 6
 
 
 class AbstractMediumPropertyMonitor(FreqMonitor, ABC):
@@ -944,7 +892,8 @@ class FieldProjectionSurface(Tidy3dBaseModel):
         return self.monitor.size.index(0.0)
 
     @field_validator("monitor")
-    def is_plane(val):
+    @classmethod
+    def is_plane(cls, val):
         """Ensures that the monitor is a plane, i.e., its ``size`` attribute has exactly 1 zero"""
         size = val.size
         if size.count(0.0) != 1:
@@ -1031,7 +980,8 @@ class AbstractFieldProjectionMonitor(SurfaceIntegrationMonitor, FreqMonitor):
         return self
 
     @field_validator("window_size")
-    def window_size_leq_one(val, info):
+    @classmethod
+    def window_size_leq_one(cls, val, info):
         """Ensures that each component of the window size is less than or equal to 1."""
         if val[0] > 1 or val[1] > 1:
             raise ValidationError(
@@ -1618,7 +1568,8 @@ class DiffractionMonitor(PlanarMonitor, FreqMonitor):
     )
 
     @field_validator("size")
-    def diffraction_monitor_size(val):
+    @classmethod
+    def diffraction_monitor_size(cls, val):
         """Ensure that the monitor is infinite in the transverse direction."""
         if val.count(inf) != 2:
             raise SetupError(

--- a/tidy3d/components/nonlinear.py
+++ b/tidy3d/components/nonlinear.py
@@ -6,14 +6,12 @@ from abc import ABC
 from typing import TYPE_CHECKING, Optional, Union
 
 import autograd.numpy as np
-from pydantic import NonNegativeFloat, PositiveFloat, Field, PositiveInt, field_validator
+from pydantic import Field, NonNegativeFloat, PositiveFloat, PositiveInt, field_validator
 
 from tidy3d.constants import MICROMETER, SECOND, VOLT, WATT
 from tidy3d.exceptions import SetupError, ValidationError
 
 from .base import Tidy3dBaseModel
-
-from tidy3d.log import log
 
 if TYPE_CHECKING:
     from .medium import AbstractMedium
@@ -122,7 +120,8 @@ class NonlinearSusceptibility(NonlinearModel):
     )
 
     @field_validator("numiters")
-    def _validate_numiters(val):
+    @classmethod
+    def _validate_numiters(cls, val):
         """Check that numiters is not too large."""
         if val is None:
             return val
@@ -363,7 +362,8 @@ class NonlinearSpec(ABC, Tidy3dBaseModel):
     )
 
     @field_validator("models")
-    def _no_duplicate_models(val):
+    @classmethod
+    def _no_duplicate_models(cls, val):
         """Ensure each type of model appears at most once."""
         if val is None:
             return val
@@ -378,7 +378,8 @@ class NonlinearSpec(ABC, Tidy3dBaseModel):
         return val
 
     @field_validator("num_iters")
-    def _validate_num_iters(val):
+    @classmethod
+    def _validate_num_iters(cls, val):
         """Check that num_iters is not too large."""
         if val > NONLINEAR_MAX_NUM_ITERS:
             raise ValidationError(
@@ -396,6 +397,7 @@ class NonlinearSpec(ABC, Tidy3dBaseModel):
         return fields
 
     @field_validator("models")
+    @classmethod
     def _consistent_models(cls, val):
         """Ensure that parameters shared between models are consistent."""
         if val is None:

--- a/tidy3d/components/parameter_perturbation.py
+++ b/tidy3d/components/parameter_perturbation.py
@@ -15,6 +15,7 @@ from tidy3d.components.types.base import ArrayComplex, ArrayFloat, discriminated
 from tidy3d.constants import C_0, CMCUBE, EPSILON_0, HERTZ, KELVIN, PERCMCUBE, inf
 from tidy3d.exceptions import DataError
 from tidy3d.log import log
+
 from .base import Tidy3dBaseModel, cached_property
 from .data.data_array import (
     ChargeDataArray,

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -15,7 +15,6 @@ except ImportError:
 from pydantic import Field, NonNegativeInt, field_validator
 
 from tidy3d.compat import Self
-
 from tidy3d.components.material.tcad.charge import (
     ChargeConductorMedium,
     SemiconductorMedium,
@@ -45,9 +44,6 @@ from .geometry.base import Box, ClipOperation, GeometryGroup
 from .geometry.utils import flatten_groups, merging_geometries_on_plane, traverse_geometries
 from .grid.grid import Coords, Grid
 from .material.multi_physics import MultiPhysicsMedium
-from .material.tcad.charge import ChargeConductorMedium, SemiconductorMedium
-from .material.tcad.heat import SolidMedium, SolidSpec
-from .material.types import MultiPhysicsMediumType3D, StructureMediumType
 from .medium import (
     AbstractCustomMedium,
     AbstractMedium,
@@ -56,8 +52,6 @@ from .medium import (
     Medium2D,
 )
 from .structure import Structure
-from .tcad.doping import ConstantDoping, GaussianDoping
-from .tcad.viz import HEAT_SOURCE_CMAP
 from .types import (
     TYPE_TAG_STR,
     Ax,
@@ -165,7 +159,8 @@ class Scene(Tidy3dBaseModel):
     _unique_structure_names = assert_unique_names("structures")
 
     @field_validator("structures")
-    def _validate_mediums(val):
+    @classmethod
+    def _validate_mediums(cls, val):
         """Error if too many mediums present. Warn if different mediums have the same name."""
 
         if val is None:
@@ -189,7 +184,8 @@ class Scene(Tidy3dBaseModel):
         return val
 
     @field_validator("structures")
-    def _validate_num_geometries(val):
+    @classmethod
+    def _validate_num_geometries(cls, val):
         """Error if too many geometries in a single structure."""
 
         if val is None:
@@ -212,6 +208,7 @@ class Scene(Tidy3dBaseModel):
         return val
 
     @field_validator("structures")
+    @classmethod
     def _validate_structures_per_medium(cls, val):
         """Error if too many structures share the same medium; suggest using GeometryGroup."""
         if val is None:

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -10,10 +10,6 @@ from os import PathLike
 from typing import Any, Literal, Optional, Union, get_args
 
 import autograd.numpy as np
-
-from tidy3d.components.microwave.mode_spec import MicrowaveModeSpec
-
-from .types.monitor import MonitorType
 import xarray as xr
 from pydantic import (
     Field,
@@ -25,6 +21,7 @@ from pydantic import (
 )
 
 from tidy3d.compat import Self
+from tidy3d.components.microwave.mode_spec import MicrowaveModeSpec
 from tidy3d.components.types.base import discriminated_union
 from tidy3d.constants import C_0, SECOND, fp_eps, inf
 from tidy3d.exceptions import SetupError, Tidy3dError, Tidy3dImportError, ValidationError
@@ -127,6 +124,7 @@ from .types import (
     PermittivityComponent,
     Symmetry,
 )
+from .types.monitor import MonitorType
 from .validators import (
     assert_objects_contained_in_sim_bounds,
     assert_objects_in_sim_bounds,
@@ -323,7 +321,6 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         ", or ``False`` to apply staircasing.",
     )
 
-
     """
     Supply :class:`.SubpixelSpec` to select subpixel averaging methods separately for dielectric, metal, and
     PEC material interfaces. Alternatively, supply ``True`` to use default subpixel averaging methods,
@@ -368,13 +365,11 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         *  `Dielectric constant assignment on Yee grids <https://www.flexcompute.com/fdtd101/Lecture-9-Dielectric-constant-assignment-on-Yee-grids/>`_
     """
 
-    simulation_type: Optional[Literal["autograd_fwd", "autograd_bwd", "tidy3d", None]] = (
-        Field(
-            "tidy3d",
-            title="Simulation Type",
-            description="Tag used internally to distinguish types of simulations for "
-            "``autograd`` gradient processing.",
-        )
+    simulation_type: Optional[Literal["autograd_fwd", "autograd_bwd", "tidy3d", None]] = Field(
+        "tidy3d",
+        title="Simulation Type",
+        description="Tag used internally to distinguish types of simulations for "
+        "``autograd`` gradient processing.",
     )
 
     post_norm: Union[float, FreqDataArray] = Field(
@@ -392,7 +387,8 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
     )
 
     @field_validator("simulation_type")
-    def _validate_simulation_type_tidy3d(val):
+    @classmethod
+    def _validate_simulation_type_tidy3d(cls, val):
         """Enforce the simulation_type is 'tidy3d' if passed as None for bkwrds compatibility."""
         return "tidy3d" if val is None else val
 
@@ -2955,7 +2951,8 @@ class Simulation(AbstractYeeGridSimulation):
     """ Validating setup """
 
     @model_validator(mode="before")
-    def _update_simulation(data):
+    @classmethod
+    def _update_simulation(cls, data):
         """Update the simulation if it is an earlier version."""
 
         # if no version, assume it's already updated
@@ -3231,7 +3228,7 @@ class Simulation(AbstractYeeGridSimulation):
 
         return self
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def _validate_frequency_mode_abc(self):
         """Warn if ModeABCBoundary expects a frequency from a source, but there are multiple sources with different central frequencies."""
 
@@ -3272,7 +3269,7 @@ class Simulation(AbstractYeeGridSimulation):
 
         return self
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def _validate_absorber_in_zero_dims(self):
         """Error if internal absorber is oriented along zero size dim."""
         val = self.internal_absorbers
@@ -3289,7 +3286,8 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @field_validator("sources")
-    def _validate_num_sources(val):
+    @classmethod
+    def _validate_num_sources(cls, val):
         """Error if too many sources present."""
 
         if val is None:
@@ -3305,7 +3303,8 @@ class Simulation(AbstractYeeGridSimulation):
         return val
 
     @field_validator("structures")
-    def _validate_2d_geometry_has_2d_medium(val):
+    @classmethod
+    def _validate_2d_geometry_has_2d_medium(cls, val):
         """Warn if a geometry bounding box has zero size in a certain dimension."""
 
         if val is None:
@@ -3330,7 +3329,8 @@ class Simulation(AbstractYeeGridSimulation):
         return val
 
     @field_validator("structures")
-    def _validate_incompatible_material_intersections(val):
+    @classmethod
+    def _validate_incompatible_material_intersections(cls, val):
         """Check for intersections of incompatible materials."""
         structures = val
         incompatible_indices = []
@@ -3616,7 +3616,7 @@ class Simulation(AbstractYeeGridSimulation):
 
         return mediums
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def _abc_boundaries_homogeneous(self):
         """Error if abc boundaries intersect multiple mediums or anisotropic mediums."""
         val = self.boundary_spec
@@ -3668,7 +3668,7 @@ class Simulation(AbstractYeeGridSimulation):
 
     @field_validator("monitors")
     @classmethod
-    def _projection_direction(cls, val, values):
+    def _projection_direction(cls, val):
         """Warn if field projection observation points are behind surface projection monitors."""
         # This validator is in simulation.py rather than monitor.py because volume monitors are
         # eventually converted to their bounding surface projection monitors, in which case we
@@ -5832,19 +5832,19 @@ class Simulation(AbstractYeeGridSimulation):
 
     def padded_copy(
         self,
-        x: Optional[tuple[pydantic.NonNegativeFloat, pydantic.NonNegativeFloat]] = None,
-        y: Optional[tuple[pydantic.NonNegativeFloat, pydantic.NonNegativeFloat]] = None,
-        z: Optional[tuple[pydantic.NonNegativeFloat, pydantic.NonNegativeFloat]] = None,
+        x: Optional[tuple[NonNegativeFloat, NonNegativeFloat]] = None,
+        y: Optional[tuple[NonNegativeFloat, NonNegativeFloat]] = None,
+        z: Optional[tuple[NonNegativeFloat, NonNegativeFloat]] = None,
     ) -> Simulation:
         """Created a copy of simulation with padded simulation domain.
 
         Parameters
         ----------
-        x : Optional[tuple[pydantic.NonNegativeFloat, pydantic.NonNegativeFloat]] = None
+        x : Optional[tuple[NonNegativeFloat, NonNegativeFloat]] = None
             Padding sizes at the left and right boundaries of the simulation along x-axis.
-        y : Optional[tuple[pydantic.NonNegativeFloat, pydantic.NonNegativeFloat]] = None
+        y : Optional[tuple[NonNegativeFloat, NonNegativeFloat]] = None
             Padding sizes at the left and right boundaries of the simulation along y-axis.
-        z : Optional[tuple[pydantic.NonNegativeFloat, pydantic.NonNegativeFloat]] = None
+        z : Optional[tuple[NonNegativeFloat, NonNegativeFloat]] = None
             Padding sizes at the left and right boundaries of the simulation along z-axis.
 
         Returns
@@ -5858,12 +5858,12 @@ class Simulation(AbstractYeeGridSimulation):
 
         return self.updated_copy(size=padded_box.size, center=padded_box.center)
 
-    def uniformly_padded_copy(self, padding: pydantic.NonNegativeFloat) -> Simulation:
+    def uniformly_padded_copy(self, padding: NonNegativeFloat) -> Simulation:
         """Create copy of simulation with uniformly padded simulation domain.
 
         Parameters
         ----------
-        padding : pydantic.NonNegativeFloat
+        padding : NonNegativeFloat
             Padding size applied uniformly at all simulation boundaries.
 
         Returns

--- a/tidy3d/components/source/base.py
+++ b/tidy3d/components/source/base.py
@@ -62,7 +62,8 @@ class Source(Box, AbstractSource, ABC):
     _warn_traced_size = _warn_unsupported_traced_argument("size")
 
     @field_validator("source_time")
-    def _freqs_lower_bound(val):
+    @classmethod
+    def _freqs_lower_bound(cls, val):
         """Raise validation error if central frequency is too low."""
         _assert_min_freq(val._freq0_sigma_centroid, msg_start="'source_time.freq0'")
         return val

--- a/tidy3d/components/source/field.py
+++ b/tidy3d/components/source/field.py
@@ -290,7 +290,8 @@ class AngledFieldSource(DirectionalSource, ABC):
     )
 
     @field_validator("angle_theta")
-    def glancing_incidence(val):
+    @classmethod
+    def glancing_incidence(cls, val):
         """Warn if close to glancing incidence."""
         if np.abs(np.pi / 2 - val) < GLANCING_CUTOFF:
             log.warning(

--- a/tidy3d/components/source/time.py
+++ b/tidy3d/components/source/time.py
@@ -479,7 +479,8 @@ class CustomSourceTime(Pulse):
     _source_time_dataset_none_warning = warn_if_dataset_none("source_time_dataset")
 
     @field_validator("source_time_dataset")
-    def _more_than_one_time(val):
+    @classmethod
+    def _more_than_one_time(cls, val):
         """Must have more than one time to interpolate."""
         if val is None:
             return val

--- a/tidy3d/components/spice/analysis/ac.py
+++ b/tidy3d/components/spice/analysis/ac.py
@@ -43,6 +43,7 @@ class AbstractSSACAnalysis(Tidy3dBaseModel, ABC):
     )
 
     @field_validator("freqs")
+    @classmethod
     def validate_freqs(cls, val):
         if len(val) == 0:
             raise ValueError("'freqs' cannot be empty (size 0).")

--- a/tidy3d/components/spice/sources/ac.py
+++ b/tidy3d/components/spice/sources/ac.py
@@ -54,6 +54,7 @@ class SSACVoltageSource(Tidy3dBaseModel):
     )
 
     @field_validator("voltage")
+    @classmethod
     def validate_voltage(cls, val):
         for v in val:
             if v == td_inf:
@@ -61,6 +62,7 @@ class SSACVoltageSource(Tidy3dBaseModel):
         return val
 
     @field_validator("amplitude")
+    @classmethod
     def validate_amplitude(cls, val):
         if val == td_inf:
             raise ValueError(f"Signal amplitude must be finite. Current amplitude={val}.")

--- a/tidy3d/components/spice/sources/dc.py
+++ b/tidy3d/components/spice/sources/dc.py
@@ -65,7 +65,8 @@ class DCVoltageSource(Tidy3dBaseModel):
     units: Literal[VOLT] = VOLT
 
     @field_validator("voltage")
-    def check_voltage(val):
+    @classmethod
+    def check_voltage(cls, val):
         for v in val:
             if v == inf:
                 raise ValueError(f"Voltages must be finite. Currently  voltage={val}.")

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -120,7 +120,8 @@ class AbstractStructure(Tidy3dBaseModel):
     _name_validator = validate_name_str()
 
     @field_validator("geometry")
-    def _transformed_slanted_polyslabs_not_allowed(val):
+    @classmethod
+    def _transformed_slanted_polyslabs_not_allowed(cls, val):
         """Prevents the creation of slanted polyslabs rotated out of plane."""
         validate_no_transformed_polyslabs(val)
         return val
@@ -713,7 +714,8 @@ class MeshOverrideStructure(AbstractStructure):
     )
 
     @field_validator("geometry")
-    def _box_only(val):
+    @classmethod
+    def _box_only(cls, val):
         """Ensure this is a box."""
         if isinstance(val, Geometry):
             if not isinstance(val, Box):

--- a/tidy3d/components/tcad/data/monitor_data/charge.py
+++ b/tidy3d/components/tcad/data/monitor_data/charge.py
@@ -374,7 +374,6 @@ class SteadyElectricFieldData(HeatChargeMonitorData):
         """Maps the field components to their associated data."""
         return {"E": self.E}
 
-
     @model_validator(mode="after")
     def check_correct_data_type(self):
         """Issue error if incorrect data type is used"""

--- a/tidy3d/components/tcad/data/monitor_data/heat.py
+++ b/tidy3d/components/tcad/data/monitor_data/heat.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from pydantic import Field, model_validator
+from pydantic import Field
 
 from tidy3d.components.data.data_array import (
     DataArray,
-    IndexedDataArray,
-    IndexedTimeDataArray,
     ScalarFieldTimeDataArray,
     SpatialDataArray,
 )

--- a/tidy3d/components/tcad/data/sim_data.py
+++ b/tidy3d/components/tcad/data/sim_data.py
@@ -483,7 +483,8 @@ class HeatSimulationData(HeatChargeSimulationData):
     )
 
     @model_validator(mode="before")
-    def issue_warning_deprecated(data):
+    @classmethod
+    def issue_warning_deprecated(cls, data):
         """Issue warning for 'HeatSimulations'."""
         log.warning(
             "'HeatSimulationData' is deprecated and will be discontinued. Use "

--- a/tidy3d/components/tcad/doping.py
+++ b/tidy3d/components/tcad/doping.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import Union
 
 import numpy as np
-from pydantic import Field, NonNegativeFloat, PositiveFloat, model_validator
 import xarray as xr
+from pydantic import Field, NonNegativeFloat, PositiveFloat, model_validator
 
 from tidy3d.components.autograd import TracedSize
 from tidy3d.components.base import cached_property

--- a/tidy3d/components/tcad/generation_recombination.py
+++ b/tidy3d/components/tcad/generation_recombination.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Literal, Union
 
 import numpy as np
-
 from pydantic import Field, PositiveFloat, model_validator
 
 from tidy3d.components.base import Tidy3dBaseModel

--- a/tidy3d/components/tcad/grid.py
+++ b/tidy3d/components/tcad/grid.py
@@ -97,7 +97,8 @@ class GridRefinementLine(Tidy3dBaseModel, ABC):
     )
 
     @field_validator("r1", "r2")
-    def _not_inf(val, info):
+    @classmethod
+    def _not_inf(cls, val):
         """Make sure the point is not infinitiy."""
         if any(np.isinf(v) for v in val):
             raise ValidationError("Point can not contain 'td.inf' terms.")

--- a/tidy3d/components/tcad/monitors/mesh.py
+++ b/tidy3d/components/tcad/monitors/mesh.py
@@ -22,7 +22,8 @@ class VolumeMeshMonitor(HeatChargeMonitor):
     )
 
     @field_validator("size")
-    def _at_least_2d(val):
+    @classmethod
+    def _at_least_2d(cls, val):
         """Validate that the monitor has at least two non-zero dimensions."""
         if len([d for d in val if isclose(d, 0)]) > 1:
             raise ValueError("'VolumeMeshMonitor' must have at least two nonzero dimensions.")

--- a/tidy3d/components/tcad/simulation/heat.py
+++ b/tidy3d/components/tcad/simulation/heat.py
@@ -48,7 +48,8 @@ class HeatSimulation(HeatChargeSimulation):
     """
 
     @model_validator(mode="before")
-    def issue_warning_deprecated(data):
+    @classmethod
+    def issue_warning_deprecated(cls, data):
         """Issue warning for 'HeatSimulations'."""
         log.warning(
             "Setting up deprecated 'HeatSimulation'. "

--- a/tidy3d/components/tcad/simulation/heat_charge.py
+++ b/tidy3d/components/tcad/simulation/heat_charge.py
@@ -326,7 +326,8 @@ class HeatChargeSimulation(AbstractSimulation):
     )
 
     @field_validator("structures")
-    def check_unsupported_geometries(val):
+    @classmethod
+    def check_unsupported_geometries(cls, val):
         """Error if structures contain unsupported yet geometries."""
         for ind, structure in enumerate(val):
             bbox = structure.geometry.bounding_box
@@ -450,6 +451,7 @@ class HeatChargeSimulation(AbstractSimulation):
         return self
 
     @field_validator("boundary_spec")
+    @classmethod
     def check_single_ssac(cls, boundary_spec):
         ssac_present = False
         for bc in boundary_spec:
@@ -540,7 +542,8 @@ class HeatChargeSimulation(AbstractSimulation):
         return self
 
     @field_validator("size")
-    def check_zero_dim_domain(val):
+    @classmethod
+    def check_zero_dim_domain(cls, val):
         """Error if heat domain have zero dimensions."""
 
         dim_names = ["x", "y", "z"]
@@ -596,6 +599,7 @@ class HeatChargeSimulation(AbstractSimulation):
         return self
 
     @field_validator("boundary_spec")
+    @classmethod
     def check_only_one_voltage_array_provided(cls, val):
         """Issue error if more than one voltage array is provided.
         Currently we only allow to sweep over one voltage array.
@@ -938,7 +942,6 @@ class HeatChargeSimulation(AbstractSimulation):
         max_nodes = 2e6
         nodes_estimate = 0
 
-        structures = self.structures
         grid_spec = self.grid_spec
 
         non_refined_structures = grid_spec.non_refined_structures

--- a/tidy3d/components/tcad/source/abstract.py
+++ b/tidy3d/components/tcad/source/abstract.py
@@ -33,7 +33,8 @@ class StructureBasedHeatChargeSource(AbstractHeatChargeSource):
     )
 
     @field_validator("structures")
-    def check_non_empty_structures(val):
+    @classmethod
+    def check_non_empty_structures(cls, val):
         """Error if source doesn't point at any structures."""
         if len(val) == 0:
             raise SetupError("List of structures for heat source is empty.")

--- a/tidy3d/components/tcad/source/heat.py
+++ b/tidy3d/components/tcad/source/heat.py
@@ -40,7 +40,8 @@ class UniformHeatSource(HeatSource):
     # NOTE: wrapper for backwards compatibility.
 
     @model_validator(mode="before")
-    def issue_warning_deprecated(data):
+    @classmethod
+    def issue_warning_deprecated(cls, data):
         """Issue warning for 'UniformHeatSource'."""
         log.warning(
             "'UniformHeatSource' is deprecated and will be discontinued. You can use "

--- a/tidy3d/components/time_modulation.py
+++ b/tidy3d/components/time_modulation.py
@@ -152,7 +152,8 @@ class SpaceModulation(AbstractSpaceModulation):
     _no_nans = validate_no_nans("amplitude", "phase")
 
     @field_validator("amplitude", "phase")
-    def _validate_fields_real(val, info):
+    @classmethod
+    def _validate_fields_real(cls, val, info):
         """Assert that the amplitude is real."""
         if np.iscomplexobj(val):
             raise ValidationError(f"'{info.field_name}' must be real.")

--- a/tidy3d/components/transformation.py
+++ b/tidy3d/components/transformation.py
@@ -89,7 +89,8 @@ class RotationAroundAxis(AbstractRotation):
     )
 
     @field_validator("axis")
-    def _validate_axis_vector(val):
+    @classmethod
+    def _validate_axis_vector(cls, val):
         if not isinstance(val, tuple):
             axis = [0.0, 0.0, 0.0]
             axis[val] = 1.0
@@ -97,7 +98,8 @@ class RotationAroundAxis(AbstractRotation):
         return val
 
     @field_validator("axis")
-    def _validate_axis_nonzero_norm(val):
+    @classmethod
+    def _validate_axis_nonzero_norm(cls, val):
         norm = np.linalg.norm(val)
         if np.isclose(norm, 0):
             raise ValidationError(
@@ -182,7 +184,8 @@ class ReflectionFromPlane(AbstractReflection):
     )
 
     @field_validator("normal")
-    def _validate_normal_nonzero_norm(val):
+    @classmethod
+    def _validate_normal_nonzero_norm(cls, val):
         norm = np.linalg.norm(val)
         if np.isclose(norm, 0):
             raise ValidationError(

--- a/tidy3d/components/validators.py
+++ b/tidy3d/components/validators.py
@@ -14,7 +14,6 @@ from tidy3d.log import log
 from .autograd.utils import get_static, hasbox
 from .base import DATA_ARRAY_MAP
 from .geometry.base import Box
-from .mode_spec import ModeSpec
 
 """ Explanation of pydantic validators:
 
@@ -108,6 +107,7 @@ def assert_volumetric():
     """makes sure a field's ``size`` attribute has no zero entry"""
 
     @field_validator("size")
+    @classmethod
     def is_volumetric(cls, val):
         """Raise validation error if volume is 0."""
         if val.count(0.0) > 0:
@@ -126,7 +126,8 @@ def validate_name_str():
     """make sure the name does not include [, ] (used for default names)"""
 
     @field_validator("name")
-    def field_has_unique_names(val):
+    @classmethod
+    def field_has_unique_names(cls, val):
         """raise exception if '[' or ']' in name"""
         # if val and ('[' in val or ']' in val):
         #     raise SetupError(f"'[' or ']' not allowed in name: {val} (used for defaults)")
@@ -139,7 +140,8 @@ def validate_unique(*field_names: str):
     """Make sure the given field has unique entries."""
 
     @field_validator(*field_names)
-    def field_has_unique_entries(val, info):
+    @classmethod
+    def field_has_unique_entries(cls, val, info):
         """Check if the field has unique entries."""
         if len(set(val)) != len(val):
             raise SetupError(f"Entries of '{info.field_name}' must be unique.")
@@ -183,7 +185,8 @@ def assert_unique_names(*field_names: str):
     """makes sure all elements of a field have unique .name values"""
 
     @field_validator(*field_names)
-    def field_has_unique_names(val, info):
+    @classmethod
+    def field_has_unique_names(cls, val, info):
         """make sure each element of val has a unique name (if specified)."""
         field_names = [field.name for field in val if field.name]
         unique_names = set(field_names)
@@ -299,7 +302,8 @@ def warn_if_dataset_none(field_name: str):
     """Warn if a Dataset field has None in its dictionary."""
 
     @field_validator(field_name, mode="before")
-    def _warn_if_none(val: dict) -> Optional[dict]:
+    @classmethod
+    def _warn_if_none(cls, val: dict) -> Optional[dict]:
         """Warn if the DataArrays fail to load."""
         if isinstance(val, dict):
             if any((v in DATA_ARRAY_MAP for _, v in val.items() if isinstance(v, str))):
@@ -384,7 +388,8 @@ def validate_parameter_perturbation(
     """Assert perturbations do not drive a parameter out of physical bounds."""
 
     @field_validator(field_name)
-    def _warn_perturbed_val_range(val, info):
+    @classmethod
+    def _warn_perturbed_val_range(cls, val, info):
         """Assert perturbations do not drive a parameter out of physical bounds."""
 
         if val is not None:

--- a/tidy3d/components/viz/visualization_spec.py
+++ b/tidy3d/components/viz/visualization_spec.py
@@ -51,11 +51,13 @@ class VisualizationSpec(Tidy3dBaseModel):
     )
 
     @field_validator("facecolor")
-    def _validate_facecolor(value: str) -> str:
+    @classmethod
+    def _validate_facecolor(cls, value: str) -> str:
         return is_valid_color(value)
 
     @field_validator("edgecolor")
-    def _ensure_edgecolor(value, info) -> str:
+    @classmethod
+    def _ensure_edgecolor(cls, value, info) -> str:
         # if no explicit edgecolor given, fall back to facecolor
         if (value == "") and "facecolor" in info.data:
             return is_valid_color(info.data["facecolor"])

--- a/tidy3d/config/sections.py
+++ b/tidy3d/config/sections.py
@@ -446,6 +446,7 @@ class LocalCacheConfig(ConfigSection):
     )
 
     @field_validator("directory", mode="before")
+    @classmethod
     def _ensure_directory_exists(cls, v: PathLike) -> Path:
         """Expand ~, resolve path, and create directory if missing before DirectoryPath validation."""
         p = Path(v).expanduser().resolve()

--- a/tidy3d/plugins/design/parameter.py
+++ b/tidy3d/plugins/design/parameter.py
@@ -26,7 +26,8 @@ class Parameter(Tidy3dBaseModel, ABC):
     )
 
     @field_validator("values")
-    def _values_unique(val):
+    @classmethod
+    def _values_unique(cls, val):
         """Supplied unique values."""
         if (val is not None) and (len(set(val)) != len(val)):
             raise ValueError("Supplied 'values' were not unique.")
@@ -64,7 +65,8 @@ class ParameterNumeric(Parameter, ABC):
     )
 
     @field_validator("span")
-    def _span_valid(val):
+    @classmethod
+    def _span_valid(cls, val):
         """Span min <= span max."""
         span_min, span_max = val
         if span_min > span_max:
@@ -102,7 +104,8 @@ class ParameterFloat(ParameterNumeric):
     )
 
     @field_validator("span")
-    def _span_is_float(val):
+    @classmethod
+    def _span_is_float(cls, val):
         """Make sure the span contains floats."""
         low, high = val
         return float(low), float(high)
@@ -142,7 +145,8 @@ class ParameterInt(ParameterNumeric):
     )
 
     @field_validator("span")
-    def _span_is_int(val):
+    @classmethod
+    def _span_is_int(cls, val):
         """Make sure the span contains ints."""
         low, high = val
         return int(low), int(high)
@@ -178,13 +182,15 @@ class ParameterAny(Parameter):
     )
 
     @field_validator("allowed_values")
-    def _given_any_allowed_values(val):
+    @classmethod
+    def _given_any_allowed_values(cls, val):
         """Need at least one allowed value."""
         if not len(val):
             raise ValueError("Given empty tuple of allowed values. Must have at least one.")
         return val
 
     @field_validator("allowed_values")
+    @classmethod
     def _no_duplicate_allowed_values(cls, val):
         """No duplicates in allowed_values."""
         if len(val) != len(set(val)):

--- a/tidy3d/plugins/dispersion/fit.py
+++ b/tidy3d/plugins/dispersion/fit.py
@@ -53,7 +53,8 @@ class DispersionFitter(Tidy3dBaseModel):
     )
 
     @field_validator("wvl_um")
-    def _setup_wvl(val):
+    @classmethod
+    def _setup_wvl(cls, val):
         """Convert wvl_um to a numpy array."""
         if val.size == 0:
             raise ValidationError("Wavelength data cannot be empty.")

--- a/tidy3d/plugins/dispersion/web.py
+++ b/tidy3d/plugins/dispersion/web.py
@@ -348,7 +348,8 @@ class StableDispersionFitter(DispersionFitter):
     """Deprecated."""
 
     @model_validator(mode="before")
-    def _deprecate_stable_fitter(data):
+    @classmethod
+    def _deprecate_stable_fitter(cls, data):
         log.warning(
             "'StableDispersionFitter' has been deprecated. Use 'DispersionFitter' with "
             "'tidy3d.plugins.dispersion.web.run' to access the stable fitter from the web server."

--- a/tidy3d/plugins/invdes/design.py
+++ b/tidy3d/plugins/invdes/design.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import abc
-from typing import Callable, Optional, Union
-from typing import Any
+from typing import Any, Callable, Optional, Union
 
 import autograd.numpy as anp
 import numpy as np
@@ -132,6 +131,7 @@ class InverseDesign(AbstractInverseDesign):
     )
 
     @field_validator("output_monitor_names", mode="before")
+    @classmethod
     def _convert_list_to_tuple(cls, v):
         """Convert list to tuple for output_monitor_names."""
         if isinstance(v, list):
@@ -272,6 +272,7 @@ class InverseDesignMulti(AbstractInverseDesign):
     )
 
     @field_validator("output_monitor_names", mode="before")
+    @classmethod
     def _convert_list_to_tuple(cls, v):
         """Convert lists to tuples for output_monitor_names."""
         if v is None:

--- a/tidy3d/plugins/invdes/initialization.py
+++ b/tidy3d/plugins/invdes/initialization.py
@@ -89,14 +89,16 @@ class CustomInitializationSpec(AbstractInitializationSpec):
     )
 
     @field_validator("params")
-    def _validate_params_range(val):
+    @classmethod
+    def _validate_params_range(cls, val):
         """Ensure that all parameter values are between 0 and 1."""
         if np.any((val < 0) | (val > 1)):
             raise ValidationError("'params' need to be between 0 and 1.")
         return val
 
     @field_validator("params")
-    def _validate_params_dtype(val):
+    @classmethod
+    def _validate_params_dtype(cls, val):
         """Ensure that params is real-valued."""
         if np.issubdtype(val.dtype, np.bool_):
             td.log.warning(
@@ -108,7 +110,8 @@ class CustomInitializationSpec(AbstractInitializationSpec):
         return val
 
     @field_validator("params")
-    def _validate_params_3d(val):
+    @classmethod
+    def _validate_params_3d(cls, val):
         """Ensure that params is a 3D array."""
         if val.ndim != 3:
             raise ValidationError(f"'params' must be 3D, but got {val.ndim}D.")

--- a/tidy3d/plugins/invdes/region.py
+++ b/tidy3d/plugins/invdes/region.py
@@ -69,7 +69,8 @@ class DesignRegion(InvdesBaseModel, abc.ABC):
     )
 
     @field_validator("eps_bounds")
-    def _validate_ge_one(v):
+    @classmethod
+    def _validate_ge_one(cls, v):
         if any(vi < 1 for vi in v):
             raise ValueError("Each value in 'eps_bounds' must be '>=1.0'.")
         return v

--- a/tidy3d/plugins/invdes/result.py
+++ b/tidy3d/plugins/invdes/result.py
@@ -67,7 +67,8 @@ class InverseDesignResult(InvdesBaseModel):
     )
 
     @field_validator("params")
-    def _validate_and_clip_params(params_tuple):
+    @classmethod
+    def _validate_and_clip_params(cls, params_tuple):
         """Ensure all parameters in history are within [0,1] bounds, clipping if necessary."""
         if not params_tuple:
             return params_tuple

--- a/tidy3d/plugins/klayout/drc/drc.py
+++ b/tidy3d/plugins/klayout/drc/drc.py
@@ -53,6 +53,7 @@ class DRCConfig(Tidy3dBaseModel):
     )
 
     @field_validator("gdsfile")
+    @classmethod
     def _validate_gdsfile_filetype(cls, v: FilePath) -> FilePath:
         """Check GDS filetype is ``.gds``."""
         if v.suffix != ".gds":
@@ -60,6 +61,7 @@ class DRCConfig(Tidy3dBaseModel):
         return v
 
     @field_validator("drc_runset")
+    @classmethod
     def _validate_drc_runset_filetype(cls, v: FilePath) -> FilePath:
         """Check DRC runset filetype is ``.drc`` or ``.lydrc``."""
         if v.suffix not in SUPPORTED_DRC_SUFFIXES:
@@ -69,6 +71,7 @@ class DRCConfig(Tidy3dBaseModel):
         return v
 
     @field_validator("drc_runset")
+    @classmethod
     def _validate_drc_runset_format(cls, v: FilePath) -> FilePath:
         """Check if the DRC runset file is formatted correctly.
         The checks are:
@@ -88,6 +91,7 @@ class DRCConfig(Tidy3dBaseModel):
         return v
 
     @field_validator("drc_args", mode="before")
+    @classmethod
     def _validate_drc_args_stringable(cls, v: Any) -> dict[str, str]:
         """Coerce all keys and values in drc_args to strings."""
         if v is None:
@@ -101,6 +105,7 @@ class DRCConfig(Tidy3dBaseModel):
         return v
 
     @field_validator("drc_args")
+    @classmethod
     def _validate_drc_args_reserved(cls, v: dict[str, str]) -> dict[str, str]:
         """Ensure user arguments do not override the reserved keys."""
 

--- a/tidy3d/plugins/microwave/array_factor.py
+++ b/tidy3d/plugins/microwave/array_factor.py
@@ -6,11 +6,18 @@ from abc import ABC, abstractmethod
 from typing import Optional, Union
 
 import numpy as np
-from pydantic import Field, NonNegativeFloat, PositiveFloat, PositiveInt, field_validator, model_validator, conint
+from pydantic import (
+    Field,
+    NonNegativeFloat,
+    PositiveFloat,
+    PositiveInt,
+    conint,
+    field_validator,
+    model_validator,
+)
 from scipy.signal.windows import blackman, blackmanharris, chebwin, hamming, hann, kaiser, taylor
 from scipy.special import j0, jn_zeros
 
-from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.data.monitor_data import AbstractFieldProjectionData, DirectivityData
 from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.geometry.base import Box, Geometry
@@ -753,6 +760,7 @@ class RectangularAntennaArrayCalculator(AbstractAntennaArrayCalculator):
     )
 
     @field_validator("array_size", "spacings", "phase_shifts", "amp_multipliers", mode="before")
+    @classmethod
     def _convert_list_to_tuple(cls, v):
         """Convert lists to tuples for tuple fields."""
         if isinstance(v, list):
@@ -1232,7 +1240,7 @@ class RectangularTaper(AbstractTaper):
         """
         return cls(window_x=window, window_y=window, window_z=window)
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def check_at_least_one_window(self):
         if not any([self.window_x, self.window_y, self.window_z]):
             raise ValueError("At least one window (x, y, or z) must be provided.")

--- a/tidy3d/plugins/microwave/custom_path_integrals.py
+++ b/tidy3d/plugins/microwave/custom_path_integrals.py
@@ -1,7 +1,6 @@
 """Backwards compatibility - import from tidy3d.components.microwave.path_integrals.integrals instead."""
 
 from __future__ import annotations
-from pydantic import Field, field_validator
 
 from tidy3d.components.data.data_array import (
     CurrentIntegralResultType,

--- a/tidy3d/plugins/microwave/lobe_measurer.py
+++ b/tidy3d/plugins/microwave/lobe_measurer.py
@@ -87,14 +87,16 @@ class LobeMeasurer(MicrowaveBaseModel):
     )
 
     @field_validator("angle")
-    def _sorted_angle(val):
+    @classmethod
+    def _sorted_angle(cls, val):
         """Ensure the angle array is sorted."""
         if not np.all(np.diff(val) >= 0):
             raise ValidationError("The angle array must be sorted in ascending order.")
         return val
 
     @field_validator("radiation_pattern")
-    def _nonnegative_radiation_pattern(val):
+    @classmethod
+    def _nonnegative_radiation_pattern(cls, val):
         """Ensure the radiation pattern is nonnegative."""
         if not np.all(val >= 0):
             raise ValidationError("Radiation pattern must be nonnegative.")

--- a/tidy3d/plugins/resonance/resonance.py
+++ b/tidy3d/plugins/resonance/resonance.py
@@ -109,7 +109,8 @@ class ResonanceFinder(Tidy3dBaseModel):
     )
 
     @field_validator("freq_window")
-    def _check_freq_window(val):
+    @classmethod
+    def _check_freq_window(cls, val):
         """Validate ``freq_window``"""
         if val[1] < val[0]:
             raise ValidationError(

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -100,24 +100,6 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
         "Otherwise, a default source time will be constructed.",
     )
 
-    run_only: Optional[tuple[IndexType, ...]] = Field(
-        None,
-        title="Run Only",
-        description="Set of matrix indices that define the simulations to run. "
-        "If ``None``, simulations will be run for all indices in the scattering matrix. "
-        "If a tuple is given, simulations will be run only for the given matrix indices.",
-    )
-
-    element_mappings: tuple[tuple[ElementType, ElementType, Complex], ...] = Field(
-        (),
-        title="Element Mappings",
-        description="Tuple of S matrix element mappings, each described by a tuple of "
-        "(input_element, output_element, coefficient), where the coefficient is the "
-        "element_mapping coefficient describing the relationship between the input and output "
-        "matrix element. If all elements of a given column of the scattering matrix are defined "
-        "by ``element_mappings``, the simulation corresponding to this column is skipped automatically.",
-    )
-
     @field_validator("simulation")
     @classmethod
     def _sim_has_no_sources(cls, val):

--- a/tidy3d/plugins/smatrix/component_modelers/modal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/modal.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Optional
 
 import autograd.numpy as np
-from pydantic import Field, NonNegativeInt, field_validator
+from pydantic import Field
 
 from tidy3d.components.base import cached_property
 from tidy3d.components.data.sim_data import SimulationData
@@ -179,7 +179,9 @@ class ModalComponentModeler(AbstractComponentModeler):
             name=port.name,
         )
 
-    def to_source(self, port: Port, mode_index: int, num_freqs: int = 1, **kwargs: Any) -> ModeSource:
+    def to_source(
+        self, port: Port, mode_index: int, num_freqs: int = 1, **kwargs: Any
+    ) -> ModeSource:
         """Creates a mode source from a given port.
 
         This source is used to excite a specific mode at the port.

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -179,24 +179,6 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         "by ``element_mappings``, the simulation corresponding to this column is skipped automatically.",
     )
 
-    run_only: Optional[tuple[NetworkIndex, ...]] = Field(
-        None,
-        title="Run Only",
-        description="Set of matrix indices that define the simulations to run. "
-        "If ``None``, simulations will be run for all indices in the scattering matrix. "
-        "If a tuple is given, simulations will be run only for the given matrix indices.",
-    )
-
-    element_mappings: tuple[tuple[NetworkElement, NetworkElement, Complex], ...] = Field(
-        (),
-        title="Element Mappings",
-        description="Tuple of S matrix element mappings, each described by a tuple of "
-        "(input_element, output_element, coefficient), where the coefficient is the "
-        "element_mapping coefficient describing the relationship between the input and output "
-        "matrix element. If all elements of a given column of the scattering matrix are defined "
-        "by ``element_mappings``, the simulation corresponding to this column is skipped automatically.",
-    )
-
     radiation_monitors: tuple[
         discriminated_union(Union[DirectivityMonitor, DirectivityMonitorSpec]), ...
     ] = Field(
@@ -232,6 +214,7 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
     )
 
     @model_validator(mode="before")
+    @classmethod
     def _warn_refactor_2_10(cls, values):
         log.warning(
             f"ℹ️ ⚠️ The {cls.__name__} class was refactored in tidy3d version 2.10. Migration documentation will be provided, and existing functionality can be accessed in a different way.",

--- a/tidy3d/plugins/smatrix/data/base.py
+++ b/tidy3d/plugins/smatrix/data/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Optional
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, model_validator
 
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.data.data_array import DataArray
@@ -53,7 +53,7 @@ class AbstractComponentModelerData(ABC, Tidy3dBaseModel):
 
         # It's good practice to handle cases where 'modeler' might not be present
         if not modeler or not hasattr(modeler, "sim_dict"):
-            return val
+            return self
 
         # Use sets for an order-insensitive comparison
         modeler_keys = set(modeler.sim_dict.keys())

--- a/tidy3d/plugins/smatrix/data/modal.py
+++ b/tidy3d/plugins/smatrix/data/modal.py
@@ -1,7 +1,6 @@
 """Data structures for post-processing modal component simulations to calculate S-matrices."""
 
 from __future__ import annotations
-from typing import Optional
 
 from pydantic import Field
 

--- a/tidy3d/plugins/smatrix/data/terminal.py
+++ b/tidy3d/plugins/smatrix/data/terminal.py
@@ -227,6 +227,7 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
         return self.change_port_reference_planes(self.smatrix(), port_shifts=port_shifts)
 
     @model_validator(mode="before")
+    @classmethod
     def _warn_rf_license(cls, values):
         log.warning(
             "ℹ️ ⚠️ RF simulations are subject to new license requirements in the future. You have instantiated at least one RF-specific component.",

--- a/tidy3d/plugins/smatrix/ports/base.py
+++ b/tidy3d/plugins/smatrix/ports/base.py
@@ -20,6 +20,7 @@ class AbstractBasePort(Tidy3dBaseModel, ABC):
     )
 
     @field_validator("name")
+    @classmethod
     def _valid_port_name(cls, val):
         """Make sure port name does not include the '@' symbol, so that task names will always be unique."""
         if "@" in val:

--- a/tidy3d/plugins/smatrix/ports/coaxial_lumped.py
+++ b/tidy3d/plugins/smatrix/ports/coaxial_lumped.py
@@ -87,7 +87,8 @@ class CoaxialLumpedPort(AbstractLumpedPort, AbstractAxesRH):
         return self.normal_axis
 
     @field_validator("center")
-    def _center_not_inf(val):
+    @classmethod
+    def _center_not_inf(cls, val):
         """Make sure center is not infinity."""
         if any(np.isinf(v) for v in val):
             raise ValidationError("'center' can not contain 'td.inf' terms.")

--- a/tidy3d/plugins/smatrix/ports/wave.py
+++ b/tidy3d/plugins/smatrix/ports/wave.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Optional, Union
 
-from pydantic import Field, NonNegativeInt, field_validator, model_validator, NonNegativeFloat
+from pydantic import Field, NonNegativeFloat, NonNegativeInt, field_validator, model_validator
 
 from tidy3d.components.base import cached_property
 from tidy3d.components.boundary import ABCBoundary, InternalAbsorber, ModeABCBoundary
@@ -343,6 +343,7 @@ class WavePort(AbstractTerminalPort, Box):
         return self
 
     @field_validator("mode_index")
+    @classmethod
     def _mode_index_deprecated(cls, val):
         """Warn that 'mode_index' is deprecated in favor of 'mode_selection'."""
         if val is not None:

--- a/tidy3d/plugins/waveguide/rectangular_dielectric.py
+++ b/tidy3d/plugins/waveguide/rectangular_dielectric.py
@@ -205,7 +205,8 @@ class RectangularDielectric(Tidy3dBaseModel):
     )
 
     @field_validator("wavelength", "core_width", "gap")
-    def _set_non_negative_array(val):
+    @classmethod
+    def _set_non_negative_array(cls, val):
         """Ensure values are not negative and convert to numpy arrays."""
         val = numpy.array(val, ndmin=1)
         if any(val < 0):
@@ -213,7 +214,8 @@ class RectangularDielectric(Tidy3dBaseModel):
         return val
 
     @field_validator("core_medium", "clad_medium", "box_medium")
-    def _check_non_metallic(val, info):
+    @classmethod
+    def _check_non_metallic(cls, val, info):
         if val is None:
             return val
         media = val if isinstance(val, tuple) else (val,)

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -9,11 +9,8 @@ from autograd.extend import defvjp, primitive
 
 import tidy3d as td
 from tidy3d.components.autograd import AutogradFieldMap
-from tidy3d.components.base import TRACED_FIELD_KEYS_ATTR
-from tidy3d.components.autograd.derivative_utils import DerivativeInfo
 from tidy3d.components.autograd.types import TracedDict
-from tidy3d.components.data.data_array import DataArray
-from tidy3d.components.grid.grid_spec import GridSpec
+from tidy3d.components.base import TRACED_FIELD_KEYS_ATTR
 from tidy3d.components.types.workflow import WorkflowDataType, WorkflowType
 from tidy3d.config import config
 from tidy3d.exceptions import AdjointError

--- a/tidy3d/web/api/autograd/utils.py
+++ b/tidy3d/web/api/autograd/utils.py
@@ -1,7 +1,7 @@
 # utility functions for autograd web API
 from __future__ import annotations
 
-from typing import Any, Union
+from typing import Union
 
 import numpy as np
 

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -600,7 +600,8 @@ class Job(WebContainer):
             parent_dir.mkdir(parents=True, exist_ok=True)
 
     @model_validator(mode="before")
-    def set_task_name_if_none(data: dict[str, Any]) -> dict[str, Any]:
+    @classmethod
+    def set_task_name_if_none(cls, data: dict[str, Any]) -> dict[str, Any]:
         """
         Auto-assign a task_name if user did not provide one.
         """

--- a/tidy3d/web/core/file_util.py
+++ b/tidy3d/web/core/file_util.py
@@ -82,6 +82,6 @@ def read_simulation_from_hdf5(file_name: os.PathLike) -> bytes:
 
 def read_simulation_from_json(file_name: os.PathLike) -> str:
     """read simulation str from json"""
-    with open(file_name, encoding='utf-8') as json_file:
+    with open(file_name, encoding="utf-8") as json_file:
         json_data = json_file.read()
     return json_data

--- a/tidy3d/web/core/task_core.py
+++ b/tidy3d/web/core/task_core.py
@@ -12,7 +12,7 @@ from typing import Callable, Optional, Union
 
 import requests
 from botocore.exceptions import ClientError
-from pydantic import Field, TypeAdapter, model_validator
+from pydantic import Field, TypeAdapter
 
 import tidy3d as td
 from tidy3d.config import config


### PR DESCRIPTION
Implemented the following improvements:
- field_validator has classmethod decorator everywhere consistently
- same goes for model_validator(mode="before")
- removed duplicate code that originated from erroneous rebase handling
- some additional improvements to satisfy mypy pre-commit hook
- formatting changes according to ruff

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR implements a systematic refactoring to ensure consistency with pydantic v2 requirements and improve type safety. The changes include:

- **Added `@classmethod` decorators** to all `field_validator` and `model_validator(mode="before")` decorators across 97 files for pydantic v2 compliance
- **Removed duplicate code** originating from erroneous rebase handling:
  - Removed duplicate `AbstractMediumPropertyMonitor` class definition in `monitor.py` (58 lines)
  - Removed duplicate field definitions (`run_only`, `element_mappings`) in smatrix component modelers (36 lines total)
- **Improved type annotations** for mypy compatibility:
  - Fixed `pydantic.NonNegativeFloat` references to use imported `NonNegativeFloat`
  - Removed duplicate `Literal` import in `base.py`
  - Cleaned up unused `typing_extensions.Self` imports
- **Cleaned up validator signatures** by removing unused `info` or `values` parameters where appropriate, while preserving them where needed
- **Code formatting improvements**: Fixed trailing whitespace, import ordering, and quote style consistency per ruff/black standards

All changes are mechanical refactoring with no behavioral modifications. The PR successfully addresses technical debt from the pydantic v2 migration.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk - it consists entirely of mechanical refactoring changes that improve code consistency
- The refactoring is systematic and follows clear patterns: adding @classmethod decorators for pydantic v2 compliance, removing duplicate code from rebase errors, and cleaning up type annotations. All changes are non-behavioral and improve code quality. The duplicate code removal eliminates potential bugs from maintenance drift between duplicates.
- No files require special attention - all changes follow consistent patterns

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/base.py | 5/5 | Added @classmethod decorator to _validate_name_no_special_characters field validator, removed duplicate Literal import, removed unused typing_extensions.Self import (using tidy3d.compat.Self instead), fixed trailing whitespace |
| tidy3d/components/monitor.py | 5/5 | Added @classmethod decorators to field validators, removed duplicate AbstractMediumPropertyMonitor class definition (58 lines of duplicate code from erroneous rebase) |
| tidy3d/components/medium.py | 5/5 | Added @classmethod decorators to 15+ field validators and model validators, removed unused 'info' parameter from validators that don't use it, kept 'info' parameter where needed (e.g., _isotropic_xx, _check_permittivity_conductivity_interpolate), reordered imports |
| tidy3d/components/simulation.py | 5/5 | Added @classmethod decorators to validators, removed unused 'values' parameter from _projection_direction, fixed pydantic.NonNegativeFloat references to use imported NonNegativeFloat, reordered imports, fixed quote style consistency in decorators |
| tidy3d/plugins/smatrix/component_modelers/base.py | 5/5 | Removed duplicate field definitions for run_only and element_mappings (18 lines of duplicate code from erroneous rebase) |
| tidy3d/plugins/smatrix/component_modelers/terminal.py | 5/5 | Added @classmethod decorator to _warn_refactor_2_10 model validator, removed duplicate run_only and element_mappings field definitions (18 lines) |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Pydantic
    participant Validator
    participant Model

    User->>Pydantic: Create model instance
    Pydantic->>Pydantic: Parse input data
    
    Note over Pydantic,Validator: Before: Missing @classmethod
    Pydantic->>Validator: Call field_validator (incorrect signature)
    Validator--xPydantic: TypeError or incorrect cls binding
    
    Note over Pydantic,Validator: After: With @classmethod
    Pydantic->>Validator: Call field_validator(cls, value, info)
    Validator->>Validator: Validate field value
    alt Validation passes
        Validator-->>Pydantic: Return validated value
        Pydantic->>Model: Construct model instance
        Model-->>User: Return validated model
    else Validation fails
        Validator-->>Pydantic: Raise ValidationError
        Pydantic-->>User: Raise ValidationError
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->