### PR TITLE
feat(tidy3d): FXC-4260-allow-users-to-swap-custom-cmaps-in-field-visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `smoothed_projection` for topology optimization of completely binarized designs.
 - Added more RF-specific mode characteristics to `MicrowaveModeData`, including propagation constants (alpha, beta, gamma), phase/group velocities, wave impedance, and automatic mode classification with configurable polarization thresholds in `MicrowaveModeSpec`.
 - Introduce `tidy3d.rf` namespace to consolidate all RF classes.
+- Added support for custom colormaps in `plot_field`.
 
 ### Breaking Changes
 - Edge singularity correction at PEC and lossy metal edges defaults to `True`.

--- a/tests/test_components/test_eme.py
+++ b/tests/test_components/test_eme.py
@@ -1093,6 +1093,19 @@ def test_eme_sim_data():
     _ = sim_data.plot_field(
         "field", "E", eme_port_index=0, val="abs^2", f=td.C_0, mode_index=0, ax=AX
     )
+    _ = sim_data.plot_field(
+        "field", "Ex", eme_port_index=0, val="real", f=td.C_0, mode_index=0, cmap="plasma", ax=AX
+    )
+    _ = sim_data.plot_field(
+        "field",
+        "Ex",
+        eme_port_index=0,
+        val="real",
+        f=td.C_0,
+        mode_index=0,
+        cmap=plt.get_cmap("cividis"),
+        ax=AX,
+    )
 
     # test smatrix in basis with sweep
     smatrix = _get_eme_smatrix_dataset(num_modes_1=5, num_modes_2=5, num_sweep=10)

--- a/tests/test_data/test_sim_data.py
+++ b/tests/test_data/test_sim_data.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pydantic.v1 as pydantic
 import pytest
+from matplotlib import colors as mcolors
 
 import tidy3d as td
 from tidy3d.components.data.data_array import ScalarFieldTimeDataArray
@@ -191,6 +192,22 @@ def test_plot(phase):
         )
         plt.close()
     _ = sim_data.plot_field("mode_solver", "int", f=1e14, mode_index=1, phase=phase)
+    plt.close()
+
+
+def test_plot_field_custom_cmap():
+    sim_data = make_sim_data()
+    _ = sim_data.plot_field("field", "Ex", val="real", f=2e14, z=0.10, cmap="viridis")
+    plt.close()
+    custom_cmap = mcolors.LinearSegmentedColormap.from_list("two", ["black", "white"])
+    _ = sim_data.plot_field(
+        "field",
+        "Ez",
+        val="imag",
+        f=2e14,
+        z=0.10,
+        cmap=custom_cmap,
+    )
     plt.close()
 
 

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -8,7 +8,7 @@ import re
 from abc import ABC
 from collections import defaultdict
 from os import PathLike
-from typing import Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 import h5py
 import numpy as np
@@ -33,6 +33,9 @@ from tidy3d.log import log
 
 from .data_array import FreqDataArray, TimeDataArray
 from .monitor_data import AbstractFieldData, FieldTimeData
+
+if TYPE_CHECKING:
+    from matplotlib.colors import Colormap
 
 DATA_TYPE_MAP = {data.__fields__["monitor"].type_: data for data in MonitorDataTypes}
 
@@ -456,6 +459,7 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
         vmax: Optional[float] = None,
         ax: Ax = None,
         shading: str = "flat",
+        cmap: Optional[Union[str, Colormap]] = None,
         **sel_kwargs: Any,
     ) -> Ax:
         """Plot the field data for a monitor with simulation plot overlaid.
@@ -492,6 +496,8 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
             matplotlib axes to plot on, if not specified, one is created.
         shading: str = 'flat'
             Shading argument for Xarray plot method ('flat','nearest','goraud')
+        cmap : Optional[Union[str, Colormap]] = None
+            Colormap for visualizing the field values. ``None`` uses the default which infers it from the data.
         sel_kwargs : keyword arguments used to perform ``.sel()`` selection in the monitor data.
             These kwargs can select over the spatial dimensions (``x``, ``y``, ``z``),
             frequency or time dimensions (``f``, ``t``) or ``mode_index``, if applicable.
@@ -656,6 +662,7 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
             cmap_type=cmap_type,
             ax=ax,
             shading=shading,
+            cmap=cmap,
             infer_intervals=True if shading == "flat" else False,
         )
 
@@ -672,6 +679,7 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
         vmax: Optional[float] = None,
         ax: Ax = None,
         shading: str = "flat",
+        cmap: Optional[Union[str, Colormap]] = None,
         **sel_kwargs: Any,
     ) -> Ax:
         """Plot the field data for a monitor with simulation plot overlaid.
