### PR TITLE
fix(config): skip web/local_cache sections in WASM builds

### DIFF
--- a/tidy3d/_runtime.py
+++ b/tidy3d/_runtime.py
@@ -1,0 +1,12 @@
+"""Runtime environment detection for tidy3d.
+
+This module must have ZERO dependencies on other tidy3d modules to avoid
+circular imports. It is imported very early in the initialization chain.
+"""
+
+from __future__ import annotations
+
+import sys
+
+# Detect WASM/Pyodide environment where web and filesystem features are unavailable
+WASM_BUILD = "pyodide" in sys.modules or sys.platform == "emscripten"

--- a/tidy3d/config/legacy.py
+++ b/tidy3d/config/legacy.py
@@ -13,6 +13,7 @@ from typing import Any, Optional
 
 import toml
 
+from tidy3d._runtime import WASM_BUILD
 from tidy3d.log import LogLevel, log
 
 # TODO(FXC-3827): Remove LegacyConfigWrapper/Environment shims and related helpers in Tidy3D 2.12.
@@ -304,7 +305,7 @@ class LegacyEnvironmentConfig:
 
     def _web_section(self) -> dict[str, Any]:
         manager = self.manager
-        if manager is None:
+        if manager is None or WASM_BUILD:
             return {}
         profile = normalize_profile_name(self._name)
         if manager.profile == profile:

--- a/tidy3d/config/sections.py
+++ b/tidy3d/config/sections.py
@@ -22,6 +22,7 @@ from pydantic import (
     field_validator,
 )
 
+from tidy3d._runtime import WASM_BUILD
 from tidy3d.log import DEFAULT_LEVEL, LogLevel, log, set_log_suppression, set_logging_level
 
 from .registry import get_manager as _get_attached_manager
@@ -279,7 +280,6 @@ def apply_adjoint(config: AdjointConfig) -> None:
     )
 
 
-@register_section("web")
 class WebConfig(ConfigSection):
     """Web/HTTP configuration."""
 
@@ -411,7 +411,6 @@ class WebConfig(ConfigSection):
         return "/".join([base.rstrip("/"), path_str.lstrip("/")])
 
 
-@register_handler("web")
 def apply_web(config: WebConfig) -> None:
     """Apply web-related environment variable overrides."""
 
@@ -437,7 +436,6 @@ def _default_cache_directory() -> Path:
     return (base / "tidy3d" / "simulations").resolve()
 
 
-@register_section("local_cache")
 class LocalCacheConfig(ConfigSection):
     """Settings controlling the optional local simulation cache."""
 
@@ -489,8 +487,17 @@ class PluginsContainer(ConfigSection):
     model_config = ConfigDict(extra="allow")
 
 
+# Register web and local_cache sections only in non-WASM environments
+# where filesystem and network features are available
+if not WASM_BUILD:
+    register_section("web")(WebConfig)
+    register_handler("web")(apply_web)
+    register_section("local_cache")(LocalCacheConfig)
+
+
 __all__ = [
     "AdjointConfig",
+    "LocalCacheConfig",
     "LoggingConfig",
     "MicrowaveConfig",
     "PluginsContainer",


### PR DESCRIPTION
## Summary
- Add `tidy3d/_runtime.py` with `WASM_BUILD` detection flag
- Conditionally skip registration of `WebConfig` and `LocalCacheConfig` sections in WASM
- Update `LegacyEnvironment` to return empty config when `WASM_BUILD` is true

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Adds WASM build detection to conditionally disable web and local cache configuration sections that require filesystem and network access unavailable in browser-based WASM environments. The implementation introduces a new `_runtime.py` module with a `WASM_BUILD` flag that detects Pyodide/Emscripten environments, then uses this flag to skip registration of `WebConfig` and `LocalCacheConfig` sections while keeping the classes defined for backward compatibility. The legacy environment wrapper also returns empty configuration when running in WASM mode.

**Key changes:**
- Created `tidy3d/_runtime.py` with zero dependencies for early-stage import safety
- Modified conditional registration using runtime check instead of decorator-time application
- Updated legacy environment to gracefully handle WASM builds by returning empty configs
- Classes remain exported in `__all__` to preserve import compatibility with existing code

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The implementation is well-designed with proper separation of concerns. The new `_runtime.py` module has zero dependencies preventing circular imports, the detection logic is straightforward, and the conditional registration preserves backward compatibility by keeping classes defined. The changes are minimal, focused, and follow the existing architecture patterns.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/_runtime.py | 5/5 | introduces WASM detection flag checking for pyodide in sys.modules or emscripten platform |
| tidy3d/config/sections.py | 5/5 | conditionally registers WebConfig and LocalCacheConfig sections only in non-WASM environments while keeping classes always defined |
| tidy3d/config/legacy.py | 5/5 | returns empty config dict in _web_section when WASM_BUILD is true to avoid accessing unavailable web configuration |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application Code
    participant Runtime as tidy3d._runtime
    participant Sections as config.sections
    participant Registry as config.registry
    participant Legacy as config.legacy
    participant Manager as ConfigManager

    Note over Runtime: Module load time
    Runtime->>Runtime: Check sys.modules for 'pyodide'<br/>or sys.platform == 'emscripten'
    Runtime->>Runtime: Set WASM_BUILD flag

    Note over Sections: sections.py imports
    Sections->>Runtime: Import WASM_BUILD
    Sections->>Sections: Define WebConfig class
    Sections->>Sections: Define LocalCacheConfig class
    Sections->>Sections: Define apply_web handler
    
    alt WASM_BUILD is False
        Sections->>Registry: register_section("web")(WebConfig)
        Registry->>Registry: Store WebConfig in _SECTIONS
        Sections->>Registry: register_handler("web")(apply_web)
        Registry->>Registry: Store apply_web in _HANDLERS
        Sections->>Registry: register_section("local_cache")(LocalCacheConfig)
        Registry->>Registry: Store LocalCacheConfig in _SECTIONS
    else WASM_BUILD is True
        Note over Sections,Registry: Skip registration<br/>Web/cache sections unavailable
    end

    Note over App: Runtime usage
    App->>Manager: get_section("web")
    
    alt Section registered (non-WASM)
        Manager->>Registry: Lookup "web" section
        Registry-->>Manager: Return WebConfig schema
        Manager-->>App: Return web config instance
    else Section not registered (WASM)
        Manager-->>App: Error or empty config
    end

    Note over Legacy: Legacy environment access
    App->>Legacy: Access Env.current.web_api_endpoint
    Legacy->>Legacy: Call _web_section()
    
    alt WASM_BUILD is True
        Legacy-->>App: Return {} (empty dict)
    else manager is None
        Legacy-->>App: Return {} (empty dict)
    else Normal operation
        Legacy->>Manager: get_section("web")
        Manager-->>Legacy: Return web config
        Legacy-->>App: Return web config dict
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->