### PR TITLE
fix(tidy3d_extras): fix error message in tidy3d_extras importing

### DIFF
--- a/tidy3d/packaging.py
+++ b/tidy3d/packaging.py
@@ -199,7 +199,7 @@ def _check_tidy3d_extras_available():
         raise Tidy3dImportError(
             "The package 'tidy3d-extras' is absent. "
             "Please install the 'tidy3d-extras' package using, for "
-            "example, 'pip install tidy3d[extras]'."
+            r"example, 'pip install tidy3d\[extras]'."
         )
 
     try:
@@ -209,6 +209,13 @@ def _check_tidy3d_extras_available():
         raise Tidy3dImportError(
             "The package 'tidy3d-extras' did not initialize correctly."
         ) from exc
+
+    if not hasattr(tidy3d_extras_mod, "__version__"):
+        raise Tidy3dImportError(
+            "The package 'tidy3d-extras' did not initialize correctly. "
+            "Please install the 'tidy3d-extras' package using, for "
+            r"example, 'pip install tidy3d\[extras]'."
+        )
 
     version = tidy3d_extras_mod.__version__
 
@@ -222,7 +229,7 @@ def _check_tidy3d_extras_available():
         raise Tidy3dImportError(
             f"The version of 'tidy3d-extras' is {version}, but the version of 'tidy3d' is {__version__}. "
             "They must match. You can install the correct "
-            "version using 'pip install tidy3d[extras]'."
+            r"version using 'pip install tidy3d\[extras]'."
         )
 
     tidy3d_extras["mod"] = tidy3d_extras_mod


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR improves error messaging in the `tidy3d_extras` import checking function by:
- Escaping square brackets in shell command examples (`pip install tidy3d\[extras]`) to prevent them from being interpreted as glob patterns in some shells
- Adding a check for `__version__` attribute existence before attempting to access it, providing a clearer error message when the package didn't initialize properly

**Issue Found:**
- Missing space after period in error message on line 215

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with one minor formatting fix needed
- The changes are straightforward improvements to error messages. The escaped square brackets fix a real issue where shells could interpret the brackets as globs. The added `__version__` check provides better error handling. One syntax issue (missing space) needs correction before merging.
- tidy3d/packaging.py needs a minor spacing fix on line 215

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/packaging.py | 4/5 | Escapes square brackets in error messages and adds `__version__` check; missing space after period on line 215 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Function as _check_tidy3d_extras_available()
    participant ImportSystem as Import System
    participant Module as tidy3d_extras module

    User->>Function: Call function requiring tidy3d_extras
    Function->>Function: Check if already loaded (tidy3d_extras["mod"])
    alt Already loaded
        Function-->>User: Return (skip checks)
    end
    
    Function->>ImportSystem: find_spec("tidy3d_extras")
    alt Module not found
        ImportSystem-->>Function: None
        Function->>User: Raise error with escaped brackets
    end
    
    Function->>Module: import tidy3d_extras
    alt Import fails
        Module-->>Function: ImportError
        Function->>User: Raise Tidy3dImportError
    end
    
    Function->>Module: Check hasattr(__version__)
    alt __version__ missing (NEW CHECK)
        Module-->>Function: False
        Function->>User: Raise error with install instructions
    end
    
    Function->>Module: Get __version__
    alt version is None
        Module-->>Function: None
        Function->>User: Raise error (invalid API key)
    end
    
    alt version mismatch
        Function->>User: Raise error with version info
    end
    
    Function->>Function: Store module reference
    Function-->>User: Success
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->