### PR TITLE
fix: rf license warnings and docs (FXC-4427)

### DIFF
--- a/docs/api/plugins/smatrix.rst
+++ b/docs/api/plugins/smatrix.rst
@@ -6,7 +6,7 @@ S-Matrix Component Modelers Plugin
 This plugin provides component modelers for computing S-parameters (scattering parameters) for both **photonics** and **RF/microwave** applications. The plugin supports:
 
 * **Photonics**: Modal component modelers for photonic devices (waveguides, splitters, filters, etc.)
-* **RF/Microwave**: Terminal component modelers for microwave circuits and antennas (available in :class:`tidy3d.rf` subpackage)
+* **RF/Microwave**: Terminal component modelers for microwave circuits and antennas (available in :class:`tidy3d.rf` subpackage as well)
 
 .. warning::
 
@@ -28,21 +28,26 @@ For photonics applications, use the **ModalComponentModeler** which computes mod
 
 RF/Microwave Component Modelers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. seealso::
+   
+   For classes related to microwave/RF modeling, please refer to the main `Microwave and RF <../microwave/index.html>`_ page and `tidy3d.rf` sub-package. 
 
-For RF and microwave applications, use the **TerminalComponentModeler** (available in ``tidy3d.rf``) which computes terminal-based S-parameters.
+
+For RF and microwave applications, use the **TerminalComponentModeler** (available in ``tidy3d.rf`` as well) which computes terminal-based S-parameters.
 
 .. warning::
 
    RF simulations will require new license requirements in an upcoming release. All RF-specific classes are available in the ``tidy3d.rf`` subpackage.
 
+
 .. autosummary::
    :toctree: ../_autosummary/
    :template: module.rst
 
-   tidy3d.rf.TerminalComponentModeler
-   tidy3d.rf.TerminalComponentModelerData
-   tidy3d.rf.LumpedPort
-   tidy3d.rf.CoaxialLumpedPort
+   tidy3d.plugins.smatrix.TerminalComponentModeler
+   tidy3d.plugins.smatrix.TerminalComponentModelerData
+   tidy3d.plugins.smatrix.LumpedPort
+   tidy3d.plugins.smatrix.CoaxialLumpedPort
    tidy3d.rf.WavePort
    tidy3d.rf.MicrowaveSMatrixData
    tidy3d.rf.TerminalPortDataArray

--- a/tests/test_components/test_microwave.py
+++ b/tests/test_components/test_microwave.py
@@ -1912,17 +1912,6 @@ def test_impedance_calculator_mode_direction_handling():
     assert hasattr(impedance_mode, "values")
 
 
-def test_RF_license_suppression():
-    """Ensure license warnings are being emitted properly and default instantiations avoid the warning."""
-    original_setting = td.config.microwave.suppress_rf_license_warning
-    td.config.microwave.suppress_rf_license_warning = False
-    with AssertLogLevel("WARNING", contains_str="new license requirements"):
-        mode_spec = td.MicrowaveModeSpec()
-    with AssertLogLevel(None):
-        mode_spec = td.MicrowaveModeSpec._default_without_license_warning()
-    td.config.microwave.suppress_rf_license_warning = original_setting
-
-
 def test_microwave_mode_data_reordering_with_transmission_line_data():
     """Test that transmission_line_data is correctly reordered when modes are reordered."""
     from tidy3d.components.data.data_array import (

--- a/tidy3d/components/microwave/base.py
+++ b/tidy3d/components/microwave/base.py
@@ -2,28 +2,12 @@
 
 from __future__ import annotations
 
-import pydantic.v1 as pd
-
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.config import config
-from tidy3d.log import log
 
 
 class MicrowaveBaseModel(Tidy3dBaseModel):
     """Base model that all RF and microwave specific components inherit from."""
-
-    @pd.root_validator(pre=False)
-    def _warn_rf_license(cls, values):
-        from tidy3d.config import config
-
-        # Skip warning when globally suppressed via config
-        if not config.microwave.suppress_rf_license_warning:
-            log.warning(
-                "ℹ️ ⚠️ RF simulations are subject to new license requirements in the future. "
-                "You have instantiated at least one RF-specific component.",
-                log_once=True,
-            )
-        return values
 
     @classmethod
     def _default_without_license_warning(cls) -> MicrowaveBaseModel:

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -4282,7 +4282,7 @@ class Simulation(AbstractYeeGridSimulation):
 
         # issue warning
         if rf_component_breakdown_msg != "":
-            msg = " ℹ️ ⚠️ RF simulations are subject to new license requirements in the future. You are using RF-specific components in this simulation."
+            msg = "RF simulations and functionality will require new license requirements in an upcoming release. All RF-specific classes are now available within the sub-package 'tidy3d.rf'."
             msg += rf_component_breakdown_msg
             log.warning(msg, log_once=True)
 

--- a/tidy3d/log.py
+++ b/tidy3d/log.py
@@ -251,6 +251,13 @@ class Logger:
     ) -> None:
         """Distribute log messages to all handlers"""
 
