### PR TITLE
fix: _stored_freqs in MicrowaveModeSolverMonitor

### DIFF
--- a/tests/test_components/test_mode_interp.py
+++ b/tests/test_components/test_mode_interp.py
@@ -885,6 +885,112 @@ def test_mode_solver_with_reduce_data_but_small_num_freqs():
     assert data.interpolated_copy == data
 
 
+@pytest.mark.parametrize(
+    "num_freqs,num_points,reduce_data,expected_stored_len",
+    [
+        # No interp_spec (num_points=None)
+        (10, None, None, 10),
+        # interp_spec with reduce_data=False
+        (10, 5, False, 10),
+        (10, 8, False, 10),
+        # interp_spec with reduce_data=True and num_points < len(monitor.freqs)
+        (20, 5, True, 5),
+        (20, 10, True, 10),
+        # interp_spec with reduce_data=True and num_points >= len(monitor.freqs)
+        (10, 10, True, 10),
+        (10, 15, True, 10),
+        (5, 10, True, 5),
+    ],
+)
+@pytest.mark.parametrize("rf", [False, True])
+def test_mode_solver_data_stored_freqs(num_freqs, num_points, reduce_data, expected_stored_len, rf):
+    """Test that _stored_freqs in ModeSolverData is correct based on interp_spec.
+
+    Cases tested:
+    1. No interp_spec: _stored_freqs matches monitor.freqs
+    2. interp_spec with reduce_data=False: _stored_freqs matches monitor.freqs
+    3. interp_spec with reduce_data=True and num_points < len(monitor.freqs):
+       len(_stored_freqs) == num_points
+    4. interp_spec with reduce_data=True and num_points >= len(monitor.freqs):
+       _stored_freqs matches monitor.freqs
+    """
+    from tidy3d.components.data.data_array import ModeIndexDataArray
+
+    from ..test_data.test_data_arrays import SIM, make_scalar_mode_field_data_array
+
+    freqs = np.linspace(1e14, 2e14, num_freqs)
+
+    # Create mode_spec based on parameters
+    if num_points is None:
+        # No interp_spec
+        mode_spec = td.ModeSpec(
+            num_modes=2,
+            sort_spec=td.ModeSortSpec(track_freq="central"),
+        )
+    else:
+        # With interp_spec
+        mode_spec = td.ModeSpec(
+            num_modes=2,
+            sort_spec=td.ModeSortSpec(track_freq="central"),
+            interp_spec=td.ModeInterpSpec.uniform(
+                num_points=num_points, method="linear", reduce_data=reduce_data
+            ),
+        )
+
+    # Create monitor
+    monitor = td.ModeSolverMonitor(
+        center=(0, 0, 0),
+        size=SIZE_2D,
+        freqs=freqs,
+        mode_spec=mode_spec,
+        name="test_monitor",
+        colocate=False,
+    )
+
+    # Create n_complex with the expected stored frequencies
+    mode_indices = np.arange(2)
+    n_complex_values = (1.5 + 0.1j) * np.ones((expected_stored_len, 2))
+    n_complex = ModeIndexDataArray(
+        n_complex_values,
+        coords={"f": np.linspace(1e14, 2e14, expected_stored_len), "mode_index": mode_indices},
+    )
+
+    # Create ModeSolverData
+    data = td.ModeSolverData(
+        monitor=monitor,
+        Ex=make_scalar_mode_field_data_array("Ex", symmetry=False),
+        Ey=make_scalar_mode_field_data_array("Ey", symmetry=False),
+        Ez=make_scalar_mode_field_data_array("Ez", symmetry=False),
+        Hx=make_scalar_mode_field_data_array("Hx", symmetry=False),
+        Hy=make_scalar_mode_field_data_array("Hy", symmetry=False),
+        Hz=make_scalar_mode_field_data_array("Hz", symmetry=False),
+        n_complex=n_complex,
+        symmetry=(0, 0, 0),
+        symmetry_center=(0, 0, 0),
+        grid_expanded=SIM.discretize_monitor(monitor),
+    )
+
+    if rf:
+        mode_spec = td.MicrowaveModeSpec(**mode_spec.dict(exclude={"type"}))
+        monitor = td.MicrowaveModeSolverMonitor(
+            **monitor.dict(exclude={"type", "mode_spec"}), mode_spec=mode_spec
+        )
+        data = td.ModeSolverData(**data.dict(exclude={"type", "monitor"}), monitor=monitor)
+
+    # Check _stored_freqs length
+    assert len(data.monitor._stored_freqs) == expected_stored_len, (
+        f"Expected _stored_freqs length {expected_stored_len}, "
+        f"got {len(data.monitor._stored_freqs)}"
+    )
+
+    # Check that monitor.freqs always matches original freqs
+    assert len(data.monitor.freqs) == num_freqs
+    assert np.allclose(data.monitor.freqs, freqs)
+
+    # Check data shape matches _stored_freqs
+    assert data.n_complex.shape[0] == expected_stored_len
+
+
 # ============================================================================
 # Monitor Integration Tests (Phase 6)
 # ============================================================================

