### PR TITLE
fix(geometry): remove validators on the number of geometries in ClipOperation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Improved performance of antenna metrics calculation by utilizing cached wave amplitude calculations instead of recomputing wave amplitudes for each port excitation in the `TerminalComponentModelerData`.
 - Changed hashing method in `Tidy3dBaseModel` from sha256 to md5.
-- Allowing for more geometries in a ClipOperation geometry.
+- Removed validators on limiting the number of geometries in a ClipOperation geometry.
 - Improved the speed of computing `Box` shape derivatives when used inside a `GeometryGroup`.
 - All RF and microwave specific components now inherit from `MicrowaveBaseModel`.
 - `DirectivityMonitor` now forces `far_field_approx` to `True`, which was previously configurable.

--- a/tests/test_components/test_scene.py
+++ b/tests/test_components/test_scene.py
@@ -9,7 +9,7 @@ import pydantic.v1 as pd
 import pytest
 
 import tidy3d as td
-from tidy3d.components.scene import MAX_GEOMETRY_COUNT, MAX_NUM_MEDIUMS
+from tidy3d.components.scene import MAX_NUM_MEDIUMS
 from tidy3d.components.viz import STRUCTURE_EPS_CMAP, STRUCTURE_EPS_CMAP_R
 from tidy3d.exceptions import SetupError
 
@@ -333,37 +333,37 @@ def test_perturbed_mediums_copy(unstructured, z):
     assert isinstance(new_scene.structures[0].medium, td.CustomPoleResidue)
 
 
-def test_max_geometry_validation():
-    too_many = [td.Box(size=(1, 1, 1)) for _ in range(MAX_GEOMETRY_COUNT + 1)]
+# def test_max_geometry_validation():
+#     too_many = [td.Box(size=(1, 1, 1)) for _ in range(MAX_GEOMETRY_COUNT + 1)]
 
-    fine = [
-        td.Structure(
-            geometry=td.ClipOperation(
-                operation="union",
-                geometry_a=td.Box(size=(1, 1, 1)),
-                geometry_b=td.GeometryGroup(geometries=too_many),
-            ),
-            medium=td.Medium(permittivity=2.0),
-        ),
-        td.Structure(
-            geometry=td.GeometryGroup(geometries=too_many),
-            medium=td.Medium(permittivity=2.0),
-        ),
-    ]
-    _ = td.Scene(structures=fine)
+#     fine = [
+#         td.Structure(
+#             geometry=td.ClipOperation(
+#                 operation="union",
+#                 geometry_a=td.Box(size=(1, 1, 1)),
+#                 geometry_b=td.GeometryGroup(geometries=too_many),
+#             ),
+#             medium=td.Medium(permittivity=2.0),
+#         ),
+#         td.Structure(
+#             geometry=td.GeometryGroup(geometries=too_many),
+#             medium=td.Medium(permittivity=2.0),
+#         ),
+#     ]
+#     _ = td.Scene(structures=fine)
 
-    not_fine = [
-        td.Structure(
-            geometry=td.ClipOperation(
-                operation="difference",
-                geometry_a=td.Box(size=(1, 1, 1)),
-                geometry_b=td.GeometryGroup(geometries=too_many),
-            ),
-            medium=td.Medium(permittivity=2.0),
-        ),
-    ]
-    with pytest.raises(pd.ValidationError, match=f" {MAX_GEOMETRY_COUNT + 2} "):
-        _ = td.Scene(structures=not_fine)
+#     not_fine = [
+#         td.Structure(
+#             geometry=td.ClipOperation(
+#                 operation="difference",
+#                 geometry_a=td.Box(size=(1, 1, 1)),
+#                 geometry_b=td.GeometryGroup(geometries=too_many),
+#             ),
+#             medium=td.Medium(permittivity=2.0),
+#         ),
+#     ]
+#     with pytest.raises(pd.ValidationError, match=f" {MAX_GEOMETRY_COUNT + 2} "):
+#         _ = td.Scene(structures=not_fine)
 
 
 def test_structure_manual_priority():

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -13,7 +13,7 @@ from matplotlib.testing.compare import compare_images
 
 import tidy3d as td
 from tidy3d.components import simulation
