### PR TITLE
fix(rf): validate auto path integrals against all conductors and the mode plane bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Fixed `AutoImpedanceSpec` validation to check path intersections against all conductors, not just filtered ones, as well as the mode plane bounds.
 
 ## [2.10.0] - 2025-12-18
 

--- a/tests/test_components/test_microwave.py
+++ b/tests/test_components/test_microwave.py
@@ -708,6 +708,87 @@ def test_mode_plane_analyzer_errors():
         )
 
 
+@pytest.mark.parametrize("include_ground_plane", [True, False])
+def test_mode_plane_analyzer_coarse_grid_errors(include_ground_plane):
+    """Test that coarse grids produce appropriate errors for auto path generation.
+
+    With a coarse grid the snapped bounding box around the signal trace can:
+    - intersect other conductors,
+    - extend outside the mode plane bounds which is beyond the domain of the monitor data.
+    """
+    width = 3 * mm
+    metal_thickness = 0.1 * mm
+    coarse_dl = 1.0 * mm
+
+    sim_size = (10 * mm, 10 * mm, 10 * mm)
+    sim_center = (0, 0, sim_size[2] / 2)
+
+    # Signal trace near bottom of mode plane
+    signal_trace = td.Structure(
+        geometry=td.Box(
+            center=(0, 0, 0.3 * mm),
+            size=(td.inf, width, metal_thickness),
+        ),
+        medium=td.PEC,
+    )
+
+    structures = [signal_trace]
+
+    if include_ground_plane:
+        # Ground plane at z=0, extending infinitely in y to touch mode plane y-boundaries
+        # This will be filtered out, but should still be checked for path intersections
+        ground_plane = td.Structure(
+            geometry=td.Box(
+                center=(0, 0, 0),
+                size=(td.inf, td.inf, metal_thickness),
+            ),
+            medium=td.PEC,
+        )
+        structures.append(ground_plane)
+        # Mode plane spans full simulation for ground plane case
+        mode_plane_size = (0, sim_size[1], sim_size[2])
+        mode_plane_center = (0, 0, sim_center[2])
+    else:
+        # Small mode plane that doesn't span full sim, so bounding box extends outside
+        mode_plane_size = (0, sim_size[1], 1.0 * mm)
+        mode_plane_center = (0, 0, 0.5 * mm)
+
+    sim = td.Simulation(
+        center=sim_center,
+        size=sim_size,
+        grid_spec=td.GridSpec.uniform(dl=coarse_dl),
+        structures=structures,
+        sources=[],
+        run_time=1e-12,
+    )
+
+    mode_plane = td.Box(center=mode_plane_center, size=mode_plane_size)
+    path_spec_gen = ModePlaneAnalyzer(
+        center=mode_plane.center,
+        size=mode_plane.size,
+        field_data_colocated=False,
+    )
+
+    if include_ground_plane:
+        # Should raise SetupError because auto-generated path intersects the ground plane
+        with pytest.raises(SetupError, match="intersect with a conductor"):
+            path_spec_gen.get_conductor_bounding_boxes(
+                sim.structures,
+                sim.grid,
+                sim.symmetry,
+                sim.bounding_box,
+            )
+    else:
+        # Should raise SetupError because bounding box extends outside mode plane
+        with pytest.raises(SetupError, match="extends outside the mode solving plane"):
+            path_spec_gen.get_conductor_bounding_boxes(
+                sim.structures,
+                sim.grid,
+                sim.symmetry,
+                sim.bounding_box,
+            )
+
+
 @pytest.mark.parametrize("colocate", [False, True])
 @pytest.mark.parametrize("tline_type", ["microstrip", "cpw", "coax"])
 def test_mode_plane_analyzer_canonical_shapes(colocate, tline_type):

--- a/tidy3d/components/microwave/path_integrals/mode_plane_analyzer.py
+++ b/tidy3d/components/microwave/path_integrals/mode_plane_analyzer.py
@@ -209,13 +209,15 @@ class ModePlaneAnalyzer(Box):
         min_b_3d, max_b_3d = self._get_mode_limits(grid, mode_symmetry_3d)
 
         intersection_plane = Box.from_bounds(min_b_3d, max_b_3d)
