### PR TITLE
feat(rf): FXC-1604 API for extending structures into pml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added autograd support for `Sphere`.
 
 ### Breaking Changes
+- Added optional automatic extrusion of structures at the simulation boundaries into/through PML/Absorber layers via `extrude_structures` field in class `AbsorberSpec`.
 - Added `structure_priority_mode` for `TerminalComponentModeler` and default to `"conductor"` to ensure metal structures override dielectrics regardless of structure order, preventing order-dependent results in RF simulations.
 - 1D lumped elements (with zero lateral extent) are no longer allowed. Use a small finite lateral extent (e.g., `1e-6`) instead.
 - Added `GaussianOverlapMonitor` and `AstigmaticGaussianOverlapMonitor` for decomposing electromagnetic fields onto Gaussian beam profiles.

--- a/schemas/EMESimulation.json
+++ b/schemas/EMESimulation.json
@@ -36,6 +36,10 @@
           "default": {},
           "type": "object"
         },
+        "extrude_structures": {
+          "default": false,
+          "type": "boolean"
+        },
         "name": {
           "type": "string"
         },
@@ -1008,6 +1012,7 @@
         "minus": {
           "default": {
             "attrs": {},
+            "extrude_structures": true,
             "name": null,
             "num_layers": 12,
             "parameters": {
@@ -1072,6 +1077,7 @@
         "plus": {
           "default": {
             "attrs": {},
+            "extrude_structures": true,
             "name": null,
             "num_layers": 12,
             "parameters": {
@@ -1167,6 +1173,7 @@
             "attrs": {},
             "minus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -1186,6 +1193,7 @@
             },
             "plus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -1216,6 +1224,7 @@
             "attrs": {},
             "minus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -1235,6 +1244,7 @@
             },
             "plus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -1265,6 +1275,7 @@
             "attrs": {},
             "minus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -1284,6 +1295,7 @@
             },
             "plus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -9411,6 +9423,10 @@
           "default": {},
           "type": "object"
         },
+        "extrude_structures": {
+          "default": true,
+          "type": "boolean"
+        },
         "name": {
           "type": "string"
         },
@@ -11351,6 +11367,10 @@
         "attrs": {
           "default": {},
           "type": "object"
+        },
+        "extrude_structures": {
+          "default": true,
+          "type": "boolean"
         },
         "name": {
           "type": "string"

--- a/schemas/ModeSimulation.json
+++ b/schemas/ModeSimulation.json
@@ -36,6 +36,10 @@
           "default": {},
           "type": "object"
         },
+        "extrude_structures": {
+          "default": false,
+          "type": "boolean"
+        },
         "name": {
           "type": "string"
         },
@@ -1008,6 +1012,7 @@
         "minus": {
           "default": {
             "attrs": {},
+            "extrude_structures": true,
             "name": null,
             "num_layers": 12,
             "parameters": {
@@ -1072,6 +1077,7 @@
         "plus": {
           "default": {
             "attrs": {},
+            "extrude_structures": true,
             "name": null,
             "num_layers": 12,
             "parameters": {
@@ -1167,6 +1173,7 @@
             "attrs": {},
             "minus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -1186,6 +1193,7 @@
             },
             "plus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -1216,6 +1224,7 @@
             "attrs": {},
             "minus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -1235,6 +1244,7 @@
             },
             "plus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -1265,6 +1275,7 @@
             "attrs": {},
             "minus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -1284,6 +1295,7 @@
             },
             "plus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -9115,6 +9127,10 @@
           "default": {},
           "type": "object"
         },
+        "extrude_structures": {
+          "default": true,
+          "type": "boolean"
+        },
         "name": {
           "type": "string"
         },
@@ -11056,6 +11072,10 @@
           "default": {},
           "type": "object"
         },
+        "extrude_structures": {
+          "default": true,
+          "type": "boolean"
+        },
         "name": {
           "type": "string"
         },
@@ -12208,6 +12228,7 @@
           "attrs": {},
           "minus": {
             "attrs": {},
+            "extrude_structures": true,
             "name": null,
             "num_layers": 12,
             "parameters": {
@@ -12227,6 +12248,7 @@
           },
           "plus": {
             "attrs": {},
+            "extrude_structures": true,
             "name": null,
             "num_layers": 12,
             "parameters": {
@@ -12250,6 +12272,7 @@
           "attrs": {},
           "minus": {
             "attrs": {},
+            "extrude_structures": true,
             "name": null,
             "num_layers": 12,
             "parameters": {
@@ -12269,6 +12292,7 @@
           },
           "plus": {
             "attrs": {},
+            "extrude_structures": true,
             "name": null,
             "num_layers": 12,
             "parameters": {
@@ -12292,6 +12316,7 @@
           "attrs": {},
           "minus": {
             "attrs": {},
+            "extrude_structures": true,
             "name": null,
             "num_layers": 12,
             "parameters": {
@@ -12311,6 +12336,7 @@
           },
           "plus": {
             "attrs": {},
+            "extrude_structures": true,
             "name": null,
             "num_layers": 12,
             "parameters": {

--- a/schemas/Simulation.json
+++ b/schemas/Simulation.json
@@ -36,6 +36,10 @@
           "default": {},
           "type": "object"
         },
+        "extrude_structures": {
+          "default": false,
+          "type": "boolean"
+        },
         "name": {
           "type": "string"
         },
@@ -1631,6 +1635,7 @@
         "minus": {
           "default": {
             "attrs": {},
+            "extrude_structures": true,
             "name": null,
             "num_layers": 12,
             "parameters": {
@@ -1695,6 +1700,7 @@
         "plus": {
           "default": {
             "attrs": {},
+            "extrude_structures": true,
             "name": null,
             "num_layers": 12,
             "parameters": {
@@ -1790,6 +1796,7 @@
             "attrs": {},
             "minus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -1809,6 +1816,7 @@
             },
             "plus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -1839,6 +1847,7 @@
             "attrs": {},
             "minus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -1858,6 +1867,7 @@
             },
             "plus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -1888,6 +1898,7 @@
             "attrs": {},
             "minus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -1907,6 +1918,7 @@
             },
             "plus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -13554,6 +13566,10 @@
           "default": {},
           "type": "object"
         },
+        "extrude_structures": {
+          "default": true,
+          "type": "boolean"
+        },
         "name": {
           "type": "string"
         },
@@ -15863,6 +15879,10 @@
           "default": {},
           "type": "object"
         },
+        "extrude_structures": {
+          "default": true,
+          "type": "boolean"
+        },
         "name": {
           "type": "string"
         },
@@ -17360,6 +17380,7 @@
           "attrs": {},
           "minus": {
             "attrs": {},
+            "extrude_structures": true,
             "name": null,
             "num_layers": 12,
             "parameters": {
@@ -17379,6 +17400,7 @@
           },
           "plus": {
             "attrs": {},
+            "extrude_structures": true,
             "name": null,
             "num_layers": 12,
             "parameters": {
@@ -17402,6 +17424,7 @@
           "attrs": {},
           "minus": {
             "attrs": {},
+            "extrude_structures": true,
             "name": null,
             "num_layers": 12,
             "parameters": {
@@ -17421,6 +17444,7 @@
           },
           "plus": {
             "attrs": {},
+            "extrude_structures": true,
             "name": null,
             "num_layers": 12,
             "parameters": {
@@ -17444,6 +17468,7 @@
           "attrs": {},
           "minus": {
             "attrs": {},
+            "extrude_structures": true,
             "name": null,
             "num_layers": 12,
             "parameters": {
@@ -17463,6 +17488,7 @@
           },
           "plus": {
             "attrs": {},
+            "extrude_structures": true,
             "name": null,
             "num_layers": 12,
             "parameters": {

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -36,6 +36,10 @@
           "default": {},
           "type": "object"
         },
+        "extrude_structures": {
+          "default": false,
+          "type": "boolean"
+        },
         "name": {
           "type": "string"
         },
@@ -1631,6 +1635,7 @@
         "minus": {
           "default": {
             "attrs": {},
+            "extrude_structures": true,
             "name": null,
             "num_layers": 12,
             "parameters": {
@@ -1695,6 +1700,7 @@
         "plus": {
           "default": {
             "attrs": {},
+            "extrude_structures": true,
             "name": null,
             "num_layers": 12,
             "parameters": {
@@ -1790,6 +1796,7 @@
             "attrs": {},
             "minus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -1809,6 +1816,7 @@
             },
             "plus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -1839,6 +1847,7 @@
             "attrs": {},
             "minus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -1858,6 +1867,7 @@
             },
             "plus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -1888,6 +1898,7 @@
             "attrs": {},
             "minus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -1907,6 +1918,7 @@
             },
             "plus": {
               "attrs": {},
+              "extrude_structures": true,
               "name": null,
               "num_layers": 12,
               "parameters": {
@@ -13934,6 +13946,10 @@
           "default": {},
           "type": "object"
         },
+        "extrude_structures": {
+          "default": true,
+          "type": "boolean"
+        },
         "name": {
           "type": "string"
         },
@@ -15964,6 +15980,7 @@
               "attrs": {},
               "minus": {
                 "attrs": {},
+                "extrude_structures": true,
                 "name": null,
                 "num_layers": 12,
                 "parameters": {
@@ -15983,6 +16000,7 @@
               },
               "plus": {
                 "attrs": {},
+                "extrude_structures": true,
                 "name": null,
                 "num_layers": 12,
                 "parameters": {
@@ -16006,6 +16024,7 @@
               "attrs": {},
               "minus": {
                 "attrs": {},
+                "extrude_structures": true,
                 "name": null,
                 "num_layers": 12,
                 "parameters": {
@@ -16025,6 +16044,7 @@
               },
               "plus": {
                 "attrs": {},
+                "extrude_structures": true,
                 "name": null,
                 "num_layers": 12,
                 "parameters": {
@@ -16048,6 +16068,7 @@
               "attrs": {},
               "minus": {
                 "attrs": {},
+                "extrude_structures": true,
                 "name": null,
                 "num_layers": 12,
                 "parameters": {
@@ -16067,6 +16088,7 @@
               },
               "plus": {
                 "attrs": {},
+                "extrude_structures": true,
                 "name": null,
                 "num_layers": 12,
                 "parameters": {
@@ -16992,6 +17014,10 @@
         "attrs": {
           "default": {},
           "type": "object"
+        },
+        "extrude_structures": {
+          "default": true,
+          "type": "boolean"
         },
         "name": {
           "type": "string"

--- a/tests/test_components/test_boundaries.py
+++ b/tests/test_components/test_boundaries.py
@@ -193,6 +193,33 @@ def test_boundaryspec_classmethods():
     )
 
 
+def test_extrude_structures_to_pml():
+    """Test ``extrude_structures`` field in PML/Absorber API."""
+
+    # check default state
+    boundary_pml = PML()
+    boundary_abs = Absorber()
+    boundary_bloch = BlochBoundary(bloch_vec=1)
+    boundary_pec = PECBoundary()
+
+    assert boundary_pml.extrude_structures is True
+    assert boundary_abs.extrude_structures is False
+
+    # make sure attribute error is raised if other BC attempt to access/use the feature
+    with pytest.raises(AttributeError):
+        boundary_bloch.extrude_structures
+    with pytest.raises(AttributeError):
+        boundary_pec.extrude_structures
+
+    # change state of boundary condition
+    boundary_pml = PML(extrude_structures=False)
+    boundary_abs = Absorber(extrude_structures=True)
+
+    # make sure field values were correctly updated
+    assert boundary_pml.extrude_structures is False
+    assert boundary_abs.extrude_structures is True
+
+
 @pytest.mark.parametrize("absorber_type", [PML, StablePML, Absorber])
 def test_num_layers_validator(absorber_type):
     """Test the Field validators that enforce ``num_layers>0``."""

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -628,7 +628,8 @@ def test_validate_symmetry_boundaries():
 
 
 def test_validate_components_none():
-    assert SIM._structures_not_at_edges(val=None, values=SIM.dict()) is None
+    # _structures_not_at_edges is now a post-init validator method, not a pydantic validator
+    # so it's tested via _post_init_validators() instead
     assert SIM._validate_num_sources(val=None) is None
     assert SIM._warn_monitor_mediums_frequency_range(val=None, values=SIM.dict()) is None
     assert SIM._warn_monitor_simulation_frequency_range(val=None, values=SIM.dict()) is None
@@ -1665,7 +1666,9 @@ def test_warn_lumped_elements_outside_sim_bounds():
 def test_sim_validate_structure_bounds_pml(box_length, absorb_type, log_level):
     """Make sure we warn if structure bounds are within the PML exactly to simulation edges."""
 
-    boundary = td.PML() if absorb_type == "PML" else td.Absorber()
+    # For PML, set extrude_structures=False to test the warning behavior
+    # (with extrude_structures=True, structures are automatically extended so no warning is needed)
+    boundary = td.PML(extrude_structures=False) if absorb_type == "PML" else td.Absorber()
 
     src = td.UniformCurrentSource(
         source_time=td.GaussianPulse(freq0=3e14, fwidth=1e13),
@@ -3953,3 +3956,401 @@ def test_finalized_volumetric_structures_respects_priority_mode(structure_priori
         assert finalized_structures[-1].medium == dielectric.medium
         assert isinstance(finalized_structures[1].medium, td.LossyMetalMedium)
         assert finalized_structures[0].medium == td.PEC
+
+
+def test_extrusion_suppresses_structure_at_edges_warning():
+    """Test that structure at edges warning is suppressed when extrude_structures=True."""
+
+    # Create a structure that extends exactly to x-min edge only
+    # Simulation: size=(2, 1, 1), center=(0, 0, 0) → bounds x:[-1, 1], y:[-0.5, 0.5], z:[-0.5, 0.5]
+    # Structure: center=(-0.5, 0, 0), size=(1, 0.4, 0.4) → x-min = -1 (touches x-min edge), y:[-0.2, 0.2], z:[-0.2, 0.2] (inside bounds)
+    structure = td.Structure(
+        geometry=td.Box(size=(1, 0.4, 0.4), center=(-0.5, 0, 0)),  # Touches x-min edge at -1 only
+        medium=td.Medium(permittivity=2.0),
+    )
+
+    # Use PointDipole to avoid PlaneWave validation issues with structure intersections
+    source = td.PointDipole(
+        source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
+        center=(0, 0, 0),
+        polarization="Ex",
+    )
+
+    # Test 1: Warning should appear when extrude_structures=False
+    boundary_spec_no_extrusion = td.BoundarySpec(
+        x=td.Boundary(
+            minus=td.PML(extrude_structures=False), plus=td.PML(extrude_structures=False)
+        ),
+        y=td.Boundary.pml(),
+        z=td.Boundary.pml(),
+    )
+
+    with AssertLogLevel("WARNING", contains_str="has bounds that extend exactly"):
+        sim = td.Simulation(
+            size=(2, 1, 1),
+            center=(0, 0, 0),
+            structures=[structure],
+            sources=[source],
+            boundary_spec=boundary_spec_no_extrusion,
+            run_time=1e-12,
+        )
+
+    # Test 2: Warning should be suppressed when extrude_structures=True on x-min
+    boundary_spec_with_extrusion = td.BoundarySpec(
+        x=td.Boundary(minus=td.PML(extrude_structures=True), plus=td.PML(extrude_structures=True)),
+        y=td.Boundary.pml(),
+        z=td.Boundary.pml(),
+    )
+
+    # Verify the "structure at edges" warning is NOT present (other warnings may still appear)
+    with AssertLogStr(log_level_expected="WARNING", excludes_str="has bounds that extend exactly"):
+        sim = td.Simulation(
+            size=(2, 1, 1),
+            center=(0, 0, 0),
+            structures=[structure],
+            sources=[source],
+            boundary_spec=boundary_spec_with_extrusion,
+            run_time=1e-12,
+        )
+
+
+def test_extrusion_suppresses_structure_in_pml_warning():
+    """Test that structure in PML warning is suppressed when extrude_structures=True."""
+
+    # Create a structure that extends into PML region on x-min side only
+    # Simulation: size=(2, 1, 1), center=(0, 0, 0) → bounds x:[-1, 1], y:[-0.5, 0.5], z:[-0.5, 0.5]
+    # PML extends beyond x=-1, so structure x-min needs to be < -1 to be in PML
+    # Structure must be partially inside simulation domain for extrusion to work (within 2 cells of boundary)
+    # Structure: center=(-0.95, 0, 0), size=(0.2, 0.4, 0.4) → x-min = -1.05 (in PML), x-max = -0.85 (in simulation domain), y/z inside bounds
+    structure = td.Structure(
+        geometry=td.Box(
+            size=(1.2, 0.4, 0.4), center=(-0.5, 0, 0)
+        ),  # Partially in simulation domain, extends into PML
+        medium=td.Medium(permittivity=2.0),
+    )
+
+    # Use PointDipole to avoid PlaneWave validation issues
+    source = td.PointDipole(
+        source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
+        center=(0.5, 0, 0),  # Place away from structure
+        polarization="Ex",
+    )
+
+    # Test 1: Warning should appear when extrude_structures=False
+    boundary_spec_no_extrusion = td.BoundarySpec(
+        x=td.Boundary(
+            minus=td.PML(extrude_structures=False, num_layers=12),
+            plus=td.PML(extrude_structures=False, num_layers=12),
+        ),
+        y=td.Boundary.pml(),
+        z=td.Boundary.pml(),
+    )
+
+    with AssertLogLevel("WARNING", contains_str="within the simulation PML"):
+        sim = td.Simulation(
+            size=(2, 4, 4),
+            center=(0, 0, 0),
+            structures=[structure],
+            sources=[source],
+            boundary_spec=boundary_spec_no_extrusion,
+            run_time=1e-12,
+        )
+
+    # Test 2: Warning should be suppressed when extrude_structures=True
+    boundary_spec_with_extrusion = td.BoundarySpec(
+        x=td.Boundary(
+            minus=td.PML(extrude_structures=True, num_layers=12),
+            plus=td.PML(extrude_structures=True, num_layers=12),
+        ),
+        y=td.Boundary.pml(),
+        z=td.Boundary.pml(),
+    )
+
+    # Verify the "structure in PML" warning is NOT present (other warnings may still appear)
+    with AssertLogStr(log_level_expected="WARNING", excludes_str="within the simulation PML"):
+        sim = td.Simulation(
+            size=(2, 4, 4),
+            center=(0, 0, 0),
+            structures=[structure],
+            sources=[source],
+            boundary_spec=boundary_spec_with_extrusion,
+            run_time=1e-12,
+        )
+
+
+def test_extrusion_warns_automatic_extrusion():
+    """Test that automatic extrusion warning appears when structure is close to PML with extrude_structures=True."""
+
+    # Create a structure close to PML boundary (within half wavelength AND within 2 cells)
+    freq0 = 2e14  # 200 THz
+    wavelength = 3e8 / freq0 * 1e6  # Convert to um: ~1.5 um
+    half_wavelength = wavelength / 2
+
+    # Structure positioned just inside simulation boundary, close to PML
+    # Use longer simulation domain to ensure better grid resolution and clipping margin coverage
+    sim_size = (10, 1, 1)  # In um - longer in x direction
+    sim_bound_min = -sim_size[0] / 2
+
+    # Structure extends from -4.95 um to 3 um
+    structure_x_min = -4.95  # Very close to boundary (within 2 cells for typical grid)
+    structure_x_max = 3.0
+    structure_size_x = structure_x_max - structure_x_min  # 7.95 um
+    structure_center_x = (structure_x_min + structure_x_max) / 2  # -0.975 um
+    structure = td.Structure(
+        geometry=td.Box(size=(structure_size_x, 10, 10), center=(structure_center_x, 0, 0)),
+        medium=td.Medium(permittivity=2.0),
+    )
+
+    # Use PointDipole to avoid PlaneWave validation issues
+    source = td.PointDipole(
+        source_time=td.GaussianPulse(freq0=freq0, fwidth=freq0 * 0.1),
+        center=(0, 0, 0),
+        polarization="Ex",
+    )
+
+    # Test: Warning should appear when extrude_structures=True and structure is within clipping margin
+    boundary_spec_with_extrusion = td.BoundarySpec.all_sides(
+        boundary=td.PML(extrude_structures=True, num_layers=12)
+    )
+
+    with AssertLogLevel("WARNING", contains_str="will be automatically extruded"):
+        sim = td.Simulation(
+            size=sim_size,
+            center=(0, 0, 0),
+            structures=[structure],
+            sources=[source],
+            boundary_spec=boundary_spec_with_extrusion,
+            run_time=1e-12,
+        )
+
+
+def test_extrusion_warning_not_triggered_when_far_from_pml():
+    """Test extrusion warning behavior based on structure distance from PML.
+
+    Case 1: Structure > half_wavelength AND > 2 cells away → no warning
+    Case 2: Structure < half_wavelength BUT > 2 cells away → warns about distance to PML, but does not trigger automatic extrusion
+    """
+
+    freq0 = 2e14  # 200 THz
+    wavelength = 3e8 / freq0 * 1e6  # Convert to um: ~1.5 um
+    half_wavelength = wavelength / 2
+
+    sim_size = (2, 1, 1)  # In um
+    sim_bound_min = -sim_size[0] / 2
+
+    # Use PointDipole to avoid PlaneWave validation issues
+    source = td.PointDipole(
+        source_time=td.GaussianPulse(freq0=freq0, fwidth=freq0 * 0.1),
+        center=(0, 0, 0),
+        polarization="Ex",
+    )
+
+    boundary_spec_with_extrusion = td.BoundarySpec.all_sides(
+        boundary=td.PML(extrude_structures=True, num_layers=12)
+    )
+
+    # Case 1: Structure is more than half_wavelength AND more than 2 cells away from boundary
+    # No warning expected
+    # Place structure near center with small size to ensure it's > half_wavelength from both boundaries
+    # Structure bounds: x: [-0.1, 0.1], distance from boundaries: 0.9 um > 0.75 um (half_wavelength) ✓
+    structure_far = td.Structure(
+        geometry=td.Box(size=(0.2, 10, 10), center=(0.0, 0, 0)),
+        medium=td.Medium(permittivity=2.0),
+    )
+
+    # Verify no warning when structure is far from PML
+    with AssertLogStr(
+        log_level_expected="WARNING", excludes_str="less than half of a central wavelength"
+    ):
+        sim = td.Simulation(
+            size=sim_size,
+            center=(0, 0, 0),
+            structures=[structure_far],
+            sources=[source],
+            boundary_spec=boundary_spec_with_extrusion,
+            run_time=1e-12,
+        )
+
+    # Case 2: Structure is closer than half_wavelength BUT more than 2 cells away (outside clipping margin)
+    # Should warn about distance to PML (not automatic extrusion, since it's outside clipping margin)
+    # Place structure so its x-min bound is inside simulation domain but within half_wavelength of boundary
+    structure_size_x = 0.3
+    structure_x_min_close = (
+        sim_bound_min + half_wavelength * 0.4
+    )  # x-min close to boundary (< half_wavelength)
+    structure_center_x_close = (
+        structure_x_min_close + structure_size_x / 2
+    )  # Center so x-min is at desired position
+    structure_close = td.Structure(
+        geometry=td.Box(size=(structure_size_x, 10, 10), center=(structure_center_x_close, 0, 0)),
+        medium=td.Medium(permittivity=2.0),
+    )
+
+    # Verify warning about distance to PML (contains distance warning, excludes automatic extrusion warning)
+    with AssertLogStr(
+        log_level_expected="WARNING",
+        contains_str="less than half of a central wavelength",
+        excludes_str="will be automatically extruded",
+    ):
+        sim = td.Simulation(
+            size=sim_size,
+            center=(0, 0, 0),
+            structures=[structure_close],
+            sources=[source],
+            boundary_spec=boundary_spec_with_extrusion,
+            run_time=1e-12,
+        )
+
+
+def test_extrusion_warnings_with_absorber():
+    """Test that extrusion warnings work correctly with Absorber boundaries."""
+
+    # Structure that touches x-min edge only
+    # Simulation: size=(2, 1, 1), center=(0, 0, 0) → bounds x:[-1, 1], y:[-0.5, 0.5], z:[-0.5, 0.5]
+    # Structure: center=(-0.5, 0, 0), size=(1, 0.4, 0.4) → x-min = -1 (touches edge), y/z inside bounds
+    structure = td.Structure(
+        geometry=td.Box(size=(1, 0.4, 0.4), center=(-0.5, 0, 0)),
+        medium=td.Medium(permittivity=2.0),
+    )
+
+    # Use PointDipole to avoid PlaneWave validation issues
+    source = td.PointDipole(
+        source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
+        center=(0, 0, 0),
+        polarization="Ex",
+    )
+
+    # Test with Absorber (default extrude_structures=False)
+    boundary_spec_absorber_no_extrusion = td.BoundarySpec(
+        x=td.Boundary(
+            minus=td.Absorber(extrude_structures=False), plus=td.Absorber(extrude_structures=False)
+        ),
+        y=td.Boundary.pml(),
+        z=td.Boundary.pml(),
+    )
+
+    with AssertLogLevel("WARNING", contains_str="has bounds that extend exactly"):
+        sim = td.Simulation(
+            size=(2, 1, 1),
+            center=(0, 0, 0),
+            structures=[structure],
+            sources=[source],
+            boundary_spec=boundary_spec_absorber_no_extrusion,
+            run_time=1e-12,
+        )
+
+    # Test with Absorber (extrude_structures=True)
+    boundary_spec_absorber_with_extrusion = td.BoundarySpec(
+        x=td.Boundary(
+            minus=td.Absorber(extrude_structures=True), plus=td.Absorber(extrude_structures=True)
+        ),
+        y=td.Boundary.pml(),
+        z=td.Boundary.pml(),
+    )
+
+    # Verify the "structure at edges" warning is NOT present (other warnings may still appear)
+    with AssertLogStr(log_level_expected="WARNING", excludes_str="has bounds that extend exactly"):
+        sim = td.Simulation(
+            size=(2, 1, 1),
+            center=(0, 0, 0),
+            structures=[structure],
+            sources=[source],
+            boundary_spec=boundary_spec_absorber_with_extrusion,
+            run_time=1e-12,
+        )
+
+
+def test_extrusion_warnings_with_non_pml_boundaries():
+    """Test that extrusion warnings are not triggered for non-PML boundaries."""
+
+    # Structure that touches x-min edge only
+    # Simulation: size=(2, 1, 1), center=(0, 0, 0) → bounds x:[-1, 1], y:[-0.5, 0.5], z:[-0.5, 0.5]
+    # Structure: center=(-0.5, 0, 0), size=(1, 0.4, 0.4) → x-min = -1 (touches edge), y/z inside bounds
+    structure = td.Structure(
+        geometry=td.Box(size=(1, 0.4, 0.4), center=(-0.5, 0, 0)),
+        medium=td.Medium(permittivity=2.0),
+    )
+
+    # Use PointDipole to avoid PlaneWave validation issues
+    source = td.PointDipole(
+        source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
+        center=(0, 0, 0),
+        polarization="Ex",
+    )
+
+    # Test with PEC boundary (no extrude_structures attribute)
+    boundary_spec_pec = td.BoundarySpec(
+        x=td.Boundary(minus=td.PECBoundary(), plus=td.PECBoundary()),
+        y=td.Boundary.pml(),
+        z=td.Boundary.pml(),
+    )
+
+    # Should still warn about structure at edges (extrusion not applicable)
+    with AssertLogLevel("WARNING", contains_str="has bounds that extend exactly"):
+        sim = td.Simulation(
+            size=(2, 1, 1),
+            center=(0, 0, 0),
+            structures=[structure],
+            sources=[source],
+            boundary_spec=boundary_spec_pec,
+            run_time=1e-12,
+        )
+
+    # Test with Periodic boundary (no extrude_structures attribute)
+    boundary_spec_periodic = td.BoundarySpec(
+        x=td.Boundary(minus=td.Periodic(), plus=td.Periodic()),
+        y=td.Boundary.pml(),
+        z=td.Boundary.pml(),
+    )
+
+    # Should still warn about structure at edges
+    with AssertLogLevel("WARNING", contains_str="has bounds that extend exactly"):
+        sim = td.Simulation(
+            size=(2, 1, 1),
+            center=(0, 0, 0),
+            structures=[structure],
+            sources=[source],
+            boundary_spec=boundary_spec_periodic,
+            run_time=1e-12,
+        )
+
+
+def test_extrusion_warnings_mixed_boundaries():
+    """Test that warnings work correctly when different boundaries are used on different sides."""
+
+    # Structure that touches x-min edge only
+    # Simulation: size=(2, 1, 1), center=(0, 0, 0) → bounds x:[-1, 1], y:[-0.5, 0.5], z:[-0.5, 0.5]
+    # Structure: center=(-0.5, 0, 0), size=(1, 0.4, 0.4) → x-min = -1 (touches x-min edge only), y/z inside bounds
+    structure = td.Structure(
+        geometry=td.Box(size=(1, 0.4, 0.4), center=(-0.5, 0, 0)),
+        medium=td.Medium(permittivity=2.0),
+    )
+
+    # Use PointDipole to avoid PlaneWave validation issues
+    source = td.PointDipole(
+        source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
+        center=(0.5, 0, 0),  # Place away from structure
+        polarization="Ex",
+    )
+
+    # PML with extrusion on x-min, PML without extrusion on x-max
+    boundary_spec_mixed = td.BoundarySpec(
+        x=td.Boundary(
+            minus=td.PML(extrude_structures=True),
+            plus=td.PML(extrude_structures=False),
+        ),
+        y=td.Boundary.pml(),
+        z=td.Boundary.pml(),
+    )
+
+    # Warning should be suppressed for x-min (extrusion enabled)
+    # Since structure only touches x-min, no warning should appear
+    with AssertLogStr(log_level_expected="WARNING", excludes_str="has bounds that extend exactly"):
+        sim = td.Simulation(
+            size=(2, 1, 1),
+            center=(0, 0, 0),
+            structures=[structure],
+            sources=[source],
+            boundary_spec=boundary_spec_mixed,
+            run_time=1e-12,
+        )

--- a/tidy3d/components/base_sim/simulation.py
+++ b/tidy3d/components/base_sim/simulation.py
@@ -161,7 +161,6 @@ class AbstractSimulation(Box, ABC):
     @skip_if_fields_missing(["size", "center"])
     def _structures_not_at_edges(cls, val, values):
         """Warn if any structures lie at the simulation boundaries."""
-
         if val is None:
             return val
 
@@ -188,6 +187,62 @@ class AbstractSimulation(Box, ABC):
         return val
 
     """ Post-init validators """
+
+    def _validate_structures_not_at_edges(self) -> None:
+        """Warn if any structures lie at the simulation boundaries (post-init check with full field access)."""
+        if not self.structures:
+            return
+
+        sim_bound_min, sim_bound_max = self.bounds
+        sim_bounds = list(sim_bound_min) + list(sim_bound_max)
+
+        # Get boundaries - now guaranteed to be available since we're post-init
+        boundary_spec = self.boundary_spec
+        try:
+            boundaries = (
+                boundary_spec.to_list
+                if boundary_spec is not None and hasattr(boundary_spec, "to_list")
+                else None
+            )
+        except Exception:
+            boundaries = None
+
+        with log as consolidated_logger:
+            for istruct, structure in enumerate(self.structures):
+                struct_bound_min, struct_bound_max = structure.geometry.bounds
+                struct_bounds = list(struct_bound_min) + list(struct_bound_max)
+
+                for idx, (sim_val, struct_val) in enumerate(zip(sim_bounds, struct_bounds)):
+                    if anp.isclose(sim_val, struct_val):
+                        # Check if extrusion is enabled for this boundary
+                        # Index 0-2: min bounds for x, y, z → boundaries[axis][0] (minus side)
+                        # Index 3-5: max bounds for x, y, z → boundaries[axis][1] (plus side)
+                        axis_idx = idx % 3
+                        side_idx = idx // 3
+
+                        extrusion_enabled = False
+                        if boundaries is not None:
+                            try:
+                                boundary_edge = boundaries[axis_idx][side_idx]
+                                if (
+                                    hasattr(boundary_edge, "extrude_structures")
+                                    and boundary_edge.extrude_structures
+                                ):
+                                    extrusion_enabled = True
+                            except (IndexError, AttributeError):
+                                pass
+
+                        # Skip warning if extrusion is enabled
+                        if extrusion_enabled:
+                            continue
+
+                        consolidated_logger.warning(
+                            f"Structure at 'structures[{istruct}]' has bounds that extend exactly "
+                            "to simulation edges. This can cause unexpected behavior. "
+                            "If intending to extend the structure to infinity along one dimension, "
+                            "use td.inf as a size variable instead to make this explicit.",
+                            custom_loc=["structures", istruct],
+                        )
 
     def _post_init_validators(self) -> None:
         """Call validators taking z`self` that get run after init."""

--- a/tidy3d/components/boundary.py
+++ b/tidy3d/components/boundary.py
@@ -32,6 +32,10 @@ MIN_NUM_PML_LAYERS = 6
 MIN_NUM_STABLE_PML_LAYERS = 6
 MIN_NUM_ABSORBER_LAYERS = 6
 
+# Margin (in grid cells) defining the extrusion clipping region. The clipping bounding box is inset
+# by this margin on both the lower and upper bounds of each axis.
+CLIPPING_MARGIN = 2
+
 
 def warn_num_layers_factory(min_num_layers: int, descr: str):
     """Several similar classes defined have a ``num_layers`` data member, and they generate
@@ -672,6 +676,17 @@ class AbsorberSpec(BoundaryEdge):
         description="Parameters to fine tune the absorber profile and properties.",
     )
 
+    extrude_structures: bool = pd.Field(
+        False,
+        title="Enable structure extrusion to PML",
+        description="Automatically extrude structures into the absorbing region (e.g., PML or adiabatic absorber). "
+        f"Any structure located within {CLIPPING_MARGIN} cells of a simulation boundary will be extended "
+        "through the full thickness of the PML/absorber. "
+        f"The extruded region is assigned the material properties of the structure {CLIPPING_MARGIN} cells "
+        "from the simulation boundary. "
+        "Extrusion is performed along the direction normal to the PML/absorber surface.",
+    )
+
 
 class PML(AbsorberSpec):
     """Specifies a standard PML along a single dimension.
@@ -794,6 +809,17 @@ class PML(AbsorberSpec):
         min_num_layers=MIN_NUM_PML_LAYERS, descr="perfectly-matched layer"
     )
 
+    extrude_structures: bool = pd.Field(
+        True,
+        title="Enable structure extrusion to PML",
+        description="Automatically extrude structures into the absorbing region (e.g., PML or adiabatic absorber). "
+        f"Any structure located within {CLIPPING_MARGIN} cells of a simulation boundary will be extended "
+        "through the full thickness of the PML/absorber. "
+        f"The extruded region is assigned the material properties of the structure {CLIPPING_MARGIN} cells "
+        "from the simulation boundary. "
+        "Extrusion is performed along the direction normal to the PML/absorber surface.",
+    )
+
 
 class StablePML(AbsorberSpec):
     """Specifies a 'stable' PML along a single dimension.
@@ -834,6 +860,17 @@ class StablePML(AbsorberSpec):
 
     _warn_num_layers = warn_num_layers_factory(
         min_num_layers=MIN_NUM_STABLE_PML_LAYERS, descr="stable perfectly-matched layer"
+    )
+
+    extrude_structures: bool = pd.Field(
+        True,
+        title="Enable structure extrusion to PML",
+        description="Automatically extrude structures into the absorbing region (e.g., PML or adiabatic absorber). "
+        f"Any structure located within {CLIPPING_MARGIN} cells of a simulation boundary will be extended "
+        "through the full thickness of the PML/absorber. "
+        f"The extruded region is assigned the material properties of the structure {CLIPPING_MARGIN} cells "
+        "from the simulation boundary. "
+        "Extrusion is performed along the direction normal to the PML/absorber surface.",
     )
 
 

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -40,6 +40,7 @@ from .autograd.types import AutogradFieldMap
 from .base import cached_property, skip_if_fields_missing
 from .base_sim.simulation import AbstractSimulation
 from .boundary import (
+    CLIPPING_MARGIN,
     PML,
     ABCBoundary,
     Absorber,
@@ -3079,6 +3080,17 @@ class Simulation(AbstractYeeGridSimulation):
     _mode_sources_symmetries = validate_mode_objects_symmetry("sources")
     _mode_monitors_symmetries = validate_mode_objects_symmetry("monitors")
 
+    @pydantic.validator("structures", always=True)
+    @skip_if_fields_missing(["size", "center"])
+    def _structures_not_at_edges(cls, val, values):
+        """Override AbstractSimulation validator to disable it for Simulation class.
+
+        The validation is handled by _validate_structures_not_at_edges() in _post_init_validators()
+        which has access to boundary_spec and can check for extrusion settings.
+        """
+        # Skip validation here - handled by post-init validator instead
+        return val
+
     # _few_enough_mediums = validate_num_mediums()
     # _structures_not_at_edges = validate_structure_bounds_not_at_edges()
     # _gap_size_ok = validate_pml_gap_size()
@@ -3465,66 +3477,6 @@ class Simulation(AbstractYeeGridSimulation):
                         "Please ensure that the bounding boxes of the two geometries "
                         "do not intersect."
                     )
-        return val
-
-    @pydantic.validator("boundary_spec", always=True)
-    @skip_if_fields_missing(["sources", "center", "size", "structures"])
-    def _structures_not_close_pml(cls, val, values):
-        """Warn if any structures lie at the simulation boundaries."""
-
-        sim_box = Box(size=values.get("size"), center=values.get("center"))
-        sim_bound_min, sim_bound_max = sim_box.bounds
-
-        boundaries = val.to_list
-        structures = values.get("structures")
-        sources = values.get("sources")
-
-        if (not structures) or (not sources):
-            return val
-
-        with log as consolidated_logger:
-
-            def warn(structure, istruct, side) -> None:
-                """Warning message for a structure too close to PML."""
-                obj_descr = named_obj_descr(structure, "structures", istruct)
-                consolidated_logger.warning(
-                    f"Structure: {obj_descr} was detected as being less "
-                    f"than half of a central wavelength from a PML on side {side}. "
-                    "To avoid inaccurate results or divergence, please increase gap between "
-                    "any structures and PML or fully extend structure through the pml.",
-                    custom_loc=["structures", istruct],
-                )
-
-            for istruct, structure in enumerate(structures):
-                struct_bound_min, struct_bound_max = structure.geometry.bounds
-
-                for source in sources:
-                    lambda0 = C_0 / source.source_time._freq0
-
-                    zipped = zip(["x", "y", "z"], sim_bound_min, struct_bound_min, boundaries)
-                    for axis, sim_val, struct_val, boundary in zipped:
-                        # The test is required only for PML and stable PML
-                        if not isinstance(boundary[0], (PML, StablePML)):
-                            continue
-                        if (
-                            boundary[0].num_layers > 0
-                            and struct_val > sim_val
-                            and abs(sim_val - struct_val) < lambda0 / 2
-                        ):
-                            warn(structure, istruct, axis + "-min")
-
-                    zipped = zip(["x", "y", "z"], sim_bound_max, struct_bound_max, boundaries)
-                    for axis, sim_val, struct_val, boundary in zipped:
-                        # The test is required only for PML and stable PML
-                        if not isinstance(boundary[1], (PML, StablePML)):
-                            continue
-                        if (
-                            boundary[1].num_layers > 0
-                            and struct_val < sim_val
-                            and abs(sim_val - struct_val) < lambda0 / 2
-                        ):
-                            warn(structure, istruct, axis + "-max")
-
         return val
 
     @pydantic.validator("monitors", always=True)
@@ -4287,7 +4239,9 @@ class Simulation(AbstractYeeGridSimulation):
     def _post_init_validators(self) -> None:
         """Call validators taking z`self` that get run after init."""
         _ = self.scene
+        self._validate_structures_not_at_edges()
         self._validate_no_structures_pml()
+        self._validate_no_structures_close_to_pml()
         self._validate_tfsf_nonuniform_grid()
         self._validate_tfsf_aux_sources()
         self._validate_nonlinear_specs()
@@ -4420,7 +4374,14 @@ class Simulation(AbstractYeeGridSimulation):
                         sim_pos_pml = sim_pos + pm_val * pml
                         in_pml_plus = (pm_val > 0) and (sim_pos < geo_pos <= sim_pos_pml)
                         in_pml_mnus = (pm_val < 0) and (sim_pos > geo_pos >= sim_pos_pml)
-                        if not isinstance(bound_edge, Absorber) and (in_pml_plus or in_pml_mnus):
+                        if (
+                            not isinstance(bound_edge, Absorber)
+                            and (in_pml_plus or in_pml_mnus)
+                            and (
+                                not hasattr(bound_edge, "extrude_structures")
+                                or not bound_edge.extrude_structures
+                            )
+                        ):
                             warn = True
                 if warn:
                     obj_descr = named_obj_descr(structure, "structures", i)
@@ -4432,6 +4393,120 @@ class Simulation(AbstractYeeGridSimulation):
                         "invariant within the PML.",
                         custom_loc=["structures", i],
                     )
+
+    def _validate_no_structures_close_to_pml(self) -> None:
+        """Warn if structures are too close to PML boundaries and may be automatically extruded."""
+        if not self.structures or not self.sources:
+            return
+
+        sim_bound_min, sim_bound_max = self.bounds
+        boundaries = self.boundary_spec.to_list
+
+        # Access grid - this will compute it once and cache it
+        grid_boundaries = self.grid.boundaries.to_list
+        num_pml_layers = self.num_pml_layers
+
+        def is_within_clipping_margin(axis_idx: int, struct_val: float, side_idx: int) -> bool:
+            """Check if structure is within ``CLIPPING_MARGIN`` cells from absorber start.
+
+            Returns True if structure is within ``CLIPPING_MARGIN`` cells from where the absorber starts.
+
+            Args:
+                axis_idx: Axis index (0=x, 1=y, 2=z)
+                struct_val: Structure boundary coordinate value
+                side_idx: Side index (0=min, 1=max)
+            """
+            if num_pml_layers[axis_idx][side_idx] == 0:
+                return False
+
+            grid_axis = grid_boundaries[axis_idx]
+            num_layers = num_pml_layers[axis_idx][side_idx]
+
+            if side_idx == 0:
+                # Absorber starts at cell index num_layers
+                # Extrusion clipping bound is at num_layers + CLIPPING_MARGIN
+                clipping_bound_idx = num_layers + CLIPPING_MARGIN
+                if clipping_bound_idx >= len(grid_axis):
+                    return False
+                absorber_start_coord = grid_axis[num_layers]
+                clipping_bound_coord = grid_axis[clipping_bound_idx]
+                # Structure is within clipping margin if it's between absorber start and clipping bound
+                return absorber_start_coord <= struct_val <= clipping_bound_coord
+            else:
+                # Absorber starts at cell index len(grid_axis) - num_layers - 1
+                # Extrusion clipping bound is at len(grid_axis) - num_layers - 1 - CLIPPING_MARGIN
+                absorber_start_idx = len(grid_axis) - num_layers - 1
+                clipping_bound_idx = absorber_start_idx - CLIPPING_MARGIN
+                if clipping_bound_idx < 0:
+                    return False
+                absorber_start_coord = grid_axis[absorber_start_idx]
+                clipping_bound_coord = grid_axis[clipping_bound_idx]
+                # Structure is within clipping margin if it's between clipping bound and absorber start
+                return clipping_bound_coord <= struct_val <= absorber_start_coord
+
+        with log as consolidated_logger:
+
+            def warn(structure, istruct, side, extrusion_flag) -> None:
+                """Warn when a structure is within half a wavelength of a PML boundary.
+                If ``extrusion_flag`` is True, warns about automatic extrusion. Otherwise, warns about
+                potential inaccuracies and suggests increasing the gap or extending the structure.
+                """
+                obj_descr = named_obj_descr(structure, "structures", istruct)
+
+                if extrusion_flag:
+                    consolidated_logger.warning(
+                        f"Structure: {obj_descr} was detected as being less "
+                        f"than half of a central wavelength from a PML on side {side}. "
+                        "The structure will be automatically extruded to the end of the PML region "
+                        "to ensure translational invariance.",
+                        custom_loc=["structures", istruct],
+                    )
+                else:
+                    consolidated_logger.warning(
+                        f"Structure: {obj_descr} was detected as being less "
+                        f"than half of a central wavelength from a PML on side {side}. "
+                        "To avoid inaccurate results or divergence, please increase gap between "
+                        "any structures and PML or fully extend structure through the pml.",
+                        custom_loc=["structures", istruct],
+                    )
+
+            for istruct, structure in enumerate(self.structures):
+                struct_bound_min, struct_bound_max = structure.geometry.bounds
+
+                for source in self.sources:
+                    lambda0 = C_0 / source.source_time._freq0
+
+                    # Check both min (side_idx=0) and max (side_idx=1) sides
+                    for side_idx in [0, 1]:
+                        sim_bound_side = sim_bound_min if side_idx == 0 else sim_bound_max
+                        struct_bound_side = struct_bound_min if side_idx == 0 else struct_bound_max
+                        side_suffix = "-min" if side_idx == 0 else "-max"
+
+                        zipped = zip(
+                            ["x", "y", "z"],
+                            [0, 1, 2],
+                            sim_bound_side,
+                            struct_bound_side,
+                            boundaries,
+                        )
+                        for axis, axis_idx, sim_val, struct_val, boundary in zipped:
+                            # The test is required only for PML and stable PML
+                            if not isinstance(boundary[side_idx], (PML, StablePML)):
+                                continue
+                            # Min side: struct_val > sim_val, Max side: struct_val < sim_val
+                            if (
+                                boundary[side_idx].num_layers > 0
+                                and (
+                                    struct_val > sim_val if side_idx == 0 else struct_val < sim_val
+                                )
+                                and abs(sim_val - struct_val) < lambda0 / 2
+                            ):
+                                extrusion_flag = boundary[
+                                    side_idx
+                                ].extrude_structures and is_within_clipping_margin(
+                                    axis_idx, struct_val, side_idx
+                                )
+                                warn(structure, istruct, axis + side_suffix, extrusion_flag)
 
     def _validate_tfsf_nonuniform_grid(self) -> None:
         """Warn if the grid is nonuniform along the directions tangential to the injection plane,


### PR DESCRIPTION
This PR adds feature for automatic extrusion of structures located next to the simulation boundaries into PML/Absorber. This is facilitated by additional field `enable_extrusion` in class `AbsorberSpec`.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds an API field `enable_extrusion` to the `AbsorberSpec` class, allowing users to enable automatic extrusion of structures into PML/Absorber boundary regions. The field is properly documented and tested.

**Key Changes:**
- Added `enable_extrusion` boolean field to `AbsorberSpec` class (inherited by `PML`, `StablePML`, and `Absorber`)
- Field defaults to `False` to maintain backward compatibility
- Added comprehensive test coverage verifying the field works only on absorber types
- Updated all simulation schemas to reflect the new field
- Added clear changelog entry

**Important Notes:**
- This appears to be an API-only addition; the actual implementation logic that uses this field is not present in this PR
- The field is stored but not consumed by any simulation or validation logic yet
- Similar to the `extrude_structures` field in `WavePort`, this likely prepares the groundwork for future implementation

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk as it only adds an API field without implementation logic
- Score of 4 reflects that this is a clean API addition with proper documentation and tests, but the field is not yet used anywhere in the codebase. Minor style improvements suggested for test assertions. The change is backward compatible and follows established patterns.
- No files require special attention - all changes are straightforward API additions

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/boundary.py | 5/5 | Added `enable_extrusion` boolean field to `AbsorberSpec` class with proper default value and documentation |
| tests/test_components/test_boundaries.py | 4/5 | Added test for `enable_extrusion` field checking default values and exclusivity to absorber types; uses direct equality instead of `is` for boolean checks |
| CHANGELOG.md | 5/5 | Added clear user-facing changelog entry documenting the new `enable_extrusion` field in `AbsorberSpec` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Simulation
    participant BoundarySpec
    participant AbsorberSpec
    participant PML/Absorber
    
    User->>Simulation: Create simulation with boundary conditions
    User->>PML/Absorber: PML(enable_extrusion=True)
    PML/Absorber->>AbsorberSpec: Initialize with enable_extrusion field
    AbsorberSpec->>AbsorberSpec: Store enable_extrusion=True
    AbsorberSpec-->>PML/Absorber: Return configured boundary
    PML/Absorber-->>Simulation: Add to boundary specification
    Simulation->>BoundarySpec: Configure x/y/z boundaries
    
    Note over Simulation,BoundarySpec: Field is stored but not yet used in implementation
    Note over User,PML/Absorber: API surface prepared for future extrusion logic
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default boundary behavior (PML now extrudes structures by default) and rewires validation/warning logic to be post-init and grid-dependent, which could alter existing simulations’ behavior and warning expectations.
> 
> **Overview**
> Introduces a new `extrude_structures` boolean on absorber boundary types (`PML`, `StablePML`, `Absorber`) to optionally *auto-extend structures into/through absorbing layers*, with defaults set to `true` for PMLs and `false` for `Absorber`.
> 
> Updates `Simulation` validation to run structure-boundary checks post-init (so `boundary_spec` is available), suppressing “structure at edges” and “structure in PML” warnings when extrusion is enabled, and adding a new post-init warning path that distinguishes between “too close to PML” vs “will be automatically extruded” based on distance to the absorber and a `CLIPPING_MARGIN` cell threshold. Schemas and tests are updated accordingly, and the CHANGELOG notes this as a breaking change due to new default behavior at boundaries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 185326b6bb26d1d6687933965b5e1335f94b4fa7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->