### PR TITLE
Fix bug in PolySlab's intersections_plane method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cropped adjoint monitor sizes in 2D simulations to planar geometry intersection.
 - Fixed `Batch.download()` silently succeeding when background downloads fail (e.g., gzip extraction errors).
 - Handling of zero values when using `sim_data.plot_field` with `scale=dB`.
+- Fixed `intersections_plane` method in `PolySlab`, which sometimes missed vertices for planes coincident with `PolySlab` side faces.
 
 ## [2.10.0] - 2025-12-18
 

--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -941,6 +941,75 @@ def test_polyslab_intersection_inf_bounds():
     assert poly.intersections_plane(x=0)[0] == shapely.box(-1, -LARGE_NUMBER, 1, 0)
 
 
+def test_polyslab_intersection_with_coincident_plane():
+    """Test if intersection returns the correct shape when the plane is coincident with the side face."""
+    poly = td.PolySlab(
+        vertices=[[500.0, -7500.0], [500.0, 7500.0], [-500.0, 7500.0], [-500.0, -7500.0]],
+        slab_bounds=[0, 50],
+        axis=2,
+    )
+    # Each case should give one side face of the polyslab
+    expected_x_face = shapely.box(-7500, 0, 7500, 50)  # y-extent × z-extent
+    expected_y_face = shapely.box(-500, 0, 500, 50)  # x-extent × z-extent
+
+    assert poly.intersections_plane(x=-500) == [expected_x_face]
+    assert poly.intersections_plane(x=500) == [expected_x_face]
+    assert poly.intersections_plane(y=-7500) == [expected_y_face]
+    assert poly.intersections_plane(y=7500) == [expected_y_face]
+
+
+def test_polyslab_intersection_rotated_square():
+    """Test PolySlab plane intersection with a rotated square (diamond shape)."""
+    # Create a diamond by rotating a square 45 degrees
+    size = 2.0
+    angle = np.pi / 4
+    base_vertices = np.array(
+        [[-size / 2, -size / 2], [size / 2, -size / 2], [size / 2, size / 2], [-size / 2, size / 2]]
+    )
+    cos_a, sin_a = np.cos(angle), np.sin(angle)
+    rotation = np.array([[cos_a, -sin_a], [sin_a, cos_a]])
+    rotated = base_vertices @ rotation.T
+    rotated = rotated - rotated.min(axis=0) + 0.5  # shift to positive quadrant
+    vertices = [tuple(v) for v in rotated]
+
+    polyslab = td.PolySlab(vertices=vertices, slab_bounds=(0, 3), axis=2)
+
+    all_verts = np.array(vertices)
+    left_tip_x = all_verts[:, 0].min()
+    bottom_tip_y = all_verts[:, 1].min()
+    x_center = (all_verts[:, 0].min() + all_verts[:, 0].max()) / 2
+
+    # Test 1: Cut at z=1.5 (middle of slab) - should give full diamond
+    cross_section = polyslab.intersections_plane(z=1.5)
+    assert len(cross_section) == 1
+    assert np.isclose(cross_section[0].area, 4.0)
+
+    # Test 2: Cut through center at x=x_center - should give rectangle
+    cross_section = polyslab.intersections_plane(x=x_center)
+    assert len(cross_section) == 1
+    assert cross_section[0].area > 0
+
+    # Test 3: Cut at left corner tip (tangent touch) - should give degenerate shape
+    cross_section = polyslab.intersections_plane(x=left_tip_x)
+    assert len(cross_section) == 1
+    assert np.isclose(cross_section[0].area, 0.0)
+
+    # Test 4: Cut near left corner (slightly inside) - should give small shape
+    cross_section = polyslab.intersections_plane(x=left_tip_x + 0.3)
+    assert len(cross_section) == 1
+    assert cross_section[0].area > 0
+
+    # Test 5: Cut at bottom corner (tangent touch) - should give degenerate shape
+    cross_section = polyslab.intersections_plane(y=bottom_tip_y)
+    assert len(cross_section) == 1
+    assert np.isclose(cross_section[0].area, 0.0)
+
+    # Test 6: Cut at z=0 (bottom boundary) - should give full diamond
+    cross_section = polyslab.intersections_plane(z=0)
+    assert len(cross_section) == 1
+    assert np.isclose(cross_section[0].area, 4.0)
+
+
 def test_from_shapely():
     ring = shapely.LinearRing([(-16, 9), (-8, 9), (-12, 2)])
     poly = shapely.Polygon([(-2, 0), (-10, 0), (-6, 7)])

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -858,23 +858,22 @@ class PolySlab(base.Planar):
         x_vertices_f, _ = vertices_f.T
         x_vertices_axis, _ = vertices_axis.T
 
