### PR TITLE
fix(packaging): suppress ERROR logging for optional feature checks

### DIFF
--- a/tests/test_components/test_packaging.py
+++ b/tests/test_components/test_packaging.py
@@ -154,5 +154,45 @@ def test_supports_local_subpixel_requires_extras_when_forced(monkeypatch):
         reload_config(profile="default")
 
 
+def test_supports_local_subpixel_no_error_logged_when_optional(monkeypatch, caplog):
+    """Regression test for FXC-4374: no ERROR should be logged when preference=None
+    and tidy3d-extras is unavailable, since the decorator handles it gracefully."""
+    import logging
+
+    reload_config(profile="default")
+    tidy3d_extras["mod"] = None
+    tidy3d_extras["use_local_subpixel"] = None
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "tidy3d_extras":
+            raise ImportError("forced failure")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    try:
+        # preference=None is the default - feature is optional
+        config.update_section("simulation", use_local_subpixel=None)
+
+        @supports_local_subpixel
+        def get_flag():
+            return tidy3d_extras["use_local_subpixel"]
+
+        with caplog.at_level(logging.ERROR):
+            result = get_flag()
+
+        # Should fall back gracefully without logging errors
+        assert result is False
+        assert not any("tidy3d-extras" in record.message for record in caplog.records), (
+            "ERROR was logged but should have been suppressed for optional feature check"
+        )
+    finally:
+        tidy3d_extras["mod"] = None
+        tidy3d_extras["use_local_subpixel"] = None
+        reload_config(profile="default")
+
+
 if __name__ == "__main__":
     pytest.main()

--- a/tidy3d/exceptions.py
+++ b/tidy3d/exceptions.py
@@ -10,10 +10,11 @@ from .log import log
 class Tidy3dError(ValueError):
     """Any error in tidy3d"""
 
-    def __init__(self, message: Optional[str] = None) -> None:
+    def __init__(self, message: Optional[str] = None, log_error: bool = True) -> None:
         """Log just the error message and then raise the Exception."""
         super().__init__(message)
-        log.error(message)
+        if log_error:
+            log.error(message)
 
 
 class ConfigError(Tidy3dError):

--- a/tidy3d/packaging.py
+++ b/tidy3d/packaging.py
@@ -183,8 +183,13 @@ def get_numpy_major_version(module=np):
     return major_version
 
 
-def _check_tidy3d_extras_available():
+def _check_tidy3d_extras_available(quiet: bool = False):
     """Helper function to check if 'tidy3d-extras' is available and version matched.
+
+    Parameters
+    ----------
+    quiet : bool
+        If True, suppress error logging when raising exceptions.
 
     Raises
     ------
@@ -199,7 +204,8 @@ def _check_tidy3d_extras_available():
         raise Tidy3dImportError(
             "The package 'tidy3d-extras' is absent. "
             "Please install the 'tidy3d-extras' package using, for "
-            r"example, 'pip install tidy3d\[extras]'."
+            r"example, 'pip install tidy3d\[extras]'.",
+            log_error=not quiet,
         )
 
     try:
@@ -207,14 +213,16 @@ def _check_tidy3d_extras_available():
 
     except ImportError as exc:
         raise Tidy3dImportError(
-            "The package 'tidy3d-extras' did not initialize correctly."
+            "The package 'tidy3d-extras' did not initialize correctly.",
+            log_error=not quiet,
         ) from exc
 
     if not hasattr(tidy3d_extras_mod, "__version__"):
         raise Tidy3dImportError(
             "The package 'tidy3d-extras' did not initialize correctly. "
             "Please install the 'tidy3d-extras' package using, for "
-            r"example, 'pip install tidy3d\[extras]'."
+            r"example, 'pip install tidy3d\[extras]'.",
+            log_error=not quiet,
         )
 
     version = tidy3d_extras_mod.__version__
@@ -222,26 +230,30 @@ def _check_tidy3d_extras_available():
     if version is None:
         raise Tidy3dImportError(
             "The package 'tidy3d-extras' did not initialize correctly, "
-            "likely due to an invalid API key."
+            "likely due to an invalid API key.",
+            log_error=not quiet,
         )
 
     if version != __version__:
         raise Tidy3dImportError(
             f"The version of 'tidy3d-extras' is {version}, but the version of 'tidy3d' is {__version__}. "
             "They must match. You can install the correct "
-            r"version using 'pip install tidy3d\[extras]'."
+            r"version using 'pip install tidy3d\[extras]'.",
+            log_error=not quiet,
         )
 
     tidy3d_extras["mod"] = tidy3d_extras_mod
 
 
-def check_tidy3d_extras_licensed_feature(feature_name: str):
+def check_tidy3d_extras_licensed_feature(feature_name: str, quiet: bool = False):
     """Helper function to check if a specific feature is licensed in 'tidy3d-extras'.
 
     Parameters
     ----------
     feature_name : str
         The name of the feature to check for.
+    quiet : bool
+        If True, suppress error logging when raising exceptions.
 
     Raises
     ------
