### PR TITLE
chore: rf namespace and consolidation (FXC-3912, FXC-3965)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,19 +41,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `interp_spec` in `EMEModeSpec` to enable faster multi-frequency EME simulations. Note that the default is now `ModeInterpSpec.cheb(num_points=3, reduce_data=True)`; previously the computation was repeated at all frequencies.
 - Added `smoothed_projection` for topology optimization of completely binarized designs.
 - Added more RF-specific mode characteristics to `MicrowaveModeData`, including propagation constants (alpha, beta, gamma), phase/group velocities, wave impedance, and automatic mode classification with configurable polarization thresholds in `MicrowaveModeSpec`.
+- Introduce `tidy3d.rf` namespace to consolidate all RF classes.
 
 ### Breaking Changes
 - Edge singularity correction at PEC and lossy metal edges defaults to `True`.
 - `angle_threshold` in `CornerFinderSpec` now defaults to `pi/4`.
-**Note: These breaking changes only affect the microwave and smatrix plugins.**
-- Renamed path integral classes for improved consistency. Please see our migration guide for details on updating your code.
+- `WavePort` has been refactored to use `MicrowaveModeSpec`. The fields `voltage_integral`, and `current_integral` have been removed. Impedance specifications are now defined in `MicrowaveModeSpec.impedance_specs`. Please see our migration guide for details on updating your code.
+
+### Planned Deprecation
+**Note: These changes only affect the microwave and smatrix plugins.**
+- Renamed path integral classes for improved consistency. Please see our migration guide for details on updating your code. Old class naming is aliased to the new classes for 2.10.
   - `VoltageIntegralAxisAligned` → `AxisAlignedVoltageIntegral`
   - `CurrentIntegralAxisAligned` → `AxisAlignedCurrentIntegral`
   - `CustomPathIntegral2D` → `Custom2DPathIntegral`
   - `CustomVoltageIntegral2D` → `Custom2DVoltageIntegral`
   - `CustomCurrentIntegral2D` → `Custom2DCurrentIntegral`
   - Path integral and impedance calculator classes have been refactored and moved from the microwave plugin into Tidy3D components. They are now publicly exported via the top-level package `__init__.py`.
-- `WavePort` has been refactored to use `MicrowaveModeSpec`. The fields `voltage_integral`, and `current_integral` have been removed. Impedance specifications are now defined in `MicrowaveModeSpec.impedance_specs`. Please see our migration guide for details on updating your code.
 
 ### Changed
 - Improved performance of antenna metrics calculation by utilizing cached wave amplitude calculations instead of recomputing wave amplitudes for each port excitation in the `TerminalComponentModelerData`.

--- a/tests/rf/test_rf_import.py
+++ b/tests/rf/test_rf_import.py
@@ -1,0 +1,10 @@
+"""Test that the rf namespace is correctly populated."""
+
+from __future__ import annotations
+
+import tidy3d.rf
+
+
+def test_rf_import():
+    """Test that tidy3d.rf can be imported."""
+    assert tidy3d.rf is not None

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -484,6 +484,12 @@ Transformed.update_forward_refs()
 ClipOperation.update_forward_refs()
 GeometryGroup.update_forward_refs()
 
