### PR TITLE
chore(tidy3d): FXC-4695 hotfix zizmor version update

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -287,7 +287,7 @@ jobs:
         uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
 
       - name: Run zizmor 🌈
-        run: uvx zizmor .github/workflows/*.y* --format=sarif . > results.sarif 
+        run: uvx zizmor==1.19.0 .github/workflows/*.y* --format=sarif . > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
 
@@ -298,7 +298,7 @@ jobs:
           category: zizmor
       
       - name: run zizmor directly  # this gets a success or fail result
-        run: uvx zizmor  .github/workflows/*.y*
+        run: uvx zizmor==1.19.0  .github/workflows/*.y*
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
   

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         entry: bash -c 'commitlint --edit || exit 0'
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
     # Zizmor version.
-    rev: v1.15.2
+    rev: v1.19.0
     hooks:
       - id: zizmor
         stages: [pre-commit]


### PR DESCRIPTION
This is the hotfix for zizmor update handling which currently hinders us from merging PRs.
First, let's just pin the zizmor version.
A more sophisticated workflow for update handling should follow.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR updates the zizmor security scanning tool from version 1.15.2 to 1.19.0 across both the pre-commit configuration and GitHub Actions workflow. The changes ensure version consistency between local development and CI environments by explicitly pinning zizmor to 1.19.0 in workflow steps and updating the pre-commit hook version.

**Key Changes:**
- Updated `.pre-commit-config.yaml` to use zizmor v1.19.0
- Pinned zizmor version to 1.19.0 in two GitHub Actions workflow steps for reproducibility
- Fixed trailing whitespace in the workflow file

**Notes:**
The approach of pinning the version in workflow steps is reasonable for ensuring reproducible CI runs. This addresses the "zizmor update handling" mentioned in the PR description by providing explicit version control. A more sophisticated workflow for automatic updates could be implemented in the future as noted in the PR description.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk. It makes straightforward dependency updates with no functional code changes.
- The PR receives a 4/5 confidence score because: (1) the changes are simple and focused - only version updates to zizmor and pre-commit configuration, (2) no application code is modified, (3) pinning the version in workflows improves reproducibility and CI stability, (4) the changes align the pre-commit config with the CI environment. The score is not higher because the PR lacks detailed context about why version 1.19.0 specifically was chosen and whether there are any breaking changes or new features in this version bump.
- No files require special attention. Both modified files contain straightforward configuration updates with no complex logic or potential side effects.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/tidy3d-python-client-tests.yml | Updates zizmor version pinning from unspecified to `1.19.0` in two workflow steps. This ensures reproducible zizmor runs in CI. The changes are straightforward: pinning the version with `uvx zizmor==1.19.0` syntax and fixing trailing whitespace. This is a reasonable approach to handle version compatibility issues. |
| .pre-commit-config.yaml | Updates zizmor pre-commit hook version from `v1.15.2` to `v1.19.0`. This aligns the pre-commit configuration with the pinned version in CI workflows. The update ensures consistency across development and CI environments. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor Developer
    participant PreCommit as Pre-commit Hook
    participant CI as GitHub Actions Workflow
    participant Zizmor as Zizmor v1.19.0

    Developer->>PreCommit: Trigger pre-commit
    PreCommit->>Zizmor: Run zizmor scan (v1.19.0)
    Zizmor-->>PreCommit: Security analysis results
    PreCommit-->>Developer: Pass/Fail feedback

    Note over CI: CI Workflow
    CI->>Zizmor: uvx zizmor==1.19.0 (with SARIF output)
    Zizmor-->>CI: SARIF format results
    CI->>CI: Upload SARIF to CodeQL
    CI->>Zizmor: uvx zizmor==1.19.0 (direct check)
    Zizmor-->>CI: Success/Fail status
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->