### PR TITLE
fix(tidy3d): FXC-4089 fix hashing in web.run()

### DIFF
--- a/tests/test_web/test_local_cache.py
+++ b/tests/test_web/test_local_cache.py
@@ -415,6 +415,13 @@ def _test_verbosity(monkeypatch, basic_simulation):
             f"Expected 'Got 1 simulation from cache' in log, got '{buf.getvalue()}'"
         )
 
+        # if some found
+        buf.truncate(0)
+        buf.seek(0)
+        run([basic_simulation, sim2], verbose=False)
+        assert buf.getvalue().strip() == "", f"Expected empty log, got '{buf.getvalue()}'"
+
+        # if all found
         buf.truncate(0)
         buf.seek(0)
         run([basic_simulation, sim2], verbose=False)

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -870,8 +870,9 @@ class Batch(WebContainer):
                 self.start(priority=priority)
             self.monitor(path_dir=path_dir, download_on_success=True)
         else:
-            console = get_logging_console()
-            console.log("Found all simulations in cache.")
+            if self.verbose:
+                console = get_logging_console()
+                console.log("Found all simulations in cache.")
             self.download(path_dir=path_dir)  # moves cache files
         return self.load(path_dir=path_dir, skip_download=True)
 

--- a/tidy3d/web/api/run.py
+++ b/tidy3d/web/api/run.py
@@ -37,7 +37,7 @@ def _collect_by_hash(
     if found is None:
         found = {}
     if isinstance(node, WorkflowType):
-        found[str(hash(node))] = node
+        found[node._hash_self()] = node
         return found
     if isinstance(node, (list, tuple)):
         for v in node:
@@ -63,7 +63,7 @@ def _reconstruct_by_hash(node: RunInput, h2data: dict[str, WorkflowDataType]) ->
 
     def _recur(n: RunInput) -> RunOutput:
         if isinstance(n, WorkflowType):
-            h = str(hash(n))
+            h = n._hash_self()
             data = h2data[h]
             if h in seen:
                 return data.copy()


### PR DESCRIPTION
`web.run` uses currently `hash()` and not `_hash_self()` to determine unique simulations in a run.

Sidefix: No verbosity with "Found all simulations in local cache" for all-jobs-cached case.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Replaced Python's built-in `hash()` with `_hash_self()` in `web.run()` deduplication logic to ensure consistent, session-independent hashing of simulations. Also suppressed the "Found all simulations in cache" log message when `verbose=False`.

Key changes:
- **tidy3d/web/api/run.py**: Replaced `str(hash(node))` with `node._hash_self()` in both `_collect_by_hash()` and `_reconstruct_by_hash()` functions
- **tidy3d/web/api/container.py**: Added verbosity check before logging "Found all simulations in cache" message
- **tests/test_web/test_local_cache.py**: Added test case to verify no output when `verbose=False` with partially cached simulations

The fix addresses a critical issue where Python's built-in `hash()` returns different values across sessions for the same object, breaking simulation deduplication. The `_hash_self()` method uses MD5 hashing of the HDF5 serialization, providing consistent hashes across sessions.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no identified risks
- The changes are focused, well-tested, and fix a critical hashing bug. The switch from `hash()` to `_hash_self()` is the correct solution for session-independent hashing, and the verbosity fix is a minor quality-of-life improvement. Both changes are covered by tests.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/web/api/run.py | 5/5 | Replaced `hash()` with `_hash_self()` for consistent, session-independent simulation hashing in deduplication logic |
| tidy3d/web/api/container.py | 5/5 | Added verbosity guard to prevent logging when `verbose=False` in all-cached scenario |
| tests/test_web/test_local_cache.py | 5/5 | Added test case to verify no log output when `verbose=False` with partially cached simulations |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant run
    participant _collect_by_hash
    participant _reconstruct_by_hash
    participant Simulation
    participant Batch

    User->>run: web.run(simulations, verbose=False)
    run->>_collect_by_hash: collect simulations
    _collect_by_hash->>Simulation: _hash_self()
    Note over _collect_by_hash,Simulation: Uses _hash_self() instead of hash()<br/>for consistent session-independent hashing
    Simulation-->>_collect_by_hash: MD5 hash string
    _collect_by_hash-->>run: {hash: simulation} dict
    
    alt Multiple simulations
        run->>Batch: run_async(simulations, verbose)
        Batch->>Batch: Check cache for all sims
        alt All found in cache
            Note over Batch: Only log if verbose=True
            Batch->>Batch: download from cache
        else Some/none found
            Batch->>Batch: upload, start, monitor
        end
        Batch-->>run: {task_id: data} dict
    end
    
    run->>_reconstruct_by_hash: reconstruct with data
    _reconstruct_by_hash->>Simulation: _hash_self()
    Simulation-->>_reconstruct_by_hash: MD5 hash string
    _reconstruct_by_hash-->>run: Result structure matching input
    run-->>User: Simulation results
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->