### PR TITLE
fixes for notebook warnings

### DIFF
--- a/tests/test_data/test_monitor_data.py
+++ b/tests/test_data/test_monitor_data.py
@@ -38,8 +38,10 @@ from .test_data_arrays import (
     FIELD_MONITOR_2D,
     FIELD_TIME_MONITOR,
     FIELD_TIME_MONITOR_2D,
+    FIELDS,
     FLUX_MONITOR,
     FLUX_TIME_MONITOR,
+    FREQS,
     MEDIUM_MONITOR,
     MODE_MONITOR,
     MODE_MONITOR_WITH_FIELDS,
@@ -1133,3 +1135,39 @@ class TestZBF:
         # this should fail
         with pytest.raises(ValueError) as e:
             _ = td.FieldDataset.from_zbf(filename=zbf_filename, dim1=dim1, dim2=dim2)
+
+
+def test_symmetry_expansion_no_interpolation_warning():
+    """Regression test: symmetry_expanded_copy should not warn when monitor is on
+    the negative side of the symmetry center. Bug was using coords[-1] (negative)
+    instead of coords_interp[-1] (positive) for coordinate matching."""
+    # Monitor entirely on negative y side (need size > 0 for multiple coords)
+    monitor = td.FieldMonitor(
+        size=(2, 0.5, 5), center=(0, -1.0, 0), fields=FIELDS, name="field", freqs=FREQS
+    )
+    sim = SIM_SYM.updated_copy(monitors=[monitor], symmetry=(0, -1, 0))
+    grid = sim.discretize_monitor(monitor)
+
+    # Grid y coords are negative; data stored at mirrored positive coords
+    y_grid = grid["Ex"].y
+    assert len(y_grid) > 1 and all(y < 0 for y in y_grid)
+    y_data = [-y for y in y_grid]
+
+    data = td.ScalarFieldDataArray(
+        np.ones((len(grid["Ex"].x), len(y_data), len(grid["Ex"].z), len(FREQS))) + 0j,
+        coords={"x": grid["Ex"].x, "y": y_data, "z": grid["Ex"].z, "f": FREQS},
+    )
+    field_data = FieldData(
+        monitor=monitor,
+        Ex=data,
+        Ey=data,
+        Ez=data,
+        Hx=data,
+        Hz=data,
+        symmetry=sim.symmetry,
+        symmetry_center=sim.center,
+        grid_expanded=grid,
+    )
+
+    with AssertLogLevel(None):
+        _ = field_data.symmetry_expanded_copy

--- a/tests/test_plugins/autograd/test_functions.py
+++ b/tests/test_plugins/autograd/test_functions.py
@@ -448,6 +448,30 @@ def test_rescale_exceptions(array, out_min, out_max, in_min, in_max, expected_me
         rescale(array, out_min, out_max, in_min, in_max)
 
 
+def test_rescale_clips_output_to_bounds():
+    """Test that rescale clips output to [out_min, out_max] even when input is slightly outside [in_min, in_max].
+
+    This is a regression test for a numerical precision issue where filter_project + tanh_projection
+    could produce values slightly outside [0, 1] (e.g., -1e-15), causing rescale to produce
+    permittivity values slightly below 1.0, which would fail CustomMedium validation.
+    """
+    # Simulate input slightly outside the expected [0, 1] range due to numerical precision
+    array_with_numerical_error = np.array([-1e-15, 0.5, 1.0 + 1e-15])
+
+    out_min, out_max = 1.0, 2.75
+    in_min, in_max = 0.0, 1.0
+
+    result = rescale(array_with_numerical_error, out_min, out_max, in_min, in_max)
+
+    # Without clipping, result[0] would be slightly below 1.0 (e.g., 0.999999999999998)
+    # and result[2] would be slightly above 2.75
+    assert result.min() >= out_min, f"Output {result.min()} is below out_min={out_min}"
+    assert result.max() <= out_max, f"Output {result.max()} is above out_max={out_max}"
+
+    npt.assert_equal(result[0], out_min)
+    npt.assert_equal(result[2], out_max)
+
+
 @pytest.mark.parametrize(
     "ary, vmin, vmax, level, expected",
     [

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -309,7 +309,7 @@ class AbstractFieldData(MonitorData, AbstractFieldDataset, ABC):
                 # then we need to interpolate, which is slower.
                 use_sel = (
                     len(scalar_data.coords[dim_name]) == 1
-                    or coords[-1] in scalar_data.coords[dim_name]
+                    or coords_interp[-1] in scalar_data.coords[dim_name]
                 )
                 if use_sel:
                     scalar_data = scalar_data.sel(**{dim_name: coords_interp}, method="nearest")

--- a/tidy3d/plugins/autograd/functions.py
+++ b/tidy3d/plugins/autograd/functions.py
@@ -709,7 +709,9 @@ def rescale(
         raise ValueError(f"'in_min' ({in_min}) must be less than 'in_max' ({in_max}).")
 
     scaled = (array - in_min) / (in_max - in_min)
-    return scaled * (out_max - out_min) + out_min
+    result = scaled * (out_max - out_min) + out_min
+
+    return np.clip(result, out_min, out_max)
 
 
 def threshold(


### PR DESCRIPTION
Two fixes for autograd-related issues in the notebooks:

1. `rescale()` clips output to bounds - Filter/projection can produce values slightly outside `[0,1]` due to floating-point
   precision causing `CustomMedium` validation to fail. `rescale()` now clips output to `[out_min, out_max]`.
2. `symmetry_expanded_copy` coordinate check - spurious warning when monitors are on the negative side of symmetry center. Fixed by comparing `coords_interp[-1]` instead of `coords[-1]` (which is negative).

Both include regression tests.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed two autograd-related issues that were causing warnings in notebooks:

- **`rescale()` clipping**: Added `np.clip()` to bound output to `[out_min, out_max]`. Filter/projection operations can produce values slightly outside `[0,1]` due to floating-point precision (e.g., `-1e-15`), which caused `CustomMedium` validation failures when rescaling to permittivity values.

- **Symmetry expansion coordinate check**: Fixed spurious warning when monitors are on the negative side of symmetry center. The bug was using `coords[-1]` (negative value) instead of `coords_interp[-1]` (mirrored positive value) for matching coordinates in the data, causing unnecessary interpolation warnings.

Both fixes include comprehensive regression tests that verify the expected behavior.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no concerns
- Both fixes are minimal, well-targeted changes that address specific bugs. The `rescale()` clipping is a defensive fix that prevents numerical precision errors, and the coordinate check fix corrects an obvious logic error (using negative instead of positive coordinates). Comprehensive regression tests verify both fixes work correctly.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/autograd/functions.py | 5/5 | Added `np.clip()` to `rescale()` function to prevent floating-point precision errors from producing values outside `[out_min, out_max]` |
| tidy3d/components/data/monitor_data.py | 5/5 | Fixed spurious warning by using `coords_interp[-1]` (mirrored positive) instead of `coords[-1]` (negative) for coordinate matching in symmetry expansion |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as User/Notebook
    participant Filter as filter_project/tanh_projection
    participant Rescale as rescale()
    participant CustomMedium as CustomMedium
    participant Monitor as FieldMonitor
    participant SymExpand as symmetry_expanded_copy
    participant CoordCheck as Coordinate Check

    Note over User,CustomMedium: Fix 1: Rescale Clipping
    User->>Filter: Apply filter/projection
    Filter-->>Rescale: Values slightly outside [0,1]<br/>(e.g., -1e-15, 1+1e-15)
    Rescale->>Rescale: Scale to [out_min, out_max]
    Rescale->>Rescale: np.clip(result, out_min, out_max)
    Rescale-->>CustomMedium: Valid permittivity values
    CustomMedium->>CustomMedium: Validation passes ✓

    Note over Monitor,CoordCheck: Fix 2: Symmetry Coordinate Check
    User->>Monitor: Monitor on negative side of symmetry
    Monitor->>SymExpand: symmetry_expanded_copy
    SymExpand->>SymExpand: coords = negative values
    SymExpand->>SymExpand: coords_interp = mirrored positive values
    SymExpand->>CoordCheck: Check coords_interp[-1] in data coords
    CoordCheck-->>SymExpand: Match found, use sel (fast path)
    SymExpand-->>User: No warning ✓
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->