### PR TITLE
fix: pydanticv2 speed improvements

### DIFF
--- a/tests/test_package/test_log.py
+++ b/tests/test_package/test_log.py
@@ -6,7 +6,7 @@ import json
 
 import numpy as np
 import pytest
-from pydantic import ValidationError
+from pydantic import ValidationError, model_validator
 
 import tidy3d as td
 from tidy3d.exceptions import Tidy3dError
@@ -253,6 +253,35 @@ def test_logging_warning_capture():
         td.log.set_capture(False)
 
         assert str(error_without) == str(error_with)
+
+
+def test_warning_capture_during_model_validation():
+    from tidy3d.components.base import Tidy3dBaseModel
+    from tidy3d.log import log
+
+    class _CaptureChild(Tidy3dBaseModel):
+        x: int
+
+        @model_validator(mode="after")
+        def _warn_child(self):
+            log.warning("child warning")
+            return self
+
+    class _CaptureParent(Tidy3dBaseModel):
+        child: _CaptureChild
+
+        @model_validator(mode="after")
+        def _warn_parent(self):
+            log.warning("parent warning")
+            return self
+
+    td.log.set_capture(True)
+    _CaptureParent(child={"x": 1})
+    warning_list = td.log.captured_warnings()
+    td.log.set_capture(False)
+
+    assert {"loc": [], "msg": "parent warning"} in warning_list
+    assert {"loc": ["child"], "msg": "child warning"} in warning_list
 
 
 def test_log_suppression():

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -201,12 +201,6 @@ class Tidy3dBaseModel(BaseModel):
                 )
         return name
 
