### PR TITLE
FXC-4440: outer_dot output frequencies order not matching input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added optional `max_results` handling to the kLayout `DRCLoader` and `DRCRunner` and speeded up parsing of big result sets.
 
 ### Fixed
+- Fix to `outer_dot` when frequencies stored in the data were not in increasing order. Previously, the result would be provided with re-sorted frequencies, which would not match the order of the original data.
 - Fixed bug where an extra spatial coordinate could appear in `complex_flux` and `ImpedanceCalculator` results.
 
 ## [2.10.0rc3] - 2025-11-26

--- a/tests/test_data/test_monitor_data.py
+++ b/tests/test_data/test_monitor_data.py
@@ -850,7 +850,22 @@ def test_outer_dot():
 
     dot = mode_data.outer_dot(field_data)
 
-    assert len(dot.f) == 2
+    expected_freqs = [freq for freq in mode_data.Ex.f.values if freq in field_data.Ex.f.values]
+    assert dot.sizes["f"] == len(expected_freqs)
+    assert np.array_equal(dot.f.values, np.array(expected_freqs))
+
+    # ensure frequency order follows the first dataset when the other is unordered
+    field_data_full = make_field_data_2d()
+    reversed_inds = list(range(field_data_full.Ex.sizes["f"] - 1, -1, -1))
+    field_data_reordered = field_data_full.copy(
+        update={
+            name: component.isel(f=reversed_inds)
+            for name, component in field_data_full.field_components.items()
+        }
+    )
+
+    dot_ordered = field_data_full.outer_dot(field_data_reordered)
+    assert np.array_equal(dot_ordered.f.values, field_data_full.Ex.f.values)
 
 
 def test_translated_copy():
@@ -1118,7 +1133,7 @@ class TestZBF:
 
     def test_tozbf_modedata_fails(self, tmp_path, mode_data):
         """Asserts that Modedata.to_zbf() fails if mode_index is not specified"""
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueError):
             _ = mode_data.to_zbf(
                 fname=tmp_path / "testzbf_modedata_fail.zbf",
                 background_refractive_index=1,
@@ -1133,7 +1148,7 @@ class TestZBF:
     @pytest.mark.parametrize("n_y", [16, 2**14, 33])
     def test_tozbf_nxny_fails(self, tmp_path, field_data, n_x, n_y):
         """Asserts that to_zbf() fails when n_x and n_y are invalid values."""
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueError):
             _ = field_data.to_zbf(
                 fname=tmp_path / "testzbf_nxny_fail.zbf",
                 background_refractive_index=1,
@@ -1146,7 +1161,7 @@ class TestZBF:
     @pytest.mark.parametrize("units", ["mmm", "123"])
     def test_tozbf_units_fails(self, tmp_path, field_data, units):
         """Asserts that to_zbf() fails when units are invalid."""
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueError):
             _ = field_data.to_zbf(
                 fname=tmp_path / "testzbf_nxny_fail.zbf",
                 background_refractive_index=1,
@@ -1190,7 +1205,7 @@ class TestZBF:
             units="mm",
         )
         # this should fail
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueError):
             _ = td.FieldDataset.from_zbf(filename=zbf_filename, dim1=dim1, dim2=dim2)
 
 

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Literal, Optional, Union, get_args
 import autograd.numpy as np
 import pydantic.v1 as pd
 import xarray as xr
-from pandas import DataFrame
+from pandas import DataFrame, Index
 
 from tidy3d.components.base import cached_property, skip_if_fields_missing
 from tidy3d.components.base_sim.data.monitor_data import AbstractMonitorData
@@ -916,9 +916,13 @@ class ElectromagneticFieldData(AbstractFieldData, ElectromagneticFieldDataset, A
         coords = (arrays[0].coords, arrays[1].coords)
 
         # Common frequencies to both data arrays
-        f = np.array(sorted(set(coords[0]["f"].values).intersection(coords[1]["f"].values)))
-        isel1 = [list(coords[0]["f"].values).index(freq) for freq in f]
-        isel2 = [list(coords[1]["f"].values).index(freq) for freq in f]
+        freq_self = Index(coords[0]["f"].values)
+        freq_other = Index(coords[1]["f"].values)
+        common_freqs = freq_self.intersection(freq_other, sort=False)
+        f = common_freqs.to_numpy()
+        # Keep frequency order consistent with the current data while aligning the other dataset.
+        isel1 = freq_self.get_indexer(common_freqs)
+        isel2 = freq_other.get_indexer(common_freqs)
 
         # Mode indices, if available
         modes_in_self = "mode_index" in coords[0]


### PR DESCRIPTION
Tom noticed that `outer_dot` would always return the overlap data with frequency coords that are sorted in increasing order, making them mismatch the original data if it e.g. had them in decreasing order. This fixes that.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR fixes a bug in the `outer_dot` method where frequency coordinates were being sorted in increasing order, breaking alignment when the original data had frequencies in a different order (e.g., decreasing). The fix replaces the old implementation that used `sorted(set(...).intersection(...))` with pandas `Index.intersection(sort=False)` to preserve the frequency order from the first dataset.

**Key changes:**
- Replaced frequency intersection logic with pandas Index operations that preserve order
- Added `get_indexer` to properly map frequencies between datasets
- Added comprehensive test coverage for reversed frequency ordering
- Cleaned up unused exception variables in tests (`as e` removed where not used)

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no concerns
- The fix is minimal, well-tested, and uses the correct pandas API to preserve frequency order. The implementation correctly replaces the problematic sorted intersection with order-preserving Index operations. Comprehensive test coverage validates both the intersection size and order preservation with reversed frequencies.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/data/monitor_data.py | 5/5 | Replaced sorted set intersection with pandas Index.intersection(sort=False) to preserve frequency order from first dataset |
| tests/test_data/test_monitor_data.py | 5/5 | Added test case for reversed frequency order and removed unused exception variables in test assertions |
| CHANGELOG.md | 5/5 | Added entry under Fixed section describing the frequency order bug fix in `outer_dot` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Client Code
    participant Self as ElectromagneticFieldData (self)
    participant Other as ElectromagneticFieldData (other)
    participant PI as pandas.Index
    
    Client->>Self: outer_dot(field_data)
    Self->>Self: Get tangential fields from self
    Self->>Other: _interpolated_tangential_fields()
    Other-->>Self: Return interpolated fields
    
    Self->>Self: Extract frequency coords from both datasets
    Self->>PI: Index(coords[0]["f"].values)
    PI-->>Self: freq_self Index
    Self->>PI: Index(coords[1]["f"].values)
    PI-->>Self: freq_other Index
    
    Self->>PI: freq_self.intersection(freq_other, sort=False)
    Note over PI: Preserves order from freq_self<br/>(unlike old sorted approach)
    PI-->>Self: common_freqs Index
    
    Self->>PI: freq_self.get_indexer(common_freqs)
    PI-->>Self: isel1 (indices for self)
    Self->>PI: freq_other.get_indexer(common_freqs)
    PI-->>Self: isel2 (indices for other)
    
    Self->>Self: Apply isel1 to self fields
    Self->>Other: Apply isel2 to other fields
    
    Self->>Self: Compute dot product with aligned frequencies
    Self-->>Client: Return result with original frequency order
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->