### PR TITLE
feat(meshing): avoid unnecessary parse_structures calls in gap refinement

### DIFF
--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -57,6 +57,7 @@ class GridSpec1d(Tidy3dBaseModel, ABC):
         wavelength: pd.PositiveFloat,
         num_pml_layers: tuple[pd.NonNegativeInt, pd.NonNegativeInt],
         snapping_points: tuple[CoordinateOptional, ...],
+        cached_parsed_intervals: Optional[tuple[ArrayFloat1D, ArrayFloat1D]] = None,
     ) -> Coords1D:
         """Generate 1D coords to be used as grid boundaries, based on simulation parameters.
         Symmetry, and PML layers will be treated here.
@@ -79,6 +80,9 @@ class GridSpec1d(Tidy3dBaseModel, ABC):
             number of layers in the absorber + and - direction along one dimension.
         snapping_points : Tuple[CoordinateOptional, ...]
             A set of points that enforce grid boundaries to pass through them.
+        cached_parsed_intervals : Optional[tuple[ArrayFloat1D, ArrayFloat1D]]
+            Cached results from parse_structures to avoid repeated parsing.
+            Contains (interval_coords, max_dl_list).
 
         Returns
         -------
@@ -98,6 +102,7 @@ class GridSpec1d(Tidy3dBaseModel, ABC):
             symmetry=symmetry,
             is_periodic=is_periodic,
             snapping_points=snapping_points,
+            cached_parsed_intervals=cached_parsed_intervals,
         )
 
         # incorporate symmetries
@@ -589,16 +594,14 @@ class AbstractAutoGrid(GridSpec1d):
         """Grid step size after applying minimal and maximal filtering."""
         return max(min(dl, self._dl_max(sim_size)), self._dl_min)
 
-    def _make_coords_initial(
+    def _parse_structures_for_axis(
         self,
         axis: Axis,
         structures: list[StructureType],
         wavelength: float,
         symmetry: Symmetry,
-        is_periodic: bool,
-        snapping_points: tuple[CoordinateOptional, ...],
-    ) -> Coords1D:
-        """Customized 1D coords to be used as grid boundaries.
+    ) -> tuple[ArrayFloat1D, ArrayFloat1D]:
+        """Parse structures and return interval coordinates and max dl list.
 
         Parameters
         ----------
@@ -611,17 +614,14 @@ class AbstractAutoGrid(GridSpec1d):
         symmetry : Tuple[Symmetry, Symmetry, Symmetry]
             Reflection symmetry across a plane bisecting the simulation domain
             normal to each of the three axes.
-        is_periodic : bool
-            Apply periodic boundary condition or not.
-        snapping_points : Tuple[CoordinateOptional, ...]
-            A set of points that enforce grid boundaries to pass through them.
 
         Returns
         -------
-        :class:`.Coords1D`:
-            1D coords to be used as grid boundaries.
+        interval_coords : ArrayFloat1D
+            Interval coordinates from parsed structures.
+        max_dl_list : ArrayFloat1D
+            Maximum dl list from parsed structures.
         """
-
         sim_cent = list(structures[0].geometry.center)
         sim_size = list(structures[0].geometry.size)
 
@@ -657,6 +657,63 @@ class AbstractAutoGrid(GridSpec1d):
             self._dl_min,
             dl_max,
         )
