### PR TITLE
chore(tidy3d): FXC-4352-mypy-typedefs-for-remaining-component-files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -343,14 +343,6 @@ python_version = "3.10"
 files = [
   "tidy3d",
 ]
-exclude = [
-  "tidy3d/components/simulation.py",
-  "tidy3d/components/validators.py",
-  "tidy3d/components/medium.py",
-  "tidy3d/components/boundary.py",
-  "tidy3d/components/base.py",
-  "tidy3d/components/monitor.py",
-]
 ignore_missing_imports = true
 follow_imports = "skip"
 disallow_untyped_defs = true

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -24,6 +24,7 @@ import xarray as xr
 import yaml
 from autograd.tracer import isbox
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator
+from pydantic.fields import FieldInfo
 
 from tidy3d.compat import Self
 from tidy3d.exceptions import FileError
@@ -44,15 +45,17 @@ FORBID_SPECIAL_CHARACTERS = ["/"]
 TRACED_FIELD_KEYS_ATTR = "__tidy3d_traced_field_keys__"
 TYPE_TO_CLASS_MAP: dict[str, type[Tidy3dBaseModel]] = {}
 
+_CacheReturn = TypeVar("_CacheReturn")
 
-def cache(prop):
+
+def cache(prop: Callable[[Any], _CacheReturn]) -> Callable[[Any], _CacheReturn]:
     """Decorates a property to cache the first computed value and return it on subsequent calls."""
 
     # note, we could also just use `prop` as dict key, but hashing property might be slow
     prop_name = prop.__name__
 
     @wraps(prop)
-    def cached_property_getter(self):
+    def cached_property_getter(self: Any) -> _CacheReturn:
         """The new property method to be returned by decorator."""
 
         stored_value = self._cached_properties.get(prop_name)
@@ -67,20 +70,25 @@ def cache(prop):
     return cached_property_getter
 
 
-def cached_property(cached_property_getter):
+def cached_property(cached_property_getter: Callable[[Any], _CacheReturn]) -> property:
     """Shortcut for property(cache()) of a getter."""
 
     return property(cache(cached_property_getter))
 
 
-def cached_property_guarded(key_func):
+_GuardedReturn = TypeVar("_GuardedReturn")
+
+
+def cached_property_guarded(
+    key_func: Callable[[Any], Any],
+) -> Callable[[Callable[[Any], _GuardedReturn]], property]:
     """Like cached_property, but invalidates when the key_func(self) changes."""
 
-    def _decorator(getter):
+    def _decorator(getter: Callable[[Any], _GuardedReturn]) -> property:
         prop_name = getter.__name__
 
         @wraps(getter)
-        def _guarded(self):
+        def _guarded(self: Any) -> _GuardedReturn:
             cache_store = self._cached_properties.get(prop_name)
             current_key = key_func(self)
             if cache_store is not None:
@@ -126,7 +134,7 @@ def _get_valid_extension(fname: PathLike) -> str:
     )
 
 
-def _fmt_ann_literal(ann) -> str:
+def _fmt_ann_literal(ann: Any) -> str:
     """Spell the annotation exactly as written."""
     if ann is None:
         return "Any"
@@ -175,7 +183,7 @@ class Tidy3dBaseModel(BaseModel):
 
     @field_validator("name", check_fields=False)
     @classmethod
-    def _validate_name_no_special_characters(cls, name):
+    def _validate_name_no_special_characters(cls: type[T], name: Optional[str]) -> Optional[str]:
         if name is None:
             return name
         for character in FORBID_SPECIAL_CHARACTERS:
@@ -185,13 +193,13 @@ class Tidy3dBaseModel(BaseModel):
                 )
         return name
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         """Init method, includes post-init validators."""
         log.begin_capture()
         super().__init__(**kwargs)
         log.end_capture(self)
 
-    def __init_subclass__(cls: type[T], **kwargs):
+    def __init_subclass__(cls: type[T], **kwargs: Any) -> None:
         """Injects a constant discriminator field before Pydantic builds the model.
 
         Adds
@@ -211,7 +219,7 @@ class Tidy3dBaseModel(BaseModel):
         super().__init_subclass__(**kwargs)
 
     @classmethod
-    def __pydantic_init_subclass__(cls: type[T], **kwargs):
+    def __pydantic_init_subclass__(cls: type[T], **kwargs: Any) -> None:
         super().__pydantic_init_subclass__(**kwargs)
 
         # add docstring once pydantic is done constructing the class
@@ -306,7 +314,7 @@ class Tidy3dBaseModel(BaseModel):
         if not update:
             return {}
 
-        def get_tuple_element_type(annotation) -> Optional[type]:
+        def get_tuple_element_type(annotation: Any) -> Optional[type]:
             """Get the element type of a tuple annotation if it has one consistent type."""
             origin = get_origin(annotation)
             if origin is tuple:
@@ -320,7 +328,7 @@ class Tidy3dBaseModel(BaseModel):
                         return args[0]
             return None
 
-        def should_convert_to_tuple(annotation) -> tuple[bool, Optional[type]]:
+        def should_convert_to_tuple(annotation: Any) -> tuple[bool, Optional[type[Any]]]:
             """Check if the given annotation represents a tuple type and return element type if any."""
             origin = get_origin(annotation)
 
@@ -336,7 +344,7 @@ class Tidy3dBaseModel(BaseModel):
 
             return False, None
 
-        def convert_value(value: Any, field_info) -> Any:
+        def convert_value(value: Any, field_info: FieldInfo) -> Any:
             """Convert value based on field type information."""
             annotation = field_info.annotation
 
@@ -423,7 +431,11 @@ class Tidy3dBaseModel(BaseModel):
         return processed
 
     def copy(
-        self, *, deep: bool = True, validate: bool = True, update: Mapping[str, Any] | None = None
+        self,
+        *,
+        deep: bool = True,
+        validate: bool = True,
+        update: Optional[Mapping[str, Any]] = None,
     ) -> Self:
         """Return a copy of the model.
 
@@ -433,7 +445,7 @@ class Tidy3dBaseModel(BaseModel):
             Whether to make a deep copy first (same as v1).
         validate : bool = True
             If ``True``, run full Pydantic validation on the copied data.
-        update : Mapping[str, Any] | None = None
+        update : Optional[Mapping[str, Any]] = None
             Optional mapping of fields to overwrite (passed straight
             through to ``model_copy(update=...)``).
         """
@@ -458,7 +470,12 @@ class Tidy3dBaseModel(BaseModel):
         return new_model
 
     def updated_copy(
-        self, path: str | None = None, *, deep: bool = True, validate: bool = True, **kwargs: Any
+        self,
+        path: Optional[str] = None,
+        *,
+        deep: bool = True,
+        validate: bool = True,
+        **kwargs: Any,
     ) -> Self:
         """Make copy of a component instance with ``**kwargs`` indicating updated field values.
 
@@ -680,7 +697,7 @@ class Tidy3dBaseModel(BaseModel):
         fname: PathLike,
         group_path: Optional[str] = None,
         lazy: bool = False,
-        on_load: Optional[Callable] = None,
+        on_load: Optional[Callable[[Any], None]] = None,
         **parse_obj_kwargs: Any,
     ) -> Self:
         """Loads a :class:`Tidy3dBaseModel` from .yaml, .json, .hdf5, or .hdf5.gz file.
@@ -689,13 +706,13 @@ class Tidy3dBaseModel(BaseModel):
         ----------
         fname : PathLike
             Full path to the file to load the :class:`Tidy3dBaseModel` from.
-        group_path : str | None = None
+        group_path : Optional[str] = None
             Path to a group inside the file to use as the base level. Only for hdf5 files.
             Starting `/` is optional.
         lazy : bool = False
             Whether to load the actual data (``lazy=False``) or return a proxy that loads
             the data when accessed (``lazy=True``).
-        on_load : Callable | None = None
+        on_load : Optional[Callable[[Any], None]] = None
             Callback function executed once the model is fully materialized.
             Only used if ``lazy=True``. The callback is invoked with the loaded
             instance as its sole argument, enabling post-processing such as
@@ -963,7 +980,9 @@ class Tidy3dBaseModel(BaseModel):
         return {cls.get_tuple_group_name(index=i): val for i, val in enumerate(tuple_values)}
 
     @classmethod
-    def get_sub_model(cls: type[T], group_path: str, model_dict: dict | list) -> dict:
+    def get_sub_model(
+        cls: type[T], group_path: str, model_dict: Union[dict[str, Any], list[Any]]
+    ) -> dict:
         """Get the sub model for a given group path."""
 
         for key in group_path.split("/"):
@@ -1115,14 +1134,14 @@ class Tidy3dBaseModel(BaseModel):
 
     def to_hdf5(
         self,
-        fname: PathLike | io.BytesIO,
+        fname: Union[PathLike, io.BytesIO],
         custom_encoders: Optional[list[Callable]] = None,
     ) -> None:
         """Exports :class:`Tidy3dBaseModel` instance to .hdf5 file.
 
         Parameters
         ----------
-        fname : PathLike | BytesIO
+        fname : Union[PathLike, BytesIO]
             Full path to the .hdf5 file or buffer to save the :class:`Tidy3dBaseModel` to.
         custom_encoders : List[Callable]
             List of functions accepting (fname: str, group_path: str, value: Any) that take
@@ -1260,13 +1279,15 @@ class Tidy3dBaseModel(BaseModel):
         return cls._validate_model_dict(model_dict, **model_validate_kwargs)
 
     def to_hdf5_gz(
-        self, fname: PathLike | io.BytesIO, custom_encoders: Optional[list[Callable]] = None
+        self,
+        fname: Union[PathLike, io.BytesIO],
+        custom_encoders: Optional[list[Callable]] = None,
     ) -> None:
         """Exports :class:`Tidy3dBaseModel` instance to .hdf5.gz file.
 
         Parameters
         ----------
-        fname : PathLike | BytesIO
+        fname : Union[PathLike, BytesIO]
             Full path to the .hdf5.gz file or buffer to save the :class:`Tidy3dBaseModel` to.
         custom_encoders : List[Callable]
             List of functions accepting (fname: str, group_path: str, value: Any) that take
@@ -1305,7 +1326,7 @@ class Tidy3dBaseModel(BaseModel):
         if getattr(self, "__pydantic_extra__", None) != getattr(other, "__pydantic_extra__", None):
             return False
 
-        def _fields_equal(a, b) -> bool:
+        def _fields_equal(a: Any, b: Any) -> bool:
             a = get_static(a)
             b = get_static(b)
 
@@ -1439,7 +1460,7 @@ class Tidy3dBaseModel(BaseModel):
         """Recursively insert a map of paths to autograd-traced fields into a copy of this obj."""
         self_dict = self.model_dump(round_trip=True)
 
-        def insert_value(x, path: tuple[str, ...], sub_dict: dict) -> None:
+        def insert_value(x: Any, path: tuple[str, ...], sub_dict: dict[str, Any]) -> None:
             """Insert a value into the path into a dictionary."""
             current_dict = sub_dict
             for key in path[:-1]:
@@ -1464,7 +1485,7 @@ class Tidy3dBaseModel(BaseModel):
         return self.__class__.model_validate(self_dict)
 
     def _serialized_traced_field_keys(
-        self, field_mapping: AutogradFieldMap | None = None
+        self, field_mapping: Optional[AutogradFieldMap] = None
     ) -> Optional[str]:
         """Return a serialized, order-independent representation of traced field paths."""
 
@@ -1643,7 +1664,7 @@ class Tidy3dBaseModel(BaseModel):
 
         return sci_min, sci_max
 
-    def __rich_repr__(self):
+    def __rich_repr__(self) -> rich.repr.Result:
         """How to pretty-print instances of ``Tidy3dBaseModel``."""
         for name in type(self).model_fields:
             value = getattr(self, name)
@@ -1672,9 +1693,9 @@ class Tidy3dBaseModel(BaseModel):
 
 
 def _make_lazy_proxy(
-    target_cls: type,
+    target_cls: type[Tidy3dBaseModel],
     on_load: Optional[Callable[[Any], None]] = None,
-) -> type:
+) -> type[Tidy3dBaseModel]:
     """
     Return a lazy-loading proxy subclass of ``target_cls``.
 
@@ -1682,7 +1703,7 @@ def _make_lazy_proxy(
     ----------
     target_cls : type
         Must implement ``dict_from_file`` and ``model_validate``.
-    on_load : Callable[[Any], None] | None = None
+    on_load : Optional[Callable[[Any], None]] = None
         A function to call with the fully loaded instance once loaded.
 
     Returns
@@ -1700,13 +1721,13 @@ def _make_lazy_proxy(
             fname: PathLike,
             group_path: Optional[str],
             parse_obj_kwargs: Any,
-        ):
+        ) -> None:
             # store lazy context only in __dict__
             object.__setattr__(self, "_lazy_fname", Path(fname))
             object.__setattr__(self, "_lazy_group_path", group_path)
             object.__setattr__(self, "_lazy_parse_obj_kwargs", dict(parse_obj_kwargs or {}))
 
-        def copy(self, **kwargs: Any):
+        def copy(self, **kwargs: Any) -> Self:
             """Return another lazy proxy instead of materializing."""
             return _LazyProxy(
                 object.__getattribute__(self, "_lazy_fname"),
@@ -1717,7 +1738,7 @@ def _make_lazy_proxy(
                 },
             )
 
-        def __getattribute__(self, name: str):
+        def __getattribute__(self, name: str) -> Any:
             # Attributes that must *not* trigger materialization
             if name.startswith("_lazy_") or name in {
                 "__class__",

--- a/tidy3d/components/boundary.py
+++ b/tidy3d/components/boundary.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Any, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 import numpy as np
+from numpy.typing import NDArray
 from pydantic import (
     Field,
     NonNegativeFloat,
@@ -41,14 +42,16 @@ MIN_NUM_STABLE_PML_LAYERS = 6
 MIN_NUM_ABSORBER_LAYERS = 6
 
 
-def warn_num_layers_factory(min_num_layers: int, descr: str):
+def warn_num_layers_factory(
+    min_num_layers: int, descr: str
+) -> Callable[[type[AbsorberSpec], int], int]:
     """Several similar classes defined have a ``num_layers`` data member, and they generate
     similar warning messages when ``num_layers`` is too small.  This function creates a pydantic
     validator which can be shared with all of these classes to create these warning messages."""
 
     @field_validator("num_layers")
     @classmethod
-    def _warn_num_layers(cls, val):
+    def _warn_num_layers(cls: type[AbsorberSpec], val: int) -> int:
         if val < min_num_layers:
             cls_name = cls.__name__
             log.warning(
@@ -87,7 +90,7 @@ class Periodic(BoundaryEdge):
     """Periodic boundary condition class."""
 
     @property
-    def bloch_vec(self):
+    def bloch_vec(self) -> int:
         """Periodic boundaries are effectively Bloch boundaries with ``bloch_vec == 0``.
         In practice, periodic boundaries do not force the use of complex fields, while Bloch
         boundaries do, even with ``bloch_vec == 0``. Thus, it is more efficient to use periodic.
@@ -133,7 +136,7 @@ class ABCBoundary(AbstractABCBoundary):
     )
 
     @model_validator(mode="after")
-    def _conductivity_only_with_float_permittivity(self):
+    def _conductivity_only_with_float_permittivity(self) -> Self:
         """Validate that conductivity can be provided only with float permittivity."""
         if self.conductivity is not None and self.permittivity is None:
             raise ValidationError(
@@ -204,7 +207,7 @@ class BroadbandModeABCSpec(Tidy3dBaseModel):
 
     @field_validator("frequency_range", mode="after")
     @classmethod
-    def validate_frequency_range(cls, val):
+    def validate_frequency_range(cls, val: FreqBound) -> FreqBound:
         """Validate that max frequency is greater than min frequency."""
         _assert_min_freq(val[0], "min frequency")
         if val[1] <= val[0]:
@@ -244,7 +247,7 @@ class BroadbandModeABCSpec(Tidy3dBaseModel):
         )
 
     @property
-    def _frequency_grid(self) -> np.ndarray:
+    def _frequency_grid(self) -> NDArray:
         """Frequency grid for the broadband mode absorption boundary conditions.
         Propagation constant is sampled at these frequencies and fitted using pole-residue pair model.
         """
@@ -288,7 +291,7 @@ class ModeABCBoundary(AbstractABCBoundary):
 
     @field_validator("plane")
     @classmethod
-    def is_plane(cls, val):
+    def is_plane(cls, val: Box) -> Box:
         """Raise validation error if not planar."""
         if val.size.count(0.0) != 1:
             raise ValidationError(
@@ -301,7 +304,7 @@ class ModeABCBoundary(AbstractABCBoundary):
         cls,
         source: ModeSource,
         freq_spec: Optional[Union[PositiveFloat, BroadbandModeABCSpec]] = None,
-    ) -> ModeABCBoundary:
+    ) -> Self:
         """Instantiate from a ``ModeSource``.
 
         Parameters
@@ -340,7 +343,7 @@ class ModeABCBoundary(AbstractABCBoundary):
         monitor: Union[ModeMonitor, ModeSolverMonitor],
         mode_index: NonNegativeInt = 0,
         freq_spec: Optional[Union[PositiveFloat, BroadbandModeABCSpec]] = None,
-    ) -> ModeABCBoundary:
+    ) -> Self:
         """Instantiate from a ``ModeMonitor`` or ``ModeSolverMonitor``.
 
         Parameters
@@ -402,7 +405,9 @@ class InternalAbsorber(Box):
 
     @field_validator("boundary_spec")
     @classmethod
-    def _must_provide_permittivity(cls, val):
+    def _must_provide_permittivity(
+        cls, val: Union[ModeABCBoundary, ABCBoundary]
+    ) -> Union[ModeABCBoundary, ABCBoundary]:
         """Validate that permittivity is provided for ABCBoundary."""
         if isinstance(val, ABCBoundary) and val.permittivity is None:
             raise ValidationError(
@@ -428,7 +433,7 @@ class InternalAbsorber(Box):
         x: Optional[float] = None,
         y: Optional[float] = None,
         z: Optional[float] = None,
-        ax: Ax = None,
+        ax: Optional[Ax] = None,
         **patch_kwargs: Any,
     ) -> Ax:
         """Plot this absorber."""
@@ -494,7 +499,11 @@ class BlochBoundary(BoundaryEdge):
 
     @classmethod
     def from_source(
-        cls, source: BlochSourceType, domain_size: float, axis: Axis, medium: Medium = None
+        cls,
+        source: BlochSourceType,
+        domain_size: float,
+        axis: Axis,
+        medium: Optional[Medium] = None,
     ) -> Self:
         """Set the Bloch vector component based on a given angled source and its center frequency.
            Note that if a broadband angled source is used, only the frequency components near the
@@ -966,7 +975,7 @@ class Boundary(Tidy3dBaseModel):
     )
 
     @model_validator(mode="after")
