### PR TITLE
feat(tidy3d): FXC-4258-automate-adding-k-layout-to-the-path-for-this-python-session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `symmetrize_mirror`, `symmetrize_rotation`, `symmetrize_diagonal` functions to the autograd plugin. They can be used for enforcing symmetries in topology optimization.
+- Klayout plugin automatically finds klayout installation path at common locations.
 
 ### Changed
 - Removed validator that would warn if `PerturbationMedium` values could become numerically unstable, since an error will anyway be raised if this actually happens when the medium is converted using actual perturbation data.

--- a/tests/test_plugins/klayout/drc/test_drc.py
+++ b/tests/test_plugins/klayout/drc/test_drc.py
@@ -13,7 +13,6 @@ import tidy3d as td
 from tidy3d.exceptions import FileError
 from tidy3d.plugins.klayout.drc.drc import DRCConfig, DRCRunner, run_drc_on_gds
 from tidy3d.plugins.klayout.drc.results import DRCResults, parse_violation_value
-from tidy3d.plugins.klayout.util import check_installation
 
 filepath = Path(os.path.dirname(os.path.abspath(__file__)))
 KLAYOUT_PLUGIN_PATH = "tidy3d.plugins.klayout"
@@ -93,23 +92,6 @@ def _capture_log_warnings(monkeypatch):
 
     monkeypatch.setattr(td.log, "warning", fake_warning)
     return messages
-
-
-def test_check_klayout_not_installed(monkeypatch):
-    """check_installation raises when KLayout is not on PATH.
-
-    Use monkeypatch to simulate absence, avoiding reliance on CI environment.
-    """
-    monkeypatch.setattr(f"{KLAYOUT_PLUGIN_PATH}.util.which", lambda _cmd: None)
-    with pytest.raises(RuntimeError):
-        check_installation(raise_error=True)
-
-
-def test_check_klayout_installed(monkeypatch):
-    """check_installation returns a path and does not raise when present."""
-    fake_path = "/usr/local/bin/klayout"
-    monkeypatch.setattr(f"{KLAYOUT_PLUGIN_PATH}.util.which", lambda _cmd: fake_path)
-    assert check_installation(raise_error=True) == fake_path
 
 
 def test_runner_passes_drc_args_to_config(monkeypatch, tmp_path):

--- a/tests/test_plugins/klayout/test_util.py
+++ b/tests/test_plugins/klayout/test_util.py
@@ -1,0 +1,47 @@
+"""Tests for tidy3d.plugins.klayout.util."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tidy3d.plugins.klayout import util
+
+KLAYOUT_PLUGIN_PATH = "tidy3d.plugins.klayout"
+
+
+def test_check_klayout_not_installed(monkeypatch):
+    """check_installation raises when KLayout is not on PATH."""
+    monkeypatch.setattr(f"{KLAYOUT_PLUGIN_PATH}.util.which", lambda _cmd: None)
+    monkeypatch.setattr(f"{KLAYOUT_PLUGIN_PATH}.util._common_install_locations", lambda: ())
+    with pytest.raises(RuntimeError):
+        util.check_installation(raise_error=True)
+
+
+def test_check_klayout_installed(monkeypatch):
+    """check_installation returns a path and does not raise when present."""
+    fake_path = "/usr/local/bin/klayout"
+    monkeypatch.setattr(f"{KLAYOUT_PLUGIN_PATH}.util.which", lambda _cmd: fake_path)
+    monkeypatch.setattr(f"{KLAYOUT_PLUGIN_PATH}.util._common_install_locations", lambda: ())
+    assert util.check_installation(raise_error=True) == fake_path
+
+
+def test_check_installation_finds_known_location(monkeypatch, tmp_path):
+    """Return a discovered installation path even when PATH is empty."""
+
+    fake_binary = tmp_path / "KLayout.app" / "Contents" / "MacOS" / "klayout"
+    fake_binary.parent.mkdir(parents=True)
+    fake_binary.write_text("#!/bin/sh\nexit 0\n")
+    fake_binary.chmod(0o755)
+
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setattr(
+        f"{KLAYOUT_PLUGIN_PATH}.util._common_install_locations",
+        lambda: (fake_binary,),
+    )
+    monkeypatch.setattr(f"{KLAYOUT_PLUGIN_PATH}.util.which", lambda _cmd: None)
+
+    resolved = util.check_installation(raise_error=True)
+    assert resolved == str(fake_binary)
+    assert os.environ["PATH"] == ""

--- a/tidy3d/plugins/klayout/drc/README.md
+++ b/tidy3d/plugins/klayout/drc/README.md
@@ -19,19 +19,21 @@ For a full quickstart example, please see [this quickstart notebook](https://git
 
 To install KLayout, please refer to https://www.klayout.de/build.html. 
 
-After installation, the application may need to be manually added to the system PATH. The method to add KLayout to your system PATH depends on your operating system. For example, on MacOS, you can add the following line to your `~/.zshrc` file. This will permanently add KLayout to your PATH:
-```zsh
-export PATH="$PATH:/Applications/klayout.app/Contents/MacOS"
-```
+This module will attempt to locate the klayout executable in the typical installation locations after KLayout has been installed on your system.
 
-To check if KLayout has been added to the system PATH, you can use the provided `check_installation()` utility:
+To check if KLayout is found by this module, you can use the provided `check_installation()` utility:
 ```python
 from tidy3d.plugins.klayout import check_installation
 # Prints the full path to the executable if found, otherwise returns None
 print(check_installation())
 ```
-
 The full path to the application should be displayed if KLayout has been added to the system PATH.
+
+If the installation could not be found, the application may need to be manually added to the system PATH. The method to add KLayout to your system PATH depends on your operating system. For example, on MacOS, you can add the following line to your `~/.zshrc` file. This will permanently add KLayout to your PATH:
+```zsh
+export PATH="$PATH:/Applications/klayout.app/Contents/MacOS"
+```
+Run `check_installation()` again to check if the application is found.
 
 2. Provide a KLayout DRC runset script that defines the source (input gds) using `source($gdsfile)` and the report (output result file) using `report("DRC results", $resultsfile)`. Please refer to the [DRC Runset Formatting section below](#drc-runset-file-formatting).
 

--- a/tidy3d/plugins/klayout/drc/drc.py
+++ b/tidy3d/plugins/klayout/drc/drc.py
@@ -248,7 +248,7 @@ def run_drc_on_gds(config: DRCConfig, max_results: Optional[int] = None) -> DRCR
     >>> results = run_drc_on_gds(config) # doctest: +SKIP
     >>> print(results) # doctest: +SKIP
     """
