### PR TITLE
fix(rf) : fix bug where an extra spatial coord could appear in flux and impedance results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added optional `max_results` handling to the kLayout `DRCLoader` and `DRCRunner` and speeded up parsing of big result sets.
 
 ### Fixed
+- Fixed bug where an extra spatial coordinate could appear in `complex_flux` and `ImpedanceCalculator` results.
 
 ## [2.10.0rc3] - 2025-11-26
 

--- a/tests/test_data/test_data_arrays.py
+++ b/tests/test_data/test_data_arrays.py
@@ -69,7 +69,10 @@ PERMITTIVITY_MONITOR = td.PermittivityMonitor(size=SIZE_3D, name="permittivity",
 MEDIUM_MONITOR = td.MediumMonitor(size=SIZE_3D, name="medium", freqs=FREQS)
 MODE_MONITOR = td.ModeMonitor(size=SIZE_2D, name="mode", mode_spec=MODE_SPEC, freqs=FREQS)
 MODE_MONITOR_WITH_FIELDS = td.ModeMonitor(
-    size=SIZE_2D, name="mode_solver", mode_spec=MODE_SPEC, freqs=FS, store_fields_direction="+"
+    size=SIZE_2D, name="mode_with_fields", mode_spec=MODE_SPEC, freqs=FS, store_fields_direction="+"
+)
+MODE_SOLVER_MONITOR = td.ModeSolverMonitor(
+    size=SIZE_2D, name="mode_solver", mode_spec=MODE_SPEC, freqs=FS, direction="+"
 )
 FLUX_MONITOR = td.FluxMonitor(size=SIZE_2D, freqs=FREQS, name="flux")
 FLUX_TIME_MONITOR = td.FluxTimeMonitor(size=SIZE_2D, interval=INTERVAL, name="flux_time")
@@ -99,6 +102,7 @@ MONITORS = [
     FLUX_TIME_MONITOR,
     DIFFRACTION_MONITOR,
     DIRECTIVITY_MONITOR,
+    MODE_SOLVER_MONITOR,
 ]
 
 GRID_SPEC = td.GridSpec(wavelength=2.0)
@@ -187,6 +191,20 @@ def make_scalar_mode_field_data_array_smooth(grid_key: str, symmetry=True, rot: 
             + np.sin(rot) * np.array(ZS)[None, None, :, None, None]
         )
     )