-    def bloch_on_both_sides(self):
+    def bloch_on_both_sides(self) -> Self:
         """Error if a Bloch boundary is applied on only one side."""
         num_bloch = isinstance(self.plus, BlochBoundary) + isinstance(self.minus, BlochBoundary)
         if num_bloch == 1:
@@ -976,7 +985,7 @@ class Boundary(Tidy3dBaseModel):
         return self
 
     @model_validator(mode="after")
-    def periodic_with_pml(self):
+    def periodic_with_pml(self) -> Self:
         """Error if PBC is specified with a PML."""
         num_pbc = isinstance(self.plus, Periodic) + isinstance(self.minus, Periodic)
         num_pml = isinstance(
@@ -987,7 +996,7 @@ class Boundary(Tidy3dBaseModel):
         return self
 
     @model_validator(mode="after")
-    def periodic_with_pec_pmc(self):
+    def periodic_with_pec_pmc(self) -> Self:
         """
         If a PBC is specified along with PEC or PMC on the other side, manually set the PBC
         to PEC or PMC so that no special treatment of halos is required.
@@ -1014,7 +1023,7 @@ class Boundary(Tidy3dBaseModel):
         return self
 
     @classmethod
-    def periodic(cls):
+    def periodic(cls) -> Self:
         """Periodic boundary specification on both sides along a dimension.
 
         Example
@@ -1026,7 +1035,7 @@ class Boundary(Tidy3dBaseModel):
         return cls(plus=plus, minus=minus)
 
     @classmethod
-    def bloch(cls, bloch_vec: complex):
+    def bloch(cls, bloch_vec: complex) -> Self:
         """Bloch boundary specification on both sides along a dimension.
 
         Parameters
@@ -1045,8 +1054,12 @@ class Boundary(Tidy3dBaseModel):
 
     @classmethod
     def bloch_from_source(
-        cls, source: BlochSourceType, domain_size: float, axis: Axis, medium: Medium = None
-    ):
+        cls,
+        source: BlochSourceType,
+        domain_size: float,
+        axis: Axis,
+        medium: Optional[Medium] = None,
+    ) -> Self:
         """Bloch boundary specification on both sides along a dimension based on a given source.
 
         Parameters
@@ -1078,7 +1091,7 @@ class Boundary(Tidy3dBaseModel):
         return cls(plus=plus, minus=minus)
 
     @classmethod
-    def pec(cls):
+    def pec(cls) -> Self:
         """PEC boundary specification on both sides along a dimension.
 
         Example
@@ -1090,7 +1103,7 @@ class Boundary(Tidy3dBaseModel):
         return cls(plus=plus, minus=minus)
 
     @classmethod
-    def pmc(cls):
+    def pmc(cls) -> Self:
         """PMC boundary specification on both sides along a dimension.
 
         Example
@@ -1106,7 +1119,7 @@ class Boundary(Tidy3dBaseModel):
         cls,
         permittivity: Optional[PositiveFloat] = None,
         conductivity: Optional[NonNegativeFloat] = None,
-    ):
+    ) -> Self:
         """ABC boundary specification on both sides along a dimension.
 
         Example
@@ -1130,7 +1143,7 @@ class Boundary(Tidy3dBaseModel):
         mode_spec: ModeSpecType = DEFAULT_MODE_SPEC_MODE_ABC,
         mode_index: NonNegativeInt = 0,
         freq_spec: Optional[Union[PositiveFloat, BroadbandModeABCSpec]] = None,
-    ):
+    ) -> Self:
         """One-way wave equation mode ABC boundary specification on both sides along a dimension.
 
         Parameters
@@ -1170,7 +1183,7 @@ class Boundary(Tidy3dBaseModel):
         cls,
         source: ModeSource,
         freq_spec: Optional[Union[PositiveFloat, BroadbandModeABCSpec]] = None,
-    ):
+    ) -> Self:
         """One-way wave equation mode ABC boundary specification on both sides along a dimension constructed from a mode source.
 
         Parameters
@@ -1197,7 +1210,7 @@ class Boundary(Tidy3dBaseModel):
         monitor: Union[ModeMonitor, ModeSolverMonitor],
         mode_index: NonNegativeInt = 0,
         freq_spec: Optional[Union[PositiveFloat, BroadbandModeABCSpec]] = None,
-    ):
+    ) -> Self:
         """One-way wave equation mode ABC boundary specification on both sides along a dimension constructed from a mode monitor.
 
         Example
@@ -1219,7 +1232,9 @@ class Boundary(Tidy3dBaseModel):
         return cls(plus=plus, minus=minus)
 
     @classmethod
-    def pml(cls, num_layers: NonNegativeInt = 12, parameters: PMLParams = DefaultPMLParameters):
+    def pml(
+        cls, num_layers: NonNegativeInt = 12, parameters: PMLParams = DefaultPMLParameters
+    ) -> Self:
         """PML boundary specification on both sides along a dimension.
 
         Parameters
@@ -1239,8 +1254,10 @@ class Boundary(Tidy3dBaseModel):
 
     @classmethod
     def stable_pml(
-        cls, num_layers: NonNegativeInt = 40, parameters: PMLParams = DefaultStablePMLParameters
-    ):
+        cls,
+        num_layers: NonNegativeInt = 40,
+        parameters: PMLParams = DefaultStablePMLParameters,
+    ) -> Self:
         """Stable PML boundary specification on both sides along a dimension.
 
         Parameters
@@ -1260,8 +1277,10 @@ class Boundary(Tidy3dBaseModel):
 
     @classmethod
     def absorber(
-        cls, num_layers: NonNegativeInt = 40, parameters: PMLParams = DefaultAbsorberParameters
-    ):
+        cls,
+        num_layers: NonNegativeInt = 40,
+        parameters: PMLParams = DefaultAbsorberParameters,
+    ) -> Self:
         """Adiabatic absorber boundary specification on both sides along a dimension.
 
         Parameters
@@ -1341,7 +1360,7 @@ class BoundarySpec(Tidy3dBaseModel):
 
     @field_validator("x", "y", "z", mode="before")
     @classmethod
-    def dict_to_boundary(cls, v):
+    def dict_to_boundary(cls, v: Any) -> Any:
         """Convert dict representation to Boundary object if needed."""
         if isinstance(v, dict) and "plus" in v and "minus" in v:
             return Boundary(**v)
@@ -1369,7 +1388,7 @@ class BoundarySpec(Tidy3dBaseModel):
         raise DataError(f"field_name '{field_name}' not found")
 
     @classmethod
-    def pml(cls, x: bool = False, y: bool = False, z: bool = False):
+    def pml(cls, x: bool = False, y: bool = False, z: bool = False) -> Self:
         """PML along specified directions
 
         Parameters
@@ -1392,7 +1411,7 @@ class BoundarySpec(Tidy3dBaseModel):
         )
 
     @classmethod
-    def pec(cls, x: bool = False, y: bool = False, z: bool = False):
+    def pec(cls, x: bool = False, y: bool = False, z: bool = False) -> Self:
         """PEC along specified directions
 
         Parameters
@@ -1415,7 +1434,7 @@ class BoundarySpec(Tidy3dBaseModel):
         )
 
     @classmethod
-    def pmc(cls, x: bool = False, y: bool = False, z: bool = False):
+    def pmc(cls, x: bool = False, y: bool = False, z: bool = False) -> Self:
         """PMC along specified directions
 
         Parameters
@@ -1438,7 +1457,7 @@ class BoundarySpec(Tidy3dBaseModel):
         )
 
     @classmethod
-    def all_sides(cls, boundary: BoundaryEdge):
+    def all_sides(cls, boundary: BoundaryEdge) -> Self:
         """Set a given boundary condition on all six sides of the domain
 
         Parameters

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -4,15 +4,19 @@ from __future__ import annotations
 
 import functools
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from math import isclose
-from typing import Any, Callable, Literal, Optional, Union
+from typing import Any, Callable, Literal, Optional, TypeVar, Union
 
 import autograd.numpy as np
 import numpy as npo
 import xarray as xr
 from autograd.differential_operators import tensor_jacobian_product
+from autograd.numpy.numpy_boxes import ArrayBox
+from numpy.typing import NDArray
 from pydantic import (
     Field,
+    FieldValidationInfo,
     NonNegativeFloat,
     PositiveFloat,
     PositiveInt,
@@ -103,6 +107,13 @@ from .types import (
 from .validators import validate_name_str, validate_parameter_perturbation
 from .viz import VisualizationSpec, add_ax_if_none
 
+ArrayFloat = NDArray[npo.floating]
+ArrayComplex = NDArray[np.complexfloating]
+ArrayGeneric = NDArray[Any]
+FrequencyArray = Union[Sequence[float], ArrayFloat]
+WeightFunction = Callable[[float], ArrayComplex]
+ComplexArrayOrScalar = Union[complex, ArrayGeneric]
+
 # evaluate frequency as this number (Hz) if inf
 FREQ_EVAL_INF = 1e50
 
@@ -116,11 +127,13 @@ LOSSY_METAL_DEFAULT_MAX_POLES = 5
 LOSSY_METAL_DEFAULT_TOLERANCE_RMS = 1e-3
 
 
-def ensure_freq_in_range(eps_model: Callable[[float], complex]) -> Callable[[float], complex]:
+def ensure_freq_in_range(
+    eps_model: Callable[[AbstractMedium, float], complex],
+) -> Callable[[AbstractMedium, float], complex]:
     """Decorate ``eps_model`` to log warning if frequency supplied is out of bounds."""
 
     @functools.wraps(eps_model)
-    def _eps_model(self, frequency: float) -> complex:
+    def _eps_model(self: AbstractMedium, frequency: float) -> complex:
         """New eps_model function."""
         # evaluate infs and None as FREQ_EVAL_INF
         is_inf_scalar = isinstance(frequency, float) and np.isinf(frequency)
@@ -220,7 +233,7 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
     )
 
     @model_validator(mode="after")
-    def _validate_nonlinear_spec(self) -> None:
+    def _validate_nonlinear_spec(self) -> Self:
         """Check compatibility with nonlinear_spec."""
         if self.__class__.__name__ == "AnisotropicMedium" and any(
             comp.nonlinear_spec is not None for comp in [self.xx, self.yy, self.zz]
@@ -260,7 +273,7 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
         return self
 
     @model_validator(mode="after")
-    def _check_either_modulation_or_nonlinear_spec(self):
+    def _check_either_modulation_or_nonlinear_spec(self) -> Self:
         """Check compatibility with modulation_spec."""
         val = self.modulation_spec
         nonlinear_spec = self.nonlinear_spec
@@ -294,7 +307,7 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
         return None
 
     @property
-    def heat(self):
+    def heat(self) -> Optional[ThermalSpecType]:
         return self.heat_spec
 
     @property
@@ -522,7 +535,7 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
 
     @cached_property
     @abstractmethod
-    def n_cfl(self) -> None:
+    def n_cfl(self) -> float:
         # TODO this should be moved out of here into FDTD Simulation Mediums?
         """To ensure a stable FDTD simulation, it is essential to select an appropriate
         time step size in accordance with the CFL condition. The maximal time step
@@ -713,7 +726,7 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
         return eps_real * (1 + 1j * loss_tangent)
 
     @staticmethod
-    def eV_to_angular_freq(f_eV: float):
+    def eV_to_angular_freq(f_eV: float) -> float:
         """Convert frequency in unit of eV to rad/s.
 
         Parameters
@@ -724,7 +737,7 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
         return f_eV / HBAR
 
     @staticmethod
-    def angular_freq_to_eV(f_rad: float):
+    def angular_freq_to_eV(f_rad: float) -> float:
         """Convert frequency in unit of rad/s to eV.
 
         Parameters
@@ -735,7 +748,7 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
         return f_rad * HBAR
 
     @staticmethod
-    def angular_freq_to_Hz(f_rad: float):
+    def angular_freq_to_Hz(f_rad: float) -> float:
         """Convert frequency in unit of rad/s to Hz.
 
         Parameters
@@ -746,7 +759,7 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
         return f_rad / 2 / np.pi
 
     @staticmethod
-    def Hz_to_angular_freq(f_hz: float):
+    def Hz_to_angular_freq(f_hz: float) -> float:
         """Convert frequency in unit of Hz to rad/s.
 
         Parameters
@@ -777,12 +790,12 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
         return sigma
 
     @cached_property
-    def is_pec(self):
+    def is_pec(self) -> bool:
         """Whether the medium is a PEC."""
         return False
 
     @cached_property
-    def is_pmc(self):
+    def is_pmc(self) -> bool:
         """Whether the medium is a PMC."""
         return False
 
@@ -853,7 +866,7 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
 
         return vjp_value
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """If the medium has a name, use it as the representation. Otherwise, use the default representation."""
         if self.name:
             return self.name
@@ -1017,7 +1030,7 @@ class AbstractCustomMedium(AbstractMedium, ABC):
         eps_spatial_array = (_get_numpy_array(eps_comp).ravel() for eps_comp in eps_spatial)
         return tuple(eps_comp[np.argmax(np.abs(eps_comp))] for eps_comp in eps_spatial_array)
 
-    def _get_real_vals(self, x: np.ndarray) -> np.ndarray:
+    def _get_real_vals(self, x: ArrayGeneric) -> ArrayFloat:
         """Grab the real part of the values in array.
         Used for _eps_bounds()
         """
@@ -1062,7 +1075,7 @@ class AbstractCustomMedium(AbstractMedium, ABC):
         return np.all([AbstractCustomMedium._validate_isreal_dataarray(f) for f in dataarray_tuple])
 
     @abstractmethod
-    def _sel_custom_data_inside(self, bounds: Bound) -> None:
+    def _sel_custom_data_inside(self, bounds: Bound) -> Self:
         """Return a new medium that contains the minimal amount custom data necessary to cover
         a spatial region defined by ``bounds``."""
 
@@ -1087,7 +1100,7 @@ class AbstractCustomMedium(AbstractMedium, ABC):
         return self_mod_data_reduced._sel_custom_data_inside(bounds)
 
     @staticmethod
-    def _not_loaded(field):
+    def _not_loaded(field: Any) -> bool:
         """Check whether data was not loaded."""
         if isinstance(field, str) and field in DATA_ARRAY_MAP:
             return True
@@ -1109,7 +1122,7 @@ class AbstractCustomMedium(AbstractMedium, ABC):
         E_der_map: ElectromagneticFieldDataset,
         spatial_data: PermittivityDataset,
         dim: str,
-    ) -> np.ndarray:
+    ) -> ArrayGeneric:
         coords_interp = {key: val for key, val in spatial_data.coords.items() if len(val) > 1}
         dims_sum = {dim for dim in spatial_data.coords.keys() if dim not in coords_interp}
 
@@ -1183,7 +1196,7 @@ class PECMedium(AbstractMedium):
 
     @field_validator("modulation_spec")
     @classmethod
