### PR TITLE
fix output of FilterAndProject parameterization to be between 0 and 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed adjoint gradients being treated as zero due to scale-dependent `np.allclose(..., atol=1e-8)` checks, which could skip adjoint simulations and return zero gradients.
 - Fixed interpolation handling for permittivity and conductivity gradients in CustomMedium.
 - Restored original batch-load logging by suppressing per-task “Loading simulation…” messages. 
+- Fixed output range of `tidy3d.plugins.invdes.FilterAndProject` to be between 0 and 1.
 
 ## [2.10.0] - 2025-12-18
 

--- a/tests/test_plugins/autograd/invdes/test_parametrizations.py
+++ b/tests/test_plugins/autograd/invdes/test_parametrizations.py
@@ -10,20 +10,29 @@ from tidy3d.plugins.autograd.types import PaddingType
 @pytest.mark.parametrize("radius", [1, 2, (1, 2)])
 @pytest.mark.parametrize("dl", [0.1, 0.2, (0.1, 0.2)])
 @pytest.mark.parametrize("size_px", [None, 5, (5, 7)])
+@pytest.mark.parametrize("beta", [1.0, 10.0])
 @pytest.mark.parametrize("filter_type", ["circular", "conic", "gaussian"])
 @pytest.mark.parametrize("padding", PaddingType.__args__)
-def test_make_filter_and_project(rng, radius, dl, size_px, filter_type, padding):
+@pytest.mark.parametrize("init_type", ("random", "binary_low_border", "binary_high_border"))
+def test_make_filter_and_project(rng, radius, dl, size_px, beta, filter_type, padding, init_type):
     """Test make_filter_and_project function for various parameters."""
     filter_and_project_func = make_filter_and_project(
         radius=radius,
         dl=dl,
         size_px=size_px,
-        beta=10,
+        beta=beta,
         eta=0.5,
         filter_type=filter_type,
         padding=padding,
     )
-    array = rng.random((51, 51))
+    if init_type == "random":
+        array = rng.random((51, 51))
+    elif init_type == "binary_low_border":
+        array = np.zeros((100, 100))
+        array[40:60, 40:60] = 1.0
+    else:
+        array = np.ones((100, 100))
+        array[40:60, 40:60] = 0.0
     result = filter_and_project_func(array)
     assert result.shape == array.shape
     assert np.all(result >= 0) and np.all(result <= 1)

--- a/tests/test_plugins/test_invdes.py
+++ b/tests/test_plugins/test_invdes.py
@@ -715,3 +715,26 @@ def test_result_params_out_of_bounds():
 
     # get_sim should work without issues
     sim = result.get_sim(index=0)
+
+
+@pytest.mark.parametrize("check_low", [False, True])
+def test_transformation_clipping(check_low):
+    """Test the output of `FilterProject` is between 0 and 1."""
+
+    filter_project = tdi.FilterProject(radius=0.5, beta=1.0)
+    design_region_dl = 0.02
+
+    if check_low:
+        test_region = np.zeros((100, 100))
+        test_region[40:60, 40:60] = 1.0
+
+        output_region = filter_project.evaluate(test_region, design_region_dl)
+
+        assert np.min(output_region) >= 0.0, "Output region minimum below 0.0"
+    else:
+        test_region = np.ones((100, 100))
+        test_region[40:60, 40:60] = 0.0
+
+        output_region = filter_project.evaluate(test_region, design_region_dl)
+
+        assert np.max(output_region) <= 1.0, "Output region maximum above 1.0"

--- a/tidy3d/components/autograd/functions.py
+++ b/tidy3d/components/autograd/functions.py
@@ -259,6 +259,25 @@ def add_at(x: NDArray, indices_x: tuple, y: NDArray) -> NDArray:
     return _add_at(x, indices_x, y)
 
 
