### PR TITLE
chore(tidy3d): FXC-4545-move-type-hints-imports-behind-type-checking

### DIFF
--- a/tidy3d/components/apodization.py
+++ b/tidy3d/components/apodization.py
@@ -2,18 +2,21 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 from pydantic import Field, NonNegativeFloat, PositiveFloat, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.constants import SECOND
 from tidy3d.exceptions import SetupError
 
 from .base import Tidy3dBaseModel
-from .types import ArrayFloat1D, Ax
 from .viz import add_ax_if_none
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
+
+    from .types import ArrayFloat1D, Ax
 
 
 class ApodizationSpec(Tidy3dBaseModel):

--- a/tidy3d/components/autograd/boxes.py
+++ b/tidy3d/components/autograd/boxes.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import importlib
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any
 
 import autograd.numpy as anp
 from autograd.extend import VJPNode, defjvp, register_notrace
 from autograd.numpy.numpy_boxes import ArrayBox
 from autograd.numpy.numpy_wrapper import _astype
+
+if TYPE_CHECKING:
+    from typing import Callable
 
 TidyArrayBox = ArrayBox  # NOT a subclass
 

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
-from typing import Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import numpy as np
-import xarray as xr
 from numpy.typing import NDArray
 
-from tidy3d.compat import Self
 from tidy3d.components.data.data_array import FreqDataArray, ScalarFieldDataArray
 from tidy3d.components.types import ArrayLike, Bound, Complex
 from tidy3d.config import config
@@ -18,6 +16,13 @@ from tidy3d.log import log
 
 from .types import PathType
 from .utils import get_static
+
+if TYPE_CHECKING:
+    from typing import Callable
+
+    import xarray as xr
+
+    from tidy3d.compat import Self
 
 FieldData = dict[str, ScalarFieldDataArray]
 PermittivityData = dict[str, ScalarFieldDataArray]

--- a/tidy3d/components/autograd/field_map.py
+++ b/tidy3d/components/autograd/field_map.py
@@ -3,17 +3,17 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Callable, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from pydantic import Field
 
-from tidy3d.components.autograd.types import (
-    AutogradFieldMap,
-    TracedArrayLike,
-    TracedComplex,
-    TracedFloat,
-)
+from tidy3d.components.autograd.types import TracedArrayLike, TracedComplex, TracedFloat
 from tidy3d.components.base import Tidy3dBaseModel
+
+if TYPE_CHECKING:
+    from typing import Callable
+
+    from tidy3d.components.autograd.types import AutogradFieldMap
 
 
 class Tracer(Tidy3dBaseModel):

--- a/tidy3d/components/autograd/functions.py
+++ b/tidy3d/components/autograd/functions.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
 import itertools
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import autograd.numpy as anp
 import numpy as np
 from autograd.extend import defjvp, defvjp, primitive
 from autograd.numpy.numpy_jvps import broadcast
 from autograd.numpy.numpy_vjps import unbroadcast_f
-from numpy.typing import NDArray
 