-    def _validate_modulation_spec(cls, val):
+    def _validate_modulation_spec(cls, val: Optional[ModulationSpec]) -> Optional[ModulationSpec]:
         """Check compatibility with modulation_spec."""
         if val is not None:
             raise ValidationError(
@@ -1198,7 +1211,7 @@ class PECMedium(AbstractMedium):
         return 0j * frequency + pec_val
 
     @cached_property
-    def n_cfl(self):
+    def n_cfl(self) -> float:
         """This property computes the index of refraction related to CFL condition, so that
         the FDTD with this medium is stable when the time step size that doesn't take
         material factor into account is multiplied by ``n_cfl``.
@@ -1206,7 +1219,7 @@ class PECMedium(AbstractMedium):
         return 1.0
 
     @cached_property
-    def is_pec(self):
+    def is_pec(self) -> bool:
         """Whether the medium is a PEC."""
         return True
 
@@ -1230,7 +1243,7 @@ class PMCMedium(AbstractMedium):
 
     @field_validator("modulation_spec")
     @classmethod
-    def _validate_modulation_spec(cls, val):
+    def _validate_modulation_spec(cls, val: Optional[ModulationSpec]) -> Optional[ModulationSpec]:
         """Check compatibility with modulation_spec."""
         if val is not None:
             raise ValidationError(
@@ -1245,7 +1258,7 @@ class PMCMedium(AbstractMedium):
         return 1.0 + 0j
 
     @cached_property
-    def n_cfl(self):
+    def n_cfl(self) -> float:
         """This property computes the index of refraction related to CFL condition, so that
         the FDTD with this medium is stable when the time step size that doesn't take
         material factor into account is multiplied by ``n_cfl``.
@@ -1253,7 +1266,7 @@ class PMCMedium(AbstractMedium):
         return 1.0
 
     @cached_property
-    def is_pmc(self):
+    def is_pmc(self) -> bool:
         """Whether the medium is a PMC."""
         return True
 
@@ -1308,7 +1321,7 @@ class Medium(AbstractMedium):
     )
 
     @model_validator(mode="after")
-    def _passivity_validation(self):
+    def _passivity_validation(self) -> Self:
         """Assert passive medium if ``allow_gain`` is False."""
         val = self.conductivity
         if not self.allow_gain and val < 0:
@@ -1320,7 +1333,7 @@ class Medium(AbstractMedium):
         return self
 
     @model_validator(mode="after")
-    def _permittivity_modulation_validation(self):
+    def _permittivity_modulation_validation(self) -> Self:
         """Assert modulated permittivity cannot be <= 0."""
         val = self.permittivity
         modulation = self.modulation_spec
@@ -1335,7 +1348,7 @@ class Medium(AbstractMedium):
         return self
 
     @model_validator(mode="after")
-    def _passivity_modulation_validation(self):
+    def _passivity_modulation_validation(self) -> Self:
         """Assert passive medium if ``allow_gain`` is False."""
         val = self.conductivity
         modulation = self.modulation_spec
@@ -1354,7 +1367,7 @@ class Medium(AbstractMedium):
         return self
 
     @cached_property
-    def n_cfl(self):
+    def n_cfl(self) -> float:
         """This property computes the index of refraction related to CFL condition, so that
         the FDTD with this medium is stable when the time step size that doesn't take
         material factor into account is multiplied by ``n_cfl``.
@@ -1380,7 +1393,7 @@ class Medium(AbstractMedium):
         return self._eps_model(self.permittivity, self.conductivity, frequency)
 
     @classmethod
-    def from_nk(cls, n: float, k: float, freq: float, **kwargs: Any):
+    def from_nk(cls, n: float, k: float, freq: float, **kwargs: Any) -> Self:
         """Convert ``n`` and ``k`` values at frequency ``freq`` to :class:`.Medium`.
 
         Parameters
@@ -1500,7 +1513,9 @@ class CustomIsotropicMedium(AbstractCustomMedium, Medium):
 
     @field_validator("permittivity")
     @classmethod
-    def _eps_inf_greater_no_less_than_one(cls, val):
+    def _eps_inf_greater_no_less_than_one(
+        cls, val: Optional[CustomSpatialDataTypeAnnotated]
+    ) -> Optional[CustomSpatialDataTypeAnnotated]:
         """Assert any eps_inf must be >=1"""
 
         if not CustomIsotropicMedium._validate_isreal_dataarray(val):
@@ -1512,7 +1527,7 @@ class CustomIsotropicMedium(AbstractCustomMedium, Medium):
         return val
 
     @model_validator(mode="after")
-    def _conductivity_real_and_correct_shape(self):
+    def _conductivity_real_and_correct_shape(self) -> Self:
         """Assert conductivity is real and of right shape."""
         val = self.conductivity
 
@@ -1527,7 +1542,7 @@ class CustomIsotropicMedium(AbstractCustomMedium, Medium):
         return self
 
     @model_validator(mode="after")
-    def _passivity_validation(self):
+    def _passivity_validation(self) -> Self:
         """Assert passive medium if ``allow_gain`` is False."""
         val = self.conductivity
         if val is None:
@@ -1548,7 +1563,7 @@ class CustomIsotropicMedium(AbstractCustomMedium, Medium):
         return self.permittivity.is_uniform and self.conductivity.is_uniform
 
     @cached_property
-    def n_cfl(self):
+    def n_cfl(self) -> float:
         """This property computes the index of refraction related to CFL condition, so that
         the FDTD with this medium is stable when the time step size that doesn't take
         material factor into account is multiplied by ``n_cfl``.
@@ -1562,7 +1577,7 @@ class CustomIsotropicMedium(AbstractCustomMedium, Medium):
         return n
 
     @cached_property
-    def is_isotropic(self):
+    def is_isotropic(self) -> bool:
         """Whether the medium is isotropic."""
         return True
 
@@ -1603,7 +1618,7 @@ class CustomIsotropicMedium(AbstractCustomMedium, Medium):
         eps = self.eps_sigma_to_eps_complex(self.permittivity, conductivity, frequency)
         return (eps, eps, eps)
 
-    def _sel_custom_data_inside(self, bounds: Bound):
+    def _sel_custom_data_inside(self, bounds: Bound) -> Self:
         """Return a new custom medium that contains the minimal amount data necessary to cover
         a spatial region defined by ``bounds``.
 
@@ -1708,7 +1723,7 @@ class CustomMedium(AbstractCustomMedium):
         return data
 
     @model_validator(mode="after")
-    def _deprecation_dataset(self):
+    def _deprecation_dataset(self) -> Self:
         """Raise deprecation warning if dataset supplied and convert to dataset."""
 
         eps_dataset = self.eps_dataset
@@ -1758,7 +1773,9 @@ class CustomMedium(AbstractCustomMedium):
 
     @field_validator("eps_dataset")
     @classmethod
-    def _eps_dataset_single_frequency(cls, val):
+    def _eps_dataset_single_frequency(
+        cls, val: Optional[PermittivityDataset]
+    ) -> Optional[PermittivityDataset]:
         """Assert only one frequency supplied."""
         if val is None:
             return val
@@ -1773,7 +1790,7 @@ class CustomMedium(AbstractCustomMedium):
         return val
 
     @model_validator(mode="after")
-    def _eps_dataset_eps_inf_greater_no_less_than_one_sigma_positive(self):
+    def _eps_dataset_eps_inf_greater_no_less_than_one_sigma_positive(self) -> Self:
         """Assert any eps_inf must be >=1"""
         val = self.eps_dataset
         if val is None:
@@ -1822,7 +1839,7 @@ class CustomMedium(AbstractCustomMedium):
         return self
 
     @model_validator(mode="after")
-    def _eps_inf_greater_no_less_than_one(self):
+    def _eps_inf_greater_no_less_than_one(self) -> Self:
         """Assert any eps_inf must be >=1"""
         val = self.permittivity
         if val is None:
@@ -1846,7 +1863,7 @@ class CustomMedium(AbstractCustomMedium):
         return self
 
     @model_validator(mode="after")
-    def _conductivity_non_negative_correct_shape(self):
+    def _conductivity_non_negative_correct_shape(self) -> Self:
         """Assert conductivity>=0"""
         val = self.conductivity
 
@@ -1870,7 +1887,7 @@ class CustomMedium(AbstractCustomMedium):
         return self
 
     @model_validator(mode="after")
-    def _passivity_modulation_validation(self):
+    def _passivity_modulation_validation(self) -> Self:
         """Assert passive medium at any time during modulation if ``allow_gain`` is False."""
         val = self.conductivity
 
@@ -1896,7 +1913,9 @@ class CustomMedium(AbstractCustomMedium):
 
     @field_validator("permittivity", "conductivity")
     @classmethod
-    def _check_permittivity_conductivity_interpolate(cls, val, info):
+    def _check_permittivity_conductivity_interpolate(
+        cls, val: Optional[CustomSpatialDataType], info: FieldValidationInfo
+    ) -> Optional[CustomSpatialDataType]:
         """Check that the custom medium 'SpatialDataArrays' can be interpolated."""
 
         if isinstance(val, SpatialDataArray):
@@ -1919,7 +1938,7 @@ class CustomMedium(AbstractCustomMedium):
         return self._medium.is_spatially_uniform
 
     @cached_property
-    def freqs(self) -> np.ndarray:
+    def freqs(self) -> ArrayFloat:
         """float array of frequencies.
         This field is to be deprecated in v3.0.
         """
@@ -1935,7 +1954,7 @@ class CustomMedium(AbstractCustomMedium):
         )
 
     @cached_property
-    def _medium(self):
+    def _medium(self) -> CustomAnisotropicMedium:
         """Internal representation in the form of
         either `CustomIsotropicMedium` or `CustomAnisotropicMedium`.
         """
@@ -1984,7 +2003,7 @@ class CustomMedium(AbstractCustomMedium):
         return self._medium._interp_method(comp)
 
     @cached_property
-    def n_cfl(self):
+    def n_cfl(self) -> float:
         """This property computes the index of refraction related to CFL condition, so that
         the FDTD with this medium is stable when the time step size that doesn't take
         material factor into account is multiplied by ``n_cfl```.
@@ -2072,7 +2091,7 @@ class CustomMedium(AbstractCustomMedium):
         freq: Optional[float] = None,
         interp_method: InterpMethod = "nearest",
         **kwargs: Any,
-    ) -> CustomMedium:
+    ) -> Self:
         """Construct a :class:`.CustomMedium` from datasets containing raw permittivity values.
 
         Parameters
@@ -2142,7 +2161,7 @@ class CustomMedium(AbstractCustomMedium):
         freq: Optional[float] = None,
         interp_method: InterpMethod = "nearest",
         **kwargs: Any,
-    ) -> CustomMedium:
+    ) -> Self:
         """Construct a :class:`.CustomMedium` from datasets containing n and k values.
 
         Parameters
@@ -2233,7 +2252,7 @@ class CustomMedium(AbstractCustomMedium):
         def make_grid(scalar_field: Union[ScalarFieldDataArray, SpatialDataArray]) -> Grid:
             """Make a grid for a single dataset."""
 
-            def make_bound_coords(coords: np.ndarray, pt_min: float, pt_max: float) -> list[float]:
+            def make_bound_coords(coords: ArrayFloat, pt_min: float, pt_max: float) -> list[float]:
                 """Convert user supplied coords into boundary coords to use in :class:`.Grid`."""
 
                 # get coordinates of the bondaries halfway between user-supplied data
@@ -2271,7 +2290,7 @@ class CustomMedium(AbstractCustomMedium):
 
         return grids
 
-    def _sel_custom_data_inside(self, bounds: Bound):
+    def _sel_custom_data_inside(self, bounds: Bound) -> Self:
         """Return a new custom medium that contains the minimal amount data necessary to cover
         a spatial region defined by ``bounds``.
 
@@ -2372,9 +2391,9 @@ class CustomMedium(AbstractCustomMedium):
         E_der_map: ElectromagneticFieldDataset,
         spatial_data: CustomSpatialDataTypeAnnotated,
         dim: str,
-        freqs: np.ndarray,
+        freqs: ArrayFloat,
         component: str = "real",
-    ) -> np.ndarray:
+    ) -> ArrayGeneric:
         """Compute the derivative with respect to a material property component."""
         coords_interp = {key: spatial_data.coords[key] for key in "xyz"}
         coords_interp = {key: val for key, val in coords_interp.items() if len(val) > 1}
@@ -2512,11 +2531,11 @@ class DispersiveMedium(AbstractMedium, ABC):
     """
 
     @staticmethod
-    def _permittivity_modulation_validation():
+    def _permittivity_modulation_validation() -> Callable[[T], T]:
         """Assert modulated permittivity cannot be <= 0 at any time."""
 
         @model_validator(mode="after")
-        def _validate_permittivity_modulation(self):
+        def _validate_permittivity_modulation(self: T) -> T:
             """Assert modulated permittivity cannot be <= 0."""
             val = self.eps_inf
             modulation = self.modulation_spec
@@ -2533,11 +2552,11 @@ class DispersiveMedium(AbstractMedium, ABC):
         return _validate_permittivity_modulation
 
     @staticmethod
-    def _conductivity_modulation_validation():
+    def _conductivity_modulation_validation() -> Callable[[T], T]:
         """Assert passive medium at any time if not ``allow_gain``."""
 
         @model_validator(mode="after")
-        def _validate_conductivity_modulation(self):
+        def _validate_conductivity_modulation(self: T) -> T:
             """With conductivity modulation, the medium can exhibit gain during the cycle.
             So `allow_gain` must be True when the conductivity is modulated.
             """
@@ -2561,12 +2580,12 @@ class DispersiveMedium(AbstractMedium, ABC):
         """Dict representation of Medium as a pole-residue model."""
 
     @cached_property
-    def pole_residue(self):
+    def pole_residue(self) -> PoleResidue:
         """Representation of Medium as a pole-residue model."""
         return PoleResidue(**self._pole_residue_dict(), allow_gain=self.allow_gain)
 
     @cached_property
-    def n_cfl(self):
+    def n_cfl(self) -> float:
         """This property computes the index of refraction related to CFL condition, so that
         the FDTD with this medium is stable when the time step size that doesn't take
         material factor into account is multiplied by ``n_cfl``.
@@ -2594,7 +2613,9 @@ class DispersiveMedium(AbstractMedium, ABC):
         return (value.real, value.imag)
 
     # --- shared autograd helpers for dispersive models ---
-    def _tjp_inputs(self, derivative_info):
+    def _tjp_inputs(
+        self, derivative_info: DerivativeInfo
+    ) -> tuple[NDArray, Union[ArrayFloat, ArrayBox]]:
         """Prepare shared inputs for TJP: frequencies and packed adjoint vector."""
         dJ = self._derivative_eps_complex_volume(
             E_der_map=derivative_info.E_der_map, bounds=derivative_info.bounds
@@ -2604,12 +2625,20 @@ class DispersiveMedium(AbstractMedium, ABC):
         return freqs, pack_complex_vec(dJv)
 
     @staticmethod
-    def _tjp_grad(theta0, eps_vec_fn, vec):
+    def _tjp_grad(
+        theta0: ArrayFloat,
+        eps_vec_fn: Callable[[ArrayFloat], Union[ArrayComplex, ArrayBox]],
+        vec: Union[ArrayComplex, ArrayBox],
+    ) -> ArrayFloat:
         """Run a tensor-Jacobian-product to get J^T @ vec."""
         return tensor_jacobian_product(eps_vec_fn)(theta0, vec)
 
     @staticmethod
-    def _map_grad_real(g, paths, mapping):
+    def _map_grad_real(
+        g: TracedFloat,
+        paths: set[tuple],
+        mapping: Sequence[tuple[tuple, int]],
+    ) -> AutogradFieldMap:
         """Map flat gradient to model paths, taking the real part."""
         out = {}
         for k, idx in mapping:
@@ -2622,7 +2651,7 @@ class CustomDispersiveMedium(AbstractCustomMedium, DispersiveMedium, ABC):
     """A spatially varying dispersive medium."""
 
     @cached_property
-    def n_cfl(self):
+    def n_cfl(self) -> float:
         """This property computes the index of refraction related to CFL condition, so that
         the FDTD with this medium is stable when the time step size that doesn't take
         material factor into account is multiplied by ``n_cfl``.
@@ -2637,12 +2666,12 @@ class CustomDispersiveMedium(AbstractCustomMedium, DispersiveMedium, ABC):
         return n
 
     @cached_property
-    def is_isotropic(self):
+    def is_isotropic(self) -> bool:
         """Whether the medium is isotropic."""
         return True
 
     @cached_property
-    def pole_residue(self):
+    def pole_residue(self) -> CustomPoleResidue:
         """Representation of Medium as a pole-residue model."""
         return CustomPoleResidue(
             **self._pole_residue_dict(),
@@ -2652,14 +2681,16 @@ class CustomDispersiveMedium(AbstractCustomMedium, DispersiveMedium, ABC):
         )
 
     @staticmethod
-    def _warn_if_data_none(nested_tuple_field: str):
+    def _warn_if_data_none(
+        nested_tuple_field: str,
+    ) -> Callable[[type[AbstractMedium], dict[str, Any]], dict[str, Any]]:
         """Warn if any of `eps_inf` and nested_tuple_field are not loaded,
         and return a vacuum with eps_inf = 1.
         """
 
         @model_validator(mode="before")
         @classmethod
-        def _warn_if_none(cls, data: dict):
+        def _warn_if_none(cls: type[AbstractMedium], data: dict[str, Any]) -> dict[str, Any]:
             is_not_loaded = AbstractCustomMedium._not_loaded
 
             eps_inf = data.get("eps_inf")
@@ -2693,7 +2724,7 @@ class CustomDispersiveMedium(AbstractCustomMedium, DispersiveMedium, ABC):
         self,
         derivative_info: DerivativeInfo,
         spatial_ref: PermittivityDataset,
-    ) -> np.ndarray:
+    ) -> ArrayComplex:
         """Sum complex permittivity sensitivities over xyz on the given spatial grid.
 
         Parameters
@@ -2718,13 +2749,13 @@ class CustomDispersiveMedium(AbstractCustomMedium, DispersiveMedium, ABC):
         return dJ
 
     @staticmethod
-    def _accum_real_inner(dJ: np.ndarray, weight: np.ndarray) -> np.ndarray:
+    def _accum_real_inner(dJ: ArrayComplex, weight: ArrayComplex) -> ArrayFloat:
         """Compute Re(dJ * conj(weight)) with proper broadcasting."""
         return np.real(dJ * np.conj(weight))
 
     def _sum_over_freqs(
-        self, freqs: list[float] | np.ndarray, dJ: np.ndarray, weight_fn
-    ) -> np.ndarray:
+        self, freqs: FrequencyArray, dJ: ArrayComplex, weight_fn: WeightFunction
+    ) -> ArrayFloat:
         """Accumulate gradient contributions over frequencies using provided weight function.
 
         Parameters
@@ -2795,7 +2826,7 @@ class PoleResidue(DispersiveMedium):
 
     @field_validator("poles")
     @classmethod
-    def _causality_validation(cls, val):
+    def _causality_validation(cls, val: TracedPolesAndResidues) -> TracedPolesAndResidues:
         """Assert causal medium."""
         for a, _ in val:
             if np.any(np.real(_get_numpy_array(a)) > 0):
@@ -2804,7 +2835,7 @@ class PoleResidue(DispersiveMedium):
 
     @field_validator("poles")
     @classmethod
-    def _poles_largest_value(cls, val):
+    def _poles_largest_value(cls, val: TracedPolesAndResidues) -> TracedPolesAndResidues:
         """Assert pole parameters are not too large."""
         for a, c in val:
             if np.any(abs(_get_numpy_array(a)) > LARGEST_FP_NUMBER):
@@ -2846,7 +2877,7 @@ class PoleResidue(DispersiveMedium):
             "name": self.name,
         }
 
-    def __str__(self):
+    def __str__(self) -> str:
         """string representation"""
         return (
             f"td.PoleResidue("
@@ -2856,7 +2887,7 @@ class PoleResidue(DispersiveMedium):
         )
 
     @classmethod
-    def from_medium(cls, medium: Medium) -> PoleResidue:
+    def from_medium(cls, medium: Medium) -> Self:
         """Convert a :class:`.Medium` to a pole residue model.
 
         Parameters