-        # find which segments intersect
-        f_left_to_intersect = x_vertices_f <= position
-        orig_right_to_intersect = x_vertices_axis > position
-        intersects_b = np.logical_and(f_left_to_intersect, orig_right_to_intersect)
+        # Find which segments intersect:
+        # 1. Strictly crossing: one endpoint strictly left, one strictly right
+        # 2. Touching: exactly one endpoint on the plane (xor), which excludes
+        #    edges lying entirely on the plane (both endpoints at position).
+        orig_on_plane = np.isclose(x_vertices_axis, position, rtol=_IS_CLOSE_RTOL)
+        f_on_plane = np.roll(orig_on_plane, shift=-1)
+        crosses_b = (x_vertices_axis > position) & (x_vertices_f < position)
+        crosses_f = (x_vertices_axis < position) & (x_vertices_f > position)
 
-        f_right_to_intersect = x_vertices_f > position
-        orig_left_to_intersect = x_vertices_axis <= position
-        intersects_f = np.logical_and(f_right_to_intersect, orig_left_to_intersect)
-
-        # exclude vertices at the position if exclude_on_vertices is True
         if exclude_on_vertices:
-            intersects_on = np.isclose(x_vertices_axis, position, rtol=_IS_CLOSE_RTOL)
-            intersects_f_on = np.isclose(x_vertices_f, position, rtol=_IS_CLOSE_RTOL)
-            intersects_both_off = np.logical_not(np.logical_or(intersects_on, intersects_f_on))
-            intersects_f &= intersects_both_off
-            intersects_b &= intersects_both_off
-        intersects_segment = np.logical_or(intersects_b, intersects_f)
+            # exclude vertices at the position
+            not_touching = np.logical_not(orig_on_plane | f_on_plane)
+            intersects_segment = (crosses_b | crosses_f) & not_touching
+        else:
+            single_touch = np.logical_xor(orig_on_plane, f_on_plane)
+            intersects_segment = crosses_b | crosses_f | single_touch
 
         iverts_b = vertices_axis[intersects_segment]
         iverts_f = vertices_f[intersects_segment]
@@ -893,10 +892,27 @@ class PolySlab(base.Planar):
         ints_y = np.array(ints_y)
         ints_angle = np.array(ints_angle)
 
-        sort_index = np.argsort(ints_y)
-        ints_y_sort = ints_y[sort_index]
+        # Get rid of duplicate intersection points (vertices counted twice if directly on position)
+        ints_y_sort, sort_index = np.unique(ints_y, return_index=True)
         ints_angle_sort = ints_angle[sort_index]
 