@@ -709,6 +717,8 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
             matplotlib axes to plot on, if not specified, one is created.
         shading: str = 'flat'
             Shading argument for Xarray plot method ('flat','nearest','goraud')
+        cmap : Optional[Union[str, Colormap]] = None
+            Colormap for visualizing the field values. ``None`` uses the default which infers it from the data.
         sel_kwargs : keyword arguments used to perform ``.sel()`` selection in the monitor data.
             These kwargs can select over the spatial dimensions (``x``, ``y``, ``z``),
             frequency or time dimensions (``f``, ``t``) or ``mode_index``, if applicable.
@@ -736,6 +746,7 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
             vmax=vmax,
             ax=ax,
             shading=shading,
+            cmap=cmap,
             **sel_kwargs,
         )
 
@@ -752,6 +763,7 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
         vmin: Optional[float] = None,
         vmax: Optional[float] = None,
         cmap_type: ColormapType = "divergent",
+        cmap: Optional[Union[str, Colormap]] = None,
         ax: Ax = None,
         **kwargs: Any,
     ) -> Ax:
@@ -784,6 +796,8 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
             inferred from the data and other keyword arguments.
         cmap_type : Literal["divergent", "sequential", "cyclic"] = "divergent"
             Type of color map to use for plotting.
+        cmap : Optional[Union[str, Colormap]] = None
+            Colormap for visualizing the field values. ``None`` uses the default which infers it from the data. Overrides inferred colormap from `cmap_type`.
         ax : matplotlib.axes._subplots.Axes = None
             matplotlib axes to plot on, if not specified, one is created.
         **kwargs : Extra arguments to ``DataArray.plot``.
@@ -798,19 +812,23 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
         interp_kwarg = {"xyz"[axis]: position}
 
         if cmap_type == "divergent":
-            cmap = "RdBu"
+            default_cmap = "RdBu"
             center = 0.0
             eps_reverse = False
         elif cmap_type == "sequential":
-            cmap = "magma"
+            default_cmap = "magma"
             center = False
             eps_reverse = True
         elif cmap_type == "cyclic":
-            cmap = "twilight"
+            default_cmap = "twilight"
             vmin = -np.pi
             vmax = np.pi
             center = False
             eps_reverse = False
+        else:
+            default_cmap = None
+
+        cmap_to_use = default_cmap if cmap is None else cmap
 
         # plot the field
         xy_coord_labels = list("xyz")
@@ -820,7 +838,7 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
             ax=ax,
             x=x_coord_label,
             y=y_coord_label,
-            cmap=cmap,
+            cmap=cmap_to_use,
             vmin=vmin,
             vmax=vmax,
             robust=robust,

--- a/tidy3d/components/mode/data/sim_data.py
+++ b/tidy3d/components/mode/data/sim_data.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 import pydantic.v1 as pd
 
@@ -15,6 +15,9 @@ from tidy3d.components.types import TYPE_TAG_STR, Ax, PlotScale
 from tidy3d.components.types.monitor_data import ModeSolverDataType
 
 ModeSimulationMonitorDataType = Union[PermittivityData, MediumData]
+
+if TYPE_CHECKING:
+    from matplotlib.colors import Colormap
 
 
 class ModeSimulationData(AbstractYeeGridSimulationData):
@@ -53,6 +56,7 @@ class ModeSimulationData(AbstractYeeGridSimulationData):
         vmin: Optional[float] = None,
         vmax: Optional[float] = None,
         ax: Ax = None,