@@ -2931,7 +2962,7 @@ class PoleResidue(DispersiveMedium):
     @classmethod
     def from_lo_to(
         cls, poles: tuple[tuple[float, float, float, float], ...], eps_inf: PositiveFloat = 1
-    ) -> PoleResidue:
+    ) -> Self:
         """Construct a pole residue model from the LO-TO form
         (longitudinal and transverse optical modes).
         The LO-TO form is :math:`\\epsilon_\\infty \\prod_{i=1}^l \\frac{\\omega_{LO, i}^2 - \\omega^2 - i \\omega \\gamma_{LO, i}}{\\omega_{TO, i}^2 - \\omega^2 - i \\omega \\gamma_{TO, i}}` as given in the paper:
@@ -3054,8 +3085,8 @@ class PoleResidue(DispersiveMedium):
 
     @staticmethod
     def _get_vjps_from_params(
-        dJ_deps_complex: Union[complex, np.ndarray],
-        poles_vals: list[tuple[Union[complex, np.ndarray], Union[complex, np.ndarray]]],
+        dJ_deps_complex: ComplexArrayOrScalar,
+        poles_vals: list[tuple[ComplexArrayOrScalar, ComplexArrayOrScalar]],
         omega: float,
         requested_paths: list[tuple],
         project_real: bool = False,
@@ -3123,8 +3154,8 @@ class PoleResidue(DispersiveMedium):
 
     @classmethod
     def _real_partial_fraction_decomposition(
-        cls, a: np.ndarray, b: np.ndarray, tol: PositiveFloat = 1e-2
-    ) -> tuple[list[tuple[Complex, Complex]], np.ndarray]:
+        cls, a: ArrayFloat, b: ArrayFloat, tol: PositiveFloat = 1e-2
+    ) -> tuple[list[tuple[Complex, Complex]], ArrayFloat]:
         """Computes the complex conjugate pole residue pairs given a rational expression with
         real coefficients.
 
@@ -3199,11 +3230,11 @@ class PoleResidue(DispersiveMedium):
     @classmethod
     def from_admittance_coeffs(
         cls,
-        a: np.ndarray,
-        b: np.ndarray,
+        a: ArrayFloat,
+        b: ArrayFloat,
         eps_inf: PositiveFloat = 1,
         pole_tol: PositiveFloat = 1e-2,
-    ) -> PoleResidue:
+    ) -> Self:
         """Construct a :class:`.PoleResidue` model from an admittance function defining the
         relationship between the electric field and the polarization current density in the
         Laplace domain.
@@ -3388,7 +3419,7 @@ class CustomPoleResidue(CustomDispersiveMedium, PoleResidue):
 
     @field_validator("eps_inf")
     @classmethod
-    def _eps_inf_positive(cls, val):
+    def _eps_inf_positive(cls, val: CustomSpatialDataType) -> CustomSpatialDataType:
         """eps_inf must be positive"""
         if not CustomDispersiveMedium._validate_isreal_dataarray(val):
             raise SetupError("'eps_inf' must be real.")
@@ -3397,7 +3428,7 @@ class CustomPoleResidue(CustomDispersiveMedium, PoleResidue):
         return val
 
     @model_validator(mode="after")
-    def _poles_correct_shape(self):
+    def _poles_correct_shape(self) -> Self:
         """poles must have the same shape."""
         val = self.poles
 
@@ -3476,7 +3507,7 @@ class CustomPoleResidue(CustomDispersiveMedium, PoleResidue):
         return tuple((fun_interp(a), fun_interp(c)) for (a, c) in self.poles)
 
     @classmethod
-    def from_medium(cls, medium: CustomMedium) -> CustomPoleResidue:
+    def from_medium(cls, medium: CustomMedium) -> Self:
         """Convert a :class:`.CustomMedium` to a pole residue model.
 
         Parameters
@@ -3524,7 +3555,7 @@ class CustomPoleResidue(CustomDispersiveMedium, PoleResidue):
         """Not implemented yet."""
         raise SetupError("To be implemented.")
 
-    def _sel_custom_data_inside(self, bounds: Bound):
+    def _sel_custom_data_inside(self, bounds: Bound) -> Self:
         """Return a new custom medium that contains the minimal amount data necessary to cover
         a spatial region defined by ``bounds``.
 
@@ -3559,9 +3590,9 @@ class CustomPoleResidue(CustomDispersiveMedium, PoleResidue):
         E_der_map: ElectromagneticFieldDataset,
         spatial_data: CustomSpatialDataTypeAnnotated,
         dim: str,
-        freqs=None,
+        freqs: Optional[ArrayFloat] = None,
         component: str = "complex",
-    ) -> np.ndarray:
+    ) -> ArrayGeneric:
         """Compatibility wrapper for derivative computation.
 
         Accepts the extended signature used by other custom media (
@@ -3657,7 +3688,7 @@ class Sellmeier(DispersiveMedium):
     )
 
     @model_validator(mode="after")
-    def _passivity_validation(self):
+    def _passivity_validation(self) -> Self:
         """Assert passive medium if `allow_gain` is False."""
         val = self.coeffs
         if self.allow_gain:
@@ -3674,7 +3705,9 @@ class Sellmeier(DispersiveMedium):
 
     @field_validator("modulation_spec")
     @classmethod
-    def _validate_permittivity_modulation(cls, val):
+    def _validate_permittivity_modulation(
+        cls, val: Optional[ModulationSpec]
+    ) -> Optional[ModulationSpec]:
         """Assert modulated permittivity cannot be <= 0."""
 
         if val is None or val.permittivity is None:
@@ -3728,7 +3761,9 @@ class Sellmeier(DispersiveMedium):
         }
 
     @staticmethod
-    def _from_dispersion_to_coeffs(n: float, freq: float, dn_dwvl: float):
+    def _from_dispersion_to_coeffs(
+        n: float, freq: ArrayFloat, dn_dwvl: float
+    ) -> list[tuple[float, float]]:
         """Compute Sellmeier coefficients from dispersion."""
         wvl = C_0 / np.array(freq)
         nsqm1 = n**2 - 1
@@ -3737,7 +3772,7 @@ class Sellmeier(DispersiveMedium):
         return [(b_coeff, c_coeff)]
 
     @classmethod
-    def from_dispersion(cls, n: float, freq: float, dn_dwvl: float = 0, **kwargs: Any):
+    def from_dispersion(cls, n: float, freq: float, dn_dwvl: float = 0, **kwargs: Any) -> Self:
         """Convert ``n`` and wavelength dispersion ``dn_dwvl`` values at frequency ``freq`` to
         a single-pole :class:`Sellmeier` medium.
 
@@ -3776,7 +3811,7 @@ class Sellmeier(DispersiveMedium):
         C0 = np.array([float(c) for (_b, c) in self.coeffs])
         theta0 = np.concatenate([B0, C0])
 
-        def _eps_vec(theta):
+        def _eps_vec(theta: Sequence[PositiveFloat]) -> Union[NDArray, ArrayBox]:
             B = theta[:N]
             C = theta[N : 2 * N]
             coeffs = tuple((B[i], C[i]) for i in range(N))
@@ -3791,21 +3826,33 @@ class Sellmeier(DispersiveMedium):
         return self._map_grad_real(g, derivative_info.paths, mapping)
 
     @staticmethod
-    def _lam2(freq):
+    def _lam2(
+        freq: Union[float, ArrayFloat],
+    ) -> Union[float, ArrayFloat]:
         return (C_0 / freq) ** 2
 
     @staticmethod
-    def _sellmeier_den(lam2, C):
+    def _sellmeier_den(
+        lam2: Union[float, ArrayFloat],
+        C: Union[float, ArrayFloat],
+    ) -> Union[float, ArrayFloat]:
         return lam2 - C
 
     # frequency weights for custom Sellmeier
     @staticmethod
-    def _w_B(freq, C):
+    def _w_B(
+        freq: Union[float, ArrayFloat],
+        C: Union[float, ArrayFloat],
+    ) -> Union[float, ArrayFloat]:
         lam2 = Sellmeier._lam2(freq)
         return lam2 / Sellmeier._sellmeier_den(lam2, C)
 
     @staticmethod
-    def _w_C(freq, B, C):
+    def _w_C(
+        freq: Union[float, ArrayFloat],
+        B: Union[float, ArrayFloat],
+        C: Union[float, ArrayFloat],
+    ) -> Union[float, ArrayFloat]:
         lam2 = Sellmeier._lam2(freq)
         den = Sellmeier._sellmeier_den(lam2, C)
         return B * lam2 / (den**2)
@@ -3860,7 +3907,9 @@ class CustomSellmeier(CustomDispersiveMedium, Sellmeier):
 
     @field_validator("coeffs")
     @classmethod
-    def _correct_shape_and_sign(cls, val):
+    def _correct_shape_and_sign(
+        cls, val: tuple[tuple[CustomSpatialDataType, CustomSpatialDataType], ...]
+    ) -> tuple[tuple[CustomSpatialDataType, CustomSpatialDataType], ...]:
         """every term in coeffs must have the same shape, and B>=0 and C>0."""
         if len(val) == 0:
             return val
@@ -3876,7 +3925,7 @@ class CustomSellmeier(CustomDispersiveMedium, Sellmeier):
         return val
 
     @model_validator(mode="after")
-    def _passivity_validation(self):
+    def _passivity_validation(self) -> Self:
         """Assert passive medium if `allow_gain` is False."""
         val = self.coeffs
         if self.allow_gain:
@@ -3893,7 +3942,9 @@ class CustomSellmeier(CustomDispersiveMedium, Sellmeier):
 
     @field_validator("coeffs")
     @classmethod
-    def _coeffs_C_all_near_zero_or_much_greater(cls, val):
+    def _coeffs_C_all_near_zero_or_much_greater(
+        cls, val: tuple[tuple[float, PositiveFloat], ...]
+    ) -> tuple[tuple[float, PositiveFloat], ...]:
         """We restrict either all C~=0, or very different from 0."""
         for _, C in val:
             c_array_near_zero = np.isclose(_get_numpy_array(C), 0)
@@ -3964,9 +4015,9 @@ class CustomSellmeier(CustomDispersiveMedium, Sellmeier):
         n: CustomSpatialDataType,
         freq: float,
         dn_dwvl: CustomSpatialDataType,
-        interp_method="nearest",
+        interp_method: InterpMethod = "nearest",
         **kwargs: Any,
-    ):
+    ) -> Self:
         """Convert ``n`` and wavelength dispersion ``dn_dwvl`` values at frequency ``freq`` to
         a single-pole :class:`CustomSellmeier` medium.
 
@@ -4009,7 +4060,7 @@ class CustomSellmeier(CustomDispersiveMedium, Sellmeier):
             **kwargs,
         )
 
-    def _sel_custom_data_inside(self, bounds: Bound):
+    def _sel_custom_data_inside(self, bounds: Bound) -> Self:
         """Return a new custom medium that contains the minimal amount data necessary to cover
         a spatial region defined by ``bounds``.
 
@@ -4134,7 +4185,9 @@ class Lorentz(DispersiveMedium):
 
     @field_validator("coeffs")
     @classmethod
-    def _coeffs_unequal_f_delta(cls, val):
+    def _coeffs_unequal_f_delta(
+        cls, val: tuple[tuple[float, float, NonNegativeFloat], ...]
+    ) -> tuple[tuple[float, float, NonNegativeFloat], ...]:
         """f**2 and delta**2 cannot be exactly the same."""
         for _, f, delta in val:
             if f**2 == delta**2:
@@ -4142,7 +4195,7 @@ class Lorentz(DispersiveMedium):
         return val
 
     @model_validator(mode="after")
-    def _passivity_validation(self):
+    def _passivity_validation(self) -> Self:
         """Assert passive medium if ``allow_gain`` is False."""
         val = self.coeffs
         if self.allow_gain:
@@ -4198,14 +4251,17 @@ class Lorentz(DispersiveMedium):
         }
 
     @staticmethod
-    def _all_larger(coeff_a, coeff_b) -> bool:
+    def _all_larger(
+        coeff_a: tuple[tuple[CustomSpatialDataType, CustomSpatialDataType], ...],
+        coeff_b: tuple[tuple[CustomSpatialDataType, CustomSpatialDataType], ...],
+    ) -> bool:
         """``coeff_a`` and ``coeff_b`` can be either float or SpatialDataArray."""
         if isinstance(coeff_a, CustomSpatialDataType.__args__):
             return np.all(_get_numpy_array(coeff_a) > _get_numpy_array(coeff_b))
         return coeff_a > coeff_b
 
     @classmethod
-    def from_nk(cls, n: float, k: float, freq: float, **kwargs: Any):
+    def from_nk(cls, n: float, k: float, freq: float, **kwargs: Any) -> Self:
         """Convert ``n`` and ``k`` values at frequency ``freq`` to a single-pole Lorentz
         medium.
 
@@ -4276,7 +4332,7 @@ class Lorentz(DispersiveMedium):
         d0 = np.array([float(dd) for (_de, _f, dd) in self.coeffs]) if N else np.array([])
         theta0 = np.concatenate([np.array([eps_inf0]), de0, f0, d0])
 
-        def _eps_vec(theta):
+        def _eps_vec(theta: Sequence[PositiveFloat]) -> Union[NDArray, ArrayBox]:
             eps_inf = theta[0]
             de = theta[1 : 1 + N]
             fi = theta[1 + N : 1 + 2 * N]
@@ -4295,21 +4351,39 @@ class Lorentz(DispersiveMedium):
         return self._map_grad_real(g, derivative_info.paths, mapping)
 
     @staticmethod
-    def _den(freq, f0, delta):
+    def _den(
+        freq: Union[float, ArrayFloat],
+        f0: Union[float, ArrayFloat],
+        delta: Union[float, ArrayFloat],
+    ) -> Union[complex, ArrayComplex]:
         return (f0**2) - 2j * (freq * delta) - (freq**2)
 
     # frequency weights for custom Lorentz
     @staticmethod
-    def _w_de(freq, f0, delta):
+    def _w_de(
+        freq: Union[float, ArrayFloat],
+        f0: Union[float, ArrayFloat],
+        delta: Union[float, ArrayFloat],
+    ) -> Union[complex, ArrayComplex]:
         return (f0**2) / Lorentz._den(freq, f0, delta)
 
     @staticmethod
-    def _w_f0(freq, de, f0, delta):
+    def _w_f0(
+        freq: Union[float, ArrayFloat],
+        de: Union[float, ArrayFloat],
+        f0: Union[float, ArrayFloat],
+        delta: Union[float, ArrayFloat],
+    ) -> Union[complex, ArrayComplex]:
         den = Lorentz._den(freq, f0, delta)
         return (2.0 * de * f0 * (den - f0**2)) / (den**2)
 
     @staticmethod
