### PR TITLE
fix(tidy3d): FXC-4644-tidy-3-d-client-add-support-for-num-py-2-4-0

### DIFF
--- a/tests/test_components/test_mode_interp.py
+++ b/tests/test_components/test_mode_interp.py
@@ -620,12 +620,10 @@ def test_mode_solver_data_interp_single_frequency():
         field_data = getattr(data_interp, field_name)
         assert field_data is not None
         assert field_data.coords["f"].size == 1
-        assert float(field_data.coords["f"]) == 1.5e14
+        assert float(field_data.coords["f"].item()) == 1.5e14
 
     # Check n_group_raw and dispersion_raw if present
     if data_interp.n_group_raw is not None:
-        print(data_interp.n_group_raw.shape)
-        print((1, original_num_modes))
         assert data_interp.n_group_raw.shape == (1, original_num_modes)
     if data_interp.dispersion_raw is not None:
         assert data_interp.dispersion_raw.shape == (1, original_num_modes)

--- a/tests/test_plugins/autograd/test_functions.py
+++ b/tests/test_plugins/autograd/test_functions.py
@@ -9,6 +9,7 @@ from autograd import grad
 from autograd.test_util import check_grads
 from scipy.signal import convolve as convolve_sp
 
+from tidy3d.compat import np_trapezoid
 from tidy3d.plugins.autograd import (
     add_at,
     convolve,
@@ -552,7 +553,7 @@ class TestTrapz:
         """Test trapz values against NumPy for different array dimensions and integration axes."""
         y, x, dx = self.generate_y_x_dx(rng, shape, use_x)
         result_custom = trapz(y, x=x, dx=dx, axis=axis)
-        result_numpy = np.trapz(y, x=x, dx=dx, axis=axis)
+        result_numpy = np_trapezoid(y, x=x, dx=dx, axis=axis)
         npt.assert_allclose(result_custom, result_numpy)
 
     def test_trapz_grad(self, rng, shape, axis, use_x):

--- a/tidy3d/compat.py
+++ b/tidy3d/compat.py
@@ -12,10 +12,15 @@ try:
 except ImportError:
     from xarray.core import alignment
 
+try:
+    from numpy import trapezoid as np_trapezoid
+except ImportError:  # NumPy < 2.0
+    from numpy import trapz as np_trapezoid
+
 
 @functools.lru_cache(maxsize=8)
 def _shapely_is_older_than(version: str) -> bool:
     return parse_version(importlib.metadata.version("shapely")) < parse_version(version)
 
 
-__all__ = ["alignment"]
+__all__ = ["alignment", "np_trapezoid"]

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -12,7 +12,8 @@ from functools import wraps
 from math import ceil
 from os import PathLike
 from pathlib import Path
-from typing import Any, Callable, Literal, Optional, Union
+from types import UnionType
+from typing import Any, Callable, Literal, Optional, Union, get_args, get_origin
 
 import h5py
 import numpy as np
@@ -160,6 +161,21 @@ def skip_if_fields_missing(fields: list[str], root=False):
     return actual_decorator
 
 
+def field_allows_scalar(field: ModelField) -> bool:
+    annotation = field.outer_type_
+
+    def allows_scalar(a: Any) -> bool:
+        origin = get_origin(a)
+        if origin in (Union, UnionType):
+            args = (arg for arg in get_args(a) if arg is not type(None))
+            return any(allows_scalar(arg) for arg in args)
+        if origin is not None:
+            return False
+        return isinstance(a, type) and issubclass(a, (float, int, np.generic))
+
+    return allows_scalar(annotation)
+
+
 class Tidy3dBaseModel(pydantic.BaseModel):
     """Base pydantic model that all Tidy3d components inherit from.
     Defines configuration for handling data structures
@@ -187,6 +203,20 @@ class Tidy3dBaseModel(pydantic.BaseModel):
         super().__init__(**kwargs)
         self._post_init_validators()
         log.end_capture(self)
+
+    @pydantic.validator("*", pre=True, allow_reuse=True)
+    def coerce_numpy_scalars_for_model(cls, v: Any, field: ModelField) -> Any:
+        """
+        Wildcard field validator: coerce numpy scalars / size-1 arrays to native Python
+        scalars, but only for fields whose annotations allow scalars.
+        """
+        if not field_allows_scalar(field):
+            return v
+
+        if isinstance(v, np.generic) or (isinstance(v, np.ndarray) and v.size == 1):
+            return v.item()
+
+        return v
 
     def _post_init_validators(self) -> None:
         """Call validators taking ``self`` that get run after init, implement in subclasses."""

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -3544,13 +3544,11 @@ class GeometryGroup(Geometry):
 
     def _volume(self, bounds: Bound) -> float:
         """Returns object's volume within given bounds."""
-        individual_volumes = (geometry.volume(bounds) for geometry in self.geometries)
-        return np.sum(individual_volumes)
+        return sum(geometry.volume(bounds) for geometry in self.geometries)
 
     def _surface_area(self, bounds: Bound) -> float:
         """Returns object's surface area within given bounds."""
-        individual_areas = (geometry.surface_area(bounds) for geometry in self.geometries)
-        return np.sum(individual_areas)
+        return sum(geometry.surface_area(bounds) for geometry in self.geometries)
 
     @cached_property
     def _normal_2dmaterial(self) -> Axis:

--- a/tidy3d/components/geometry/utils.py
+++ b/tidy3d/components/geometry/utils.py
@@ -736,7 +736,7 @@ def _shift_value_signed(
 
     # get the index of the grid cell where the obj lies
     obj_position = obj.center[normal_axis]
-    obj_pos_gt_grid_bounds = np.argwhere(obj_position > grid_boundaries)
+    obj_pos_gt_grid_bounds = np.flatnonzero(obj_position > grid_boundaries)
 
     # no obj index can be determined
     if len(obj_pos_gt_grid_bounds) == 0 or obj_position > grid_boundaries[-1]:

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -3236,7 +3236,7 @@ class PoleResidue(DispersiveMedium):
         for freq in freqs:
             dJ_deps_complex_f = dJ_deps_complex.sel(f=freq)
             vjps_f = self._get_vjps_from_params(
-                dJ_deps_complex=complex(dJ_deps_complex_f),
+                dJ_deps_complex=complex(dJ_deps_complex_f.item()),
                 poles_vals=poles_vals,
                 omega=2 * np.pi * freq,
                 requested_paths=derivative_info.paths,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added support for NumPy 2.4.0 by addressing breaking changes in scalar handling, array indexing, and deprecated functions.

**Key Changes:**
- Added automatic numpy scalar coercion in `Tidy3dBaseModel` via root validator to convert `np.generic` and 0-d arrays to Python scalars
- Replaced `np.sum()` with built-in `sum()` for generator expressions to avoid numpy scalar issues
- Fixed `np.argwhere()` calls to explicitly extract first column (`[:, 0]`) since numpy 2.4.0 always returns 2D arrays
- Added `.item()` calls before `float()`/`complex()` conversions of xarray coordinates
- Added compatibility shim for `np.trapezoid` (numpy ≥2.0) vs `np.trapz` (numpy <2.0)
- Updated imports: moved `Callable` to `collections.abc` and `Self` to `typing` module

**Issues Found:**
- Two similar locations (`tidy3d/components/data/sim_data.py:649` and `tidy3d/components/tcad/data/sim_data.py:436`) still use `float(field_data.coords[...])` without `.item()` and will fail with numpy 2.4.0

<h3>Confidence Score: 3/5</h3>


- This PR has critical gaps - two runtime errors remain unfixed that will fail with numpy 2.4.0
- The PR makes good progress on numpy 2.4.0 compatibility with thoughtful changes including a root validator for automatic scalar coercion. However, two identical issues were missed in `sim_data.py` files that use the same pattern (`float(coords[...])`) fixed elsewhere. These will cause runtime failures with numpy 2.4.0, making the compatibility incomplete.
- Pay close attention to `tidy3d/components/data/sim_data.py` and `tidy3d/components/tcad/data/sim_data.py` - both have missing `.item()` calls that will cause runtime failures

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/components/base.py | Added numpy scalar coercion via root validator to handle numpy 2.4.0 changes; moved `Callable` import to `collections.abc` and `Self` to `typing` |
| tidy3d/components/geometry/utils.py | Added `[:, 0]` indexing to extract first column from `np.argwhere` result for numpy 2.4.0 compatibility |
| tidy3d/components/data/sim_data.py | Missing `.item()` call when converting xarray coordinate to float - will fail with numpy 2.4.0 |
| tidy3d/components/tcad/data/sim_data.py | Missing `.item()` call when converting xarray coordinate to float - will fail with numpy 2.4.0 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as User Code
    participant Base as Tidy3dBaseModel
    participant Geom as GeometryGroup
    participant Utils as geometry/utils
    participant XArray as xarray Coords
    participant NumPy as NumPy 2.4.0

    Note over NumPy: NumPy 2.4.0 changes:<br/>- Scalars no longer cast implicitly<br/>- argwhere returns 2D array<br/>- trapz renamed to trapezoid

    User->>Base: Create model with numpy scalar
    Base->>Base: _coerce_numpy_scalars (root validator)
    Base->>NumPy: Check if np.generic or 0-d array
    NumPy-->>Base: Return numpy scalar type
    Base->>Base: Call .item() to extract Python scalar
    Base-->>User: Model created with Python scalars

    User->>Geom: Calculate volume/surface_area
    Geom->>Geom: Use sum() instead of np.sum()
    Note over Geom: Built-in sum() works with<br/>generators, avoids numpy issues
    Geom-->>User: Return calculated value

    User->>Utils: _shift_value_signed
    Utils->>NumPy: np.argwhere(condition)
    NumPy-->>Utils: 2D array [[idx], ...]
    Utils->>Utils: Extract [:, 0] to get 1D array
    Utils-->>User: Return correct indices

    User->>XArray: Access xarray coordinate
    XArray-->>User: Returns numpy scalar (2.4.0)
    User->>User: Call .item() before float()/complex()
    User-->>User: Correctly converted to Python type
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves compatibility with NumPy ≥2.0 (incl. 2.4) and cleans up scalar/array handling.
> 
> - **Model scalar coercion:** Add wildcard validator in `Tidy3dBaseModel` to coerce NumPy scalars/size-1 arrays to Python scalars when the field allows (`field_allows_scalar`).
> - **Integration shim:** Introduce `tidy3d.compat.np_trapezoid` (maps to `numpy.trapezoid` or `numpy.trapz`) and update tests to use it.
> - **Indexing fix:** Replace `np.argwhere(...)` with `np.flatnonzero(...)` in `geometry/utils.py` to avoid 2D return semantics.
> - **Generator reductions:** Use built-in `sum()` for volume/surface-area aggregations in `geometry/base.py`.
> - **Scalar extraction:** Add `.item()` before `float()/complex()` conversions where needed (tests and `components/medium.py`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bf715a5e7a6e756f81291930439fb113a7112da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->