### PR TITLE
refactor(tidy3d): FXC-4436-avoid-ssl-import-for-wasm-build

### DIFF
--- a/tests/config/test_legacy_env.py
+++ b/tests/config/test_legacy_env.py
@@ -43,9 +43,9 @@ def test_env_pending_overrides_apply_on_activation(mock_config_dir, config_manag
         assert current_manager.profile == "dev"
         dev_web = current_manager.get_section("web")
         assert dev_web.enable_caching is False
-        assert dev_web.ssl_version == ssl.TLSVersion.TLSv1_2
+        assert dev_web.ssl_version == "TLSv1_2"
         assert Env.current.enable_caching is False
-        assert Env.current.ssl_version == ssl.TLSVersion.TLSv1_2
+        assert Env.current.ssl_version == "TLSv1_2"
     finally:
         reload_config(profile="default")
 

--- a/tests/config/test_web_config.py
+++ b/tests/config/test_web_config.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import ssl
+
+import pytest
+
 from tidy3d.config.sections import WebConfig
 
 
@@ -21,3 +25,21 @@ def test_build_api_url_returns_base_for_empty_path():
 def test_build_api_url_without_base_returns_path():
     web = WebConfig.model_construct(api_endpoint="")
     assert web.build_api_url("/v1/tasks") == "v1/tasks"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (ssl.TLSVersion.TLSv1, "TLSv1"),
+        (ssl.TLSVersion.TLSv1_1, "TLSv1_1"),
+    ],
+)
+def test_web_config_normalizes_ssl_version_aliases(value, expected):
+    web = WebConfig(ssl_version=value)
+    assert web.ssl_version == expected
+
+
+@pytest.mark.parametrize("value", ["", "TLSv2", "SSLv3", "udp1.0"])
+def test_web_config_rejects_invalid_ssl_version(value):
+    with pytest.raises(ValueError):
+        WebConfig(ssl_version=value)

--- a/tests/test_web/test_env.py
+++ b/tests/test_web/test_env.py
@@ -14,14 +14,14 @@ def test_tidy3d_env():
 
 
 def test_set_ssl_version():
-    Env.set_ssl_version(ssl.TLSVersion.TLSv1_3)
-    assert Env.current.ssl_version == ssl.TLSVersion.TLSv1_3
+    Env.set_ssl_version("TLSv1_3")
+    assert Env.current.ssl_version == "TLSv1_3"
 
     Env.set_ssl_version(ssl.TLSVersion.TLSv1_2)
-    assert Env.current.ssl_version == ssl.TLSVersion.TLSv1_2
+    assert Env.current.ssl_version == "TLSv1_2"
 
     Env.set_ssl_version(ssl.TLSVersion.TLSv1_1)
-    assert Env.current.ssl_version == ssl.TLSVersion.TLSv1_1
+    assert Env.current.ssl_version == "TLSv1_1"
 
     Env.set_ssl_version(None)
     assert Env.current.ssl_version is None

--- a/tidy3d/config/legacy.py
+++ b/tidy3d/config/legacy.py
@@ -7,7 +7,6 @@ and is intended to be removed in a future release.
 from __future__ import annotations
 
 import os
-import ssl
 import warnings
 from pathlib import Path
 from typing import Any, Optional
@@ -160,7 +159,7 @@ class LegacyEnvironmentConfig:
         s3_region: Optional[str] = None,
         ssl_verify: Optional[bool] = None,
         enable_caching: Optional[bool] = None,
-        ssl_version: Optional[ssl.TLSVersion] = None,
+        ssl_version: Optional[str] = None,
         env_vars: Optional[dict[str, str]] = None,
         environment: Optional[LegacyEnvironment] = None,
     ) -> None:
@@ -239,11 +238,11 @@ class LegacyEnvironmentConfig:
         self._set_pending("enable_caching", value)
 
     @property
-    def ssl_version(self) -> Optional[ssl.TLSVersion]:
+    def ssl_version(self) -> Optional[str]:
         return self._value("ssl_version")
 
     @ssl_version.setter
