### PR TITLE
fix: Handling of zero values when using plot_fields with scale=dB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed output range of `tidy3d.plugins.invdes.FilterAndProject` to be between 0 and 1.
 - Cropped adjoint monitor sizes in 2D simulations to planar geometry intersection.
 - Fixed `Batch.download()` silently succeeding when background downloads fail (e.g., gzip extraction errors).
+- Handling of zero values when using `sim_data.plot_field` with `scale=dB`.
 
 ## [2.10.0] - 2025-12-18
 

--- a/tests/test_data/test_sim_data.py
+++ b/tests/test_data/test_sim_data.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pydantic.v1 as pydantic
@@ -624,3 +626,49 @@ def test_plot_field_monitor_data_unsupported_scale():
             val="real",
             scale="invalid",
         )
+
+
+def test_plot_field_with_zeros_db_scale():
+    """Test that plotting field data with zeros using dB scale doesn't produce warnings."""
+    sim_data = make_sim_data()
+
+    # Get the existing field data and modify it to include zeros
+    field_monitor_data = sim_data["field"]
+    ex_data = field_monitor_data.Ex
+
+    # Create modified data with some zeros
+    values = ex_data.values.copy()
+    values[np.abs(values) < np.abs(values).max() * 0.3] = 0  # Set small values to zero
+    ex_with_zeros = ex_data.copy(data=values)
+
+    # Create new field data with zeros
+    field_data_with_zeros = field_monitor_data.updated_copy(Ex=ex_with_zeros)
+    f_sel = ex_data.f.values[0]
+    x_sel = ex_data.x.values[0]
+
+    # Plot with dB scale - this should not produce divide by zero warnings
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", message="divide by zero")
+        sim_data.plot_field_monitor_data(
+            field_monitor_data=field_data_with_zeros,
+            field_name="Ex",
+            val="abs",
+            scale="dB",
+            f=f_sel,
+            x=x_sel,
+        )
+        plt.close()
+
+    # Also test with vmin specified (zeros replaced with floor value)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", message="divide by zero")
+        sim_data.plot_field_monitor_data(
+            field_monitor_data=field_data_with_zeros,
+            field_name="Ex",
+            val="abs",
+            scale="dB",
+            f=f_sel,
+            x=x_sel,
+            vmin=-50,
+        )
+        plt.close()

--- a/tidy3d/components/base_sim/data/sim_data.py
+++ b/tidy3d/components/base_sim/data/sim_data.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pathlib
 from abc import ABC
 from os import PathLike
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 import numpy as np
 import pydantic.v1 as pd
@@ -131,6 +131,40 @@ class AbstractSimulationData(Tidy3dBaseModel, ABC):
             )
 
         return field_value
+
+    @staticmethod
+    def _apply_log_scale(
+        field_data: xr.DataArray,
+        vmin: Optional[float] = None,
+        db_factor: float = 1.0,
+    ) -> xr.DataArray:
+        """Prepare field data for log-scale plotting by handling zeros.
+
+        Takes absolute value of the data, replaces zeros with a fill value
+        (to prevent log10(0) warnings), and applies log10 scaling.
+
+        Parameters
+        ----------
+        field_data : xr.DataArray
+            The field data to prepare.
+        vmin : float, optional
+            The minimum value for the color scale. If provided, zeros are replaced
+            with ``10 ** (vmin / db_factor)`` instead of NaN.
+        db_factor : float
+            Factor to multiply the log10 result by (e.g., 20 for dB scale of field,
+            10 for dB scale of power). Default is 1 (pure log10 scale).
+
+        Returns
+        -------
+        xr.DataArray
+            The log-scaled field data.
+        """
+        fill_val = np.nan
+        if vmin is not None:
+            fill_val = 10 ** (vmin / db_factor)
+        field_data = np.abs(field_data)
+        field_data = field_data.where((field_data > 0) | np.isnan(field_data), fill_val)
+        return db_factor * np.log10(field_data)
 
     def get_monitor_by_name(self, name: str) -> AbstractMonitor:
         """Return monitor named 'name'."""

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -545,7 +545,7 @@ class AbstractYeeGridSimulationData(AbstractSimulationData, ABC):
                 ("E", "abs^2"): 10,
                 ("H", "abs^2"): 10,
             }.get((field_name[0], val), 20)
-            field_data = db_factor * np.log10(np.abs(field_data))
+            field_data = self._apply_log_scale(field_data, vmin=vmin, db_factor=db_factor)
             field_data.name += " (dB)"
             cmap_type = "sequential"
         elif scale == "lin":


### PR DESCRIPTION
Warnings were being emitted by xarray/numpy when plotting with `scale=dB`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents divide-by-zero warnings when plotting fields with `scale='dB'` by safely handling zeros.
> 
> - Introduces `AbstractSimulationData._apply_log_scale()` to replace zeros (respecting optional `vmin`) and apply log10 with appropriate `db_factor`
> - Refactors `plot_field_monitor_data` to use the new helper for dB scaling
> - Adds tests covering zero-valued data with and without `vmin` to ensure no warnings
> - Updates `CHANGELOG.md` under Fixed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ca813ea073f4524e95546274c4e01e0de69bea6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

