### PR TITLE
custom autograd hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for `nonlinear_spec` in `CustomMedium` and `CustomDispersiveMedium`.
 - `tidy3d.plugins.design.DesignSpace.run(..., fn_post=...)` now accepts a `priority` keyword to propagate vGPU queue priority to all automatically batched simulations.
 - Introduced `BroadbandPulse` for exciting simulations across a wide frequency spectrum.
+- Added `user_vjp` and `numerical_structures` to new custom run functions that provide hooks into adjoint for user-defined gradient calculations.
 
 ### Breaking Changes
 - Edge singularity correction at PEC and lossy metal edges defaults to `True`.

--- a/tests/test_components/autograd/numerical/test_autograd_cm_user_vjp_numerical_structures.py
+++ b/tests/test_components/autograd/numerical/test_autograd_cm_user_vjp_numerical_structures.py
@@ -14,6 +14,7 @@ import xarray as xr
 import tidy3d as td
 from tidy3d.plugins.smatrix import ComponentModeler, Port
 from tidy3d.plugins.smatrix.run import _run_local
+from tidy3d.web.api.autograd.types import UserVJPConfig
 
 PLOT_FD_ADJ_COMPARISON = True
 NUM_FINITE_DIFFERENCE = 10
@@ -155,15 +156,18 @@ def vjp_sphere(sphere, derivative_info):
 
     vjps = {}
     for path in derivative_info.paths:
-        if path == ("radius",):
+        if path[0:2] == (
+            "geometry",
+            "radius",
+        ):
             sphere_up = sphere.updated_copy(radius=sphere.radius + step_size)
             sphere_down = sphere.updated_copy(radius=sphere.radius - step_size)
             vjps[path] = finite_difference_gradient(sphere_up, sphere_down, derivative_info)
-        elif "center" in path:
-            if len(path) == 1:
+        elif path[0:2] == ("geometry", "center"):
+            if len(path) == 2:
                 center_indices = (0, 1, 2)
             else:
-                _, center_index = path
+                _, center_index = path[1:]
                 center_indices = [center_index]
 
             vjp_result = []
@@ -181,7 +185,7 @@ def vjp_sphere(sphere, derivative_info):
                     finite_difference_gradient(sphere_up, sphere_down, derivative_info)
                 )
 
-            vjps[path] = vjp_result if len(path) == 1 else vjp_result[0]
+            vjps[path] = vjp_result if len(path) == 2 else vjp_result[0]
 
     return vjps
 
@@ -283,11 +287,16 @@ def create_objective_function(geometry, create_sim_base, adj_wvl_um, sim_path_di
                 }
             }
 
+            user_vjp_single = UserVJPConfig(
+                structure_index=3,
+                compute_derivatives=vjp_sphere,
+            )
+
             sim_data[key] = _run_local(
                 modeler,
                 local_gradient=LOCAL_GRADIENT,
                 verbose=VERBOSE,
-                user_vjp=((3, "radius", vjp_sphere), (3, "center", vjp_sphere)),
+                user_vjp=user_vjp_single,
                 numerical_structures=ring_generator,
             )
 

--- a/tests/test_components/autograd/numerical/test_autograd_cm_user_vjp_numerical_structures.py
+++ b/tests/test_components/autograd/numerical/test_autograd_cm_user_vjp_numerical_structures.py
@@ -14,7 +14,7 @@ import xarray as xr
 import tidy3d as td
 from tidy3d.plugins.smatrix import ComponentModeler, Port
 from tidy3d.plugins.smatrix.run import _run_local
-from tidy3d.web.api.autograd.types import UserVJPConfig
+from tidy3d.web.api.autograd.types import NumericalStructureConfig, UserVJPConfig
 
 PLOT_FD_ADJ_COMPARISON = True
 NUM_FINITE_DIFFERENCE = 10
@@ -279,13 +279,12 @@ def create_objective_function(geometry, create_sim_base, adj_wvl_um, sim_path_di
                 freqs=[td.C_0 / adj_wvl_um],
             )
 
-            ring_generator = {
-                0: {
-                    "function": create_ring,
-                    "parameters": geom_dict[key][4:],
-                    "vjp": vjp_ring,
-                }
-            }
+            ring_numerical_structure = NumericalStructureConfig(
+                create=create_ring,
+                compute_derivatives=vjp_ring,
+                parameters=geom_dict[key][4:],
+                structure_index=0,
+            )
 
             user_vjp_single = UserVJPConfig(
                 structure_index=3,
@@ -297,7 +296,7 @@ def create_objective_function(geometry, create_sim_base, adj_wvl_um, sim_path_di
                 local_gradient=LOCAL_GRADIENT,
                 verbose=VERBOSE,
                 user_vjp=user_vjp_single,
-                numerical_structures=ring_generator,
+                numerical_structures=ring_numerical_structure,
             )
 
         objective_vals = []

--- a/tests/test_components/autograd/numerical/test_autograd_cm_user_vjp_numerical_structures.py
+++ b/tests/test_components/autograd/numerical/test_autograd_cm_user_vjp_numerical_structures.py
@@ -140,12 +140,13 @@ def vjp_sphere(sphere, derivative_info):
         "paths": list(ps_paths),
         "deep": False,
     }
-    derivative_info_custom_medium = derivative_info.updated_copy(**update_kwargs)
 
     def finite_difference_gradient(perturb_up, perturb_down, derivative_info_):
-        eps_up = derivative_info.updated_epsilon(sphere_up)
-        eps_down = derivative_info.updated_epsilon(sphere_down)
+        eps_up = derivative_info.updated_epsilon(perturb_up)
+        eps_down = derivative_info.updated_epsilon(perturb_down)
         eps_grad = (eps_up - eps_down) / (2 * step_size)
+
+        derivative_info_custom_medium = derivative_info_.updated_copy(**update_kwargs)
 
         custom_medium = td.CustomMedium(permittivity=xr.ones_like(eps_grad.isel(f=0, drop=True)))
         vjps_custom_medium = custom_medium._compute_derivatives(derivative_info_custom_medium)

--- a/tests/test_components/autograd/numerical/test_autograd_cm_user_vjp_numerical_structures.py
+++ b/tests/test_components/autograd/numerical/test_autograd_cm_user_vjp_numerical_structures.py
@@ -1,0 +1,469 @@
+# tests user_vjp and numerical_structures autograd hooks for ComponentModeler and compares to numerically computed finite difference gradients
+from __future__ import annotations
+
+import operator
+import sys
+
+import autograd as ag
+import matplotlib.pylab as plt
+import numpy as np
+import pytest
+import trimesh
+import xarray as xr
+
+import tidy3d as td
+from tidy3d.plugins.smatrix import ComponentModeler, Port
+from tidy3d.plugins.smatrix.run import _run_local
+
+PLOT_FD_ADJ_COMPARISON = True
+NUM_FINITE_DIFFERENCE = 10
+SAVE_FD_ADJ_DATA = True
+SAVE_FD_LOC = 0
+SAVE_ADJ_LOC = 1
+LOCAL_GRADIENT = True
+VERBOSE = False
+NUMERICAL_RESULTS_DATA_DIR = "./numerical_cm_user_vjp_numerical_structures_test/"
+SHOW_PRINT_STATEMENTS = True
+
+OVERLAP_ERROR_THRESHOLD_DEG = 10.0
+
+ADJOINT_PERMITTIVITY = 1.5**2
+
+if PLOT_FD_ADJ_COMPARISON:
+    pytestmark = pytest.mark.usefixtures("mpl_config_interactive")
+else:
+    pytestmark = pytest.mark.usefixtures("mpl_config_noninteractive")
+
+if SHOW_PRINT_STATEMENTS:
+    sys.stdout = sys.stderr
+
+
+SIMULATION_SIZE_MESH_WVL_FACTOR = 7
+SIMULATION_HEIGHT_WVL_FACTOR = 3
+
+SPHERE_OFFSET_MAX_MESH_WVL_FACTOR = 0.25
+SPHERE_MIN_RADIUS_MESH_WVL_FACTOR = 0.3
+SPHERE_MAX_RADIUS_MESH_WVL_FACTOR = 0.4
+
+FD_STEP_MESH_WVL_FACTOR = 1.0 / 75.0
+
+
+def get_sim_geometry(mesh_wvl_um):
+    return td.Box(
+        size=(
+            SIMULATION_SIZE_MESH_WVL_FACTOR * mesh_wvl_um,
+            SIMULATION_SIZE_MESH_WVL_FACTOR * mesh_wvl_um,
+            SIMULATION_HEIGHT_WVL_FACTOR * mesh_wvl_um,
+        ),
+        center=(0, 0, 0),
+    )
+
+
+def make_base_sim(
+    mesh_wvl_um,
+    adj_wvl_um,
+    monitor_bg_index=1.0,
+    run_time=2e-11,
+):
+    sim_geometry = get_sim_geometry(mesh_wvl_um)
+    sim_size_um = sim_geometry.size
+    sim_center_um = sim_geometry.center
+
+    input_waveguide = td.Structure(
+        geometry=td.Box(
+            center=(-0.35 * sim_size_um[0], sim_center_um[1], sim_center_um[2]),
+            size=(0.5 * sim_size_um[0], 0.35 * adj_wvl_um, 0.2 * adj_wvl_um),
+        ),
+        medium=td.Medium(permittivity=3.5**2),
+    )
+
+    output_waveguide = td.Structure(
+        geometry=td.Box(
+            center=(0.35 * sim_size_um[0], sim_center_um[1], sim_center_um[2]),
+            size=(0.5 * sim_size_um[0], 0.35 * adj_wvl_um, 0.2 * adj_wvl_um),
+        ),
+        medium=td.Medium(permittivity=3.5**2),
+    )
+
+    num_modes = 1
+
+    port_left = Port(
+        center=input_waveguide.geometry.center,
+        size=(0.0, adj_wvl_um, adj_wvl_um),
+        mode_spec=td.ModeSpec(num_modes=num_modes),
+        direction="+",
+        name="left",
+    )
+
+    port_right = Port(
+        center=output_waveguide.geometry.center,
+        size=(0.0, adj_wvl_um, adj_wvl_um),
+        mode_spec=td.ModeSpec(num_modes=num_modes),
+        direction="-",
+        name="right",
+    )
+
+    boundary_spec = td.BoundarySpec(
+        x=td.Boundary.pml(),
+        y=td.Boundary.pml(),
+        z=td.Boundary.pml(),
+    )
+
+    ports = [port_left, port_right]
+
+    return ports, td.Simulation(
+        center=sim_center_um,
+        size=sim_size_um,
+        grid_spec=td.GridSpec.auto(
+            min_steps_per_wvl=30,
+            wavelength=1.5,
+        ),
+        boundary_spec=boundary_spec,
+        sources=[],
+        monitors=[],
+        structures=[input_waveguide, output_waveguide],
+        run_time=1e-11,
+    )
+
+
+def vjp_sphere(sphere, derivative_info):
+    max_frequency = np.max(derivative_info.frequencies)
+    min_wvl = td.C_0 / max_frequency
+
+    step_size = min_wvl / 20.0
+
+    ps_paths = set()
+    ps_paths.update({("permittivity",)})
+
+    update_kwargs = {
+        "paths": list(ps_paths),
+        "deep": False,
+    }
+    derivative_info_custom_medium = derivative_info.updated_copy(**update_kwargs)
+
+    def finite_difference_gradient(perturb_up, perturb_down, derivative_info_):
+        eps_up = derivative_info.updated_epsilon(sphere_up)
+        eps_down = derivative_info.updated_epsilon(sphere_down)
+        eps_grad = (eps_up - eps_down) / (2 * step_size)
+
+        custom_medium = td.CustomMedium(permittivity=xr.ones_like(eps_grad.isel(f=0, drop=True)))
+        vjps_custom_medium = custom_medium._compute_derivatives(derivative_info_custom_medium)
+
+        total_grad = np.real(np.sum(eps_grad.sum("f").data * vjps_custom_medium[("permittivity",)]))
+
+        return total_grad
+
+    vjps = {}
+    for path in derivative_info.paths:
+        if path == ("radius",):
+            sphere_up = sphere.updated_copy(radius=sphere.radius + step_size)
+            sphere_down = sphere.updated_copy(radius=sphere.radius - step_size)
+            vjps[path] = finite_difference_gradient(sphere_up, sphere_down, derivative_info)
+        elif "center" in path:
+            if len(path) == 1:
+                center_indices = (0, 1, 2)
+            else:
+                _, center_index = path
+                center_indices = [center_index]
+
+            vjp_result = []
+            for center_index in center_indices:
+                center_up = list(sphere.center)
+                center_down = list(sphere.center)
+
+                center_up[center_index] += step_size
+                center_down[center_index] -= step_size
+
+                sphere_up = sphere.updated_copy(center=center_up)
+                sphere_down = sphere.updated_copy(center=center_down)
+
+                vjp_result.append(
+                    finite_difference_gradient(sphere_up, sphere_down, derivative_info)
+                )
+
+            vjps[path] = vjp_result if len(path) == 1 else vjp_result[0]
+
+    return vjps
+
+
+def create_ring(params):
+    ring_mesh = trimesh.creation.annulus(
+        r_min=params[0], r_max=params[1], height=params[2], sections=100
+    )
+
+    rotator = trimesh.transformations.rotation_matrix(np.radians(90), [0, 1, 0])
+    ring_mesh.apply_transform(rotator)
+
+    translate = trimesh.transformations.translation_matrix([-0.65, 0, 0])
+    ring_mesh.apply_transform(translate)
+
+    ring_geo = td.TriangleMesh.from_trimesh(ring_mesh)
+
+    return td.Structure(geometry=ring_geo, medium=td.Medium(permittivity=ADJOINT_PERMITTIVITY))
+
+
+def vjp_ring(parameters, derivative_info):
+    max_frequency = np.max(derivative_info.frequencies)
+    min_wvl = td.C_0 / max_frequency
+
+    step_size = min_wvl / 20.0
+
+    ps_paths = set()
+    ps_paths.update({("permittivity",)})
+
+    # pass interpolators to PolySlab if available to avoid redundant conversions
+    update_kwargs = {
+        "paths": list(ps_paths),
+        "deep": False,
+    }
+    derivative_info_custom_medium = derivative_info.updated_copy(**update_kwargs)
+
+    params_np = np.array(parameters)
+
+    vjps = {}
+    for path in derivative_info.paths:
+        param_idx = path[0]
+
+        params_up = params_np.copy()
+        params_down = params_np.copy()
+
+        params_up[param_idx] += step_size
+        params_down[param_idx] -= step_size
+
+        ring_up = create_ring(params_up)
+        ring_down = create_ring(params_down)
+
+        eps_up = derivative_info.updated_epsilon(ring_up.geometry)
+        eps_down = derivative_info.updated_epsilon(ring_down.geometry)
+
+        eps_grad = (eps_up - eps_down) / (2 * step_size)
+
+        custom_medium = td.CustomMedium(permittivity=xr.ones_like(eps_grad.isel(f=0, drop=True)))
+        vjps_custom_medium = custom_medium._compute_derivatives(derivative_info_custom_medium)
+
+        total_grad = np.real(np.sum(eps_grad.sum("f").data * vjps_custom_medium[("permittivity",)]))
+
+        vjps[path] = total_grad
+
+    return vjps
+
+
+def create_objective_function(geometry, create_sim_base, adj_wvl_um, sim_path_dir):
+    def objective(geom_parameters_lists):
+        ports, sim_base = create_sim_base()
+
+        simulation_dict = {}
+        geom_dict = {}
+        for idx, geom_parameters in enumerate(geom_parameters_lists):
+            sphere_structure = td.Structure(
+                geometry=td.Sphere(center=geom_parameters[0:3], radius=geom_parameters[3]),
+                medium=td.Medium(permittivity=ADJOINT_PERMITTIVITY),
+            )
+
+            sim_with_sphere = sim_base.updated_copy(
+                structures=(*sim_base.structures, sphere_structure)
+            )
+
+            simulation_dict[f"numerical_user_vjp_testing_{idx}"] = sim_with_sphere.copy()
+            geom_dict[f"numerical_user_vjp_testing_{idx}"] = geom_parameters
+
+        sim_data = {}
+        for key, sim_val in simulation_dict.items():
+            modeler = ComponentModeler(
+                simulation=sim_val,
+                ports=ports,
+                freqs=[td.C_0 / adj_wvl_um],
+            )
+
+            ring_generator = {
+                0: {
+                    "function": create_ring,
+                    "parameters": geom_dict[key][4:],
+                    "vjp": vjp_ring,
+                }
+            }
+
+            sim_data[key] = _run_local(
+                modeler,
+                local_gradient=LOCAL_GRADIENT,
+                verbose=VERBOSE,
+                user_vjp=((3, "radius", vjp_sphere), (3, "center", vjp_sphere)),
+                numerical_structures=ring_generator,
+            )
+
+        objective_vals = []
+        for idx in range(len(geom_parameters_lists)):
+            smatrix = sim_data[f"numerical_user_vjp_testing_{idx}"]
+            objective_vals.append(np.sum(np.abs(smatrix.smatrix().values) ** 2))
+
+        if len(geom_parameters_lists) == 1:
+            return objective_vals[0]
+
+        return objective_vals
+
+    return objective
+
+
+background_indices = [1.0]
+mesh_wvls_um = [1.5]
+adj_wvls_um = [1.5]
+
+test_parameters = []
+
+test_number = 0
+for idx in range(len(mesh_wvls_um)):
+    mesh_wvl_um = mesh_wvls_um[idx]
+    adj_wvl_um = adj_wvls_um[idx]
+
+    for monitor_bg_index in background_indices:
+        test_parameters.append(
+            {
+                "mesh_wvl_um": mesh_wvl_um,
+                "adj_wvl_um": adj_wvl_um,
+                "monitor_bg_index": monitor_bg_index,
+                "test_number": test_number,
+            }
+        )
+
+        test_number += 1
+
+
+@pytest.mark.numerical
+@pytest.mark.parametrize(
+    "test_parameters, dir_name",
+    zip(
+        test_parameters,
+        ([NUMERICAL_RESULTS_DATA_DIR] if SAVE_FD_ADJ_DATA else [None]) * len(test_parameters),
+    ),
+    indirect=["dir_name"],
+)
+def test_finite_difference_user_vjp(test_parameters, rng, tmp_path, create_directory):
+    """Test a variety of autograd permittivity gradients for DiffractionData by"""
+    """comparing them to numerical finite difference."""
+
+    test_number = test_parameters["test_number"]
+
+    (
+        mesh_wvl_um,
+        adj_wvl_um,
+        monitor_bg_index,
+        test_number,
+    ) = operator.itemgetter(
+        "mesh_wvl_um",
+        "adj_wvl_um",
+        "monitor_bg_index",
+        "test_number",
+    )(test_parameters)
+
+    sim_geometry = get_sim_geometry(mesh_wvl_um)
+
+    dim_um = mesh_wvl_um
+    thickness_um = 0.5 * mesh_wvl_um
+    block = td.Box(
+        center=(sim_geometry.center[0], sim_geometry.center[1], 0),
+        size=(dim_um, dim_um, thickness_um),
+    )
+
+    sim_path_dir = tmp_path / f"test{test_number}"
+    sim_path_dir.mkdir()
+
+    objective = create_objective_function(
+        block,
+        lambda mesh_wvl_um=mesh_wvl_um,
+        adj_wvl_um=adj_wvl_um,
+        monitor_bg_index=monitor_bg_index: make_base_sim(
+            mesh_wvl_um=mesh_wvl_um,
+            adj_wvl_um=adj_wvl_um,
+            monitor_bg_index=monitor_bg_index,
+        ),
+        adj_wvl_um,
+        sim_path_dir=str(sim_path_dir),
+    )
+
+    obj_val_and_grad = ag.value_and_grad(objective)
+
+    sphere_init = [
+        *rng.uniform(
+            low=-SPHERE_OFFSET_MAX_MESH_WVL_FACTOR * mesh_wvl_um,
+            high=SPHERE_OFFSET_MAX_MESH_WVL_FACTOR * mesh_wvl_um,
+            size=2,
+        ),
+        0.0,
+        *rng.uniform(
+            low=SPHERE_MIN_RADIUS_MESH_WVL_FACTOR * mesh_wvl_um,
+            high=SPHERE_MAX_RADIUS_MESH_WVL_FACTOR * mesh_wvl_um,
+            size=1,
+        ),
+    ]
+
+    ring_init_mesh_wvl_factor = [0.15, 0.30, 0.2]
+    ring_init = [r * mesh_wvl_um for r in ring_init_mesh_wvl_factor]
+
+    geom_init = sphere_init + ring_init
+
+    test_results = np.zeros((2, len(geom_init)))
+
+    obj, adj_grad = obj_val_and_grad([geom_init])
+    adj_grad = np.squeeze(np.array(adj_grad))
+
+    # empirical step size for finite difference calculation
+    fd_step = FD_STEP_MESH_WVL_FACTOR * mesh_wvl_um
+
+    all_params = []
+
+    for fd_idx in range(len(geom_init)):
+        geom_up = geom_init.copy()
+        geom_down = geom_init.copy()
+
+        geom_up[fd_idx] += fd_step
+        geom_down[fd_idx] -= fd_step
+
+        all_params.append(geom_up)
+        all_params.append(geom_down)
+
+    all_obj = objective(all_params)
+
+    fd_grad = np.zeros(len(geom_init))
+    for fd_idx in range(len(geom_init)):
+        obj_up_location = 2 * fd_idx
+        obj_down_location = 2 * fd_idx + 1
+
+        fd_grad[fd_idx] = (all_obj[obj_up_location] - all_obj[obj_down_location]) / (2 * fd_step)
+
+    rms_error = np.linalg.norm(fd_grad - adj_grad)
+    fd_mag = np.linalg.norm(fd_grad)
+    adj_mag = np.linalg.norm(adj_grad)
+
+    dot = np.sum((fd_grad / fd_mag) * (adj_grad / adj_mag))
+    overlap_deg = np.arccos(dot) * 180.0 / np.pi
+
+    print("\n" * 3)
+    print("-" * 20)
+    print(f"Numerical test #{test_number}")
+    print(f"Mesh and adjoint wavelengths: {mesh_wvl_um}, {adj_wvl_um}")
+    print(f"Background index for monitor: {monitor_bg_index}")
+    print(f"RMS Error: {rms_error}")
+    print(f"Gradient overlap (deg): {overlap_deg}")
+    print(f"FD, Adj magnitudes: {fd_mag}, {adj_mag}")
+    print("-" * 20)
+    print("\n" * 3)
+
+    assert overlap_deg < OVERLAP_ERROR_THRESHOLD_DEG, (
+        "Adjoint and finite difference gradients misaligned."
+    )
+
+    test_results[SAVE_FD_LOC, :] = fd_grad
+    test_results[SAVE_ADJ_LOC, :] = adj_grad
+
+    test_number += 1
+
+    if PLOT_FD_ADJ_COMPARISON:
+        plt.plot(adj_grad, color="g", linewidth=2.0)
+        plt.plot(fd_grad, color="b", linewidth=1.5, linestyle="--")
+        plt.legend(["Adjoint", "Finite difference"])
+        plt.xlabel("Sample number")
+        plt.ylabel("Gradient value")
+        plt.show()
+
+    if SAVE_FD_ADJ_DATA:
+        np.save(f"{NUMERICAL_RESULTS_DATA_DIR}/results_{test_number}.npy", test_results)

--- a/tests/test_components/autograd/numerical/test_autograd_numerical_structures.py
+++ b/tests/test_components/autograd/numerical/test_autograd_numerical_structures.py
@@ -171,10 +171,10 @@ def vjp_ring(parameters, derivative_info):
         params_up[param_idx] += step_size
         params_down[param_idx] -= step_size
 
-        rin_up = create_ring(params_up)
+        ring_up = create_ring(params_up)
         ring_down = create_ring(params_down)
 
-        eps_up = derivative_info.updated_epsilon(rin_up.geometry)
+        eps_up = derivative_info.updated_epsilon(ring_up.geometry)
         eps_down = derivative_info.updated_epsilon(ring_down.geometry)
 
         eps_grad = (eps_up - eps_down) / (2 * step_size)

