### PR TITLE
Hotfix/fix scene doping limits

### DIFF
--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -1979,8 +1979,8 @@ class Scene(Tidy3dBaseModel):
     def doping_bounds(self):
         """Get the maximum and minimum of the doping"""
 
-        acceptors_lims = [1e50, -1e50]
-        donors_lims = [1e50, -1e50]
+        acceptors_lims = [np.inf, -np.inf]
+        donors_lims = [np.inf, -np.inf]
 
         for struct in self.all_structures:
             if isinstance(struct.medium.charge, SemiconductorMedium):
@@ -2020,6 +2020,15 @@ class Scene(Tidy3dBaseModel):
                                     limits[0] = min_value
                                 if max_value > limits[1]:
                                     limits[1] = max_value
+        # make sure we have recorded some values. Otherwise, set to 0
+        if np.isinf(acceptors_lims[0]):
+            acceptors_lims[0] = 0
+        if np.isinf(acceptors_lims[1]):
+            acceptors_lims[1] = 0
+        if np.isinf(donors_lims[0]):
+            donors_lims[0] = 0
+        if np.isinf(donors_lims[1]):
+            donors_lims[1] = 0
         return acceptors_lims, donors_lims
 
     def doping_absolute_minimum(self):


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Fixed `doping_bounds()` to return `[0, 0]` instead of sentinel values `[1e50, -1e50]` when no doping structures are present
- This prevents invalid visualization limits when scenes lack semiconductor doping configurations

<h3>Confidence Score: 3/5</h3>


- This PR fixes a visualization bug but uses direct float equality which could fail in edge cases
- The fix correctly handles the empty doping case but violates the floating-point comparison best practice (custom rule 4a0cb6d3). Direct equality `== 1e50` should use `np.isclose()` for robustness. The logic is sound but the implementation needs a minor correction.
- Pay attention to `tidy3d/components/scene.py` - the sentinel value checks need tolerance-based comparison

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/components/scene.py | Added sentinel value checks to handle empty doping case, but uses direct float equality instead of tolerance-based comparison |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Scene
    participant doping_bounds
    participant Structures

    User->>Scene: "Visualize doping properties (N_a, N_d, or doping)"
    Scene->>doping_bounds: "Calculate doping bounds"
    doping_bounds->>Structures: "Loop through all_structures"
    alt Structures with SemiconductorMedium found
        Structures-->>doping_bounds: "Update acceptors_lims and donors_lims"
    else No structures with doping
        Structures-->>doping_bounds: "Limits remain at sentinel values [1e50, -1e50]"
    end
    doping_bounds->>doping_bounds: "Check if limits are still at sentinel values"
    alt Limits are sentinel values
        doping_bounds->>doping_bounds: "Set limits to [0, 0]"
    end
    doping_bounds-->>Scene: "Return acceptors_lims, donors_lims"
    Scene-->>User: "Use limits for visualization"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->