-    def __init__(self, **kwargs: Any) -> None:
-        """Init method, includes post-init validators."""
-        log.begin_capture()
-        super().__init__(**kwargs)
-        log.end_capture(self)
-
     def __init_subclass__(cls: type[T], **kwargs: Any) -> None:
         """Injects a constant discriminator field before Pydantic builds the model.
 
@@ -235,10 +229,33 @@ class Tidy3dBaseModel(BaseModel):
 
     def __hash__(self) -> int:
         """Hash method."""
-        try:
-            return super().__hash__(self)
-        except TypeError:
-            return hash(self.model_dump_json())
+        # This function needs to take special care because of mutable attributes inside of frozen pydantic models
+        to_hash_list = []
+        for k, v in dict(self).items():
+            if k == "attrs":
+                continue
+            if isinstance(v, np.ndarray):
+                # numpy arrays are not hashable by default, use byte representation
+                v_hash = hashlib.md5(v.tobytes()).hexdigest()
+            elif isinstance(v, (xr.DataArray, xr.Dataset)):
+                # we choose to not hash data arrays as this would require a lot of careful handling of units, metadata.
+                # technically this is incorrect, but should never lead to bugs in current implementation
+                v_hash = str(v.__class__.__name__)
+            elif isinstance(v, list):
+                # this assumes all objects in lists are hashable by default and do not require special handling
+                v_hash = tuple([hash(vi) for vi in v])
+            else:
+                v_hash = hash(v)
+            to_hash_list.append((k, v_hash))
+
+        # attrs is mutable, use serialized output as safe hashing option
+        if self.attrs:
+            attrs_json = self.model_dump_json(include={"attrs"})
+            attrs_hash = hash(attrs_json)
+            to_hash_list.append(("attrs", attrs_hash))
+
+        result_hash = hash(tuple(to_hash_list))
+        return result_hash
 
     def _hash_self(self) -> str:
         """Hash this component with ``hashlib`` in a way that is the same every session."""

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -262,28 +262,33 @@ class Tidy3dBaseModel(BaseModel):
         for k, v in dict(self).items():
             if k == "attrs":
                 continue
-            if isinstance(v, np.ndarray):
-                # numpy arrays are not hashable by default, use byte representation
-                v_hash = hashlib.md5(v.tobytes()).hexdigest()
-            elif isinstance(v, (xr.DataArray, xr.Dataset)):
-                # we choose to not hash data arrays as this would require a lot of careful handling of units, metadata.
-                # technically this is incorrect, but should never lead to bugs in current implementation
-                v_hash = str(v.__class__.__name__)
-            elif isinstance(v, list):
-                # this assumes all objects in lists are hashable by default and do not require special handling
-                v_hash = tuple([hash(vi) for vi in v])
-            else:
-                v_hash = hash(v)
+            v_hash = self._recursive_hash(v)
             to_hash_list.append((k, v_hash))
 
         # attrs is mutable, use serialized output as safe hashing option
         if self.attrs:
-            attrs_json = self.model_dump_json(include={"attrs"})
-            attrs_hash = hash(attrs_json)
+            attrs_str = self._attrs_digest()
+            attrs_hash = hash(attrs_str)
             to_hash_list.append(("attrs", attrs_hash))
 
         result_hash = hash(tuple(to_hash_list))
         return result_hash
+
+    @staticmethod
+    def _recursive_hash(value: Any) -> int:
+        if isinstance(value, np.ndarray):
+            # numpy arrays are not hashable by default, use byte representation
+            v_hash = hashlib.md5(value.tobytes()).hexdigest()
+            return hash(v_hash)
+        if isinstance(value, (xr.DataArray, xr.Dataset)):
+            # we choose to not hash data arrays as this would require a lot of careful handling of units, metadata.
+            # technically this is incorrect, but should never lead to bugs in current implementation
+            return hash(str(value.__class__.__name__))
+        if isinstance(value, list):
+            # this assumes all objects in lists are hashable by default and do not require special handling
+            v_hash = tuple([Tidy3dBaseModel._recursive_hash(vi) for vi in value])
+            return hash(v_hash)
+        return hash(value)
 
     def _hash_self(self) -> str:
         """Hash this component with ``hashlib`` in a way that is the same every session."""

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -23,7 +23,8 @@ import rich
 import xarray as xr
 import yaml
 from autograd.tracer import isbox
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_validator
+from pydantic.functional_validators import ModelWrapValidatorHandler
 
 from tidy3d.exceptions import FileError
 from tidy3d.log import log
@@ -218,6 +219,16 @@ class Tidy3dBaseModel(BaseModel):
         setattr(cls, TYPE_TAG_STR, tag)
         TYPE_TO_CLASS_MAP[tag] = cls
 
+        if "__tidy3d_end_capture__" not in cls.__dict__:
+
+            @model_validator(mode="after")
+            def __tidy3d_end_capture__(self: T) -> T:
+                if log._capture:
+                    log.end_capture(self)
+                return self
+
+            cls.__tidy3d_end_capture__ = __tidy3d_end_capture__
+
         super().__init_subclass__(**kwargs)
 
     @classmethod
@@ -226,6 +237,23 @@ class Tidy3dBaseModel(BaseModel):
 
         # add docstring once pydantic is done constructing the class
         cls.__doc__ = cls.generate_docstring()
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def _capture_validation_warnings(
+        cls: type[T],
+        data: Any,
+        handler: ModelWrapValidatorHandler[T],
+    ) -> T:
+        if not log._capture:
+            return handler(data)
+
+        log.begin_capture()
+        try:
+            return handler(data)
+        except Exception:
+            log.abort_capture()
+            raise
 
     def __hash__(self) -> int:
         """Hash method."""

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -4259,19 +4259,6 @@ class Simulation(AbstractYeeGridSimulation):
         return self
 
     @model_validator(mode="after")
-    def _validate_scene(self) -> Self:
-        _ = self.scene
-        self._validate_no_structures_pml()
-        self._validate_tfsf_nonuniform_grid()
-        self._validate_tfsf_aux_sources()
-        self._validate_nonlinear_specs()
-        self._validate_custom_source_time()
-        self._validate_mode_objects()
-        self._warn_rf_license()
-        self._validate_internal_abc_no_fully_anisotropic()
-        return self
-
-    @model_validator(mode="after")
     def _warn_rf_license(self) -> Self:
         """
         Warn about new licensing requirements for RF simulations. This function details all the conditions in which a
