### PR TITLE
FXC-4570 feat(rf): Added `symmetric_pseudo` option for `s_param_def`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `ModeSortSpec.sort_key` is now required with a default of `"n_eff"` (previously optional with `None` default). `ModeSortSpec.sort_order` is now optional with a default of `None`, which automatically selects the natural order based on `sort_key` and `sort_reference`: ascending when a reference is provided (closest first), otherwise descending for `n_eff` and polarization fractions (higher values first), ascending for `k_eff` and `mode_area` (lower values first).
+- Added `symmetric_pseudo` option for `s_param_def` in `TerminalComponentModeler` which applies a scaling factor that ensures the S-matrix is symmetric in reciprocal systems.
 
 ### Fixed
 - Fixed intermittent "API key not found" errors in parallel job launches by making configuration directory detection race-safe.

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -18345,7 +18345,8 @@
       "default": "pseudo",
       "enum": [
         "power",
-        "pseudo"
+        "pseudo",
+        "symmetric_pseudo"
       ],
       "type": "string"
     },

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -121,7 +121,7 @@ def make_t_network_impedance_matrix(
     return np.array([[z11, z12], [z21, z22]])
 
 
-def calc_transmission_line_S_matrix_pseudo(Z0, Zref1, Zref2, gamma, length):
+def calc_transmission_line_S_matrix_pseudo(Z0, Zref1, Zref2, gamma, length, symmetric=False):
     """
     Calculate complete 2x2 S-parameter matrix for a transmission line
     using pseudo wave definition
@@ -141,6 +141,9 @@ def calc_transmission_line_S_matrix_pseudo(Z0, Zref1, Zref2, gamma, length):
         Propagation constant (can be frequency-dependent)
     length : float
         Length (scalar only)
+    symmetric : bool, optional
+        If True, use symmetric_pseudo scaling (F = 1/(2*sqrt(Z))) which ensures
+        S12 = S21 for reciprocal networks. Default is False.
 
     Returns:
     --------
@@ -163,17 +166,31 @@ def calc_transmission_line_S_matrix_pseudo(Z0, Zref1, Zref2, gamma, length):
     numerator_S22 = (Z0**2 - Zref1 * Zref2) * tanh_gamma_ell + Z0 * (Zref1 - Zref2)
     S22 = numerator_S22 / denom
 
-    # Calculate S21 (transmission from port 1 to port 2)
-    numerator_S21 = (
-        np.sqrt(np.real(Zref1) / np.real(Zref2)) * (np.abs(Zref2) / np.abs(Zref1)) * 2 * Z0 * Zref1
-    )
-    S21 = numerator_S21 / (denom * cosh_gamma_ell)
+    # Calculate S12 and S21 (off-diagonal transmission terms)
+    if symmetric:
+        # For symmetric_pseudo: F = 1/(2*sqrt(Z)), so F1/F2 = sqrt(Z2/Z1)
+        # This gives S12 = S21 for reciprocal networks
+        numerator_S12 = 2 * Z0 * np.sqrt(Zref1 * Zref2)
+        numerator_S21 = numerator_S12
+    else:
+        # For pseudo: F = sqrt(Re(Z))/(2|Z|)
+        numerator_S12 = (
+            np.sqrt(np.real(Zref1) / np.real(Zref2))
+            * (np.abs(Zref2) / np.abs(Zref1))
+            * 2
+            * Z0
+            * Zref1
+        )
+        numerator_S21 = (
+            np.sqrt(np.real(Zref2) / np.real(Zref1))
+            * (np.abs(Zref1) / np.abs(Zref2))
+            * 2
+            * Z0
+            * Zref2
+        )
 
-    # Calculate S12 (transmission from port 2 to port 1)
-    numerator_S12 = (
-        np.sqrt(np.real(Zref2) / np.real(Zref1)) * (np.abs(Zref1) / np.abs(Zref2)) * 2 * Z0 * Zref2
-    )
     S12 = numerator_S12 / (denom * cosh_gamma_ell)
+    S21 = numerator_S21 / (denom * cosh_gamma_ell)
 
     # Construct the S-parameter matrix (nfreq, 2, 2)
     nfreq = len(np.atleast_1d(S11))
@@ -434,6 +451,7 @@ def test_complex_reference_s_to_z_component_modeler():
     skrf_S_50ohm = skrf.Network.from_z(z=Z, f=freqs)
     skrf_S_power = skrf.Network.from_z(z=Z, f=freqs, s_def="power", z0=z0)
     skrf_S_pseudo = skrf.Network.from_z(z=Z, f=freqs, s_def="pseudo", z0=z0)
+    skrf_S_traveling = skrf.Network.from_z(z=Z, f=freqs, s_def="traveling", z0=z0)
 
     ports = ["port1", "port2"]
     smatrix = TerminalPortDataArray(
@@ -454,6 +472,14 @@ def test_complex_reference_s_to_z_component_modeler():
     smatrix.values = skrf_S_pseudo.s
     z_tidy3d = s_to_z(smatrix, reference=z0_tidy3d, s_param_def="pseudo")
     assert np.all(np.isclose(z_tidy3d.values, Z))
+    # Our symmetric_pseudo name is equivalent to "traveling" definition in scikit-rf
+    smatrix.values = skrf_S_traveling.s
+    z_tidy3d = s_to_z(smatrix, reference=z0_tidy3d, s_param_def="symmetric_pseudo")
+    assert np.all(np.isclose(z_tidy3d.values, Z))
+
+    # Check that invalid s_param_def raises ValueError
+    with pytest.raises(ValueError, match="Unsupported S-parameter definition"):
+        s_to_z(smatrix, reference=z0_tidy3d, s_param_def="invalid")
 
 
 def test_data_s_to_z(monkeypatch):
@@ -1428,23 +1454,41 @@ def test_internal_construct_smatrix_with_port_vi(monkeypatch):
     )
     Z0 = np.array(
         [
+            12.843105732941 + 15.394208173652j,
+            28.567192048123 + 9.1023847562915j,
+            31.209457618234 + 3.8475102934671j,
+        ]
+    )
+    Z01 = np.array(
+        [
             18.725191534567 + 12.672421364213j,
             34.038884625562 + 7.8654410284980j,
             35.725175635077 + 4.5490999181327j,
         ]
     )
+    Z02 = np.array(
+        [
+            24.156839210485 + 10.234195827361j,
+            41.892301567293 + 6.7812039451120j,
+            29.451276384019 + 5.1298475620183j,
+        ]
+    )
     # Break the reference impedance symmetry
-    Zref = np.column_stack((0.5 * Z0, 2 * Z0))
+    Zref = np.column_stack((Z01, Z02))
     # Calculate analytical S matrices for power and pseudo wave formulations
     S_pseudo = calc_transmission_line_S_matrix_pseudo(Z0, Zref[:, 0], Zref[:, 1], gamma, length)
+    S_symmetric_pseudo = calc_transmission_line_S_matrix_pseudo(
+        Z0, Zref[:, 0], Zref[:, 1], gamma, length, symmetric=True
+    )
     S_power = calc_transmission_line_S_matrix_power(Z0, Zref[:, 0], Zref[:, 1], gamma, length)
-
+    Zref3 = Zref[:, :, np.newaxis]
     # Calculate A and B matrices where A is diagonal and B = S @ A
+
     A = np.tile(np.eye(2), (len(freqs), 1, 1))  # Identity matrix for each frequency
     B = S_pseudo @ A
     # Now get Voltages and Currents at each port due to excitations from each port
-    Vscale = np.abs(Zref[:, :, np.newaxis]) / np.sqrt(np.real(Zref[:, :, np.newaxis]))
-    Iscale = Vscale / Zref[:, :, np.newaxis]
+    Vscale = np.abs(Zref3) / np.sqrt(np.real(Zref3))
+    Iscale = Vscale / Zref3
     voltages = Vscale * (A + B)  # (f x port_out x port_in)
     currents = Iscale * (A - B)  # (f x port_out x port_in)
 
@@ -1497,7 +1541,6 @@ def test_internal_construct_smatrix_with_port_vi(monkeypatch):
     )
 
     # Test the _internal_construct_smatrix method
-    S_computed = modeler_data.smatrix().data.values
 
     def check_S_matrix(S_computed, S_expected, tol=1e-12):
         # Check that S-matrix has correct shape
@@ -1519,11 +1562,20 @@ def test_internal_construct_smatrix_with_port_vi(monkeypatch):
             )
 
     # Check pseudo wave S matrix
+    S_computed = modeler_data.smatrix().data.values
     check_S_matrix(S_computed, S_pseudo)
 
     # Check power wave S matrix
     S_computed = modeler_data.smatrix(s_param_def="power").data.values
     check_S_matrix(S_computed, S_power)
+
+    # Check symmetric_pseudo wave S matrix
+    S_computed = modeler_data.smatrix(s_param_def="symmetric_pseudo").data.values
+    check_S_matrix(S_computed, S_symmetric_pseudo)
+
+    # Check that invalid s_param_def raises ValueError
+    with pytest.raises(ValueError, match="Unsupported S-parameter definition"):
+        modeler_data.smatrix(s_param_def="invalid")
 
 
 def test_wave_port_to_absorber(tmp_path):

--- a/tidy3d/plugins/smatrix/analysis/terminal.py
+++ b/tidy3d/plugins/smatrix/analysis/terminal.py
@@ -58,8 +58,8 @@ def terminal_construct_smatrix(
         waves at other ports. This simplifies the S-matrix calculation and is
         required if not all ports are excited. Default is ``False``.
     s_param_def : SParamDef, optional
-        The definition of S-parameters to use depends whether "pseudo waves"
-        or "power waves" are calculated. Default is "pseudo".
+        Wave definition: "pseudo", "power", or "symmetric_pseudo". Default is "pseudo".
+        See :class:`.TerminalComponentModeler` for details.
 
     Returns
     -------
@@ -73,8 +73,15 @@ def terminal_construct_smatrix(
 
     if s_param_def == "pseudo":
         a_matrix, b_matrix = modeler_data.port_pseudo_wave_matrices
-    else:
+    elif s_param_def == "symmetric_pseudo":
+        a_matrix, b_matrix = modeler_data.port_symmetric_pseudo_wave_matrices
+    elif s_param_def == "power":
         a_matrix, b_matrix = modeler_data.port_power_wave_matrices
+    else:
+        raise ValueError(
+            f"Unsupported S-parameter definition '{s_param_def}'. "
+            "Supported values are 'pseudo', 'symmetric_pseudo', and 'power'."
+        )
 
     # If excitation is assumed ideal, a_matrix is assumed to be diagonal
     # and the explicit inverse can be avoided. When only a subset of excitations
@@ -225,10 +232,6 @@ def _compute_wave_amplitudes_from_VI(
     specified wave definition. The conversion handles impedance sign consistency and
     applies the appropriate normalization based on the chosen S-parameter definition.
 
-    The wave amplitudes are computed using:
-    - Pseudo waves: Equations 53-54 from Marks and Williams [1]
-    - Power waves: Equation 4.67 from Pozar [2]
-
     Parameters
     ----------
     port_reference_impedances : :class:`.PortDataArray`
@@ -238,8 +241,8 @@ def _compute_wave_amplitudes_from_VI(
     port_currents : :class:`.PortDataArray`
         Current values at each port with dimensions (f, port).
     s_param_def : SParamDef, optional
-        Wave definition type: "pseudo" for pseudo waves or "power" for power waves.
-        Defaults to "pseudo".
+        Wave definition: "pseudo", "power", or "symmetric_pseudo". Default is "pseudo".
+        See :class:`.TerminalComponentModeler` for details.
 
     Returns
     -------
@@ -295,8 +298,8 @@ def compute_wave_amplitudes_at_each_port(
     sim_data : :class:`.SimulationData`
         Results from a single simulation run.
     s_param_def : SParamDef
-        The type of waves computed, either pseudo waves defined by Equation 53 and
-        Equation 54 in [1], or power waves defined by Equation 4.67 in [2].
+        Wave definition: "pseudo", "power", or "symmetric_pseudo".
+        See :class:`.TerminalComponentModeler` for details.
 
     Returns
     -------

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -141,6 +141,25 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
     Notes
     -----
 
+    **S-Parameter Definitions**
+
+    The ``s_param_def`` parameter controls which wave definition is used to compute scattering
+    parameters. Three definitions are supported:
+
+    - ``"pseudo"`` (default): Pseudo-waves as defined by Marks and Williams [1]. Uses scaling
+      factor :math:`F = \\sqrt{\\text{Re}(Z)} / (2|Z|)`. Wave amplitudes are :math:`a = F(V + ZI)`
+      and :math:`b = F(V - ZI)`.
+
+    - ``"power"``: Power waves as defined by Kurokawa [3] and described in Pozar [2]. Uses
+      scaling factor :math:`F = 1 / (2\\sqrt{\\text{Re}(Z)})`. Wave amplitudes are
+      :math:`a = F(V + ZI)` and :math:`b = F(V - Z^*I)` where :math:`Z^*` is the complex
+      conjugate. Ensures :math:`|a|^2 - |b|^2` represents actual power flow.
+
+    - ``"symmetric_pseudo"``: Equivalent to pseudo-waves except for the scaling factor. Uses
+      :math:`F = 1 / (2\\sqrt{Z})` where the square root is complex. This choice of scaling
+      factor ensures the S-matrix will be symmetric when the simulated device is reciprocal.
+
+
     **References**
 
     .. [1]  R. B. Marks and D. F. Williams, "A general waveguide circuit theory,"
@@ -148,6 +167,9 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
 
     .. [2]  D. M. Pozar, Microwave Engineering, 4th ed. Hoboken, NJ, USA:
             John Wiley & Sons, 2012.
+
+    .. [3]  K. Kurokawa, "Power Waves and the Scattering Matrix," IEEE Trans.
+            Microwave Theory Tech., vol. 13, no. 2, pp. 194-202, March 1965.
     """
 
     ports: tuple[TerminalPortType, ...] = pd.Field(
@@ -200,7 +222,7 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
     s_param_def: SParamDef = pd.Field(
         "pseudo",
         title="Scattering Parameter Definition",
-        description="Whether to compute scattering parameters using the 'pseudo' or 'power' wave definitions.",
+        description="Wave definition: 'pseudo', 'power', or 'symmetric_pseudo'. Default is 'pseudo'.",
     )
 
     low_freq_smoothing: Optional[ModelerLowFrequencySmoothingSpec] = pd.Field(

--- a/tidy3d/plugins/smatrix/data/terminal.py
+++ b/tidy3d/plugins/smatrix/data/terminal.py
@@ -52,7 +52,7 @@ class MicrowaveSMatrixData(MicrowaveBaseModel):
     s_param_def: SParamDef = pd.Field(
         "pseudo",
         title="Scattering Parameter Definition",
-        description="Whether scattering parameters are defined using the 'pseudo' or 'power' wave definitions.",
+        description="Wave definition: 'pseudo', 'power', or 'symmetric_pseudo'.",
     )
 
 
@@ -68,6 +68,25 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
     with the original simulation definition, and port simulation data, and the solver log.
 
 
+    **S-Parameter Definitions**
+
+    The ``s_param_def`` parameter controls which wave definition is used to compute scattering
+    parameters. Three definitions are supported:
+
+    - ``"pseudo"`` (default): Pseudo-waves as defined by Marks and Williams [1]. Uses scaling
+      factor :math:`F = \\sqrt{\\text{Re}(Z)} / (2|Z|)`. Wave amplitudes are :math:`a = F(V + ZI)`
+      and :math:`b = F(V - ZI)`.
+
+    - ``"power"``: Power waves as defined by Kurokawa [3] and described in Pozar [2]. Uses
+      scaling factor :math:`F = 1 / (2\\sqrt{\\text{Re}(Z)})`. Wave amplitudes are
+      :math:`a = F(V + ZI)` and :math:`b = F(V - Z^*I)` where :math:`Z^*` is the complex
+      conjugate. Ensures :math:`|a|^2 - |b|^2` represents actual power flow.
+
+    - ``"symmetric_pseudo"``: Equivalent to pseudo-waves except for the scaling factor. Uses
+      :math:`F = 1 / (2\\sqrt{Z})` where the square root is complex. This choice of scaling
+      factor ensures the S-matrix will be symmetric when the simulated device is reciprocal.
+
+
     **References**
 
     .. [1]  R. B. Marks and D. F. Williams, "A general waveguide circuit theory,"
@@ -75,6 +94,9 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
 
     .. [2]  D. M. Pozar, Microwave Engineering, 4th ed. Hoboken, NJ, USA:
             John Wiley & Sons, 2012.
+
+    .. [3]  K. Kurokawa, "Power Waves and the Scattering Matrix," IEEE Trans.
+            Microwave Theory Tech., vol. 13, no. 2, pp. 194-202, March 1965.
     """
 
     modeler: TerminalComponentModeler = pd.Field(
@@ -97,9 +119,9 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
             does not produce incident waves at other ports. This simplifies the
             S-matrix calculation and is required if not all ports are excited. If not
             provided, ``modeler.assume_ideal_excitation`` is used.
-        s_param_def: The definition of S-parameters to use, determining whether
-            "pseudo waves" or "power waves" are calculated. If not provided,
-            ``modeler.s_param_def`` is used.
+        s_param_def: Wave definition: "pseudo", "power", or "symmetric_pseudo".
+            If not provided, ``modeler.s_param_def`` is used.
+            See :class:`.TerminalComponentModeler` for details.
 
         Returns
         -------
@@ -348,8 +370,8 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
             Reference impedance at each port. If not provided, it is computed from the cached
             property :meth:`.port_reference_impedances`. Defaults to ``None``.
         s_param_def : SParamDef
-            The type of waves computed, either pseudo waves defined by Equation 53 and Equation 54 in [1],
-            or power waves defined by Equation 4.67 in [2].
+            Wave definition: "pseudo", "power", or "symmetric_pseudo".
+            See :class:`.TerminalComponentModeler` for details.
 
         Returns
         -------
@@ -425,9 +447,8 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
             S-matrix calculation and is required if not all ports are excited. If not
             provided, ``modeler.assume_ideal_excitation`` is used.
         s_param_def : SParamDef, optional
-            The definition of the scattering parameters used in the S-matrix calculation.
-            This can be either "pseudo" for pseudo waves (see [1]) or "power" for power
-            waves (see [2]). Defaults to "pseudo".
+            Wave definition: "pseudo", "power", or "symmetric_pseudo". Default is "pseudo".
+            See :class:`.TerminalComponentModeler` for details.
 
         Returns
         -------
@@ -512,8 +533,8 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
         Parameters
         ----------
         s_param_def : SParamDef, optional
-            The type of waves to compute, either "pseudo" waves (Equation 53-54 in [1]) or
-            "power" waves (Equation 4.67 in [2]). Defaults to "pseudo".
+            Wave definition: "pseudo", "power", or "symmetric_pseudo". Default is "pseudo".
+            See :class:`.TerminalComponentModeler` for details.
 
         Returns
         -------
@@ -576,6 +597,25 @@ class TerminalComponentModelerData(AbstractComponentModelerData, MicrowaveBaseMo
             the power-wave amplitudes at each output port due to excitation at each input port.
         """
         return self.compute_port_wave_amplitude_matrices(s_param_def="power")
+
+    @cached_property
+    def port_symmetric_pseudo_wave_matrices(
+        self,
+    ) -> tuple[TerminalPortDataArray, TerminalPortDataArray]:
+        """Compute symmetric-pseudo wave amplitude matrices for all port combinations.
+
+        This method returns the incident (a) and reflected (b) symmetric-pseudo wave amplitude
+        matrices. These are equivalent to pseudo-waves except for the scaling factor, which
+        ensures the S-matrix will be symmetric when the simulated device is reciprocal.
+
+        Returns
+        -------
+        tuple[:class:`.TerminalPortDataArray`, :class:`.TerminalPortDataArray`]
+            A tuple containing the incident (a) and reflected (b) symmetric-pseudo wave
+            amplitude matrices. Each matrix has dimensions (f, port_out, port_in) representing
+            the wave amplitudes at each output port due to excitation at each input port.
+        """
+        return self.compute_port_wave_amplitude_matrices(s_param_def="symmetric_pseudo")
 
     # Mirror Utils
     # So they can be reused elsewhere without a class reimport

--- a/tidy3d/plugins/smatrix/types.py
+++ b/tidy3d/plugins/smatrix/types.py
@@ -11,6 +11,10 @@ Element = tuple[MatrixIndex, MatrixIndex]  # the 'ij' in S_ij
 NetworkIndex = str  # the 'i' in S_ij
 NetworkElement = tuple[NetworkIndex, NetworkIndex]  # the 'ij' in S_ij
 
-# The definition of wave amplitudes used to construct the scattering matrix
-# in the TerminalComponentModeler
-SParamDef = Literal["pseudo", "power"]
+# The wave definition used to construct the scattering matrix in the TerminalComponentModeler.
+# See the TerminalComponentModeler and TerminalComponentModelerData docstrings for details.
+SParamDef = Literal[
+    "pseudo",
+    "power",
+    "symmetric_pseudo",
+]

--- a/tidy3d/plugins/smatrix/utils.py
+++ b/tidy3d/plugins/smatrix/utils.py
@@ -107,22 +107,19 @@ def check_port_impedance_sign(Z_numpy: np.ndarray) -> None:
 
 def compute_F(Z_numpy: ArrayFloat1D, s_param_def: SParamDef = "pseudo"):
     r"""Helper to convert port impedance matrix to F, which is used for
-    computing scattering parameters
+    computing scattering parameters and represents the scaling factor
+    applied to forward and backward waves.
 
     The matrix F is used when converting between S and Z parameters for circuits
-    with differing port impedances. Its diagonal elements are defined as
-
-    .. math::
-
-        F_{kk} = 1 / (2 * \sqrt{Re(Z_k)})
-
+    with differing port impedances.
 
     Parameters
     ----------
     Z_numpy : ArrayFloat1D
         NumPy array of complex port impedances.
     s_param_def : SParamDef, optional
-        The type of wave amplitudes, by default "pseudo".
+        Wave definition: "pseudo", "power", or "symmetric_pseudo". Default is "pseudo".
+        See :class:`.TerminalComponentModeler` for details.
 
     Returns
     -------
@@ -132,8 +129,16 @@ def compute_F(Z_numpy: ArrayFloat1D, s_param_def: SParamDef = "pseudo"):
     # Defined in [2] after equation 4.67
     if s_param_def == "power":
         return 1.0 / (2.0 * np.sqrt(np.real(Z_numpy)))
-    # Equation 75 from [1]
-    return np.sqrt(np.real(Z_numpy)) / (2.0 * np.abs(Z_numpy))
+    elif s_param_def == "pseudo":
+        # Equation 75 from [1]
+        return np.sqrt(np.real(Z_numpy)) / (2.0 * np.abs(Z_numpy))
+    elif s_param_def == "symmetric_pseudo":
+        return 1.0 / (2.0 * np.sqrt(Z_numpy))
+    else:
+        raise ValueError(
+            f"Unsupported S-parameter definition '{s_param_def}'. "
+            "Supported values are 'pseudo', 'symmetric_pseudo', and 'power'."
+        )
 
 
 def compute_port_VI(
@@ -231,9 +236,8 @@ def s_to_z(
     reference : Union[complex, :class:`.PortDataArray`]
         The reference impedance used at each port.
     s_param_def : SParamDef, optional
-        The type of wave amplitudes used for computing the scattering matrix, either pseudo waves
-        defined by Equation 53 and Equation 54 in [1] or power waves defined by Equation 4.67 in [2].
-        By default "pseudo".
+        Wave definition: "pseudo", "power", or "symmetric_pseudo". Default is "pseudo".
+        See :class:`.TerminalComponentModeler` for details.
 
     Returns
     -------
@@ -269,7 +273,7 @@ def s_to_z(
     # Use conjugate when S matrix is power-wave based
     if s_param_def == "power":
         Zport_mod = np.conj(Zport)
-    else:
+    else:  # both pseudo and symmetric pseudo use this
         Zport_mod = Zport
 
     # From equation 74 from [1] for pseudo waves


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds a new `symmetric_pseudo` option for `s_param_def` in `TerminalComponentModeler`, which provides an alternative S-parameter formulation equivalent to the "traveling wave" definition in scikit-rf. The implementation applies a different scaling factor (`F = sqrt(1/(2*Z))`) that ensures the resulting S-matrix is symmetric when port impedances differ.

Key changes:
- Extended `SParamDef` type to include `symmetric_pseudo` as a valid literal value
- Modified `compute_F()` to handle the new symmetric_pseudo scaling with proper mathematical documentation
- Updated `terminal_construct_smatrix()` to route `symmetric_pseudo` requests to pseudo wave matrices (reusing existing infrastructure)
- Added comprehensive error handling with consistent error messages across all modified functions
- Extended `s_to_z()` conversion logic to properly handle symmetric_pseudo (treating it like pseudo for conjugate handling)
- Added test coverage validating symmetric_pseudo against scikit-rf's "traveling" wave definition

Issues found:
- Test file contains debugging `print()` statements that should be removed
- Some test assertions are commented out and need to be either removed or uncommented and fixed

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge after removing debugging code
- The implementation is mathematically sound and follows established patterns in the codebase. Error handling is consistent and comprehensive. The only issues are temporary debugging artifacts (print statements and commented-out tests) that should be cleaned up before merge.
- tests/test_plugins/smatrix/test_terminal_component_modeler.py needs cleanup of debugging code

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/plugins/smatrix/utils.py | implemented symmetric_pseudo scaling in `compute_F()` with proper documentation and error handling |
| tidy3d/plugins/smatrix/analysis/terminal.py | added symmetric_pseudo case to `terminal_construct_smatrix()` with proper error handling |
| tests/test_plugins/smatrix/test_terminal_component_modeler.py | added tests for symmetric_pseudo but contains debugging print statements and commented-out assertions that need cleanup |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ModelerData as TerminalComponentModelerData
    participant Constructor as terminal_construct_smatrix
    participant Utils as utils.compute_F
    participant S2Z as utils.s_to_z

    User->>ModelerData: smatrix(s_param_def="symmetric_pseudo")
    ModelerData->>Constructor: terminal_construct_smatrix(s_param_def="symmetric_pseudo")
    
    alt symmetric_pseudo
        Constructor->>ModelerData: get port_pseudo_wave_matrices
        Note over Constructor: Reuses pseudo wave matrices<br/>with different scaling
    else power
        Constructor->>ModelerData: get port_power_wave_matrices
    else pseudo
        Constructor->>ModelerData: get port_pseudo_wave_matrices
    end
    
    ModelerData-->>Constructor: a_matrix, b_matrix
    Constructor->>Constructor: compute S = b @ inv(a)
    Constructor-->>ModelerData: S-matrix
    ModelerData-->>User: MicrowaveSMatrixData
    
    opt Convert to Z-matrix
        User->>ModelerData: s_to_z(s_param_def="symmetric_pseudo")
        ModelerData->>S2Z: s_to_z(S, reference, s_param_def)
        S2Z->>Utils: compute_F(Z, "symmetric_pseudo")
        Utils-->>S2Z: F = sqrt(1/(2*Z))
        Note over S2Z: Uses non-conjugate Zport<br/>(same as pseudo)
        S2Z->>S2Z: Z = solve(I - F^-1*S*F, ...)
        S2Z-->>ModelerData: Z-matrix
        ModelerData-->>User: Impedance matrix
    end
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Remove temporary debugging code (print() calls), commented-out code, and other workarounds before fi... ([source](https://app.greptile.com/review/custom-context?memory=f6a669d8-0060-4f11-9cac-10ac7ee749ea))

<!-- /greptile_comment -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new S-parameter wave definition `"symmetric_pseudo"` (equivalent to scikit-rf "traveling") that uses scaling `F = 1/(2*sqrt(Z))` to yield symmetric S-matrices for reciprocal networks.
> 
> - Extend `SParamDef` and schema to include `"symmetric_pseudo"`; update error handling for invalid `s_param_def`
> - Implement scaling in `compute_F()` and propagate through wave conversions and S-matrix construction (`terminal_construct_smatrix`); add `port_symmetric_pseudo_wave_matrices`
> - Update `s_to_z()` to support `symmetric_pseudo` (conjugation handling like `pseudo`)
> - Enhance docs/comments across modeler/data APIs and add CHANGELOG entry
> - Expand tests: transmission-line analytic helper now supports symmetric mode; verify equivalence with scikit-rf `s_def="traveling"`; add invalid option checks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e20d4f60b157da789676c1d1b7b81c72aebbcad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->