### PR TITLE
update box gradients to use automatic permittivity detection (FXC-4551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug where an extra spatial coordinate could appear in `complex_flux` and `ImpedanceCalculator` results.
 - Fixed normal for `Box` shape gradient computation to always point outward from boundary which is needed for correct PEC handling.
 - Fixed `Box` gradients within `GeometryGroup` where the group intersection boundaries were forwarded.
+- Fixed `Box` gradients to use automatic permittivity detection for inside/outside permittivity.
 
 ## [2.10.0rc3] - 2025-11-26
 

--- a/tidy3d/web/api/autograd/backward.py
+++ b/tidy3d/web/api/autograd/backward.py
@@ -174,52 +174,49 @@ def postprocess_adj(
         else:
             eps_background = None
 
-        # auto permittivity detection for non-box geometries
-        if not isinstance(structure.geometry, td.Box):
-            sim_orig = sim_data_orig.simulation
-            plane_eps = eps_fwd.monitor.geometry
+        # auto permittivity detection
+        sim_orig = sim_data_orig.simulation
+        plane_eps = eps_fwd.monitor.geometry
 
-            sim_orig_grid_spec = td.components.grid.grid_spec.GridSpec.from_grid(sim_orig.grid)
+        sim_orig_grid_spec = td.components.grid.grid_spec.GridSpec.from_grid(sim_orig.grid)
 
-            # permittivity without this structure
-            structs_no_struct = list(sim_orig.structures)
-            structs_no_struct.pop(structure_index)
-            sim_no_structure = sim_orig.updated_copy(
-                structures=structs_no_struct, monitors=[], sources=[], grid_spec=sim_orig_grid_spec
+        # permittivity without this structure
+        structs_no_struct = list(sim_orig.structures)
+        structs_no_struct.pop(structure_index)
+        sim_no_structure = sim_orig.updated_copy(
+            structures=structs_no_struct, monitors=[], sources=[], grid_spec=sim_orig_grid_spec
+        )
+
+        eps_no_structure_data = [
+            sim_no_structure.epsilon(box=plane_eps, coord_key="centers", freq=f)
+            for f in adjoint_frequencies
+        ]
+
+        eps_no_structure = xr.concat(eps_no_structure_data, dim="f").assign_coords(
+            f=adjoint_frequencies
+        )
+
+        if structure.medium.is_pec:
+            eps_inf_structure = None
+        else:
+            # permittivity with infinite structure
+            structs_inf_struct = list(sim_orig.structures)[structure_index + 1 :]
+            sim_inf_structure = sim_orig.updated_copy(
+                structures=structs_inf_struct,
+                medium=structure.medium,
+                monitors=[],
+                sources=[],
+                grid_spec=sim_orig_grid_spec,
             )
 
-            eps_no_structure_data = [
-                sim_no_structure.epsilon(box=plane_eps, coord_key="centers", freq=f)
+            eps_inf_structure_data = [
+                sim_inf_structure.epsilon(box=plane_eps, coord_key="centers", freq=f)
                 for f in adjoint_frequencies
             ]
 
-            eps_no_structure = xr.concat(eps_no_structure_data, dim="f").assign_coords(
+            eps_inf_structure = xr.concat(eps_inf_structure_data, dim="f").assign_coords(
                 f=adjoint_frequencies
             )
-
-            if structure.medium.is_pec:
-                eps_inf_structure = None
-            else:
-                # permittivity with infinite structure
-                structs_inf_struct = list(sim_orig.structures)[structure_index + 1 :]
-                sim_inf_structure = sim_orig.updated_copy(
-                    structures=structs_inf_struct,
-                    medium=structure.medium,
-                    monitors=[],
-                    sources=[],
-                    grid_spec=sim_orig_grid_spec,
-                )
-
-                eps_inf_structure_data = [
-                    sim_inf_structure.epsilon(box=plane_eps, coord_key="centers", freq=f)
-                    for f in adjoint_frequencies
-                ]
-
-                eps_inf_structure = xr.concat(eps_inf_structure_data, dim="f").assign_coords(
-                    f=adjoint_frequencies
-                )
-        else:
-            eps_no_structure = eps_inf_structure = None
 
         # compute bounds intersection
         struct_bounds = rmin_struct, rmax_struct = structure.geometry.bounds


### PR DESCRIPTION
We recently updated Box to use the same shape gradient code as PolySlab, but the automatic permittivity detection was still only being applied in non-box geometry cases. This PR updates that so we use the same permittivity detection for box.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR removes a conditional check that excluded `Box` geometries from automatic permittivity detection during adjoint gradient computation. Previously, `Box` geometries had `eps_no_structure` and `eps_inf_structure` set to `None`, while other geometries (like `PolySlab`) computed these values automatically from the simulation context. This inconsistency existed because Box originally used different gradient code, but recent changes unified Box to use the same shape gradient code as PolySlab.

**Key changes:**
- Removed the `if not isinstance(structure.geometry, td.Box):` conditional in `postprocess_adj()` that skipped automatic permittivity detection for Box geometries
- Box gradients now compute `eps_no_structure` (permittivity without the structure) and `eps_inf_structure` (permittivity with infinite structure) for more accurate inside/outside permittivity determination at boundaries

This change ensures consistent gradient computation behavior across all geometry types.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it's a straightforward refactoring that unifies existing behavior across geometry types.
- The change removes an exclusionary conditional, applying existing well-tested permittivity detection logic to Box geometries. The DerivativeInfo structure already fully supports these optional fields, and the evaluate_gradient_at_points method handles them gracefully. Existing tests comparing Box and PolySlab gradients validate this unified approach.
- No files require special attention.

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/web/api/autograd/backward.py | 5/5 | Removed the `if not isinstance(structure.geometry, td.Box):` conditional that excluded Box geometries from automatic permittivity detection, now applying it uniformly to all geometry types. |
| CHANGELOG.md | 5/5 | Added entry documenting the fix for Box gradients to use automatic permittivity detection, correctly categorized under "Fixed" section. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PA as postprocess_adj()
    participant SI as Simulation
    participant DI as DerivativeInfo
    participant GEO as Box/PolySlab Geometry

    PA->>SI: Get original simulation
    PA->>SI: Create sim_no_structure (without target structure)
    SI-->>PA: Return epsilon without structure
    PA->>SI: Create sim_inf_structure (infinite target structure)
    SI-->>PA: Return epsilon with infinite structure
    PA->>DI: Create DerivativeInfo with eps_no_structure & eps_inf_structure
    PA->>GEO: _compute_derivatives(derivative_info)
    GEO->>DI: create_interpolators() (includes eps_no, eps_inf)
    GEO->>DI: evaluate_gradient_at_points()
    DI-->>GEO: Return gradient values using auto-detected permittivity
    GEO-->>PA: Return VJP values
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->