### PR TITLE
docs update for seminar notebooks

### DIFF
--- a/docs/_ext/custom-meta.py
+++ b/docs/_ext/custom-meta.py
@@ -5,8 +5,9 @@ import os
 
 def html_page_context(app, pagename, templatename, context, doctree):
     notebook_path = app.env.doc2path(os.path.abspath("" + pagename), base=None)
-    if "notebook" in notebook_path or notebook_path.endswith("examples.rst"):
-        context["metatags"] += "".join(['\n\t<meta content="noindex" name="robots" />'])
+    if "/notebooks/" in notebook_path or notebook_path.endswith("examples.rst"):
+        if "metatags" in context:
+            context["metatags"] += "".join(['\n\t<meta content="noindex" name="robots" />'])
 
 
 def setup(app):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -168,6 +168,7 @@ include_patterns = [
     "tidy3d/*",
     "faq/docs/**",
     "notebooks/*.ipynb",
+    "notebooks/**/*.ipynb",
     "notebooks/docs/*",
     "**.rst",
     "**.png",

--- a/docs/lectures/fabrication_invdes.rst
+++ b/docs/lectures/fabrication_invdes.rst
@@ -1,0 +1,39 @@
+Fabrication-aware inverse design
+================================
+
+.. meta::
+   :description: Fabrication-aware inverse design seminar notebooks and walkthrough
+   :keywords: tidy3d, inverse design, fabrication-aware, adjoint, grating coupler
+
+The October 9, 2025 seminar walks through a complete dual-layer grating coupler workflow: start from a uniform baseline, pull a strong seed design with Bayesian optimization, switch to adjoint gradients for per-tooth control, study fabrication sensitivities, and close the loop with measurement-driven calibration. Everything runs inside Tidy3D, so you can rerun the exact same jobs or adapt the utilities to your own device stack.
+
+Seminar recording: `YouTube link <https://www.youtube.com/watch?v=OpVBJmomzoo>`_
+
+Notebook lineup
+----------------
+* :doc:`Setup Guide: Building the Simulation <../notebooks/2025-10-09-invdes-seminar/00_setup_guide>` - builds the nominal SiN stack, launches the reference simulation, and visualizes the initial geometry so the later notebooks can reuse the cached job ID.
+* :doc:`Bayesian Optimization: Finding a Strong Baseline <../notebooks/2025-10-09-invdes-seminar/01_bayes>` - uses a five-parameter Bayesian search to quickly find a good uniform grating. This provides a practical baseline before investing in gradients.
+* :doc:`Adjoint Optimization: High-Dimensional Refinement <../notebooks/2025-10-09-invdes-seminar/02_adjoint>` - expands to per-tooth parameters and applies Adam with adjoint sensitivities to apodize the grating and boost efficiency.
+* :doc:`Fabrication Sensitivity Analysis: Is Our Design Robust? <../notebooks/2025-10-09-invdes-seminar/03_sensitivity>` - sweeps :math:`\pm 20` nm etch bias, runs Monte Carlo samples, and logs adjoint-derived sensitivity units (:math:`\Delta` objective / :math:`\Delta` parameter) so readers understand what the gradients mean physically.
+* :doc:`Robust Adjoint Optimization for Manufacturability <../notebooks/2025-10-09-invdes-seminar/04_adjoint_robust>` - penalizes variance across nominal/over/under corners, illustrating a fabrication-aware adjoint loop that matches what we demoed live.
+* :doc:`Monte Carlo View: Nominal vs Robust Grating <../notebooks/2025-10-09-invdes-seminar/05_robust_comparison>` - reruns the Monte Carlo campaign for both nominal and robust devices to quantify yield improvements.
+* :doc:`Measurement Calibration: Bridging Simulation and Fabrication <../notebooks/2025-10-09-invdes-seminar/06_measurement_calibration>` - demonstrates gradient-based calibration of tooth widths against (synthetic) spectra, using adjoint sensitivities to recover the as-fabricated geometry from optical measurements.
+
+Getting the code
+----------------
+The notebooks are available in the `Tidy3D notebooks repository <https://github.com/flexcompute/tidy3d-notebooks/tree/develop/2025-10-09-invdes-seminar>`_. You will need the ``.ipynb`` files as well as the helper scripts `setup.py <https://github.com/flexcompute/tidy3d-notebooks/blob/develop/2025-10-09-invdes-seminar/setup.py>`_ and `optim.py <https://github.com/flexcompute/tidy3d-notebooks/blob/develop/2025-10-09-invdes-seminar/optim.py>`_ to run the examples.
+
+How to run the series
+---------------------
+1. Install ``tidy3d`` and ``bayesian-optimization`` (``pip install tidy3d bayesian-optimization``) and configure your API key.
+2. Execute the notebooks in order; each step writes results into ``results/`` and later notebooks assume those JSON files exist.
+
+Supporting assets
+-----------------
+* `setup.py <https://github.com/flexcompute/tidy3d-notebooks/blob/develop/2025-10-09-invdes-seminar/setup.py>`_ - shared simulation builders, fabrication constraints, and helper functions.
+* `optim.py <https://github.com/flexcompute/tidy3d-notebooks/blob/develop/2025-10-09-invdes-seminar/optim.py>`_ - a lightweight, autograd-friendly Adam implementation with parameter clipping.
+* ``results/`` - JSON checkpoints (Bayes best point, adjoint refinements, robust design) consumed by subsequent notebooks.
+
+
+
+

--- a/docs/lectures/fabrication_invdes_notebooks.rst
+++ b/docs/lectures/fabrication_invdes_notebooks.rst
@@ -1,0 +1,12 @@
+:orphan:
+
+.. toctree::
+
+   ../notebooks/2025-10-09-invdes-seminar/00_setup_guide
+   ../notebooks/2025-10-09-invdes-seminar/01_bayes
+   ../notebooks/2025-10-09-invdes-seminar/02_adjoint
+   ../notebooks/2025-10-09-invdes-seminar/03_sensitivity
+   ../notebooks/2025-10-09-invdes-seminar/04_adjoint_robust
+   ../notebooks/2025-10-09-invdes-seminar/05_robust_comparison
+   ../notebooks/2025-10-09-invdes-seminar/06_measurement_calibration
+

--- a/docs/lectures/index.rst
+++ b/docs/lectures/index.rst
@@ -10,8 +10,10 @@ Welcome to our lecture series!
     fdtd101
     fdtd_workshop
     inversedesign
+    fabrication_invdes
 
 
 .. include:: /lectures/fdtd101.rst
 .. include:: /lectures/fdtd_workshop.rst
 .. include:: /lectures/inversedesign.rst
+.. include:: /lectures/fabrication_invdes.rst


### PR DESCRIPTION
merge after https://github.com/flexcompute/tidy3d-notebooks/pull/421

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds documentation for the October 2025 fabrication-aware inverse design seminar series. The changes include:

- New RST documentation page (`fabrication_invdes.rst`) with descriptions of 7 seminar notebooks covering Bayesian optimization, adjoint optimization, fabrication sensitivity analysis, and measurement calibration
- Orphan toctree file for notebook navigation
- Updated lectures index to include the new section
- Submodule update to include the new notebook content

Additionally, a bug fix in `custom-meta.py` prevents branch names containing "notebook" (e.g., `feature/notebook-fix`) from incorrectly triggering the noindex meta tag - now only paths containing `/notebooks/` directory are matched. A defensive check for `metatags` key presence was also added.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it only adds documentation and includes a defensive bug fix with no risk of breaking existing functionality.
- Score reflects documentation-only changes with a simple, well-reasoned bug fix. The changes are straightforward: new RST files for seminar documentation, a submodule update, and a targeted fix to prevent false matches in the custom-meta extension.
- No files require special attention.

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| docs/_ext/custom-meta.py | 5/5 | Bug fix: Changed substring check from "notebook" to "/notebooks/" to prevent false matches on branch names, and added safety check for "metatags" key presence. |
| docs/conf.py | 5/5 | Added glob pattern for nested notebook directories to include_patterns. |
| docs/lectures/fabrication_invdes.rst | 5/5 | New documentation page for fabrication-aware inverse design seminar with notebook links and descriptions. |
| docs/lectures/fabrication_invdes_notebooks.rst | 5/5 | New orphan toctree file for seminar notebook navigation. |
| docs/lectures/index.rst | 5/5 | Added fabrication_invdes to toctree and includes for new lecture section. |
| docs/notebooks | 5/5 | Submodule pointer updated to include new seminar notebooks. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Sphinx as Sphinx Build
    participant CustomMeta as custom-meta.py
    participant Conf as conf.py
    participant Index as lectures/index.rst
    participant Notebook as notebooks submodule

    Sphinx->>Conf: Load configuration
    Conf->>Sphinx: include_patterns with notebooks/**/*.ipynb
    Sphinx->>Index: Process lectures index
    Index->>Sphinx: Include fabrication_invdes.rst
    Sphinx->>Notebook: Fetch seminar notebooks
    Notebook->>Sphinx: Return .ipynb files
    Sphinx->>CustomMeta: html-page-context event
    CustomMeta->>CustomMeta: Check if /notebooks/ in path
    alt Path contains /notebooks/
        CustomMeta->>Sphinx: Add noindex meta tag
    else Path does not contain /notebooks/
        CustomMeta->>Sphinx: Skip meta tag
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->