### PR TITLE
chore: moving diverged states from error to completed

### DIFF
--- a/tidy3d/web/api/states.py
+++ b/tidy3d/web/api/states.py
@@ -8,8 +8,6 @@ ERROR_STATES = {
     "validate_error",
     "error",
     "errored",
-    "diverge",
-    "diverged",
     "blocked",
     "preprocess_error",
     "run_error",
@@ -32,7 +30,15 @@ POST_RUN_STATES = {
     "run_success",
 }
 
-COMPLETED_STATES = {"visualize", "success", "completed", "processed", "postprocess_success"}
+COMPLETED_STATES = {
+    "visualize",
+    "success",
+    "completed",
+    "processed",
+    "postprocess_success",
+    "diverge",
+    "diverged",
+}
 
 END_STATES = ERROR_STATES | COMPLETED_STATES
 
@@ -92,8 +98,8 @@ STATE_PROGRESS_PERCENTAGE = {
     "validate_fail": 0,
     "error": 0,
     "errored": 0,
-    "diverge": 0,
-    "diverged": 0,
+    "diverge": 100,
+    "diverged": 100,
     "blocked": 0,
     "run_failed": 0,
     "aborted": 0,


### PR DESCRIPTION
`web.monitor` would error when a simulation diverges. Previously we did not want this to happen because a diverged simulation still contains results if the user e.g. wants to examine where the divergence happens, etc.

Moving the diverge(d) statuses to completed state restores previous behavior. The user still sees a warning when the SimulationData is loaded.

<img width="1432" height="262" alt="image" src="https://github.com/user-attachments/assets/77cc0084-4e86-4ceb-908e-8dc9ac1fcfe3" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Moved `diverge` and `diverged` states from ERROR_STATES to COMPLETED_STATES to restore previous behavior where `web.monitor` doesn't error on diverged simulations.

- **Key change**: Diverged simulations now complete successfully instead of erroring, allowing users to examine results at the point of divergence
- **Issue found**: STATE_PROGRESS_PERCENTAGE dictionary still marks `diverge`/`diverged` as 0% instead of COMPLETED_PERCENT (100%), creating inconsistency with their new classification as completed states

<h3>Confidence Score: 3/5</h3>


- This PR is mostly safe but has an inconsistency that should be fixed
- The core logic change is sound and restores expected behavior, but there's an inconsistency in STATE_PROGRESS_PERCENTAGE where diverge/diverged states still show 0% instead of 100%, which could cause confusion or incorrect progress reporting
- tidy3d/web/api/states.py requires attention to fix the STATE_PROGRESS_PERCENTAGE inconsistency

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/web/api/states.py | 3/5 | Moved `diverge` and `diverged` from ERROR_STATES to COMPLETED_STATES, but STATE_PROGRESS_PERCENTAGE still shows them as 0% instead of 100% |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant web.monitor
    participant get_status
    participant states
    
    User->>web.monitor: monitor(task_id)
    web.monitor->>get_status: get_status(task_id)
    get_status->>states: check status in END_STATES
    
    alt Status is "diverged" (BEFORE this PR)
        states-->>get_status: status in ERROR_STATES
        get_status-->>web.monitor: raise WebError
        web.monitor-->>User: Error thrown
    else Status is "diverged" (AFTER this PR)
        states-->>get_status: status in COMPLETED_STATES
        get_status-->>web.monitor: status = "diverged"
        web.monitor-->>User: Complete successfully
        Note over User: User can load SimulationData<br/>and see warning about divergence
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->