### PR TITLE
cleanup: Remove warnings on perturbed medium ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Removed validator that would warn if `PerturbationMedium` values could become numerically unstable, since an error will anyway be raised if this actually happens when the medium is converted using actual perturbation data.
 
 ### Fixed
 

--- a/tests/test_components/test_perturbation_medium.py
+++ b/tests/test_components/test_perturbation_medium.py
@@ -61,17 +61,14 @@ def test_perturbation_medium(unstructured):
             perturbation_spec=td.IndexPerturbation(delta_n=pp_real, freq=td.C_0),
         )
 
-    with AssertLogLevel("WARNING"):
-        pmed_direct = td.PerturbationMedium(permittivity=1.21, permittivity_perturbation=pp_real)
-    with AssertLogLevel("WARNING"):
-        pmed_perm = td.PerturbationMedium(
-            permittivity=1.21, perturbation_spec=td.PermittivityPerturbation(delta_eps=pp_real)
-        )
-    with AssertLogLevel("WARNING"):
-        pmed_index = td.PerturbationMedium(
-            permittivity=1.21,
-            perturbation_spec=td.IndexPerturbation(delta_n=pp_real, freq=td.C_0),
-        )
+    pmed_direct = td.PerturbationMedium(permittivity=1.21, permittivity_perturbation=pp_real)
+    pmed_perm = td.PerturbationMedium(
+        permittivity=1.21, perturbation_spec=td.PermittivityPerturbation(delta_eps=pp_real)
+    )
+    pmed_index = td.PerturbationMedium(
+        permittivity=1.21,
+        perturbation_spec=td.IndexPerturbation(delta_n=pp_real, freq=td.C_0),
+    )
 
     # test from_unperturbed function
     pmed_direct_from_med = td.PerturbationMedium.from_unperturbed(
@@ -120,18 +117,15 @@ def test_perturbation_medium(unstructured):
             subpixel=False,
         )
 
-    with AssertLogLevel("WARNING"):
-        pmed_direct = td.PerturbationMedium(conductivity_perturbation=pp_real, subpixel=False)
-    with AssertLogLevel("WARNING"):
-        pmed_perm = td.PerturbationMedium(
-            perturbation_spec=td.PermittivityPerturbation(delta_sigma=pp_real), subpixel=False
-        )
-    with AssertLogLevel("WARNING"):
-        pmed_index = td.PerturbationMedium(
-            permittivity=2,
-            perturbation_spec=td.IndexPerturbation(delta_k=pp_real, freq=td.C_0),
-            subpixel=False,
-        )
+    pmed_direct = td.PerturbationMedium(conductivity_perturbation=pp_real, subpixel=False)
+    pmed_perm = td.PerturbationMedium(
+        perturbation_spec=td.PermittivityPerturbation(delta_sigma=pp_real), subpixel=False
+    )
+    pmed_index = td.PerturbationMedium(
+        permittivity=2,
+        perturbation_spec=td.IndexPerturbation(delta_k=pp_real, freq=td.C_0),
+        subpixel=False,
+    )
 
     for pmed in [pmed_direct, pmed_perm, pmed_index]:
         cmed = pmed.perturbed_copy(0.9 * temperature)  # positive conductivity
@@ -182,33 +176,30 @@ def test_perturbation_medium(unstructured):
             allow_gain=True,
         )
 
-    with AssertLogLevel("WARNING"):
-        pmed_direct = td.PerturbationPoleResidue(
-            eps_inf=0.2,
-            poles=[(1j, 3), (2j, 4)],
-            eps_inf_perturbation=pp_real,
-            poles_perturbation=[(None, pp_real), (pp_complex, None)],
-            subpixel=False,
-            allow_gain=True,
-        )
+    pmed_direct = td.PerturbationPoleResidue(
+        eps_inf=0.2,
+        poles=[(1j, 3), (2j, 4)],
+        eps_inf_perturbation=pp_real,
+        poles_perturbation=[(None, pp_real), (pp_complex, None)],
+        subpixel=False,
+        allow_gain=True,
+    )
 
-    with AssertLogLevel("WARNING"):
-        pmed_perm = td.PerturbationPoleResidue(
-            eps_inf=0.2,
-            poles=[(1j, 3), (2j, 4)],
-            perturbation_spec=td.PermittivityPerturbation(delta_eps=pp_real),
-            subpixel=False,
-            allow_gain=True,
-        )
+    pmed_perm = td.PerturbationPoleResidue(
+        eps_inf=0.2,
+        poles=[(1j, 3), (2j, 4)],
+        perturbation_spec=td.PermittivityPerturbation(delta_eps=pp_real),
+        subpixel=False,
+        allow_gain=True,
+    )
 
