### PR TITLE
chore(tidy3d): FXC-4466-standardize-chained-exception-messages-enforce-via-ci

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -224,6 +224,28 @@ jobs:
           echo "extras_integration_tests=$extras_integration_tests"
           echo "test_type=$test_type"
 
+  check-error-blind-chaining:
+    name: check blind-chaining of error messages
+    needs: determine-test-scope
+    if: needs.determine-test-scope.outputs.code_quality_tests == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: false
+          persist-credentials: false
+
+      - name: set-python-3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Run blind-chaining test
+        run: |
+          set -euo pipefail
+          python scripts/check_blind_chaining.py
+
   lint:
     needs: determine-test-scope
     if: needs.determine-test-scope.outputs.code_quality_tests == 'true'
@@ -981,6 +1003,7 @@ jobs:
       - determine-test-scope
       - local-tests
       - remote-tests
+      - check-error-blind-chaining
       - lint
       - mypy
       - verify-schema-change
@@ -993,6 +1016,12 @@ jobs:
       - extras-integration-tests
     runs-on: ubuntu-latest
     steps:
+      - name: check-error-blind-chaining
+        if: ${{ needs.determine-test-scope.outputs.code_quality_tests == 'true' && needs.check-error-blind-chaining.result != 'success' && needs.check-error-blind-chaining.result != 'skipped' }}
+        run: |
+          echo "❌ Detected blind-chained error messages."
+          exit 1
+
       - name: check-linting-result
         if: ${{ needs.determine-test-scope.outputs.code_quality_tests == 'true' && needs.lint.result != 'success' && needs.lint.result != 'skipped' }}
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,14 @@ repos:
        stages: [pre-commit]
      - id: ruff-format
        stages: [pre-commit]
+  - repo: local
+    hooks:
+      - id: blind-chaining-check
+        name: blind-chaining-check
+        entry: python scripts/check_blind_chaining.py
+        language: system
+        types: [python]
+        pass_filenames: false
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
     rev: v9.22.0
     hooks:

--- a/scripts/check_blind_chaining.py
+++ b/scripts/check_blind_chaining.py
@@ -1,0 +1,160 @@
+"""Detect blind exception chaining that hides original errors.
+
+Usage:
+    python scripts/check_blind_chaining.py [paths ...]
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+SKIP_COMMENT = "# noqa: BC"
+ALLOWLIST_DIRS = (
+    Path("tidy3d/web/cli/develop"),
+    Path("tidy3d/packaging"),
+)
+ALLOWLIST_PATHS = (
+    Path("tidy3d/packaging.py"),
+    Path("tidy3d/updater.py"),
+)
+
+
+def contains_name(node: ast.AST | None, target: str) -> bool:
+    """Return True if any ``ast.Name`` inside ``node`` matches ``target``."""
+
+    if node is None:
+        return False
+    return any(isinstance(child, ast.Name) and child.id == target for child in ast.walk(node))
+
+
+def iter_python_files(paths: Iterable[Path]) -> Iterable[Path]:
+    """Yield Python files under the provided paths, respecting skips."""
+
+    for root in paths:
+        if root.is_file() and root.suffix == ".py":
+            yield root
+            continue
+        if not root.is_dir():
+            continue
+        yield from root.rglob("*.py")
+
+
+def _primary_message_expr(exc: ast.AST) -> ast.AST | None:
+    """
+    Heuristic: identify the expression that most serializers/GUI layers display.
+
+    - For `SomeError("msg", ...)`: first positional arg.
+    - For `SomeError(message="msg")` / `detail=...`: preferred keyword.
+    - Otherwise: None (unknown).
+    """
+    if not isinstance(exc, ast.Call):
+        return None
+
+    if exc.args:
+        return exc.args[0]
+    return None
+
+
+def find_blind_chaining(path: Path) -> list[tuple[Path, int, int, str]]:
+    """
+    Find `raise <new_exc> from <cause>` where `<cause>` is *not* referenced in the
+    user-visible message expression (first positional arg or message-like kwarg).
+
+    Returns: (path, lineno, col_offset, cause_name)
+    """
+    errors: list[tuple[Path, int, int, str]] = []
+    try:
+        src = path.read_text(encoding="utf-8")
+        tree = ast.parse(src, filename=str(path))
+    except SyntaxError:
+        return errors
+
+    lines = src.splitlines()
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Raise):
+            continue
+
+        # Handles `raise from e` (node.exc is None) safely.
+        if node.exc is None:
+            continue
+
+        # Ignore `raise X from None` (intentional suppression).
+        if isinstance(node.cause, ast.Constant) and node.cause.value is None:
+            continue
+
+        # Only enforce for simple `from <name>` patterns (e.g., `except ... as e:`).
+        if not isinstance(node.cause, ast.Name):
+            continue
+        cause_name = node.cause.id
+
+        # Avoid noisy false positives for `raise existing_exc from e`.
+        if isinstance(node.exc, ast.Name):
+            continue
+
+        # Prefer checking the “primary message” expression if we can identify it.
+        msg_expr = _primary_message_expr(node.exc)
+
+        if msg_expr is not None:
+            ok = contains_name(msg_expr, cause_name)
+        else:
+            # Fallback: at least require the cause to be used somewhere in the exc expression.
+            ok = contains_name(node.exc, cause_name)
+
+        if not ok:
+            lineno = getattr(node, "lineno", 1)
+            col = getattr(node, "col_offset", 0)
+            if lineno - 1 < len(lines):
+                if SKIP_COMMENT in lines[lineno - 1]:
+                    continue
+            errors.append((path, lineno, col, cause_name))
+
+    return errors
+
+
+def is_allowlisted(path: Path) -> bool:
+    """Return True if ``path`` resides in an allowlisted directory."""
+
+    resolved_path = path.resolve()
+    if any(resolved_path == allow_path.resolve() for allow_path in ALLOWLIST_PATHS):
+        return True
+    for allow_dir in ALLOWLIST_DIRS:
+        if resolved_path.is_relative_to(allow_dir.resolve()):
+            return True
+    return False
+
+
+def main(argv: list[str]) -> int:
+    paths = [Path(arg) for arg in argv] if argv else [Path("tidy3d")]
+    existing_paths = [path for path in paths if path.exists()]
+    if not existing_paths:
+        existing_paths = [Path(".")]
+
+    failures: list[tuple[Path, int, int, str]] = []
+    for file_path in iter_python_files(existing_paths):
+        failures.extend(find_blind_chaining(file_path))
+
+    filtered_failures = [
+        (path, lineno, cause_name)
+        for path, lineno, _, cause_name in failures
+        if not is_allowlisted(path)
+    ]
+
+    if filtered_failures:
+        print("Blind exception chaining detected (missing original cause in raised message):")
+        for path, lineno, cause_name in sorted(filtered_failures):
+            print(
+                f"  {path}:{lineno} cause variable '{cause_name}' not referenced in raised exception"
+            )
+        print(f"Add '{SKIP_COMMENT}' to the raise line to suppress intentionally.")
+        return 1
+
+    print("No blind exception chaining instances found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/make_script.py
+++ b/scripts/make_script.py
@@ -88,7 +88,7 @@ def main(args):
     except subprocess.CalledProcessError as exc:
         raise RuntimeError(
             "Ruff formatting failed. Your script might not be compatible with make_script.py. "
-            "This could be due to unsupported features like CustomMedium."
+            f"This could be due to unsupported features like CustomMedium.\n{exc!s}"
         ) from exc
     finally:
         # remove the temporary file

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -208,7 +208,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         try:
             type_value = obj[TYPE_TAG_STR]
         except KeyError as exc:
-            raise ValueError(f'Missing "{TYPE_TAG_STR}" in data') from exc
+            raise ValueError(f'Missing "{TYPE_TAG_STR}" in data: {exc!s}') from exc
         if not isinstance(type_value, str) or not type_value:
             raise ValueError(f'Invalid "{TYPE_TAG_STR}" value: {type_value!r}')
         return type_value
@@ -218,7 +218,7 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         try:
             return TYPE_TO_CLASS_MAP[type_value]
         except KeyError as exc:
-            raise ValueError(f"Unknown type: {type_value}") from exc
+            raise ValueError(f"Unknown type: {type_value}: {exc!s}") from exc
 
     @classmethod
     def _should_dispatch_to(cls, target_cls: type[Tidy3dBaseModel]) -> bool:
@@ -387,7 +387,8 @@ class Tidy3dBaseModel(pydantic.BaseModel):
             raise AttributeError(
                 f"Could not field field '{field_name}' in the sub-component `path`. "
                 f"Found fields of '{tuple(self.__fields__.keys())}'. "
-                "Please double check the `path` passed to `.updated_copy()`."
+                "Please double check the `path` passed to `.updated_copy()`: "
+                f"{e!s}"
             ) from e
 
         if isinstance(sub_component, (list, tuple)):

--- a/tidy3d/components/base_sim/data/sim_data.py
+++ b/tidy3d/components/base_sim/data/sim_data.py
@@ -67,7 +67,7 @@ class AbstractSimulationData(Tidy3dBaseModel, ABC):
             except Tidy3dKeyError as exc:
                 raise DataError(
                     f"Data with monitor name '{monitor_name}' supplied "
-                    f"but not found in the original '{sim.type}'."
+                    f"but not found in the original '{sim.type}': {exc!s}"
                 ) from exc
         return values
 

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -520,7 +520,8 @@ class DataArray(xr.DataArray):
             raise ValueError(
                 "Couldn't reshape the supplied 'data' to update 'DataArray'. The provided data was "
                 f"of shape {data.shape} and tried to reshape to {new_shape}. If you encounter this "
-                "error please raise an issue on the tidy3d github repository with the context."
+                "error please raise an issue on the tidy3d github repository with the context: "
+                f"{e!s}"
             ) from e
 
         # broadcast data to repeat data along the selected dimensions to match mask

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -1382,5 +1382,6 @@ class SimulationData(AbstractYeeGridSimulationData):
             savemat(fname, modified_sim_dict, **kwargs)
         except Exception as e:
             raise ValueError(
-                "Could not save supplied 'SimulationData' to file. As this is an experimental feature, we may not be able to support the contents of your dataset. If you receive this error, please feel free to raise an issue on our front end repository so we can investigate."
+                "Could not save supplied 'SimulationData' to file. As this is an experimental feature, we may not be able to support the contents of your dataset. If you receive this error, please feel free to raise an issue on our front end repository so we can investigate "
+                f"{e!s}"
             ) from e

--- a/tidy3d/components/field_projection.py
+++ b/tidy3d/components/field_projection.py
@@ -423,7 +423,7 @@ class FieldProjector(Tidy3dBaseModel):
             currents_f = currents.sel(f=frequency)
         except Exception as e:
             raise SetupError(
-                f"Frequency {frequency} not found in fields for monitor '{surface.monitor.name}'."
+                f"Frequency {frequency} not found in fields for monitor '{surface.monitor.name}': {e!s}"
             ) from e
 
         idx_w, idx_uv = surface.monitor.pop_axis((0, 1, 2), axis=surface.axis)

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -1473,7 +1473,7 @@ class Geometry(Tidy3dBaseModel, ABC):
         except ImportError as e:
             raise Tidy3dImportError(
                 "Python module 'gdstk' not found. To export geometries to .gds "
-                "files, please install it."
+                f"files, please install it: {e!s}"
             ) from e
 
         library = gdstk.Library()

--- a/tidy3d/components/microwave/path_integrals/factory.py
+++ b/tidy3d/components/microwave/path_integrals/factory.py
@@ -148,6 +148,7 @@ def make_path_integrals(
             raise SetupError(
                 f"Failed to construct path integrals for the mode with index {idx} "
                 "from the impedance specification. "
-                "Please create a github issue so that the problem can be investigated."
+                "Please create a github issue so that the problem can be investigated: "
+                f"{e!s}"
             ) from e
     return (tuple(v_integrals), tuple(i_integrals))

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -632,7 +632,7 @@ class Structure(AbstractStructure):
         except ImportError as e:
             raise Tidy3dImportError(
                 "Python module 'gdstk' not found. To export geometries to .gds "
-                "files, please install it."
+                f"files, please install it: {e!s}"
             ) from e
         cell = library.new_cell(gds_cell_name)
         self.to_gds(

--- a/tidy3d/components/viz/plot_sim_3d.py
+++ b/tidy3d/components/viz/plot_sim_3d.py
@@ -68,7 +68,7 @@ def plot_sim_3d(sim, width=800, height=800, is_gz_base64=False) -> None:
     except ImportError as e:
         raise SetupError(
             "3D plotting requires ipython to be installed "
-            "and the code to be running on a jupyter notebook."
+            f"and the code to be running on a jupyter notebook: {e!s}"
         ) from e
 
     from base64 import b64encode

--- a/tidy3d/plugins/autograd/functions.py
+++ b/tidy3d/plugins/autograd/functions.py
@@ -51,7 +51,7 @@ def _normalize_axes(
             try:
                 ax = int(ax)
             except Exception as e:
-                raise TypeError(f"Axis {ax!r} could not be converted to an integer.") from e
+                raise TypeError(f"Axis {ax!r} could not be converted to an integer: {e!s}") from e
 
         if not -ndim <= ax < ndim:
             raise ValueError(f"Invalid axis {ax} for {kind} with ndim {ndim}.")
@@ -209,7 +209,7 @@ def _get_pad_indices(
     try:
         indices = onp.pad(onp.arange(n), (pad_left, pad_right), mode=mode)
     except ValueError as error:
-        raise ValueError(f"Unsupported padding mode: {mode}") from error
+        raise ValueError(f"Unsupported padding mode: {mode}: {error!s}") from error
     return numpy_module.asarray(indices, dtype=int)
 
 

--- a/tidy3d/plugins/autograd/utilities.py
+++ b/tidy3d/plugins/autograd/utilities.py
@@ -232,7 +232,7 @@ def scalar_objective(func: Optional[Callable] = None, *, has_aux: bool = False) 
             raise Tidy3dError(
                 "An objective function's return value must be a scalar "
                 "but got an array with shape "
-                f"{getattr(result, 'shape', 'N/A')}."
+                f"{getattr(result, 'shape', 'N/A')}: {e!s}"
             ) from e
 
         # Ensure the result is real

--- a/tidy3d/plugins/dispersion/fit.py
+++ b/tidy3d/plugins/dispersion/fit.py
@@ -603,7 +603,9 @@ class DispersionFitter(Tidy3dBaseModel):
                 try:
                     _ = [float(x) for x in row]
                 except Exception as e:
-                    raise ValidationError("Invalid URL. Float data cannot be recognized.") from e
+                    raise ValidationError(
+                        f"Invalid URL. Float data cannot be recognized: {e!s}"
+                    ) from e
 
         if has_k > 1:
             raise ValidationError("Invalid URL. Too many k labels.")
@@ -663,7 +665,9 @@ class DispersionFitter(Tidy3dBaseModel):
         try:
             resp.raise_for_status()
         except Exception as e:
-            raise WebError("Connection to the website failed. Please provide a valid URL.") from e
+            raise WebError(
+                f"Connection to the website failed. Please provide a valid URL: {e!s}"
+            ) from e
 
         data_url = list(
             csv.reader(codecs.iterdecode(resp.iter_lines(), "utf-8"), delimiter=delimiter)

--- a/tidy3d/plugins/dispersion/web.py
+++ b/tidy3d/plugins/dispersion/web.py
@@ -253,7 +253,7 @@ class FitterData(AdvancedFitterParam):
             resp = requests.get(f"{url_server}/health", verify=ssl_verify)
             resp.raise_for_status()
         except Exception as e:
-            raise WebError("Connection to the server failed. Please try again.") from e
+            raise WebError(f"Connection to the server failed. Please try again: {e!s}") from e
 
         return get_headers(), ssl_verify
 
@@ -292,10 +292,10 @@ class FitterData(AdvancedFitterParam):
                         "inner iterations, or to relax the RMS tolerance."
                     )
                 )
-                raise Tidy3dError(msg) from e
+                raise Tidy3dError(f"{msg}: {e!s}") from e
 
             raise WebError(
-                "Fitter failed. Try again, tune the parameters, or contact us for more help."
+                f"Fitter failed. Try again, tune the parameters, or contact us for more help: {e!s}"
             ) from e
 
         run_result = resp.json()

--- a/tidy3d/plugins/klayout/drc/drc.py
+++ b/tidy3d/plugins/klayout/drc/drc.py
@@ -98,7 +98,9 @@ class DRCConfig(Tidy3dBaseModel):
         try:
             v = {str(k): str(v) for k, v in v.items()}
         except Exception as e:
-            raise ValidationError("Could not coerce keys and values of drc_args to strings.") from e
+            raise ValidationError(
+                f"Could not coerce keys and values of drc_args to strings: {e!s}"
+            ) from e
         return v
 
     @validator("drc_args")

--- a/tidy3d/plugins/klayout/drc/results.py
+++ b/tidy3d/plugins/klayout/drc/results.py
@@ -413,9 +413,11 @@ def violations_from_file(
     try:
         xmltree = ET.parse(resultsfile)
     except FileNotFoundError as err:
-        raise FileError(f"DRC result file not found: '{resultsfile}'.") from err
+        raise FileError(f"DRC result file not found: '{resultsfile}': {err!s}") from err
     except ET.ParseError as err:
-        raise ET.ParseError(f"Invalid XML format in DRC result file: '{resultsfile}'.") from err
+        raise ET.ParseError(
+            f"Invalid XML format in DRC result file: '{resultsfile}': {err!s}"
+        ) from err
 
     # Initialize violations dict with all the categories
     violations = {}

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -511,7 +511,8 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
                     raise ValueError(
                         "Automatic construction of radiation monitors failed. "
                         "Please address the reason or provide a tuple of DirectivityMonitor "
-                        "objects to the 'radiation_monitors' parameter."
+                        "objects to the 'radiation_monitors' parameter: "
+                        f"{e!s}"
                     ) from e
             else:
                 # DirectivityMonitor - use as-is

--- a/tidy3d/web/api/mode.py
+++ b/tidy3d/web/api/mode.py
@@ -630,7 +630,8 @@ class ModeSolverTask(ResourceLifecycle, Submittable, extra=pydantic.Extra.allow)
             except Exception as e:
                 raise WebError(
                     "Failed to download the simulation data file from the server. "
-                    "Please confirm that the task was successfully run."
+                    "Please confirm that the task was successfully run: "
+                    f"{e!s}"
                 ) from e
 
         data = ModeSolverData.from_hdf5(to_file)

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -121,7 +121,7 @@ def _batch_detail_error(resource_id: str) -> Optional[WebError]:
         status = batch_detail.status.lower()
     except Exception as e:
         log.error(f"Could not retrieve batch details for '{resource_id}': {e}")
-        raise WebError(f"Failed to retrieve status for batch '{resource_id}'.") from e
+        raise WebError(f"Failed to retrieve status for batch '{resource_id}': {e!s}") from e
 
     if status not in ERROR_STATES:
         return
@@ -141,7 +141,7 @@ def _batch_detail_error(resource_id: str) -> Optional[WebError]:
             )
         except Exception as e:
             raise WebError(
-                "One or more subtasks failed validation. Failed to parse validation errors."
+                f"One or more subtasks failed validation. Failed to parse validation errors: {e!s}"
             ) from e
         raise WebError(full_error_msg)
 
@@ -1671,10 +1671,9 @@ def test() -> None:
         console.log("Authentication configured successfully!")
     except (WebError, HTTPError) as e:
         url = "https://docs.flexcompute.com/projects/tidy3d/en/latest/index.html"
-        msg = (
-            str(e)
-            + "\n\n"
-            + "It looks like the Tidy3D Python interface is not configured with your "
+        raise WebError(
+            f"{e!s}\n\n"
+            "It looks like the Tidy3D Python interface is not configured with your "
             "unique API key. "
             "To get your API key, sign into 'https://tidy3d.simulation.cloud' and copy it "
             "from your 'Account' page. Then you can configure tidy3d through command line "
@@ -1683,5 +1682,4 @@ def test() -> None:
             "'.tidy3d/config' (windows) with content like: \n\n"
             "apikey = 'XXX' \n\nHere XXX is your API key copied from your account page within quotes.\n\n"
             f"For details, check the instructions at {url}."
-        )
-        raise WebError(msg) from e
+        ) from e

--- a/tidy3d/web/core/task_core.py
+++ b/tidy3d/web/core/task_core.py
@@ -322,7 +322,8 @@ class WebTask(ResourceLifecycle, Submittable, extra=Extra.allow):
             except Exception as e:
                 raise WebError(
                     "Failed to download the data file from the server. "
-                    "Please confirm that the task completed successfully."
+                    "Please confirm that the task completed successfully: "
+                    f"{e!s}"
                 ) from e
         return file
 
@@ -820,7 +821,8 @@ class SimulationTask(WebTask):
                 except Exception as e:
                     raise ValidationError(
                         "The parent task must be a 'VolumeMesher' task which has been successfully "
-                        "run and is associated to the same 'HeatChargeSimulation' as provided here."
+                        "run and is associated to the same 'HeatChargeSimulation' as provided here: "
+                        f"{e!s}"
                     ) from e
 
             except Exception as e:


### PR DESCRIPTION
Ensures that we don't do blind chaining when raising exceptions to have expressive errors logs in the GUI.
Same question as in https://github.com/flexcompute/tidy3d/pull/3093 :
- do we want to do that in the pre-commit-hook? Or only CI?

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR standardizes exception chaining across the codebase by ensuring that when exceptions are re-raised using `raise NewError(...) from e`, the original exception context is included in the error message using `{e!s}` formatting. This prevents "blind chaining" where the original error details are lost to the user.

**Key changes:**
- New static analysis script (`scripts/check_blind_chaining.py`) using AST to detect blind exception chaining patterns
- Integrated check into both pre-commit hooks and CI pipeline to enforce this pattern going forward
- Updated 20+ exception handlers across components, plugins, and web API to include original error context
- All error messages now follow pattern: `"Description of new error: {original_exception!s}"`

**Impact:**
- Significantly improves debugging experience by preserving full error context
- Automated enforcement prevents regression
- Consistent error reporting across the entire codebase

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor formatting issues
- The changes are mechanical and improve error handling without altering logic. The static analyzer is well-designed with appropriate safeguards. One minor formatting issue in sim_data.py with awkward spacing, and one potentially incorrect comment about pre-commit configuration that may confuse future maintainers
- Pay attention to `tidy3d/components/data/sim_data.py` for the formatting issue with space before colon

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| scripts/check_blind_chaining.py | 5/5 | New AST-based static analyzer that detects blind exception chaining patterns where original error context is lost |
| .github/workflows/tidy3d-python-client-tests.yml | 5/5 | Added CI step to run blind chaining check as part of code quality checks |
| .pre-commit-config.yaml | 5/5 | Added pre-commit hook for blind chaining check to catch issues early in development |
| tidy3d/components/base.py | 5/5 | Updated exception messages to include original error context using {exc!s} format |
| tidy3d/web/api/webapi.py | 5/5 | Standardized exception chaining in web API error handling to preserve original error details |
| tidy3d/components/data/sim_data.py | 4/5 | Added exception context to savemat error message; minor formatting issue with space before colon |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant PreCommit as Pre-commit Hook
    participant CI as CI Pipeline
    participant Script as check_blind_chaining.py
    participant Code as Codebase

    Dev->>Dev: Write code with raise...from
    Dev->>PreCommit: git commit
    PreCommit->>Script: Run blind chaining check
    Script->>Code: Parse Python files with AST
    Code-->>Script: Return AST nodes
    Script->>Script: Find raise...from patterns
    Script->>Script: Check if cause variable in message
    alt Blind chaining detected
        Script-->>PreCommit: Exit 1 (fail)
        PreCommit-->>Dev: Commit blocked
        Dev->>Dev: Add {e!s} to error message
    else No issues
        Script-->>PreCommit: Exit 0 (pass)
        PreCommit-->>Dev: Commit succeeds
    end
    
    Dev->>CI: Push to remote
    CI->>Script: Run blind chaining check
    Script->>Code: Parse Python files with AST
    Code-->>Script: Return AST nodes
    Script->>Script: Validate all raise...from patterns
    alt All patterns valid
        Script-->>CI: Exit 0 (pass)
        CI-->>Dev: Build passes
    else Invalid patterns found
        Script-->>CI: Exit 1 (fail)
        CI-->>Dev: Build fails
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->