### PR TITLE
ci: develop-cli tests remove push based trigger (FXC-4061)

### DIFF
--- a/.github/workflows/tidy3d-python-client-develop-cli.yml
+++ b/.github/workflows/tidy3d-python-client-develop-cli.yml
@@ -24,11 +24,6 @@ on:
   schedule:
     - cron: '0 2 * * *'  # Runs every day at 2:00 AM UTC
   
-  push:
-    branches:
-      - develop
-      - latest
-
 permissions:
   contents: read
 
@@ -36,10 +31,7 @@ jobs:
   test-dev-commands:
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || inputs.release_tag }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code (HEAD)


### PR DESCRIPTION
Remove on push trigger of the python client

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Removed the `on.push` trigger for `develop` and `latest` branches from the develop-CLI workflow. This change reduces unnecessary CI runs, as the workflow is already invoked by the main test workflow when needed via `workflow_call`, runs daily via `schedule`, and can be manually triggered via `workflow_dispatch`.

- Workflow still runs on schedule (daily at 2:00 AM UTC)
- Can still be manually triggered via workflow_dispatch
- Still callable by other workflows (e.g., `tidy3d-python-client-tests.yml`)
- Reduces redundant CI execution on every push to develop/latest branches

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The change only removes a trigger from a CI workflow without affecting any logic or functionality. The workflow remains accessible through three other mechanisms (scheduled runs, manual dispatch, and workflow_call from other workflows), ensuring no loss of functionality while reducing unnecessary CI runs.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/tidy3d-python-client-develop-cli.yml | 5/5 | Removed push trigger for `develop` and `latest` branches; workflow now only runs on schedule, manual dispatch, or when called by other workflows |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub
    participant MainTests as python-client-tests.yml
    participant CLIWorkflow as develop-cli.yml
    participant Scheduler as Cron Scheduler

    Note over Dev,Scheduler: Before This PR
    Dev->>GH: Push to develop/latest
    GH->>CLIWorkflow: Trigger on push
    CLIWorkflow->>CLIWorkflow: Run CLI tests

    Note over Dev,Scheduler: After This PR
    Dev->>GH: Push to develop/latest
    Note over GH,CLIWorkflow: No automatic trigger

    Note over Dev,Scheduler: Workflow Still Accessible Via:
    
    Scheduler->>CLIWorkflow: Daily cron (2:00 AM UTC)
    CLIWorkflow->>CLIWorkflow: Run CLI tests
    
    Dev->>GH: Manual workflow_dispatch
    GH->>CLIWorkflow: Trigger manually
    CLIWorkflow->>CLIWorkflow: Run CLI tests
    
    MainTests->>CLIWorkflow: workflow_call (when cli_tests=true)
    CLIWorkflow->>CLIWorkflow: Run CLI tests
    CLIWorkflow->>MainTests: Return success status
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->