--- a/tidy3d/components/microwave/data/monitor_data.py
+++ b/tidy3d/components/microwave/data/monitor_data.py
@@ -8,6 +8,7 @@ from typing import Literal, Optional
 
 import pydantic.v1 as pd
 import xarray as xr
+from typing_extensions import Self
 
 from tidy3d.components.data.data_array import FieldProjectionAngleDataArray, FreqDataArray
 from tidy3d.components.data.monitor_data import DirectivityData, ModeData, ModeSolverData
@@ -201,7 +202,95 @@ class AntennaMetricsData(DirectivityData, MicrowaveBaseModel):
         return partial_G.Gtheta + partial_G.Gphi
 
 
-class MicrowaveModeData(ModeData, MicrowaveBaseModel):
+class MicrowaveModeDataBase(MicrowaveBaseModel):
+    """Base class for microwave mode data that extends standard mode data with RF/microwave features.
+
+    This base class adds microwave-specific functionality to mode data classes, including:
+
+    - **Transmission line data**: Characteristic impedance (Z0), voltage coefficients, and
+      current coefficients for transmission line analysis
+    - **Enhanced modes_info**: Includes impedance data in the mode properties dataset
+    - **Group index handling**: Properly filters transmission line data when computing group indices
+    - **Mode reordering**: Ensures transmission line data tracks with reordered modes
+
+    Notes
+    -----
+    This is a mixin class that must be combined with mode data classes (:class:`.ModeData` or
+    :class:`.ModeSolverData`). It uses ``super()`` to call methods on the mixed-in class, extending
+    their functionality rather than replacing it.
+
+    The mixin should be placed first in the inheritance list to ensure its method overrides
+    are used.
+    """
+
+    transmission_line_data: Optional[TransmissionLineDataset] = pd.Field(
+        None,
+        title="Transmission Line Data",
+        description="Additional data relevant to transmission lines in RF and microwave applications, "
+        "like characteristic impedance. This field is populated when a :class:`MicrowaveModeSpec` has "
+        "been used to set up the monitor or mode solver.",
+    )
+
+    @property
+    def modes_info(self) -> xr.Dataset:
+        """Dataset collecting various properties of the stored modes."""
+        super_info = super().modes_info
+
+        # Add transmission line data if present
+        if self.transmission_line_data is not None:
+            super_info["Re(Z0)"] = self.transmission_line_data.Z0.real
+            super_info["Im(Z0)"] = self.transmission_line_data.Z0.imag
+        return super_info
+
+    def _group_index_post_process(self, frequency_step: float) -> Self:
+        """Calculate group index and remove added frequencies used only for this calculation.
+
+        Parameters
+        ----------
+        frequency_step: float
+            Fractional frequency step used to calculate the group index.
+
+        Returns
+        -------
+        Self
+            Filtered data with calculated group index.
+        """
+        super_data = super()._group_index_post_process(frequency_step)
+
+        # Add transmission line data handling if present
+        if self.transmission_line_data is not None:
+            _, center_inds, _ = self._group_index_freq_slices()
+            update_dict = {
+                "Z0": self.transmission_line_data.Z0.isel(f=center_inds),
+                "voltage_coeffs": self.transmission_line_data.voltage_coeffs.isel(f=center_inds),
+                "current_coeffs": self.transmission_line_data.current_coeffs.isel(f=center_inds),
+            }
+            super_data = super_data.updated_copy(**update_dict, path="transmission_line_data")
+        return super_data
+
+    def _apply_mode_reorder(self, sort_inds_2d):
+        """Apply a mode reordering along mode_index for all frequency indices.
+
+        Parameters
+        ----------
+        sort_inds_2d : np.ndarray
+            Array of shape (num_freqs, num_modes) where each row is the
+            permutation to apply to the mode_index for that frequency.
+        """
+        main_data_reordered = super()._apply_mode_reorder(sort_inds_2d)
+
+        # Add transmission line data handling if present
+        if self.transmission_line_data is not None:
+            transmission_line_data_reordered = self.transmission_line_data._apply_mode_reorder(
+                sort_inds_2d
+            )
+            main_data_reordered = main_data_reordered.updated_copy(
+                transmission_line_data=transmission_line_data_reordered
+            )
+        return main_data_reordered
+
+
+class MicrowaveModeData(MicrowaveModeDataBase, ModeData):
     """
     Data associated with a :class:`.ModeMonitor` for microwave and RF applications: modal amplitudes,
     propagation indices, mode profiles, and transmission line data.
@@ -264,68 +353,8 @@ class MicrowaveModeData(ModeData, MicrowaveBaseModel):
         ..., title="Monitor", description="Mode monitor associated with the data."
     )
 
-    transmission_line_data: Optional[TransmissionLineDataset] = pd.Field(
-        None,
-        title="Transmission Line Data",
-        description="Additional data relevant to transmission lines in RF and microwave applications, "
-        "like characteristic impedance. This field is populated when a :class:`MicrowaveModeSpec` has "
-        "been used to set up the monitor or mode solver.",
-    )
 
-    @property
-    def modes_info(self) -> xr.Dataset:
-        """Dataset collecting various properties of the stored modes."""
-        super_info = super().modes_info
-        if self.transmission_line_data is not None:
-            super_info["Re(Z0)"] = self.transmission_line_data.Z0.real
-            super_info["Im(Z0)"] = self.transmission_line_data.Z0.imag
-        return super_info
-
-    def _group_index_post_process(self, frequency_step: float) -> ModeData:
-        """Calculate group index and remove added frequencies used only for this calculation.
-
-        Parameters
-        ----------
-        frequency_step: float
-            Fractional frequency step used to calculate the group index.
-
-        Returns
-        -------
-        :class:`.ModeData`
-            Filtered data with calculated group index.
-        """
-        super_data = super()._group_index_post_process(frequency_step)
-        if self.transmission_line_data is not None:
-            _, center_inds, _ = self._group_index_freq_slices()
-            update_dict = {
-                "Z0": self.transmission_line_data.Z0.isel(f=center_inds),
-                "voltage_coeffs": self.transmission_line_data.voltage_coeffs.isel(f=center_inds),
-                "current_coeffs": self.transmission_line_data.current_coeffs.isel(f=center_inds),
-            }
-            super_data = super_data.updated_copy(**update_dict, path="transmission_line_data")
-        return super_data
-
-    def _apply_mode_reorder(self, sort_inds_2d):
-        """Apply a mode reordering along mode_index for all frequency indices.
-
-        Parameters
-        ----------
-        sort_inds_2d : np.ndarray
-            Array of shape (num_freqs, num_modes) where each row is the
-            permutation to apply to the mode_index for that frequency.
-        """
-        main_data_reordered = super()._apply_mode_reorder(sort_inds_2d)
-        if self.transmission_line_data is not None:
-            transmission_line_data_reordered = self.transmission_line_data._apply_mode_reorder(
-                sort_inds_2d
-            )
-            main_data_reordered = main_data_reordered.updated_copy(
-                transmission_line_data=transmission_line_data_reordered
-            )
-        return main_data_reordered
-
-
-class MicrowaveModeSolverData(ModeSolverData, MicrowaveModeData):
+class MicrowaveModeSolverData(MicrowaveModeDataBase, ModeSolverData):
     """
     Data associated with a :class:`.ModeSolverMonitor` for microwave and RF applications: scalar components
     of E and H fields plus characteristic impedance data.

