### PR TITLE
feat: Moving TYPE_TO_CLASS_MAP logic from Expressions to Tidy3dBaseModel

### DIFF
--- a/tests/test_components/test_base.py
+++ b/tests/test_components/test_base.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import numpy as np
 import pytest
+from pydantic.v1 import ValidationError
 
 import tidy3d as td
 from tidy3d.components.base import Tidy3dBaseModel
@@ -275,3 +278,19 @@ def test_updated_hash_and_json_with_changed_attr():
 
     assert new_hash != old_hash
     assert json_old != json_new
+
+
+def test_parse_obj_respects_subclasses():
+    class DispatchBase(Tidy3dBaseModel):
+        type: Literal["DispatchBase"] = "DispatchBase"
+        value: int
+
+    class DispatchChild(DispatchBase):
+        type: Literal["DispatchChild"] = "DispatchChild"
+
+    data = {"type": "DispatchChild", "value": 1}
+    parsed = Tidy3dBaseModel._parse_model_dict(data)
+    assert isinstance(parsed, DispatchChild)
+
+    with pytest.raises(ValidationError):
+        DispatchChild.parse_obj({"type": "DispatchBase", "value": 2})

--- a/tests/test_plugins/expressions/test_dispatch.py
+++ b/tests/test_plugins/expressions/test_dispatch.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+from tidy3d.components.simulation import Simulation  # noqa: F401  # ensure type registration
+from tidy3d.plugins.expressions.base import Expression
+from tidy3d.plugins.expressions.variables import Constant
+
+
+def test_expression_parse_obj_round_trip():
+    expr = Constant(3.14)
+    parsed = Expression.parse_obj(expr.dict())
+    assert isinstance(parsed, Constant)
+    assert parsed.value == pytest.approx(3.14)
+
+
+def test_expression_parse_obj_rejects_unrelated_types():
+    # Simulation registers a distinct type in the global map; parsing via Expression should fail.
+    with pytest.raises(ValueError, match="Cannot parse type"):
+        Expression.parse_obj({"type": "Simulation"})

--- a/tests/test_web/test_local_cache.py
+++ b/tests/test_web/test_local_cache.py
@@ -26,7 +26,11 @@ from tidy3d.web import Job, common, run, run_async
 from tidy3d.web.api import webapi as web
 from tidy3d.web.api.autograd import autograd, engine, io_utils
 from tidy3d.web.api.autograd.autograd import run as run_autograd
