### PR TITLE
perf(tidy3d): FXC-3721 Speed up test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,5 +135,6 @@ htmlcov/
 .idea
 .vscode
 
-# cProfile output
+# profile outputs
 *.prof
+pytest_profile_stats.txt

--- a/docs/development/usage.rst
+++ b/docs/development/usage.rst
@@ -67,6 +67,12 @@ There are a range of handy development functions that you might want to use to s
     * - Running ``pytest`` commands inside the ``poetry`` environment.
       - Make sure you have already installed ``tidy3d`` in ``poetry`` and you are in the root directory.
       - ``poetry run pytest``
+    * - Analyze slow ``pytest`` runs with durations / cProfile / debug subset helpers.
+      - Use ``--debug`` to run only the first N collected tests or ``--profile`` to capture call stacks.
+      - ``python scripts/profile_pytest.py [options]``
+    * - Track ``pytest`` RAM usage over time and per test.
+      - Defaults to pytest's configured parallelism; use ``--single-process`` to disable xdist.
+      - ``poetry run python scripts/pytest_ram_profile.py [options]``
     * - Run ``coverage`` testing from the ``poetry`` environment.
       -
       - ``poetry run coverage run -m pytest``
@@ -82,6 +88,4 @@ There are a range of handy development functions that you might want to use to s
     * - Update and replace all the docstrings in the codebase between versions
       -
       - ``poetry run tidy3d develop replace-in-files``
-
-
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -396,18 +396,18 @@ css = ["tinycss2 (>=1.1.0,<1.5)"]
 
 [[package]]
 name = "boto3"
-version = "1.42.27"
+version = "1.42.28"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "boto3-1.42.27-py3-none-any.whl", hash = "sha256:39dfec51aff3f9356e8c7331195f324cb498ec75b2601a902fc62aa127b8fd00"},
-    {file = "boto3-1.42.27.tar.gz", hash = "sha256:a8a53abb98ff1a24d9a88d9d8c0285bf02d23189666130456e8951ede2f7db98"},
+    {file = "boto3-1.42.28-py3-none-any.whl", hash = "sha256:7994bc2a094c1894f6a4221a1696c5d18af6c9c888191051866f1d05c4fba431"},
+    {file = "boto3-1.42.28.tar.gz", hash = "sha256:7d56c298b8d98f5e9b04cf5d6627f68e7792e25614533aef17f815681b5e1096"},
 ]
 
 [package.dependencies]
-botocore = ">=1.42.27,<1.43.0"
+botocore = ">=1.42.28,<1.43.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.16.0,<0.17.0"
 
@@ -416,14 +416,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.42.27"
+version = "1.42.28"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "botocore-1.42.27-py3-none-any.whl", hash = "sha256:d51fb3b8dd1a944c8d238d2827a0dd6e5528d6da49a3bd9eccad019c533e4c9c"},
-    {file = "botocore-1.42.27.tar.gz", hash = "sha256:c8e1e3ffb6c871622b1c8054f064d60cbc786aa5ca1f97f5f9fd5fa0a9d82d05"},
+    {file = "botocore-1.42.28-py3-none-any.whl", hash = "sha256:d26c7a0851489ce1a18279f9802fe434bd736ea861d4888cc2c7d83fb1f6af8f"},
+    {file = "botocore-1.42.28.tar.gz", hash = "sha256:0c15e78d1accf97df691083331f682e97b1bef73ef12dcdaadcf652abf9c182c"},
 ]
 
 [package.dependencies]
@@ -1390,15 +1390,15 @@ tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipyth
 
 [[package]]
 name = "fastcore"
-version = "1.11.3"
+version = "1.11.4"
 description = "Python supercharged for fastai development"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"dev\" or extra == \"docs\""
 files = [
-    {file = "fastcore-1.11.3-py3-none-any.whl", hash = "sha256:998825f8f69c44ab16a156bb60e9a6d0988f3e8aa5b2459ec95289b520cf1c0b"},
-    {file = "fastcore-1.11.3.tar.gz", hash = "sha256:5eac82affc11d529f5ed1c3ab1eea6c957301f876a9077f8425a9ead895ecc36"},
+    {file = "fastcore-1.11.4-py3-none-any.whl", hash = "sha256:eaf673c80a07dc4da3996ab599af501b09425136abdb63c0df8f3172e4939c5b"},
+    {file = "fastcore-1.11.4.tar.gz", hash = "sha256:9e2143406849d106746a19f1b06a95f6f1e6eed9c9cf9ebebf8868c3e2db27d8"},
 ]
 
 [package.dependencies]
@@ -2606,15 +2606,15 @@ test = ["jupyter-server[test]", "pytest"]
 
 [[package]]
 name = "jupyter-server-terminals"
-version = "0.5.3"
+version = "0.5.4"
 description = "A Jupyter Server Extension Providing Terminals."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "extra == \"dev\" or extra == \"docs\""
 files = [
-    {file = "jupyter_server_terminals-0.5.3-py3-none-any.whl", hash = "sha256:41ee0d7dc0ebf2809c668e0fc726dfaf258fcd3e769568996ca731b6194ae9aa"},
-    {file = "jupyter_server_terminals-0.5.3.tar.gz", hash = "sha256:5ae0295167220e9ace0edcfdb212afd2b01ee8d179fe6f23c899590e9b8a5269"},
+    {file = "jupyter_server_terminals-0.5.4-py3-none-any.whl", hash = "sha256:55be353fc74a80bc7f3b20e6be50a55a61cd525626f578dcb66a5708e2007d14"},
+    {file = "jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5"},
 ]
 
 [package.dependencies]
@@ -4650,15 +4650,15 @@ virtualenv = ">=20.10.0"
 
 [[package]]
 name = "prometheus-client"
-version = "0.24.0"
+version = "0.24.1"
 description = "Python client for the Prometheus monitoring system."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"dev\" or extra == \"docs\""
 files = [
-    {file = "prometheus_client-0.24.0-py3-none-any.whl", hash = "sha256:4ab6d4fb5a1b25ad74b58e6271857e356fff3399473e599d227ab5d0ce6637f0"},
-    {file = "prometheus_client-0.24.0.tar.gz", hash = "sha256:726b40c0d499f4904d4b5b7abe8d43e6aff090de0d468ae8f2226290b331c667"},
+    {file = "prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055"},
+    {file = "prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9"},
 ]
 
 [package.extras]
