### PR TITLE
feat: add EMESimulationData.coeffs (FXC-4275)

### DIFF
--- a/tidy3d/packaging.py
+++ b/tidy3d/packaging.py
@@ -291,7 +291,7 @@ def supports_local_subpixel(fn):
             return fn(*args, **kwargs)
 
         try:
-            check_tidy3d_extras_licensed_feature("local_subpixel", quiet=True)
+            check_tidy3d_extras_licensed_feature("local_subpixel", quiet=(preference is None))
         except Tidy3dImportError as exc:
             tidy3d_extras["use_local_subpixel"] = False
             if preference is True:


### PR DESCRIPTION
After https://github.com/flexcompute/tidy3d/pull/3069, all error logging in `supports_local_subpixel` is suppressed via `quiet=True`. This is correct for the default case (`preference=None`) where the feature is optional, but when a user explicitly sets `use_local_subpixel=True`, the diagnostic messages (e.g., "likely due to an invalid API key") should be logged to help them understand why the feature failed.

https://github.com/flexcompute/compute/pull/2990

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds `EMESimulationData.coeffs` to store internal coefficients from EME simulations, including mode overlaps, interface S matrices, and effective propagation indices. This data is useful for debugging and optimization workflows.

**Key Changes:**
- Added new data array types: `EMEInterfaceSMatrixDataArray` and `EMEFluxDataArray`
- Added new dataset types: `EMEInterfaceSMatrixDataset` and `EMEOverlapDataset`
- Extended `EMECoefficientDataset` with fields for `n_complex`, `flux`, `interface_smatrices`, and `overlaps`
- Added `normalized_copy` cached property to `EMECoefficientDataset` for flux-normalized coefficients
- Added `store_coeffs` parameter to `EMESimulation` (default: `True`) with storage size estimation
- Deprecated `EMECoefficientMonitor` in favor of the new `coeffs` field
- Fixed logging behavior in `supports_local_subpixel` decorator to properly log errors when explicitly enabled

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it adds a well-designed feature with comprehensive tests and follows existing patterns in the codebase.
- The implementation follows established patterns in the codebase, includes proper validation and size estimation, adds comprehensive tests for new functionality, properly deprecates the old approach, and makes all new fields optional with sensible defaults.
- No files require special attention.

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/eme/data/dataset.py | 5/5 | Added `EMEInterfaceSMatrixDataset`, `EMEOverlapDataset` classes and extended `EMECoefficientDataset` with new fields (`n_complex`, `flux`, `interface_smatrices`, `overlaps`) and a `normalized_copy` cached property. |
| tidy3d/components/eme/data/sim_data.py | 5/5 | Added optional `coeffs` field to `EMESimulationData` for storing coefficient data from the EME simulation. |
| tidy3d/components/eme/simulation.py | 5/5 | Added `store_coeffs` parameter and coefficient storage size calculation in `_validate_monitor_size`. Added deprecation warning for `EMECoefficientMonitor`. |
| tidy3d/components/data/data_array.py | 5/5 | Added `EMEInterfaceSMatrixDataArray` and `EMEFluxDataArray` data array types. |
| tests/test_components/test_eme.py | 5/5 | Added comprehensive tests for new data array types, datasets, and the `normalized_copy` functionality. Updated existing tests to handle deprecated `EMECoefficientMonitor` warnings. |
| tidy3d/packaging.py | 5/5 | Fixed logging behavior in `supports_local_subpixel` decorator - now logs errors when user explicitly sets `use_local_subpixel=True` but feature is unavailable. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant EMESimulation
    participant EMESolver as EME Solver (Backend)
    participant EMESimulationData
    participant EMECoefficientDataset

    User->>EMESimulation: Create simulation with store_coeffs=True
    EMESimulation->>EMESimulation: validate_pre_upload() - estimate coeffs size
    User->>EMESolver: Run simulation
    EMESolver->>EMESolver: Compute modes, overlaps, S matrices
    EMESolver->>EMESimulationData: Return with coeffs data
    EMESimulationData->>User: Access coeffs (A, B, n_complex, flux, interface_smatrices, overlaps)
    User->>EMECoefficientDataset: normalized_copy
    EMECoefficientDataset->>EMECoefficientDataset: Normalize A, B, S12, S21 by flux
    EMECoefficientDataset->>User: Return normalized dataset (flux=None)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->