### PR TITLE
fix: autorelease secret inheritance (FXC-3911)

### DIFF
--- a/.github/workflows/tidy3d-python-client-release.yml
+++ b/.github/workflows/tidy3d-python-client-release.yml
@@ -400,6 +400,7 @@ jobs:
       cli_tests: ${{ needs.determine-workflow-scope.outputs.run_cli_tests == 'true' }}
       submodule_tests: ${{ needs.determine-workflow-scope.outputs.run_submodule_tests == 'true' }}
       version_match_tests: true
+    secrets: inherit # zizmor: ignore[secrets-inherit]
   
   compile-tests-results:
     name: compile-tests-results


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Added `secrets: inherit` directive to the `run-client-tests` job call in the release workflow. This enables the reusable test workflow to access required secrets (`GITHUB_TOKEN` for git operations and `GH_TIDY3D_COVERAGE_GIST` for coverage reporting) that were previously unavailable.

**Changes:**
- Added `secrets: inherit` with zizmor ignore directive at line 403
- Follows same pattern as other reusable workflow calls (`create-tag` at line 383, `sync-readthedocs` at line 470)
- Resolves FXC-3911 where tests were failing due to missing secret access

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a straightforward one-line addition that follows established patterns in the same file. The `secrets: inherit` directive is already used in two other reusable workflow calls (create-tag and sync-readthedocs), and this change simply applies the same pattern to run-client-tests. The zizmor ignore directive indicates proper security review acknowledgment. No logic changes, no new functionality - just enabling required secret access for an existing workflow
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/tidy3d-python-client-release.yml | 5/5 | Added `secrets: inherit` to `run-client-tests` job call with zizmor ignore directive - enables required secret propagation to reusable workflow |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Trigger as Release Workflow
    participant Scope as determine-workflow-scope
    participant Tag as create-tag
    participant Tests as run-client-tests
    participant Compile as compile-tests-results
    participant Deploy as Deploy Jobs

    Trigger->>Scope: Start workflow with release_tag
    Scope->>Scope: Determine test/deploy scope
    Scope-->>Tag: run_tag=true
    Scope-->>Tests: run_client_tests=true
    
    Note over Tag: Uses secrets: inherit<br/>(GH_PAT)
    Tag->>Tag: Create and push git tag
    
    Note over Tests: NEW: secrets: inherit<br/>(GITHUB_TOKEN, GH_TIDY3D_COVERAGE_GIST)
    Tests->>Tests: Run local/remote/CLI/submodule tests
    Tests->>Tests: Access GITHUB_TOKEN for git operations
    Tests->>Tests: Access GH_TIDY3D_COVERAGE_GIST for coverage
    Tests-->>Compile: workflow_success output
    
    Compile->>Compile: Validate all test results
    Compile-->>Deploy: proceed_deploy=true
    
    Note over Deploy: Continue with deployment<br/>if tests pass
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->