--- a/tests/test_components/autograd/numerical/test_autograd_numerical_structures.py
+++ b/tests/test_components/autograd/numerical/test_autograd_numerical_structures.py
@@ -1,0 +1,451 @@
+# tests numerical_structures autograd hook for run_custom and run_async_custom and compares to numerically computed finite difference gradients
+from __future__ import annotations
+
+import operator
+import sys
+
+import autograd as ag
+import matplotlib.pylab as plt
+import numpy as np
+import pytest
+import trimesh
+import xarray as xr
+
+import tidy3d as td
+from tidy3d.web.api.autograd.autograd import run_async_custom, run_custom
+
+PLOT_FD_ADJ_COMPARISON = True
+NUM_FINITE_DIFFERENCE = 10
+SAVE_FD_ADJ_DATA = True
+SAVE_FD_LOC = 0
+SAVE_ADJ_LOC = 1
+LOCAL_GRADIENT = True
+VERBOSE = False
+NUMERICAL_RESULTS_DATA_DIR = "./numerical_numerical_structures_test/"
+SHOW_PRINT_STATEMENTS = True
+
+OVERLAP_ERROR_THRESHOLD_DEG = 15.0
+
+ADJOINT_SPHERE_PERMITTIVITY = 1.5**2
+
+RMS_THRESHOLD = 0.25
+
+if PLOT_FD_ADJ_COMPARISON:
+    pytestmark = pytest.mark.usefixtures("mpl_config_interactive")
+else:
+    pytestmark = pytest.mark.usefixtures("mpl_config_noninteractive")
+
+if SHOW_PRINT_STATEMENTS:
+    sys.stdout = sys.stderr
+
+
+SIMULATION_SIZE_MESH_WVL_FACTOR = 3.5
+SIMULATION_HEIGHT_WVL_FACTOR = 5
+
+RING_OFFSET_MAX_MESH_WVL_FACTOR = 0.25
+RING_MIN_RADIUS_MESH_WVL_FACTOR = 0.3
+RING_MAX_RADIUS_MESH_WVL_FACOTOR = 0.4
+
+FD_STEP_MESH_WVL_FACTOR = 1.0 / 75.0
+
+
+def get_sim_geometry(mesh_wvl_um):
+    return td.Box(
+        size=(
+            SIMULATION_SIZE_MESH_WVL_FACTOR * mesh_wvl_um,
+            SIMULATION_SIZE_MESH_WVL_FACTOR * mesh_wvl_um,
+            SIMULATION_HEIGHT_WVL_FACTOR * mesh_wvl_um,
+        ),
+        center=(0, 0, 0),
+    )
+
+
+def make_base_sim(
+    mesh_wvl_um,
+    adj_wvl_um,
+    pw_angle_deg,
+    monitor_bg_index=1.0,
+    run_time=2e-11,
+):
+    sim_geometry = get_sim_geometry(mesh_wvl_um)
+    sim_size_um = sim_geometry.size
+    sim_center_um = sim_geometry.center
+
+    src_size = sim_size_um[0:2] + (0,)
+
+    wl_min_src_um = 0.9 * adj_wvl_um
+    wl_max_src_um = 1.1 * adj_wvl_um
+
+    fwidth_src = td.C_0 * ((1.0 / wl_min_src_um) - (1.0 / wl_max_src_um))
+    freq0 = td.C_0 / adj_wvl_um
+
+    pulse = td.GaussianPulse(freq0=freq0, fwidth=fwidth_src)
+
+    src = td.PlaneWave(
+        center=(sim_center_um[0], sim_center_um[1], -2.0),
+        size=[td.inf, td.inf, 0],
+        source_time=pulse,
+        direction="+",
+        angle_theta=(pw_angle_deg * np.pi / 180.0),
+    )
+
+    boundary_spec = td.BoundarySpec(
+        x=td.Boundary.pml(),
+        y=td.Boundary.pml(),
+        z=td.Boundary.pml(),
+    )
+
+    field_monitor = td.FieldMonitor(
+        center=(
+            sim_center_um[0],
+            sim_center_um[1],
+            mesh_wvl_um / 1.5,
+        ),
+        size=(mesh_wvl_um, mesh_wvl_um, 0),
+        name="monitor_fields",
+        freqs=[freq0],
+    )
+
+    monitor_index_block = td.Box(
+        center=(sim_center_um[0], sim_center_um[1], 0.25 * sim_size_um[2] + mesh_wvl_um),
+        size=(*tuple(2 * size for size in sim_size_um[0:2]), mesh_wvl_um + 0.5 * sim_size_um[2]),
+    )
+    monitor_index_block_structure = td.Structure(
+        geometry=monitor_index_block, medium=td.Medium(permittivity=monitor_bg_index**2)
+    )
+
+    sim_base = td.Simulation(
+        center=sim_center_um,
+        size=sim_size_um,
+        grid_spec=td.GridSpec.auto(
+            min_steps_per_wvl=30,
+            wavelength=mesh_wvl_um,
+        ),
+        structures=[monitor_index_block_structure],
+        sources=[src],
+        monitors=[field_monitor],
+        run_time=run_time,
+        boundary_spec=boundary_spec,
+        subpixel=True,
+    )
+
+    return sim_base
+
+
+def create_ring(params):
+    ring_mesh = trimesh.creation.annulus(
+        r_min=params[0], r_max=params[1], height=params[2], sections=100
+    )
+
+    ring_geo = td.TriangleMesh.from_trimesh(ring_mesh)
+
+    return td.Structure(geometry=ring_geo, medium=td.Medium(permittivity=1.5**2))
+
+
+def vjp_ring(parameters, derivative_info):
+    max_frequency = np.max(derivative_info.frequencies)
+    min_wvl = td.C_0 / max_frequency
+
+    step_size = min_wvl / 20.0
+
+    ps_paths = set()
+    ps_paths.update({("permittivity",)})
+
+    # pass interpolators to PolySlab if available to avoid redundant conversions
+    update_kwargs = {
+        "paths": list(ps_paths),
+        "deep": False,
+    }
+    derivative_info_custom_medium = derivative_info.updated_copy(**update_kwargs)
+
+    params_np = np.array(parameters)
+
+    vjps = {}
+    for path in derivative_info.paths:
+        param_idx = path[0]
+
+        params_up = params_np.copy()
+        params_down = params_np.copy()
+
+        params_up[param_idx] += step_size
+        params_down[param_idx] -= step_size
+
+        rin_up = create_ring(params_up)
+        ring_down = create_ring(params_down)
+
+        eps_up = derivative_info.updated_epsilon(rin_up.geometry)
+        eps_down = derivative_info.updated_epsilon(ring_down.geometry)
+
+        eps_grad = (eps_up - eps_down) / (2 * step_size)
+
+        custom_medium = td.CustomMedium(permittivity=xr.ones_like(eps_grad.isel(f=0, drop=True)))
+        vjps_custom_medium = custom_medium._compute_derivatives(derivative_info_custom_medium)
+
+        total_grad = np.real(np.sum(eps_grad.sum("f").data * vjps_custom_medium[("permittivity",)]))
+
+        vjps[path] = total_grad
+
+    return vjps
+
+
+def create_objective_function(geometry, create_sim_base, eval_fn, run_fn, sim_path_dir):
+    def objective(ring_parameters_lists):
+        sim_base = create_sim_base()
+
+        simulation_dict = {}
+        for idx in range(len(ring_parameters_lists)):
+            simulation_dict[f"numerical_numerical_structures_testing_{idx}"] = sim_base.copy()
+
+        assert (run_fn == "run_custom") or (run_fn == "run_async_custom"), (
+            "Unrecognized run function!"
+        )
+        if run_fn == "run_custom":
+            sim_data = {}
+            idx = 0
+            for key, sim_val in simulation_dict.items():
+                ring_generator = {
+                    0: {
+                        "function": create_ring,
+                        "parameters": ring_parameters_lists[idx],
+                        "vjp": vjp_ring,
+                    }
+                }
+                sim_data[key] = run_custom(
+                    sim_val,
+                    local_gradient=LOCAL_GRADIENT,
+                    verbose=VERBOSE,
+                    numerical_structures=ring_generator,
+                )
+
+                idx += 1
+        elif run_fn == "run_async_custom":
+            user_vjp_dict = {}
+            numerical_structures_dict = {}
+
+            for idx, key in enumerate(simulation_dict):
+                user_vjp_dict[key] = ((1, "radius", vjp_ring), (1, "center", vjp_ring))
+
+                ring_generator = {
+                    0: {
+                        "function": create_ring,
+                        "parameters": ring_parameters_lists[idx],
+                        "vjp": vjp_ring,
+                    }
+                }
+                numerical_structures_dict[key] = ring_generator
+
+            sim_data = run_async_custom(
+                simulation_dict,
+                path_dir=sim_path_dir,
+                local_gradient=LOCAL_GRADIENT,
+                verbose=VERBOSE,
+                numerical_structures=numerical_structures_dict,
+            )
+
+        objective_vals = []
+        for idx in range(len(ring_parameters_lists)):
+            objective_vals.append(
+                eval_fn(sim_data[f"numerical_numerical_structures_testing_{idx}"])
+            )
+
+        if len(ring_parameters_lists) == 1:
+            return objective_vals[0]
+
+        return objective_vals
+
+    return objective
+
+
+def make_eval_fns():
+    def transmission(sim_data):
+        total = 0.0
+
+        return np.sum(np.abs(sim_data["monitor_fields"].flux.data) ** 2)
+
+    eval_fns = [transmission]
+    eval_fn_names = ["transmission"]
+
+    return eval_fns, eval_fn_names
+
+
+background_indices = [1.0]
+mesh_wvls_um = [1.5]
+adj_wvls_um = [1.5]
+
+orders_x = [(1,)]
+orders_y = [(0,)]
+polarizations = ["p"]
+
+
+pw_angles_deg = [0.0]
+
+run_functions = ["run_custom", "run_async_custom"]
+
+test_parameters = []
+
+test_number = 0
+for idx in range(len(mesh_wvls_um)):
+    mesh_wvl_um = mesh_wvls_um[idx]
+    adj_wvl_um = adj_wvls_um[idx]
+
+    eval_fns, eval_fn_names = make_eval_fns()
+
+    for pw_angle_deg in pw_angles_deg:
+        for monitor_bg_index in background_indices:
+            for eval_fn_idx, eval_fn in enumerate(eval_fns):
+                for run_fn in run_functions:
+                    test_parameters.append(
+                        {
+                            "mesh_wvl_um": mesh_wvl_um,
+                            "adj_wvl_um": adj_wvl_um,
+                            "monitor_bg_index": monitor_bg_index,
+                            "pw_angle_deg": pw_angle_deg,
+                            "eval_fn": eval_fn,
+                            "eval_fn_name": eval_fn_names[eval_fn_idx],
+                            "run_fn": run_fn,
+                            "test_number": test_number,
+                        }
+                    )
+
+                    test_number += 1
+
+
+@pytest.mark.numerical
+@pytest.mark.parametrize(
+    "test_parameters, dir_name",
+    zip(
+        test_parameters,
+        ([NUMERICAL_RESULTS_DATA_DIR] if SAVE_FD_ADJ_DATA else [None]) * len(test_parameters),
+    ),
+    indirect=["dir_name"],
+)
+def test_finite_difference_numerical_structures(test_parameters, rng, tmp_path, create_directory):
+    """Test a variety of autograd permittivity gradients for DiffractionData by"""
+    """comparing them to numerical finite difference."""
+
+    test_number = test_parameters["test_number"]
+
+    (
+        mesh_wvl_um,
+        adj_wvl_um,
+        monitor_bg_index,
+        pw_angle_deg,
+        eval_fn,
+        eval_fn_name,
+        run_fn,
+        test_number,
+    ) = operator.itemgetter(
+        "mesh_wvl_um",
+        "adj_wvl_um",
+        "monitor_bg_index",
+        "pw_angle_deg",
+        "eval_fn",
+        "eval_fn_name",
+        "run_fn",
+        "test_number",
+    )(test_parameters)
+
+    sim_geometry = get_sim_geometry(mesh_wvl_um)
+
+    dim_um = mesh_wvl_um
+    thickness_um = 0.5 * mesh_wvl_um
+    block = td.Box(
+        center=(sim_geometry.center[0], sim_geometry.center[1], 0),
+        size=(dim_um, dim_um, thickness_um),
+    )
+
+    eval_fns, eval_fn_names = make_eval_fns()
+
+    sim_path_dir = tmp_path / f"test{test_number}"
+    sim_path_dir.mkdir()
+
+    objective = create_objective_function(
+        block,
+        lambda mesh_wvl_um=mesh_wvl_um,
+        adj_wvl_um=adj_wvl_um,
+        pw_angle_deg=pw_angle_deg,
+        monitor_bg_index=monitor_bg_index: make_base_sim(
+            mesh_wvl_um=mesh_wvl_um,
+            adj_wvl_um=adj_wvl_um,
+            pw_angle_deg=pw_angle_deg,
+            monitor_bg_index=monitor_bg_index,
+        ),
+        eval_fn,
+        run_fn,
+        sim_path_dir=str(sim_path_dir),
+    )
+
+    obj_val_and_grad = ag.value_and_grad(objective)
+
+    ring_init_mesh_wvl_factor = [0.15, 0.30, 0.2]
+    ring_init = [r * mesh_wvl_um for r in ring_init_mesh_wvl_factor]
+
+    test_results = np.zeros((2, len(ring_init)))
+
+    obj, adj_grad = obj_val_and_grad([ring_init])
+    adj_grad = np.squeeze(np.array(adj_grad))
+
+    # empirical step size from running other finite difference tests for field
+    # cases with permittivity
+    fd_step = FD_STEP_MESH_WVL_FACTOR * mesh_wvl_um
+
+    all_rings = []
+    for fd_idx in range(len(ring_init)):
+        rin_up = ring_init.copy()
+        ring_down = ring_init.copy()
+
+        rin_up[fd_idx] += fd_step
+        ring_down[fd_idx] -= fd_step
+
+        all_rings.append(rin_up)
+        all_rings.append(ring_down)
+
+    all_obj = objective(all_rings)
+
+    fd_grad = np.zeros(len(ring_init))
+    for fd_idx in range(len(ring_init)):
+        obj_up_location = 2 * fd_idx
+        obj_down_location = 2 * fd_idx + 1
+
+        fd_grad[fd_idx] = (all_obj[obj_up_location] - all_obj[obj_down_location]) / (2 * fd_step)
+
+    rms_error = np.linalg.norm(fd_grad - adj_grad)
+    fd_mag = np.linalg.norm(fd_grad)
+    adj_mag = np.linalg.norm(adj_grad)
+
+    dot = np.sum((fd_grad / fd_mag) * (adj_grad / adj_mag))
+    overlap_deg = np.arccos(dot) * 180.0 / np.pi
+
+    print("\n" * 3)
+    print("-" * 20)
+    print(f"Numerical test #{test_number}")
+    print(f"Mesh and adjoint wavelengths: {mesh_wvl_um}, {adj_wvl_um}")
+    print(f"Input plane wave angle (deg): {pw_angle_deg}")
+    print(f"Background index for monitor: {monitor_bg_index}")
+    print(f"Eval function: {eval_fn_name}")
+    print(f"RMS Error: {rms_error}")
+    print(f"Gradient overlap (deg): {overlap_deg}")
+    print(f"FD, Adj magnitudes: {fd_mag}, {adj_mag}")
+    print("-" * 20)
+    print("\n" * 3)
+
+    assert overlap_deg < OVERLAP_ERROR_THRESHOLD_DEG, (
+        "Adjoint and finite difference gradients misaligned."
+    )
+
+    test_results[SAVE_FD_LOC, :] = fd_grad
+    test_results[SAVE_ADJ_LOC, :] = adj_grad
+
+    test_number += 1
+
+    if PLOT_FD_ADJ_COMPARISON:
+        plt.plot(adj_grad, color="g", linewidth=2.0)
+        plt.plot(fd_grad, color="b", linewidth=1.5, linestyle="--")
+        plt.title(f"Gradient for objective: {eval_fn_name}")
+        plt.legend(["Adjoint", "Finite difference"])
+        plt.xlabel("Sample number")
+        plt.ylabel("Gradient value")
+        plt.show()
+
+    if SAVE_FD_ADJ_DATA:
+        np.save(f"{NUMERICAL_RESULTS_DATA_DIR}/results_{test_number}.npy", test_results)

--- a/tests/test_components/autograd/numerical/test_autograd_numerical_structures.py
+++ b/tests/test_components/autograd/numerical/test_autograd_numerical_structures.py
@@ -13,6 +13,7 @@ import xarray as xr
 
 import tidy3d as td
 from tidy3d.web.api.autograd.autograd import run_async_custom, run_custom
+from tidy3d.web.api.autograd.types import NumericalStructureConfig
 
 PLOT_FD_ADJ_COMPARISON = True
 NUM_FINITE_DIFFERENCE = 10