@@ -7018,59 +7018,59 @@ python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"extras\""
 files = [
-    {file = "tidy3d_extras-2.10.1-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:3fc2ee19668ac018ace8b1e087a1d9aeba7305aa6c7ff5bd518017a0873caae3"},
-    {file = "tidy3d_extras-2.10.1-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:abc27801f48ec10806c8dd8710317496cb1f03e3534c6818c9ed768e1f2fef6f"},
-    {file = "tidy3d_extras-2.10.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e6d7acaa74c5d9efe39d1f280c8d2e71a9025a06eca26cccc69d2558b0b1b150"},
-    {file = "tidy3d_extras-2.10.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b23ff10101a3c2a060937d0e2b932222bbb2249072e72344680527db3e347173"},
-    {file = "tidy3d_extras-2.10.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1445acb5d875a4803a9875599c758173454a4a9f67866d9dc3207e64a35ba225"},
-    {file = "tidy3d_extras-2.10.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:559efbdcef4af07f7e48531a8dc8c36356073c013dd3936c0a3067814563a982"},
-    {file = "tidy3d_extras-2.10.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:78053be19dde50c5d18ba4f49167f49dca85a6d79d9d91387a10533461898e85"},
-    {file = "tidy3d_extras-2.10.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:da7d6e657946ddb490b73c5b2d5f0a2b7fdc16c1e5c3e7c801886aa36a207196"},
-    {file = "tidy3d_extras-2.10.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:40326ad299ed08147879b38910d838343aecb07126d66c7a3175e5b26af2ab3a"},
-    {file = "tidy3d_extras-2.10.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cdeaaa4bfb97a49d1477279451b874601c29ce0c55b401d872f8b0e263aee13d"},
-    {file = "tidy3d_extras-2.10.1-cp310-cp310-win_amd64.whl", hash = "sha256:7301fc5cad87d2fc3422adceea7ff3a5d4d46f6c2655ed2ec1425e3affeb20b3"},
-    {file = "tidy3d_extras-2.10.1-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:20b86f662a088c2f58f425f2fe90c819a086fe265f46661ec7a288ba7df70824"},
-    {file = "tidy3d_extras-2.10.1-cp311-cp311-macosx_15_0_x86_64.whl", hash = "sha256:a1194132a324edbe758adae022f3ca48efb41d5c3ab3a54e9870bc7947f5690c"},
-    {file = "tidy3d_extras-2.10.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34cc7527ac9af7fa6bc7511e7d1d106f385eaf502dbc236dda4703eec626cc69"},
-    {file = "tidy3d_extras-2.10.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d344298dac8a774af329c083d74f3ffcbedf3790f7e52f6231f204919a28312"},
-    {file = "tidy3d_extras-2.10.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c4724300b09a83e72308692158a78a8904399db50400732879bca99e1ff084f"},
-    {file = "tidy3d_extras-2.10.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:2c395b969239604b9a7f7f404132b5a606a44fefe047b2e519b0085c2ac7f1ce"},
-    {file = "tidy3d_extras-2.10.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:c7596e7614dfc5a9673defe87ebccf55da591ef4542114b855fa0ec90be9ad9e"},
-    {file = "tidy3d_extras-2.10.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0c201944cd9576332a1b71c222456cf1c9af664f91c357742977b43d75cf8bea"},
-    {file = "tidy3d_extras-2.10.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:9301abc4d64bcc168659dd20584df2af864869317c50223d54a1527756f8b76d"},
-    {file = "tidy3d_extras-2.10.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8bbbcea649a4ef4acfdee49822af38ada14bbcbd3485ad7ea9354fa5d5ec3044"},
-    {file = "tidy3d_extras-2.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:b0e82cd5f890040ad0d854bbcbbfd1a5df48734d8c0ec605feb1a02a10925d32"},
-    {file = "tidy3d_extras-2.10.1-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:186843b3014098f52cd50d68b7676b84b552cace2dbc9000acc5cb05492c54a0"},
-    {file = "tidy3d_extras-2.10.1-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:67b9a4f0eb293a4bcd85bd7b55bef285cc69b931778e75bbff7d2e3e2cf93ad6"},
-    {file = "tidy3d_extras-2.10.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54cead85ff5f06ceac2d5d0cfdfb6a96ab27112117589c33dfdbc009908f4eb6"},
-    {file = "tidy3d_extras-2.10.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:29f70c92d63eeb3b6af3f753d2b0441e202c94934c051578cf4194e441cd445d"},
-    {file = "tidy3d_extras-2.10.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d8d46bbcca56ff0321321dc98dbdd87824b92b919a0d0f7db1a6414a6b99f34"},
-    {file = "tidy3d_extras-2.10.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e73a0d8017f9263d5e4a1dbf159062ea77b9e42f6f663c4fff8017eb17ae6122"},
-    {file = "tidy3d_extras-2.10.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b2ed5ff8ac7b270dcdd61145205a7ea4d1604024f0dd0fcad0ae1c3ee2cfebdc"},
-    {file = "tidy3d_extras-2.10.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5c4000559ad1b45af63a88bbbe7f9cd0c3a12ce17ba6dac1eeb2e9103c05712b"},
-    {file = "tidy3d_extras-2.10.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4da72ed63c8ba8b5550c4b8874e2afb93954def26b7df64e9bf783988343fccf"},
-    {file = "tidy3d_extras-2.10.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d6231becff077075215f02d5ecf8fe3c1b74d2d981ae8fb4a04b0adf3eaa89b8"},
-    {file = "tidy3d_extras-2.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:8bdc74a75ad23ff2ac390e9d75b4e502c6bee8e292a75b7363d4f8ded422d166"},
-    {file = "tidy3d_extras-2.10.1-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:54712852a3d00cbcc3d18faae8a95ff18d16b071c069a4a07d8b64a05ca74f78"},
-    {file = "tidy3d_extras-2.10.1-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:e899b303f4d4c3bd8e7dde7ea10f7a465e1bfae05c77d0d965b479a816ad272f"},
-    {file = "tidy3d_extras-2.10.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45dd682543cf064fa9b662f1276b20294c8232b0eb29f8b0abdec0fc0411a227"},
-    {file = "tidy3d_extras-2.10.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:307de89f5f6accd98e66b322abea4903bb33162b3c867a18fa28cc5f058f2586"},
-    {file = "tidy3d_extras-2.10.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:930c3bd683bafd627e7cea626ce0d7db3958b1a7f43834248222e4ca3b5b887a"},
-    {file = "tidy3d_extras-2.10.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:12501a6a1461e641b3ac557eca441cf0fda8bdfa4a0076bf0f74e6a8e61ec95a"},
-    {file = "tidy3d_extras-2.10.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3f8de35c477e6d3963208c5c3b2dde1d46d270a0fc6f320c495003c297b8de6d"},
-    {file = "tidy3d_extras-2.10.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:27db207a9e47ea59124d261c0fb10d3852cc545272a65a6ab15387679ecc8066"},
-    {file = "tidy3d_extras-2.10.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1b0ca7eee0245804e39b491f1424ccfd7b189dd40c8f71df5ec88811ad50b6b6"},
-    {file = "tidy3d_extras-2.10.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:659191c6f957abbc93ff9ffd5d596b0584262131da8994e422067d3f6a4115b4"},
-    {file = "tidy3d_extras-2.10.1-cp313-cp313-win_amd64.whl", hash = "sha256:4938db8477c9d0133719652a8050505ed784d0d5203cdef848aa780864b20b25"},
-    {file = "tidy3d_extras-2.10.1-cp39-cp39-macosx_15_0_x86_64.whl", hash = "sha256:483cb328ea4979c0028a6dfce43112cca7e443eaae226e55f930a3bc99a596a5"},
-    {file = "tidy3d_extras-2.10.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f22fa00973f6639acb60460f3324313f8aebd5f7eb0cc850f4124e7fac94142"},
-    {file = "tidy3d_extras-2.10.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4bde4d93e8d1d87851d851c13c3a392be0ba91bc653152179a51127c5a8c5a35"},
-    {file = "tidy3d_extras-2.10.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:128c26b37418fe8e9b41a2d913713730625a0e80b0c6da002f43eabc2ef1a2ba"},
-    {file = "tidy3d_extras-2.10.1-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:8443cf2ed0c36c02ca822e995d55c96f5dba8d24e1fdbacf3cc9b00b437cf286"},
-    {file = "tidy3d_extras-2.10.1-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:a99a5156eb1496a875ee8166bfad00888c081d996a242feccf66aa4a7e80469b"},
-    {file = "tidy3d_extras-2.10.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:2b65dfb57fc9a82c140f6ef0a2f6de2cf71becf47930d3943669ddb476dac716"},
-    {file = "tidy3d_extras-2.10.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:db63e00968aaada0e269abe6d3b4284a2dcffb0045266876519bdf6c12078ce3"},
-    {file = "tidy3d_extras-2.10.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:5f23fbda320b5bada3b374ebf9691ae0c2e9743727631afafd90a2887a895fb9"},
+    {file = "tidy3d_extras-2.10.1-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:c3a97a0eba0399203501c6859ade3bd09e11a16823ae7fd94f9dc40b051a82f1"},
+    {file = "tidy3d_extras-2.10.1-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:ff567b3660c51d1c0f587d95a41f4745a603a034ccd8e366b0364d35e1fce688"},
+    {file = "tidy3d_extras-2.10.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2fc670e77bb2219dba729c90c7535a435b6b955c1af794e347ff932ae22b99e2"},
+    {file = "tidy3d_extras-2.10.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a27eb108de63d0f1ffe4646d94854f4e2b2b8704bcdac8c8cc76c959a18b11b9"},
+    {file = "tidy3d_extras-2.10.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85e1755475f84159afae4f9647feba58b3e2bb9c9fe89aeb74773c5191f3f00d"},
+    {file = "tidy3d_extras-2.10.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:e355dcc8ba2252292cd287c8c23e8b70bfff8022b9b6a89969fb112cb4d00721"},
+    {file = "tidy3d_extras-2.10.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:f8063a450936fc435e3a3e4bdb2cb2b65bbd27467edf7831cbcba52f5d69a154"},
+    {file = "tidy3d_extras-2.10.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:34683b738568a6d624d28d06361342ae6d3078afa7397c82b546583f3155c772"},
+    {file = "tidy3d_extras-2.10.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:374db174b6600980b696c5ed9a58cffafed0a336e20a1baaa024553d28fc603b"},
+    {file = "tidy3d_extras-2.10.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d1093a400ff8d13bb2945c25447eb6e5527e63ac12c4f0af7dc1e62ed6f4cba5"},
+    {file = "tidy3d_extras-2.10.1-cp310-cp310-win_amd64.whl", hash = "sha256:ce4a176c09896fc12790e811074d203b153adc5722991948f82b24724be960a0"},
+    {file = "tidy3d_extras-2.10.1-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:93a7ed71d6d81fe847f44ce22e01bc838cf4c984711fb440852591eced207477"},
+    {file = "tidy3d_extras-2.10.1-cp311-cp311-macosx_15_0_x86_64.whl", hash = "sha256:73a830cbddbe2079c1cfc19fa9e1cfbb4d89459e637e3089f8fe2216e8bceb04"},
+    {file = "tidy3d_extras-2.10.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:86a0429b1a974871a23bc4e7e55e743cd2c74648b677221d2d7e850db3938c22"},
+    {file = "tidy3d_extras-2.10.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8c1cb25b29ede65c94a75dc663a94f0ad6ceba63442e43ec73c8a69cb78b7089"},
+    {file = "tidy3d_extras-2.10.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:499c69f398ef17b91daa601ec6407ff251c4524253f61f57736c699ac99fa55e"},
+    {file = "tidy3d_extras-2.10.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:703b6460d852c8f539ef57359b19b2dd981bc8eb4fd5556237a2b17e590181f7"},
+    {file = "tidy3d_extras-2.10.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a89b8da93d297e60864e37b07ead6ed23d6a1b45c0eecc9b3c4ef5062cc15e89"},
+    {file = "tidy3d_extras-2.10.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ccd1dcded97f8052cf16f264fd395940e061a84d16cb14bdb1b2db2c26749a10"},
+    {file = "tidy3d_extras-2.10.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:f9a0f7bc1ee0f1ee209c4ae6d6f743d722493893222a069bb263c6268cc0874c"},
+    {file = "tidy3d_extras-2.10.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b3bb4000b17f20375d12f067f1860636c29a3c8ce65a91c57c2d52015fc31bd3"},
+    {file = "tidy3d_extras-2.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:6e3b94cf91f9376bdf07813510d084f3e23e9797e6b28cd6f1ab8546a165c9fe"},
+    {file = "tidy3d_extras-2.10.1-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:4b48345ad45a2788a7826e9ba782aa41cf18f14d6f2c285aae3e5a79bacc07d8"},
+    {file = "tidy3d_extras-2.10.1-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:0ffd4a48e9a1581ec77e53568999b3dc451adc3088e6e09fa1c98624b174762b"},
+    {file = "tidy3d_extras-2.10.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:87925c2240601102c0fd51423cb895ab70ca69088f50c3faa4f5120937299a33"},
+    {file = "tidy3d_extras-2.10.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f79469174f2c4086fdca7b59975fe1cc17c7849147c60e3040b81d314ff58956"},
+    {file = "tidy3d_extras-2.10.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ffe35fcd02eca6cdb45c670bc67b7da94dd8dd3ed1988193c8996007247e31f"},
+    {file = "tidy3d_extras-2.10.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:53dd66c97034b49a6ae5ca656cdf41cc5ea73ce361c53cada35d8ad47a5c42c2"},
+    {file = "tidy3d_extras-2.10.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4254a51e24d93cd7899d8e26fd217f59ac851d71e9a651a1bc4962f11ea2e6e7"},
+    {file = "tidy3d_extras-2.10.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:14dc06675f7a3caf08714249833971a8c54a6d43752af106fd73245511d8c2fe"},
+    {file = "tidy3d_extras-2.10.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:9138ec49d63ae8349ee8dde07fd0ecba4e675a66d10376b508e44a005c3c61ad"},
+    {file = "tidy3d_extras-2.10.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb3b91d79fcad259f682e7585b87e4063d4f3764b17cfb317f42ed494b335"},
+    {file = "tidy3d_extras-2.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:ccb1e1578f99d240f5d3f050c84a3ac120b57157e73c3ff3f7fbd6c2a94b4cfc"},
+    {file = "tidy3d_extras-2.10.1-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:5313abf3146f99dcd1f83027e991766095e42438743c584a30a1904c222e9b20"},
+    {file = "tidy3d_extras-2.10.1-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:e2e301275339c7653dab3e38d4a9f9fb3f6d305770bf7e1343889397bafddfc0"},
+    {file = "tidy3d_extras-2.10.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22a32ce0cb84757c5a93ee352b1475348fde0b42155d3136f29e093d2c9faa91"},
+    {file = "tidy3d_extras-2.10.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:971539fa7cba087185b0c21295fc89ce1e2f4b3fa13938a5c2ca73c8eedb5520"},
+    {file = "tidy3d_extras-2.10.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3ea1356c99aaf5c40f747232f8528220f8f73ecab5f718a7ea28432b01aa9c"},
+    {file = "tidy3d_extras-2.10.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a316ac0fbd05a1fbdaf35ef956cd3dff15d8fa7bd17680d2335960fc090b7653"},
+    {file = "tidy3d_extras-2.10.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:923b1c275dc51a613609de22c4efd701ee06f1f5c09d34b85bb955916e4e7cd8"},
+    {file = "tidy3d_extras-2.10.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:72f306a65b0f3f095fc41c6c112ca74e6c115d08f0ed7e61ef59249627ef4cf3"},
+    {file = "tidy3d_extras-2.10.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:027e3da081effef7c3642aa4eecaa76bf138e1299e03e50814d4fac1b1f4b0da"},
+    {file = "tidy3d_extras-2.10.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:db836275f30a1330657590d75e8b915b7e5204ec24d118ceefd6d4fa3462c066"},
+    {file = "tidy3d_extras-2.10.1-cp313-cp313-win_amd64.whl", hash = "sha256:f433eb0fff58dd4b3bd64e44a050e927bba42584292abb87e337d9a4cf0a0830"},
+    {file = "tidy3d_extras-2.10.1-cp39-cp39-macosx_15_0_x86_64.whl", hash = "sha256:bf63d351c65b01417fd8da507952327ba770f104233a53e59e88359afeac34ce"},
+    {file = "tidy3d_extras-2.10.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:695f987bcabe58081ebad8cd42006d4c116b34f492f8287a5cfe14706cf87667"},
+    {file = "tidy3d_extras-2.10.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:af35187cf96ab4efd90a0ea8beeac2b94db56a4d981456cda332f3ec77a7a54a"},
+    {file = "tidy3d_extras-2.10.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80f9f0484e89f61ff78f5c85f9c91f5ae0ba1cacada866c1b454b5b3329275ad"},
+    {file = "tidy3d_extras-2.10.1-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:948ae21788925877a11c87da73d9017e7a629a6074bdb36ee4a37a2715ef6421"},
+    {file = "tidy3d_extras-2.10.1-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:4dd03a54b3eb3a1e4dcef83ba9fc4cded58439c5dbebfe99872b069d5710d450"},
+    {file = "tidy3d_extras-2.10.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ea79aad8114ce9e426482003d8aedd9bdc4ce6add8deb2323f4d416ed31dfe8b"},
+    {file = "tidy3d_extras-2.10.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:b792d4c10dae61ce7c3a27f013fd11b6854a4dde94e13a603d6337ee67258417"},
+    {file = "tidy3d_extras-2.10.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:1bc45b824f977260c83bc786e76b43fd1b0c91ab1727e12c3d76f4c8a5e24970"},
 ]
 
 [package.dependencies]