-from .types import InterpolationType
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    from .types import InterpolationType
 
 
 def _evaluate_nearest(

--- a/tidy3d/components/autograd/types.py
+++ b/tidy3d/components/autograd/types.py
@@ -3,20 +3,26 @@
 from __future__ import annotations
 
 import copy
-from typing import Annotated, Any, Literal, Optional, Union, get_origin
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Union, get_origin
 
 import autograd.numpy as anp
 from autograd.builtins import dict as TracedDict
 from autograd.extend import Box, defvjp, primitive
 from autograd.numpy.numpy_boxes import ArrayBox
-from pydantic import BeforeValidator, PlainSerializer, PositiveFloat, SerializationInfo, TypeAdapter
+from pydantic import BeforeValidator, PlainSerializer, PositiveFloat, TypeAdapter
 
-from tidy3d.compat import TypeAlias
 from tidy3d.components.types import ArrayFloat2D, ArrayLike, Complex, Size1D
 from tidy3d.components.types.base import _auto_serializer
 from tidy3d.components.types.utils import _add_schema
 
 from .utils import get_static, hasbox
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from pydantic import SerializationInfo
+
+    from tidy3d.compat import TypeAlias
 
 # add schema to the Box
 _add_schema(Box, title="AutogradBox", field_type_str="autograd.tracer.Box")

--- a/tidy3d/components/autograd/utils.py
+++ b/tidy3d/components/autograd/utils.py
@@ -2,12 +2,16 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
-from typing import Any, Union
+from typing import TYPE_CHECKING, Any
 
 import autograd.numpy as anp
-from autograd.numpy.numpy_boxes import ArrayBox
 from autograd.tracer import getval, isbox
-from numpy.typing import ArrayLike, NDArray
+
+if TYPE_CHECKING:
+    from typing import Union
+
+    from autograd.numpy.numpy_boxes import ArrayBox
+    from numpy.typing import ArrayLike, NDArray
 
 __all__ = [
     "asarray1d",

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -10,12 +10,12 @@ import os
 import tempfile
 import typing as _t
 from collections import defaultdict
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from functools import total_ordering, wraps
 from math import ceil
 from os import PathLike
 from pathlib import Path
-from typing import Any, Callable, Literal, Optional, TypeVar, Union, get_args, get_origin
+from typing import TYPE_CHECKING, Any, Literal, Optional, TypeVar, Union, get_args, get_origin
 
 import h5py
 import numpy as np
@@ -24,17 +24,25 @@ import xarray as xr
 import yaml
 from autograd.tracer import isbox
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator
-from pydantic.fields import FieldInfo
 
-from tidy3d.compat import Self
 from tidy3d.exceptions import FileError
 from tidy3d.log import log
 
-from .autograd.types import AutogradFieldMap, TracedDict
+from .autograd.types import TracedDict
 from .autograd.utils import get_static
 from .data.data_array import DATA_ARRAY_MAP
 from .file_util import compress_file_to_gzip, extract_gzip_file
 from .types import TYPE_TAG_STR, Undefined
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from typing import Callable
+
+    from pydantic.fields import FieldInfo
+
+    from tidy3d.compat import Self
+
+    from .autograd.types import AutogradFieldMap
 
 INDENT_JSON_FILE = 4  # default indentation of json string in json files
 INDENT = None  # default indentation of json string used internally

--- a/tidy3d/components/base_sim/data/sim_data.py
+++ b/tidy3d/components/base_sim/data/sim_data.py
@@ -3,20 +3,25 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
-import xarray as xr
 from pydantic import Field, field_validator, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.base_sim.data.monitor_data import AbstractMonitorData
 from tidy3d.components.base_sim.simulation import AbstractSimulation
-from tidy3d.components.data.utils import UnstructuredGridDatasetType
-from tidy3d.components.monitor import AbstractMonitor
-from tidy3d.components.types import FieldVal
 from tidy3d.exceptions import DataError, Tidy3dKeyError, ValidationError
+
+if TYPE_CHECKING:
+    from typing import Union
+
+    import xarray as xr
+
+    from tidy3d.compat import Self
+    from tidy3d.components.data.utils import UnstructuredGridDatasetType
+    from tidy3d.components.monitor import AbstractMonitor
+    from tidy3d.components.types import FieldVal
 
 
 class AbstractSimulationData(Tidy3dBaseModel, ABC):

--- a/tidy3d/components/base_sim/monitor.py
+++ b/tidy3d/components/base_sim/monitor.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 import numpy as np
 from pydantic import Field
 
 from tidy3d.components.base import cached_property
 from tidy3d.components.geometry.base import Box
-from tidy3d.components.types import ArrayFloat1D, Axis
 from tidy3d.components.validators import _warn_unsupported_traced_argument
-from tidy3d.components.viz import PlotParams, plot_params_monitor
+from tidy3d.components.viz import plot_params_monitor
+
+if TYPE_CHECKING:
+    from tidy3d.components.types import ArrayFloat1D, Axis
+    from tidy3d.components.viz import PlotParams
 
 
 class AbstractMonitor(Box, ABC):

--- a/tidy3d/components/base_sim/simulation.py
+++ b/tidy3d/components/base_sim/simulation.py
@@ -3,37 +3,33 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 import autograd.numpy as anp
 from pydantic import Field, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import cached_property
 from tidy3d.components.geometry.base import Box
 from tidy3d.components.medium import Medium, MediumType3D
 from tidy3d.components.scene import Scene
 from tidy3d.components.structure import Structure
-from tidy3d.components.types import (
-    TYPE_TAG_STR,
-    Ax,
-    Axis,
-    Bound,
-    LengthUnit,
-    PriorityMode,
-    Symmetry,
-)
+from tidy3d.components.types import TYPE_TAG_STR, LengthUnit, PriorityMode, Symmetry
 from tidy3d.components.validators import (
     _warn_unsupported_traced_argument,
     assert_objects_in_sim_bounds,
     assert_unique_names,
 )
-from tidy3d.components.viz import PlotParams, add_ax_if_none, equal_aspect, plot_params_symmetry
+from tidy3d.components.viz import add_ax_if_none, equal_aspect, plot_params_symmetry
 from tidy3d.exceptions import Tidy3dKeyError
 from tidy3d.log import log
 from tidy3d.version import __version__
 
-from .monitor import AbstractMonitor
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
+    from tidy3d.components.types import Ax, Axis, Bound
+    from tidy3d.components.viz import PlotParams
+
+    from .monitor import AbstractMonitor
 
 
 class AbstractSimulation(Box, ABC):

--- a/tidy3d/components/base_sim/source.py
+++ b/tidy3d/components/base_sim/source.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from pydantic import Field
 
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.validators import validate_name_str
-from tidy3d.components.viz import PlotParams
+
+if TYPE_CHECKING:
+    from tidy3d.components.viz import PlotParams
 
 
 class AbstractSource(Tidy3dBaseModel, ABC):

--- a/tidy3d/components/beam.py
+++ b/tidy3d/components/beam.py
@@ -4,10 +4,9 @@ astigmatic Gaussian beam."""
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Literal, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import autograd.numpy as np
-from numpy.typing import NDArray
 from pydantic import Field, PositiveFloat
 
 from tidy3d.constants import C_0, ETA_0, HERTZ, MICROMETER, RADIAN
@@ -22,6 +21,11 @@ from .monitor import FieldMonitor
 from .source.field import FixedAngleSpec, FixedInPlaneKSpec
 from .types import TYPE_TAG_STR, Direction, FreqArray
 from .validators import assert_plane, warn_backward_waist_distance
+
+if TYPE_CHECKING:
+    from typing import Literal
+
+    from numpy.typing import NDArray
 
 DEFAULT_RESOLUTION = 200
 

--- a/tidy3d/components/boundary.py
+++ b/tidy3d/components/boundary.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import numpy as np
-from numpy.typing import NDArray
 from pydantic import (
     Field,
     NonNegativeFloat,
@@ -16,14 +15,8 @@ from pydantic import (
     model_validator,
 )
 
-from tidy3d.compat import Self
 from tidy3d.components.validators import _assert_min_freq, assert_plane
-from tidy3d.components.viz import (
-    ARROW_ALPHA,
-    ARROW_COLOR_ABSORBER,
-    PlotParams,
-    plot_params_absorber,
-)
+from tidy3d.components.viz import ARROW_ALPHA, ARROW_COLOR_ABSORBER, plot_params_absorber
 from tidy3d.constants import C_0, CONDUCTIVITY, EPSILON_0, HERTZ, MU_0, PML_SIGMA
 from tidy3d.exceptions import DataError, SetupError, ValidationError
 from tidy3d.log import log
@@ -32,10 +25,20 @@ from .base import Tidy3dBaseModel, cached_property
 from .geometry.base import Box
 from .medium import Medium
 from .mode_spec import ModeSpec
-from .monitor import ModeMonitor, ModeSolverMonitor
 from .source.field import TFSF, GaussianBeam, ModeSource, PlaneWave
-from .types import TYPE_TAG_STR, Ax, Axis, Complex, Direction, FreqBound
+from .types import TYPE_TAG_STR, Direction, FreqBound
 from .types.mode_spec import ModeSpecType
+
+if TYPE_CHECKING:
+    from typing import Callable
+
+    from numpy.typing import NDArray
+
+    from tidy3d.compat import Self
+    from tidy3d.components.viz import PlotParams
+
+    from .monitor import ModeMonitor, ModeSolverMonitor
+    from .types import Ax, Axis, Complex
 
 MIN_NUM_PML_LAYERS = 6
 MIN_NUM_STABLE_PML_LAYERS = 6

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -4,36 +4,23 @@ from __future__ import annotations
 
 import pathlib
 from abc import ABC
-from collections.abc import Mapping
-from os import PathLike
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import autograd.numpy as anp
 import h5py
 import numpy as np
 import xarray as xr
 from autograd.tracer import isbox
-from numpy.typing import NDArray
-from pydantic.annotated_handlers import GetCoreSchemaHandler
-from pydantic.json_schema import GetJsonSchemaHandler, JsonSchemaValue
 from pydantic_core import core_schema
 from xarray.core import missing
 from xarray.core.indexes import PandasIndex
 from xarray.core.indexing import _outer_to_numpy_indexer
-from xarray.core.types import InterpOptions, Self
 from xarray.core.utils import OrderedSet, either_dict_or_kwargs
 from xarray.core.variable import as_variable
 
 from tidy3d.compat import alignment
-from tidy3d.components.autograd import (
-    InterpolationType,
-    TidyArrayBox,
-    get_static,
-    interpn,
-    is_tidy_box,
-)
+from tidy3d.components.autograd import TidyArrayBox, get_static, interpn, is_tidy_box
 from tidy3d.components.geometry.bound_ops import bounds_contains
-from tidy3d.components.types import Axis, Bound
 from tidy3d.constants import (
     AMP,
     HERTZ,
@@ -46,6 +33,19 @@ from tidy3d.constants import (
     WATT,
 )
 from tidy3d.exceptions import DataError, FileError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from os import PathLike
+    from typing import Optional
+
+    from numpy.typing import NDArray
+    from pydantic.annotated_handlers import GetCoreSchemaHandler
+    from pydantic.json_schema import GetJsonSchemaHandler, JsonSchemaValue
+    from xarray.core.types import InterpOptions, Self
+
+    from tidy3d.components.autograd import InterpolationType
+    from tidy3d.components.types import Axis, Bound
 
 # maps the dimension names to their attributes
 DIM_ATTRS = {

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -3,16 +3,14 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Literal, Optional, Union, get_args
+from typing import TYPE_CHECKING, Any, Optional, Union, get_args
 
 import numpy as np
 import xarray as xr
-from numpy.typing import ArrayLike
 from pydantic import Field
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel
-from tidy3d.components.types import Axis, FreqArray, xyz
+from tidy3d.components.types import xyz
 from tidy3d.constants import C_0, PICOSECOND_PER_NANOMETER_PER_KILOMETER, UnitScaling
 from tidy3d.exceptions import DataError
 from tidy3d.log import log
@@ -32,6 +30,14 @@ from .data_array import (
     TriangleMeshDataArray,
 )
 from .zbf import ZBFData
+
+if TYPE_CHECKING:
+    from typing import Callable, Literal
+
+    from numpy.typing import ArrayLike
+
+    from tidy3d.compat import Self
+    from tidy3d.components.types import Axis, FreqArray
 
 DEFAULT_MAX_SAMPLES_PER_STEP = 10_000
 DEFAULT_MAX_CELLS_PER_STEP = 10_000

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -6,21 +6,17 @@ import struct
 import warnings
 from abc import ABC
 from math import isclose
-from os import PathLike
-from typing import Any, Callable, Literal, Optional, SupportsComplex, Union, get_args
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union, get_args
 
 import autograd.numpy as np
 import xarray as xr
-from numpy.typing import NDArray
-from pandas import DataFrame, Index
+from pandas import Index
 from pydantic import Field, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import cached_property
 from tidy3d.components.base_sim.data.monitor_data import AbstractMonitorData
 from tidy3d.components.grid.grid import Coords, Grid
 from tidy3d.components.medium import Medium, MediumType
-from tidy3d.components.mode_spec import ModeSortSpec, ModeSpec
 from tidy3d.components.monitor import (
     AuxFieldTimeMonitor,
     DiffractionMonitor,
@@ -38,23 +34,15 @@ from tidy3d.components.monitor import (
     ModeSolverMonitor,
     PermittivityMonitor,
 )
-from tidy3d.components.source.base import Source
-from tidy3d.components.source.current import CustomCurrentSource, PointDipole
+from tidy3d.components.source.current import CustomCurrentSource
 from tidy3d.components.source.field import CustomFieldSource, ModeSource, PlaneWave
-from tidy3d.components.source.time import GaussianPulse, SourceTimeType
+from tidy3d.components.source.time import GaussianPulse
 from tidy3d.components.types import (
     TYPE_TAG_STR,
     ArrayFloat1D,
-    ArrayFloat2D,
     Coordinate,
-    Direction,
-    EMField,
     EpsSpecType,
-    FreqArray,
-    PolarizationBasis,
-    Size,
     Symmetry,
-    TrackFreq,
     UnitsZBF,
 )
 from tidy3d.components.types.monitor import MonitorType
@@ -78,18 +66,14 @@ from .data_array import (
     FreqDataArray,
     FreqModeDataArray,
     GroupIndexDataArray,
-    MixedModeDataArray,
     ModeAmpsDataArray,
     ModeDispersionDataArray,
-    ModeIndexDataArray,
     ScalarFieldDataArray,
-    ScalarFieldTimeDataArray,
     TimeDataArray,
 )
 from .dataset import (
     AbstractFieldDataset,
     AuxFieldTimeDataset,
-    Dataset,
     ElectromagneticFieldDataset,
     FieldDataset,
     FieldTimeDataset,
@@ -97,6 +81,31 @@ from .dataset import (
     ModeSolverDataset,
     PermittivityDataset,
 )
+
+if TYPE_CHECKING:
+    from os import PathLike
+    from typing import Literal, SupportsComplex
+
+    from numpy.typing import NDArray
+    from pandas import DataFrame
+
+    from tidy3d.compat import Self
+    from tidy3d.components.mode_spec import ModeSortSpec, ModeSpec
+    from tidy3d.components.source.base import Source
+    from tidy3d.components.source.current import PointDipole
+    from tidy3d.components.source.time import SourceTimeType
+    from tidy3d.components.types import (
+        ArrayFloat2D,
+        Direction,
+        EMField,
+        FreqArray,
+        PolarizationBasis,
+        Size,
+        TrackFreq,
+    )
+
+    from .data_array import MixedModeDataArray, ModeIndexDataArray, ScalarFieldTimeDataArray
+    from .dataset import Dataset
 
 Coords1D = ArrayFloat1D
 

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -7,43 +7,42 @@ import pathlib
 import re
 from abc import ABC
 from collections import defaultdict
-from os import PathLike
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Union
 
 import h5py
 import numpy as np
 import xarray as xr
-from numpy.typing import NDArray
 from pydantic import Field
 
 from tidy3d.components.autograd.utils import split_list
 from tidy3d.components.base import JSON_TAG, Tidy3dBaseModel, cached_property
 from tidy3d.components.base_sim.data.sim_data import AbstractSimulationData
 from tidy3d.components.file_util import replace_values
-from tidy3d.components.monitor import Monitor
 from tidy3d.components.simulation import Simulation
 from tidy3d.components.source.current import CustomCurrentSource
 from tidy3d.components.source.time import GaussianPulse
 from tidy3d.components.source.utils import SourceType
 from tidy3d.components.structure import Structure
-from tidy3d.components.types import (
-    Ax,
-    Axis,
-    ColormapType,
-    FieldVal,
-    PlotScale,
-)
 from tidy3d.components.types.base import discriminated_union
 from tidy3d.components.types.monitor_data import MonitorDataType, MonitorDataTypes
 from tidy3d.components.viz import add_ax_if_none, equal_aspect
 from tidy3d.exceptions import DataError, FileError, SetupError, Tidy3dKeyError
 from tidy3d.log import log
 
-from .data_array import DataArray, FreqDataArray, TimeDataArray
+from .data_array import FreqDataArray, TimeDataArray
 from .monitor_data import AbstractFieldData, FieldTimeData
 
 if TYPE_CHECKING:
+    from os import PathLike
+    from typing import Callable, Optional
+
     from matplotlib.colors import Colormap
+    from numpy.typing import NDArray
+
+    from tidy3d.components.monitor import Monitor
+    from tidy3d.components.types import Ax, Axis, ColormapType, FieldVal, PlotScale
+
+    from .data_array import DataArray
 
 DATA_TYPE_MAP = {data.model_fields["monitor"].annotation: data for data in MonitorDataTypes}
 

--- a/tidy3d/components/data/unstructured/base.py
+++ b/tidy3d/components/data/unstructured/base.py
@@ -4,35 +4,35 @@ from __future__ import annotations
 
 import numbers
 from abc import ABC, abstractmethod
-from os import PathLike
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import DTypeLike, NDArray
 from pandas import RangeIndex
-from pydantic import Field, PositiveInt, field_validator, model_validator
-from vtkmodules.vtkCommonCore import vtkPoints
+from pydantic import Field, field_validator, model_validator
 from xarray import DataArray as XrDataArray
 
-from tidy3d.compat import Self
 from tidy3d.components.base import cached_property
 from tidy3d.components.data.data_array import (
     DATA_ARRAY_MAP,
     CellDataArray,
-    DataArray,
     IndexedDataArray,
     IndexedDataArrayTypes,
     PointDataArray,
     SpatialDataArray,
 )
 from tidy3d.components.data.dataset import Dataset
-from tidy3d.components.types import ArrayLike, Axis, Bound
 from tidy3d.constants import inf
 from tidy3d.exceptions import DataError, Tidy3dNotImplementedError, ValidationError
 from tidy3d.log import log
 from tidy3d.packaging import requires_vtk, vtk
 
 if TYPE_CHECKING:
+    from os import PathLike
+    from typing import Literal, Optional, Union
+
+    from numpy.typing import DTypeLike, NDArray
+    from pydantic import PositiveInt
+    from vtkmodules.vtkCommonCore import vtkPoints
     from vtkmodules.vtkCommonDataModel import (
         vtkCellArray,
         vtkDataSet,
@@ -40,6 +40,10 @@ if TYPE_CHECKING:
         vtkPolyData,
         vtkUnstructuredGrid,
     )
+
+    from tidy3d.compat import Self
+    from tidy3d.components.data.data_array import DataArray
+    from tidy3d.components.types import ArrayLike, Axis, Bound
 
 DEFAULT_MAX_SAMPLES_PER_STEP = 10_000
 DEFAULT_MAX_CELLS_PER_STEP = 10_000

--- a/tidy3d/components/data/unstructured/tetrahedral.py
+++ b/tidy3d/components/data/unstructured/tetrahedral.py
@@ -2,16 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from pydantic import PositiveInt
-from xarray import DataArray
-from xarray import DataArray as XrDataArray
 
 from tidy3d.components.base import cached_property
 from tidy3d.components.data.data_array import CellDataArray, IndexedDataArray, PointDataArray
-from tidy3d.components.types import ArrayLike, Axis, Bound, Coordinate
 from tidy3d.exceptions import DataError
 from tidy3d.packaging import requires_vtk, vtk
 
@@ -19,7 +15,14 @@ from .base import UnstructuredGridDataset
 from .triangular import TriangularGridDataset
 
 if TYPE_CHECKING:
+    from typing import Literal, Optional, Union
+
+    from pydantic import PositiveInt
     from vtkmodules.vtkCommonDataModel import vtkUnstructuredGrid
+    from xarray import DataArray
+    from xarray import DataArray as XrDataArray
+
+    from tidy3d.components.types import ArrayLike, Axis, Bound, Coordinate
 
 
 class TetrahedralGridDataset(UnstructuredGridDataset):

--- a/tidy3d/components/data/unstructured/triangular.py
+++ b/tidy3d/components/data/unstructured/triangular.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from pydantic import Field, PositiveInt
-from xarray import DataArray
+from pydantic import Field
 from xarray import DataArray as XrDataArray
-
-from tidy3d.compat import Self
 
 try:
     from matplotlib import pyplot as plt
@@ -24,7 +21,7 @@ from tidy3d.components.data.data_array import (
     PointDataArray,
     SpatialDataArray,
 )
-from tidy3d.components.types import ArrayLike, Ax, Axis, Bound
+from tidy3d.components.types import Axis
 from tidy3d.components.viz import add_ax_if_none, equal_aspect, plot_params_grid
 from tidy3d.constants import inf
 from tidy3d.exceptions import DataError
@@ -39,7 +36,14 @@ from .base import (
 )
 
 if TYPE_CHECKING:
+    from typing import Literal, Optional, Union
+
+    from pydantic import PositiveInt
     from vtkmodules.vtkCommonDataModel import vtkPointSet
+    from xarray import DataArray
+
+    from tidy3d.compat import Self
+    from tidy3d.components.types import ArrayLike, Ax, Bound
 
 
 class TriangularGridDataset(UnstructuredGridDataset):

--- a/tidy3d/components/data/utils.py
+++ b/tidy3d/components/data/utils.py
@@ -2,18 +2,22 @@
 
 from __future__ import annotations
 
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
 import xarray as xr
 
-from tidy3d.components.types import ArrayLike
 from tidy3d.components.types.base import discriminated_union
 
-from .data_array import DataArray, SpatialDataArray
+from .data_array import SpatialDataArray
 from .unstructured.base import UnstructuredGridDataset
 from .unstructured.tetrahedral import TetrahedralGridDataset
 from .unstructured.triangular import TriangularGridDataset
+
+if TYPE_CHECKING:
+    from tidy3d.components.types import ArrayLike
+
+    from .data_array import DataArray
 
 UnstructuredGridDatasetType = Union[TriangularGridDataset, TetrahedralGridDataset]
 

--- a/tidy3d/components/data/validators.py
+++ b/tidy3d/components/data/validators.py
@@ -1,16 +1,20 @@
 # special validators for Datasets
 from __future__ import annotations
 
-from typing import Any, Callable, Optional
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from pydantic import field_validator
-from pydantic_core.core_schema import ValidationInfo
 
 from tidy3d.exceptions import ValidationError
 
 from .data_array import DataArray
 from .dataset import AbstractFieldDataset, ScalarFieldDataArray
+
+if TYPE_CHECKING:
+    from typing import Callable, Optional
+
+    from pydantic_core.core_schema import ValidationInfo
 
 
 # this can't go in validators.py because that file imports dataset.py

--- a/tidy3d/components/dispersion_fitter.py
+++ b/tidy3d/components/dispersion_fitter.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
-from numpy.typing import NDArray
 from pydantic import (
     Field,
     NonNegativeFloat,
@@ -15,13 +14,21 @@ from pydantic import (
     model_validator,
 )
 
-from tidy3d.compat import Self
 from tidy3d.constants import fp_eps
 from tidy3d.exceptions import ValidationError
 from tidy3d.log import Progress, get_logging_console, log
 
 from .base import Tidy3dBaseModel, cached_property
-from .types import ArrayComplex1D, ArrayComplex2D, ArrayFloat1D, ArrayFloat2D
+from .types import ArrayComplex1D
+
+if TYPE_CHECKING:
+    from typing import Union
+
+    from numpy.typing import NDArray
+
+    from tidy3d.compat import Self
+
+    from .types import ArrayComplex2D, ArrayFloat1D, ArrayFloat2D
 
 # numerical tolerance for pole relocation for fast fitter
 TOL = 1e-8

--- a/tidy3d/components/eme/data/sim_data.py
+++ b/tidy3d/components/eme/data/sim_data.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Literal, Optional, Union
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 from pydantic import Field
 
 from tidy3d.components.base import cached_property
 from tidy3d.components.data.data_array import EMEScalarFieldDataArray, EMESMatrixDataArray
-from tidy3d.components.data.monitor_data import FieldData, ModeData, ModeSolverData
+from tidy3d.components.data.monitor_data import ModeData, ModeSolverData
 from tidy3d.components.data.sim_data import AbstractYeeGridSimulationData
 from tidy3d.components.eme.simulation import EMESimulation
 from tidy3d.components.geometry.base import Box
@@ -18,7 +18,14 @@ from tidy3d.exceptions import SetupError
 from tidy3d.log import log
 
 from .dataset import EMECoefficientDataset, EMESMatrixDataset
-from .monitor_data import EMEFieldData, EMEModeSolverData, EMEMonitorDataType
+from .monitor_data import EMEModeSolverData, EMEMonitorDataType
+
+if TYPE_CHECKING:
+    from typing import Literal, Union
+
+    from tidy3d.components.data.monitor_data import FieldData
+
+    from .monitor_data import EMEFieldData
 
 
 class EMESimulationData(AbstractYeeGridSimulationData):

--- a/tidy3d/components/eme/grid.py
+++ b/tidy3d/components/eme/grid.py
@@ -3,27 +3,25 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 import numpy as np
-from pydantic import (
-    Field,
-    NonNegativeFloat,
-    NonNegativeInt,
-    PositiveInt,
-    field_validator,
-    model_validator,
-)
+from pydantic import Field, PositiveInt, field_validator, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.geometry.base import Box
 from tidy3d.components.grid.grid import Coords1D
 from tidy3d.components.mode_spec import ModeInterpSpec, ModeSpec
-from tidy3d.components.structure import Structure
-from tidy3d.components.types import ArrayFloat1D, Axis, Coordinate, Size
+from tidy3d.components.types import ArrayFloat1D, Axis
 from tidy3d.constants import RADIAN, fp_eps, inf
 from tidy3d.exceptions import SetupError, ValidationError
+
+if TYPE_CHECKING:
+    from pydantic import NonNegativeFloat, NonNegativeInt
+
+    from tidy3d.compat import Self
+    from tidy3d.components.structure import Structure
+    from tidy3d.components.types import Coordinate, Size
 
 # grid limits
 MAX_NUM_MODES = 100

--- a/tidy3d/components/eme/simulation.py
+++ b/tidy3d/components/eme/simulation.py
@@ -2,48 +2,32 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 import numpy as np
-from pydantic import (
-    Field,
-    NonNegativeFloat,
-    NonNegativeInt,
-    PositiveInt,
-    field_validator,
-    model_validator,
-)
+from pydantic import Field, NonNegativeFloat, field_validator, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import cached_property
 from tidy3d.components.boundary import BoundarySpec, PECBoundary
 from tidy3d.components.geometry.base import Box
-from tidy3d.components.grid.grid import Grid
 from tidy3d.components.grid.grid_spec import GridSpec
 from tidy3d.components.medium import FullyAnisotropicMedium
-from tidy3d.components.monitor import AbstractModeMonitor, ModeSolverMonitor, Monitor
+from tidy3d.components.monitor import AbstractModeMonitor, ModeSolverMonitor
 from tidy3d.components.scene import Scene
 from tidy3d.components.simulation import (
     AbstractYeeGridSimulation,
     Simulation,
     validate_boundaries_for_zero_dims,
 )
-from tidy3d.components.structure import Structure
-from tidy3d.components.types import (
-    Ax,
-    Axis,
-    FreqArray,
-    Symmetry,
-)
+from tidy3d.components.types import Axis, FreqArray
 from tidy3d.components.types.base import discriminated_union
-from tidy3d.components.types.monitor import MonitorType
 from tidy3d.components.validators import MIN_FREQUENCY, validate_freqs_min, validate_freqs_not_empty
 from tidy3d.components.viz import add_ax_if_none, equal_aspect
 from tidy3d.constants import C_0, inf
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
 
-from .grid import EMECompositeGrid, EMEExplicitGrid, EMEGrid, EMEGridSpec, EMEGridSpecType
+from .grid import EMECompositeGrid, EMEExplicitGrid, EMEGridSpecType
 from .monitor import (
     EMECoefficientMonitor,
     EMEFieldMonitor,
@@ -52,6 +36,20 @@ from .monitor import (
     EMEMonitorType,
 )
 from .sweep import EMEFreqSweep, EMELengthSweep, EMEModeSweep, EMEPeriodicitySweep, EMESweepSpecType
+
+if TYPE_CHECKING:
+    from typing import Union
+
+    from pydantic import NonNegativeInt, PositiveInt
+
+    from tidy3d.compat import Self
+    from tidy3d.components.grid.grid import Grid
+    from tidy3d.components.monitor import Monitor
+    from tidy3d.components.structure import Structure
+    from tidy3d.components.types import Ax, Symmetry
+    from tidy3d.components.types.monitor import MonitorType
+
+    from .grid import EMEGrid, EMEGridSpec
 
 try:
     import matplotlib as mpl

--- a/tidy3d/components/field_projection.py
+++ b/tidy3d/components/field_projection.py
@@ -3,17 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import autograd.numpy as anp
 import numpy as np
 import xarray as xr
-from autograd.numpy.numpy_boxes import ArrayBox
-from numpy.typing import ArrayLike, NDArray
 from pydantic import Field, model_validator
 from rich.progress import track
 
-from tidy3d.compat import Self
 from tidy3d.constants import C_0, EPSILON_0, ETA_0, MICROMETER, MU_0
 from tidy3d.exceptions import SetupError
 from tidy3d.log import get_logging_console
@@ -33,16 +30,22 @@ from .data.monitor_data import (
     FieldProjectionKSpaceData,
 )
 from .data.sim_data import SimulationData
-from .medium import MediumType
 from .monitor import (
-    AbstractFieldProjectionMonitor,
-    FieldMonitor,
     FieldProjectionAngleMonitor,
     FieldProjectionCartesianMonitor,
-    FieldProjectionKSpaceMonitor,
     FieldProjectionSurface,
 )
-from .types import ArrayComplex4D, Coordinate, Direction
+from .types import ArrayComplex4D, Coordinate
+
+if TYPE_CHECKING:
+    from autograd.numpy.numpy_boxes import ArrayBox
+    from numpy.typing import ArrayLike, NDArray
+
+    from tidy3d.compat import Self
+
+    from .medium import MediumType
+    from .monitor import AbstractFieldProjectionMonitor, FieldMonitor, FieldProjectionKSpaceMonitor
+    from .types import Direction
 
 # Default number of points per wavelength in the background medium to use for resampling fields.
 PTS_PER_WVL = 10

--- a/tidy3d/components/file_util.py
+++ b/tidy3d/components/file_util.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import gzip
 import pathlib
 import shutil
-from io import BytesIO
-from os import PathLike
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
+
+if TYPE_CHECKING:
+    from io import BytesIO
+    from os import PathLike
 
 
 def compress_file_to_gzip(input_file: PathLike, output_gz_file: PathLike | BytesIO) -> None:

--- a/tidy3d/components/frequencies.py
+++ b/tidy3d/components/frequencies.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import NDArray
 from pydantic import Field, PositiveFloat, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.source.time import GaussianPulse
 from tidy3d.constants import C_0
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    from tidy3d.compat import Self
 
 O_BAND = (1.260, 1.360)
 E_BAND = (1.360, 1.460)

--- a/tidy3d/components/frequency_extrapolation.py
+++ b/tidy3d/components/frequency_extrapolation.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from pydantic import Field, NonNegativeFloat, field_validator, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
 
 
 class AbstractLowFrequencySmoothingSpec(Tidy3dBaseModel):

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -5,58 +5,23 @@ from __future__ import annotations
 import functools
 import pathlib
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Sequence
-from os import PathLike
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 import autograd.numpy as np
-import pydantic
 import shapely
-from numpy.typing import ArrayLike, NDArray
-from pydantic import (
-    Field,
-    NonNegativeFloat,
-    NonNegativeInt,
-    PositiveFloat,
-    field_validator,
-    model_validator,
-)
-from typing_extensions import Self
+from pydantic import Field, NonNegativeFloat, field_validator, model_validator
 
 from tidy3d.compat import _package_is_older_than
-from tidy3d.components.autograd import (
-    AutogradFieldMap,
-    TracedCoordinate,
-    TracedFloat,
-    TracedSize,
-    get_static,
-)
-from tidy3d.components.autograd.derivative_utils import DerivativeInfo
+from tidy3d.components.autograd import TracedCoordinate, TracedFloat, TracedSize, get_static
 from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.geometry.bound_ops import bounds_intersection, bounds_union
 from tidy3d.components.geometry.float_utils import increment_float
 from tidy3d.components.transformation import ReflectionFromPlane, RotationAroundAxis
-from tidy3d.components.types import (
-    ArrayFloat2D,
-    ArrayFloat3D,
-    Ax,
-    Axis,
-    Bound,
-    ClipOperationType,
-    Coordinate,
-    Coordinate2D,
-    LengthUnit,
-    MatrixReal4x4,
-    PlanePosition,
-    Shapely,
-    Size,
-)
+from tidy3d.components.types import Axis, ClipOperationType, MatrixReal4x4, PlanePosition
 from tidy3d.components.types.base import discriminated_union
 from tidy3d.components.viz import (
     ARROW_LENGTH,
     PLOT_BUFFER,
-    PlotParams,
-    VisualizationSpec,
     add_ax_if_none,
     arrow_style,
     equal_aspect,
@@ -76,9 +41,32 @@ from tidy3d.log import log
 from tidy3d.packaging import verify_packages_import
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from os import PathLike
+    from typing import Callable, Union
+
+    import pydantic
     from gdstk import Cell
     from matplotlib.backend_bases import Event
     from matplotlib.patches import FancyArrowPatch
+    from numpy.typing import ArrayLike, NDArray
+    from pydantic import NonNegativeInt, PositiveFloat
+    from typing_extensions import Self
+
+    from tidy3d.components.autograd import AutogradFieldMap
+    from tidy3d.components.autograd.derivative_utils import DerivativeInfo
+    from tidy3d.components.types import (
+        ArrayFloat2D,
+        ArrayFloat3D,
+        Ax,
+        Bound,
+        Coordinate,
+        Coordinate2D,
+        LengthUnit,
+        Shapely,
+        Size,
+    )
+    from tidy3d.components.viz import PlotParams, VisualizationSpec
 
 try:
     from matplotlib import patches

--- a/tidy3d/components/geometry/bound_ops.py
+++ b/tidy3d/components/geometry/bound_ops.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from math import isclose
+from typing import TYPE_CHECKING
 
-from tidy3d.components.types import Bound
 from tidy3d.constants import fp_eps
+
+if TYPE_CHECKING:
+    from tidy3d.components.types import Bound
 
 
 def bounds_intersection(bounds1: Bound, bounds2: Bound) -> Bound:

--- a/tidy3d/components/geometry/mesh.py
+++ b/tidy3d/components/geometry/mesh.py
@@ -3,21 +3,18 @@
 from __future__ import annotations
 
 from abc import ABC
-from os import PathLike
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
 from autograd import numpy as anp
 from numpy.typing import NDArray
 from pydantic import Field, PrivateAttr, field_validator, model_validator
 
-from tidy3d.components.autograd import AutogradFieldMap, get_static
-from tidy3d.components.autograd.derivative_utils import DerivativeInfo
+from tidy3d.components.autograd import get_static
 from tidy3d.components.base import cached_property
 from tidy3d.components.data.data_array import DATA_ARRAY_MAP, TriangleMeshDataArray
 from tidy3d.components.data.dataset import TriangleMeshDataset
 from tidy3d.components.data.validators import validate_no_nans
-from tidy3d.components.types import Ax, Bound, Coordinate, MatrixReal4x4, Shapely
 from tidy3d.components.viz import add_ax_if_none, equal_aspect
 from tidy3d.config import config
 from tidy3d.constants import fp_eps, inf
@@ -28,7 +25,14 @@ from tidy3d.packaging import verify_packages_import
 from . import base
 
 if TYPE_CHECKING:
+    from os import PathLike
+    from typing import Callable, Literal, Union
+
     from trimesh import Trimesh
+
+    from tidy3d.components.autograd import AutogradFieldMap
+    from tidy3d.components.autograd.derivative_utils import DerivativeInfo
+    from tidy3d.components.types import Ax, Bound, Coordinate, MatrixReal4x4, Shapely
 
 AREA_SIZE_THRESHOLD = 1e-36
 

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -5,33 +5,19 @@ from __future__ import annotations
 import math
 from copy import copy
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 import autograd.numpy as np
 import shapely
 from autograd.tracer import getval
 from numpy.polynomial.legendre import leggauss as _leggauss
-from numpy.typing import NDArray
-from pydantic import Field, PositiveFloat, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 
-from tidy3d.compat import Self
-from tidy3d.components.autograd import AutogradFieldMap, TracedArrayFloat2D, get_static
-from tidy3d.components.autograd.derivative_utils import DerivativeInfo
+from tidy3d.components.autograd import TracedArrayFloat2D, get_static
 from tidy3d.components.autograd.types import TracedFloat
 from tidy3d.components.autograd.utils import hasbox
 from tidy3d.components.base import cached_property
 from tidy3d.components.transformation import ReflectionFromPlane, RotationAroundAxis
-from tidy3d.components.types import (
-    ArrayFloat1D,
-    ArrayFloat2D,
-    ArrayLike,
-    Axis,
-    Bound,
-    Coordinate,
-    MatrixReal4x4,
-    PlanePosition,
-    Shapely,
-)
 from tidy3d.config import config
 from tidy3d.constants import LARGE_NUMBER, MICROMETER, fp_eps
 from tidy3d.exceptions import SetupError, Tidy3dImportError, ValidationError
@@ -41,7 +27,26 @@ from tidy3d.packaging import verify_packages_import
 from . import base, triangulation
 
 if TYPE_CHECKING:
+    from typing import Optional, Union
+
     from gdstk import Cell
+    from numpy.typing import NDArray
+    from pydantic import PositiveFloat
+
+    from tidy3d.compat import Self
+    from tidy3d.components.autograd import AutogradFieldMap
+    from tidy3d.components.autograd.derivative_utils import DerivativeInfo
+    from tidy3d.components.types import (
+        ArrayFloat1D,
+        ArrayFloat2D,
+        ArrayLike,
+        Axis,
+        Bound,
+        Coordinate,
+        MatrixReal4x4,
+        PlanePosition,
+        Shapely,
+    )
 
 # sampling polygon along dilation for validating polygon to be
 # non self-intersecting during the entire dilation process

--- a/tidy3d/components/geometry/primitives.py
+++ b/tidy3d/components/geometry/primitives.py
@@ -3,27 +3,33 @@
 from __future__ import annotations
 
 from math import isclose
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import autograd.numpy as anp
 import numpy as np
 import shapely
 from pydantic import Field, PrivateAttr, model_validator
-from shapely.geometry.base import BaseGeometry
 
-from tidy3d.compat import Self
-from tidy3d.components.autograd import AutogradFieldMap, TracedSize1D
-from tidy3d.components.autograd.derivative_utils import DerivativeInfo
+from tidy3d.components.autograd import TracedSize1D
 from tidy3d.components.base import cached_property
 from tidy3d.components.geometry import base
 from tidy3d.components.geometry.mesh import TriangleMesh
 from tidy3d.components.geometry.polyslab import PolySlab
-from tidy3d.components.types import Axis, Bound, Coordinate, MatrixReal4x4, Shapely
 from tidy3d.config import config
 from tidy3d.constants import LARGE_NUMBER, MICROMETER
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
 from tidy3d.packaging import verify_packages_import
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from shapely.geometry.base import BaseGeometry
+
+    from tidy3d.compat import Self
+    from tidy3d.components.autograd import AutogradFieldMap
+    from tidy3d.components.autograd.derivative_utils import DerivativeInfo
+    from tidy3d.components.types import Axis, Bound, Coordinate, MatrixReal4x4, Shapely
 
 # for sampling conical frustum in visualization
 _N_SAMPLE_CURVE_SHAPELY = 40

--- a/tidy3d/components/geometry/triangulation.py
+++ b/tidy3d/components/geometry/triangulation.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import numpy as np
 import shapely
 
-from tidy3d.components.types import ArrayFloat1D, ArrayFloat2D
+from tidy3d.components.types import ArrayFloat1D
 from tidy3d.exceptions import Tidy3dError
+
+if TYPE_CHECKING:
+    from tidy3d.components.types import ArrayFloat2D
 
 
 @dataclass

--- a/tidy3d/components/geometry/utils.py
+++ b/tidy3d/components/geometry/utils.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Iterable
 from enum import Enum
 from math import isclose
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import numpy as np
 import shapely
-from numpy.typing import ArrayLike
 from pydantic import Field, NonNegativeInt
 from shapely.geometry import (
     Polygon,
@@ -22,21 +20,27 @@ from shapely.geometry.base import (
 from tidy3d.components.autograd.utils import get_static
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.geometry.base import Box
-from tidy3d.components.grid.grid import Grid
-from tidy3d.components.types import (
-    ArrayFloat2D,
-    Axis,
-    Bound,
-    Coordinate,
-    Direction,
-    MatrixReal4x4,
-    PlanePosition,
-    Shapely,
-)
+from tidy3d.components.types import Shapely
 from tidy3d.constants import fp_eps
 from tidy3d.exceptions import SetupError, Tidy3dError
 
 from . import base, mesh, polyslab, primitives
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from numpy.typing import ArrayLike
+
+    from tidy3d.components.grid.grid import Grid
+    from tidy3d.components.types import (
+        ArrayFloat2D,
+        Axis,
+        Bound,
+        Coordinate,
+        Direction,
+        MatrixReal4x4,
+        PlanePosition,
+    )
 
 GeometryType = Union[
     base.Box,

--- a/tidy3d/components/geometry/utils_2d.py
+++ b/tidy3d/components/geometry/utils_2d.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from math import isclose
+from typing import TYPE_CHECKING
 
 import numpy as np
 import shapely
@@ -10,11 +11,13 @@ import shapely
 from tidy3d.components.geometry.base import Box, ClipOperation, Geometry, GeometryGroup
 from tidy3d.components.geometry.float_utils import increment_float
 from tidy3d.components.geometry.polyslab import _MIN_POLYGON_AREA, PolySlab
-from tidy3d.components.grid.grid import Grid
 from tidy3d.components.scene import Scene
-from tidy3d.components.structure import Structure
-from tidy3d.components.types import Axis, Shapely
 from tidy3d.constants import fp_eps
+
+if TYPE_CHECKING:
+    from tidy3d.components.grid.grid import Grid
+    from tidy3d.components.structure import Structure
+    from tidy3d.components.types import Axis, Shapely
 
 
 def snap_coordinate_to_grid(grid: Grid, center: float, axis: Axis) -> float:

--- a/tidy3d/components/grid/corner_finder.py
+++ b/tidy3d/components/grid/corner_finder.py
@@ -2,19 +2,22 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 import numpy as np
-from numpy.typing import NDArray
 from pydantic import Field, PositiveFloat, PositiveInt
 
 from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.geometry.base import Box, ClipOperation
 from tidy3d.components.geometry.utils import merging_geometries_on_plane
 from tidy3d.components.medium import PEC, LossyMetalMedium
-from tidy3d.components.structure import Structure
-from tidy3d.components.types import ArrayFloat1D, ArrayFloat2D, Axis, Shapely
 from tidy3d.constants import inf
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    from tidy3d.components.structure import Structure
+    from tidy3d.components.types import ArrayFloat1D, ArrayFloat2D, Axis, Shapely
 
 CORNER_ANGLE_THRESOLD = 0.25 * np.pi
 # For shapely circular shapes discretization.

--- a/tidy3d/components/grid/grid.py
+++ b/tidy3d/components/grid/grid.py
@@ -2,19 +2,26 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, Union
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import NDArray
 from pydantic import Field
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.data.data_array import DataArray, ScalarFieldDataArray, SpatialDataArray
-from tidy3d.components.data.utils import UnstructuredGridDataset, UnstructuredGridDatasetType
-from tidy3d.components.geometry.base import Box, Geometry
-from tidy3d.components.types import ArrayFloat1D, ArrayLike, Axis, Coordinate, InterpMethod
+from tidy3d.components.data.utils import UnstructuredGridDataset
+from tidy3d.components.types import ArrayFloat1D
 from tidy3d.exceptions import SetupError
+
+if TYPE_CHECKING:
+    from typing import Literal, Union
+
+    from numpy.typing import NDArray
+
+    from tidy3d.compat import Self
+    from tidy3d.components.data.utils import UnstructuredGridDatasetType
+    from tidy3d.components.geometry.base import Box, Geometry
+    from tidy3d.components.types import ArrayLike, Axis, Coordinate, InterpMethod
 
 # data type of one dimensional coordinate array.
 Coords1D = ArrayFloat1D

--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 import numpy as np
 from pydantic import (
@@ -16,22 +16,15 @@ from pydantic import (
     model_validator,
 )
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.geometry.base import Box, ClipOperation
-from tidy3d.components.lumped_element import LumpedElementType
-from tidy3d.components.source.utils import SourceType
 from tidy3d.components.structure import MeshOverrideStructure, Structure, StructureType
 from tidy3d.components.types import (
     TYPE_TAG_STR,
     ArrayFloat1D,
     ArrayFloat2D,
     Axis,
-    Coordinate,
     CoordinateOptional,
-    PriorityMode,
-    Shapely,
-    Symmetry,
     Undefined,
 )
 from tidy3d.components.types.base import discriminated_union
@@ -42,6 +35,12 @@ from tidy3d.log import log
 from .corner_finder import CornerFinderSpec
 from .grid import Coords, Coords1D, Grid
 from .mesher import GradedMesher, MesherType
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
+    from tidy3d.components.lumped_element import LumpedElementType
+    from tidy3d.components.source.utils import SourceType
+    from tidy3d.components.types import Coordinate, PriorityMode, Shapely, Symmetry
 
 # Scaling factor applied to internally generated lower bound of grid size that is computed from
 # estimated minimal grid size

--- a/tidy3d/components/grid/mesher.py
+++ b/tidy3d/components/grid/mesher.py
@@ -8,21 +8,25 @@ import warnings
 from abc import ABC, abstractmethod
 from itertools import compress
 from math import isclose
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
-from pydantic import NonNegativeFloat, NonNegativeInt, PositiveFloat
 from pyroots import Brentq
 from shapely.errors import ShapelyDeprecationWarning
 from shapely.geometry import box as shapely_box
 from shapely.strtree import STRtree
 
 from tidy3d.components.base import Tidy3dBaseModel
-from tidy3d.components.structure import MeshOverrideStructure, Structure, StructureType
-from tidy3d.components.types import ArrayFloat1D, Axis, Bound, CoordinateOptional
+from tidy3d.components.structure import MeshOverrideStructure, Structure
 from tidy3d.constants import C_0, fp_eps
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
+
+if TYPE_CHECKING:
+    from pydantic import NonNegativeFloat, NonNegativeInt, PositiveFloat
+
+    from tidy3d.components.structure import StructureType
+    from tidy3d.components.types import ArrayFloat1D, Axis, Bound, CoordinateOptional
 
 _ROOTS_TOL = 1e-10
 

--- a/tidy3d/components/index.py
+++ b/tidy3d/components/index.py
@@ -5,14 +5,18 @@ a set of Tidy3D simulations, allowing them to be accessed by name.
 
 from __future__ import annotations
 
-from collections.abc import Iterator, Mapping
-from typing import Any
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
 
 from pydantic import Field, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.types.simulation import SimulationType
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from tidy3d.compat import Self
 
 
 class ValueMap(Tidy3dBaseModel, Mapping[str, Any]):

--- a/tidy3d/components/lumped_element.py
+++ b/tidy3d/components/lumped_element.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from math import isclose
-from typing import Literal, Optional, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
 import numpy as np
 from pydantic import (
@@ -16,7 +16,6 @@ from pydantic import (
     model_validator,
 )
 
-from tidy3d.compat import Self
 from tidy3d.components.types.base import discriminated_union
 from tidy3d.constants import EPSILON_0, FARAD, HENRY, MICROMETER, OHM, fp_eps
 from tidy3d.exceptions import ValidationError
@@ -32,7 +31,6 @@ from .geometry.utils import (
     snap_point_to_grid,
 )
 from .geometry.utils_2d import increment_float
-from .grid.grid import Grid
 from .medium import PEC2D, Debye, Drude, Lorentz, Medium, Medium2D, PoleResidue
 from .microwave.base import MicrowaveBaseModel
 from .microwave.formulas.circuit_parameters import (
@@ -43,16 +41,16 @@ from .microwave.formulas.circuit_parameters import (
 )
 from .monitor import FieldMonitor
 from .structure import MeshOverrideStructure, Structure
-from .types import (
-    Axis,
-    Axis2D,
-    Coordinate,
-    CoordinateOptional,
-    FreqArray,
-    LumpDistType,
-)
+from .types import Axis, Coordinate, LumpDistType
 from .validators import assert_line_or_plane, assert_plane, validate_name_str
-from .viz import PlotParams, plot_params_lumped_element
+from .viz import plot_params_lumped_element
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
+
+    from .grid.grid import Grid
+    from .types import Axis2D, CoordinateOptional, FreqArray
+    from .viz import PlotParams
 
 DEFAULT_LUMPED_ELEMENT_NUM_CELLS = 1
 LOSS_FACTOR_INDUCTOR = 1e6

--- a/tidy3d/components/material/tcad/charge.py
+++ b/tidy3d/components/material/tcad/charge.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from pydantic import Field, NonNegativeFloat, PositiveFloat, field_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.data.data_array import SpatialDataArray
 from tidy3d.components.medium import AbstractMedium
 from tidy3d.components.tcad.doping import ConstantDoping, DopingBoxType
@@ -21,6 +20,9 @@ from tidy3d.components.tcad.types import (
 )
 from tidy3d.constants import CONDUCTIVITY, ELECTRON_VOLT, PERCMCUBE, PERMITTIVITY
 from tidy3d.log import log
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
 
 
 class AbstractChargeMedium(AbstractMedium):

--- a/tidy3d/components/material/tcad/heat.py
+++ b/tidy3d/components/material/tcad/heat.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from pydantic import Field, NonNegativeFloat, PositiveFloat
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.constants import (
     DENSITY,
@@ -17,6 +16,9 @@ from tidy3d.constants import (
     THERMAL_CONDUCTIVITY,
     THERMAL_EXPANSIVITY,
 )
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
 
 
 # Liquid class

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -6,17 +6,14 @@ import functools
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from math import isclose
-from typing import Any, Callable, Literal, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, TypeVar, Union
 
 import autograd.numpy as np
 import numpy as npo
-import xarray as xr
 from autograd.differential_operators import tensor_jacobian_product
-from autograd.numpy.numpy_boxes import ArrayBox
 from numpy.typing import NDArray
 from pydantic import (
     Field,
-    FieldValidationInfo,
     NonNegativeFloat,
     PositiveFloat,
     PositiveInt,
@@ -24,9 +21,7 @@ from pydantic import (
     model_validator,
 )
 
-from tidy3d.compat import Self
 from tidy3d.components.autograd.utils import pack_complex_vec
-from tidy3d.components.types.base import PolesAndResidues
 from tidy3d.constants import (
     C_0,
     CONDUCTIVITY,
@@ -46,16 +41,11 @@ from tidy3d.constants import (
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
 
-from .autograd.derivative_utils import DerivativeInfo, integrate_within_bounds
-from .autograd.types import (
-    AutogradFieldMap,
-    TracedFloat,
-    TracedPolesAndResidues,
-    TracedPositiveFloat,
-)
+from .autograd.derivative_utils import integrate_within_bounds
+from .autograd.types import TracedFloat, TracedPolesAndResidues, TracedPositiveFloat
 from .base import Tidy3dBaseModel, cached_property
 from .data.data_array import DATA_ARRAY_MAP, ScalarFieldDataArray, SpatialDataArray
-from .data.dataset import ElectromagneticFieldDataset, PermittivityDataset
+from .data.dataset import PermittivityDataset
 from .data.unstructured.base import UnstructuredGridDataset
 from .data.utils import (
     CustomSpatialDataType,
@@ -89,23 +79,32 @@ from .parameter_perturbation import (
     PermittivityPerturbation,
 )
 from .time_modulation import ModulationSpec
-from .transformation import RotationType
-from .types import (
-    TYPE_TAG_STR,
-    ArrayComplex1D,
-    ArrayComplex3D,
-    ArrayFloat1D,
-    Ax,
-    Axis,
-    Bound,
-    Complex,
-    FreqBound,
-    InterpMethod,
-    PermittivityComponent,
-    TensorReal,
-)
+from .types import TYPE_TAG_STR, FreqBound, InterpMethod, TensorReal
 from .validators import validate_name_str, validate_parameter_perturbation
 from .viz import VisualizationSpec, add_ax_if_none
+
+if TYPE_CHECKING:
+    import xarray as xr
+    from autograd.numpy.numpy_boxes import ArrayBox
+    from pydantic import FieldValidationInfo
+
+    from tidy3d.compat import Self
+    from tidy3d.components.types.base import PolesAndResidues
+
+    from .autograd.derivative_utils import DerivativeInfo
+    from .autograd.types import AutogradFieldMap
+    from .data.dataset import ElectromagneticFieldDataset
+    from .transformation import RotationType
+    from .types import (
+        ArrayComplex1D,
+        ArrayComplex3D,
+        ArrayFloat1D,
+        Ax,
+        Axis,
+        Bound,
+        Complex,
+        PermittivityComponent,
+    )
 
 ArrayFloat = NDArray[npo.floating]
 ArrayComplex = NDArray[np.complexfloating]

--- a/tidy3d/components/microwave/base.py
+++ b/tidy3d/components/microwave/base.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
-from tidy3d.compat import Self
+from typing import TYPE_CHECKING
+
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.config import config
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
 
 
 class MicrowaveBaseModel(Tidy3dBaseModel):

--- a/tidy3d/components/microwave/data/monitor_data.py
+++ b/tidy3d/components/microwave/data/monitor_data.py
@@ -4,16 +4,12 @@ reflection efficiency, gain, and realized gain.
 
 from __future__ import annotations
 
-from typing import Literal, Optional
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
-import xarray as xr
-from numpy.typing import NDArray
 from pydantic import Field
-from typing_extensions import Self
 
 from tidy3d.components.data.data_array import (
-    FieldProjectionAngleDataArray,
     FreqDataArray,
     FreqModeDataArray,
     ImpedanceFreqModeDataArray,
@@ -21,17 +17,28 @@ from tidy3d.components.data.data_array import (
 from tidy3d.components.data.monitor_data import DirectivityData, ModeData, ModeSolverData
 from tidy3d.components.microwave.base import MicrowaveBaseModel
 from tidy3d.components.microwave.data.data_array import (
-    AttenuationConstantArray,
     GroupVelocityArray,
-    PhaseConstantArray,
     PhaseVelocityArray,
     PropagationConstantArray,
 )
 from tidy3d.components.microwave.data.dataset import TransmissionLineDataset
 from tidy3d.components.microwave.monitor import MicrowaveModeMonitor, MicrowaveModeSolverMonitor
-from tidy3d.components.types import FreqArray, ModeClassification, PolarizationBasis
 from tidy3d.constants import C_0
 from tidy3d.log import log
+
+if TYPE_CHECKING:
+    from typing import Literal
+
+    import xarray as xr
+    from numpy.typing import NDArray
+    from typing_extensions import Self
+
+    from tidy3d.components.data.data_array import FieldProjectionAngleDataArray
+    from tidy3d.components.microwave.data.data_array import (
+        AttenuationConstantArray,
+        PhaseConstantArray,
+    )
+    from tidy3d.components.types import FreqArray, ModeClassification, PolarizationBasis
 
 
 class AntennaMetricsData(DirectivityData, MicrowaveBaseModel):

--- a/tidy3d/components/microwave/formulas/circuit_parameters.py
+++ b/tidy3d/components/microwave/formulas/circuit_parameters.py
@@ -13,11 +13,15 @@ References
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 from tidy3d.components.geometry.base import Geometry
-from tidy3d.components.types import Axis
 from tidy3d.constants import EPSILON_0
+
+if TYPE_CHECKING:
+    from tidy3d.components.types import Axis
 
 
 def inductance_straight_rectangular_wire(

--- a/tidy3d/components/microwave/impedance_calculator.py
+++ b/tidy3d/components/microwave/impedance_calculator.py
@@ -2,26 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
 from pydantic import Field, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.data.data_array import (
-    CurrentIntegralResultType,
-    ImpedanceResultType,
-    VoltageIntegralResultType,
     _make_current_data_array,
     _make_impedance_data_array,
     _make_voltage_data_array,
 )
 from tidy3d.components.data.monitor_data import FieldTimeData
 from tidy3d.components.microwave.base import MicrowaveBaseModel
-from tidy3d.components.microwave.path_integrals.integrals.base import (
-    AxisAlignedPathIntegral,
-    IntegrableMonitorDataType,
-)
+from tidy3d.components.microwave.path_integrals.integrals.base import AxisAlignedPathIntegral
 from tidy3d.components.microwave.path_integrals.integrals.current import (
     AxisAlignedCurrentIntegral,
     CompositeCurrentIntegral,
@@ -33,6 +26,15 @@ from tidy3d.components.microwave.path_integrals.integrals.voltage import (
 )
 from tidy3d.components.monitor import ModeMonitor, ModeSolverMonitor
 from tidy3d.exceptions import ValidationError
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
+    from tidy3d.components.data.data_array import (
+        CurrentIntegralResultType,
+        ImpedanceResultType,
+        VoltageIntegralResultType,
+    )
+    from tidy3d.components.microwave.path_integrals.integrals.base import IntegrableMonitorDataType
 
 VoltageIntegralType = Union[AxisAlignedVoltageIntegral, Custom2DVoltageIntegral]
 CurrentIntegralType = Union[

--- a/tidy3d/components/microwave/mode_spec.py
+++ b/tidy3d/components/microwave/mode_spec.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
 from pydantic import Field, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import cached_property
-from tidy3d.components.geometry.base import Box
 from tidy3d.components.geometry.bound_ops import bounds_contains
 from tidy3d.components.microwave.base import MicrowaveBaseModel
 from tidy3d.components.microwave.path_integrals.specs.impedance import (
@@ -19,6 +17,10 @@ from tidy3d.components.microwave.path_integrals.specs.impedance import (
 from tidy3d.components.mode_spec import AbstractModeSpec
 from tidy3d.constants import fp_eps
 from tidy3d.exceptions import SetupError
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
+    from tidy3d.components.geometry.base import Box
 
 TEM_POLARIZATION_THRESHOLD = 0.995
 QTEM_POLARIZATION_THRESHOLD = 0.95

--- a/tidy3d/components/microwave/path_integrals/factory.py
+++ b/tidy3d/components/microwave/path_integrals/factory.py
@@ -2,13 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING
 
-from tidy3d.components.microwave.impedance_calculator import (
-    CurrentIntegralType,
-    VoltageIntegralType,
-)
-from tidy3d.components.microwave.mode_spec import MicrowaveModeSpec
 from tidy3d.components.microwave.path_integrals.integrals.current import (
     AxisAlignedCurrentIntegral,
     CompositeCurrentIntegral,
@@ -23,19 +18,26 @@ from tidy3d.components.microwave.path_integrals.specs.current import (
     CompositeCurrentIntegralSpec,
     Custom2DCurrentIntegralSpec,
 )
-from tidy3d.components.microwave.path_integrals.specs.impedance import (
-    AutoImpedanceSpec,
-    CustomImpedanceSpec,
-)
+from tidy3d.components.microwave.path_integrals.specs.impedance import AutoImpedanceSpec
 from tidy3d.components.microwave.path_integrals.specs.voltage import (
     AxisAlignedVoltageIntegralSpec,
     Custom2DVoltageIntegralSpec,
 )
-from tidy3d.components.microwave.path_integrals.types import (
-    CurrentPathSpecType,
-    VoltagePathSpecType,
-)
 from tidy3d.exceptions import SetupError, ValidationError
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from tidy3d.components.microwave.impedance_calculator import (
+        CurrentIntegralType,
+        VoltageIntegralType,
+    )
+    from tidy3d.components.microwave.mode_spec import MicrowaveModeSpec
+    from tidy3d.components.microwave.path_integrals.specs.impedance import CustomImpedanceSpec
+    from tidy3d.components.microwave.path_integrals.types import (
+        CurrentPathSpecType,
+        VoltagePathSpecType,
+    )
 
 
 def make_voltage_integral(path_spec: VoltagePathSpecType) -> VoltageIntegralType:

--- a/tidy3d/components/microwave/path_integrals/integrals/auto.py
+++ b/tidy3d/components/microwave/path_integrals/integrals/auto.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from tidy3d.components.geometry.base import Box
 from tidy3d.components.geometry.utils import (
     SnapBehavior,
@@ -9,15 +11,17 @@ from tidy3d.components.geometry.utils import (
     SnappingSpec,
     snap_box_to_grid,
 )
-from tidy3d.components.grid.grid import Grid
-from tidy3d.components.lumped_element import LinearLumpedElement
 from tidy3d.components.microwave.path_integrals.integrals.current import (
     AxisAlignedCurrentIntegral,
 )
 from tidy3d.components.microwave.path_integrals.integrals.voltage import (
     AxisAlignedVoltageIntegral,
 )
-from tidy3d.components.types import Direction
+
+if TYPE_CHECKING:
+    from tidy3d.components.grid.grid import Grid
+    from tidy3d.components.lumped_element import LinearLumpedElement
+    from tidy3d.components.types import Direction
 
 
 def path_integrals_from_lumped_element(

--- a/tidy3d/components/microwave/path_integrals/integrals/base.py
+++ b/tidy3d/components/microwave/path_integrals/integrals/base.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Literal, Union
+from typing import TYPE_CHECKING, Literal, Union
 
 import numpy as np
 import xarray as xr
 
 from tidy3d.components.data.data_array import (
-    IntegralResultType,
     ScalarFieldDataArray,
     ScalarFieldTimeDataArray,
     ScalarModeFieldDataArray,
@@ -21,6 +20,9 @@ from tidy3d.components.microwave.path_integrals.specs.base import (
 )
 from tidy3d.constants import fp_eps
 from tidy3d.exceptions import DataError
+
+if TYPE_CHECKING:
+    from tidy3d.components.data.data_array import IntegralResultType
 
 IntegrableMonitorDataType = Union[FieldData, FieldTimeData, ModeData, ModeSolverData]
 EMScalarFieldType = Union[ScalarFieldDataArray, ScalarFieldTimeDataArray, ScalarModeFieldDataArray]

--- a/tidy3d/components/microwave/path_integrals/integrals/current.py
+++ b/tidy3d/components/microwave/path_integrals/integrals/current.py
@@ -2,25 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 import xarray as xr
 
 from tidy3d.components.base import cached_property
-from tidy3d.components.data.data_array import (
-    CurrentIntegralResultType,
-    DataArray,
-    FreqDataArray,
-    FreqModeDataArray,
-    IntegralResultType,
-    _make_current_data_array,
-)
+from tidy3d.components.data.data_array import FreqModeDataArray, _make_current_data_array
 from tidy3d.components.data.monitor_data import FieldTimeData
 from tidy3d.components.microwave.path_integrals.integrals.base import (
     AxisAlignedPathIntegral,
     Custom2DPathIntegral,
-    IntegrableMonitorDataType,
 )
 from tidy3d.components.microwave.path_integrals.specs.current import (
     AxisAlignedCurrentIntegralSpec,
@@ -29,6 +21,17 @@ from tidy3d.components.microwave.path_integrals.specs.current import (
 )
 from tidy3d.exceptions import DataError
 from tidy3d.log import log
+
+if TYPE_CHECKING:
+    from typing import Optional, Union
+
+    from tidy3d.components.data.data_array import (
+        CurrentIntegralResultType,
+        DataArray,
+        FreqDataArray,
+        IntegralResultType,
+    )
+    from tidy3d.components.microwave.path_integrals.integrals.base import IntegrableMonitorDataType
 
 
 class AxisAlignedCurrentIntegral(AxisAlignedCurrentIntegralSpec):

--- a/tidy3d/components/microwave/path_integrals/integrals/voltage.py
+++ b/tidy3d/components/microwave/path_integrals/integrals/voltage.py
@@ -2,19 +2,21 @@
 
 from __future__ import annotations
 
-from tidy3d.components.data.data_array import (
-    VoltageIntegralResultType,
-    _make_voltage_data_array,
-)
+from typing import TYPE_CHECKING
+
+from tidy3d.components.data.data_array import _make_voltage_data_array
 from tidy3d.components.microwave.path_integrals.integrals.base import (
     AxisAlignedPathIntegral,
     Custom2DPathIntegral,
-    IntegrableMonitorDataType,
 )
 from tidy3d.components.microwave.path_integrals.specs.voltage import (
     AxisAlignedVoltageIntegralSpec,
     Custom2DVoltageIntegralSpec,
 )
+
+if TYPE_CHECKING:
+    from tidy3d.components.data.data_array import VoltageIntegralResultType
+    from tidy3d.components.microwave.path_integrals.integrals.base import IntegrableMonitorDataType
 
 
 class AxisAlignedVoltageIntegral(AxisAlignedPathIntegral, AxisAlignedVoltageIntegralSpec):

--- a/tidy3d/components/microwave/path_integrals/mode_plane_analyzer.py
+++ b/tidy3d/components/microwave/path_integrals/mode_plane_analyzer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from itertools import chain
 from math import isclose
+from typing import TYPE_CHECKING
 
 import shapely
 from pydantic import Field
@@ -19,12 +20,15 @@ from tidy3d.components.geometry.utils import (
     merging_geometries_on_plane,
     snap_box_to_grid,
 )
-from tidy3d.components.grid.grid import Grid
-from tidy3d.components.medium import LossyMetalMedium, Medium
-from tidy3d.components.structure import Structure
-from tidy3d.components.types import Axis, Bound, Coordinate, Shapely, Symmetry
+from tidy3d.components.medium import LossyMetalMedium
 from tidy3d.components.validators import assert_plane
 from tidy3d.exceptions import SetupError
+
+if TYPE_CHECKING:
+    from tidy3d.components.grid.grid import Grid
+    from tidy3d.components.medium import Medium
+    from tidy3d.components.structure import Structure
+    from tidy3d.components.types import Axis, Bound, Coordinate, Shapely, Symmetry
 
 
 class ModePlaneAnalyzer(Box):

--- a/tidy3d/components/microwave/path_integrals/specs/base.py
+++ b/tidy3d/components/microwave/path_integrals/specs/base.py
@@ -3,23 +3,30 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 import shapely
-import xarray as xr
-from numpy.typing import NDArray
 from pydantic import Field, field_validator
-from typing_extensions import Self
 
 from tidy3d.components.base import cached_property
 from tidy3d.components.geometry.base import Box, Geometry
 from tidy3d.components.microwave.base import MicrowaveBaseModel
-from tidy3d.components.types import ArrayFloat2D, Bound, Coordinate, Coordinate2D
-from tidy3d.components.types.base import Axis, Direction
+from tidy3d.components.types import ArrayFloat2D
+from tidy3d.components.types.base import Axis
 from tidy3d.components.validators import assert_line
 from tidy3d.constants import MICROMETER, fp_eps
 from tidy3d.exceptions import SetupError
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    import xarray as xr
+    from numpy.typing import NDArray
+    from typing_extensions import Self
+
+    from tidy3d.components.types import Bound, Coordinate, Coordinate2D
+    from tidy3d.components.types.base import Direction
 
 
 class AbstractAxesRH(MicrowaveBaseModel, ABC):

--- a/tidy3d/components/microwave/path_integrals/specs/current.py
+++ b/tidy3d/components/microwave/path_integrals/specs/current.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Union
 
 import numpy as np
 from pydantic import Field, field_validator
 
 from tidy3d.components.base import cached_property
-from tidy3d.components.data.data_array import DataArray
 from tidy3d.components.geometry.base import Box, Geometry
 from tidy3d.components.geometry.bound_ops import bounds_union
 from tidy3d.components.microwave.base import MicrowaveBaseModel
@@ -18,12 +17,18 @@ from tidy3d.components.microwave.path_integrals.specs.base import (
     Custom2DPathIntegralSpec,
 )
 from tidy3d.components.microwave.path_integrals.viz import ARROW_CURRENT, plot_params_current_path
-from tidy3d.components.types import Ax, Bound
-from tidy3d.components.types.base import Axis, Direction
+from tidy3d.components.types.base import Direction
 from tidy3d.components.validators import assert_plane
 from tidy3d.components.viz import add_ax_if_none
 from tidy3d.constants import fp_eps
 from tidy3d.exceptions import SetupError
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from tidy3d.components.data.data_array import DataArray
+    from tidy3d.components.types import Ax, Bound
+    from tidy3d.components.types.base import Axis
 
 
 class AxisAlignedCurrentIntegralSpec(AbstractAxesRH, Box):

--- a/tidy3d/components/microwave/path_integrals/specs/impedance.py
+++ b/tidy3d/components/microwave/path_integrals/specs/impedance.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from pydantic import Field, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.microwave.base import MicrowaveBaseModel
 from tidy3d.components.microwave.path_integrals.types import (
     CurrentPathSpecType,
     VoltagePathSpecType,
 )
 from tidy3d.exceptions import SetupError
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
 
 
 class AutoImpedanceSpec(MicrowaveBaseModel):

--- a/tidy3d/components/microwave/path_integrals/specs/voltage.py
+++ b/tidy3d/components/microwave/path_integrals/specs/voltage.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from pydantic import Field
-from typing_extensions import Self
 
 from tidy3d.components.geometry.base import Geometry
 from tidy3d.components.microwave.path_integrals.specs.base import (
@@ -18,10 +17,16 @@ from tidy3d.components.microwave.path_integrals.viz import (
     plot_params_voltage_path,
     plot_params_voltage_plus,
 )
-from tidy3d.components.types import Ax
 from tidy3d.components.types.base import Direction
 from tidy3d.components.viz import add_ax_if_none
 from tidy3d.constants import fp_eps
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from typing_extensions import Self
+
+    from tidy3d.components.types import Ax
 
 
 class AxisAlignedVoltageIntegralSpec(AxisAlignedPathIntegralSpec):

--- a/tidy3d/components/mode/data/sim_data.py
+++ b/tidy3d/components/mode/data/sim_data.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from pydantic import Field
 
@@ -10,14 +10,18 @@ from tidy3d.components.base import cached_property
 from tidy3d.components.data.monitor_data import MediumData, PermittivityData
 from tidy3d.components.data.sim_data import AbstractYeeGridSimulationData
 from tidy3d.components.mode.simulation import ModeSimulation
-from tidy3d.components.mode_spec import ModeSortSpec
-from tidy3d.components.types import TYPE_TAG_STR, Ax, PlotScale
+from tidy3d.components.types import TYPE_TAG_STR
 from tidy3d.components.types.monitor_data import ModeSolverDataType
 
 ModeSimulationMonitorDataType = Union[PermittivityData, MediumData]
 
 if TYPE_CHECKING:
+    from typing import Literal, Optional
+
     from matplotlib.colors import Colormap
+
+    from tidy3d.components.mode_spec import ModeSortSpec
+    from tidy3d.components.types import Ax, PlotScale
 
 
 class ModeSimulationData(AbstractYeeGridSimulationData):

--- a/tidy3d/components/mode/derivatives.py
+++ b/tidy3d/components/mode/derivatives.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 from numpy.typing import NDArray
@@ -11,6 +10,9 @@ from numpy.typing import NDArray
 from tidy3d.constants import EPSILON_0, ETA_0
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Literal
+
     from scipy import sparse as sp
 
 ArrayFloat = NDArray[np.floating]

--- a/tidy3d/components/mode/mode_solver.py
+++ b/tidy3d/components/mode/mode_solver.py
@@ -6,37 +6,18 @@ from __future__ import annotations
 
 from functools import wraps
 from math import isclose
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Literal,
-    Optional,
-    ParamSpec,
-    TypeVar,
-    Union,
-    get_args,
-)
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, Union, get_args
 
 import numpy as np
 import xarray as xr
-from pydantic import (
-    Field,
-    NonNegativeFloat,
-    NonNegativeInt,
-    PositiveInt,
-    field_validator,
-    model_validator,
-)
+from pydantic import Field, field_validator, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import (
     Tidy3dBaseModel,
     cached_property,
 )
 from tidy3d.components.boundary import PML, Absorber, Boundary, BoundarySpec, PECBoundary, StablePML
 from tidy3d.components.data.data_array import (
-    FreqModeDataArray,
     ModeIndexDataArray,
     ScalarModeFieldCylindricalDataArray,
     ScalarModeFieldDataArray,
@@ -49,7 +30,6 @@ from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.eme.data.sim_data import EMESimulationData
 from tidy3d.components.eme.simulation import EMESimulation
 from tidy3d.components.geometry.base import Box
-from tidy3d.components.grid.grid import Coords, Grid
 from tidy3d.components.medium import (
     FullyAnisotropicMedium,
     IsotropicUniformMediumType,
@@ -57,40 +37,18 @@ from tidy3d.components.medium import (
 )
 from tidy3d.components.microwave.data.dataset import TransmissionLineDataset
 from tidy3d.components.microwave.data.monitor_data import MicrowaveModeSolverData
-from tidy3d.components.microwave.impedance_calculator import (
-    CurrentIntegralType,
-    ImpedanceCalculator,
-    VoltageIntegralType,
-)
+from tidy3d.components.microwave.impedance_calculator import ImpedanceCalculator
 from tidy3d.components.microwave.mode_spec import MicrowaveModeSpec
 from tidy3d.components.microwave.monitor import MicrowaveModeMonitor, MicrowaveModeSolverMonitor
 from tidy3d.components.microwave.path_integrals.factory import make_path_integrals
-from tidy3d.components.mode_spec import ModeSpec
 from tidy3d.components.monitor import ModeMonitor, ModeSolverMonitor
 from tidy3d.components.scene import Scene
 from tidy3d.components.simulation import Simulation
 from tidy3d.components.source.field import ModeSource
-from tidy3d.components.source.time import SourceTime
-from tidy3d.components.structure import Structure
 from tidy3d.components.subpixel_spec import SurfaceImpedance
-from tidy3d.components.types import (
-    ArrayComplex3D,
-    ArrayComplex4D,
-    ArrayFloat1D,
-    ArrayFloat2D,
-    Ax,
-    Axis,
-    Axis2D,
-    Direction,
-    EMField,
-    EpsSpecType,
-    FreqArray,
-    PlotScale,
-    Symmetry,
-)
+from tidy3d.components.types import ArrayComplex3D, Direction, EMField, FreqArray
 from tidy3d.components.types.base import TYPE_TAG_STR, discriminated_union
 from tidy3d.components.types.mode_spec import ModeSpecType
-from tidy3d.components.types.monitor_data import ModeSolverDataType
 from tidy3d.components.validators import (
     validate_freqs_min,
     validate_freqs_not_empty,
@@ -101,7 +59,33 @@ from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
 
 if TYPE_CHECKING:
+    from typing import Callable, Literal, Optional
+
     from matplotlib.colors import Colormap
+    from pydantic import NonNegativeFloat, NonNegativeInt, PositiveInt
+
+    from tidy3d.compat import Self
+    from tidy3d.components.data.data_array import FreqModeDataArray
+    from tidy3d.components.grid.grid import Coords, Grid
+    from tidy3d.components.microwave.impedance_calculator import (
+        CurrentIntegralType,
+        VoltageIntegralType,
+    )
+    from tidy3d.components.mode_spec import ModeSpec
+    from tidy3d.components.source.time import SourceTime
+    from tidy3d.components.structure import Structure
+    from tidy3d.components.types import (
+        ArrayComplex4D,
+        ArrayFloat1D,
+        ArrayFloat2D,
+        Ax,
+        Axis,
+        Axis2D,
+        EpsSpecType,
+        PlotScale,
+        Symmetry,
+    )
+    from tidy3d.components.types.monitor_data import ModeSolverDataType
 from tidy3d.packaging import supports_local_subpixel, tidy3d_extras
 
 # Importing the local solver may not work if e.g. scipy is not installed

--- a/tidy3d/components/mode/simulation.py
+++ b/tidy3d/components/mode/simulation.py
@@ -5,13 +5,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 import numpy as np
-from pydantic import Field, PositiveFloat, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import cached_property
 from tidy3d.components.boundary import BoundarySpec
 from tidy3d.components.geometry.base import Box
-from tidy3d.components.grid.grid import Grid
 from tidy3d.components.grid.grid_spec import GridSpec
 from tidy3d.components.monitor import (
     MediumMonitor,
@@ -25,12 +23,7 @@ from tidy3d.components.simulation import (
     validate_boundaries_for_zero_dims,
 )
 from tidy3d.components.source.field import ModeSource
-from tidy3d.components.types import (
-    Ax,
-    Direction,
-    EMField,
-    FreqArray,
-)
+from tidy3d.components.types import Direction, EMField, FreqArray
 from tidy3d.components.types.base import TYPE_TAG_STR, discriminated_union
 from tidy3d.components.types.mode_spec import ModeSpecType
 from tidy3d.constants import C_0
@@ -41,7 +34,12 @@ from tidy3d.packaging import supports_local_subpixel, tidy3d_extras
 from .mode_solver import ModeSolver
 
 if TYPE_CHECKING:
+    from pydantic import PositiveFloat
+
+    from tidy3d.compat import Self
+    from tidy3d.components.grid.grid import Grid
     from tidy3d.components.mode.data.sim_data import ModeSimulationData
+    from tidy3d.components.types import Ax
 
 ModeSimulationMonitorType = Union[PermittivityMonitor, MediumMonitor]
 

--- a/tidy3d/components/mode/solver.py
+++ b/tidy3d/components/mode/solver.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from numpy.typing import NDArray
 
 from tidy3d.components.base import Tidy3dBaseModel
-from tidy3d.components.types import EpsSpecType, ModeSolverType
 from tidy3d.constants import C_0, ETA_0, fp_eps, pec_val
 
 from .derivatives import create_d_matrices as d_mats
@@ -17,7 +15,12 @@ from .derivatives import create_s_matrices as s_mats
 from .transforms import angled_transform, radial_transform
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Literal, Optional, Union
+
     from scipy import sparse as sp
+
+    from tidy3d.components.types import EpsSpecType, ModeSolverType
 
 # Consider vec to be complex if norm(vec.imag)/norm(vec) > TOL_COMPLEX
 TOL_COMPLEX = 1e-10

--- a/tidy3d/components/mode/transforms.py
+++ b/tidy3d/components/mode/transforms.py
@@ -10,10 +10,13 @@ Currently, the half-step offset in w is ignored, which should be a pretty good a
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 from numpy.typing import NDArray
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 ArrayFloat = NDArray[np.floating]
 CoordsTuple = tuple[ArrayFloat, ArrayFloat]

--- a/tidy3d/components/mode_spec.py
+++ b/tidy3d/components/mode_spec.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from math import isclose
-from typing import Literal, Optional, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
 import numpy as np
 from pydantic import (
@@ -16,13 +16,15 @@ from pydantic import (
     model_validator,
 )
 
-from tidy3d.compat import Self
 from tidy3d.constants import GLANCING_CUTOFF, MICROMETER, RADIAN, fp_eps
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
 
 from .base import Tidy3dBaseModel
 from .types import Axis2D, FreqArray, TrackFreq
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
 
 GROUP_INDEX_STEP = 0.005
 MODE_DATA_KEYS = Literal[

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -3,19 +3,11 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 import numpy as np
-from pydantic import (
-    Field,
-    FieldValidationInfo,
-    NonNegativeFloat,
-    PositiveInt,
-    field_validator,
-    model_validator,
-)
+from pydantic import Field, NonNegativeFloat, PositiveInt, field_validator, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.constants import HERTZ, MICROMETER, RADIAN, SECOND, inf
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
@@ -27,19 +19,14 @@ from .medium import MediumType
 from .microwave.base import MicrowaveBaseModel
 from .mode_spec import ModeSpec
 from .types import (
-    ArrayFloat1D,
     AuxField,
-    Ax,
     Axis,
-    Bound,
     BoxSurface,
     Coordinate,
     Direction,
     EMField,
     FreqArray,
-    FreqBound,
     ObsGridArray,
-    Size,
 )
 from .validators import (
     assert_plane,
@@ -47,6 +34,13 @@ from .validators import (
     validate_freqs_not_empty,
 )
 from .viz import ARROW_ALPHA, ARROW_COLOR_MONITOR
+
+if TYPE_CHECKING:
+    from pydantic import FieldValidationInfo
+
+    from tidy3d.compat import Self
+
+    from .types import ArrayFloat1D, Ax, Bound, FreqBound, Size
 
 BYTES_REAL = 4
 BYTES_COMPLEX = 8

--- a/tidy3d/components/parameter_perturbation.py
+++ b/tidy3d/components/parameter_perturbation.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 
 import functools
 from abc import ABC, abstractmethod
-from typing import Callable, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Optional, TypeVar, Union
 
 import numpy as np
-import xarray as xr
 from pydantic import Field, NonNegativeFloat, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.types.base import ArrayComplex, ArrayFloat, discriminated_union
 from tidy3d.constants import C_0, CMCUBE, EPSILON_0, HERTZ, KELVIN, PERCMCUBE, inf
 from tidy3d.exceptions import DataError
@@ -32,13 +30,17 @@ from .data.utils import (
     _zeros_like,
 )
 from .data.validators import validate_no_nans
-from .types import (
-    Ax,
-    Complex,
-    FieldVal,
-    InterpMethod,
-)
+from .types import Complex, InterpMethod
 from .viz import add_ax_if_none
+
+if TYPE_CHECKING:
+    from typing import Callable
+
+    import xarray as xr
+
+    from tidy3d.compat import Self
+
+    from .types import Ax, FieldVal
 
 """ Generic perturbation classes """
 

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -2,9 +2,31 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 import autograd.numpy as np
+
+if TYPE_CHECKING:
+    from typing import Literal, Union
+
+    from pydantic import NonNegativeInt
+
+    from tidy3d.compat import Self
+    from tidy3d.components.material.types import StructureMediumType
+
+    from .data.utils import CustomSpatialDataType
+    from .grid.grid import Grid
+    from .types import (
+        Ax,
+        Bound,
+        Coordinate,
+        InterpMethod,
+        PermittivityComponent,
+        PlotScale,
+        Shapely,
+        Size,
+    )
+    from .viz import PlotParams
 
 try:
     import matplotlib as mpl
@@ -12,15 +34,14 @@ try:
     from mpl_toolkits.axes_grid1 import make_axes_locatable
 except ImportError:
     pass
-from pydantic import Field, NonNegativeInt, field_validator
+from pydantic import Field, field_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.material.tcad.charge import (
     ChargeConductorMedium,
     SemiconductorMedium,
 )
 from tidy3d.components.material.tcad.heat import SolidMedium, SolidSpec
-from tidy3d.components.material.types import MultiPhysicsMediumType3D, StructureMediumType
+from tidy3d.components.material.types import MultiPhysicsMediumType3D
 from tidy3d.components.tcad.doping import (
     ConstantDoping,
     CustomDoping,
@@ -34,7 +55,6 @@ from tidy3d.log import log
 
 from .base import Tidy3dBaseModel, cached_property
 from .data.utils import (
-    CustomSpatialDataType,
     SpatialDataArray,
     TetrahedralGridDataset,
     TriangularGridDataset,
@@ -42,7 +62,7 @@ from .data.utils import (
 )
 from .geometry.base import Box
 from .geometry.utils import merging_geometries_on_plane
-from .grid.grid import Coords, Grid
+from .grid.grid import Coords
 from .material.multi_physics import MultiPhysicsMedium
 from .medium import (
     AbstractCustomMedium,
@@ -52,26 +72,13 @@ from .medium import (
     Medium2D,
 )
 from .structure import Structure
-from .types import (
-    TYPE_TAG_STR,
-    Ax,
-    Bound,
-    Coordinate,
-    InterpMethod,
-    LengthUnit,
-    PermittivityComponent,
-    PlotScale,
-    PriorityMode,
-    Shapely,
-    Size,
-)
+from .types import TYPE_TAG_STR, LengthUnit, PriorityMode
 from .validators import assert_unique_names
 from .viz import (
     MEDIUM_CMAP,
     STRUCTURE_EPS_CMAP,
     STRUCTURE_EPS_CMAP_R,
     STRUCTURE_HEAT_COND_CMAP,
-    PlotParams,
     add_ax_if_none,
     equal_aspect,
     plot_params_fluid,

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -6,12 +6,10 @@ import math
 import pathlib
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from os import PathLike
-from typing import Any, Callable, Literal, Optional, Union, get_args
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union, get_args
 
 import autograd.numpy as np
 import xarray as xr
-from numpy.typing import NDArray
 from pydantic import (
     Field,
     NonNegativeFloat,
@@ -21,7 +19,6 @@ from pydantic import (
     model_validator,
 )
 
-from tidy3d.compat import Self
 from tidy3d.components.microwave.mode_spec import MicrowaveModeSpec
 from tidy3d.components.types.base import discriminated_union
 from tidy3d.constants import C_0, SECOND, fp_eps, inf
@@ -39,7 +36,6 @@ from .boundary import (
     AbsorberSpec,
     BlochBoundary,
     Boundary,
-    BoundaryEdgeType,
     BoundarySpec,
     InternalAbsorber,
     ModeABCBoundary,
@@ -49,16 +45,14 @@ from .boundary import (
     StablePML,
 )
 from .data.data_array import FreqDataArray, IndexedDataArray
-from .data.dataset import Dataset
 from .data.unstructured.tetrahedral import TetrahedralGridDataset
 from .data.unstructured.triangular import TriangularGridDataset
-from .data.utils import CustomSpatialDataType
 from .frequency_extrapolation import LowFrequencySmoothingSpec
 from .geometry.base import Box, Geometry, GeometryGroup
 from .geometry.mesh import TriangleMesh
 from .geometry.utils import _shift_object, flatten_groups, traverse_geometries
 from .geometry.utils_2d import get_bounds, get_thickened_geom, snap_coordinate_to_grid, subdivide
-from .grid.grid import Coords, Coords1D, Grid
+from .grid.grid import Coords, Grid
 from .grid.grid_spec import AutoGrid, GridSpec, UniformGrid
 from .lumped_element import LumpedElementType
 from .medium import (
@@ -70,7 +64,6 @@ from .medium import (
     LossyMetalMedium,
     Medium,
     Medium2D,
-    MediumType,
     MediumType3D,
     PECMedium,
 )
@@ -91,7 +84,6 @@ from .monitor import (
     FreqMonitor,
     MediumMonitor,
     ModeMonitor,
-    Monitor,
     PermittivityMonitor,
     SurfaceIntegrationMonitor,
     TimeMonitor,
@@ -112,21 +104,9 @@ from .source.field import (
 from .source.frame import PECFrame
 from .source.time import ContinuousWave, CustomSourceTime
 from .source.utils import SourceType
-from .structure import MeshOverrideStructure, Structure
+from .structure import Structure
 from .subpixel_spec import SubpixelSpec
-from .types import (
-    TYPE_TAG_STR,
-    ArrayFloat1D,
-    ArrayFloat2D,
-    Ax,
-    Axis,
-    CoordinateOptional,
-    FreqBound,
-    InterpMethod,
-    PermittivityComponent,
-    Shapely,
-    Symmetry,
-)
+from .types import TYPE_TAG_STR, PermittivityComponent, Symmetry
 from .types.monitor import MonitorType
 from .validators import (
     assert_objects_contained_in_sim_bounds,
@@ -146,6 +126,32 @@ from .viz import (
     plot_params_pml,
     plot_sim_3d,
 )
+
+if TYPE_CHECKING:
+    from os import PathLike
+    from typing import Callable
+
+    from numpy.typing import NDArray
+
+    from tidy3d.compat import Self
+
+    from .boundary import BoundaryEdgeType
+    from .data.dataset import Dataset
+    from .data.utils import CustomSpatialDataType
+    from .grid.grid import Coords1D
+    from .medium import MediumType
+    from .monitor import Monitor
+    from .structure import MeshOverrideStructure
+    from .types import (
+        ArrayFloat1D,
+        ArrayFloat2D,
+        Ax,
+        Axis,
+        CoordinateOptional,
+        FreqBound,
+        InterpMethod,
+        Shapely,
+    )
 
 try:
     import matplotlib as mpl

--- a/tidy3d/components/source/base.py
+++ b/tidy3d/components/source/base.py
@@ -3,24 +3,29 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from pydantic import Field, field_validator
 
 from tidy3d.components.base import cached_property
 from tidy3d.components.base_sim.source import AbstractSource
 from tidy3d.components.geometry.base import Box
-from tidy3d.components.types import TYPE_TAG_STR, Ax
+from tidy3d.components.types import TYPE_TAG_STR
 from tidy3d.components.validators import _assert_min_freq, _warn_unsupported_traced_argument
 from tidy3d.components.viz import (
     ARROW_ALPHA,
     ARROW_COLOR_POLARIZATION,
     ARROW_COLOR_SOURCE,
-    PlotParams,
     plot_params_source,
 )
 
 from .time import SourceTimeType
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from tidy3d.components.types import Ax
+    from tidy3d.components.viz import PlotParams
 
 
 class Source(Box, AbstractSource, ABC):

--- a/tidy3d/components/source/current.py
+++ b/tidy3d/components/source/current.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC
 from math import cos, isclose, sin
-from typing import Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from pydantic import Field
 
@@ -16,7 +16,9 @@ from tidy3d.components.validators import assert_single_freq_in_range, warn_if_da
 from tidy3d.constants import MICROMETER
 
 from .base import Source
-from .time import SourceTimeType
+
+if TYPE_CHECKING:
+    from .time import SourceTimeType
 
 
 class CurrentSource(Source, ABC):

--- a/tidy3d/components/source/field.py
+++ b/tidy3d/components/source/field.py
@@ -3,19 +3,17 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import numpy as np
-from numpy.typing import NDArray
 from pydantic import Field, NonNegativeInt, PositiveFloat, field_validator, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.data.dataset import FieldDataset
 from tidy3d.components.data.validators import validate_can_interpolate, validate_no_nans
 from tidy3d.components.mode_spec import ModeSpec
 from tidy3d.components.source.frame import PECFrame
-from tidy3d.components.types import TYPE_TAG_STR, Ax, Axis, Coordinate, Direction
+from tidy3d.components.types import TYPE_TAG_STR, Axis, Direction
 from tidy3d.components.types.mode_spec import ModeSpecType
 from tidy3d.components.validators import (
     assert_plane,
@@ -29,6 +27,12 @@ from tidy3d.exceptions import SetupError
 from tidy3d.log import log
 
 from .base import Source
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    from tidy3d.compat import Self
+    from tidy3d.components.types import Ax, Coordinate
 
 # width of Chebyshev grid used for broadband sources (in units of pulse width)
 CHEB_GRID_WIDTH = 1.5

--- a/tidy3d/components/source/freq_range.py
+++ b/tidy3d/components/source/freq_range.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import NDArray
 from pydantic import Field, PositiveFloat
 
 from tidy3d import constants as td_const
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.source.time import GaussianPulse
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 
 class FreqRange(Tidy3dBaseModel):

--- a/tidy3d/components/source/time.py
+++ b/tidy3d/components/source/time.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import numpy as np
 from pydantic import Field, PositiveFloat, field_validator, model_validator
@@ -15,13 +15,16 @@ from tidy3d.components.data.data_array import TimeDataArray
 from tidy3d.components.data.dataset import TimeDataset
 from tidy3d.components.data.validators import validate_no_nans
 from tidy3d.components.time import AbstractTimeDependence
-from tidy3d.components.types import ArrayComplex1D, ArrayFloat1D, Ax, FreqBound, PlotVal
+from tidy3d.components.types import FreqBound
 from tidy3d.components.validators import warn_if_dataset_none
 from tidy3d.components.viz import add_ax_if_none
 from tidy3d.constants import HERTZ
 from tidy3d.exceptions import ValidationError
 from tidy3d.log import log
 from tidy3d.packaging import check_tidy3d_extras_licensed_feature, tidy3d_extras
+
+if TYPE_CHECKING:
+    from tidy3d.components.types import ArrayComplex1D, ArrayFloat1D, Ax, PlotVal
 
 # how many units of ``twidth`` from the ``offset`` until a gaussian pulse is considered "off"
 END_TIME_FACTOR_GAUSSIAN = 10

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -5,29 +5,18 @@ from __future__ import annotations
 import pathlib
 from collections import defaultdict
 from functools import cmp_to_key
-from os import PathLike
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 import autograd.numpy as anp
 import numpy as np
 from autograd.extend import Box as AutogradBox
-from pydantic import (
-    Field,
-    NonNegativeFloat,
-    NonNegativeInt,
-    PositiveFloat,
-    field_validator,
-    model_validator,
-)
+from pydantic import Field, PositiveFloat, field_validator, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.config import config
 from tidy3d.constants import MICROMETER
 from tidy3d.exceptions import SetupError, Tidy3dImportError
 from tidy3d.log import log
 
-from .autograd.derivative_utils import DerivativeInfo
-from .autograd.types import AutogradFieldMap
 from .autograd.utils import contains, get_static
 from .base import Tidy3dBaseModel
 from .data.data_array import ScalarFieldDataArray
@@ -38,14 +27,22 @@ from .material.multi_physics import MultiPhysicsMedium
 from .material.types import StructureMediumType
 from .medium import AbstractCustomMedium, CustomMedium, LossyMetalMedium, Medium, Medium2D
 from .monitor import FieldMonitor, PermittivityMonitor
-from .types import TYPE_TAG_STR, Ax, Axis, PriorityMode
+from .types import TYPE_TAG_STR
 from .validators import validate_name_str
 from .viz import add_ax_if_none, equal_aspect
 
 if TYPE_CHECKING:
+    from os import PathLike
+
     import gdstk
+    from pydantic import NonNegativeFloat, NonNegativeInt
 
     from tidy3d import VisualizationSpec
+    from tidy3d.compat import Self
+
+    from .autograd.derivative_utils import DerivativeInfo
+    from .autograd.types import AutogradFieldMap
+    from .types import Ax, Axis, PriorityMode
 
 try:
     gdstk_available = True

--- a/tidy3d/components/subpixel_spec.py
+++ b/tidy3d/components/subpixel_spec.py
@@ -1,14 +1,15 @@
 # Defines specifications for subpixel averaging
 from __future__ import annotations
 
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 from pydantic import Field
 
-from tidy3d.compat import Self
-
 from .base import Tidy3dBaseModel, cached_property
 from .types.base import discriminated_union
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
 
 # Default Courant number reduction rate in PEC conformal's scheme
 DEFAULT_COURANT_REDUCTION_PEC_CONFORMAL = 0.3

--- a/tidy3d/components/tcad/boundary/heat.py
+++ b/tidy3d/components/tcad/boundary/heat.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from pydantic import Field, NonNegativeFloat, PositiveFloat
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.material.tcad.heat import FluidMedium
 from tidy3d.components.tcad.boundary.abstract import HeatChargeBC
@@ -18,6 +17,9 @@ from tidy3d.constants import (
     KELVIN,
     MICROMETER,
 )
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
 
 
 class TemperatureBC(HeatChargeBC):

--- a/tidy3d/components/tcad/data/monitor_data/charge.py
+++ b/tidy3d/components/tcad/data/monitor_data/charge.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import numpy as np
 from pydantic import Field, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.data.data_array import (
     IndexedFieldVoltageDataArray,
     IndexedVoltageDataArray,
@@ -25,10 +24,14 @@ from tidy3d.components.tcad.monitors.charge import (
     SteadyFreeCarrierMonitor,
     SteadyPotentialMonitor,
 )
-from tidy3d.components.types import TYPE_TAG_STR, Ax
+from tidy3d.components.types import TYPE_TAG_STR
 from tidy3d.components.types.base import discriminated_union
 from tidy3d.components.viz import add_ax_if_none
 from tidy3d.exceptions import DataError
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
+    from tidy3d.components.types import Ax
 
 FieldDataset = Union[
     discriminated_union(Union[TriangularGridDataset, TetrahedralGridDataset]),

--- a/tidy3d/components/tcad/data/sim_data.py
+++ b/tidy3d/components/tcad/data/sim_data.py
@@ -3,16 +3,14 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
 from pydantic import Field, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.base_sim.data.sim_data import AbstractSimulationData
 from tidy3d.components.data.data_array import (
-    DataArray,
     FreqVoltageDataArray,
     SpatialDataArray,
     SteadyVoltageDataArray,
@@ -32,14 +30,19 @@ from tidy3d.components.tcad.mesher import VolumeMesher
 from tidy3d.components.tcad.monitors.mesh import VolumeMeshMonitor
 from tidy3d.components.tcad.simulation.heat import HeatSimulation
 from tidy3d.components.tcad.simulation.heat_charge import HeatChargeSimulation
-from tidy3d.components.types import Ax, RealFieldVal
 from tidy3d.components.types.base import discriminated_union
 from tidy3d.components.viz import add_ax_if_none, equal_aspect
 from tidy3d.exceptions import DataError, Tidy3dKeyError
 from tidy3d.log import log
 
 if TYPE_CHECKING:
+    from typing import Literal, Union
+
     from matplotlib.colors import Colormap
+
+    from tidy3d.compat import Self
+    from tidy3d.components.data.data_array import DataArray
+    from tidy3d.components.types import Ax, RealFieldVal
 
 
 class DeviceCharacteristics(Tidy3dBaseModel):

--- a/tidy3d/components/tcad/doping.py
+++ b/tidy3d/components/tcad/doping.py
@@ -2,20 +2,23 @@
 
 from __future__ import annotations
 
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
 import xarray as xr
-from numpy.typing import ArrayLike, NDArray
 from pydantic import Field, NonNegativeFloat, PositiveFloat, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.autograd import TracedSize
 from tidy3d.components.base import cached_property
 from tidy3d.components.data.data_array import SpatialDataArray
 from tidy3d.components.geometry.base import Box
 from tidy3d.constants import MICROMETER, PERCMCUBE, inf
 from tidy3d.exceptions import SetupError
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike, NDArray
+
+    from tidy3d.compat import Self
 
 
 class AbstractDopingBox(Box):

--- a/tidy3d/components/tcad/generation_recombination.py
+++ b/tidy3d/components/tcad/generation_recombination.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
-from typing import Literal, Union
+from typing import TYPE_CHECKING, Literal, Union
 
 import numpy as np
 from pydantic import Field, PositiveFloat, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.data.data_array import SpatialDataArray
 from tidy3d.constants import PERCMCUBE, SECOND
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
 
 
 class FossumCarrierLifetime(Tidy3dBaseModel):

--- a/tidy3d/components/tcad/grid.py
+++ b/tidy3d/components/tcad/grid.py
@@ -3,18 +3,20 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
 from pydantic import Field, NonNegativeFloat, PositiveFloat, field_validator, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.geometry.base import Box
 from tidy3d.components.types import Coordinate
 from tidy3d.components.types.base import discriminated_union
 from tidy3d.constants import MICROMETER
 from tidy3d.exceptions import ValidationError
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
 
 
 class UnstructuredGrid(Tidy3dBaseModel, ABC):

--- a/tidy3d/components/tcad/mesher.py
+++ b/tidy3d/components/tcad/mesher.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from pydantic import Field
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.tcad.monitors.mesh import VolumeMeshMonitor
 from tidy3d.components.tcad.simulation.heat_charge import HeatChargeSimulation, TCADAnalysisTypes
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
 
 
 class VolumeMesher(Tidy3dBaseModel):

--- a/tidy3d/components/tcad/monitors/abstract.py
+++ b/tidy3d/components/tcad/monitors/abstract.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 from abc import ABC
+from typing import TYPE_CHECKING
 
 from pydantic import Field
 
 from tidy3d.components.base_sim.monitor import AbstractMonitor
-from tidy3d.components.types import ArrayFloat1D
+
+if TYPE_CHECKING:
+    from tidy3d.components.types import ArrayFloat1D
 
 BYTES_REAL = 4
 

--- a/tidy3d/components/tcad/monitors/mesh.py
+++ b/tidy3d/components/tcad/monitors/mesh.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from math import isclose
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import Field, field_validator
 
-from tidy3d.components.autograd import TracedSize
 from tidy3d.components.tcad.monitors.abstract import HeatChargeMonitor
+
+if TYPE_CHECKING:
+    from tidy3d.components.autograd import TracedSize
 
 
 class VolumeMeshMonitor(HeatChargeMonitor):

--- a/tidy3d/components/tcad/simulation/heat.py
+++ b/tidy3d/components/tcad/simulation/heat.py
@@ -3,14 +3,18 @@ NOTE: Keeping this class for backward compatibility only"""
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from pydantic import model_validator
 
 from tidy3d.components.tcad.simulation.heat_charge import HeatChargeSimulation
-from tidy3d.components.types import Ax
 from tidy3d.components.viz import add_ax_if_none, equal_aspect
 from tidy3d.log import log
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from tidy3d.components.types import Ax
 
 
 class HeatSimulation(HeatChargeSimulation):

--- a/tidy3d/components/tcad/simulation/heat_charge.py
+++ b/tidy3d/components/tcad/simulation/heat_charge.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 from enum import Enum
-from typing import Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import numpy as np
-from pydantic import Field, FiniteFloat, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base_sim.simulation import AbstractSimulation
 from tidy3d.components.bc_placement import (
     MediumMediumInterface,
@@ -78,18 +76,23 @@ from tidy3d.components.tcad.viz import (
     plot_params_heat_bc,
     plot_params_heat_source,
 )
-from tidy3d.components.types import (
-    TYPE_TAG_STR,
-    Ax,
-    Bound,
-    ScalarSymmetry,
-    Shapely,
-)
-from tidy3d.components.types.base import ArrayFloat1D, discriminated_union
-from tidy3d.components.viz import PlotParams, add_ax_if_none, equal_aspect
+from tidy3d.components.types import TYPE_TAG_STR, ScalarSymmetry
+from tidy3d.components.types.base import discriminated_union
+from tidy3d.components.viz import add_ax_if_none, equal_aspect
 from tidy3d.constants import VOLUMETRIC_HEAT_RATE, inf
 from tidy3d.exceptions import SetupError
 from tidy3d.log import log
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import Literal
+
+    from pydantic import FiniteFloat
+
+    from tidy3d.compat import Self
+    from tidy3d.components.types import Ax, Bound, Shapely
+    from tidy3d.components.types.base import ArrayFloat1D
+    from tidy3d.components.viz import PlotParams
 
 try:
     from matplotlib import colormaps

--- a/tidy3d/components/tcad/source/abstract.py
+++ b/tidy3d/components/tcad/source/abstract.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 from abc import ABC
+from typing import TYPE_CHECKING
 
 from pydantic import Field, field_validator
 
 from tidy3d.components.base import cached_property
 from tidy3d.components.base_sim.source import AbstractSource
 from tidy3d.components.tcad.viz import plot_params_heat_source
-from tidy3d.components.viz import PlotParams
 from tidy3d.exceptions import SetupError
+
+if TYPE_CHECKING:
+    from tidy3d.components.viz import PlotParams
 
 
 class AbstractHeatChargeSource(AbstractSource, ABC):

--- a/tidy3d/components/time.py
+++ b/tidy3d/components/time.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 import numpy as np
 from pydantic import Field, NonNegativeFloat
@@ -11,8 +12,10 @@ from tidy3d.constants import RADIAN
 from tidy3d.exceptions import SetupError
 
 from .base import Tidy3dBaseModel
-from .types import ArrayFloat1D, Ax, PlotVal
 from .viz import add_ax_if_none
+
+if TYPE_CHECKING:
+    from .types import ArrayFloat1D, Ax, PlotVal
 
 # in spectrum computation, discard amplitudes with relative magnitude smaller than cutoff
 DFT_CUTOFF = 1e-8

--- a/tidy3d/components/time_modulation.py
+++ b/tidy3d/components/time_modulation.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from math import isclose
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
-from pydantic import Field, FieldValidationInfo, PositiveFloat, field_validator, model_validator
+from pydantic import Field, PositiveFloat, field_validator, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.constants import HERTZ, RADIAN
 from tidy3d.exceptions import ValidationError
 
@@ -17,7 +16,14 @@ from .base import Tidy3dBaseModel, cached_property
 from .data.data_array import SpatialDataArray
 from .data.validators import validate_no_nans
 from .time import AbstractTimeDependence
-from .types import Bound, InterpMethod
+from .types import InterpMethod
+
+if TYPE_CHECKING:
+    from pydantic import FieldValidationInfo
+
+    from tidy3d.compat import Self
+
+    from .types import Bound
 
 
 class AbstractTimeModulation(AbstractTimeDependence, ABC):

--- a/tidy3d/components/transformation.py
+++ b/tidy3d/components/transformation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
 from pydantic import Field, field_validator
@@ -13,7 +13,10 @@ from tidy3d.exceptions import ValidationError
 
 from .autograd import TracedFloat
 from .base import Tidy3dBaseModel, cached_property
-from .types import ArrayFloat2D, Axis, Coordinate, TensorReal
+from .types import Axis, Coordinate
+
+if TYPE_CHECKING:
+    from .types import ArrayFloat2D, TensorReal
 
 
 class AbstractRotation(ABC, Tidy3dBaseModel):

--- a/tidy3d/components/types/base.py
+++ b/tidy3d/components/types/base.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import numbers
-from typing import Annotated, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional, Union
 
 import numpy as np
-from numpy.typing import NDArray
 from pydantic import (
     BaseModel,
     BeforeValidator,
@@ -18,6 +17,9 @@ from pydantic import (
 )
 from pydantic.functional_serializers import PlainSerializer
 from pydantic.json_schema import WithJsonSchema
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 try:
     from matplotlib.axes import Axes

--- a/tidy3d/components/types/utils.py
+++ b/tidy3d/components/types/utils.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from pydantic import GetCoreSchemaHandler
 from pydantic_core import core_schema
+
+if TYPE_CHECKING:
+    from pydantic import GetCoreSchemaHandler
 
 
 def _add_schema(arbitrary_type: type, title: str, field_type_str: str) -> None:

--- a/tidy3d/components/validators.py
+++ b/tidy3d/components/validators.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, TypeVar, Union
 
 import numpy as np
 from numpy.typing import NDArray
-from pydantic import FieldValidationInfo, field_validator, model_validator
+from pydantic import field_validator, model_validator
 
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
@@ -17,6 +17,10 @@ from .base import DATA_ARRAY_MAP
 from .geometry.base import Box
 
 if TYPE_CHECKING:
+    from typing import Callable, Optional
+
+    from pydantic import FieldValidationInfo
+
     from tidy3d import Simulation
     from tidy3d.components.base_sim.simulation import AbstractSimulation
     from tidy3d.components.data.monitor_data import AbstractFieldData

--- a/tidy3d/components/viz/axes_utils.py
+++ b/tidy3d/components/viz/axes_utils.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from functools import wraps
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
-from tidy3d.components.types import Ax, Axis, LengthUnit
+from tidy3d.components.types import LengthUnit
 from tidy3d.constants import UnitScaling
 from tidy3d.exceptions import Tidy3dKeyError
 
@@ -15,6 +15,9 @@ if TYPE_CHECKING:
 
     P = ParamSpec("P")
     T = TypeVar("T", bound=Callable[..., Axes])
+    from typing import Optional
+
+    from tidy3d.components.types import Ax, Axis
 
 
 def _create_unit_aware_locator() -> ticker.Locator:

--- a/tidy3d/components/viz/descartes.py
+++ b/tidy3d/components/viz/descartes.py
@@ -15,9 +15,11 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from shapely.geometry.base import BaseGeometry
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+    from shapely.geometry.base import BaseGeometry
 
 try:
     from matplotlib.patches import PathPatch
@@ -25,7 +27,6 @@ try:
 except ImportError:
     pass
 from numpy import array, concatenate, ones
-from numpy.typing import NDArray
 
 
 class Polygon:

--- a/tidy3d/components/viz/plot_params.py
+++ b/tidy3d/components/viz/plot_params.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from numpy import inf
 from pydantic import Field, NonNegativeFloat
 
 from tidy3d.components.base import Tidy3dBaseModel
-from tidy3d.components.viz.visualization_spec import VisualizationSpec
+
+if TYPE_CHECKING:
+    from tidy3d.components.viz.visualization_spec import VisualizationSpec
 
 
 class AbstractPlotParams(Tidy3dBaseModel):

--- a/tidy3d/components/viz/plot_sim_3d.py
+++ b/tidy3d/components/viz/plot_sim_3d.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from html import escape
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from tidy3d.exceptions import SetupError
 
 if TYPE_CHECKING:
+    from typing import Union
+
     from IPython.core.display_functions import DisplayHandle
 
     from tidy3d import Scene, Simulation

--- a/tidy3d/components/viz/visualization_spec.py
+++ b/tidy3d/components/viz/visualization_spec.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
-from pydantic import Field, ValidationInfo, field_validator
+from typing import TYPE_CHECKING
+
+from pydantic import Field, field_validator
 
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.log import log
+
+if TYPE_CHECKING:
+    from pydantic import ValidationInfo
 
 MATPLOTLIB_IMPORTED = True
 try:

--- a/tidy3d/config/legacy.py
+++ b/tidy3d/config/legacy.py
@@ -8,17 +8,22 @@ from __future__ import annotations
 
 import os
 import warnings
-from pathlib import Path
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import toml
 
 from tidy3d._runtime import WASM_BUILD
-from tidy3d.log import LogLevel, log
+from tidy3d.log import log
 
 # TODO(FXC-3827): Remove LegacyConfigWrapper/Environment shims and related helpers in Tidy3D 2.12.
 from .manager import ConfigManager, normalize_profile_name
 from .profiles import BUILTIN_PROFILES
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from typing import Optional
+
+    from tidy3d.log import LogLevel
 
 
 def _warn_env_deprecated() -> None:

--- a/tidy3d/config/loader.py
+++ b/tidy3d/config/loader.py
@@ -7,7 +7,7 @@ import shutil
 import tempfile
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import toml
 import tomlkit
@@ -16,6 +16,9 @@ from tidy3d.log import log
 
 from .profiles import BUILTIN_PROFILES
 from .serializer import build_document, collect_descriptions
+
+if TYPE_CHECKING:
+    from typing import Optional
 
 
 class ConfigLoader:

--- a/tidy3d/config/manager.py
+++ b/tidy3d/config/manager.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 import os
 import shutil
 from collections import defaultdict
-from collections.abc import Iterable, Mapping
 from copy import deepcopy
 from enum import Enum
 from io import StringIO
 from pathlib import Path
-from typing import Any, Optional, get_args, get_origin
+from typing import TYPE_CHECKING, Any, get_args, get_origin
 
 from pydantic import BaseModel
 from rich.console import Console
@@ -24,6 +23,10 @@ from tidy3d.log import log
 from .loader import ConfigLoader, deep_diff, deep_merge, load_environment_overrides
 from .profiles import BUILTIN_PROFILES
 from .registry import attach_manager, get_handlers, get_sections
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+    from typing import Optional
 
 
 def normalize_profile_name(name: str) -> str:

--- a/tidy3d/config/registry.py
+++ b/tidy3d/config/registry.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Callable, Optional, TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from typing import Callable, Optional
 
 T = TypeVar("T", bound=BaseModel)
 

--- a/tidy3d/config/sections.py
+++ b/tidy3d/config/sections.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import os
-from os import PathLike
 from pathlib import Path
-from typing import Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 from urllib.parse import urlparse
 
 import numpy as np
@@ -27,6 +26,9 @@ from tidy3d.log import DEFAULT_LEVEL, LogLevel, log, set_log_suppression, set_lo
 
 from .registry import get_manager as _get_attached_manager
 from .registry import register_handler, register_section
+
+if TYPE_CHECKING:
+    from os import PathLike
 
 TLS_VERSION_CHOICES = {"TLSv1", "TLSv1_1", "TLSv1_2", "TLSv1_3"}
 

--- a/tidy3d/config/serializer.py
+++ b/tidy3d/config/serializer.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
-from typing import Any, get_args, get_origin
+from typing import TYPE_CHECKING, Any, get_args, get_origin
 
 import tomlkit
 from pydantic import BaseModel
-from pydantic.fields import FieldInfo
 from tomlkit.items import Item, Table
 
 from .registry import get_sections
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from pydantic.fields import FieldInfo
 
 Path = tuple[str, ...]
 

--- a/tidy3d/exceptions.py
+++ b/tidy3d/exceptions.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING
 
 from .log import log
+
+if TYPE_CHECKING:
+    from typing import Optional
 
 
 class Tidy3dError(ValueError):

--- a/tidy3d/log.py
+++ b/tidy3d/log.py
@@ -3,21 +3,23 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime
-from os import PathLike
-from types import TracebackType
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Union
 
-from pydantic import BaseModel
 from rich.console import Console
 from rich.text import Text
 
-from tidy3d.compat import Self
-
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from os import PathLike
+    from types import TracebackType
+    from typing import Callable, Optional
+
+    from pydantic import BaseModel
     from rich.progress import Progress as RichProgress
+
+    from tidy3d.compat import Self
 # Note: "SUPPORT" and "USER" levels are meant for backend runs only.
 # Logging in frontend code should just use the standard debug/info/warning/error/critical.
 LogLevel = Literal["DEBUG", "SUPPORT", "USER", "INFO", "WARNING", "ERROR", "CRITICAL"]

--- a/tidy3d/material_library/material_library.py
+++ b/tidy3d/material_library/material_library.py
@@ -3,14 +3,10 @@
 from __future__ import annotations
 
 import json
-from os import PathLike
 from typing import TYPE_CHECKING, Optional, Union
 
 from pydantic import Field, model_validator
-from rich.panel import Panel
-from rich.table import Table
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.material.multi_physics import MultiPhysicsMedium
 from tidy3d.components.material.tcad.charge import SemiconductorMedium
@@ -24,7 +20,6 @@ from tidy3d.components.tcad.types import (
     ShockleyReedHallRecombination,
     SlotboomBandGapNarrowing,
 )
-from tidy3d.components.types import Axis
 from tidy3d.exceptions import SetupError
 from tidy3d.log import log
 
@@ -41,7 +36,14 @@ from .util import (
 )
 
 if TYPE_CHECKING:
+    from os import PathLike
+
     from IPython.lib.pretty import RepresentationPrinter
+    from rich.panel import Panel
+    from rich.table import Table
+
+    from tidy3d.compat import Self
+    from tidy3d.components.types import Axis
 
 
 def export_matlib_to_file(fname: PathLike = "matlib.json") -> None:

--- a/tidy3d/material_library/util.py
+++ b/tidy3d/material_library/util.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from io import StringIO
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from rich.console import Console
 from rich.panel import Panel
@@ -9,12 +9,14 @@ from rich.table import Table
 from rich.text import Text
 from rich.tree import Tree
 
-from tidy3d import Medium2D, MultiPhysicsMedium, PoleResidue
 from tidy3d.components.viz import FLEXCOMPUTE_COLORS
 
 if TYPE_CHECKING:
+    from typing import Union
+
     from IPython.lib.pretty import RepresentationPrinter
 
+    from tidy3d import Medium2D, MultiPhysicsMedium, PoleResidue
     from tidy3d.material_library.material_library import (
         AbstractVariantItem,
         MaterialItem,

--- a/tidy3d/packaging.py
+++ b/tidy3d/packaging.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import functools
 from importlib import import_module
 from importlib.util import find_spec
-from typing import Any, Callable, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 import numpy as np
 
@@ -17,6 +17,9 @@ from tidy3d.config import config
 
 from .exceptions import Tidy3dImportError
 from .version import __version__
+
+if TYPE_CHECKING:
+    from typing import Literal
 
 F = TypeVar("F", bound=Callable[..., Any])
 

--- a/tidy3d/plugins/autograd/differential_operators.py
+++ b/tidy3d/plugins/autograd/differential_operators.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import TYPE_CHECKING
 
 from autograd.builtins import tuple as atuple
 from autograd.core import make_vjp
 from autograd.extend import vspace
 from autograd.wrap_util import unary_to_nary
-from numpy.typing import ArrayLike
 
 from .utilities import scalar_objective
+
+if TYPE_CHECKING:
+    from typing import Callable
+
+    from numpy.typing import ArrayLike
 
 __all__ = [
     "grad",

--- a/tidy3d/plugins/autograd/functions.py
+++ b/tidy3d/plugins/autograd/functions.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
-from types import ModuleType
-from typing import Callable, Literal, Optional, SupportsInt, Union
+from typing import TYPE_CHECKING
 
 import autograd.numpy as np
 import numpy as onp
@@ -13,12 +11,20 @@ from autograd.scipy.special import logsumexp
 from autograd.tracer import getval
 from numpy.fft import irfftn, rfftn
 from numpy.lib.stride_tricks import sliding_window_view
-from numpy.typing import NDArray
 from scipy.fft import next_fast_len
 
 from tidy3d.components.autograd.functions import add_at, interpn, trapz
 
-from .types import PaddingType
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from types import ModuleType
+    from typing import Callable, Literal, Optional, SupportsInt, Union
+
+    from numpy.typing import NDArray
+
+    from tidy3d.components.autograd import TracedArrayLike
+
+    from .types import PaddingType
 
 __all__ = [
     "add_at",
@@ -38,8 +44,6 @@ __all__ = [
     "threshold",
     "trapz",
 ]
-
-from tidy3d.components.autograd import TracedArrayLike
 
 
 def _normalize_axes(

--- a/tidy3d/plugins/autograd/invdes/filters.py
+++ b/tidy3d/plugins/autograd/invdes/filters.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
 import abc
-from collections.abc import Iterable
 from functools import lru_cache, partial
-from typing import Annotated, Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Annotated, Any, Union
 
 import numpy as np
-from numpy.typing import NDArray
 from pydantic import Field, PositiveInt
 
 import tidy3d as td
@@ -14,8 +12,16 @@ from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.types import TYPE_TAG_STR
 from tidy3d.plugins.autograd.functions import convolve
 from tidy3d.plugins.autograd.primitives import gaussian_filter as autograd_gaussian_filter
-from tidy3d.plugins.autograd.types import KernelType, PaddingType
+from tidy3d.plugins.autograd.types import PaddingType
 from tidy3d.plugins.autograd.utilities import get_kernel_size_px, make_kernel
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import Callable, Optional
+
+    from numpy.typing import NDArray
+
+    from tidy3d.plugins.autograd.types import KernelType
 
 _GAUSSIAN_SIGMA_SCALE = 0.445  # empirically matches conic kernel response in 1D/2D tests
 _GAUSSIAN_PADDING_MAP = {

--- a/tidy3d/plugins/autograd/invdes/misc.py
+++ b/tidy3d/plugins/autograd/invdes/misc.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import autograd.numpy as np
-from numpy.typing import NDArray
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 
 def grey_indicator(array: NDArray) -> float:

--- a/tidy3d/plugins/autograd/invdes/parametrizations.py
+++ b/tidy3d/plugins/autograd/invdes/parametrizations.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 from collections import deque
-from typing import Any, Callable, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import autograd.numpy as np
 from autograd import value_and_grad
-from numpy.typing import NDArray
 from pydantic import Field, NonNegativeFloat
 from scipy.optimize import minimize
 
@@ -17,6 +16,11 @@ from tidy3d.plugins.autograd.types import KernelType, PaddingType
 
 from .filters import make_filter
 from .projections import tanh_projection
+
+if TYPE_CHECKING:
+    from typing import Callable, Literal
+
+    from numpy.typing import NDArray
 
 
 class FilterAndProject(Tidy3dBaseModel):

--- a/tidy3d/plugins/autograd/invdes/penalties.py
+++ b/tidy3d/plugins/autograd/invdes/penalties.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
-from typing import Callable, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import autograd.numpy as np
-from numpy.typing import NDArray
 from pydantic import Field, NonNegativeFloat
 
 from tidy3d.components.base import Tidy3dBaseModel
-from tidy3d.components.types import ArrayFloat2D
 from tidy3d.plugins.autograd.types import PaddingType
 
 from .parametrizations import FilterAndProject
+
+if TYPE_CHECKING:
+    from typing import Callable
+
+    from numpy.typing import NDArray
+
+    from tidy3d.components.types import ArrayFloat2D
 
 
 class ErosionDilationPenalty(Tidy3dBaseModel):

--- a/tidy3d/plugins/autograd/invdes/projections.py
+++ b/tidy3d/plugins/autograd/invdes/projections.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import autograd.numpy as np
-from numpy.typing import NDArray
 
 from tidy3d.plugins.autograd.constants import BETA_DEFAULT, ETA_DEFAULT
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 
 def ramp_projection(array: NDArray, width: float = 0.1, center: float = 0.5) -> NDArray:

--- a/tidy3d/plugins/autograd/invdes/symmetries.py
+++ b/tidy3d/plugins/autograd/invdes/symmetries.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
-from numpy.typing import NDArray
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 
 def symmetrize_mirror(array: NDArray, axis: int | tuple[int, int]) -> NDArray:

--- a/tidy3d/plugins/autograd/primitives/interpolate.py
+++ b/tidy3d/plugins/autograd/primitives/interpolate.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
-from typing import Callable, Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 from autograd.extend import defvjp, primitive
-from numpy.typing import NDArray
 
 from tidy3d.log import log
+
+if TYPE_CHECKING:
+    from typing import Callable, Optional
+
+    from numpy.typing import NDArray
 
 
 def _assert_strictly_monotonic(x: NDArray) -> None:

--- a/tidy3d/plugins/autograd/primitives/misc.py
+++ b/tidy3d/plugins/autograd/primitives/misc.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from functools import cache
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any
 
 import autograd.numpy as anp
 import numpy as np
 import scipy.ndimage
 from autograd.extend import defjvp, defvjp, primitive
-from numpy.typing import NDArray
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Callable
+
+    from numpy.typing import NDArray
 
 
 def _normalize_sequence(value: float | Sequence[float], ndim: int) -> tuple[float, ...]:

--- a/tidy3d/plugins/autograd/utilities.py
+++ b/tidy3d/plugins/autograd/utilities.py
@@ -2,16 +2,20 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from functools import reduce, wraps
-from typing import Any, Callable, Optional, ParamSpec, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, overload
 
 import autograd.numpy as anp
 import numpy as np
 import xarray as xr
-from numpy.typing import NDArray
 
 from tidy3d.exceptions import Tidy3dError
 
-from .types import KernelType
+if TYPE_CHECKING:
+    from typing import Callable, Optional, Union
+
+    from numpy.typing import NDArray
+
+    from .types import KernelType
 
 P = ParamSpec("P")
 R = TypeVar("R")

--- a/tidy3d/plugins/design/design.py
+++ b/tidy3d/plugins/design/design.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import Field
 
@@ -11,7 +11,7 @@ from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.simulation import Simulation
 from tidy3d.components.types import TYPE_TAG_STR
-from tidy3d.log import Console, get_logging_console, log
+from tidy3d.log import get_logging_console, log
 from tidy3d.web.api.container import Batch, BatchData, Job
 
 from .method import (
@@ -23,6 +23,11 @@ from .method import (
 )
 from .parameter import ParameterAny, ParameterInt, ParameterType
 from .result import Result
+
+if TYPE_CHECKING:
+    from typing import Callable, Union
+
+    from tidy3d.log import Console
 
 
 class DesignSpace(Tidy3dBaseModel):

--- a/tidy3d/plugins/design/method.py
+++ b/tidy3d/plugins/design/method.py
@@ -7,18 +7,20 @@ from typing import TYPE_CHECKING, Annotated, Any, Callable, Literal, Optional, U
 
 import numpy as np
 import scipy.stats.qmc as qmc
-from numpy.typing import NDArray
 from pydantic import Field, NonNegativeFloat, PositiveFloat, PositiveInt
-from rich.console import Console
 
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.constants import inf
 
-from .parameter import ParameterAny, ParameterFloat, ParameterInt, ParameterType
+from .parameter import ParameterAny, ParameterFloat, ParameterInt
 
 if TYPE_CHECKING:
     import pygad
+    from numpy.typing import NDArray
+    from rich.console import Console
     from scipy.stats import qmc as qmc_type
+
+    from .parameter import ParameterType
 
 
 ArgsList = list[dict[str, Any]]

--- a/tidy3d/plugins/design/parameter.py
+++ b/tidy3d/plugins/design/parameter.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import numpy as np
-from numpy.typing import NDArray
 from pydantic import Field, PositiveInt, field_validator
 
 from tidy3d.components.base import Tidy3dBaseModel
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 
 class Parameter(Tidy3dBaseModel, ABC):

--- a/tidy3d/plugins/design/result.py
+++ b/tidy3d/plugins/design/result.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
 import pandas
 from pydantic import Field, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel, cached_property
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from tidy3d.compat import Self
 
 # NOTE: Coords are args_dict from method and design. This may be changed in future to unify naming
 

--- a/tidy3d/plugins/dispersion/fit.py
+++ b/tidy3d/plugins/dispersion/fit.py
@@ -4,26 +4,31 @@ from __future__ import annotations
 
 import codecs
 import csv
-from collections.abc import Sequence
-from os import PathLike
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
 import requests
 import scipy.optimize as opt
-from numpy.typing import NDArray
 from pydantic import Field, field_validator, model_validator
 from rich.progress import Progress
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.medium import AbstractMedium, PoleResidue
-from tidy3d.components.types import ArrayFloat1D, Ax
+from tidy3d.components.types import ArrayFloat1D
 from tidy3d.components.viz import add_ax_if_none
 from tidy3d.config import config
 from tidy3d.constants import C_0, HBAR, MICROMETER
 from tidy3d.exceptions import SetupError, ValidationError, WebError
 from tidy3d.log import get_logging_console, log
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from os import PathLike
+
+    from numpy.typing import NDArray
+
+    from tidy3d.compat import Self
+    from tidy3d.components.types import Ax
 
 
 class DispersionFitter(Tidy3dBaseModel):

--- a/tidy3d/plugins/dispersion/fit_fast.py
+++ b/tidy3d/plugins/dispersion/fit_fast.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
-from pydantic import NonNegativeFloat, PositiveInt
 
 from tidy3d.components.dispersion_fitter import (
     AdvancedFastFitterParam,
@@ -16,6 +15,11 @@ from tidy3d.components.medium import PoleResidue
 from tidy3d.constants import HBAR
 
 from .fit import DispersionFitter
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from pydantic import NonNegativeFloat, PositiveInt
 
 # numerical tolerance for pole relocation for fast fitter
 TOL = 1e-8

--- a/tidy3d/plugins/dispersion/web.py
+++ b/tidy3d/plugins/dispersion/web.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import ssl
 from enum import Enum
-from typing import Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 import requests
 from pydantic import Field, NonNegativeFloat, PositiveFloat, PositiveInt, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.medium import PoleResidue
 from tidy3d.components.types import Undefined
@@ -20,6 +19,9 @@ from tidy3d.log import log
 from tidy3d.web.core.http_util import get_headers
 
 from .fit import DispersionFitter
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
 
 BOUND_MAX_FACTOR = 10
 

--- a/tidy3d/plugins/expressions/base.py
+++ b/tidy3d/plugins/expressions/base.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Generator
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from tidy3d.components.base import Tidy3dBaseModel
 
-from .types import ExpressionType, NumberOrExpression, NumberType
-
 if TYPE_CHECKING:
+    from collections.abc import Generator
+    from typing import Optional
+
     from .operators import (
         Abs,
         Add,
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
         Power,
         Subtract,
     )
+    from .types import ExpressionType, NumberOrExpression, NumberType
 
 
 class Expression(Tidy3dBaseModel, ABC):

--- a/tidy3d/plugins/expressions/functions.py
+++ b/tidy3d/plugins/expressions/functions.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import autograd.numpy as anp
 from pydantic import Field, field_validator
 
 from .base import Expression
-from .types import ExpressionType, NumberOrExpression, NumberType
+from .types import NumberOrExpression
+
+if TYPE_CHECKING:
+    from .types import ExpressionType, NumberType
 
 
 class Function(Expression):

--- a/tidy3d/plugins/expressions/metrics.py
+++ b/tidy3d/plugins/expressions/metrics.py
@@ -1,19 +1,22 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import autograd.numpy as np
 import xarray as xr
 from pydantic import Field, NonNegativeInt
 
-from tidy3d.compat import Self
-from tidy3d.components.monitor import ModeMonitor
 from tidy3d.components.types import Direction, FreqArray
 
-from .base import Expression
-from .types import NumberType
 from .variables import Variable
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
+    from tidy3d.components.monitor import ModeMonitor
+
+    from .base import Expression
+    from .types import NumberType
 
 
 def generate_validation_data(expr: Expression) -> dict[str, xr.Dataset]:

--- a/tidy3d/plugins/expressions/operators.py
+++ b/tidy3d/plugins/expressions/operators.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import Field, field_validator
 
 from .base import Expression
-from .types import ExpressionType, NumberOrExpression, NumberType
+from .types import NumberOrExpression
+
+if TYPE_CHECKING:
+    from .types import ExpressionType, NumberType
 
 
 class UnaryOperator(Expression):

--- a/tidy3d/plugins/invdes/design.py
+++ b/tidy3d/plugins/invdes/design.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 import abc
-from typing import Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
-import autograd.numpy as anp
 import numpy as np
 from pydantic import Field, field_validator, model_validator
 
 import tidy3d as td
-from tidy3d.compat import Self
 from tidy3d.components.autograd import get_static
 from tidy3d.exceptions import ValidationError
 from tidy3d.plugins.expressions.metrics import Metric, generate_validation_data
@@ -19,6 +17,11 @@ from tidy3d.plugins.expressions.types import ExpressionType
 from .base import InvdesBaseModel
 from .region import DesignRegionType
 from .validators import check_pixel_size
+
+if TYPE_CHECKING:
+    import autograd.numpy as anp
+
+    from tidy3d.compat import Self
 
 PostProcessFnType = Callable[[td.SimulationData], float]
 

--- a/tidy3d/plugins/invdes/initialization.py
+++ b/tidy3d/plugins/invdes/initialization.py
@@ -3,17 +3,20 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
-from numpy.typing import NDArray
 from pydantic import Field, NonNegativeInt, field_validator, model_validator
 
 import tidy3d as td
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.types import ArrayLike
 from tidy3d.exceptions import ValidationError
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    from tidy3d.compat import Self
 
 
 class AbstractInitializationSpec(Tidy3dBaseModel, ABC):

--- a/tidy3d/plugins/invdes/optimizer.py
+++ b/tidy3d/plugins/invdes/optimizer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import abc
 from copy import deepcopy
-from typing import Callable, Optional
+from typing import TYPE_CHECKING, Optional
 
 import autograd as ag
 import autograd.numpy as anp
@@ -16,6 +16,9 @@ from tidy3d.components.types import TYPE_TAG_STR
 from .base import InvdesBaseModel
 from .design import InverseDesignType
 from .result import InverseDesignResult
+
+if TYPE_CHECKING:
+    from typing import Callable
 
 
 class AbstractOptimizer(InvdesBaseModel, abc.ABC):

--- a/tidy3d/plugins/invdes/penalty.py
+++ b/tidy3d/plugins/invdes/penalty.py
@@ -2,15 +2,17 @@
 from __future__ import annotations
 
 import abc
-from typing import Any, Union
+from typing import TYPE_CHECKING, Any, Union
 
-import autograd.numpy as anp
 from pydantic import Field, NonNegativeFloat, PositiveFloat
 
 from tidy3d.constants import MICROMETER
 from tidy3d.plugins.autograd.invdes import make_erosion_dilation_penalty
 
 from .base import InvdesBaseModel
+
+if TYPE_CHECKING:
+    import autograd.numpy as anp
 
 
 class AbstractPenalty(InvdesBaseModel, abc.ABC):

--- a/tidy3d/plugins/invdes/region.py
+++ b/tidy3d/plugins/invdes/region.py
@@ -3,16 +3,14 @@ from __future__ import annotations
 
 import abc
 import warnings
-from typing import Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 import autograd.numpy as anp
 import numpy as np
 from autograd import elementwise_grad, grad
-from numpy.typing import NDArray
 from pydantic import Field, PositiveFloat, field_validator, model_validator
 
 import tidy3d as td
-from tidy3d.compat import Self
 from tidy3d.components.types import TYPE_TAG_STR, Coordinate, Size
 from tidy3d.exceptions import ValidationError
 
@@ -20,6 +18,11 @@ from .base import InvdesBaseModel
 from .initialization import InitializationSpecType, UniformInitializationSpec
 from .penalty import PenaltyType
 from .transformation import TransformationType
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    from tidy3d.compat import Self
 
 # TODO: support auto handling of symmetry in parameters
 

--- a/tidy3d/plugins/invdes/transformation.py
+++ b/tidy3d/plugins/invdes/transformation.py
@@ -2,9 +2,8 @@
 from __future__ import annotations
 
 import abc
-from typing import Any, Union
+from typing import TYPE_CHECKING, Any, Union
 
-import autograd.numpy as anp
 from pydantic import Field, PositiveFloat
 
 import tidy3d as td
@@ -12,6 +11,9 @@ from tidy3d.plugins.autograd.functions import threshold
 from tidy3d.plugins.autograd.invdes import make_filter_and_project
 
 from .base import InvdesBaseModel
+
+if TYPE_CHECKING:
+    import autograd.numpy as anp
 
 
 class AbstractTransformation(InvdesBaseModel, abc.ABC):

--- a/tidy3d/plugins/invdes/validators.py
+++ b/tidy3d/plugins/invdes/validators.py
@@ -1,12 +1,16 @@
 # validator utilities for invdes plugin
 from __future__ import annotations
 
-from typing import Any, Callable, Optional
+from typing import TYPE_CHECKING, Any
 
 from pydantic import field_validator, model_validator
-from pydantic._internal._decorators import ModelValidatorDecoratorInfo, PydanticDescriptorProxy
 
 import tidy3d as td
+
+if TYPE_CHECKING:
+    from typing import Callable, Optional
+
+    from pydantic._internal._decorators import ModelValidatorDecoratorInfo, PydanticDescriptorProxy
 
 # warn if pixel size is > PIXEL_SIZE_WARNING_THRESHOLD * (minimum wavelength in material)
 PIXEL_SIZE_WARNING_THRESHOLD = 0.1

--- a/tidy3d/plugins/klayout/drc/drc.py
+++ b/tidy3d/plugins/klayout/drc/drc.py
@@ -6,7 +6,7 @@ import re
 from collections.abc import Mapping
 from pathlib import Path
 from subprocess import run
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from pydantic import Field, FilePath, field_validator
 
@@ -23,6 +23,9 @@ from tidy3d.plugins.klayout.drc.defaults import (
 )
 from tidy3d.plugins.klayout.drc.results import DRCResults
 from tidy3d.plugins.klayout.util import check_installation
+
+if TYPE_CHECKING:
+    from typing import Optional, Union
 
 SUPPORTED_DRC_SUFFIXES: frozenset[str] = frozenset({".drc", ".lydrc"})
 

--- a/tidy3d/plugins/klayout/drc/results.py
+++ b/tidy3d/plugins/klayout/drc/results.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import re
 import xml.etree.ElementTree as ET
-from pathlib import Path
-from typing import Optional, Union
+from typing import TYPE_CHECKING
 
 from pydantic import Field
 
@@ -13,6 +12,10 @@ from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.types import Coordinate2D
 from tidy3d.exceptions import FileError
 from tidy3d.log import log
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from typing import Optional, Union
 
 # Types for DRC markers
 DRCEdge = tuple[Coordinate2D, Coordinate2D]

--- a/tidy3d/plugins/klayout/util.py
+++ b/tidy3d/plugins/klayout/util.py
@@ -4,9 +4,12 @@ import os
 import platform
 from pathlib import Path
 from shutil import which
-from typing import Union
+from typing import TYPE_CHECKING
 
 import tidy3d as td
+
+if TYPE_CHECKING:
+    from typing import Union
 
 
 def check_installation(raise_error: bool = False) -> Union[str, None]:

--- a/tidy3d/plugins/microwave/array_factor.py
+++ b/tidy3d/plugins/microwave/array_factor.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import numpy as np
-from numpy.typing import NDArray
 from pydantic import (
     Field,
     NonNegativeFloat,
@@ -19,23 +18,32 @@ from pydantic import (
 from scipy.signal.windows import blackman, blackmanharris, chebwin, hamming, hann, kaiser, taylor
 from scipy.special import j0, jn_zeros
 
-from tidy3d.compat import Self
-from tidy3d.components.data.monitor_data import AbstractFieldProjectionData, DirectivityData
+from tidy3d.components.data.monitor_data import DirectivityData
 from tidy3d.components.data.sim_data import SimulationData
-from tidy3d.components.geometry.base import Box, Geometry
-from tidy3d.components.grid.grid_spec import GridSpec, LayerRefinementSpec
+from tidy3d.components.geometry.base import Box
+from tidy3d.components.grid.grid_spec import LayerRefinementSpec
 from tidy3d.components.lumped_element import LumpedElement
-from tidy3d.components.medium import Medium, MediumType3D
+from tidy3d.components.medium import Medium
 from tidy3d.components.microwave.base import MicrowaveBaseModel
 from tidy3d.components.monitor import AbstractFieldProjectionMonitor
-from tidy3d.components.simulation import Simulation
-from tidy3d.components.source.utils import SourceType
 from tidy3d.components.structure import MeshOverrideStructure, Structure
-from tidy3d.components.types import TYPE_TAG_STR, ArrayLike, Axis, Bound, Undefined
-from tidy3d.components.types.monitor import MonitorType
+from tidy3d.components.types import TYPE_TAG_STR, ArrayLike, Undefined
 from tidy3d.constants import C_0, inf
 from tidy3d.exceptions import Tidy3dNotImplementedError
 from tidy3d.log import log
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    from tidy3d.compat import Self
+    from tidy3d.components.data.monitor_data import AbstractFieldProjectionData
+    from tidy3d.components.geometry.base import Geometry
+    from tidy3d.components.grid.grid_spec import GridSpec
+    from tidy3d.components.medium import MediumType3D
+    from tidy3d.components.simulation import Simulation
+    from tidy3d.components.source.utils import SourceType
+    from tidy3d.components.types import Axis, Bound
+    from tidy3d.components.types.monitor import MonitorType
 
 
 class AbstractAntennaArrayCalculator(MicrowaveBaseModel, ABC):

--- a/tidy3d/plugins/microwave/lobe_measurer.py
+++ b/tidy3d/plugins/microwave/lobe_measurer.py
@@ -3,20 +3,25 @@
 from __future__ import annotations
 
 from math import isclose, isnan
-from typing import Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 from pandas import DataFrame
 from pydantic import Field, field_validator, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import cached_property
 from tidy3d.components.microwave.base import MicrowaveBaseModel
-from tidy3d.components.types import ArrayFloat1D, ArrayLike, Ax
+from tidy3d.components.types import ArrayFloat1D
 from tidy3d.constants import fp_eps
 from tidy3d.exceptions import ValidationError
 
 from .viz import plot_params_lobe_FNBW, plot_params_lobe_peak, plot_params_lobe_width
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from tidy3d.compat import Self
+    from tidy3d.components.types import ArrayLike, Ax
 
 # The minimum plateau size for peak finding, which is set to 0 to ensure that all peaks are found.
 # A value must be provided to retrieve additional information from `find_peaks`.

--- a/tidy3d/plugins/polyslab/polyslab.py
+++ b/tidy3d/plugins/polyslab/polyslab.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from tidy3d.components.geometry.polyslab import ComplexPolySlabBase
-from tidy3d.components.medium import MediumType
 from tidy3d.components.structure import Structure
+
+if TYPE_CHECKING:
+    from tidy3d.components.medium import MediumType
 
 
 class ComplexPolySlab(ComplexPolySlabBase):

--- a/tidy3d/plugins/pytorch/wrapper.py
+++ b/tidy3d/plugins/pytorch/wrapper.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import inspect
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any
 
 import torch
 from autograd import make_vjp
-from torch.autograd.function import FunctionCtx
+
+if TYPE_CHECKING:
+    from typing import Callable
+
+    from torch.autograd.function import FunctionCtx
 
 
 def to_torch(fun: Callable[..., Any]) -> Callable[..., torch.Tensor]:

--- a/tidy3d/plugins/resonance/resonance.py
+++ b/tidy3d/plugins/resonance/resonance.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Literal, Optional, Union
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 import xarray as xr
@@ -12,10 +12,15 @@ from pydantic import Field, NonNegativeFloat, PositiveInt, field_validator
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.data.data_array import ScalarFieldTimeDataArray
 from tidy3d.components.data.monitor_data import FieldTimeData
-from tidy3d.components.types import ArrayComplex1D, ArrayComplex2D, ArrayComplex3D, ArrayFloat1D
+from tidy3d.components.types import ArrayComplex1D, ArrayFloat1D
 from tidy3d.constants import HERTZ
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
+
+if TYPE_CHECKING:
+    from typing import Literal, Union
+
+    from tidy3d.components.types import ArrayComplex2D, ArrayComplex3D
 
 INIT_NUM_FREQS = 200
 

--- a/tidy3d/plugins/smatrix/analysis/antenna.py
+++ b/tidy3d/plugins/smatrix/analysis/antenna.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from tidy3d.components.microwave.data.monitor_data import AntennaMetricsData
 from tidy3d.plugins.smatrix.data.data_array import PortDataArray
-from tidy3d.plugins.smatrix.data.terminal import TerminalComponentModelerData
-from tidy3d.plugins.smatrix.types import NetworkIndex
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from tidy3d.plugins.smatrix.data.terminal import TerminalComponentModelerData
+    from tidy3d.plugins.smatrix.types import NetworkIndex
 
 
 def get_antenna_metrics_data(

--- a/tidy3d/plugins/smatrix/analysis/modal.py
+++ b/tidy3d/plugins/smatrix/analysis/modal.py
@@ -4,10 +4,14 @@ Tool for generating an S matrix automatically from a Tidy3d simulation and lumpe
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 
 from tidy3d.plugins.smatrix.data.data_array import ModalPortDataArray
-from tidy3d.plugins.smatrix.data.modal import ModalComponentModelerData
+
+if TYPE_CHECKING:
+    from tidy3d.plugins.smatrix.data.modal import ModalComponentModelerData
 
 
 def modal_construct_smatrix(modeler_data: ModalComponentModelerData) -> ModalPortDataArray:

--- a/tidy3d/plugins/smatrix/analysis/terminal.py
+++ b/tidy3d/plugins/smatrix/analysis/terminal.py
@@ -14,20 +14,25 @@ References
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 
-from tidy3d.components.data.sim_data import SimulationData
-from tidy3d.plugins.smatrix.component_modelers.terminal import TerminalComponentModeler
-from tidy3d.plugins.smatrix.data.data_array import PortDataArray, TerminalPortDataArray
-from tidy3d.plugins.smatrix.data.terminal import TerminalComponentModelerData
+from tidy3d.plugins.smatrix.data.data_array import PortDataArray
 from tidy3d.plugins.smatrix.ports.wave import WavePort
-from tidy3d.plugins.smatrix.types import SParamDef
 from tidy3d.plugins.smatrix.utils import (
     ab_to_s,
     check_port_impedance_sign,
     compute_F,
     compute_port_VI,
 )
+
+if TYPE_CHECKING:
+    from tidy3d.components.data.sim_data import SimulationData
+    from tidy3d.plugins.smatrix.component_modelers.terminal import TerminalComponentModeler
+    from tidy3d.plugins.smatrix.data.data_array import TerminalPortDataArray
+    from tidy3d.plugins.smatrix.data.terminal import TerminalComponentModelerData
+    from tidy3d.plugins.smatrix.types import SParamDef
 
 
 def terminal_construct_smatrix(

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Literal, Optional, Union
 
-from pydantic import Field, ValidationInfo, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.geometry.utils import _shift_value_signed
 from tidy3d.components.simulation import Simulation
@@ -23,13 +22,18 @@ from tidy3d.config import config
 from tidy3d.constants import HERTZ
 from tidy3d.exceptions import SetupError, Tidy3dKeyError
 from tidy3d.log import log
-from tidy3d.plugins.smatrix.ports.modal import ModalPortDataArray, Port
-from tidy3d.plugins.smatrix.ports.types import LumpedPortType, PortType, TerminalPortType
+from tidy3d.plugins.smatrix.ports.modal import Port
+from tidy3d.plugins.smatrix.ports.types import LumpedPortType, TerminalPortType
 from tidy3d.plugins.smatrix.ports.wave import WavePort
 from tidy3d.plugins.smatrix.types import Element, MatrixIndex, NetworkElement, NetworkIndex
 
 if TYPE_CHECKING:
+    from pydantic import ValidationInfo
+
+    from tidy3d.compat import Self
     from tidy3d.plugins.smatrix import MicrowaveSMatrixData
+    from tidy3d.plugins.smatrix.ports.modal import ModalPortDataArray
+    from tidy3d.plugins.smatrix.ports.types import PortType
     from tidy3d.web.core.types import PayType
 # fwidth of gaussian pulse in units of central frequency
 FWIDTH_FRAC = 1.0 / 10

--- a/tidy3d/plugins/smatrix/component_modelers/modal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/modal.py
@@ -2,24 +2,27 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import autograd.numpy as np
 from pydantic import Field
 
 from tidy3d.components.base import cached_property
-from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.index import SimulationMap
 from tidy3d.components.monitor import ModeMonitor
-from tidy3d.components.simulation import Simulation
 from tidy3d.components.source.field import ModeSource
 from tidy3d.components.source.time import GaussianPulse
-from tidy3d.components.types import Ax, Complex
+from tidy3d.components.types import Complex
 from tidy3d.components.viz import add_ax_if_none, equal_aspect
 from tidy3d.plugins.smatrix.ports.modal import Port
 from tidy3d.plugins.smatrix.types import Element, MatrixIndex
 
 from .base import FWIDTH_FRAC, AbstractComponentModeler
+
+if TYPE_CHECKING:
+    from tidy3d.components.data.sim_data import SimulationData
+    from tidy3d.components.simulation import Simulation
+    from tidy3d.components.types import Ax
 
 
 class ModalComponentModeler(AbstractComponentModeler):

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import numpy as np
 from pydantic import Field, NonNegativeInt, field_validator, model_validator
 
 from tidy3d import ClipOperation, GeometryGroup, GridSpec, PolySlab
-from tidy3d.compat import Self
 from tidy3d.components.base import cached_property
 from tidy3d.components.boundary import BroadbandModeABCSpec
 from tidy3d.components.frequency_extrapolation import (
@@ -22,9 +21,8 @@ from tidy3d.components.geometry.utils_2d import snap_coordinate_to_grid
 from tidy3d.components.index import SimulationMap
 from tidy3d.components.microwave.base import MicrowaveBaseModel
 from tidy3d.components.monitor import DirectivityMonitor, ModeMonitor
-from tidy3d.components.simulation import Simulation
 from tidy3d.components.source.time import GaussianPulse
-from tidy3d.components.types import Ax, Complex, Coordinate
+from tidy3d.components.types import Complex, Coordinate
 from tidy3d.components.types.base import discriminated_union
 from tidy3d.components.viz import add_ax_if_none, equal_aspect
 from tidy3d.constants import C_0, MICROMETER, OHM, fp_eps, inf
@@ -34,13 +32,18 @@ from tidy3d.plugins.smatrix.component_modelers.base import (
     FWIDTH_FRAC,
     AbstractComponentModeler,
 )
-from tidy3d.plugins.smatrix.data.data_array import PortDataArray
 from tidy3d.plugins.smatrix.ports.base_lumped import AbstractLumpedPort
-from tidy3d.plugins.smatrix.ports.coaxial_lumped import CoaxialLumpedPort
-from tidy3d.plugins.smatrix.ports.rectangular_lumped import LumpedPort
 from tidy3d.plugins.smatrix.ports.types import TerminalPortType
 from tidy3d.plugins.smatrix.ports.wave import WavePort
 from tidy3d.plugins.smatrix.types import NetworkElement, NetworkIndex, SParamDef
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
+    from tidy3d.components.simulation import Simulation
+    from tidy3d.components.types import Ax
+    from tidy3d.plugins.smatrix.data.data_array import PortDataArray
+    from tidy3d.plugins.smatrix.ports.coaxial_lumped import CoaxialLumpedPort
+    from tidy3d.plugins.smatrix.ports.rectangular_lumped import LumpedPort
 
 AUTO_RADIATION_MONITOR_NAME = "radiation"
 AUTO_RADIATION_MONITOR_BUFFER = 2

--- a/tidy3d/plugins/smatrix/data/base.py
+++ b/tidy3d/plugins/smatrix/data/base.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from pydantic import Field, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel
-from tidy3d.components.data.data_array import DataArray
 from tidy3d.components.data.index import SimulationDataMap
 from tidy3d.plugins.smatrix.component_modelers.base import AbstractComponentModeler
+
+if TYPE_CHECKING:
+    from tidy3d.compat import Self
+    from tidy3d.components.data.data_array import DataArray
 
 
 class AbstractComponentModelerData(ABC, Tidy3dBaseModel):

--- a/tidy3d/plugins/smatrix/data/modal.py
+++ b/tidy3d/plugins/smatrix/data/modal.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from pydantic import Field
 
 from tidy3d.plugins.smatrix.component_modelers.modal import ModalComponentModeler
 from tidy3d.plugins.smatrix.data.base import AbstractComponentModelerData
-from tidy3d.plugins.smatrix.data.data_array import ModalPortDataArray
+
+if TYPE_CHECKING:
+    from tidy3d.plugins.smatrix.data.data_array import ModalPortDataArray
 
 
 class ModalComponentModelerData(AbstractComponentModelerData):

--- a/tidy3d/plugins/smatrix/data/terminal.py
+++ b/tidy3d/plugins/smatrix/data/terminal.py
@@ -2,27 +2,20 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 from pydantic import Field
 
 from tidy3d.components.base import cached_property
 from tidy3d.components.data.data_array import FreqDataArray
-from tidy3d.components.data.monitor_data import MonitorData
-from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.microwave.base import MicrowaveBaseModel
-from tidy3d.components.microwave.data.monitor_data import AntennaMetricsData
 from tidy3d.constants import C_0
 from tidy3d.plugins.smatrix.component_modelers.terminal import TerminalComponentModeler
 from tidy3d.plugins.smatrix.data.base import AbstractComponentModelerData
-from tidy3d.plugins.smatrix.data.data_array import (
-    PortDataArray,
-    PortNameDataArray,
-    TerminalPortDataArray,
-)
+from tidy3d.plugins.smatrix.data.data_array import PortDataArray, TerminalPortDataArray
 from tidy3d.plugins.smatrix.ports.types import LumpedPortType
-from tidy3d.plugins.smatrix.types import NetworkIndex, SParamDef
+from tidy3d.plugins.smatrix.types import SParamDef
 from tidy3d.plugins.smatrix.utils import (
     ab_to_s,
     check_port_impedance_sign,
@@ -32,6 +25,15 @@ from tidy3d.plugins.smatrix.utils import (
     compute_power_wave_amplitudes,
     s_to_z,
 )
+
+if TYPE_CHECKING:
+    from typing import Union
+
+    from tidy3d.components.data.monitor_data import MonitorData
+    from tidy3d.components.data.sim_data import SimulationData
+    from tidy3d.components.microwave.data.monitor_data import AntennaMetricsData
+    from tidy3d.plugins.smatrix.data.data_array import PortNameDataArray
+    from tidy3d.plugins.smatrix.types import NetworkIndex
 
 
 class MicrowaveSMatrixData(MicrowaveBaseModel):

--- a/tidy3d/plugins/smatrix/ports/base_lumped.py
+++ b/tidy3d/plugins/smatrix/ports/base_lumped.py
@@ -3,19 +3,22 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from pydantic import Field, PositiveInt
 
 from tidy3d.components.base import cached_property
 from tidy3d.components.geometry.utils_2d import snap_coordinate_to_grid
-from tidy3d.components.grid.grid import Grid, YeeGrid
-from tidy3d.components.lumped_element import LumpedElementType
-from tidy3d.components.monitor import FieldMonitor
-from tidy3d.components.types import Complex, Coordinate, FreqArray
+from tidy3d.components.types import Complex
 from tidy3d.constants import OHM
 
 from .base_terminal import AbstractTerminalPort
+
+if TYPE_CHECKING:
+    from tidy3d.components.grid.grid import Grid, YeeGrid
+    from tidy3d.components.lumped_element import LumpedElementType
+    from tidy3d.components.monitor import FieldMonitor
+    from tidy3d.components.types import Coordinate, FreqArray
 
 DEFAULT_PORT_NUM_CELLS = 3
 DEFAULT_REFERENCE_IMPEDANCE = 50

--- a/tidy3d/plugins/smatrix/ports/base_terminal.py
+++ b/tidy3d/plugins/smatrix/ports/base_terminal.py
@@ -3,19 +3,23 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Optional, Union
+from typing import TYPE_CHECKING
 
 from tidy3d.components.base import cached_property
-from tidy3d.components.data.data_array import FreqDataArray
-from tidy3d.components.data.sim_data import SimulationData
-from tidy3d.components.grid.grid import Grid
 from tidy3d.components.microwave.base import MicrowaveBaseModel
-from tidy3d.components.monitor import FieldMonitor, ModeMonitor
-from tidy3d.components.source.base import Source
-from tidy3d.components.source.time import GaussianPulse
-from tidy3d.components.types import FreqArray
 from tidy3d.log import log
 from tidy3d.plugins.smatrix.ports.base import AbstractBasePort
+
+if TYPE_CHECKING:
+    from typing import Optional, Union
+
+    from tidy3d.components.data.data_array import FreqDataArray
+    from tidy3d.components.data.sim_data import SimulationData
+    from tidy3d.components.grid.grid import Grid
+    from tidy3d.components.monitor import FieldMonitor, ModeMonitor
+    from tidy3d.components.source.base import Source
+    from tidy3d.components.source.time import GaussianPulse
+    from tidy3d.components.types import FreqArray
 
 
 class AbstractTerminalPort(AbstractBasePort, MicrowaveBaseModel):

--- a/tidy3d/plugins/smatrix/ports/coaxial_lumped.py
+++ b/tidy3d/plugins/smatrix/ports/coaxial_lumped.py
@@ -2,32 +2,39 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
-from numpy.typing import NDArray
 from pydantic import Field, PositiveFloat, field_validator, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import cached_property
-from tidy3d.components.data.data_array import FreqDataArray, ScalarFieldDataArray
+from tidy3d.components.data.data_array import ScalarFieldDataArray
 from tidy3d.components.data.dataset import FieldDataset
-from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.geometry.base import Box, Geometry
 from tidy3d.components.geometry.utils_2d import increment_float
-from tidy3d.components.grid.grid import Grid, YeeGrid
 from tidy3d.components.lumped_element import CoaxialLumpedResistor
 from tidy3d.components.microwave.path_integrals.integrals.current import Custom2DCurrentIntegral
 from tidy3d.components.microwave.path_integrals.integrals.voltage import AxisAlignedVoltageIntegral
 from tidy3d.components.microwave.path_integrals.specs.base import AbstractAxesRH
 from tidy3d.components.monitor import FieldMonitor
 from tidy3d.components.source.current import CustomCurrentSource
-from tidy3d.components.source.time import GaussianPulse
-from tidy3d.components.types import Axis, Coordinate, Direction, FreqArray, Size
+from tidy3d.components.types import Axis, Coordinate, Direction
 from tidy3d.constants import MICROMETER
 from tidy3d.exceptions import SetupError, ValidationError
 
 from .base_lumped import AbstractLumpedPort
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from numpy.typing import NDArray
+
+    from tidy3d.compat import Self
+    from tidy3d.components.data.data_array import FreqDataArray
+    from tidy3d.components.data.sim_data import SimulationData
+    from tidy3d.components.grid.grid import Grid, YeeGrid
+    from tidy3d.components.source.time import GaussianPulse
+    from tidy3d.components.types import FreqArray, Size
 
 DEFAULT_COAX_SOURCE_NUM_POINTS = 11
 

--- a/tidy3d/plugins/smatrix/ports/rectangular_lumped.py
+++ b/tidy3d/plugins/smatrix/ports/rectangular_lumped.py
@@ -2,18 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from pydantic import Field, model_validator
 from shapely import union_all
 from shapely.geometry.base import BaseMultipartGeometry
 
-from tidy3d.compat import Self
 from tidy3d.components.base import cached_property
-from tidy3d.components.data.data_array import FreqDataArray
-from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.geometry.base import Box, Geometry
 from tidy3d.components.geometry.utils import (
     SnapBehavior,
@@ -22,20 +18,30 @@ from tidy3d.components.geometry.utils import (
     snap_box_to_grid,
 )
 from tidy3d.components.geometry.utils_2d import increment_float
-from tidy3d.components.grid.grid import Grid, YeeGrid
-from tidy3d.components.lumped_element import LinearLumpedElement, LumpedResistor, RLCNetwork
+from tidy3d.components.lumped_element import LinearLumpedElement, RLCNetwork
 from tidy3d.components.medium import LossyMetalMedium, PECMedium
 from tidy3d.components.microwave.path_integrals.integrals.current import AxisAlignedCurrentIntegral
 from tidy3d.components.microwave.path_integrals.integrals.voltage import AxisAlignedVoltageIntegral
 from tidy3d.components.monitor import FieldMonitor
 from tidy3d.components.source.current import UniformCurrentSource
-from tidy3d.components.source.time import GaussianPulse
-from tidy3d.components.structure import Structure
-from tidy3d.components.types import Axis, FreqArray, LumpDistType
+from tidy3d.components.types import Axis, LumpDistType
 from tidy3d.components.validators import assert_line_or_plane
 from tidy3d.exceptions import SetupError, ValidationError
 
 from .base_lumped import AbstractLumpedPort
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Optional
+
+    from tidy3d.compat import Self
+    from tidy3d.components.data.data_array import FreqDataArray
+    from tidy3d.components.data.sim_data import SimulationData
+    from tidy3d.components.grid.grid import Grid, YeeGrid
+    from tidy3d.components.lumped_element import LumpedResistor
+    from tidy3d.components.source.time import GaussianPulse
+    from tidy3d.components.structure import Structure
+    from tidy3d.components.types import FreqArray
 
 
 class LumpedPort(AbstractLumpedPort, Box):

--- a/tidy3d/plugins/smatrix/ports/wave.py
+++ b/tidy3d/plugins/smatrix/ports/wave.py
@@ -2,30 +2,35 @@
 
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
-from pydantic import Field, NonNegativeFloat, NonNegativeInt, field_validator, model_validator
+from pydantic import Field, NonNegativeInt, field_validator, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import cached_property
 from tidy3d.components.boundary import ABCBoundary, InternalAbsorber, ModeABCBoundary
-from tidy3d.components.data.data_array import FreqDataArray, FreqModeDataArray
 from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.geometry.base import Box
-from tidy3d.components.grid.grid import Grid
-from tidy3d.components.microwave.data.monitor_data import MicrowaveModeData
 from tidy3d.components.microwave.mode_spec import MicrowaveModeSpec
 from tidy3d.components.microwave.monitor import MicrowaveModeMonitor
-from tidy3d.components.simulation import Simulation
 from tidy3d.components.source.field import ModeSource
 from tidy3d.components.source.frame import PECFrame
-from tidy3d.components.source.time import GaussianPulse
 from tidy3d.components.structure import MeshOverrideStructure
-from tidy3d.components.types import Axis, Direction, FreqArray
+from tidy3d.components.types import Direction
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
 from tidy3d.plugins.mode import ModeSolver
 from tidy3d.plugins.smatrix.ports.base_terminal import AbstractTerminalPort
+
+if TYPE_CHECKING:
+    from pydantic import NonNegativeFloat
+
+    from tidy3d.compat import Self
+    from tidy3d.components.data.data_array import FreqDataArray, FreqModeDataArray
+    from tidy3d.components.grid.grid import Grid
+    from tidy3d.components.microwave.data.monitor_data import MicrowaveModeData
+    from tidy3d.components.simulation import Simulation
+    from tidy3d.components.source.time import GaussianPulse
+    from tidy3d.components.types import Axis, FreqArray
 
 DEFAULT_WAVE_PORT_NUM_CELLS = 5
 MIN_WAVE_PORT_NUM_CELLS = 3

--- a/tidy3d/plugins/smatrix/run.py
+++ b/tidy3d/plugins/smatrix/run.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from tidy3d.components.data.index import SimulationDataMap
 from tidy3d.log import log
 from tidy3d.plugins.smatrix.component_modelers.modal import ModalComponentModeler
 from tidy3d.plugins.smatrix.component_modelers.terminal import TerminalComponentModeler
-from tidy3d.plugins.smatrix.component_modelers.types import ComponentModelerType
 from tidy3d.plugins.smatrix.data.modal import ModalComponentModelerData
 from tidy3d.plugins.smatrix.data.terminal import TerminalComponentModelerData
-from tidy3d.plugins.smatrix.data.types import ComponentModelerDataType
-from tidy3d.web import Batch, BatchData
+from tidy3d.web import Batch
+
+if TYPE_CHECKING:
+    from tidy3d.plugins.smatrix.component_modelers.types import ComponentModelerType
+    from tidy3d.plugins.smatrix.data.types import ComponentModelerDataType
+    from tidy3d.web import BatchData
 
 DEFAULT_DATA_DIR = "."
 

--- a/tidy3d/plugins/smatrix/utils.py
+++ b/tidy3d/plugins/smatrix/utils.py
@@ -7,26 +7,28 @@ simulations.
 
 from __future__ import annotations
 
-from typing import Union
+from typing import TYPE_CHECKING
 
 import numpy as np
-from numpy.typing import NDArray
 
-from tidy3d.components.data.data_array import (
-    DataArray,
-    FreqDataArray,
-)
-from tidy3d.components.data.sim_data import SimulationData
-from tidy3d.components.types import ArrayFloat1D
 from tidy3d.exceptions import Tidy3dError
 from tidy3d.plugins.smatrix.data.data_array import PortDataArray, TerminalPortDataArray
-from tidy3d.plugins.smatrix.ports.types import (
-    LumpedPortType,
-    PortCurrentType,
-    PortVoltageType,
-    TerminalPortType,
-)
-from tidy3d.plugins.smatrix.types import SParamDef
+
+if TYPE_CHECKING:
+    from typing import Union
+
+    from numpy.typing import NDArray
+
+    from tidy3d.components.data.data_array import DataArray, FreqDataArray
+    from tidy3d.components.data.sim_data import SimulationData
+    from tidy3d.components.types import ArrayFloat1D
+    from tidy3d.plugins.smatrix.ports.types import (
+        LumpedPortType,
+        PortCurrentType,
+        PortVoltageType,
+        TerminalPortType,
+    )
+    from tidy3d.plugins.smatrix.types import SParamDef
 
 
 def port_array_inv(matrix: DataArray) -> NDArray:

--- a/tidy3d/plugins/waveguide/rectangular_dielectric.py
+++ b/tidy3d/plugins/waveguide/rectangular_dielectric.py
@@ -2,16 +2,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Annotated, Any, Optional, Union
 
 import numpy
 from matplotlib import pyplot
-from pydantic import Field, ValidationInfo, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 
-from tidy3d.compat import Self
 from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.boundary import BoundarySpec, Periodic
-from tidy3d.components.data.data_array import FreqModeDataArray, ModeIndexDataArray
 from tidy3d.components.geometry.base import Box
 from tidy3d.components.geometry.polyslab import PolySlab
 from tidy3d.components.grid.grid_spec import GridSpec
@@ -21,7 +19,7 @@ from tidy3d.components.simulation import Simulation
 from tidy3d.components.source.field import ModeSource
 from tidy3d.components.source.time import GaussianPulse
 from tidy3d.components.structure import Structure
-from tidy3d.components.types import TYPE_TAG_STR, ArrayFloat1D, Ax, Axis, Coordinate, Size1D
+from tidy3d.components.types import TYPE_TAG_STR, ArrayFloat1D, Axis, Coordinate, Size1D
 from tidy3d.components.viz import add_ax_if_none
 from tidy3d.constants import C_0, MICROMETER, RADIAN, inf
 from tidy3d.exceptions import Tidy3dError, ValidationError
@@ -29,7 +27,14 @@ from tidy3d.log import log
 from tidy3d.plugins.mode.mode_solver import ModeSolver
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from matplotlib.colors import Colormap
+    from pydantic import ValidationInfo
+
+    from tidy3d.compat import Self
+    from tidy3d.components.data.data_array import FreqModeDataArray, ModeIndexDataArray
+    from tidy3d.components.types import Ax
 
 AnnotatedMedium = Annotated[MediumType, Field(discriminator=TYPE_TAG_STR)]
 

--- a/tidy3d/updater.py
+++ b/tidy3d/updater.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import functools
 import json
-from os import PathLike
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import yaml
 from pydantic import BaseModel
@@ -15,6 +14,9 @@ from .components.base import Tidy3dBaseModel
 from .exceptions import FileError, SetupError
 from .log import log
 from .version import __version__
+
+if TYPE_CHECKING:
+    from os import PathLike
 
 """Storing version numbers."""
 

--- a/tidy3d/web/api/asynchronous.py
+++ b/tidy3d/web/api/asynchronous.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
-from os import PathLike
-from typing import Literal, Optional, Union
+from typing import TYPE_CHECKING
 
-from tidy3d.components.types.workflow import WorkflowType
 from tidy3d.log import log
 from tidy3d.web.core.types import PayType
 
-from .container import DEFAULT_DATA_DIR, Batch, BatchData
+from .container import DEFAULT_DATA_DIR, Batch
+
+if TYPE_CHECKING:
+    from os import PathLike
+    from typing import Literal, Optional, Union
+
+    from tidy3d.components.types.workflow import WorkflowType
+
+    from .container import BatchData
 
 
 def run_async(

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -1,22 +1,18 @@
 # autograd wrapper for web functions
 from __future__ import annotations
 
-from os import PathLike
 from pathlib import Path
-from typing import Any, Callable, Literal, Optional, Union, get_args
+from typing import TYPE_CHECKING, Any, get_args
 
 from autograd.extend import defvjp, primitive
 
 import tidy3d as td
-from tidy3d.components.autograd import AutogradFieldMap
 from tidy3d.components.autograd.types import TracedDict
 from tidy3d.components.base import TRACED_FIELD_KEYS_ATTR
-from tidy3d.components.types.workflow import WorkflowDataType, WorkflowType
 from tidy3d.config import config
 from tidy3d.exceptions import AdjointError
 from tidy3d.web.api.asynchronous import DEFAULT_DATA_DIR
 from tidy3d.web.api.asynchronous import run_async as run_async_webapi
-from tidy3d.web.api.container import BatchData
 from tidy3d.web.api.tidy3d_stub import Tidy3dStub
 from tidy3d.web.api.webapi import load, restore_simulation_if_cached
 from tidy3d.web.api.webapi import run as run_webapi
@@ -49,6 +45,14 @@ from .io_utils import (
 from .io_utils import (
     upload_sim_fields_keys as _upload_sim_fields_keys_impl,
 )
+
+if TYPE_CHECKING:
+    from os import PathLike
+    from typing import Callable, Literal, Optional, Union
+
+    from tidy3d.components.autograd import AutogradFieldMap
+    from tidy3d.components.types.workflow import WorkflowDataType, WorkflowType
+    from tidy3d.web.api.container import BatchData
 
 
 def _resolve_local_gradient(value: Optional[bool]) -> bool:

--- a/tidy3d/web/api/autograd/backward.py
+++ b/tidy3d/web/api/autograd/backward.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from typing import TYPE_CHECKING
 
 import numpy as np
 import xarray as xr
 
 import tidy3d as td
-from tidy3d import Medium
-from tidy3d.components.autograd import AutogradFieldMap, get_static
+from tidy3d.components.autograd import get_static
 from tidy3d.components.autograd.derivative_utils import DerivativeInfo
 from tidy3d.components.data.data_array import DataArray
 from tidy3d.config import config
@@ -15,6 +15,10 @@ from tidy3d.exceptions import AdjointError
 from tidy3d.packaging import disable_local_subpixel
 
 from .utils import E_to_D, get_derivative_maps
+
+if TYPE_CHECKING:
+    from tidy3d import Medium
+    from tidy3d.components.autograd import AutogradFieldMap
 
 
 def setup_adj(

--- a/tidy3d/web/api/autograd/forward.py
+++ b/tidy3d/web/api/autograd/forward.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
-import tidy3d as td
-from tidy3d.components.autograd import AutogradFieldMap
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import tidy3d as td
+    from tidy3d.components.autograd import AutogradFieldMap
 
 
 def setup_fwd(

--- a/tidy3d/web/api/autograd/io_utils.py
+++ b/tidy3d/web/api/autograd/io_utils.py
@@ -2,15 +2,18 @@ from __future__ import annotations
 
 import os
 import tempfile
+from typing import TYPE_CHECKING
 
 import tidy3d as td
-from tidy3d.components.autograd import AutogradFieldMap
 from tidy3d.components.autograd.field_map import FieldMap, TracerKeys
 from tidy3d.web.api.webapi import get_info, load_simulation
 from tidy3d.web.cache import resolve_local_cache
 from tidy3d.web.core.s3utils import download_file, upload_file  # type: ignore
 
 from .constants import SIM_FIELDS_KEYS_FILE, SIM_VJP_FILE
+
+if TYPE_CHECKING:
+    from tidy3d.components.autograd import AutogradFieldMap
 
 
 def upload_sim_fields_keys(

--- a/tidy3d/web/api/autograd/utils.py
+++ b/tidy3d/web/api/autograd/utils.py
@@ -1,11 +1,14 @@
 # utility functions for autograd web API
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 import tidy3d as td
+
+if TYPE_CHECKING:
+    from typing import Optional, Union
 
 """ E and D field gradient map calculation helpers. """
 

--- a/tidy3d/web/api/connect_util.py
+++ b/tidy3d/web/api/connect_util.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 from functools import wraps
-from typing import Any, Callable, Optional
+from typing import TYPE_CHECKING, Any
 
 from requests import ReadTimeout
 from requests.exceptions import ConnectionError as ConnErr
@@ -15,6 +15,9 @@ from tidy3d.exceptions import WebError
 from tidy3d.log import log
 from tidy3d.web import common
 from tidy3d.web.common import REFRESH_TIME
+
+if TYPE_CHECKING:
+    from typing import Callable, Optional
 
 
 def wait_for_connection(

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -10,26 +10,18 @@ import tempfile
 import time
 import uuid
 from abc import ABC
-from collections.abc import Iterator, Mapping
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
-from os import PathLike
 from pathlib import Path
-from typing import Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 from pydantic import Field, PositiveInt, PrivateAttr, model_validator
-from rich.progress import (
-    BarColumn,
-    Progress,
-    TaskID,
-    TaskProgressColumn,
-    TextColumn,
-    TimeElapsedColumn,
-)
+from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn, TimeElapsedColumn
 
 from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.mode.mode_solver import ModeSolver
 from tidy3d.components.types.base import discriminated_union
-from tidy3d.components.types.workflow import WorkflowDataType, WorkflowType
+from tidy3d.components.types.workflow import WorkflowType
 from tidy3d.exceptions import DataError
 from tidy3d.log import get_logging_console, log
 from tidy3d.web.api import webapi as web
@@ -49,8 +41,16 @@ from tidy3d.web.api.webapi import restore_simulation_if_cached
 from tidy3d.web.cache import _store_mode_solver_in_cache
 from tidy3d.web.core.constants import TaskId, TaskName
 from tidy3d.web.core.task_core import Folder
-from tidy3d.web.core.task_info import RunInfo, TaskInfo
 from tidy3d.web.core.types import PayType
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from os import PathLike
+
+    from rich.progress import TaskID
+
+    from tidy3d.components.types.workflow import WorkflowDataType
+    from tidy3d.web.core.task_info import RunInfo, TaskInfo
 
 # Max # of workers for parallel upload / download: above 10, performance is same but with warnings
 DEFAULT_NUM_WORKERS = 10

--- a/tidy3d/web/api/material_library.py
+++ b/tidy3d/web/api/material_library.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import Field, TypeAdapter, field_validator
 
 from tidy3d.components.medium import MediumType
-from tidy3d.web.core.http_util import JSONType, http
+from tidy3d.web.core.http_util import http
 from tidy3d.web.core.types import Queryable
+
+if TYPE_CHECKING:
+    from tidy3d.web.core.http_util import JSONType
 
 
 class MaterialLibrary(Queryable):

--- a/tidy3d/web/api/mode.py
+++ b/tidy3d/web/api/mode.py
@@ -3,18 +3,15 @@
 from __future__ import annotations
 
 import os
-import pathlib
 import tempfile
 import time
 from datetime import datetime
-from os import PathLike
-from typing import Callable, Literal, Optional, Union
+from typing import TYPE_CHECKING, Optional
 
-import requests
 from botocore.exceptions import ClientError
 from joblib import Parallel, delayed
 from pydantic import Field
-from rich.progress import Progress, TaskID
+from rich.progress import Progress
 
 from tidy3d.components.data.monitor_data import ModeSolverData
 from tidy3d.components.eme.simulation import EMESimulation
@@ -30,6 +27,14 @@ from tidy3d.web.core.http_util import http
 from tidy3d.web.core.s3utils import download_file, download_gz_file, upload_file
 from tidy3d.web.core.task_core import Folder
 from tidy3d.web.core.types import PayType, ResourceLifecycle, Submittable
+
+if TYPE_CHECKING:
+    import pathlib
+    from os import PathLike
+    from typing import Callable, Literal, Union
+
+    import requests
+    from rich.progress import TaskID
 
 SIMULATION_JSON = "simulation.json"
 SIM_FILE_HDF5_GZ = "simulation.hdf5.gz"

--- a/tidy3d/web/api/run.py
+++ b/tidy3d/web/api/run.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import typing
-from os import PathLike
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from tidy3d.components.types.workflow import WorkflowDataType, WorkflowType
 from tidy3d.config import config
@@ -11,6 +11,9 @@ from tidy3d.web.api.autograd.autograd import run as run_autograd
 from tidy3d.web.api.autograd.autograd import run_async
 from tidy3d.web.api.container import DEFAULT_DATA_DIR, DEFAULT_DATA_PATH
 from tidy3d.web.core.types import PayType
+
+if TYPE_CHECKING:
+    from os import PathLike
 
 RunInput: typing.TypeAlias = typing.Union[
     WorkflowType,

--- a/tidy3d/web/api/tidy3d_stub.py
+++ b/tidy3d/web/api/tidy3d_stub.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from os import PathLike
-from typing import Callable, Optional
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 
@@ -36,6 +35,10 @@ from tidy3d.plugins.smatrix.data.terminal import (
 )
 from tidy3d.web.core.stub import TaskStub, TaskStubData
 from tidy3d.web.core.types import TaskType
+
+if TYPE_CHECKING:
+    from os import PathLike
+    from typing import Callable, Optional
 
 TYPE_MAP: dict[type, TaskType] = {
     Simulation: TaskType.FDTD,

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import json
 import tempfile
 import time
-from os import PathLike
 from pathlib import Path
-from typing import Callable, Literal, Optional, Union
+from typing import TYPE_CHECKING
 
 from requests import HTTPError
 from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn, TimeElapsedColumn
@@ -15,7 +14,6 @@ from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn, T
 from tidy3d.components.medium import AbstractCustomMedium
 from tidy3d.components.mode.mode_solver import ModeSolver
 from tidy3d.components.mode.simulation import ModeSimulation
-from tidy3d.components.types.workflow import WorkflowDataType, WorkflowType
 from tidy3d.config import config
 from tidy3d.exceptions import WebError
 from tidy3d.log import get_logging_console, log
@@ -27,7 +25,7 @@ from tidy3d.web.api.states import (
     STATE_PROGRESS_PERCENTAGE,
     status_to_stage,
 )
-from tidy3d.web.cache import CacheEntry, _store_mode_solver_in_cache, resolve_local_cache
+from tidy3d.web.cache import _store_mode_solver_in_cache, resolve_local_cache
 from tidy3d.web.core.account import Account
 from tidy3d.web.core.constants import (
     CM_DATA_HDF5_GZ,
@@ -37,21 +35,22 @@ from tidy3d.web.core.constants import (
     SIM_FILE_HDF5,
     SIM_FILE_HDF5_GZ,
     SIMULATION_DATA_HDF5_GZ,
-    TaskId,
 )
-from tidy3d.web.core.task_core import (
-    BatchDetail,
-    BatchTask,
-    Folder,
-    SimulationTask,
-    TaskFactory,
-    WebTask,
-)
+from tidy3d.web.core.task_core import BatchTask, Folder, SimulationTask, TaskFactory, WebTask
 from tidy3d.web.core.task_info import ChargeType, TaskInfo
 from tidy3d.web.core.types import PayType, TaskType
 
 from .connect_util import REFRESH_TIME, get_grid_points_str, get_time_steps_str, wait_for_connection
 from .tidy3d_stub import Tidy3dStub, Tidy3dStubData
+
+if TYPE_CHECKING:
+    from os import PathLike
+    from typing import Callable, Literal, Optional, Union
+
+    from tidy3d.components.types.workflow import WorkflowDataType, WorkflowType
+    from tidy3d.web.cache import CacheEntry
+    from tidy3d.web.core.constants import TaskId
+    from tidy3d.web.core.task_core import BatchDetail
 
 # time between checking run status
 RUN_REFRESH_TIME = 1.0

--- a/tidy3d/web/cache.py
+++ b/tidy3d/web/cache.py
@@ -8,24 +8,27 @@ import os
 import shutil
 import tempfile
 import threading
-from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt
 
 from tidy3d import config
-from tidy3d.components.mode.mode_solver import ModeSolver
-from tidy3d.components.types.workflow import WorkflowDataType, WorkflowType
 from tidy3d.log import log
 from tidy3d.web.api.tidy3d_stub import Tidy3dStub
-from tidy3d.web.core.constants import TaskId
 from tidy3d.web.core.http_util import get_version as _get_protocol_version
 from tidy3d.web.core.types import TaskType
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from tidy3d.components.mode.mode_solver import ModeSolver
+    from tidy3d.components.types.workflow import WorkflowDataType, WorkflowType
+    from tidy3d.web.core.constants import TaskId
 
 CACHE_ARTIFACT_NAME = "simulation_data.hdf5"
 CACHE_METADATA_NAME = "metadata.json"

--- a/tidy3d/web/cli/cache.py
+++ b/tidy3d/web/cli/cache.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING
 
 import click
 
 from tidy3d import config
-from tidy3d.web.cache import LocalCache, resolve_local_cache
 from tidy3d.web.cache import clear as clear_cache
+from tidy3d.web.cache import resolve_local_cache
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    from tidy3d.web.cache import LocalCache
 
 
 def _fmt_size(num_bytes: int) -> str:

--- a/tidy3d/web/cli/develop/documentation.py
+++ b/tidy3d/web/cli/develop/documentation.py
@@ -17,12 +17,15 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import click
 
 from .index import develop
 from .utils import echo_and_check_subprocess, get_install_directory
+
+if TYPE_CHECKING:
+    from typing import Optional
 
 __all__ = [
     "build_documentation",

--- a/tidy3d/web/cli/develop/install.py
+++ b/tidy3d/web/cli/develop/install.py
@@ -9,12 +9,15 @@ from __future__ import annotations
 import platform
 import re
 import subprocess
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import click
 
 from .index import develop
 from .utils import echo_and_check_subprocess, echo_and_run_subprocess, get_install_directory
+
+if TYPE_CHECKING:
+    from typing import Optional
 
 __all__ = [
     "activate_correct_poetry_python",

--- a/tidy3d/web/core/core_config.py
+++ b/tidy3d/web/core/core_config.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import logging as log
+from typing import TYPE_CHECKING
 
-from rich.console import Console
+if TYPE_CHECKING:
+    from rich.console import Console
 
-from tidy3d.log import Logger
+    from tidy3d.log import Logger
 
 # default setting
 config_setting = {

--- a/tidy3d/web/core/exceptions.py
+++ b/tidy3d/web/core/exceptions.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import TYPE_CHECKING
 
 from .core_config import get_logger
+
+if TYPE_CHECKING:
+    from typing import Optional
 
 
 class WebError(Exception):

--- a/tidy3d/web/core/http_util.py
+++ b/tidy3d/web/core/http_util.py
@@ -7,7 +7,7 @@ import os
 import ssl
 from enum import Enum
 from functools import wraps
-from typing import Any, Callable, Optional, TypeAlias
+from typing import TYPE_CHECKING, Any
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -29,6 +29,9 @@ from .constants import (
 )
 from .core_config import get_logger
 from .exceptions import WebError, WebNotFoundError
+
+if TYPE_CHECKING:
+    from typing import Callable, Optional, TypeAlias
 
 JSONType: TypeAlias = dict[str, Any] | list[Any] | str | int
 

--- a/tidy3d/web/core/s3utils.py
+++ b/tidy3d/web/core/s3utils.py
@@ -5,15 +5,12 @@ from __future__ import annotations
 import os
 import tempfile
 import urllib
-from collections.abc import Mapping
 from datetime import datetime
 from enum import Enum
-from os import PathLike
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import TYPE_CHECKING, Any
 
 import boto3
-import rich
 from boto3.s3.transfer import TransferConfig
 from pydantic import BaseModel, Field
 from rich.progress import (
@@ -31,6 +28,13 @@ from .core_config import get_logger_console
 from .exceptions import WebError
 from .file_util import extract_gzip_file
 from .http_util import http
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from os import PathLike
+    from typing import Callable, Optional
+
+    import rich
 
 IN_TRANSIT_SUFFIX = ".tmp"
 

--- a/tidy3d/web/core/stub.py
+++ b/tidy3d/web/core/stub.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from os import PathLike
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from os import PathLike
 
 
 class TaskStubData(ABC):

--- a/tidy3d/web/core/task_core.py
+++ b/tidy3d/web/core/task_core.py
@@ -6,10 +6,8 @@ import os
 import pathlib
 import tempfile
 from datetime import datetime
-from os import PathLike
-from typing import Callable, Optional, Union
+from typing import TYPE_CHECKING, Optional
 
-import requests
 from botocore.exceptions import ClientError
 from pydantic import Field, TypeAdapter
 
@@ -32,9 +30,16 @@ from .file_util import read_simulation_from_hdf5
 from .http_util import get_version as _get_protocol_version
 from .http_util import http
 from .s3utils import download_file, download_gz_file, upload_file
-from .stub import TaskStub
 from .task_info import BatchDetail, TaskInfo
 from .types import PayType, Queryable, ResourceLifecycle, Submittable, Tidy3DResource
+
+if TYPE_CHECKING:
+    from os import PathLike
+    from typing import Callable, Union
+
+    import requests
+
+    from .stub import TaskStub
 
 
 class Folder(Tidy3DResource, Queryable, extra="allow"):


### PR DESCRIPTION
made and applied some script that moved all type-hint-related imports behind TYPE_CHECKING.
We could think about having this in our CI as well?