### PR TITLE
chore(invdes): fixed smoothed projection gradient with beta=inf

### DIFF
--- a/tests/test_plugins/autograd/invdes/test_projections.py
+++ b/tests/test_plugins/autograd/invdes/test_projections.py
@@ -2,23 +2,34 @@ from __future__ import annotations
 
 import autograd
 import numpy as np
+import pytest
+from autograd.test_util import check_grads
 
 from tidy3d.plugins.autograd.invdes.filters import ConicFilter
 from tidy3d.plugins.autograd.invdes.projections import smoothed_projection, tanh_projection
 
 
-def test_smoothed_projection_beta_inf():
-    nx, ny = 50, 50
-    arr = np.zeros((50, 50), dtype=float)
+def create_circle(nx, ny, radius):
+    # 1. Initialize array
+    arr = np.zeros((nx, ny), dtype=float)
 
-    center_x, center_y = 25, 25
-    radius = 10
+    # 2. Logic to create circle
+    center_x, center_y = nx / 2, ny / 2
     x = np.arange(nx)
     y = np.arange(ny)
-    X, Y = np.meshgrid(x, y)
+    # Note: indexing='ij' ensures x corresponds to rows (nx) and y to cols (ny)
+    X, Y = np.meshgrid(x, y, indexing="ij")
     distance = np.sqrt((X - center_x) ** 2 + (Y - center_y) ** 2)
 
     arr[distance <= radius] = 1
+    return arr
+
+
+def test_smoothed_projection_beta_inf():
+    nx, ny = 50, 50
+    radius = 10
+
+    arr = create_circle(nx, ny, radius)
 
     filter = ConicFilter(kernel_size=5)
     arr_filtered = filter(arr)
@@ -29,7 +40,7 @@ def test_smoothed_projection_beta_inf():
         eta=0.5,
     )
     assert not np.any(np.isinf(result) | np.isnan(result))
-    assert np.isclose(result[center_x, center_y], 1)
+    assert np.isclose(result[round(nx / 2), round(ny / 2)], 1)
     assert np.isclose(result[0, -1], 0)
     assert np.isclose(result[0, 0], 0)
     assert np.isclose(result[-1, 0], 0)
@@ -46,16 +57,9 @@ def test_smoothed_projection_beta_inf():
 
 def test_smoothed_projection_beta_non_inf():
     nx, ny = 50, 50
-    arr = np.zeros((50, 50), dtype=float)
-
-    center_x, center_y = 25, 25
     radius = 10
-    x = np.arange(nx)
-    y = np.arange(ny)
-    X, Y = np.meshgrid(x, y)
-    distance = np.sqrt((X - center_x) ** 2 + (Y - center_y) ** 2)
 
-    arr[distance <= radius] = 1
+    arr = create_circle(nx, ny, radius)
 
     # fully discrete input should still be fully discrete output
     discrete_result = smoothed_projection(
@@ -99,3 +103,18 @@ def test_projection_gradient():
     val, grad = autograd.value_and_grad(_helper_fn)(arr)
     assert val == 0.5
     assert np.all(~(np.isnan(grad) | np.isinf(grad)))
+
+
+@pytest.mark.parametrize("beta", [0, 5, np.inf])
+@pytest.mark.parametrize("size", [30, 50])
+@pytest.mark.parametrize("radius", [10, 15, 20])
+@pytest.mark.parametrize("smoothing_radius", [3, 5, 7])
+def test_projection_gradient_correctness(beta, size, radius, smoothing_radius):
+    arr = create_circle(size, size, radius)
+    filter = ConicFilter(kernel_size=smoothing_radius)
+    arr = filter(arr)
+
+    def _helper_fn(x):
+        return smoothed_projection(x, beta=beta, eta=0.5).mean()
+
+    check_grads(_helper_fn, modes=["fwd", "rev"], order=2)(arr)

--- a/tidy3d/plugins/autograd/invdes/projections.py
+++ b/tidy3d/plugins/autograd/invdes/projections.py
@@ -67,6 +67,8 @@ def tanh_projection(
     """
     if beta == 0:
         return array
+    if beta == np.inf:
+        return np.where(array > eta, 1.0, 0.0)
     num = np.tanh(beta * eta) + np.tanh(beta * (array - eta))
     denom = np.tanh(beta * eta) + np.tanh(beta * (1 - eta))
     return num / denom
@@ -101,10 +103,6 @@ def smoothed_projection(
         This function assumes that the device is placed on a uniform grid. When using
         ```GridSpec.auto``` in the simulation, make sure to place a ``MeshOverrideStructure`` at
         the position of the optimized geometry.
-
-    .. warning::
-        When using :math:`\\beta = \\infty` the function will produce NaN values if
-        the input is exactly equal to ``eta``.
 
     Parameters
     ----------


### PR DESCRIPTION
Fixed the gradient computation in smoothed_projection for beta=inf. The problem was that the existing tanh_projection did not handle beta=inf properly.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed gradient computation in `tanh_projection` when `beta=inf` by adding an explicit step function case using `np.where`, preventing NaN/inf gradients that occurred with the previous tanh formula. The fix enables proper gradient-based optimization in topology design with completely binarized projections.

Key changes:
- Added `beta == np.inf` special case in `tanh_projection` (projections.py:70-71) returning step function `np.where(array > eta, 1.0, 0.0)`
- Refactored tests to use `circle_2d_factory` pytest fixture eliminating code duplication
- Added comprehensive parametrized test `test_projection_gradient_correctness` using autograd's `check_grads` to verify forward and reverse mode gradients up to 2nd order
- Test coverage now includes `beta=np.inf` case across multiple array sizes, radii, and smoothing parameters

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor considerations about edge case documentation
- The fix correctly addresses the gradient computation issue for `beta=inf` by using a step function instead of the tanh formula that causes numerical instability. Comprehensive test coverage validates gradients across multiple scenarios including the `beta=inf` case. The only minor concern is documentation clarity around the `array == eta` edge case behavior.
- No files require special attention - the implementation is sound and well-tested

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/autograd/invdes/projections.py | 4/5 | Added special case handling for `beta=np.inf` in `tanh_projection` to prevent NaN/inf gradients by using step function |
| tests/test_plugins/autograd/invdes/test_projections.py | 5/5 | Refactored tests to use fixture for circle generation, added comprehensive gradient correctness tests with parametrized `beta=np.inf` cases |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant smoothed_projection
    participant tanh_projection
    participant autograd
    
    User->>smoothed_projection: call with array, beta=inf, eta
    smoothed_projection->>tanh_projection: compute original_projected
    
    alt beta == 0
        tanh_projection-->>smoothed_projection: return array (unchanged)
    else beta == inf (NEW FIX)
        tanh_projection->>tanh_projection: np.where(array > eta, 1.0, 0.0)
        tanh_projection-->>smoothed_projection: return step function
    else finite beta
        tanh_projection->>tanh_projection: compute tanh formula
        tanh_projection-->>smoothed_projection: return smooth projection
    end
    
    smoothed_projection->>smoothed_projection: compute gradients & smoothing
    smoothed_projection->>tanh_projection: compute rho_minus_eff_projected
    smoothed_projection->>tanh_projection: compute rho_plus_eff_projected
    smoothed_projection->>smoothed_projection: blend with polynom weights
    smoothed_projection-->>User: return smoothed result
    
    User->>autograd: compute gradient
    autograd->>smoothed_projection: backpropagate
    smoothed_projection->>tanh_projection: gradient through step function (when beta=inf)
    Note over tanh_projection,autograd: np.where has zero gradient<br/>(doesn't cause NaN/inf)
    autograd-->>User: return finite gradients
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->