+        # Check global cache if requested (before composing/capturing to avoid duplicates)
+        if log_once:
+            # Use the message body before composition as key
+            if message in self._static_cache:
+                return
+            self._static_cache.add(message)
+
         # Compose message
         if len(args) > 0:
             try:
@@ -266,13 +273,6 @@ class Logger:
             if custom_loc is None:
                 custom_loc = []
             self._stack[-1]["messages"].append((level_name, composed_message, custom_loc))
-
-        # Check global cache if requested
-        if log_once:
-            # Use the message body before composition as key
-            if message in self._static_cache:
-                return
-            self._static_cache.add(message)
 
         # Context-local logger emits a single message and consolidates the rest
         if self._counts is not None:

--- a/tidy3d/plugins/smatrix/__init__.py
+++ b/tidy3d/plugins/smatrix/__init__.py
@@ -33,7 +33,7 @@ from tidy3d.plugins.smatrix.ports.wave import WavePort
 # Instantiate on plugin import till we unite with toplevel
 warnings.filterwarnings(
     "once",
-    message="ℹ️ ⚠️ RF simulations are subject to new license requirements in the future. You have instantiated at least one RF-specific component.",
+    message="RF simulations and functionality will require new license requirements in an upcoming release. All RF-specific classes are now available within the sub-package 'tidy3d.rf'.",
     category=FutureWarning,
 )
 

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -102,6 +102,14 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
         "Otherwise, a default source time will be constructed.",
     )
 
+    @pd.root_validator(pre=False)
+    def _warn_refactor_2_10(cls, values):
+        log.warning(
+            f"'{cls.__name__}' was refactored (tidy3d 'v2.10.0'). Existing functionality is available differently. Please consult the migration documentation: https://docs.flexcompute.com/projects/tidy3d/en/latest/api/microwave/microwave_migration.html",
+            log_once=True,
+        )
+        return values
+
     @pd.validator("simulation", always=True)
     def _sim_has_no_sources(cls, val):
         """Make sure simulation has no sources as they interfere with tool."""

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -210,14 +210,6 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         description="The low frequency smoothing parameters for the terminal component simulation.",
     )
 
-    @pd.root_validator(pre=False)
-    def _warn_refactor_2_10(cls, values):
-        log.warning(
-            f"ℹ️ ⚠️ The {cls.__name__} class was refactored in tidy3d version 2.10. Migration documentation will be provided, and existing functionality can be accessed in a different way.",
-            log_once=True,
-        )
-        return values
-
     @property
     def _sim_with_sources(self) -> Simulation:
         """Instance of :class:`.Simulation` with all sources and absorbers added for each port, for plotting."""

--- a/tidy3d/plugins/smatrix/data/terminal.py
+++ b/tidy3d/plugins/smatrix/data/terminal.py
@@ -14,7 +14,6 @@ from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.microwave.base import MicrowaveBaseModel
 from tidy3d.components.microwave.data.monitor_data import AntennaMetricsData
 from tidy3d.constants import C_0
