### PR TITLE
feat(invdes): added symmetry functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `symmetrize_mirror`, `symmetrize_rotation`, `symmetrize_diagonal` functions to the autograd plugin. They can be used for enforcing symmetries in topology optimization.
 
 ### Changed
 - Removed validator that would warn if `PerturbationMedium` values could become numerically unstable, since an error will anyway be raised if this actually happens when the medium is converted using actual perturbation data.

--- a/docs/api/plugins/autograd.rst
+++ b/docs/api/plugins/autograd.rst
@@ -85,4 +85,7 @@ Inverse Design
     tidy3d.plugins.autograd.invdes.ramp_projection
     tidy3d.plugins.autograd.invdes.tanh_projection
     tidy3d.plugins.autograd.invdes.smoothed_projection
+    tidy3d.plugins.autograd.invdes.symmetrize_mirror
+    tidy3d.plugins.autograd.invdes.symmetrize_rotation
+    tidy3d.plugins.autograd.invdes.symmetrize_diagonal
 

--- a/tests/test_plugins/autograd/invdes/test_symmetries.py
+++ b/tests/test_plugins/autograd/invdes/test_symmetries.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import autograd.numpy as np
+import numpy as onp
+import pytest
+from autograd.test_util import check_grads
+
+from tidy3d.plugins.autograd.invdes.symmetries import (
+    symmetrize_diagonal,
+    symmetrize_mirror,
+    symmetrize_rotation,
+)
+
+# --- Helper Fixtures ---
+
+
+@pytest.fixture
+def square_array():
+    """Returns a random 5x5 array for square tests."""
+    return np.random.randn(5, 5)
+
+
+@pytest.fixture
+def rect_array():
+    """Returns a random 4x6 array for non-square tests."""
+    return np.random.randn(4, 6)
+
+
+# --- Symmetrize Mirror Tests ---
+
+
+@pytest.mark.parametrize("axis", [0, 1, (0, 1)])
+def test_mirror_gradients(axis):
+    """
+    Verifies that the gradient calculation through symmetrize_mirror is correct
+    using finite difference checks provided by autograd.
+    """
+    # Create a random array. Size doesn't need to be square.
+    x = np.random.randn(4, 5)
+
+    # We wrap the function to treat 'axis' as a fixed constant,
+    # testing the gradient only with respect to 'x'.
+    def fun(x):
+        return symmetrize_mirror(x, axis=axis)
+
+    # check_grads verifies analytical grad vs finite difference
+    check_grads(fun, modes=["rev"], order=1)(x)
+
+
+@pytest.mark.parametrize("axis", [0, 1, (0, 1)])
+def test_mirror_values(axis):
+    """Verifies numerical correctness of mirror symmetry."""
+    # Simple 2x2 case
+    # [[1, 2],
+    #  [3, 4]]
+    arr = np.array([[1.0, 2.0], [3.0, 4.0]])
+
+    res = symmetrize_mirror(arr, axis=axis)
+
+    if axis == 0:
+        # Average with vertical flip [[3, 4], [1, 2]]
+        # ([[1, 2], [3, 4]] + [[3, 4], [1, 2]]) / 2 = [[2, 3], [2, 3]]
+        expected = np.array([[2.0, 3.0], [2.0, 3.0]])
+    elif axis == 1:
+        # Average with horizontal flip [[2, 1], [4, 3]]
+        # ([[1, 2], [3, 4]] + [[2, 1], [4, 3]]) / 2 = [[1.5, 1.5], [3.5, 3.5]]
+        expected = np.array([[1.5, 1.5], [3.5, 3.5]])
+    else:  # (0, 1)
+        # Average of all 4 mirror types implied (linear combination reduces to avg of 4 corners)
+        # Result should be constant value 2.5 everywhere for this specific linear gradient input
+        expected = np.full((2, 2), 2.5)
+
+    onp.testing.assert_allclose(res, expected)
+
+
+def test_mirror_shapes_and_errors(rect_array):
+    """Test shape constraints and error handling."""
+    # Should work on rectangular arrays
+    res = symmetrize_mirror(rect_array, axis=0)
+    assert res.shape == rect_array.shape
+
+    # Error: 3D array
+    with pytest.raises(ValueError, match="Need 2d array"):
+        symmetrize_mirror(np.random.randn(2, 2, 2), axis=0)
+
+    # Error: Invalid axis
+    with pytest.raises(ValueError, match="Invalid axis"):
+        symmetrize_mirror(rect_array, axis=2)
+
+    # Error: Invalid tuple
+    with pytest.raises(ValueError, match="Invalid axis"):
+        symmetrize_mirror(rect_array, axis=(0, 0))
+
+
+# --- Symmetrize Rotation Tests ---
+
+
+def test_rotation_gradients(square_array):
+    """Verifies gradients for rotation symmetry."""
+    check_grads(symmetrize_rotation, modes=["rev"], order=1)(square_array)
+
+
+def test_rotation_values():
+    """Verifies numerical correctness of rotation symmetry."""
+    # Input with a single 1 in top-left, 0 elsewhere
+    # [[1, 0],
+    #  [0, 0]]
+    arr = np.zeros((2, 2))
+    arr[0, 0] = 1.0
+
+    res = symmetrize_rotation(arr)
+
+    # The 1 should be distributed to all 4 corners equally
+    expected = np.full((2, 2), 0.25)
+    onp.testing.assert_allclose(res, expected)
+
+
+def test_rotation_invariance(square_array):
+    """The output of symmetrize_rotation should be invariant to further 90deg rotations."""
+    sym = symmetrize_rotation(square_array)
+    rot = np.rot90(sym)
+    onp.testing.assert_allclose(sym, rot, err_msg="Output is not rotationally symmetric")
+
+
+def test_rotation_errors(rect_array):
+    """Test shape constraints for rotation."""
+    # Error: Rectangular array
+    with pytest.raises(ValueError, match="must be square"):
+        symmetrize_rotation(rect_array)
+
+
+# --- Symmetrize Diagonal Tests ---
+
+
+@pytest.mark.parametrize("anti", [False, True])
+def test_diagonal_gradients(square_array, anti):
+    """Verifies gradients for diagonal symmetry."""
+
+    def fun(x):
+        return symmetrize_diagonal(x, anti=anti)
+
+    check_grads(fun, modes=["rev"], order=1)(square_array)
+
+
+def test_diagonal_values():
+    """Verifies numerical correctness of diagonal symmetry."""
+    # [[1, 2],
+    #  [3, 4]]
+    arr = np.array([[1.0, 2.0], [3.0, 4.0]])
+
+    # Main diagonal
+    res_main = symmetrize_diagonal(arr, anti=False)
+    # Transpose is [[1, 3], [2, 4]]
+    # Avg: [[1, 2.5], [2.5, 4]]
+    expected_main = np.array([[1.0, 2.5], [2.5, 4.0]])
+    onp.testing.assert_allclose(res_main, expected_main)
+
+    # Anti diagonal
+    res_anti = symmetrize_diagonal(arr, anti=True)
+    # Anti-transpose logic check:
+    #
+    # Input:
+    # 1 2
+    # 3 4
+    #
+    # Anti-Transpose:
+    # 4 2
+    # 3 1
+    #
+    # Average:
+    # 2.5 2
+    # 3   2.5
+    expected_anti = np.array([[2.5, 2.0], [3.0, 2.5]])
+    onp.testing.assert_allclose(res_anti, expected_anti)
+
+
+def test_diagonal_errors(rect_array):
+    """Test shape constraints for diagonal."""
+    # Error: Rectangular array
+    with pytest.raises(ValueError, match="must be square"):
+        symmetrize_diagonal(rect_array)

