### PR TITLE
feat(tidy3d): FXC-4607-autograd-for-clip-operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.11.0.dev0] - 2026-02-19
 
 ### Added
+- Added `ModeSortSpec.keep_modes` which can be set to `"all"` to keep all modes in the mode solver (the default), `"filtered"` to keep only modes passing the filter defined by the `ModeSortSpec`, or an integer `N` to keep only the top `N` modes after filtering and sorting.
+- Added `fill_fraction_box` as a new filtering and sorting key which computes the field-energy fill fraction within a specified bounding box (`ModeSortSpec.bounding_box`).
+- Added `Grid.fine_mesh_info` property to identify and report locations where grid cell sizes are fine for understanding meshing hotspots.
+- Added visualization of finest grid regions in `Simulation.plot_grid()` with shaded regions highlighting areas of fine meshing.
+- Added autograd support for `Sphere`.
+- Added validation warning in `HeatChargeSimulation` for very small `Cylinder` radii to help users avoid meshing and numerical issues.
+- Added `GaussianOverlapMonitor` and `AstigmaticGaussianOverlapMonitor` for decomposing electromagnetic fields onto Gaussian beam profiles.
+- Added `GaussianPort` and `AstigmaticGaussianPort` for S-matrix calculations using Gaussian beam sources and overlap monitors.
+- Added `symmetric_pseudo` option for `s_param_def` in `TerminalComponentModeler` which applies a scaling factor that ensures the S-matrix is symmetric in reciprocal systems.
+- Added deprecation warning for ``TemperatureMonitor`` and ``SteadyPotentialMonitor`` when ``unstructured`` parameter is not explicitly set. The default value of ``unstructured`` will change from ``False`` to ``True`` after the 2.11 release.
+- Added flag `remove_fragments` to the base `UnstructuredGrid` to remove fragments in unstructured grids. This can ease meshing by eliminating internal boundaries in overlapping structures.
+- Added deprecation warning for `conformal` in TCAD heat/charge monitors when explicitly set; this option is ignored (treated as `False`) when meshing with `remove_fragments=True`.
+- Added in-memory caching for downloaded batch results, configurable via ``config.batch_data_cache``.
+- Added autograd support for `ClipOperation` geometries like unions or intersections of geometries.
 
 - Added `ModeSortSpec.keep_modes` which can be set to `"all"` to keep all modes in the mode solver (the default), `"filtered"` to keep only modes passing the filter defined by the `ModeSortSpec`, or an integer `N` to keep only the top `N` modes after filtering and sorting.
 - Added `Grid.fine_mesh_info` property to identify and report locations where grid cell sizes are fine for understanding meshing hotspots.

--- a/tests/test_components/autograd/numerical/conftest.py
+++ b/tests/test_components/autograd/numerical/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import os
 import re
 from pathlib import Path
@@ -9,11 +10,33 @@ import pytest
 ARTIFACT_ENV_VAR = "TIDY3D_NUMERICAL_ARTIFACT_DIR"
 DEFAULT_RELATIVE_DIR = Path("tests/tmp/autograd_numerical")
 
+# Optional extra cap for the per-test directory name length (in bytes, after fs encoding).
+ARTIFACT_NAME_MAX_ENV_VAR = "TIDY3D_NUMERICAL_ARTIFACT_NAME_MAX"
+
 
 def _sanitize_segment(value: str) -> str:
     sanitized = re.sub(r"[^\w.-]+", "_", value)
     sanitized = sanitized.strip("_")
     return sanitized or "case"
+
+
+def _pathconf_limit(path: Path, key: str, fallback: int) -> int:
+    """Best-effort os.pathconf lookup with a fallback."""
+    try:
+        return int(os.pathconf(str(path), key))
+    except (AttributeError, ValueError, OSError):
+        return fallback
+
+
+def _artifact_name_max_override() -> int | None:
+    """Optional user cap for artifact directory names (bytes)."""
+    raw = os.environ.get(ARTIFACT_NAME_MAX_ENV_VAR)
+    if not raw:
+        return None
+    try:
+        return max(1, int(raw))
+    except ValueError as e:
+        raise ValueError(f"{ARTIFACT_NAME_MAX_ENV_VAR} must be an integer (got {raw!r}).") from e
 
 
 def _resolve_artifact_root() -> Path:
@@ -27,6 +50,53 @@ def _resolve_artifact_root() -> Path:
     return root
 
 
+def _case_dir_name(request, artifact_root: Path) -> str:
+    """Return a filesystem-friendly per-test artifact directory name.
+
+    Uses ``request.node.name``. If truncation is needed to satisfy filesystem
+    path/name limits (and optional ``TIDY3D_NUMERICAL_ARTIFACT_NAME_MAX``), append a
+    short SHA1 digest of the full nodeid. Otherwise, no digest is added, so
+    uniqueness across files is not guaranteed.
+    """
+    raw_nodeid = request.node.nodeid
+    base_name = _sanitize_segment(request.node.name) or "case"
+
+    # Use filesystem-encoded byte lengths to be conservative under multibyte encodings.
+    def _fslen(s: str) -> int:
+        return len(os.fsencode(s))
+
+    root_abs = artifact_root.resolve()
+
+    # Common Linux defaults: NAME_MAX ~255 bytes, PATH_MAX ~4096 bytes (may vary).
+    name_max = _pathconf_limit(root_abs, "PC_NAME_MAX", 255)
+    path_max = _pathconf_limit(root_abs, "PC_PATH_MAX", 4096)
+
+    # Leave room for: <root>/<name> plus NUL (pathconf is in bytes).
+    available = path_max - _fslen(str(root_abs)) - _fslen(os.sep) - 1
+
+    max_len = min(name_max, max(1, available))
+    override = _artifact_name_max_override()
+    if override is not None:
+        max_len = min(max_len, override)
+
+    if _fslen(base_name) <= max_len:
+        return base_name
+
+    digest = hashlib.sha1(raw_nodeid.encode("utf-8")).hexdigest()[:8]
+    suffix = f"-{digest}"
+    max_base = max_len - _fslen(suffix)
+    if max_base < 1:
+        max_base = 1
+
+    # Truncate by bytes (not chars): drop codepoints until it fits.
+    while base_name and _fslen(base_name) > max_base:
+        base_name = base_name[:-1]
+    if not base_name:
+        base_name = "c"
+
+    return f"{base_name}{suffix}"
+
+
 @pytest.fixture(scope="session")
 def numerical_artifact_root() -> Path:
     return _resolve_artifact_root()
@@ -34,7 +104,6 @@ def numerical_artifact_root() -> Path:
 
 @pytest.fixture
 def numerical_case_dir(request, numerical_artifact_root: Path) -> Path:
-    safe_nodeid = _sanitize_segment(request.node.nodeid.replace(os.sep, "_"))
-    case_dir = numerical_artifact_root / safe_nodeid
+    case_dir = numerical_artifact_root / _case_dir_name(request, numerical_artifact_root)
     case_dir.mkdir(parents=True, exist_ok=True)
     return case_dir