@@ -4545,16 +4532,18 @@ class Simulation(AbstractYeeGridSimulation):
                 fields += medium.nonlinear_spec.aux_fields
         return fields
 
-    def _validate_internal_abc_no_fully_anisotropic(self) -> None:
+    @model_validator(mode="after")
+    def _validate_internal_abc_no_fully_anisotropic(self) -> Self:
         """Error if internal absorber intersect fully anisotropic mediums."""
 
         total_structures = [self.scene.background_structure, *list(self.structures)]
 
         for abc in self._shifted_internal_absorbers:
-            mediums = Scene.intersecting_media(abc, total_structures)
+            mediums = Scene.intersecting_media(abc, tuple(total_structures))
 
             if any(isinstance(med, FullyAnisotropicMedium) for med in mediums):
                 raise SetupError("A 'InternalAbsorber' cannot cross a 'FullyAnisotropicMedium'.")
+        return self
 
     """ Pre submit validation (before web.upload()) """
 

--- a/tidy3d/log.py
+++ b/tidy3d/log.py
@@ -122,8 +122,9 @@ class Logger:
     highest level of the captures messages.
 
     Messages can also be captured for post-processing. That can be enabled through 'set_capture' to
-    record all warnings emitted during model validation. A structured copy of all validation
-    messages can then be recovered through 'captured_warnings'.
+    record warnings emitted during model validation (and other explicit begin/end capture regions,
+    e.g. validation routines like ``validate_pre_upload``). A structured copy of captured warnings
+    can then be recovered through 'captured_warnings'.
     """
 
     _static_cache = set()
@@ -178,8 +179,8 @@ class Logger:
     def begin_capture(self) -> None:
         """Start capturing log stack for consolidated validation log.
 
-        This method is used before any model validation starts and is included in the initialization
-        of 'BaseModel'. It must be followed by a corresponding 'end_capture'.
+        This method should be called before a validation routine starts. It must be followed by a
+        corresponding 'end_capture'.
         """
         if not self._capture:
             return
@@ -190,11 +191,23 @@ class Logger:
         else:
             self._stack = [stack_item]
 
+    def abort_capture(self) -> None:
+        """Undo the last ``begin_capture()`` call.
+
+        This is used when validation fails before reaching the corresponding ``end_capture()``.
+        """
+        if not self._stack:
+            return
+
+        self._stack.pop()
+        if len(self._stack) == 0:
+            self._stack = None
+
     def end_capture(self, model: BaseModel) -> None:
         """End capturing log stack for consolidated validation log.
 
-        This method is used after all model validations and is included in the initialization of
-        'BaseModel'. It must follow a corresponding 'begin_capture'.
+        This method should be called after a validation routine ends. It must follow a
+        corresponding 'begin_capture'.
         """
         if not self._stack:
             return

--- a/tidy3d/plugins/expressions/metrics.py
+++ b/tidy3d/plugins/expressions/metrics.py
@@ -32,7 +32,7 @@ def generate_validation_data(expr: Expression) -> dict[str, xr.Dataset]:
     dict[str, xr.Dataset]
         The combined validation data.
     """
-    metrics = set(expr.filter(target_type=Metric))
+    metrics = set(expr.filter(target_type=Metric))  # type: ignore[type-abstract]
     combined_data = {k: v for metric in metrics for k, v in metric._validation_data.items()}
     return combined_data
 


### PR DESCRIPTION
fix hashing and double validation issues, which gives a speedup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Pydantic v2 performance and logging by eliminating double-validation and capturing warnings hierarchically during model construction.
> 
> - Integrates capture via `@model_validator`: add wrap validator to `begin_capture/abort` on errors and inject an `after` validator in subclasses to `end_capture`; remove old `__init__` capture path
> - Adds `log.abort_capture()` and clarifies capture semantics; supports explicit capture regions (e.g., `validate_pre_upload`)
> - Rewrites `__hash__` with recursive hashing for `numpy` arrays, `xarray` objects, lists, and stable digest for mutable `attrs`
> - Refactors simulation validation: drops `_validate_scene` aggregator; converts `_validate_internal_abc_no_fully_anisotropic` to `@model_validator(mode="after")` and fixes call to `Scene.intersecting_media(..., tuple(...))`
> - Tests: add hierarchical warning-capture test for nested models and update end-to-end capture checks
> - Minor: add type-ignore for abstract `Metric` filtering
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 831cd1f54d9ec30d3fb7628b76186687df126257. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR optimizes Pydantic v2 performance by removing redundant validation and fixing type handling issues. The changes address hashing of mutable attributes, eliminate double validation via consolidating model validators, and correct type signatures.