+@primitive
+def _straight_through_clip(x, a_min, a_max):
+    """Passthrough clip can be used to preserve gradients at the endpoints of the clip range where
+    there is a discontinuity in the derivative. This is useful when values are at the endpoints but may
+    have a gradient away from the boundary or in cases where numerical precision causes a function that is
+    typically bounded by the clip bounds to produce a value just outside the bounds. In the forward pass,
+    this runs the standard clip."""
+    return anp.clip(x, a_min=a_min, a_max=a_max)
+
+
+def _straight_through_clip_vjp(ans, x, a_min, a_max):
+    """Preserve original gradient information in the backward pass up until a tolerance beyond the clip bounds."""
+    tolerance = 1e-5
+    mask = (x >= a_min - tolerance) & (x <= a_max + tolerance)
+    return lambda g: g * mask
+
+
+defvjp(_straight_through_clip, _straight_through_clip_vjp)
+
 __all__ = [
     "add_at",
     "interpn",

--- a/tidy3d/plugins/autograd/invdes/parametrizations.py
+++ b/tidy3d/plugins/autograd/invdes/parametrizations.py
@@ -10,6 +10,7 @@ from numpy.typing import NDArray
 from scipy.optimize import minimize
 
 import tidy3d as td
+from tidy3d.components.autograd.functions import _straight_through_clip
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.grid.grid import Coords
 from tidy3d.plugins.autograd.constants import BETA_DEFAULT, ETA_DEFAULT
@@ -74,7 +75,9 @@ class FilterAndProject(Tidy3dBaseModel):
         beta = beta if beta is not None else self.beta
         eta = eta if eta is not None else self.eta
         projected = tanh_projection(filtered, beta, eta)
-        return projected
+        clip_projected = _straight_through_clip(projected, a_min=0.0, a_max=1.0)
+
+        return clip_projected
 
 
 def make_filter_and_project(


### PR DESCRIPTION
For certain parameter inputs, the FilterAndProject parameterization can be slightly below 0 or above 1. This causes problems in places like the invdes plugin where that gets mapped to a material density and can ultimately try and create a CustomMedium object with a permittivity value less than 1

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes a numerical precision issue where the `FilterAndProject` parameterization could produce values slightly outside the [0, 1] range. The fix adds `np.clip()` to constrain outputs, preventing downstream errors when these values are used to create `CustomMedium` objects with permittivity < 1.

**Key Changes:**
- Added `np.clip(projected, a_min=0.0, a_max=1.0)` in `FilterAndProject.__call__()` method
- Enhanced test coverage with binary edge cases (zeros with a square of ones, and vice versa) that trigger the boundary conditions
- Added parametrization for different `beta` values (1.0, 10.0) to test varying projection steepness
- Added integration test `test_transformation_clipping` to verify `FilterProject` wrapper class also respects bounds

**Root Cause:**
The `tanh_projection` function can produce values slightly outside [0, 1] due to floating-point arithmetic, especially after filtering operations on binary inputs. The filtering step (convolution) creates continuous transitions at edges, and when these filtered values are projected, numerical precision issues can cause small violations of the [0, 1] constraint.

**Issues Found:**
- Minor typo in test error message (line 715): says "minimum" when checking maximum value

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The fix is straightforward, well-tested, and addresses a clear numerical precision bug. The clipping operation is a standard defensive technique that doesn't change the expected behavior for well-formed inputs, only prevents edge case failures. The test coverage is comprehensive, including both unit tests with various parameters and integration tests.
- No files require special attention - only a minor typo fix in test error message at tests/test_plugins/test_invdes.py:715

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/plugins/autograd/invdes/parametrizations.py | Added `np.clip()` to constrain FilterAndProject output to [0, 1] range |
| tests/test_plugins/autograd/invdes/test_parametrizations.py | Enhanced test coverage with binary edge cases (low/high borders) and varying beta values |
| tests/test_plugins/test_invdes.py | Added integration test for FilterProject transformation clipping at boundaries |
| CHANGELOG.md | Added changelog entry documenting the fix |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant FilterProject
    participant FilterAndProject
    participant Filter
    participant tanh_projection
    participant np_clip

    User->>FilterProject: evaluate(spatial_data, design_region_dl)
    FilterProject->>FilterAndProject: make_filter_and_project(radius, dl, beta, eta)
    FilterAndProject-->>FilterProject: FilterAndProject instance
    FilterProject->>FilterAndProject: __call__(spatial_data)
    FilterAndProject->>Filter: make_filter(radius, dl, size_px, filter_type, padding)
    Filter-->>FilterAndProject: filter_instance
    FilterAndProject->>Filter: filter_instance(array)
    Note over Filter: Convolution operation<br/>creates continuous transitions
    Filter-->>FilterAndProject: filtered array
    FilterAndProject->>tanh_projection: tanh_projection(filtered, beta, eta)
    Note over tanh_projection: Soft thresholding<br/>may produce values<br/>slightly outside [0,1]<br/>due to FP precision
    tanh_projection-->>FilterAndProject: projected array
    FilterAndProject->>np_clip: np.clip(projected, 0.0, 1.0)
    Note over np_clip: NEW: Ensures output<br/>strictly in [0,1] range
    np_clip-->>FilterAndProject: clipped array
    FilterAndProject-->>FilterProject: final array
    FilterProject-->>User: transformed spatial data
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures inverse-design parameterizations produce valid densities and remain differentiable at bounds.
> 
> - Introduces autograd primitive `_straight_through_clip` (with VJP mask) to clip values while preserving gradients near [0,1] endpoints
> - Applies clipping in `FilterAndProject.__call__()` so outputs are strictly within `[0, 1]`
> - Expands tests: adds edge-case binary inputs, `beta` parametrization, and `FilterProject` integration checks for bounds
> - Updates `CHANGELOG.md` to note the fix
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bac48e078fc41810f4e455651f6ad48c9f1c188f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->