### PR TITLE
fix(tidy3d): FXC-4473-fix-gradients-for-box-in-geometry-group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix to `outer_dot` when frequencies stored in the data were not in increasing order. Previously, the result would be provided with re-sorted frequencies, which would not match the order of the original data.
 - Fixed bug where an extra spatial coordinate could appear in `complex_flux` and `ImpedanceCalculator` results.
 - Fixed normal for `Box` shape gradient computation to always point outward from boundary which is needed for correct PEC handling.
+- Fixed `Box` gradients within `GeometryGroup` where the group intersection boundaries were forwarded.
 
 ## [2.10.0rc3] - 2025-11-26
 

--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -5,8 +5,10 @@ import copy
 import cProfile
 import typing
 import warnings
+from dataclasses import dataclass
 from importlib import reload
 from os.path import join
+from types import MethodType
 
 import autograd as ag
 import autograd.numpy as anp
@@ -20,6 +22,7 @@ from autograd.test_util import check_grads
 
 import tidy3d as td
 import tidy3d.web as web
+from tidy3d import Box, Geometry, GeometryGroup
 from tidy3d.components.autograd.derivative_utils import DerivativeInfo
 from tidy3d.components.autograd.field_map import FieldMap
 from tidy3d.components.autograd.utils import is_tidy_box
@@ -3093,3 +3096,79 @@ def test_frequency_coordinate_alignment():
     # Selecting non-existent frequency should fail
     with pytest.raises(KeyError):
         _slice_field_data(field_data_multi, np.array([1.5e14]))
