### PR TITLE
chore: remove jedi typing (FXC-4160)

### DIFF
--- a/tidy3d/web/core/http_util.py
+++ b/tidy3d/web/core/http_util.py
@@ -6,10 +6,9 @@ import json
 import os
 from enum import Enum
 from functools import wraps
-from typing import Any, Optional, TypeAlias
+from typing import Any, Callable, Optional, TypeAlias
 
 import requests
-from jedi.inference.gradual.typing import Callable
 from requests.adapters import HTTPAdapter
 from urllib3.util.ssl_ import create_urllib3_context
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds `jedi` as a required dependency to fix an import error in `tidy3d/web/core/http_util.py:12`
- The file incorrectly imports `Callable` from `jedi.inference.gradual.typing` (an internal jedi API) instead of from the standard library `typing.Callable`
- This PR treats the symptom rather than the root cause; the import should be fixed to use `typing.Callable` and jedi removed from required dependencies

<h3>Confidence Score: 3/5</h3>


- This PR works but adds an unnecessary dependency due to an incorrect import that should be fixed
- The changes are technically correct and will resolve the immediate import error, but they address the symptom rather than fixing the root cause. The code imports `Callable` from an internal jedi module (`jedi.inference.gradual.typing`) instead of from Python's standard library (`typing`), which is incorrect and adds bloat to the dependency tree
- Pay close attention to pyproject.toml - the jedi dependency should be removed once the incorrect import is fixed

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pyproject.toml | Added `jedi = "^0.19"` as a required dependency (line 44) to fix import error in tidy3d/web/core/http_util.py:12, but the root cause should be addressed |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as "Developer"
    participant PR as "This PR"
    participant Deps as "Dependencies"
    participant Code as "http_util.py"
    
    Dev->>Code: "Import Callable from jedi (incorrect)"
    Code->>Deps: "Requires jedi package"
    Deps-->>Code: "Error: jedi not installed"
    Dev->>PR: "Add jedi to pyproject.toml"
    PR->>Deps: "Install jedi as required dependency"
    Deps-->>Code: "jedi now available"
    Code->>Code: "Import works (but still incorrect)"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->