@@ -7080,11 +7080,6 @@ xarray = ">=2024.6"
 
 [package.extras]
 test = ["pytest (>=7.2)"]
-
-[package.source]
-type = "legacy"
-url = "https://flexcompute-625554095313.d.codeartifact.us-east-1.amazonaws.com/pypi/pypi-releases/simple"
-reference = "codeartifact"
 
 [[package]]
 name = "tinycss2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -309,9 +309,11 @@ banned-module-level-imports = ["scipy", "matplotlib"]
 
 [tool.pytest.ini_options]
 # TODO: remove --assert=plain when https://github.com/scipy/scipy/issues/22236 is resolved
-addopts = "--cov=tidy3d --doctest-modules -n auto --dist worksteal --assert=plain -m 'not numerical'"
+addopts = "--cov=tidy3d --doctest-modules -n auto --dist worksteal --assert=plain -m 'not numerical and not perf'"
 markers = [
   "numerical: marks numerical tests for adjoint gradients that require running simulations (deselect with '-m \"not numerical\"')",
+  "perf: marks tests which test the runtime of operations (deselect with '-m \"not perf\"')",
+  "slow: marks tests as slow (deselect with -m 'not slow')",
 ]
 env = ["MPLBACKEND=Agg", "OMP_NUM_THREADS=1", "TIDY3D_MICROWAVE__SUPPRESS_RF_LICENSE_WARNING=true"]
 doctest_optionflags = "NORMALIZE_WHITESPACE ELLIPSIS"