--- a/tests/test_components/autograd/numerical/test_autograd_clip_operation_numerical.py
+++ b/tests/test_components/autograd/numerical/test_autograd_clip_operation_numerical.py
@@ -1,0 +1,418 @@
+"""Numerical finite-difference validation for ClipOperation gradients with real simulations."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+
+import autograd.numpy as anp
+import numpy as np
+import pytest
+from autograd import value_and_grad
+from matplotlib import pyplot as plt
+
+import tidy3d as td
+import tidy3d.web as web
+from tests.test_components.autograd.numerical.test_autograd_box_polyslab_numerical import (
+    angled_overlap_deg,
+)
+from tidy3d import config
+
+WL_UM = 0.8
+FREQ0 = td.C_0 / WL_UM
+SRC_OFFSET = -2.2
+MONITOR_OFFSET = 2.2
+SIM_SIZE = (4.0, 4.0, 6.0)
+RUN_TIME = 2e-11
+PERMITTIVITY = 1.4**2
+GRID_STEPS_PER_WVL = 30
+FINITE_DIFF_STEP = 0.05
+BASE_OFFSET = (0.05, -0.035, 0.02)
+BASE_CENTER_A = (-0.25, 0.12, 0.0)
+BASE_CENTER_B = (0.15, -0.08, 0.0)
+ANGLE_OVERLAP_FD_ADJ_THRESH_DEG = 11.0
+BASE_CENTER_A_VEC = anp.array(BASE_CENTER_A, dtype=float)
+
+SIZE_MAP = {
+    "sphere": {"a": (0.9, 0.9, 0.9), "b": (0.7, 0.7, 0.7)},
+    "box": {"a": (1.0, 0.9, 0.8), "b": (0.9, 0.75, 0.7)},
+    "polyslab": {"a": (0.95, 0.85, 0.8), "b": (0.8, 0.7, 0.6)},
+    "mesh": {"a": (0.85, 0.95, 0.95), "b": (0.7, 0.95, 0.8)},
+}
+
+STRUCTURE_MEDIUM = td.Medium(permittivity=PERMITTIVITY)
+
+
+@pytest.fixture(autouse=True)
+def _enable_local_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config.local_cache, "enabled", True)
+
+
+def _make_base_simulation() -> tuple[td.Simulation, Callable[[td.SimulationData], float]]:
+    """Shared ClipOperation simulation (plane wave excitation and Ex monitor)."""
+    source = td.PointDipole(
+        center=(0.0, 0.0, SRC_OFFSET),
+        source_time=td.GaussianPulse(freq0=FREQ0, fwidth=0.2 * FREQ0),
+        polarization="Ex",
+    )
+    field_monitor = td.FieldMonitor(
+        center=(0.0, 0.0, MONITOR_OFFSET),
+        size=(0, 0, 0.0),
+        freqs=[FREQ0],
+        name="field",
+    )
+    base_sim = td.Simulation(
+        center=(0.0, 0.0, 0.0),
+        size=SIM_SIZE,
+        sources=[source],
+        monitors=[field_monitor],
+        structures=[],
+        boundary_spec=td.BoundarySpec(
+            x=td.Boundary.pml(), y=td.Boundary.pml(), z=td.Boundary.pml()
+        ),
+        run_time=RUN_TIME,
+        grid_spec=td.GridSpec.auto(min_steps_per_wvl=GRID_STEPS_PER_WVL),
+    )
+
+    def fom(sim_data: td.SimulationData) -> float:
+        dataset = sim_data["field"]
+        ex_vals = dataset.Ex.values
+        ey_vals = dataset.Ey.values
+        ez_vals = dataset.Ez.values
+        intensity = np.abs(ex_vals) ** 2 + np.abs(ey_vals) ** 2 + np.abs(ez_vals) ** 2
+        return anp.real(anp.mean(intensity))
+
+    return base_sim, fom
+
+
+def _triangle_prism(
+    center: tuple[float, float, float], size: tuple[float, float, float]
+) -> td.PolySlab:
+    half_x, half_y, half_z = 0.5 * size[0], 0.5 * size[1], 0.5 * size[2]
+    cx, cy, cz = center
+    vertices = (
+        (cx - half_x, cy - half_y),
+        (cx + half_x, cy - half_y),
+        (cx, cy + half_y),
+    )
+    slab_bounds = (cz - half_z, cz + half_z)
+    return td.PolySlab(vertices=vertices, axis=2, slab_bounds=slab_bounds)
+
+
+def _tetra_mesh(
+    center: tuple[float, float, float], size: tuple[float, float, float]
+) -> td.TriangleMesh:
+    center_arr = _normalize_array(center)
+    half = 0.5 * _normalize_array(size)
+    cx, cy, cz = center_arr
+    vertices = anp.array(
+        [
+            (cx - half[0], cy - half[1], cz - half[2]),
+            (cx + half[0], cy - half[1], cz - half[2]),
+            (cx, cy + half[1], cz - half[2]),
+            (cx, cy, cz + half[2]),
+        ],
+        dtype=float,
+    )
+    faces = anp.array(
+        [
+            (0, 2, 1),
+            (0, 1, 3),
+            (1, 2, 3),
+            (2, 0, 3),
+        ],
+        dtype=int,
+    )
+    mesh = td.TriangleMesh.from_triangles(vertices[faces])
+    return mesh
+
+
+def _make_geometry(
+    geometry_type: str, center: tuple[float, float, float], size: tuple[float, float, float]
+) -> td.Geometry:
+    if geometry_type == "sphere":
+        radius = 0.5 * min(size)
+        return td.Sphere(center=center, radius=radius)
+    if geometry_type == "box":
+        return td.Box(center=center, size=size)
+    if geometry_type == "polyslab":
+        return _triangle_prism(center, size)
+    if geometry_type == "mesh":
+        return _tetra_mesh(center, size)
+    raise ValueError(f"Unsupported geometry_type '{geometry_type}'.")
+
+
+def _normalize_array(offset_vec):
+    """Return the offset as an autograd array of length 3."""
+
+    offset = anp.array(offset_vec, dtype=float)
+    if offset.shape != (3,):
+        raise ValueError("ClipOperation offset vector must have length 3.")
+    return offset
+
+
+def _clip_structure(offset_vec, geometry_type: str, operation: str) -> td.Structure:
+    offset = _normalize_array(offset_vec)
+    size_spec = SIZE_MAP[geometry_type]
+    center_arr = BASE_CENTER_A_VEC + offset
+    center_a = tuple(center_arr)
+    geometry_a = _make_geometry(geometry_type, center=center_a, size=size_spec["a"])
+    geometry_b = _make_geometry(geometry_type, center=BASE_CENTER_B, size=size_spec["b"])
+    clip_geom = td.ClipOperation(
+        operation=operation,
+        geometry_a=geometry_a,
+        geometry_b=geometry_b,
+    )
+    return td.Structure(geometry=clip_geom, medium=STRUCTURE_MEDIUM)
+
+
+def _run_clip_simulation(
+    base_sim: td.Simulation,
+    fom: Callable[[td.SimulationData], float],
+    offset_vec,
+    geometry_type: str,
+    operation: str,
+    result_dir: Path,
+    *,
+    local_gradient: bool,
+    tag: str,
+    structure_builder: Callable = _clip_structure,
+) -> float:
+    return _run_clip_simulation_batch(
+        base_sim,
+        fom,
+        offset_list=[offset_vec],
+        geometry_type=geometry_type,
+        operation=operation,
+        result_dir=result_dir,
+        local_gradient=local_gradient,
+        tag=tag,
+        structure_builder=structure_builder,
+    )[0]
+
+
+def _run_clip_simulation_batch(
+    base_sim: td.Simulation,
+    fom: Callable[[td.SimulationData], float],
+    offset_list,
+    geometry_type: str,
+    operation: str,
+    result_dir: Path,
+    *,
+    local_gradient: bool,
+    tag: str,
+    structure_builder: Callable = _clip_structure,
+) -> list:
+    """Run a batch of simulations (in parallel if possible) for different offsets."""
+
+    offsets = [_normalize_array(off) for off in offset_list]
+    simulations: dict[str, td.Simulation] = {}
+    key_order: list[str] = []
+
+    for idx, offset in enumerate(offsets):
+        structure = structure_builder(offset, geometry_type, operation)
+        grid_spec = td.GridSpec.auto(
+            min_steps_per_wvl=GRID_STEPS_PER_WVL, override_structures=[structure]
+        )
+        sim = base_sim.updated_copy(structures=[structure], grid_spec=grid_spec, validate=True)
+        task_name = f"clip_{geometry_type}_{operation}_{tag}_{idx}_{uuid.uuid4().hex[:6]}"
+        simulations[task_name] = sim
+        key_order.append(task_name)
+
+    result_dir.mkdir(parents=True, exist_ok=True)
+
+    if len(simulations) == 1:
+        key = key_order[0]
+        sim = simulations[key]
+        result_path = result_dir / f"{key}.hdf5"
+        sim_data = web.run(
+            sim,
+            task_name=key,
+            path=str(result_path),
+            local_gradient=local_gradient,
+            verbose=False,
+        )
+        return [fom(sim_data)]
+
+    sim_data_map = web.run_async(
+        simulations,
+        path_dir=str(result_dir),
+        local_gradient=local_gradient,
+        verbose=False,
+    )
+
+    return [fom(sim_data_map[key]) for key in key_order]
+
+
+def _make_clip_objective(
+    base_sim: td.Simulation,
+    fom,
+    geometry_type: str,
+    operation: str,
+    case_dir: Path,
+    *,
+    local_gradient: bool,
+    structure_builder: Callable = _clip_structure,
+):
+    run_dir = case_dir / ("adjoint" if local_gradient else "finite_difference")
+
+    def objective(params, *, batched: bool = False):
+        tag = "adj" if local_gradient else "fd"
+        if batched:
+            offsets = [_normalize_array(p) for p in params]
+            return _run_clip_simulation_batch(
+                base_sim,
+                fom,
+                offset_list=offsets,
+                geometry_type=geometry_type,
+                operation=operation,
+                result_dir=run_dir,
+                local_gradient=local_gradient,
+                tag=tag,
+                structure_builder=structure_builder,
+            )
+        offset = _normalize_array(params)
+        return _run_clip_simulation(
+            base_sim,
+            fom,
+            offset_vec=offset,
+            geometry_type=geometry_type,
+            operation=operation,
+            result_dir=run_dir,
+            local_gradient=local_gradient,
+            tag=tag,
+            structure_builder=structure_builder,
+        )
+
+    return objective
+
+
+def _finite_difference_gradient(objective, params: anp.ndarray, step: float) -> np.ndarray:
+    base = _normalize_array(params)
+    offsets = []
+    axis_indices = []
+
+    for idx in range(3):
+        delta = anp.array(
+            [step if dim == idx else 0.0 for dim in range(3)],
+            dtype=float,
+        )
+        offsets.append(base + delta)
+        offsets.append(base - delta)
+        axis_indices.append(idx)
+
+    results = objective(offsets, batched=True)
+    grads = np.zeros(3, dtype=float)
+    for pair_idx, axis in enumerate(axis_indices):
+        obj_up = float(np.asarray(results[2 * pair_idx], dtype=float))
+        obj_down = float(np.asarray(results[2 * pair_idx + 1], dtype=float))
+        grads[axis] = (obj_up - obj_down) / (2.0 * step)
+
+    return grads
+
+
+@pytest.mark.numerical
+@pytest.mark.parametrize("geometry_type", ["sphere", "box", "polyslab", "mesh"])
+@pytest.mark.parametrize(
+    "operation", ["union", "intersection", "difference", "symmetric_difference"]
+)
+def test_clip_operation_vs_fd(geometry_type: str, operation: str, tmp_path: Path, monkeypatch):
+    """Compare ClipOperation adjoint gradients against finite differences (3D offsets)."""
+    if operation == "symmetric_difference" and geometry_type in ("mesh", "box"):
+        # we need more sampling density in these cases
+        monkeypatch.setattr(td.config.adjoint, "default_wavelength_fraction", 0.01)
+    base_sim, fom = _make_base_simulation()
+    adjoint_objective = _make_clip_objective(
+        base_sim,
+        fom,
+        geometry_type,
+        operation,
+        tmp_path,
+        local_gradient=True,
+    )
+    params0 = anp.array(BASE_OFFSET, dtype=float)
+    _, grad = value_and_grad(adjoint_objective)(params0)
+    fd_objective = _make_clip_objective(
+        base_sim,
+        fom,
+        geometry_type,
+        operation,
+        tmp_path,
+        local_gradient=False,
+    )
+
+    autograd_grad = np.asarray(grad, dtype=float).ravel()
+    fd_grad = _finite_difference_gradient(fd_objective, params0, FINITE_DIFF_STEP)
+
+    angle = angled_overlap_deg(autograd_grad, fd_grad)
+    assert angle < ANGLE_OVERLAP_FD_ADJ_THRESH_DEG, (
+        f"FD–adjoint angle overlap too large ({angle:.2f}°) for {geometry_type}/{operation}"
+    )
+
+
+@pytest.mark.numerical
+@pytest.mark.parametrize("geometry_type", ["box", "polyslab", "mesh"])
+@pytest.mark.parametrize(
+    "operation", ["union", "intersection", "difference", "symmetric_difference"]
+)
+def test_clip_operation_fd_sweep(geometry_type: str, operation: str, numerical_case_dir: Path):
+    """Sweep FD step sizes and save comparison plots for diagnostic use."""
+
+    base_sim, fom = _make_base_simulation()
+    case_dir = numerical_case_dir / f"{geometry_type}_{operation}_fd_sweep"
+    case_dir.mkdir(parents=True, exist_ok=True)
+    adjoint_objective = _make_clip_objective(
+        base_sim,
+        fom,
+        geometry_type,
+        operation,
+        case_dir,
+        local_gradient=True,
+    )
+    fd_objective = _make_clip_objective(
+        base_sim,
+        fom,
+        geometry_type,
+        operation,
+        case_dir,
+        local_gradient=False,
+    )
+
+    params0 = anp.array(BASE_OFFSET, dtype=float)
+    _, grad = value_and_grad(adjoint_objective)(params0)
+    autograd_grad = np.asarray(grad, dtype=float).ravel()
+
+    steps = np.logspace(-4, -1, num=7)
+    fd_grads = np.array(
+        [_finite_difference_gradient(fd_objective, params0, float(step)) for step in steps]
+    )
+
+    fig, ax = plt.subplots(figsize=(6, 4))
+    labels = ("dx", "dy", "dz")
+    for idx, label in enumerate(labels):
+        ax.plot(steps, fd_grads[:, idx], marker="o", label=f"{label} FD")
+        ax.axhline(
+            autograd_grad[idx],
+            color=ax.get_lines()[-1].get_color(),
+            linestyle="--",
+            alpha=0.7,
+            label=f"{label} adjoint",
+        )
+    ax.set_xscale("log")
+    ax.set_xlabel("Finite-difference step (µm)")
+    ax.set_ylabel("Gradient value")
+    ax.set_title(f"FD sweep for {geometry_type} / {operation}")
+    ax.grid(True, which="both", linestyle=":")
+    ax.legend(loc="best", fontsize="small")
+
+    fig_path = case_dir / f"fd_sweep_{geometry_type}_{operation}.png"
+    fig.savefig(fig_path, dpi=200)
+    plt.close(fig)
+
+    np.savez(
+        case_dir / f"fd_sweep_{geometry_type}_{operation}.npz",
+        steps=steps,
+        gradients=fd_grads,
+        autograd_grad=autograd_grad,
+    )

--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -3682,8 +3682,8 @@ def test_sim_traced_center_size(use_emulated_run):
         grad = ag.grad(objective, argnum=1)(base_sim.center, base_sim.size)
 
 
-def test_error_clip(use_emulated_run):
-    """Make sure proper error raised if differentiating a ``ClipOperation``."""
+def test_clip_operation_autograd(use_emulated_run):
+    """Ensure ``ClipOperation`` geometries support differentiation."""
 
     def objective(x):
         box1 = td.Box(center=(0, 0, 0), size=(x, x, x))
@@ -3699,8 +3699,8 @@ def test_error_clip(use_emulated_run):
         data = run(sim, task_name="clip_error")
         return anp.sum(data["field"].intensity.item())
 
-    with pytest.raises(ValueError):
-        g = ag.grad(objective)(1.0)
+    grad_val = ag.grad(objective)(1.0)
+    assert anp.all(grad_val != 0.0)
 
 
 def test_custom_medium_conductivity_only_gradient(rng, use_emulated_run, tmp_path):

--- a/tests/test_components/autograd/test_autograd_clip_operation.py
+++ b/tests/test_components/autograd/test_autograd_clip_operation.py
@@ -1,0 +1,535 @@
+"""Tests for ``ClipOperation`` autograd support."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Sequence
+from typing import Callable
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+import tidy3d as td
+from tidy3d import TriangleMesh
+
+DEFAULT_SIM_BOUNDS = ((-10.0, -10.0, -10.0), (10.0, 10.0, 10.0))
+
+
+def _default_gradient(points: np.ndarray) -> np.ndarray:
+    """Deterministic gradient profile used in analytical objective evaluations."""
+    if points.size == 0:
+        return np.zeros(0, dtype=float)
+    return points[:, 0] + 0.5 * points[:, 1] - 0.25 * points[:, 2]
+
+
+class SimpleDerivativeInfo:
+    """Lightweight derivative info stub for geometry autograd testing."""
+
+    def __init__(
+        self,
+        paths: Sequence[tuple],
+        bounds: tuple[tuple[float, float, float], tuple[float, float, float]] | None = None,
+        *,
+        gradient_func: Callable[[np.ndarray], np.ndarray] | None = None,
+        spacing: float = 0.01,
+        simulation_bounds: tuple[tuple[float, float, float], tuple[float, float, float]]
+        | None = None,
+    ) -> None:
+        self.paths = list(paths)
+        self.frequencies = [200e12]
+        self.wavelength_min = 1.0
+        self.eps_in = 1.0
+        self.eps_out = 1.0
+        self.interpolators = {}
+        self._spacing = spacing
+        self.gradient_func = gradient_func or _default_gradient
+        self.simulation_bounds = simulation_bounds or DEFAULT_SIM_BOUNDS
+        self.bounds = bounds if bounds is not None else self.simulation_bounds
+        self.bounds_intersect = self.bounds
+
+    def updated_copy(self, **kwargs):
+        clone = copy.copy(self)
+        for key, value in kwargs.items():
+            setattr(clone, key, value)
+        return clone
+
+    def adaptive_vjp_spacing(self) -> float:
+        return float(self._spacing)
+
+    def create_interpolators(self, dtype=None):
+        return {}
+
+    def evaluate_gradient_at_points(
+        self, spatial_coords, normals, perps1, perps2, interpolators=None
+    ):
+        points = np.asarray(spatial_coords, dtype=float)
+        if points.size == 0:
+            return np.zeros(0, dtype=float)
+        return self.gradient_func(points)
+
+
+def _tetrahedron_mesh(center: Sequence[float], size: Sequence[float]) -> TriangleMesh:
+    """Return a watertight tetrahedron mesh centered at ``center`` with ``size`` extents."""
+
+    center = np.asarray(center, dtype=float)
+    half = 0.5 * np.asarray(size, dtype=float)
+    cx, cy, cz = center
+    hx, hy, hz = half
+    vertices = np.array(
+        [
+            (cx + hx, cy + hy, cz + hz),
+            (cx + hx, cy - hy, cz - hz),
+            (cx - hx, cy + hy, cz - hz),
+            (cx - hx, cy - hy, cz + hz),
+        ],
+        dtype=float,
+    )
+    triangles = np.array(
+        [
+            (vertices[0], vertices[1], vertices[2]),
+            (vertices[0], vertices[3], vertices[1]),
+            (vertices[0], vertices[2], vertices[3]),
+            (vertices[1], vertices[3], vertices[2]),
+        ],
+        dtype=float,
+    )
+    return TriangleMesh.from_triangles(triangles)
+
+
+def build_geometry(
+    geometry_type: str, center: Sequence[float], size: Sequence[float]
+) -> td.Geometry:
+    """Return a geometry instance of the requested type."""
+
+    center = tuple(center)
+    size = tuple(size)
+    if geometry_type == "sphere":
+        radius = 0.5 * min(size)
+        return td.Sphere(center=center, radius=radius)
+    if geometry_type == "box":
+        return td.Box(center=center, size=size)
+
+    if geometry_type == "polyslab":
+        half_x = size[0] / 2.0
+        half_y = size[1] / 2.0
+        half_z = size[2] / 2.0
+        vertices = np.array(
+            [
+                (center[0] - half_x, center[1] - half_y),
+                (center[0] + half_x, center[1] - half_y),
+                (center[0], center[1] + half_y),
+            ],
+            dtype=float,
+        )
+        slab_bounds = (center[2] - half_z, center[2] + half_z)
+        return td.PolySlab(vertices=vertices, axis=2, slab_bounds=slab_bounds)
+
+    if geometry_type == "mesh":
+        return _tetrahedron_mesh(center=center, size=size)
+
+    raise ValueError(f"Unsupported geometry type '{geometry_type}'.")
+
+
+SAMPLE_POINTS = np.array(
+    [
+        (0.0, 0.0, 0.0),
+        (1.5, 0.0, 0.0),
+        (-0.5, 0.0, 0.0),
+    ],
+    dtype=float,
+)
+SAMPLE_NORMALS = np.array(
+    [
+        (1.0, 0.0, 0.0),
+        (0.0, 1.0, 0.0),
+        (0.0, 0.0, 1.0),
+    ],
+    dtype=float,
+)
+SAMPLE_PERPS1 = np.array(
+    [
+        (0.0, 1.0, 0.0),
+        (0.0, 0.0, 1.0),
+        (1.0, 0.0, 0.0),
+    ],
+    dtype=float,
+)
+SAMPLE_PERPS2 = np.array(
+    [
+        (0.0, 0.0, 1.0),
+        (1.0, 0.0, 0.0),
+        (0.0, 1.0, 0.0),
+    ],
+    dtype=float,
+)
+SAMPLE_WEIGHTS = np.ones(3, dtype=float)
+SAMPLE_FACES = np.zeros(3, dtype=int)
+SAMPLE_BARY = np.full((3, 3), 1.0 / 3.0, dtype=float)
+INSIDE_MASK = np.array([True, False, True], dtype=bool)
+
+
+def _sample_dict() -> dict[str, np.ndarray]:
+    """Return a fresh copy of the mocked sampling dictionary."""
+
+    return {
+        "points": SAMPLE_POINTS.copy(),
+        "normals": SAMPLE_NORMALS.copy(),
+        "perps1": SAMPLE_PERPS1.copy(),
+        "perps2": SAMPLE_PERPS2.copy(),
+        "weights": SAMPLE_WEIGHTS.copy(),
+        "faces": SAMPLE_FACES.copy(),
+        "barycentric": SAMPLE_BARY.copy(),
+    }
+
+
+def _make_mesh() -> td.TriangleMesh:
+    """Create a simple triangle mesh for testing."""
+    vertices = np.array(
+        [
+            (0.0, 0.0, 0.0),
+            (1.0, 0.0, 0.0),
+            (0.0, 1.0, 0.0),
+        ],
+        dtype=float,
+    )
+    faces = np.array([(0, 1, 2)], dtype=int)
+    return td.TriangleMesh.from_vertices_faces(vertices, faces)
+
+
+def _patch_sample_collection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace surface sampling with deterministic data."""
+
+    def fake_collect(self, *args, **kwargs):
+        return _sample_dict()
+
+    monkeypatch.setattr(td.TriangleMesh, "_collect_surface_samples", fake_collect, raising=True)
+
+
+class _BaseDerivativeInfo:
+    """Shared helpers for derivative info stubs."""
+
+    def adaptive_vjp_spacing(self) -> float:
+        return 0.5
+
+    def create_interpolators(self, dtype=None):
+        return {}
+
+
+class MinimalDerivativeInfo(_BaseDerivativeInfo):
+    """Lightweight derivative info container for ClipOperation routing tests."""
+
+    def __init__(self, paths) -> None:
+        self.paths = [tuple(path) for path in paths]
+        self.interpolators = None
+        self.bounds = ((-2.0, -2.0, -2.0), (2.0, 2.0, 2.0))
+        self.simulation_bounds = self.bounds
+        self.bounds_intersect = self.bounds
+        self.frequencies = [200e12]
+        self.E_der_map = {}
+        self.D_der_map = {}
+        self.E_fwd = {}
+        self.E_adj = {}
+        self.D_fwd = {}
+        self.D_adj = {}
+        self.eps_data = {}
+        self.eps_in = 1.0
+        self.eps_out = 1.0
+        self.wavelength_min = 1.0
+
+    def updated_copy(self, **kwargs):
+        kwargs.pop("deep", None)
+        kwargs.pop("validate", None)
+        new = MinimalDerivativeInfo(self.paths)
+        new.__dict__.update(self.__dict__)
+        if "paths" in kwargs:
+            new.paths = list(kwargs.pop("paths"))
+        for key, value in kwargs.items():
+            setattr(new, key, value)
+        return new
+
+    def evaluate_gradient_at_points(
+        self,
+        spatial_coords,
+        normals,
+        perps1,
+        perps2,
+        interpolators=None,
+    ):
+        return np.zeros(len(spatial_coords), dtype=float)
+
+
+class RecordingDerivativeInfo(_BaseDerivativeInfo):
+    """DerivativeInfo stub that records sampling points."""
+
+    def __init__(self) -> None:
+        self.paths = [("mesh_dataset", "surface_mesh")]
+        self.simulation_bounds = ((-5.0, -5.0, -5.0), (5.0, 5.0, 5.0))
+        self.bounds_intersect = self.simulation_bounds
+        self.interpolators: dict | None = {}
+        self.last_points: np.ndarray | None = None
+        self.last_normals: np.ndarray | None = None
+
+    def evaluate_gradient_at_points(
+        self,
+        spatial_coords,
+        normals,
+        perps1,
+        perps2,
+        interpolators=None,
+    ):
+        self.last_points = np.array(spatial_coords)
+        self.last_normals = np.array(normals)
+        return np.ones(spatial_coords.shape[0], dtype=float)
+
+
+class RecordingDerivativeInfoNested(MinimalDerivativeInfo):
+    """DerivativeInfo that records points for nested ClipOperation tests."""
+
+    def __init__(self, paths) -> None:
+        super().__init__(paths)
+        self.last_points: np.ndarray | None = None
+        self.last_normals: np.ndarray | None = None
+
+    def updated_copy(self, **kwargs):
+        kwargs.pop("deep", None)
+        kwargs.pop("validate", None)
+        if "paths" in kwargs:
+            self.paths = list(kwargs.pop("paths"))
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+        return self
+
+    def evaluate_gradient_at_points(
+        self,
+        spatial_coords,
+        normals,
+        perps1,
+        perps2,
+        interpolators=None,
+    ):
+        self.last_points = np.asarray(spatial_coords, dtype=float)
+        self.last_normals = np.asarray(normals, dtype=float)
+        return np.ones(self.last_points.shape[0], dtype=float)
+
+
+@pytest.mark.parametrize(
+    ("operation", "expected_use", "expected_flip"),
+    [
+        ("intersection", INSIDE_MASK, np.array([False, False, False], dtype=bool)),
+        ("union", ~INSIDE_MASK, np.array([False, False, False], dtype=bool)),
+        ("difference", ~INSIDE_MASK, np.array([False, False, False], dtype=bool)),
+        ("symmetric_difference", np.array([True, True, True], dtype=bool), INSIDE_MASK),
+    ],
+)
+def test_triangle_mesh_clip_filters_geometry_a(operation, expected_use, expected_flip, monkeypatch):
+    """TriangleMesh sampling honors ClipOperation rules for geometry_a."""
+
+    mesh = _make_mesh()
+    _patch_sample_collection(monkeypatch)
+    info = RecordingDerivativeInfo()
+    other = td.Box(center=(0.0, 0.0, 0.0), size=(2.0, 2.0, 2.0))
+    clip = td.ClipOperation(operation=operation, geometry_a=mesh, geometry_b=other)
+
+    mesh._compute_derivatives(info, clip_operation=(clip, "geometry_a"))
+
+    expected_points = SAMPLE_POINTS[expected_use]
+    expected_normals = SAMPLE_NORMALS.copy()
+    expected_normals[expected_flip] *= -1.0
+    npt.assert_allclose(info.last_points, expected_points)
+    npt.assert_allclose(info.last_normals, expected_normals[expected_use])
+
+
+@pytest.mark.parametrize(
+    ("operation", "expected_use", "expected_flip"),
+    [
+        ("intersection", INSIDE_MASK, np.array([False, False, False], dtype=bool)),
+        ("union", ~INSIDE_MASK, np.array([False, False, False], dtype=bool)),
+        ("difference", INSIDE_MASK, INSIDE_MASK),
+        ("symmetric_difference", np.array([True, True, True], dtype=bool), INSIDE_MASK),
+    ],
+)
+def test_triangle_mesh_clip_filters_geometry_b(operation, expected_use, expected_flip, monkeypatch):
+    """TriangleMesh sampling honors ClipOperation rules for geometry_b."""
+
+    mesh = _make_mesh()
+    _patch_sample_collection(monkeypatch)
+    info = RecordingDerivativeInfo()
+    other = td.Box(center=(0.0, 0.0, 0.0), size=(2.0, 2.0, 2.0))
+    clip = td.ClipOperation(operation=operation, geometry_a=other, geometry_b=mesh)
+
+    mesh._compute_derivatives(info, clip_operation=(clip, "geometry_b"))
+
+    expected_points = SAMPLE_POINTS[expected_use]
+    expected_normals = SAMPLE_NORMALS.copy()
+    expected_normals[expected_flip] *= -1.0
+    npt.assert_allclose(info.last_points, expected_points)
+    npt.assert_allclose(info.last_normals, expected_normals[expected_use])
+
+
+@pytest.mark.parametrize(
+    "geometry_type, paths, expected_contexts",
+    [
+        (
+            "box",
+            [("geometry_a", "center", 0), ("geometry_b", "size", 1)],
+            ("geometry_a", "geometry_b"),
+        ),
+        ("polyslab", [("geometry_a", "vertices")], ("geometry_a",)),
+        ("sphere", [("geometry_a", "radius")], ("geometry_a",)),
+    ],
+)
+def test_clip_operation_passes_clip_context(
+    geometry_type: str,
+    paths: list[tuple],
+    expected_contexts: tuple[str, ...],
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """``ClipOperation`` forwards context when differentiating geometries."""
+
+    contexts: list[tuple[td.ClipOperation, str] | None] = []
+
+    def fake_mesh_derivatives(self, derivative_info, clip_operation=None):
+        contexts.append(clip_operation)
+        triangles = np.asarray(self.triangles, dtype=float)
+        return {("mesh_dataset", "surface_mesh"): np.zeros_like(triangles)}
+
+    monkeypatch.setattr(
+        td.TriangleMesh, "_compute_derivatives", fake_mesh_derivatives, raising=True
+    )
+
+    if geometry_type == "polyslab":
+        vertices = np.array(((0.0, 0.0), (1.0, 0.0), (0.0, 1.0)), dtype=float)
+        geometry_a = td.PolySlab(vertices=vertices, slab_bounds=(-0.5, 0.5), axis=2)
+        geometry_b = td.Box(center=(0.0, 0.0, 0.0), size=(3.0, 3.0, 3.0))
+    elif geometry_type == "sphere":
+        geometry_a = td.Sphere(center=(0.0, 0.0, 0.0), radius=0.6)
+        geometry_b = td.Box(center=(0.0, 0.0, 0.0), size=(3.0, 3.0, 3.0))
+    else:
+        geometry_a = td.Box(center=(0.0, 0.0, 0.0), size=(1.0, 1.0, 1.0))
+        geometry_b = td.Box(center=(1.0, 0.0, 0.0), size=(1.0, 1.0, 1.0))
+
+    clip = td.ClipOperation(operation="union", geometry_a=geometry_a, geometry_b=geometry_b)
+    info = MinimalDerivativeInfo(paths=paths)
+
+    result = clip._compute_derivatives(info)
+
+    expected = [(clip, which) for which in expected_contexts]
+    assert contexts == expected
+    for path in paths:
+        assert path in result
+
+
+def test_nested_clip_operation_derivatives():
+    """Nested ``ClipOperation`` should support mesh-based derivatives."""
+
+    inner_a = td.Box(center=(0.0, 0.0, 0.0), size=(1.0, 1.0, 1.0))
+    inner_b = td.Box(center=(0.4, 0.0, 0.0), size=(0.8, 0.8, 0.8))
+    inner_clip = td.ClipOperation(operation="difference", geometry_a=inner_a, geometry_b=inner_b)
+    outer_b = td.Box(center=(0.0, 0.0, 0.0), size=(2.0, 2.0, 2.0))
+    outer_clip = td.ClipOperation(operation="union", geometry_a=inner_clip, geometry_b=outer_b)
+
+    paths = [
+        ("geometry_a", "geometry_a", "center", 0),
+        ("geometry_a", "geometry_b", "size", 1),
+        ("geometry_b", "size", 2),
+    ]
+    info = MinimalDerivativeInfo(paths=paths)
+
+    result = outer_clip._compute_derivatives(info)
+
+    for path in paths:
+        assert path in result
+
+
+def test_nested_clip_operation_applies_outer_clip(monkeypatch):
+    """Nested ClipOperation should apply outer clip context to inner geometry samples."""
+
+    _patch_sample_collection(monkeypatch)
+    mesh = _make_mesh()
+
+    inner_far_box = td.Box(center=(10.0, 0.0, 0.0), size=(1.0, 1.0, 1.0))
+    inner_clip = td.ClipOperation(operation="union", geometry_a=mesh, geometry_b=inner_far_box)
+
+    outer_box = td.Box(center=(0.0, 0.0, 0.0), size=(1.0, 1.0, 1.0))
+    outer_clip = td.ClipOperation(
+        operation="intersection", geometry_a=inner_clip, geometry_b=outer_box
+    )
+
+    paths = [("geometry_a", "geometry_a", "mesh_dataset", "surface_mesh")]
+    info = RecordingDerivativeInfoNested(paths=paths)
+
+    outer_clip._compute_derivatives(info)
+
+    expected_mask = outer_box.inside(SAMPLE_POINTS[:, 0], SAMPLE_POINTS[:, 1], SAMPLE_POINTS[:, 2])
+    expected_points = SAMPLE_POINTS[expected_mask]
+    expected_normals = SAMPLE_NORMALS[expected_mask]
+
+    npt.assert_allclose(info.last_points, expected_points)
+    npt.assert_allclose(info.last_normals, expected_normals)
+
+
+FIELD_PATHS = {
+    "sphere": ("radius",),
+    "box": ("center", 0),
+    "polyslab": ("slab_bounds", 0),
+    "mesh": ("mesh_dataset", "surface_mesh"),
+}
+
+
+@pytest.mark.parametrize("geometry_type", ["sphere", "box", "polyslab", "mesh"])
+@pytest.mark.parametrize(
+    "operation, expected_scales",
+    [
+        ("union", (1.0, 0.0)),
+        ("intersection", (0.0, 1.0)),
+        ("difference", (1.0, -1.0)),
+        ("symmetric_difference", (1.0, -1.0)),
+    ],
+)
+def test_clip_operation_known_gradient_relations(geometry_type, operation, expected_scales):
+    """Compare ClipOperation gradients against analytical expectations for nested boxes."""
+
+    center_a = (0.0, 0.0, 0.0)
+    center_b = (0.2, 0.0, 0.0)
+    size_a = (2.0, 1.4, 1.0)
+    size_b = (1.0, 0.8, 0.6)
+
+    geometry_a = build_geometry(geometry_type, center=center_a, size=size_a)
+    geometry_b = build_geometry(geometry_type, center=center_b, size=size_b)
+
+    field_path = FIELD_PATHS[geometry_type]
+    geo_di_a = SimpleDerivativeInfo(paths=[field_path], bounds=geometry_a.bounds)
+    geo_di_b = SimpleDerivativeInfo(paths=[field_path], bounds=geometry_b.bounds)
+    if geometry_type == "sphere":
+        baseline_a = geometry_a._compute_derivatives_via_mesh(geo_di_a).get(field_path, 0.0)
+        baseline_b = geometry_b._compute_derivatives_via_mesh(geo_di_b).get(field_path, 0.0)
+    else:
+        baseline_a = geometry_a._compute_derivatives(geo_di_a).get(field_path, 0.0)
+        baseline_b = geometry_b._compute_derivatives(geo_di_b).get(field_path, 0.0)
+
+    clip = td.ClipOperation(operation=operation, geometry_a=geometry_a, geometry_b=geometry_b)
+    clip_path_a = ("geometry_a", *field_path)
+    clip_path_b = ("geometry_b", *field_path)
+    clip_di = SimpleDerivativeInfo(paths=[clip_path_a, clip_path_b], bounds=clip.bounds)
+    gradients = clip._compute_derivatives(clip_di)
+
+    expected_scale_a, expected_scale_b = expected_scales
+    grad_a = gradients.get(clip_path_a, 0.0)
+    grad_b = gradients.get(clip_path_b, 0.0)
+
+    rtol = 6e-2
+    atol = 3e-2
+
+    np.testing.assert_allclose(
+        np.asarray(grad_a, dtype=float),
+        expected_scale_a * np.asarray(baseline_a, dtype=float),
+        rtol=rtol,
+        atol=atol,
+    )
+    np.testing.assert_allclose(
+        np.asarray(grad_b, dtype=float),
+        expected_scale_b * np.asarray(baseline_b, dtype=float),
+        rtol=rtol,
+        atol=atol,
+    )

--- a/tests/test_components/autograd/test_mesh_derivatives.py
+++ b/tests/test_components/autograd/test_mesh_derivatives.py
@@ -1,0 +1,101 @@
+"""Regression tests comparing mesh-based derivatives to legacy implementations."""
+
+from __future__ import annotations
+
+import copy
+
+import numpy as np
+import numpy.testing as npt
+
+import tidy3d as td
+
+
+class DummyDerivativeInfo:
+    """Minimal derivative info stub used for geometry unit tests."""
+
+    def __init__(self, grad_func, paths):
+        self.paths = paths
+        self._grad_func = grad_func
+        self.frequencies = [200e12]
+        self.eps_in = 12.0
+        self._spacing = 0.05
+        self.simulation_bounds = ((-2.0, -2.0, -2.0), (2.0, 2.0, 2.0))
+        self.bounds = self.simulation_bounds
+        self.bounds_intersect = self.simulation_bounds
+        self.interpolators = None
+
+    def adaptive_vjp_spacing(self) -> float:
+        return self._spacing
+
+    def create_interpolators(self, dtype=None):
+        return {}
+
+    def updated_copy(self, **kwargs):
+        kwargs.pop("deep", None)
+        kwargs.pop("validate", None)
+        new_info = copy.copy(self)
+        for key, value in kwargs.items():
+            setattr(new_info, key, value)
+        return new_info
+
+    @property
+    def wavelength_min(self) -> float:
+        return td.C_0 / max(self.frequencies)
+
+    def evaluate_gradient_at_points(
+        self,
+        spatial_coords=None,
+        normals=None,
+        perps1=None,
+        perps2=None,
+        interpolators=None,
+    ):
+        coords = spatial_coords if spatial_coords is not None else np.zeros((0, 3))
+        return self._grad_func(coords)
+
+
+def linear_grad(points: np.ndarray) -> np.ndarray:
+    if points.size == 0:
+        return np.zeros(0, dtype=float)
+    return points[:, 0] + 0.5 * points[:, 1] - 0.25 * points[:, 2]
+
+
+def _assert_mesh_legacy_match(geometry: td.Geometry, derivative_info: DummyDerivativeInfo) -> None:
+    derivative_info.bounds = geometry.bounds
+    derivative_info.bounds_intersect = geometry.bounds
+    mesh_vjps = geometry._compute_derivatives_via_mesh(derivative_info)
+    legacy_vjps = geometry._compute_derivatives(derivative_info)
+
+    assert set(mesh_vjps) == set(legacy_vjps)
+    for key in mesh_vjps:
+        mesh_val = mesh_vjps[key]
+        legacy_val = legacy_vjps[key]
+        npt.assert_allclose(mesh_val, legacy_val, rtol=1e-4, atol=1e-6)
+
+
+def test_box_mesh_derivatives_match_legacy_gradients():
+    box = td.Box(center=(0.2, -0.1, 0.05), size=(1.2, 0.9, 0.8))
+
+    derivative_info = DummyDerivativeInfo(
+        linear_grad,
+        paths=[("center",), ("size",)],
+    )
+
+    _assert_mesh_legacy_match(box, derivative_info)
+
+
+def test_cylinder_mesh_derivatives_match_legacy_gradients():
+    cylinder = td.Cylinder(
+        center=(-0.3, 0.15, 0.0),
+        radius=0.45,
+        length=1.1,
+        axis=2,
+        sidewall_angle=0.08,
+    )
+
+    derivative_info = DummyDerivativeInfo(
+        linear_grad,
+        paths=[("center", 0), ("center", 1), ("radius",), ("length",), ("sidewall_angle",)],
+    )
+
+    _assert_mesh_legacy_match(cylinder, derivative_info)

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import functools
 import pathlib
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 import autograd.numpy as np
 import shapely
-from pydantic import Field, NonNegativeFloat, field_validator, model_validator
+from pydantic import Field, NonNegativeFloat, PrivateAttr, field_validator, model_validator
 
 from tidy3d.compat import _package_is_older_than
 from tidy3d.components.autograd import TracedCoordinate, TracedFloat, TracedSize, get_static
@@ -34,6 +34,7 @@ from tidy3d.components.viz import (
     polygon_patch,
     set_default_labels_and_title,
 )
+from tidy3d.config import config
 from tidy3d.constants import LARGE_NUMBER, MICROMETER, RADIAN, fp_eps, inf
 from tidy3d.exceptions import (
     SetupError,
@@ -58,6 +59,7 @@ if TYPE_CHECKING:
     from pydantic import NonNegativeInt, PositiveFloat
     from typing_extensions import Self
 
+    from tidy3d import TriangleMesh
     from tidy3d.components.autograd import AutogradFieldMap
     from tidy3d.components.autograd.derivative_utils import DerivativeInfo
     from tidy3d.components.types import (
@@ -1577,9 +1579,22 @@ class Geometry(Tidy3dBaseModel, ABC):
         fname.parent.mkdir(parents=True, exist_ok=True)
         library.write_gds(fname)
 
-    def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
+    def _compute_derivatives(
+        self,
+        derivative_info: DerivativeInfo,
+    ) -> AutogradFieldMap:
         """Compute the adjoint derivatives for this object."""
         raise NotImplementedError(f"Can't compute derivative for 'Geometry': '{type(self)}'.")
+
+    def _compute_derivatives_via_mesh(
+        self,
+        derivative_info: DerivativeInfo,
+        clip_operation: Optional[ClipOperationContext] = None,
+    ) -> AutogradFieldMap:
+        """Compute the adjoint derivatives for this object."""
+        raise NotImplementedError(
+            f"Can't compute derivative for clipped 'Geometry': '{type(self)}'."
+        )
 
     def _as_union(self) -> list[Geometry]:
         """Return a list of geometries that, united, make up the given geometry."""
@@ -2017,6 +2032,50 @@ class Circular(Geometry):
 """Primitive classes"""
 
 
+def _default_box_faces() -> NDArray:
+    """Return the canonical triangle indices for a cube with CCW winding."""
+
+    # faces ordered as: bottom, top, y-, y+, x+, x-
+    return np.asarray(
+        [
+            (0, 2, 1),
+            (0, 3, 2),
+            (4, 5, 6),
+            (4, 6, 7),
+            (0, 5, 4),
+            (0, 1, 5),
+            (2, 7, 6),
+            (2, 3, 7),
+            (1, 6, 5),
+            (1, 2, 6),
+            (0, 7, 3),
+            (0, 4, 7),
+        ],
+        dtype=int,
+    )
+
+
+_BOX_VERTEX_SIGNS = np.asarray(
+    [
+        (-1.0, -1.0, -1.0),
+        (1.0, -1.0, -1.0),
+        (1.0, 1.0, -1.0),
+        (-1.0, 1.0, -1.0),
+        (-1.0, -1.0, 1.0),
+        (1.0, -1.0, 1.0),
+        (1.0, 1.0, 1.0),
+        (-1.0, 1.0, 1.0),
+    ],
+    dtype=float,
+)
+
+_BOX_FACE_VERTEX_INDICES = {
+    0: ((0, 3, 7, 4), (1, 2, 6, 5)),
+    1: ((0, 4, 5, 1), (3, 7, 6, 2)),
+    2: ((0, 1, 2, 3), (4, 5, 6, 7)),
+}
+
+
 class Box(SimplePlaneIntersection, Centered):
     """Rectangular prism.
        Also base class for :class:`.Simulation`, :class:`Monitor`, and :class:`Source`.