--- a/tidy3d/components/microwave/monitor.py
+++ b/tidy3d/components/microwave/monitor.py
@@ -68,3 +68,8 @@ class MicrowaveModeSolverMonitor(MicrowaveModeMonitor, ModeSolverMonitor):
     ...     mode_spec=mode_spec,
     ...     name='mode_monitor')
     """
+
+    @property
+    def _stored_freqs(self) -> list[float]:
+        """Return actually stored frequencies of the data."""
+        return self.mode_spec._sampling_freqs_mode_solver_data(freqs=self.freqs)

--- a/tidy3d/components/microwave/monitor.py
+++ b/tidy3d/components/microwave/monitor.py
@@ -9,7 +9,27 @@ from tidy3d.components.microwave.mode_spec import MicrowaveModeSpec
 from tidy3d.components.monitor import ModeMonitor, ModeSolverMonitor
 
 
-class MicrowaveModeMonitor(MicrowaveBaseModel, ModeMonitor):
+class MicrowaveModeMonitorBase(MicrowaveBaseModel):
+    """Base class for microwave mode monitors that use :class:`.MicrowaveModeSpec`.
+
+    This mixin provides the ``mode_spec`` field configured for RF and microwave applications,
+    including characteristic impedance calculations and transmission line analysis.
+
+    Notes
+    -----
+    This is a mixin class that provides the :class:`.MicrowaveModeSpec` field for mode monitors.
+    It must be placed first in the inheritance list to ensure its ``mode_spec`` field takes
+    precedence over the base :class:`.ModeSpec` field from :class:`.AbstractModeMonitor`.
+    """
+
+    mode_spec: MicrowaveModeSpec = pydantic.Field(
+        default_factory=MicrowaveModeSpec._default_without_license_warning,
+        title="Mode Specification",
+        description="Parameters to feed to mode solver which determine modes measured by monitor.",
+    )
+
+
+class MicrowaveModeMonitor(MicrowaveModeMonitorBase, ModeMonitor):
     """:class:`Monitor` that records amplitudes from modal decomposition of fields on plane.
 
     Notes
