### PR TITLE
fix: github release after pypi (FXC-3911)

### DIFF
--- a/.github/workflows/tidy3d-python-client-release.yml
+++ b/.github/workflows/tidy3d-python-client-release.yml
@@ -497,11 +497,13 @@ jobs:
   
   github-release:
     name: create-github-release
-    needs: [determine-workflow-scope, compile-tests-results]
+    needs: [determine-workflow-scope, compile-tests-results, deploy-packages]
     if: |
       always() &&
       (needs.compile-tests-results.outputs.proceed_deploy == 'true' || needs.compile-tests-results.result == 'skipped') &&
-      needs.determine-workflow-scope.outputs.deploy_github_release == 'true'
+      needs.determine-workflow-scope.outputs.deploy_github_release == 'true' &&
+      needs.determine-workflow-scope.outputs.deploy_pypi == 'true' &&
+      needs.deploy-packages.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/poetry.lock
+++ b/poetry.lock
@@ -396,18 +396,18 @@ css = ["tinycss2 (>=1.1.0,<1.5)"]
 
 [[package]]
 name = "boto3"
-version = "1.42.7"
+version = "1.42.8"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "boto3-1.42.7-py3-none-any.whl", hash = "sha256:c5cb2ada690c14e2dfa1e1c59ef7ef399c5e381f5514f1541d28310e35192300"},
-    {file = "boto3-1.42.7.tar.gz", hash = "sha256:eda49046c0f6a21ac159f9b2d609e5cc70d1dd019b7ac9618eec99285282b3db"},
+    {file = "boto3-1.42.8-py3-none-any.whl", hash = "sha256:747acc83488fc80b0e7d1c4ff0c533039ff3ede21bdbd4e89544e25b010b070c"},
+    {file = "boto3-1.42.8.tar.gz", hash = "sha256:e967706af5887339407481562c389c612d5eae641eb854ddd59026d049df740e"},
 ]
 
 [package.dependencies]
-botocore = ">=1.42.7,<1.43.0"
+botocore = ">=1.42.8,<1.43.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.16.0,<0.17.0"
 
@@ -416,14 +416,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.42.7"
+version = "1.42.8"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "botocore-1.42.7-py3-none-any.whl", hash = "sha256:92128d56654342f026d5c20a92bf0e8b546be1eb38df2c0efc7433e8bbc39045"},
-    {file = "botocore-1.42.7.tar.gz", hash = "sha256:cc401b4836eae2a781efa1d1df88b2e92f9245885a6ae1bf9a6b26bc97b3efd2"},
+    {file = "botocore-1.42.8-py3-none-any.whl", hash = "sha256:4cb89c74dd9083d16e45868749b999265a91309b2499907c84adeffa0a8df89b"},
+    {file = "botocore-1.42.8.tar.gz", hash = "sha256:4921aa454f82fed0880214eab21126c98a35fe31ede952693356f9c85ce3574b"},
 ]
 
 [package.dependencies]
@@ -4181,14 +4181,14 @@ test = ["flax (>=0.5.3)", "scikit-learn", "scipy (>=1.7.1)"]
 
 [[package]]
 name = "orbax-checkpoint"
-version = "0.11.30"
+version = "0.11.31"
 description = "Orbax Checkpoint"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "orbax_checkpoint-0.11.30-py3-none-any.whl", hash = "sha256:56b15d07af7a4ff655f18d219de850d86944b1552e5143e81f5b15480f240a46"},
-    {file = "orbax_checkpoint-0.11.30.tar.gz", hash = "sha256:5395e9fc80b750ee3644ee19f969923c7e3c83369133da5ea256a86d9bb838a6"},
+    {file = "orbax_checkpoint-0.11.31-py3-none-any.whl", hash = "sha256:b00e39cd61cbd6c7c78b091ccac0ed1bbf3cf7788e761618e7070761195bfcc0"},
+    {file = "orbax_checkpoint-0.11.31.tar.gz", hash = "sha256:f021193a619782655798bc4a285f40612f6fe647ddeb303d1f49cdbc5645e319"},
 ]
 
 [package.dependencies]
