### PR TITLE
result optimization

### DIFF
--- a/tidy3d/web/core/http_util.py
+++ b/tidy3d/web/core/http_util.py
@@ -195,7 +195,10 @@ def http_interceptor(func: Callable[..., Any]) -> Callable[..., JSONType]:
                 log = get_logger()
                 log.warning(warning)
 
-        return result.get("data") if "data" in result else result
+        if isinstance(result, dict) and "data" in result:
+            return result.get("data")
+        else:
+            return result
 
     return wrapper
 


### PR DESCRIPTION
If `result` is boolean type, it will throw:
return result.get("data") if "data" in result else result
TypeError: argument of type 'bool' is not iterable

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed `TypeError` in `http_interceptor` when API responses contain boolean values. The original code attempted to use the `in` operator on non-dict types, which fails for booleans.

**Key Changes:**
- Added `isinstance(result, dict)` check before accessing dict methods (`"data" in result` and `result.get("data")`)
- Ensures proper handling of all valid JSON types (dict, list, str, int, bool)

**Issue Found:**
- The `JSONType` type alias on line 33 is incomplete and doesn't include `bool` or `None`, even though both can be returned by the function (boolean from `resp.json()`, `None` from line 189)

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge after updating the `JSONType` alias to include missing types
- The fix correctly addresses the reported bug using `isinstance()` checks (per coding standards). However, the `JSONType` type alias remains incomplete, which could lead to type confusion but won't cause runtime errors. The core logic change is sound and follows best practices.
- Pay attention to `tidy3d/web/core/http_util.py` - update the `JSONType` alias to match actual return types

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/web/core/http_util.py | 4/5 | Fixed `TypeError` when API returns boolean by adding `isinstance()` check before accessing dict methods. Type alias `JSONType` should be updated to include bool and None types. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant HttpSessionManager
    participant http_interceptor
    participant API
    
    Client->>HttpSessionManager: get/post/put/delete(path, json)
    HttpSessionManager->>http_interceptor: @decorator wraps function
    http_interceptor->>API: Execute HTTP request
    API-->>http_interceptor: Response (status, body)
    
    alt Response status != 200
        alt Response status == 404 and suppress_404=True
            http_interceptor-->>Client: None
        else
            http_interceptor-->>Client: Raise WebError/WebNotFoundError
        end
    else Response text is empty
        http_interceptor-->>Client: None
    else Response has JSON body
        http_interceptor->>http_interceptor: Parse resp.json()
        alt result is dict with "warning"
            http_interceptor->>http_interceptor: Log warning
        end
        alt result is dict with "data" key
            http_interceptor-->>Client: result["data"]
        else result is bool/str/int/list/dict
            http_interceptor-->>Client: result (unchanged)
        end
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Use isinstance() for type checking instead of type() to correctly handle inheritance. ([source](https://app.greptile.com/review/custom-context?memory=b6377568-7845-4bad-a952-1ebe486d8912))

<!-- /greptile_comment -->