@@ -47,14 +67,8 @@ class MicrowaveModeMonitor(MicrowaveBaseModel, ModeMonitor):
         * `ModalSourcesMonitors <../../notebooks/ModalSourcesMonitors.html>`_
     """
 
-    mode_spec: MicrowaveModeSpec = pydantic.Field(
-        default_factory=MicrowaveModeSpec._default_without_license_warning,
-        title="Mode Specification",
-        description="Parameters to feed to mode solver which determine modes measured by monitor.",
-    )
 
-
-class MicrowaveModeSolverMonitor(MicrowaveModeMonitor, ModeSolverMonitor):
+class MicrowaveModeSolverMonitor(MicrowaveModeMonitorBase, ModeSolverMonitor):
     """:class:`Monitor` that stores the mode field profiles returned by the mode solver in the
     monitor plane.
 
@@ -68,8 +82,3 @@ class MicrowaveModeSolverMonitor(MicrowaveModeMonitor, ModeSolverMonitor):
     ...     mode_spec=mode_spec,
     ...     name='mode_monitor')
     """
-
-    @property
-    def _stored_freqs(self) -> list[float]:
-        """Return actually stored frequencies of the data."""
-        return self.mode_spec._sampling_freqs_mode_solver_data(freqs=self.freqs)


### PR DESCRIPTION
This is a little bit silly: while `MicrowaveModeSolverData` is inherited `ModeSolverData`, which contains the correct `_stored_freqs`, it also is inherited from `MicrowaveModeData`, which takes the priority and which is, in its turn, inherited from `ModeData`, with `_stored_freqs` incompatible with `ModeSolverData`/`MicrowaveModeSolverData`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixes a Python Method Resolution Order (MRO) bug in `MicrowaveModeSolverMonitor` where the `_stored_freqs` property was returning incorrect values due to inheritance priority.

**The Issue:**
- `MicrowaveModeSolverMonitor` inherits from both `MicrowaveModeMonitor` (which inherits `ModeMonitor`) and `ModeSolverMonitor`
- Python's MRO gives priority to `MicrowaveModeMonitor`, which inherits `_stored_freqs` from `ModeMonitor` (returns all frequencies)
- But `ModeSolverMonitor._stored_freqs` correctly handles frequency reduction with `interp_spec` by calling `mode_spec._sampling_freqs_mode_solver_data`
- Result: `MicrowaveModeSolverMonitor` was using the wrong implementation that ignored `interp_spec` settings

**The Fix:**
- Added explicit `_stored_freqs` property override in `MicrowaveModeSolverMonitor` that calls `mode_spec._sampling_freqs_mode_solver_data`
- Added comprehensive parametrized test covering various scenarios with/without `interp_spec` and `reduce_data` flags
- Test validates both regular `ModeSolverMonitor` and `MicrowaveModeSolverMonitor` behavior (via `rf` parameter)

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The fix is surgical and correct - it adds a 3-line property override that resolves a specific MRO inheritance bug. The implementation mirrors the existing `ModeSolverMonitor._stored_freqs` logic exactly. Comprehensive test coverage verifies the fix across multiple scenarios including edge cases.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/microwave/monitor.py | 5/5 | Added `_stored_freqs` property override to fix MRO inheritance issue with mode solver data storage |
| tests/test_components/test_mode_interp.py | 5/5 | Added comprehensive parametrized test to verify `_stored_freqs` behavior for both regular and microwave mode solver monitors |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant MicrowaveModeSolverMonitor
    participant MicrowaveModeMonitor
    participant ModeMonitor
    participant ModeSolverMonitor
    
    Note over MicrowaveModeSolverMonitor: Class hierarchy: MicrowaveModeSolverMonitor(MicrowaveModeMonitor, ModeSolverMonitor)
    Note over MicrowaveModeMonitor: MicrowaveModeMonitor inherits from ModeMonitor
    Note over ModeMonitor: ModeMonitor._stored_freqs returns self.freqs (all frequencies)
    Note over ModeSolverMonitor: ModeSolverMonitor._stored_freqs calls mode_spec._sampling_freqs_mode_solver_data (reduced frequencies with interp_spec)
    
    User->>MicrowaveModeSolverMonitor: Access _stored_freqs property
    
    rect rgb(255, 200, 200)
        Note over MicrowaveModeSolverMonitor: BEFORE FIX: MRO looks up MicrowaveModeMonitor first
        MicrowaveModeSolverMonitor->>MicrowaveModeMonitor: Check for _stored_freqs
        MicrowaveModeMonitor->>ModeMonitor: Inherit _stored_freqs
        ModeMonitor-->>MicrowaveModeSolverMonitor: Returns self.freqs (WRONG - ignores interp_spec)
    end
    
    rect rgb(200, 255, 200)
        Note over MicrowaveModeSolverMonitor: AFTER FIX: Override _stored_freqs directly
        MicrowaveModeSolverMonitor->>MicrowaveModeSolverMonitor: Use own _stored_freqs
        MicrowaveModeSolverMonitor->>MicrowaveModeSolverMonitor: Call mode_spec._sampling_freqs_mode_solver_data
        MicrowaveModeSolverMonitor-->>User: Returns reduced frequencies (CORRECT - respects interp_spec)
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->