### PR TITLE
fix(packaging): fix and improve error messages in tidy3d_extras features

### DIFF
--- a/tidy3d/packaging.py
+++ b/tidy3d/packaging.py
@@ -246,7 +246,7 @@ def check_tidy3d_extras_licensed_feature(feature_name: str):
         _check_tidy3d_extras_available()
     except Tidy3dImportError as exc:
         raise Tidy3dImportError(
-            "The package 'tidy3d-extras' is required for this feature '{feature_name}'."
+            f"The package 'tidy3d-extras' is required for this feature '{feature_name}'."
         ) from exc
 
     features = tidy3d_extras["mod"].extension._features()
@@ -275,7 +275,7 @@ def supports_local_subpixel(fn):
             tidy3d_extras["use_local_subpixel"] = False
             if preference is True:
                 raise Tidy3dImportError(
-                    f"{exc!s} To suppress this error, you can set "
+                    "To suppress this error, you can set "
                     "'config.simulation.use_local_subpixel=False'."
                 ) from exc
             # preference is None, so we can just return


### PR DESCRIPTION
Now the complete trace of messages are

>              ERROR: error=Incorrect API Key. You can find your API key in your  
>              Account page.; None account associate with this API Key.; 401; 401 
>              UNAUTHORIZED [HTTP 401 GET                                         
>              https://.......]                                                              
>              ERROR: The package 'tidy3d-extras' did not initialize correctly,   
>              likely due to an invalid API key.                                  
>              ERROR: The package 'tidy3d-extras' is required for this feature    
>              'local_subpixel'.                                                  
>              ERROR: To suppress this error, you can set                         
>              'config.simulation.use_local_subpixel=False'.                      
>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed two error message issues in `tidy3d_extras` package error handling: added missing f-string prefix to enable variable interpolation for the feature name, and removed redundant exception message that was already displayed via exception chaining.

- Fixed missing f-string prefix on line 249 so `{feature_name}` is properly interpolated
- Removed `{exc!s}` from error message on line 278 to avoid duplicate error information (the chained exception already displays via `from exc`)

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk - it fixes clear bugs in error message formatting
- Both changes are straightforward bug fixes that improve error message quality. The first fix adds a missing f-string prefix that prevented variable interpolation, and the second removes redundant error text since Python's exception chaining already displays the original error. The changes follow the codebase style guide (rule 9b45957a) by using single quotes for code references in error messages. No logic changes or side effects.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/packaging.py | 5/5 | Fixed missing f-string prefix for variable interpolation and removed redundant exception message from error output |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant supports_local_subpixel
    participant check_tidy3d_extras_licensed_feature
    participant _check_tidy3d_extras_available
    participant tidy3d_extras_mod
    participant log

    User->>supports_local_subpixel: Call decorated function
    supports_local_subpixel->>supports_local_subpixel: Check config preference
    
    alt preference is False
        supports_local_subpixel->>User: Execute function (subpixel disabled)
    else preference is True or None
        supports_local_subpixel->>check_tidy3d_extras_licensed_feature: Verify "local_subpixel" feature
        check_tidy3d_extras_licensed_feature->>_check_tidy3d_extras_available: Check if package available
        
        alt Package not found
            _check_tidy3d_extras_available->>log: log.error("package absent")
            _check_tidy3d_extras_available-->>check_tidy3d_extras_licensed_feature: Raise Tidy3dImportError
            check_tidy3d_extras_licensed_feature->>log: log.error("required for feature 'local_subpixel'")
            check_tidy3d_extras_licensed_feature-->>supports_local_subpixel: Raise Tidy3dImportError (with chaining)
            
            alt preference is True
                supports_local_subpixel->>log: log.error("To suppress this error...")
                supports_local_subpixel-->>User: Raise Tidy3dImportError (with chaining)
            else preference is None
                supports_local_subpixel->>User: Execute function (subpixel disabled)
            end
        else Package found but version mismatch
            _check_tidy3d_extras_available->>tidy3d_extras_mod: import and check version
            _check_tidy3d_extras_available->>log: log.error("version mismatch")
            _check_tidy3d_extras_available-->>check_tidy3d_extras_licensed_feature: Raise Tidy3dImportError
            check_tidy3d_extras_licensed_feature->>log: log.error("required for feature 'local_subpixel'")
            check_tidy3d_extras_licensed_feature-->>supports_local_subpixel: Raise Tidy3dImportError (with chaining)
            
            alt preference is True
                supports_local_subpixel->>log: log.error("To suppress this error...")
                supports_local_subpixel-->>User: Raise Tidy3dImportError (with chaining)
            else preference is None
                supports_local_subpixel->>User: Execute function (subpixel disabled)
            end
        else Package OK, feature not licensed
            check_tidy3d_extras_licensed_feature->>tidy3d_extras_mod: Check feature availability
            check_tidy3d_extras_licensed_feature->>log: log.error("feature not available")
            check_tidy3d_extras_licensed_feature-->>supports_local_subpixel: Raise Tidy3dImportError
            
            alt preference is True
                supports_local_subpixel->>log: log.error("To suppress this error...")
                supports_local_subpixel-->>User: Raise Tidy3dImportError (with chaining)
            else preference is None
                supports_local_subpixel->>User: Execute function (subpixel disabled)
            end
        else All checks pass
            check_tidy3d_extras_licensed_feature-->>supports_local_subpixel: Success
            supports_local_subpixel->>User: Execute function (subpixel enabled)
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->