### PR TITLE
feat(invdes): FXC-4605 added priority attribute to TopologyDesignRegion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added priority attribute to `TopologyDesignRegion` to enable manual control of overlapping structures.
 
 ### Changed
 

--- a/tests/test_plugins/test_invdes.py
+++ b/tests/test_plugins/test_invdes.py
@@ -156,6 +156,19 @@ def test_region_inf_size():
     _ = region.to_structure(params_0_inf)
 
 
+def test_region_priority():
+    region = make_design_region()
+
+    # Test default priority (None)
+    structure_default = region.to_structure(region.params_zeros)
+    assert structure_default.priority is None
+
+    # Test explicit priority value
+    region = region.updated_copy(priority=1)
+    structure = region.to_structure(region.params_zeros)
+    assert structure.priority == 1
+
+
 def post_process_fn(sim_data: td.SimulationData, **kwargs) -> float:
     """Define a post-processing function with extra kwargs (recommended)."""
     intensity = sim_data.get_intensity(MNT_NAME1)

--- a/tidy3d/plugins/invdes/region.py
+++ b/tidy3d/plugins/invdes/region.py
@@ -179,6 +179,16 @@ class TopologyDesignRegion(DesignRegion):
         "Supplying ``False`` will completely leave out the override structure.",
     )
 
+    priority: int = pd.Field(
+        None,
+        title="Priority",
+        description="Priority of the structure applied in structure overlapping region. "
+        "The material property in the overlapping region is dictated by the structure "
+        "of higher priority. For structures of equal priority, "
+        "the structure added later to the structure list takes precedence. When `priority` is None, "
+        "the value is automatically assigned based on `structure_priority_mode` in the `Simulation`.",
+    )
+
     def _validate_eps_values(self) -> None:
         """Validate the epsilon values by evaluating the transformations."""
         try:
@@ -329,7 +339,7 @@ class TopologyDesignRegion(DesignRegion):
         eps_values = self.eps_values(params)
         eps_data_array = td.SpatialDataArray(eps_values, coords=coords)
         medium = td.CustomMedium(permittivity=eps_data_array)
-        return td.Structure(geometry=self.geometry, medium=medium)
+        return td.Structure(geometry=self.geometry, medium=medium, priority=self.priority)
 
     @property
     def _override_structure_dl(self) -> float:


### PR DESCRIPTION
Added the priority attribute to TopologyDesignRegion to enable manual control of structures in overlapping regions. Previously a static structure of priority=1 would always override the TopologyDesignRegion.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds a `priority` attribute to `TopologyDesignRegion` to enable manual control of structure overlapping behavior, matching the functionality already available in the `Structure` class. The implementation correctly passes the priority value through to the created structure.

- Added `priority` field to `TopologyDesignRegion` class with the same definition as `Structure.priority`
- Updated `to_structure()` method to pass priority when creating the structure
- Added test to verify priority propagation
- Updated CHANGELOG with clear user-facing description

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The implementation is straightforward and follows the existing pattern from the `Structure` class. The field definition is identical to the existing `priority` field, and the change only adds passthrough functionality without modifying existing behavior.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/plugins/invdes/region.py | Added `priority` field to `TopologyDesignRegion` class, matching the `Structure` class definition, and passed it through to the created structure |
| tests/test_plugins/test_invdes.py | Added basic test to verify priority is propagated to structure, but missing test for default None behavior |
| CHANGELOG.md | Added clear and user-focused changelog entry describing the new feature |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant TopologyDesignRegion
    participant Structure
    participant Simulation
    
    User->>TopologyDesignRegion: Create with priority=1
    Note over TopologyDesignRegion: Store priority field
    
    User->>TopologyDesignRegion: Call to_structure(params)
    TopologyDesignRegion->>TopologyDesignRegion: Compute eps_values(params)
    TopologyDesignRegion->>TopologyDesignRegion: Create CustomMedium with permittivity
    TopologyDesignRegion->>Structure: Create Structure(geometry, medium, priority)
    Structure-->>TopologyDesignRegion: Return Structure with priority=1
    TopologyDesignRegion-->>User: Return Structure
    
    User->>Simulation: Add Structure to simulation
    Note over Simulation: Apply priority rules in overlapping regions
    Note over Simulation: Higher priority structure takes precedence
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->