--- a/scripts/profile_pytest.py
+++ b/scripts/profile_pytest.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Helper utilities for profiling ``pytest`` runs inside the Poetry env.
+
+This script can:
+* run the full test suite (default) while surfacing the slowest tests via ``--durations``;
+* run in "debug" mode to execute only the first N collected tests; and
+* wrap ``pytest`` in ``cProfile`` to identify the most expensive function calls.
+
+Examples::
+
+    python scripts/profile_pytest.py  # full suite with slowest 25 tests listed
+    python scripts/profile_pytest.py --debug --debug-limit 10
+    python scripts/profile_pytest.py --profile --profile-output results.prof
+    python scripts/profile_pytest.py -t tests/test_components/test_scene.py \
+        --pytest-args "-k basic"
+
+Forward any additional `pytest` CLI flags via ``--pytest-args"...`` and provide
+explicit test targets with ``-t/--tests`` (defaults to the entire ``tests`` dir).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+from collections import defaultdict
+from collections.abc import Iterable
+from pathlib import Path
+
+try:
+    import pstats
+except ImportError as exc:  # pragma: no cover - stdlib module should exist
+    raise SystemExit("pstats from the standard library is required") from exc
+
+DURATION_LINE_RE = re.compile(r"^\s*(?P<secs>\d+(?:\.\d+)?)s\s+\w+\s+(?P<nodeid>\S+)\s*$")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Profile pytest executions launched via Poetry.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Run only a subset of collected tests (see --debug-limit).",
+    )
+    parser.add_argument(
+        "--list-limit",
+        type=int,
+        default=30,
+        help="How many entries to show in aggregated duration summaries (set 0 for all).",
+    )
+    parser.add_argument(
+        "--debug-limit",
+        type=int,
+        default=25,
+        help="Number of test node ids to execute when --debug is enabled.",
+    )
+    parser.add_argument(
+        "--durations",
+        type=int,
+        default=0,
+        help="Pass-through value for pytest's --durations flag (use 0 for all tests).",
+    )
+    parser.add_argument(
+        "--profile",
+        action="store_true",
+        help="Wrap pytest in cProfile and display the heaviest call sites afterward.",
+    )
+    parser.add_argument(
+        "--profile-output",
+        default="results.prof",
+        help="Where to write the binary cProfile stats (used when --profile is set).",
+    )
+    parser.add_argument(
+        "--profile-top",
+        type=int,
+        default=30,
+        help="How many rows of aggregated profile data to print.",
+    )
+    parser.add_argument(
+        "--profile-sort",
+        choices=["cumulative", "tottime", "calls", "time"],
+        default="cumulative",
+        help="Sort order for the profile summary table.",
+    )
+    parser.add_argument(
+        "-t",
+        "--tests",
+        action="append",
+        dest="tests",
+        metavar="PATH_OR_NODE",
+        help="Explicit pytest targets. Repeatable.",
+    )
+    parser.add_argument(
+        "--pytest-args",
+        default="",
+        help="Extra pytest CLI args as a quoted string (e.g. '--maxfail=1 -k smoke').",
+    )
+    return parser.parse_args()
+
+
+def ensure_poetry_available() -> None:
+    if shutil.which("poetry") is None:
+        raise SystemExit("'poetry' command not found in PATH.")
+
+
+def build_pytest_base(profile: bool, profile_output: Path) -> list[str]:
+    base_cmd = ["poetry", "run"]
+    if profile:
+        base_cmd += [
+            "python",
+            "-m",
+            "cProfile",
+            "-o",
+            str(profile_output.resolve()),
+            "-m",
+            "pytest",
+        ]
+    else:
+        base_cmd.append("pytest")
+    return base_cmd
+
+
+def collect_node_ids(extra_args: Iterable[str], tests: Iterable[str]) -> list[str]:
+    cmd = ["poetry", "run", "pytest", "--collect-only", "-q"]
+    cmd.extend(extra_args)
+    cmd.extend(tests)
+    print(f"Collecting tests via: {' '.join(shlex.quote(part) for part in cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    if result.returncode != 0:
+        raise SystemExit(result.returncode)
+
+    node_ids: list[str] = []
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith(("<", "collected ")):
+            continue
+        node_ids.append(stripped)
+    if not node_ids:
+        raise SystemExit("No tests collected; check your --tests / --pytest-args filters.")
+    return node_ids
+
+
+def summarize_profile(stats_path: Path, sort: str, top: int) -> None:
+    if not stats_path.exists():
+        print(f"Profile file {stats_path} not found; skipping summary.")
+        return
+    stats = pstats.Stats(str(stats_path))
+    stats.sort_stats(sort)
+    print("\nTop profiled call sites (via cProfile):")
+    stats.print_stats(top)
+
+
+def extract_durations_from_output(output: str) -> list[tuple[float, str]]:
+    """Parse pytest --durations lines from stdout."""
+
+    durations: list[tuple[float, str]] = []
+    for line in output.splitlines():
+        match = DURATION_LINE_RE.match(line)
+        if not match:
+            continue
+        secs = float(match.group("secs"))
+        nodeid = match.group("nodeid")
+        durations.append((secs, nodeid))
+    return durations
+
+
+def print_aggregated_durations(
+    durations: list[tuple[float, str]],
+    list_limit: int,
+) -> None:
+    """Print durations aggregated by file and by test (collapsing parametrizations)."""
+
+    if not durations:
+        print("\n[durations] no --durations lines found in pytest output.")
+        return
+
+    by_file: dict[str, float] = defaultdict(float)
+    by_test: dict[str, float] = defaultdict(float)
+
+    for secs, nodeid in durations:
+        base = nodeid.split("[", 1)[0]
+        file_name = base.split("::", 1)[0]
+        by_file[file_name] += secs
+        by_test[base] += secs
+
+    def _print_section(title: str, mapping: dict[str, float]) -> None:
+        print(f"\nAggregated durations ({title}):")
+        items = sorted(mapping.items(), key=lambda kv: kv[1], reverse=True)
+        if list_limit > 0:
+            items = items[:list_limit]
+        for name, total in items:
+            print(f"{total:8.02f}s  {name}")
+
+    _print_section("by file", by_file)
+    _print_section("by test (parametrizations combined)", by_test)
+
+
+def truncate_pytest_durations_output(output: str, limit: int) -> str:
+    """Keep pytest's duration section header, but show only the top `limit` lines."""
+    lines = output.splitlines()
+    out_lines = []
+    in_durations_section = False
+    kept = 0
+
+    for line in lines:
+        if "slowest" in line and "durations" in line:
+            in_durations_section = True
+            kept = 0
+            out_lines.append(line)
+            continue
+
+        if in_durations_section:
+            # Stop after we've shown N durations or reached next blank section
+            if not line.strip():
+                in_durations_section = False
+            elif kept >= limit:
+                continue
+            else:
+                kept += 1
+
+        out_lines.append(line)
+    return "\n".join(out_lines)
+
+
+def export_to_file(result, args, filtered_stdout, durations):
+    sys.stdout.write(filtered_stdout)
+    sys.stderr.write(result.stderr)
+
+    # Write the filtered output to a file as well
+    output_file = "pytest_profile_stats.txt"
+    results_path = Path(output_file)
+    results_path.write_text(filtered_stdout)
+
+    if durations:
+        print_aggregated_durations(durations, args.list_limit)
+
+        with results_path.open("a") as f:
+            f.write("\n\n[Aggregated Durations]\n")
+            for secs, nodeid in durations:
+                f.write(f"{secs:.2f}s  {nodeid}\n")
+    print(f"Stats were written to {output_file}")
+
+
+def main() -> int:
+    args = parse_args()
+    ensure_poetry_available()
+
+    if args.debug and args.debug_limit <= 0:
+        raise SystemExit("--debug-limit must be a positive integer.")
+
+    tests = args.tests or ["tests"]
+    extra_args = shlex.split(args.pytest_args)
+
+    # Handle debug collection (collect-only)
+    if args.debug:
+        collected = collect_node_ids(extra_args, tests)
+        pytest_targets = collected[: args.debug_limit]
+        print(f"\nDebug mode: running the first {len(pytest_targets)} collected test(s).")
+    else:
+        pytest_targets = tests
+
+    # Build the full pytest command
+    base_cmd = build_pytest_base(args.profile, Path(args.profile_output))
+    pytest_cmd = base_cmd + extra_args
+    if args.durations is not None:
+        pytest_cmd.append(f"--durations={args.durations}")
+    pytest_cmd.extend(pytest_targets)
+
+    print(f"\nExecuting: {' '.join(shlex.quote(part) for part in pytest_cmd)}\n")
+
+    # Run pytest
+    result = subprocess.run(
+        pytest_cmd,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+    # Extract and truncate outputs
+    filtered_stdout = truncate_pytest_durations_output(result.stdout, args.list_limit)
+    durations = extract_durations_from_output(result.stdout) if args.durations is not None else []
+
+    # Print once and export
+    export_to_file(result, args, filtered_stdout, durations)
+
+    # Profile summary (if enabled)
+    if args.profile and result.returncode == 0:
+        summarize_profile(Path(args.profile_output), args.profile_sort, args.profile_top)
+
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_components/test_IO.py
+++ b/tests/test_components/test_IO.py
@@ -176,16 +176,18 @@ def test_1a_simulation_load_export2(tmp_path):
     assert SIM2 == SIM3, "original and loaded simulations are not the same"
 
 
+@pytest.mark.perf
 def test_validation_speed(tmp_path):
     sizes_bytes = []
     times_sec = []
     path = str(tmp_path / "simulation.json")
 
     _ = SIM
-    N_tests = 10
+    N_tests = 5  # may be increased temporarily, makes it slow for routine tests
+    max_structures = np.log10(100)  # may be increased temporarily, makes it slow for routine tests
 
     # adjust as needed, keeping small to speed tests up
-    num_structures = np.logspace(0, 2, N_tests).astype(int)
+    num_structures = np.logspace(0, max_structures, N_tests).astype(int)
 
     for n in num_structures:
         new_structures = []

--- a/tests/test_components/test_custom.py
+++ b/tests/test_components/test_custom.py
@@ -718,6 +718,7 @@ def verify_custom_dispersive_medium_methods(mat, reduced_fields):
 
 
 @pytest.mark.parametrize("unstructured", [False, True])
+@pytest.mark.slow
 def test_custom_pole_residue(unstructured):
     """Custom pole residue medium."""
     seed = 98345
@@ -776,6 +777,7 @@ def test_custom_pole_residue(unstructured):
 
 
 @pytest.mark.parametrize("unstructured", [False, True])
+@pytest.mark.slow
 def test_custom_sellmeier(unstructured):
     """Custom Sellmeier medium."""
     seed = 897245
@@ -838,6 +840,7 @@ def test_custom_sellmeier(unstructured):
 
 
 @pytest.mark.parametrize("unstructured", [False, True])
+@pytest.mark.slow
 def test_custom_lorentz(unstructured):
     """Custom Lorentz medium."""
     seed = 31342
@@ -991,6 +994,7 @@ def test_custom_debye(unstructured):
 
 
 @pytest.mark.parametrize("unstructured", [True])
+@pytest.mark.slow
 def test_custom_anisotropic_medium(unstructured):
     """Custom anisotropic medium."""
     seed = 43243

--- a/tests/test_components/test_eme.py
+++ b/tests/test_components/test_eme.py
@@ -1032,6 +1032,7 @@ def _get_eme_mode_solver_data(num_sweep=0):
     )
 
 
+@pytest.mark.slow
 def _get_eme_field_data(num_sweep=0):
     dataset = _get_eme_field_dataset(num_sweep=num_sweep)
     kwargs = dataset.field_components
@@ -1099,6 +1100,7 @@ def _get_eme_port_modes(num_sweep=0):
     return mode_data.updated_copy(n_complex=n_complex, **kwargs)
 
 
+@pytest.mark.slow
 def test_eme_sim_data():
     sim = make_eme_sim()
     mode_monitor_data = _get_eme_mode_solver_data()

--- a/tests/test_components/test_scene.py
+++ b/tests/test_components/test_scene.py
@@ -10,7 +10,7 @@ import pytest
 
 import tidy3d as td
 import tidy3d.components.scene as scene_mod
-from tidy3d.components.scene import MAX_NUM_MEDIUMS
+from tidy3d.components import scene
 from tidy3d.components.viz import STRUCTURE_EPS_CMAP, STRUCTURE_EPS_CMAP_R
 from tidy3d.exceptions import SetupError
 
@@ -19,6 +19,7 @@ from ..utils import SIM_FULL, cartesian_to_unstructured
 SCENE = td.Scene()
 
 SCENE_FULL = SIM_FULL.scene
+TEST_MAX_NUM_MEDIUMS = 3
 
 
 def test_scene_init():
@@ -240,11 +241,11 @@ def test_structure_eps_color_mapping_no_matplotlib(
     assert np.allclose(params.facecolor, expected)
 
 
-def test_num_mediums():
+def test_num_mediums(monkeypatch):
     """Make sure we error if too many mediums supplied."""
-
+    monkeypatch.setattr(scene, "MAX_NUM_MEDIUMS", TEST_MAX_NUM_MEDIUMS)
     structures = []
-    for i in range(MAX_NUM_MEDIUMS):
+    for i in range(TEST_MAX_NUM_MEDIUMS):
         structures.append(
             td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=td.Medium(permittivity=i + 1))
         )

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -12,8 +12,7 @@ import pytest
 from matplotlib.testing.compare import compare_images
 
 import tidy3d as td
-from tidy3d.components import simulation
-from tidy3d.components.scene import MAX_NUM_MEDIUMS
+from tidy3d.components import scene, simulation
 from tidy3d.components.simulation import MAX_NUM_SOURCES
 from tidy3d.exceptions import SetupError, Tidy3dError, Tidy3dKeyError
 from tidy3d.plugins.mode import ModeSolver
@@ -29,6 +28,7 @@ from ..utils import (
 SIM = td.Simulation(size=(1, 1, 1), run_time=1e-12, grid_spec=td.GridSpec(wavelength=1.0))
 
 RTOL = 0.01
+TEST_MAX_NUM_MEDIUMS = 3
 
 
 def test_sim_init():
@@ -1694,12 +1694,10 @@ def test_sim_validate_structure_bounds_pml(box_length, absorb_type, log_level):
 
 def test_num_mediums(monkeypatch):
     """Make sure we error if too many mediums supplied."""
-
-    max_num_mediums = 10
-    monkeypatch.setattr(simulation, "MAX_NUM_MEDIUMS", max_num_mediums)
+    monkeypatch.setattr(simulation, "MAX_NUM_MEDIUMS", TEST_MAX_NUM_MEDIUMS)
     structures = []
     grid_spec = td.GridSpec.auto(wavelength=1.0)
-    for i in range(max_num_mediums):
+    for i in range(TEST_MAX_NUM_MEDIUMS):
         structures.append(
             td.Structure(geometry=td.Box(size=(1, 1, 1)), medium=td.Medium(permittivity=i + 1))
         )
@@ -2172,13 +2170,14 @@ def test_tfsf_structures_grid():
 
 
 @pytest.mark.parametrize(
-    "size, num_struct, log_level", [(1, 1, None), (50, 1, "WARNING"), (1, 11, "WARNING")]
+    "size, num_struct, log_level", [(1, 1, None), (2, 1, "WARNING"), (1, 11, "WARNING")]
 )
 @td.packaging.disable_local_subpixel
 def test_warn_large_epsilon(monkeypatch, size, num_struct, log_level):
     """Make sure we get a warning if the epsilon grid is too large."""
 
     monkeypatch.setattr(simulation, "NUM_STRUCTURES_WARN_EPSILON", 10)
+    monkeypatch.setattr(simulation, "NUM_CELLS_WARN_EPSILON", 2_000)
     structures = [
         td.Structure(
             geometry=td.Box(center=(0, 0, 0), size=(0.1, 0.1, 0.1)),
@@ -3226,9 +3225,9 @@ def test_advanced_material_intersection():
         sim = sim.updated_copy(structures=[struct1, struct2])
 
 
-def test_num_lumped_elements():
+def test_num_lumped_elements(monkeypatch):
     """Make sure we error if too many lumped elements supplied."""
-
+    monkeypatch.setattr(simulation, "MAX_NUM_MEDIUMS", TEST_MAX_NUM_MEDIUMS)
     resistor = td.LumpedResistor(
         size=(0, 1, 2), center=(0, 0, 0), name="R1", voltage_axis=2, resistance=75
     )
@@ -3238,7 +3237,7 @@ def test_num_lumped_elements():
         size=(5, 5, 5),
         grid_spec=grid_spec,
         structures=[],
-        lumped_elements=[resistor] * MAX_NUM_MEDIUMS,
+        lumped_elements=[resistor] * TEST_MAX_NUM_MEDIUMS,
         run_time=1e-12,
     )
     with pytest.raises(pydantic.ValidationError):
@@ -3246,7 +3245,7 @@ def test_num_lumped_elements():
             size=(5, 5, 5),
             grid_spec=grid_spec,
             structures=[],
-            lumped_elements=[resistor] * (MAX_NUM_MEDIUMS + 1),
+            lumped_elements=[resistor] * (TEST_MAX_NUM_MEDIUMS + 1),
             run_time=1e-12,
         )
 
@@ -3748,7 +3747,6 @@ def test_messages_contain_object_names():
 
 def test_structures_per_medium(monkeypatch):
     """Test if structures that share the same medium warn or error appropriately."""
-    import tidy3d.components.scene as scene
 
     # Set low thresholds to keep the test fast; ensure len(structures) > MAX to avoid early return
     monkeypatch.setattr(scene, "WARN_STRUCTURES_PER_MEDIUM", 2)

--- a/tests/test_package/test_parametric_variants.py
+++ b/tests/test_package/test_parametric_variants.py
@@ -32,7 +32,8 @@ def test_graphene_defaults():
     _ = graphene.numerical_conductivity(freqs)
 
 
-@pytest.mark.parametrize("rng_seed", np.arange(0, 15))
+@pytest.mark.parametrize("rng_seed", np.arange(0, 8))
+@pytest.mark.slow
 def test_graphene(rng_seed):
     """test graphene for range of physical parameters"""
     rng = default_rng(rng_seed)

--- a/tests/test_plugins/test_design.py
+++ b/tests/test_plugins/test_design.py
@@ -18,7 +18,7 @@ from ..utils import run_emulated
 SWEEP_METHODS = {
     "grid": tdd.MethodGrid(),
     "monte_carlo": tdd.MethodMonteCarlo(num_points=5, seed=1),
-    "bay_opt": tdd.MethodBayOpt(initial_iter=5, n_iter=2, seed=1),
+    "bay_opt": tdd.MethodBayOpt(initial_iter=3, n_iter=2, seed=2),
     "gen_alg": tdd.MethodGenAlg(
         solutions_per_pop=6,
         n_generations=2,
@@ -323,15 +323,15 @@ def init_design_space(sweep_method):
     radius_variable = tdd.ParameterFloat(
         name="radius",
         span=(0, 1.5),
-        num_points=5,  # note: only used for MethodGrid
+        num_points=3,  # note: only used for MethodGrid
     )
 
     num_spheres_variable = tdd.ParameterInt(
         name="num_spheres",
-        span=(0, 3),
+        span=(0, 2),
     )
 
-    tag_variable = tdd.ParameterAny(name="tag", allowed_values=("tag1", "tag2", "tag3"))
+    tag_variable = tdd.ParameterAny(name="tag", allowed_values=("tag1", "tag2"))
 
     design_space = tdd.DesignSpace(
         parameters=[radius_variable, num_spheres_variable, tag_variable],
@@ -344,6 +344,7 @@ def init_design_space(sweep_method):
 
 
 @pytest.mark.parametrize("sweep_method", SWEEP_METHODS.values())
+@pytest.mark.slow
 def test_sweep(sweep_method, monkeypatch):
     # Problem, simulate scattering cross section of sphere ensemble
     # 	simulation consists of `num_spheres` spheres of radius `radius`.

--- a/tests/test_plugins/test_invdes.py
+++ b/tests/test_plugins/test_invdes.py
@@ -406,6 +406,7 @@ def test_continue_run_fns(use_emulated_run):  # noqa: F811
     )
 
 
+@pytest.mark.slow
 def test_continue_run_from_file(use_emulated_run):  # noqa: F811
     """Test continuing an already run inverse design from file."""
     result_orig = make_result(use_emulated_run)

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -1084,18 +1084,22 @@ def test_job_run_accepts_pathlikes(monkeypatch, tmp_path, path_builder):
     [_pathlib_builder, _posix_builder, _str_builder, _fspath_builder],
     ids=["pathlib.Path", "posixpath_str", "str", "PathLike"],
 )
+@pytest.mark.slow
 def test_batch_run_accepts_pathlike_dir(monkeypatch, tmp_path, dir_builder):
     """Batch.run(path_dir=...) accepts any PathLike directory location."""
-    sims = {"A": make_sim(), "B": make_sim()}
+    sims = {"A": make_sim()}
     out_dir = dir_builder(tmp_path, "batch_out")
 
     # Map task_ids to sims: upload() is patched to return task_name, which for dict input
     # corresponds to the dict keys ("A", "B"), so we map those.
-    apply_common_patches(monkeypatch, tmp_path, taskid_to_sim={"A": sims["A"], "B": sims["B"]})
+    apply_common_patches(monkeypatch, tmp_path, taskid_to_sim={"A": sims["A"]})
 
     b = Batch(simulations=sims, folder_name=PROJECT_NAME)
     b.run(path_dir=out_dir)
 
-    # Directory created and two .hdf5 outputs produced
+    # Directory created and .hdf5 output produced
     out_dir_str = os.fspath(out_dir)
     assert os.path.isdir(out_dir_str)
+
+    batch_file = Path(out_dir) / "batch.hdf5"
+    assert batch_file.is_file()


### PR DESCRIPTION
As our test suite does have a quite long runtime, this PR addresses the identification of the most time-intensive modules/functions/runs and speeds up the most critical ones.

- added a `profile_pytest.py` in scripts to analyze the most time-consuming modules/functions/runs (see report below)
- added a `pytest.mark.slow` for the most time-consuming tests. May be used later for skipping for faster test modes.
- made some optimizations in `test_autograd.py` as the most critical module (10 min raw runtime!) -> cut it down by roughly the half. Made sure these tests run in the beginning such that we avoid non-fully-parallelized works are on them at the end.
   - do we want to skip some structures for async? Shouldn't be the async run functionality independently from the structures?
- made some "obvious" minor performance optimizations for other test functions
- reduction of total test time by roughly 30%

I'm open for more inputs how to speedup the tests.

Analysis before PR:
```
============================== slowest durations ===============================
58.40s call     tests/test_plugins/test_design.py::test_sweep[sweep_method0]
27.68s call     tests/test_components/test_simulation.py::test_num_lumped_elements
21.97s call     tests/test_components/test_scene.py::test_num_mediums
19.13s call     tests/test_components/autograd/test_autograd.py::test_autograd_async[True-<ALL>-diff]
18.59s call     tests/test_components/autograd/test_autograd.py::test_autograd_async[True-<ALL>-field_vol]
18.47s call     tests/test_components/autograd/test_autograd.py::test_autograd_async[True-<ALL>-field_point]
18.32s call     tests/test_components/autograd/test_autograd.py::test_autograd_async[True-<ALL>-mode]
17.95s call     tests/test_components/autograd/test_autograd.py::test_autograd_async[False-<ALL>-diff]
17.77s call     tests/test_components/autograd/test_autograd.py::test_autograd_async[False-<ALL>-field_point]
17.69s call     tests/test_components/autograd/test_autograd.py::test_autograd_async[False-<ALL>-mode]
16.93s call     tests/test_components/test_IO.py::test_validation_speed
16.49s call     tests/test_components/autograd/test_autograd.py::test_autograd_async[False-<ALL>-field_vol]
14.61s call     tests/test_components/test_custom.py::test_custom_lorentz[True]
13.80s call     tests/test_components/test_eme.py::test_eme_sim_data
13.53s call     tests/test_plugins/test_design.py::test_sweep[sweep_method2]
13.50s call     tests/test_plugins/test_invdes.py::test_continue_run_from_file
12.29s call     tests/test_components/autograd/test_autograd.py::test_autograd_async_server[<ALL>-diff]
12.17s call     tests/test_plugins/test_dispersion_fitter.py::test_dispersion_set_wvg_range
11.90s call     tests/test_components/autograd/test_autograd.py::test_autograd_async_server[<ALL>-field_vol]
11.88s call     tests/test_plugins/test_design.py::test_sweep[sweep_method3]
11.65s call     tests/test_components/autograd/test_autograd.py::test_autograd_async_server[<ALL>-mode]
11.62s call     tests/test_components/autograd/test_autograd.py::test_autograd_async_server[<ALL>-field_point]
11.11s call     tests/test_components/test_custom.py::test_custom_sellmeier[True]
10.31s call     tests/test_data/test_sim_data.py::test_plot[1.0]
10.28s call     tests/test_components/test_custom.py::test_custom_pole_residue[True]
10.20s call     tests/test_plugins/test_invdes.py::test_result_store_full_results_is_false
9.68s call     tests/test_components/test_custom.py::test_custom_anisotropic_medium[True]
9.32s call     tests/test_data/test_sim_data.py::test_plot[0]
9.28s call     tests/test_components/autograd/test_autograd.py::test_autograd_async_some_zero_grad[<ALL>-diff]
8.74s call     tests/test_components/autograd/test_autograd.py::test_autograd_async_some_zero_grad[<ALL>-mode]

(28084 durations < 0.005s hidden.  Use -vv to show these durations.)
========== 10559 passed, 67 skipped, 6 warnings in 195.88s (0:03:15) ===========
Aggregated durations (by file):
  635.72s  tests/test_components/autograd/test_autograd.py
  132.66s  tests/test_components/test_simulation.py
  109.70s  tests/test_plugins/test_design.py
   77.06s  tests/test_components/test_custom.py
   58.46s  tests/test_plugins/test_mode_solver.py
   50.78s  tests/test_components/test_IO.py
   49.24s  tests/test_plugins/test_dispersion_fitter.py
   45.02s  tests/test_plugins/test_invdes.py
   40.38s  tests/test_plugins/smatrix/test_terminal_component_modeler.py
   35.89s  tests/test_data/test_sim_data.py
   32.64s  tests/test_plugins/autograd/invdes/test_filters.py
   32.34s  tests/test_data/test_monitor_data.py
   29.58s  tests/test_components/test_scene.py
   18.20s  tests/test_components/test_eme.py
   18.17s  tests/test_web/test_webapi.py
   16.96s  tests/test_package/test_parametric_variants.py
   16.66s  tests/test_components/test_sidewall.py
   11.37s  tests/test_components/test_microwave.py
   10.19s  tests/test_plugins/autograd/invdes/test_penalties.py
    9.67s  tests/test_plugins/smatrix/test_component_modeler.py
    9.65s  tests/test_data/test_datasets.py
    8.41s  tests/test_plugins/autograd/invdes/test_parametrizations.py
    8.16s  tests/test_components/test_medium.py
    7.56s  tests/test_components/autograd/test_autograd_polyslab.py
    6.30s  tests/test_components/test_heat_charge.py
    6.22s  tests/test_plugins/smatrix/test_component_modeler_autograd.py
    5.00s  tests/test_components/test_mode.py
    4.59s  tests/test_components/test_field_projection.py
    4.34s  tests/test_components/test_parameter_perturbation.py
    4.26s  tests/test_components/test_heat.py

Aggregated durations (by test (parametrizations combined)):
  220.42s  tests/test_components/autograd/test_autograd.py::test_autograd_async
   98.23s  tests/test_plugins/test_design.py::test_sweep
   72.02s  tests/test_components/autograd/test_autograd.py::test_autograd_async_server
   56.05s  tests/test_components/autograd/test_autograd.py::test_autograd_async_some_zero_grad
   46.61s  tests/test_components/autograd/test_autograd.py::test_multi_frequency_equivalence
   39.50s  tests/test_components/autograd/test_autograd.py::test_autograd_objective
   38.17s  tests/test_components/autograd/test_autograd.py::test_autograd_server
   37.65s  tests/test_components/autograd/test_autograd.py::TestFieldProjection::test_field_projection_grad_prop
   31.49s  tests/test_components/test_simulation.py::test_sim_subsection
   27.68s  tests/test_components/test_simulation.py::test_num_lumped_elements
   25.01s  tests/test_components/autograd/test_autograd.py::test_interp_objectives
   21.97s  tests/test_components/test_scene.py::test_num_mediums
   20.08s  tests/test_components/test_simulation.py::TestAnisotropicPlotting::test_plot_fully_anisotropic_medium_diff
   20.00s  tests/test_components/autograd/test_autograd.py::TestFieldProjection::test_error_if_server_side_projection
   19.63s  tests/test_data/test_sim_data.py::test_plot
   18.48s  tests/test_components/autograd/test_autograd.py::test_vjp_nan
   17.49s  tests/test_components/test_custom.py::test_custom_lorentz
   16.93s  tests/test_components/test_IO.py::test_validation_speed
   16.19s  tests/test_plugins/autograd/invdes/test_filters.py::TestMakeFilter::test_make_filter
   16.12s  tests/test_package/test_parametric_variants.py::test_graphene
   15.68s  tests/test_data/test_monitor_data.py::TestZBF::test_fielddata_tozbf_readzbf
   13.80s  tests/test_components/test_eme.py::test_eme_sim_data
   13.50s  tests/test_plugins/test_invdes.py::test_continue_run_from_file
   12.86s  tests/test_components/test_custom.py::test_custom_sellmeier
   12.73s  tests/test_web/test_webapi.py::test_batch_run_accepts_pathlike_dir
   12.47s  tests/test_components/test_custom.py::test_custom_pole_residue
   12.17s  tests/test_plugins/test_dispersion_fitter.py::test_dispersion_set_wvg_range
   10.92s  tests/test_plugins/test_mode_solver.py::test_mode_solver_unstructured_custom_medium
   10.48s  tests/test_components/test_custom.py::test_custom_debye
   10.46s  tests/test_components/autograd/test_autograd.py::test_multi_freq_edge_cases
```
    
**Analysis after PR**
```
============================== slowest durations ===============================
40.14s call     tests/test_components/autograd/test_autograd.py::test_autograd_async_all
39.39s call     tests/test_components/autograd/test_autograd.py::test_autograd_async_server
21.09s call     tests/test_plugins/test_mode_solver.py::test_sort_spec_track_freq
16.44s call     tests/test_components/test_eme.py::test_eme_sim_data
14.87s call     tests/test_components/test_custom.py::test_custom_lorentz[True]
14.56s call     tests/test_plugins/test_invdes.py::test_continue_run_from_file
14.02s call     tests/test_plugins/test_design.py::test_sweep[sweep_method0]
12.81s call     tests/test_plugins/test_design.py::test_sweep[sweep_method3]
12.45s call     tests/test_plugins/test_dispersion_fitter.py::test_dispersion_set_wvg_range
12.12s call     tests/test_components/test_custom.py::test_custom_sellmeier[True]
10.32s call     tests/test_plugins/test_invdes.py::test_result_store_full_results_is_false
10.29s call     tests/test_plugins/test_design.py::test_sweep[sweep_method2]
10.28s call     tests/test_components/test_custom.py::test_custom_pole_residue[True]
9.83s call     tests/test_components/test_custom.py::test_custom_anisotropic_medium[True]
9.75s call     tests/test_plugins/test_dispersion_fitter.py::test_dispersion_loss_samples
9.73s call     tests/test_data/test_sim_data.py::test_plot[1.0]
9.46s call     tests/test_components/test_sidewall.py::test_intersection_with_inside_poly
9.30s call     tests/test_components/test_simulation.py::test_sim_subsection[True-13]
9.23s call     tests/test_data/test_sim_data.py::test_plot[0]
8.70s call     tests/test_plugins/test_dispersion_fitter.py::test_lossy_dispersion
8.57s call     tests/test_components/test_custom.py::test_custom_debye[True]
8.54s call     tests/test_components/test_mode.py::test_mode_sim
8.37s call     tests/test_components/test_microwave.py::test_mode_solver_with_microwave_mode_spec
8.17s call     tests/test_plugins/test_invdes.py::test_continue_run_fns
8.15s call     tests/test_plugins/test_dispersion_fitter.py::test_lossless_dispersion
8.04s call     tests/test_plugins/test_design.py::test_sweep[sweep_method4]
7.58s call     tests/test_components/autograd/test_autograd.py::test_autograd_server[<ALL>-field_point]
7.58s call     tests/test_components/autograd/test_autograd.py::test_web_run_duplicate_simulations
7.42s call     tests/test_components/test_simulation.py::test_sim_subsection[True-1]
7.40s call     tests/test_plugins/test_mode_solver.py::test_mode_solver_straight_vs_angled

(27789 durations < 0.005s hidden.  Use -vv to show these durations.)
========= 10469 passed, 66 skipped, 193 warnings in 137.23s (0:02:17) ==========
Aggregated durations (by file):
  330.78s  tests/test_components/autograd/test_autograd.py
  113.18s  tests/test_plugins/test_mode_solver.py
  101.27s  tests/test_components/test_simulation.py
   79.02s  tests/test_components/test_custom.py
   62.36s  tests/test_plugins/test_design.py
   52.02s  tests/test_plugins/test_dispersion_fitter.py
   47.17s  tests/test_plugins/test_invdes.py
   39.07s  tests/test_plugins/smatrix/test_terminal_component_modeler.py
   35.71s  tests/test_data/test_sim_data.py
   34.52s  tests/test_components/test_IO.py
   33.87s  tests/test_plugins/autograd/invdes/test_filters.py
   31.98s  tests/test_data/test_monitor_data.py
   21.22s  tests/test_components/test_eme.py
   19.61s  tests/test_components/test_microwave.py
   17.33s  tests/test_components/test_sidewall.py
   11.67s  tests/test_web/test_webapi.py
   10.97s  tests/test_plugins/autograd/invdes/test_penalties.py
   10.11s  tests/test_data/test_datasets.py
    9.85s  tests/test_plugins/smatrix/test_component_modeler.py
    9.49s  tests/test_components/test_mode.py
    9.28s  tests/test_package/test_parametric_variants.py
    8.79s  tests/test_plugins/autograd/invdes/test_parametrizations.py
    7.86s  tests/test_components/test_medium.py
    7.71s  tests/test_components/test_scene.py
    7.64s  tests/test_components/autograd/test_autograd_polyslab.py
    7.12s  tests/test_components/test_heat_charge.py
    6.17s  tests/test_plugins/smatrix/test_component_modeler_autograd.py
    5.24s  tests/test_components/test_parameter_perturbation.py
    5.13s  tests/test_plugins/autograd/test_functions.py
    4.86s  tests/test_plugins/test_array_factor.py

Aggregated durations (by test (parametrizations combined)):
   51.15s  tests/test_plugins/test_design.py::test_sweep
   40.99s  tests/test_components/autograd/test_autograd.py::test_autograd_server
   40.67s  tests/test_components/autograd/test_autograd.py::test_autograd_objective
   40.14s  tests/test_components/autograd/test_autograd.py::test_autograd_async_all
   39.44s  tests/test_components/autograd/test_autograd.py::TestFieldProjection::test_field_projection_grad_prop
   39.39s  tests/test_components/autograd/test_autograd.py::test_autograd_async_server
   30.82s  tests/test_components/test_simulation.py::test_sim_subsection
   26.26s  tests/test_components/autograd/test_autograd.py::test_interp_objectives
   24.16s  tests/test_plugins/test_mode_solver.py::test_mode_solver_unstructured_custom_medium
   22.55s  tests/test_components/autograd/test_autograd.py::TestFieldProjection::test_error_if_server_side_projection
   21.09s  tests/test_plugins/test_mode_solver.py::test_sort_spec_track_freq
   19.51s  tests/test_components/test_simulation.py::TestAnisotropicPlotting::test_plot_fully_anisotropic_medium_diff
   18.96s  tests/test_data/test_sim_data.py::test_plot
   17.98s  tests/test_components/test_custom.py::test_custom_lorentz
   16.51s  tests/test_plugins/autograd/invdes/test_filters.py::TestMakeFilter::test_make_filter
   16.44s  tests/test_components/test_eme.py::test_eme_sim_data
   15.57s  tests/test_data/test_monitor_data.py::TestZBF::test_fielddata_tozbf_readzbf
   14.56s  tests/test_plugins/test_invdes.py::test_continue_run_from_file
   13.92s  tests/test_components/test_custom.py::test_custom_sellmeier
   12.89s  tests/test_components/autograd/test_autograd.py::test_multi_freq_edge_cases
   12.70s  tests/test_components/test_custom.py::test_custom_pole_residue
   12.45s  tests/test_plugins/test_dispersion_fitter.py::test_dispersion_set_wvg_range
   10.97s  tests/test_plugins/autograd/invdes/test_penalties.py::test_make_erosion_dilation_penalty
   10.57s  tests/test_components/test_custom.py::test_custom_debye
   10.32s  tests/test_plugins/test_invdes.py::test_result_store_full_results_is_false
    9.92s  tests/test_plugins/test_mode_solver.py::test_mode_solver_simple
    9.83s  tests/test_components/test_custom.py::test_custom_anisotropic_medium
    9.75s  tests/test_plugins/test_dispersion_fitter.py::test_dispersion_loss_samples
    9.46s  tests/test_components/test_sidewall.py::test_intersection_with_inside_poly
    8.79s  tests/test_plugins/autograd/invdes/test_parametrizations.py::test_make_filter_and_project
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR successfully optimizes the test suite runtime by ~30% (from 195s to 137s total, with `test_autograd.py` reduced from 635s to 330s) through strategic refactoring:

**Major Changes:**
- Added `profile_pytest.py` script to identify and track slow tests
- Consolidated parameterized async autograd tests into batched operations with equivalence validation
- Introduced `@pytest.mark.slow` and `@pytest.mark.perf` markers for better test categorization
- Added `pytest-order` dependency to run heavy autograd tests first (avoiding non-parallelized tail execution)
- Reduced test parameter spaces where appropriate (e.g., design sweep grid points 5→3, validation test iterations 10→2)
- Used monkeypatch to reduce `MAX_NUM_MEDIUMS` constant from production values to 3 in tests

**Trade-offs:**
The optimizations reduce some test coverage (e.g., `test_multi_frequency_equivalence` now only tests one structure type instead of 12, async tests run 2 structure/monitor combinations instead of 16×2=32), but this is reasonable since the core functionality is validated through equivalence checks and the reduced coverage focuses on structural diversity rather than functional correctness.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor review of test coverage trade-offs
- The changes successfully achieve the performance goal with well-structured optimizations. Score of 4 (not 5) reflects intentional test coverage reductions that, while reasonable for speed improvements, should be acknowledged. The refactored async test logic properly validates equivalence between sync and async modes, and the new profiling infrastructure is valuable. One minor style issue with an outdated comment.
- No files require special attention - the test coverage reductions are intentional and documented in the PR description

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| scripts/profile_pytest.py | 5/5 | New profiling script added to help analyze test performance - well-structured helper utility with proper argument parsing and documentation |
| pyproject.toml | 5/5 | Added pytest-order dependency and new test markers (`perf`, `slow`) - proper pytest configuration updates |
| tests/test_components/autograd/test_autograd.py | 4/5 | Major refactoring of async tests to reduce parameterization and run them first via pytest.mark.order(0). Consolidated multiple parameterized test runs into batched operations. Some test coverage reduced but performance significantly improved |
| tests/test_components/test_IO.py | 5/5 | Reduced validation speed test iterations from 10 to 2 and max structures from 100 to 2, marked with `@pytest.mark.perf` |
| tests/test_plugins/test_design.py | 5/5 | Reduced test parameter space (grid points 5→3, sphere range 0-3→0-2, tag values 3→2), marked with `@pytest.mark.slow` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Script as profile_pytest.py
    participant PyTest as pytest
    participant Tests as Test Suite
    
    Dev->>Script: Run profiling script
    Script->>PyTest: Execute with --durations flag
    PyTest->>Tests: Run test collection
    
    Note over Tests: Tests run with optimizations:<br/>- Reduced parameterizations<br/>- Batched async operations<br/>- Marked slow tests<br/>- Reduced iteration counts
    
    Tests-->>PyTest: Test results + timing data
    PyTest-->>Script: Duration statistics
    Script->>Script: Parse & aggregate durations
    Script->>Script: Generate report by file & test
    Script-->>Dev: Performance report (pytest_profile_stats.txt)
    
    Note over Dev: 30% faster test suite<br/>635s → 330s for autograd tests
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves test suite performance and adds tooling to analyze slow tests.
> 
> - New `scripts/profile_pytest.py`: run full or subsetted pytest with `--durations`, optional `cProfile`, and export aggregated timing to `pytest_profile_stats.txt`
> - Pytest config: adds `slow` and `perf` markers, excludes `perf` by default in `addopts`, expands test discovery and warning filters
> - Tests: mark slow paths (`@pytest.mark.slow`/`perf`), reduce iteration/seeds and parameter spaces (e.g., design sweeps, graphene variants), and monkeypatch resource limits (e.g., `MAX_NUM_MEDIUMS`) to shrink runtime
> - Docs: usage guide updated with profiling and RAM tracking helpers; `.gitignore` includes profile outputs
> - Lockfile/deps: minor version bumps (e.g., boto3/botocore, fastcore, jupyter-server-terminals, prometheus-client) and wheel list adjustments for `tidy3d-extras`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07da9747fa1f7149c632d31c36feb9cab4333366. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->