### PR TITLE
feat(FXC-4519): Added check to warn of duplicated voltage values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `to_mat_file()` method is now available on `ModeSimulationData` and `HeatChargeSimulationData` for exporting results to MATLAB `.mat` files.
 - Added autograd support for diagonal `AnisotropicMedium` and `CustomAnisotropicMedium` with diagonal permittivity tensor.
 - Added support of numpy 2.4
+- Added validation to `DCVoltageSource` that warns when duplicate voltage values are detected in the `voltage` array, including treating `0` and `-0` as the same value.
 
 ### Changed
 

--- a/tests/test_components/test_heat_charge.py
+++ b/tests/test_components/test_heat_charge.py
@@ -903,6 +903,25 @@ def test_heat_charge_bcs_validation(boundary_conditions):
         td.VoltageBC(source=td.SSACVoltageSource(voltage=np.array([td.inf, 0, 1]), amplitude=1e-2))
 
 
+def test_repeated_voltage_warning():
+    """Test that a warning is raised when repeated voltage values are present."""
+    # No warning for unique values
+    with AssertLogLevel(None):
+        td.DCVoltageSource(voltage=[0, 1, 2, 3])
+
+    # Warning for repeated values
+    with AssertLogLevel("WARNING"):
+        td.DCVoltageSource(voltage=[1, 2, 2, 3])
+
+    # Warning for 0 and -0 (treated as duplicates)
+    with AssertLogLevel("WARNING"):
+        td.DCVoltageSource(voltage=[0.0, -0.0, 1, 2])
+
+    # Warning for multiple repeated values
+    with AssertLogLevel("WARNING"):
+        td.DCVoltageSource(voltage=[1, 1, 2, 2, 3])
+
+
 def test_freqs_validation():
     """Test validation that freqs requires SSACVoltageSource."""
     solid_box_1 = td.Box(center=(0, 0, 0), size=(2, 2, 2))

--- a/tidy3d/components/spice/sources/dc.py
+++ b/tidy3d/components/spice/sources/dc.py
@@ -23,12 +23,14 @@ from __future__ import annotations
 
 from typing import Literal, Optional
 
+import numpy as np
 import pydantic.v1 as pd
 
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.types import ArrayFloat1D
 from tidy3d.constants import AMP, VOLT
 from tidy3d.constants import inf as td_inf
+from tidy3d.log import log
 
 
 class DCVoltageSource(Tidy3dBaseModel):
@@ -71,6 +73,41 @@ class DCVoltageSource(Tidy3dBaseModel):
         for v in val:
             if v == td_inf:
                 raise ValueError(f"Voltages must be finite. Currently  voltage={val}.")
+        return val
+
+    @staticmethod
+    def _count_unique_with_tolerance(arr, rtol=1e-9, atol=1e-12):
+        """Count unique values treating values within tolerance as duplicates.
+
+        Uses sorted comparison to group values that are practically equal
+        due to floating-point representation differences (e.g., single vs double precision).
+        """
+        if len(arr) == 0:
+            return 0
+        sorted_arr = np.sort(arr)
+        # Count values that are "different enough" from their predecessor
+        unique_count = 1
+        for i in range(1, len(sorted_arr)):
+            if not np.isclose(sorted_arr[i], sorted_arr[i - 1], rtol=rtol, atol=atol):
+                unique_count += 1
+        return unique_count
+
+    @pd.validator("voltage")
+    def check_repeated_voltage(cls, val):
+        """Warn if repeated voltage values are present, treating 0 and -0 as the same value.
+
+        Uses tolerance-based comparison to handle floating-point representation
+        differences (e.g., values from single vs double precision sources).
+        """
+        # Normalize all zero values (both 0.0 and -0.0) to 0.0 so they are treated as duplicates
+        normalized = np.where(np.isclose(val, 0, atol=1e-10), 0.0, val)
+        unique_count = cls._count_unique_with_tolerance(normalized)
+        if unique_count < len(val):
+            log.warning(
+                "Duplicate voltage values detected in 'voltage' array. "
+                f"Found {len(val)} values but only {unique_count} are unique. "
+                "Note: values within floating-point tolerance are considered duplicates."
+            )
         return val
 
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added validation to `DCVoltageSource` that warns users when duplicate voltage values are detected in the `voltage` array. The implementation treats `0` and `-0` as the same value by normalizing zeros before checking for duplicates.

- Implemented `check_repeated_voltage` validator that normalizes zero values and uses `np.unique()` to detect duplicates
- Added comprehensive test coverage including edge cases for zero normalization and multiple duplicates
- Updated CHANGELOG.md with clear user-facing description of the new feature

**Note:** Previous thread comments identified a floating-point precision issue - the current implementation only normalizes zeros but uses direct equality for non-zero values via `np.unique()`, which may miss near-duplicate floating-point values like `1.0` and `1.0000000001`.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor style improvements recommended
- The implementation is functionally correct for the intended use case of detecting exact duplicates and normalizing zeros. Previous thread already identified the floating-point precision consideration for non-zero values. Test coverage is comprehensive. Only minor style improvement suggested for message formatting.
- Pay attention to `tidy3d/components/spice/sources/dc.py` regarding the floating-point comparison approach discussed in previous comments

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/components/spice/sources/dc.py | Added duplicate voltage validation with zero normalization. Previous thread identified floating-point precision issue that needs addressing. |
| tests/test_components/test_heat_charge.py | Comprehensive test coverage for duplicate voltage warning, including edge cases like 0/-0 and multiple duplicates. |
| CHANGELOG.md | Clear changelog entry in Added section describing the new validation feature. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant DCVoltageSource
    participant Validator
    participant numpy as NumPy
    participant Logger

    User->>DCVoltageSource: Create with voltage array
    DCVoltageSource->>Validator: @validator("voltage") check_voltage
    Validator->>Validator: Check for infinite values
    Validator-->>DCVoltageSource: Return validated values
    
    DCVoltageSource->>Validator: @validator("voltage") check_repeated_voltage
    Validator->>numpy: np.isclose(val, 0, atol=1e-10)
    numpy-->>Validator: Boolean mask for zeros
    Validator->>numpy: np.where(mask, 0.0, val)
    numpy-->>Validator: Normalized array (zeros unified)
    Validator->>numpy: np.unique(normalized)
    numpy-->>Validator: Unique values array
    Validator->>Validator: Compare len(unique_values) < len(val)
    alt Duplicates found
        Validator->>Logger: log.warning(duplicate message)
        Logger-->>User: Display warning
    end
    Validator-->>DCVoltageSource: Return original values
    DCVoltageSource-->>User: Instance created
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a tolerance-based warning for duplicate entries in `DCVoltageSource.voltage`, normalizing `0`/`-0` and logging a warning when repeats are detected.
> 
> - Adds `_count_unique_with_tolerance` and a `@validator` (`check_repeated_voltage`) in `dc.py` to detect near-duplicates via `np.isclose`, treating `0` and `-0` as the same
> - Extends tests with `test_repeated_voltage_warning` to assert warning behavior for unique values, exact duplicates, `0` vs `-0`, and multiple repeats
> - Updates `CHANGELOG.md` to document the new validation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80e8e39dcbb6f35fb215878c7cb0fdd360772f15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->