+        # For tangent touches (vertex on plane, both neighbors on same side),
+        # add y-value back to form a degenerate pair
+        if not exclude_on_vertices:
+            n = len(vertices_axis)
+            for idx in np.where(orig_on_plane)[0]:
+                prev_on = orig_on_plane[(idx - 1) % n]
+                next_on = orig_on_plane[(idx + 1) % n]
+                if not prev_on and not next_on:
+                    prev_side = x_vertices_axis[(idx - 1) % n] > position
+                    next_side = x_vertices_axis[(idx + 1) % n] > position
+                    if prev_side == next_side:
+                        ints_y_sort = np.append(ints_y_sort, vertices_axis[idx, 1])
+                        ints_angle_sort = np.append(ints_angle_sort, 0)
+
+            sort_index = np.argsort(ints_y_sort)
+            ints_y_sort = ints_y_sort[sort_index]
+            ints_angle_sort = ints_angle_sort[sort_index]
         return ints_y_sort, ints_angle_sort
 
     def _find_intersecting_ys_angle_slant(


### PR DESCRIPTION
intersections_plane for PolySlab was missing intersections with planes that were coincident on the + side of polyslab side walls.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes a bug in `PolySlab.intersections_plane` where intersections were missed when a plane was coincident with the positive side of PolySlab side faces. The fix replaces asymmetric inequality checks (`<=` and `>`) with symmetric strict inequalities plus explicit handling of edges that touch the plane.

**Key Changes:**
- Replaced directional inequality logic with clear separation between strictly crossing edges and touching edges
- Uses XOR logic to detect edges where exactly one vertex is on the plane, excluding edges that lie entirely on the plane
- Added explanatory comments describing the intersection detection strategy
- Test coverage for all four sides of a rectangular PolySlab with coincident planes
- Proper changelog entry under Fixed section

**Technical Details:**
The old logic used `f <= position AND orig > position` which would miss edges starting on the plane and extending in the negative direction. The new logic explicitly includes all edges where exactly one endpoint is on the plane via `touches = np.logical_xor(orig_on_plane, f_on_plane)`, ensuring symmetric handling of both directions.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The fix is well-reasoned and addresses a clear geometric edge case. The logic correctly handles floating-point comparisons using np.isclose, and the XOR-based touching detection elegantly excludes edges lying on the plane while including edges with one endpoint on the plane. The change automatically propagates to the slanted case via method reuse. Test coverage is adequate and the implementation follows project conventions.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/components/geometry/polyslab.py | Fixed edge intersection detection logic to handle planes coincident with side faces using XOR-based touching detection and clear comments |
| tests/test_components/test_geometry.py | Added test for coincident plane intersections covering all four sides of a rectangular PolySlab; could verify actual intersection shapes |
| CHANGELOG.md | Clear and properly formatted changelog entry under Fixed section with appropriate code identifier formatting |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant PolySlab
    participant IntersectionMethod as _find_intersecting_ys_angle_vertical
    participant NPUtils as numpy operations
    
    User->>PolySlab: intersections_plane(x=500)
    PolySlab->>IntersectionMethod: _find_intersecting_ys_angle_vertical(vertices, 500, axis=0)
    
    Note over IntersectionMethod: Process vertices for axis orientation
    IntersectionMethod->>IntersectionMethod: Roll vertices to get forward edges
    
    Note over IntersectionMethod: Detect intersection types
    IntersectionMethod->>NPUtils: np.isclose(x_vertices_axis, position)
    NPUtils-->>IntersectionMethod: orig_on_plane (boolean array)
    IntersectionMethod->>NPUtils: np.isclose(x_vertices_f, position)
    NPUtils-->>IntersectionMethod: f_on_plane (boolean array)
    
    Note over IntersectionMethod: NEW: Calculate touching edges
    IntersectionMethod->>NPUtils: np.logical_xor(orig_on_plane, f_on_plane)
    NPUtils-->>IntersectionMethod: touches (edges with one vertex on plane)
    
    Note over IntersectionMethod: Calculate crossing edges
    IntersectionMethod->>IntersectionMethod: crosses_b = (orig > pos) & (f < pos)
    IntersectionMethod->>IntersectionMethod: crosses_f = (orig < pos) & (f > pos)
    
    Note over IntersectionMethod: Combine intersection types
    IntersectionMethod->>IntersectionMethod: intersects_b = crosses_b | touches
    IntersectionMethod->>IntersectionMethod: intersects_f = crosses_f | touches
    
    Note over IntersectionMethod: Calculate intersection points
    IntersectionMethod->>IntersectionMethod: For each intersecting segment:<br/>compute slope and y-coordinate
    
    IntersectionMethod-->>PolySlab: ints_y_sort, ints_angle_sort
    PolySlab-->>User: List of intersection shapes
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses missed intersections when a slicing plane is coincident with `PolySlab` side faces.
> 
> - Reworks `intersections_plane` edge tests to use symmetric strict crossings plus explicit single-endpoint-on-plane detection (excludes whole-edge-on-plane); respects `exclude_on_vertices`
> - Deduplicates intersection points and restores degenerate pairs for tangent touches to ensure correct polygon construction
> - Adds tests covering coincident planes on all sides of a rectangular `PolySlab` and a rotated-square (diamond) case, including tangent-touch degeneracies
> - Updates `CHANGELOG.md` under Fixed to note the `PolySlab.intersections_plane` bugfix
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a12f5a566b6d88c99893be4f178e0b3a7b2c8454. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->