### PR TITLE
fix: include original error when pec frames fail a simulation

### DIFF
--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -2295,8 +2295,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
             _ = self._finalized
         except Exception as e:
             raise Tidy3dError(
-                "Simulation fails after requested mode source PEC frames are added. "
-                "Please inspect '._finalized'."
+                f"Simulation fails after requested mode source PEC frames are added with the following error:\n{e!s}"
             ) from e
 
 


### PR DESCRIPTION
Example:
<img width="432" height="462" alt="Screenshot_20251210_082227" src="https://github.com/user-attachments/assets/7a52b89f-13ae-4944-ac8d-ff671a67ce4b" />

probably ok to merge in 2.10?

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Improves error reporting in the `_validate_finalized` method by including the original exception message when a simulation fails after mode source PEC frames are added.

- Error message now displays the underlying exception details directly, removing the need for users to manually inspect the internal `._finalized` property
- Maintains proper exception chaining with `from e` to preserve the full traceback for debugging
- Follows the established codebase pattern for exception wrapping (consistent with patterns in lines 4330-4338 of the same file)

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it's a minimal error message improvement with no behavioral changes
- Score of 5 reflects the simplicity of the change (2 lines modified), no logic changes, follows existing codebase patterns, and improves user experience without risk
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/simulation.py | 5/5 | Improved error message in `_validate_finalized` to include original exception details instead of suggesting manual inspection of `._finalized` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Simulation
    participant _validate_finalized
    participant _finalized

    User->>Simulation: validate_pre_upload()
    Simulation->>_validate_finalized: _validate_finalized()
    _validate_finalized->>_finalized: Access ._finalized property
    alt Validation succeeds
        _finalized-->>_validate_finalized: Returns finalized sim
        _validate_finalized-->>Simulation: Success
    else Validation fails
        _finalized-->>_validate_finalized: Raises Exception e
        Note over _validate_finalized: Wraps error with original message
        _validate_finalized-->>Simulation: Raises Tidy3dError(f"...{e!s}") from e
        Simulation-->>User: Error with detailed message
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->