@@ -2031,6 +2090,9 @@ class Box(SimplePlaneIntersection, Centered):
         description="Size in x, y, and z directions.",
         json_schema_extra={"units": MICROMETER},
     )
+
+    _triangle_faces: NDArray[np.int_] = PrivateAttr(default_factory=_default_box_faces)
+    _triangle_mesh_cache: Optional[TriangleMesh] = PrivateAttr(default=None)
 
     @classmethod
     def from_bounds(cls, rmin: Coordinate, rmax: Coordinate, **kwargs: Any) -> Self:
@@ -2651,6 +2713,78 @@ class Box(SimplePlaneIntersection, Centered):
 
     """ Autograd code """
 
+    def _box_vertices_array(self, dtype: np.dtype | None = None) -> NDArray:
+        dtype = dtype or config.adjoint.gradient_dtype_float
+        center = np.asarray(self.center, dtype=dtype)
+        half_size = 0.5 * np.asarray(self.size, dtype=dtype)
+        return center + half_size * _BOX_VERTEX_SIGNS.astype(dtype)
+
+    def to_triangle_mesh(self) -> TriangleMesh:
+        """Return (and lazily construct) the triangle mesh representation."""
+
+        if self._triangle_mesh_cache is None:
+            from .mesh import TriangleMesh
+
+            vertices = self._box_vertices_array()
+            self._triangle_mesh_cache = TriangleMesh.from_vertices_faces(
+                vertices, self._triangle_faces
+            )
+        return self._triangle_mesh_cache
+
+    def _accumulate_vertex_gradients(self, triangle_grads: NDArray) -> NDArray:
+        """Aggregate per-triangle gradients into unique vertex gradients."""
+
+        num_vertices = _BOX_VERTEX_SIGNS.shape[0]
+        vertex_grads = np.zeros((num_vertices, 3), dtype=triangle_grads.dtype)
+        for face_index, face in enumerate(self._triangle_faces):
+            for local_idx, vertex_idx in enumerate(face):
+                vertex_grads[vertex_idx] += triangle_grads[face_index, local_idx]
+        return vertex_grads
+
+    def _compute_derivatives_via_mesh(
+        self,
+        derivative_info: DerivativeInfo,
+        clip_operation: Optional[ClipOperationContext] = None,
+    ) -> AutogradFieldMap:
+        """Compute the adjoint derivatives using the ``TriangleMesh`` surface sampling."""
+
+        mesh = self.to_triangle_mesh()
+        original_paths = derivative_info.paths
+        derivative_info.paths = [("mesh_dataset", "surface_mesh")]
+        try:
+            mesh_vjps = mesh._compute_derivatives(derivative_info, clip_operation=clip_operation)
+        finally:
+            derivative_info.paths = original_paths
+        gradient_key = ("mesh_dataset", "surface_mesh")
+        if gradient_key not in mesh_vjps:
+            return {}
+
+        triangle_grads = mesh_vjps[gradient_key]
+        vertex_grads = np.asarray(self._accumulate_vertex_gradients(triangle_grads), dtype=float)
+        vjps_faces = np.zeros((2, 3), dtype=vertex_grads.dtype)
+
+        for axis in range(3):
+            for min_max_index, indices in enumerate(_BOX_FACE_VERTEX_INDICES[axis]):
+                direction = -1.0 if min_max_index == 0 else 1.0
+                vjps_faces[min_max_index, axis] = direction * float(
+                    np.sum(vertex_grads[np.asarray(indices), axis])
+                )
+
+        vjps_center_size = self._derivatives_center_size(vjps_faces)
+
+        derivative_map: AutogradFieldMap = {}
+        for field_path in derivative_info.paths:
+            field_name, *index = field_path
+
+            if field_name in vjps_center_size:
+                if index and len(index) == 1:
+                    idx = int(index[0])
+                    derivative_map[field_path] = vjps_center_size[field_name][idx]
+                else:
+                    derivative_map[field_path] = vjps_center_size[field_name]
+
+        return derivative_map
+
     def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
         """Compute the adjoint derivatives for this object."""
 
