### PR TITLE
Set default path names

### DIFF
--- a/docs/api/microwave/component_modeler.rst
+++ b/docs/api/microwave/component_modeler.rst
@@ -55,6 +55,9 @@ Alternatively, use the ``tidy3d.web.run()`` method to perform all of the above i
    # Upload, run simulation, and download data
    my_tcm_data = tidy3d.web.run(my_tcm, task_name='my_task_name', path='my/local/download/path')
 
+If ``path`` is omitted, the component modeler results download to ``cm_data.hdf5`` in the working
+directory by default.
+
 To get the S-matrix from the results, use the ``smatrix()`` method of the :class:`.TerminalComponentModelerData` object.
 
 .. code-block:: python

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -19,7 +19,7 @@ from tidy3d.web.api.asynchronous import DEFAULT_DATA_DIR
 from tidy3d.web.api.asynchronous import run_async as run_async_webapi
 from tidy3d.web.api.container import BatchData
 from tidy3d.web.api.tidy3d_stub import Tidy3dStub
-from tidy3d.web.api.webapi import load, restore_simulation_if_cached
+from tidy3d.web.api.webapi import default_data_filename, load, restore_simulation_if_cached
 from tidy3d.web.api.webapi import run as run_webapi
 from tidy3d.web.core.types import PayType
 
