### PR TITLE
Fix(FXC-4474) BC plotting for Charge and Conduction simulations

### DIFF
--- a/tidy3d/components/tcad/simulation/heat_charge.py
+++ b/tidy3d/components/tcad/simulation/heat_charge.py
@@ -1402,9 +1402,9 @@ class HeatChargeSimulation(AbstractSimulation):
         plot_params = plot_params_heat_bc
         condition = boundary_spec.condition
 
-        if isinstance(condition, TemperatureBC):
+        if isinstance(condition, (TemperatureBC, VoltageBC)):
             plot_params = plot_params.updated_copy(facecolor=HEAT_BC_COLOR_TEMPERATURE)
-        elif isinstance(condition, HeatFluxBC):
+        elif isinstance(condition, (HeatFluxBC, CurrentBC)):
             plot_params = plot_params.updated_copy(facecolor=HEAT_BC_COLOR_FLUX)
         elif isinstance(condition, ConvectionBC):
             plot_params = plot_params.updated_copy(facecolor=HEAT_BC_COLOR_CONVECTION)


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed boundary condition plotting for Charge and Conduction simulations by adding `VoltageBC` and `CurrentBC` to the color mapping logic in `_get_bc_plot_params()`. These charge-related boundary conditions are now correctly visualized with appropriate colors (orange for `VoltageBC` matching `TemperatureBC`, green for `CurrentBC` matching `HeatFluxBC`), ensuring consistency with the classification of Electric BC types defined in the codebase.

- Fixed `VoltageBC` now maps to orange color (temperature BC color)
- Fixed `CurrentBC` now maps to green color (flux BC color)
- Check that a CHANGELOG entry under `<h3>Fixed` section is added per repository guidelines</h3>

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Score reflects a straightforward, well-targeted bug fix that extends existing logic to handle previously missing boundary condition types. The change is minimal, follows established patterns, all necessary BC types are already imported, and the fix correctly maps charge BCs to appropriate thermal BC colors based on their analogous behavior.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/tcad/simulation/heat_charge.py | 5/5 | Added `VoltageBC` and `CurrentBC` to plotting color mapping logic to fix missing boundary condition visualization |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant HeatChargeSimulation
    participant plot_boundaries
    participant _get_bc_plot_params
    participant _plot_boundary_condition
    participant Matplotlib

    User->>HeatChargeSimulation: plot_boundaries(x, y, z, property)
    HeatChargeSimulation->>plot_boundaries: Determine plotting plane
    plot_boundaries->>plot_boundaries: Filter boundaries by property type
    Note over plot_boundaries: property="heat_conductivity" filters HeatBCTypes<br/>property="electric_conductivity" filters ElectricBCTypes
    
    loop For each boundary condition
        plot_boundaries->>_plot_boundary_condition: Plot BC with shape
        _plot_boundary_condition->>_get_bc_plot_params: Get color for BC type
        
        alt VoltageBC or TemperatureBC
            _get_bc_plot_params-->>_plot_boundary_condition: Return orange color (HEAT_BC_COLOR_TEMPERATURE)
        else CurrentBC or HeatFluxBC
            _get_bc_plot_params-->>_plot_boundary_condition: Return green color (HEAT_BC_COLOR_FLUX)
        else ConvectionBC
            _get_bc_plot_params-->>_plot_boundary_condition: Return brown color (HEAT_BC_COLOR_CONVECTION)
        else InsulatingBC
            _get_bc_plot_params-->>_plot_boundary_condition: Return black color (CHARGE_BC_INSULATOR)
        end
        
        _plot_boundary_condition->>Matplotlib: Render shape with color
    end
    
    plot_boundaries-->>User: Return matplotlib axes with plotted BCs
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Require a changelog entry for any PR that is not purely an internal refactor. ([source](https://app.greptile.com/review/custom-context?memory=b72c7231-b258-4d03-aed2-51a50a9fe757))

<!-- /greptile_comment -->