### PR TITLE
fix(web): Add 'warning' to post validate states

### DIFF
--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -37,10 +37,11 @@ from tidy3d.web.api import webapi as web
 from tidy3d.web.api.states import (
     COMPLETED_PERCENT,
     COMPLETED_STATES,
+    DRAFT_STATES,
     END_STATES,
     ERROR_STATES,
     PRE_ERROR_STATES,
-    PRE_VALIDATE_STATES,
+    QUEUED_STATES,
     RUNNING_STATES,
     STATE_PROGRESS_PERCENTAGE,
 )
@@ -1068,7 +1069,7 @@ class Batch(WebContainer):
                 status_part = f"→ [red]{status:<{status_width}}"
             elif status in COMPLETED_STATES:
                 status_part = f"→ [green]{status:<{status_width}}"
-            elif status in (PRE_ERROR_STATES | PRE_VALIDATE_STATES):
+            elif status in (PRE_ERROR_STATES | DRAFT_STATES | QUEUED_STATES):
                 status_part = f"→ [yellow]{status:<{status_width}}"
             elif status in RUNNING_STATES:
                 status_part = f"→ [blue]{status:<{status_width}}"

--- a/tidy3d/web/api/states.py
+++ b/tidy3d/web/api/states.py
@@ -1,5 +1,18 @@
 from __future__ import annotations
 
+# progression order for a typical run
+PROGRESSION_ORDER = (
+    "draft",
+    "queued",
+    "preprocess",
+    "running",
+    "postprocess",
+    "success",
+)
+
+MAX_STEPS = len(PROGRESSION_ORDER) - 1
+COMPLETED_PERCENT = 100
+
 PRE_ERROR_STATES = {
     "aborting",
 }