This PR fixes divide-by-zero warnings when plotting field data with `scale=dB` by replacing zero values before applying `log10`. The implementation correctly handles both the case where `vmin` is specified (zeros map to the floor value) and when it's not (zeros map to NaN). The mathematical logic is sound: when `vmin` is provided, `fill_val = 10 ** (vmin / db_factor)` ensures that zeros ultimately map to exactly `vmin` dB after the log transformation.

**Key Changes:**
- Modified `plot_field_monitor_data` to use `xarray.where()` to replace zeros while preserving NaN values
- Added comprehensive test coverage for both `vmin=None` and `vmin=-50` cases
- Added changelog entry under Fixed section

**Observations:**
- The fix maintains backward compatibility by preserving existing behavior for non-zero values
- NaN preservation logic is correct: `np.isnan(field_data)` works properly with xarray DataArrays
- Test uses `warnings.filterwarnings("error")` to ensure no divide-by-zero warnings are raised

### Confidence Score: 5/5

- This PR is safe to merge with high confidence
- The implementation is mathematically correct and well-tested. The fix properly handles the edge cases (zeros, NaN, positive/negative vmin values). The code follows project conventions including proper use of `is not None` checks. Test coverage validates the fix prevents warnings in both scenarios (with and without vmin).
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/data/sim_data.py | 5/5 | Fixed zero-value handling in dB scale plotting by replacing zeros with NaN or floor value before log10, preventing divide-by-zero warnings. Implementation is mathematically correct. |
| tests/test_data/test_sim_data.py | 4/5 | Added test to verify no divide-by-zero warnings when plotting with dB scale and zero values. Tests both with and without vmin. Could benefit from explicit NaN value testing. |
| CHANGELOG.md | 5/5 | Added changelog entry under Fixed section for handling zero values in plot_field with dB scale. Entry follows format conventions with proper backticks. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant SimulationData
    participant plot_field_monitor_data
    participant _field_component_value
    participant numpy
    participant xarray
    
    User->>SimulationData: plot_field(scale="dB")
    SimulationData->>plot_field_monitor_data: call with field_data
    plot_field_monitor_data->>_field_component_value: get field values (val="abs")
    _field_component_value->>numpy: np.abs(field_component)
    numpy-->>_field_component_value: absolute values
    _field_component_value-->>plot_field_monitor_data: field_data (xarray)
    
    alt scale == "dB"
        plot_field_monitor_data->>plot_field_monitor_data: determine db_factor
        
        alt vmin is not None
            plot_field_monitor_data->>plot_field_monitor_data: fill_val = 10 ** (vmin / db_factor)
        else vmin is None
            plot_field_monitor_data->>plot_field_monitor_data: fill_val = np.nan
        end
        
        plot_field_monitor_data->>numpy: np.abs(field_data)
        numpy-->>plot_field_monitor_data: absolute values
        
        plot_field_monitor_data->>xarray: field_data.where((field_data > 0) | np.isnan(field_data), fill_val)
        Note over xarray: Replace zeros with fill_val,<br/>preserve NaN values
        xarray-->>plot_field_monitor_data: field_data with zeros replaced
        
        plot_field_monitor_data->>numpy: db_factor * np.log10(field_data)
        Note over numpy: No divide-by-zero warnings<br/>because zeros were replaced
        numpy-->>plot_field_monitor_data: dB values
    end
    
    plot_field_monitor_data-->>User: plot with dB scale
```

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/data/sim_data.py | 5/5 | Fixed zero-value handling in dB scale plotting by replacing zeros with NaN or floor value before log10, preventing divide-by-zero warnings. Implementation is mathematically correct. |
| tests/test_data/test_sim_data.py | 4/5 | Added test to verify no divide-by-zero warnings when plotting with dB scale and zero values. Tests both with and without vmin. Could benefit from explicit NaN value testing. |
| CHANGELOG.md | 5/5 | Added changelog entry under Fixed section for handling zero values in plot_field with dB scale. Entry follows format conventions with proper backticks. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant SimulationData
    participant plot_field_monitor_data
    participant _field_component_value
    participant numpy
    participant xarray
    
    User->>SimulationData: plot_field(scale="dB")
    SimulationData->>plot_field_monitor_data: call with field_data
    plot_field_monitor_data->>_field_component_value: get field values (val="abs")
    _field_component_value->>numpy: np.abs(field_component)
    numpy-->>_field_component_value: absolute values
    _field_component_value-->>plot_field_monitor_data: field_data (xarray)
    
    alt scale == "dB"
        plot_field_monitor_data->>plot_field_monitor_data: determine db_factor
        
        alt vmin is not None
            plot_field_monitor_data->>plot_field_monitor_data: fill_val = 10 ** (vmin / db_factor)
        else vmin is None
            plot_field_monitor_data->>plot_field_monitor_data: fill_val = np.nan
        end
        
        plot_field_monitor_data->>numpy: np.abs(field_data)
        numpy-->>plot_field_monitor_data: absolute values
        
        plot_field_monitor_data->>xarray: field_data.where((field_data > 0) | np.isnan(field_data), fill_val)
        Note over xarray: Replace zeros with fill_val,<br/>preserve NaN values
        xarray-->>plot_field_monitor_data: field_data with zeros replaced
        
        plot_field_monitor_data->>numpy: db_factor * np.log10(field_data)
        Note over numpy: No divide-by-zero warnings<br/>because zeros were replaced
        numpy-->>plot_field_monitor_data: dB values
    end
    
    plot_field_monitor_data-->>User: plot with dB scale
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->