### PR TITLE
(FXC-4465) correct normal for box minimum face in shape gradient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix to `outer_dot` when frequencies stored in the data were not in increasing order. Previously, the result would be provided with re-sorted frequencies, which would not match the order of the original data.
 - Fixed bug where an extra spatial coordinate could appear in `complex_flux` and `ImpedanceCalculator` results.
+- Fixed normal for `Box` shape gradient computation to always point outward from boundary which is needed for correct PEC handling.
 
 ## [2.10.0rc3] - 2025-11-26
 

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -2740,7 +2740,7 @@ class Box(SimplePlaneIntersection, Centered):
         perps1 = np.zeros_like(grid_points)
         perps2 = np.zeros_like(grid_points)
 
-        normals[:, axis_normal] = 1
+        normals[:, axis_normal] = -1 if (min_max_index == 0) else 1
         perps1[:, axis_perp[0]] = 1
         perps2[:, axis_perp[1]] = 1
 


### PR DESCRIPTION
@yaugenst-flex , this is the error I was mentioning this morning. I was going to include it in my boundary handling PR but just in case that takes a little bit to fully get in, I figured it was worth having this fix in sooner since it's needed for correct PEC handling.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR fixes a critical bug in the `Box` geometry's shape gradient computation where the normal vector for the minimum face was incorrectly pointing inward (+1) instead of outward (-1). The `evaluate_gradient_at_points` method requires outward-pointing normals for correct PEC (Perfect Electric Conductor) boundary handling in adjoint optimization.

Key changes:
- Modified `tidy3d/components/geometry/base.py:2743` to conditionally set normal direction based on `min_max_index`
- When `min_max_index == 0` (minimum face), normal now points in -1 direction (outward from lower bound)
- When `min_max_index == 1` (maximum face), normal continues to point in +1 direction (outward from upper bound)
- Added appropriate changelog entry under "Fixed" section describing the impact

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk - it's a targeted bug fix with clear correctness improvement
- The fix is minimal, mathematically correct, and addresses a clear bug. The change correctly implements outward-pointing normals as required by the API documentation. The logic is straightforward: minimum faces need negative normals, maximum faces need positive normals. No other code paths are affected.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| CHANGELOG.md | 5/5 | Added clear, user-facing changelog entry describing the bug fix for Box shape gradient normal direction |
| tidy3d/components/geometry/base.py | 5/5 | Corrected normal vector direction for Box minimum face to point outward (-1 direction) as required by shape gradient API |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Adjoint Client
    participant BoxFaces as Box._derivative_faces
    participant BoxFace as Box._derivative_face
    participant Eval as DerivativeInfo.evaluate_gradient_at_points
    
    Client->>BoxFaces: Compute shape gradients
    BoxFaces->>BoxFaces: Loop over min_max_index
    BoxFaces->>BoxFace: Call with min_max_index and axis_normal
    
    BoxFace->>BoxFace: Get coord from bounds_normal[min_max_index]
    BoxFace->>BoxFace: Build grid_points on face
    
    Note over BoxFace: Critical Fix: Set normal direction
    alt min_max_index equals 0
        BoxFace->>BoxFace: Set normals[:, axis_normal] = -1
    else min_max_index equals 1
        BoxFace->>BoxFace: Set normals[:, axis_normal] = +1
    end
    
    BoxFace->>Eval: Call with spatial_coords and normals
    Note over Eval: Requires outward-pointing normals for correct PEC handling
    Eval-->>BoxFace: Return gradient values
    
    BoxFace->>BoxFace: Compute vjp_value with integration_weight
    BoxFace-->>BoxFaces: Return vjp_value
    BoxFaces-->>Client: Return vjp_faces array
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->