@@ -18,14 +31,17 @@ ERROR_STATES = {
 
 PRE_VALIDATE_STATES = {
     "draft",
-    "queued",
-    "queued_solver",
-    "preprocess",
     "validating",
     "validate",
 }
 
-POST_RUN_STATES = {
+QUEUED_STATES = {"queued", "queued_solver"}
+
+PREPROCESS_STATES = {"preprocess"}
+
+RUNNING_STATES = {"running", "preprocess_success"}
+
+POSTPROCESS_STATES = {
     "postprocess",
     "run_success",
 }
@@ -42,70 +58,66 @@ COMPLETED_STATES = {
 
 END_STATES = ERROR_STATES | COMPLETED_STATES
 
-POST_VALIDATE_STATES = {"validate_success", "validate_warn"}
+POST_VALIDATE_STATES = {"validate_success", "validate_warn", "warning"}
 
-RUNNING_STATES = (
-    PRE_VALIDATE_STATES | POST_VALIDATE_STATES | {"running"} | POST_RUN_STATES | COMPLETED_STATES
+DRAFT_STATES = PRE_VALIDATE_STATES | POST_VALIDATE_STATES
+
+ALL_POST_VALIDATE_STATES = POST_VALIDATE_STATES | RUNNING_STATES | POSTPROCESS_STATES | END_STATES
+
+VALID_PROGRESS_STATES = (
+    DRAFT_STATES
+    | QUEUED_STATES
+    | POST_VALIDATE_STATES
+    | RUNNING_STATES
+    | POSTPROCESS_STATES
+    | COMPLETED_STATES
+    | PRE_ERROR_STATES
 )
-
-ALL_POST_VALIDATE_STATES = POST_VALIDATE_STATES | {"running"} | POST_RUN_STATES | END_STATES
-
-VALID_PROGRESS_STATES = RUNNING_STATES | PRE_ERROR_STATES
 
 ALL_STATES = VALID_PROGRESS_STATES | ERROR_STATES
 
-
-PROGRESSION_ORDER = (
-    "draft",
-    "queued",
-    "queued_solver",
-    "preprocess",
-    "validating",
-    "validate",
-    "validate_success",
-    "validate_warn",
-    "running",
-    "postprocess",
-    "run_success",
-    "visualize",
-    "success",
-    "completed",
+STATE_PROGRESS_PERCENTAGE = dict.fromkeys(ALL_STATES, 0)
+STATE_PROGRESS_PERCENTAGE.update(dict.fromkeys(COMPLETED_STATES, COMPLETED_PERCENT))
+STATE_PROGRESS_PERCENTAGE.update(
+    {state: round((1 / MAX_STEPS) * COMPLETED_PERCENT) for state in QUEUED_STATES}
+)
+STATE_PROGRESS_PERCENTAGE.update(
+    {state: round((2 / MAX_STEPS) * COMPLETED_PERCENT) for state in PREPROCESS_STATES}
+)
+STATE_PROGRESS_PERCENTAGE.update(
+    {state: round((3 / MAX_STEPS) * COMPLETED_PERCENT) for state in RUNNING_STATES}
+)
+STATE_PROGRESS_PERCENTAGE.update(
+    {state: round((4 / MAX_STEPS) * COMPLETED_PERCENT) for state in POSTPROCESS_STATES}
 )
 
-MAX_STEPS = len(PROGRESSION_ORDER) - 1
-COMPLETED_PERCENT = 100
 
+def status_to_stage(status: str) -> tuple[str, int]:
+    """Map task status to monotonic stage for progress bars.
 
-STATE_PROGRESS_PERCENTAGE = {
-    # --- Progression States ---
-    "draft": round((0 / MAX_STEPS) * COMPLETED_PERCENT),  # 0%
-    "queued": round((1 / MAX_STEPS) * COMPLETED_PERCENT),  # 8%
-    "queued_solver": round((2 / MAX_STEPS) * COMPLETED_PERCENT),  # 15%
-    "preprocess": round((3 / MAX_STEPS) * COMPLETED_PERCENT),  # 23%
-    "validating": round((4 / MAX_STEPS) * COMPLETED_PERCENT),  # 31%
-    "validate": round((5 / MAX_STEPS) * COMPLETED_PERCENT),  # 38%
-    "validate_success": round((6 / MAX_STEPS) * COMPLETED_PERCENT),  # 46%
-    "validate_warn": round((7 / MAX_STEPS) * COMPLETED_PERCENT),  # 54%
-    "running": round((8 / MAX_STEPS) * COMPLETED_PERCENT),  # 62%
-    "run_success": round((9 / MAX_STEPS) * COMPLETED_PERCENT),  # 69%
-    "postprocess": round((10 / MAX_STEPS) * COMPLETED_PERCENT),  # 77%
-    "visualize": round((11 / MAX_STEPS) * COMPLETED_PERCENT),  # 85%
-    "success": COMPLETED_PERCENT,  # 100%
-    "completed": COMPLETED_PERCENT,  # 100%
-    "postprocess_success": COMPLETED_PERCENT,  # 100%
-    "diverge": COMPLETED_PERCENT,
-    "diverged": COMPLETED_PERCENT,
-    # --- Error States ---
-    # All error states map to 0%
-    "validate_fail": 0,
-    "error": 0,
-    "errored": 0,
-    "blocked": 0,
-    "run_failed": 0,
-    "aborted": 0,
-    "deleted": 0,
-    "validate_error": 0,
-    "preprocess_error": 0,
-    "run_error": 0,
-    "postprocess_error": 0,
-}
+    Parameters
+    ----------
+    status : str
+        The task status string.
+
+    Returns
+    -------
+    tuple[str, int]
+        A tuple of (stage_name, stage_index) where stage_index corresponds
+        to the position in PROGRESSION_ORDER.
+    """
+    s = (status or "").lower()
+    if s in DRAFT_STATES:
+        return ("draft", 0)
+    if s in QUEUED_STATES:
+        return ("queued", 1)
+    if s in PREPROCESS_STATES:
+        return ("preprocess", 2)
+    if s in RUNNING_STATES:
+        return ("running", 3)
+    if s in POSTPROCESS_STATES:
+        return ("postprocess", 4)
+    if s in COMPLETED_STATES:
+        return ("success", 5)
+    # Unknown states map to earliest stage to avoid showing 100% prematurely
+    return (s or "unknown", 0)

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -23,7 +23,9 @@ from tidy3d.web.api.states import (
     ALL_POST_VALIDATE_STATES,
     END_STATES,
     ERROR_STATES,
+    MAX_STEPS,
     STATE_PROGRESS_PERCENTAGE,
+    status_to_stage,
 )
 from tidy3d.web.cache import CacheEntry, _store_mode_solver_in_cache, resolve_local_cache
 from tidy3d.web.core.account import Account
@@ -1192,28 +1194,6 @@ def load(
     return stub_data
 
 
-def _status_to_stage(status: str) -> tuple[str, int]:
-    """Map task status to monotonic stage for progress bars."""
-    s = (status or "").lower()
-    # Map a broader set of states to monotonic stages for progress bars
-    if s in ("draft", "created"):
-        return ("draft", 0)
-    if s in ("queue", "queued"):
-        return ("queued", 1)
-    if s in ("validating",):
-        return ("validating", 2)
-    if s in ("validate_success", "validate_warn", "preprocess", "preprocessing"):
-        return ("preprocess", 3)
-    if s in ("running", "preprocess_success"):
-        return ("running", 4)
-    if s in ("run_success", "postprocess"):
-        return ("postprocess", 5)
-    if s in ("success", "postprocess_success"):
-        return ("success", 6)
-    # Unknown states map to earliest stage to avoid showing 100% prematurely
-    return (s or "unknown", 0)
-
-
 def _monitor_modeler_batch(
     task_id: str,
     verbose: bool = True,
@@ -1230,7 +1210,7 @@ def _monitor_modeler_batch(
     # Non-verbose path: poll without progress bars then return
     if not verbose:
         # Run phase
-        while _status_to_stage(status)[0] not in END_STATES:
+        while status_to_stage(status)[0] not in END_STATES:
             time.sleep(REFRESH_TIME)
             detail = _get_batch_detail_handle_error_status(task)
             status = detail.status.lower()
@@ -1252,8 +1232,8 @@ def _monitor_modeler_batch(
         # Phase: Run (aggregate + per-task)
         p_run = progress.add_task("Run Total", total=1.0)
         task_bars: dict[str, int] = {}
-        stage = _status_to_stage(status)[0]
-        prev_stage = _status_to_stage(status)[0]
+        stage = status_to_stage(status)[0]
+        prev_stage = status_to_stage(status)[0]
         console.log(f"Batch status = {status}")
 
         # Note: get_status errors if an erroring status occurred
@@ -1270,7 +1250,7 @@ def _monitor_modeler_batch(
                 for name, t in name_to_task.items():
                     if name not in task_bars:
                         tstatus = (t.status or "draft").lower()
-                        _, idx = _status_to_stage(tstatus)
+                        _, idx = status_to_stage(tstatus)
                         pbar = progress.add_task(
                             f"  {name}",
                             total=1.0,
@@ -1285,8 +1265,8 @@ def _monitor_modeler_batch(
                 for t in detail.tasks or []:
                     n_members += 1
                     tstatus = (t.status or "draft").lower()
-                    _, idx = _status_to_stage(tstatus)
-                    acc += max(0.0, min(1.0, idx / 6.0))
+                    _, idx = status_to_stage(tstatus)
+                    acc += max(0.0, min(1.0, idx / MAX_STEPS))
                 run_frac = (acc / float(n_members)) if n_members else 0.0
             else:
                 run_frac = (r / total) if total else 0.0
@@ -1300,7 +1280,7 @@ def _monitor_modeler_batch(
                     if not t:
                         continue
                     tstatus = (t.status or "draft").lower()
-                    _, idx = _status_to_stage(tstatus)
+                    _, idx = status_to_stage(tstatus)
                     desc = f"  {tname} [{tstatus or 'draft'}]"
                     progress.update(
                         pbar,
@@ -1313,7 +1293,7 @@ def _monitor_modeler_batch(
             time.sleep(REFRESH_TIME)
             detail = _get_batch_detail_handle_error_status(task)
             status = detail.status.lower()
-            stage = _status_to_stage(status)[0]
+            stage = status_to_stage(status)[0]
 
         if console is not None:
             console.log("Modeler has finished running successfully.")


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds a new "warning" state to `POST_VALIDATE_STATES` to handle an additional valid post-validation state from the backend.

- Added "warning" to `POST_VALIDATE_STATES` set which propagates to `RUNNING_STATES` and `ALL_POST_VALIDATE_STATES` through set unions
- **Missing update**: The "warning" state was not added to `STATE_PROGRESS_PERCENTAGE` dictionary, which can cause `KeyError` exceptions in `webapi.py` when displaying progress bars for tasks with "warning" status

<h3>Confidence Score: 2/5</h3>


- This PR introduces a potential KeyError bug due to incomplete propagation of the new state across related dictionaries
- Score of 2 reflects a likely runtime error: 'warning' state added to POST_VALIDATE_STATES but not to STATE_PROGRESS_PERCENTAGE, causing KeyError when webapi.py accesses progress percentage for tasks with 'warning' status
- tidy3d/web/api/states.py needs STATE_PROGRESS_PERCENTAGE update for 'warning' state

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/web/api/states.py | 3/5 | Adds 'warning' to POST_VALIDATE_STATES, but 'warning' is missing from STATE_PROGRESS_PERCENTAGE which can cause KeyError in webapi.py |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant webapi.py
    participant states.py
    participant Backend

    User->>webapi.py: run_batch() / monitor task
    webapi.py->>Backend: get task status
    Backend-->>webapi.py: status = "warning"
    webapi.py->>states.py: POST_VALIDATE_STATES check
    states.py-->>webapi.py: "warning" in set ✓
    webapi.py->>states.py: STATE_PROGRESS_PERCENTAGE["warning"]
    states.py-->>webapi.py: KeyError ✗
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - When modifying a piece of logic, ensure the change is propagated to all independent functions or cal... ([source](https://app.greptile.com/review/custom-context?memory=809457d4-6b33-46ed-b49b-37057d02807e))

<!-- /greptile_comment -->