+
+
+def test_geometry_group_passes_intersected_bounds_to_children():
+    """GeometryGroup should clip bounds_intersect for each child geometry."""
+
+    @dataclass
+    class SimpleDerivativeInfo:
+        paths: list[tuple]
+        bounds: tuple
+        bounds_intersect: tuple
+        simulation_bounds: tuple
+        interpolators: dict | None = None
+
+        def create_interpolators(self, dtype: float = float):
+            return self.interpolators or {}
+
+        def updated_copy(self, **kwargs):
+            data = {
+                "paths": self.paths,
+                "bounds": self.bounds,
+                "bounds_intersect": self.bounds_intersect,
+                "simulation_bounds": self.simulation_bounds,
+                "interpolators": self.interpolators,
+            }
+            data.update({k: v for k, v in kwargs.items() if k in data})
+            return SimpleDerivativeInfo(**data)
+
+    fully_inside_box = Box(center=(-1.0, 0.0, 0.0), size=(1.0, 1.0, 1.0))
+    big_box = Box(center=(0.0, 0.0, 0.0), size=(10.0, 10.0, 10.0))
+
+    def record_method(self, derivative_info):
+        object.__setattr__(self, "recorded_bounds_intersect", derivative_info.bounds_intersect)
+        return {derivative_info.paths[0]: 0.0}
+
+    boxes = (fully_inside_box, big_box)
+
+    for box in boxes:
+        object.__setattr__(box, "recorded_bounds_intersect", None)
+        object.__setattr__(box, "_compute_derivatives", MethodType(record_method, box))
+    group = GeometryGroup(geometries=boxes)
+
+    # case where group bounds bigger than sim bounds
+    sim_bounds = ((-5.0, -5.0, -5.0), (5.0, 5.0, 5.0))
+
+    deriv_info = SimpleDerivativeInfo(
+        paths=[("geom", idx, "dummy") for idx, _ in enumerate(boxes)],
+        bounds=group.bounds,
+        bounds_intersect=Geometry.bounds_intersection(group.bounds, sim_bounds),
+        simulation_bounds=sim_bounds,
+        interpolators={},
+    )
+
+    group._compute_derivatives(deriv_info)
+
+    assert (
+        object.__getattribute__(fully_inside_box, "recorded_bounds_intersect")
+        == fully_inside_box.bounds
+    )
+    assert object.__getattribute__(big_box, "recorded_bounds_intersect") == sim_bounds
+
+    # case where sim bounds bigger than group bounds
+    sim_bounds = ((-20.0, -20.0, -20.0), (20.0, 20.0, 20.0))
+
+    deriv_info = SimpleDerivativeInfo(
+        paths=[("geom", idx, "dummy") for idx, _ in enumerate(boxes)],
+        bounds=group.bounds,
+        bounds_intersect=Geometry.bounds_intersection(group.bounds, sim_bounds),
+        simulation_bounds=sim_bounds,
+        interpolators={},
+    )
+
+    group._compute_derivatives(deriv_info)
+
+    assert object.__getattribute__(big_box, "recorded_bounds_intersect") == group.bounds, (
+        f"got {object.__getattribute__(big_box, 'recorded_bounds_intersect')} and {group.bounds}"
+    )

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -3594,6 +3594,9 @@ class GeometryGroup(Geometry):
             geo_info = derivative_info.updated_copy(
                 paths=[tuple(geo_path)],
                 bounds=geo.bounds,
+                bounds_intersect=self.bounds_intersection(
+                    geo.bounds, derivative_info.simulation_bounds
+                ),
                 eps_approx=True,
                 deep=False,
                 interpolators=interpolators,


### PR DESCRIPTION
Previously, we took the `DerivativeInfo.bounds_intersect` from the geometry group for the individual geometries which led to flawed gradients in `Box`. So this PR lets `GeometryGroup` compute individual `bounds_intersect` for every geometry when computing derivatives.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR fixes a gradient computation bug in `Box` geometries when used within a `GeometryGroup`. Previously, the group's `bounds_intersect` was incorrectly forwarded to all child geometries, causing flawed gradient calculations. The fix computes individual clipped `bounds_intersect` for each child geometry by intersecting the group's bounds with each geometry's own bounds.

- Corrected `GeometryGroup._compute_derivatives` to compute per-geometry `bounds_intersect` using element-wise max/min operations
- Added comprehensive test with mocked `_compute_derivatives` to verify correct bounds are passed to children
- Updated CHANGELOG.md with clear user-facing description

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no concerns
- The fix is minimal, well-targeted, and mathematically correct. It properly computes the intersection of bounds using element-wise max/min operations, which is the standard approach for bounding box intersections. The comprehensive test validates the fix, and the change only affects gradient computation in a specific scenario that was previously broken
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/geometry/base.py | 5/5 | Correctly computes per-geometry bounds_intersect by intersecting group bounds with each child geometry's bounds |
| tests/test_components/autograd/test_autograd.py | 5/5 | Adds comprehensive test verifying that GeometryGroup passes correct clipped bounds_intersect to child geometries |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Gradient Computation
    participant GG as GeometryGroup
    participant Box1 as Box (left)
    participant Box2 as Box (right)
    participant DI as DerivativeInfo

    Client->>GG: _compute_derivatives(derivative_info)
    Note over GG: derivative_info.bounds_intersect = group_bounds
    
    GG->>GG: Create shared interpolators
    
    loop For each geometry in group
        GG->>GG: Get geometry bounds
        Note over GG: Compute geo_bounds_intersect:<br/>max(geo.bounds[0], group_bounds[0])<br/>min(geo.bounds[1], group_bounds[1])
        
        GG->>DI: updated_copy(bounds=geo.bounds,<br/>bounds_intersect=geo_bounds_intersect)
        DI-->>GG: geo_info
        
        alt Geometry is Box1 (left)
            GG->>Box1: _compute_derivatives(geo_info)
            Note over Box1: Uses geo_info.bounds_intersect<br/>for gradient computation
            Box1-->>GG: vjp_dict_geo
        else Geometry is Box2 (right)
            GG->>Box2: _compute_derivatives(geo_info)
            Note over Box2: Uses geo_info.bounds_intersect<br/>for gradient computation
            Box2-->>GG: vjp_dict_geo
        end
        
        GG->>GG: Store gradients in grad_vjps
    end
    
    GG-->>Client: grad_vjps (all gradients)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->