-    def _w_delta(freq, de, f0, delta):
+    def _w_delta(
+        freq: Union[float, ArrayFloat],
+        de: Union[float, ArrayFloat],
+        f0: Union[float, ArrayFloat],
+        delta: Union[float, ArrayFloat],
+    ) -> Union[complex, ArrayComplex]:
         den = Lorentz._den(freq, f0, delta)
         return (2j * freq * de * (f0**2)) / (den**2)
 
@@ -4377,7 +4451,7 @@ class CustomLorentz(CustomDispersiveMedium, Lorentz):
 
     @field_validator("eps_inf")
     @classmethod
-    def _eps_inf_positive(cls, val):
+    def _eps_inf_positive(cls, val: CustomSpatialDataType) -> CustomSpatialDataType:
         """eps_inf must be positive"""
         if not CustomDispersiveMedium._validate_isreal_dataarray(val):
             raise SetupError("'eps_inf' must be real.")
@@ -4387,7 +4461,9 @@ class CustomLorentz(CustomDispersiveMedium, Lorentz):
 
     @field_validator("coeffs")
     @classmethod
-    def _coeffs_unequal_f_delta(cls, val):
+    def _coeffs_unequal_f_delta(
+        cls, val: tuple[tuple[CustomSpatialDataType, CustomSpatialDataType], ...]
+    ) -> tuple[tuple[CustomSpatialDataType, CustomSpatialDataType], ...]:
         """f and delta cannot be exactly the same.
         Not needed for now because we have a more strict
         validator `_coeffs_delta_all_smaller_or_larger_than_fi`.
@@ -4395,7 +4471,7 @@ class CustomLorentz(CustomDispersiveMedium, Lorentz):
         return val
 
     @model_validator(mode="after")
-    def _coeffs_correct_shape(self):
+    def _coeffs_correct_shape(self) -> Self:
         """coeffs must have consistent shape."""
         val = self.coeffs
         for de, f, delta in val:
@@ -4414,7 +4490,9 @@ class CustomLorentz(CustomDispersiveMedium, Lorentz):
 
     @field_validator("coeffs")
     @classmethod
-    def _coeffs_delta_all_smaller_or_larger_than_fi(cls, val):
+    def _coeffs_delta_all_smaller_or_larger_than_fi(
+        cls, val: tuple[tuple[CustomSpatialDataType, CustomSpatialDataType], ...]
+    ) -> tuple[tuple[CustomSpatialDataType, CustomSpatialDataType], ...]:
         """We restrict either all f**2>delta**2 or all f**2<delta**2 for now."""
         for _, f, delta in val:
             f2 = f**2
@@ -4427,7 +4505,7 @@ class CustomLorentz(CustomDispersiveMedium, Lorentz):
         return val
 
     @model_validator(mode="after")
-    def _passivity_validation(self):
+    def _passivity_validation(self) -> Self:
         """Assert passive medium if ``allow_gain`` is False."""
         val = self.coeffs
         allow_gain = self.allow_gain
@@ -4488,7 +4566,7 @@ class CustomLorentz(CustomDispersiveMedium, Lorentz):
         eps = Lorentz.eps_model(self, frequency)
         return (eps, eps, eps)
 
-    def _sel_custom_data_inside(self, bounds: Bound):
+    def _sel_custom_data_inside(self, bounds: Bound) -> Self:
         """Return a new custom medium that contains the minimal amount data necessary to cover
         a spatial region defined by ``bounds``.
 
@@ -4556,9 +4634,6 @@ class CustomLorentz(CustomDispersiveMedium, Lorentz):
             g_de = 0.0 if not need_de else np.zeros_like(de, dtype=float)
             g_f0 = 0.0 if not need_f0 else np.zeros_like(f0, dtype=float)
             g_dl = 0.0 if not need_dl else np.zeros_like(dl, dtype=float)
-
-            def _den(f, f0=f0, dl=dl):
-                return Lorentz._den(f, f0, dl)
 
             if need_de:
                 g_de = g_de + self._sum_over_freqs(
@@ -4691,7 +4766,7 @@ class Drude(DispersiveMedium):
         d0 = np.array([float(dd) for (_fp, dd) in self.coeffs]) if N else np.array([])
         theta0 = np.concatenate([np.array([eps_inf0]), fp0, d0])
 
-        def _eps_vec(theta):
+        def _eps_vec(theta: Sequence[PositiveFloat]) -> Union[NDArray, ArrayBox]:
             eps_inf = theta[0]
             fp = theta[1 : 1 + N]
             dd = theta[1 + N : 1 + 2 * N]
@@ -4708,16 +4783,27 @@ class Drude(DispersiveMedium):
         return self._map_grad_real(g, derivative_info.paths, mapping)
 
     @staticmethod
-    def _den(freq, delta):
+    def _den(
+        freq: Union[float, ArrayFloat],
+        delta: Union[float, ArrayFloat],
+    ) -> Union[complex, ArrayComplex]:
         return (freq**2) + 1j * (freq * delta)
 
     # frequency weights for custom Drude
     @staticmethod
-    def _w_fp(freq, fp, delta):
+    def _w_fp(
+        freq: Union[float, ArrayFloat],
+        fp: Union[float, ArrayFloat],
+        delta: Union[float, ArrayFloat],
+    ) -> Union[complex, ArrayComplex]:
         return -(2.0 * fp) / Drude._den(freq, delta)
 
     @staticmethod
-    def _w_delta(freq, fp, delta):
+    def _w_delta(
+        freq: Union[float, ArrayFloat],
+        fp: Union[float, ArrayFloat],
+        delta: Union[float, ArrayFloat],
+    ) -> Union[complex, ArrayComplex]:
         den = Drude._den(freq, delta)
         return (1j * freq * (fp**2)) / (den**2)
 
@@ -4780,7 +4866,7 @@ class CustomDrude(CustomDispersiveMedium, Drude):
 
     @field_validator("eps_inf")
     @classmethod
-    def _eps_inf_positive(cls, val):
+    def _eps_inf_positive(cls, val: TracedPositiveFloat) -> TracedPositiveFloat:
         """eps_inf must be positive"""
         if not CustomDispersiveMedium._validate_isreal_dataarray(val):
             raise SetupError("'eps_inf' must be real.")
@@ -4789,7 +4875,7 @@ class CustomDrude(CustomDispersiveMedium, Drude):
         return val
 
     @model_validator(mode="after")
-    def _coeffs_correct_shape_and_sign(self):
+    def _coeffs_correct_shape_and_sign(self) -> Self:
         """coeffs must have consistent shape and sign."""
         val = self.coeffs
         for f, delta in val:
@@ -4851,7 +4937,7 @@ class CustomDrude(CustomDispersiveMedium, Drude):
         eps = Drude.eps_model(self, frequency)
         return (eps, eps, eps)
 
-    def _sel_custom_data_inside(self, bounds: Bound):
+    def _sel_custom_data_inside(self, bounds: Bound) -> Self:
         """Return a new custom medium that contains the minimal amount data necessary to cover
         a spatial region defined by ``bounds``.
 
@@ -4972,7 +5058,7 @@ class Debye(DispersiveMedium):
     )
 
     @model_validator(mode="after")
-    def _passivity_validation(self):
+    def _passivity_validation(self) -> Self:
         """Assert passive medium if `allow_gain` is False."""
         val = self.coeffs
         if self.allow_gain:
@@ -5001,7 +5087,11 @@ class Debye(DispersiveMedium):
 
     # --- unified helpers for autograd + tests ---
 
-    def _pole_residue_dict(self):
+    def _pole_residue_dict(
+        self,
+    ) -> dict[
+        str, Union[PositiveFloat, list[tuple[complex, complex]], Optional[FreqBound], Optional[str]]
+    ]:
         """Dict representation of Medium as a pole-residue model."""
 
         poles = []
@@ -5038,7 +5128,7 @@ class Debye(DispersiveMedium):
         tau0 = np.array([float(t) for (_de, t) in self.coeffs]) if N else np.array([])
         theta0 = np.concatenate([np.array([eps_inf0]), de0, tau0])
 
-        def _eps_vec(theta):
+        def _eps_vec(theta: Sequence[PositiveFloat]) -> Union[NDArray, ArrayBox]:
             eps_inf = theta[0]
             de = theta[1 : 1 + N]
             tau = theta[1 + N : 1 + 2 * N]
@@ -5055,16 +5145,26 @@ class Debye(DispersiveMedium):
         return self._map_grad_real(g, derivative_info.paths, mapping)
 
     @staticmethod
-    def _den(freq, tau):
+    def _den(
+        freq: Union[float, ArrayFloat],
+        tau: Union[float, ArrayFloat],
+    ) -> Union[complex, ArrayComplex]:
         return 1 - 1j * (freq * tau)
 
     # frequency weights for custom Debye
     @staticmethod
-    def _w_de(freq, tau):
+    def _w_de(
+        freq: Union[float, ArrayFloat],
+        tau: Union[float, ArrayFloat],
+    ) -> Union[complex, ArrayComplex]:
         return 1.0 / Debye._den(freq, tau)
 
     @staticmethod
-    def _w_tau(freq, de, tau):
+    def _w_tau(
+        freq: Union[float, ArrayFloat],
+        de: Union[float, ArrayFloat],
+        tau: Union[float, ArrayFloat],
+    ) -> Union[complex, ArrayComplex]:
         den = Debye._den(freq, tau)
         return (1j * freq * de) / (den**2)
 
@@ -5126,7 +5226,7 @@ class CustomDebye(CustomDispersiveMedium, Debye):
 
     @field_validator("eps_inf")
     @classmethod
-    def _eps_inf_positive(cls, val):
+    def _eps_inf_positive(cls, val: TracedPositiveFloat) -> TracedPositiveFloat:
         """eps_inf must be positive"""
         if not CustomDispersiveMedium._validate_isreal_dataarray(val):
             raise SetupError("'eps_inf' must be real.")
@@ -5135,7 +5235,7 @@ class CustomDebye(CustomDispersiveMedium, Debye):
         return val
 
     @model_validator(mode="after")
-    def _coeffs_correct_shape(self):
+    def _coeffs_correct_shape(self) -> Self:
         """coeffs must have consistent shape."""
         val = self.coeffs
         for de, tau in val:
@@ -5152,7 +5252,9 @@ class CustomDebye(CustomDispersiveMedium, Debye):
 
     @field_validator("coeffs")
     @classmethod
-    def _coeffs_tau_all_sufficient_positive(cls, val):
+    def _coeffs_tau_all_sufficient_positive(
+        cls, val: tuple[tuple[CustomSpatialDataType, CustomSpatialDataType], ...]
+    ) -> tuple[tuple[CustomSpatialDataType, CustomSpatialDataType], ...]:
         """We restrict either all tau is sufficently greater than 0."""
         for _, tau in val:
             if np.any(_get_numpy_array(tau) < 1 / 2 / np.pi / LARGEST_FP_NUMBER):
@@ -5203,7 +5305,7 @@ class CustomDebye(CustomDispersiveMedium, Debye):
         return grads
 
     @model_validator(mode="after")
-    def _passivity_validation(self):
+    def _passivity_validation(self) -> Self:
         """Assert passive medium if ``allow_gain`` is False."""
         val = self.coeffs
         allow_gain = self.allow_gain
@@ -5264,7 +5366,7 @@ class CustomDebye(CustomDispersiveMedium, Debye):
         eps = Debye.eps_model(self, frequency)
         return (eps, eps, eps)
 
-    def _sel_custom_data_inside(self, bounds: Bound):
+    def _sel_custom_data_inside(self, bounds: Bound) -> Self:
         """Return a new custom medium that contains the minimal amount data necessary to cover
         a spatial region defined by ``bounds``.
 
@@ -5471,7 +5573,7 @@ class HuraySurfaceRoughness(AbstractSurfaceRoughness):
     )
 
     @classmethod
-    def from_cannonball_huray(cls, radius: float) -> HuraySurfaceRoughness:
+    def from_cannonball_huray(cls, radius: float) -> Self:
         """Construct a Cannonball-Huray model.
 
         Note
@@ -5597,7 +5699,7 @@ class LossyMetalMedium(Medium):
 
     @field_validator("frequency_range")
     @classmethod
-    def _validate_frequency_range(cls, val):
+    def _validate_frequency_range(cls, val: FreqBound) -> FreqBound:
         """Validate that frequency range is finite and non-zero."""
         for freq in val:
             if not np.isfinite(freq):
@@ -5650,7 +5752,7 @@ class LossyMetalMedium(Medium):
         """Number of poles in the fitted model."""
         return len(self.scaled_surface_impedance_model.poles)
 
-    def surface_impedance(self, frequencies: ArrayFloat1D):
+    def surface_impedance(self, frequencies: ArrayFloat1D) -> ArrayComplex:
         """Computing surface impedance including surface roughness effects."""
         # compute complex-valued skin depth
         n, k = self.nk_model(frequencies)
@@ -5809,7 +5911,7 @@ class AnisotropicMedium(AbstractMedium):
 
     @field_validator("modulation_spec")
     @classmethod
-    def _validate_modulation_spec(cls, val):
+    def _validate_modulation_spec(cls, val: Optional[ModulationSpec]) -> Optional[ModulationSpec]:
         """Check compatibility with modulation_spec."""
         if val is not None:
             raise ValidationError(
@@ -5820,7 +5922,7 @@ class AnisotropicMedium(AbstractMedium):
         return val
 
     @model_validator(mode="after")
-    def _ignored_fields(self):
+    def _ignored_fields(self) -> Self:
         """The field is ignored."""
         if self.xx is not None and self.allow_gain is not None:
             log.warning(
@@ -5839,7 +5941,7 @@ class AnisotropicMedium(AbstractMedium):
         return any(mat.is_time_modulated for mat in self.components.values())
 
     @cached_property
-    def n_cfl(self):
+    def n_cfl(self) -> float:
         """This property computes the index of refraction related to CFL condition, so that
         the FDTD with this medium is stable when the time step size that doesn't take
         material factor into account is multiplied by ``n_cfl``.
@@ -5943,24 +6045,24 @@ class AnisotropicMedium(AbstractMedium):
         return {"xx": self.xx, "yy": self.yy, "zz": self.zz}
 
     @cached_property
-    def is_pec(self):
+    def is_pec(self) -> bool:
         """Whether the medium is a PEC."""
         return any(self.is_comp_pec(i) for i in range(3))
 
     @cached_property
-    def is_pmc(self):
+    def is_pmc(self) -> bool:
         """Whether the medium is a PMC."""
         return any(self.is_comp_pmc(i) for i in range(3))
 
-    def is_comp_pec(self, comp: Axis):
+    def is_comp_pec(self, comp: Axis) -> bool:
         """Whether the medium is a PEC."""
         return isinstance(self.components[["xx", "yy", "zz"][comp]], PECMedium)
 
-    def is_comp_pmc(self, comp: Axis):
+    def is_comp_pmc(self, comp: Axis) -> bool:
         """Whether the medium is a PMC."""
         return isinstance(self.components[["xx", "yy", "zz"][comp]], PMCMedium)
 
-    def sel_inside(self, bounds: Bound):
+    def sel_inside(self, bounds: Bound) -> Self:
         """Return a new medium that contains the minimal amount data necessary to cover
         a spatial region defined by ``bounds``.
 
@@ -6045,7 +6147,7 @@ class FullyAnisotropicMedium(AbstractMedium):
 
     @field_validator("modulation_spec")
     @classmethod
-    def _validate_modulation_spec(cls, val):
+    def _validate_modulation_spec(cls, val: Optional[ModulationSpec]) -> Optional[ModulationSpec]:
         """Check compatibility with modulation_spec."""
         if val is not None:
             raise ValidationError(
@@ -6056,7 +6158,7 @@ class FullyAnisotropicMedium(AbstractMedium):
 
     @field_validator("permittivity")
     @classmethod
-    def permittivity_spd_and_ge_one(cls, val):
+    def permittivity_spd_and_ge_one(cls, val: TracedFloat) -> TracedFloat:
         """Check that provided permittivity tensor is symmetric positive definite
         with eigenvalues >= 1.
         """
@@ -6070,7 +6172,7 @@ class FullyAnisotropicMedium(AbstractMedium):
         return val
 
     @model_validator(mode="after")
-    def conductivity_commutes(self):
+    def conductivity_commutes(self) -> Self:
         """Check that the symmetric part of conductivity tensor commutes with permittivity tensor
         (that is, simultaneously diagonalizable).
         """
@@ -6088,7 +6190,7 @@ class FullyAnisotropicMedium(AbstractMedium):
         return self
 
     @model_validator(mode="after")
-    def _passivity_validation(self):
+    def _passivity_validation(self) -> Self:
         """Assert passive medium if ``allow_gain`` is False."""
         val = self.conductivity
         if self.allow_gain:
@@ -6105,7 +6207,7 @@ class FullyAnisotropicMedium(AbstractMedium):
         return self
 
     @classmethod
-    def from_diagonal(cls, xx: Medium, yy: Medium, zz: Medium, rotation: RotationType):
+    def from_diagonal(cls, xx: Medium, yy: Medium, zz: Medium, rotation: RotationType) -> Self:
         """Construct a fully anisotropic medium by rotating a diagonally anisotropic medium.
 
         Parameters