-    with AssertLogLevel("WARNING"):
-        pmed_index = td.PerturbationPoleResidue(
-            eps_inf=0.05,
-            poles=[(0, 0.0001)],
-            perturbation_spec=td.IndexPerturbation(delta_k=pp_real, freq=td.C_0),
-            subpixel=False,
-            allow_gain=True,
-        )
+    pmed_index = td.PerturbationPoleResidue(
+        eps_inf=0.05,
+        poles=[(0, 0.0001)],
+        perturbation_spec=td.IndexPerturbation(delta_k=pp_real, freq=td.C_0),
+        subpixel=False,
+        allow_gain=True,
+    )
 
     # test from_unperturbed function
     pmed_direct_from_med = td.PerturbationPoleResidue.from_unperturbed(

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -93,7 +93,7 @@ from .types import (
     TensorReal,
     annotate_type,
 )
-from .validators import _warn_potential_error, validate_name_str, validate_parameter_perturbation
+from .validators import validate_name_str, validate_parameter_perturbation
 from .viz import VisualizationSpec, add_ax_if_none
 
 # evaluate frequency as this number (Hz) if inf
@@ -6679,16 +6679,12 @@ class PerturbationMedium(Medium, AbstractPerturbationMedium):
     _permittivity_perturbation_validator = validate_parameter_perturbation(
         "permittivity_perturbation",
         "permittivity",
-        allowed_real_range=[(1.0, None)],
-        allowed_imag_range=[None],
         allowed_complex=False,
     )
 
     _conductivity_perturbation_validator = validate_parameter_perturbation(
         "conductivity_perturbation",
         "conductivity",
-        allowed_real_range=[(0.0, None)],
-        allowed_imag_range=[None],
         allowed_complex=False,
     )
 
@@ -6709,44 +6705,6 @@ class PerturbationMedium(Medium, AbstractPerturbationMedium):
                 "but not in both ways simultaneously."
             )
 
-        return values
-
-    @pd.root_validator(skip_on_failure=True)
-    def _check_perturbation_spec_ranges(cls, values):
-        """Check perturbation ranges if defined as ``perturbation_spec``."""
-        p_spec = values["perturbation_spec"]
-        if p_spec is None:
-            return values
-
-        perm = values["permittivity"]
-        cond = values["conductivity"]
-
-        if isinstance(p_spec, IndexPerturbation):
-            eps_complex = Medium._eps_model(
-                permittivity=perm, conductivity=cond, frequency=p_spec.freq
-            )
-            n, k = Medium.eps_complex_to_nk(eps_c=eps_complex)
-            delta_eps_range, delta_sigma_range = p_spec._delta_eps_delta_sigma_ranges(n, k)
-        elif isinstance(p_spec, PermittivityPerturbation):
-            delta_eps_range, delta_sigma_range = p_spec._delta_eps_delta_sigma_ranges()
-        else:
-            raise SetupError("Unknown type of 'perturbation_spec'.")
-
-        _warn_potential_error(
-            field_name="permittivity",
-            base_value=perm,
-            val_change_range=delta_eps_range,
-            allowed_real_range=(1.0, None),
-            allowed_imag_range=None,
-        )
-
-        _warn_potential_error(
-            field_name="conductivity",
-            base_value=cond,
-            val_change_range=delta_sigma_range,
-            allowed_real_range=(0.0, None),
-            allowed_imag_range=None,
-        )
         return values
 
     def perturbed_copy(
@@ -6899,16 +6857,12 @@ class PerturbationPoleResidue(PoleResidue, AbstractPerturbationMedium):
     _eps_inf_perturbation_validator = validate_parameter_perturbation(
         "eps_inf_perturbation",
         "eps_inf",
-        allowed_real_range=[(0.0, None)],
-        allowed_imag_range=[None],
         allowed_complex=False,
     )
 
     _poles_perturbation_validator = validate_parameter_perturbation(
         "poles_perturbation",
         "poles",
-        allowed_real_range=[(None, 0.0), (None, None)],
-        allowed_imag_range=[None, None],
     )
 
     @pd.root_validator(pre=True)
@@ -6927,37 +6881,6 @@ class PerturbationPoleResidue(PoleResidue, AbstractPerturbationMedium):
                 "'eps_inf_perturbation' and 'poles_perturbation', "
                 "but not in both ways simultaneously."
             )