+
+        return interval_coords, max_dl_list
+
+    def _make_coords_initial(
+        self,
+        axis: Axis,
+        structures: list[StructureType],
+        wavelength: float,
+        symmetry: Symmetry,
+        is_periodic: bool,
+        snapping_points: tuple[CoordinateOptional, ...],
+        cached_parsed_intervals: Optional[tuple[ArrayFloat1D, ArrayFloat1D]] = None,
+    ) -> Coords1D:
+        """Customized 1D coords to be used as grid boundaries.
+
+        Parameters
+        ----------
+        axis : Axis
+            Axis of this direction.
+        structures : List[StructureType]
+            List of structures present in simulation.
+        wavelength : float
+            Free-space wavelength.
+        symmetry : Tuple[Symmetry, Symmetry, Symmetry]
+            Reflection symmetry across a plane bisecting the simulation domain
+            normal to each of the three axes.
+        is_periodic : bool
+            Apply periodic boundary condition or not.
+        snapping_points : Tuple[CoordinateOptional, ...]
+            A set of points that enforce grid boundaries to pass through them.
+        cached_parsed_intervals : Optional[tuple[ArrayFloat1D, ArrayFloat1D]]
+            Cached results from parse_structures to avoid repeated parsing.
+            Contains (interval_coords, max_dl_list).
+
+        Returns
+        -------
+        :class:`.Coords1D`:
+            1D coords to be used as grid boundaries.
+        """
+
+        # Compute sim_cent, sim_size, and symmetry_domain (needed for boundary fixing)
+        sim_cent = list(structures[0].geometry.center)
+        sim_size = list(structures[0].geometry.size)
+        for dim, sym in enumerate(symmetry):
+            if sym != 0:
+                sim_cent[dim] += sim_size[dim] / 4
+                sim_size[dim] /= 2
+        symmetry_domain = Box(center=sim_cent, size=sim_size)
+
+        # Use cached parsed intervals if available, otherwise parse now
+        if cached_parsed_intervals is not None:
+            interval_coords, max_dl_list = cached_parsed_intervals
+        else:
+            interval_coords, max_dl_list = self._parse_structures_for_axis(
+                axis, structures, wavelength, symmetry
+            )
+
         # insert snapping_points
         interval_coords, max_dl_list = self.mesher.insert_snapping_points(
             self._dl_min, axis, interval_coords, max_dl_list, snapping_points
@@ -2646,6 +2703,31 @@ class GridSpec(Tidy3dBaseModel):
             Entire simulation grid and snapping points generated during iterative gap meshing.
         """
 
+        # Pre-compute parsed structures for each axis to avoid repeated parsing
+        cached_parsed_intervals = {}
+        if len(self.layer_refinement_specs) > 0:
+            wavelength = self.get_wavelength(sources)
+            sim_size = list(structures[0].geometry.size)
+            all_structures = list(structures) + self.all_override_structures(
+                list(structures),
+                wavelength,
+                sim_size,
+                lumped_elements,
+                structure_priority_mode,
+                internal_override_structures,
+            )
+
+            grids_1d = [self.grid_x, self.grid_y, self.grid_z]
+            for idim, grid_1d in enumerate(grids_1d):
+                # Only cache for AbstractAutoGrid instances since those use parse_structures
+                if isinstance(grid_1d, AbstractAutoGrid):
+                    cached_parsed_intervals[idim] = grid_1d._parse_structures_for_axis(
+                        axis=idim,
+                        structures=all_structures,
+                        wavelength=wavelength,
+                        symmetry=symmetry,
+                    )
+
         old_grid = self._make_grid_one_iteration(
             structures=structures,
             symmetry=symmetry,
@@ -2656,6 +2738,7 @@ class GridSpec(Tidy3dBaseModel):
             internal_override_structures=internal_override_structures,
             internal_snapping_points=internal_snapping_points,
             structure_priority_mode=structure_priority_mode,
+            cached_parsed_intervals=cached_parsed_intervals if cached_parsed_intervals else None,
         )
 
         snapping_lines = []
@@ -2698,6 +2781,7 @@ class GridSpec(Tidy3dBaseModel):
                     internal_snapping_points=snapping_lines + internal_snapping_points,
                     dl_min_from_gaps=0.45 * min_gap_width,
                     structure_priority_mode=structure_priority_mode,
+                    cached_parsed_intervals=cached_parsed_intervals,
                 )
 
                 same = old_grid == new_grid
@@ -2725,6 +2809,7 @@ class GridSpec(Tidy3dBaseModel):
         internal_snapping_points: Optional[list[CoordinateOptional]] = None,
         dl_min_from_gaps: pd.PositiveFloat = inf,
         structure_priority_mode: PriorityMode = "equal",
+        cached_parsed_intervals: Optional[dict[int, tuple[ArrayFloat1D, ArrayFloat1D]]] = None,
     ) -> Grid:
         """Make the entire simulation grid based on some simulation parameters.
 
@@ -2753,6 +2838,9 @@ class GridSpec(Tidy3dBaseModel):
             Minimal grid size computed based on autodetected gaps.
         structure_priority_mode : PriorityMode
             Structure priority setting.
+        cached_parsed_intervals : Optional[dict[int, tuple[ArrayFloat1D, ArrayFloat1D]]]
+            Cached parse_structures results for each axis to avoid repeated parsing in iterative refinement.
+            Keys are axis indices (0, 1, 2), values are (interval_coords, max_dl_list).
 
         Returns
         -------
@@ -2839,6 +2927,11 @@ class GridSpec(Tidy3dBaseModel):
 
         coords_dict = {}
         for idim, (dim, grid_1d) in enumerate(zip("xyz", grids_1d)):
+            # Get cached parsed structures for this axis if available
+            axis_cache = None
+            if cached_parsed_intervals is not None and idim in cached_parsed_intervals:
+                axis_cache = cached_parsed_intervals[idim]
+
             coords_dict[dim] = grid_1d.make_coords(
                 axis=idim,
                 structures=all_structures,
@@ -2849,6 +2942,7 @@ class GridSpec(Tidy3dBaseModel):
                 snapping_points=self.all_snapping_points(
                     structures, lumped_elements, internal_snapping_points
                 ),
+                cached_parsed_intervals=axis_cache,
             )
 
         coords = Coords(**coords_dict)


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR refactors structure parsing logic to enable caching for performance optimization during iterative gap refinement. The key change extracts `_parse_structures_for_axis` from `_make_coords_initial` and pre-computes parsing results once to avoid redundant computations across refinement iterations.

**Key Changes:**
- Extracted `_parse_structures_for_axis` method to separate structure parsing logic
- Added `cached_parsed_intervals` parameter throughout the call chain to pass cached results
- Pre-compute parsed intervals once at the start of `make_grid` when layer refinement is used

**Critical Issue:**
- The caching logic has a correctness bug: cached intervals are computed using the grid's initial `_dl_min` value, but in `_make_grid_one_iteration`, grids with undefined `dl_min` are updated with new values computed from gaps (line 2926). The stale cache computed with the original `_dl_min` is still used, which will produce incorrect meshing results since `parse_structures` output depends on the `dl_min` parameter.

<h3>Confidence Score: 1/5</h3>


- This PR introduces a critical logic bug that can produce incorrect mesh generation results
- The caching optimization has a fundamental correctness issue where cached parsing results computed with one `dl_min` value are reused after `dl_min` is updated. Since the parsing output directly depends on `dl_min`, this will cause incorrect mesh coordinates to be generated when grids have undefined `dl_min` values that get computed from gap analysis
- tidy3d/components/grid/grid_spec.py - the caching logic in `make_grid` method (lines 2706-2729) needs to account for potential `dl_min` updates that occur in `_make_grid_one_iteration`

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/grid/grid_spec.py | 2/5 | Refactored structure parsing into separate method and added caching, but cache invalidation logic has critical bug with dl_min updates |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GS as GridSpec.make_grid
    participant Cache as cached_parsed_intervals
    participant GSI as _make_grid_one_iteration
    participant AG as AbstractAutoGrid
    participant Parse as _parse_structures_for_axis

    Note over GS: if layer_refinement_specs > 0
    GS->>GS: get wavelength & all_structures
    loop for each axis
        GS->>AG: _parse_structures_for_axis(all_structures, symmetry)
        AG->>Parse: compute interval_coords, max_dl_list
        Note over Parse: uses grid's current _dl_min
        Parse-->>AG: return (interval_coords, max_dl_list)
        AG-->>Cache: store in cache[axis]
    end

    GS->>GSI: _make_grid_one_iteration(cached_parsed_intervals)
    GSI->>GSI: build grids_1d from grid_x/y/z
    Note over GSI: if grid._undefined_dl_min
    GSI->>GSI: compute new_dl_min from gaps
    GSI->>GSI: grid.updated_copy(dl_min=new_dl_min)
    Note over GSI,Cache: BUG: cache was computed with OLD dl_min!
    loop for each axis
        GSI->>AG: make_coords(cached_parsed_intervals[axis])
        Note over AG: uses stale cache with wrong dl_min
        AG-->>GSI: return coordinates
    end
    GSI-->>GS: return old_grid

    Note over GS: iterative gap refinement loop
    loop gap meshing iterations
        GS->>GSI: _make_grid_one_iteration(cached_parsed_intervals)
        Note over GSI: same bug: cache reused with potentially wrong dl_min
        GSI-->>GS: return new_grid
        GS->>GS: check if grid changed
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->