+# Backwards compatibility: Remove 2.11 renamed integral classes
+VoltageIntegralAxisAligned = AxisAlignedVoltageIntegral
+CurrentIntegralAxisAligned = AxisAlignedCurrentIntegral
+CustomVoltageIntegral2D = Custom2DVoltageIntegral
+CustomCurrentIntegral2D = Custom2DCurrentIntegral
+
 __all__ = [
     "C_0",
     "DATA_TYPE_MAP",
@@ -549,12 +555,14 @@ __all__ = [
     "Coords1D",
     "CornerFinderSpec",
     "CurrentBC",
+    "CurrentIntegralAxisAligned",  # Backwards compatibility alias
     "Custom2DCurrentIntegral",
     "Custom2DCurrentIntegralSpec",
     "Custom2DVoltageIntegral",
     "Custom2DVoltageIntegralSpec",
     "CustomAnisotropicMedium",
     "CustomChargePerturbation",
+    "CustomCurrentIntegral2D",  # Backwards compatibility alias
     "CustomCurrentSource",
     "CustomDebye",
     "CustomDoping",
@@ -570,6 +578,7 @@ __all__ = [
     "CustomSampling",
     "CustomSellmeier",
     "CustomSourceTime",
+    "CustomVoltageIntegral2D",  # Backwards compatibility alias
     "Cylinder",
     "DCCurrentSource",
     "DCVoltageSource",
@@ -830,6 +839,7 @@ __all__ = [
     "VerticalNaturalConvectionCoeffModel",
     "VisualizationSpec",
     "VoltageBC",
+    "VoltageIntegralAxisAligned",  # Backwards compatibility alias
     "VoltageSourceType",
     "VolumeMeshData",
     "VolumeMeshMonitor",

--- a/tidy3d/plugins/microwave/__init__.py
+++ b/tidy3d/plugins/microwave/__init__.py
@@ -40,9 +40,14 @@ from .array_factor import (
 from .lobe_measurer import LobeMeasurer
 from .rf_material_library import rf_material_library
 
-# Backwards compatibility
+# Backwards compatibility: Remove 2.11 renamed integral classes
 CurrentIntegralTypes = CurrentIntegralType
 VoltageIntegralTypes = VoltageIntegralType
+VoltageIntegralAxisAligned = AxisAlignedVoltageIntegral
+CurrentIntegralAxisAligned = AxisAlignedCurrentIntegral
+CustomPathIntegral2D = Custom2DPathIntegral
+CustomVoltageIntegral2D = Custom2DVoltageIntegral
+CustomCurrentIntegral2D = Custom2DCurrentIntegral
 
 __all__ = [
     "AxisAlignedCurrentIntegral",
@@ -52,10 +57,14 @@ __all__ = [
     "BlackmanWindow",
     "ChebWindow",
     "CompositeCurrentIntegral",
+    "CurrentIntegralAxisAligned",  # Backwards compatibility alias
     "CurrentIntegralTypes",
     "Custom2DCurrentIntegral",
     "Custom2DPathIntegral",
     "Custom2DVoltageIntegral",
+    "CustomCurrentIntegral2D",  # Backwards compatibility alias
+    "CustomPathIntegral2D",  # Backwards compatibility alias
+    "CustomVoltageIntegral2D",  # Backwards compatibility alias
     "HammingWindow",
     "HannWindow",
     "ImpedanceCalculator",
@@ -65,6 +74,7 @@ __all__ = [
     "RectangularAntennaArrayCalculator",
     "RectangularTaper",
     "TaylorWindow",
+    "VoltageIntegralAxisAligned",  # Backwards compatibility alias
     "VoltageIntegralTypes",
     "models",
     "path_integrals_from_lumped_element",

--- a/tidy3d/rf.py
+++ b/tidy3d/rf.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import warnings
+
+# Boundary
+from tidy3d.components.boundary import InternalAbsorber
+
+# Directivity monitor
+from tidy3d.components.data.monitor_data import DirectivityData
+
+# Frequency extrapolation
+from tidy3d.components.frequency_extrapolation import LowFrequencySmoothingSpec
+
+# Grid spec
+from tidy3d.components.grid.grid_spec import CornerFinderSpec, LayerRefinementSpec
+
+# Lumped elements
+from tidy3d.components.lumped_element import (
+    AdmittanceNetwork,
+    CoaxialLumpedResistor,
+    LinearLumpedElement,
+    LumpedResistor,
+    RectangularLumpedElement,
+    RLCNetwork,
+)
+
+# Material
+from tidy3d.components.medium import (
+    HammerstadSurfaceRoughness,
+    HuraySurfaceRoughness,
+    LossyMetalMedium,
+    SurfaceImpedanceFitterParam,
+)
+
+# Microwave data
+from tidy3d.components.microwave.data.monitor_data import (
+    AntennaMetricsData,
+    MicrowaveModeData,
+    MicrowaveModeSolverData,
+)
+
+# Impedance calculator
+from tidy3d.components.microwave.impedance_calculator import (
+    CurrentIntegralType,
+    ImpedanceCalculator,
+    VoltageIntegralType,
+)
+
+# Microwave mode spec
+from tidy3d.components.microwave.mode_spec import MicrowaveModeSpec
+
+# Microwave monitors
+from tidy3d.components.microwave.monitor import MicrowaveModeMonitor, MicrowaveModeSolverMonitor
+
+# Path integrals (actual integrals, not specs)
+from tidy3d.components.microwave.path_integrals.integrals.auto import (
+    path_integrals_from_lumped_element,
+)
+from tidy3d.components.microwave.path_integrals.integrals.base import (
+    AxisAlignedPathIntegral,
+    Custom2DPathIntegral,
+)
+from tidy3d.components.microwave.path_integrals.integrals.current import (
+    AxisAlignedCurrentIntegral,
+    CompositeCurrentIntegral,
+    Custom2DCurrentIntegral,
+)
+from tidy3d.components.microwave.path_integrals.integrals.voltage import (
+    AxisAlignedVoltageIntegral,
+    Custom2DVoltageIntegral,
+)
+
+# Path integral specs
+from tidy3d.components.microwave.path_integrals.specs.current import (
+    AxisAlignedCurrentIntegralSpec,
+    CompositeCurrentIntegralSpec,
+    Custom2DCurrentIntegralSpec,
+)
+from tidy3d.components.microwave.path_integrals.specs.impedance import (
+    AutoImpedanceSpec,
+    CustomImpedanceSpec,
+)
+from tidy3d.components.microwave.path_integrals.specs.voltage import (
+    AxisAlignedVoltageIntegralSpec,
+    Custom2DVoltageIntegralSpec,
+)
+from tidy3d.components.monitor import DirectivityMonitor
+
+# Source frame
+from tidy3d.components.source.frame import PECFrame
+
+# Subpixel spec
+from tidy3d.components.subpixel_spec import SurfaceImpedance
+from tidy3d.plugins.microwave import models
+from tidy3d.plugins.microwave.array_factor import (
+    BlackmanHarrisWindow,
+    BlackmanWindow,
+    ChebWindow,
+    HammingWindow,
+    HannWindow,
+    KaiserWindow,
+    RadialTaper,
+    RectangularAntennaArrayCalculator,
+    RectangularTaper,
+    TaylorWindow,
+)
+from tidy3d.plugins.microwave.lobe_measurer import LobeMeasurer
+from tidy3d.plugins.microwave.rf_material_library import rf_material_library
+from tidy3d.plugins.smatrix.component_modelers.base import (
+    AbstractComponentModeler,
+)
+from tidy3d.plugins.smatrix.component_modelers.terminal import (
+    DirectivityMonitorSpec,
+    ModelerLowFrequencySmoothingSpec,
+    TerminalComponentModeler,
+)
+from tidy3d.plugins.smatrix.component_modelers.types import ComponentModelerType
+from tidy3d.plugins.smatrix.data.data_array import (
+    PortDataArray,
+    TerminalPortDataArray,
+)
+from tidy3d.plugins.smatrix.data.terminal import (
+    MicrowaveSMatrixData,
+    TerminalComponentModelerData,
+)
+from tidy3d.plugins.smatrix.data.types import ComponentModelerDataType
+from tidy3d.plugins.smatrix.ports.coaxial_lumped import CoaxialLumpedPort
+from tidy3d.plugins.smatrix.ports.rectangular_lumped import LumpedPort
+from tidy3d.plugins.smatrix.ports.wave import WavePort
+
+# Backwards compatibility
+CurrentIntegralTypes = CurrentIntegralType
+VoltageIntegralTypes = VoltageIntegralType
+# Instantiate on plugin import till we unite with toplevel
+warnings.filterwarnings(
+    "once",
+    message="ℹ️ ⚠️ RF simulations are subject to new license requirements in the future. You have instantiated at least one RF-specific component.",
+    category=FutureWarning,
+)
+
+
+__all__ = [
+    "AbstractComponentModeler",
+    "AdmittanceNetwork",
+    "AntennaMetricsData",
+    "AutoImpedanceSpec",
+    "AxisAlignedCurrentIntegral",
+    "AxisAlignedCurrentIntegralSpec",
+    "AxisAlignedPathIntegral",
+    "AxisAlignedVoltageIntegral",
+    "AxisAlignedVoltageIntegralSpec",
+    "BlackmanHarrisWindow",
+    "BlackmanWindow",
+    "ChebWindow",
+    "CoaxialLumpedPort",
+    "CoaxialLumpedResistor",
+    "ComponentModelerDataType",
+    "ComponentModelerType",
+    "CompositeCurrentIntegral",
+    "CompositeCurrentIntegralSpec",
+    "CornerFinderSpec",
+    "CurrentIntegralTypes",
+    "Custom2DCurrentIntegral",
+    "Custom2DCurrentIntegralSpec",
+    "Custom2DPathIntegral",
+    "Custom2DVoltageIntegral",
+    "Custom2DVoltageIntegralSpec",
+    "CustomImpedanceSpec",
+    "DirectivityData",
+    "DirectivityMonitor",
+    "DirectivityMonitorSpec",
+    "HammerstadSurfaceRoughness",
+    "HammingWindow",
+    "HannWindow",
+    "HuraySurfaceRoughness",
+    "ImpedanceCalculator",
+    "InternalAbsorber",
+    "KaiserWindow",
+    "LayerRefinementSpec",
+    "LinearLumpedElement",
+    "LobeMeasurer",
+    "LossyMetalMedium",
+    "LowFrequencySmoothingSpec",
+    "LumpedPort",
+    "LumpedResistor",
+    "MicrowaveModeData",
+    "MicrowaveModeMonitor",
+    "MicrowaveModeSolverData",
+    "MicrowaveModeSolverMonitor",
+    "MicrowaveModeSpec",
+    "MicrowaveSMatrixData",
+    "ModelerLowFrequencySmoothingSpec",
+    "PECFrame",
+    "PortDataArray",
+    "RLCNetwork",
+    "RadialTaper",
+    "RectangularAntennaArrayCalculator",
+    "RectangularLumpedElement",
+    "RectangularTaper",
+    "SurfaceImpedance",
+    "SurfaceImpedanceFitterParam",
+    "TaylorWindow",
+    "TerminalComponentModeler",
+    "TerminalComponentModelerData",
+    "TerminalPortDataArray",
+    "VoltageIntegralTypes",
+    "WavePort",
+    "models",
+    "path_integrals_from_lumped_element",
+    "rf_material_library",
+]


### PR DESCRIPTION
* `from tidy3d.rf import *`
* Backwards compatible changes

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR introduces a new `tidy3d.rf` namespace to consolidate all RF-related classes from the microwave and smatrix plugins, making them accessible via `from tidy3d.rf import *`. The PR also adds backwards compatibility aliases for renamed path integral classes in both the top-level package and microwave plugin.

Key changes:
- Created new `tidy3d/rf.py` module that exports all RF classes from microwave and smatrix plugins
- Added backwards compatibility aliases in `tidy3d/__init__.py` for four renamed integral classes
- Added backwards compatibility aliases in `tidy3d/plugins/microwave/__init__.py` for all five renamed integral classes
- Updated `CHANGELOG.md` to document the new namespace and reorganize breaking changes into "Breaking Changes" and "Planned Deprecation" sections

**Critical issue found**: The new `tidy3d.rf` module is missing the `CustomPathIntegral2D` backwards compatibility alias that exists in the microwave plugin. This breaks backwards compatibility for users importing from the new RF namespace.

<h3>Confidence Score: 2/5</h3>


- This PR has a critical backwards compatibility issue that will cause runtime errors for users
- Score reflects a critical missing backwards compatibility alias (`CustomPathIntegral2D`) in the new RF namespace that exists in the microwave plugin, which will break user code that relies on the deprecated class name when importing from `tidy3d.rf`. Additionally, the warning message contains emojis which violates the codebase style guidelines.
- Pay close attention to `tidy3d/rf.py` which has critical missing backwards compatibility alias and style violation

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/rf.py | 2/5 | New RF namespace module missing `CustomPathIntegral2D` backwards compatibility alias and contains emoji in warning message |
| tidy3d/__init__.py | 5/5 | Added backwards compatibility aliases for renamed integral classes, properly exported in `__all__` |
| tidy3d/plugins/microwave/__init__.py | 5/5 | Added all backwards compatibility aliases including `CustomPathIntegral2D`, properly exported in `__all__` |
| CHANGELOG.md | 5/5 | Added entry for new `tidy3d.rf` namespace and reorganized breaking changes into proper sections |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant tidy3d.rf
    participant tidy3d.__init__
    participant microwave_plugin
    participant components

    Note over User,components: New RF Namespace Consolidation

    User->>tidy3d.rf: from tidy3d.rf import *
    tidy3d.rf->>components: Import path integrals
    tidy3d.rf->>microwave_plugin: Import models, array_factor, rf_material_library
    tidy3d.rf->>microwave_plugin: Import smatrix components
    tidy3d.rf-->>User: Return consolidated RF classes
    
    Note over tidy3d.rf: Create backwards compatibility aliases:<br/>CurrentIntegralTypes, VoltageIntegralTypes,<br/>ComponentModeler, CustomPathIntegral2D (MISSING)

    User->>tidy3d.__init__: from tidy3d import VoltageIntegralAxisAligned
    tidy3d.__init__->>components: Import AxisAlignedVoltageIntegral
    Note over tidy3d.__init__: Create backwards compatibility alias:<br/>VoltageIntegralAxisAligned
    tidy3d.__init__-->>User: Return aliased class

    User->>microwave_plugin: from tidy3d.plugins.microwave import CustomPathIntegral2D
    microwave_plugin->>components: Import Custom2DPathIntegral
    Note over microwave_plugin: Create backwards compatibility alias:<br/>CustomPathIntegral2D
    microwave_plugin-->>User: Return aliased class
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->