@@ -3194,18 +3328,6 @@ class ClipOperation(Geometry):
         description="Second operand for the set operation. It can also be any geometry type.",
     )
 
-    @field_validator("geometry_a", "geometry_b")
-    @classmethod
-    def _geometries_untraced(cls, val: GeometryType) -> GeometryType:
-        """Make sure that ``ClipOperation`` geometries do not contain tracers."""
-        traced = val._strip_traced_fields()
-        if traced:
-            raise ValidationError(
-                f"{val.type} contains traced fields {list(traced.keys())}. Note that "
-                "'ClipOperation' does not currently support automatic differentiation."
-            )
-        return val
-
     @staticmethod
     def to_polygon_list(base_geometry: Shapely, cleanup: bool = False) -> list[Shapely]:
         """Return a list of valid polygons from a shapely geometry, discarding points, lines, and
@@ -3270,6 +3392,102 @@ class ClipOperation(Geometry):
                 "'symmetric_difference'."
             )
         return result
+
+    def _geometry_from_key(self, which: ClipGeometryKey) -> Geometry:
+        """Return the geometry referenced by ``which``."""
+        if which == "geometry_a":
+            return self.geometry_a
+        if which == "geometry_b":
+            return self.geometry_b
+        raise ValueError(f"Unsupported geometry key '{which}'.")
+
+    def _other_geometry(self, which: ClipGeometryKey) -> Geometry:
+        """Return the opposing geometry for ``which``."""
+        return self.geometry_b if which == "geometry_a" else self.geometry_a
+
+    @staticmethod
+    def _points_to_array(points: ArrayLike) -> tuple[np.ndarray, bool]:
+        """Convert sample points to a 2D array and track whether input was a single point."""
+        arr = np.asarray(points, dtype=float)
+        single_point = arr.ndim == 1
+        if arr.size == 0:
+            arr = arr.reshape((0, 3))
+        else:
+            arr = arr.reshape((-1, 3))
+        return arr, single_point
+
+    @staticmethod
+    def _clip_use_mask(
+        operation: ClipOperationType, which: ClipGeometryKey, inside_mask: np.ndarray
+    ) -> np.ndarray:
+        """Return the inclusion mask for the requested clip operation."""
+
+        mask = np.asarray(inside_mask, dtype=bool)
+        if operation == "intersection":
+            return mask.copy()
+        if operation == "union":
+            return ~mask
+        if operation == "difference":
+            return (~mask) if which == "geometry_a" else mask.copy()
+        if operation == "symmetric_difference":
+            return np.ones_like(mask, dtype=bool)
+        raise ValueError(f"Unsupported clip operation '{operation}'.")
+
+    @staticmethod
+    def _clip_flip_mask(
+        operation: ClipOperationType, which: ClipGeometryKey, inside_mask: np.ndarray
+    ) -> np.ndarray:
+        """Return the normal flip mask for the requested clip operation."""
+
+        mask = np.asarray(inside_mask, dtype=bool)
+        if operation == "difference":
+            if which == "geometry_b":
+                return mask.copy()
+            return np.zeros_like(mask, dtype=bool)
+        if operation == "symmetric_difference":
+            return mask.copy()
+        return np.zeros_like(mask, dtype=bool)
+
+    def _clip_masks_from_inside(
+        self, which: ClipGeometryKey, inside_mask: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Return (use_mask, flip_mask) from a precomputed inside mask."""
+
+        use_mask = self._clip_use_mask(self.operation, which, inside_mask)
+        flip_mask = self._clip_flip_mask(self.operation, which, inside_mask)
+        return use_mask, flip_mask
+
+    def _clip_masks_for_points(
+        self, which: ClipGeometryKey, points: ArrayLike
+    ) -> tuple[np.ndarray, np.ndarray, bool]:
+        """Return (use_mask, flip_mask, single_point) for sample points."""
+
+        points_arr, single_point = self._points_to_array(points)
+        if points_arr.size == 0:
+            empty = np.zeros(0, dtype=bool)
+            return empty, empty, single_point
+
+        other = self._other_geometry(which)
+        inside_other = np.asarray(
+            other.inside(points_arr[:, 0], points_arr[:, 1], points_arr[:, 2]), dtype=bool
+        )
+
+        use_mask, flip_mask = self._clip_masks_from_inside(which, inside_other)
+        return use_mask, flip_mask, single_point
+
+    def sample_points_should_use(
+        self, which: ClipGeometryKey, points: ArrayLike
+    ) -> Union[bool, NDArray[np.bool_]]:
+        """Return a mask indicating which samples contribute to the gradient."""
+        use_mask, _, single_point = self._clip_masks_for_points(which, points)
+        return bool(use_mask[0]) if single_point else use_mask
+
+    def sample_normals_should_flip(
+        self, which: ClipGeometryKey, points: ArrayLike
+    ) -> Union[bool, NDArray[np.bool_]]:
+        """Return a mask indicating which sample normals require flipping."""
+        _, flip_mask, single_point = self._clip_masks_for_points(which, points)
+        return bool(flip_mask[0]) if single_point else flip_mask
 
     def intersections_tilted_plane(
         self,
@@ -3471,6 +3689,61 @@ class ClipOperation(Geometry):
         new_geom_a = self.geometry_a._update_from_bounds(bounds=bounds, axis=axis)
         new_geom_b = self.geometry_b._update_from_bounds(bounds=bounds, axis=axis)
         return self.updated_copy(geometry_a=new_geom_a, geometry_b=new_geom_b)
+
+    def _compute_derivatives(
+        self,
+        derivative_info: DerivativeInfo,
+        clip_operation: Optional[ClipOperationContext] = None,
+    ) -> AutogradFieldMap:
+        """Compute adjoint gradients for both operands in the clip operation."""
+
+        grad_vjps: AutogradFieldMap = {}
+        interpolators = derivative_info.interpolators or derivative_info.create_interpolators()
+
+        for field_path in derivative_info.paths:
+            if not field_path:
+                continue
+            which, *geo_path = field_path
+            if which not in ("geometry_a", "geometry_b"):
+                raise ValueError(
+                    "ClipOperation derivatives are only defined for 'geometry_a' or 'geometry_b'."
+                )
+            if not geo_path:
+                raise ValueError("ClipOperation derivative path must specify a geometry field.")
+            geometry = self._geometry_from_key(which)
+            geo_info = derivative_info.updated_copy(
+                paths=[tuple(geo_path)],
+                bounds=geometry.bounds,
+                bounds_intersect=self.bounds_intersection(
+                    geometry.bounds, derivative_info.simulation_bounds
+                ),
+                deep=False,
+                interpolators=interpolators,
+            )
+            context = (self, which)
+            if clip_operation is None:
+                clip_context = context
+            else:
+                clip_context = (context, clip_operation)
+            vjps_geo = geometry._compute_derivatives_via_mesh(geo_info, clip_operation=clip_context)
+            if len(vjps_geo) != 1:
+                raise AssertionError("Expected a single gradient value for each geometry field.")
+            grad_vjps[field_path] = vjps_geo.popitem()[1]
+
+        return grad_vjps
+
+    def _compute_derivatives_via_mesh(
+        self,
+        derivative_info: DerivativeInfo,
+        clip_operation: Optional[ClipOperationContext] = None,
+    ) -> AutogradFieldMap:
+        """Compute adjoint gradients for clipped geometries (mesh-based path)."""
+
+        return self._compute_derivatives(derivative_info, clip_operation=clip_operation)
+
+
+ClipGeometryKey = Literal["geometry_a", "geometry_b"]
+ClipOperationContext = tuple[ClipOperation, ClipGeometryKey]
 
 
 class GeometryGroup(Geometry):
@@ -3684,7 +3957,18 @@ class GeometryGroup(Geometry):
         )
         return self.updated_copy(geometries=new_geometries)
 