-from tidy3d.components.scene import MAX_GEOMETRY_COUNT, MAX_NUM_MEDIUMS
+from tidy3d.components.scene import MAX_NUM_MEDIUMS
 from tidy3d.components.simulation import MAX_NUM_SOURCES
 from tidy3d.exceptions import SetupError, Tidy3dError, Tidy3dKeyError
 from tidy3d.plugins.mode import ModeSolver
@@ -673,38 +673,38 @@ def test_validate_mnt_size(monkeypatch):
         s._validate_monitor_size()
 
 
-def test_max_geometry_validation():
-    gs = td.GridSpec(wavelength=1.0)
-    too_many = [td.Box(size=(1, 1, 1)) for _ in range(MAX_GEOMETRY_COUNT + 1)]
+# def test_max_geometry_validation():
+#     gs = td.GridSpec(wavelength=1.0)
+#     too_many = [td.Box(size=(1, 1, 1)) for _ in range(MAX_GEOMETRY_COUNT + 1)]
 
-    fine = [
-        td.Structure(
-            geometry=td.ClipOperation(
-                operation="union",
-                geometry_a=td.Box(size=(1, 1, 1)),
-                geometry_b=td.GeometryGroup(geometries=too_many),
-            ),
-            medium=td.Medium(permittivity=2.0),
-        ),
-        td.Structure(
-            geometry=td.GeometryGroup(geometries=too_many),
-            medium=td.Medium(permittivity=2.0),
-        ),
-    ]
-    _ = td.Simulation(size=(1, 1, 1), run_time=1, grid_spec=gs, structures=fine)
+#     fine = [
+#         td.Structure(
+#             geometry=td.ClipOperation(
+#                 operation="union",
+#                 geometry_a=td.Box(size=(1, 1, 1)),
+#                 geometry_b=td.GeometryGroup(geometries=too_many),
+#             ),
+#             medium=td.Medium(permittivity=2.0),
+#         ),
+#         td.Structure(
+#             geometry=td.GeometryGroup(geometries=too_many),
+#             medium=td.Medium(permittivity=2.0),
+#         ),
+#     ]
+#     _ = td.Simulation(size=(1, 1, 1), run_time=1, grid_spec=gs, structures=fine)
 
-    not_fine = [
-        td.Structure(
-            geometry=td.ClipOperation(
-                operation="difference",
-                geometry_a=td.Box(size=(1, 1, 1)),
-                geometry_b=td.GeometryGroup(geometries=too_many),
-            ),
-            medium=td.Medium(permittivity=2.0),
-        ),
-    ]
-    with pytest.raises(pydantic.ValidationError, match=f" {MAX_GEOMETRY_COUNT + 2} "):
-        _ = td.Simulation(size=(1, 1, 1), run_time=1, grid_spec=gs, structures=not_fine)
+#     not_fine = [
+#         td.Structure(
+#             geometry=td.ClipOperation(
+#                 operation="difference",
+#                 geometry_a=td.Box(size=(1, 1, 1)),
+#                 geometry_b=td.GeometryGroup(geometries=too_many),
+#             ),
+#             medium=td.Medium(permittivity=2.0),
+#         ),
+#     ]
+#     with pytest.raises(pydantic.ValidationError, match=f" {MAX_GEOMETRY_COUNT + 2} "):
+#         _ = td.Simulation(size=(1, 1, 1), run_time=1, grid_spec=gs, structures=not_fine)
 
 
 def test_no_monitor():

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -39,8 +39,8 @@ from .data.utils import (
     TriangularGridDataset,
     UnstructuredGridDataset,
 )