@@ -199,22 +200,22 @@ def create_objective_function(geometry, create_sim_base, eval_fn, run_fn, sim_pa
         assert (run_fn == "run_custom") or (run_fn == "run_async_custom"), (
             "Unrecognized run function!"
         )
+
         if run_fn == "run_custom":
             sim_data = {}
             idx = 0
             for key, sim_val in simulation_dict.items():
-                ring_generator = {
-                    0: {
-                        "function": create_ring,
-                        "parameters": ring_parameters_lists[idx],
-                        "vjp": vjp_ring,
-                    }
-                }
+                ring_numerical_structure = NumericalStructureConfig(
+                    create=create_ring,
+                    compute_derivatives=vjp_ring,
+                    parameters=ring_parameters_lists[idx],
+                    structure_index=0,
+                )
                 sim_data[key] = run_custom(
                     sim_val,
                     local_gradient=LOCAL_GRADIENT,
                     verbose=VERBOSE,
-                    numerical_structures=ring_generator,
+                    numerical_structures=ring_numerical_structure,
                 )
 
                 idx += 1
@@ -223,16 +224,14 @@ def create_objective_function(geometry, create_sim_base, eval_fn, run_fn, sim_pa
             numerical_structures_dict = {}
 
             for idx, key in enumerate(simulation_dict):
+                ring_numerical_structure = NumericalStructureConfig(
+                    create=create_ring,
+                    compute_derivatives=vjp_ring,
+                    parameters=ring_parameters_lists[idx],
+                    structure_index=0,
+                )
                 user_vjp_dict[key] = ((1, "radius", vjp_ring), (1, "center", vjp_ring))
-
-                ring_generator = {
-                    0: {
-                        "function": create_ring,
-                        "parameters": ring_parameters_lists[idx],
-                        "vjp": vjp_ring,
-                    }
-                }
-                numerical_structures_dict[key] = ring_generator
+                numerical_structures_dict[key] = ring_numerical_structure
 
             sim_data = run_async_custom(
                 simulation_dict,
@@ -391,13 +390,13 @@ def test_finite_difference_numerical_structures(test_parameters, rng, tmp_path, 
 
     all_rings = []
     for fd_idx in range(len(ring_init)):
-        rin_up = ring_init.copy()
+        ring_up = ring_init.copy()
         ring_down = ring_init.copy()
 
-        rin_up[fd_idx] += fd_step
+        ring_up[fd_idx] += fd_step
         ring_down[fd_idx] -= fd_step
 
-        all_rings.append(rin_up)
+        all_rings.append(ring_up)
         all_rings.append(ring_down)
 
     all_obj = objective(all_rings)

--- a/tests/test_components/autograd/numerical/test_autograd_periodic_numerical.py
+++ b/tests/test_components/autograd/numerical/test_autograd_periodic_numerical.py
@@ -122,7 +122,6 @@ def make_base_sim(
         )
     else:
         diffraction_monitor = td.DiffractionMonitor(
-            # center=(0, 0, -0.35 * sim_size_um[2]),
             center=(sim_center_um[0], sim_center_um[1], -0.35 * sim_size_um[2]),
             size=(np.inf, np.inf, 0),
             name="monitor_diffraction",

--- a/tests/test_components/autograd/numerical/test_autograd_user_vjp.py
+++ b/tests/test_components/autograd/numerical/test_autograd_user_vjp.py
@@ -272,7 +272,6 @@ orders_x = [(1,)]
 orders_y = [(0,)]
 polarizations = ["p"]
 
-
 pw_angles_deg = [0.0]
 
 run_functions = ["run_custom", "run_async_custom"]

--- a/tests/test_components/autograd/numerical/test_autograd_user_vjp.py
+++ b/tests/test_components/autograd/numerical/test_autograd_user_vjp.py
@@ -1,0 +1,454 @@
+# tests user_vjp autograd hook for run_custom and run_async_custom and compares to numerically computed finite difference gradients
+from __future__ import annotations
+
+import operator
+import sys
+
+import autograd as ag
+import matplotlib.pylab as plt
+import numpy as np
+import pytest
+import xarray as xr
+
+import tidy3d as td
+from tidy3d.web.api.autograd.autograd import run_async_custom, run_custom
+
+PLOT_FD_ADJ_COMPARISON = True
+NUM_FINITE_DIFFERENCE = 10
+SAVE_FD_ADJ_DATA = True
+SAVE_FD_LOC = 0
+SAVE_ADJ_LOC = 1
+LOCAL_GRADIENT = True
+VERBOSE = False
+NUMERICAL_RESULTS_DATA_DIR = "./numerical_user_vjp_test/"
+SHOW_PRINT_STATEMENTS = True
+
+OVERLAP_ERROR_THRESHOLD_DEG = 10.0
+
+ADJOINT_SPHERE_PERMITTIVITY = 1.5**2
+
+if PLOT_FD_ADJ_COMPARISON:
+    pytestmark = pytest.mark.usefixtures("mpl_config_interactive")
+else:
+    pytestmark = pytest.mark.usefixtures("mpl_config_noninteractive")
+
+if SHOW_PRINT_STATEMENTS:
+    sys.stdout = sys.stderr
+
+
+SIMULATION_SIZE_MESH_WVL_FACTOR = 3.5
+SIMULATION_HEIGHT_WVL_FACTOR = 5
+
+SPHERE_OFFSET_MAX_MESH_WVL_FACTOR = 0.25
+SPHERE_MIN_RADIUS_MESH_WVL_FACTOR = 0.3
+SPHERE_MAX_RADIUS_MESH_WVL_FACTOR = 0.4
+
+FD_STEP_MESH_WVL_FACTOR = 1.0 / 75.0
+
+
+def get_sim_geometry(mesh_wvl_um):
+    return td.Box(
+        size=(
+            SIMULATION_SIZE_MESH_WVL_FACTOR * mesh_wvl_um,
+            SIMULATION_SIZE_MESH_WVL_FACTOR * mesh_wvl_um,
+            SIMULATION_HEIGHT_WVL_FACTOR * mesh_wvl_um,
+        ),
+        center=(0, 0, 0),
+    )
+
+
+def make_base_sim(
+    mesh_wvl_um,
+    adj_wvl_um,
+    pw_angle_deg,
+    monitor_bg_index=1.0,
+    run_time=2e-11,
+):
+    sim_geometry = get_sim_geometry(mesh_wvl_um)
+    sim_size_um = sim_geometry.size
+    sim_center_um = sim_geometry.center
+
+    src_size = sim_size_um[0:2] + (0,)
+
+    wl_min_src_um = 0.9 * adj_wvl_um
+    wl_max_src_um = 1.1 * adj_wvl_um
+
+    fwidth_src = td.C_0 * ((1.0 / wl_min_src_um) - (1.0 / wl_max_src_um))
+    freq0 = td.C_0 / adj_wvl_um
+
+    pulse = td.GaussianPulse(freq0=freq0, fwidth=fwidth_src)
+
+    src = td.PlaneWave(
+        center=(sim_center_um[0], sim_center_um[1], -2.0),
+        size=[td.inf, td.inf, 0],
+        source_time=pulse,
+        direction="+",
+        angle_theta=(pw_angle_deg * np.pi / 180.0),
+    )
+
+    boundary_spec = td.BoundarySpec(
+        x=td.Boundary.pml(),
+        y=td.Boundary.pml(),
+        z=td.Boundary.pml(),
+    )
+
+    field_monitor = td.FieldMonitor(
+        center=(
+            sim_center_um[0],
+            sim_center_um[1],
+            mesh_wvl_um / 1.5,
+        ),
+        size=(mesh_wvl_um, mesh_wvl_um, 0),
+        name="monitor_fields",
+        freqs=[freq0],
+    )
+
+    monitor_index_block = td.Box(
+        center=(sim_center_um[0], sim_center_um[1], 0.25 * sim_size_um[2] + mesh_wvl_um),
+        size=(*tuple(2 * size for size in sim_size_um[0:2]), mesh_wvl_um + 0.5 * sim_size_um[2]),
+    )
+    monitor_index_block_structure = td.Structure(
+        geometry=monitor_index_block, medium=td.Medium(permittivity=monitor_bg_index**2)
+    )
+
+    sim_base = td.Simulation(
+        center=sim_center_um,
+        size=sim_size_um,
+        grid_spec=td.GridSpec.auto(
+            min_steps_per_wvl=30,
+            wavelength=mesh_wvl_um,
+        ),
+        structures=[monitor_index_block_structure],
+        sources=[src],
+        monitors=[field_monitor],
+        run_time=run_time,
+        boundary_spec=boundary_spec,
+        subpixel=True,
+    )
+
+    return sim_base
+
+
+def vjp_sphere(sphere, derivative_info):
+    max_frequency = np.max(derivative_info.frequencies)
+    min_wvl = td.C_0 / max_frequency
+
+    step_size = min_wvl / 20.0
+
+    ps_paths = set()
+    ps_paths.update({("permittivity",)})
+
+    update_kwargs = {
+        "paths": list(ps_paths),
+        "deep": False,
+    }
+    derivative_info_custom_medium = derivative_info.updated_copy(**update_kwargs)
+
+    def finite_difference_gradient(perturb_up, perturb_down, derivative_info_):
+        eps_up = derivative_info.updated_epsilon(sphere_up)
+        eps_down = derivative_info.updated_epsilon(sphere_down)
+        eps_grad = (eps_up - eps_down) / (2 * step_size)
+
+        custom_medium = td.CustomMedium(permittivity=xr.ones_like(eps_grad.isel(f=0, drop=True)))
+        vjps_custom_medium = custom_medium._compute_derivatives(derivative_info_custom_medium)
+
+        total_grad = np.real(np.sum(eps_grad.sum("f").data * vjps_custom_medium[("permittivity",)]))
+
+        return total_grad
+
+    vjps = {}
+    for path in derivative_info.paths:
+        if path == ("radius",):
+            sphere_up = sphere.updated_copy(radius=sphere.radius + step_size)
+            sphere_down = sphere.updated_copy(radius=sphere.radius - step_size)
+            vjps[path] = finite_difference_gradient(sphere_up, sphere_down, derivative_info)
+        elif "center" in path:
+            if len(path) == 1:
+                center_indices = (0, 1, 2)
+            else:
+                _, center_index = path
+                center_indices = [center_index]
+
+            vjp_result = []
+            for center_index in center_indices:
+                center_up = list(sphere.center)
+                center_down = list(sphere.center)
+
+                center_up[center_index] += step_size
+                center_down[center_index] -= step_size
+
+                sphere_up = sphere.updated_copy(center=center_up)
+                sphere_down = sphere.updated_copy(center=center_down)
+
+                vjp_result.append(
+                    finite_difference_gradient(sphere_up, sphere_down, derivative_info)
+                )
+
+            vjps[path] = vjp_result if len(path) == 1 else vjp_result[0]
+
+    return vjps
+
+
+def create_objective_function(geometry, create_sim_base, eval_fn, run_fn, sim_path_dir):
+    def objective(sphere_parameters_lists):
+        sim_base = create_sim_base()
+
+        simulation_dict = {}
+        for idx, sphere_parameters in enumerate(sphere_parameters_lists):
+            sphere_structure = td.Structure(
+                geometry=td.Sphere(center=sphere_parameters[0:3], radius=sphere_parameters[3]),
+                medium=td.Medium(permittivity=ADJOINT_SPHERE_PERMITTIVITY),
+            )
+
+            sim_with_sphere = sim_base.updated_copy(
+                structures=(*sim_base.structures, sphere_structure)
+            )
+
+            simulation_dict[f"numerical_user_vjp_testing_{idx}"] = sim_with_sphere.copy()
+
+        assert (run_fn == "run_custom") or (run_fn == "run_async_custom"), (
+            "Unrecognized run function!"
+        )
+        if run_fn == "run_custom":
+            sim_data = {}
+            for key, sim_val in simulation_dict.items():
+                sim_data[key] = run_custom(
+                    sim_val,
+                    local_gradient=LOCAL_GRADIENT,
+                    verbose=VERBOSE,
+                    user_vjp=((1, "radius", vjp_sphere), (1, "center", vjp_sphere)),
+                )
+        elif run_fn == "run_async_custom":
+            user_vjp_dict = {}
+            for key in simulation_dict:
+                user_vjp_dict[key] = ((1, "radius", vjp_sphere), (1, "center", vjp_sphere))
+            sim_data = run_async_custom(
+                simulation_dict,
+                path_dir=sim_path_dir,
+                local_gradient=LOCAL_GRADIENT,
+                verbose=VERBOSE,
+                user_vjp=user_vjp_dict,
+            )
+
+        objective_vals = []
+        for idx in range(len(sphere_parameters_lists)):
+            objective_vals.append(eval_fn(sim_data[f"numerical_user_vjp_testing_{idx}"]))
+
+        if len(sphere_parameters_lists) == 1:
+            return objective_vals[0]
+
+        return objective_vals
+
+    return objective
+
+
+# def make_eval_fns(orders_x, orders_y, polarization):
+def make_eval_fns():
+    def transmission(sim_data):
+        total = 0.0
+
+        return np.sum(np.abs(sim_data["monitor_fields"].flux.data) ** 2)
+
+        return np.mean(np.abs(sim_data["monitor_fields"].Ez.data) ** 2)
+        # return np.mean(np.abs(sim_data["monitor_fields"].Ex.data)**2 + np.abs(sim_data["monitor_fields"].Ey.data)**2)
+
+    eval_fns = [transmission]
+    eval_fn_names = ["transmission"]
+
+    return eval_fns, eval_fn_names
+
+
+background_indices = [1.0]
+mesh_wvls_um = [1.5]
+adj_wvls_um = [1.5]
+
+orders_x = [(1,)]
+orders_y = [(0,)]
+polarizations = ["p"]
+
+
+pw_angles_deg = [0.0]
+
+run_functions = ["run_custom", "run_async_custom"]
+
+test_parameters = []
+
+test_number = 0
+for idx in range(len(mesh_wvls_um)):
+    mesh_wvl_um = mesh_wvls_um[idx]
+    adj_wvl_um = adj_wvls_um[idx]
+
+    eval_fns, eval_fn_names = make_eval_fns()
+
+    for pw_angle_deg in pw_angles_deg:
+        for monitor_bg_index in background_indices:
+            for eval_fn_idx, eval_fn in enumerate(eval_fns):
+                for run_fn in run_functions:
+                    test_parameters.append(
+                        {
+                            "mesh_wvl_um": mesh_wvl_um,
+                            "adj_wvl_um": adj_wvl_um,
+                            "monitor_bg_index": monitor_bg_index,
+                            "pw_angle_deg": pw_angle_deg,
+                            "eval_fn": eval_fn,
+                            "eval_fn_name": eval_fn_names[eval_fn_idx],
+                            "run_fn": run_fn,
+                            "test_number": test_number,
+                        }
+                    )
+
+                    test_number += 1
+
+
+@pytest.mark.numerical
+@pytest.mark.parametrize(
+    "test_parameters, dir_name",
+    zip(
+        test_parameters,
+        ([NUMERICAL_RESULTS_DATA_DIR] if SAVE_FD_ADJ_DATA else [None]) * len(test_parameters),
+    ),
+    indirect=["dir_name"],
+)
+def test_finite_difference_user_vjp(test_parameters, rng, tmp_path, create_directory):
+    """Test a variety of autograd permittivity gradients for DiffractionData by"""
+    """comparing them to numerical finite difference."""
+
+    test_number = test_parameters["test_number"]
+
+    (
+        mesh_wvl_um,
+        adj_wvl_um,
+        monitor_bg_index,
+        pw_angle_deg,
+        eval_fn,
+        eval_fn_name,
+        run_fn,
+        test_number,
+    ) = operator.itemgetter(
+        "mesh_wvl_um",
+        "adj_wvl_um",
+        "monitor_bg_index",
+        "pw_angle_deg",
+        "eval_fn",
+        "eval_fn_name",
+        "run_fn",
+        "test_number",
+    )(test_parameters)
+
+    sim_geometry = get_sim_geometry(mesh_wvl_um)
+
+    dim_um = mesh_wvl_um
+    thickness_um = 0.5 * mesh_wvl_um
+    block = td.Box(
+        center=(sim_geometry.center[0], sim_geometry.center[1], 0),
+        size=(dim_um, dim_um, thickness_um),
+    )
+
+    eval_fns, eval_fn_names = make_eval_fns()
+
+    sim_path_dir = tmp_path / f"test{test_number}"
+    sim_path_dir.mkdir()
+
+    objective = create_objective_function(
+        block,
+        lambda mesh_wvl_um=mesh_wvl_um,
+        adj_wvl_um=adj_wvl_um,
+        pw_angle_deg=pw_angle_deg,
+        monitor_bg_index=monitor_bg_index: make_base_sim(
+            mesh_wvl_um=mesh_wvl_um,
+            adj_wvl_um=adj_wvl_um,
+            pw_angle_deg=pw_angle_deg,
+            monitor_bg_index=monitor_bg_index,
+        ),
+        eval_fn,
+        run_fn,
+        sim_path_dir=str(sim_path_dir),
+    )
+
+    obj_val_and_grad = ag.value_and_grad(objective)
+
+    sphere_init = [
+        *rng.uniform(
+            low=-SPHERE_OFFSET_MAX_MESH_WVL_FACTOR * mesh_wvl_um,
+            high=SPHERE_OFFSET_MAX_MESH_WVL_FACTOR * mesh_wvl_um,
+            size=2,
+        ),
+        0.0,
+        *rng.uniform(
+            low=SPHERE_MIN_RADIUS_MESH_WVL_FACTOR * mesh_wvl_um,
+            high=SPHERE_MAX_RADIUS_MESH_WVL_FACTOR * mesh_wvl_um,
+            size=1,
+        ),
+    ]
+
+    test_results = np.zeros((2, len(sphere_init)))
+
+    obj, adj_grad = obj_val_and_grad([sphere_init])
+    adj_grad = np.squeeze(np.array(adj_grad))
+
+    # empirical step size from running other finite difference tests for field
+    # cases with permittivity
+    fd_step = FD_STEP_MESH_WVL_FACTOR * mesh_wvl_um
+
+    all_spheres = []
+    # pattern_dot_adj_gradient = np.zeros(len(sphere_init))
+
+    for fd_idx in range(len(sphere_init)):
+        sphere_up = sphere_init.copy()
+        sphere_down = sphere_init.copy()
+
+        sphere_up[fd_idx] += fd_step
+        sphere_down[fd_idx] -= fd_step
+
+        all_spheres.append(sphere_up)
+        all_spheres.append(sphere_down)
+
+    all_obj = objective(all_spheres)
+
+    fd_grad = np.zeros(len(sphere_init))
+    for fd_idx in range(len(sphere_init)):
+        obj_up_location = 2 * fd_idx
+        obj_down_location = 2 * fd_idx + 1
+
+        fd_grad[fd_idx] = (all_obj[obj_up_location] - all_obj[obj_down_location]) / (2 * fd_step)
+
+    rms_error = np.linalg.norm(fd_grad - adj_grad)
+    fd_mag = np.linalg.norm(fd_grad)
+    adj_mag = np.linalg.norm(adj_grad)
+
+    dot = np.sum((fd_grad / fd_mag) * (adj_grad / adj_mag))
+    overlap_deg = np.arccos(dot) * 180.0 / np.pi
+
+    print("\n" * 3)
+    print("-" * 20)
+    print(f"Numerical test #{test_number}")
+    print(f"Mesh and adjoint wavelengths: {mesh_wvl_um}, {adj_wvl_um}")
+    print(f"Input plane wave angle (deg): {pw_angle_deg}")
+    print(f"Background index for monitor: {monitor_bg_index}")
+    print(f"Eval function: {eval_fn_name}")
+    print(f"RMS Error: {rms_error}")
+    print(f"Gradient overlap (deg): {overlap_deg}")
+    print(f"FD, Adj magnitudes: {fd_mag}, {adj_mag}")
+    print("-" * 20)
+    print("\n" * 3)
+
+    assert overlap_deg < OVERLAP_ERROR_THRESHOLD_DEG, (
+        "Adjoint and finite difference gradients misaligned."
+    )
+
+    test_results[SAVE_FD_LOC, :] = fd_grad
+    test_results[SAVE_ADJ_LOC, :] = adj_grad
+
+    test_number += 1
+
+    if PLOT_FD_ADJ_COMPARISON:
+        plt.plot(adj_grad, color="g", linewidth=2.0)
+        plt.plot(fd_grad, color="b", linewidth=1.5, linestyle="--")
+        plt.title(f"Gradient for objective: {eval_fn_name}")
+        plt.legend(["Adjoint", "Finite difference"])
+        plt.xlabel("Sample number")
+        plt.ylabel("Gradient value")
+        plt.show()
+
+    if SAVE_FD_ADJ_DATA:
+        np.save(f"{NUMERICAL_RESULTS_DATA_DIR}/results_{test_number}.npy", test_results)

--- a/tests/test_components/autograd/numerical/test_autograd_user_vjp.py
+++ b/tests/test_components/autograd/numerical/test_autograd_user_vjp.py
@@ -12,6 +12,7 @@ import xarray as xr
 
 import tidy3d as td
 from tidy3d.web.api.autograd.autograd import run_async_custom, run_custom
+from tidy3d.web.api.autograd.types import UserVJPConfig
 
 PLOT_FD_ADJ_COMPARISON = True
 NUM_FINITE_DIFFERENCE = 10
@@ -158,15 +159,18 @@ def vjp_sphere(sphere, derivative_info):
 
     vjps = {}
     for path in derivative_info.paths:
-        if path == ("radius",):
+        if path[0:2] == (
+            "geometry",
+            "radius",
+        ):
             sphere_up = sphere.updated_copy(radius=sphere.radius + step_size)
             sphere_down = sphere.updated_copy(radius=sphere.radius - step_size)
             vjps[path] = finite_difference_gradient(sphere_up, sphere_down, derivative_info)
-        elif "center" in path:
-            if len(path) == 1:
+        elif path[0:2] == ("geometry", "center"):
+            if len(path) == 2:
                 center_indices = (0, 1, 2)
             else:
-                _, center_index = path
+                _, center_index = path[1:]
                 center_indices = [center_index]
 
             vjp_result = []
@@ -184,7 +188,7 @@ def vjp_sphere(sphere, derivative_info):
                     finite_difference_gradient(sphere_up, sphere_down, derivative_info)
                 )
 
-            vjps[path] = vjp_result if len(path) == 1 else vjp_result[0]
+            vjps[path] = vjp_result if len(path) == 2 else vjp_result[0]
 
     return vjps
 
@@ -206,6 +210,11 @@ def create_objective_function(geometry, create_sim_base, eval_fn, run_fn, sim_pa
 
             simulation_dict[f"numerical_user_vjp_testing_{idx}"] = sim_with_sphere.copy()
 
+        user_vjp_single = UserVJPConfig(
+            structure_index=1,
+            compute_derivatives=vjp_sphere,
+        )
+
         assert (run_fn == "run_custom") or (run_fn == "run_async_custom"), (
             "Unrecognized run function!"
         )
@@ -216,18 +225,15 @@ def create_objective_function(geometry, create_sim_base, eval_fn, run_fn, sim_pa
                     sim_val,
                     local_gradient=LOCAL_GRADIENT,
                     verbose=VERBOSE,
-                    user_vjp=((1, "radius", vjp_sphere), (1, "center", vjp_sphere)),
+                    user_vjp=user_vjp_single,
                 )
         elif run_fn == "run_async_custom":
-            user_vjp_dict = {}
-            for key in simulation_dict:
-                user_vjp_dict[key] = ((1, "radius", vjp_sphere), (1, "center", vjp_sphere))
             sim_data = run_async_custom(
                 simulation_dict,
                 path_dir=sim_path_dir,
                 local_gradient=LOCAL_GRADIENT,
                 verbose=VERBOSE,
-                user_vjp=user_vjp_dict,
+                user_vjp=user_vjp_single,
             )
 
         objective_vals = []

--- a/tests/test_components/autograd/numerical/test_autograd_user_vjp.py
+++ b/tests/test_components/autograd/numerical/test_autograd_user_vjp.py
@@ -143,12 +143,13 @@ def vjp_sphere(sphere, derivative_info):
         "paths": list(ps_paths),
         "deep": False,
     }
-    derivative_info_custom_medium = derivative_info.updated_copy(**update_kwargs)
 
     def finite_difference_gradient(perturb_up, perturb_down, derivative_info_):
-        eps_up = derivative_info.updated_epsilon(sphere_up)
-        eps_down = derivative_info.updated_epsilon(sphere_down)
+        eps_up = derivative_info.updated_epsilon(perturb_up)
+        eps_down = derivative_info.updated_epsilon(perturb_down)
         eps_grad = (eps_up - eps_down) / (2 * step_size)
+
+        derivative_info_custom_medium = derivative_info_.updated_copy(**update_kwargs)
 
         custom_medium = td.CustomMedium(permittivity=xr.ones_like(eps_grad.isel(f=0, drop=True)))
         vjps_custom_medium = custom_medium._compute_derivatives(derivative_info_custom_medium)
@@ -248,15 +249,11 @@ def create_objective_function(geometry, create_sim_base, eval_fn, run_fn, sim_pa
     return objective
 
 
-# def make_eval_fns(orders_x, orders_y, polarization):
 def make_eval_fns():
     def transmission(sim_data):
         total = 0.0
 
         return np.sum(np.abs(sim_data["monitor_fields"].flux.data) ** 2)
-
-        return np.mean(np.abs(sim_data["monitor_fields"].Ez.data) ** 2)
-        # return np.mean(np.abs(sim_data["monitor_fields"].Ex.data)**2 + np.abs(sim_data["monitor_fields"].Ey.data)**2)
 
     eval_fns = [transmission]
     eval_fn_names = ["transmission"]
@@ -318,8 +315,6 @@ def test_finite_difference_user_vjp(test_parameters, rng, tmp_path, create_direc
     """Test a variety of autograd permittivity gradients for DiffractionData by"""
     """comparing them to numerical finite difference."""
 
-    test_number = test_parameters["test_number"]
-
     (
         mesh_wvl_um,
         adj_wvl_um,
@@ -348,8 +343,6 @@ def test_finite_difference_user_vjp(test_parameters, rng, tmp_path, create_direc
         center=(sim_geometry.center[0], sim_geometry.center[1], 0),
         size=(dim_um, dim_um, thickness_um),
     )
-
-    eval_fns, eval_fn_names = make_eval_fns()
 
     sim_path_dir = tmp_path / f"test{test_number}"
     sim_path_dir.mkdir()

--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -28,8 +28,11 @@ from tidy3d.components.data.data_array import DataArray
 from tidy3d.config import config
 from tidy3d.exceptions import AdjointError
 from tidy3d.plugins.polyslab import ComplexPolySlab
+from tidy3d.plugins.smatrix import ComponentModeler, Port
+from tidy3d.plugins.smatrix.run import _run_local
 from tidy3d.web import run, run_async
 from tidy3d.web.api.autograd import autograd as autograd_module
+from tidy3d.web.api.autograd.autograd import run_async_custom, run_custom
 
 from ...utils import SIM_FULL, AssertLogLevel, run_emulated, tracer_arr
 
@@ -101,6 +104,7 @@ def _make_di(paths, freq):
         ),
         bounds_intersect=((-1, -1, -1), (1, 1, 1)),
         simulation_bounds=((-2, -2, -2), (2, 2, 2)),
+        updated_epsilon=None,
     )
 
 
@@ -116,6 +120,7 @@ LZ = 7.0 * WVL
 
 IS_3D = False
 POLYSLAB_AXIS = 2
+POLYSLAB_SELECT_VERTICES = 0
 
 # angle of the measurement waveguide
 ROT_ANGLE_WG = 0 * np.pi / 4
@@ -239,7 +244,6 @@ def use_emulated_run(monkeypatch):
 
         def emulated_run_bwd(simulation, task_name, **run_kwargs) -> td.SimulationData:
             """What gets called instead of ``web/api/autograd/autograd.py::_run_tidy3d_bwd``."""
-
             task_name_fwd = "".join(task_name.partition("_adjoint")[:-2])
 
             # run the adjoint sim
@@ -259,6 +263,8 @@ def use_emulated_run(monkeypatch):
                 sim_data_orig=sim_data_orig,
                 sim_data_fwd=sim_data_fwd,
                 sim_fields_keys=sim_fields_keys,
+                user_vjp=None,
+                numerical_info=None,
             )
 
             return traced_fields_vjp
@@ -266,6 +272,7 @@ def use_emulated_run(monkeypatch):
         def emulated_run_async_fwd(simulations, **run_kwargs) -> td.SimulationData:
             batch_data_orig, task_ids_fwd = {}, {}
             sim_fields_keys_dict = run_kwargs.pop("sim_fields_keys_dict", None)
+
             for task_name, simulation in simulations.items():
                 if sim_fields_keys_dict is not None:
                     run_kwargs["sim_fields_keys"] = sim_fields_keys_dict[task_name]
@@ -306,7 +313,9 @@ def use_emulated_run(monkeypatch):
         return emulated_run_fwd, emulated_run_bwd
 
 
-def make_structures(params: anp.ndarray) -> dict[str, td.Structure]:
+def make_structures(
+    params: anp.ndarray, polyslab_axis: int = POLYSLAB_AXIS
+) -> dict[str, td.Structure]:
     """Make a dictionary of the structures given the parameters."""
 
     np.random.seed(0)
@@ -406,7 +415,7 @@ def make_structures(params: anp.ndarray) -> dict[str, td.Structure]:
     matrix = np.random.random((N_PARAMS,)) - 0.5
     params_01 = 0.5 * (anp.tanh(matrix @ params / 3) + 1)
 
-    free_param = "vertices" if POLYSLAB_AXIS == 0 else "slab_bounds"
+    free_param = "vertices" if polyslab_axis == POLYSLAB_SELECT_VERTICES else "slab_bounds"
 
     if free_param == "vertices":
         radii = 0.5 + 0.5 * params_01
@@ -415,8 +424,6 @@ def make_structures(params: anp.ndarray) -> dict[str, td.Structure]:
         radii = 1.0
         shift = 0.1 * params_01
         slab_bounds = (-0.5 + shift, 0.5 + shift)
-        # slab_bounds = (-0.5 + shift, 0.5)
-        # slab_bounds = (-0.5, 0.5 + shift)
 
     phis = 2 * anp.pi * anp.linspace(0, 1, NUM_VERTICES + 1)[:NUM_VERTICES]
     xs = radii * anp.cos(phis)
@@ -427,7 +434,7 @@ def make_structures(params: anp.ndarray) -> dict[str, td.Structure]:
         geometry=td.PolySlab(
             vertices=vertices,
             slab_bounds=slab_bounds,
-            axis=POLYSLAB_AXIS,
+            axis=polyslab_axis,
             sidewall_angle=0.00,
             dilation=0.00,
         ),
@@ -438,7 +445,7 @@ def make_structures(params: anp.ndarray) -> dict[str, td.Structure]:
         geometry=td.PolySlab(
             vertices=vertices,
             slab_bounds=slab_bounds,
-            axis=POLYSLAB_AXIS,
+            axis=polyslab_axis,
             sidewall_angle=0.00,
             dilation=0.00,
         ),
@@ -681,10 +688,10 @@ def get_functions(structure_key: str, monitor_key: str) -> dict[str, typing.Call
         monitors.append(monitor_traced)
         monitor_pp_fns[monitor_key] = monitor_pp_fn
 
-    def make_sim(*args) -> td.Simulation:
+    def make_sim(*args, polyslab_axis=POLYSLAB_AXIS) -> td.Simulation:
         """Make the simulation with all of the fields."""
 
-        structures_traced_dict = make_structures(*args)
+        structures_traced_dict = make_structures(*args, polyslab_axis=polyslab_axis)
 
         structures = list(SIM_BASE.structures)
         for structure_key in structure_keys:
@@ -725,6 +732,442 @@ def test_polyslab_axis_ops(axis):
     edges = vertices_next - vertices
 
     basis_vecs = p.edge_basis_vectors(edges=edges)
+
+
+def make_polyslab_user_vjp(user_vjp_val):
+    def polyslab_user_vjp(polyslab, derivative_info):
+        vjps = {}
+
+        for path in derivative_info.paths:
+            if path[0] == "vertices":
+                vjps[path] = user_vjp_val * np.ones(polyslab.vertices.shape)
+            elif path[0] == "slab_bounds":
+                vjps[path] = (user_vjp_val, user_vjp_val)
+
+        return vjps
+
+    return polyslab_user_vjp
+
+
+user_vjp_args = [("polyslab", "mode")]
+
+
+@pytest.mark.parametrize("structure_key, monitor_key", user_vjp_args)
+@pytest.mark.parametrize("polyslab_axis", [0, 1, 2])
+@pytest.mark.parametrize("use_run_async", [True, False])
+@pytest.mark.parametrize("use_task_names", [True, False])
+@pytest.mark.parametrize("local_gradient", [True, False])
+def test_autograd_user_vjp(
+    use_emulated_run,
+    structure_key,
+    monitor_key,
+    polyslab_axis,
+    use_run_async,
+    use_task_names,
+    local_gradient,
+):
+    """Test that we can override a vjp with a user defined function."""
+
+    fn_dict = get_functions(structure_key, monitor_key)
+    make_sim = fn_dict["sim"]
+    postprocess = fn_dict["postprocess"]
+
+    task_names = {"test_a", "adjoint", "_test"}
+
+    def make_objective(user_vjp_val):
+        polyslab_user_vjp = make_polyslab_user_vjp(user_vjp_val)
+
+        def objective(*args):
+            if use_task_names:
+                sims = {
+                    task_name: make_sim(*args, polyslab_axis=polyslab_axis)
+                    for task_name in task_names
+                }
+                user_vjp = dict.fromkeys(
+                    task_names,
+                    ((1, "vertices", polyslab_user_vjp), (1, "slab_bounds", polyslab_user_vjp)),
+                )
+            else:
+                sims = [make_sim(*args, polyslab_axis=polyslab_axis)] * len(task_names)
+                user_vjp = [
+                    ((1, "vertices", polyslab_user_vjp), (1, "slab_bounds", polyslab_user_vjp))
+                ] * len(task_names)
+
+            batch_data = {}
+            if use_run_async:
+                batch_data = run_async_custom(
+                    sims, user_vjp=user_vjp, local_gradient=local_gradient
+                )
+            else:
+                if use_task_names:
+                    for task_name, sim in sims.items():
+                        batch_data[task_name] = run_custom(
+                            sim,
+                            task_name,
+                            user_vjp=user_vjp[task_name],
+                            local_gradient=local_gradient,
+                        )
+                else:
+                    for idx, sim in enumerate(sims):
+                        batch_data[idx] = run_custom(
+                            sim, user_vjp=user_vjp[idx], local_gradient=local_gradient
+                        )
+
+            value = 0.0
+
+            for _, sim_data in batch_data.items():
+                value += postprocess(sim_data)
+            return value
+
+        return objective
+
+    user_vjp_val = 1.0
+    user_vjp_val_scale = 10.0 * user_vjp_val
+
+    if not local_gradient:
+        with pytest.raises(
+            td.exceptions.AdjointError,
+            match="User VJP specified for a remote gradient not supported.",
+        ):
+            val, grad = ag.value_and_grad(make_objective(user_vjp_val))(params0)
+    else:
+        val, grad = ag.value_and_grad(make_objective(user_vjp_val))(params0)
+        val_scale, grad_scale = ag.value_and_grad(make_objective(user_vjp_val_scale))(params0)
+
+        assert np.isclose(
+            np.sum(np.abs(grad * (user_vjp_val_scale / user_vjp_val) - grad_scale)), 0.0
+        ), "Gradients were not set by the user vjp"
+
+
+@pytest.mark.parametrize("structure_key, monitor_key", user_vjp_args)
+@pytest.mark.parametrize("polyslab_axis", [0, 1, 2])
+@pytest.mark.parametrize("use_run_async", [True, False])
+@pytest.mark.parametrize("use_task_names", [True, False])
+def test_autograd_user_vjp_selective(
+    use_emulated_run, structure_key, monitor_key, polyslab_axis, use_run_async, use_task_names
+):
+    """Test that we can selectively override a vjp with a user defined function that covers some of, but not all, gradient keys."""
+
+    fn_dict = get_functions(structure_key, monitor_key)
+    make_sim = fn_dict["sim"]
+    postprocess = fn_dict["postprocess"]
+
+    task_names = {"test_a", "adjoint", "_test"}
+
+    def make_objective(user_vjp_val):
+        polyslab_user_vjp = make_polyslab_user_vjp(user_vjp_val)
+
+        def objective(*args):
+            if use_task_names:
+                sims = {
+                    task_name: make_sim(*args, polyslab_axis=polyslab_axis)
+                    for task_name in task_names
+                }
+                user_vjp = dict.fromkeys(task_names, ((1, "vertices", polyslab_user_vjp),))
+            else:
+                sims = [make_sim(*args, polyslab_axis=polyslab_axis)] * len(task_names)
+                user_vjp = [((1, "vertices", polyslab_user_vjp),)] * len(task_names)
+
+            batch_data = {}
+            if use_run_async:
+                batch_data = run_async_custom(sims, user_vjp=user_vjp, local_gradient=True)
+            else:
+                if use_task_names:
+                    for task_name, sim in sims.items():
+                        batch_data[task_name] = run_custom(
+                            sim, task_name, user_vjp=user_vjp[task_name], local_gradient=True
+                        )
+                else:
+                    for idx, sim in enumerate(sims):
+                        batch_data[idx] = run_custom(
+                            sim, user_vjp=user_vjp[idx], local_gradient=True
+                        )
+
+            value = 0.0
+
+            for _, sim_data in batch_data.items():
+                value += postprocess(sim_data)
+            return value
+
+        return objective
+
+    user_vjp_val = 1.0
+    user_vjp_val_scale = 10.0 * user_vjp_val
+
+    val, grad = ag.value_and_grad(make_objective(user_vjp_val))(params0)
+    val_scale, grad_scale = ag.value_and_grad(make_objective(user_vjp_val_scale))(params0)
+
+    if polyslab_axis == POLYSLAB_SELECT_VERTICES:
+        assert np.isclose(
+            np.sum(np.abs(grad * (user_vjp_val_scale / user_vjp_val) - grad_scale)), 0.0
+        ), "Gradients were not set by the user vjp when they should have been"
+    else:
+        assert not np.isclose(
+            np.sum(np.abs(grad * (user_vjp_val_scale / user_vjp_val) - grad_scale)), 0.0
+        ), "Gradients were set by the user vjp when they should not have been"
+
+
+@pytest.mark.parametrize("structure_key, monitor_key", user_vjp_args)
+@pytest.mark.parametrize("polyslab_axis", [0, 1, 2])
+@pytest.mark.parametrize("local_gradient", [True, False])
+def test_autograd_cm_user_vjp(
+    use_emulated_run, structure_key, monitor_key, polyslab_axis, local_gradient
+):
+    """Test that we can override a vjp with a user defined function in component modeler simulations."""
+
+    fn_dict = get_functions(structure_key, monitor_key)
+    make_sim = fn_dict["sim"]
+    postprocess = fn_dict["postprocess"]
+
+    def make_objective(user_vjp_val):
+        polyslab_user_vjp = make_polyslab_user_vjp(user_vjp_val)
+
+        def objective(*args):
+            base_sim = make_sim(*args, polyslab_axis=polyslab_axis)
+            find_mode_monitors = [
+                monitor for monitor in base_sim.monitors if isinstance(monitor, td.ModeMonitor)
+            ]
+
+            select_mode_monitor = find_mode_monitors[0]
+
+            stripped_sim = base_sim.updated_copy(sources=[], monitors=[])
+
+            input_port = Port(
+                center=select_mode_monitor.center,
+                size=select_mode_monitor.size,
+                mode_spec=select_mode_monitor.mode_spec,
+                direction="-",
+                name="input_port",
+            )
+
+            modeler = ComponentModeler(
+                simulation=stripped_sim,
+                ports=[input_port],
+                freqs=select_mode_monitor.freqs,
+            )
+
+            smatrix = _run_local(
+                modeler,
+                user_vjp=(
+                    (1, "vertices", polyslab_user_vjp),
+                    (1, "slab_bounds", polyslab_user_vjp),
+                ),
+                local_gradient=local_gradient,
+            )
+            return np.sum(np.abs(smatrix.smatrix().values) ** 2)
+
+        return objective
+
+    user_vjp_val = 1.0
+    user_vjp_val_scale = 10.0 * user_vjp_val
+
+    if not local_gradient:
+        with pytest.raises(
+            td.exceptions.AdjointError,
+            match="User VJP specified for a remote gradient not supported.",
+        ):
+            val, grad = ag.value_and_grad(make_objective(user_vjp_val))(params0)
+    else:
+        val, grad = ag.value_and_grad(make_objective(user_vjp_val))(params0)
+        val_scale, grad_scale = ag.value_and_grad(make_objective(user_vjp_val_scale))(params0)
+
+        assert np.isclose(
+            np.sum(np.abs(grad * (user_vjp_val_scale / user_vjp_val) - grad_scale)), 0.0
+        ), "Gradients were not set by the user vjp"
+
+
+@pytest.mark.parametrize("structure_key, monitor_key", user_vjp_args)
+@pytest.mark.parametrize("polyslab_axis", [0, 1, 2])
+@pytest.mark.parametrize("use_run_async", [True, False])
+@pytest.mark.parametrize("use_task_names", [True, False])
+@pytest.mark.parametrize("local_gradient", [True, False])
+def test_autograd_numerical_structures(
+    use_emulated_run,
+    structure_key,
+    monitor_key,
+    polyslab_axis,
+    use_run_async,
+    use_task_names,
+    local_gradient,
+):
+    """Test that we can numerical structures to autograd simulations."""
+
+    fn_dict = get_functions(structure_key, monitor_key)
+    make_sim = fn_dict["sim"]
+    postprocess = fn_dict["postprocess"]
+
+    task_names = {"test_a", "adjoint", "_test"}
+
+    def make_objective(user_vjp_val):
+        def objective(*args):
+            def make_first_polyslab(param):
+                return make_sim(*args, polyslab_axis=polyslab_axis).structures[1]
+
+            def vjp(parameters, derivative_info):
+                vjps = {}
+
+                for path in derivative_info.paths:
+                    param_idx = path[0]
+
+                    vjps[path] = user_vjp_val
+
+                return vjps
+
+            structure_generator = {
+                1: {
+                    "function": make_first_polyslab,
+                    "parameters": np.array(args).flatten(),
+                    "vjp": vjp,
+                }
+            }
+
+            sim = make_sim(*args, polyslab_axis=polyslab_axis)
+
+            structures = [s for idx, s in enumerate(sim.structures) if (not (idx == 1))]
+            sim_strip_structure = sim.updated_copy(structures=structures)
+
+            if use_task_names:
+                sims = dict.fromkeys(task_names, sim_strip_structure)
+                numerical_structures = dict.fromkeys(task_names, structure_generator)
+            else:
+                sims = [sim_strip_structure] * len(task_names)
+                numerical_structures = [structure_generator] * len(task_names)
+
+            batch_data = {}
+            if use_run_async:
+                batch_data = run_async_custom(
+                    sims, numerical_structures=numerical_structures, local_gradient=local_gradient
+                )
+            else:
+                if use_task_names:
+                    for task_name, sim in sims.items():
+                        batch_data[task_name] = run_custom(
+                            sim,
+                            task_name,
+                            numerical_structures=numerical_structures[task_name],
+                            local_gradient=local_gradient,
+                        )
+                else:
+                    for idx, sim in enumerate(sims):
+                        batch_data[idx] = run_custom(
+                            sim,
+                            numerical_structures=numerical_structures[idx],
+                            local_gradient=local_gradient,
+                        )
+
+            value = 0.0
+
+            for _, sim_data in batch_data.items():
+                value += postprocess(sim_data)
+            return value
+
+        return objective
+
+    user_vjp_val = 1.0
+    user_vjp_val_scale = 10.0 * user_vjp_val
+
+    if not local_gradient:
+        with pytest.raises(
+            td.exceptions.AdjointError,
+            match="Numerical structures specified for a remote gradient not supported.",
+        ):
+            val, grad = ag.value_and_grad(make_objective(user_vjp_val))(params0)
+    else:
+        val, grad = ag.value_and_grad(make_objective(user_vjp_val))(params0)
+        val_scale, grad_scale = ag.value_and_grad(make_objective(user_vjp_val_scale))(params0)
+
+        assert np.isclose(
+            np.sum(np.abs(grad * (user_vjp_val_scale / user_vjp_val) - grad_scale)), 0.0
+        ), "Gradients were not set by the user vjp"
+
+
+@pytest.mark.parametrize("structure_key, monitor_key", user_vjp_args)
+@pytest.mark.parametrize("polyslab_axis", [0, 1, 2])
+@pytest.mark.parametrize("local_gradient", [True, False])
+def test_autograd_cm_numerical_structures(
+    use_emulated_run, structure_key, monitor_key, polyslab_axis, local_gradient
+):
+    """Test that we can numerical structures to component modeler autograd simulations."""
+
+    fn_dict = get_functions(structure_key, monitor_key)
+    make_sim = fn_dict["sim"]
+    postprocess = fn_dict["postprocess"]
+
+    def make_objective(user_vjp_val):
+        def objective(*args):
+            def make_first_polyslab(param):
+                return make_sim(*args, polyslab_axis=polyslab_axis).structures[1]
+
+            def vjp(parameters, derivative_info):
+                vjps = {}
+
+                for path in derivative_info.paths:
+                    param_idx = path[0]
+
+                    vjps[path] = user_vjp_val
+
+                return vjps
+
+            structure_generator = {
+                1: {
+                    "function": make_first_polyslab,
+                    "parameters": np.array(args).flatten(),
+                    "vjp": vjp,
+                }
+            }
+
+            sim = make_sim(*args, polyslab_axis=polyslab_axis)
+
+            structures = [s for idx, s in enumerate(sim.structures) if (not (idx == 1))]
+            sim_strip_structure = sim.updated_copy(structures=structures)
+
+            find_mode_monitors = [
+                monitor
+                for monitor in sim_strip_structure.monitors
+                if isinstance(monitor, td.ModeMonitor)
+            ]
+
+            select_mode_monitor = find_mode_monitors[0]
+
+            stripped_sim = sim_strip_structure.updated_copy(sources=[], monitors=[])
+
+            input_port = Port(
+                center=select_mode_monitor.center,
+                size=select_mode_monitor.size,
+                mode_spec=select_mode_monitor.mode_spec,
+                direction="-",
+                name="input_port",
+            )
+
+            modeler = ComponentModeler(
+                simulation=stripped_sim,
+                ports=[input_port],
+                freqs=select_mode_monitor.freqs,
+            )
+
+            smatrix = _run_local(
+                modeler, numerical_structures=structure_generator, local_gradient=local_gradient
+            )
+            return np.sum(np.abs(smatrix.smatrix().values) ** 2)
+
+        return objective
+
+    user_vjp_val = 1.0
+    user_vjp_val_scale = 10.0 * user_vjp_val
+
+    if not local_gradient:
+        with pytest.raises(
+            td.exceptions.AdjointError,
+            match="ComponentModeler autograd with traced numerical structures requires local_gradient=True.",
+        ):
+            val, grad = ag.value_and_grad(make_objective(user_vjp_val))(params0)
+    else:
+        val, grad = ag.value_and_grad(make_objective(user_vjp_val))(params0)
+        val_scale, grad_scale = ag.value_and_grad(make_objective(user_vjp_val_scale))(params0)
+
+        assert np.isclose(
+            np.sum(np.abs(grad * (user_vjp_val_scale / user_vjp_val) - grad_scale)), 0.0
+        ), "Gradients were not set by the user vjp"
 
 
 @pytest.mark.skipif(not RUN_NUMERICAL, reason="Numerical gradient tests runs through web API.")
@@ -1847,6 +2290,7 @@ def test_pole_residue(monkeypatch):
         ),
         bounds_intersect=((-1, -1, -1), (1, 1, 1)),
         simulation_bounds=((-2, -2, -2), (2, 2, 2)),
+        updated_epsilon=None,
     )
 
     grads_computed = pr._compute_derivatives(derivative_info=info)
@@ -1889,6 +2333,7 @@ def test_adaptive_spacing(eps_real):
         eps_inf_structure={},
         bounds_intersect=((-1, -1, -1), (1, 1, 1)),
         simulation_bounds=((-2, -2, -2), (2, 2, 2)),
+        updated_epsilon=None,
     )
 
     with AssertLogLevel("WARNING", contains_str="Based on the material, the adaptive spacing"):
@@ -1919,6 +2364,7 @@ def test_cylinder_discretization(eps_real):
         eps_inf_structure={},
         bounds_intersect=((-1, -1, -1), (1, 1, 1)),
         simulation_bounds=((-2, -2, -2), (2, 2, 2)),
+        updated_epsilon=None,
     )
 
     with AssertLogLevel(
@@ -2000,6 +2446,7 @@ def test_custom_pole_residue(monkeypatch):
         ),
         bounds_intersect=((-1, -1, -1), (1, 1, 1)),
         simulation_bounds=((-2, -2, -2), (2, 2, 2)),
+        updated_epsilon=None,
     )
 
     grads_computed = pr._compute_derivatives(derivative_info=info)

--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -20,6 +20,7 @@ from autograd.test_util import check_grads
 
 import tidy3d as td
 import tidy3d.web as web
+from tidy3d.components.autograd import get_static
 from tidy3d.components.autograd.derivative_utils import DerivativeInfo
 from tidy3d.components.autograd.field_map import FieldMap
 from tidy3d.components.autograd.utils import is_tidy_box
@@ -33,7 +34,7 @@ from tidy3d.plugins.smatrix.run import _run_local
 from tidy3d.web import run, run_async
 from tidy3d.web.api.autograd import autograd as autograd_module
 from tidy3d.web.api.autograd.autograd import run_async_custom, run_custom
-from tidy3d.web.api.autograd.types import UserVJPConfig
+from tidy3d.web.api.autograd.types import NumericalStructureConfig, UserVJPConfig
 
 from ...utils import SIM_FULL, AssertLogLevel, run_emulated, tracer_arr
 
@@ -265,7 +266,7 @@ def use_emulated_run(monkeypatch):
                 sim_data_fwd=sim_data_fwd,
                 sim_fields_keys=sim_fields_keys,
                 user_vjp=None,
-                numerical_info=None,
+                numerical_structures=None,
             )
 
             return traced_fields_vjp
@@ -666,9 +667,6 @@ if TEST_POLYSLAB_SPEED:
     args = [("polyslab", "mode")]
 
 
-# args = [("polyslab", "mode")]
-
-
 def get_functions(structure_key: str, monitor_key: str) -> dict[str, typing.Callable]:
     if structure_key == ALL_KEY:
         structure_keys = structure_keys_
@@ -755,10 +753,7 @@ def make_polyslab_user_vjp(user_vjp_val):
     return polyslab_user_vjp
 
 
-user_vjp_args = [("polyslab", "mode")]
-
-
-@pytest.mark.parametrize("structure_key, monitor_key", user_vjp_args)
+@pytest.mark.parametrize("structure_key, monitor_key", [("polyslab", "mode")])
 @pytest.mark.parametrize("polyslab_axis", [0, 1, 2])
 @pytest.mark.parametrize("use_run_async", [True, False])
 @pytest.mark.parametrize("use_task_names", [True, False])
