### PR TITLE
fix: Setting visualization doping limits

### DIFF
--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -2002,6 +2002,9 @@ class Scene(Tidy3dBaseModel):
                         if max_value > limits[1]:
                             limits[1] = max_value
                     if isinstance(doping, tuple):
+                        if len(doping) == 0:
+                            limits[0] = 0
+                            limits[1] = 0
                         for doping_box in doping:
                             if isinstance(doping_box, ConstantDoping):
                                 if doping_box.concentration < limits[0]:

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -2002,9 +2002,6 @@ class Scene(Tidy3dBaseModel):
                         if max_value > limits[1]:
                             limits[1] = max_value
                     if isinstance(doping, tuple):
-                        if len(doping) == 0:
-                            limits[0] = 0
-                            limits[1] = 0
                         for doping_box in doping:
                             if isinstance(doping_box, ConstantDoping):
                                 if doping_box.concentration < limits[0]:
@@ -2023,6 +2020,15 @@ class Scene(Tidy3dBaseModel):
                                     limits[0] = min_value
                                 if max_value > limits[1]:
                                     limits[1] = max_value
+        # make sure we have recorded some values. Otherwise, set to 0
+        if acceptors_lims[0] == 1e50:
+            acceptors_lims[0] = 0
+        if acceptors_lims[1] == -1e50:
+            acceptors_lims[1] = 0
+        if donors_lims[0] == 1e50:
+            donors_lims[0] = 0
+        if donors_lims[1] == -1e50:
+            donors_lims[1] = 0
         return acceptors_lims, donors_lims
 
     def doping_absolute_minimum(self):


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Fixed visualization doping limits to be set to `[0, 0]` when an empty tuple is provided for doping concentrations
- The fix addresses the issue where limits initialized to `[1e50, -1e50]` would remain at extreme values when no doping structures exist

<h3>Confidence Score: 1/5</h3>


- This PR contains a critical logic bug that needs to be fixed before merging
- The implementation resets doping limits to [0, 0] inside the structure iteration loop, which causes limits from structures with actual doping values to be overwritten when a subsequent structure has an empty doping tuple. This will produce incorrect visualization bounds when multiple semiconductor structures exist with mixed doping configurations.
- Pay close attention to `tidy3d/components/scene.py` - the logic for resetting limits needs to be moved outside the loop

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/components/scene.py | Added check for empty doping tuples to set visualization limits to 0, but logic error causes limits to be reset incorrectly when multiple structures exist |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Scene
    participant SemiconductorMedium
    participant DopingLimits
    
    User->>Scene: plot doping visualization
    Scene->>Scene: doping_bounds()
    Scene->>DopingLimits: initialize [1e50, -1e50]
    loop for each structure
        Scene->>SemiconductorMedium: get N_a, N_d
        alt doping is tuple
            alt tuple is empty
                Scene->>DopingLimits: set [0, 0]
            else tuple has values
                Scene->>DopingLimits: update min/max
            end
        end
    end
    Scene->>User: return limits
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->