### PR TITLE
fix(tidy3d): FXC-4704-reduce-verbosity-when-loading-data-from-batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `AutoImpedanceSpec` validation to check path intersections against all conductors, not just filtered ones, as well as the mode plane bounds.
 - Fixed adjoint gradients being treated as zero due to scale-dependent `np.allclose(..., atol=1e-8)` checks, which could skip adjoint simulations and return zero gradients.
 - Fixed interpolation handling for permittivity and conductivity gradients in CustomMedium.
+- Restored original batch-load logging by suppressing per-task “Loading simulation…” messages. 
 
 ## [2.10.0] - 2025-12-18
 

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -624,7 +624,7 @@ class BatchData(Tidy3dBaseModel, Mapping):
         return web.load(
             task_id=None if from_cache else task_id,
             path=task_data_path,
-            verbose=self.verbose,
+            verbose=False,
             replace_existing=not (from_cache or self.is_downloaded),
             lazy=self.lazy,
         )


### PR DESCRIPTION
When loading data from batches with `verbose=True`, we currently flood the console with all the “Loading simulation from…” messages which is not wanted in this case.
Therefore, I fixed `verbose=False` for `web.load` in the batch scenario.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces noisy console output when iterating over batch results.
> 
> - In `BatchData.load_sim_data()`, pass `verbose=False` to `web.load()` to suppress per-task “Loading simulation…” messages
> - Update `CHANGELOG.md` under *Fixed* to note restored original batch-load logging behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b049ffcbc3a85574b65e6a991b5ab3729192eb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes excessive verbosity when loading batch simulation data by hardcoding `verbose=False` in the `BatchData.load_sim_data()` method.

**Changes:**
- Modified `tidy3d/web/api/container.py:627` to pass `verbose=False` instead of `self.verbose` to `web.load()`
- Previously, when `BatchData.verbose=True`, each individual simulation load would print "Loading simulation from {path}", flooding the console with repetitive messages
- The fix suppresses these per-simulation messages while preserving batch-level progress tracking

**Impact:**
- Users will no longer see redundant "Loading simulation from..." messages for each task when iterating through batch results
- Batch-level verbosity controls (progress bars, upload/download status) remain unaffected
- This aligns with the expected behavior where `verbose=True` controls batch operations, not individual data loads

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The change is minimal, well-scoped, and directly addresses the reported issue. It only affects console output verbosity without changing any logic or behavior. The fix is a single-line change that hardcodes `verbose=False` when loading individual simulations from a batch, preventing console flooding while preserving all functionality.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/web/api/container.py | Changed `verbose=self.verbose` to `verbose=False` in `BatchData.load_sim_data()` to suppress individual "Loading simulation from..." messages when loading batch data |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Batch
    participant BatchData
    participant web.load
    participant Console

    User->>Batch: run(verbose=True)
    Batch->>BatchData: load() with verbose=True
    Note over BatchData: BatchData.verbose = True
    
    loop For each task in batch
        User->>BatchData: __getitem__(task_name)
        BatchData->>BatchData: load_sim_data(task_name)
        BatchData->>web.load: load(verbose=False)
        Note over web.load: BEFORE: verbose=self.verbose<br/>AFTER: verbose=False
        alt verbose=False (AFTER fix)
            web.load-->>BatchData: Returns data silently
        else verbose=True (BEFORE fix)
            web.load->>Console: "Loading simulation from {path}"
            web.load-->>BatchData: Returns data with log message
        end
        BatchData-->>User: Returns simulation data
    end
    
    Note over User,Console: Fix prevents console flooding<br/>with repeated load messages
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->