@@ -6245,7 +6347,7 @@ class FullyAnisotropicMedium(AbstractMedium):
         ).real
 
     @cached_property
-    def n_cfl(self):
+    def n_cfl(self) -> float:
         """This property computes the index of refraction related to CFL condition, so that
         the FDTD with this medium is stable when the time step size that doesn't take
         material factor into account is multiplied by ``n_cfl``.
@@ -6353,14 +6455,16 @@ class CustomAnisotropicMedium(AbstractCustomMedium, AnisotropicMedium):
 
     @field_validator("xx", "yy", "zz")
     @classmethod
-    def _isotropic_xx(cls, val, info):
+    def _isotropic_xx(
+        cls, val: Union[IsotropicCustomMediumType, CustomMedium], info: FieldValidationInfo
+    ) -> Union[IsotropicCustomMediumType, CustomMedium]:
         """If it's `CustomMedium`, make sure it's isotropic."""
         if isinstance(val, CustomMedium) and not val.is_isotropic:
             raise SetupError(f"The {info.field_name}-component medium type is not isotropic.")
         return val
 
     @model_validator(mode="after")
-    def _ignored_fields(self):
+    def _ignored_fields(self) -> Self:
         """The field is ignored."""
         if self.xx is not None:
             if self.allow_gain is not None:
@@ -6379,7 +6483,7 @@ class CustomAnisotropicMedium(AbstractCustomMedium, AnisotropicMedium):
         return any(comp.is_spatially_uniform for comp in self.components.values())
 
     @cached_property
-    def n_cfl(self):
+    def n_cfl(self) -> float:
         """This property computes the index of refraction related to CFL condition, so that
         the FDTD with this medium is stable when the time step size that doesn't take
         material factor into account is multiplied by ``n_cfl``.
@@ -6389,7 +6493,7 @@ class CustomAnisotropicMedium(AbstractCustomMedium, AnisotropicMedium):
         return min(mat_component.n_cfl for mat_component in self.components.values())
 
     @cached_property
-    def is_isotropic(self):
+    def is_isotropic(self) -> bool:
         """Whether the medium is isotropic."""
         return False
 
@@ -6473,7 +6577,7 @@ class CustomAnisotropicMedium(AbstractCustomMedium, AnisotropicMedium):
             f"Plotting component '{eps_component}' of a diagonally-anisotropic permittivity tensor is not supported."
         )
 
-    def _sel_custom_data_inside(self, bounds: Bound):
+    def _sel_custom_data_inside(self, bounds: Bound) -> Self:
         return self
 
 
@@ -6595,7 +6699,7 @@ class AbstractPerturbationMedium(ABC, Tidy3dBaseModel):
         subpixel: bool = True,
         perturbation_spec: Union[PermittivityPerturbation, IndexPerturbation] = None,
         **kwargs: Any,
-    ) -> AbstractPerturbationMedium:
+    ) -> Self:
         """Construct a medium with pertubation models from an unpertubed one.
 
         Parameters
@@ -6674,7 +6778,7 @@ class PerturbationMedium(Medium, AbstractPerturbationMedium):
     )
 
     @model_validator(mode="after")
-    def _check_overdefining(self):
+    def _check_overdefining(self) -> Self:
         """Check that perturbation model is provided either directly or through
         ``perturbation_spec``, but not both.
         """
@@ -6851,7 +6955,7 @@ class PerturbationPoleResidue(PoleResidue, AbstractPerturbationMedium):
     )
 
     @model_validator(mode="after")
-    def _check_overdefining(self):
+    def _check_overdefining(self) -> Self:
         """Check that perturbation model is provided either directly or through
         ``perturbation_spec``, but not both.
         """
@@ -6979,9 +7083,11 @@ class PerturbationPoleResidue(PoleResidue, AbstractPerturbationMedium):
 
 PerturbationMediumType = Union[PerturbationMedium, PerturbationPoleResidue]
 
+T = TypeVar("T")
+
 
 # Update forward references for all Custom medium classes that inherit from AbstractCustomMedium
-def _get_all_subclasses(cls):
+def _get_all_subclasses(cls: T) -> list[type[T]]:
     """Recursively get all subclasses of a class."""
     all_subclasses = []
     for subclass in cls.__subclasses__():
@@ -7054,7 +7160,7 @@ class Medium2D(AbstractMedium):
 
     @field_validator("modulation_spec")
     @classmethod
-    def _validate_modulation_spec(cls, val):
+    def _validate_modulation_spec(cls, val: Optional[ModulationSpec]) -> Optional[ModulationSpec]:
         """Check compatibility with modulation_spec."""
         if val is not None:
             raise ValidationError(
@@ -7064,7 +7170,7 @@ class Medium2D(AbstractMedium):
         return val
 
     @model_validator(mode="after")
-    def _validate_inplane_pec(self):
+    def _validate_inplane_pec(self) -> Self:
         """ss/tt components must be both PEC or non-PEC."""
         val = self.tt
         if isinstance(val, PECMedium) != isinstance(self.ss, PECMedium):
@@ -7228,7 +7334,7 @@ class Medium2D(AbstractMedium):
         return self.to_pole_residue(thickness=thickness).to_medium()
 
     @classmethod
-    def from_medium(cls, medium: Medium, thickness: float) -> Medium2D:
+    def from_medium(cls, medium: Medium, thickness: float) -> Self:
         """Generate a :class:`.Medium2D` equivalent of a :class:`.Medium`
         with a given thickness.
 
@@ -7248,7 +7354,7 @@ class Medium2D(AbstractMedium):
         return Medium2D(ss=med, tt=med, frequency_range=medium.frequency_range)
 
     @classmethod
-    def from_dispersive_medium(cls, medium: DispersiveMedium, thickness: float) -> Medium2D:
+    def from_dispersive_medium(cls, medium: DispersiveMedium, thickness: float) -> Self:
         """Generate a :class:`.Medium2D` equivalent of a :class:`.DispersiveMedium`
         with a given thickness.
 
@@ -7270,7 +7376,7 @@ class Medium2D(AbstractMedium):
     @classmethod
     def from_anisotropic_medium(
         cls, medium: AnisotropicMedium, axis: Axis, thickness: float
-    ) -> Medium2D:
+    ) -> Self:
         """Generate a :class:`.Medium2D` equivalent of a :class:`.AnisotropicMedium`
         with given normal axis and thickness. The ``ss`` and ``tt`` components of the resulting
         2D medium correspond to the first of the ``xx``, ``yy``, and ``zz`` components of
@@ -7397,7 +7503,7 @@ class Medium2D(AbstractMedium):
         return {"ss": self.ss, "tt": self.tt}
 
     @cached_property
-    def n_cfl(self):
+    def n_cfl(self) -> float:
         """This property computes the index of refraction related to CFL condition, so that
         the FDTD with this medium is stable when the time step size that doesn't take
         material factor into account is multiplied by ``n_cfl``.
@@ -7405,11 +7511,11 @@ class Medium2D(AbstractMedium):
         return 1.0
 
     @cached_property
-    def is_pec(self):
+    def is_pec(self) -> bool:
         """Whether the medium is a PEC."""
         return any(isinstance(comp, PECMedium) for comp in self.elements.values())
 
-    def is_comp_pec_2d(self, comp: Axis, axis: Axis):
+    def is_comp_pec_2d(self, comp: Axis, axis: Axis) -> bool:
         """Whether the medium is a PEC."""
         elements_3d = Geometry.unpop_axis(
             ax_coord=Medium(), plane_coords=self.elements.values(), axis=axis

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -6,8 +6,16 @@ from abc import ABC, abstractmethod
 from typing import Any, Literal, Optional
 
 import numpy as np
-from pydantic import Field, NonNegativeFloat, PositiveInt, field_validator, model_validator
+from pydantic import (
+    Field,
+    FieldValidationInfo,
+    NonNegativeFloat,
+    PositiveInt,
+    field_validator,
+    model_validator,
+)
 
+from tidy3d.compat import Self
 from tidy3d.constants import HERTZ, MICROMETER, RADIAN, SECOND, inf
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
@@ -73,7 +81,7 @@ class Monitor(AbstractMonitor):
     )
 
     @property
-    def _to_solver_monitor(self):
+    def _to_solver_monitor(self) -> Self:
         """Monitor definition that will be used to define the field recording during the time
         stepping."""
         return self
@@ -111,7 +119,9 @@ class FreqMonitor(Monitor, ABC):
 
     @field_validator("freqs")
     @classmethod
-    def _warn_num_freqs(cls, val, info):
+    def _warn_num_freqs(
+        cls: type[FreqMonitor], val: FreqArray, info: FieldValidationInfo
+    ) -> FreqArray:
         """Warn if number of frequencies is too large."""
         if len(val) > WARN_NUM_FREQS:
             log.warning(
@@ -163,7 +173,7 @@ class TimeMonitor(Monitor, ABC):
     )
 
     @model_validator(mode="after")
-    def _warn_interval_default(self):
+    def _warn_interval_default(self) -> Self:
         """If all defaults used for time sampler, warn and set ``interval=1`` internally."""
         val = self.interval
 
@@ -190,7 +200,7 @@ class TimeMonitor(Monitor, ABC):
         return self
 
     @model_validator(mode="after")
-    def stop_greater_than_start(self):
+    def stop_greater_than_start(self) -> Self:
         """Ensure sure stop is greater than or equal to start."""
         stop = self.stop
         start = self.start
@@ -412,7 +422,9 @@ class AbstractModeMonitor(PlanarMonitor, FreqMonitor):
 
     @field_validator("mode_spec")
     @classmethod
-    def _warn_num_modes(cls, val, info):
+    def _warn_num_modes(
+        cls: type[ModeMonitor], val: ModeSpec, info: FieldValidationInfo
+    ) -> ModeSpec:
         """Warn if number of modes is too large."""
         if val.num_modes > WARN_NUM_MODES:
             log.warning(
@@ -654,14 +666,14 @@ class SurfaceIntegrationMonitor(Monitor, ABC):
     )
 
     @property
-    def integration_surfaces(self):
+    def integration_surfaces(self) -> list[SurfaceIntegrationMonitor]:
         """Surfaces of the monitor where fields will be recorded for subsequent integration."""
         if self.size.count(0.0) == 0:
             return self.surfaces_with_exclusion(**self.model_dump())
         return [self]
 
     @model_validator(mode="after")
-    def normal_dir_exists_for_surface(self):
+    def normal_dir_exists_for_surface(self) -> Self:
         """If the monitor is a surface, set default ``normal_dir`` if not provided.
         If the monitor is a box, warn that ``normal_dir`` is relevant only for surfaces."""
         if self.size.count(0.0) != 1:
@@ -676,7 +688,7 @@ class SurfaceIntegrationMonitor(Monitor, ABC):
         return self
 
     @model_validator(mode="after")
-    def check_excluded_surfaces(self):
+    def check_excluded_surfaces(self) -> Self:
         """Error if ``exclude_surfaces`` is provided for a surface monitor."""
         exclude_surfaces = self.exclude_surfaces
         if exclude_surfaces is None:
@@ -803,7 +815,7 @@ class ModeMonitor(AbstractModeMonitor):
     """
 
     @property
-    def _to_solver_monitor(self):
+    def _to_solver_monitor(self) -> Self:
         """Monitor definition that will be used to define the field recording during the time
         stepping."""
         return self.updated_copy(colocate=False)
@@ -863,7 +875,7 @@ class ModeSolverMonitor(AbstractModeMonitor):
         return self.mode_spec._sampling_freqs_mode_solver_data(freqs=self.freqs)
 
     @model_validator(mode="after")
-    def set_store_fields(self):
+    def set_store_fields(self) -> Self:
         """Ensure 'store_fields_direction' is compatible with 'direction'."""
         store_fields_direction = self.store_fields_direction
         direction = self.direction
@@ -919,7 +931,7 @@ class FieldProjectionSurface(Tidy3dBaseModel):
 
     @field_validator("monitor")
     @classmethod
-    def is_plane(cls, val):
+    def is_plane(cls, val: FieldMonitor) -> FieldMonitor:
         """Ensures that the monitor is a plane, i.e., its ``size`` attribute has exactly 1 zero"""
         size = val.size
         if size.count(0.0) != 1:
@@ -991,7 +1003,7 @@ class AbstractFieldProjectionMonitor(SurfaceIntegrationMonitor, FreqMonitor):
     )
 
     @model_validator(mode="after")
-    def window_size_for_surface(self):
+    def window_size_for_surface(self) -> Self:
         """Ensures that windowing is applied for surface monitors only."""
         val = self.window_size
         size = self.size
@@ -1007,7 +1019,11 @@ class AbstractFieldProjectionMonitor(SurfaceIntegrationMonitor, FreqMonitor):
 
     @field_validator("window_size")
     @classmethod
-    def window_size_leq_one(cls, val, info):
+    def window_size_leq_one(
+        cls: type[AbstractFieldProjectionMonitor],
+        val: tuple[float, float],
+        info: FieldValidationInfo,
+    ) -> tuple[float, float]:
         """Ensures that each component of the window size is less than or equal to 1."""
         if val[0] > 1 or val[1] > 1:
             raise ValidationError(
@@ -1519,7 +1535,7 @@ class FieldProjectionKSpaceMonitor(AbstractFieldProjectionMonitor):
     )
 
     @model_validator(mode="after")
-    def reciprocal_vector_range(self):
+    def reciprocal_vector_range(self) -> Self:
         """Ensure that ux, uy are in [-1, 1]."""
         maxabs_ux = max(list(self.ux), key=abs)
         maxabs_uy = max(list(self.uy), key=abs)
@@ -1595,7 +1611,7 @@ class DiffractionMonitor(PlanarMonitor, FreqMonitor):
 
     @field_validator("size")
     @classmethod