-    check_installation(raise_error=True)
+    klayout_cmd = check_installation(raise_error=True)
 
     if config.verbose:
         console = get_logging_console()
@@ -257,7 +257,7 @@ def run_drc_on_gds(config: DRCConfig, max_results: Optional[int] = None) -> DRCR
         )
     # run klayout DRC as a subprocess
     cmd = [
-        "klayout",
+        klayout_cmd,
         "-b",
         "-r",
         config.drc_runset,

--- a/tidy3d/plugins/klayout/util.py
+++ b/tidy3d/plugins/klayout/util.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+import platform
+from pathlib import Path
 from shutil import which
 from typing import Union
 
@@ -7,9 +10,8 @@ import tidy3d as td
 
 
 def check_installation(raise_error: bool = False) -> Union[str, None]:
-    """Checks if KLayout is installed and added to the system PATH.
-    If it is, this returns the path to the executable. Otherwise, returns ``None``.
-    Equivalent to $which("klayout") in the terminal.
+    """Return the path to the KLayout executable if it is installed.
+    The executable is located by checking the system PATH and common platform-specific installation locations.
 
     Parameters
     ----------
@@ -21,11 +23,90 @@ def check_installation(raise_error: bool = False) -> Union[str, None]:
     Union[str, None]
         The path to the KLayout executable. If KLayout is not found, returns ``None``.
     """
-    path = which("klayout")
-    msg = "KLayout was not found in the system PATH. Please ensure KLayout is installed and added to your system PATH before running KLayout."
+
+    path = _resolve_klayout_executable()
+    msg = "KLayout was not found. Please ensure KLayout is installed and added to your system PATH before running KLayout."
     if path is None:
         if raise_error:
             raise RuntimeError(msg)
-        else:
-            td.log.warning(msg)
+        td.log.warning(msg)
     return path
+
+
+def _resolve_klayout_executable() -> Union[str, None]:
+    """Return the path to the first platform-relevant KLayout executable we can find."""
+
+    system = platform.system().lower()
+
+    if system == "windows":
+        names = ("klayout_app.exe", "klayout.exe")
+    else:  # macOS ("darwin") and Linux
+        names = ("klayout",)
+
+    for name in names:
+        resolved = which(name)
+        if resolved:
+            return resolved
+
+    for binary in _common_install_locations():
+        if binary.exists():
+            return str(binary)
+    return None
+
+
+def _common_install_locations() -> tuple[Path, ...]:
+    """Return possible platform-dependent installation paths for KLayout."""
+
+    home = Path.home()
+    system = platform.system().lower()
+    paths: list[Path] = []
+
+    if system == "darwin":
+        apps = [
+            Path("/Applications") / "KLayout.app" / "Contents" / "MacOS" / "klayout",
+            Path("/Applications") / "klayout.app" / "Contents" / "MacOS" / "klayout",
+            home / "Applications" / "KLayout.app" / "Contents" / "MacOS" / "klayout",
+        ]
+        brew_bins = [
+            Path("/opt/homebrew/bin/klayout"),
+            Path("/usr/local/bin/klayout"),
+        ]
+        paths.extend(apps + brew_bins)
+    elif system == "windows":
+        program_files = [
+            Path(os.environ.get("ProgramFiles", r"C:\\Program Files")),
+            Path(os.environ.get("ProgramFiles(x86)", r"C:\\Program Files (x86)")),
+        ]
+        for root in program_files:
+            paths.extend(
+                [
+                    root / "KLayout" / "klayout_app.exe",
+                    root / "KLayout" / "klayout.exe",
+                ]
+            )
+        local_programs = home / "AppData" / "Local" / "Programs" / "KLayout"
+        paths.extend(
+            [
+                local_programs / "klayout_app.exe",
+                local_programs / "klayout.exe",
+            ]
+        )
+    else:  # Linux and other Unix variants
+        paths.extend(
+            [
+                Path("/usr/bin/klayout"),
+                Path("/usr/local/bin/klayout"),
+                Path("/snap/bin/klayout"),
+                Path("/opt/klayout/klayout"),
+                home / ".local" / "bin" / "klayout",
+            ]
+        )
+
+    seen = set()
+    unique_paths = []
+    for path in paths:
+        if path not in seen:
+            unique_paths.append(path)
+            seen.add(path)
+
+    return tuple(unique_paths)


### PR DESCRIPTION
 ̶B̶e̶f̶o̶r̶e̶ ̶`̶c̶h̶e̶c̶k̶_̶i̶n̶s̶t̶a̶l̶l̶a̶t̶i̶o̶n̶`̶ ̶i̶n̶ ̶`̶p̶l̶u̶g̶i̶n̶s̶.̶k̶l̶a̶y̶o̶u̶t̶.̶u̶t̶i̶l̶`̶,̶ ̶s̶y̶s̶t̶e̶m̶-̶s̶p̶e̶c̶i̶f̶i̶c̶ ̶p̶a̶t̶h̶ ̶a̶t̶ ̶t̶y̶p̶i̶c̶a̶l̶ ̶l̶o̶c̶a̶t̶i̶o̶n̶s̶ ̶i̶s̶ ̶a̶d̶d̶e̶d̶ ̶t̶o̶ ̶P̶A̶T̶H̶ ̶(̶i̶f̶ ̶f̶o̶u̶n̶d̶)̶.̶
̶A̶l̶s̶o̶ ̶e̶n̶s̶u̶r̶e̶d̶ ̶t̶h̶a̶t̶ ̶t̶h̶e̶ ̶a̶c̶t̶u̶a̶l̶ ̶f̶o̶u̶n̶d̶ ̶c̶o̶m̶m̶a̶n̶d̶/̶p̶a̶t̶h̶ ̶f̶r̶o̶m̶ ̶`̶w̶h̶i̶c̶h̶`̶ ̶i̶s̶ ̶u̶s̶e̶d̶.̶
̶C̶o̶u̶l̶d̶ ̶n̶o̶t̶ ̶t̶e̶s̶t̶ ̶t̶h̶a̶t̶ ̶o̶n̶ ̶W̶i̶n̶d̶o̶w̶s̶,̶ ̶c̶a̶n̶ ̶a̶n̶y̶b̶o̶d̶y̶?̶
̶F̶i̶x̶e̶d̶ ̶t̶h̶e̶ ̶g̶r̶e̶p̶t̶i̶l̶e̶-̶m̶e̶n̶t̶i̶o̶n̶e̶d̶ ̶f̶l̶a̶w̶s̶ ̶o̶f̶ ̶t̶h̶e̶ ̶t̶e̶s̶t̶s̶.̶
̶
̶`̶`̶`̶
̶f̶r̶o̶m̶ ̶t̶i̶d̶y̶3̶d̶.̶p̶l̶u̶g̶i̶n̶s̶.̶k̶l̶a̶y̶o̶u̶t̶.̶u̶t̶i̶l̶ ̶i̶m̶p̶o̶r̶t̶ ̶c̶h̶e̶c̶k̶_̶i̶n̶s̶t̶a̶l̶l̶a̶t̶i̶o̶n̶
̶i̶m̶p̶o̶r̶t̶ ̶o̶s̶
̶o̶s̶.̶e̶n̶v̶i̶r̶o̶n̶[̶"̶P̶A̶T̶H̶"̶]̶ ̶=̶ ̶"̶"̶
̶c̶h̶e̶c̶k̶_̶i̶n̶s̶t̶a̶l̶l̶a̶t̶i̶o̶n̶(̶r̶a̶i̶s̶e̶_̶e̶r̶r̶o̶r̶=̶T̶r̶u̶e̶)̶
̶`̶`̶`̶
̶T̶h̶i̶s̶ ̶s̶h̶o̶u̶l̶d̶ ̶p̶a̶s̶s̶ ̶i̶f̶ ̶k̶l̶a̶y̶o̶u̶t̶ ̶i̶n̶s̶t̶a̶l̶l̶e̶d̶ ̶a̶n̶d̶ ̶s̶h̶o̶u̶l̶d̶ ̶n̶o̶t̶ ̶p̶a̶s̶s̶ ̶i̶f̶ ̶y̶o̶u̶ ̶r̶e̶m̶o̶v̶e̶ ̶t̶h̶e̶ ̶`̶_̶e̶n̶s̶u̶r̶e̶_̶c̶o̶m̶m̶o̶n̶_̶i̶n̶s̶t̶a̶l̶l̶_̶l̶o̶c̶a̶t̶i̶o̶n̶s̶_̶o̶n̶_̶p̶a̶t̶h̶(̶)̶`̶ ̶i̶n̶ ̶`̶c̶h̶e̶c̶k̶_̶i̶n̶s̶t̶a̶l̶l̶a̶t̶i̶o̶n̶`̶.̶
We decided to just run the found executable instead of the unnecessary PATH manipulation.

Fixed 2 more tiny bugs: Convert config.drc_runset safely to str when executing cmd. Also, take the absolute resultsfile path as klayout will interpret it relatively to its own location.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Automatically adds KLayout installation directories to PATH when using the klayout plugin, improving user experience by removing the manual PATH configuration requirement.

**Major Changes:**
- Added platform-specific detection for common KLayout installation paths (macOS app bundles, Windows Program Files, Linux standard locations)
- Modified `check_installation()` to automatically prepend discovered KLayout directories to PATH before checking
- Refactored to use the resolved klayout executable path instead of hardcoded `"klayout"` command
- Moved and enhanced tests for klayout utility functions to dedicated test file

**Issues Found:**
- Test `test_check_klayout_not_installed` has a critical bug where it doesn't monkeypatch `_common_install_locations`, which will cause the test to fail if KLayout is installed at a common location on the test machine
- Test `test_check_klayout_installed` should also monkeypatch `_common_install_locations` for consistency and robustness

<h3>Confidence Score: 3/5</h3>


- This PR has a critical test bug that will cause failures in certain CI environments, but the core functionality is solid
- The implementation of automatic PATH detection is well-designed and handles multiple platforms correctly. However, the test for the negative case (klayout not installed) has a logic bug that will cause it to fail if KLayout is actually installed on the test machine at common locations. This is a critical issue for CI reliability.
- Pay close attention to `tests/test_plugins/klayout/test_util.py` - the test monkeypatching is incomplete

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/klayout/util.py | 4/5 | Added automatic PATH detection for KLayout installations across platforms (macOS, Windows, Linux); implementation looks solid but has minor style considerations |
| tests/test_plugins/klayout/test_util.py | 3/5 | New test file with moved and new tests; tests have a fragility issue where they don't monkeypatch all dependencies |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant check_installation
    participant _ensure_common_install_locations_on_path
    participant _resolve_klayout_executable
    participant _common_install_locations
    participant _prepend_to_path
    participant which

    User->>check_installation: call with raise_error=True
    check_installation->>_ensure_common_install_locations_on_path: ensure PATH is set up
    _ensure_common_install_locations_on_path->>_resolve_klayout_executable: check if already on PATH
    _resolve_klayout_executable->>which: check "klayout" (or "klayout_app.exe" on Windows)
    which-->>_resolve_klayout_executable: None (not found)
    _resolve_klayout_executable-->>_ensure_common_install_locations_on_path: None
    _ensure_common_install_locations_on_path->>_common_install_locations: get platform-specific paths
    _common_install_locations-->>_ensure_common_install_locations_on_path: list of Path objects
    loop for each binary path
        _ensure_common_install_locations_on_path->>_ensure_common_install_locations_on_path: check if binary.exists()
        alt binary exists
            _ensure_common_install_locations_on_path->>_prepend_to_path: add binary.parent to PATH
            _prepend_to_path->>_prepend_to_path: update os.environ["PATH"]
            _prepend_to_path-->>_ensure_common_install_locations_on_path: done
        end
    end
    _ensure_common_install_locations_on_path-->>check_installation: PATH updated
    check_installation->>_resolve_klayout_executable: resolve executable
    _resolve_klayout_executable->>which: check again
    which-->>_resolve_klayout_executable: /Applications/KLayout.app/Contents/MacOS/klayout
    _resolve_klayout_executable-->>check_installation: path to klayout
    check_installation-->>User: return klayout path
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->