### PR TITLE
bugfix: http_interceptor fails if result is not of type dict (FXC-4739)

### DIFF
--- a/tidy3d/web/core/http_util.py
+++ b/tidy3d/web/core/http_util.py
@@ -195,7 +195,10 @@ def http_interceptor(func: Callable[..., Any]) -> Callable[..., JSONType]:
                 log = get_logger()
                 log.warning(warning)
 
-        return result.get("data") if "data" in result else result
+            if 'data' in result:
+                return result['data']
+            
+        return result
 
     return wrapper
 

--- a/tidy3d/web/core/http_util.py
+++ b/tidy3d/web/core/http_util.py
@@ -195,9 +195,9 @@ def http_interceptor(func: Callable[..., Any]) -> Callable[..., JSONType]:
                 log = get_logger()
                 log.warning(warning)
 
-            if 'data' in result:
-                return result['data']
-            
+            if "data" in result:
+                return result["data"]
+
         return result
 
     return wrapper


### PR DESCRIPTION
I tried to delete a `ModeSolverTask` as part of my automation scripts. However, deletion failed with the following error message:

```
Cell In[10], line 90
     87         continue
     89 if time.time() - start_times[eidx] > eval_timeout_s:
---> 90     exp.mode_solver_task.delete()
     91     if retries[eidx] < eval_retries:
     92         print(f" Simulation {exp.param_hash} has timed out. Resubmitting...")

File ~/.conda/envs/tidy3d_py312/lib/python3.12/site-packages/tidy3d/web/api/mode.py:489, in ModeSolverTask.delete(self)
    487 """Delete the mode solver and its corresponding task from the server."""
    488 # Delete mode solver
--> 489 http.delete(f"{MODESOLVER_API}/{self.task_id}/{self.solver_id}")
    490 # Delete parent task
    491 http.delete(f"tidy3d/tasks/{self.task_id}")

File ~/.conda/envs/tidy3d_py312/lib/python3.12/site-packages/tidy3d/web/core/http_util.py:198, in http_interceptor.<locals>.wrapper(*args, **kwargs)
    195         log = get_logger()
    196         log.warning(warning)
--> 198 return result.get("data") if "data" in result else result

TypeError: argument of type 'bool' is not iterable
```

The last line (l198) triggering the error incorrectly assumes that result is an iterable. My suggested fix only checks for the existence of the "data" key if result is of type dict, otherwise simply returns result.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes response handling in `http_interceptor` to avoid assuming JSON is always a dict.
> 
> - Only accesses `result["data"]` when `result` is a `dict`; otherwise returns the parsed JSON as-is
> - Preserves existing warning logging and behavior for dict responses
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2a60472d43b5348f7c84a79bfcefe1b0e01570e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed a `TypeError` in `http_interceptor` that occurred when API responses returned non-dict types (e.g., boolean values from DELETE operations). The fix adds an `isinstance(result, dict)` check before attempting dictionary operations like membership testing and key access.

- Added type guard using `isinstance()` before checking for 'data' key in response
- Prevents `TypeError: argument of type 'bool' is not iterable` when DELETE endpoints return boolean success values
- Maintains backward compatibility with existing dict responses containing 'data' key
- Minor style inconsistencies: mixed quote styles and trailing whitespace

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with only minor style improvements needed
- The fix correctly addresses a real TypeError bug by adding proper type checking. The logic is sound and maintains backward compatibility. Score reduced by 1 point only due to minor style inconsistencies (mixed quotes and trailing whitespace) that should be cleaned up before merge.
- No files require special attention - the change is straightforward and the logic is correct

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/web/core/http_util.py | Fixed TypeError when HTTP response returns non-dict types (e.g., boolean) by adding isinstance check before accessing dict members |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as API Client
    participant HTTP as http_interceptor
    participant API as Tidy3D API
    
    Client->>HTTP: http.delete(endpoint)
    HTTP->>API: DELETE request
    API-->>HTTP: 200 OK + JSON response
    
    alt Response has text
        HTTP->>HTTP: Parse JSON
        
        alt Result is dict
            HTTP->>HTTP: Check for warning
            opt Warning exists
                HTTP->>HTTP: Log warning
            end
            
            alt Has "data" key
                HTTP-->>Client: Return result["data"]
            else No "data" key
                HTTP-->>Client: Return result (entire dict)
            end
        else Result is not dict (e.g., boolean)
            Note over HTTP: NEW: Skip dict operations
            HTTP-->>Client: Return result directly
        end
    else Response has no text
        HTTP-->>Client: Return None
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->