@@ -827,9 +822,6 @@ def test_autograd_user_vjp(
                 user_vjp = [user_vjp_element] * len(task_names)
             batch_data = {}
             if use_run_async:
-                # print(f'user vjp = {user_vjp}')
-                # asdf
-
                 batch_data = run_async_custom(
                     sims, user_vjp=user_vjp, local_gradient=local_gradient
                 )
@@ -862,7 +854,7 @@ def test_autograd_user_vjp(
     if not local_gradient:
         with pytest.raises(
             td.exceptions.AdjointError,
-            match="User VJP specified for a remote gradient not supported.",
+            match="user_vjp specified for a remote gradient not supported.",
         ):
             val, grad = ag.value_and_grad(make_objective(user_vjp_val))(params0)
     else:
@@ -874,7 +866,7 @@ def test_autograd_user_vjp(
         ), "Gradients were not set by the user vjp"
 
 
-@pytest.mark.parametrize("structure_key, monitor_key", user_vjp_args)
+@pytest.mark.parametrize("structure_key, monitor_key", [("polyslab", "mode")])
 @pytest.mark.parametrize("polyslab_axis", [0, 1, 2])
 @pytest.mark.parametrize("use_run_async", [True, False])
 @pytest.mark.parametrize("use_task_names", [True, False])
@@ -975,12 +967,19 @@ def test_autograd_user_vjp_selective(
         ), "Gradients were set by the user vjp when they should not have been"
 
 
-@pytest.mark.parametrize("structure_key, monitor_key", user_vjp_args)
+@pytest.mark.parametrize("structure_key, monitor_key", [("polyslab", "mode")])
 @pytest.mark.parametrize("polyslab_axis", [0, 1, 2])
 @pytest.mark.parametrize("use_single_user_vjp", [True, False])
+@pytest.mark.parametrize("run_function", [_run_local, run_custom])
 @pytest.mark.parametrize("local_gradient", [True, False])
 def test_autograd_cm_user_vjp(
-    use_emulated_run, structure_key, monitor_key, polyslab_axis, use_single_user_vjp, local_gradient
+    use_emulated_run,
+    structure_key,
+    monitor_key,
+    polyslab_axis,
+    use_single_user_vjp,
+    run_function,
+    local_gradient,
 ):
     """Test that we can override a vjp with a user defined function in component modeler simulations."""
 
@@ -1045,7 +1044,7 @@ def test_autograd_cm_user_vjp(
                 freqs=select_mode_monitor.freqs,
             )
 
-            smatrix = _run_local(
+            smatrix = run_function(
                 modeler,
                 user_vjp=user_vjp_element,
                 local_gradient=local_gradient,
@@ -1060,7 +1059,7 @@ def test_autograd_cm_user_vjp(
     if not local_gradient:
         with pytest.raises(
             td.exceptions.AdjointError,
-            match="User VJP specified for a remote gradient not supported.",
+            match="user_vjp specified for a remote gradient not supported.",
         ):
             val, grad = ag.value_and_grad(make_objective(user_vjp_val))(params0)
     else:
@@ -1072,10 +1071,12 @@ def test_autograd_cm_user_vjp(
         ), "Gradients were not set by the user vjp"
 
 
-@pytest.mark.parametrize("structure_key, monitor_key", user_vjp_args)
+@pytest.mark.parametrize("structure_key, monitor_key", [("polyslab", "mode")])
 @pytest.mark.parametrize("polyslab_axis", [0, 1, 2])
 @pytest.mark.parametrize("use_run_async", [True, False])
+@pytest.mark.parametrize("use_single_numerical_structure", [True, False])
 @pytest.mark.parametrize("use_task_names", [True, False])
+@pytest.mark.parametrize("specify_numerical_structure_index", [True, False])
 @pytest.mark.parametrize("local_gradient", [True, False])
 def test_autograd_numerical_structures(
     use_emulated_run,
@@ -1083,10 +1084,12 @@ def test_autograd_numerical_structures(
     monitor_key,
     polyslab_axis,
     use_run_async,
+    use_single_numerical_structure,
     use_task_names,
+    specify_numerical_structure_index,
     local_gradient,
 ):
-    """Test that we can numerical structures to autograd simulations."""
+    """Test that we can add numerical structures to autograd simulations."""
 
     fn_dict = get_functions(structure_key, monitor_key)
     make_sim = fn_dict["sim"]
@@ -1096,7 +1099,7 @@ def test_autograd_numerical_structures(
 
     def make_objective(user_vjp_val):
         def objective(*args):
-            def make_first_polyslab(param):
+            def make_first_polyslab(params):
                 return make_sim(*args, polyslab_axis=polyslab_axis).structures[1]
 
             def vjp(parameters, derivative_info):
@@ -1109,25 +1112,37 @@ def test_autograd_numerical_structures(
 
                 return vjps
 
-            structure_generator = {
-                1: {
-                    "function": make_first_polyslab,
-                    "parameters": np.array(args).flatten(),
-                    "vjp": vjp,
-                }
-            }
-
-            sim = make_sim(*args, polyslab_axis=polyslab_axis)
+            # ensure the numerical_structures are the reason for the autograd run by stripping
+            # tracers for the simulation creation
+            static_args = [get_static(arg) for arg in args]
+            sim = make_sim(*static_args, polyslab_axis=polyslab_axis)
 
             structures = [s for idx, s in enumerate(sim.structures) if (not (idx == 1))]
             sim_strip_structure = sim.updated_copy(structures=structures)
 
+            if specify_numerical_structure_index:
+                numerical_structure = NumericalStructureConfig(
+                    create=make_first_polyslab,
+                    compute_derivatives=vjp,
+                    parameters=np.array(args).flatten(),
+                    structure_index=1,
+                )
+            else:
+                numerical_structure = NumericalStructureConfig(
+                    create=make_first_polyslab,
+                    compute_derivatives=vjp,
+                    parameters=np.array(args).flatten(),
+                )
+            numerical_structures = (
+                numerical_structure if use_single_numerical_structure else (numerical_structure,)
+            )
+
             if use_task_names:
                 sims = dict.fromkeys(task_names, sim_strip_structure)
-                numerical_structures = dict.fromkeys(task_names, structure_generator)
+                numerical_structures = dict.fromkeys(task_names, numerical_structures)
             else:
                 sims = [sim_strip_structure] * len(task_names)
-                numerical_structures = [structure_generator] * len(task_names)
+                numerical_structures = [numerical_structures] * len(task_names)
 
             batch_data = {}
             if use_run_async:
@@ -1165,25 +1180,39 @@ def test_autograd_numerical_structures(
     if not local_gradient:
         with pytest.raises(
             td.exceptions.AdjointError,
-            match="Numerical structures specified for a remote gradient not supported.",
+            match="numerical_structures specified for a remote gradient not supported.",
         ):
             val, grad = ag.value_and_grad(make_objective(user_vjp_val))(params0)
     else:
         val, grad = ag.value_and_grad(make_objective(user_vjp_val))(params0)
         val_scale, grad_scale = ag.value_and_grad(make_objective(user_vjp_val_scale))(params0)
 
+        assert np.allclose(grad, len(task_names) * user_vjp_val), (
+            "Gradients did not accumulate correctly."
+        )
+
         assert np.isclose(
             np.sum(np.abs(grad * (user_vjp_val_scale / user_vjp_val) - grad_scale)), 0.0
         ), "Gradients were not set by the user vjp"
 
 
-@pytest.mark.parametrize("structure_key, monitor_key", user_vjp_args)
+@pytest.mark.parametrize("structure_key, monitor_key", [("polyslab", "mode")])
 @pytest.mark.parametrize("polyslab_axis", [0, 1, 2])
+@pytest.mark.parametrize("numerical_structures_specification", ["single", "tuple"])
+@pytest.mark.parametrize("run_function", [_run_local, run_custom])
+@pytest.mark.parametrize("specify_numerical_structure_index", [True, False])
 @pytest.mark.parametrize("local_gradient", [True, False])
 def test_autograd_cm_numerical_structures(
-    use_emulated_run, structure_key, monitor_key, polyslab_axis, local_gradient
+    use_emulated_run,
+    structure_key,
+    monitor_key,
+    polyslab_axis,
+    numerical_structures_specification,
+    run_function,
+    specify_numerical_structure_index,
+    local_gradient,
 ):
-    """Test that we can numerical structures to component modeler autograd simulations."""
+    """Test that we can add numerical structures to component modeler autograd simulations."""
 
     fn_dict = get_functions(structure_key, monitor_key)
     make_sim = fn_dict["sim"]
@@ -1191,7 +1220,7 @@ def test_autograd_cm_numerical_structures(
 
     def make_objective(user_vjp_val):
         def objective(*args):
-            def make_first_polyslab(param):
+            def make_first_polyslab(params):
                 return make_sim(*args, polyslab_axis=polyslab_axis).structures[1]
 
             def vjp(parameters, derivative_info):
@@ -1204,15 +1233,28 @@ def test_autograd_cm_numerical_structures(
 
                 return vjps
 
-            structure_generator = {
-                1: {
-                    "function": make_first_polyslab,
-                    "parameters": np.array(args).flatten(),
-                    "vjp": vjp,
-                }
-            }
+            if specify_numerical_structure_index:
+                numerical_structure = NumericalStructureConfig(
+                    create=make_first_polyslab,
+                    compute_derivatives=vjp,
+                    parameters=np.array(args).flatten(),
+                    structure_index=1,
+                )
+            else:
+                numerical_structure = NumericalStructureConfig(
+                    create=make_first_polyslab,
+                    compute_derivatives=vjp,
+                    parameters=np.array(args).flatten(),
+                )
+            if numerical_structures_specification == "single":
+                numerical_structures = numerical_structure
+            elif numerical_structures_specification == "tuple":
+                numerical_structures = (numerical_structure,)
 
-            sim = make_sim(*args, polyslab_axis=polyslab_axis)
+            # ensure the numerical_structures are the reason for the autograd run by stripping
+            # tracers for the simulation creation
+            static_args = [get_static(arg) for arg in args]
+            sim = make_sim(*static_args, polyslab_axis=polyslab_axis)
 
             structures = [s for idx, s in enumerate(sim.structures) if (not (idx == 1))]
             sim_strip_structure = sim.updated_copy(structures=structures)
@@ -1241,8 +1283,8 @@ def test_autograd_cm_numerical_structures(
                 freqs=select_mode_monitor.freqs,
             )
 
-            smatrix = _run_local(
-                modeler, numerical_structures=structure_generator, local_gradient=local_gradient
+            smatrix = run_function(
+                modeler, numerical_structures=numerical_structures, local_gradient=local_gradient
             )
             return np.sum(np.abs(smatrix.smatrix().values) ** 2)
 

--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -265,8 +265,8 @@ def use_emulated_run(monkeypatch):
                 sim_data_orig=sim_data_orig,
                 sim_data_fwd=sim_data_fwd,
                 sim_fields_keys=sim_fields_keys,
-                user_vjp=None,
                 numerical_structures=None,
+                user_vjp=None,
             )
 
             return traced_fields_vjp
@@ -754,11 +754,11 @@ def make_polyslab_user_vjp(user_vjp_val):
 
 
 @pytest.mark.parametrize("structure_key, monitor_key", [("polyslab", "mode")])
-@pytest.mark.parametrize("polyslab_axis", [0, 1, 2])
-@pytest.mark.parametrize("use_run_async", [True, False])
+@pytest.mark.parametrize("polyslab_axis", [0])  # , 1, 2])
+@pytest.mark.parametrize("use_run_async", [False])  # [True, False])
 @pytest.mark.parametrize("use_task_names", [True, False])
 @pytest.mark.parametrize("use_single_user_vjp", [True, False])
-@pytest.mark.parametrize("local_gradient", [True, False])
+@pytest.mark.parametrize("local_gradient", [True])  # , False])
 def test_autograd_user_vjp(
     use_emulated_run,
     structure_key,

--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -738,11 +738,16 @@ def make_polyslab_user_vjp(user_vjp_val):
     def polyslab_user_vjp(polyslab, derivative_info):
         vjps = {}
 
+        # should there only be one path here since that is how user_vjp is specified?
         for path in derivative_info.paths:
-            if path[0] == "vertices":
+            # print(f'working on path = {path}')
+            if path[0:2] == ("geometry", "vertices"):
                 vjps[path] = user_vjp_val * np.ones(polyslab.vertices.shape)
-            elif path[0] == "slab_bounds":
-                vjps[path] = (user_vjp_val, user_vjp_val)
+            elif path[0:2] == ("geometry", "slab_bounds"):
+                if len(path) == 3:
+                    vjps[path] = (user_vjp_val, user_vjp_val)[path[2]]
+                else:
+                    vjps[path] = (user_vjp_val, user_vjp_val)
 
         return vjps
 
@@ -751,11 +756,14 @@ def make_polyslab_user_vjp(user_vjp_val):
 
 user_vjp_args = [("polyslab", "mode")]
 
+from tidy3d.web.api.autograd.types import UserVJPConfig
+
 
 @pytest.mark.parametrize("structure_key, monitor_key", user_vjp_args)
 @pytest.mark.parametrize("polyslab_axis", [0, 1, 2])
 @pytest.mark.parametrize("use_run_async", [True, False])
 @pytest.mark.parametrize("use_task_names", [True, False])
+@pytest.mark.parametrize("use_single_user_vjp", [True, False])
 @pytest.mark.parametrize("local_gradient", [True, False])
 def test_autograd_user_vjp(
     use_emulated_run,
@@ -764,6 +772,7 @@ def test_autograd_user_vjp(
     polyslab_axis,
     use_run_async,
     use_task_names,
+    use_single_user_vjp,
     local_gradient,
 ):
     """Test that we can override a vjp with a user defined function."""
@@ -777,24 +786,51 @@ def test_autograd_user_vjp(
     def make_objective(user_vjp_val):
         polyslab_user_vjp = make_polyslab_user_vjp(user_vjp_val)
 
+        user_vjp_tuple = (
+            UserVJPConfig(
+                structure_index=1,
+                compute_derivatives=polyslab_user_vjp,
+                path_key=(
+                    (
+                        "geometry",
+                        "vertices",
+                    )
+                ),
+            ),
+            UserVJPConfig(
+                structure_index=1,
+                compute_derivatives=polyslab_user_vjp,
+                path_key=(
+                    (
+                        "geometry",
+                        "slab_bounds",
+                    )
+                ),
+            ),
+        )
+
+        user_vjp_single = UserVJPConfig(
+            structure_index=1,
+            compute_derivatives=polyslab_user_vjp,
+        )
+
+        user_vjp_element = user_vjp_single if use_single_user_vjp else user_vjp_tuple
+
         def objective(*args):
             if use_task_names:
                 sims = {
                     task_name: make_sim(*args, polyslab_axis=polyslab_axis)
                     for task_name in task_names
                 }
-                user_vjp = dict.fromkeys(
-                    task_names,
-                    ((1, "vertices", polyslab_user_vjp), (1, "slab_bounds", polyslab_user_vjp)),
-                )
+                user_vjp = dict.fromkeys(sims.keys(), user_vjp_element)
             else:
                 sims = [make_sim(*args, polyslab_axis=polyslab_axis)] * len(task_names)
-                user_vjp = [
-                    ((1, "vertices", polyslab_user_vjp), (1, "slab_bounds", polyslab_user_vjp))
-                ] * len(task_names)
-
+                user_vjp = [user_vjp_element] * len(task_names)
             batch_data = {}
             if use_run_async:
+                # print(f'user vjp = {user_vjp}')
+                # asdf
+
                 batch_data = run_async_custom(
                     sims, user_vjp=user_vjp, local_gradient=local_gradient
                 )
@@ -843,8 +879,15 @@ def test_autograd_user_vjp(
 @pytest.mark.parametrize("polyslab_axis", [0, 1, 2])
 @pytest.mark.parametrize("use_run_async", [True, False])
 @pytest.mark.parametrize("use_task_names", [True, False])
+@pytest.mark.parametrize("use_single_user_vjp", [True, False])
 def test_autograd_user_vjp_selective(
-    use_emulated_run, structure_key, monitor_key, polyslab_axis, use_run_async, use_task_names
+    use_emulated_run,
+    structure_key,
+    monitor_key,
+    polyslab_axis,
+    use_run_async,
+    use_task_names,
+    use_single_user_vjp,
 ):
     """Test that we can selectively override a vjp with a user defined function that covers some of, but not all, gradient keys."""
 
@@ -857,16 +900,42 @@ def test_autograd_user_vjp_selective(
     def make_objective(user_vjp_val):
         polyslab_user_vjp = make_polyslab_user_vjp(user_vjp_val)
 
+        user_vjp_tuple = (
+            UserVJPConfig(
+                structure_index=1,
+                compute_derivatives=polyslab_user_vjp,
+                path_key=(
+                    (
+                        "geometry",
+                        "vertices",
+                    )
+                ),
+            ),
+        )
+
+        user_vjp_single = UserVJPConfig(
+            structure_index=1,
+            compute_derivatives=polyslab_user_vjp,
+            path_key=(
+                (
+                    "geometry",
+                    "vertices",
+                )
+            ),
+        )
+
+        user_vjp_element = user_vjp_single if use_single_user_vjp else user_vjp_tuple
+
         def objective(*args):
             if use_task_names:
                 sims = {
                     task_name: make_sim(*args, polyslab_axis=polyslab_axis)
                     for task_name in task_names
                 }
-                user_vjp = dict.fromkeys(task_names, ((1, "vertices", polyslab_user_vjp),))
+                user_vjp = dict.fromkeys(task_names, user_vjp_element)
             else:
                 sims = [make_sim(*args, polyslab_axis=polyslab_axis)] * len(task_names)
-                user_vjp = [((1, "vertices", polyslab_user_vjp),)] * len(task_names)
+                user_vjp = [user_vjp_element] * len(task_names)
 
             batch_data = {}
             if use_run_async:
@@ -909,9 +978,10 @@ def test_autograd_user_vjp_selective(
 
 @pytest.mark.parametrize("structure_key, monitor_key", user_vjp_args)
 @pytest.mark.parametrize("polyslab_axis", [0, 1, 2])
+@pytest.mark.parametrize("use_single_user_vjp", [True, False])
 @pytest.mark.parametrize("local_gradient", [True, False])
 def test_autograd_cm_user_vjp(
-    use_emulated_run, structure_key, monitor_key, polyslab_axis, local_gradient
+    use_emulated_run, structure_key, monitor_key, polyslab_axis, use_single_user_vjp, local_gradient
 ):
     """Test that we can override a vjp with a user defined function in component modeler simulations."""
 
@@ -921,6 +991,36 @@ def test_autograd_cm_user_vjp(
 
     def make_objective(user_vjp_val):
         polyslab_user_vjp = make_polyslab_user_vjp(user_vjp_val)
+
+        user_vjp_tuple = (
+            UserVJPConfig(
+                structure_index=1,
+                compute_derivatives=polyslab_user_vjp,
+                path_key=(
+                    (
+                        "geometry",
+                        "vertices",
+                    )
+                ),
+            ),
+            UserVJPConfig(
+                structure_index=1,
+                compute_derivatives=polyslab_user_vjp,
+                path_key=(
+                    (
+                        "geometry",
+                        "slab_bounds",
+                    )
+                ),
+            ),
+        )
+
+        user_vjp_single = UserVJPConfig(
+            structure_index=1,
+            compute_derivatives=polyslab_user_vjp,
+        )
+
+        user_vjp_element = user_vjp_single if use_single_user_vjp else user_vjp_tuple
 
         def objective(*args):
             base_sim = make_sim(*args, polyslab_axis=polyslab_axis)
@@ -948,10 +1048,7 @@ def test_autograd_cm_user_vjp(
 
             smatrix = _run_local(
                 modeler,
-                user_vjp=(
-                    (1, "vertices", polyslab_user_vjp),
-                    (1, "slab_bounds", polyslab_user_vjp),
-                ),
+                user_vjp=user_vjp_element,
                 local_gradient=local_gradient,
             )
             return np.sum(np.abs(smatrix.smatrix().values) ** 2)

--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -33,6 +33,7 @@ from tidy3d.plugins.smatrix.run import _run_local
 from tidy3d.web import run, run_async
 from tidy3d.web.api.autograd import autograd as autograd_module
 from tidy3d.web.api.autograd.autograd import run_async_custom, run_custom
+from tidy3d.web.api.autograd.types import UserVJPConfig
 
 from ...utils import SIM_FULL, AssertLogLevel, run_emulated, tracer_arr
 
@@ -755,8 +756,6 @@ def make_polyslab_user_vjp(user_vjp_val):
 
 
 user_vjp_args = [("polyslab", "mode")]
-
-from tidy3d.web.api.autograd.types import UserVJPConfig
 
 
 @pytest.mark.parametrize("structure_key, monitor_key", user_vjp_args)

--- a/tests/test_components/autograd/test_autograd_custom_dispersive_vjps.py
+++ b/tests/test_components/autograd/test_autograd_custom_dispersive_vjps.py
@@ -48,6 +48,7 @@ def _deriv_info(freq):
         "eps_inf_structure": eps_inf,
         "bounds_intersect": ((-1, -1, -1), (1, 1, 1)),
         "simulation_bounds": ((-2, -2, -2), (2, 2, 2)),
+        "updated_epsilon": None,
     }
 
 

--- a/tidy3d/components/autograd/__init__.py
+++ b/tidy3d/components/autograd/__init__.py
@@ -5,6 +5,7 @@ from .functions import interpn
 from .types import (
     AutogradFieldMap,
     AutogradTraced,
+    NumericalStructureInfo,
     TracedCoordinate,
     TracedFloat,
     TracedSize,
@@ -16,6 +17,7 @@ from .utils import get_static, is_tidy_box, split_list
 __all__ = [
     "AutogradFieldMap",
     "AutogradTraced",
+    "NumericalStructureInfo",
     "TidyArrayBox",
     "TracedCoordinate",
     "TracedFloat",

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -115,6 +115,9 @@ class DerivativeInfo:
     frequencies: ArrayLike
     """Frequencies at which the adjoint gradient should be computed."""
 
+    updated_epsilon: Callable
+    """Function to return the permittivity upon geometry replacement."""
+
     H_der_map: Optional[FieldData] = None
     """Magnetic field gradient map.
     Dataset where the field components ("Hx", "Hy", "Hz") store the multiplication

--- a/tidy3d/components/autograd/types.py
+++ b/tidy3d/components/autograd/types.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import copy
 import typing
+from dataclasses import dataclass
 
 import pydantic.v1 as pd
 from autograd.builtins import dict as dict_ag
@@ -40,13 +41,27 @@ TracedPoleAndResidue = tuple[TracedComplex, TracedComplex]
 # The data type that we pass in and out of the web.run() @autograd.primitive
 AutogradTraced = typing.Union[Box, ArrayLike]
 PathType = tuple[typing.Union[int, str], ...]
+CustomVJPPathType = tuple[typing.Union[int, str, typing.Callable], ...]
 AutogradFieldMap = dict_ag[PathType, AutogradTraced]
 
 InterpolationType = typing.Literal["nearest", "linear"]
 
+
+@dataclass(frozen=True)
+class NumericalStructureInfo:
+    """Metadata describing a user-supplied numerical structure insertion."""
+
+    index: int
+    parameters: typing.Any
+    function: typing.Callable[..., typing.Any]
+    structure: typing.Any
+    vjp: typing.Callable[..., typing.Any]
+
+
 __all__ = [
     "AutogradFieldMap",
     "AutogradTraced",
+    "NumericalStructureInfo",
     "TracedCoordinate",
     "TracedFloat",
     "TracedSize",

--- a/tidy3d/components/autograd/utils.py
+++ b/tidy3d/components/autograd/utils.py
@@ -5,11 +5,14 @@ from collections.abc import Iterable
 from typing import Any
 
 import autograd.numpy as anp
+import numpy as np
+from autograd.extend import Box
 from autograd.tracer import getval
 
 __all__ = [
     "asarray1d",
     "contains",
+    "contains_tracer",
     "get_static",
     "is_tidy_box",
     "pack_complex_vec",
@@ -41,6 +44,20 @@ def contains(target: Any, seq: Iterable[Any]) -> bool:
         if isinstance(x, Iterable) and not isinstance(x, (str, bytes)):
             if contains(target, x):
                 return True
+    return False
+
+
+def contains_tracer(value) -> bool:
+    if isinstance(value, Box):
+        return True
+    if isinstance(value, np.ndarray):
+        return any(contains_tracer(v) for v in value.flat)
+    if isinstance(value, dict):
+        return any(contains_tracer(v) for v in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(contains_tracer(v) for v in value)
+    if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
+        return any(contains_tracer(v) for v in value)
     return False
 
 

--- a/tidy3d/components/geometry/primitives.py
+++ b/tidy3d/components/geometry/primitives.py
@@ -42,6 +42,13 @@ class Sphere(base.Centered, base.Circular):
     >>> b = Sphere(center=(1,2,3), radius=2)
     """
 
+    radius: TracedSize1D = pydantic.Field(
+        ...,
+        title="Radius",
+        description="Radius of geometry at the ``reference_plane``.",
+        units=MICROMETER,
+    )
+
     def inside(
         self, x: np.ndarray[float], y: np.ndarray[float], z: np.ndarray[float]
     ) -> np.ndarray[bool]:

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -4818,9 +4818,24 @@ class Simulation(AbstractYeeGridSimulation):
         """Get lists of field and permittivity monitors for this simulation."""
 
         index_to_keys = defaultdict(list)
+        numerical_indices = set()
 
-        for _, index, *fields in sim_fields_keys:
-            index_to_keys[index].append(fields)
+        for namespace, index, *fields in sim_fields_keys:
+            if namespace not in {"structures", "numerical"}:
+                log.warning(
+                    "Encountered unknown namespace '%s' while creating adjoint monitors; ignoring.",
+                    namespace,
+                )
+                continue
+
+            if namespace == "structures":
+                index_to_keys[index].append(fields)
+            elif namespace == "numerical":
+                numerical_indices.add(index)
+
+        for index in numerical_indices:
+            if not index_to_keys[index]:
+                index_to_keys[index].append([])
 
         freqs = self._freqs_adjoint
 

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pathlib
+import typing
 from collections import defaultdict
 from functools import cmp_to_key
 from os import PathLike
@@ -347,9 +348,12 @@ class Structure(AbstractStructure):
         return mnt_fld, mnt_eps
 
     def _compute_derivatives(
-        self, derivative_info: DerivativeInfo, vjp_fns=None
+        self,
+        derivative_info: DerivativeInfo,
+        vjp_fns: typing.Optional[dict[tuple[str, str], typing.Callable[..., typing.Any]]] = None,
     ) -> AutogradFieldMap:
-        """Compute adjoint gradients given the forward and adjoint fields"""
+        """Compute adjoint gradients given the forward and adjoint fields provided in derivative_info."""
+        """vjp_fns provide alternate derivative computation paths for the geometry or medium derivatives."""
 
         # generate a mapping from the 'medium', or 'geometry' tag to the list of fields for VJP
         structure_fields_map = defaultdict(list)

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -384,8 +384,15 @@ class Structure(AbstractStructure):
             for path_key, paths in collect_paths_by_keys.items():
                 info = derivative_info.updated_copy(paths=paths, deep=False)
 
-                if (vjp_fns is not None) and (path_key in vjp_fns):
-                    derivative_values_map.update(vjp_fns[path_key](med_or_geo_field, info))
+                full_path = (med_or_geo, path_key)
+                if (vjp_fns is not None) and (full_path in vjp_fns):
+                    full_paths = ((med_or_geo, *path) for path in paths)
+                    info = derivative_info.updated_copy(paths=full_paths, deep=False)
+
+                    vjp = vjp_fns[full_path](med_or_geo_field, info)
+                    vjp_strip_med_or_geo = {key[1:]: val for key, val in vjp.items()}
+
+                    derivative_values_map.update(vjp_strip_med_or_geo)
                 else:
                     derivative_values_map.update(
                         med_or_geo_field._compute_derivatives(derivative_info=info)

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -346,7 +346,9 @@ class Structure(AbstractStructure):
 
         return mnt_fld, mnt_eps
 
-    def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
+    def _compute_derivatives(
+        self, derivative_info: DerivativeInfo, vjp_fns=None
+    ) -> AutogradFieldMap:
         """Compute adjoint gradients given the forward and adjoint fields"""
 
         # generate a mapping from the 'medium', or 'geometry' tag to the list of fields for VJP
@@ -366,11 +368,28 @@ class Structure(AbstractStructure):
 
         # loop through sub fields, compute VJPs, and store in the derivative map {path -> vjp_value}
         derivative_map = {}
+        # the first level of integration would be to
         for med_or_geo, field_paths in structure_fields_map.items():
             # grab derivative values {field_name -> vjp_value}
             med_or_geo_field = self.medium if med_or_geo == "medium" else self.geometry
-            info = derivative_info.updated_copy(paths=field_paths, deep=False)
-            derivative_values_map = med_or_geo_field._compute_derivatives(derivative_info=info)
+
+            collect_paths_by_keys = {}
+            for path in field_paths:
+                if path[0] in collect_paths_by_keys:
+                    collect_paths_by_keys[path[0]].append(path)
+                else:
+                    collect_paths_by_keys[path[0]] = [path]
+
+            derivative_values_map = {}
+            for path_key, paths in collect_paths_by_keys.items():
+                info = derivative_info.updated_copy(paths=paths, deep=False)
+
+                if (vjp_fns is not None) and (path_key in vjp_fns):
+                    derivative_values_map.update(vjp_fns[path_key](med_or_geo_field, info))
+                else:
+                    derivative_values_map.update(
+                        med_or_geo_field._compute_derivatives(derivative_info=info)
+                    )
 
             # construct map of {field path -> derivative value}
             for field_path, derivative_value in derivative_values_map.items():

--- a/tidy3d/plugins/smatrix/run.py
+++ b/tidy3d/plugins/smatrix/run.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import copy
 import json
+import typing
 from os import PathLike
-from typing import Any
 
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.data.index import SimulationDataMap
@@ -20,6 +20,7 @@ from tidy3d.web.api.autograd import (
     has_traced_numerical_structures,
     insert_numerical_structures_static,
 )
+from tidy3d.web.api.autograd.types import UserVJPConfig
 
 DEFAULT_DATA_DIR = "."
 
@@ -133,7 +134,7 @@ def compose_modeler_data_from_batch_data(
 
 def create_batch(
     modeler: ComponentModelerType,
-    **kwargs: Any,
+    **kwargs: typing.Any,
 ) -> Batch:
     """Create a simulation Batch from a component modeler.
 
@@ -161,8 +162,8 @@ def _run_local(
     modeler: ComponentModelerType,
     path_dir: str = DEFAULT_DATA_DIR,
     numerical_structures=None,
-    user_vjp=None,
-    **kwargs: Any,
+    user_vjp: typing.Optional[typing.Union[UserVJPConfig, tuple[UserVJPConfig]]] = None,
+    **kwargs: typing.Any,
 ) -> ComponentModelerDataType:
     """Execute the full simulation workflow for a given component modeler.
 
@@ -193,10 +194,6 @@ def _run_local(
     sims = modeler.sim_dict
 
     numerical_structures_modeler = numerical_structures or {}
-    user_vjp_modeler = user_vjp
-    user_vjp_modeler_normalized = None
-    if user_vjp_modeler is not None:
-        user_vjp_modeler_normalized = web_ag.normalize_user_vjp_spec(user_vjp_modeler)
 
     should_use_autograd = any(web_ag.is_valid_for_autograd(sim) for sim in sims.values())
 
@@ -233,7 +230,6 @@ def _run_local(
             first_sim = next(iter(sims.values()))
             web_ag.validate_numerical_structures(
                 numerical_structures=numerical_structures_modeler,
-                user_vjp=user_vjp_modeler_normalized,
                 simulation=first_sim,
             )
 
@@ -243,15 +239,16 @@ def _run_local(
         else:
             numerical_structures_broadcast = None
 
-        if user_vjp_modeler_normalized is not None:
-            user_vjp_broadcast = dict.fromkeys(sims, user_vjp_modeler_normalized)
-        else:
-            user_vjp_broadcast = None
+        if isinstance(user_vjp, UserVJPConfig):
+            user_vjp = (user_vjp,)
+
+        if user_vjp:
+            user_vjp = dict.fromkeys(sims, user_vjp)
 
         sim_data_map = _run_async(
             simulations=sims,
             numerical_structures=numerical_structures_broadcast,
-            user_vjp=user_vjp_broadcast,
+            user_vjp=user_vjp,
             **kwargs,
         )
 

--- a/tidy3d/plugins/smatrix/run.py
+++ b/tidy3d/plugins/smatrix/run.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import json
 import typing
 from os import PathLike
@@ -16,11 +15,10 @@ from tidy3d.plugins.smatrix.data.modal import ModalComponentModelerData
 from tidy3d.plugins.smatrix.data.terminal import TerminalComponentModelerData
 from tidy3d.plugins.smatrix.data.types import ComponentModelerDataType
 from tidy3d.web import Batch, BatchData
-from tidy3d.web.api.autograd import (
-    has_traced_numerical_structures,
-    insert_numerical_structures_static,
+from tidy3d.web.api.autograd.types import (
+    NumericalStructureConfig,
+    UserVJPConfig,
 )
-from tidy3d.web.api.autograd.types import UserVJPConfig
 
 DEFAULT_DATA_DIR = "."
 
@@ -161,7 +159,9 @@ def create_batch(
 def _run_local(
     modeler: ComponentModelerType,
     path_dir: str = DEFAULT_DATA_DIR,
-    numerical_structures=None,
+    numerical_structures: typing.Optional[
+        typing.Union[NumericalStructureConfig, tuple[NumericalStructureConfig]]
+    ] = None,
     user_vjp: typing.Optional[typing.Union[UserVJPConfig, tuple[UserVJPConfig]]] = None,
     **kwargs: typing.Any,
 ) -> ComponentModelerDataType:
@@ -193,12 +193,15 @@ def _run_local(
 
     sims = modeler.sim_dict
 
-    numerical_structures_modeler = numerical_structures or {}
+    if isinstance(numerical_structures, NumericalStructureConfig):
+        numerical_structures = (numerical_structures,)
 
-    should_use_autograd = any(web_ag.is_valid_for_autograd(sim) for sim in sims.values())
-
-    if not should_use_autograd and has_traced_numerical_structures(numerical_structures_modeler):
-        should_use_autograd = True
+    traced_numerical_structures = numerical_structures and web_ag.has_traced_numerical_structures(
+        numerical_structures
+    )
+    should_use_autograd = traced_numerical_structures or any(
+        web_ag.is_valid_for_autograd(sim) for sim in sims.values()
+    )
 
     if should_use_autograd:
         if len(modeler.element_mappings) > 0:
@@ -218,26 +221,18 @@ def _run_local(
 
         local_gradient = kwargs.get("local_gradient", True)
 
-        if (user_vjp is not None) and (not local_gradient):
-            raise AdjointError("User VJP specified for a remote gradient not supported.")
+        if not local_gradient:
+            if user_vjp is not None:
+                raise AdjointError("user_vjp specified for a remote gradient not supported.")
 
-        if (not local_gradient) and has_traced_numerical_structures(numerical_structures_modeler):
-            raise AdjointError(
-                "ComponentModeler autograd with traced numerical structures requires local_gradient=True."
-            )
+            if traced_numerical_structures:
+                raise AdjointError(
+                    "ComponentModeler autograd with traced numerical structures requires local_gradient=True."
+                )
 
-        if numerical_structures_modeler:
-            first_sim = next(iter(sims.values()))
-            web_ag.validate_numerical_structures(
-                numerical_structures=numerical_structures_modeler,
-                simulation=first_sim,
-            )
-
-            numerical_structures_broadcast = {
-                key: copy.deepcopy(numerical_structures_modeler) for key in sims
-            }
-        else:
-            numerical_structures_broadcast = None
+        if numerical_structures:
+            web_ag.validate_numerical_structure_parameters(numerical_structures)
+            numerical_structures = dict.fromkeys(sims, numerical_structures)
 
         if isinstance(user_vjp, UserVJPConfig):
             user_vjp = (user_vjp,)
@@ -245,9 +240,15 @@ def _run_local(
         if user_vjp:
             user_vjp = dict.fromkeys(sims, user_vjp)
 
+        if numerical_structures is not None:
+            for key in numerical_structures:
+                numerical_structures[key] = web_ag.populate_numerical_structures(
+                    simulation=sims[key], numerical_structures=numerical_structures[key]
+                )
+
         sim_data_map = _run_async(
             simulations=sims,
-            numerical_structures=numerical_structures_broadcast,
+            numerical_structures=numerical_structures,
             user_vjp=user_vjp,
             **kwargs,
         )
@@ -256,7 +257,7 @@ def _run_local(
 
     if numerical_structures is not None:
         modeler = modeler.updated_copy(
-            simulation=insert_numerical_structures_static(
+            simulation=web_ag.insert_numerical_structures_static(
                 simulation=modeler.simulation, numerical_structures=numerical_structures
             )
         )

--- a/tidy3d/plugins/smatrix/run.py
+++ b/tidy3d/plugins/smatrix/run.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import copy
 import json
 from os import PathLike
 from typing import Any
 
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.data.index import SimulationDataMap
+from tidy3d.exceptions import AdjointError
 from tidy3d.log import log
 from tidy3d.plugins.smatrix.component_modelers.modal import ModalComponentModeler
 from tidy3d.plugins.smatrix.component_modelers.terminal import TerminalComponentModeler
@@ -14,6 +16,10 @@ from tidy3d.plugins.smatrix.data.modal import ModalComponentModelerData
 from tidy3d.plugins.smatrix.data.terminal import TerminalComponentModelerData
 from tidy3d.plugins.smatrix.data.types import ComponentModelerDataType
 from tidy3d.web import Batch, BatchData
+from tidy3d.web.api.autograd import (
+    has_traced_numerical_structures,
+    insert_numerical_structures_static,
+)
 
 DEFAULT_DATA_DIR = "."
 
@@ -154,6 +160,8 @@ def create_batch(
 def _run_local(
     modeler: ComponentModelerType,
     path_dir: str = DEFAULT_DATA_DIR,
+    numerical_structures=None,
+    user_vjp=None,
     **kwargs: Any,
 ) -> ComponentModelerDataType:
     """Execute the full simulation workflow for a given component modeler.
@@ -183,7 +191,19 @@ def _run_local(
     from tidy3d.web.api.autograd import autograd as web_ag
 
     sims = modeler.sim_dict
-    if any(web_ag.is_valid_for_autograd(sim) for sim in sims.values()):
+
+    numerical_structures_modeler = numerical_structures or {}
+    user_vjp_modeler = user_vjp
+    user_vjp_modeler_normalized = None
+    if user_vjp_modeler is not None:
+        user_vjp_modeler_normalized = web_ag.normalize_user_vjp_spec(user_vjp_modeler)
+
+    should_use_autograd = any(web_ag.is_valid_for_autograd(sim) for sim in sims.values())
+
+    if not should_use_autograd and has_traced_numerical_structures(numerical_structures_modeler):
+        should_use_autograd = True
+
+    if should_use_autograd:
         if len(modeler.element_mappings) > 0:
             log.warning(
                 "Element mappings are used to populate S-matrix values, but autograd gradients "
@@ -199,9 +219,50 @@ def _run_local(
         kwargs.setdefault("simulation_type", "tidy3d_autograd_async")
         kwargs.setdefault("path_dir", path_dir)
 
-        sim_data_map = _run_async(simulations=sims, **kwargs)
+        local_gradient = kwargs.get("local_gradient", True)
+
+        if (user_vjp is not None) and (not local_gradient):
+            raise AdjointError("User VJP specified for a remote gradient not supported.")
+
+        if (not local_gradient) and has_traced_numerical_structures(numerical_structures_modeler):
+            raise AdjointError(
+                "ComponentModeler autograd with traced numerical structures requires local_gradient=True."
+            )
+
+        if numerical_structures_modeler:
+            first_sim = next(iter(sims.values()))
+            web_ag.validate_numerical_structures(
+                numerical_structures=numerical_structures_modeler,
+                user_vjp=user_vjp_modeler_normalized,
+                simulation=first_sim,
+            )
+
+            numerical_structures_broadcast = {
+                key: copy.deepcopy(numerical_structures_modeler) for key in sims
+            }
+        else:
+            numerical_structures_broadcast = None
+
+        if user_vjp_modeler_normalized is not None:
+            user_vjp_broadcast = dict.fromkeys(sims, user_vjp_modeler_normalized)
+        else:
+            user_vjp_broadcast = None
+
+        sim_data_map = _run_async(
+            simulations=sims,
+            numerical_structures=numerical_structures_broadcast,
+            user_vjp=user_vjp_broadcast,
+            **kwargs,
+        )
 
         return compose_modeler_data_from_batch_data(modeler=modeler, batch_data=sim_data_map)
+
+    if numerical_structures is not None:
+        modeler = modeler.updated_copy(
+            simulation=insert_numerical_structures_static(
+                simulation=modeler.simulation, numerical_structures=numerical_structures
+            )
+        )
 
     # Filter kwargs to only include valid Batch parameters
     batch_kwargs = {

--- a/tidy3d/plugins/smatrix/run.py
+++ b/tidy3d/plugins/smatrix/run.py
@@ -178,6 +178,12 @@ def _run_local(
         The component modeler defining the simulations to be run.
     path_dir : str, optional
         The directory where the batch file will be saved. Defaults to ".".
+    numerical_structures : typing.Union[NumericalStructureConfig, tuple[NumericalStructureConfig]] = None
+        Specification of additional structures to add to the base simulation that can be traced via
+        autograd. This can be a single structure or multiple structures specified in a tuple.
+    user_vjp : typing.Union[UserVJPConfig, tuple[UserVJPConfig]] = None
+        Specification of alternate gradient function for certain structures in the simulation.
+        This can be a single vjp configuration or multiple specified in a tuple.
     **kwargs
         Extra keyword arguments propagated to the Batch creation.
 

--- a/tidy3d/web/__init__.py
+++ b/tidy3d/web/__init__.py
@@ -11,8 +11,6 @@ from .core import core_config
 # set logger to tidy3d.log before it's invoked in other imports
 core_config.set_config(log, get_logging_console(), __version__)
 
-# from .api.asynchronous import run_async # NOTE: we use autograd one now (see below)
-# autograd compatible wrappers for run and run_async
 from .api.autograd.autograd import run_async
 from .api.container import Batch, BatchData, Job
 from .api.run import run

--- a/tidy3d/web/api/autograd/__init__.py
+++ b/tidy3d/web/api/autograd/__init__.py
@@ -1,5 +1,15 @@
 from __future__ import annotations
 
-from .autograd import has_traced_numerical_structures, insert_numerical_structures_static
+from .autograd import (
+    has_traced_numerical_structures,
+    insert_numerical_structures_static,
+    populate_numerical_structures,
+    validate_numerical_structure_parameters,
+)
 
-__all__ = ["has_traced_numerical_structures", "insert_numerical_structures_static"]
+__all__ = [
+    "has_traced_numerical_structures",
+    "insert_numerical_structures_static",
+    "populate_numerical_structures",
+    "validate_numerical_structure_parameters",
+]

--- a/tidy3d/web/api/autograd/__init__.py
+++ b/tidy3d/web/api/autograd/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .autograd import has_traced_numerical_structures, insert_numerical_structures_static
+
+__all__ = ["has_traced_numerical_structures", "insert_numerical_structures_static"]

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import typing
+from dataclasses import replace
 from os import PathLike
 from pathlib import Path
 from typing import Any
@@ -12,7 +13,6 @@ from autograd.extend import defvjp, primitive
 
 import tidy3d as td
 from tidy3d.components.autograd import AutogradFieldMap, get_static
-from tidy3d.components.autograd.types import CustomVJPPathType, NumericalStructureInfo
 from tidy3d.components.autograd.utils import contains_tracer
 from tidy3d.components.base import TRACED_FIELD_KEYS_ATTR
 from tidy3d.components.types.workflow import WorkflowDataType, WorkflowType
@@ -30,7 +30,6 @@ from .backward import postprocess_adj as _postprocess_adj_impl
 from .backward import setup_adj as _setup_adj_impl
 from .constants import (
     AUX_KEY_FWD_TASK_ID,
-    AUX_KEY_NUMERICAL_STRUCTURES,
     AUX_KEY_SIM_DATA_FWD,
     AUX_KEY_SIM_DATA_ORIGINAL,
 )
@@ -58,8 +57,6 @@ from .types import (
     NumericalStructureConfig,
     SetupRunResult,
     UserVJPConfig,
-    UserVjpEntry,
-    UserVjpSpec,
 )
 
 
@@ -72,32 +69,17 @@ def _resolve_local_gradient(value: typing.Optional[bool]) -> bool:
 
 def insert_numerical_structures_static(
     simulation: td.Simulation,
-    numerical_structures: dict[int, dict[str, typing.Any]],
+    numerical_structures: typing.Sequence[NumericalStructureConfig],
 ) -> td.Simulation:
     """Return a Simulation with numerical structures inserted, without autograd metadata."""
 
     structures = list(simulation.structures)
 
-    for index in sorted(numerical_structures):
-        config = numerical_structures[index]
-        func = config["function"]
-        params_input = config["parameters"]
+    for numerical_cfg in numerical_structures:
+        structure = numerical_cfg.create(get_static(numerical_cfg.parameters))
+        structures.insert(numerical_cfg.structure_index, structure)
 
-        try:
-            structure = func(get_static(params_input))
-        except Exception as exc:  # pragma: no cover - defensive
-            raise AdjointError(
-                f"Failed to construct numerical structure at index {index}: {exc}"
-            ) from exc
-
-        if not isinstance(structure, td.Structure):
-            raise AdjointError(
-                "Numerical structure creation functions must return a tidy3d.Structure instance."
-            )
-
-        structures.insert(index, structure)
-
-    return simulation.copy(update={"structures": structures})
+    return simulation.updated_copy(structures=structures)
 
 
 def _normalize_simulations_input(
@@ -119,58 +101,35 @@ def _normalize_simulations_input(
     return normalized, name_mapping
 
 
-def normalize_user_vjp_spec(spec: tuple[CustomVJPPathType, ...]) -> typing.Optional[UserVjpSpec]:
-    """Normalize a user-provided VJP specification into canonical tuple entries."""
-
-    if spec is None:
-        return None
-
-    if not spec:
-        return ()
-
-    return tuple(UserVjpEntry(entry[0], (entry[1],), entry[2]) for entry in spec)
-
-
-def _normalize_user_vjp_input(
-    simulations: dict[str, td.Simulation],
-    user_vjp: dict[str, tuple[CustomVJPPathType, ...]],
-    name_mapping: dict[str, int],
-) -> dict[str, typing.Optional[UserVjpSpec]]:
-    """Normalize per-task user VJP configurations keyed by task names."""
-
-    if isinstance(simulations, dict):
-        task_names = tuple(simulations.keys())
-        if user_vjp is None:
-            return dict.fromkeys(task_names)
-        return {
-            task_name: normalize_user_vjp_spec(user_vjp.get(task_name)) for task_name in task_names
-        }
-
-
 def has_traced_numerical_structures(
-    numerical_structures: typing.Optional[dict[int, dict[str, typing.Any]]],
+    numerical_structures: typing.Union[
+        tuple[NumericalStructureConfig],
+        list[NumericalStructureConfig],
+        dict[str, NumericalStructureConfig],
+    ],
 ) -> bool:
-    if not numerical_structures:
-        return False
-
-    for cfg in numerical_structures.values():
-        params = cfg.get("parameters")
-        if contains_tracer(params):
+    iterable_structures = (
+        numerical_structures.values()
+        if isinstance(numerical_structures, dict)
+        else numerical_structures
+    )
+    for cfg in iterable_structures:
+        if contains_tracer(cfg.parameters):
             return True
+
     return False
 
 
-def validate_numerical_structures(
-    numerical_structures: dict[int, dict[str, typing.Any]],
-    simulation: td.Simulation,
+def validate_numerical_structure_parameters(
+    numerical_structures: tuple[NumericalStructureConfig],
 ) -> None:
     """Validate user-supplied numerical structure configuration."""
 
-    for index, numerical_config in numerical_structures.items():
-        array_params = np.array(numerical_config["parameters"])
+    for numerical_config in numerical_structures:
+        array_params = np.array(numerical_config.parameters)
         if array_params.ndim != 1:
             raise AdjointError(
-                f"Parameters for numerical structure index {index} must be 1D array-like."
+                f"Parameters for numerical structure index {numerical_config.structure_index} must be 1D array-like."
             )
 
 
@@ -234,8 +193,6 @@ def run_custom(
     pay_type: typing.Union[PayType, str] = PayType.AUTO,
     priority: typing.Optional[int] = None,
     lazy: typing.Optional[bool] = None,
-    # numerical_structures: typing.Optional[dict[int, dict[str, typing.Any]]] = None,
-    # user_vjp: typing.Optional[tuple[CustomVJPPathType, ...]] = None,
     numerical_structures: typing.Optional[
         typing.Union[NumericalStructureConfig, tuple[NumericalStructureConfig]]
     ] = None,
@@ -345,8 +302,6 @@ def run_custom(
         stub = Tidy3dStub(simulation=simulation)
         task_name = stub.get_default_task_name()
 
-    ##### put numerical_structures and user_vjp into tuple form if only a single is specified
-
     if numerical_structures is not None:
         if isinstance(numerical_structures, NumericalStructureConfig):
             numerical_structures = (numerical_structures,)
@@ -355,24 +310,10 @@ def run_custom(
         if isinstance(user_vjp, UserVJPConfig):
             user_vjp = (user_vjp,)
 
-    #####
+    if numerical_structures is not None:
+        validate_numerical_structure_parameters(numerical_structures=numerical_structures)
 
-    # user_vjp_normalized = None
-    # if user_vjp is not None:
-    #     user_vjp_normalized = normalize_user_vjp_spec(user_vjp)
-
-    numerical_structures_validated = None
-    if isinstance(simulation, td.Simulation):
-        if numerical_structures is not None:
-            validate_numerical_structures(
-                numerical_structures=numerical_structures,
-                simulation=simulation,
-            )
-            numerical_structures_validated = numerical_structures
-        else:
-            numerical_structures_validated = {}
-
-    # numerical_vjp_map = user_vjp_normalized
+    traced_numerical_structures = has_traced_numerical_structures(numerical_structures or [])
 
     # component modeler path: route autograd-valid modelers to local run
     from tidy3d.plugins.smatrix.component_modelers.types import ComponentModelerType
@@ -380,17 +321,9 @@ def run_custom(
     path = Path(path)
 
     if isinstance(simulation, typing.get_args(ComponentModelerType)):
-        sim_dict = simulation.sim_dict
-
-        numerical_structures_modeler = numerical_structures or {}
-        if not numerical_structures_modeler and isinstance(numerical_structures_validated, dict):
-            numerical_structures_modeler = numerical_structures_validated
-
-        should_use_component_autograd = any(
-            is_valid_for_autograd(sim) for sim in sim_dict.values()
-        ) or has_traced_numerical_structures(numerical_structures_modeler)
-
-        if should_use_component_autograd:
+        if traced_numerical_structures or (
+            any(is_valid_for_autograd(s) for s in simulation.sim_dict.values())
+        ):
             from tidy3d.plugins.smatrix import run as smatrix_run
 
             path_dir = path.parent
@@ -405,32 +338,30 @@ def run_custom(
                 priority=priority,
                 local_gradient=local_gradient,
                 max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
-                numerical_structures=numerical_structures_modeler,
+                numerical_structures=numerical_structures,
                 user_vjp=user_vjp,
             )
 
     should_use_autograd = False
     if isinstance(simulation, td.Simulation):
-        should_use_autograd = is_valid_for_autograd(simulation)
-        if not should_use_autograd and numerical_structures:
-            for cfg in numerical_structures.values():
-                params = cfg.get("parameters")
-                if contains_tracer(params):
-                    should_use_autograd = True
-                    break
+        should_use_autograd = is_valid_for_autograd(simulation) or traced_numerical_structures
+
+        if numerical_structures is not None:
+            numerical_structures = populate_numerical_structures(
+                simulation=simulation, numerical_structures=numerical_structures
+            )
 
     if should_use_autograd:
         if (user_vjp is not None) and (not local_gradient):
-            raise AdjointError("User VJP specified for a remote gradient not supported.")
+            raise AdjointError("user_vjp specified for a remote gradient not supported.")
 
-        if has_traced_numerical_structures(numerical_structures_validated) and (not local_gradient):
+        if traced_numerical_structures and (not local_gradient):
             raise AdjointError(
-                "Numerical structures specified for a remote gradient not supported."
+                "numerical_structures specified for a remote gradient not supported."
             )
 
         return _run(
             simulation=simulation,
-            numerical_structures=numerical_structures_validated,
             task_name=task_name,
             folder_name=folder_name,
             path=path,
@@ -444,6 +375,7 @@ def run_custom(
             parent_tasks=parent_tasks,
             local_gradient=local_gradient,
             max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
+            numerical_structures=numerical_structures,
             user_vjp=user_vjp,
             pay_type=pay_type,
             priority=priority,
@@ -451,12 +383,12 @@ def run_custom(
         )
 
     simulation_static = simulation
-    if isinstance(simulation, td.Simulation) and numerical_structures_validated:
+    if isinstance(simulation, td.Simulation) and (numerical_structures is not None):
         # if there are numerical_structures without traced parameters, we still want
         # to insert them into the simulation
         simulation_static = insert_numerical_structures_static(
             simulation=simulation,
-            numerical_structures=numerical_structures_validated,
+            numerical_structures=numerical_structures,
         )
 
     return run_webapi(
@@ -542,24 +474,22 @@ def run_async_custom(
     lazy: typing.Optional[bool] = None,
     numerical_structures: typing.Optional[
         typing.Union[
-            dict[str, dict[int, dict[str, typing.Any]]],
-            typing.Sequence[typing.Optional[dict[int, dict[str, typing.Any]]]],
+            NumericalStructureConfig,
+            dict[str, NumericalStructureConfig],
+            typing.Sequence[NumericalStructureConfig],
+            dict[str, typing.Sequence[NumericalStructureConfig]],
+            typing.Sequence[typing.Sequence[NumericalStructureConfig]],
         ]
     ] = None,
     user_vjp: typing.Optional[
         typing.Union[
             UserVJPConfig,
             dict[str, UserVJPConfig],
-            tuple[UserVJPConfig],
-            list[UserVJPConfig],
+            typing.Sequence[UserVJPConfig],
+            dict[str, typing.Sequence[UserVJPConfig]],
+            typing.Sequence[typing.Sequence[UserVJPConfig]],
         ]
     ] = None,
-    # user_vjp: typing.Optional[
-    #     typing.Union[
-    #         dict[str, typing.Any],
-    #         typing.Sequence[typing.Any],
-    #     ]
-    # ] = None,
 ) -> BatchData:
     """Submits a set of Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`] objects to server,
     starts running, monitors progress, downloads, and loads results as a :class:`.BatchData` object.
@@ -627,97 +557,107 @@ def run_async_custom(
 
     lazy = True if lazy is None else bool(lazy)
 
-    if isinstance(user_vjp, UserVJPConfig):
-        if isinstance(simulations, (tuple, list)):
-            user_vjp = (type(simulations)(user_vjp)) * len(simulations)
-        else:
-            user_vjp = dict.fromkeys(simulations.keys(), user_vjp)
+    def validate_and_expand(
+        fn_arg: typing.Union[NumericalStructureConfig, UserVJPConfig],
+        fn_arg_name: str,
+        base_type: type[typing.Union[NumericalStructureConfig, UserVJPConfig]],
+        orig_sim_arg: typing.Union[
+            dict[str, td.Simulation], tuple[td.Simulation], list[td.Simulation]
+        ],
+        sim_dict: dict[str, tuple[td.Simulation]],
+    ) -> dict[str, typing.Sequence[typing.Union[NumericalStructureConfig, UserVJPConfig]]]:
+        if fn_arg is None:
+            return fn_arg
 
-    if isinstance(simulations, (tuple, list, dict)):
-        if type(user_vjp) is not type(simulations):
+        expanded = None
+        if isinstance(fn_arg, base_type):
+            expanded = dict.fromkeys(sim_dict.keys(), fn_arg)
+
+        if not isinstance(fn_arg, type(orig_sim_arg)):
             raise AdjointError(
-                f"user_vjp type ({type(user_vjp)}) should match simulations type ({type(simulations)})"
+                f"{fn_arg_name} type ({type(fn_arg)}) should match simulations type ({type(simulations)})"
             )
 
-        if isinstance(simulations, dict):
-            check_keys = user_vjp.keys() == simulations.keys()
+        if isinstance(orig_sim_arg, dict):
+            check_keys = fn_arg.keys() == sim_dict.keys()
 
             if not check_keys:
-                raise AdjointError("user vjp keys do not match simulations keys")
-        else:
-            if not (len(user_vjp) == len(simulations)):
+                raise AdjointError(f"{fn_arg_name} keys do not match simulations keys")
+
+            expanded = {}
+            for key, val in fn_arg.items():
+                if isinstance(val, base_type):
+                    expanded[key] = (val,)
+                else:
+                    expanded[key] = val
+
+        elif isinstance(orig_sim_arg, (list, tuple)):
+            if not (len(fn_arg) == len(orig_sim_arg)):
                 raise AdjointError(
-                    f"user vjp is not the same length as simulations ({len(user_vjp)} vs. {len(simulations)})"
+                    f"{fn_arg_name} is not the same length as simulations ({len(fn_arg)} vs. {len(simulations)})"
                 )
+
+            expanded = {}
+            for idx, key in enumerate(sim_dict.keys()):
+                val = fn_arg[idx]
+                if isinstance(val, (list, tuple)):
+                    expanded[key] = val
+                else:
+                    expanded[key] = (val,)
+
+        return expanded
 
     if isinstance(simulations, (tuple, list)):
         sim_dict = {}
         for i, sim in enumerate(simulations, 1):
             task_name = Tidy3dStub(simulation=sim).get_default_task_name() + f"_{i}"
             sim_dict[task_name] = sim
+    else:
+        sim_dict = simulations
 
-        if user_vjp is not None:
-            # set up the user_vjp_dict to have the same keys as the simulation dict
-            user_vjp = {
-                task_name: user_vjp[task_idx] for task_idx, task_name in enumerate(sim_dict)
-            }
+    numerical_structures = validate_and_expand(
+        numerical_structures,
+        "numerical_structures",
+        NumericalStructureConfig,
+        simulations,
+        sim_dict,
+    )
+    if numerical_structures is not None:
+        for _, numerical_structures_configs in numerical_structures.items():
+            validate_numerical_structure_parameters(
+                numerical_structures=numerical_structures_configs
+            )
 
-        if numerical_structures is not None:
-            if type(numerical_structures) is not type(simulations):
-                raise AdjointError(
-                    f"numerical_structures type ({type(numerical_structures)}) should match simulations type ({type(simulations)})"
-                )
+    user_vjp = validate_and_expand(user_vjp, "user_vjp", UserVJPConfig, simulations, sim_dict)
 
-            # set up the numerical_structures_dict to have the same keys as the simulation dict
-            numerical_structures_dict = {}
-            for task_idx, task_name in enumerate(sim_dict):
-                numerical_structures_dict[task_name] = numerical_structures[task_idx]
-
-            numerical_structures = numerical_structures_dict
-
-        simulations = sim_dict
+    simulations = sim_dict
 
     path_dir = Path(path_dir)
 
     simulations_norm, name_mapping = _normalize_simulations_input(simulations)
 
-    numerical_structures = (
-        dict.fromkeys(name_mapping) if numerical_structures is None else numerical_structures
+    should_use_autograd_async = is_valid_for_autograd_async(simulations_norm)
+    traced_numerical_structures = (numerical_structures is not None) and any(
+        has_traced_numerical_structures(numerical_structure)
+        for _, numerical_structure in numerical_structures.items()
+    )
+    should_use_autograd_async = (
+        is_valid_for_autograd_async(simulations_norm) or traced_numerical_structures
     )
 
-    # user_vjp_norm = _normalize_user_vjp_input(
-    #     simulations=simulations,
-    #     user_vjp=user_vjp,
-    #     name_mapping=name_mapping,
-    # )
-
-    for name, numerical_structures_config in numerical_structures.items():
-        cfg = numerical_structures_config or {}
-        validate_numerical_structures(
-            numerical_structures=cfg,
-            simulation=simulations_norm[name],
-        )
-
-    should_use_autograd_async = is_valid_for_autograd_async(simulations_norm)
-    if not should_use_autograd_async:
-        for name, _ in simulations_norm.items():
-            if numerical_structures.get(name):
-                configs = numerical_structures[name]
-                for cfg in configs.values():
-                    params = cfg.get("parameters")
-                    if contains_tracer(params):
-                        should_use_autograd_async = True
-                        if not local_gradient:
-                            raise AdjointError(
-                                "Numerical structures specified for a remote gradient not supported."
-                            )
-                        break
-            if should_use_autograd_async:
-                break
+    if numerical_structures is not None:
+        for key in numerical_structures:
+            numerical_structures[key] = populate_numerical_structures(
+                simulation=simulations_norm[key], numerical_structures=numerical_structures[key]
+            )
 
     if should_use_autograd_async:
         if (user_vjp is not None) and (not local_gradient):
-            raise AdjointError("User VJP specified for a remote gradient not supported.")
+            raise AdjointError("user_vjp specified for a remote gradient not supported.")
+        if traced_numerical_structures and (not local_gradient):
+            raise AdjointError(
+                "numerical_structures specified for a remote gradient not supported."
+            )
 
         return _run_async(
             simulations=simulations_norm,
@@ -739,17 +679,20 @@ def run_async_custom(
         )
 
     # insert numerical_structures even if not traced
-    simulations_static = {
-        name: (
-            insert_numerical_structures_static(
-                simulation=simulations_norm[name],
-                numerical_structures=numerical_structures[name],
+    if numerical_structures is not None:
+        simulations_static = {
+            name: (
+                insert_numerical_structures_static(
+                    simulation=simulations_norm[name],
+                    numerical_structures=numerical_structures[name],
+                )
+                if numerical_structures[name]
+                else simulations_norm[name]
             )
-            if numerical_structures[name]
-            else simulations_norm[name]
-        )
-        for name in simulations_norm
-    }
+            for name in simulations_norm
+        }
+    else:
+        simulations_static = simulations_norm
 
     return run_async_webapi(
         simulations=simulations_static,
@@ -813,9 +756,9 @@ def run_async(
 def _run(
     simulation: td.Simulation,
     task_name: str,
-    numerical_structures: typing.Optional[dict[int, dict[str, typing.Any]]] = None,
     local_gradient: bool = False,
     max_num_adjoint_per_fwd: typing.Optional[int] = None,
+    numerical_structures: typing.Optional[tuple[NumericalStructureConfig]] = None,
     user_vjp: typing.Optional[tuple[UserVJPConfig]] = None,
     **run_kwargs: Any,
 ) -> td.SimulationData:
@@ -855,12 +798,10 @@ def _run(
         aux_data=aux_data,
         local_gradient=local_gradient,
         max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
+        numerical_structures=numerical_structures,
         user_vjp=user_vjp,
         **run_kwargs,
     )
-
-    if setup_result.numerical_info:
-        aux_data[AUX_KEY_NUMERICAL_STRUCTURES] = setup_result.numerical_info
 
     return postprocess_run(traced_fields_data=traced_fields_data, aux_data=aux_data)
 
@@ -869,15 +810,10 @@ def _run_async(
     simulations: dict[str, td.Simulation],
     local_gradient: bool = False,
     max_num_adjoint_per_fwd: typing.Optional[int] = None,
-    numerical_structures: typing.Optional[dict[str, dict[int, dict[str, typing.Any]]]] = None,
-    user_vjp: typing.Optional[
-        typing.Union[
-            UserVJPConfig,
-            dict[str, UserVJPConfig],
-            tuple[UserVJPConfig],
-            list[UserVJPConfig],
-        ]
+    numerical_structures: typing.Optional[
+        dict[str, typing.Sequence[NumericalStructureConfig]]
     ] = None,
+    user_vjp: typing.Optional[dict[str, typing.Sequence[UserVJPConfig]]] = None,
     **run_async_kwargs: Any,
 ) -> dict[str, td.SimulationData]:
     """User-facing ``web.run_async`` function, compatible with ``autograd`` differentiation."""
@@ -891,7 +827,7 @@ def _run_async(
         max_num_adjoint_per_fwd = config.adjoint.max_adjoint_per_fwd
 
     numerical_structures = numerical_structures or {}
-    # user_vjp = user_vjp or {}
+    aux_data_dict = {task_name: {} for task_name in task_names}
 
     for task_name in task_names:
         sim = simulations[task_name]
@@ -901,7 +837,6 @@ def _run_async(
         )
         sim_prepared = setup_result.simulation
         traced_fields = setup_result.sim_fields
-        has_numerical_tracers = bool(setup_result.numerical_info)
 
         sims_prepared[task_name] = sim_prepared
 
@@ -912,32 +847,19 @@ def _run_async(
             sim_static.attrs[TRACED_FIELD_KEYS_ATTR] = payload
 
         sims_original[task_name] = sim_static
-        if has_numerical_tracers:
-            aux_entry = {AUX_KEY_NUMERICAL_STRUCTURES: setup_result.numerical_info}
-            run_async_kwargs.setdefault("aux_data_seed", {})[task_name] = aux_entry
-        run_async_kwargs.setdefault("numerical_structures_info", {})[task_name] = (
-            setup_result.numerical_info or {}
-        )
 
     # TODO: shortcut primitive running for any items with no tracers?
     traced_fields_sim_dict = dict_ag(traced_fields_sim_dict)
     sims_original = {name: sims_original[name] for name in traced_fields_sim_dict.keys()}
 
-    numerical_info_map_full = run_async_kwargs.pop("numerical_structures_info", {})
-    numerical_info_map = {
-        name: numerical_info_map_full.get(name, {}) for name in traced_fields_sim_dict.keys()
-    }
-    # user_vjp = {name: user_vjp.get(name) for name in traced_fields_sim_dict.keys()}
-
-    aux_data_dict = {task_name: {} for task_name in task_names}
     traced_fields_data_dict = _run_async_primitive(
         traced_fields_sim_dict,  # if you pass as a kwarg it will not trace :/
         sims_original=sims_original,
         aux_data_dict=aux_data_dict,
         local_gradient=local_gradient,
         max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
+        numerical_structures=setup_result.numerical_structures,
         user_vjp=user_vjp,
-        numerical_structures_info=numerical_info_map,
         **run_async_kwargs,
     )
 
@@ -946,45 +868,52 @@ def _run_async(
     for task_name in traced_fields_sim_dict.keys():
         traced_fields_data = traced_fields_data_dict[task_name]
         aux_data = aux_data_dict[task_name]
-        if numerical_info_map.get(task_name) and AUX_KEY_NUMERICAL_STRUCTURES not in aux_data:
-            aux_data[AUX_KEY_NUMERICAL_STRUCTURES] = numerical_info_map[task_name]
         sim_data = postprocess_run(traced_fields_data=traced_fields_data, aux_data=aux_data)
         sim_data_dict[task_name] = sim_data
 
     return sim_data_dict
 
 
+def populate_numerical_structures(
+    simulation: td.Simulation,
+    numerical_structures: tuple[NumericalStructureConfig],
+) -> typing.Optional[tuple[NumericalStructureConfig]]:
+    populated_numerical_structures = []
+
+    last_structure_index = len(simulation.structures)
+
+    for numerical_structure in numerical_structures:
+        structure_index = numerical_structure.structure_index
+
+        if structure_index == -1:
+            populated_numerical_structures.append(
+                replace(numerical_structure, structure_index=last_structure_index)
+            )
+        else:
+            populated_numerical_structures.append(numerical_structure)
+
+        last_structure_index += 1
+
+    return tuple(populated_numerical_structures)
+
+
 def setup_run(
     simulation: td.Simulation,
-    numerical_structures: typing.Optional[dict[int, dict[str, typing.Any]]] = None,
+    numerical_structures: typing.Optional[tuple[NumericalStructureConfig]] = None,
 ) -> SetupRunResult:
     """Prepare simulation and traced fields, including numerical structure insertions."""
 
-    numerical_info: dict[int, NumericalStructureInfo] = {}
     sim_prepared = simulation
+
+    numerical_structures_indices = [
+        numerical_structure.structure_index for numerical_structure in numerical_structures
+    ]
 
     if numerical_structures:
         structures = list(simulation.structures)
-        td.log.info(
-            "Inserting %d numerical structures via autograd local gradient path.",
-            len(numerical_structures),
-        )
-        for index in sorted(numerical_structures):
-            config = numerical_structures[index]
-            func = config["function"]
-            params_flat = config["parameters"]
-            vjp_callable = config["vjp"]
-
-            structure = func(get_static(params_flat))
-
-            structures.insert(index, structure)
-            numerical_info[index] = NumericalStructureInfo(
-                index=index,
-                parameters=params_flat,
-                function=func,
-                structure=structure,
-                vjp=vjp_callable,
-            )
+        for config in numerical_structures:
+            structure = config.create(get_static(config.parameters))
+            structures.insert(config.structure_index, structure)
 
             sim_prepared = simulation.updated_copy(structures=structures)
 
@@ -992,25 +921,25 @@ def setup_run(
         include_untraced_data_arrays=False, starting_path=("structures",)
     )
 
-    if numerical_info:
+    if numerical_structures:
         # collect sim fields for structures that go through regular derivative path
         sim_fields_dict = {
             key: value
             for key, value in sim_fields_map.items()
-            if not (key[0] == "structures" and key[1] in numerical_info)
+            if not (key[0] == "structures" and key[1] in numerical_structures_indices)
         }
 
         # collect sim fields for structures that go through numerical derivative path
-        for index, info in numerical_info.items():
-            for idx, param in enumerate(info.parameters):
-                sim_fields_dict[("numerical", index, idx)] = param
+        for config in numerical_structures:
+            for idx, param in enumerate(config.parameters):
+                sim_fields_dict[("numerical", config.structure_index, idx)] = param
 
         sim_fields_map = dict_ag(sim_fields_dict)
 
     return SetupRunResult(
         sim_fields=sim_fields_map,
         simulation=sim_prepared,
-        numerical_info=numerical_info,
+        numerical_structures=numerical_structures,
     )
 
 
@@ -1103,16 +1032,10 @@ def _run_async_primitive(
     aux_data_dict: dict[dict[str, typing.Any]],
     local_gradient: bool,
     max_num_adjoint_per_fwd: int,
-    # user_vjp: typing.Optional[dict[str, typing.Optional[UserVjpSpec]]] = None,
-    user_vjp: typing.Optional[
-        typing.Union[
-            UserVJPConfig,
-            dict[str, UserVJPConfig],
-            tuple[UserVJPConfig],
-            list[UserVJPConfig],
-        ]
+    numerical_structures: typing.Optional[
+        dict[str, typing.Sequence[NumericalStructureConfig]],
     ] = None,
-    numerical_structures_info: typing.Optional[dict[str, dict[int, NumericalStructureInfo]]] = None,
+    user_vjp: typing.Optional[dict[str, typing.Sequence[UserVJPConfig]],] = None,
     **run_async_kwargs: Any,
 ) -> dict[str, AutogradFieldMap]:
     task_names = sim_fields_dict.keys()
@@ -1135,8 +1058,6 @@ def _run_async_primitive(
             sim_data_combined = batch_data_combined[task_name]
             sim_original = sims_original[task_name]
             aux_data = aux_data_dict[task_name]
-            if numerical_structures_info and task_name in numerical_structures_info:
-                aux_data[AUX_KEY_NUMERICAL_STRUCTURES] = numerical_structures_info[task_name]
             field_map_fwd_dict[task_name] = postprocess_fwd(
                 sim_data_combined=sim_data_combined,
                 sim_original=sim_original,
@@ -1166,8 +1087,6 @@ def _run_async_primitive(
             aux_data = aux_data_dict[task_name]
             aux_data[AUX_KEY_FWD_TASK_ID] = task_id_fwd
             aux_data[AUX_KEY_SIM_DATA_ORIGINAL] = sim_data_orig
-            if numerical_structures_info and task_name in numerical_structures_info:
-                aux_data[AUX_KEY_NUMERICAL_STRUCTURES] = numerical_structures_info[task_name]
             field_map = sim_data_orig._strip_traced_fields(
                 include_untraced_data_arrays=True, starting_path=("data",)
             )
@@ -1223,6 +1142,7 @@ def _run_bwd(
     aux_data: dict,
     local_gradient: bool,
     max_num_adjoint_per_fwd: int,
+    numerical_structures: tuple[NumericalStructureConfig],
     user_vjp: tuple[UserVJPConfig],
     **run_kwargs: Any,
 ) -> typing.Callable[[AutogradFieldMap], AutogradFieldMap]:
@@ -1292,13 +1212,14 @@ def _run_bwd(
             vjp_fields_dict = {}
             for task_name_adj, sim_data_adj in batch_data_adj.items():
                 td.log.info(f"Processing VJP contribution from {task_name_adj}")
+
                 vjp_fields_dict[task_name_adj] = postprocess_adj(
                     sim_data_adj=sim_data_adj,
                     sim_data_orig=sim_data_orig,
                     sim_data_fwd=sim_data_fwd,
                     sim_fields_keys=sim_fields_keys,
                     user_vjp=user_vjp,
-                    numerical_info=aux_data.get(AUX_KEY_NUMERICAL_STRUCTURES, {}),
+                    numerical_structures=numerical_structures,
                 )
         else:
             td.log.info("Starting server-side batch of adjoint simulations ...")
@@ -1350,15 +1271,10 @@ def _run_async_bwd(
     aux_data_dict: dict[str, dict[str, typing.Any]],
     local_gradient: bool,
     max_num_adjoint_per_fwd: int,
-    user_vjp: typing.Optional[
-        typing.Union[
-            UserVJPConfig,
-            dict[str, UserVJPConfig],
-            tuple[UserVJPConfig],
-            list[UserVJPConfig],
-        ]
+    numerical_structures: typing.Optional[
+        dict[str, typing.Sequence[NumericalStructureConfig]],
     ] = None,
-    numerical_structures_info: typing.Optional[dict[str, dict[int, NumericalStructureInfo]]] = None,
+    user_vjp: typing.Optional[dict[str, typing.Sequence[UserVJPConfig]],] = None,
     **run_async_kwargs: Any,
 ) -> typing.Callable[[dict[str, AutogradFieldMap]], dict[str, AutogradFieldMap]]:
     """VJP-maker for ``_run_primitive()``. Constructs and runs adjoint simulation, computes grad."""
@@ -1368,14 +1284,7 @@ def _run_async_bwd(
 
     task_names = data_fields_original_dict.keys()
 
-    if numerical_structures_info is None:
-        numerical_structures_info = {}
-
     user_vjp = user_vjp or {}
-    # if isinstance(user_vjp, dict):
-    #     user_vjp_map = user_vjp
-    # else:
-    #     user_vjp_map = dict.fromkeys(task_names, user_vjp)
 
     # get the fwd epsilon and field data from the cached aux_data
     sim_data_orig_dict = {}
@@ -1388,8 +1297,6 @@ def _run_async_bwd(
 
         if local_gradient:
             sim_data_fwd_dict[task_name] = aux_data[AUX_KEY_SIM_DATA_FWD]
-
-    td.log.info("constructing custom vjp function for backwards pass.")
 
     def vjp(data_fields_dict_vjp: dict[str, AutogradFieldMap]) -> dict[str, AutogradFieldMap]:
         """dJ/d{sim.traced_fields()} as a function of Function of dJ/d{data.traced_fields()}"""
@@ -1424,10 +1331,6 @@ def _run_async_bwd(
                 adj_task_name = f"{task_name}_adjoint_{i}"
                 all_sims_adj[adj_task_name] = sim_adj
                 task_name_mapping[adj_task_name] = task_name
-                # Carry per-task numerical metadata
-                aux = aux_data_dict[task_name]
-                if AUX_KEY_NUMERICAL_STRUCTURES in aux:
-                    numerical_structures_info[adj_task_name] = aux[AUX_KEY_NUMERICAL_STRUCTURES]
 
         if not all_sims_adj:
             td.log.warning(
@@ -1467,7 +1370,7 @@ def _run_async_bwd(
                     sim_data_fwd=sim_data_fwd,
                     sim_fields_keys=sim_fields_keys,
                     user_vjp=task_user_vjp,
-                    numerical_info=aux_data_dict[task_name].get(AUX_KEY_NUMERICAL_STRUCTURES, {}),
+                    numerical_structures=numerical_structures,
                 )
         else:
             # Set up parent tasks mapping for all adjoint simulations
@@ -1488,7 +1391,6 @@ def _run_async_bwd(
             # Run all adjoint simulations in a single batch
             vjp_results = _run_async_tidy3d_bwd(
                 simulations=all_sims_adj,
-                numerical_structures_info=numerical_structures_info,
                 **run_async_kwargs,
             )
 
@@ -1534,8 +1436,8 @@ def postprocess_adj(
     sim_data_orig: td.SimulationData,
     sim_data_fwd: td.SimulationData,
     sim_fields_keys: list[tuple],
-    user_vjp: typing.Optional[UserVjpSpec],
-    numerical_info: dict[int, NumericalStructureInfo],
+    user_vjp: tuple[UserVJPConfig],
+    numerical_structures: tuple[NumericalStructureConfig],
 ) -> AutogradFieldMap:
     """Postprocess adjoint results into VJPs (delegated)."""
     return _postprocess_adj_impl(
@@ -1544,7 +1446,7 @@ def postprocess_adj(
         sim_data_fwd=sim_data_fwd,
         sim_fields_keys=sim_fields_keys,
         user_vjp=user_vjp,
-        numerical_info=numerical_info,
+        numerical_structures=numerical_structures,
     )
 
 

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -54,7 +54,13 @@ from .io_utils import (
 from .io_utils import (
     upload_sim_fields_keys as _upload_sim_fields_keys_impl,
 )
-from .types import SetupRunResult, UserVjpEntry, UserVjpSpec
+from .types import (
+    NumericalStructureConfig,
+    SetupRunResult,
+    UserVJPConfig,
+    UserVjpEntry,
+    UserVjpSpec,
+)
 
 
 def _resolve_local_gradient(value: typing.Optional[bool]) -> bool:
@@ -156,7 +162,6 @@ def has_traced_numerical_structures(
 
 def validate_numerical_structures(
     numerical_structures: dict[int, dict[str, typing.Any]],
-    user_vjp: tuple[CustomVJPPathType, ...],
     simulation: td.Simulation,
 ) -> None:
     """Validate user-supplied numerical structure configuration."""
@@ -167,14 +172,6 @@ def validate_numerical_structures(
             raise AdjointError(
                 f"Parameters for numerical structure index {index} must be 1D array-like."
             )
-
-    # Reject user_vjp entries that try to target numerical namespace
-    if user_vjp:
-        for entry in user_vjp:
-            if entry.path and entry.path[0] == "numerical":
-                raise AdjointError(
-                    "Global 'user_vjp' cannot target 'numerical' namespace; specify VJP via numerical structure entry."
-                )
 
 
 def is_valid_for_autograd(simulation: td.Simulation) -> bool:
@@ -237,8 +234,12 @@ def run_custom(
     pay_type: typing.Union[PayType, str] = PayType.AUTO,
     priority: typing.Optional[int] = None,
     lazy: typing.Optional[bool] = None,
-    numerical_structures: typing.Optional[dict[int, dict[str, typing.Any]]] = None,
-    user_vjp: typing.Optional[tuple[CustomVJPPathType, ...]] = None,
+    # numerical_structures: typing.Optional[dict[int, dict[str, typing.Any]]] = None,
+    # user_vjp: typing.Optional[tuple[CustomVJPPathType, ...]] = None,
+    numerical_structures: typing.Optional[
+        typing.Union[NumericalStructureConfig, tuple[NumericalStructureConfig]]
+    ] = None,
+    user_vjp: typing.Optional[typing.Union[UserVJPConfig, tuple[UserVJPConfig]]] = None,
 ) -> WorkflowDataType:
     """
     Submits a :class:`.Simulation` to server, starts running, monitors progress, downloads,
@@ -344,23 +345,34 @@ def run_custom(
         stub = Tidy3dStub(simulation=simulation)
         task_name = stub.get_default_task_name()
 
-    user_vjp_normalized = None
+    ##### put numerical_structures and user_vjp into tuple form if only a single is specified
+
+    if numerical_structures is not None:
+        if isinstance(numerical_structures, NumericalStructureConfig):
+            numerical_structures = (numerical_structures,)
+
     if user_vjp is not None:
-        user_vjp_normalized = normalize_user_vjp_spec(user_vjp)
+        if isinstance(user_vjp, UserVJPConfig):
+            user_vjp = (user_vjp,)
+
+    #####
+
+    # user_vjp_normalized = None
+    # if user_vjp is not None:
+    #     user_vjp_normalized = normalize_user_vjp_spec(user_vjp)
 
     numerical_structures_validated = None
     if isinstance(simulation, td.Simulation):
         if numerical_structures is not None:
             validate_numerical_structures(
                 numerical_structures=numerical_structures,
-                user_vjp=user_vjp_normalized,
                 simulation=simulation,
             )
             numerical_structures_validated = numerical_structures
         else:
             numerical_structures_validated = {}
 
-    numerical_vjp_map = user_vjp_normalized
+    # numerical_vjp_map = user_vjp_normalized
 
     # component modeler path: route autograd-valid modelers to local run
     from tidy3d.plugins.smatrix.component_modelers.types import ComponentModelerType
@@ -432,7 +444,7 @@ def run_custom(
             parent_tasks=parent_tasks,
             local_gradient=local_gradient,
             max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
-            user_vjp=numerical_vjp_map,
+            user_vjp=user_vjp,
             pay_type=pay_type,
             priority=priority,
             lazy=lazy,
@@ -536,10 +548,18 @@ def run_async_custom(
     ] = None,
     user_vjp: typing.Optional[
         typing.Union[
-            dict[str, typing.Any],
-            typing.Sequence[typing.Any],
+            UserVJPConfig,
+            dict[str, UserVJPConfig],
+            tuple[UserVJPConfig],
+            list[UserVJPConfig],
         ]
     ] = None,
+    # user_vjp: typing.Optional[
+    #     typing.Union[
+    #         dict[str, typing.Any],
+    #         typing.Sequence[typing.Any],
+    #     ]
+    # ] = None,
 ) -> BatchData:
     """Submits a set of Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`] objects to server,
     starts running, monitors progress, downloads, and loads results as a :class:`.BatchData` object.
@@ -607,6 +627,29 @@ def run_async_custom(
 
     lazy = True if lazy is None else bool(lazy)
 
+    if isinstance(user_vjp, UserVJPConfig):
+        if isinstance(simulations, (tuple, list)):
+            user_vjp = (type(simulations)(user_vjp)) * len(simulations)
+        else:
+            user_vjp = dict.fromkeys(simulations.keys(), user_vjp)
+
+    if isinstance(simulations, (tuple, list, dict)):
+        if type(user_vjp) is not type(simulations):
+            raise AdjointError(
+                f"user_vjp type ({type(user_vjp)}) should match simulations type ({type(simulations)})"
+            )
+
+        if isinstance(simulations, dict):
+            check_keys = user_vjp.keys() == simulations.keys()
+
+            if not check_keys:
+                raise AdjointError("user vjp keys do not match simulations keys")
+        else:
+            if not (len(user_vjp) == len(simulations)):
+                raise AdjointError(
+                    f"user vjp is not the same length as simulations ({len(user_vjp)} vs. {len(simulations)})"
+                )
+
     if isinstance(simulations, (tuple, list)):
         sim_dict = {}
         for i, sim in enumerate(simulations, 1):
@@ -614,17 +657,10 @@ def run_async_custom(
             sim_dict[task_name] = sim
 
         if user_vjp is not None:
-            if type(user_vjp) is not type(simulations):
-                raise AdjointError(
-                    f"user_vjp type ({type(user_vjp)}) should match simulations type ({type(simulations)})"
-                )
-
             # set up the user_vjp_dict to have the same keys as the simulation dict
-            user_vjp_dict = {}
-            for task_idx, task_name in enumerate(sim_dict):
-                user_vjp_dict[task_name] = user_vjp[task_idx]
-
-            user_vjp = user_vjp_dict
+            user_vjp = {
+                task_name: user_vjp[task_idx] for task_idx, task_name in enumerate(sim_dict)
+            }
 
         if numerical_structures is not None:
             if type(numerical_structures) is not type(simulations):
@@ -649,17 +685,16 @@ def run_async_custom(
         dict.fromkeys(name_mapping) if numerical_structures is None else numerical_structures
     )
 
-    user_vjp_norm = _normalize_user_vjp_input(
-        simulations=simulations,
-        user_vjp=user_vjp,
-        name_mapping=name_mapping,
-    )
+    # user_vjp_norm = _normalize_user_vjp_input(
+    #     simulations=simulations,
+    #     user_vjp=user_vjp,
+    #     name_mapping=name_mapping,
+    # )
 
     for name, numerical_structures_config in numerical_structures.items():
         cfg = numerical_structures_config or {}
         validate_numerical_structures(
             numerical_structures=cfg,
-            user_vjp=user_vjp_norm.get(name),
             simulation=simulations_norm[name],
         )
 
@@ -697,7 +732,7 @@ def run_async_custom(
             local_gradient=local_gradient,
             max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
             numerical_structures=numerical_structures,
-            user_vjp=user_vjp_norm,
+            user_vjp=user_vjp,
             pay_type=pay_type,
             priority=priority,
             lazy=lazy,
@@ -781,7 +816,7 @@ def _run(
     numerical_structures: typing.Optional[dict[int, dict[str, typing.Any]]] = None,
     local_gradient: bool = False,
     max_num_adjoint_per_fwd: typing.Optional[int] = None,
-    user_vjp: typing.Optional[tuple[CustomVJPPathType, ...]] = None,
+    user_vjp: typing.Optional[tuple[UserVJPConfig]] = None,
     **run_kwargs: Any,
 ) -> td.SimulationData:
     """User-facing ``web.run`` function, compatible with ``autograd`` differentiation."""
@@ -789,7 +824,6 @@ def _run(
     setup_result = setup_run(
         simulation=simulation,
         numerical_structures=numerical_structures,
-        user_vjp=user_vjp,
     )
     traced_fields_sim = setup_result.sim_fields
     simulation = setup_result.simulation
@@ -836,7 +870,14 @@ def _run_async(
     local_gradient: bool = False,
     max_num_adjoint_per_fwd: typing.Optional[int] = None,
     numerical_structures: typing.Optional[dict[str, dict[int, dict[str, typing.Any]]]] = None,
-    user_vjp: typing.Optional[dict[str, typing.Optional[UserVjpSpec]]] = None,
+    user_vjp: typing.Optional[
+        typing.Union[
+            UserVJPConfig,
+            dict[str, UserVJPConfig],
+            tuple[UserVJPConfig],
+            list[UserVJPConfig],
+        ]
+    ] = None,
     **run_async_kwargs: Any,
 ) -> dict[str, td.SimulationData]:
     """User-facing ``web.run_async`` function, compatible with ``autograd`` differentiation."""
@@ -850,14 +891,13 @@ def _run_async(
         max_num_adjoint_per_fwd = config.adjoint.max_adjoint_per_fwd
 
     numerical_structures = numerical_structures or {}
-    user_vjp = user_vjp or {}
+    # user_vjp = user_vjp or {}
 
     for task_name in task_names:
         sim = simulations[task_name]
         setup_result = setup_run(
             simulation=sim,
             numerical_structures=numerical_structures.get(task_name),
-            user_vjp=user_vjp.get(task_name),
         )
         sim_prepared = setup_result.simulation
         traced_fields = setup_result.sim_fields
@@ -887,7 +927,7 @@ def _run_async(
     numerical_info_map = {
         name: numerical_info_map_full.get(name, {}) for name in traced_fields_sim_dict.keys()
     }
-    user_vjp = {name: user_vjp.get(name) for name in traced_fields_sim_dict.keys()}
+    # user_vjp = {name: user_vjp.get(name) for name in traced_fields_sim_dict.keys()}
 
     aux_data_dict = {task_name: {} for task_name in task_names}
     traced_fields_data_dict = _run_async_primitive(
@@ -917,7 +957,6 @@ def _run_async(
 def setup_run(
     simulation: td.Simulation,
     numerical_structures: typing.Optional[dict[int, dict[str, typing.Any]]] = None,
-    user_vjp: typing.Optional[tuple[CustomVJPPathType, ...]] = None,
 ) -> SetupRunResult:
     """Prepare simulation and traced fields, including numerical structure insertions."""
 
@@ -995,7 +1034,7 @@ def _run_primitive(
     aux_data: dict,
     local_gradient: bool,
     max_num_adjoint_per_fwd: int,
-    user_vjp: tuple[CustomVJPPathType, ...],
+    user_vjp: typing.Optional[typing.Union[UserVJPConfig, tuple[UserVJPConfig]]] = None,
     **run_kwargs: Any,
 ) -> AutogradFieldMap:
     """Autograd-traced 'run()' function: runs simulation, strips tracer data, caches fwd data."""
@@ -1064,7 +1103,15 @@ def _run_async_primitive(
     aux_data_dict: dict[dict[str, typing.Any]],
     local_gradient: bool,
     max_num_adjoint_per_fwd: int,
-    user_vjp: typing.Optional[dict[str, typing.Optional[UserVjpSpec]]] = None,
+    # user_vjp: typing.Optional[dict[str, typing.Optional[UserVjpSpec]]] = None,
+    user_vjp: typing.Optional[
+        typing.Union[
+            UserVJPConfig,
+            dict[str, UserVJPConfig],
+            tuple[UserVJPConfig],
+            list[UserVJPConfig],
+        ]
+    ] = None,
     numerical_structures_info: typing.Optional[dict[str, dict[int, NumericalStructureInfo]]] = None,
     **run_async_kwargs: Any,
 ) -> dict[str, AutogradFieldMap]:
@@ -1176,7 +1223,7 @@ def _run_bwd(
     aux_data: dict,
     local_gradient: bool,
     max_num_adjoint_per_fwd: int,
-    user_vjp: tuple[CustomVJPPathType, ...],
+    user_vjp: tuple[UserVJPConfig],
     **run_kwargs: Any,
 ) -> typing.Callable[[AutogradFieldMap], AutogradFieldMap]:
     """VJP-maker for ``_run_primitive()``. Constructs and runs adjoint simulations, computes grad."""
@@ -1303,7 +1350,14 @@ def _run_async_bwd(
     aux_data_dict: dict[str, dict[str, typing.Any]],
     local_gradient: bool,
     max_num_adjoint_per_fwd: int,
-    user_vjp: typing.Optional[dict[str, typing.Optional[UserVjpSpec]]] = None,
+    user_vjp: typing.Optional[
+        typing.Union[
+            UserVJPConfig,
+            dict[str, UserVJPConfig],
+            tuple[UserVJPConfig],
+            list[UserVJPConfig],
+        ]
+    ] = None,
     numerical_structures_info: typing.Optional[dict[str, dict[int, NumericalStructureInfo]]] = None,
     **run_async_kwargs: Any,
 ) -> typing.Callable[[dict[str, AutogradFieldMap]], dict[str, AutogradFieldMap]]:
@@ -1317,10 +1371,11 @@ def _run_async_bwd(
     if numerical_structures_info is None:
         numerical_structures_info = {}
 
-    if isinstance(user_vjp, dict):
-        user_vjp_map = user_vjp
-    else:
-        user_vjp_map = dict.fromkeys(task_names, user_vjp)
+    user_vjp = user_vjp or {}
+    # if isinstance(user_vjp, dict):
+    #     user_vjp_map = user_vjp
+    # else:
+    #     user_vjp_map = dict.fromkeys(task_names, user_vjp)
 
     # get the fwd epsilon and field data from the cached aux_data
     sim_data_orig_dict = {}
@@ -1402,7 +1457,9 @@ def _run_async_bwd(
                 sim_fields_keys = sim_fields_keys_dict[task_name]
 
                 # Compute VJP contribution
-                task_user_vjp = user_vjp_map.get(task_name)
+                task_user_vjp = user_vjp.get(task_name)
+                if isinstance(task_user_vjp, UserVJPConfig):
+                    task_user_vjp = (task_user_vjp,)
 
                 vjp_results[adj_task_name] = postprocess_adj(
                     sim_data_adj=sim_data_adj,

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -6,11 +6,14 @@ from os import PathLike
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 from autograd.builtins import dict as dict_ag
 from autograd.extend import defvjp, primitive
 
 import tidy3d as td
-from tidy3d.components.autograd import AutogradFieldMap
+from tidy3d.components.autograd import AutogradFieldMap, get_static
+from tidy3d.components.autograd.types import CustomVJPPathType, NumericalStructureInfo
+from tidy3d.components.autograd.utils import contains_tracer
 from tidy3d.components.base import TRACED_FIELD_KEYS_ATTR
 from tidy3d.components.types.workflow import WorkflowDataType, WorkflowType
 from tidy3d.config import config
@@ -27,6 +30,7 @@ from .backward import postprocess_adj as _postprocess_adj_impl
 from .backward import setup_adj as _setup_adj_impl
 from .constants import (
     AUX_KEY_FWD_TASK_ID,
+    AUX_KEY_NUMERICAL_STRUCTURES,
     AUX_KEY_SIM_DATA_FWD,
     AUX_KEY_SIM_DATA_ORIGINAL,
 )
@@ -50,6 +54,7 @@ from .io_utils import (
 from .io_utils import (
     upload_sim_fields_keys as _upload_sim_fields_keys_impl,
 )
+from .types import SetupRunResult, UserVjpEntry, UserVjpSpec
 
 
 def _resolve_local_gradient(value: typing.Optional[bool]) -> bool:
@@ -57,6 +62,119 @@ def _resolve_local_gradient(value: typing.Optional[bool]) -> bool:
         return bool(value)
 
     return bool(config.adjoint.local_gradient)
+
+
+def insert_numerical_structures_static(
+    simulation: td.Simulation,
+    numerical_structures: dict[int, dict[str, typing.Any]],
+) -> td.Simulation:
+    """Return a Simulation with numerical structures inserted, without autograd metadata."""
+
+    structures = list(simulation.structures)
+
+    for index in sorted(numerical_structures):
+        config = numerical_structures[index]
+        func = config["function"]
+        params_input = config["parameters"]
+
+        try:
+            structure = func(get_static(params_input))
+        except Exception as exc:  # pragma: no cover - defensive
+            raise AdjointError(
+                f"Failed to construct numerical structure at index {index}: {exc}"
+            ) from exc
+
+        if not isinstance(structure, td.Structure):
+            raise AdjointError(
+                "Numerical structure creation functions must return a tidy3d.Structure instance."
+            )
+
+        structures.insert(index, structure)
+
+    return simulation.copy(update={"structures": structures})
+
+
+def _normalize_simulations_input(
+    simulations: typing.Union[dict[str, td.Simulation], tuple[td.Simulation], list[td.Simulation]],
+) -> tuple[dict[str, td.Simulation], dict[str, int]]:
+    """Normalize simulations to a dict and map each task name to its positional index."""
+
+    if isinstance(simulations, dict):
+        return simulations, {name: idx for idx, name in enumerate(simulations)}
+
+    normalized: dict[str, td.Simulation] = {}
+    name_mapping: dict[str, int] = {}
+
+    for idx, sim in enumerate(simulations):
+        task_name = Tidy3dStub(simulation=sim).get_default_task_name() + f"_{idx + 1}"
+        normalized[task_name] = sim
+        name_mapping[task_name] = idx
+
+    return normalized, name_mapping
+
+
+def normalize_user_vjp_spec(spec: tuple[CustomVJPPathType, ...]) -> typing.Optional[UserVjpSpec]:
+    """Normalize a user-provided VJP specification into canonical tuple entries."""
+
+    if spec is None:
+        return None
+
+    if not spec:
+        return ()
+
+    return tuple(UserVjpEntry(entry[0], (entry[1],), entry[2]) for entry in spec)
+
+
+def _normalize_user_vjp_input(
+    simulations: dict[str, td.Simulation],
+    user_vjp: dict[str, tuple[CustomVJPPathType, ...]],
+    name_mapping: dict[str, int],
+) -> dict[str, typing.Optional[UserVjpSpec]]:
+    """Normalize per-task user VJP configurations keyed by task names."""
+
+    if isinstance(simulations, dict):
+        task_names = tuple(simulations.keys())
+        if user_vjp is None:
+            return dict.fromkeys(task_names)
+        return {
+            task_name: normalize_user_vjp_spec(user_vjp.get(task_name)) for task_name in task_names
+        }
+
+
+def has_traced_numerical_structures(
+    numerical_structures: typing.Optional[dict[int, dict[str, typing.Any]]],
+) -> bool:
+    if not numerical_structures:
+        return False
+
+    for cfg in numerical_structures.values():
+        params = cfg.get("parameters")
+        if contains_tracer(params):
+            return True
+    return False
+
+
+def validate_numerical_structures(
+    numerical_structures: dict[int, dict[str, typing.Any]],
+    user_vjp: tuple[CustomVJPPathType, ...],
+    simulation: td.Simulation,
+) -> None:
+    """Validate user-supplied numerical structure configuration."""
+
+    for index, numerical_config in numerical_structures.items():
+        array_params = np.array(numerical_config["parameters"])
+        if array_params.ndim != 1:
+            raise AdjointError(
+                f"Parameters for numerical structure index {index} must be 1D array-like."
+            )
+
+    # Reject user_vjp entries that try to target numerical namespace
+    if user_vjp:
+        for entry in user_vjp:
+            if entry.path and entry.path[0] == "numerical":
+                raise AdjointError(
+                    "Global 'user_vjp' cannot target 'numerical' namespace; specify VJP via numerical structure entry."
+                )
 
 
 def is_valid_for_autograd(simulation: td.Simulation) -> bool:
@@ -100,7 +218,7 @@ def is_valid_for_autograd_async(simulations: dict[str, td.Simulation]) -> bool:
     return True
 
 
-def run(
+def run_custom(
     simulation: WorkflowType,
     task_name: typing.Optional[str] = None,
     folder_name: str = "default",
@@ -119,6 +237,8 @@ def run(
     pay_type: typing.Union[PayType, str] = PayType.AUTO,
     priority: typing.Optional[int] = None,
     lazy: typing.Optional[bool] = None,
+    numerical_structures: typing.Optional[dict[int, dict[str, typing.Any]]] = None,
+    user_vjp: typing.Optional[tuple[CustomVJPPathType, ...]] = None,
 ) -> WorkflowDataType:
     """
     Submits a :class:`.Simulation` to server, starts running, monitors progress, downloads,
@@ -224,13 +344,41 @@ def run(
         stub = Tidy3dStub(simulation=simulation)
         task_name = stub.get_default_task_name()
 
+    user_vjp_normalized = None
+    if user_vjp is not None:
+        user_vjp_normalized = normalize_user_vjp_spec(user_vjp)
+
+    numerical_structures_validated = None
+    if isinstance(simulation, td.Simulation):
+        if numerical_structures is not None:
+            validate_numerical_structures(
+                numerical_structures=numerical_structures,
+                user_vjp=user_vjp_normalized,
+                simulation=simulation,
+            )
+            numerical_structures_validated = numerical_structures
+        else:
+            numerical_structures_validated = {}
+
+    numerical_vjp_map = user_vjp_normalized
+
     # component modeler path: route autograd-valid modelers to local run
     from tidy3d.plugins.smatrix.component_modelers.types import ComponentModelerType
 
     path = Path(path)
 
     if isinstance(simulation, typing.get_args(ComponentModelerType)):
-        if any(is_valid_for_autograd(s) for s in simulation.sim_dict.values()):
+        sim_dict = simulation.sim_dict
+
+        numerical_structures_modeler = numerical_structures or {}
+        if not numerical_structures_modeler and isinstance(numerical_structures_validated, dict):
+            numerical_structures_modeler = numerical_structures_validated
+
+        should_use_component_autograd = any(
+            is_valid_for_autograd(sim) for sim in sim_dict.values()
+        ) or has_traced_numerical_structures(numerical_structures_modeler)
+
+        if should_use_component_autograd:
             from tidy3d.plugins.smatrix import run as smatrix_run
 
             path_dir = path.parent
@@ -245,11 +393,32 @@ def run(
                 priority=priority,
                 local_gradient=local_gradient,
                 max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
+                numerical_structures=numerical_structures_modeler,
+                user_vjp=user_vjp,
             )
 
-    if isinstance(simulation, td.Simulation) and is_valid_for_autograd(simulation):
+    should_use_autograd = False
+    if isinstance(simulation, td.Simulation):
+        should_use_autograd = is_valid_for_autograd(simulation)
+        if not should_use_autograd and numerical_structures:
+            for cfg in numerical_structures.values():
+                params = cfg.get("parameters")
+                if contains_tracer(params):
+                    should_use_autograd = True
+                    break
+
+    if should_use_autograd:
+        if (user_vjp is not None) and (not local_gradient):
+            raise AdjointError("User VJP specified for a remote gradient not supported.")
+
+        if has_traced_numerical_structures(numerical_structures_validated) and (not local_gradient):
+            raise AdjointError(
+                "Numerical structures specified for a remote gradient not supported."
+            )
+
         return _run(
             simulation=simulation,
+            numerical_structures=numerical_structures_validated,
             task_name=task_name,
             folder_name=folder_name,
             path=path,
@@ -263,13 +432,23 @@ def run(
             parent_tasks=parent_tasks,
             local_gradient=local_gradient,
             max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
+            user_vjp=numerical_vjp_map,
             pay_type=pay_type,
             priority=priority,
             lazy=lazy,
         )
 
+    simulation_static = simulation
+    if isinstance(simulation, td.Simulation) and numerical_structures_validated:
+        # if there are numerical_structures without traced parameters, we still want
+        # to insert them into the simulation
+        simulation_static = insert_numerical_structures_static(
+            simulation=simulation,
+            numerical_structures=numerical_structures_validated,
+        )
+
     return run_webapi(
-        simulation=simulation,
+        simulation=simulation_static,
         task_name=task_name,
         folder_name=folder_name,
         path=path,
@@ -288,7 +467,52 @@ def run(
     )
 
 
-def run_async(
+def run(
+    simulation: WorkflowType,
+    task_name: typing.Optional[str] = None,
+    folder_name: str = "default",
+    path: PathLike = "simulation_data.hdf5",
+    callback_url: typing.Optional[str] = None,
+    verbose: bool = True,
+    progress_callback_upload: typing.Optional[typing.Callable[[float], None]] = None,
+    progress_callback_download: typing.Optional[typing.Callable[[float], None]] = None,
+    solver_version: typing.Optional[str] = None,
+    worker_group: typing.Optional[str] = None,
+    simulation_type: str = "tidy3d",
+    parent_tasks: typing.Optional[list[str]] = None,
+    local_gradient: typing.Optional[bool] = None,
+    max_num_adjoint_per_fwd: typing.Optional[int] = None,
+    reduce_simulation: typing.Literal["auto", True, False] = "auto",
+    pay_type: typing.Union[PayType, str] = PayType.AUTO,
+    priority: typing.Optional[int] = None,
+    lazy: typing.Optional[bool] = None,
+) -> WorkflowDataType:
+    """Wrapper for run_custom for usage without numerical_structures or user_vjp for public facing API."""
+    return run_custom(
+        simulation=simulation,
+        task_name=task_name,
+        folder_name=folder_name,
+        path=path,
+        callback_url=callback_url,
+        verbose=verbose,
+        progress_callback_upload=progress_callback_upload,
+        progress_callback_download=progress_callback_download,
+        solver_version=solver_version,
+        worker_group=worker_group,
+        simulation_type=simulation_type,
+        parent_tasks=parent_tasks,
+        local_gradient=local_gradient,
+        max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
+        reduce_simulation=reduce_simulation,
+        pay_type=pay_type,
+        priority=priority,
+        lazy=lazy,
+        numerical_structures=None,
+        user_vjp=None,
+    )
+
+
+def run_async_custom(
     simulations: typing.Union[dict[str, td.Simulation], tuple[td.Simulation], list[td.Simulation]],
     folder_name: str = "default",
     path_dir: PathLike = DEFAULT_DATA_DIR,
@@ -304,6 +528,18 @@ def run_async(
     pay_type: typing.Union[PayType, str] = PayType.AUTO,
     priority: typing.Optional[int] = None,
     lazy: typing.Optional[bool] = None,
+    numerical_structures: typing.Optional[
+        typing.Union[
+            dict[str, dict[int, dict[str, typing.Any]]],
+            typing.Sequence[typing.Optional[dict[int, dict[str, typing.Any]]]],
+        ]
+    ] = None,
+    user_vjp: typing.Optional[
+        typing.Union[
+            dict[str, typing.Any],
+            typing.Sequence[typing.Any],
+        ]
+    ] = None,
 ) -> BatchData:
     """Submits a set of Union[:class:`.Simulation`, :class:`.HeatSimulation`, :class:`.EMESimulation`] objects to server,
     starts running, monitors progress, downloads, and loads results as a :class:`.BatchData` object.
@@ -376,13 +612,80 @@ def run_async(
         for i, sim in enumerate(simulations, 1):
             task_name = Tidy3dStub(simulation=sim).get_default_task_name() + f"_{i}"
             sim_dict[task_name] = sim
+
+        if user_vjp is not None:
+            if type(user_vjp) is not type(simulations):
+                raise AdjointError(
+                    f"user_vjp type ({type(user_vjp)}) should match simulations type ({type(simulations)})"
+                )
+
+            # set up the user_vjp_dict to have the same keys as the simulation dict
+            user_vjp_dict = {}
+            for task_idx, task_name in enumerate(sim_dict):
+                user_vjp_dict[task_name] = user_vjp[task_idx]
+
+            user_vjp = user_vjp_dict
+
+        if numerical_structures is not None:
+            if type(numerical_structures) is not type(simulations):
+                raise AdjointError(
+                    f"numerical_structures type ({type(numerical_structures)}) should match simulations type ({type(simulations)})"
+                )
+
+            # set up the numerical_structures_dict to have the same keys as the simulation dict
+            numerical_structures_dict = {}
+            for task_idx, task_name in enumerate(sim_dict):
+                numerical_structures_dict[task_name] = numerical_structures[task_idx]
+
+            numerical_structures = numerical_structures_dict
+
         simulations = sim_dict
 
     path_dir = Path(path_dir)
 
-    if is_valid_for_autograd_async(simulations):
+    simulations_norm, name_mapping = _normalize_simulations_input(simulations)
+
+    numerical_structures = (
+        dict.fromkeys(name_mapping) if numerical_structures is None else numerical_structures
+    )
+
+    user_vjp_norm = _normalize_user_vjp_input(
+        simulations=simulations,
+        user_vjp=user_vjp,
+        name_mapping=name_mapping,
+    )
+
+    for name, numerical_structures_config in numerical_structures.items():
+        cfg = numerical_structures_config or {}
+        validate_numerical_structures(
+            numerical_structures=cfg,
+            user_vjp=user_vjp_norm.get(name),
+            simulation=simulations_norm[name],
+        )
+
+    should_use_autograd_async = is_valid_for_autograd_async(simulations_norm)
+    if not should_use_autograd_async:
+        for name, _ in simulations_norm.items():
+            if numerical_structures.get(name):
+                configs = numerical_structures[name]
+                for cfg in configs.values():
+                    params = cfg.get("parameters")
+                    if contains_tracer(params):
+                        should_use_autograd_async = True
+                        if not local_gradient:
+                            raise AdjointError(
+                                "Numerical structures specified for a remote gradient not supported."
+                            )
+                        break
+            if should_use_autograd_async:
+                break
+
+    if should_use_autograd_async:
+        if (user_vjp is not None) and (not local_gradient):
+            raise AdjointError("User VJP specified for a remote gradient not supported.")
+
         return _run_async(
-            simulations=simulations,
+            simulations=simulations_norm,
             folder_name=folder_name,
             path_dir=path_dir,
             callback_url=callback_url,
@@ -393,13 +696,28 @@ def run_async(
             parent_tasks=parent_tasks,
             local_gradient=local_gradient,
             max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
+            numerical_structures=numerical_structures,
+            user_vjp=user_vjp_norm,
             pay_type=pay_type,
             priority=priority,
             lazy=lazy,
         )
 
+    # insert numerical_structures even if not traced
+    simulations_static = {
+        name: (
+            insert_numerical_structures_static(
+                simulation=simulations_norm[name],
+                numerical_structures=numerical_structures[name],
+            )
+            if numerical_structures[name]
+            else simulations_norm[name]
+        )
+        for name in simulations_norm
+    }
+
     return run_async_webapi(
-        simulations=simulations,
+        simulations=simulations_static,
         folder_name=folder_name,
         path_dir=path_dir,
         callback_url=callback_url,
@@ -415,19 +733,66 @@ def run_async(
     )
 
 
+def run_async(
+    simulations: typing.Union[dict[str, td.Simulation], tuple[td.Simulation], list[td.Simulation]],
+    folder_name: str = "default",
+    path_dir: PathLike = DEFAULT_DATA_DIR,
+    callback_url: typing.Optional[str] = None,
+    num_workers: typing.Optional[int] = None,
+    verbose: bool = True,
+    simulation_type: str = "tidy3d",
+    solver_version: typing.Optional[str] = None,
+    parent_tasks: typing.Optional[dict[str, list[str]]] = None,
+    local_gradient: typing.Optional[bool] = None,
+    max_num_adjoint_per_fwd: typing.Optional[int] = None,
+    reduce_simulation: typing.Literal["auto", True, False] = "auto",
+    pay_type: typing.Union[PayType, str] = PayType.AUTO,
+    priority: typing.Optional[int] = None,
+    lazy: typing.Optional[bool] = None,
+) -> BatchData:
+    """Wrapper for run_async_custom for usage without numerical_structures or user_vjp for public facing API."""
+    return run_async_custom(
+        simulations=simulations,
+        folder_name=folder_name,
+        path_dir=path_dir,
+        callback_url=callback_url,
+        num_workers=num_workers,
+        verbose=verbose,
+        simulation_type=simulation_type,
+        solver_version=solver_version,
+        parent_tasks=parent_tasks,
+        local_gradient=local_gradient,
+        max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
+        reduce_simulation=reduce_simulation,
+        pay_type=pay_type,
+        priority=priority,
+        lazy=lazy,
+        numerical_structures=None,
+        user_vjp=None,
+    )
+
+
 """ User-facing ``run`` and `run_async`` functions, compatible with ``autograd`` """
 
 
 def _run(
     simulation: td.Simulation,
     task_name: str,
+    numerical_structures: typing.Optional[dict[int, dict[str, typing.Any]]] = None,
     local_gradient: bool = False,
     max_num_adjoint_per_fwd: typing.Optional[int] = None,
+    user_vjp: typing.Optional[tuple[CustomVJPPathType, ...]] = None,
     **run_kwargs: Any,
 ) -> td.SimulationData:
     """User-facing ``web.run`` function, compatible with ``autograd`` differentiation."""
 
-    traced_fields_sim = setup_run(simulation=simulation)
+    setup_result = setup_run(
+        simulation=simulation,
+        numerical_structures=numerical_structures,
+        user_vjp=user_vjp,
+    )
+    traced_fields_sim = setup_result.sim_fields
+    simulation = setup_result.simulation
 
     # if we register this as not needing adjoint at all (no tracers), call regular run function
     if not traced_fields_sim:
@@ -456,8 +821,12 @@ def _run(
         aux_data=aux_data,
         local_gradient=local_gradient,
         max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
+        user_vjp=user_vjp,
         **run_kwargs,
     )
+
+    if setup_result.numerical_info:
+        aux_data[AUX_KEY_NUMERICAL_STRUCTURES] = setup_result.numerical_info
 
     return postprocess_run(traced_fields_data=traced_fields_data, aux_data=aux_data)
 
@@ -466,26 +835,59 @@ def _run_async(
     simulations: dict[str, td.Simulation],
     local_gradient: bool = False,
     max_num_adjoint_per_fwd: typing.Optional[int] = None,
+    numerical_structures: typing.Optional[dict[str, dict[int, dict[str, typing.Any]]]] = None,
+    user_vjp: typing.Optional[dict[str, typing.Optional[UserVjpSpec]]] = None,
     **run_async_kwargs: Any,
 ) -> dict[str, td.SimulationData]:
     """User-facing ``web.run_async`` function, compatible with ``autograd`` differentiation."""
-
     task_names = simulations.keys()
 
     traced_fields_sim_dict: dict[str, AutogradFieldMap] = {}
     sims_original: dict[str, td.Simulation] = {}
+    sims_prepared: dict[str, td.Simulation] = {}
+
+    if max_num_adjoint_per_fwd is None:
+        max_num_adjoint_per_fwd = config.adjoint.max_adjoint_per_fwd
+
+    numerical_structures = numerical_structures or {}
+    user_vjp = user_vjp or {}
+
     for task_name in task_names:
         sim = simulations[task_name]
-        traced_fields = setup_run(simulation=sim)
+        setup_result = setup_run(
+            simulation=sim,
+            numerical_structures=numerical_structures.get(task_name),
+            user_vjp=user_vjp.get(task_name),
+        )
+        sim_prepared = setup_result.simulation
+        traced_fields = setup_result.sim_fields
+        has_numerical_tracers = bool(setup_result.numerical_info)
+
+        sims_prepared[task_name] = sim_prepared
+
         traced_fields_sim_dict[task_name] = traced_fields
-        payload = sim._serialized_traced_field_keys(traced_fields)
-        sim_static = sim.to_static()
+        payload = sim_prepared._serialized_traced_field_keys(traced_fields)
+        sim_static = sim_prepared.to_static()
         if payload:
             sim_static.attrs[TRACED_FIELD_KEYS_ATTR] = payload
+
         sims_original[task_name] = sim_static
-    traced_fields_sim_dict = dict_ag(traced_fields_sim_dict)
+        if has_numerical_tracers:
+            aux_entry = {AUX_KEY_NUMERICAL_STRUCTURES: setup_result.numerical_info}
+            run_async_kwargs.setdefault("aux_data_seed", {})[task_name] = aux_entry
+        run_async_kwargs.setdefault("numerical_structures_info", {})[task_name] = (
+            setup_result.numerical_info or {}
+        )
 
     # TODO: shortcut primitive running for any items with no tracers?
+    traced_fields_sim_dict = dict_ag(traced_fields_sim_dict)
+    sims_original = {name: sims_original[name] for name in traced_fields_sim_dict.keys()}
+
+    numerical_info_map_full = run_async_kwargs.pop("numerical_structures_info", {})
+    numerical_info_map = {
+        name: numerical_info_map_full.get(name, {}) for name in traced_fields_sim_dict.keys()
+    }
+    user_vjp = {name: user_vjp.get(name) for name in traced_fields_sim_dict.keys()}
 
     aux_data_dict = {task_name: {} for task_name in task_names}
     traced_fields_data_dict = _run_async_primitive(
@@ -494,27 +896,82 @@ def _run_async(
         aux_data_dict=aux_data_dict,
         local_gradient=local_gradient,
         max_num_adjoint_per_fwd=max_num_adjoint_per_fwd,
+        user_vjp=user_vjp,
+        numerical_structures_info=numerical_info_map,
         **run_async_kwargs,
     )
 
-    # TODO: package this as a Batch? it might be not possible as autograd tracers lose their
-    # powers when we save them to file.
+    # TODO: package this as a Batch? it might be not possible as autograd tracers lose their powers when we save them to file.
     sim_data_dict = {}
-    for task_name in task_names:
+    for task_name in traced_fields_sim_dict.keys():
         traced_fields_data = traced_fields_data_dict[task_name]
         aux_data = aux_data_dict[task_name]
+        if numerical_info_map.get(task_name) and AUX_KEY_NUMERICAL_STRUCTURES not in aux_data:
+            aux_data[AUX_KEY_NUMERICAL_STRUCTURES] = numerical_info_map[task_name]
         sim_data = postprocess_run(traced_fields_data=traced_fields_data, aux_data=aux_data)
         sim_data_dict[task_name] = sim_data
 
     return sim_data_dict
 
 
-def setup_run(simulation: td.Simulation) -> AutogradFieldMap:
-    """Process a user-supplied ``Simulation`` into inputs to ``_run_primitive``."""
+def setup_run(
+    simulation: td.Simulation,
+    numerical_structures: typing.Optional[dict[int, dict[str, typing.Any]]] = None,
+    user_vjp: typing.Optional[tuple[CustomVJPPathType, ...]] = None,
+) -> SetupRunResult:
+    """Prepare simulation and traced fields, including numerical structure insertions."""
 
-    # get a mapping of all the traced fields in the provided simulation
-    return simulation._strip_traced_fields(
+    numerical_info: dict[int, NumericalStructureInfo] = {}
+    sim_prepared = simulation
+
+    if numerical_structures:
+        structures = list(simulation.structures)
+        td.log.info(
+            "Inserting %d numerical structures via autograd local gradient path.",
+            len(numerical_structures),
+        )
+        for index in sorted(numerical_structures):
+            config = numerical_structures[index]
+            func = config["function"]
+            params_flat = config["parameters"]
+            vjp_callable = config["vjp"]
+
+            structure = func(get_static(params_flat))
+
+            structures.insert(index, structure)
+            numerical_info[index] = NumericalStructureInfo(
+                index=index,
+                parameters=params_flat,
+                function=func,
+                structure=structure,
+                vjp=vjp_callable,
+            )
+
+            sim_prepared = simulation.updated_copy(structures=structures)
+
+    sim_fields_map = sim_prepared._strip_traced_fields(
         include_untraced_data_arrays=False, starting_path=("structures",)
+    )
+
+    if numerical_info:
+        # collect sim fields for structures that go through regular derivative path
+        sim_fields_dict = {
+            key: value
+            for key, value in sim_fields_map.items()
+            if not (key[0] == "structures" and key[1] in numerical_info)
+        }
+
+        # collect sim fields for structures that go through numerical derivative path
+        for index, info in numerical_info.items():
+            for idx, param in enumerate(info.parameters):
+                sim_fields_dict[("numerical", index, idx)] = param
+
+        sim_fields_map = dict_ag(sim_fields_dict)
+
+    return SetupRunResult(
+        sim_fields=sim_fields_map,
+        simulation=sim_prepared,
+        numerical_info=numerical_info,
     )
 
 
@@ -523,6 +980,7 @@ def postprocess_run(traced_fields_data: AutogradFieldMap, aux_data: dict) -> td.
 
     # grab the user's 'SimulationData' and return with the autograd-tracers inserted
     sim_data_original = aux_data[AUX_KEY_SIM_DATA_ORIGINAL]
+
     return sim_data_original._insert_traced_fields(traced_fields_data)
 
 
@@ -537,6 +995,7 @@ def _run_primitive(
     aux_data: dict,
     local_gradient: bool,
     max_num_adjoint_per_fwd: int,
+    user_vjp: tuple[CustomVJPPathType, ...],
     **run_kwargs: Any,
 ) -> AutogradFieldMap:
     """Autograd-traced 'run()' function: runs simulation, strips tracer data, caches fwd data."""
@@ -605,6 +1064,8 @@ def _run_async_primitive(
     aux_data_dict: dict[dict[str, typing.Any]],
     local_gradient: bool,
     max_num_adjoint_per_fwd: int,
+    user_vjp: typing.Optional[dict[str, typing.Optional[UserVjpSpec]]] = None,
+    numerical_structures_info: typing.Optional[dict[str, dict[int, NumericalStructureInfo]]] = None,
     **run_async_kwargs: Any,
 ) -> dict[str, AutogradFieldMap]:
     task_names = sim_fields_dict.keys()
@@ -627,6 +1088,8 @@ def _run_async_primitive(
             sim_data_combined = batch_data_combined[task_name]
             sim_original = sims_original[task_name]
             aux_data = aux_data_dict[task_name]
+            if numerical_structures_info and task_name in numerical_structures_info:
+                aux_data[AUX_KEY_NUMERICAL_STRUCTURES] = numerical_structures_info[task_name]
             field_map_fwd_dict[task_name] = postprocess_fwd(
                 sim_data_combined=sim_data_combined,
                 sim_original=sim_original,
@@ -653,8 +1116,11 @@ def _run_async_primitive(
         field_map_fwd_dict = {}
         for task_name, task_id_fwd in task_ids_fwd_dict.items():
             sim_data_orig = sim_data_orig_dict[task_name]
-            aux_data_dict[task_name][AUX_KEY_FWD_TASK_ID] = task_id_fwd
-            aux_data_dict[task_name][AUX_KEY_SIM_DATA_ORIGINAL] = sim_data_orig
+            aux_data = aux_data_dict[task_name]
+            aux_data[AUX_KEY_FWD_TASK_ID] = task_id_fwd
+            aux_data[AUX_KEY_SIM_DATA_ORIGINAL] = sim_data_orig
+            if numerical_structures_info and task_name in numerical_structures_info:
+                aux_data[AUX_KEY_NUMERICAL_STRUCTURES] = numerical_structures_info[task_name]
             field_map = sim_data_orig._strip_traced_fields(
                 include_untraced_data_arrays=True, starting_path=("data",)
             )
@@ -710,6 +1176,7 @@ def _run_bwd(
     aux_data: dict,
     local_gradient: bool,
     max_num_adjoint_per_fwd: int,
+    user_vjp: tuple[CustomVJPPathType, ...],
     **run_kwargs: Any,
 ) -> typing.Callable[[AutogradFieldMap], AutogradFieldMap]:
     """VJP-maker for ``_run_primitive()``. Constructs and runs adjoint simulations, computes grad."""
@@ -761,7 +1228,6 @@ def _run_bwd(
         td.log.info(f"Running {len(sims_adj)} adjoint simulations")
 
         vjp_traced_fields = {}
-
         if local_gradient:
             # Run all adjoint sims in batch
             td.log.info("Starting local batch adjoint simulations")
@@ -784,6 +1250,8 @@ def _run_bwd(
                     sim_data_orig=sim_data_orig,
                     sim_data_fwd=sim_data_fwd,
                     sim_fields_keys=sim_fields_keys,
+                    user_vjp=user_vjp,
+                    numerical_info=aux_data.get(AUX_KEY_NUMERICAL_STRUCTURES, {}),
                 )
         else:
             td.log.info("Starting server-side batch of adjoint simulations ...")
@@ -835,6 +1303,8 @@ def _run_async_bwd(
     aux_data_dict: dict[str, dict[str, typing.Any]],
     local_gradient: bool,
     max_num_adjoint_per_fwd: int,
+    user_vjp: typing.Optional[dict[str, typing.Optional[UserVjpSpec]]] = None,
+    numerical_structures_info: typing.Optional[dict[str, dict[int, NumericalStructureInfo]]] = None,
     **run_async_kwargs: Any,
 ) -> typing.Callable[[dict[str, AutogradFieldMap]], dict[str, AutogradFieldMap]]:
     """VJP-maker for ``_run_primitive()``. Constructs and runs adjoint simulation, computes grad."""
@@ -843,6 +1313,14 @@ def _run_async_bwd(
     run_async_kwargs["is_adjoint"] = True
 
     task_names = data_fields_original_dict.keys()
+
+    if numerical_structures_info is None:
+        numerical_structures_info = {}
+
+    if isinstance(user_vjp, dict):
+        user_vjp_map = user_vjp
+    else:
+        user_vjp_map = dict.fromkeys(task_names, user_vjp)
 
     # get the fwd epsilon and field data from the cached aux_data
     sim_data_orig_dict = {}
@@ -891,6 +1369,10 @@ def _run_async_bwd(
                 adj_task_name = f"{task_name}_adjoint_{i}"
                 all_sims_adj[adj_task_name] = sim_adj
                 task_name_mapping[adj_task_name] = task_name
+                # Carry per-task numerical metadata
+                aux = aux_data_dict[task_name]
+                if AUX_KEY_NUMERICAL_STRUCTURES in aux:
+                    numerical_structures_info[adj_task_name] = aux[AUX_KEY_NUMERICAL_STRUCTURES]
 
         if not all_sims_adj:
             td.log.warning(
@@ -920,11 +1402,15 @@ def _run_async_bwd(
                 sim_fields_keys = sim_fields_keys_dict[task_name]
 
                 # Compute VJP contribution
+                task_user_vjp = user_vjp_map.get(task_name)
+
                 vjp_results[adj_task_name] = postprocess_adj(
                     sim_data_adj=sim_data_adj,
                     sim_data_orig=sim_data_orig,
                     sim_data_fwd=sim_data_fwd,
                     sim_fields_keys=sim_fields_keys,
+                    user_vjp=task_user_vjp,
+                    numerical_info=aux_data_dict[task_name].get(AUX_KEY_NUMERICAL_STRUCTURES, {}),
                 )
         else:
             # Set up parent tasks mapping for all adjoint simulations
@@ -945,6 +1431,7 @@ def _run_async_bwd(
             # Run all adjoint simulations in a single batch
             vjp_results = _run_async_tidy3d_bwd(
                 simulations=all_sims_adj,
+                numerical_structures_info=numerical_structures_info,
                 **run_async_kwargs,
             )
 
@@ -990,6 +1477,8 @@ def postprocess_adj(
     sim_data_orig: td.SimulationData,
     sim_data_fwd: td.SimulationData,
     sim_fields_keys: list[tuple],
+    user_vjp: typing.Optional[UserVjpSpec],
+    numerical_info: dict[int, NumericalStructureInfo],
 ) -> AutogradFieldMap:
     """Postprocess adjoint results into VJPs (delegated)."""
     return _postprocess_adj_impl(
@@ -997,6 +1486,8 @@ def postprocess_adj(
         sim_data_orig=sim_data_orig,
         sim_data_fwd=sim_data_fwd,
         sim_fields_keys=sim_fields_keys,
+        user_vjp=user_vjp,
+        numerical_info=numerical_info,
     )
 
 

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -566,13 +566,16 @@ def run_async_custom(
         ],
         sim_dict: dict[str, tuple[td.Simulation]],
     ) -> dict[str, typing.Sequence[typing.Union[NumericalStructureConfig, UserVJPConfig]]]:
+        """Check and validate the provided numerical_structures or user_vjp type and expand as"""
+        """necessary to match the provided simulation specification."""
         if fn_arg is None:
             return fn_arg
 
-        expanded = None
         if isinstance(fn_arg, base_type):
             expanded = dict.fromkeys(sim_dict.keys(), fn_arg)
+            return expanded
 
+        expanded = {}
         if not isinstance(fn_arg, type(orig_sim_arg)):
             raise AdjointError(
                 f"{fn_arg_name} type ({type(fn_arg)}) should match simulations type ({type(simulations)})"
@@ -584,7 +587,6 @@ def run_async_custom(
             if not check_keys:
                 raise AdjointError(f"{fn_arg_name} keys do not match simulations keys")
 
-            expanded = {}
             for key, val in fn_arg.items():
                 if isinstance(val, base_type):
                     expanded[key] = (val,)
@@ -594,10 +596,9 @@ def run_async_custom(
         elif isinstance(orig_sim_arg, (list, tuple)):
             if not (len(fn_arg) == len(orig_sim_arg)):
                 raise AdjointError(
-                    f"{fn_arg_name} is not the same length as simulations ({len(fn_arg)} vs. {len(simulations)})"
+                    f"{fn_arg_name} is not the same length as simulations ({len(expanded)} vs. {len(simulations)})"
                 )
 
-            expanded = {}
             for idx, key in enumerate(sim_dict.keys()):
                 val = fn_arg[idx]
                 if isinstance(val, (list, tuple)):
@@ -905,10 +906,6 @@ def setup_run(
 
     sim_prepared = simulation
 
-    numerical_structures_indices = [
-        numerical_structure.structure_index for numerical_structure in numerical_structures
-    ]
-
     if numerical_structures:
         structures = list(simulation.structures)
         for config in numerical_structures:
@@ -922,6 +919,10 @@ def setup_run(
     )
 
     if numerical_structures:
+        numerical_structures_indices = [
+            numerical_structure.structure_index for numerical_structure in numerical_structures
+        ]
+
         # collect sim fields for structures that go through regular derivative path
         sim_fields_dict = {
             key: value
@@ -1218,8 +1219,8 @@ def _run_bwd(
                     sim_data_orig=sim_data_orig,
                     sim_data_fwd=sim_data_fwd,
                     sim_fields_keys=sim_fields_keys,
-                    user_vjp=user_vjp,
                     numerical_structures=numerical_structures,
+                    user_vjp=user_vjp,
                 )
         else:
             td.log.info("Starting server-side batch of adjoint simulations ...")
@@ -1369,8 +1370,8 @@ def _run_async_bwd(
                     sim_data_orig=sim_data_orig,
                     sim_data_fwd=sim_data_fwd,
                     sim_fields_keys=sim_fields_keys,
-                    user_vjp=task_user_vjp,
                     numerical_structures=numerical_structures,
+                    user_vjp=task_user_vjp,
                 )
         else:
             # Set up parent tasks mapping for all adjoint simulations

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -244,6 +244,13 @@ def run_custom(
     lazy: Optional[bool] = None
         Whether to return lazy data proxies. Defaults to ``False`` for single runs when
         unspecified, matching :func:`tidy3d.web.run`.
+    numerical_structures : typing.Optional[typing.Union[NumericalStructureConfig, tuple[NumericalStructureConfig]]] = None
+        Specification of additional structures to add to the simulation (or base simulation for ComponentModeler workflows)
+        that can be traced via autograd. This can be a single structure or multiple structures specified in a tuple.
+    user_vjp : typing.Optional[typing.Union[UserVJPConfig, tuple[UserVJPConfig]]] = None
+        Specification of alternate gradient function for certain structures in the simulation.
+        This can be a single vjp configuration or multiple specified in a tuple.
+
     Returns
     -------
     Union[:class:`.SimulationData`, :class:`.HeatSimulationData`, :class:`.EMESimulationData`, :class:`.ModalComponentModelerData`, :class:`.TerminalComponentModelerData`]
@@ -530,6 +537,30 @@ def run_async_custom(
     lazy: Optional[bool] = None
         Whether to return lazy data proxies. Defaults to ``True`` for batch runs when
         unspecified, matching :func:`tidy3d.web.run`.
+    numerical_structures: typing.Optional[typing.Union[
+            NumericalStructureConfig,
+            dict[str, NumericalStructureConfig],
+            typing.Sequence[NumericalStructureConfig],
+            dict[str, typing.Sequence[NumericalStructureConfig]],
+            typing.Sequence[typing.Sequence[NumericalStructureConfig]],
+        ]] = None
+        Specification of additional structures to add to the simulations that can be traced via autograd. Different
+        numerical_structures can be added for different simulations or the same set can be broadcasted to all simulations.
+        Specifying a single config will broadcast to all simluations. Specifying a dict or a sequence with single configs
+        as values will set one config for each simluation. Most generally, multiple structures can be specified for each
+        simulation by specifying a dict with sequence values or a sequence of sequences.
+    user_vjp: typing.Optional[typing.Union[
+            UserVJPConfig,
+            dict[str, UserVJPConfig],
+            typing.Sequence[UserVJPConfig],
+            dict[str, typing.Sequence[UserVJPConfig]],
+            typing.Sequence[typing.Sequence[UserVJPConfig]],
+        ]] = None
+        Specification of alternate gradient function for certain structures in the simulation. Different
+        user_vjp's can be added for different simulations or the same set can be broadcasted to all simulations.
+        Specifying a single config will broadcast to all simluations. Specifying a dict or a sequence with single configs
+        as values will set one config for each simluation. Most generally, multiple user_vjp's can be specified for each
+        simulation by specifying a dict with sequence values or a sequence of sequences.
 
     Returns
     ------

--- a/tidy3d/web/api/autograd/backward.py
+++ b/tidy3d/web/api/autograd/backward.py
@@ -17,10 +17,13 @@ from tidy3d.config import config
 from tidy3d.exceptions import AdjointError
 from tidy3d.packaging import disable_local_subpixel
 
+from .types import (
+    UserVJPConfig,
+)
 from .utils import E_to_D, get_derivative_maps
 
 if typing.TYPE_CHECKING:
-    from .autograd import UserVjpSpec
+    pass
 
 
 def setup_adj(
@@ -111,19 +114,43 @@ def postprocess_adj(
     sim_data_orig: td.SimulationData,
     sim_data_fwd: td.SimulationData,
     sim_fields_keys: list[tuple],
-    user_vjp: typing.Optional[UserVjpSpec],
+    user_vjp: tuple[UserVJPConfig],
     numerical_info: dict[int, NumericalStructureInfo],
 ) -> AutogradFieldMap:
     """Postprocess some data from the adjoint simulation into the VJP for the original sim flds."""
 
     # prepare lookup for user-provided VJPs keyed by structure and field entry
+
+    ####
+
+    # here is where we can decide if we are using the vjp for all entries or not
+    # we might want to do some checking on the user_vjp to make sure we don't have collisions
+    # runtime validation of it
+
+    ####
+
+    # todo: fix this return typing
+    def get_all_paths(match_structure_index: int) -> tuple[str, ...]:
+        all_paths = tuple(
+            tuple(structure_path)
+            for namespace, structure_index, *structure_path in sim_fields_keys
+            if structure_index == match_structure_index
+        )
+
+        return all_paths
+
     user_vjp_lookup: dict[int, dict[typing.Hashable, typing.Callable[..., typing.Any]]] = {}
     if user_vjp:
-        for structure_index, path, vjp_fn in user_vjp:
-            if not path:
-                continue
-            field_key = path[0]
-            user_vjp_lookup.setdefault(structure_index, {})[field_key] = vjp_fn
+        for vjp_config in user_vjp:
+            structure_index = vjp_config.structure_index
+            vjp_fn = vjp_config.compute_derivatives
+            path = vjp_config.path_key
+
+            if path is None:
+                for match_path in get_all_paths(structure_index):
+                    user_vjp_lookup.setdefault(structure_index, {})[match_path[0:2]] = vjp_fn
+            else:
+                user_vjp_lookup.setdefault(structure_index, {})[path] = vjp_fn
 
     # map of index into 'structures' and 'numerical' to the paths we need VJPs for
     sim_vjp_map = defaultdict(list)

--- a/tidy3d/web/api/autograd/backward.py
+++ b/tidy3d/web/api/autograd/backward.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import typing
 from collections import defaultdict
 
 import numpy as np
@@ -7,14 +8,19 @@ import xarray as xr
 
 import tidy3d as td
 from tidy3d import Medium
-from tidy3d.components.autograd import AutogradFieldMap, get_static
+from tidy3d.components.autograd import AutogradFieldMap, NumericalStructureInfo, get_static
 from tidy3d.components.autograd.derivative_utils import DerivativeInfo
-from tidy3d.components.data.data_array import DataArray
+from tidy3d.components.data.data_array import DataArray, FreqDataArray, ScalarFieldDataArray
+from tidy3d.components.geometry.base import Box
+from tidy3d.components.geometry.utils import GeometryType
 from tidy3d.config import config
 from tidy3d.exceptions import AdjointError
 from tidy3d.packaging import disable_local_subpixel
 
 from .utils import E_to_D, get_derivative_maps
+
+if typing.TYPE_CHECKING:
+    from .autograd import UserVjpSpec
 
 
 def setup_adj(
@@ -105,18 +111,52 @@ def postprocess_adj(
     sim_data_orig: td.SimulationData,
     sim_data_fwd: td.SimulationData,
     sim_fields_keys: list[tuple],
+    user_vjp: typing.Optional[UserVjpSpec],
+    numerical_info: dict[int, NumericalStructureInfo],
 ) -> AutogradFieldMap:
     """Postprocess some data from the adjoint simulation into the VJP for the original sim flds."""
 
-    # map of index into 'structures' to the list of paths we need vjps for
+    # prepare lookup for user-provided VJPs keyed by structure and field entry
+    user_vjp_lookup: dict[int, dict[typing.Hashable, typing.Callable[..., typing.Any]]] = {}
+    if user_vjp:
+        for structure_index, path, vjp_fn in user_vjp:
+            if not path:
+                continue
+            field_key = path[0]
+            user_vjp_lookup.setdefault(structure_index, {})[field_key] = vjp_fn
+
+    # map of index into 'structures' and 'numerical' to the paths we need VJPs for
     sim_vjp_map = defaultdict(list)
-    for _, structure_index, *structure_path in sim_fields_keys:
+    numerical_vjp_map = defaultdict(set)
+    for namespace, structure_index, *structure_path in sim_fields_keys:
         structure_path = tuple(structure_path)
-        sim_vjp_map[structure_index].append(structure_path)
+        if namespace == "structures":
+            sim_vjp_map[structure_index].append(structure_path)
+        elif namespace == "numerical":
+            numerical_vjp_map[structure_index].add(structure_path)
 
     # store the derivative values given the forward and adjoint data
     sim_fields_vjp = {}
-    for structure_index, structure_paths in sim_vjp_map.items():
+    all_structure_indices = sorted(set(sim_vjp_map.keys()) | set(numerical_vjp_map.keys()))
+
+    for structure_index in all_structure_indices:
+        structure_paths = tuple(sim_vjp_map.get(structure_index, ()))
+        numerical_paths_raw = numerical_vjp_map.get(structure_index, set())
+        numerical_paths_ordered: tuple[tuple, ...] = ()
+        numerical_value_map: dict[tuple, typing.Any] = {}
+        numerical_vjp_fn = None
+        numerical_params_static: tuple[typing.Any, ...] = ()
+
+        if numerical_paths_raw:
+            info = numerical_info.get(structure_index)
+            if info is None:
+                raise AdjointError(
+                    f"Missing numerical structure metadata for index {structure_index}."
+                )
+            numerical_vjp_fn = info.vjp
+            numerical_params_static = tuple(get_static(param) for param in info.parameters)
+            numerical_paths_ordered = tuple(sorted(numerical_paths_raw))
+
         # grab the forward and adjoint data
         fld_fwd = sim_data_fwd._get_adjoint_data(structure_index, data_type="fld")
         eps_fwd = sim_data_fwd._get_adjoint_data(structure_index, data_type="eps")
@@ -215,6 +255,35 @@ def postprocess_adj(
         rmax_intersect = tuple([min(a, b) for a, b in zip(rmax_sim, rmax_struct)])
         bounds_intersect = (rmin_intersect, rmax_intersect)
 
+        def updated_epsilon_full(
+            replacement_geometry: GeometryType,
+            adjoint_frequencies: typing.Optional[FreqDataArray] = adjoint_frequencies,
+            structure_index: typing.Optional[int] = structure_index,
+            eps_box: typing.Optional[Box] = eps_fwd.monitor.geometry,
+        ) -> ScalarFieldDataArray:
+            # Return the simulation permittivity for eps_box after replacing the geometry
+            # for this structure with a new geometry. This is helpful for carrying out finite
+            # difference permittivity computations
+            sim_orig = sim_data_orig.simulation
+            sim_orig_grid_spec = td.components.grid.grid_spec.GridSpec.from_grid(sim_orig.grid)
+
+            update_sim = sim_orig.updated_copy(
+                structures=[
+                    sim_orig.structures[idx].updated_copy(geometry=replacement_geometry)
+                    if idx == structure_index
+                    else sim_orig.structures[idx]
+                    for idx in range(len(sim_orig.structures))
+                ],
+                grid_spec=sim_orig_grid_spec,
+            )
+
+            eps_by_f = [
+                update_sim.epsilon(box=eps_box, coord_key="centers", freq=f)
+                for f in adjoint_frequencies
+            ]
+
+            return xr.concat(eps_by_f, dim="f").assign_coords(f=adjoint_frequencies)
+
         # get chunk size - if None, process all frequencies as one chunk
         freq_chunk_size = config.adjoint.solver_freq_chunk_size
         n_freqs = len(adjoint_frequencies)
@@ -277,48 +346,105 @@ def postprocess_adj(
                 else None
             )
 
-            # create derivative info with sliced data
-            derivative_info = DerivativeInfo(
-                paths=structure_paths,
-                E_der_map=E_der_map_chunk,
-                D_der_map=D_der_map_chunk,
-                H_der_map=H_der_map_chunk,
-                E_fwd=E_fwd_chunk,
-                E_adj=E_adj_chunk,
-                D_fwd=D_fwd_chunk,
-                D_adj=D_adj_chunk,
-                H_fwd=H_fwd_chunk,
-                H_adj=H_adj_chunk,
-                eps_data=eps_data_chunk,
-                eps_in=eps_in_chunk,
-                eps_out=eps_out_chunk,
-                eps_background=eps_background_chunk,
-                frequencies=select_adjoint_freqs,  # only chunk frequencies
-                eps_no_structure=eps_no_structure_chunk,
-                eps_inf_structure=eps_inf_structure_chunk,
-                bounds=struct_bounds,
-                bounds_intersect=bounds_intersect,
-                simulation_bounds=sim_data_orig.simulation.bounds,
-                is_medium_pec=structure.medium.is_pec,
-            )
+            def updated_epsilon(
+                replacement_geometry: GeometryType,
+                select_adjoint_freqs: typing.Optional[FreqDataArray] = select_adjoint_freqs,
+                updated_epsilon_full: typing.Optional[typing.Callable] = updated_epsilon_full,
+            ) -> ScalarFieldDataArray:
+                # Get permittivity function for a subset of frequencies
+                return updated_epsilon_full(replacement_geometry).sel(f=select_adjoint_freqs)
 
-            # compute derivatives for chunk
-            vjp_chunk = structure._compute_derivatives(derivative_info)
+            common_kwargs = {
+                "E_der_map": E_der_map_chunk,
+                "D_der_map": D_der_map_chunk,
+                "H_der_map": H_der_map_chunk,
+                "E_fwd": E_fwd_chunk,
+                "E_adj": E_adj_chunk,
+                "D_fwd": D_fwd_chunk,
+                "D_adj": D_adj_chunk,
+                "H_fwd": H_fwd_chunk,
+                "H_adj": H_adj_chunk,
+                "eps_data": eps_data_chunk,
+                "eps_in": eps_in_chunk,
+                "eps_out": eps_out_chunk,
+                "eps_background": eps_background_chunk,
+                "frequencies": select_adjoint_freqs,
+                "eps_no_structure": eps_no_structure_chunk,
+                "eps_inf_structure": eps_inf_structure_chunk,
+                "updated_epsilon": updated_epsilon,
+                "bounds": struct_bounds,
+                "bounds_intersect": bounds_intersect,
+                "simulation_bounds": sim_data_orig.simulation.bounds,
+                "is_medium_pec": structure.medium.is_pec,
+            }
 
-            # accumulate results
-            for path, value in vjp_chunk.items():
-                if path in vjp_value_map:
-                    val = vjp_value_map[path]
-                    if isinstance(val, (list, tuple)) and isinstance(value, (list, tuple)):
-                        vjp_value_map[path] = type(val)(x + y for x, y in zip(val, value))
+            if structure_paths:
+                derivative_info_struct = DerivativeInfo(
+                    paths=structure_paths,
+                    **common_kwargs,
+                )
+
+                vjp_fns = user_vjp_lookup.get(structure_index)
+                vjp_chunk = structure._compute_derivatives(derivative_info_struct, vjp_fns=vjp_fns)
+
+                for path, value in vjp_chunk.items():
+                    if path in vjp_value_map:
+                        existing = vjp_value_map[path]
+                        if isinstance(existing, (list, tuple)) and isinstance(value, (list, tuple)):
+                            vjp_value_map[path] = type(existing)(
+                                x + y for x, y in zip(existing, value)
+                            )
+                        else:
+                            vjp_value_map[path] = existing + value
                     else:
-                        vjp_value_map[path] += value
+                        vjp_value_map[path] = value
+
+            if numerical_paths_ordered and numerical_vjp_fn is not None:
+                derivative_info_num = DerivativeInfo(
+                    paths=numerical_paths_ordered,
+                    **common_kwargs,
+                )
+
+                gradients = numerical_vjp_fn(
+                    parameters=numerical_params_static, derivative_info=derivative_info_num
+                )
+
+                if isinstance(gradients, dict):
+                    gradient_items = (
+                        (path, gradients.get(path)) for path in numerical_paths_ordered
+                    )
                 else:
-                    vjp_value_map[path] = value
+                    gradients_seq = tuple(gradients)
+                    if len(gradients_seq) != len(numerical_paths_ordered):
+                        raise AdjointError(
+                            f"User VJP for numerical structure index {structure_index} returned {len(gradients_seq)} gradients, "
+                            f"expected {len(numerical_paths_ordered)}."
+                        )
+                    gradient_items = zip(numerical_paths_ordered, gradients_seq)
+
+                for path, grad_value in gradient_items:
+                    if grad_value is None:
+                        continue
+                    if path in numerical_value_map:
+                        existing = numerical_value_map[path]
+                        if isinstance(existing, (list, tuple)) and isinstance(
+                            grad_value, (list, tuple)
+                        ):
+                            numerical_value_map[path] = type(existing)(
+                                x + y for x, y in zip(existing, grad_value)
+                            )
+                        else:
+                            numerical_value_map[path] = existing + grad_value
+                    else:
+                        numerical_value_map[path] = grad_value
 
         # store vjps in output map
         for structure_path, vjp_value in vjp_value_map.items():
             sim_path = ("structures", structure_index, *list(structure_path))
             sim_fields_vjp[sim_path] = vjp_value
+
+        for numerical_path, gradient_value in numerical_value_map.items():
+            sim_path = ("numerical", structure_index, *list(numerical_path))
+            sim_fields_vjp[sim_path] = gradient_value
 
     return sim_fields_vjp

--- a/tidy3d/web/api/autograd/backward.py
+++ b/tidy3d/web/api/autograd/backward.py
@@ -8,7 +8,7 @@ import xarray as xr
 
 import tidy3d as td
 from tidy3d import Medium
-from tidy3d.components.autograd import AutogradFieldMap, NumericalStructureInfo, get_static
+from tidy3d.components.autograd import AutogradFieldMap, get_static
 from tidy3d.components.autograd.derivative_utils import DerivativeInfo
 from tidy3d.components.data.data_array import DataArray, FreqDataArray, ScalarFieldDataArray
 from tidy3d.components.geometry.base import Box
@@ -18,6 +18,7 @@ from tidy3d.exceptions import AdjointError
 from tidy3d.packaging import disable_local_subpixel
 
 from .types import (
+    NumericalStructureConfig,
     UserVJPConfig,
 )
 from .utils import E_to_D, get_derivative_maps
@@ -115,7 +116,7 @@ def postprocess_adj(
     sim_data_fwd: td.SimulationData,
     sim_fields_keys: list[tuple],
     user_vjp: tuple[UserVJPConfig],
-    numerical_info: dict[int, NumericalStructureInfo],
+    numerical_structures: tuple[NumericalStructureConfig],
 ) -> AutogradFieldMap:
     """Postprocess some data from the adjoint simulation into the VJP for the original sim flds."""
 
@@ -155,12 +156,19 @@ def postprocess_adj(
     # map of index into 'structures' and 'numerical' to the paths we need VJPs for
     sim_vjp_map = defaultdict(list)
     numerical_vjp_map = defaultdict(set)
+    numerical_structure_indices = []
     for namespace, structure_index, *structure_path in sim_fields_keys:
         structure_path = tuple(structure_path)
         if namespace == "structures":
             sim_vjp_map[structure_index].append(structure_path)
         elif namespace == "numerical":
             numerical_vjp_map[structure_index].add(structure_path)
+            numerical_structure_indices.append(structure_index)
+
+    def lookup_numerical_structure(structure_index: int) -> NumericalStructureConfig:
+        for numerical_structure in numerical_structures:
+            if numerical_structure.structure_index == structure_index:
+                return numerical_structure
 
     # store the derivative values given the forward and adjoint data
     sim_fields_vjp = {}
@@ -168,20 +176,22 @@ def postprocess_adj(
 
     for structure_index in all_structure_indices:
         structure_paths = tuple(sim_vjp_map.get(structure_index, ()))
+
+        use_numerical_vjp = structure_index in numerical_structure_indices
+
         numerical_paths_raw = numerical_vjp_map.get(structure_index, set())
         numerical_paths_ordered: tuple[tuple, ...] = ()
         numerical_value_map: dict[tuple, typing.Any] = {}
         numerical_vjp_fn = None
         numerical_params_static: tuple[typing.Any, ...] = ()
 
-        if numerical_paths_raw:
-            info = numerical_info.get(structure_index)
-            if info is None:
-                raise AdjointError(
-                    f"Missing numerical structure metadata for index {structure_index}."
-                )
-            numerical_vjp_fn = info.vjp
-            numerical_params_static = tuple(get_static(param) for param in info.parameters)
+        if use_numerical_vjp:
+            numerical_structure = lookup_numerical_structure(structure_index)
+
+            numerical_vjp_fn = numerical_structure.compute_derivatives
+            numerical_params_static = tuple(
+                get_static(param) for param in numerical_structure.parameters
+            )
             numerical_paths_ordered = tuple(sorted(numerical_paths_raw))
 
         # grab the forward and adjoint data
@@ -426,7 +436,7 @@ def postprocess_adj(
                     else:
                         vjp_value_map[path] = value
 
-            if numerical_paths_ordered and numerical_vjp_fn is not None:
+            if use_numerical_vjp:
                 derivative_info_num = DerivativeInfo(
                     paths=numerical_paths_ordered,
                     **common_kwargs,

--- a/tidy3d/web/api/autograd/backward.py
+++ b/tidy3d/web/api/autograd/backward.py
@@ -115,23 +115,14 @@ def postprocess_adj(
     sim_data_orig: td.SimulationData,
     sim_data_fwd: td.SimulationData,
     sim_fields_keys: list[tuple],
-    user_vjp: tuple[UserVJPConfig],
-    numerical_structures: tuple[NumericalStructureConfig],
+    numerical_structures: typing.Optional[tuple[NumericalStructureConfig]] = None,
+    user_vjp: typing.Optional[tuple[UserVJPConfig]] = None,
 ) -> AutogradFieldMap:
     """Postprocess some data from the adjoint simulation into the VJP for the original sim flds."""
 
-    # prepare lookup for user-provided VJPs keyed by structure and field entry
-
-    ####
-
-    # here is where we can decide if we are using the vjp for all entries or not
-    # we might want to do some checking on the user_vjp to make sure we don't have collisions
-    # runtime validation of it
-
-    ####
-
-    # todo: fix this return typing
-    def get_all_paths(match_structure_index: int) -> tuple[str, ...]:
+    def get_all_paths(match_structure_index: int) -> tuple[tuple[str, str, int]]:
+        """Get all the paths that may appear in autograd for this structure index. This allows a"""
+        """user_vjp to be called for all autograd paths for the structure."""
         all_paths = tuple(
             tuple(structure_path)
             for namespace, structure_index, *structure_path in sim_fields_keys
@@ -140,7 +131,7 @@ def postprocess_adj(
 
         return all_paths
 
-    user_vjp_lookup: dict[int, dict[typing.Hashable, typing.Callable[..., typing.Any]]] = {}
+    user_vjp_lookup: dict[int, dict[tuple[str, str], typing.Callable[..., typing.Any]]] = {}
     if user_vjp:
         for vjp_config in user_vjp:
             structure_index = vjp_config.structure_index

--- a/tidy3d/web/api/autograd/constants.py
+++ b/tidy3d/web/api/autograd/constants.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 # keys for data into auxiliary dictionary (re-exported in autograd.py for tests)
 AUX_KEY_SIM_DATA_ORIGINAL = "sim_data"
 AUX_KEY_SIM_DATA_FWD = "sim_data_fwd_adjoint"
+AUX_KEY_NUMERICAL_STRUCTURES = "numerical_structures"
 AUX_KEY_FWD_TASK_ID = "task_id_fwd"
 AUX_KEY_SIM_ORIGINAL = "sim_original"
 

--- a/tidy3d/web/api/autograd/constants.py
+++ b/tidy3d/web/api/autograd/constants.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 # keys for data into auxiliary dictionary (re-exported in autograd.py for tests)
 AUX_KEY_SIM_DATA_ORIGINAL = "sim_data"
 AUX_KEY_SIM_DATA_FWD = "sim_data_fwd_adjoint"
-AUX_KEY_NUMERICAL_STRUCTURES = "numerical_structures"
 AUX_KEY_FWD_TASK_ID = "task_id_fwd"
 AUX_KEY_SIM_ORIGINAL = "sim_original"
 

--- a/tidy3d/web/api/autograd/engine.py
+++ b/tidy3d/web/api/autograd/engine.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
+import typing
+from os.path import basename, dirname, join
 
 import tidy3d as td
+from tidy3d.components.autograd.types import NumericalStructureInfo
 from tidy3d.web.api.container import DEFAULT_DATA_PATH, Batch, Job
 
 from .io_utils import get_vjp_traced_fields, upload_sim_fields_keys
@@ -75,6 +78,7 @@ def _run_async_tidy3d(
 
 def _run_async_tidy3d_bwd(
     simulations: dict[str, td.Simulation],
+    numerical_structures_info: typing.Optional[dict[str, dict[int, NumericalStructureInfo]]] = None,
     **run_kwargs: Any,
 ) -> dict[str, dict]:
     """Run a batch of adjoint simulations using regular web.run()."""

--- a/tidy3d/web/api/autograd/types.py
+++ b/tidy3d/web/api/autograd/types.py
@@ -2,10 +2,42 @@ from __future__ import annotations
 
 import typing
 from collections.abc import Hashable
+from dataclasses import dataclass
 
 import tidy3d as td
 from tidy3d.components.autograd import AutogradFieldMap
 from tidy3d.components.autograd.types import NumericalStructureInfo
+
+
+@dataclass
+class NumericalStructureConfig:
+    create: typing.Callable
+    """Function that creates the structure given an untraced version of the parameters"""
+
+    compute_derivatives: typing.Callable
+    """Function that computes the vjp for the structure given the same arguments
+    that the internal _compute_derivatives function gets."""
+
+    parameters: typing.Any
+    """Parameters used for creating the structure."""
+
+    # we could consider making this Optional and if it is not specified, we could
+    # just append it to the structures list in the simulation
+    structure_index: typing.Optional[int] = -1
+    """Index for structure in the simulation. If not specified, assume the structure is appended into the structure list."""
+
+
+@dataclass
+class UserVJPConfig:
+    structure_index: int
+    """Index for structure to replace vjp."""
+
+    compute_derivatives: typing.Callable
+    """Function that computes the vjp for the structure given the same arguments
+    that the internal _compute_derivatives function gets."""
+
+    path_key: typing.Optional[str] = None
+    """Path key this is relevant for. If not specified, assume the supplied function applies for all keys."""
 
 
 class UserVjpEntry(typing.NamedTuple):

--- a/tidy3d/web/api/autograd/types.py
+++ b/tidy3d/web/api/autograd/types.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
 import typing
-from collections.abc import Hashable
 from dataclasses import dataclass
 
 import tidy3d as td
 from tidy3d.components.autograd import AutogradFieldMap
-from tidy3d.components.autograd.types import NumericalStructureInfo
 
 
 @dataclass
@@ -40,23 +38,12 @@ class UserVJPConfig:
     """Path key this is relevant for. If not specified, assume the supplied function applies for all keys."""
 
 
-class UserVjpEntry(typing.NamedTuple):
-    structure_index: int
-    path: tuple[Hashable, ...]
-    fn: typing.Callable[..., typing.Any]
-
-
-UserVjpSpec = tuple[UserVjpEntry, ...]
-
-
 class SetupRunResult(typing.NamedTuple):
     sim_fields: AutogradFieldMap
     simulation: td.Simulation
-    numerical_info: dict[int, NumericalStructureInfo]
+    numerical_structures: tuple[NumericalStructureConfig]
 
 
 __all__ = [
     "SetupRunResult",
-    "UserVjpEntry",
-    "UserVjpSpec",
 ]

--- a/tidy3d/web/api/autograd/types.py
+++ b/tidy3d/web/api/autograd/types.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import typing
+from collections.abc import Hashable
+
+import tidy3d as td
+from tidy3d.components.autograd import AutogradFieldMap
+from tidy3d.components.autograd.types import NumericalStructureInfo
+
+
+class UserVjpEntry(typing.NamedTuple):
+    structure_index: int
+    path: tuple[Hashable, ...]
+    fn: typing.Callable[..., typing.Any]
+
+
+UserVjpSpec = tuple[UserVjpEntry, ...]
+
+
+class SetupRunResult(typing.NamedTuple):
+    sim_fields: AutogradFieldMap
+    simulation: td.Simulation
+    numerical_info: dict[int, NumericalStructureInfo]
+
+
+__all__ = [
+    "SetupRunResult",
+    "UserVjpEntry",
+    "UserVjpSpec",
+]


### PR DESCRIPTION
This adds custom user hooks for plugging into autograd. They are not exposed externally, but meant to be used/tested privately for now to help implement new/custom features and integrate with things like photonforge.

There are two hooks. The first is user_vjp which allows one to override the vjp calculation for a given structure that we already have in our library. For example, the sphere gradient could be computed with permittivity finite differences using this method. The second hook is numerical_structures which allows aa different custom integration. It allows the specification of a function that creates a tidy3d structure based on input parameters and then provides a vjp for those parameters. This is useful for cases where the adjoint fields are needed for that vjp. For example, you can implement a ring structure with a trimesh that depends on the inner and outer radius. This structure is inserted into the simulation and then the adjoint fields are available inside the vjp to write a numerical or other type of gradient calculation.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR introduces custom autograd hooks (`user_vjp` and `numerical_structures`) for gradient computation in electromagnetic simulations. The implementation adds two new internal functions `run_custom` and `run_async_custom` that wrap the existing public API.

**Key Changes:**
- New `user_vjp` parameter allows overriding VJP calculations for existing structure geometries (e.g., computing sphere gradients via permittivity finite differences)
- New `numerical_structures` parameter enables dynamic structure insertion with custom gradient functions, useful when adjoint fields are needed for gradient computation (e.g., trimesh-based ring structures)
- Both hooks integrate into the existing adjoint gradient pipeline through modifications to `_compute_derivatives` and `postprocess_adj`
- Public `run` and `run_async` functions remain unchanged; new functionality accessed via `run_custom` and `run_async_custom`

**Issues Found:**
- Type checking using `type()` instead of `isinstance()` in two locations (lines 617, 630 of autograd.py) 
- Potential logic issue in structure.py where empty dict for `vjp_fns` may not correctly trigger custom VJP
- Consider more explicit None checks vs truthiness checks for optional dict parameters

**Testing:**
Comprehensive numerical tests compare custom VJP/numerical structure gradients against finite differences for both single and batch runs.

<h3>Confidence Score: 3/5</h3>


- Safe to merge after fixing type checking issues, though logic issue should be investigated
- The PR adds significant new functionality with good test coverage, but contains syntax issues using `type()` instead of `isinstance()` that violate coding standards and could cause inheritance issues. There's also a potential logic bug in the custom VJP dispatch that needs verification. The implementation is complex but well-structured, and the hooks are appropriately kept internal for now.
- Pay close attention to `tidy3d/web/api/autograd/autograd.py` (type checking violations) and `tidy3d/components/structure.py` (potential VJP dispatch logic issue)

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/web/api/autograd/autograd.py | 3/5 | Core autograd entry point with new `run_custom` and `run_async_custom` functions. Contains type checking issues using `type()` instead of `isinstance()`. Complex flow for handling numerical structures and user VJP hooks. |
| tidy3d/web/api/autograd/backward.py | 4/5 | Implements backward pass for adjoint gradients. Adds support for numerical structures and user VJP hooks. New `updated_epsilon` function provides permittivity computation for finite differences. |
| tidy3d/web/api/autograd/types.py | 5/5 | New file defining type structures for user VJP and numerical structure metadata. Clean implementation using NamedTuples and dataclasses. |
| tidy3d/components/autograd/types.py | 5/5 | Adds `NumericalStructureInfo` dataclass and `CustomVJPPathType` to existing autograd types. Clean addition to type system. |
| tidy3d/components/structure.py | 3/5 | Modified `_compute_derivatives` to accept optional `vjp_fns` parameter. Has potential logic issue where empty dict for `vjp_fns` may not trigger custom VJP correctly. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant run_custom
    participant setup_run
    participant _run_primitive
    participant run_webapi
    participant setup_adj
    participant postprocess_adj
    participant Structure
    
    User->>run_custom: simulation, numerical_structures, user_vjp
    
    alt has numerical_structures or traced fields
        run_custom->>setup_run: prepare simulation with hooks
        setup_run->>setup_run: insert numerical structures
        setup_run->>setup_run: extract traced fields
        setup_run-->>run_custom: sim_fields, prepared_sim, numerical_info
        
        run_custom->>_run_primitive: execute forward simulation
        _run_primitive->>run_webapi: run forward with aux_data
        run_webapi-->>_run_primitive: sim_data_fwd
        _run_primitive-->>run_custom: traced_fields_data
        
        Note over User,Structure: Backward Pass (when gradient needed)
        
        User->>setup_adj: request gradients with vjp seeds
        setup_adj->>setup_adj: create adjoint simulations
        setup_adj->>run_webapi: run adjoint simulations
        run_webapi-->>setup_adj: sim_data_adj
        setup_adj-->>User: adjoint data
        
        User->>postprocess_adj: compute VJPs from adjoint data
        
        alt user_vjp provided
            postprocess_adj->>Structure: _compute_derivatives(vjp_fns)
            Structure->>Structure: call user-provided VJP function
            Structure-->>postprocess_adj: custom gradients
        else numerical_structures
            postprocess_adj->>postprocess_adj: call numerical VJP function
            postprocess_adj->>postprocess_adj: compute finite difference
        else default
            postprocess_adj->>Structure: _compute_derivatives()
            Structure->>Structure: compute analytical gradients
            Structure-->>postprocess_adj: gradients
        end
        
        postprocess_adj-->>User: final VJP values
        
    else no traced fields or numerical structures
        run_custom->>run_webapi: regular simulation run
        run_webapi-->>User: simulation data
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Use isinstance() for type checking instead of type() to correctly handle inheritance. ([source](https://app.greptile.com/review/custom-context?memory=b6377568-7845-4bad-a952-1ebe486d8912))

<!-- /greptile_comment -->