+
+    return td.ScalarModeFieldDataArray(
+        values, coords={"x": XS, "y": [0.0], "z": ZS, "f": FS, "mode_index": MODE_INDICES}
+    )
+
+
+def make_scalar_mode_field_solver_data_array(
+    grid_key: str, symmetry=True, colocate: Optional[bool] = None
+):
+    monitor = MODE_SOLVER_MONITOR
+    if colocate is not None:
+        monitor = monitor.updated_copy(colocate=colocate)
+    XS, YS, ZS = get_xyz(monitor, grid_key, symmetry)
+    values = (1 + 0.1j) * np.random.random((len(XS), 1, len(ZS), len(FS), len(MODE_INDICES)))
 
     return td.ScalarModeFieldDataArray(
         values, coords={"x": XS, "y": [0.0], "z": ZS, "f": FS, "mode_index": MODE_INDICES}

--- a/tests/test_data/test_monitor_data.py
+++ b/tests/test_data/test_monitor_data.py
@@ -23,9 +23,11 @@ from tidy3d.components.data.monitor_data import (
     FluxTimeData,
     MediumData,
     ModeData,
+    ModeSolverData,
     PermittivityData,
 )
 from tidy3d.components.data.zbf import ZBFData
+from tidy3d.components.mode.mode_solver import ModeSolver
 from tidy3d.constants import UnitScaling
 from tidy3d.exceptions import DataError
 
@@ -45,6 +47,7 @@ from .test_data_arrays import (
     MEDIUM_MONITOR,
     MODE_MONITOR,
     MODE_MONITOR_WITH_FIELDS,
+    MODE_SOLVER_MONITOR,
     PERMITTIVITY_MONITOR,
     SIM,
     SIM_SYM,
@@ -59,6 +62,7 @@ from .test_data_arrays import (
     make_scalar_field_time_data_array,
     make_scalar_mode_field_data_array,
     make_scalar_mode_field_data_array_smooth,
+    make_scalar_mode_field_solver_data_array,
 )
 
 # data array instances
@@ -144,7 +148,7 @@ def make_aux_field_time_data(symmetry: bool = True):
     )
 
 
-def make_mode_solver_data():
+def make_mode_data_with_fields():
     mode_data = ModeData(
         monitor=MODE_MONITOR_WITH_FIELDS,
         Ex=make_scalar_mode_field_data_array("Ex"),
@@ -168,7 +172,7 @@ def make_mode_solver_data():
     return mode_data_norm
 
 
-def make_mode_solver_data_smooth(conjugated_dot_product: bool = True):
+def make_mode_data_with_fields_smooth(conjugated_dot_product: bool = True):
     mode_data = ModeData(
         monitor=MODE_MONITOR_WITH_FIELDS.updated_copy(
             conjugated_dot_product=conjugated_dot_product
@@ -186,6 +190,41 @@ def make_mode_solver_data_smooth(conjugated_dot_product: bool = True):
         n_group=N_GROUP.copy(),
         grid_primal_correction=GRID_CORRECTION,
         grid_dual_correction=GRID_CORRECTION,
+        amps=AMPS.copy(),
+    )
+    # Mode solver data needs to be normalized
+    scaling = np.sqrt(np.abs(mode_data.symmetry_expanded_copy.flux))
+    norm_data_dict = {key: val / scaling for key, val in mode_data.field_components.items()}
+    mode_data_norm = mode_data.copy(update=norm_data_dict)
+    return mode_data_norm
+
+
+def make_mode_solver_data():
+    # finite grid corrections
+    grid_factors, relative_grid_distances = ModeSolver._grid_correction(
+        simulation=SIM_SYM,
+        plane=MODE_SOLVER_MONITOR,
+        mode_spec=MODE_SOLVER_MONITOR.mode_spec,
+        n_complex=N_COMPLEX,
+        direction=MODE_SOLVER_MONITOR.direction,
+    )
+
+    mode_data = ModeSolverData(
+        monitor=MODE_SOLVER_MONITOR,
+        Ex=make_scalar_mode_field_solver_data_array("Ex"),
+        Ey=make_scalar_mode_field_solver_data_array("Ey"),
+        Ez=make_scalar_mode_field_solver_data_array("Ez"),
+        Hx=make_scalar_mode_field_solver_data_array("Hx"),
+        Hy=make_scalar_mode_field_solver_data_array("Hy"),
+        Hz=make_scalar_mode_field_solver_data_array("Hz"),
+        symmetry=SIM_SYM.symmetry,
+        symmetry_center=SIM_SYM.center,
+        grid_expanded=SIM_SYM.discretize_monitor(MODE_SOLVER_MONITOR),
+        n_complex=N_COMPLEX.copy(),
+        grid_primal_correction=grid_factors[0],
+        grid_dual_correction=grid_factors[1],
+        grid_distances_primal=relative_grid_distances[0],
+        grid_distances_dual=relative_grid_distances[1],
         amps=AMPS.copy(),
     )
     # Mode solver data needs to be normalized
@@ -340,8 +379,8 @@ def test_field_time_data():
         _ = data.dot(data)
 
 
-def test_mode_solver_data():
-    data = make_mode_solver_data()
+def test_mode_data_with_fields():
+    data = make_mode_data_with_fields()
     for field in "EH":
         for component in "xyz":
             _ = getattr(data, field + component)
@@ -394,6 +433,24 @@ def test_mode_solver_data():
         np.shape(modes_info[key]) == ()
         for key in ["TE (Ex) fraction", "wg TE fraction", "wg TM fraction", "mode area"]
     )
+
+
+def test_mode_solver_data():
+    data = make_mode_solver_data()
+    for field in "EH":
+        for component in "xyz":
+            _ = getattr(data, field + component)
+
+    # Compute flux directly
+    flux1 = np.abs(data.flux)
+    # Compute flux as dot product with itself
+    flux2 = np.abs(data.dot(data))
+    # Assert result is the same
+    assert np.allclose(flux1, flux2)
+
+    # Make sure bug fixed where extra coord was still present in poynting field
+    normal_dim = "xyz"[data.monitor._normal_axis]
+    assert normal_dim not in data.poynting.coords
 
 
 def test_permittivity_data():
@@ -557,7 +614,7 @@ def test_colocate():
     _ = data.colocate(x=[+0.1, 0.5], y=None, z=[+0.1, 0.5])
 
     # data outside range of len(coord)==1 dimension
-    data = make_mode_solver_data()
+    data = make_mode_data_with_fields()
     with pytest.raises(DataError):
         _ = data.colocate(x=[+0.1, 0.5], y=1.0, z=[+0.1, 0.5])
 
@@ -567,7 +624,7 @@ def test_colocate():
 
 def test_time_reversed_copy():
     _ = make_field_data().time_reversed_copy
-    _ = make_mode_solver_data().time_reversed_copy
+    _ = make_mode_data_with_fields().time_reversed_copy
     time_data = make_field_time_data()
     reversed_time_data = time_data.time_reversed_copy
     assert np.allclose(time_data.Ex.values, reversed_time_data.Ex.values[..., ::-1])
@@ -645,7 +702,7 @@ def test_empty_io(tmp_path):
 
 def test_mode_solver_plot_field():
     """Ensure we get a helpful error if trying to .plot_field with a ModeData."""
-    ms_data = make_mode_solver_data()
+    ms_data = make_mode_data_with_fields()
     with pytest.raises(DeprecationWarning):
         ms_data.plot_field(1, 2, 3, z=5, b=True)
     plt.close()
@@ -701,7 +758,7 @@ def test_diffraction_data_use_medium():
 
 
 @pytest.mark.parametrize("conjugated_dot_product", [True, False])
-def test_mode_solver_data_sort(conjugated_dot_product):
+def test_mode_data_with_fields_sort(conjugated_dot_product):
     # test basic matching algorithm
     arr = np.array([[1, 2, 3], [6, 5, 4], [7, 9, 8]])
     pairs, values = ModeData._find_closest_pairs(arr)
@@ -710,7 +767,7 @@ def test_mode_solver_data_sort(conjugated_dot_product):
 
     # test sorting function
     # get smooth data
-    data = make_mode_solver_data_smooth(conjugated_dot_product=conjugated_dot_product)
+    data = make_mode_data_with_fields_smooth(conjugated_dot_product=conjugated_dot_product)
     # make it unsorted
     num_modes = len(data.Ex.coords["mode_index"])
     num_freqs = len(data.Ex.coords["f"])
@@ -753,7 +810,7 @@ def test_mode_solver_data_sort(conjugated_dot_product):
 
 
 def test_mode_solver_numerical_grid_data():
-    mode_data = make_mode_solver_data().symmetry_expanded_copy
+    mode_data = make_mode_data_with_fields().symmetry_expanded_copy
     # _tangential_fields property applies the numerical correction and expands the symmetry
     tan_fields = mode_data._tangential_fields
     # Check that data is only slightly different
@@ -765,7 +822,7 @@ def test_mode_solver_numerical_grid_data():
 
 
 def test_outer_dot():
-    mode_data = make_mode_solver_data()
+    mode_data = make_mode_data_with_fields()
     field_data = make_field_data_2d()
     dot = mode_data.outer_dot(mode_data)
     assert "mode_index_0" in dot.coords and "mode_index_1" in dot.coords
@@ -797,7 +854,7 @@ def test_outer_dot():
 
 
 def test_translated_copy():
-    mode_data = make_mode_solver_data()
+    mode_data = make_mode_data_with_fields()
     field_data = make_field_data_2d()
 
     vector = (1, 0, 0)

--- a/tests/test_data/test_sim_data.py
+++ b/tests/test_data/test_sim_data.py
@@ -27,6 +27,7 @@ from .test_monitor_data import (
     make_flux_data,
     make_flux_time_data,
     make_mode_data,
+    make_mode_data_with_fields,
     make_mode_solver_data,
     make_permittivity_data,
 )
@@ -42,7 +43,9 @@ AUX_FIELD_TIME = make_aux_field_time_data(symmetry=False)
 PERMITTIVITY_SYM = make_permittivity_data()
 PERMITTIVITY = make_permittivity_data(symmetry=False)
 MODE = make_mode_data()
+MODE_WITH_FIELDS = make_mode_data_with_fields()
 MODE_SOLVER = make_mode_solver_data()
+
 FLUX = make_flux_data()
 FLUX_TIME = make_flux_time_data()
 DIFFRACTION = make_diffraction_data()
@@ -53,25 +56,27 @@ MONITOR_DATA = (
     FIELD,
     FIELD_TIME,
     AUX_FIELD_TIME,
-    MODE_SOLVER,
+    MODE_WITH_FIELDS,
     PERMITTIVITY,
     MODE,
     FLUX,
     FLUX_TIME,
     DIFFRACTION,
     DIRECTIVITY,
+    MODE_SOLVER,
 )
 MONITOR_DATA_SYM = (
     FIELD_SYM,
     FIELD_TIME_SYM,
     AUX_FIELD_TIME_SYM,
-    MODE_SOLVER,
+    MODE_WITH_FIELDS,
     PERMITTIVITY_SYM,
     MODE,
     FLUX,
     FLUX_TIME,
     DIFFRACTION,
     DIRECTIVITY,
+    MODE_SOLVER,
 )
 MONITOR_DATA_DICT = {data.monitor.name: data for data in MONITOR_DATA}
 MONITOR_DATA_DICT_SYM = {data.monitor.name: data for data in MONITOR_DATA_SYM}
@@ -188,10 +193,10 @@ def test_plot(phase):
     # plot mode field data
     for field_cmp in ("Ex", "Ey", "Ez", "Hx", "Hy", "Hz"):
         _ = sim_data.plot_field(
-            "mode_solver", field_cmp, val="real", f=1e14, mode_index=1, phase=phase
+            "mode_with_fields", field_cmp, val="real", f=1e14, mode_index=1, phase=phase
         )
         plt.close()
-    _ = sim_data.plot_field("mode_solver", "int", f=1e14, mode_index=1, phase=phase)
+    _ = sim_data.plot_field("mode_with_fields", "int", f=1e14, mode_index=1, phase=phase)
     plt.close()
 
 
@@ -223,13 +228,13 @@ def test_plot_field_missing_field_value():
         sim_data.plot_field(field_monitor_name="field", field_name="Ex", val="test")
 
 
-@pytest.mark.parametrize("monitor_name", ["field", "field_time", "mode_solver"])
+@pytest.mark.parametrize("monitor_name", ["field", "field_time", "mode_with_fields"])
 def test_intensity(monitor_name):
     sim_data = make_sim_data()
     _ = sim_data.get_intensity(monitor_name)
 
 
-@pytest.mark.parametrize("monitor_name", ["field", "field_time", "mode_solver"])
+@pytest.mark.parametrize("monitor_name", ["field", "field_time", "mode_with_fields"])
 def test_poynting(monitor_name):
     sim_data = make_sim_data()
     mnt_data = sim_data[monitor_name]
@@ -329,7 +334,7 @@ def test_logscale():
 def test_sel_kwarg_freq():
     """Use freq in sel_kwarg, should still work (but warning) for 1.6.x"""
     sim_data = make_sim_data()
-    sim_data.plot_field("mode_solver", "Ex", y=0.0, val="real", freq=1e14, mode_index=1)
+    sim_data.plot_field("mode_with_fields", "Ex", y=0.0, val="real", freq=1e14, mode_index=1)
     plt.close()
 
 
@@ -346,12 +351,12 @@ def test_sel_kwarg_len1():
     # data has no y dimension (only exists at y=0)
 
     # passing y=0 sel kwarg should still work
-    sim_data.plot_field("mode_solver", "Ex", y=0.0, val="real", f=1e14, mode_index=1)
+    sim_data.plot_field("mode_with_fields", "Ex", y=0.0, val="real", f=1e14, mode_index=1)
     plt.close()
 
     # passing y=1 sel kwarg should error
     with pytest.raises(KeyError):
-        sim_data.plot_field("mode_solver", "Ex", y=-1.0, val="real", f=1e14, mode_index=1)
+        sim_data.plot_field("mode_with_fields", "Ex", y=-1.0, val="real", f=1e14, mode_index=1)
         plt.close()
 
 

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -687,11 +687,14 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
         return self.complex_poynting.real
 
     def package_flux_results(self, flux_values: DataArray) -> Any:
-        """How to package flux"""
+        """How to package flux based on the coordinates present in the data."""
+        # Choose appropriate data array type based on coordinates
+        if "mode_index" in flux_values.dims:
+            return FreqModeDataArray(flux_values)
         return FluxDataArray(flux_values)
 
     @cached_property
-    def complex_flux(self) -> FluxDataArray:
+    def complex_flux(self) -> Union[FluxDataArray, FreqModeDataArray]:
         """Flux for data corresponding to a 2D monitor."""
 
         # Compute flux by integrating Poynting vector in-plane
@@ -704,7 +707,7 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
         return self.package_flux_results(flux_values)
 
     @cached_property
-    def flux(self) -> FluxDataArray:
+    def flux(self) -> Union[FluxDataArray, FreqModeDataArray]:
         """Flux for data corresponding to a 2D monitor."""
         return self.complex_flux.real
 
@@ -2549,11 +2552,11 @@ class ModeSolverData(ModeData):
 
         # Fields are modified by a linear interpolation to the exact monitor position
         if distances_primal.size > 1:
-            phase_primal = phase_primal.interp(**{normal_dim: 0})
+            phase_primal = phase_primal.interp(**{normal_dim: 0}).drop_vars(normal_dim)
         else:
             phase_primal = phase_primal.squeeze(dim=normal_dim)
         if distances_dual.size > 1:
-            phase_dual = phase_dual.interp(**{normal_dim: 0})
+            phase_dual = phase_dual.interp(**{normal_dim: 0}).drop_vars(normal_dim)
         else:
             phase_dual = phase_dual.squeeze(dim=normal_dim)
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR fixes a bug where an extra spatial coordinate could appear in `complex_flux` and `ImpedanceCalculator` results after spatial integration. The fix adds `reset_coords(drop=True)` to clean up non-dimension coordinates after the integration step, and introduces a helper method `package_flux_results` that correctly returns either `FluxDataArray` or `FreqModeDataArray` based on whether `mode_index` is present in the result.

Key changes:
- Added `reset_coords(drop=True)` in `package_flux_results` to remove spurious coordinates after integration
- Introduced proper type dispatching based on presence of `mode_index` dimension
- Updated return type annotations for `complex_flux` and `flux` to reflect they can return either `FluxDataArray` or `FreqModeDataArray`
- Improved docstring for `package_flux_results` to explain its purpose

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk - it's a focused bug fix addressing coordinate handling
- Score reflects a well-targeted bug fix with proper type handling. Deducted one point because there are no accompanying tests to verify the fix prevents regression, though the logic is sound and follows existing patterns in the codebase
- No files require special attention - both changes are straightforward and follow established patterns

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| CHANGELOG.md | 5/5 | Added changelog entry for bug fix in proper "Fixed" category with clear description |
| tidy3d/components/data/monitor_data.py | 4/5 | Fixed bug where extra spatial coord appeared in flux results by adding `reset_coords(drop=True)` and proper type handling |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant FieldData as ElectromagneticFieldData
    participant Helper as package_flux_results
    participant ImpCalc as ImpedanceCalculator
    
    User->>FieldData: Request complex_flux property
    FieldData->>FieldData: Compute complex_poynting
    FieldData->>FieldData: Get _diff_area
    FieldData->>FieldData: Multiply poynting * d_area
    FieldData->>FieldData: Sum over spatial dims
    Note over FieldData: Result may have extra<br/>spatial coord as non-dim coord
    FieldData->>Helper: package_flux_results(flux_values)
    Helper->>Helper: reset_coords(drop=True)
    Note over Helper: Removes extra spatial coord
    Helper->>Helper: Check if "mode_index" in dims
    alt mode_index present
        Helper-->>FieldData: Return FreqModeDataArray
    else no mode_index
        Helper-->>FieldData: Return FluxDataArray
    end
    FieldData-->>User: Return cleaned flux result
    
    User->>ImpCalc: compute_impedance(em_field)
    ImpCalc->>FieldData: Access em_field.complex_flux
    Note over ImpCalc: Now receives correctly<br/>typed result without<br/>extra coords
    ImpCalc-->>User: Return impedance result
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->