-from tidy3d.web.api.autograd.constants import SIM_VJP_FILE
+from tidy3d.web.api.autograd.constants import (
+    AUX_KEY_SIM_DATA_FWD,
+    AUX_KEY_SIM_DATA_ORIGINAL,
+    SIM_VJP_FILE,
+)
 from tidy3d.web.api.container import Batch, WebContainer
 from tidy3d.web.api.webapi import load_simulation_if_cached
 from tidy3d.web.cache import (
@@ -181,13 +185,37 @@ def _patch_run_pipeline(monkeypatch):
         if str(remote_filename) == SIM_VJP_FILE:
             counters["download"] += 1
 
-    def _fake_from_file(*args, **kwargs):
-        field_map = FieldMap(tracers=())
-        return field_map
+    def _fake_postprocess_fwd(*, sim_data_combined=None, sim_original=None, aux_data=None, **_):
+        """Mimic ``autograd.postprocess_fwd`` side effects for tests."""
+        if sim_original is None:
+            sim_original = next(iter(PATH_TO_SIM.values()), None)
+        if sim_original is None:
+            sim_original = td.Simulation(
+                size=(1, 1, 1),
+                grid_spec=td.GridSpec.auto(wavelength=1.0),
+                run_time=1e-12,
+            )
+        stub_data = _FakeStubData(sim_original)
+        if aux_data is not None:
+            aux_data[AUX_KEY_SIM_DATA_ORIGINAL] = stub_data
+            aux_data[AUX_KEY_SIM_DATA_FWD] = stub_data
+        return stub_data._strip_traced_fields()
+
+    def _fake_postprocess_adj(
+        sim_data_adj=None, sim_data_orig=None, sim_data_fwd=None, sim_fields_keys=None, **_
+    ):
+        """Return zeros for every requested field key."""
+        counters["download"] += 1  # mimic VJP file download per autograd run
+        sim_fields_keys = sim_fields_keys or []
+        return dict.fromkeys(sim_fields_keys, 0.0)
+
+    def _fake_field_map_from_file(*args, **kwargs):
+        return FieldMap(tracers=())
 
     monkeypatch.setattr(io_utils, "download_file", _fake_download_file)
-    monkeypatch.setattr(autograd, "postprocess_fwd", _fake_from_file)
-    monkeypatch.setattr(FieldMap, "from_file", _fake_from_file)
+    monkeypatch.setattr(autograd, "postprocess_fwd", _fake_postprocess_fwd)
+    monkeypatch.setattr(autograd, "postprocess_adj", _fake_postprocess_adj)
+    monkeypatch.setattr(FieldMap, "from_file", _fake_field_map_from_file)
     monkeypatch.setattr(WebContainer, "_check_folder", _fake__check_folder)
     monkeypatch.setattr(web, "upload", _fake_upload)
     monkeypatch.setattr(web, "start", _fake_start)

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -42,7 +42,7 @@ JSON_TAG = "JSON_STRING"
 MAX_STRING_LENGTH = 1_000_000_000
 FORBID_SPECIAL_CHARACTERS = ["/"]
 TRACED_FIELD_KEYS_ATTR = "__tidy3d_traced_field_keys__"
-TYPE_TO_CLASS_MAP: dict[str, Any] = {}
+TYPE_TO_CLASS_MAP: dict[str, type[Tidy3dBaseModel]] = {}
 
 
 def cache(prop):
@@ -201,24 +201,71 @@ class Tidy3dBaseModel(pydantic.BaseModel):
             TYPE_TO_CLASS_MAP[type_value.default] = cls
 
     @classmethod
-    def _parse_obj(cls, obj: dict[str, Any]) -> Tidy3dBaseModel:
+    def _get_type_value(cls, obj: dict[str, Any]) -> str:
+        """Return the type tag from a raw dictionary."""
         if not isinstance(obj, dict):
             raise TypeError("Input must be a dict")
-        type_value = obj.get(TYPE_TAG_STR)
-        if type_value is None:
-            raise ValueError('Missing "type" in data')
-        subclass = TYPE_TO_CLASS_MAP.get(type_value)
-        if subclass is None:
-            raise ValueError(f"Unknown type: {type_value}")
-        return subclass(**obj)
+        try:
+            type_value = obj[TYPE_TAG_STR]
+        except KeyError as exc:
+            raise ValueError(f'Missing "{TYPE_TAG_STR}" in data') from exc
+        if not isinstance(type_value, str) or not type_value:
+            raise ValueError(f'Invalid "{TYPE_TAG_STR}" value: {type_value!r}')
+        return type_value
 
     @classmethod
-    def parse_obj(cls, obj: dict[str, Any]) -> Tidy3dBaseModel:
-        """Specialized parse_obj to handle any Tidy3D component, but only if called from
-        ``Tidy3dBaseModel``. Otherwise, call the regular pyadantic parse_obj."""
-        if cls.__name__ == "Tidy3dBaseModel":
-            return cls._parse_obj(obj)
-        return super().parse_obj(obj)
+    def _get_registered_class(cls, type_value: str) -> type[Tidy3dBaseModel]:
+        try:
+            return TYPE_TO_CLASS_MAP[type_value]
+        except KeyError as exc:
+            raise ValueError(f"Unknown type: {type_value}") from exc
+
+    @classmethod
+    def _should_dispatch_to(cls, target_cls: type[Tidy3dBaseModel]) -> bool:
+        """Return True if ``cls`` allows auto-dispatch to ``target_cls``."""
+        return issubclass(target_cls, cls)
+
+    @classmethod
+    def _resolve_dispatch_target(cls, obj: dict[str, Any]) -> type[Tidy3dBaseModel]:
+        """Determine which subclass should receive ``obj``."""
+        type_value = cls._get_type_value(obj)
+        target_cls = cls._get_registered_class(type_value)
+        if cls._should_dispatch_to(target_cls):
+            return target_cls
+        if target_cls is cls:
+            return cls
+        raise ValueError(
+            f'Cannot parse type "{type_value}" using {cls.__name__}; expected subclass of {cls.__name__}.'
+        )
+
+    @classmethod
+    def _target_cls_from_file(
+        cls, fname: PathLike, group_path: Optional[str] = None
+    ) -> type[Tidy3dBaseModel]:
+        """Peek the file metadata to determine the subclass to instantiate."""
+        model_dict = cls.dict_from_file(
+            fname=fname,
+            group_path=group_path,
+            load_data_arrays=False,
+        )
+        return cls._resolve_dispatch_target(model_dict)
+
+    @classmethod
+    def _parse_obj(cls, obj: dict[str, Any], **parse_obj_kwargs: Any) -> Tidy3dBaseModel:
+        """Dispatch ``obj`` to the correct subclass registered in the type map."""
+        target_cls = cls._resolve_dispatch_target(obj)
+        if target_cls is cls:
+            return super().parse_obj(obj, **parse_obj_kwargs)
+        return target_cls.parse_obj(obj, **parse_obj_kwargs)
+
+    @classmethod
+    def _parse_model_dict(
+        cls, model_dict: dict[str, Any], **parse_obj_kwargs: Any
+    ) -> Tidy3dBaseModel:
+        """Parse ``model_dict`` while optionally auto-dispatching when called on the base class."""
+        if cls is Tidy3dBaseModel:
+            return cls._parse_obj(model_dict, **parse_obj_kwargs)
+        return cls.parse_obj(model_dict, **parse_obj_kwargs)
 
     class Config:
         """Sets config for all :class:`Tidy3dBaseModel` objects.
@@ -428,16 +475,19 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         >>> simulation = Simulation.from_file(fname='folder/sim.json') # doctest: +SKIP
         """
         if lazy:
-            Proxy = _make_lazy_proxy(cls, on_load=on_load)  # staticmethod usage
+            target_cls = cls._target_cls_from_file(fname=fname, group_path=group_path)
+            Proxy = _make_lazy_proxy(target_cls, on_load=on_load)
             return Proxy(fname, group_path, parse_obj_kwargs)
         model_dict = cls.dict_from_file(fname=fname, group_path=group_path)
-        obj = cls.parse_obj(model_dict, **parse_obj_kwargs)
+        obj = cls._parse_model_dict(model_dict, **parse_obj_kwargs)
         if not lazy and on_load is not None:
             on_load(obj)
         return obj
 
     @classmethod
-    def dict_from_file(cls, fname: PathLike, group_path: Optional[str] = None) -> dict:
+    def dict_from_file(
+        cls, fname: PathLike, group_path: Optional[str] = None, *, load_data_arrays: bool = True
+    ) -> dict:
         """Loads a dictionary containing the model from a .yaml, .json, .hdf5, or .hdf5.gz file.
 
         Parameters
@@ -461,10 +511,13 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         kwargs = {"fname": fname_path}
 
         if group_path is not None:
-            if extension == ".hdf5" or extension == ".hdf5.gz":
+            if extension in {".hdf5", ".hdf5.gz", ".h5"}:
                 kwargs["group_path"] = group_path
             else:
                 log.warning("'group_path' provided, but this feature only works with hdf5 files.")
+
+        if extension in {".hdf5", ".hdf5.gz", ".h5"}:
+            kwargs["load_data_arrays"] = load_data_arrays
 
         converter = {
             ".json": cls.dict_from_json,
@@ -517,7 +570,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         >>> simulation = Simulation.from_json(fname='folder/sim.json') # doctest: +SKIP
         """
         model_dict = cls.dict_from_json(fname=fname)
-        return cls.parse_obj(model_dict, **parse_obj_kwargs)
+        return cls._parse_model_dict(model_dict, **parse_obj_kwargs)
 
     @classmethod
     def dict_from_json(cls, fname: PathLike) -> dict:
@@ -582,7 +635,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         >>> simulation = Simulation.from_yaml(fname='folder/sim.yaml') # doctest: +SKIP
         """
         model_dict = cls.dict_from_yaml(fname=fname)
-        return cls.parse_obj(model_dict, **parse_obj_kwargs)
+        return cls._parse_model_dict(model_dict, **parse_obj_kwargs)
 
     @classmethod
     def dict_from_yaml(cls, fname: PathLike) -> dict:
@@ -703,6 +756,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         fname: PathLike,
         group_path: str = "",
         custom_decoders: Optional[list[Callable]] = None,
+        load_data_arrays: bool = True,
     ) -> dict:
         """Loads a dictionary containing the model contents from a .hdf5 file.
 
@@ -776,7 +830,8 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         model_dict = json.loads(cls._json_string_from_hdf5(fname=fname_path))
         group_path = cls._construct_group_path(group_path)
         model_dict = cls.get_sub_model(group_path=group_path, model_dict=model_dict)
-        load_data_from_file(model_dict=model_dict, group_path=group_path)
+        if load_data_arrays:
+            load_data_from_file(model_dict=model_dict, group_path=group_path)
         return model_dict
 
     @classmethod
@@ -814,7 +869,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
             group_path=group_path,
             custom_decoders=custom_decoders,
         )