-    def ssl_version(self, value: Optional[ssl.TLSVersion]) -> None:
+    def ssl_version(self, value: Optional[str]) -> None:
         self._set_pending("ssl_version", value)
 
     @property
@@ -363,7 +362,7 @@ class LegacyEnvironment:
         config.enable_caching = enable_caching
         self._sync_to_manager()
 
-    def set_ssl_version(self, ssl_version: Optional[ssl.TLSVersion]) -> None:
+    def set_ssl_version(self, ssl_version: Optional[str]) -> None:
         config = self.current
         config.ssl_version = ssl_version
         self._sync_to_manager()

--- a/tidy3d/config/sections.py
+++ b/tidy3d/config/sections.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import ssl
 from os import PathLike
 from pathlib import Path
 from typing import Any, Literal, Optional
@@ -27,6 +26,8 @@ from tidy3d.log import DEFAULT_LEVEL, LogLevel, log, set_log_suppression, set_lo
 
 from .registry import get_manager as _get_attached_manager
 from .registry import register_handler, register_section
+
+TLS_VERSION_CHOICES = {"TLSv1", "TLSv1_1", "TLSv1_2", "TLSv1_3"}
 
 
 class ConfigSection(BaseModel):
@@ -328,10 +329,13 @@ class WebConfig(ConfigSection):
         le=300,
     )
 
