### PR TITLE
fix(autograd): use data coords with validation

### DIFF
--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -3040,3 +3040,56 @@ def test_autograd_polyslab_sidewall(use_emulated_run, monitor_key):
 
     assert np.isfinite(val)
     assert grad != 0.0
+
+
+def test_frequency_coordinate_alignment():
+    """Test that frequency coordinate handling is robust to floating-point drift.
+
+    Regression test for FXC-4349: KeyError in adjoint postprocessing due to
+    frequency coordinate mismatch between forward and adjoint data.
+    """
+    from tidy3d.web.api.autograd.backward import _slice_field_data
+
+    # Typical optical frequency
+    freq = 2e14
+
+    # Create field data with exact frequency (single frequency, single value)
+    data = xr.DataArray(
+        np.array([1.0]),
+        coords={"f": [freq]},
+        dims=["f"],
+    )
+    field_data = {"Ex": data, "Ey": data, "Ez": data}
+
+    # Test 1: Exact match should work
+    freqs_exact = np.array([freq])
+    result = _slice_field_data(field_data, freqs_exact)
+    assert len(result) == 3
+    assert all(k in result for k in ["Ex", "Ey", "Ez"])
+
+    # Test 2: Tiny FP drift (within typical precision) should fail with KeyError
+    # This demonstrates the original bug - even 0.1 Hz difference causes failure
+    freqs_drifted = np.array([freq + 0.1])  # 0.1 Hz drift at 2e14 Hz scale
+    with pytest.raises(KeyError):
+        _slice_field_data(field_data, freqs_drifted)
+
+    # Test 3: Component indicator filtering works
+    result_e_only = _slice_field_data(field_data, freqs_exact, component_indicator="E")
+    assert len(result_e_only) == 3
+
+    # Test 4: Multiple frequencies
+    freqs_multi = [1e14, 2e14, 3e14]
+    data_multi = xr.DataArray(
+        np.array([1.0, 2.0, 3.0]),
+        coords={"f": freqs_multi},
+        dims=["f"],
+    )
+    field_data_multi = {"Ex": data_multi}
+
+    # Selecting subset should work
+    result_subset = _slice_field_data(field_data_multi, np.array([2e14]))
+    assert result_subset["Ex"].sizes["f"] == 1
+
+    # Selecting non-existent frequency should fail
+    with pytest.raises(KeyError):
+        _slice_field_data(field_data_multi, np.array([1.5e14]))

--- a/tidy3d/web/api/autograd/backward.py
+++ b/tidy3d/web/api/autograd/backward.py
@@ -150,7 +150,20 @@ def postprocess_adj(
         structure = sim_data_fwd.simulation.structures[structure_index]
 
         # compute epsilon arrays for all frequencies
-        adjoint_frequencies = np.array(fld_adj.monitor.freqs)
+        # use frequencies from the actual computed derivative map to ensure they exist
+        # in both forward and adjoint data (E_der_map = fld_fwd * fld_adj)
+        first_field_component = next(iter(E_der_map.field_components.values()))
+        adjoint_frequencies = np.array(first_field_component.coords["f"].values)
+
+        monitor_freqs = np.array(fld_adj.monitor.freqs)
+        if len(adjoint_frequencies) != len(monitor_freqs) or not np.allclose(
+            np.sort(adjoint_frequencies), np.sort(monitor_freqs), rtol=1e-10, atol=0
+        ):
+            raise ValueError(
+                f"Frequency mismatch in adjoint postprocessing for structure {structure_index}. "
+                f"Expected frequencies from monitor: {monitor_freqs}, "
+                f"but derivative map has: {adjoint_frequencies}. "
+            )
 
         eps_in = _compute_eps_array(structure.medium, adjoint_frequencies)
         eps_out = _compute_eps_array(sim_data_orig.simulation.medium, adjoint_frequencies)


### PR DESCRIPTION
@momchil-flex this is tentative because I don't know if this is the actual root cause of the error but I suppose the handling is better like this either way.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR fixes a `KeyError` in adjoint postprocessing caused by floating-point coordinate drift between forward and adjoint simulation data. The fix extracts frequency coordinates from the actual computed derivative map data instead of relying on monitor frequencies, ensuring coordinate alignment when slicing field data.

**Key Changes:**
- Extracts `adjoint_frequencies` from `E_der_map.field_components` data coordinates instead of `fld_adj.monitor.freqs`
- Adds validation to ensure frequencies from data match monitor frequencies within tolerance (`rtol=1e-10`)
- Adds comprehensive regression test (`test_frequency_coordinate_alignment`) covering exact matches, float drift scenarios, and multi-frequency cases

**Issues Found:**
- Minor style issue: error message should wrap variable names in single quotes per style guide

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk after addressing the style issue
- The fix properly addresses the floating-point drift issue by using actual data coordinates instead of monitor frequencies. The validation check ensures frequencies remain aligned within tolerance. Comprehensive test coverage validates the fix. Only a minor style violation in error message formatting was found.
- Pay attention to `tidy3d/web/api/autograd/backward.py` for the style issue in error message formatting (single quotes around variable names)

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/web/api/autograd/backward.py | 4/5 | Fixed frequency coordinate mismatch by extracting frequencies from actual data instead of monitor, added validation check; minor style issue with error message formatting |
| tests/test_components/autograd/test_autograd.py | 5/5 | Added comprehensive regression test for frequency coordinate alignment, covering exact matches, float drift, component filtering, and multiple frequencies |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PM as postprocess_adj
    participant DM as get_derivative_maps
    participant ED as E_der_map
    participant FD as fld_adj
    participant CM as _compute_eps_array
    participant SD as _slice_field_data
    
    PM->>DM: get_derivative_maps(fld_fwd, eps_fwd, fld_adj, eps_adj)
    DM->>ED: Create E_der_map (fld_fwd * fld_adj)
    DM-->>PM: Return E_der_map, D_der_map, H_der_map
    
    Note over PM,ED: OLD: adjoint_frequencies = fld_adj.monitor.freqs<br/>NEW: Extract from actual data coords
    
    PM->>ED: Extract first_field_component.coords["f"].values
    ED-->>PM: Return adjoint_frequencies (from data)
    
    PM->>FD: Get fld_adj.monitor.freqs
    FD-->>PM: Return monitor_freqs
    
    Note over PM: Validate frequencies match<br/>(rtol=1e-10)
    
    alt Frequencies mismatch
        PM->>PM: Raise ValueError
    else Frequencies match
        PM->>CM: _compute_eps_array(medium, adjoint_frequencies)
        CM-->>PM: Return eps arrays
        
        loop For each frequency chunk
            PM->>SD: _slice_field_data(field_data, select_freqs)
            SD->>SD: xarray.sel(f=select_freqs)
            SD-->>PM: Return sliced field data
        end
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Do not use markdown formatting in exception or warning messages; use single quotes to highlight vari... ([source](https://app.greptile.com/review/custom-context?memory=9b45957a-2d0d-4c24-a5d3-eef6f721cbfd))

<!-- /greptile_comment -->