### PR TITLE
FXC-3275: warning for upcoming change in waist_distance convention with direction='-'

### DIFF
--- a/tests/test_components/test_beam.py
+++ b/tests/test_components/test_beam.py
@@ -13,6 +13,8 @@ from tidy3d.components.beam import (
 )
 from tidy3d.components.data.monitor_data import FieldData
 
+from ..utils import AssertLogLevel
+
 FREQS = np.linspace(1e14, 2e14, 10).tolist()
 
 
@@ -88,6 +90,63 @@ def test_astigmatic_gaussian_beam():
     # field_data_bwd.Ez.abs.isel(f=0).plot(ax=ax[2, 1])
     # plt.show()
     assert field_data.flux == -field_data_bwd.flux
+
+
+def test_gaussian_beam_profile_backward_waist_distance_warning():
+    center = (0, 0, 0)
+    size = (10, 10, 0)
+    resolution = 100
+
+    with AssertLogLevel(
+        "WARNING",
+        contains_str="GaussianBeamProfile with direction '-' and non-zero 'waist_distance'",
+    ):
+        GaussianBeamProfile(
+            center=center,
+            size=size,
+            resolution=resolution,
+            freqs=FREQS,
+            direction="-",
+            waist_distance=1.0,
+        )
+
+    with AssertLogLevel(None):
+        GaussianBeamProfile(
+            center=center,
+            size=size,
+            resolution=resolution,
+            freqs=FREQS,
+            direction="-",
+            waist_distance=0.0,
+        )
+
+
+def test_astigmatic_gaussian_beam_profile_backward_waist_distance_warning():
+    center = (0, 0, 0)
+    size = (0, 20, 20)
+
+    with AssertLogLevel(
+        "WARNING",
+        contains_str="AstigmaticGaussianBeamProfile with direction '-' and non-zero 'waist_distances'",
+    ):
+        AstigmaticGaussianBeamProfile(
+            center=center,
+            size=size,
+            freqs=FREQS,
+            direction="-",
+            waist_sizes=(4.0, 2.0),
+            waist_distances=(1.0, 0.0),
+        )
+
+    with AssertLogLevel(None):
+        AstigmaticGaussianBeamProfile(
+            center=center,
+            size=size,
+            freqs=FREQS,
+            direction="-",
+            waist_sizes=(4.0, 2.0),
+            waist_distances=(0.0, 0.0),
+        )
 
 
 def test_invalid_beam_size():

--- a/tests/test_components/test_source.py
+++ b/tests/test_components/test_source.py
@@ -338,6 +338,58 @@ def test_FieldSource():
     # plt.close()
 
 
+def test_gaussian_beam_backward_waist_distance_warning():
+    g = td.GaussianPulse(freq0=1e12, fwidth=0.1e12)
+
+    with AssertLogLevel(
+        "WARNING",
+        contains_str="GaussianBeam with direction '-' and non-zero 'waist_distance'",
+    ):
+        td.GaussianBeam(
+            size=(0, 1, 1),
+            source_time=g,
+            pol_angle=np.pi / 2,
+            direction="-",
+            waist_distance=1.0,
+        )
+
+    with AssertLogLevel(None):
+        td.GaussianBeam(
+            size=(0, 1, 1),
+            source_time=g,
+            pol_angle=np.pi / 2,
+            direction="-",
+            waist_distance=0.0,
+        )
+
+
+def test_astigmatic_gaussian_beam_backward_waist_distance_warning():
+    g = td.GaussianPulse(freq0=1e12, fwidth=0.1e12)
+
+    with AssertLogLevel(
+        "WARNING",
+        contains_str="AstigmaticGaussianBeam with direction '-' and non-zero 'waist_distances'",
+    ):
+        td.AstigmaticGaussianBeam(
+            size=(0, 1, 1),
+            source_time=g,
+            pol_angle=np.pi / 2,
+            direction="-",
+            waist_sizes=(0.2, 0.4),
+            waist_distances=(0.1, 0.0),
+        )
+
+    with AssertLogLevel(None):
+        td.AstigmaticGaussianBeam(
+            size=(0, 1, 1),
+            source_time=g,
+            pol_angle=np.pi / 2,
+            direction="-",
+            waist_sizes=(0.2, 0.4),
+            waist_distances=(0.0, 0.0),
+        )
+
+
 def test_pol_arrow():
     g = td.GaussianPulse(freq0=1e12, fwidth=0.1e12)
 

--- a/tidy3d/components/beam.py
+++ b/tidy3d/components/beam.py
@@ -20,7 +20,7 @@ from .medium import Medium, MediumType
 from .monitor import FieldMonitor
 from .source.field import FixedAngleSpec, FixedInPlaneKSpec
 from .types import TYPE_TAG_STR, Direction, FreqArray, Numpy
-from .validators import assert_plane
+from .validators import assert_plane, warn_backward_waist_distance
 
 DEFAULT_RESOLUTION = 200
 
@@ -374,6 +374,7 @@ class GaussianBeamProfile(BeamProfile):
         "For an angled beam, the distance is defined along the rotated propagation direction.",
         units=MICROMETER,
     )
+    _backward_waist_warning = warn_backward_waist_distance("waist_distance")
 
     def beam_params(self, z: Numpy, k0: Numpy) -> tuple[Numpy, Numpy, Numpy]:
         """Compute the parameters needed to evaluate a Gaussian beam at z.
@@ -440,6 +441,7 @@ class AstigmaticGaussianBeamProfile(BeamProfile):
         "the beam plane.",
         units=MICROMETER,
     )
+    _backward_waist_warning = warn_backward_waist_distance("waist_distances")
 
     def beam_params(self, z: Numpy, k0: Numpy) -> tuple[Numpy, Numpy, Numpy, Numpy]:
         """Compute the parameters needed to evaluate an astigmatic Gaussian beam at z.