-        return cls.parse_obj(model_dict, **parse_obj_kwargs)
+        return cls._parse_model_dict(model_dict, **parse_obj_kwargs)
 
     def to_hdf5(
         self,
@@ -885,6 +940,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         fname: PathLike,
         group_path: str = "",
         custom_decoders: Optional[list[Callable]] = None,
+        load_data_arrays: bool = True,
     ) -> dict:
         """Loads a dictionary containing the model contents from a .hdf5.gz file.
 
@@ -917,6 +973,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
                 extracted_path,
                 group_path=group_path,
                 custom_decoders=custom_decoders,
+                load_data_arrays=load_data_arrays,
             )
         finally:
             extracted_path.unlink(missing_ok=True)
@@ -958,7 +1015,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
             group_path=group_path,
             custom_decoders=custom_decoders,
         )
-        return cls.parse_obj(model_dict, **parse_obj_kwargs)
+        return cls._parse_model_dict(model_dict, **parse_obj_kwargs)
 
     def to_hdf5_gz(
         self, fname: PathLike | io.BytesIO, custom_encoders: Optional[list[Callable]] = None
@@ -1172,7 +1229,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         for path, value in field_mapping.items():
             insert_value(value, path=path, sub_dict=self_dict)
 
-        return self.parse_obj(self_dict)
+        return type(self)._parse_model_dict(self_dict)
 
     def _serialized_traced_field_keys(
         self, field_mapping: AutogradFieldMap | None = None
@@ -1385,6 +1442,8 @@ def _make_lazy_proxy(
         ``(fname, group_path, parse_obj_kwargs)``.
     """
 
