### PR TITLE
FXC-4725: Fix flaky xdist failures in async web tests

### DIFF
--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -821,10 +821,10 @@ def test_batch_monitor_skips_existing_download(monkeypatch, tmp_path):
 
 @responses.activate
 @pytest.mark.parametrize("task_name", [TASK_NAME, None])
-def test_async(mock_webapi, mock_job_status, task_name):
+def test_async(mock_webapi, mock_job_status, tmp_path, task_name):
     # monkeypatch.setattr("tidy3d.web.api.container.Job.status", property(lambda self: "success"))
     sims = {TASK_NAME: make_sim()} if task_name else [make_sim()]
-    _ = run_async(sims, folder_name=PROJECT_NAME)
+    _ = run_async(sims, folder_name=PROJECT_NAME, path_dir=str(tmp_path))
 
 
 """ Main """

--- a/tests/test_web/test_webapi_eme.py
+++ b/tests/test_web/test_webapi_eme.py
@@ -378,7 +378,7 @@ def test_batch(mock_webapi, mock_job_status, tmp_path):
 
 
 @responses.activate
-def test_async(mock_webapi, mock_job_status):
+def test_async(mock_webapi, mock_job_status, tmp_path):
     # monkeypatch.setattr("tidy3d.web.api.container.Job.status", property(lambda self: "success"))
     sims = {TASK_NAME: make_eme_sim()}
-    _ = run_async(sims, folder_name=PROJECT_NAME)
+    _ = run_async(sims, folder_name=PROJECT_NAME, path_dir=str(tmp_path))

--- a/tests/test_web/test_webapi_heat.py
+++ b/tests/test_web/test_webapi_heat.py
@@ -357,7 +357,7 @@ def test_batch(mock_webapi, mock_job_status, tmp_path):
 
 
 @responses.activate
-def test_async(mock_webapi, mock_job_status):
+def test_async(mock_webapi, mock_job_status, tmp_path):
     # monkeypatch.setattr("tidy3d.web.api.container.Job.status", property(lambda self: "success"))
     sims = {TASK_NAME: make_heat_sim()}
-    _ = run_async(sims, folder_name=PROJECT_NAME)
+    _ = run_async(sims, folder_name=PROJECT_NAME, path_dir=str(tmp_path))

--- a/tests/test_web/test_webapi_mode.py
+++ b/tests/test_web/test_webapi_mode.py
@@ -415,12 +415,12 @@ def test_batch(mock_webapi, mock_job_status, tmp_path, monkeypatch):
 
 
 @responses.activate
-def test_async(mock_webapi, mock_job_status, monkeypatch):
+def test_async(mock_webapi, mock_job_status, monkeypatch, tmp_path):
     # monkeypatch.setattr("tidy3d.web.api.container.Job.status", property(lambda self: "success"))
     monkeypatch.setattr(f"{api_path}.load", lambda *args, **kwargs: True)
 
     sims = {TASK_NAME: make_mode_sim()}
-    _ = run_async(sims, folder_name=PROJECT_NAME)
+    _ = run_async(sims, folder_name=PROJECT_NAME, path_dir=str(tmp_path))
 
 
 @responses.activate

--- a/tests/test_web/test_webapi_mode_sim.py
+++ b/tests/test_web/test_webapi_mode_sim.py
@@ -410,7 +410,7 @@ def test_batch(mock_webapi, mock_job_status, tmp_path):
 
 
 @responses.activate
-def test_async(mock_webapi, mock_job_status):
+def test_async(mock_webapi, mock_job_status, tmp_path):
     # monkeypatch.setattr("tidy3d.web.api.container.Job.status", property(lambda self: "success"))
     sims = {TASK_NAME: make_mode_sim()}
-    _ = run_async(sims, folder_name=PROJECT_NAME)
+    _ = run_async(sims, folder_name=PROJECT_NAME, path_dir=str(tmp_path))