@@ -104,7 +104,7 @@ def run(
     simulation: WorkflowType,
     task_name: typing.Optional[str] = None,
     folder_name: str = "default",
-    path: PathLike = "simulation_data.hdf5",
+    path: typing.Optional[PathLike] = None,
     callback_url: typing.Optional[str] = None,
     verbose: bool = True,
     progress_callback_upload: typing.Optional[typing.Callable[[float], None]] = None,
@@ -132,8 +132,9 @@ def run(
         Name of task. If not provided, a default name will be generated.
     folder_name : str = "default"
         Name of folder to store task on web UI.
-    path : PathLike = "simulation_data.hdf5"
-        Path to download results file (.hdf5), including filename.
+    path : Optional[PathLike] = None
+        Path to download results file (.hdf5), including filename. When ``None``, a task-type-
+        specific default filename is used.
     callback_url : str = None
         Http PUT url to receive simulation finish event. The body content is a json file with
         fields ``{'id', 'status', 'name', 'workUnit', 'solverVersion'}``.
@@ -220,20 +221,20 @@ def run(
 
     lazy = False if lazy is None else bool(lazy)
 
+    stub = Tidy3dStub(simulation=simulation)
     if task_name is None:
-        stub = Tidy3dStub(simulation=simulation)
         task_name = stub.get_default_task_name()
 
     # component modeler path: route autograd-valid modelers to local run
     from tidy3d.plugins.smatrix.component_modelers.types import ComponentModelerType
 
-    path = Path(path)
+    resolved_path = Path(path) if path is not None else Path(default_data_filename(stub.get_type()))
 
     if isinstance(simulation, typing.get_args(ComponentModelerType)):
         if any(is_valid_for_autograd(s) for s in simulation.sim_dict.values()):
             from tidy3d.plugins.smatrix import run as smatrix_run
 
-            path_dir = path.parent
+            path_dir = resolved_path.parent
             return smatrix_run._run_local(
                 simulation,
                 path_dir=path_dir,
@@ -252,7 +253,7 @@ def run(
             simulation=simulation,
             task_name=task_name,
             folder_name=folder_name,
-            path=path,
+            path=resolved_path,
             callback_url=callback_url,
             verbose=verbose,
             progress_callback_upload=progress_callback_upload,
@@ -272,7 +273,7 @@ def run(
         simulation=simulation,
         task_name=task_name,
         folder_name=folder_name,
-        path=path,
+        path=resolved_path,
         callback_url=callback_url,
         verbose=verbose,
         progress_callback_upload=progress_callback_upload,
@@ -563,7 +564,7 @@ def _run_primitive(
         )
     else:
         sim_original = sim_original.updated_copy(simulation_type="autograd_fwd", deep=False)
-        restored_path, task_id_fwd = restore_simulation_if_cached(
+        restored_path, task_id_fwd, _ = restore_simulation_if_cached(
             simulation=sim_original,
             path=run_kwargs.get("path", None),
             reduce_simulation=run_kwargs.get("reduce_simulation", "auto"),

--- a/tidy3d/web/api/autograd/engine.py
+++ b/tidy3d/web/api/autograd/engine.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Any
 
 import tidy3d as td
-from tidy3d.web.api.container import DEFAULT_DATA_PATH, Batch, Job
+from tidy3d.web.api.container import Batch, Job
 
 from .io_utils import get_vjp_traced_fields, upload_sim_fields_keys
 
@@ -27,7 +27,11 @@ def _run_tidy3d(
     if job.simulation_type == "autograd_fwd":
         verbose = run_kwargs.get("verbose", False)
         upload_sim_fields_keys(run_kwargs["sim_fields_keys"], task_id=job.task_id, verbose=verbose)
-    path = Path(run_kwargs.get("path", DEFAULT_DATA_PATH))
+    path_arg = run_kwargs.get("path")
+    if path_arg is None:
+        path = Job._resolve_output_path(None, job._task_type_hint())
+    else:
+        path = Path(path_arg)
     priority = run_kwargs.get("priority")
     if task_name.endswith("_adjoint"):
         suffixes = "".join(path.suffixes)

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -259,6 +259,7 @@ class Job(WebContainer):
 
     _stash_path: Optional[str] = PrivateAttr(default=None)
     _cached_task_id: Optional[TaskId] = PrivateAttr(default=None)
+    _cached_task_type: Optional[str] = PrivateAttr(default=None)
 
     @cached_property
     def _stash_path_for_job(self) -> str:
@@ -266,6 +267,20 @@ class Job(WebContainer):
         stash_dir = Path(tempfile.gettempdir()) / "tidy3d_stash"
         stash_dir.mkdir(parents=True, exist_ok=True)
         return str(Path(stash_dir / f"{uuid.uuid4()}.hdf5"))
+
+    def _task_type_hint(self) -> Optional[str]:
+        """Best-effort task type derived from the simulation for default filename selection."""
+
+        try:
+            return Tidy3dStub(simulation=self.simulation).get_type()
+        except Exception:
+            return None
+
+    @staticmethod
+    def _resolve_output_path(path: Optional[PathLike], task_type_hint: Optional[str]) -> Path:
+        """Resolve a user-provided or default output path."""
+
+        return Path(path) if path is not None else Path(web.default_data_filename(task_type_hint))
 
     def _materialize_from_stash(self, dst_path: os.PathLike) -> None:
         """Atomic copy from stash to requested path."""
@@ -300,15 +315,16 @@ class Job(WebContainer):
 
     def run(
         self,
-        path: PathLike = DEFAULT_DATA_PATH,
+        path: Optional[PathLike] = None,
         priority: Optional[int] = None,
     ) -> WorkflowDataType:
         """Run :class:`Job` all the way through and return data.
 
         Parameters
         ----------
-        path : PathLike = "./simulation_data.hdf5"
-            Path to download results file (.hdf5), including filename.
+        path : Optional[PathLike] = None
+            Path to download results file (.hdf5), including filename. When ``None``, a task-type-
+            specific default filename is used.
         priority: int = None
             Priority of the simulation in the Virtual GPU (vGPU) queue (1 = lowest, 10 = highest).
             It affects only simulations from vGPU licenses and does not impact simulations using FlexCredits.
@@ -317,7 +333,8 @@ class Job(WebContainer):
         :class:`WorkflowDataType`
             Object containing simulation results.
         """
-        self._check_path_dir(path=path)
+        if path is not None:
+            self._check_path_dir(path=path)
 
         loaded_from_cache = self.load_if_cached
         if not loaded_from_cache:
@@ -337,15 +354,17 @@ class Job(WebContainer):
         # use temporary path as final destination is unknown
         stash_path = self._stash_path_for_job
 
-        restored, cached_task_id = restore_simulation_if_cached(
+        restored, cached_task_id, cached_task_type = restore_simulation_if_cached(
             simulation=self.simulation,
             path=stash_path,
             reduce_simulation=self.reduce_simulation,
             verbose=self.verbose,
         )
         self._cached_task_id = cached_task_id
+        self._cached_task_type = cached_task_type
 
         if restored is None:
+            self._cached_task_type = None
             return False
 
         self._stash_path = stash_path
@@ -437,44 +456,56 @@ class Job(WebContainer):
             return
         web.monitor(self.task_id, verbose=self.verbose)
 
-    def download(self, path: PathLike = DEFAULT_DATA_PATH) -> None:
+    def download(self, path: Optional[PathLike] = None) -> None:
         """Download results of simulation.
 
         Parameters
         ----------
-        path : PathLike = "./simulation_data.hdf5"
-            Path to download data as ``.hdf5`` file (including filename).
+        path : Optional[PathLike] = None
+            Path to download data as ``.hdf5`` file (including filename). When ``None``, a task-
+            type-specific default filename is used.
 
         Note
         ----
         To load the data after download, use :meth:`Job.load`.
         """
         if self.load_if_cached:
-            self._materialize_from_stash(path)
+            target_path = self._resolve_output_path(path, self._cached_task_type)
+            self._check_path_dir(path=target_path)
+            self._materialize_from_stash(target_path)
             return
-        self._check_path_dir(path=path)
+        if path is not None:
+            self._check_path_dir(path=path)
         web.download(task_id=self.task_id, path=path, verbose=self.verbose)
 
-    def load(self, path: PathLike = DEFAULT_DATA_PATH) -> WorkflowDataType:
+    def load(self, path: Optional[PathLike] = None) -> WorkflowDataType:
         """Download job results and load them into a data object.
 
         Parameters
         ----------
-        path : PathLike = "./simulation_data.hdf5"
-            Path to download data as ``.hdf5`` file (including filename).
+        path : Optional[PathLike] = None
+            Path to download data as ``.hdf5`` file (including filename). When ``None``, a task-
+            type-specific default filename is used.
 
         Returns
         -------
         Union[:class:`.SimulationData`, :class:`.HeatSimulationData`, :class:`.EMESimulationData`]
             Object containing simulation results.
         """
-        self._check_path_dir(path=path)
+        resolved_path = Path(path) if path is not None else None
         if self.load_if_cached:
-            self._materialize_from_stash(path)
+            task_type_hint = self._cached_task_type or self._task_type_hint()
+            resolved_path = self._resolve_output_path(resolved_path, task_type_hint)
+            self._check_path_dir(path=resolved_path)
+            self._materialize_from_stash(resolved_path)
+        else:
+            if resolved_path is None:
+                resolved_path = self._resolve_output_path(None, self._task_type_hint())
+            self._check_path_dir(path=resolved_path)
 
         data = web.load(
             task_id=None if self.load_if_cached else self.task_id,
-            path=path,
+            path=resolved_path,
             verbose=self.verbose,
             lazy=self.lazy,
         )
@@ -484,7 +515,7 @@ class Job(WebContainer):
                     self.task_id,
                     self.simulation,
                     data,
-                    path,
+                    resolved_path,
                 )
             self.simulation._patch_data(data=data)
 

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -76,6 +76,53 @@ SOLVER_NAME = {
     "VOLUME_MESH": "VolumeMesher",
 }
 
+# map task_type to default data filename
+DEFAULT_DATA_FILENAME = {
+    "FDTD": "simulation_data.hdf5",
+    "MODE_SOLVER": "simulation_data.hdf5",
+    "MODE": "simulation_data.hdf5",
+    "EME": "simulation_data.hdf5",
+    "HEAT": "simulation_data.hdf5",
+    "HEAT_CHARGE": "simulation_data.hdf5",
+    "VOLUME_MESH": "simulation_data.hdf5",
+    "MODAL_CM": "cm_data.hdf5",
+    "TERMINAL_CM": "cm_data.hdf5",
+    "COMPONENT_MODELER": "cm_data.hdf5",
+    "TERMINAL_COMPONENT_MODELER": "cm_data.hdf5",
+    "RF": "cm_data.hdf5",
+}
+
+
+def default_data_filename(task_type: Optional[str]) -> str:
+    """Return the default results filename for the given task type."""
+
+    return DEFAULT_DATA_FILENAME.get(task_type or "", "simulation_data.hdf5")
+
+
+def _get_default_path(
+    task_id: str, provided_path: Optional[PathLike]
+) -> tuple[Path, bool, Optional[str]]:
+    """Determine the effective download path and task metadata for a task."""
+
+    task = TaskFactory.get(task_id, verbose=False)
+    if task is None:
+        raise ValueError("Task not found.")
+
+    is_batch = isinstance(task, BatchTask)
+
+    if provided_path is not None:
+        path = Path(provided_path)
+        return path, is_batch, None
+
+    if is_batch:
+        task_type = "RF"
+    else:
+        task_info = get_info(task_id, verbose=False)
+        task_type = getattr(task_info, "taskType", None)
+
+    default_filename = default_data_filename(task_type)
+    return Path(default_filename), is_batch, task_type
+
 
 def _get_url(task_id: str) -> str:
     """Get the URL for a task on our server."""
@@ -184,7 +231,7 @@ def restore_simulation_if_cached(
     path: Optional[PathLike] = None,
     reduce_simulation: Literal["auto", True, False] = "auto",
     verbose: bool = True,
-) -> tuple[Optional[PathLike], Optional[TaskId]]:
+) -> tuple[Optional[PathLike], Optional[TaskId], Optional[str]]:
     """
     Attempt to restore simulation data from a local cache entry, if available.
 
@@ -207,10 +254,13 @@ def restore_simulation_if_cached(
         The path to the restored simulation data if found in cache, otherwise None. If no path is specified, the cache entry path is returned, otherwise the given path is returned.
     Optional[TaskId]
         The original task id of the restored simulation data.
+    Optional[str]
+        The workflow task type associated with the cached entry, if available.
     """
     simulation_cache = resolve_local_cache()
     retrieved_simulation_path = None
     cached_task_id = None
+    cached_workflow_type = None
     if simulation_cache is not None:
         sim_for_cache = simulation
         if isinstance(simulation, (ModeSolver, ModeSimulation)):
@@ -231,7 +281,7 @@ def restore_simulation_if_cached(
                 console.log(
                     f"Loading simulation from local cache. View cached task using web UI at [link={url}]'{url}'[/link]."
                 )
-    return retrieved_simulation_path, cached_task_id
+    return retrieved_simulation_path, cached_task_id, cached_workflow_type
 
 
 def load_simulation_if_cached(
@@ -260,7 +310,7 @@ def load_simulation_if_cached(
     Optional[WorkflowDataType]
         The loaded simulation data if found in cache, otherwise None.
     """
-    restored_path, _ = restore_simulation_if_cached(
+    restored_path, _, _ = restore_simulation_if_cached(
         simulation, path, reduce_simulation, verbose=verbose
     )
     if restored_path is not None:
@@ -281,7 +331,7 @@ def run(
     simulation: WorkflowType,
     task_name: Optional[str] = None,
     folder_name: str = "default",
-    path: PathLike = "simulation_data.hdf5",
+    path: Optional[PathLike] = None,
     callback_url: Optional[str] = None,
     verbose: bool = True,
     progress_callback_upload: Optional[Callable[[float], None]] = None,
@@ -307,8 +357,9 @@ def run(
         Name of task. If not provided, a default name will be generated.
     folder_name : str = "default"
         Name of folder to store task on web UI.
-    path : PathLike = "simulation_data.hdf5"
-        Path to download results file (.hdf5), including filename.
+    path : Optional[PathLike] = None
+        Path to download results file (.hdf5), including filename. When ``None``, a task-type-
+        specific default filename is used.
     callback_url : str = None
         Http PUT url to receive simulation finish event. The body content is a json file with
         fields ``{'id', 'status', 'name', 'workUnit', 'solverVersion'}``.
@@ -379,7 +430,7 @@ def run(
     :meth:`tidy3d.web.api.container.Batch.monitor`
         Monitor progress of each of the running tasks.
     """
-    restored_path, _ = restore_simulation_if_cached(
+    restored_path, _cached_task_id, _ = restore_simulation_if_cached(
         simulation=simulation,
         path=path,
         reduce_simulation=reduce_simulation,
@@ -410,17 +461,24 @@ def run(
     else:
         task_id = None
 
+    download_path = Path(restored_path) if restored_path is not None else None
+    if download_path is None and path is not None:
+        download_path = Path(path)
+
+    if task_id is not None and download_path is None:
+        download_path, _, _ = _get_default_path(task_id, None)
+
     data = load(
         task_id=task_id,
-        path=path,
+        path=download_path,
         verbose=verbose,
         progress_callback=progress_callback_download,
         lazy=lazy,
     )
 
     if isinstance(simulation, ModeSolver):
-        if task_id is not None:
-            _store_mode_solver_in_cache(task_id, simulation, data, path)
+        if task_id is not None and download_path is not None:
+            _store_mode_solver_in_cache(task_id, simulation, data, download_path)
         simulation._patch_data(data=data)
 
     return data
@@ -965,7 +1023,7 @@ def abort(task_id: TaskId) -> Optional[TaskInfo]:
 @wait_for_connection
 def download(
     task_id: TaskId,
-    path: PathLike = "simulation_data.hdf5",
+    path: Optional[PathLike] = None,
     verbose: bool = True,
     progress_callback: Optional[Callable[[float], None]] = None,
 ) -> None:
@@ -975,32 +1033,37 @@ def download(
     ----------
     task_id : str
         Unique identifier of task on server.  Returned by :meth:`upload`.
-    path : PathLike = "simulation_data.hdf5"
-        Download path to .hdf5 data file (including filename).
+    path : Optional[PathLike] = None
+        Download path to .hdf5 data file (including filename). When ``None``, a task-type-
+        specific default filename is used.
     verbose : bool = True
         If ``True``, will print progressbars and status, otherwise, will run silently.
     progress_callback : Callable[[float], None] = None
         Optional callback function called when downloading file with ``bytes_in_chunk`` as argument.
 
     """
-    path = Path(path)
+    resolved_path, is_batch, task_type = _get_default_path(task_id, path)
     task = TaskFactory.get(task_id, verbose=False)
-    if isinstance(task, BatchTask):
-        if path.name == "simulation_data.hdf5":
-            path = path.with_name("cm_data.hdf5")
+
+    if is_batch:
         task.get_data_hdf5(
-            to_file=path,
+            to_file=resolved_path,
             remote_data_file_gz=CM_DATA_HDF5_GZ,
             verbose=verbose,
             progress_callback=progress_callback,
         )
         return
-    info = get_info(task_id, verbose=False)
+
+    if task_type is None:
+        task_info = get_info(task_id, verbose=False)
+        task_type = getattr(task_info, "taskType", None)
+
     remote_data_file = SIMULATION_DATA_HDF5_GZ
-    if info.taskType == "MODE_SOLVER":
+    if task_type == TaskType.MODE_SOLVER.name:
         remote_data_file = MODE_DATA_HDF5_GZ
+
     task.get_data_hdf5(
-        to_file=path,
+        to_file=resolved_path,
         remote_data_file_gz=remote_data_file,
         verbose=verbose,
         progress_callback=progress_callback,
@@ -1100,7 +1163,7 @@ def download_log(
 @wait_for_connection
 def load(
     task_id: Optional[TaskId],
-    path: PathLike = "simulation_data.hdf5",
+    path: Optional[PathLike] = None,
     replace_existing: bool = True,
     verbose: bool = True,
     progress_callback: Optional[Callable[[float], None]] = None,
@@ -1126,8 +1189,9 @@ def load(
     ----------
     task_id : Optional[str] = None
         Unique identifier of task on server. Returned by :meth:`upload`. If None, file is assumed to exist already from cache.
-    path : PathLike
-        Download path to .hdf5 data file (including filename).
+    path : Optional[PathLike]
+        Download path to .hdf5 data file (including filename). When ``None`` and ``task_id`` is provided,
+        a task-type-specific default filename is used.
     replace_existing : bool = True
         Downloads the data even if path exists (overwriting the existing).
     verbose : bool = True
@@ -1143,35 +1207,39 @@ def load(
     Union[:class:`.SimulationData`, :class:`.HeatSimulationData`, :class:`.EMESimulationData`]
         Object containing simulation data.
     """
-    path = Path(path)
-    task = TaskFactory.get(task_id) if task_id else None
-    # For component modeler batches, default to a clearer filename if the default was used.
-    if (
-        task_id
-        and isinstance(task, BatchTask)
-        and path.name in {"simulation_data.hdf5", "simulation_data.hdf5.gz"}
-    ):
-        path = path.with_name(path.name.replace("simulation", "cm"))
+    if task_id is not None:
+        resolved_path, is_batch, task_type = _get_default_path(task_id, path)
+    else:
+        resolved_path = Path(path) if path is not None else Path(default_data_filename(None))
+        is_batch = False
+        task_type = None
 
     if task_id is None:
-        if not path.exists():
+        if not resolved_path.exists():
             raise FileNotFoundError("Cached file not found.")
-    elif not path.exists() or replace_existing:
-        download(task_id=task_id, path=path, verbose=verbose, progress_callback=progress_callback)
+    elif not resolved_path.exists() or replace_existing:
+        download(
+            task_id=task_id,
+            path=resolved_path,
+            verbose=verbose,
+            progress_callback=progress_callback,
+        )
 
     if verbose and task_id is not None:
         console = get_logging_console()
-        if isinstance(task, BatchTask):
-            console.log(f"Loading component modeler data from {path}")
+        if is_batch:
+            console.log(f"Loading component modeler data from {resolved_path}")
         else:
-            console.log(f"Loading simulation from {path}")
+            console.log(f"Loading simulation from {resolved_path}")
 
-    stub_data = Tidy3dStubData.postprocess(path, lazy=lazy)
+    stub_data = Tidy3dStubData.postprocess(resolved_path, lazy=lazy)
 
     simulation_cache = resolve_local_cache()
     if simulation_cache is not None and task_id is not None:
-        info = get_info(task_id, verbose=False)
-        workflow_type = getattr(info, "taskType", None)
+        workflow_type = task_type
+        if workflow_type is None:
+            info = get_info(task_id, verbose=False)
+            workflow_type = getattr(info, "taskType", None)
         if (
             workflow_type != TaskType.MODE_SOLVER.name
         ):  # we cannot get the simulation from data or web for mode solver
@@ -1186,7 +1254,7 @@ def load(
             simulation_cache.store_result(
                 stub_data=stub_data,
                 task_id=task_id,
-                path=path,
+                path=resolved_path,
                 workflow_type=workflow_type,
                 simulation=simulation,
             )


### PR DESCRIPTION
Replaces #2993 

@yaugenst @marcorudolphflex @daquintero  probably too ambitious to aim for 2.10. :D

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Refactors path handling to use task-type-specific defaults when path is omitted, replacing hardcoded logic with centralized `DEFAULT_DATA_FILENAME` configuration. Key changes include making the path parameter optional in `run()`, `download()`, and `load()` functions, with defaults of `simulation_data.hdf5` for FDTD/MODE/EME/HEAT tasks and `cm_data.hdf5` for component modeler tasks.

**Major improvements:**
- Task-type-specific default filenames via `DEFAULT_DATA_FILENAME` dictionary mapping
- User-provided paths are now always respected (no silent overwriting)
- Added `_get_default_path()` helper function to centralize path resolution logic
- Updated `Job` class methods and autograd integration to support optional paths
- Documentation updated to reflect new behavior

**Issues found:**
- Redundant API call in `download()` function defeats the optimization purpose - `_get_default_path()` fetches the task but `download()` fetches it again immediately after

<h3>Confidence Score: 3/5</h3>


- Safe to merge with one critical performance issue that should be fixed
- The refactoring is well-structured with proper abstraction and comprehensive updates across all affected modules. However, the redundant `TaskFactory.get()` call in `download()` defeats the stated 50-67% API latency optimization goal. The logic is sound and backwards-compatible, but this performance regression needs addressing.
- Pay close attention to `tidy3d/web/api/webapi.py` - the redundant API call in the `download()` function needs to be fixed to achieve the promised performance improvements

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/web/api/webapi.py | 3/5 | Added `DEFAULT_DATA_FILENAME` mapping and helper functions; refactored `download()`, `load()`, and `run()` to use optional path with task-type defaults. Contains redundant API call in `download()` function. |
| tidy3d/web/api/container.py | 4/5 | Updated `Job` class methods (`run()`, `download()`, `load()`) to support optional path parameter; added `_task_type_hint()` and `_resolve_output_path()` helper methods. Clean implementation with proper caching support. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API as web.download()/load()
    participant Helper as _get_default_path()
    participant TaskFactory
    participant Server as get_info()

    User->>API: download(task_id, path=None)
    API->>Helper: _get_default_path(task_id, None)
    Helper->>TaskFactory: get(task_id)
    TaskFactory-->>Helper: task object
    Helper->>Helper: Check if BatchTask
    alt is BatchTask
        Helper->>Helper: task_type = "RF"
    else not BatchTask
        Helper->>Server: get_info(task_id)
        Server-->>Helper: task_info
        Helper->>Helper: Extract taskType
    end
    Helper->>Helper: default_data_filename(task_type)
    Helper-->>API: (Path, is_batch, task_type)
    API->>TaskFactory: get(task_id) [REDUNDANT]
    TaskFactory-->>API: task object
    API->>API: Download data to resolved_path
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->