+        cmap: Optional[Union[str, Colormap]] = None,
         **sel_kwargs: Any,
     ) -> Ax:
         """Plot the field for a :class:`.ModeSolverData` with :class:`.Simulation` plot overlaid.
@@ -80,6 +84,8 @@ class ModeSimulationData(AbstractYeeGridSimulationData):
             inferred from the data and other keyword arguments.
         ax : matplotlib.axes._subplots.Axes = None
             matplotlib axes to plot on, if not specified, one is created.
+        cmap : Optional[Union[str, Colormap]] = None
+            Colormap for visualizing the field values. ``None`` uses the default which infers it from the data.
         sel_kwargs : keyword arguments used to perform ``.sel()`` selection in the monitor data.
             These kwargs can select over the spatial dimensions (``x``, ``y``, ``z``),
             frequency or time dimensions (``f``, ``t``) or `mode_index`, if applicable.
@@ -102,6 +108,7 @@ class ModeSimulationData(AbstractYeeGridSimulationData):
             vmin=vmin,
             vmax=vmax,
             ax=ax,
+            cmap=cmap,
             **sel_kwargs,
         )
 

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from functools import wraps
 from math import isclose
-from typing import Any, Literal, Optional, Union, get_args
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union, get_args
 
 import numpy as np
 import pydantic.v1 as pydantic
@@ -82,6 +82,9 @@ from tidy3d.components.viz import make_ax, plot_params_pml
 from tidy3d.constants import C_0, fp_eps
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
+
+if TYPE_CHECKING:
+    from matplotlib.colors import Colormap
 from tidy3d.packaging import supports_local_subpixel, tidy3d_extras
 
 # Importing the local solver may not work if e.g. scipy is not installed
@@ -2249,6 +2252,7 @@ class ModeSolver(Tidy3dBaseModel):
         vmin: Optional[float] = None,
         vmax: Optional[float] = None,
         ax: Ax = None,
+        cmap: Optional[Union[str, Colormap]] = None,
         **sel_kwargs: Any,
     ) -> Ax:
         """Plot the field for a :class:`.ModeSolverData` with :class:`.Simulation` plot overlaid.
@@ -2276,6 +2280,8 @@ class ModeSolver(Tidy3dBaseModel):
             inferred from the data and other keyword arguments.
         ax : matplotlib.axes._subplots.Axes = None
             matplotlib axes to plot on, if not specified, one is created.
+        cmap : Optional[Union[str, Colormap]] = None
+            Colormap for visualizing the field values. ``None`` uses the default which infers it from the data.
         sel_kwargs : keyword arguments used to perform ``.sel()`` selection in the monitor data.
             These kwargs can select over the spatial dimensions (``x``, ``y``, ``z``),
             frequency or time dimensions (``f``, ``t``) or `mode_index`, if applicable.
@@ -2300,6 +2306,7 @@ class ModeSolver(Tidy3dBaseModel):
             vmin=vmin,
             vmax=vmax,
             ax=ax,
+            cmap=cmap,
             **sel_kwargs,
         )
 

--- a/tidy3d/components/tcad/data/sim_data.py
+++ b/tidy3d/components/tcad/data/sim_data.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 import numpy as np
 import pydantic.v1 as pd
@@ -34,6 +34,9 @@ from tidy3d.components.types import Ax, RealFieldVal, annotate_type
 from tidy3d.components.viz import add_ax_if_none, equal_aspect
 from tidy3d.exceptions import DataError, Tidy3dKeyError
 from tidy3d.log import log
+
+if TYPE_CHECKING:
+    from matplotlib.colors import Colormap
 
 
 class DeviceCharacteristics(Tidy3dBaseModel):
@@ -281,6 +284,7 @@ class HeatChargeSimulationData(AbstractHeatChargeSimulationData):
         vmin: Optional[float] = None,
         vmax: Optional[float] = None,
         ax: Ax = None,