-    def diffraction_monitor_size(cls, val):
+    def diffraction_monitor_size(cls: type[DiffractionMonitor], val: Size) -> Size:
         """Ensure that the monitor is infinite in the transverse direction."""
         if val.count(inf) != 2:
             raise SetupError(

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -7,10 +7,11 @@ import pathlib
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from os import PathLike
-from typing import Any, Literal, Optional, Union, get_args
+from typing import Any, Callable, Literal, Optional, Union, get_args
 
 import autograd.numpy as np
 import xarray as xr
+from numpy.typing import NDArray
 from pydantic import (
     Field,
     NonNegativeFloat,
@@ -38,6 +39,7 @@ from .boundary import (
     AbsorberSpec,
     BlochBoundary,
     Boundary,
+    BoundaryEdgeType,
     BoundarySpec,
     InternalAbsorber,
     ModeABCBoundary,
@@ -192,11 +194,13 @@ FIXED_ANGLE_DT_SAFETY_FACTOR = 0.9
 RF_FREQ_WARNING = 300e9
 
 
-def validate_boundaries_for_zero_dims(warn_on_change: bool = True):
+def validate_boundaries_for_zero_dims(
+    warn_on_change: bool = True,
+) -> Callable[[AbstractYeeGridSimulation], AbstractYeeGridSimulation]:
     """Error if absorbing boundaries, bloch boundaries, unmatching pec/pmc, or symmetry is used along a zero dimension."""
 
     @model_validator(mode="after")
-    def boundaries_for_zero_dims(self):
+    def boundaries_for_zero_dims(self: AbstractYeeGridSimulation) -> AbstractYeeGridSimulation:
         """Error if absorbing boundaries, bloch boundaries, unmatching pec/pmc, or symmetry is used along a zero dimension."""
         val = self.boundary_spec
         boundaries = val.to_list
@@ -366,7 +370,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         *  `Dielectric constant assignment on Yee grids <https://www.flexcompute.com/fdtd101/Lecture-9-Dielectric-constant-assignment-on-Yee-grids/>`_
     """
 
-    simulation_type: Optional[Literal["autograd_fwd", "autograd_bwd", "tidy3d", None]] = Field(
+    simulation_type: Optional[Literal["autograd_fwd", "autograd_bwd", "tidy3d"]] = Field(
         "tidy3d",
         title="Simulation Type",
         description="Tag used internally to distinguish types of simulations for "
@@ -389,12 +393,14 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
 
     @field_validator("simulation_type")
     @classmethod
-    def _validate_simulation_type_tidy3d(cls, val):
+    def _validate_simulation_type_tidy3d(
+        cls, val: Optional[Literal["autograd_fwd", "autograd_bwd", "tidy3d"]]
+    ) -> Literal["autograd_fwd", "autograd_bwd", "tidy3d"]:
         """Enforce the simulation_type is 'tidy3d' if passed as None for bkwrds compatibility."""
         return "tidy3d" if val is None else val
 
     @model_validator(mode="after")
-    def _validate_num_lumped_elements(self):
+    def _validate_num_lumped_elements(self) -> Self:
         """Error if too many lumped elements present."""
         val = self.lumped_elements
         if val is None:
@@ -411,7 +417,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         return self
 
     @model_validator(mode="after")
-    def _check_3d_simulation_with_lumped_elements(self):
+    def _check_3d_simulation_with_lumped_elements(self) -> Self:
         """Error if Simulation contained lumped elements and is not a 3D simulation"""
         val = self.lumped_elements
         size = self.size
@@ -444,7 +450,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         return num_cells_in_monitor(monitor)
 
     @model_validator(mode="after")
-    def _validate_boundary_spec_symmetry(self):
+    def _validate_boundary_spec_symmetry(self) -> Self:
         """Error if symmetry is imposed along an axis but the boundary conditions are not the same
         on both sides."""
 
@@ -982,7 +988,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         return pml_thicknesses
 
     @cached_property
-    def _internal_layerrefinement_boundary_types(self):
+    def _internal_layerrefinement_boundary_types(self) -> list[list[Optional[str]]]:
         """Boundary types for layer refinement."""
         boundary_types = [[None, None], [None, None], [None, None]]
         for dim, boundary in enumerate(self.boundary_spec.to_list):
@@ -1292,7 +1298,12 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
             The supplied or created matplotlib axes.
         """
 
-        def set_plot_params(boundary_edge, lim, side, thickness):
+        def set_plot_params(
+            boundary_edge: Union[ABCBoundary, ModeABCBoundary, BoundaryEdgeType],
+            lim: float,
+            side: Literal[-1, 1],
+            thickness: float,
+        ) -> tuple[PlotParams, float]:
             """Return the line plot properties such as color and opacity based on the boundary"""
             if isinstance(boundary_edge, PECBoundary):
                 plot_params = plot_params_pec.copy(deep=True)
@@ -1488,7 +1499,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         """Dictionary collecting various properties of the grids in the simulation."""
         return self.grid.info
 
-    def _subgrid(self, span_inds: np.ndarray, grid: Grid = None):
+    def _subgrid(self, span_inds: np.ndarray, grid: Grid = None) -> Grid:
         """Take a subgrid of the simulation grid with cell span defined by ``span_inds`` along the
         three dimensions. Optionally, a grid different from the simulation grid can be provided.
         The ``span_inds`` can also extend beyond the grid, in which case the grid is padded based
@@ -1534,7 +1545,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
 
         return num_layers
 
-    def _snap_zero_dim(self, grid: Grid, skip_axis: Axis = None):
+    def _snap_zero_dim(self, grid: Grid, skip_axis: Optional[Axis] = None) -> Grid:
         """Snap a grid to the simulation center along any dimension along which simulation is
         effectively 0D, defined as having a single pixel. This is more general than just checking
         size = 0."""
@@ -1560,7 +1571,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
 
     def _discretize_inds_monitor(
         self, monitor: Union[Monitor, Box], colocate: Optional[bool] = None
-    ):
+    ) -> NDArray:
         """Start and stopping indexes for the cells where data needs to be recorded to fully cover
         a ``monitor``. This is used during the solver run. The final grid on which a monitor data
         lives is computed in ``discretize_monitor``, with the difference being that 0-sized
@@ -1705,7 +1716,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
             subpixel_sim = tidy3d_extras["mod"].SubpixelSimulation.from_simulation(self)
             return subpixel_sim.epsilon_on_grid(grid=grid, coord_key=coord_key, freq=freq)
 
-        def get_eps(structure: Structure, frequency: float, coords: Coords):
+        def get_eps(structure: Structure, frequency: float, coords: Coords) -> complex:
             """Select the correct epsilon component if field locations are requested."""
             if coord_key[0] != "E":
                 return np.mean(structure.eps_diagonal(frequency, coords), axis=0)
@@ -1716,7 +1727,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
                 col = ["x", "y", "z"].index(coord_key[2])
             return structure.eps_comp(row, col, frequency, coords)
 
-        def make_eps_data(coords: Coords):
+        def make_eps_data(coords: Coords) -> xr.DataArray:
             """returns epsilon data on grid of points defined by coords"""
             arrays = (np.array(coords.x), np.array(coords.y), np.array(coords.z))
             eps_background = get_eps(
@@ -3014,7 +3025,7 @@ class Simulation(AbstractYeeGridSimulation):
 
     @model_validator(mode="before")
     @classmethod
-    def _update_simulation(cls, data):
+    def _update_simulation(cls, data: dict[str, Any]) -> dict[str, Any]:
         """Update the simulation if it is an earlier version."""
 
         # if no version, assume it's already updated
@@ -3026,7 +3037,7 @@ class Simulation(AbstractYeeGridSimulation):
         return updater.update_to_current()
 
     @model_validator(mode="after")
-    def _validate_auto_grid_wavelength(self):
+    def _validate_auto_grid_wavelength(self) -> Self:
         """Check that wavelength can be defined if there is auto grid spec."""
         val = self.grid_spec
         if val.wavelength is None and val.auto_grid_used:
@@ -3048,7 +3059,7 @@ class Simulation(AbstractYeeGridSimulation):
     # _plane_waves_in_homo = validate_plane_wave_intersections()
 
     @model_validator(mode="after")
-    def bloch_with_symmetry(self):
+    def bloch_with_symmetry(self) -> Self:
         """Error if a Bloch boundary is applied with symmetry"""
         val = self.boundary_spec
         boundaries = val.to_list
@@ -3062,7 +3073,7 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @model_validator(mode="after")
-    def plane_wave_boundaries(self):
+    def plane_wave_boundaries(self) -> Self:
         """Error if there are plane wave sources incompatible with boundary conditions."""
         boundaries = self.boundary_spec.to_list
         sources = self.sources
@@ -3115,7 +3126,7 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @model_validator(mode="after")
-    def bloch_boundaries_diff_mnt(self):
+    def bloch_boundaries_diff_mnt(self) -> Self:
         """Error if there are diffraction monitors incompatible with boundary conditions."""
 
         monitors = self.monitors
@@ -3154,7 +3165,7 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @model_validator(mode="after")
-    def tfsf_boundaries(self):
+    def tfsf_boundaries(self) -> Self:
         """Error if the boundary conditions are incompatible with TFSF sources, if any."""
         boundaries = self.boundary_spec.to_list
         sources = self.sources
@@ -3227,7 +3238,7 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @model_validator(mode="after")
-    def tfsf_with_symmetry(self):
+    def tfsf_with_symmetry(self) -> Self:
         """Error if a TFSF source is applied with symmetry"""
         for source in self.sources:
             if isinstance(source, TFSF) and not all(sym == 0 for sym in self.symmetry):
@@ -3243,7 +3254,7 @@ class Simulation(AbstractYeeGridSimulation):
         ]
 
     @model_validator(mode="after")
-    def check_fixed_angle_components(self):
+    def check_fixed_angle_components(self) -> Self:
         """Error if a fixed-angle plane wave is combined with other sources
         or fully anisotropic mediums or gain mediums."""
 
@@ -3291,10 +3302,12 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @model_validator(mode="after")
-    def _validate_frequency_mode_abc(self):
+    def _validate_frequency_mode_abc(self) -> Self:
         """Warn if ModeABCBoundary expects a frequency from a source, but there are multiple sources with different central frequencies."""
 
-        def boundary_needs_freq(boundary):
+        def boundary_needs_freq(
+            boundary: Union[ModeABCBoundary, ABCBoundary, BoundaryEdgeType],
+        ) -> bool:
             return (isinstance(boundary, ModeABCBoundary) and boundary.freq_spec is None) or (
                 isinstance(boundary, ABCBoundary)
                 and (
@@ -3332,7 +3345,7 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @model_validator(mode="after")
-    def _validate_absorber_in_zero_dims(self):
+    def _validate_absorber_in_zero_dims(self) -> Self:
         """Error if internal absorber is oriented along zero size dim."""
         val = self.internal_absorbers
         if val is None:
@@ -3349,7 +3362,9 @@ class Simulation(AbstractYeeGridSimulation):
 
     @field_validator("sources")
     @classmethod
-    def _validate_num_sources(cls, val):
+    def _validate_num_sources(
+        cls, val: Optional[tuple[SourceType, ...]]
+    ) -> Optional[tuple[SourceType, ...]]:
         """Error if too many sources present."""
 
         if val is None:
@@ -3366,7 +3381,9 @@ class Simulation(AbstractYeeGridSimulation):
 
     @field_validator("structures")
     @classmethod
-    def _validate_2d_geometry_has_2d_medium(cls, val):
+    def _validate_2d_geometry_has_2d_medium(
+        cls, val: tuple[Structure, ...]
+    ) -> tuple[Structure, ...]:
         """Warn if a geometry bounding box has zero size in a certain dimension."""
 
         if val is None:
@@ -3392,7 +3409,9 @@ class Simulation(AbstractYeeGridSimulation):
 
     @field_validator("structures")
     @classmethod
-    def _validate_incompatible_material_intersections(cls, val):
+    def _validate_incompatible_material_intersections(
+        cls, val: tuple[Structure, ...]
+    ) -> tuple[Structure, ...]:
         """Check for intersections of incompatible materials."""
         structures = val
         incompatible_indices = []
@@ -3422,7 +3441,7 @@ class Simulation(AbstractYeeGridSimulation):
         return val
 
     @model_validator(mode="after")
-    def _structures_not_close_pml(self):
+    def _structures_not_close_pml(self) -> Self:
         """Warn if any structures lie at the simulation boundaries."""
         val = self.boundary_spec
 
@@ -3438,7 +3457,7 @@ class Simulation(AbstractYeeGridSimulation):
 
         with log as consolidated_logger:
 
-            def warn(structure, istruct, side) -> None:
+            def warn(structure: Structure, istruct: int, side: str) -> None:
                 """Warning message for a structure too close to PML."""
                 obj_descr = named_obj_descr(structure, "structures", istruct)
                 consolidated_logger.warning(
@@ -3482,7 +3501,7 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @model_validator(mode="after")
-    def _warn_monitor_mediums_frequency_range(self):
+    def _warn_monitor_mediums_frequency_range(self) -> Self:
         """Warn user if any DFT monitors have frequencies outside of medium frequency range."""
         val = self.monitors
 
@@ -3535,7 +3554,7 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @model_validator(mode="after")
-    def _warn_monitor_simulation_frequency_range(self):
+    def _warn_monitor_simulation_frequency_range(self) -> Self:
         """Warn if any DFT monitors have frequencies outside of the simulation frequency range."""
         val = self.monitors
 
@@ -3571,7 +3590,7 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @model_validator(mode="after")
-    def diffraction_monitor_boundaries(self):
+    def diffraction_monitor_boundaries(self) -> Self:
         """If any :class:`.DiffractionMonitor` exists, ensure boundary conditions in the
         transverse directions are periodic or Bloch."""
         monitors = self.monitors
@@ -3595,7 +3614,7 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @model_validator(mode="after")
-    def _projection_monitors_homogeneous(self):
+    def _projection_monitors_homogeneous(self) -> Self:
         """Error if any field projection monitor is not in a homogeneous region."""
         val = self.monitors
 
@@ -3679,7 +3698,7 @@ class Simulation(AbstractYeeGridSimulation):
         return mediums
 
     @model_validator(mode="after")
-    def _abc_boundaries_homogeneous(self):
+    def _abc_boundaries_homogeneous(self) -> Self:
         """Error if abc boundaries intersect multiple mediums or anisotropic mediums."""
         val = self.boundary_spec
         if val is None:
@@ -3730,7 +3749,7 @@ class Simulation(AbstractYeeGridSimulation):
 
     @field_validator("monitors")
     @classmethod
-    def _projection_direction(cls, val):
+    def _projection_direction(cls, val: tuple[MonitorType, ...]) -> tuple[MonitorType, ...]:
         """Warn if field projection observation points are behind surface projection monitors."""
         # This validator is in simulation.py rather than monitor.py because volume monitors are
         # eventually converted to their bounding surface projection monitors, in which case we
@@ -3792,7 +3811,7 @@ class Simulation(AbstractYeeGridSimulation):
         return val
 
     @model_validator(mode="after")
-    def proj_distance_for_approx(self):
+    def proj_distance_for_approx(self) -> Self:
         """Warn if projection distance for projection monitors is not large compared to monitor or,
         simulation size, yet far_field_approx is True."""
         val = self.monitors
@@ -3822,7 +3841,7 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @model_validator(mode="after")
-    def _integration_surfaces_in_bounds(self):
+    def _integration_surfaces_in_bounds(self) -> Self:
         """Error if all of the integration surfaces are outside of the simulation domain."""
         val = self.monitors
 
@@ -3843,7 +3862,7 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @model_validator(mode="after")
-    def _projection_monitors_distance(self):
+    def _projection_monitors_distance(self) -> Self:
         """Warn if the projection distance is large for exact projections."""
         val = self.monitors
 
@@ -3876,7 +3895,7 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @model_validator(mode="after")
-    def _projection_mnts_2d(self):
+    def _projection_mnts_2d(self) -> Self:
         """
         Validate if the field projection monitor is set up for a 2D simulation and
         ensure the observation parameters are configured correctly.
@@ -3981,7 +4000,7 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @model_validator(mode="after")
-    def diffraction_and_directivity_monitor_medium(self):
+    def diffraction_and_directivity_monitor_medium(self) -> Self:
         """If any :class:`.DiffractionMonitor` or  :class:`.DirectivityMonitor` exists, ensure it does not lie in a lossy medium."""
         monitors = self.monitors
         structures = self.structures
@@ -3999,7 +4018,7 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @model_validator(mode="after")
-    def _warn_grid_size_too_small(self):
+    def _warn_grid_size_too_small(self) -> Self:
         """Warn user if any grid size is too large compared to minimum wavelength in material."""
         val = self.grid_spec
 
@@ -4062,7 +4081,7 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @model_validator(mode="after")
-    def _source_homogeneous_isotropic(self):
+    def _source_homogeneous_isotropic(self) -> Self:
         """Error if a plane wave or gaussian beam source is not in a homogeneous and isotropic
         region.
         """
@@ -4135,7 +4154,7 @@ class Simulation(AbstractYeeGridSimulation):
                         and source.num_freqs > 1
                     ):
 
-                        def radius(waist_radius, waist_distance, k0):
+                        def radius(waist_radius: float, waist_distance: float, k0: float) -> float:
                             """Gaussian beam radius at a given waist distance and k0."""
                             z_r = waist_radius**2 * k0 / 2
                             return waist_radius * np.sqrt(1 + (waist_distance / z_r) ** 2)
@@ -4178,7 +4197,7 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @model_validator(mode="after")
-    def _check_normalize_index(self):
+    def _check_normalize_index(self) -> Self:
         """Check validity of normalize index in context of simulation.sources."""
         val = self.normalize_index
 
@@ -4217,7 +4236,7 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @model_validator(mode="after")
-    def _validate_low_freq_smoothing(self):
+    def _validate_low_freq_smoothing(self) -> Self:
         """Validate the low frequency smoothing parameters."""
         # check that all monitors are present and they are mode monitors
         val = self.low_freq_smoothing
@@ -4235,7 +4254,7 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @model_validator(mode="after")
-    def _validate_scene(self):
+    def _validate_scene(self) -> Self:
         _ = self.scene
         self._validate_no_structures_pml()
         self._validate_tfsf_nonuniform_grid()
@@ -5081,7 +5100,7 @@ class Simulation(AbstractYeeGridSimulation):
         )
         return Scene.intersecting_structures(test_object=test_object, structures=structures)
 
-    def monitor_medium(self, monitor: MonitorType):
+    def monitor_medium(self, monitor: MonitorType) -> AbstractMedium:
         """Return the medium in which the given monitor resides.
 
         Parameters
@@ -5221,7 +5240,7 @@ class Simulation(AbstractYeeGridSimulation):
 
     def to_gds(
         self,
-        cell,
+        cell: gdstk.Cell,
         x: Optional[float] = None,
         y: Optional[float] = None,
         z: Optional[float] = None,
@@ -5364,7 +5383,7 @@ class Simulation(AbstractYeeGridSimulation):
 
         return (freq_min, freq_max)
 
-    def plot_3d(self, width=800, height=800) -> None:
+    def plot_3d(self, width: int = 800, height: int = 800) -> None:
         """Render 3D plot of ``Simulation`` (in jupyter notebook only).
         Parameters
         ----------
@@ -5525,7 +5544,7 @@ class Simulation(AbstractYeeGridSimulation):
         return int(np.prod([float(nc) for nc in self.grid.num_cells]))
 
     @property
-    def _num_computational_grid_points_dim(self):
+    def _num_computational_grid_points_dim(self) -> list[int]:
         """Number of cells in the computational domain for this simulation along each dimension."""
         num_cells = self.grid.num_cells
         num_cells_comp_domain = []
@@ -5540,7 +5559,7 @@ class Simulation(AbstractYeeGridSimulation):
         return num_cells_comp_domain
 
     @property
-    def num_computational_grid_points(self):
+    def num_computational_grid_points(self) -> int:
         """Number of cells in the computational domain for this simulation. This is usually
         different from ``num_cells`` due to the boundary conditions. Specifically, all boundary
         conditions apart from :class:`Periodic` require an extra pixel at the end of the simulation

--- a/tidy3d/components/validators.py
+++ b/tidy3d/components/validators.py
@@ -2,18 +2,29 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union
 
 import numpy as np
-from pydantic import field_validator, model_validator
+from numpy.typing import NDArray
+from pydantic import FieldValidationInfo, field_validator, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
 
 from .autograd.utils import get_static, hasbox
 from .base import DATA_ARRAY_MAP
 from .geometry.base import Box
+
+if TYPE_CHECKING:
+    from tidy3d import Simulation
+    from tidy3d.components.base_sim.simulation import AbstractSimulation
+    from tidy3d.components.data.monitor_data import AbstractFieldData
+    from tidy3d.components.types import FreqArray
+    from tidy3d.plugins.smatrix import AbstractComponentModeler
+
+
+T = TypeVar("T")
 
 """ Explanation of pydantic validators:
 
@@ -50,6 +61,8 @@ from .geometry.base import Box
 # Lowest frequency supported (Hz)
 MIN_FREQUENCY = 1e5
 
+FloatArray = Union[Sequence[float], NDArray]
+
 
 def named_obj_descr(obj: Any, field_name: str, position_index: int) -> str:
     """Generate a string describing a named object which can be used in error messages."""
@@ -59,12 +72,12 @@ def named_obj_descr(obj: Any, field_name: str, position_index: int) -> str:
     return descr
 
 
-def assert_line():
+def assert_line() -> Callable[[type, tuple[float, ...]], tuple[float, ...]]:
     """makes sure a field's ``size`` attribute has exactly 2 zeros"""
 
     @field_validator("size")
     @classmethod
-    def is_line(cls, val):
+    def is_line(cls: type, val: tuple[float, ...]) -> tuple[float, ...]:
         """Raise validation error if not 1 dimensional."""
         if val.count(0.0) != 2:
             raise ValidationError(f"'{cls.__name__}' object must be a line, given size={val}")
@@ -73,12 +86,12 @@ def assert_line():
     return is_line
 
 
-def assert_plane():
+def assert_plane() -> Callable[[type, tuple[float, ...]], tuple[float, ...]]:
     """makes sure a field's ``size`` attribute has exactly 1 zero"""
 
     @field_validator("size")
     @classmethod
-    def is_plane(cls, val):
+    def is_plane(cls: type, val: tuple[float, ...]) -> tuple[float, ...]:
         """Raise validation error if not planar."""
         if val.count(0.0) != 1:
             raise ValidationError(f"'{cls.__name__}' object must be planar, given size={val}")
@@ -87,12 +100,12 @@ def assert_plane():
     return is_plane
 
 
-def assert_line_or_plane():
+def assert_line_or_plane() -> Callable[[type, tuple[float, ...]], tuple[float, ...]]:
     """makes sure a field's ``size`` attribute has either 1 or 2 zeros"""
 
     @field_validator("size")
     @classmethod
-    def is_line_or_plane(cls, val):
+    def is_line_or_plane(cls: type, val: tuple[float, ...]) -> tuple[float, ...]:
         """Raise validation error if not a line or plane."""
         if val.count(0.0) == 0 or val.count(0.0) == 3:
             raise ValidationError(
@@ -103,12 +116,12 @@ def assert_line_or_plane():
     return is_line_or_plane
 
 
-def assert_volumetric():
+def assert_volumetric() -> Callable[[type, tuple[float, ...]], tuple[float, ...]]:
     """makes sure a field's ``size`` attribute has no zero entry"""
 
     @field_validator("size")
     @classmethod
-    def is_volumetric(cls, val):
+    def is_volumetric(cls: type, val: tuple[float, ...]) -> tuple[float, ...]:
         """Raise validation error if volume is 0."""
         if val.count(0.0) > 0:
             raise ValidationError(
@@ -122,12 +135,12 @@ def assert_volumetric():
 
 
 # FIXME: this validator doesn't do anything
-def validate_name_str():
+def validate_name_str() -> Callable[[type, Optional[str]], Optional[str]]:
     """make sure the name does not include [, ] (used for default names)"""
 
     @field_validator("name")
     @classmethod
-    def field_has_unique_names(cls, val):
+    def field_has_unique_names(cls: type, val: Optional[str]) -> Optional[str]:
         """raise exception if '[' or ']' in name"""
         # if val and ('[' in val or ']' in val):
         #     raise SetupError(f"'[' or ']' not allowed in name: {val} (used for defaults)")
@@ -136,12 +149,16 @@ def validate_name_str():
     return field_has_unique_names
 
 
-def validate_unique(*field_names: str):
+def validate_unique(
+    *field_names: str,
+) -> Callable[[type, Sequence[Any], FieldValidationInfo], Sequence[Any]]:
     """Make sure the given field has unique entries."""
 
     @field_validator(*field_names)
     @classmethod
-    def field_has_unique_entries(cls, val, info):
+    def field_has_unique_entries(
+        cls: type, val: Sequence[Any], info: FieldValidationInfo
+    ) -> Sequence[Any]:
         """Check if the field has unique entries."""
         if len(set(val)) != len(val):
             raise SetupError(f"Entries of '{info.field_name}' must be unique.")
@@ -150,16 +167,16 @@ def validate_unique(*field_names: str):
     return field_has_unique_entries
 
 
-def validate_mode_objects_symmetry(field_name: str):
+def validate_mode_objects_symmetry(field_name: str) -> Callable[[T], T]:
     """If a Mode object, this checks that the object is fully in the main quadrant in the presence
     of symmetry along a given axis, or else centered on the symmetry center."""
 
     obj_type = "ModeSource" if field_name == "sources" else "ModeMonitor"
 
     @model_validator(mode="after")
-    def check_symmetry(self):
+    def check_symmetry(self: T) -> T:
         """check for intersection of each structure with simulation bounds."""
-        val = getattr(self, field_name)
+        val: Sequence[Any] = getattr(self, field_name)
         sim_center = self.center
         for position_index, geometric_object in enumerate(val):
             if geometric_object.type == obj_type:
@@ -181,12 +198,16 @@ def validate_mode_objects_symmetry(field_name: str):
     return check_symmetry
 
 
-def assert_unique_names(*field_names: str):
+def assert_unique_names(
+    *field_names: str,
+) -> Callable[[type, Sequence[Any], FieldValidationInfo], Sequence[Any]]:
     """makes sure all elements of a field have unique .name values"""
 
     @field_validator(*field_names)
     @classmethod
-    def field_has_unique_names(cls, val, info):
+    def field_has_unique_names(
+        cls: type, val: Sequence[Any], info: FieldValidationInfo
+    ) -> Sequence[Any]:
         """make sure each element of val has a unique name (if specified)."""
         field_names = [field.name for field in val if field.name]
         unique_names = set(field_names)
@@ -199,19 +220,19 @@ def assert_unique_names(*field_names: str):
 
 def assert_objects_in_sim_bounds(
     field_name: str, error: bool = True, strict_inequality: bool = False
-):
+) -> Callable[[AbstractSimulation], AbstractSimulation]:
     """Makes sure all objects in field are at least partially inside of simulation bounds."""
 
     @model_validator(mode="after")
-    def objects_in_sim_bounds(self):
+    def objects_in_sim_bounds(self: AbstractSimulation) -> AbstractSimulation:
         """check for intersection of each structure with simulation bounds."""
-        val = getattr(self, field_name)
+        val: Sequence[Any] = getattr(self, field_name)
         sim_center = self.center
         sim_size = self.size
         sim_box = Box(size=sim_size, center=sim_center)
 
         # Do a strict check, unless simulation is 0D along a dimension
-        strict_ineq = [size != 0 and strict_inequality for size in sim_size]
+        strict_ineq: list[bool] = [size != 0 and strict_inequality for size in sim_size]
 
         with log as consolidated_logger:
             for position_index, geometric_object in enumerate(val):
@@ -233,19 +254,19 @@ def assert_objects_contained_in_sim_bounds(
     error: bool = True,
     strict_inequality: bool = False,
     strict_for_zero_size_dim: bool = False,
-):
+) -> Callable[[Simulation], Simulation]:
     """Makes sure all objects in field are completely inside the simulation bounds."""
 
     @model_validator(mode="after")
-    def objects_contained_in_sim_bounds(self):
+    def objects_contained_in_sim_bounds(self: Simulation) -> Simulation:
         """check for containment of each structure with simulation bounds."""
-        val = getattr(self, field_name)
+        val: Sequence[Any] = getattr(self, field_name)
         sim_center = self.center
         sim_size = self.size
         sim_box = Box(size=sim_size, center=sim_center)
 
         # Do a strict check, unless simulation is 0D along a dimension
-        strict_ineq = [size != 0 and strict_inequality for size in sim_size]
+        strict_ineq: list[bool] = [size != 0 and strict_inequality for size in sim_size]
         with log as consolidated_logger:
             for position_index, geometric_object in enumerate(val):
                 geo_strict_ineq = list(strict_ineq)
@@ -269,11 +290,11 @@ def assert_objects_contained_in_sim_bounds(
     return objects_contained_in_sim_bounds
 
 
-def enforce_monitor_fields_present():
+def enforce_monitor_fields_present() -> Callable[[AbstractFieldData], AbstractFieldData]:
     """Make sure all of the fields in the monitor are present in the corresponding data."""
 
     @model_validator(mode="after")
-    def _contains_fields(self):
+    def _contains_fields(self: AbstractFieldData) -> AbstractFieldData:
         """Make sure the initially specified fields are here."""
         for field_name in self.monitor.fields:
             if getattr(self, field_name) is None:
@@ -283,11 +304,11 @@ def enforce_monitor_fields_present():
     return _contains_fields
 
 
-def required_if_symmetry_present(field_name: str):
+def required_if_symmetry_present(field_name: str) -> Callable[[T], T]:
     """Make a field required (not None) if any non-zero symmetry eigenvalue is present."""
 
     @model_validator(mode="after")
-    def _make_required(self):
+    def _make_required(self: T) -> T:
         """Ensure val is not None if the symmetry is non-zero along any dimension."""
         val = getattr(self, field_name)
         symmetry = self.symmetry
@@ -298,12 +319,14 @@ def required_if_symmetry_present(field_name: str):
     return _make_required
 
 
-def warn_if_dataset_none(field_name: str):
+def warn_if_dataset_none(
+    field_name: str,
+) -> Callable[[type, Optional[dict[str, Any]]], Optional[dict[str, Any]]]:
     """Warn if a Dataset field has None in its dictionary."""
 
     @field_validator(field_name, mode="before")
     @classmethod
-    def _warn_if_none(cls, val: dict) -> Optional[dict]:
+    def _warn_if_none(cls: type, val: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
         """Warn if the DataArrays fail to load."""
         if isinstance(val, dict):
             if any((v in DATA_ARRAY_MAP for _, v in val.items() if isinstance(v, str))):
@@ -314,11 +337,11 @@ def warn_if_dataset_none(field_name: str):
     return _warn_if_none
 
 
-def assert_single_freq_in_range(field_name: str):
+def assert_single_freq_in_range(field_name: str) -> Callable[[T], T]:
     """Assert only one frequency supplied in source and it's in source time range."""
 
     @model_validator(mode="after")
-    def _single_frequency_in_range(self) -> Self:
+    def _single_frequency_in_range(self: T) -> T:
         """Assert only one frequency supplied and it's in source time range."""
         val = getattr(self, field_name, None)
         if val is None:
@@ -347,12 +370,12 @@ def validate_parameter_perturbation(
     field_name: str,
     base_field_name: str,
     allowed_complex: bool = True,
-):
+) -> Callable[[type, Any, FieldValidationInfo], Any]:
     """Assert perturbations have a valid shape and data type."""
 
     @field_validator(field_name)
     @classmethod
-    def _check_perturbed_val(cls, val, info):
+    def _check_perturbed_val(cls: type, val: Any, info: FieldValidationInfo) -> Any:
         """Assert perturbations have a valid shape and data type."""
 
         if val is not None:
@@ -380,7 +403,7 @@ def validate_parameter_perturbation(
     return _check_perturbed_val
 
 
-def _assert_min_freq(freqs, msg_start: str) -> None:
+def _assert_min_freq(freqs: FloatArray, msg_start: str) -> None:
     """Check if all ``freqs`` are above the minimum frequency."""
     if np.min(freqs) < MIN_FREQUENCY:
         raise ValidationError(
@@ -389,12 +412,12 @@ def _assert_min_freq(freqs, msg_start: str) -> None:
         )
 
 
-def validate_freqs_min():
+def validate_freqs_min() -> Callable[[type, FreqArray], FreqArray]:
     """Validate lower bound for monitor, and mode solver frequencies."""
 
     @field_validator("freqs")
     @classmethod
-    def freqs_lower_bound(cls, val):
+    def freqs_lower_bound(cls: type, val: FreqArray) -> FreqArray:
         """Raise validation error if any of ``freqs`` is lower than ``MIN_FREQUENCY``."""
         _assert_min_freq(val, msg_start=f"All of '{cls.__name__}.freqs'")
         return val
@@ -402,12 +425,12 @@ def validate_freqs_min():
     return freqs_lower_bound
 
 
-def validate_freqs_not_empty():
+def validate_freqs_not_empty() -> Callable[[type, FreqArray], FreqArray]:
     """Validate that the array of frequencies is not empty."""
 
     @field_validator("freqs")
     @classmethod
-    def freqs_not_empty(cls, val):
+    def freqs_not_empty(cls: type, val: FreqArray) -> FreqArray:
         """Raise validation error if ``freqs`` is an empty Tuple."""
         if len(val) == 0:
             raise ValidationError(f"'{cls.__name__}.freqs' cannot be empty (size 0).")
@@ -416,12 +439,12 @@ def validate_freqs_not_empty():
     return freqs_not_empty
 
 
-def validate_freqs_unique():
+def validate_freqs_unique() -> Callable[[AbstractComponentModeler, FreqArray], FreqArray]:
     """Validate that the array of frequencies does not have duplicate entries."""
 
     @field_validator("freqs")
     @classmethod
-    def freqs_unique(cls, val):
+    def freqs_unique(cls: AbstractComponentModeler, val: FreqArray) -> FreqArray:
         """Raise validation error if ``freqs`` has duplicate entries."""
         if len(set(val)) != len(val):
             raise ValidationError(f"'{cls.__name__}.freqs' must not contain duplicate entries.")
@@ -430,10 +453,12 @@ def validate_freqs_unique():
     return freqs_unique
 
 
-def _warn_unsupported_traced_argument(*names: str):
+def _warn_unsupported_traced_argument(
+    *names: str,
+) -> Callable[[type, Any, FieldValidationInfo], Any]:
     @field_validator(*names)
     @classmethod
-    def _warn_traced_arg(cls, val, info):
+    def _warn_traced_arg(cls: type, val: Any, info: FieldValidationInfo) -> Any:
         if hasbox(val):
             log.warning(
                 f"Field '{info.field_name}' of '{cls.__name__}' received an autograd tracer "


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds comprehensive mypy type annotations to several core component files (`base.py`, `boundary.py`, `medium.py`, `monitor.py`, `simulation.py`, `validators.py`) and removes these files from the mypy exclude list in `pyproject.toml`.

**Key Changes:**
- Added type annotations to decorators, validators, classmethods, and helper functions
- Introduced type aliases like `ArrayFloat`, `ArrayComplex`, `FrequencyArray` in `medium.py` 
- Added `Self` return types for model validators and copy methods
- Added `FieldValidationInfo` parameter types for validators using `info` parameter

**Issues Found:**
- **Critical:** Missing `@classmethod` decorator on `assert_plane` validator in `validators.py` - will cause runtime errors
- **Minor:** Return type mismatch in `ensure_freq_in_range` decorator (`type[AbstractMedium]` vs `AbstractMedium`)

<h3>Confidence Score: 3/5</h3>


- PR has one critical bug (missing decorator) that needs to be fixed before merging.
- The missing `@classmethod` decorator in `validators.py` is a regression that will cause validators using `assert_plane()` to fail at runtime. The type annotation work itself is well-done, but this bug needs to be addressed.
- `tidy3d/components/validators.py` - missing `@classmethod` decorator is a critical bug

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| pyproject.toml | 5/5 | Removed mypy exclusions for component files that now have proper type annotations. |
| tidy3d/components/base.py | 5/5 | Added comprehensive type annotations for cache decorators, Tidy3dBaseModel methods, and helper functions. No issues found. |
| tidy3d/components/boundary.py | 4/5 | Added type annotations for validators and classmethods. Style issues with `cls: Self` annotations for classmethods noted in prior reviews. |
| tidy3d/components/medium.py | 4/5 | Added custom type aliases (ArrayFloat, ArrayComplex, etc.) and comprehensive type annotations. Minor type annotation inconsistency in `ensure_freq_in_range` decorator return type. |
| tidy3d/components/monitor.py | 5/5 | Added type annotations for validators and methods using proper Self return types and FieldValidationInfo. |
| tidy3d/components/simulation.py | 5/5 | Added type annotations for simulation validators and methods. Uses proper Self returns and NDArray types. |
| tidy3d/components/validators.py | 2/5 | Added type annotations but accidentally removed `@classmethod` decorator from `assert_plane` validator - a bug that could cause runtime errors. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant mypy as mypy Type Checker
    participant pyproject as pyproject.toml
    participant components as Component Files
    
    Note over pyproject: Before: Files excluded from mypy
    pyproject->>components: Exclusion list removed
    Note over components: base.py, boundary.py, medium.py<br/>monitor.py, simulation.py, validators.py
    
    components->>components: Add type annotations
    Note over components: TypeVar, Self, NDArray,<br/>Callable, Optional types
    
    mypy->>components: Type check enabled
    components-->>mypy: Type errors now caught
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->