--- a/tidy3d/plugins/autograd/__init__.py
+++ b/tidy3d/plugins/autograd/__init__.py
@@ -36,6 +36,10 @@ from .invdes import (
     make_filter_and_project,
     make_gaussian_filter,
     ramp_projection,
+    smoothed_projection,
+    symmetrize_diagonal,
+    symmetrize_mirror,
+    symmetrize_rotation,
     tanh_projection,
 )
 from .primitives import gaussian_filter, interpolate_spline
@@ -79,6 +83,10 @@ __all__ = [
     "scalar_objective",
     "smooth_max",
     "smooth_min",
+    "smoothed_projection",
+    "symmetrize_diagonal",
+    "symmetrize_mirror",
+    "symmetrize_rotation",
     "tanh_projection",
     "threshold",
     "trapz",

--- a/tidy3d/plugins/autograd/invdes/__init__.py
+++ b/tidy3d/plugins/autograd/invdes/__init__.py
@@ -17,6 +17,7 @@ from .parametrizations import (
 )
 from .penalties import ErosionDilationPenalty, make_curvature_penalty, make_erosion_dilation_penalty
 from .projections import ramp_projection, smoothed_projection, tanh_projection
+from .symmetries import symmetrize_diagonal, symmetrize_mirror, symmetrize_rotation
 
 __all__ = [
     "CircularFilter",
@@ -35,5 +36,8 @@ __all__ = [
     "make_gaussian_filter",
     "ramp_projection",
     "smoothed_projection",
+    "symmetrize_diagonal",
+    "symmetrize_mirror",
+    "symmetrize_rotation",
     "tanh_projection",
 ]

--- a/tidy3d/plugins/autograd/invdes/symmetries.py
+++ b/tidy3d/plugins/autograd/invdes/symmetries.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from numpy.typing import NDArray
+
+
+def symmetrize_mirror(array: NDArray, axis: int | tuple[int, int]) -> NDArray:
+    """
+    Symmetrizes the parameter array by averaging the mirrored parts of the array. The axis argument specifies the
+    symmetry axis.
+
+    Parameters
+    ----------
+    array : NDArray
+        The input array to be symmetrized.
+    axis: int | tuple[int, int]
+        The symmetry axis. This can either be a single axis (x=0 or y=1) or a tuple of both axes.
+
+    Returns
+    -------
+    NDArray
+        The array after applying the mirror symmetrization.
+
+    Example
+    -------
+        >>> import autograd.numpy as np
+        >>> from tidy3d.plugins.autograd.invdes.symmetries import symmetrize_mirror
+        >>> arr = np.asarray([
+        ...     [1, 2],
+        ...     [3, 4]
+        ... ])
+        >>> res_x = symmetrize_mirror(arr, axis=0)
+        >>> res_y = symmetrize_mirror(arr, axis=1)
+        >>> assert np.all(np.isclose(res_x, np.asarray([
+        ...     [2, 3],
+        ...     [2, 3]
+        ... ])))
+        >>> assert np.all(np.isclose(res_y, np.asarray([
+        ...     [1.5, 1.5],
+        ...     [3.5, 3.5]
+        ... ])))
+    """
+    if isinstance(axis, int) and (axis != 0 and axis != 1):
+        raise ValueError(f"Invalid axis: expected 0, 1, or Sequence thereof, but got {axis}")
+    if array.ndim != 2:
+        raise ValueError(f"Invalid array shape: {array.shape}. Need 2d array.")
+    if isinstance(axis, Sequence) and (
+        len(axis) != 2 or axis[0] not in [0, 1] or axis[1] not in [0, 1] or axis[0] == axis[1]
+    ):
+        raise ValueError(f"Invalid axis: expected 0, 1, or Sequence thereof, but got {axis}")
+
+    # Helper function to flip along a specific axis using slicing
+    # Autograd supports slicing (e.g. ::-1) but lacks VJP for np.flip
+    def flip_axis(arr, ax):
+        if ax == 0:
+            return arr[::-1, :]
+        elif ax == 1:
+            return arr[:, ::-1]
+        return arr
+
+    # Case 1: Symmetrize along both axes
+    if isinstance(axis, Sequence):
+        # Symmetrize along axis 0
+        array = (array + flip_axis(array, 0)) / 2.0
+        # Symmetrize along axis 1
+        array = (array + flip_axis(array, 1)) / 2.0
+        return array
+
+    # Case 2: Symmetrize along a single axis
+    return (array + flip_axis(array, axis)) / 2.0
+
+
+def symmetrize_rotation(array: NDArray) -> NDArray:
+    """
+    Symmetrizes the parameter array by averaging over all four 90-degree rotations.
+    The input array must be square.
+
+    Parameters
+    ----------
+    array : NDArray
+        The input array to be symmetrized.
+
+    Returns
+    -------
+    NDArray
+        The array after applying rotational symmetrization.
+
+    Example
+    -------
+        >>> import autograd.numpy as np
+        >>> from tidy3d.plugins.autograd.invdes.symmetries import symmetrize_rotation
+        >>> arr = np.asarray([
+        ...     [0, 0, 0],
+        ...     [1, 5, 2],
+        ...     [8, 1, 8]
+        ... ])
+        >>> res = symmetrize_rotation(arr)
+        >>> assert np.all(np.isclose(res, np.asarray([
+        ...     [4, 1, 4],
+        ...     [1, 5, 1],
+        ...     [4, 1, 4]
+        ... ])))
+    """
+    if array.ndim != 2:
+        raise ValueError(f"Invalid array shape: {array.shape}. Need 2d array.")
+
+    if array.shape[0] != array.shape[1]:
+        raise ValueError(
+            f"Invalid array shape: {array.shape}. Array must be square for rotational symmetry."
+        )
+
+    # Average the array with its 90, 180, and 270 degree rotations
+    # We manually implement rotations using Transpose (.T) and Slicing ([::-1])
+    # to ensure full compatibility with autograd.
+
+    # 0 degrees: array
+    # 90 degrees CCW: Transpose -> Flip Rows (equivalent to array.T[::-1, :])
+    rot90 = array.T[::-1, :]
+
+    # 180 degrees: Flip Rows -> Flip Cols (equivalent to array[::-1, ::-1])
+    rot180 = array[::-1, ::-1]
+
+    # 270 degrees CCW: Transpose -> Flip Cols (equivalent to array.T[:, ::-1])
+    rot270 = array.T[:, ::-1]
+
+    return (array + rot90 + rot180 + rot270) / 4.0
+
+
+def symmetrize_diagonal(array: NDArray, anti: bool = False) -> NDArray:
+    """
+    Symmetrizes the parameter array by averaging it with its transpose.
+    Can symmetrize along the main diagonal or the anti-diagonal.
+
+    Parameters
+    ----------
+    array : NDArray
+        The input array to be symmetrized. Must be square.
+    anti : bool, optional
+        If False (default), symmetrizes along the main diagonal (top-left to bottom-right).
+        If True, symmetrizes along the anti-diagonal (top-right to bottom-left).
+
+    Returns
+    -------
+    NDArray
+        The array after applying diagonal symmetrization.
+
+    Example
+    -------
+        >>> import autograd.numpy as np
+        >>> from tidy3d.plugins.autograd.invdes.symmetries import symmetrize_diagonal
+        >>> arr = np.asarray([
+        ...     [1, 2],
+        ...     [4, 7],
+        ... ])
+        >>> res = symmetrize_diagonal(arr)
+        >>> res_anti = symmetrize_diagonal(arr, anti=True)
+        >>> assert np.all(np.isclose(res, np.asarray([
+        ...     [1, 3],
+        ...     [3, 7]
+        ... ])))
+        >>> assert np.all(np.isclose(res_anti, np.asarray([
+        ...     [4, 2],
+        ...     [4, 4]
+        ... ])))
+    """
+    if array.ndim != 2:
+        raise ValueError(f"Invalid array shape: {array.shape}. Need 2d array.")
+
+    if array.shape[0] != array.shape[1]:
+        raise ValueError(
+            f"Invalid array shape: {array.shape}. Array must be square for diagonal symmetry."
+        )
+
+    if anti:
+        # Anti-diagonal symmetrization.
+        # Mathematically equivalent to averaging A with the flip of A transposed.
+        # np.flip(array.T) is equivalent to array.T[::-1, ::-1]
+        anti_transpose = array.T[::-1, ::-1]
+        return (array + anti_transpose) / 2.0
+
+    # Standard main diagonal symmetry: (A + A_transpose) / 2
+    return (array + array.T) / 2.0


### PR DESCRIPTION
Added symmetry functions according to https://flow360.atlassian.net/browse/FXC-4347

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds three symmetry functions (`symmetrize_mirror`, `symmetrize_rotation`, `symmetrize_diagonal`) for topology optimization in inverse design workflows. These functions enforce known symmetries during optimization by averaging arrays with their transformed versions.

- `symmetrize_mirror`: averages with axis-flipped versions for mirror symmetry
- `symmetrize_rotation`: averages over 90° rotations for 4-fold rotational symmetry  
- `symmetrize_diagonal`: averages with transpose for diagonal symmetry

The implementation uses autograd-compatible operations (slicing, transpose) to maintain gradient flow. Tests verify gradient correctness, numerical accuracy, and error handling.

**Key Issues:**
- Uses generic `Exception` instead of `ValueError` for input validation (violates codebase pattern)
- Copy-paste error in `symmetrize_mirror` docstring mentions "ramp projection"

<h3>Confidence Score: 4/5</h3>


- Safe to merge after fixing exception types and docstring
- Implementation is mathematically sound with comprehensive tests, but uses wrong exception type for validation (should be ValueError not Exception) and has a docstring copy-paste error. These are straightforward fixes.
- tidy3d/plugins/autograd/invdes/symmetries.py needs error handling corrections

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/autograd/invdes/symmetries.py | 3/5 | New symmetry functions with minor issues: uses generic `Exception` instead of `ValueError` for validation, and has copy-paste error in docstring |
| tests/test_plugins/autograd/invdes/test_symmetries.py | 5/5 | Comprehensive test coverage with gradient checks, value verification, invariance tests, and error handling |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as User/Optimizer
    participant Sym as symmetrize_* functions
    participant AG as Autograd
    participant Array as NDArray
    
    Note over User,Array: Topology Optimization Flow
    
    User->>Sym: Call symmetry function (array, params)
    activate Sym
    
    Sym->>Array: Validate array shape (ndim=2)
    alt Invalid shape
        Array-->>Sym: Raise Exception
        Sym-->>User: Error
    end
    
    alt symmetrize_mirror
        Sym->>Array: Flip array along axis
        Array-->>Sym: Flipped array
        Sym->>Sym: Average original + flipped
    else symmetrize_rotation
        Sym->>Array: Apply rotations (90°, 180°, 270°)
        Array-->>Sym: Rotated arrays
        Sym->>Sym: Average 4 rotations
    else symmetrize_diagonal
        Sym->>Array: Transpose array
        alt Anti-diagonal
            Array-->>Sym: Flipped transpose
        else Main diagonal
            Array-->>Sym: Regular transpose
        end
        Sym->>Sym: Average original + transpose
    end
    
    Sym->>AG: Return symmetrized array
    deactivate Sym
    
    Note over User,AG: Gradient Flow (Backpropagation)
    
    User->>AG: Compute gradients
    AG->>Sym: Backward pass through symmetry ops
    Sym->>Array: Compute VJP (slicing, transpose)
    Array-->>AG: Gradient tensors
    AG-->>User: Gradients w.r.t. input
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Use `log.error` instead of `assert` statements for error handling in production code. ([source](https://app.greptile.com/review/custom-context?memory=708d3d0c-2078-4d4f-a710-1416e9aca32f))

<!-- /greptile_comment -->