### PR TITLE
feat: add to_mat_file to ModeSimulationData and HeatChargeSimulationData

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,5 +45,6 @@
 - Follow Conventional Commits per `.commitlintrc.json`.
 - Branch names must use an allowed prefix (`chore`, `hotfix`, `daily-chore`) or include a Jira key to satisfy CI.
 - PRs should link issues, summarize behavior changes, list the `poetry run …` checks you executed, and call out docs/schema updates.
+- Add a changelog entry under `## [Unreleased]` in `CHANGELOG.md` for user-facing changes (new features, bug fixes, breaking changes).
 
 _Reminder: update this AGENTS.md whenever workflow, tooling, or review expectations change so agents stay in sync with the repo._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added priority attribute to `TopologyDesignRegion` to enable manual control of overlapping structures.
+- `to_mat_file()` method is now available on `ModeSimulationData` and `HeatChargeSimulationData` for exporting results to MATLAB `.mat` files.
 
 ### Changed
 

--- a/tests/test_data/test_sim_data.py
+++ b/tests/test_data/test_sim_data.py
@@ -16,6 +16,7 @@ from tidy3d.components.file_util import replace_values
 from tidy3d.components.monitor import FieldMonitor, FieldTimeMonitor, ModeMonitor
 from tidy3d.exceptions import DataError, SetupError, Tidy3dKeyError
 
+from ..test_components.test_mode import get_mode_sim_data
 from ..utils import get_nested_shape
 from .test_data_arrays import FIELD_MONITOR, SIM, SIM_SYM
 from .test_monitor_data import (
@@ -94,6 +95,59 @@ def make_sim_data(symmetry: bool = True):
         data=data,
         log="- Time step    827 / time 4.13e-14s (  4 % done), field decay: 0.110e+00",
     )
+
+
+def make_heat_charge_sim_data():
+    """Create a simple HeatChargeSimulationData for testing."""
+    temp_mnt = td.TemperatureMonitor(size=(1, 2, 3), name="temperature")
+
+    tet_grid_points = td.PointDataArray(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+        dims=("index", "axis"),
+    )
+    tet_grid_cells = td.CellDataArray(
+        [[0, 1, 2, 4], [1, 2, 3, 4]],
+        dims=("cell_index", "vertex_index"),
+    )
+    tet_grid_values = td.IndexedDataArray(
+        np.linspace(300, 350, tet_grid_points.shape[0]),
+        dims=("index",),
+        name="T",
+    )
+
+    tet_grid = td.TetrahedralGridDataset(
+        points=tet_grid_points,
+        cells=tet_grid_cells,
+        values=tet_grid_values,
+    )
+
+    temp_data = td.TemperatureData(monitor=temp_mnt, temperature=tet_grid)
+
+    heat_sim = td.HeatChargeSimulation(
+        size=(3.0, 3.0, 3.0),
+        structures=[
+            td.Structure(
+                geometry=td.Box(size=(1, 1, 1), center=(0, 0, 0)),
+                medium=td.Medium(
+                    permittivity=2.0,
+                    heat_spec=td.SolidSpec(conductivity=1, capacity=1),
+                ),
+                name="box",
+            ),
+        ],
+        medium=td.Medium(permittivity=3.0, heat_spec=td.FluidSpec()),
+        grid_spec=td.UniformUnstructuredGrid(dl=0.1),
+        sources=[td.HeatSource(rate=1, structures=["box"])],
+        boundary_spec=[
+            td.HeatChargeBoundarySpec(
+                placement=td.StructureBoundary(structure="box"),
+                condition=td.TemperatureBC(temperature=500),
+            )
+        ],
+        monitors=[temp_mnt],
+    )
+
+    return td.HeatChargeSimulationData(simulation=heat_sim, data=(temp_data,))
 
 
 def test_sim_data():
@@ -542,11 +596,16 @@ def test_replace_values_list():
     assert original_shape == new_shape and new_list[3] == [] and new_list[2][5][0] == []
 
 
-def test_to_mat_file(tmp_path):
+@pytest.mark.parametrize(
+    "make_sim_data_fn",
+    [make_sim_data, get_mode_sim_data, make_heat_charge_sim_data],
+    ids=["SimulationData", "ModeSimulationData", "HeatChargeSimulationData"],
+)
+def test_to_mat_file(tmp_path, make_sim_data_fn):
     """
-    Test output of ``.mat`` file completes without error.
+    Test output of ``.mat`` file completes without error for all simulation data types.
     """
-    sim_data = make_sim_data()
+    sim_data = make_sim_data_fn()
     path = str(tmp_path / "test.mat")
     sim_data.to_mat_file(path)
 

