### PR TITLE
fix: avoid scale-dependent zero gradient filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed `AutoImpedanceSpec` validation to check path intersections against all conductors, not just filtered ones, as well as the mode plane bounds.
+- Fixed adjoint gradients being treated as zero due to scale-dependent `np.allclose(..., atol=1e-8)` checks, which could skip adjoint simulations and return zero gradients.
 
 ## [2.10.0] - 2025-12-18
 

--- a/tests/test_plugins/test_invdes.py
+++ b/tests/test_plugins/test_invdes.py
@@ -8,6 +8,7 @@ import pytest
 
 import tidy3d as td
 import tidy3d.plugins.invdes as tdi
+from tidy3d.exceptions import SetupError
 from tidy3d.plugins.expressions import ModeAmp, ModePower
 from tidy3d.plugins.invdes.initialization import (
     CustomInitializationSpec,
@@ -316,8 +317,32 @@ def test_warn_zero_grad(use_emulated_run):  # noqa: F811
     """Test default paramns running the optimization defined in the ``InverseDesign`` object."""
 
     optimizer = make_optimizer()
-    with AssertLogLevel("WARNING", contains_str="All elements of the gradient are almost zero"):
+    design_region = optimizer.design.design_region.updated_copy(penalties=())
+    design = optimizer.design.updated_copy(design_region=design_region)
+    optimizer = optimizer.updated_copy(design=design)
+
+    with pytest.raises(SetupError, match="All elements of the gradient are exactly zero"):
         optimizer.run(post_process_fn=post_process_fn_untraced)
+
+
+def test_scaled_objective_grad_not_filtered(use_emulated_run):  # noqa: F811
+    """Test that scaled objectives do not result in an all-zero gradient."""
+
+    optimizer = make_optimizer()
+    design_region = optimizer.design.design_region.updated_copy(penalties=())
+    design = optimizer.design.updated_copy(design_region=design_region)
+    optimizer = optimizer.updated_copy(design=design)
+
+    scale = 1e-10
+
+    def post_process_fn_scaled(sim_data: td.SimulationData, **kwargs) -> float:
+        intensity = sim_data.get_intensity(MNT_NAME1)
+        return scale * anp.sum(intensity.values)
+
+    result = optimizer.run(post_process_fn=post_process_fn_scaled)
+
+    grad = result.grad[-1]
+    assert np.count_nonzero(grad) > 0
 
 
 def make_result_multi(use_emulated_run):  # noqa: F811

--- a/tidy3d/plugins/invdes/optimizer.py
+++ b/tidy3d/plugins/invdes/optimizer.py
@@ -12,6 +12,7 @@ import pydantic.v1 as pd
 
 import tidy3d as td
 from tidy3d.components.types import TYPE_TAG_STR
+from tidy3d.exceptions import SetupError
 
 from .base import InvdesBaseModel
 from .design import InverseDesignType
@@ -180,9 +181,9 @@ class AbstractOptimizer(InvdesBaseModel, abc.ABC):
             aux_data = {}
             val, grad = val_and_grad_fn(params, aux_data=aux_data)
 
-            if anp.allclose(grad, 0.0):
-                td.log.warning(
-                    "All elements of the gradient are almost zero. This likely indicates "
+            if np.count_nonzero(grad) == 0:
+                raise SetupError(
+                    "All elements of the gradient are exactly zero. This likely indicates "
                     "a problem with the optimization set up. This can occur if the symmetry of the "
                     "simulation and design region are preventing any data to be recorded in the "
                     "'output_monitors'. In this case, we recommend initializing with a "

--- a/tidy3d/web/api/autograd/backward.py
+++ b/tidy3d/web/api/autograd/backward.py
@@ -27,10 +27,14 @@ def setup_adj(
 
     td.log.info("Running custom vjp (adjoint) pipeline.")
 
-    # filter out any data_fields_vjp with all 0's
-    data_fields_vjp = {
-        k: get_static(v) for k, v in data_fields_vjp.items() if not np.allclose(v, 0)
-    }
+    # filter out any data_fields_vjp with exact all 0's
+    data_fields_vjp_static = {}
+    for k, v in data_fields_vjp.items():
+        v_static = get_static(v)
+        if np.count_nonzero(v_static) == 0:
+            continue
+        data_fields_vjp_static[k] = v_static
+    data_fields_vjp = data_fields_vjp_static
 
     for k, v in data_fields_vjp.items():
         if np.any(np.isnan(v)):


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes a critical scale-dependent bug in adjoint gradient computation where `np.allclose()` with default tolerance (`atol=1e-8`) was incorrectly filtering out small but valid gradients. The fix replaces tolerance-based comparisons with exact zero checks using `np.count_nonzero() == 0`.

**Key Changes:**
- In `backward.py`: replaced `np.allclose(v, 0)` with exact zero check to prevent valid small gradients from being filtered
- In `optimizer.py`: changed from warning with `anp.allclose(grad, 0.0)` to error with exact zero check using `np.count_nonzero()`
- Added comprehensive test `test_scaled_objective_grad_not_filtered()` that verifies scaled objectives (e.g., `1e-10 * value`) work correctly
- Updated existing test to expect `SetupError` instead of warning

**Impact:**
This fix allows optimization with scaled objective functions where gradients may be legitimately small (e.g., 1e-10) without being incorrectly treated as zero. The change from warning to error for true zero gradients also improves user feedback for genuine setup issues.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no identified issues
- The fix correctly addresses a well-defined bug with appropriate tests. The change from tolerance-based to exact zero checking is the right approach for gradient filtering. The new test case specifically validates the bug fix scenario. All changes are logically consistent and improve the robustness of the gradient computation
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/web/api/autograd/backward.py | Fixed gradient filtering to check for exact zeros instead of using scale-dependent `np.allclose`, properly handling small but non-zero gradients |
| tidy3d/plugins/invdes/optimizer.py | Changed zero gradient check from warning to error with exact zero checking, ensuring true setup issues are caught while allowing scaled objectives |
| tests/test_plugins/test_invdes.py | Updated test to expect `SetupError` instead of warning, added comprehensive test for scaled objective gradients not being filtered |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Optimizer as AbstractOptimizer
    participant Autograd as Autograd (val_and_grad)
    participant Backward as backward.setup_adj()
    participant Filter as Gradient Filter
    
    Note over Optimizer: User calls optimizer.run()
    Optimizer->>Autograd: val_and_grad_fn(params)
    Autograd->>Backward: Compute VJP with data_fields_vjp
    
    Note over Backward: OLD: np.allclose(v, 0, atol=1e-8)
    Note over Backward: NEW: np.count_nonzero(v) == 0
    
    Backward->>Filter: Filter gradient fields
    alt Gradient has small values (e.g., 1e-10)
        Filter-->>Backward: OLD: Filtered out (treated as zero)
        Filter-->>Backward: NEW: Kept (non-zero)
    else Gradient is exactly zero
        Filter-->>Backward: Both: Filtered out
    end
    
    Backward->>Autograd: Return adjoint simulations (or empty list)
    Autograd->>Optimizer: Return (val, grad)
    
    Note over Optimizer: OLD: anp.allclose(grad, 0.0)
    Note over Optimizer: NEW: np.count_nonzero(grad) == 0
    
    alt All gradient elements exactly zero
        Optimizer->>Optimizer: Raise SetupError
    else Gradient has non-zero elements
        Optimizer->>Optimizer: Continue optimization
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->