-    ssl_version: Optional[ssl.TLSVersion] = Field(
+    ssl_version: Optional[str] = Field(
         None,
         title="SSL/TLS version",
-        description="Optional SSL/TLS version to enforce for requests.",
+        description=(
+            "Optional TLS version override to enforce for requests. Accepts values such as "
+            "'TLSv1_2'."
+        ),
     )
 
     env_vars: dict[str, str] = Field(
@@ -349,13 +353,33 @@ class WebConfig(ConfigSection):
             secret = data.get("apikey")
             if isinstance(secret, SecretStr):
                 data["apikey"] = secret.get_secret_value()
-        ssl_version = data.get("ssl_version")
-        if isinstance(ssl_version, ssl.TLSVersion):
-            data["ssl_version"] = ssl_version.value
         for field in ("api_endpoint", "website_endpoint"):
             if field in data and data[field] is not None:
                 data[field] = str(data[field])
         return data
+
+    @field_validator("ssl_version", mode="before")
+    @classmethod
+    def _convert_and_check_ssl_version_name(cls, value: Any) -> Optional[str]:
+        """Convert SSL enum to string and check if valid.
+
+        Accepted examples:
+            "TLSv1"
+            "TLSv1_2"
+            ssl.TLSVersion.TLSv1_2.name  -> "TLSv1_2"
+        """
+        if value is None:
+            return None
+
+        # Prefer enum.name if present, otherwise raw string
+        candidate = getattr(value, "name", value)
+        candidate = str(candidate).strip()
+
+        if candidate not in TLS_VERSION_CHOICES:
+            allowed = ", ".join(sorted(TLS_VERSION_CHOICES))
+            raise ValueError(f"Invalid TLS version {candidate!r}. Must be one of: {allowed}")
+
+        return candidate
 
     @field_validator("api_endpoint", "website_endpoint", mode="before")
     @classmethod

--- a/tidy3d/web/core/http_util.py
+++ b/tidy3d/web/core/http_util.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import ssl
 from enum import Enum
 from functools import wraps
 from typing import Any, Callable, Optional, TypeAlias
@@ -12,6 +13,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.ssl_ import create_urllib3_context
 
+from tidy3d import log
 from tidy3d.config import config
 
 from . import core_config
@@ -200,7 +202,16 @@ def http_interceptor(func: Callable[..., Any]) -> Callable[..., JSONType]:
 
 class TLSAdapter(HTTPAdapter):
     def init_poolmanager(self, *args: Any, **kwargs: Any) -> None:
-        context = create_urllib3_context(ssl_version=config.web.ssl_version)
+        try:
+            ssl_version = (
+                ssl.TLSVersion[config.web.ssl_version]
+                if config.web.ssl_version is not None
+                else None
+            )
+        except KeyError:
+            log.warning(f"Invalid SSL/TLS version '{config.web.ssl_version}', using default")
+            ssl_version = None
+        context = create_urllib3_context(ssl_version=ssl_version)
         kwargs["ssl_context"] = context
         return super().init_poolmanager(*args, **kwargs)
 


### PR DESCRIPTION
We need to remove the heavy ssl import for the WASM build.
As this is urgent and moving all typing imports behind TYPE_CHECKING is not straightforward with automatic fixes due to pydantic models and the original ssl problem is not solvable by that in general, I decided to only remove this import/type in the config package for now.

Open question: Do we want to extend the except block for all exceptions to catch `ssl.SSLError`?

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR successfully removes the `ssl` module import from the config package (`tidy3d/config/`) by changing the `ssl_version` field from `ssl.TLSVersion` enum to string-based storage. The implementation includes comprehensive validation that normalizes various TLS version input formats (e.g., "TLS 1.2", "tls1.2", "1.2") into canonical forms (e.g., "TLSv1_2"), and converts back to the enum at the point of use in `http_util.py`.

- Removed `ssl` import from `tidy3d/config/legacy.py` and `tidy3d/config/sections.py`
- Added robust TLS version validation with regex-based normalization supporting multiple input formats
- Updated type hints from `Optional[ssl.TLSVersion]` to `Optional[str]` throughout config modules
- Maintained backward compatibility by accepting `ssl.TLSVersion` enum objects as input (via `.name` attribute)
- Added comprehensive test coverage for normalization and validation logic
- Updated existing tests to expect string outputs instead of enum values

**Note**: Two other files (`tidy3d/web/cli/app.py` and `tidy3d/plugins/dispersion/web.py`) still import and catch `ssl.SSLError`, which relates to the PR author's open question about extending exception handling. These files were not modified in this PR and may need future attention for WASM compatibility.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk, as it maintains backward compatibility and includes comprehensive tests
- Score of 4 reflects a well-implemented refactor with thorough testing. The string-based TLS version storage successfully removes ssl imports from the config package while maintaining full backward compatibility. The validation logic is robust and handles edge cases well. Minor deduction because: (1) there's a theoretical edge case where an invalid string could bypass validation and cause a KeyError in http_util.py (though unlikely with current validation), and (2) the PR doesn't address ssl.SSLError handling in other modules (web/cli/app.py, plugins/dispersion/web.py), though this appears intentional as noted in the PR description.
- No files require special attention - the implementation is solid across all changed files

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/config/sections.py | 4/5 | Added TLS version normalization with string-based storage instead of ssl.TLSVersion enum; comprehensive validation logic handles multiple input formats |
| tidy3d/web/core/http_util.py | 5/5 | Converts string TLS version back to ssl.TLSVersion enum when creating SSL context; maintains backward compatibility |
| tidy3d/config/legacy.py | 5/5 | Updated type hints from ssl.TLSVersion to str; removed ssl import from legacy config module |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant WebConfig
    participant Validator
    participant HttpUtil
    participant SSLContext

    User->>WebConfig: Set ssl_version="TLS 1.2"
    WebConfig->>Validator: _normalize_ssl_version_name(value)
    Validator->>Validator: Strip spaces & normalize
    Validator->>Validator: Regex match TLS version
    Validator->>Validator: Convert to canonical "TLSv1_2"
    Validator->>Validator: Validate against TLS_VERSION_CHOICES
    Validator-->>WebConfig: Return "TLSv1_2" (string)
    WebConfig-->>User: Store as string

    User->>HttpUtil: Make HTTPS request
    HttpUtil->>WebConfig: Get ssl_version (string)
    WebConfig-->>HttpUtil: "TLSv1_2"
    HttpUtil->>HttpUtil: Convert ssl.TLSVersion["TLSv1_2"]
    HttpUtil->>SSLContext: create_urllib3_context(ssl_version=enum)
    SSLContext-->>HttpUtil: SSL context with TLS 1.2
    HttpUtil-->>User: Execute request with SSL context
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->