+        cmap: Optional[Union[str, Colormap]] = None,
         **sel_kwargs: Any,
     ) -> Ax:
         """Plot the data for a monitor with simulation structures overlaid.
@@ -310,6 +314,8 @@ class HeatChargeSimulationData(AbstractHeatChargeSimulationData):
             inferred from the data and other keyword arguments.
         ax : matplotlib.axes._subplots.Axes = None
             matplotlib axes to plot on, if not specified, one is created.
+        cmap : Optional[Union[str, Colormap]] = None
+            Colormap for visualizing the field values. ``None`` uses the default which infers it from the data.
         sel_kwargs : keyword arguments used to perform ``.sel()`` selection in the monitor data.
             These kwargs can select over the spatial dimensions (``x``, ``y``, ``z``),
             or time dimension (``t``) if applicable.
@@ -345,7 +351,7 @@ class HeatChargeSimulationData(AbstractHeatChargeSimulationData):
         if scale == "log":
             field_data = np.log10(np.abs(field_data))
 
-        cmap = "coolwarm"
+        cmap_to_use = "coolwarm" if cmap is None else cmap
 
         # do sel on unstructured data
         # it could produce either SpatialDataArray or UnstructuredGridDatasetType
@@ -361,7 +367,7 @@ class HeatChargeSimulationData(AbstractHeatChargeSimulationData):
         if isinstance(field_data, TriangularGridDataset):
             field_data.plot(
                 ax=ax,
-                cmap=cmap,
+                cmap=cmap_to_use,
                 vmin=vmin,
                 vmax=vmax,
                 cbar_kwargs={"label": field_name},
@@ -436,7 +442,7 @@ class HeatChargeSimulationData(AbstractHeatChargeSimulationData):
                 ax=ax,
                 x=x_coord_label,
                 y=y_coord_label,
-                cmap=cmap,
+                cmap=cmap_to_use,
                 vmin=vmin,
                 vmax=vmax,
                 robust=robust,

--- a/tidy3d/plugins/waveguide/rectangular_dielectric.py
+++ b/tidy3d/plugins/waveguide/rectangular_dielectric.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional, Union
 
 import numpy
 import pydantic.v1 as pydantic
@@ -26,6 +26,9 @@ from tidy3d.constants import C_0, MICROMETER, RADIAN, inf
 from tidy3d.exceptions import Tidy3dError, ValidationError
 from tidy3d.log import log
 from tidy3d.plugins.mode.mode_solver import ModeSolver
+
+if TYPE_CHECKING:
+    from matplotlib.colors import Colormap
 
 AnnotatedMedium = Annotated[MediumType, pydantic.Field(discriminator=TYPE_TAG_STR)]
 
@@ -1099,6 +1102,7 @@ class RectangularDielectric(Tidy3dBaseModel):
         vmax: Optional[float] = None,
         ax: Ax = None,
         geometry_edges: Optional[str] = None,
+        cmap: Optional[Union[str, Colormap]] = None,
         **sel_kwargs: Any,
     ) -> Ax:
         """Plot the field for a :class:`.ModeSolverData` with :class:`.Simulation` plot overlaid.
@@ -1127,6 +1131,8 @@ class RectangularDielectric(Tidy3dBaseModel):
         ax : matplotlib.axes._subplots.Axes = None
             matplotlib axes to plot on, if not specified, one is created.
         geometry_edges : Optional color to use for the geometry edges overlaid on the fields.
+        cmap : Optional[Union[str, Colormap]] = None
+            Colormap for visualizing the field values. ``None`` uses the default which infers it from the data.
         sel_kwargs : keyword arguments used to perform ``.sel()`` selection in the monitor data.
             These kwargs can select over the spatial dimensions (``x``, ``y``, ``z``),
             frequency or time dimensions (``f``, ``t``) or `mode_index`, if applicable.
@@ -1147,6 +1153,7 @@ class RectangularDielectric(Tidy3dBaseModel):
             vmin=vmin,
             vmax=vmax,
             ax=ax,
+            cmap=cmap,
             **sel_kwargs,
         )
         if geometry_edges is not None:


### PR DESCRIPTION
Enables the support of custom colormaps in field visualizations.
Usage example:
```
fig, axes = plt.subplots(1, 3, figsize=(12, 4))
sim_data.plot_field(
    "adjoint_fld_2",
    "Ex",
    val="real",
    z=0.0,
    ax=axes[0],
    cmap=None,
)
axes[0].set_title("Default colormap")

sim_data.plot_field(
    "adjoint_fld_2",
    "Ex",
    val="real",
    z=0.0,
    ax=axes[1],
    cmap="cividis",
)
axes[1].set_title("Custom 'cividis' colormap")

custom_cmap = mcolors.LinearSegmentedColormap.from_list("two", ["green", "blue"])
sim_data.plot_field(
    "adjoint_fld_2",
    "Ex",
    val="real",
    z=0.0,
    ax=axes[2],
    cmap=custom_cmap,
)
axes[2].set_title("Custom user colormap")
plt.show()
```
    
    
<img width="1007" height="381" alt="image" src="https://github.com/user-attachments/assets/38582379-a8f7-4b85-8409-a3c354863ccf" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Adds support for custom colormaps in field visualization methods across the codebase. Users can now pass a `cmap` parameter (either a string colormap name or a matplotlib Colormap object) to `plot_field` methods, which overrides the default colormap inferred from the field type.

**Key Changes:**
- Added `cmap` parameter to `plot_field`, `plot_field_monitor_data`, and `plot_scalar_array` methods in `AbstractYeeGridSimulationData`
- Extended support to specialized simulation data classes: `ModeSimulationData`, `HeatChargeSimulationData`, `ModeSolver`, and `RectangularDielectric`
- Implemented proper fallback logic: custom `cmap` overrides default colormap inferred from `cmap_type`
- Added comprehensive tests for both string colormap names and custom Colormap objects
- Updated CHANGELOG.md with user-facing feature description

**Issues Found:**
- Import ordering issue in `mode_solver.py`: import statement appears immediately after `TYPE_CHECKING` block without proper separation

<h3>Confidence Score: 4/5</h3>


- Safe to merge with one minor syntax fix for import ordering
- The implementation is well-structured and comprehensive, with proper parameter passing through the call chain, good test coverage, and appropriate documentation. However, there is one import ordering issue in `mode_solver.py` where an import statement is incorrectly placed immediately after a `TYPE_CHECKING` block, which should be fixed before merging.
- Pay attention to `tidy3d/components/mode/mode_solver.py` - fix import ordering issue on line 82-84

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tests/test_data/test_sim_data.py | 5/5 | Added test for custom colormap parameter with string and LinearSegmentedColormap |
| tidy3d/components/data/sim_data.py | 5/5 | Added `cmap` parameter to all plot methods with proper handling and fallback to defaults |
| tidy3d/components/mode/mode_solver.py | 3/5 | Added `cmap` parameter to `plot_field` method; import ordering issue detected |
| tidy3d/components/tcad/data/sim_data.py | 5/5 | Added `cmap` parameter with proper fallback to 'coolwarm' default and TYPE_CHECKING import |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant plot_field
    participant plot_field_monitor_data
    participant plot_scalar_array
    participant XarrayPlot
    
    User->>plot_field: plot_field(monitor_name, field_name, cmap="viridis")
    Note over plot_field: Accept cmap parameter<br/>(str or Colormap object)
    plot_field->>plot_field: load_field_monitor(monitor_name)
    plot_field->>plot_field_monitor_data: plot_field_monitor_data(..., cmap=cmap)
    Note over plot_field_monitor_data: Process field data<br/>and infer cmap_type
    plot_field_monitor_data->>plot_scalar_array: plot_scalar_array(..., cmap_type=cmap_type, cmap=cmap)
    Note over plot_scalar_array: Determine default_cmap<br/>from cmap_type if cmap is None
    plot_scalar_array->>plot_scalar_array: cmap_to_use = default_cmap if cmap is None else cmap
    plot_scalar_array->>XarrayPlot: field_data.plot(..., cmap=cmap_to_use)
    XarrayPlot-->>User: Returns matplotlib axes with field visualization
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->