### PR TITLE
fix(tidy3d): FXC-4541-avoid-mpl-import-for-wasm

### DIFF
--- a/tests/test_components/test_scene.py
+++ b/tests/test_components/test_scene.py
@@ -9,6 +9,7 @@ import pydantic.v1 as pd
 import pytest
 
 import tidy3d as td
+import tidy3d.components.scene as scene_mod
 from tidy3d.components.scene import MAX_NUM_MEDIUMS
 from tidy3d.components.viz import STRUCTURE_EPS_CMAP, STRUCTURE_EPS_CMAP_R
 from tidy3d.exceptions import SetupError
@@ -198,6 +199,45 @@ def test_structure_eps_color_mapping():
     )
     expected_max_reverse = mpl.cm.get_cmap(STRUCTURE_EPS_CMAP_R)(norm(5.0))
     assert np.allclose(pp_max_reverse.facecolor, expected_max_reverse)
+
+
+@pytest.mark.parametrize(
+    "medium, eps_min, eps_max, reverse, expected",
+    [
+        pytest.param(
+            td.Medium(permittivity=1.0), 1.0, 5.0, False, (1.0, 1.0, 1.0, 1.0), id="min-forward"
+        ),
+        pytest.param(
+            td.Medium(permittivity=5.0), 1.0, 5.0, False, (0.0, 0.0, 0.0, 1.0), id="max-forward"
+        ),
+        pytest.param(
+            td.Medium(permittivity=1.0), 1.0, 5.0, True, (0.0, 0.0, 0.0, 1.0), id="min-reverse"
+        ),
+        pytest.param(
+            td.Medium(permittivity=5.0), 1.0, 5.0, True, (1.0, 1.0, 1.0, 1.0), id="max-reverse"
+        ),
+        pytest.param(
+            td.Medium(permittivity=2.0), 2.0, 2.0, False, (0.5, 0.5, 0.5, 1.0), id="equal-forward"
+        ),
+        pytest.param(
+            td.Medium(permittivity=2.0), 2.0, 2.0, True, (0.5, 0.5, 0.5, 1.0), id="equal-reverse"
+        ),
+    ],
+)
+def test_structure_eps_color_mapping_no_matplotlib(
+    monkeypatch, medium, eps_min, eps_max, reverse, expected
+):
+    monkeypatch.setattr(scene_mod, "mpl", None)
+
+    params = SCENE_FULL._get_structure_eps_plot_params(
+        medium=medium,
+        freq=1,
+        eps_min=eps_min,
+        eps_max=eps_max,
+        reverse=reverse,
+    )
+
+    assert np.allclose(params.facecolor, expected)
 
 
 def test_num_mediums():

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -11,7 +11,7 @@ try:
     import matplotlib.pylab as plt
     from mpl_toolkits.axes_grid1 import make_axes_locatable
 except ImportError:
-    pass
+    mpl = None
 import pydantic.v1 as pd
 
 from tidy3d.components.material.tcad.charge import (
@@ -1446,14 +1446,24 @@ class Scene(Tidy3dBaseModel):
             plot_params = plot_params.copy(update={"edgecolor": "k", "linewidth": 1})
         else:
             eps_medium = medium._eps_plot(frequency=freq, eps_component=eps_component)
-            active_norm = (
-                norm if norm is not None else mpl.colors.Normalize(vmin=eps_min, vmax=eps_max)
-            )
-            color_value = float(active_norm(eps_medium))
+            if norm is not None:
+                color_value = float(norm(eps_medium))
+            elif mpl is not None:
+                active_norm = mpl.colors.Normalize(vmin=eps_min, vmax=eps_max)
+                color_value = float(active_norm(eps_medium))
+            else:
+                if eps_max == eps_min:
+                    color_value = 0.5
+                else:
+                    color_value = (eps_medium - eps_min) / (eps_max - eps_min)
             color_value = min(1.0, max(0.0, color_value))
-            cmap_name = _get_colormap(reverse=reverse)
-            cmap = mpl.cm.get_cmap(cmap_name)
-            rgba = tuple(float(component) for component in cmap(color_value))
+            if mpl is not None:
+                cmap_name = _get_colormap(reverse=reverse)
+                cmap = mpl.cm.get_cmap(cmap_name)
+                rgba = tuple(float(component) for component in cmap(color_value))
+            else:
+                gray_value = color_value if reverse else 1.0 - color_value
+                rgba = (gray_value, gray_value, gray_value, 1.0)
             plot_params = plot_params.copy(update={"facecolor": rgba})
 
         return plot_params


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR enables the `_get_structure_eps_plot_params` method to function in WASM/Pyodide environments where matplotlib may not be available.

**Changes made:**
- Modified the matplotlib import exception handler to set `mpl = None` instead of silently passing, enabling runtime detection of matplotlib availability
- Added fallback logic in `_get_structure_eps_plot_params` to compute normalized color values manually when matplotlib is unavailable
- Implemented grayscale color mapping as a fallback when matplotlib colormaps are not available
- Added comprehensive parametrized tests to verify the fallback behavior

The grayscale fallback provides a reasonable approximation: low permittivity values map to white (or black when reversed) and high values map to black (or white when reversed), maintaining visual consistency with the original colormap's light-to-dark gradient.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it adds a fallback code path without modifying the existing matplotlib-based behavior.
- The changes are well-scoped, adding only fallback functionality when matplotlib is unavailable. The existing code path remains unchanged when matplotlib is present. The implementation correctly handles edge cases (eps_min == eps_max) and includes comprehensive tests covering all scenarios.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/scene.py | 5/5 | Added fallback grayscale color calculation when matplotlib is unavailable, allowing WASM builds to function without matplotlib dependency. |
| tests/test_components/test_scene.py | 5/5 | Added parametrized test for grayscale fallback behavior when matplotlib is unavailable, covering forward/reverse colormap and edge cases. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Scene
    participant mpl as matplotlib
    
    Client->>Scene: _get_structure_eps_plot_params(medium, freq, eps_min, eps_max, reverse)
    
    alt matplotlib available (mpl is not None)
        Scene->>mpl: Normalize(vmin=eps_min, vmax=eps_max)
        mpl-->>Scene: active_norm
        Scene->>Scene: color_value = active_norm(eps_medium)
        Scene->>mpl: cm.get_cmap(cmap_name)
        mpl-->>Scene: cmap
        Scene->>Scene: rgba = cmap(color_value)
    else matplotlib unavailable (mpl is None)
        Scene->>Scene: Manual normalization: (eps_medium - eps_min) / (eps_max - eps_min)
        Scene->>Scene: Grayscale: gray_value = color_value if reverse else 1.0 - color_value
        Scene->>Scene: rgba = (gray_value, gray_value, gray_value, 1.0)
    end
    
    Scene-->>Client: PlotParams with facecolor=rgba
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->