+    proxy_name = f"{target_cls.__name__}Proxy"
+
     class _LazyProxy(target_cls):
         def __init__(
             self,
@@ -1406,6 +1465,7 @@ def _make_lazy_proxy(
 
         def __getattribute__(self, name: str):
             if name in (
+                "__class__",
                 "__dict__",
                 "__weakref__",
                 "__post_root_validators__",
@@ -1420,7 +1480,7 @@ def _make_lazy_proxy(
                 kwargs = d["_lazy_parse_obj_kwargs"]
 
                 model_dict = target_cls.dict_from_file(fname=fname, group_path=group_path)
-                target = target_cls.parse_obj(model_dict, **kwargs)
+                target = target_cls._parse_model_dict(model_dict, **kwargs)
 
                 d.clear()
                 d.update(target.__dict__)
@@ -1435,5 +1495,5 @@ def _make_lazy_proxy(
 
             return object.__getattribute__(self, name)
 
-    _LazyProxy.__name__ = "LazyProxy"
+    _LazyProxy.__name__ = proxy_name
     return _LazyProxy

--- a/tidy3d/plugins/expressions/base.py
+++ b/tidy3d/plugins/expressions/base.py
@@ -43,7 +43,7 @@ class Expression(Tidy3dBaseModel, ABC):
 
     @classmethod
     def parse_obj(cls, obj: dict[str, Any]) -> ExpressionType:
-        return Tidy3dBaseModel._parse_obj(obj)
+        return super()._parse_obj(obj)
 
     def filter(
         self, target_type: type[Expression], target_field: Optional[str] = None


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Refactored the type dispatching logic for `parse_obj` from the `Expression` class to the base `Tidy3dBaseModel` class, making it available to all Tidy3d components.

**Key Changes:**
- Added `_get_type_value`, `_get_registered_class`, `_should_dispatch_to`, and `_resolve_dispatch_target` helper methods to `Tidy3dBaseModel` for structured type dispatching
- Modified `_parse_obj` to use the new `_resolve_dispatch_target` logic with proper subclass validation
- Updated `from_file` lazy loading to correctly determine target class before creating proxy using new `_target_cls_from_file` method
- Added `load_data_arrays` parameter to `dict_from_file`, `dict_from_hdf5`, and `dict_from_hdf5_gz` to support peeking at metadata without loading large data arrays
- Changed `Expression.parse_obj` to call `super()._parse_obj()` instead of directly calling `Tidy3dBaseModel._parse_obj()`
- Added `__class__` to the list of attributes that don't trigger lazy loading in `_LazyProxy`
- Updated lazy proxy naming to include target class name for better debugging
- Added comprehensive tests for dispatch behavior and subclass validation

<h3>Confidence Score: 4/5</h3>


- This PR is generally safe to merge with thorough testing of lazy loading and type dispatch edge cases
- The refactoring is well-structured with proper error handling and comprehensive tests. The main concern is the complexity of the lazy loading changes and ensuring all edge cases are covered, particularly around the new `load_data_arrays` parameter and proxy class behavior
- Pay close attention to `tidy3d/components/base.py` for the lazy loading logic and ensure existing code using `from_file(lazy=True)` still works correctly

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/base.py | 4/5 | Moved `TYPE_TO_CLASS_MAP` dispatch logic from `Expression` to `Tidy3dBaseModel`, adding proper subclass validation and lazy loading support |
| tidy3d/plugins/expressions/base.py | 5/5 | Simplified `parse_obj` to call `super()._parse_obj()` instead of `Tidy3dBaseModel._parse_obj()` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Tidy3dBaseModel
    participant Expression
    participant TYPE_TO_CLASS_MAP
    participant TargetClass

    Note over Tidy3dBaseModel: Registration Phase
    Tidy3dBaseModel->>TYPE_TO_CLASS_MAP: Register all subclasses with type tags

    Note over Client: Parse Object Flow
    Client->>Expression: parse_obj({"type": "Constant", ...})
    Expression->>Tidy3dBaseModel: super()._parse_obj(obj)
    Tidy3dBaseModel->>Tidy3dBaseModel: _resolve_dispatch_target(obj)
    Tidy3dBaseModel->>Tidy3dBaseModel: _get_type_value(obj)
    Tidy3dBaseModel-->>Tidy3dBaseModel: "Constant"
    Tidy3dBaseModel->>Tidy3dBaseModel: _get_registered_class("Constant")
    Tidy3dBaseModel->>TYPE_TO_CLASS_MAP: Lookup "Constant"
    TYPE_TO_CLASS_MAP-->>Tidy3dBaseModel: ConstantClass
    Tidy3dBaseModel->>Tidy3dBaseModel: _should_dispatch_to(ConstantClass)
    Tidy3dBaseModel-->>Tidy3dBaseModel: issubclass(ConstantClass, Expression)
    Tidy3dBaseModel->>TargetClass: __init__(**obj)
    TargetClass-->>Client: Constant instance

    Note over Client: Lazy Loading Flow
    Client->>Tidy3dBaseModel: from_file(fname, lazy=True)
    Tidy3dBaseModel->>Tidy3dBaseModel: _target_cls_from_file(fname)
    Tidy3dBaseModel->>Tidy3dBaseModel: dict_from_file(load_data_arrays=False)
    Tidy3dBaseModel->>Tidy3dBaseModel: _resolve_dispatch_target(model_dict)
    Tidy3dBaseModel-->>Tidy3dBaseModel: TargetClass
    Tidy3dBaseModel->>Tidy3dBaseModel: _make_lazy_proxy(TargetClass)
    Tidy3dBaseModel-->>Client: LazyProxy instance
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->