--- a/tidy3d/components/base_sim/data/sim_data.py
+++ b/tidy3d/components/base_sim/data/sim_data.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import pathlib
 from abc import ABC
-from typing import Union
+from os import PathLike
+from typing import Any, Union
 
 import numpy as np
 import pydantic.v1 as pd
@@ -13,9 +15,10 @@ from tidy3d.components.base import Tidy3dBaseModel, skip_if_fields_missing
 from tidy3d.components.base_sim.data.monitor_data import AbstractMonitorData
 from tidy3d.components.base_sim.simulation import AbstractSimulation
 from tidy3d.components.data.utils import UnstructuredGridDatasetType
+from tidy3d.components.file_util import replace_values
 from tidy3d.components.monitor import AbstractMonitor
 from tidy3d.components.types import FieldVal
-from tidy3d.exceptions import DataError, Tidy3dKeyError, ValidationError
+from tidy3d.exceptions import DataError, FileError, Tidy3dKeyError, ValidationError
 
 
 class AbstractSimulationData(Tidy3dBaseModel, ABC):
@@ -132,3 +135,53 @@ class AbstractSimulationData(Tidy3dBaseModel, ABC):
     def get_monitor_by_name(self, name: str) -> AbstractMonitor:
         """Return monitor named 'name'."""
         return self.simulation.get_monitor_by_name(name)
+
+    def to_mat_file(self, fname: PathLike, **kwargs: Any) -> None:
+        """Output the simulation data object as ``.mat`` MATLAB file.
+
+        Parameters
+        ----------
+        fname : PathLike
+            Full path to the output file. Should include ``.mat`` file extension.
+        **kwargs : dict, optional
+            Extra arguments to ``scipy.io.savemat``: see ``scipy`` documentation for more detail.
+
+        Example
+        -------
+        >>> sim_data.to_mat_file('/path/to/file/data.mat') # doctest: +SKIP
+        """
+        # Check .mat file extension is given
+        extension = pathlib.Path(fname).suffixes[0].lower()
+        if len(extension) == 0:
+            raise FileError(f"File '{fname}' missing extension.")
+        if extension != ".mat":
+            raise FileError(f"File '{fname}' should have a .mat extension.")
+
+        # Handle m_dict in kwargs
+        if "m_dict" in kwargs:
+            raise ValueError(
+                "'m_dict' is automatically determined by 'to_mat_file', can't pass to 'savemat'."
+            )
+
+        # Get SimData object as dictionary
+        sim_dict = self.dict()
+
+        # set long field names true by default, otherwise it wont save fields with > 31 characters
+        if "long_field_names" not in kwargs:
+            kwargs["long_field_names"] = True
+
+        # Remove NoneType values from dict
+        # Built from theory discussed in https://github.com/scipy/scipy/issues/3488
+        modified_sim_dict = replace_values(sim_dict, None, [])
+
+        try:
+            from scipy.io import savemat
+
+            savemat(fname, modified_sim_dict, **kwargs)
+        except Exception as e:
+            raise ValueError(
+                "Could not save supplied simulation data to file. As this is an experimental "
+                "feature, we may not be able to support the contents of your dataset. If you "
+                "receive this error, please feel free to raise an issue on our front end "
+                "repository so we can investigate."
+            ) from e

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -18,7 +18,6 @@ import xarray as xr
 from tidy3d.components.autograd.utils import split_list
 from tidy3d.components.base import JSON_TAG, Tidy3dBaseModel, cached_property
 from tidy3d.components.base_sim.data.sim_data import AbstractSimulationData
-from tidy3d.components.file_util import replace_values
 from tidy3d.components.monitor import Monitor
 from tidy3d.components.simulation import Simulation
 from tidy3d.components.source.current import CustomCurrentSource
@@ -28,7 +27,7 @@ from tidy3d.components.structure import Structure
 from tidy3d.components.types import Ax, Axis, ColormapType, FieldVal, PlotScale, annotate_type
 from tidy3d.components.types.monitor_data import MonitorDataType, MonitorDataTypes
 from tidy3d.components.viz import add_ax_if_none, equal_aspect
-from tidy3d.exceptions import DataError, FileError, SetupError, Tidy3dKeyError
+from tidy3d.exceptions import DataError, SetupError, Tidy3dKeyError
 from tidy3d.log import log
 
 from .data_array import FreqDataArray, TimeDataArray
@@ -1337,50 +1336,3 @@ class SimulationData(AbstractYeeGridSimulationData):
 
         monitor_name = Structure._get_monitor_name(index=structure_index, data_type=data_type)
         return self[monitor_name]