**Key Changes:**
- **base.py**: Removed `__init__` method (no longer needed in Pydantic v2) and rewrote `__hash__` to explicitly handle mutable attributes (`attrs`), numpy arrays, xarray objects, and lists. Potential issue identified: list hashing assumes all items are hashable and may fail on nested collections.
- **simulation.py**: Removed redundant `_validate_scene` aggregator method and converted `_validate_internal_abc_no_fully_anisotropic` to a standalone `@model_validator`. Fixed type signature by converting list to tuple when calling `Scene.intersecting_media(abc, tuple(...))`.
- **metrics.py**: Added type checker suppression comment for abstract base class usage.

**Testing Notes:** Changes align with Pydantic v2 validator patterns. All validation methods remain independent and will execute during model construction.

<h3>Confidence Score: 3/5</h3>


- PR contains a potential hash function issue that could cause runtime failures with nested collections in fields.
- The PR makes valid Pydantic v2 optimizations and the core changes are sound. However, the new `__hash__` implementation (line 244-246 in base.py) has a logical flaw: it assumes all list items are hashable but does not handle nested collections (lists, dicts) that appear in some Tidy3d component fields. This could cause silent hash failures or TypeErrors at runtime. The validation refactoring is correct and all validators remain active through independent `@model_validator` decorators. The metrics.py change is trivial and safe.
- tidy3d/components/base.py - The hash function needs defensive handling for unhashable items in lists, particularly for complex nested types used in Tidy3d components.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/components/base.py | Hash implementation refactored to handle mutable attributes and special types (numpy arrays, xarray objects). Removed __init__ method (Pydantic v2 no longer requires it). Potential issue: list items in line 246 are hashed individually but if any list contains unhashable items (nested lists, dicts), hashing will fail despite the comment's assumption. |
| tidy3d/components/simulation.py | Removed _validate_scene method and split its responsibilities into individual @model_validator methods. Fixed type signature by converting list to tuple when calling Scene.intersecting_media. All validation methods now independently decorated with @model_validator(mode='after'). |
| tidy3d/plugins/expressions/metrics.py | Added type: ignore[type-abstract] comment to suppress type checker warning when passing abstract Metric class to filter method. Minimal, non-functional change. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Pydantic
    participant OldValidation as Old: _validate_scene
    participant NewValidators as New: @model_validator methods
    
    User->>Pydantic: Create Simulation()
    
    alt Old Approach (Removed)
        Pydantic->>OldValidation: _validate_scene()
        OldValidation->>OldValidation: _validate_no_structures_pml()
        OldValidation->>OldValidation: _validate_tfsf_nonuniform_grid()
        OldValidation->>OldValidation: _validate_tfsf_aux_sources()
        OldValidation->>OldValidation: _validate_nonlinear_specs()
        OldValidation->>OldValidation: _validate_custom_source_time()
        OldValidation->>OldValidation: _validate_mode_objects()
        OldValidation->>OldValidation: _warn_rf_license()
        OldValidation->>OldValidation: _validate_internal_abc_no_fully_anisotropic()
    end
    
    alt New Approach (Current)
        Pydantic->>NewValidators: @model_validator(mode="after")
        par
            NewValidators->>NewValidators: _validate_no_structures_pml()
        and
            NewValidators->>NewValidators: _validate_tfsf_nonuniform_grid()
        and
            NewValidators->>NewValidators: _validate_internal_abc_no_fully_anisotropic()
        and
            NewValidators->>NewValidators: (other validators)
        end
    end
    
    Pydantic->>User: Return Simulation instance
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->