@@ -6207,7 +6207,7 @@ description = "Easily download, build, install, upgrade, and uninstall Python pa
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
-markers = "(extra == \"dev\" or extra == \"docs\" or python_version >= \"3.12\") and (sys_platform == \"darwin\" or extra == \"dev\" or extra == \"docs\" or extra == \"pytorch\") and (python_version >= \"3.12\" or extra == \"dev\" or extra == \"docs\" or extra == \"pytorch\") and (extra == \"dev\" or extra == \"pytorch\" or extra == \"docs\")"
+markers = "(extra == \"dev\" or extra == \"docs\") and (extra == \"dev\" or extra == \"pytorch\" or extra == \"docs\") or python_version >= \"3.12\" and (extra == \"dev\" or extra == \"docs\" or extra == \"pytorch\")"
 files = [
     {file = "setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922"},
     {file = "setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c"},
@@ -7031,59 +7031,59 @@ python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"extras\""
 files = [
-    {file = "tidy3d_extras-2.10.0-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:40a3b4f5d96e0484601337e35859d9d3b2199abdeeda4e7e18c56c7d54a7f278"},
-    {file = "tidy3d_extras-2.10.0-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:464200ea2a0c300393b2be8ec4ac19fb8f6456293bc67ab3924f3a9eccb30184"},
-    {file = "tidy3d_extras-2.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63b7ce2f15d73b22351bf1d1cfe29bbcc7459118189220f5b6cb767d0dbfdc2d"},
-    {file = "tidy3d_extras-2.10.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:69647ababd5f49f0199fcd8873716e8a57f77f6a52d3cd179a23c57c4557f6de"},
-    {file = "tidy3d_extras-2.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bead3694ec4cd75eab258ee5f84c023236ced58c334201c345c1441ae655c48b"},
-    {file = "tidy3d_extras-2.10.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:3ed1ee84fd3925af8bf1d8393862abd462e09a7eecc4449ae1a9db1797275559"},
-    {file = "tidy3d_extras-2.10.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:5b56b9f866266ca812b19eae1cebc7319d46a63e4a6cd3816a067e5c92aac568"},
-    {file = "tidy3d_extras-2.10.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:94f8df9a1c6b296dc0a07e71dafafc983ed5d6deb0201f577a3ec4a22c222c49"},
-    {file = "tidy3d_extras-2.10.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:b1709bbb1548b4bd5533374bf1f2c9e77685f96e0488bb5a4bd6d7c1427b6e99"},
-    {file = "tidy3d_extras-2.10.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:63ef50e1d18b31cd7436cf7bed1c94aef169a306e65ab6b650d89f41a461cdc0"},
-    {file = "tidy3d_extras-2.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:33fc9436b2e7875c55b75b40d4ffb489d3a00a094443353af17f2d81aa72b2df"},
-    {file = "tidy3d_extras-2.10.0-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:bec89c8af91a5ee49c42a9ae52b632572185a381b45ca1dd744b8c9bee7f8d6f"},
-    {file = "tidy3d_extras-2.10.0-cp311-cp311-macosx_15_0_x86_64.whl", hash = "sha256:798b7fae5ddb6e796a924791c9094fac8257cfe8e035a04453415c8fb9db88ae"},
-    {file = "tidy3d_extras-2.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf43782ebc69e8b5f7c490f3761deef7159dd6e1aa3fd67a609edacccd0bf457"},
-    {file = "tidy3d_extras-2.10.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:629fa6e2ac4141a73c4646cc4e0e5161b9f70812fcdfc923b4fbdf5381323937"},
-    {file = "tidy3d_extras-2.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83e5a57c549f6df7f61bfdf638b2151e0714405b1d8b0189ddf24f8a5a608422"},
-    {file = "tidy3d_extras-2.10.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0b19c24121975cd3e38085e5c022add96796a1e3e2e8b0f21173a6be502abe2e"},
-    {file = "tidy3d_extras-2.10.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:df37bcc087fa93d272c641f68aec98b77f1f90f26dd4c5d10c504e255259eeec"},
-    {file = "tidy3d_extras-2.10.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:06cbb2b88d223833e8f9c37c05bd243fe34ff20d441bb0421ca9de00ef6809ea"},
-    {file = "tidy3d_extras-2.10.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0e058b11dd143e68df2eee563eb2570cf7e1fbb34137f53380c8c41ba101c51a"},
-    {file = "tidy3d_extras-2.10.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bb528e610187d9e405d4b6b1e8dcb10975ccd833a413d5073d20b5a2a747b7be"},
-    {file = "tidy3d_extras-2.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:71ad3619d971716a0a3bf6cd336607be76f0bb6c5d66131ef2b98e3f16078ee4"},
-    {file = "tidy3d_extras-2.10.0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:fc941e276b4385cb2f3abd15782937b7cefff6dbf059929d0c566f37b2f1a4b3"},
-    {file = "tidy3d_extras-2.10.0-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:d878ebce47756b4bdf97e40de78acba42d1357d997ea007a10cb8f86467ca414"},
-    {file = "tidy3d_extras-2.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d840591ee799524a57d15ee408ac11d9714d0e8ff82ad41930327119de421fd6"},
-    {file = "tidy3d_extras-2.10.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b54718d21b1d8ca3ef502227a8451d34a828a88d2966308554bdde01f91c0c89"},
-    {file = "tidy3d_extras-2.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:29be226e7a6f15415454928177640416593795e0e0622fa5f3b6de2503bab9a7"},
-    {file = "tidy3d_extras-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:ff9af3ad682f2859484041f91107d5575c8dcd75aaae70a43846b8b5a08a855e"},
-    {file = "tidy3d_extras-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0197d4e54c50b13c0ef8a4fc825bd20ef4572354440b4830f700d770578a3c83"},
-    {file = "tidy3d_extras-2.10.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4596c22948ec63fb1e5c7944d605b82f5aabeeba66d7a2f04fae320d9c6cdd5d"},
-    {file = "tidy3d_extras-2.10.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0942ce9a06721be5545b4997888e4a111950b3f0fafa4e870d06cb78d5a4c9b2"},
-    {file = "tidy3d_extras-2.10.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:12bf8b95c854aa5ea506fe5523da7c562c9a65774b51739aa92f8ec3a56460de"},
-    {file = "tidy3d_extras-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:5d7888bc3d0cf06ae15bc74a4452c4be8ac9cc4b4fab8626516096640008c058"},
-    {file = "tidy3d_extras-2.10.0-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:78a1efe5b93b6d3af418d6736dae6e7d2d89a44a24ded97594b68877568c727c"},
-    {file = "tidy3d_extras-2.10.0-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:558d0954393f36af43028b7dcc451a71edeb250ab26a4c4ba292bd7fcc3e4060"},
-    {file = "tidy3d_extras-2.10.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94da7790ff3856598dab96284233c76cdb9e72b9f7a4bebadbb4e35e558132b7"},
-    {file = "tidy3d_extras-2.10.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3264e4a5c657f0f4f56e8cebf57d976be672348275368735c291c218c0e2b99e"},
-    {file = "tidy3d_extras-2.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4173ef3bc0e70db0638f2b32f66159eb69499f0d220fd50af0c498a61f201111"},
-    {file = "tidy3d_extras-2.10.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:ac06894fda1a82cc06853b3969bd78f43ac3d989f4f82d3b5497f53704ec0880"},
-    {file = "tidy3d_extras-2.10.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:279d4e2680e4570492364a27827ec3370a546d338aa5dc1b08e3232e8acd50f6"},
-    {file = "tidy3d_extras-2.10.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0ead85ec5f57a864d8807ebd07d58e5e352ec3ba839829d8de6f1166f8451e10"},
-    {file = "tidy3d_extras-2.10.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:75114d1776458675571efc0305b1e2db518bd7cd0af3e3e5045f442725718602"},
-    {file = "tidy3d_extras-2.10.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e490aa636ae5fcd846fdcbc9bfa9d9f7490bc2816c55c77bfc4f405026f6a476"},
-    {file = "tidy3d_extras-2.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:fcd1b8c17f4db63f8878ac555ae2693e4632003a09d0d3ede3302d28936eac65"},
-    {file = "tidy3d_extras-2.10.0-cp39-cp39-macosx_15_0_x86_64.whl", hash = "sha256:c2a0fe8d922a8f390612beac3142f3d247979c677d5a729b37c9207add521b99"},
-    {file = "tidy3d_extras-2.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d407fe86b4e0218559fc509d843119904726a86ffa987fef4cc9188cb3c1cc7a"},
-    {file = "tidy3d_extras-2.10.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1860d1305c9ff0d07838a0a9a85786fabe7a8e8ebbe0e876d1bcf0cf88cdc25d"},
-    {file = "tidy3d_extras-2.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1d8998e644dcc761acd70cd79d3727e3065440c52690e84792c06c8cf425a18"},
-    {file = "tidy3d_extras-2.10.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:3dd37a0e00b5dbe3eede5cba856fb48c47eee79e0c023ac2213a2bdf4696574f"},
-    {file = "tidy3d_extras-2.10.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:9bee5bd75dd9b0a657961c0b79794a2e963251cb5eb5ca91c525170d90cd154d"},
-    {file = "tidy3d_extras-2.10.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1abd8edc76bc2aec3bd4913a00789bd64ee3e59e661fe3ff0a3bab63eb83896e"},
-    {file = "tidy3d_extras-2.10.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:59913eb6ca7147596c192082e560179f9c59b4a71a62d4c1723689e1c1a1588a"},
-    {file = "tidy3d_extras-2.10.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:eba07888acfe138a3e9eeb02a717e6a0c5c6bd3c7339fcab362db4a8c2cf4f95"},
+    {file = "tidy3d_extras-2.10.0-cp310-cp310-macosx_15_0_arm64.whl", hash = "sha256:32f7c2f07626d0adf4c755a80591cee5f5aaafaca81ffb204c969adb6d9e275b"},
+    {file = "tidy3d_extras-2.10.0-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:ae2f6533f04f95ecb5a0658106f59a55f2c634df59ec3e7180f5b3f217190db5"},
+    {file = "tidy3d_extras-2.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec12f5ca1955ddfec3af087d333c3fced80fbff895cd89c89230885fd1ba27a3"},
+    {file = "tidy3d_extras-2.10.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5d3df624d057f7a37f136db9363ccd874390f42107a930700e83a25efe0de0fb"},
+    {file = "tidy3d_extras-2.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27ee925e10c72b91abed3dfd671cc4bc2b2162cdd0465632eb9063e87359f888"},
+    {file = "tidy3d_extras-2.10.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:2fcd7d871b059ec01856892e43c7a58143f981f65e773fefb3e5681703e94d19"},
+    {file = "tidy3d_extras-2.10.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:cc36a8fff05a6e3c1a48f43a05aca5da5525554d026362571fb42c0945ec08de"},
+    {file = "tidy3d_extras-2.10.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a9067f0dc078e7fc83b50a91e522520ac4250a36ec35b0ccb40d774bc0decedb"},
+    {file = "tidy3d_extras-2.10.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5cce9b22e0e2c229bbc1d2c4623d1b40352ad854aed6c20004072ab9c55cb538"},
+    {file = "tidy3d_extras-2.10.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2a2d7b97b133eaee3015554fd0c1bb77cf7880324217f9a61ae09296ebf75c0d"},
+    {file = "tidy3d_extras-2.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:b3e4f746ca1a009f4f42a9579fa6fbffbfe2c4e7d2541fa7bf20d96a6289bcbe"},
+    {file = "tidy3d_extras-2.10.0-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:00e026347d13d00439b6c7682c0071ee5ec2a14046923df42f3339fa7a42d753"},
+    {file = "tidy3d_extras-2.10.0-cp311-cp311-macosx_15_0_x86_64.whl", hash = "sha256:54e4de2575c69b38b5eb3091768272019b61a8942048cb6678994892d07c39de"},
+    {file = "tidy3d_extras-2.10.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd944fe41685ad30e3bde6bd50ab1ba7b2c7f307342483243f812a05d0abb644"},
+    {file = "tidy3d_extras-2.10.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7f4d14cf780f87da173550357a3fadd3dafff3544d7661261da7f2034110264a"},
+    {file = "tidy3d_extras-2.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9af346baa876316cc6f8055e71c9f5eca4d0d64e21e16d88659eae2001e9f9b"},
+    {file = "tidy3d_extras-2.10.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:cd5dede1a8da864ee55630b1744f9b415e01be83c7d3274b7ac80879c5cd2038"},
+    {file = "tidy3d_extras-2.10.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:e27b1667546218631212bbd67ad467d5e9a2aa806ac74b7b1e2ccad580939e09"},
+    {file = "tidy3d_extras-2.10.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:265e59f4c6cdb84a55ceb0c6b9925eb3c63263d6feb5f4e53000f17b1b722674"},
+    {file = "tidy3d_extras-2.10.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:f6ab60fcbe4692a6fbe9255854d0b8f456dbe5650b952681af8f6f480939c7d1"},
+    {file = "tidy3d_extras-2.10.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b3b3741d12cdfd532e252cc8411721ba51f06860a621a8ff4e44c88c92e24bc0"},
+    {file = "tidy3d_extras-2.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:0dd1ff5ecdb47d0af1ceb9321bcc93d3cbf21d6dd49677b05af453e10998b277"},
+    {file = "tidy3d_extras-2.10.0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:8d3835c043bb3210e841ac2b3a667a27f8a99d8bde87eadf253e83c4f188d0b4"},
+    {file = "tidy3d_extras-2.10.0-cp312-cp312-macosx_15_0_x86_64.whl", hash = "sha256:3fb3a0214e4584e204d07f8f8f5b0518c69fb2dc50627c4ccaa7ee0b252c3084"},
+    {file = "tidy3d_extras-2.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d586f3d3030692cc77fca69058a48b1b3729d99762efe5ef145a027eae22baa5"},
+    {file = "tidy3d_extras-2.10.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:13080cd5e5a0fa6bad7ed5f8aa088499d55457feda1577dfbe75eec20cd29621"},
+    {file = "tidy3d_extras-2.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a658ff913a9c914ed793b6601f9adfe34823abb522856680502afbc03b87325"},
+    {file = "tidy3d_extras-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:185428d2c3fc3815abc304f2f687ef3e72e6f7d3a2e9d7aec1d4e5ed82a3e305"},
+    {file = "tidy3d_extras-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:60c127ee7170c5ce3ca3575dcb629669ffe990b03e4709237d0878e164eb72d3"},
+    {file = "tidy3d_extras-2.10.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b03f23b92c5cea674ce8ff887ef37cee9755ad65be4a8ca8f27b4e467162dc2a"},
+    {file = "tidy3d_extras-2.10.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:87e161346e168c7fc975c14ca428289d124029a0ad3d66481754e80cd7de4968"},
+    {file = "tidy3d_extras-2.10.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9b946546db5207c98496b74a1e84dd33c940b88f46a0de6dfcb1e550d907b9e1"},
+    {file = "tidy3d_extras-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:bcbd58ca25f222b449fb9ce888b94484b8b5a8003e3168957086e6e7a60f650f"},
+    {file = "tidy3d_extras-2.10.0-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:b1375591209db8655489e2363e65eee87dea19dfe886dc7a5a28f844098b48f9"},
+    {file = "tidy3d_extras-2.10.0-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:fcac5938eb344609ea57ab3a01c1654ec6ca028a0fa3739ac1ec59c52a5931da"},
+    {file = "tidy3d_extras-2.10.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c571277752ae3c8b9b71c15b2e277cb0f50c2e3749b3bfd717f09c89668e12ac"},
+    {file = "tidy3d_extras-2.10.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:299701d99c217a5ad1d343b49a7c7c10069ffe880857514d4eab82725c9cdcc4"},
+    {file = "tidy3d_extras-2.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3657d6e009715fb84d7d2ce543b6edd0141bde4d33cea1c42236935cf9815fe3"},
+    {file = "tidy3d_extras-2.10.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:c4a2627b3fc47266064b1229548c2ed8e170cbc1b8acb114d564b3aca1408071"},
+    {file = "tidy3d_extras-2.10.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:f99c36bf13cc5d570a316edc7f9bda92e3fd963f5b07eaa1be6ed6ff3ca4cc93"},
+    {file = "tidy3d_extras-2.10.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0ec1e0d3aea5d5438725cd364748826c74ce547e067425521099b7ce6e0e8130"},
+    {file = "tidy3d_extras-2.10.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:409b6a1700c9ba97cd2fbf6e309b2a89a9ff68a8b9c755e1b0ed7d0c0b45dca8"},
+    {file = "tidy3d_extras-2.10.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8e397626aadcc1e1be3b25c941f0e1a1acf39f49d17ac92506296376c440985a"},
+    {file = "tidy3d_extras-2.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:2d9c0d5de319061f92025b799962c2f60baf3fd2cb7c699f9e8e272249758a43"},
+    {file = "tidy3d_extras-2.10.0-cp39-cp39-macosx_15_0_x86_64.whl", hash = "sha256:4c6424af18c0c1501560db2fdc31a18d05564b2c12501327bf655507844a7385"},
+    {file = "tidy3d_extras-2.10.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569bf3dfd6ac141f3620d4ee62944502a44c59b4888bb5eae121848f8679824c"},
+    {file = "tidy3d_extras-2.10.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01c8cc6b87e5c29e3839752fa314ca5f9a12fcd47f5330ede1cebfa371aa8f0f"},
+    {file = "tidy3d_extras-2.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6325229fcf6c0c3d3cb054dbed8ec33fab0742edefd64edf7f27ac6aaff01da8"},
+    {file = "tidy3d_extras-2.10.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:a0a48fbe60a0db55dcc7bc6b1acc687d9c774bfde0a6c688061df1ff7219dbbc"},
+    {file = "tidy3d_extras-2.10.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:cebacc06551e184776e578d542b171d0d10d63e2e8caa52fcd05ad98db12eee6"},
+    {file = "tidy3d_extras-2.10.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:6c48e0a3301e3288b9bd8a7d695df285d9418042fa7a34a720e48ae5d87a5681"},
+    {file = "tidy3d_extras-2.10.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:11c92b91acd9fc465109d735a826eb41300df49466b9213aef54336202bd97c4"},
+    {file = "tidy3d_extras-2.10.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:6c99408823d382692587ce7321403c1d44cf9391a80959efa8b4d7db9f2ec493"},
 ]
 
 [package.dependencies]
@@ -7565,14 +7565,14 @@ dev = ["flake8", "flake8-annotations", "flake8-bandit", "flake8-bugbear", "flake
 
 [[package]]
 name = "urllib3"
-version = "2.6.1"
+version = "2.6.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "urllib3-2.6.1-py3-none-any.whl", hash = "sha256:e67d06fe947c36a7ca39f4994b08d73922d40e6cca949907be05efa6fd75110b"},
-    {file = "urllib3-2.6.1.tar.gz", hash = "sha256:5379eb6e1aba4088bae84f8242960017ec8d8e3decf30480b3a1abdaa9671a3f"},
+    {file = "urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd"},
+    {file = "urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797"},
 ]
 
 [package.extras]


### PR DESCRIPTION
this was happening before pypi on a successful autorelease run

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR modifies the GitHub release workflow to ensure releases are only created after successful PyPI deployment. The `github-release` job now depends on the `deploy-packages` job and requires both `deploy_pypi == 'true'` and `deploy-packages.result == 'success'`.

**Key Changes:**
- Added `deploy-packages` to the `needs` array of the `github-release` job
- Added condition `deploy_pypi == 'true'` to restrict GitHub releases to PyPI deployments only
- Added condition `deploy-packages.result == 'success'` to ensure PyPI deployment succeeded before creating release

**Impact:**
- GitHub releases will no longer be created for draft or TestPyPI-only releases (breaking change from previous behavior)
- GitHub releases will only be created after successful PyPI deployment, preventing release creation if deployment fails
- An outdated comment at line 304 suggests GitHub releases should "always" be created, which is no longer accurate

<h3>Confidence Score: 4/5</h3>


- This PR is mostly safe to merge with minor documentation improvements needed
- The logic change correctly ensures GitHub releases happen after successful PyPI deployment, achieving the stated goal. However, there's a breaking behavior change (GitHub releases no longer created for non-PyPI releases) and an outdated comment that should be updated for code clarity
- Pay attention to `.github/workflows/tidy3d-python-client-release.yml` for the comment update and potential breaking change in GitHub release behavior

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/tidy3d-python-client-release.yml | 5/5 | Added dependency on `deploy-packages` job and conditions to ensure GitHub release only created after successful PyPI deployment |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Scope as determine-workflow-scope
    participant Tests as compile-tests-results
    participant Deploy as deploy-packages
    participant GitHub as github-release

    Note over Scope: Determine release type<br/>and deployment targets
    Scope->>Tests: run if tests enabled
    Scope->>Deploy: run if deploy enabled
    Note over Tests: Compile test results<br/>and check if deployment<br/>should proceed
    Tests->>Deploy: proceed_deploy output
    Note over Deploy: Deploy to TestPyPI/PyPI<br/>(only if deploy_testpypi<br/>or deploy_pypi == true)
    Deploy->>GitHub: Wait for success
    Tests->>GitHub: Check proceed_deploy
    Scope->>GitHub: Check deploy_github_release<br/>and deploy_pypi flags
    Note over GitHub: Create GitHub release<br/>ONLY if:<br/>- deploy_pypi == true<br/>- deploy-packages succeeded<br/>- tests passed
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->