-
-    def to_mat_file(self, fname: PathLike, **kwargs: Any) -> None:
-        """Output the ``SimulationData`` object as ``.mat`` MATLAB file.
-
-        Parameters
-        ----------
-        fname : PathLike
-            Full path to the output file. Should include ``.mat`` file extension.
-        **kwargs : dict, optional
-            Extra arguments to ``scipy.io.savemat``: see ``scipy`` documentation for more detail.
-
-        Example
-        -------
-        >>> simData.to_mat_file('/path/to/file/data.mat') # doctest: +SKIP
-        """
-        # Check .mat file extension is given
-        extension = pathlib.Path(fname).suffixes[0].lower()
-        if len(extension) == 0:
-            raise FileError(f"File '{fname}' missing extension.")
-        if extension != ".mat":
-            raise FileError(f"File '{fname}' should have a .mat extension.")
-
-        # Handle m_dict in kwargs
-        if "m_dict" in kwargs:
-            raise ValueError(
-                "'m_dict' is automatically determined by 'to_mat_file', can't pass to 'savemat'."
-            )
-
-        # Get SimData object as dictionary
-        sim_dict = self.dict()
-
-        # set long field names true by default, otherwise it wont save fields with > 31 characters
-        if "long_field_names" not in kwargs:
-            kwargs["long_field_names"] = True
-
-        # Remove NoneType values from dict
-        # Built from theory discussed in https://github.com/scipy/scipy/issues/3488
-        modified_sim_dict = replace_values(sim_dict, None, [])
-
-        try:
-            from scipy.io import savemat
-
-            savemat(fname, modified_sim_dict, **kwargs)
-        except Exception as e:
-            raise ValueError(
-                "Could not save supplied 'SimulationData' to file. As this is an experimental feature, we may not be able to support the contents of your dataset. If you receive this error, please feel free to raise an issue on our front end repository so we can investigate."
-            ) from e


### PR DESCRIPTION
## Summary
- Move `to_mat_file()` from `SimulationData` to `AbstractSimulationData` base class
- Now available on `ModeSimulationData` and `HeatChargeSimulationData`
- Add parametrized test covering all simulation data types

## Test plan
- [x] `poetry run pytest tests/test_data/test_sim_data.py::test_to_mat_file -v` passes for all 3 types
- [x] `poetry run pre-commit run --all-files` passes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR refactors the `to_mat_file()` method by moving it from the `SimulationData` class to the `AbstractSimulationData` base class, making MATLAB `.mat` file export available to `ModeSimulationData` and `HeatChargeSimulationData` in addition to the original `SimulationData`.

**Key changes:**
- Moved `to_mat_file()` implementation from `tidy3d/components/data/sim_data.py` to `tidy3d/components/base_sim/data/sim_data.py`
- Updated error message to be more generic ("simulation data" instead of "'SimulationData'")
- Added comprehensive parametrized test covering all three simulation data types
- Created helper function `make_heat_charge_sim_data()` to generate test data
- Added changelog entry documenting the new capability

The refactoring follows proper inheritance patterns, where all simulation data types (`SimulationData`, `ModeSimulationData`, `HeatChargeSimulationData`) inherit from `AbstractSimulationData` either directly or through intermediate base classes.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no identified issues
- The refactoring is well-executed with proper test coverage, follows object-oriented design principles by moving functionality to the appropriate base class, and maintains backward compatibility since the method signature and behavior remain unchanged
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/components/base_sim/data/sim_data.py | Moved `to_mat_file()` method from `SimulationData` to base class, making it available to all simulation data types |
| tidy3d/components/data/sim_data.py | Removed `to_mat_file()` method and unused imports since functionality moved to base class |
| tests/test_data/test_sim_data.py | Added parametrized test covering all three simulation data types and helper function for `HeatChargeSimulationData` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant SimulationData
    participant ModeSimulationData
    participant HeatChargeSimulationData
    participant AbstractSimulationData
    participant scipy

    Note over AbstractSimulationData: to_mat_file() moved here

    User->>SimulationData: sim_data.to_mat_file(fname)
    SimulationData->>AbstractSimulationData: to_mat_file(fname)
    
    User->>ModeSimulationData: mode_sim_data.to_mat_file(fname)
    ModeSimulationData->>AbstractSimulationData: to_mat_file(fname)
    
    User->>HeatChargeSimulationData: heat_sim_data.to_mat_file(fname)
    HeatChargeSimulationData->>AbstractSimulationData: to_mat_file(fname)

    AbstractSimulationData->>AbstractSimulationData: Validate .mat extension
    AbstractSimulationData->>AbstractSimulationData: Convert to dict
    AbstractSimulationData->>AbstractSimulationData: Replace None with []
    AbstractSimulationData->>scipy: savemat(fname, modified_dict)
    scipy-->>AbstractSimulationData: Success/Exception
    AbstractSimulationData-->>User: File saved or ValueError
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->