### PR TITLE
fix: SCRF-2132: add regression test for non-dict interceptor payloads

### DIFF
--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -580,6 +580,23 @@ def test_delete_old(set_api_key):
 
 
 @responses.activate
+@pytest.mark.parametrize("payload", [7, "data", ["data", 3], None])
+def test_http_interceptor_handles_non_dict_json_payload(set_api_key, payload):
+    """Non-dict JSON payloads should be returned without unwrapping."""
+    import tidy3d.web.core.http_util as http_module
+
+    request_path = f"tidy3d/non-dict/{type(payload).__name__}"
+    responses.add(
+        responses.GET,
+        f"{Env.current.web_api_endpoint}/{request_path}",
+        json=payload,
+        status=200,
+    )
+
+    assert http_module.http.get(request_path) == payload
+
+
+@responses.activate
 def test_get_tasks(set_api_key):
     responses.add(
         responses.GET,


### PR DESCRIPTION
When `result` is bool type, it will throw:

return result.get("data") if "data" in result else result

TypeError: argument of type 'bool' is not iterable

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed a type safety issue in `http_interceptor` where checking for the `"data"` key in API responses could fail or behave incorrectly when the response is a list, string, or integer instead of a dictionary.

Key changes:
- Added `isinstance(result, dict)` check before accessing the `"data"` key in HTTP response handling
- Prevents unexpected behavior when API returns non-dict JSON types (lists, strings, integers)
- Addresses a real bug since some endpoints return lists directly (e.g., task list endpoint returns `list[SimulationTask]`)

Missing:
- No changelog entry added (required by project standards for non-refactor PRs)

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor considerations
- The code change is correct and fixes a real type safety bug. The logic is sound and improves robustness. Score reduced by 1 point due to missing changelog entry which is required by project standards.
- No files require special attention - the change is straightforward and correct

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/web/core/http_util.py | 5/5 | Added type guard to prevent checking for dict keys on non-dict types (lists, strings, integers) |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as HTTP Client
    participant Wrapper as http_interceptor wrapper
    participant API as External API
    participant Logger as Logger

    Client->>Wrapper: HTTP request (get/post/put/delete)
    Wrapper->>API: Forward request
    API-->>Wrapper: HTTP Response
    
    alt Response is not 200 OK
        alt Response is 404 and suppress_404=True
            Wrapper-->>Client: Return None
        else Response is 404 and suppress_404=False
            Wrapper-->>Client: Raise WebNotFoundError
        else Other error status
            Wrapper-->>Client: Raise WebError with details
        end
    else Response is 200 OK
        alt Response body is empty
            Wrapper-->>Client: Return None
        else Response has body
            Wrapper->>Wrapper: Parse JSON response
            alt Result is dict with "warning" key
                Wrapper->>Logger: Log warning
            end
            alt Result is dict with "data" key [FIXED]
                Wrapper-->>Client: Return result["data"]
            else Result is list/str/int or dict without "data" [FIXED]
                Wrapper-->>Client: Return result as-is
            end
        end
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Require a changelog entry for any PR that is not purely an internal refactor. ([source](https://app.greptile.com/review/custom-context?memory=b72c7231-b258-4d03-aed2-51a50a9fe757))

<!-- /greptile_comment -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-scoped robustness fix in HTTP response handling with targeted test coverage; minimal behavioral change limited to endpoints returning non-dict JSON.
> 
> **Overview**
> Fixes `http_interceptor` to only unwrap `result["data"]` (and read `warning`) when the parsed JSON response is a `dict`, returning non-dict JSON payloads (e.g., `int`, `str`, `list`, `None`) as-is instead of raising type errors.
> 
> Adds a parametrized regression test in `tests/test_web/test_webapi.py` verifying `http.get()` returns non-dict JSON responses unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c76e2d25bca59d0b58a9dcbcb347c0b3313989ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->