### PR TITLE
fix: disable default low freq smoothing

### DIFF
--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -18245,15 +18245,7 @@
         {
           "$ref": "#/definitions/ModelerLowFrequencySmoothingSpec"
         }
-      ],
-      "default": {
-        "attrs": {},
-        "max_deviation": 0.5,
-        "max_sampling_time": 5.0,
-        "min_sampling_time": 1.0,
-        "order": 1,
-        "type": "ModelerLowFrequencySmoothingSpec"
-      }
+      ]
     },
     "name": {
       "default": "",

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -133,9 +133,6 @@ class ModelerLowFrequencySmoothingSpec(AbstractLowFrequencySmoothingSpec):
     """
 
 
-DEFAULT_LOW_FREQUENCY_SMOOTHING_SPEC = ModelerLowFrequencySmoothingSpec()
-
-
 class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
     """
     Tool for modeling two-terminal multiport devices and computing port parameters
@@ -208,7 +205,7 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
     )
 
     low_freq_smoothing: Optional[ModelerLowFrequencySmoothingSpec] = pd.Field(
-        DEFAULT_LOW_FREQUENCY_SMOOTHING_SPEC,
+        None,
         title="Low Frequency Smoothing",
         description="The low frequency smoothing parameters for the terminal component simulation.",
     )


### PR DESCRIPTION
Something that caused issues in notebook. The plan is to take another careful look at it between rc3 and official 2.10, but disable for now

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Disabled default low frequency smoothing in `TerminalComponentModeler` by changing the `low_freq_smoothing` field default from `ModelerLowFrequencySmoothingSpec()` to `None`.

- Removed the `DEFAULT_LOW_FREQUENCY_SMOOTHING_SPEC` constant
- Changed default value of `low_freq_smoothing` field from an instance to `None`
- Low frequency smoothing can still be explicitly enabled by passing a `ModelerLowFrequencySmoothingSpec` instance
- The conditional check on line 474 ensures backward compatibility for users who explicitly set this parameter

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk as it's a simple default value change
- The change is straightforward and well-contained: removing a default constant and changing a field default from an instance to None. The existing conditional check on line 474 ensures the code handles None gracefully. Score is 4 instead of 5 due to missing changelog entry for this user-facing behavior change.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/smatrix/component_modelers/terminal.py | 4/5 | Removed default value for `low_freq_smoothing` field, changing from `ModelerLowFrequencySmoothingSpec()` to `None` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant TerminalComponentModeler
    participant Simulation
    participant ModeMonitor
    
    User->>TerminalComponentModeler: Create modeler (low_freq_smoothing=None by default)
    TerminalComponentModeler->>TerminalComponentModeler: Check low_freq_smoothing field
    
    alt low_freq_smoothing is None (NEW behavior)
        TerminalComponentModeler->>Simulation: Create simulation without low freq smoothing
        Note over TerminalComponentModeler,Simulation: No extrapolation applied
    else low_freq_smoothing is set
        TerminalComponentModeler->>ModeMonitor: Get mode monitors
        TerminalComponentModeler->>Simulation: Create LowFrequencySmoothingSpec
        TerminalComponentModeler->>Simulation: Apply smoothing to mode monitors
        Note over TerminalComponentModeler,Simulation: Extrapolation applied at low frequencies
    end
    
    Simulation->>User: Return configured simulation
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Require a changelog entry for any PR that is not purely an internal refactor. ([source](https://app.greptile.com/review/custom-context?memory=b72c7231-b258-4d03-aed2-51a50a9fe757))

<!-- /greptile_comment -->