-
-        return values
-
-    @pd.root_validator(skip_on_failure=True)
-    def _check_perturbation_spec_ranges(cls, values):
-        """Check perturbation ranges if defined as ``perturbation_spec``."""
-        p_spec = values["perturbation_spec"]
-        if p_spec is None:
-            return values
-
-        eps_inf = values["eps_inf"]
-        poles = values["poles"]
-
-        if isinstance(p_spec, IndexPerturbation):
-            eps_complex = PoleResidue._eps_model(
-                eps_inf=eps_inf, poles=poles, frequency=p_spec.freq
-            )
-            n, k = Medium.eps_complex_to_nk(eps_c=eps_complex)
-            delta_eps_range, _ = p_spec._delta_eps_delta_sigma_ranges(n, k)
-        elif isinstance(p_spec, PermittivityPerturbation):
-            delta_eps_range, _ = p_spec._delta_eps_delta_sigma_ranges()
-        else:
-            raise SetupError("Unknown type of 'perturbation_spec'.")
-
-        _warn_potential_error(
-            field_name="eps_inf",
-            base_value=eps_inf,
-            val_change_range=delta_eps_range,
-            allowed_real_range=(0.0, None),
-            allowed_imag_range=None,
-        )
 
         return values
 

--- a/tidy3d/components/validators.py
+++ b/tidy3d/components/validators.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 import pydantic.v1 as pydantic
@@ -335,53 +335,16 @@ def assert_single_freq_in_range(field_name: str):
     return _single_frequency_in_range
 
 
-def _warn_potential_error(
-    field_name: str,
-    base_value: float,
-    val_change_range: tuple[float, float],
-    allowed_real_range: tuple[float, float],
-    allowed_imag_range: tuple[float, float],
-) -> None:
-    """Basic validation that perturbations do not drive a parameter out of physical bounds."""
-
-    min_val = val_change_range[0] + base_value
-    max_val = val_change_range[1] + base_value
-
-    for part_range, part_func, part_name in zip(
-        [allowed_real_range, allowed_imag_range], [np.real, np.imag], ["Re", "Im"]
-    ):
-        if part_range is not None:
-            min_allowed, max_allowed = part_range
-
-            if min_allowed is not None and part_func(min_val) < min_allowed:
-                log.warning(
-                    f"'{part_name}({field_name})' could "
-                    f"become less than '{min_allowed}' for a perturbation "
-                    "medium.",
-                    custom_loc=[field_name],
-                )
-
-            if max_allowed is not None and part_func(max_val) > max_allowed:
-                log.warning(
-                    f"'{part_name}({field_name})' could "
-                    f"become greater than '{max_allowed}' for a perturbation "
-                    "medium.",
-                    custom_loc=[field_name],
-                )
-
-
 def validate_parameter_perturbation(
     field_name: str,
     base_field_name: str,
-    allowed_real_range: tuple[tuple[float, float], ...],
-    allowed_imag_range: Optional[tuple[tuple[float, float], ...]] = None,
     allowed_complex: bool = True,
 ):
-    """Assert perturbations do not drive a parameter out of physical bounds."""
+    """Assert perturbations have a valid shape and data type."""
 
     @pydantic.validator(field_name, always=True, allow_reuse=True)
-    def _warn_perturbed_val_range(cls, val, values):
-        """Assert perturbations do not drive a parameter out of physical bounds."""
+    def _check_perturbed_val(cls, val, values):
+        """Assert perturbations have a valid shape and data type."""
 
         if val is not None:
             # get base values
@@ -394,18 +357,8 @@ def validate_parameter_perturbation(
                     f" with shape of base parameter '{base_field_name}' ({np.shape(base_values)})."
                 )
 
-            for tuple_ind, (base_tuple, perturb_tuple) in enumerate(
-                zip(np.atleast_1d(base_values), np.atleast_1d(val))
-            ):
-                tuple_ind_str = "" if np.shape(base_values) == () else f"[{tuple_ind}]"
-                for paramer_ind, (base_value, perturb, real_range, imag_range) in enumerate(
-                    zip(
-                        np.atleast_1d(base_tuple),
-                        np.atleast_1d(perturb_tuple),
-                        allowed_real_range,
-                        allowed_imag_range,
-                    )
-                ):
+            for perturb_tuple in np.atleast_1d(val):
+                for perturb in np.atleast_1d(perturb_tuple):
                     if perturb is not None:
                         # check real/complex type
                         if perturb.is_complex and not allowed_complex:
@@ -413,22 +366,9 @@ def validate_parameter_perturbation(
                                 f"Perturbation of '{base_field_name}' cannot be complex."
                             )
 
-                        ind_pointer = tuple_ind_str + (
-                            "" if np.shape(base_tuple) == () else f"[{paramer_ind}]"
-                        )
-
-                        sub_field_name = base_field_name + ind_pointer
-
-                        _warn_potential_error(
-                            field_name=sub_field_name,
-                            base_value=base_value,
-                            val_change_range=perturb.perturbation_range,
-                            allowed_real_range=real_range,
-                            allowed_imag_range=imag_range,
-                        )
         return val
 
-    return _warn_perturbed_val_range
+    return _check_perturbed_val
 
 
 def _assert_min_freq(freqs, msg_start: str) -> None:


### PR DESCRIPTION
These validators were producing the warning in a number of our notebooks, in some cases quite a lot of warnings being printed out (e.g. when you have multiple structures with the same perturbation medium, and then you also do multiple simulations like a voltage scan).

The thing is, we already have validators that will *error* if the produced CustomMedia after a given perturbation are unphysical. So it seems like the warnings are a bit too cautious and can be skipped.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Removes preemptive warnings that checked if perturbations could potentially drive medium parameters out of physical bounds. The warnings were overly cautious since error validators already exist in `CustomMedium` that will raise errors when unphysical media are actually created.

**Key Changes:**
- Removed `_warn_potential_error` helper function from `validators.py`
- Removed `_check_perturbation_spec_ranges` root validators from `PerturbationMedium` and `PerturbationPoleResidue` classes
- Simplified `validate_parameter_perturbation` to only check shape and type compatibility, removing range checking logic
- Updated function docstring to reflect the narrower validation scope

**Impact:**
The change shifts validation from warning at perturbation definition time to erroring when `perturbed_copy()` creates unphysical `CustomMedium` instances. This reduces noise in notebooks with multiple perturbed structures while maintaining safety through existing error validators (permittivity >= 1, conductivity >= 0).

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it removes redundant warnings while preserving actual error checking
- The change eliminates overly cautious warnings without compromising safety. Error validators in `CustomMedium` (lines 1828-1829 for permittivity >= 1, lines 1853-1859 for conductivity >= 0) will still catch unphysical values when `perturbed_copy()` creates the actual medium. The removed code only warned about potential issues that may never materialize, causing noise without adding protection.
- Consider removing unused parameters `allowed_real_range` and `allowed_imag_range` from `validate_parameter_perturbation` signature for cleaner code

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/validators.py | 5/5 | Removed `_warn_potential_error` function and simplified `validate_parameter_perturbation` to only check shape/type, removing range warnings |
| tidy3d/components/medium.py | 5/5 | Removed `_check_perturbation_spec_ranges` validators from `PerturbationMedium` and `PerturbationPoleResidue`, eliminating preemptive warnings about perturbation ranges |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant PerturbationMedium
    participant Validator
    participant CustomMedium
    
    User->>PerturbationMedium: Create with perturbation_spec
    Note over PerturbationMedium,Validator: Before: _check_perturbation_spec_ranges<br/>warned about potential issues
    PerturbationMedium-->>Validator: [REMOVED] Check if perturbations<br/>could exceed bounds
    Validator-->>PerturbationMedium: [REMOVED] log.warning if potential issue
    
    User->>PerturbationMedium: Call perturbed_copy()
    PerturbationMedium->>PerturbationMedium: Calculate delta_eps, delta_sigma
    PerturbationMedium->>PerturbationMedium: Apply perturbations
    PerturbationMedium->>CustomMedium: Create with perturbed values
    CustomMedium->>CustomMedium: Validate permittivity >= 1
    CustomMedium->>CustomMedium: Validate conductivity >= 0
    alt Unphysical values
        CustomMedium-->>User: ❌ SetupError/ValidationError
    else Physical values
        CustomMedium-->>User: ✓ Valid CustomMedium
    end
    
    Note over User,CustomMedium: Warnings removed at construction time<br/>Errors still raised when unphysical media created
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->