-        conductor_shapely = self._get_isolated_conductors_as_shapely(intersection_plane, structures)
-
-        conductor_shapely = self._filter_conductors_touching_sim_bounds(
-            (min_b_3d, max_b_3d), mode_symmetry_3d, conductor_shapely
+        isolated_conductor_shapely = self._get_isolated_conductors_as_shapely(
+            intersection_plane, structures
         )
 
-        if len(conductor_shapely) < 1:
+        filtered_conductor_shapely = self._filter_conductors_touching_sim_bounds(
+            (min_b_3d, max_b_3d), mode_symmetry_3d, isolated_conductor_shapely
+        )
+
+        if len(filtered_conductor_shapely) < 1:
             raise SetupError(
                 "No valid isolated conductors were found in the mode plane. Please ensure that a 'Structure' "
                 "with a medium of type 'PEC' or 'LossyMetalMedium' intersects the mode plane and is not touching "
@@ -228,15 +230,16 @@ class ModePlaneAnalyzer(Box):
         snap_spec = self._snap_spec
 
         bounding_boxes = []
-        for shape in conductor_shapely:
+        for shape in filtered_conductor_shapely:
             box = bounding_box_from_shapely(shape)
             boxes = self._apply_symmetries(symmetry, sim_box.center, box)
             for box in boxes:
                 box_snapped = snap_box_to_grid(grid, box, snap_spec)
                 bounding_boxes.append(box_snapped)
 
+        # TODO Improve these checks once FXC-4112-PEC-boundary-position-not-respected-by-ModeSolver is merged
         for bounding_box in bounding_boxes:
-            if self._check_box_intersects_with_conductors(conductor_shapely, bounding_box):
+            if self._check_box_intersects_with_conductors(isolated_conductor_shapely, bounding_box):
                 raise SetupError(
                     "Failed to automatically generate path specification because a generated path "
                     "specification was found to intersect with a conductor. There is currently limited "
@@ -244,7 +247,24 @@ class ModePlaneAnalyzer(Box):
                     "path specification through a 'CustomImpedanceSpec'. Alternatively, enforce a "
                     "smaller grid around the conductors in the mode plane, which may resolve the issue."
                 )
-        return bounding_boxes, conductor_shapely
+
+        # Check that bounding boxes don't extend outside the original mode plane bounds
+        mode_plane_min, mode_plane_max = self.bounds
+        for bounding_box in bounding_boxes:
+            box_min, box_max = bounding_box.bounds
+            if any(box_min[i] < mode_plane_min[i] for i in range(3)) or any(
+                box_max[i] > mode_plane_max[i] for i in range(3)
+            ):
+                raise SetupError(
+                    "Failed to automatically generate path specification because a generated path "
+                    "specification extends outside the mode solving plane bounds. This issue can be fixed "
+                    "by enlarging the mode solving plane and ensuring that there is a buffer of at "
+                    "least 2 grid cells between the mode solving plane bounds and the nearest conductors."
+                    "Alternatively, enforce a smaller grid around the conductors in the mode plane, "
+                    "which may resolve the issue."
+                )
+
+        return bounding_boxes, filtered_conductor_shapely
 
     def _check_box_intersects_with_conductors(
         self, shapely_list: list[Shapely], bounding_box: Box


### PR DESCRIPTION
Adding more aggressive validation, so users do not get confusing errors later.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR enhances validation in `AutoImpedanceSpec` path generation by adding two critical checks that prevent confusing errors from occurring later in the simulation pipeline:

1. **Validation against ALL conductors**: Changed the conductor intersection check from using `filtered_conductor_shapely` (which excludes conductors touching PEC boundaries) to `isolated_conductor_shapely` (all conductors). This prevents auto-generated path specifications from intersecting with ground planes or other conductors that were filtered out for being shorted to boundaries.

2. **Mode plane bounds validation**: Added a new check to ensure bounding boxes don't extend outside the original mode plane bounds, which can happen with coarse grids causing snapped bounding boxes to expand beyond the intended region.

The changes include comprehensive test coverage with a parametrized test that validates both error scenarios using intentionally coarse grids.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with one minor issue to address regarding error message formatting consistency
- The logic changes are correct and well-tested. The fix properly addresses the issue by checking path intersections against all conductors (not just filtered ones) and validating bounds. Comprehensive tests cover both edge cases. However, there's one formatting inconsistency in error messages that should be corrected to follow project style guidelines
- tidy3d/components/microwave/path_integrals/mode_plane_analyzer.py needs a minor formatting fix in error messages

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/components/microwave/path_integrals/mode_plane_analyzer.py | Added two critical validation checks: one to detect path intersections with ALL conductors (not just filtered ones), and another to ensure bounding boxes stay within mode plane bounds |
| tests/test_components/test_microwave.py | Added comprehensive parametrized test covering both edge cases: ground plane intersection and mode plane boundary extension scenarios |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant ModePlaneAnalyzer
    participant get_conductor_bounding_boxes
    participant _get_isolated_conductors_as_shapely
    participant _filter_conductors_touching_sim_bounds
    participant _check_box_intersects_with_conductors

    Client->>ModePlaneAnalyzer: get_conductor_bounding_boxes(structures, grid, symmetry, sim_box)
    ModePlaneAnalyzer->>get_conductor_bounding_boxes: Process conductors
    get_conductor_bounding_boxes->>_get_isolated_conductors_as_shapely: Extract all conductors from structures
    _get_isolated_conductors_as_shapely-->>get_conductor_bounding_boxes: isolated_conductor_shapely (all conductors)
    get_conductor_bounding_boxes->>_filter_conductors_touching_sim_bounds: Filter conductors touching boundaries
    _filter_conductors_touching_sim_bounds-->>get_conductor_bounding_boxes: filtered_conductor_shapely (subset)
    
    Note over get_conductor_bounding_boxes: Generate bounding boxes from<br/>filtered_conductor_shapely
    
    loop For each bounding_box
        get_conductor_bounding_boxes->>_check_box_intersects_with_conductors: Check against isolated_conductor_shapely (NEW: uses ALL conductors)
        _check_box_intersects_with_conductors-->>get_conductor_bounding_boxes: intersection_detected
        alt Intersection detected
            get_conductor_bounding_boxes->>Client: Raise SetupError (conductor intersection)
        end
    end
    
    loop For each bounding_box
        alt Box extends outside mode plane bounds (NEW validation)
            get_conductor_bounding_boxes->>Client: Raise SetupError (extends outside bounds)
        end
    end
    
    get_conductor_bounding_boxes-->>Client: Return (bounding_boxes, filtered_conductor_shapely)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->