### PR DESCRIPTION
Fixes intermittent `h5py` file-locking errors under xdist when multiple `test_async` cases call `run_async` with the default `path_dir="."`, causing concurrent writes to `./batch.hdf5`.

Changes:
- Pass `path_dir=str(tmp_path)` to `run_async` in async web tests so each worker writes to an isolated directory.

Checks:
- `poetry run pytest -q --no-cov -W ignore tests/test_web/ --maxfail=1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses xdist flakiness by isolating async test artifacts per worker.
> 
> - Update async tests in `test_webapi*.py` to pass `path_dir=str(tmp_path)` to `run_async`
> - Add `tmp_path` fixture to corresponding `test_async` signatures
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1a54c152801f4a84f033e8a750fee608a95adee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes flaky xdist failures in async web tests by isolating test artifacts per worker. The issue occurred when multiple test workers concurrently called `run_async` with the default `path_dir="."`, causing concurrent writes to the same `./batch.hdf5` file and h5py file-locking errors.

**Changes:** All five async test functions (`test_async` in `test_webapi.py`, `test_webapi_eme.py`, `test_webapi_heat.py`, `test_webapi_mode.py`, and `test_webapi_mode_sim.py`) now:
- Accept the `tmp_path` pytest fixture parameter
- Pass `path_dir=str(tmp_path)` to `run_async()` calls

This ensures each test worker writes to its own isolated temporary directory, preventing file contention and flaky failures under parallel test execution.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no concerns - it only adjusts test isolation to fix xdist flakiness.
- Score reflects minimal, targeted changes that directly address the root cause of xdist flakiness. All five test files are updated consistently and correctly. The changes use the standard pytest `tmp_path` fixture as recommended by the custom instruction rule 6efa8f43. No logic changes, no API changes, and no side effects to existing functionality.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tests/test_web/test_webapi.py | Added `tmp_path` fixture to `test_async` function signature and passed `path_dir=str(tmp_path)` to `run_async()` call to isolate async test artifacts to temporary directory per worker. |
| tests/test_web/test_webapi_eme.py | Added `tmp_path` fixture to `test_async` function signature and passed `path_dir=str(tmp_path)` to `run_async()` call to isolate async test artifacts to temporary directory per worker. |
| tests/test_web/test_webapi_heat.py | Added `tmp_path` fixture to `test_async` function signature and passed `path_dir=str(tmp_path)` to `run_async()` call to isolate async test artifacts to temporary directory per worker. |
| tests/test_web/test_webapi_mode.py | Added `tmp_path` fixture to `test_async` function signature and passed `path_dir=str(tmp_path)` to `run_async()` call to isolate async test artifacts to temporary directory per worker. |
| tests/test_web/test_webapi_mode_sim.py | Added `tmp_path` fixture to `test_async` function signature and passed `path_dir=str(tmp_path)` to `run_async()` call to isolate async test artifacts to temporary directory per worker. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Worker1 as Test Worker 1
    participant Worker2 as Test Worker 2
    participant tmpPath as tmp_path Fixture
    participant runAsync as run_async
    participant batchFile as batch.hdf5

    Worker1->>tmpPath: Get isolated tmp_dir_1
    Worker2->>tmpPath: Get isolated tmp_dir_2
    
    Worker1->>runAsync: run_async(..., path_dir=tmp_dir_1)
    Worker2->>runAsync: run_async(..., path_dir=tmp_dir_2)
    
    runAsync->>batchFile: Write to tmp_dir_1/batch.hdf5
    runAsync->>batchFile: Write to tmp_dir_2/batch.hdf5
    
    Note over Worker1,Worker2: No file contention - isolated directories
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Utilize standard pytest fixtures like tmp_path (for files) and monkeypatch (for mocking state or imp... ([source](https://app.greptile.com/review/custom-context?memory=6efa8f43-94f4-47d3-be62-b47f84cb3f8f))

<!-- /greptile_comment -->