-from tidy3d.log import log
 from tidy3d.plugins.smatrix.component_modelers.terminal import TerminalComponentModeler
 from tidy3d.plugins.smatrix.data.base import AbstractComponentModelerData
 from tidy3d.plugins.smatrix.data.data_array import (
@@ -226,14 +225,6 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
     def smatrix_deembedded(self, port_shifts: np.ndarray = None) -> MicrowaveSMatrixData:
         """Interface function returns  de-embedded S-parameter matrix."""
         return self.change_port_reference_planes(self.smatrix(), port_shifts=port_shifts)
-
-    @pd.root_validator(pre=False)
-    def _warn_rf_license(cls, values):
-        log.warning(
-            "ℹ️ ⚠️ RF simulations are subject to new license requirements in the future. You have instantiated at least one RF-specific component.",
-            log_once=True,
-        )
-        return values
 
     def _monitor_data_at_port_amplitude(
         self,

--- a/tidy3d/rf.py
+++ b/tidy3d/rf.py
@@ -134,7 +134,7 @@ VoltageIntegralTypes = VoltageIntegralType
 # Instantiate on plugin import till we unite with toplevel
 warnings.filterwarnings(
     "once",
-    message="ℹ️ ⚠️ RF simulations are subject to new license requirements in the future. You have instantiated at least one RF-specific component.",
+    message="RF simulations and functionality will require new license requirements in an upcoming release. All RF-specific classes are now available within the sub-package 'tidy3d.rf'.",
     category=FutureWarning,
 )
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR consolidates and improves RF license warnings across the codebase. The changes remove redundant per-class warning validators in favor of centralized warnings in `Simulation._validate_rf_component_warnings()`, update warning messages to be clearer and remove emojis (following style guidelines), and optimize the `log_once` mechanism to check for duplicates before message composition.

Key changes:
- Removed `_warn_rf_license` root validator from `MicrowaveBaseModel`, `TerminalComponentModeler`, and `TerminalComponentModelerData`
- Moved refactor warning from `TerminalComponentModeler` to base class `AbstractComponentModeler` to reduce duplication
- Updated all RF license warning messages to standardized text without emojis
- Optimized `Logger._log()` to check `log_once` cache before composing messages
- Updated documentation to improve cross-references and correct autosummary paths

**Potential issues:**
- Test `test_RF_license_suppression()` may fail since it expects warnings when instantiating `MicrowaveModeSpec()` directly, but the validator that emitted these warnings was removed
- The `log_once` optimization changes behavior: duplicate messages are no longer captured in the message stack, which could affect tests that check captured warnings

<h3>Confidence Score: 3/5</h3>


- This PR is mostly safe but requires test verification before merging
- The refactoring is well-intentioned and consolidates warnings properly, but removing the `_warn_rf_license` validator from `MicrowaveBaseModel` will likely break `test_RF_license_suppression()` which expects warnings when instantiating RF classes directly. The `log_once` optimization also changes message capture behavior. These issues need verification before merge.
- Pay close attention to tidy3d/components/microwave/base.py and tidy3d/log.py - test suite must be run to verify no regressions

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/microwave/base.py | 3/5 | Removed `_warn_rf_license` root validator entirely; `_default_without_license_warning` method remains but warning mechanism removed from base class |
| tidy3d/log.py | 5/5 | Moved `log_once` check before message composition to prevent duplicate message processing - good optimization |
| tidy3d/plugins/smatrix/component_modelers/base.py | 5/5 | Added refactor warning to base class; improved message with migration link and proper formatting |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant MicrowaveClass
    participant MicrowaveBaseModel
    participant Logger
    participant Simulation
    
    Note over User,Simulation: Before PR (removed validators)
    User->>MicrowaveClass: Instantiate (e.g., MicrowaveModeSpec())
    MicrowaveClass->>MicrowaveBaseModel: __init__()
    MicrowaveBaseModel->>MicrowaveBaseModel: _warn_rf_license() [REMOVED]
    MicrowaveBaseModel-->>Logger: log.warning() [NO LONGER CALLED]
    
    Note over User,Simulation: After PR (centralized warnings)
    User->>Simulation: Create Simulation with RF components
    Simulation->>Simulation: _validate_rf_component_warnings()
    Simulation->>Logger: log.warning() with new message
    
    Note over User,Simulation: Factory method (unchanged)
    User->>MicrowaveClass: _default_without_license_warning()
    MicrowaveClass->>MicrowaveBaseModel: Temporarily set suppress flag
    MicrowaveBaseModel->>MicrowaveClass: __init__() (no warning)
    MicrowaveBaseModel->>MicrowaveBaseModel: Restore suppress flag
```

<!-- greptile_other_comments_section -->

<details><summary><h4>Context used (3)</h4></summary>

- Rule from `dashboard` - Do not use markdown formatting in exception or warning messages; use single quotes to highlight vari... ([source](https://app.greptile.com/review/custom-context?memory=9b45957a-2d0d-4c24-a5d3-eef6f721cbfd))
- Rule from `dashboard` - Make log messages and warnings informative by including relevant context and enclosing variable name... ([source](https://app.greptile.com/review/custom-context?memory=fde8f555-a63c-41a0-9f5f-b26988a0e882))
- Rule from `dashboard` - Keep docstrings and comments synchronized with code changes to ensure they are always accurate and n... ([source](https://app.greptile.com/review/custom-context?memory=8947a127-e303-4dbf-b326-493579e5f047))
</details>


<!-- /greptile_comment -->