-    def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
+    def _compute_derivatives_via_mesh(
+        self,
+        derivative_info: DerivativeInfo,
+        clip_operation: Optional[ClipOperationContext] = None,
+    ) -> AutogradFieldMap:
+        return self._compute_derivatives(derivative_info, clip_operation=clip_operation)
+
+    def _compute_derivatives(
+        self,
+        derivative_info: DerivativeInfo,
+        clip_operation: Optional[ClipOperationContext] = None,
+    ) -> AutogradFieldMap:
         """Compute the adjoint derivatives for this object."""
 
         grad_vjps = {}
@@ -3707,8 +3991,12 @@ class GeometryGroup(Geometry):
                     deep=False,
                     interpolators=interpolators,
                 )
-
-                vjp_dict_geo = geo._compute_derivatives(geo_info)
+                if clip_operation is not None:
+                    vjp_dict_geo = geo._compute_derivatives_via_mesh(
+                        geo_info, clip_operation=clip_operation
+                    )
+                else:
+                    vjp_dict_geo = geo._compute_derivatives(geo_info)
 
                 if len(vjp_dict_geo) != 1:
                     raise AssertionError("Got multiple gradients for single geometry field.")

--- a/tidy3d/components/geometry/mesh.py
+++ b/tidy3d/components/geometry/mesh.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
@@ -26,7 +27,7 @@ from . import base
 
 if TYPE_CHECKING:
     from os import PathLike
-    from typing import Callable, Literal, Union
+    from typing import Any, Callable, Literal, Optional, Union
 
     from trimesh import Trimesh
 
@@ -752,7 +753,18 @@ class TriangleMesh(base.Geometry, ABC):
 
         return base.Geometry.plot(self, x=x, y=y, z=z, ax=ax, **patch_kwargs)
 
-    def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
+    def _compute_derivatives_via_mesh(
+        self,
+        derivative_info: DerivativeInfo,
+        clip_operation: Optional[base.ClipOperationContext] = None,
+    ) -> AutogradFieldMap:
+        return self._compute_derivatives(derivative_info, clip_operation=clip_operation)
+
+    def _compute_derivatives(
+        self,
+        derivative_info: DerivativeInfo,
+        clip_operation: Optional[base.ClipOperationContext] = None,
+    ) -> AutogradFieldMap:
         """Compute adjoint derivatives for a ``TriangleMesh`` geometry."""
         vjps: AutogradFieldMap = {}
 
@@ -789,6 +801,8 @@ class TriangleMesh(base.Geometry, ABC):
             sim_min=sim_min,
             sim_max=sim_max,
         )
+        if clip_operation is not None:
+            samples = self._apply_clip_filters(samples, clip_operation)
 
         if samples["points"].shape[0] == 0:
             zeros = np.zeros_like(triangles)
@@ -825,6 +839,139 @@ class TriangleMesh(base.Geometry, ABC):
         vjps[("mesh_dataset", "surface_mesh")] = triangle_grads
         return vjps
 