-from .geometry.base import Box, ClipOperation, GeometryGroup
-from .geometry.utils import flatten_groups, merging_geometries_on_plane, traverse_geometries
+from .geometry.base import Box
+from .geometry.utils import merging_geometries_on_plane
 from .grid.grid import Coords, Grid
 from .material.multi_physics import MultiPhysicsMedium
 from .medium import (
@@ -82,8 +82,8 @@ from .viz import (
 # maximum number of mediums supported
 MAX_NUM_MEDIUMS = 65530
 
-# maximum geometry count in a single structure
-MAX_GEOMETRY_COUNT = 5000
+# # maximum geometry count in a single structure
+# MAX_GEOMETRY_COUNT = 5000
 
 # warn and error out if the same medium is present in too many structures
 WARN_STRUCTURES_PER_MEDIUM = 200
@@ -175,28 +175,28 @@ class Scene(Tidy3dBaseModel):
 
         return val
 
-    @pd.validator("structures", always=True)
-    def _validate_num_geometries(cls, val):
-        """Error if too many geometries in a single structure."""
+    # @pd.validator("structures", always=True)
+    # def _validate_num_geometries(cls, val):
+    #     """Error if too many geometries in a single structure."""
 
-        if val is None:
-            return val
+    #     if val is None:
+    #         return val
 
-        for i, structure in enumerate(val):
-            for geometry in flatten_groups(structure.geometry, flatten_transformed=True):
-                count = sum(
-                    1
-                    for g in traverse_geometries(geometry)
-                    if not isinstance(g, (GeometryGroup, ClipOperation))
-                )
-                if count > MAX_GEOMETRY_COUNT:
-                    raise SetupError(
-                        f"Structure at 'structures[{i}]' has {count} geometries that cannot be "
-                        f"flattened. A maximum of {MAX_GEOMETRY_COUNT} is supported due to "
-                        f"preprocessing performance."
-                    )
+    #     for i, structure in enumerate(val):
+    #         for geometry in flatten_groups(structure.geometry, flatten_transformed=True):
+    #             count = sum(
+    #                 1
+    #                 for g in traverse_geometries(geometry)
+    #                 if not isinstance(g, (GeometryGroup, ClipOperation))
+    #             )
+    #             if count > MAX_GEOMETRY_COUNT:
+    #                 raise SetupError(
+    #                     f"Structure at 'structures[{i}]' has {count} geometries that cannot be "
+    #                     f"flattened. A maximum of {MAX_GEOMETRY_COUNT} is supported due to "
+    #                     f"preprocessing performance."
+    #                 )
 
-        return val
+    #     return val
 
     @pd.validator("structures", always=True)
     def _validate_structures_per_medium(cls, val):


### PR DESCRIPTION
Let's remove this validator as we have speed up preprocessing.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Removed validation limiting geometry count in `ClipOperation` structures to improve performance after preprocessing optimizations.

**Key Changes:**
- Commented out `_validate_num_geometries` validator in `Scene` class
- Commented out `MAX_GEOMETRY_COUNT` constant (5000 limit)
- Removed imports for `ClipOperation`, `GeometryGroup`, `flatten_groups`, and `traverse_geometries` that are no longer needed
- Updated CHANGELOG.md to describe the change

**Critical Issues:**
- `MAX_GEOMETRY_COUNT` is still imported by test files (tests/test_components/test_scene.py:12 and tests/test_components/test_simulation.py:16), causing import errors since it's now commented out
- Tests `test_max_geometry_validation` in both test files will fail when trying to reference the commented constant

<h3>Confidence Score: 1/5</h3>


- This PR will break existing tests and cannot be merged in its current state
- The constant `MAX_GEOMETRY_COUNT` is commented out but still imported by two test files. This will cause immediate import failures when tests run. The tests need to be updated to either remove the import or the constant should remain defined (though unused) for backward compatibility.
- Pay close attention to tidy3d/components/scene.py where `MAX_GEOMETRY_COUNT` is commented out, breaking test imports

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/scene.py | 1/5 | Commented out validator and constant; breaks tests that import `MAX_GEOMETRY_COUNT`; removed now-unused imports |
| CHANGELOG.md | 5/5 | Updated changelog entry to reflect validator removal instead of "allowing more geometries" |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Scene
    participant Validator
    participant Tests

    Note over User,Tests: Before PR (Current Behavior)
    User->>Scene: Create Scene with structures
    Scene->>Validator: _validate_num_geometries()
    Validator->>Validator: Count geometries in ClipOperation
    alt Geometry count > MAX_GEOMETRY_COUNT
        Validator-->>Scene: Raise SetupError
        Scene-->>User: Validation failed
    else Geometry count <= MAX_GEOMETRY_COUNT
        Validator-->>Scene: Validation passed
        Scene-->>User: Scene created successfully
    end
    
    Tests->>Scene: Import MAX_GEOMETRY_COUNT
    Scene-->>Tests: Return constant value (5000)
    
    Note over User,Tests: After PR (New Behavior)
    User->>Scene: Create Scene with structures
    Note over Validator: _validate_num_geometries() commented out
    Scene-->>User: Scene created (no validation)
    
    Tests->>Scene: Import MAX_GEOMETRY_COUNT
    Note over Scene: MAX_GEOMETRY_COUNT commented out
    Scene--xTests: ImportError/AttributeError
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->