### PR TITLE
fix: change default EME store_coeffs to False and add validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `symmetrize_mirror`, `symmetrize_rotation`, `symmetrize_diagonal` functions to the autograd plugin. They can be used for enforcing symmetries in topology optimization.
 - Klayout plugin automatically finds klayout installation path at common locations.
 - Added autograd support for `TriangleMesh`, allowing gradient computation with respect to mesh vertices for inverse design.
-- Added `EMESimulationData.coeffs` to store coefficients from the EME solver, including mode overlaps, interface S matrices, and effective propagation indices.
+- Added `EMESimulation.store_coeffs` to store coefficients from the EME solver, including mode overlaps, interface S matrices, and effective propagation indices.
 - Get cell-related information from violation markers in `DRCResults` and `DRCViolation` to the klayout plugin: Use for example `DRCResults.violations_by_cell` to group them.
 
 ### Changed

--- a/tests/test_components/test_eme.py
+++ b/tests/test_components/test_eme.py
@@ -473,7 +473,7 @@ def test_eme_simulation():
         grid_spec=sim.grid_spec.updated_copy(wavelength=1),
     )
     with AssertLogLevel("WARNING", contains_str="store_coeffs"):
-        sim_bad.validate_pre_upload()
+        sim_bad.updated_copy(store_coeffs=True).validate_pre_upload()
     sim_bad = sim.updated_copy(
         size=(10, 10, 10),
         monitors=[large_monitor],
@@ -1433,15 +1433,16 @@ def test_eme_periodicity():
 
     # remove the field monitor, now it passes
     desired_cell_index_pairs = set([(i, i + 1) for i in range(6)] + [(5, 1)])
-    with AssertLogLevel("WARNING", contains_str="deprecated"):
-        sim = sim.updated_copy(
-            monitors=[m for m in sim.monitors if not isinstance(m, td.EMEFieldMonitor)]
-        )
-        sim2 = sim.updated_copy(num_reps=2, path="eme_grid_spec/subgrids/1")
-        assert set(sim2._cell_index_pairs) == desired_cell_index_pairs
+    sim = sim.updated_copy(
+        monitors=[m for m in sim.monitors if not isinstance(m, td.EMEFieldMonitor)]
+    )
+    sim2 = sim.updated_copy(num_reps=2, path="eme_grid_spec/subgrids/1")
+    assert set(sim2._cell_index_pairs) == desired_cell_index_pairs
     # sweep can't have coeff monitor
     with pytest.raises(SetupError):
         _ = sim.updated_copy(sweep_spec=sweep_spec)
+    with pytest.raises(SetupError):
+        _ = sim.updated_copy(sweep_spec=sweep_spec, store_coeffs=True, monitors=[])
     # remove coeff monitor too, now it passes
     with AssertLogLevel(None):
         sim = sim.updated_copy(

--- a/tidy3d/components/eme/monitor.py
+++ b/tidy3d/components/eme/monitor.py
@@ -286,15 +286,6 @@ class EMECoefficientMonitor(EMEMonitor):
         "Not all monitors support values different from 1.",
     )
 
-    num_sweep: Optional[pd.NonNegativeInt] = pd.Field(
-        None,
-        title="Number of Sweep Indices",
-        description="Number of sweep indices for the monitor to record. "
-        "Cannot exceed the number of sweep indices for the simulation. "
-        "If the sweep does not change the monitor data, the sweep index "
-        "will be omitted. A value of 'None' will record all sweep indices.",
-    )
-
     def storage_size(
         self,
         num_cells: int,

--- a/tidy3d/components/eme/simulation.py
+++ b/tidy3d/components/eme/simulation.py
@@ -235,7 +235,7 @@ class EMESimulation(AbstractYeeGridSimulation):
     )
 
     store_coeffs: bool = pd.Field(
-        True,
+        False,
         title="Store Coefficients",
         description="Whether to store the internal coefficients from the EME simulation. "
         "The results are stored in 'EMESimulationData.coeffs'.",
@@ -756,16 +756,14 @@ class EMESimulation(AbstractYeeGridSimulation):
                         f"Monitor '{monitor.name}' at 'monitors[{i}]' is an 'EMECoefficientMonitor', "
                         "which is not compatible with 'EMEPeriodicitySweep'."
                     )
+            if self.store_coeffs:
+                raise SetupError(
+                    "'EMESimulation.store_coeffs' is not compatible with 'EMEPeriodicitySweep'."
+                )
 
     def _validate_monitor_setup(self) -> None:
         """Check monitor setup."""
         for i, monitor in enumerate(self.monitors):
-            if isinstance(monitor, EMECoefficientMonitor):
-                log.warning(
-                    "'EMECoefficientMonitor' is deprecated. "
-                    "The full coefficient data is stored in "
-                    "'EMESimulationData.coeffs'."
-                )
             if isinstance(monitor, EMEMonitor):
                 _ = self._monitor_eme_cell_indices(monitor=monitor)
             if (


### PR DESCRIPTION
EME fixes:
- changed default to `store_coeffs=False`
- validate it is incompatible with periodicity sweep
- reverts two earlier changes: deprecating EME coefficient monitor, and the change from default `num_sweep=1` to default `num_sweep=None` (which can be slow).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Changed default value of `EMESimulation.store_coeffs` from True to False and added validation to ensure it's incompatible with `EMEPeriodicitySweep`.

- Reverted `EMECoefficientMonitor.num_sweep` default from None back to 1 (inherited from base class)
- Removed deprecation warning for `EMECoefficientMonitor` 
- Fixed CHANGELOG entry to correctly reference `EMESimulation.store_coeffs` instead of `EMESimulationData.coeffs`
- Updated tests to validate new behavior, including test for `store_coeffs=True` with periodicity sweep

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- All changes are well-contained and properly tested. The default value change is conservative (False means less storage), validation logic is straightforward, and tests cover the new behavior including edge cases.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| CHANGELOG.md | 5/5 | corrected changelog entry to reference `EMESimulation.store_coeffs` instead of `EMESimulationData.coeffs` |
| tidy3d/components/eme/simulation.py | 5/5 | changed `store_coeffs` default to False and added validation that it's incompatible with periodicity sweep, removed deprecation warning |
| tidy3d/components/eme/monitor.py | 5/5 | removed `num_sweep` field override from `EMECoefficientMonitor`, reverting to base class default of 1 |
| tests/test_components/test_eme.py | 5/5 | updated tests to validate new `store_coeffs` behavior and removed assertions for deprecated warning |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant EMESimulation
    participant Validation
    participant EMEPeriodicitySweep
    
    User->>EMESimulation: Create simulation with sweep_spec
    EMESimulation->>EMESimulation: store_coeffs=False (new default)
    
    alt Has EMEPeriodicitySweep
        EMESimulation->>Validation: _validate_sweep_setup()
        Validation->>Validation: Check for EMEFieldMonitor
        Validation->>Validation: Check for EMECoefficientMonitor
        Validation->>Validation: Check store_coeffs flag
        alt store_coeffs=True
            Validation-->>User: SetupError: incompatible with periodicity sweep
        else store_coeffs=False
            Validation->>EMESimulation: Validation passes
        end
    end
    
    User->>EMESimulation: Create EMECoefficientMonitor
    EMESimulation->>EMECoefficientMonitor: num_sweep inherits from base (=1)
    Note over EMECoefficientMonitor: Previously overridden to None<br/>Now uses base class default of 1
    
    EMESimulation-->>User: Simulation ready
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->