+    def _apply_clip_filters(
+        self,
+        samples: dict[str, np.ndarray],
+        clip_operation: base.ClipOperationContext,
+    ) -> dict[str, np.ndarray]:
+        """Filter and adjust samples according to clip operation rules."""
+
+        clip_contexts = self._normalize_clip_contexts(clip_operation)
+        filtered = samples
+        for context in clip_contexts:
+            filtered = self._apply_clip_filters_single(filtered, context)
+            if filtered["points"].shape[0] == 0:
+                return filtered
+        return filtered
+
+    @staticmethod
+    def _normalize_clip_contexts(
+        clip_operation: base.ClipOperationContext,
+    ) -> list[base.ClipOperationContext]:
+        """Normalize clip contexts into a flat list."""
+
+        if (
+            isinstance(clip_operation, tuple)
+            and len(clip_operation) == 2
+            and isinstance(clip_operation[0], base.ClipOperation)
+        ):
+            return [clip_operation]
+
+        contexts: list[base.ClipOperationContext] = []
+        for entry in clip_operation:
+            if (
+                isinstance(entry, tuple)
+                and len(entry) == 2
+                and isinstance(entry[0], base.ClipOperation)
+            ):
+                contexts.append(entry)
+        if not contexts:
+            raise ValueError("Invalid ClipOperation context provided.")
+        return contexts
+
+    def _apply_clip_filters_single(
+        self,
+        samples: dict[str, np.ndarray],
+        clip_operation: base.ClipOperationContext,
+    ) -> dict[str, np.ndarray]:
+        """Filter samples for a single clip operation context."""
+
+        clip_obj, which = clip_operation
+        other_geometry = clip_obj._other_geometry(which)
+        if not isinstance(other_geometry, TriangleMesh):
+            return self._apply_basic_clip_filters(samples, clip_operation)
+
+        clip_geometry = self._prepare_clip_geometry(other_geometry)
+
+        points = np.asarray(samples["points"], dtype=config.adjoint.gradient_dtype_float)
+        normals = np.asarray(samples["normals"], dtype=config.adjoint.gradient_dtype_float)
+        total_points = points.shape[0]
+        if total_points == 0:
+            return samples
+
+        shift = max(float(config.adjoint.edge_clip_tolerance), 1e-9)
+        probe_points = points - normals * shift
+        inside_mask = np.asarray(
+            clip_geometry.inside(
+                probe_points[:, 0],
+                probe_points[:, 1],
+                probe_points[:, 2],
+            ),
+            dtype=bool,
+        ).reshape(-1)
+
+        use_mask, flip_mask = clip_obj._clip_masks_from_inside(which, inside_mask)
+        if use_mask.size != total_points:
+            raise ValueError("ClipOperation sample mask has incorrect shape.")
+        if not np.any(use_mask):
+            return {key: np.asarray(value[:0]).copy() for key, value in samples.items()}
+
+        filtered = {key: np.asarray(value[use_mask]).copy() for key, value in samples.items()}
+
+        if flip_mask.size != total_points:
+            raise ValueError("ClipOperation normal flip mask has incorrect shape.")
+        flip_mask = flip_mask[use_mask]
+        if np.any(flip_mask):
+            flip_signs = np.where(flip_mask[:, None], -1.0, 1.0)
+            filtered["normals"] = filtered["normals"] * flip_signs
+
+        return filtered
+
+    def _apply_basic_clip_filters(
+        self,
+        samples: dict[str, np.ndarray],
+        clip_operation: base.ClipOperationContext,
+    ) -> dict[str, np.ndarray]:
+        """Fallback clip filtering that mirrors the historical behavior."""
+
+        clip_obj, which = clip_operation
+        points = samples["points"]
+        total_points = points.shape[0]
+        if total_points == 0:
+            return {key: np.asarray(value[:0]).copy() for key, value in samples.items()}
+
+        use_mask, flip_mask, _ = clip_obj._clip_masks_for_points(which, points)
+        if not np.any(use_mask):
+            return {key: np.asarray(value[:0]).copy() for key, value in samples.items()}
+
+        filtered = {key: np.asarray(value[use_mask]).copy() for key, value in samples.items()}
+
+        flip_mask = flip_mask[use_mask]
+        if np.any(flip_mask):
+            flip_signs = np.where(flip_mask[:, None], -1.0, 1.0)
+            filtered["normals"] = filtered["normals"] * flip_signs
+
+        return filtered
+
+    @staticmethod
+    def _prepare_clip_geometry(other: base.Geometry) -> base.Geometry:
+        """Return a TriangleMesh suitable for geometric clipping operations."""
+
+        if not isinstance(other, TriangleMesh):
+            return other
+
+        try:
+            tri_mesh = other.trimesh
+        except Exception:
+            return other
+
+        if not tri_mesh.is_volume:
+            raise ValueError(
+                "ClipOperation requires volume TriangleMesh geometry for clip filtering."
+            )
+
+        return other
+
     def _collect_surface_samples(
         self,
         triangles: NDArray,
@@ -840,16 +987,41 @@ class TriangleMesh(base.Geometry, ABC):
         sim_min = np.asarray(sim_min, dtype=dtype)
         sim_max = np.asarray(sim_max, dtype=dtype)
 
-        points_list: list[np.ndarray] = []
-        normals_list: list[np.ndarray] = []
-        perps1_list: list[np.ndarray] = []
-        perps2_list: list[np.ndarray] = []
-        weights_list: list[np.ndarray] = []
-        faces_list: list[np.ndarray] = []
-        bary_list: list[np.ndarray] = []
+        samples = self._SampleAccumulators.empty()
 
         spacing = max(float(spacing), np.finfo(float).eps)
         triangles_arr = np.asarray(triangles, dtype=dtype)
+        if triangles_arr.size == 0:
+            return self._empty_sample_result(dtype)
+
+        edges01 = triangles_arr[:, 1, :] - triangles_arr[:, 0, :]
+        edges02 = triangles_arr[:, 2, :] - triangles_arr[:, 0, :]
+        edges12 = triangles_arr[:, 2, :] - triangles_arr[:, 1, :]
+        cross = np.cross(edges01, edges02)
+        norm = np.linalg.norm(cross, axis=1)
+        areas = 0.5 * norm
+
+        normals = np.zeros((triangles_arr.shape[0], 3), dtype=dtype)
+        nonzero_norm = norm > 0.0
+        normals[nonzero_norm] = cross[nonzero_norm] / norm[nonzero_norm][:, None]
+
+        edge_tol = np.finfo(dtype).eps
+        edge_choice = np.where(
+            (np.linalg.norm(edges01, axis=1) > edge_tol)[:, None],
+            edges01,
+            edges12,
+        )
+        edge_choice_norm = np.linalg.norm(edge_choice, axis=1)
+        has_edge = edge_choice_norm > edge_tol
+        perps1 = np.zeros_like(normals)
+        perps1[has_edge] = edge_choice[has_edge] / edge_choice_norm[has_edge][:, None]
+        perps2_tmp = np.cross(normals, perps1)
+        perps2_norm = np.linalg.norm(perps2_tmp, axis=1)
+        has_basis = perps2_norm > edge_tol
+        perps2 = np.zeros_like(normals)
+        perps2[has_basis] = perps2_tmp[has_basis] / perps2_norm[has_basis][:, None]
+
+        usable_mask = (areas > AREA_SIZE_THRESHOLD) & has_edge & has_basis
 
         sim_extents = sim_max - sim_min
         valid_axes = np.abs(sim_extents) > tol
@@ -860,229 +1032,346 @@ class TriangleMesh(base.Geometry, ABC):
             collapsed_axis = int(collapsed_indices[0])
             plane_value = float(sim_min[collapsed_axis])
 
+        if collapsed_axis is not None and plane_value is not None:
+            return self._collect_plane_samples(
+                triangles_arr=triangles_arr,
+                normals=normals,
+                perps1=perps1,
+                perps2=perps2,
+                usable_mask=usable_mask,
+                spacing=spacing,
+                sim_min=sim_min,
+                sim_max=sim_max,
+                valid_axes=valid_axes,
+                collapsed_axis=collapsed_axis,
+                plane_value=plane_value,
+                tol=tol,
+                dtype=dtype,
+            )
+
+        tri_min = np.min(triangles_arr, axis=1)
+        tri_max = np.max(triangles_arr, axis=1)
+        overlaps = np.all(tri_max >= (sim_min - tol), axis=1) & np.all(
+            tri_min <= (sim_max + tol), axis=1
+        )
+        usable_mask &= overlaps
+
+        fully_inside = (
+            usable_mask
+            & np.all(tri_min >= (sim_min - tol), axis=1)
+            & np.all(tri_max <= (sim_max + tol), axis=1)
+        )
+        needs_clip = usable_mask & ~fully_inside
+
         warned = False
-        warning_msg = "Some triangles from the mesh lie outside the simulation bounds - this may lead to inaccurate gradients."
-        for face_index, tri in enumerate(triangles_arr):
-            area, normal = self._triangle_area_and_normal(tri)
-            if area <= AREA_SIZE_THRESHOLD:
-                continue
 
-            perps = self._triangle_tangent_basis(tri, normal)
-            if perps is None:
-                continue
-            perp1, perp2 = perps
+        if np.any(fully_inside):
+            face_indices = np.flatnonzero(fully_inside)
+            tri_inside = triangles_arr[face_indices]
+            normals_inside = normals[face_indices]
+            perp1_inside = perps1[face_indices]
+            perp2_inside = perps2[face_indices]
+            areas_inside = areas[face_indices]
+            edge_lengths = np.linalg.norm(
+                np.stack(
+                    (
+                        edges01[face_indices],
+                        edges02[face_indices],
+                        edges12[face_indices],
+                    ),
+                    axis=1,
+                ),
+                axis=2,
+            )
+            subdivisions = self._vectorized_subdivisions(areas_inside, spacing, edge_lengths)
+            unique_subdiv, inverse = np.unique(subdivisions, return_inverse=True)
 
-            if collapsed_axis is not None and plane_value is not None:
-                samples, outside_bounds = self._collect_surface_samples_2d(
-                    triangle=tri,
-                    face_index=face_index,
-                    normal=normal,
-                    perp1=perp1,
-                    perp2=perp2,
-                    spacing=spacing,
-                    collapsed_axis=collapsed_axis,
-                    plane_value=plane_value,
-                    sim_min=sim_min,
-                    sim_max=sim_max,
-                    valid_axes=valid_axes,
-                    tol=tol,
-                    dtype=dtype,
-                )
-            else:
-                samples, outside_bounds = self._collect_surface_samples_3d(
-                    triangle=tri,
-                    face_index=face_index,
-                    normal=normal,
-                    perp1=perp1,
-                    perp2=perp2,
-                    area=area,
-                    spacing=spacing,
-                    sim_min=sim_min,
-                    sim_max=sim_max,
-                    valid_axes=valid_axes,
-                    tol=tol,
+            for group_idx, group_subdiv in enumerate(unique_subdiv):
+                group_faces = np.flatnonzero(inverse == group_idx)
+                if group_faces.size == 0:
+                    continue
+                barycentric = self._get_barycentric_samples(int(group_subdiv), dtype)
+                self._append_barycentric_group(
+                    samples=samples,
+                    barycentric=barycentric,
+                    triangles=tri_inside[group_faces],
+                    normals=normals_inside[group_faces],
+                    perps1=perp1_inside[group_faces],
+                    perps2=perp2_inside[group_faces],
+                    areas=areas_inside[group_faces],
+                    face_ids=face_indices[group_faces],
                     dtype=dtype,
                 )
 
-            if outside_bounds and not warned:
-                log.warning(warning_msg)
-                warned = True
+        if np.any(needs_clip):
+            for face_index in np.flatnonzero(needs_clip):
+                tri = triangles_arr[face_index]
+                normal = normals[face_index]
+                perp1 = perps1[face_index]
+                perp2 = perps2[face_index]
+                clipped, was_clipped = self._clip_triangle_to_bounds(tri, sim_min, sim_max, tol)
+                if was_clipped and not warned:
+                    log.warning(
+                        "Some triangles from the mesh lie outside the simulation bounds - this may lead to inaccurate gradients."
+                    )
+                    warned = True
+                if not clipped:
+                    continue
 
-            if samples is None:
-                continue
+                for tri_clip in clipped:
+                    area_clip, _ = self._triangle_area_and_normal(tri_clip)
+                    if area_clip <= AREA_SIZE_THRESHOLD:
+                        continue
 
-            points_list.append(samples["points"])
-            normals_list.append(samples["normals"])
-            perps1_list.append(samples["perps1"])
-            perps2_list.append(samples["perps2"])
-            weights_list.append(samples["weights"])
-            faces_list.append(samples["faces"])
-            bary_list.append(samples["barycentric"])
+                    edge_lengths = (
+                        np.linalg.norm(tri_clip[1] - tri_clip[0]),
+                        np.linalg.norm(tri_clip[2] - tri_clip[1]),
+                        np.linalg.norm(tri_clip[0] - tri_clip[2]),
+                    )
+                    subdivisions = self._subdivision_count(area_clip, spacing, edge_lengths)
+                    barycentric_clip = self._get_barycentric_samples(subdivisions, dtype)
+                    num_samples = barycentric_clip.shape[0]
+                    base_weight = area_clip / num_samples
 
-        if not points_list:
-            return {
-                "points": np.zeros((0, 3), dtype=dtype),
-                "normals": np.zeros((0, 3), dtype=dtype),
-                "perps1": np.zeros((0, 3), dtype=dtype),
-                "perps2": np.zeros((0, 3), dtype=dtype),
-                "weights": np.zeros((0,), dtype=dtype),
-                "faces": np.zeros((0,), dtype=int),
-                "barycentric": np.zeros((0, 3), dtype=dtype),
-            }
+                    bary_basis = np.stack(
+                        [
+                            self._barycentric_coordinates(tri, vertex[None, :], tol)[0]
+                            for vertex in tri_clip
+                        ],
+                        axis=0,
+                    )
+                    bary_orig = barycentric_clip @ bary_basis
+                    sample_points = bary_orig @ tri
 
-        return {
-            "points": np.concatenate(points_list, axis=0),
-            "normals": np.concatenate(normals_list, axis=0),
-            "perps1": np.concatenate(perps1_list, axis=0),
-            "perps2": np.concatenate(perps2_list, axis=0),
-            "weights": np.concatenate(weights_list, axis=0),
-            "faces": np.concatenate(faces_list, axis=0),
-            "barycentric": np.concatenate(bary_list, axis=0),
-        }
+                    weights_tile = np.full(num_samples, base_weight, dtype=dtype)
+                    faces_tile = np.full(num_samples, face_index, dtype=int)
+                    samples.append(
+                        sample=self._SampleBlock(
+                            points=sample_points,
+                            normals=np.repeat(normal[None, :], num_samples, axis=0),
+                            perps1=np.repeat(perp1[None, :], num_samples, axis=0),
+                            perps2=np.repeat(perp2[None, :], num_samples, axis=0),
+                            weights=weights_tile,
+                            faces=faces_tile,
+                            barycentric=bary_orig,
+                        )
+                    )
 
-    def _collect_surface_samples_2d(
+        return self._finalize_sample_lists(dtype, samples)
+
+    def _collect_plane_samples(
         self,
-        triangle: NDArray,
-        face_index: int,
-        normal: np.ndarray,
-        perp1: np.ndarray,
-        perp2: np.ndarray,
+        triangles_arr: np.ndarray,
+        normals: np.ndarray,
+        perps1: np.ndarray,
+        perps2: np.ndarray,
+        usable_mask: np.ndarray,
         spacing: float,
+        sim_min: np.ndarray,
+        sim_max: np.ndarray,
+        valid_axes: np.ndarray,
         collapsed_axis: int,
         plane_value: float,
-        sim_min: np.ndarray,
-        sim_max: np.ndarray,
-        valid_axes: np.ndarray,
         tol: float,
         dtype: np.dtype,
-    ) -> tuple[Optional[dict[str, np.ndarray]], bool]:
-        """Collect samples when the simulation bounds collapse onto a 2D plane."""
+    ) -> dict[str, np.ndarray]:
+        """Sample intersection of triangles with a collapsed-axis plane."""
 
-        segments = self._triangle_plane_segments(
-            triangle=triangle, axis=collapsed_axis, plane_value=plane_value, tol=tol
-        )
+        samples = self._SampleAccumulators.empty()
 
-        points: list[np.ndarray] = []
-        normals: list[np.ndarray] = []
-        perps1_list: list[np.ndarray] = []
-        perps2_list: list[np.ndarray] = []
-        weights: list[np.ndarray] = []
-        faces: list[np.ndarray] = []
-        barycentric: list[np.ndarray] = []
-        outside_bounds = False
+        warned = False
+        face_indices = np.flatnonzero(usable_mask)
+        for face_index in face_indices:
+            tri = triangles_arr[face_index]
+            normal = normals[face_index]
+            perp1 = perps1[face_index]
+            perp2 = perps2[face_index]
 
-        for start, end in segments:
-            vec = end - start
-            length = float(np.linalg.norm(vec))
-            if length <= tol:
-                continue
+            segments = self._triangle_plane_segments(
+                triangle=tri, axis=collapsed_axis, plane_value=plane_value, tol=tol
+            )
+            for start, end in segments:
+                vec = end - start
+                length = float(np.linalg.norm(vec))
+                if length <= tol:
+                    continue
 
-            subdivisions = max(1, int(np.ceil(length / spacing)))
-            t_vals = (np.arange(subdivisions, dtype=dtype) + 0.5) / subdivisions
-            sample_points = start[None, :] + t_vals[:, None] * vec[None, :]
-            bary = self._barycentric_coordinates(triangle, sample_points, tol)
+                subdivisions = max(1, int(np.ceil(length / spacing)))
+                t_vals = (np.arange(subdivisions, dtype=dtype) + 0.5) / subdivisions
+                sample_points = start[None, :] + t_vals[:, None] * vec[None, :]
+                barycentric = self._barycentric_coordinates(tri, sample_points, tol)
 
-            inside_mask = np.ones(sample_points.shape[0], dtype=bool)
-            if np.any(valid_axes):
-                min_bound = (sim_min - tol)[valid_axes]
-                max_bound = (sim_max + tol)[valid_axes]
-                coords = sample_points[:, valid_axes]
-                inside_mask = np.all(coords >= min_bound, axis=1) & np.all(
-                    coords <= max_bound, axis=1
+                inside_mask = np.ones(sample_points.shape[0], dtype=bool)
+                if np.any(valid_axes):
+                    min_bound = (sim_min - tol)[valid_axes]
+                    max_bound = (sim_max + tol)[valid_axes]
+                    coords = sample_points[:, valid_axes]
+                    inside_mask = np.all(coords >= min_bound, axis=1) & np.all(
+                        coords <= max_bound, axis=1
+                    )
+
+                if not np.all(inside_mask) and not warned:
+                    log.warning(
+                        "Some triangles from the mesh lie outside the simulation bounds - this may lead to inaccurate gradients."
+                    )
+                    warned = True
+
+                if not np.any(inside_mask):
+                    continue
+
+                sample_points = sample_points[inside_mask]
+                bary_inside = barycentric[inside_mask]
+                n_inside = sample_points.shape[0]
+
+                weights_tile = np.full(n_inside, length / subdivisions, dtype=dtype)
+                faces_tile = np.full(n_inside, face_index, dtype=int)
+                samples.append(
+                    sample=self._SampleBlock(
+                        points=sample_points,
+                        normals=np.repeat(normal[None, :], n_inside, axis=0),
+                        perps1=np.repeat(perp1[None, :], n_inside, axis=0),
+                        perps2=np.repeat(perp2[None, :], n_inside, axis=0),
+                        weights=weights_tile,
+                        faces=faces_tile,
+                        barycentric=bary_inside,
+                    )
                 )
 
-            outside_bounds = outside_bounds or (not np.all(inside_mask))
-            if not np.any(inside_mask):
-                continue
+        return self._finalize_sample_lists(dtype, samples)
 
-            sample_points = sample_points[inside_mask]
-            bary_inside = bary[inside_mask]
-            n_inside = sample_points.shape[0]
+    @staticmethod
+    def _vectorized_subdivisions(
+        areas: np.ndarray, spacing: float, edge_lengths: np.ndarray
+    ) -> np.ndarray:
+        """Compute subdivision counts for many triangles at once."""
 
-            normal_tile = np.repeat(normal[None, :], n_inside, axis=0)
-            perp1_tile = np.repeat(perp1[None, :], n_inside, axis=0)
-            perp2_tile = np.repeat(perp2[None, :], n_inside, axis=0)
-            weights_tile = np.full(n_inside, length / subdivisions, dtype=dtype)
-            faces_tile = np.full(n_inside, face_index, dtype=int)
+        spacing = max(float(spacing), np.finfo(float).eps)
+        target = np.sqrt(np.maximum(areas, 0.0))
+        area_based = np.ceil(np.sqrt(2.0) * target / spacing)
 
-            points.append(sample_points)
-            normals.append(normal_tile)
-            perps1_list.append(perp1_tile)
-            perps2_list.append(perp2_tile)
-            weights.append(weights_tile)
-            faces.append(faces_tile)
-            barycentric.append(bary_inside)
+        max_edge = np.max(edge_lengths, axis=1)
+        edge_based = np.ceil(max_edge / spacing)
 
-        if not points:
-            return None, outside_bounds
+        subdivisions = np.maximum(area_based, edge_based)
+        subdivisions = np.maximum(subdivisions, 1.0)
+        return subdivisions.astype(int)
 
-        samples = {
-            "points": np.concatenate(points, axis=0),
-            "normals": np.concatenate(normals, axis=0),
-            "perps1": np.concatenate(perps1_list, axis=0),
-            "perps2": np.concatenate(perps2_list, axis=0),
-            "weights": np.concatenate(weights, axis=0),
-            "faces": np.concatenate(faces, axis=0),
-            "barycentric": np.concatenate(barycentric, axis=0),
+    @staticmethod
+    def _empty_sample_result(dtype: np.dtype) -> dict[str, np.ndarray]:
+        """Return the default empty sampling dictionary."""
+
+        zeros_vec = np.zeros((0, 3), dtype=dtype)
+        zeros_scalar = np.zeros((0,), dtype=dtype)
+        zeros_faces = np.zeros((0,), dtype=int)
+        return {
+            "points": zeros_vec,
+            "normals": zeros_vec.copy(),
+            "perps1": zeros_vec.copy(),
+            "perps2": zeros_vec.copy(),
+            "weights": zeros_scalar,
+            "faces": zeros_faces,
+            "barycentric": zeros_vec.copy(),
         }
-        return samples, outside_bounds
 
-    def _collect_surface_samples_3d(
-        self,
-        triangle: NDArray,
-        face_index: int,
-        normal: np.ndarray,
-        perp1: np.ndarray,
-        perp2: np.ndarray,
-        area: float,
-        spacing: float,
-        sim_min: np.ndarray,
-        sim_max: np.ndarray,
-        valid_axes: np.ndarray,
-        tol: float,
+    @dataclass
+    class _SampleAccumulators:
+        """Holds sample arrays before concatenation."""
+
+        points: list[np.ndarray]
+        normals: list[np.ndarray]
+        perps1: list[np.ndarray]
+        perps2: list[np.ndarray]
+        weights: list[np.ndarray]
+        faces: list[np.ndarray]
+        barycentric: list[np.ndarray]
+
+        @classmethod
+        def empty(cls) -> TriangleMesh._SampleAccumulators:
+            return cls(
+                points=[],
+                normals=[],
+                perps1=[],
+                perps2=[],
+                weights=[],
+                faces=[],
+                barycentric=[],
+            )
+
+        def append(self, *, sample: TriangleMesh._SampleBlock) -> None:
+            self.points.append(sample.points)
+            self.normals.append(sample.normals)
+            self.perps1.append(sample.perps1)
+            self.perps2.append(sample.perps2)
+            self.weights.append(sample.weights)
+            self.faces.append(sample.faces)
+            self.barycentric.append(sample.barycentric)
+
+    @dataclass
+    class _SampleBlock:
+        """Single sample batch to append."""
+
+        points: np.ndarray
+        normals: np.ndarray
+        perps1: np.ndarray
+        perps2: np.ndarray
+        weights: np.ndarray
+        faces: np.ndarray
+        barycentric: np.ndarray
+
+    @staticmethod
+    def _finalize_sample_lists(
         dtype: np.dtype,
-    ) -> tuple[Optional[dict[str, np.ndarray]], bool]:
-        """Collect samples when the simulation bounds represent a full 3D region."""
+        samples: TriangleMesh._SampleAccumulators,
+    ) -> dict[str, np.ndarray]:
+        """Concatenate accumulated sampling data or return an empty structure."""
 
-        edge_lengths = (
-            np.linalg.norm(triangle[1] - triangle[0]),
-            np.linalg.norm(triangle[2] - triangle[1]),
-            np.linalg.norm(triangle[0] - triangle[2]),
-        )
-        subdivisions = self._subdivision_count(area, spacing, edge_lengths)
-        barycentric = self._get_barycentric_samples(subdivisions, dtype)
-        num_samples = barycentric.shape[0]
-        base_weight = area / num_samples
+        if not samples.points:
+            return TriangleMesh._empty_sample_result(dtype)
 
-        sample_points = barycentric @ triangle
-
-        inside_mask = np.all(
-            sample_points[:, valid_axes] >= (sim_min - tol)[valid_axes], axis=1
-        ) & np.all(sample_points[:, valid_axes] <= (sim_max + tol)[valid_axes], axis=1)
-        outside_bounds = not np.all(inside_mask)
-        if not np.any(inside_mask):
-            return None, outside_bounds
-
-        sample_points = sample_points[inside_mask]
-        bary_inside = barycentric[inside_mask]
-        n_samples_inside = sample_points.shape[0]
-
-        normal_tile = np.repeat(normal[None, :], n_samples_inside, axis=0)
-        perp1_tile = np.repeat(perp1[None, :], n_samples_inside, axis=0)
-        perp2_tile = np.repeat(perp2[None, :], n_samples_inside, axis=0)
-        weights_tile = np.full(n_samples_inside, base_weight, dtype=dtype)
-        faces_tile = np.full(n_samples_inside, face_index, dtype=int)
-
-        samples = {
-            "points": sample_points,
-            "normals": normal_tile,
-            "perps1": perp1_tile,
-            "perps2": perp2_tile,
-            "weights": weights_tile,
-            "faces": faces_tile,
-            "barycentric": bary_inside,
+        return {
+            "points": np.concatenate(samples.points, axis=0),
+            "normals": np.concatenate(samples.normals, axis=0),
+            "perps1": np.concatenate(samples.perps1, axis=0),
+            "perps2": np.concatenate(samples.perps2, axis=0),
+            "weights": np.concatenate(samples.weights, axis=0),
+            "faces": np.concatenate(samples.faces, axis=0),
+            "barycentric": np.concatenate(samples.barycentric, axis=0),
         }
-        return samples, outside_bounds
+
+    def _append_barycentric_group(
+        self,
+        *,
+        samples: TriangleMesh._SampleAccumulators,
+        barycentric: np.ndarray,
+        triangles: np.ndarray,
+        normals: np.ndarray,
+        perps1: np.ndarray,
+        perps2: np.ndarray,
+        areas: np.ndarray,
+        face_ids: np.ndarray,
+        dtype: np.dtype,
+    ) -> None:
+        """Append barycentric samples for a group of triangles sharing subdivision count."""
+
+        num_samples = barycentric.shape[0]
+        sample_points = np.einsum("sb,fbc->fsc", barycentric, triangles).reshape(-1, 3)
+        bary_tile = np.broadcast_to(barycentric, (triangles.shape[0], num_samples, 3)).reshape(
+            -1, 3
+        )
+        weights = np.repeat((areas / num_samples).astype(dtype), num_samples)
+        faces = np.repeat(face_ids, num_samples)
+
+        samples.append(
+            sample=self._SampleBlock(
+                points=sample_points,
+                normals=np.repeat(normals, num_samples, axis=0),
+                perps1=np.repeat(perps1, num_samples, axis=0),
+                perps2=np.repeat(perps2, num_samples, axis=0),
+                weights=weights,
+                faces=faces,
+                barycentric=bary_tile,
+            )
+        )
 
     @staticmethod
     def _triangle_area_and_normal(triangle: NDArray) -> tuple[float, np.ndarray]:
@@ -1154,6 +1443,88 @@ class TriangleMesh(base.Geometry, ABC):
             return [(points[0], points[1])]
 
         return []
+
+    @staticmethod
+    def _clip_polygon_with_plane(
+        polygon: list[np.ndarray], axis: int, bound: float, keep_below: bool, tol: float
+    ) -> list[np.ndarray]:
+        """Clip a polygon with an axis-aligned plane."""
+
+        if not polygon:
+            return []
+
+        result: list[np.ndarray] = []
+        prev = polygon[-1]
+        prev_val = prev[axis]
+        prev_inside = (prev_val <= bound + tol) if keep_below else (prev_val >= bound - tol)
+
+        for current in polygon:
+            curr_val = current[axis]
+            curr_inside = (curr_val <= bound + tol) if keep_below else (curr_val >= bound - tol)
+
+            if curr_inside:
+                if not prev_inside:
+                    result.append(
+                        TriangleMesh._segment_plane_intersection(prev, current, axis, bound, tol)
+                    )
+                result.append(current)
+            elif prev_inside:
+                result.append(
+                    TriangleMesh._segment_plane_intersection(prev, current, axis, bound, tol)
+                )
+
+            prev = current
+            prev_inside = curr_inside
+
+        return result
+
+    @staticmethod
+    def _segment_plane_intersection(
+        p0: np.ndarray, p1: np.ndarray, axis: int, bound: float, tol: float
+    ) -> np.ndarray:
+        """Return intersection point between segment (p0,p1) and axis-aligned plane."""
+
+        v0 = float(p0[axis]) - bound
+        v1 = float(p1[axis]) - bound
+        denom = v1 - v0
+        if abs(denom) <= tol:
+            return p0.copy()
+        t = -v0 / denom
+        t = float(np.clip(t, 0.0, 1.0))
+        return p0 + t * (p1 - p0)
+
+    @classmethod
+    def _clip_triangle_to_bounds(
+        cls, triangle: NDArray, sim_min: NDArray, sim_max: NDArray, tol: float
+    ) -> tuple[list[NDArray], bool]:
+        """Clip triangle against axis-aligned bounds, return list of sub-triangles and flag."""
+
+        vertices = np.asarray(triangle)
+        inside = np.all(vertices >= (sim_min - tol), axis=1) & np.all(
+            vertices <= (sim_max + tol), axis=1
+        )
+        if np.all(inside):
+            return [triangle], False
+
+        polygon = [triangle[0].copy(), triangle[1].copy(), triangle[2].copy()]
+        clipped_flag = True
+        for axis in range(3):
+            polygon = cls._clip_polygon_with_plane(polygon, axis, sim_min[axis], False, tol)
+            if not polygon:
+                return [], True
+            polygon = cls._clip_polygon_with_plane(polygon, axis, sim_max[axis], True, tol)
+            if not polygon:
+                return [], True
+
+        if len(polygon) < 3:
+            return [], True
+
+        triangles: list[NDArray] = []
+        anchor = polygon[0]
+        for idx in range(1, len(polygon) - 1):
+            tri_clip = np.array([anchor, polygon[idx], polygon[idx + 1]], dtype=triangle.dtype)
+            triangles.append(tri_clip)
+        return triangles, clipped_flag
 
     @staticmethod
     def _barycentric_coordinates(triangle: NDArray, points: np.ndarray, tol: float) -> np.ndarray:

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -9,9 +9,11 @@ from typing import TYPE_CHECKING, Any
 
 import autograd.numpy as np
 import shapely
+from autograd.core import make_vjp
 from autograd.tracer import getval
+from numpy._typing import NDArray
 from numpy.polynomial.legendre import leggauss as _leggauss
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, PrivateAttr, field_validator, model_validator
 
 from tidy3d.components.autograd import TracedArrayFloat2D, get_static
 from tidy3d.components.autograd.types import TracedFloat
@@ -103,6 +105,8 @@ class PolySlab(base.Planar):
         "the slab normal axis is ``axis=y``, the coordinate of the vertices will be in (x, z)",
         json_schema_extra={"units": MICROMETER},
     )
+
+    _mesh_faces: Optional[tuple[NDArray[np.int_], dict[str, slice]]] = PrivateAttr(default=None)
 
     @staticmethod
     def make_shapely_polygon(vertices: ArrayLike) -> shapely.Polygon:
@@ -1464,6 +1468,74 @@ class PolySlab(base.Planar):
 
     """ Autograd code """
 
+    def _compute_derivatives_via_mesh(
+        self,
+        derivative_info: DerivativeInfo,
+        clip_operation: Optional[base.ClipOperationContext] = None,
+    ) -> AutogradFieldMap:
+        """Compute adjoint derivatives via mesh-based sampling."""
+
+        if not self._mesh_derivatives_supported():
+            return self._zero_derivative_map(derivative_info)
+
+        dtype = config.adjoint.gradient_dtype_float
+        vertices_arr = np.asarray(self.vertices, dtype=dtype)
+        slab_bounds_arr = np.asarray(self.slab_bounds, dtype=dtype)
+        sidewall_angle_val = np.array(self.sidewall_angle, dtype=dtype)
+
+        if vertices_arr.shape[0] < 3:
+            return self._zero_derivative_map(derivative_info)
+
+        mesh_vertices, base_polygon, top_polygon = self._mesh_vertex_positions(
+            vertices=vertices_arr,
+            slab_bounds=slab_bounds_arr,
+            sidewall_angle=sidewall_angle_val,
+        )
+
+        faces, partitions = self._ensure_mesh_faces(base_polygon, top_polygon)
+
+        if mesh_vertices.size == 0 or faces.size == 0:
+            return self._zero_derivative_map(derivative_info)
+
+        from .mesh import TriangleMesh
+
+        mesh = TriangleMesh.from_vertices_faces(mesh_vertices, faces)
+
+        original_paths = derivative_info.paths
+        derivative_info.paths = [("mesh_dataset", "surface_mesh")]
+        try:
+            mesh_vjps = mesh._compute_derivatives(derivative_info, clip_operation=clip_operation)
+        finally:
+            derivative_info.paths = original_paths
+        gradient_key = ("mesh_dataset", "surface_mesh")
+        if gradient_key not in mesh_vjps:
+            return self._zero_derivative_map(derivative_info)
+
+        triangle_grads = mesh_vjps[gradient_key]
+        num_vertices = mesh_vertices.shape[0]
+        base_slice = partitions["base"]
+        top_slice = partitions["top"]
+        side_slice = partitions["side"]
+
+        vertex_grads_side = self._accumulate_vertex_gradients(
+            triangle_grads[side_slice], faces[side_slice], num_vertices=num_vertices
+        )
+        vertex_grads_base = self._accumulate_vertex_gradients(
+            triangle_grads[base_slice], faces[base_slice], num_vertices=num_vertices
+        )
+        vertex_grads_top = self._accumulate_vertex_gradients(
+            triangle_grads[top_slice], faces[top_slice], num_vertices=num_vertices
+        )
+        vertex_grads_caps = vertex_grads_base + vertex_grads_top
+        return self._map_mesh_vjps_to_fields(
+            vertex_grads_side,
+            vertex_grads_caps,
+            derivative_info,
+            vertices_arr,
+            slab_bounds_arr,
+            sidewall_angle_val,
+        )
+
     def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
         """
         Return VJPs while handling several edge-cases:
@@ -1532,6 +1604,269 @@ class PolySlab(base.Planar):
                 raise ValueError(f"No derivative defined w.r.t. 'PolySlab' field '{path}'.")
 
         return vjps
+
+    def _mesh_derivatives_supported(self) -> bool:
+        """Return ``True`` if we can evaluate mesh-based derivatives."""
+
+        return True
+
+    def _mesh_vertex_positions(
+        self,
+        vertices: NDArray,
+        slab_bounds: NDArray,
+        sidewall_angle: NDArray,
+        *,
+        return_numpy: bool = True,
+    ) -> tuple[NDArray, NDArray, NDArray]:
+        """Return stacked vertex coordinates for the PolySlab mesh."""
+
+        dtype = config.adjoint.gradient_dtype_float
+
+        def empty_result() -> tuple[NDArray, NDArray, NDArray]:
+            verts3d = np.zeros((0, 3), dtype=dtype)
+            polys = np.zeros((0, 2), dtype=dtype)
+            return verts3d, polys, polys
+
+        reference_polygon = PolySlab._proper_vertices(vertices)
+        if reference_polygon.shape[0] < 3:
+            return empty_result()
+
+        bounds_vals = np.array([getval(slab_bounds[0]), getval(slab_bounds[1])], dtype=float)
+        length_val = bounds_vals[1] - bounds_vals[0]
+        if length_val <= fp_eps:
+            return empty_result()
+
+        zmin = np.maximum(slab_bounds[0], -LARGE_NUMBER)
+        zmax = np.minimum(slab_bounds[1], LARGE_NUMBER)
+        finite_length = zmax - zmin
+        half_length = finite_length / 2.0
+
+        tan_val = np.tan(sidewall_angle)
+        offset = np.where(np.isclose(tan_val, 0.0), 0.0, -half_length * tan_val)
+
+        if self.reference_plane == "bottom":
+            middle_polygon = PolySlab._shift_vertices(reference_polygon, offset)[0]
+        elif self.reference_plane == "top":
+            middle_polygon = PolySlab._shift_vertices(reference_polygon, -offset)[0]
+        else:
+            middle_polygon = reference_polygon
+
+        if self.reference_plane == "bottom":
+            base_polygon = reference_polygon
+        else:
+            base_polygon = PolySlab._shift_vertices(middle_polygon, -offset)[0]
+
+        if self.reference_plane == "top":
+            top_polygon = reference_polygon
+        else:
+            top_polygon = PolySlab._shift_vertices(middle_polygon, offset)[0]
+
+        planar = np.vstack((base_polygon, top_polygon))
+        axis_vals = np.concatenate(
+            (
+                np.full(base_polygon.shape[0], zmin),
+                np.full(top_polygon.shape[0], zmax),
+            )
+        )
+        coords = np.vstack(self.unpop_axis(axis_vals, (planar[:, 0], planar[:, 1]), self.axis))
+        vertices3d = coords.T
+        if return_numpy:
+            return (
+                np.asarray(vertices3d, dtype=dtype),
+                np.asarray(base_polygon, dtype=dtype),
+                np.asarray(top_polygon, dtype=dtype),
+            )
+        return vertices3d, base_polygon, top_polygon
+
+    def _ensure_mesh_faces(
+        self, base_polygon: NDArray, top_polygon: NDArray
+    ) -> tuple[NDArray[np.int_], dict[str, slice]]:
+        """Construct (and cache) the triangle indices for the PolySlab mesh."""
+
+        if self._mesh_faces is not None:
+            return self._mesh_faces
+
+        def empty_faces() -> tuple[NDArray[np.int_], dict[str, slice]]:
+            faces = np.zeros((0, 3), dtype=int)
+            empty = slice(0, 0)
+            partitions = {"base": empty, "top": empty, "side": empty}
+            self._mesh_faces = (faces, partitions)
+            return self._mesh_faces
+
+        n_base = int(base_polygon.shape[0])
+        n_top = int(top_polygon.shape[0])
+        if n_base < 3 or n_top < 3 or n_base != n_top:
+            return empty_faces()
+
+        try:
+            base_triangles = triangulation.triangulate(base_polygon)
+            if math.isclose(self.sidewall_angle, 0):
+                top_triangles = base_triangles
+            else:
+                top_triangles = triangulation.triangulate(top_polygon)
+        except Exception as exc:
+            log.debug("Failed to triangulate 'PolySlab' mesh faces: %s", exc)
+            return empty_faces()
+
+        base_faces = [[a, b, c] for c, b, a in base_triangles]
+        top_shift = n_base
+        top_faces = [[top_shift + a, top_shift + b, top_shift + c] for a, b, c in top_triangles]
+        side_faces = [(i, (i + 1) % n_base, n_base + i) for i in range(n_base)] + [
+            ((i + 1) % n_base, n_base + ((i + 1) % n_base), n_base + i) for i in range(n_base)
+        ]
+
+        faces = np.asarray(base_faces + top_faces + side_faces, dtype=int)
+        partitions = {
+            "base": slice(0, len(base_faces)),
+            "top": slice(len(base_faces), len(base_faces) + len(top_faces)),
+            "side": slice(len(base_faces) + len(top_faces), faces.shape[0]),
+        }
+
+        self._mesh_faces = (faces, partitions)
+        return self._mesh_faces
+
+    @staticmethod
+    def _accumulate_vertex_gradients(
+        triangle_grads: NDArray, faces: NDArray, *, num_vertices: Optional[int] = None
+    ) -> NDArray:
+        """Aggregate per-triangle gradients into per-vertex values."""
+
+        if triangle_grads.size == 0 or faces.size == 0:
+            length = int(num_vertices or 0)
+            return np.zeros((length, 3), dtype=triangle_grads.dtype)
+
+        if num_vertices is None:
+            num_vertices = int(faces.max() + 1)
+
+        vertex_grads = np.zeros((num_vertices, 3), dtype=triangle_grads.dtype)
+        for face_index, face in enumerate(faces):
+            for local_idx, vertex_idx in enumerate(face):
+                vertex_grads[vertex_idx] += triangle_grads[face_index, local_idx]
+        return vertex_grads
+
+    def _map_mesh_vjps_to_fields(
+        self,
+        vertex_grads_side: NDArray,
+        vertex_grads_caps: NDArray,
+        derivative_info: DerivativeInfo,
+        vertices: NDArray,
+        slab_bounds: NDArray,
+        sidewall_angle: NDArray,
+    ) -> AutogradFieldMap:
+        """Convert mesh vertex gradients into PolySlab field derivatives."""
+
+        grad_vertices_side, _, grad_angle_side = self._mesh_parameter_gradients(
+            vertex_grads_side, vertices, slab_bounds, sidewall_angle
+        )
+        grad_vertices_caps, grad_bounds, grad_angle_caps = self._mesh_parameter_gradients(
+            vertex_grads_caps, vertices, slab_bounds, sidewall_angle
+        )
+        grad_vertices = grad_vertices_side + grad_vertices_caps
+        grad_vertices *= self._planar_orientation_sign()
+        grad_bounds *= self._planar_orientation_sign()
+        if self._is_2d_slice(derivative_info):
+            slab_thickness = float(getval(slab_bounds[1]) - getval(slab_bounds[0]))
+            if not np.isfinite(slab_thickness) or slab_thickness <= fp_eps:
+                thickness = 1.0
+            else:
+                thickness = slab_thickness
+            grad_vertices /= thickness
+
+        sim_min, sim_max = map(np.asarray, derivative_info.simulation_bounds)
+        intersect_min, intersect_max = map(np.asarray, derivative_info.bounds_intersect)
+        is_2d = np.isclose(intersect_max[self.axis] - intersect_min[self.axis], 0.0)
+        if is_2d:
+            grad_bounds = np.zeros_like(grad_bounds)
+        interpolators = derivative_info.interpolators or derivative_info.create_interpolators(
+            dtype=config.adjoint.gradient_dtype_float
+        )
+        grad_angle_exact = self._compute_derivative_sidewall_angle(
+            derivative_info,
+            sim_min,
+            sim_max,
+            is_2d=is_2d,
+            interpolators=interpolators,
+        )
+
+        results: AutogradFieldMap = {}
+        for path in derivative_info.paths:
+            if path == ("vertices",):
+                results[path] = grad_vertices
+            elif path == ("sidewall_angle",):
+                results[path] = float(grad_angle_exact)
+            elif path[0] == "slab_bounds":
+                idx = int(path[1])
+                results[path] = float(grad_bounds[idx])
+            else:
+                raise ValueError(f"No derivative defined w.r.t. 'PolySlab' field '{path}'.")
+
+        return results
+
+    def _planar_orientation_sign(self) -> float:
+        """Return +1 or -1 based on (plane_axes, axis) permutation parity."""
+
+        plane_axes = [idx for idx in range(3) if idx != self.axis]
+        perm = (*plane_axes, self.axis)
+        even_perms = {(0, 1, 2), (1, 2, 0), (2, 0, 1)}
+        return 1.0 if perm in even_perms else -1.0
+
+    def _is_2d_slice(self, derivative_info: DerivativeInfo) -> bool:
+        """Return True if the intersection bounds collapse along the extrusion axis."""
+
+        intersect_min, intersect_max = derivative_info.bounds_intersect
+        axis_extent = intersect_max[self.axis] - intersect_min[self.axis]
+        return np.isclose(axis_extent, 0.0)
+
+    def _zero_derivative_map(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
+        """Return a zero-valued derivative map for requested fields."""
+
+        result: AutogradFieldMap = {}
+        for path in derivative_info.paths:
+            if path == ("vertices",):
+                result[path] = np.zeros_like(self.vertices)
+            elif path == ("sidewall_angle",):
+                result[path] = 0.0
+            elif path[0] == "slab_bounds":
+                result[path] = 0.0
+            else:
+                raise ValueError(f"No derivative defined w.r.t. 'PolySlab' field '{path}'.")
+        return result
+
+    def _mesh_parameter_gradients(
+        self,
+        vertex_grads: NDArray,
+        vertices: NDArray,
+        slab_bounds: NDArray,
+        sidewall_angle: NDArray,
+    ) -> tuple[NDArray, NDArray, float]:
+        """Return gradients w.r.t. (vertices, slab_bounds, sidewall_angle) parameters."""
+
+        dtype = config.adjoint.gradient_dtype_float
+        flattened = np.asarray(vertex_grads, dtype=dtype).reshape(-1)
+
+        vertex_flat = np.asarray(vertices, dtype=dtype).reshape(-1)
+        bounds_flat = np.asarray(slab_bounds, dtype=dtype)
+        angle_flat = np.array([sidewall_angle], dtype=dtype)
+        param = np.concatenate((vertex_flat, bounds_flat, angle_flat))
+
+        num_vertex_params = vertex_flat.size
+        bounds_offset = num_vertex_params
+        angle_offset = num_vertex_params + 2
+
+        def param_builder(packed: Any) -> Any:
+            verts = packed[:num_vertex_params].reshape(vertices.shape)
+            bounds = packed[bounds_offset : bounds_offset + 2]
+            angle = packed[angle_offset]
+            coords, _, _ = self._mesh_vertex_positions(verts, bounds, angle, return_numpy=False)
+            return coords.reshape(-1)
+
+        vjp_fn, _ = make_vjp(param_builder, param)
+        grad_param = np.asarray(vjp_fn(flattened))
+
+        grad_vertices = grad_param[:num_vertex_params].reshape(vertices.shape)
+        grad_bounds = grad_param[bounds_offset : bounds_offset + 2]
+        grad_angle = grad_param[angle_offset]
+        return grad_vertices, grad_bounds, float(grad_angle)
 
     # ---- Shared helpers for VJP surface integrations ----
     def _z_slices(

--- a/tidy3d/components/geometry/primitives.py
+++ b/tidy3d/components/geometry/primitives.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from tidy3d.compat import Self
     from tidy3d.components.autograd import AutogradFieldMap
     from tidy3d.components.autograd.derivative_utils import DerivativeInfo
+    from tidy3d.components.geometry.base import ClipOperationContext
     from tidy3d.components.types import Axis, Bound, Coordinate, MatrixReal4x4, Shapely
 
 # for sampling conical frustum in visualization
@@ -336,8 +337,9 @@ class Sphere(base.Centered, base.Circular):
         )
         return unit_tris
 
-    def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
-        """Compute adjoint derivatives using smooth sphere surface samples."""
+    def _validate_derivative_paths(self, derivative_info: DerivativeInfo) -> None:
+        """Validate derivative paths for Sphere."""
+
         valid_paths = {("radius",), *{("center", i) for i in range(3)}}
         for path in derivative_info.paths:
             if path not in valid_paths:
@@ -345,6 +347,81 @@ class Sphere(base.Centered, base.Circular):
                     f"No derivative defined w.r.t. 'Sphere' field '{path}'. "
                     "Supported fields are 'radius' and 'center'."
                 )
+
+    @staticmethod
+    def _zero_derivative_map(derivative_info: DerivativeInfo) -> AutogradFieldMap:
+        """Return a zero-valued derivative map for requested fields."""
+
+        return dict.fromkeys(derivative_info.paths, 0.0)
+
+    def _compute_derivatives_via_mesh(
+        self,
+        derivative_info: DerivativeInfo,
+        clip_operation: Optional[ClipOperationContext] = None,
+    ) -> AutogradFieldMap:
+        """Compute adjoint derivatives using a triangle-mesh surface representation."""
+
+        self._validate_derivative_paths(derivative_info)
+
+        if not derivative_info.paths:
+            return {}
+
+        radius = float(get_static(self.radius))
+        if radius == 0.0:
+            log.warning(
+                "Sphere gradients cannot be computed for zero radius; gradients are zero.",
+                log_once=True,
+            )
+            return self._zero_derivative_map(derivative_info)
+
+        grid_cfg = config.adjoint
+        wvl_mat = discretization_wavelength(derivative_info, "sphere")
+        target_edge = max(wvl_mat / grid_cfg.points_per_wavelength, np.finfo(float).eps)
+        triangles, _ = self._triangulated_surface(max_edge_length=target_edge)
+        triangles = np.asarray(triangles, dtype=grid_cfg.gradient_dtype_float)
+        if triangles.size == 0:
+            return self._zero_derivative_map(derivative_info)
+
+        mesh = TriangleMesh.from_triangles(triangles)
+        original_paths = derivative_info.paths
+        derivative_info.paths = [("mesh_dataset", "surface_mesh")]
+        try:
+            mesh_vjps = mesh._compute_derivatives(derivative_info, clip_operation=clip_operation)
+        finally:
+            derivative_info.paths = original_paths
+
+        gradient_key = ("mesh_dataset", "surface_mesh")
+        if gradient_key not in mesh_vjps:
+            return self._zero_derivative_map(derivative_info)
+
+        triangle_grads = np.asarray(mesh_vjps[gradient_key], dtype=float)
+        if triangle_grads.size == 0:
+            return self._zero_derivative_map(derivative_info)
+
+        center = np.asarray(self.center, dtype=float)
+        relative = triangles - center
+        norms = np.linalg.norm(relative, axis=2, keepdims=True)
+        norms = np.where(norms == 0.0, 1.0, norms)
+        unit = relative / norms
+
+        grad_center = np.sum(triangle_grads, axis=(0, 1))
+        grad_radius = float(np.sum(triangle_grads * unit))
+
+        result: AutogradFieldMap = {}
+        for path in derivative_info.paths:
+            if path == ("radius",):
+                result[path] = grad_radius
+            elif path[0] == "center":
+                idx = int(path[1])
+                result[path] = float(grad_center[idx])
+            else:
+                raise ValueError(f"No derivative defined w.r.t. 'Sphere' field '{path}'.")
+
+        return result
+
+    def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
+        """Compute adjoint derivatives using smooth sphere surface samples."""
+        self._validate_derivative_paths(derivative_info)
 
         if not derivative_info.paths:
             return {}
@@ -356,7 +433,7 @@ class Sphere(base.Centered, base.Circular):
                 "Sphere gradients cannot be computed for zero radius; gradients are zero.",
                 log_once=True,
             )
-            return dict.fromkeys(derivative_info.paths, 0.0)
+            return self._zero_derivative_map(derivative_info)
 
         wvl_mat = discretization_wavelength(derivative_info, "sphere")
         target_edge = max(wvl_mat / grid_cfg.points_per_wavelength, np.finfo(float).eps)
@@ -373,7 +450,7 @@ class Sphere(base.Centered, base.Circular):
         collapsed_indices = np.flatnonzero(np.isclose(sim_extents, 0.0, atol=tol))
         if collapsed_indices.size:
             if collapsed_indices.size > 1:
-                return dict.fromkeys(derivative_info.paths, 0.0)
+                return self._zero_derivative_map(derivative_info)
             axis_idx = int(collapsed_indices[0])
             plane_value = float(sim_min[axis_idx])
             return self._compute_derivatives_collapsed_axis(
@@ -391,7 +468,7 @@ class Sphere(base.Centered, base.Circular):
         normals = verts_centered / norms
 
         if vertices.size == 0:
-            return dict.fromkeys(derivative_info.paths, 0.0)
+            return self._zero_derivative_map(derivative_info)
 
         # get vertex weights
         faces = np.asarray(trimesh_obj.faces, dtype=int)
@@ -409,7 +486,7 @@ class Sphere(base.Centered, base.Circular):
         ) & np.all(vertices[:, valid_axes] <= (sim_max + tol)[valid_axes], axis=1)
 
         if not np.any(inside_mask):
-            return dict.fromkeys(derivative_info.paths, 0.0)
+            return self._zero_derivative_map(derivative_info)
 
         points = vertices[inside_mask]
         normals_sel = normals[inside_mask]
@@ -753,7 +830,20 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
         ys = np.sin(angles)
         return np.stack((xs, ys), axis=0)
 
-    def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
+    def _compute_derivatives_via_mesh(
+        self,
+        derivative_info: DerivativeInfo,
+        clip_operation: base.Optional[ClipOperationContext] = None,
+    ) -> AutogradFieldMap:
+        return self._compute_derivatives(
+            derivative_info=derivative_info, clip_operation=clip_operation
+        )
+
+    def _compute_derivatives(
+        self,
+        derivative_info: DerivativeInfo,
+        clip_operation: Optional[base.ClipOperationContext] = None,
+    ) -> AutogradFieldMap:
         """Compute the adjoint derivatives for this object."""
 
         # compute circumference discretization
@@ -795,7 +885,12 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
             update_kwargs["interpolators"] = derivative_info.interpolators
 
         derivative_info_polyslab = derivative_info.updated_copy(**update_kwargs)
-        vjps_polyslab = polyslab._compute_derivatives(derivative_info_polyslab)
+        if clip_operation is not None:
+            vjps_polyslab = polyslab._compute_derivatives_via_mesh(
+                derivative_info_polyslab, clip_operation=clip_operation
+            )
+        else:
+            vjps_polyslab = polyslab._compute_derivatives(derivative_info_polyslab)
 
         vjps = {}
         for path in derivative_info.paths:

--- a/tidy3d/material_library/material_library.py
+++ b/tidy3d/material_library/material_library.py
@@ -241,12 +241,12 @@ class MaterialItemUniaxial(MaterialItem):
 
 
 LiNbO3_Zelmon1997 = VariantItemUniaxial(
-    ordinary=Sellmeier(
+    ordinary=Sellmeier(  # type: ignore[has-type]
         coeffs=((2.6734, 0.01764), (1.2290, 0.05914), (12.614, 474.60)),
         frequency_range=(59958491600000.0, 749481145000000.0),
         name="LiNbO3_Zelmon1997",
     ).pole_residue,
-    extraordinary=Sellmeier(
+    extraordinary=Sellmeier(  # type: ignore[has-type]
         coeffs=((2.9804, 0.02047), (0.5981, 0.0666), (8.9543, 416.08)),
         frequency_range=(59958491600000.0, 749481145000000.0),
         name="LiNbO3_Zelmon1997",

--- a/tidy3d/plugins/mode/mode_solver.py
+++ b/tidy3d/plugins/mode/mode_solver.py
@@ -7,7 +7,4 @@ from __future__ import annotations
 from tidy3d.components.data.monitor_data import ModeSolverData
 from tidy3d.components.mode.mode_solver import MODE_MONITOR_NAME, MODE_PLANE_TYPE, ModeSolver
 
-_ = ModeSolver
-_ = ModeSolverData
-_ = MODE_MONITOR_NAME
-_ = MODE_PLANE_TYPE
+__all__ = ["MODE_MONITOR_NAME", "MODE_PLANE_TYPE", "ModeSolver", "ModeSolverData"]


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Implements autograd (automatic differentiation) support for `ClipOperation` geometries like unions, intersections, and differences to enable gradient-based optimization workflows
- Adds mesh-based derivative computation methods to geometry classes (`Box`, `Cylinder`, `PolySlab`, `TriangleMesh`) for handling complex surface interactions during clipped operations
- Introduces comprehensive test coverage including unit tests and numerical validation comparing autograd gradients against finite difference approximations

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| tidy3d/components/geometry/base.py | Core implementation of ClipOperation autograd support with mesh-based differentiation, surface sampling logic, and removal of validator blocking traced fields in clip operations |
| tidy3d/components/geometry/polyslab.py | Adds complete mesh-based derivative computation pipeline with caching, gradient accumulation, and parameter mapping for PolySlab geometries in clip operations |
| tidy3d/components/geometry/mesh.py | Implements clip operation context handling and vectorized surface sampling for TriangleMesh derivative computation |
| tests/test_components/autograd/test_autograd_clip_operation.py | New comprehensive test file for ClipOperation autograd support covering different geometry types and Boolean operations |

<h3>Confidence score: 3/5</h3>


- This PR introduces complex functionality that requires careful review due to the mathematical complexity of automatic differentiation through geometric operations
- Score reflects potential issues with commented-out code, debugging artifacts, and incomplete sphere geometry handling mentioned in PR description  
- Pay close attention to the mesh-based derivative computation logic in geometry classes and the numerical test validation approach

<!-- greptile_other_comments_section -->

<details><summary><h3>Context used (5)</h3></summary>

- Rule from `dashboard` - Remove commented-out or obsolete code; rely on version control for history. ([source](https://app.greptile.com/review/custom-context?memory=0ee31792-33ef-48e0-8328-48277c2ef438))
- Rule from `dashboard` - Remove temporary debugging code (print() calls), commented-out code, and other workarounds before fi... ([source](https://app.greptile.com/review/custom-context?memory=f6a669d8-0060-4f11-9cac-10ac7ee749ea))
- Rule from `dashboard` - Update the CHANGELOG.md file when making changes that affect user-facing functionality or fix bugs. ([source](https://app.greptile.com/review/custom-context?memory=a109c62a-aa8c-4cc4-b515-0ad947c47929))
- Rule from `dashboard` - Use changelog categories correctly: "Fixed" for bug fixes, "Changed" for modifications to existing f... ([source](https://app.greptile.com/review/custom-context?memory=17997812-233f-4a81-bee2-4d7666605061))
- Rule from `dashboard` - Assert the direct outcome of an operation rather than a side effect (like a log message) when possib... ([source](https://app.greptile.com/review/custom-context?memory=82bf390c-5e3e-49d3-8311-2467151aa6af))
</details>


<!-- /greptile_comment -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core geometry/autograd derivative paths and refactors `TriangleMesh` surface sampling/clipping logic, so gradient correctness and numerical stability could regress across multiple geometry types and boolean operations.
> 
> **Overview**
> Adds autograd support for `ClipOperation` (union/intersection/difference/xor) by introducing a mesh-based derivative pathway (`_compute_derivatives_via_mesh`) and routing clipped gradients through operand-specific sampling masks and normal flipping.
> 
> Implements mesh-based derivative backends for key geometries (`Box`, `Sphere`, `PolySlab`, `Cylinder`, `TriangleMesh`) and updates `GeometryGroup` to propagate clip context; `TriangleMesh` derivative sampling is heavily refactored (vectorized sampling, triangle clipping to sim bounds, and nested clip-context filtering).
> 
> Expands test coverage with new unit + numerical finite-difference validation for `ClipOperation`, updates an existing test to assert gradients are produced (not an error), and hardens numerical artifact directory naming to avoid filesystem path-length issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e64e1f5a51a92c88d0c8bc2888d3d429bc24a609. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->