@@ -250,17 +262,19 @@ def check_tidy3d_extras_licensed_feature(feature_name: str):
     """
 
     try:
-        _check_tidy3d_extras_available()
+        _check_tidy3d_extras_available(quiet=quiet)
     except Tidy3dImportError as exc:
         raise Tidy3dImportError(
-            f"The package 'tidy3d-extras' is required for this feature '{feature_name}'."
+            f"The package 'tidy3d-extras' is required for this feature '{feature_name}'.",
+            log_error=not quiet,
         ) from exc
 
     features = tidy3d_extras["mod"].extension._features()
     if feature_name not in features:
         raise Tidy3dImportError(
             f"The feature '{feature_name}' is not available with your license. "
-            "Please contact Tidy3D support, or upgrade your license."
+            "Please contact Tidy3D support, or upgrade your license.",
+            log_error=not quiet,
         )
 
 
@@ -277,7 +291,7 @@ def supports_local_subpixel(fn):
             return fn(*args, **kwargs)
 
         try:
-            check_tidy3d_extras_licensed_feature("local_subpixel")
+            check_tidy3d_extras_licensed_feature("local_subpixel", quiet=True)
         except Tidy3dImportError as exc:
             tidy3d_extras["use_local_subpixel"] = False
             if preference is True:


### PR DESCRIPTION
## Summary
- Add `quiet` parameter to `check_tidy3d_extras_licensed_feature` to suppress error logging when checks are speculative
- Add `log_error` parameter to `Tidy3dError` base class to allow silent exception construction
- Update `supports_local_subpixel` decorator to use `quiet=True` for optional checks

## Behavior Change for `supports_local_subpixel`

### Before
| `use_local_subpixel` | tidy3d-extras installed? | Console Output | Behavior |
|----------------------|--------------------------|----------------|----------|
| `False` | N/A | Nothing | Skips check, uses standard subpixel |
| `True` | No | **ERROR logged** | Raises exception (correct) |
| `True` | Yes | Nothing | Uses local subpixel |
| `None` (default) | No | **ERROR logged** | Silently falls back to standard subpixel |
| `None` (default) | Yes | Nothing | Uses local subpixel |

### After
| `use_local_subpixel` | tidy3d-extras installed? | Console Output | Behavior |
|----------------------|--------------------------|----------------|----------|
| `False` | N/A | Nothing | Skips check, uses standard subpixel |
| `True` | No | **ERROR logged** | Raises exception (correct) |
| `True` | Yes | Nothing | Uses local subpixel |
| `None` (default) | No | **Nothing** | Silently falls back to standard subpixel |
| `None` (default) | Yes | Nothing | Uses local subpixel |

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR fixes a UX issue where ERROR logs were displayed to users when checking for optional features (FXC-4374). The changes introduce a `quiet` parameter to suppress error logging during speculative feature availability checks.

**Key Changes:**
- Added `log_error` parameter to `Tidy3dError` base class to allow conditional error logging
- Added `quiet` parameter to `_check_tidy3d_extras_available` and `check_tidy3d_extras_licensed_feature` functions
- Updated `supports_local_subpixel` decorator to use `quiet=True` when `preference=None` (optional check)
- Added regression test that verifies no ERROR logs appear during optional feature checks

**Impact:**
When `config.simulation.use_local_subpixel=None` (default), users no longer see scary ERROR messages when `tidy3d-extras` is unavailable. The feature gracefully falls back to standard subpixel without logging errors.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are well-designed with backward compatibility, proper parameter defaults, comprehensive test coverage, and a focused scope. The `log_error` parameter defaults to `True` ensuring existing code behavior is unchanged. The implementation correctly distinguishes between mandatory checks (preference=True) and optional checks (preference=None).
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/exceptions.py | 5/5 | Added `log_error` parameter to `Tidy3dError.__init__` with backward-compatible default |
| tidy3d/packaging.py | 5/5 | Added `quiet` parameter to suppress error logging in optional feature checks |
| tests/test_components/test_packaging.py | 5/5 | Added regression test verifying no ERROR logs when optional feature unavailable |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant supports_local_subpixel
    participant check_tidy3d_extras_licensed_feature
    participant _check_tidy3d_extras_available
    participant Tidy3dImportError
    participant Logger

    User->>supports_local_subpixel: Call decorated function
    supports_local_subpixel->>supports_local_subpixel: Check preference from config
    
    alt preference is False
        supports_local_subpixel->>supports_local_subpixel: Set use_local_subpixel=False
        supports_local_subpixel->>User: Execute function
    else preference is True or None
        supports_local_subpixel->>check_tidy3d_extras_licensed_feature: Check feature (quiet=True)
        check_tidy3d_extras_licensed_feature->>_check_tidy3d_extras_available: Check package (quiet=True)
        
        alt tidy3d-extras not available
            _check_tidy3d_extras_available->>Tidy3dImportError: Raise with log_error=False
            Tidy3dImportError-->>Logger: Skip logging (log_error=False)
            Tidy3dImportError->>check_tidy3d_extras_licensed_feature: Exception raised
            check_tidy3d_extras_licensed_feature->>supports_local_subpixel: Catch exception
            
            alt preference is True
                supports_local_subpixel->>Tidy3dImportError: Raise error (logged)
                Tidy3dImportError->>Logger: Log error
                Tidy3dImportError->>User: Exception propagated
            else preference is None
                supports_local_subpixel->>supports_local_subpixel: Set use_local_subpixel=False
                supports_local_subpixel->>User: Execute function (graceful fallback)
            end
        else tidy3d-extras available
            _check_tidy3d_extras_available->>check_tidy3d_extras_licensed_feature: Success
            check_tidy3d_extras_licensed_feature->>supports_local_subpixel: Feature available
            supports_local_subpixel->>supports_local_subpixel: Set use_local_subpixel=True
            supports_local_subpixel->>User: Execute function
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->