--- a/tidy3d/components/source/field.py
+++ b/tidy3d/components/source/field.py
@@ -19,6 +19,7 @@ from tidy3d.components.validators import (
     assert_plane,
     assert_single_freq_in_range,
     assert_volumetric,
+    warn_backward_waist_distance,
     warn_if_dataset_none,
 )
 from tidy3d.constants import GLANCING_CUTOFF, MICROMETER, RADIAN, inf
@@ -602,6 +603,7 @@ class GaussianBeam(AngledFieldSource, PlanarSource, BroadbandSource):
         ge=1,
         le=20,
     )
+    _backward_waist_warning = warn_backward_waist_distance("waist_distance")
 
 
 class AstigmaticGaussianBeam(AngledFieldSource, PlanarSource, BroadbandSource):
@@ -662,6 +664,7 @@ class AstigmaticGaussianBeam(AngledFieldSource, PlanarSource, BroadbandSource):
         ge=1,
         le=20,
     )
+    _backward_waist_warning = warn_backward_waist_distance("waist_distances")
 
 
 class TFSF(AngledFieldSource, VolumeSource, BroadbandSource):

--- a/tidy3d/components/validators.py
+++ b/tidy3d/components/validators.py
@@ -306,6 +306,31 @@ def warn_if_dataset_none(field_name: str):
     return _warn_if_none
 
 
+def warn_backward_waist_distance(field_name: str):
+    """Warn if a backward-propagating beam uses a non-zero waist distance."""
+
+    @pydantic.root_validator(allow_reuse=True)
+    def _warn_backward_nonzero(cls, values):
+        """Emit deprecation warning for backward propagation with non-zero waist."""
+        direction = values.get("direction")
+        if direction != "-":
+            return values
+        waist_value = values.get(field_name)
+        waist_array = np.atleast_1d(waist_value)
+        if not np.all(np.isclose(waist_array, 0.0)):
+            log.warning(
+                f"Behavior of {cls.__name__} with direction '-' and non-zero '{field_name}' will "
+                "change in version 2.11 to be consistent with upcoming beam overlap monitors and "
+                "ports. Currently, the waist distance is interpreted w.r.t. the directed "
+                "propagation axis, so switching 'direction' also switches the position of the "
+                "waist in the global reference frame. In the future, the waist position will be "
+                "defined such that it is the same for backward- and forward-propagating beams.",
+            )
+        return values
+
+    return _warn_backward_nonzero
+
+
 def assert_single_freq_in_range(field_name: str):
     """Assert only one frequency supplied in source and it's in source time range."""
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds deprecation warnings for backward-propagating Gaussian beams (`direction='-'`) with non-zero `waist_distance` values. The warnings inform users about an upcoming behavior change in version 2.11 where waist position will be defined consistently for both forward and backward beams.

- Added `warn_backward_waist_distance()` validator factory in `validators.py` that checks for backward direction with non-zero waist distance
- Applied the validator to `GaussianBeamProfile`, `AstigmaticGaussianBeamProfile`, `GaussianBeam`, and `AstigmaticGaussianBeam` classes
- Added comprehensive test coverage for the new warnings
- **Missing CHANGELOG entry** - this user-facing behavioral change warning should be documented per custom instruction rule a109c62a-aa8c-4cc4-b515-0ad947c47929
- **Critical import error** in `tests/test_components/test_beam.py` will cause test failure

<h3>Confidence Score: 2/5</h3>


- This PR has a critical test import error that will cause immediate failure
- Score reflects the broken import in test_beam.py that will prevent tests from running, and the missing CHANGELOG entry required by project conventions
- Pay close attention to `tests/test_components/test_beam.py` - the import statement needs to be fixed before merging

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tests/test_components/test_beam.py | 2/5 | added tests for backward waist distance warnings, but has critical import error that will cause test failure |
| tests/test_components/test_source.py | 5/5 | added tests for backward waist distance warnings with correct imports and proper test structure |
| tidy3d/components/beam.py | 5/5 | added validator hooks to `GaussianBeamProfile` and `AstigmaticGaussianBeamProfile` for backward waist distance warnings |
| tidy3d/components/source/field.py | 5/5 | added validator hooks to `GaussianBeam` and `AstigmaticGaussianBeam` for backward waist distance warnings |
| tidy3d/components/validators.py | 5/5 | added new `warn_backward_waist_distance` validator factory that emits deprecation warnings for backward-propagating beams with non-zero waist distance |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant GaussianBeam
    participant Validator
    participant Logger

    User->>GaussianBeam: create with direction='-', waist_distance≠0
    GaussianBeam->>Validator: _backward_waist_warning (pydantic root_validator)
    Validator->>Validator: check direction == '-'
    Validator->>Validator: check waist_distance != 0 (using np.isclose)
    alt non-zero waist distance found
        Validator->>Logger: log.warning (deprecation notice)
        Logger-->>User: warning about v2.11 behavior change
    end
    Validator->>GaussianBeam: return validated values
    GaussianBeam-->>User: beam instance created
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Update the CHANGELOG.md file when making changes that affect user-facing functionality or fix bugs. ([source](https://app.greptile.com/review/custom-context?memory=a109c62a-aa8c-4cc4-b515-0ad947c47929))

<!-- /greptile_comment -->