### PR TITLE
fix: regenerate EME schema

### DIFF
--- a/schemas/EMESimulation.json
+++ b/schemas/EMESimulation.json
@@ -4718,6 +4718,7 @@
           "type": "integer"
         },
         "num_sweep": {
+          "default": 1,
           "minimum": 0,
           "type": "integer"
         },
@@ -12880,7 +12881,7 @@
       "type": "array"
     },
     "store_coeffs": {
-      "default": true,
+      "default": false,
       "type": "boolean"
     },
     "store_port_modes": {


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Regenerated the EME simulation JSON schema to reflect recent default value changes from the parent commit (1cbb351). The schema now correctly shows `store_coeffs` defaulting to `false` and `num_sweep` defaulting to `1`, aligning with the Python model definitions in the codebase.

Changes:
- Updated `store_coeffs` default from `true` to `false` (line 12883)
- Added `num_sweep` default value of `1` (line 4721)

This schema regeneration follows the standard process using `scripts/regenerate_schema.py` and correctly reflects the corresponding Python model field definitions in `tidy3d/components/eme/simulation.py` and `tidy3d/components/eme/monitor.py`.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- Score reflects that this is an automated schema regeneration that correctly mirrors Python code changes. The schema changes are minimal, well-defined, and match the source model definitions exactly. No custom instruction violations detected.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| schemas/EMESimulation.json | 5/5 | Regenerated schema to reflect default value changes: `store_coeffs` now defaults to `false` (line 12883) and `num_sweep` now defaults to `1` (line 4721) |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant PY as Python Models
    participant Script as regenerate_schema.py
    participant Schema as EMESimulation.json
    
    Note over Dev,PY: Parent Commit (1cbb351)
    Dev->>PY: Update EMESimulation.store_coeffs default: True → False
    Dev->>PY: Update EMEMonitor.num_sweep default: None → 1
    
    Note over Dev,Schema: Current PR (1bf6dd0)
    Dev->>Script: Run python scripts/regenerate_schema.py
    Script->>PY: Import EMESimulation model
    Script->>PY: Call EMESimulation.schema()
    PY-->>Script: Return Pydantic schema dict
    Script->>Script: Canonicalize schema (remove docs, sort keys)
    Script->>Schema: Write updated EMESimulation.json
    Note over Schema: store_coeffs: "default": false<br/>num_sweep: "default": 1
    Schema-->>Dev: Schema regeneration complete
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->