### PR TITLE
fix(tidy3d): FXC-4742-avoid-any-non-temporary-hdf-5-writing-in-tests

### DIFF
--- a/tests/test_plugins/test_mode_solver.py
+++ b/tests/test_plugins/test_mode_solver.py
@@ -384,7 +384,7 @@ def test_mode_solver_fields():
 
 @pytest.mark.parametrize("local", [True, False])
 @responses.activate
-def test_mode_solver_simple(mock_remote_api, local):
+def test_mode_solver_simple(mock_remote_api, local, tmp_path):
     """Simple mode solver run (with symmetry)"""
 
     simulation = td.Simulation(
@@ -423,7 +423,7 @@ def test_mode_solver_simple(mock_remote_api, local):
         check_ms_reduction(ms)
 
     else:
-        _ = msweb.run(ms)
+        _ = msweb.run(ms, results_file=tmp_path / "tmp.hdf5")
 
     # Testing issue 807 functions
     freq0 = td.C_0 / 1.55
@@ -888,7 +888,7 @@ def test_group_index(mock_remote_api, local, tmp_path):
         mode_spec=mode_spec.copy(update={"group_index_step": True}),
         freqs=freqs,
     )
-    modes = ms.solve() if local else msweb.run(ms)
+    modes = ms.solve() if local else msweb.run(ms, results_file=tmp_path / "tmp.hdf5")
     if local:
         assert (modes.n_group.sel(mode_index=0).values > 3.9).all()
         assert (modes.n_group.sel(mode_index=0).values < 4.2).all()
@@ -1030,7 +1030,7 @@ def test_mode_solver_method_defaults():
 
 
 @responses.activate
-def test_mode_solver_web_run_batch(mock_remote_api):
+def test_mode_solver_web_run_batch(mock_remote_api, tmp_path):
     """Testing run_batch function for the web mode solver."""
 
     wav = 1.5
@@ -1065,7 +1065,13 @@ def test_mode_solver_web_run_batch(mock_remote_api):
         )
 
     # Run mode solver one at a time
-    results = msweb.run_batch(mode_solver_list, verbose=False, folder_name="Mode Solver")
+    results_files = [tmp_path / f"ms_batch_{i}.hdf5" for i in range(num_of_sims)]
+    results = msweb.run_batch(
+        mode_solver_list,
+        verbose=False,
+        folder_name="Mode Solver",
+        results_files=results_files,
+    )
     print(*results, sep="\n")
     assert all(isinstance(x, ModeSolverData) for x in results)
     assert (results[i].n_eff.shape == (num_freqs, i + 1) for i in range(num_of_sims))
@@ -1144,7 +1150,7 @@ def test_mode_solver_plot():
 
 @pytest.mark.parametrize("local", [True, False])
 @responses.activate
-def test_modes_eme_sim(mock_remote_api, local):
+def test_modes_eme_sim(mock_remote_api, local, tmp_path):
     lambda0 = 1
     freq0 = td.C_0 / lambda0
     sim_size = (1, 1, 1)
@@ -1161,8 +1167,10 @@ def test_modes_eme_sim(mock_remote_api, local):
         _ = solver.data
     else:
         with pytest.raises(SetupError):
-            _ = msweb.run(solver)
-        _ = msweb.run(solver.to_fdtd_mode_solver())
+            _ = msweb.run(solver, results_file=tmp_path / "eme_solver_remote.hdf5")
+        _ = msweb.run(
+            solver.to_fdtd_mode_solver(), results_file=tmp_path / "eme_solver_fdtd_remote.hdf5"
+        )
 
     _ = solver.reduced_simulation_copy
 

--- a/tests/test_web/test_local_cache.py
+++ b/tests/test_web/test_local_cache.py
@@ -285,7 +285,7 @@ def _test_load_simulation_if_cached(monkeypatch, tmp_path, basic_simulation):
     assert counters == {"upload": 1, "start": 1, "monitor": 1, "download": 1}
     assert len(cache) == 1
 
-    sim_data_from_cache = load_simulation_if_cached(basic_simulation)
+    sim_data_from_cache = load_simulation_if_cached(basic_simulation, path=tmp_path / "tmp.hdf5")
     assert sim_data_from_cache is not None
     assert sim_data_from_cache.simulation == basic_simulation
 
@@ -296,20 +296,20 @@ def _test_load_simulation_if_cached(monkeypatch, tmp_path, basic_simulation):
 
 def _test_mode_solver_caching(monkeypatch, tmp_path):
     counters = _patch_run_pipeline(monkeypatch)
-
+    tmp_file = tmp_path / "tmp.hdf5"
     # store in cache
     mode_sim = make_mode_sim()
-    mode_sim_data = web.run(mode_sim)
+    mode_sim_data = web.run(mode_sim, path=tmp_file)
 
     # test basic loading from cache
-    from_cache_data = load_simulation_if_cached(mode_sim)
+    from_cache_data = load_simulation_if_cached(mode_sim, path=tmp_file)
     assert from_cache_data is not None
     assert isinstance(from_cache_data, _FakeStubData)
     assert mode_sim_data.simulation == from_cache_data.simulation
 
     # test loading from run
     _reset_counters(counters)
-    mode_sim_data_run = web.run(mode_sim)
+    mode_sim_data_run = web.run(mode_sim, path=tmp_file)
     assert counters["download"] == 0
     assert isinstance(mode_sim_data_run, _FakeStubData)
     assert mode_sim_data.simulation == mode_sim_data_run.simulation
@@ -317,7 +317,7 @@ def _test_mode_solver_caching(monkeypatch, tmp_path):
     # test loading from job
     _reset_counters(counters)
     job = Job(simulation=mode_sim, task_name="test")
-    job_data = job.run()
+    job_data = job.run(path=tmp_file)
     assert counters["download"] == 0
     assert isinstance(job_data, _FakeStubData)
     assert mode_sim_data.simulation == job_data.simulation
@@ -334,14 +334,14 @@ def _test_mode_solver_caching(monkeypatch, tmp_path):
     cache = resolve_local_cache(True)
     # test storing via job
     cache.clear()
-    Job(simulation=mode_sim, task_name="test").run()
-    assert load_simulation_if_cached(mode_sim) is not None
+    Job(simulation=mode_sim, task_name="test").run(path=tmp_file)
+    assert load_simulation_if_cached(mode_sim, path=tmp_file) is not None
 
     # test storing via batch
     cache.clear()
     batch_mode_data = Batch(simulations={"sim1": mode_sim}).run(path_dir=tmp_path)
     _ = batch_mode_data["sim1"]  # access to store
-    assert load_simulation_if_cached(mode_sim) is not None
+    assert load_simulation_if_cached(mode_sim, path=tmp_file) is not None
 
 
 def _test_run_cache_hit_async(monkeypatch, basic_simulation, tmp_path):
@@ -382,7 +382,7 @@ def _test_run_cache_hit_async(monkeypatch, basic_simulation, tmp_path):
     assert len(cache) == 3
 
 
-def _test_verbosity(monkeypatch, basic_simulation):
+def _test_verbosity(monkeypatch, basic_simulation, tmp_path):
     _CSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")  # ANSI CSI
     _OSC8_RE = re.compile(r"\x1b\]8;.*?(?:\x1b\\|\x07)", re.DOTALL)  # OSC-8 hyperlinks
 
@@ -403,8 +403,8 @@ def _test_verbosity(monkeypatch, basic_simulation):
     _reset_counters(counters)
     sim2 = basic_simulation.updated_copy(shutoff=1e-4)
     sim3 = basic_simulation.updated_copy(shutoff=1e-3)
-
-    run(basic_simulation, verbose=True)  # seed cache
+    tmp_file = tmp_path / "tmp.hdf5"
+    run(basic_simulation, verbose=True, path=tmp_file)  # seed cache
 
     log_mod = importlib.import_module("tidy3d.log")
 
@@ -424,7 +424,7 @@ def _test_verbosity(monkeypatch, basic_simulation):
         buf.seek(0)
 
         # test for load_simulation_if_cached
-        sim_data = load_simulation_if_cached(basic_simulation, verbose=True)
+        sim_data = load_simulation_if_cached(basic_simulation, verbose=True, path=tmp_file)
         assert sim_data is not None
         assert "Loading simulation from" in buf.getvalue(), (
             f"Expected 'Loading simulation from' in log, got '{buf.getvalue()}'"
@@ -432,14 +432,14 @@ def _test_verbosity(monkeypatch, basic_simulation):
 
         buf.truncate(0)
         buf.seek(0)
-        load_simulation_if_cached(basic_simulation, verbose=False)
+        load_simulation_if_cached(basic_simulation, verbose=False, path=tmp_file)
         assert sim_data is not None
         assert buf.getvalue().strip() == "", f"Expected empty log, got '{buf.getvalue()}'"
 
         # test for batched runs
         buf.truncate(0)
         buf.seek(0)
-        run([basic_simulation, sim3], verbose=True)
+        run([basic_simulation, sim3], verbose=True, path=tmp_path)
         txt = _normalize_console_text(buf.getvalue())
         assert "Got 1 simulation from cache" in txt, (
             f"Expected 'Got 1 simulation from cache' in log, got '{buf.getvalue()}'"
@@ -448,13 +448,13 @@ def _test_verbosity(monkeypatch, basic_simulation):
         # if some found
         buf.truncate(0)
         buf.seek(0)
-        run([basic_simulation, sim2], verbose=False)
+        run([basic_simulation, sim2], verbose=False, path=tmp_path)
         assert buf.getvalue().strip() == "", f"Expected empty log, got '{buf.getvalue()}'"
 
         # if all found
         buf.truncate(0)
         buf.seek(0)
-        run([basic_simulation, sim2], verbose=False)
+        run([basic_simulation, sim2], verbose=False, path=tmp_path)
         assert buf.getvalue().strip() == "", f"Expected empty log, got '{buf.getvalue()}'"
 
     finally:
@@ -467,7 +467,7 @@ def _test_job_run_cache(monkeypatch, basic_simulation, tmp_path):
     cache = resolve_local_cache(use_cache=True)
     cache.clear()
     job = Job(simulation=basic_simulation, task_name="test")
-    job.run()
+    job.run(path=tmp_path / "tmp.hdf5")
 
     assert len(cache) == 1
 
@@ -485,7 +485,7 @@ def _test_job_run_cache(monkeypatch, basic_simulation, tmp_path):
     assert os.path.exists(out2_path)
 
 
-def _test_autograd_cache(monkeypatch, request):
+def _test_autograd_cache(monkeypatch, request, tmp_path):
     counters = _patch_run_pipeline(monkeypatch)
 
     # "Original" rule: the one autograd uses by default
@@ -526,7 +526,7 @@ def _test_autograd_cache(monkeypatch, request):
     def objective(params):
         sim = make_sim(params)
         sim.attrs["params"] = params
-        sim_data = run_autograd(sim)
+        sim_data = run_autograd(sim, path=tmp_path / "tmp.hdf5")
         value = postprocess(sim_data)
         return value
 
@@ -823,9 +823,9 @@ def test_cache_sequential(
     _test_cache_stats_sync(monkeypatch, tmp_path_factory, basic_simulation)
     _test_run_cache_hit_async(monkeypatch, basic_simulation, tmp_path)
     _test_job_run_cache(monkeypatch, basic_simulation, tmp_path)
-    _test_autograd_cache(monkeypatch, request)
+    _test_autograd_cache(monkeypatch, request, tmp_path)
     _test_configure_cache_roundtrip(monkeypatch, tmp_path)
     _test_store_and_fetch_do_not_iterate(monkeypatch, tmp_path, basic_simulation)
     _test_mode_solver_caching(monkeypatch, tmp_path)
-    _test_verbosity(monkeypatch, basic_simulation)
+    _test_verbosity(monkeypatch, basic_simulation, tmp_path)
     _test_cache_cli_commands(monkeypatch, tmp_path_factory, basic_simulation)

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -852,6 +852,8 @@ def test_main(mock_webapi, monkeypatch, mock_job_status, tmp_path):
             PROJECT_NAME,
             "--inspect_credits",
             "--inspect_sim",
+            "-o",
+            str(tmp_path / "tmp.hdf5"),
         ]
     )
 
@@ -865,6 +867,8 @@ def test_main(mock_webapi, monkeypatch, mock_job_status, tmp_path):
                 "--folder_name",
                 PROJECT_NAME,
                 "--inspect_credits",
+                "-o",
+                str(tmp_path / "tmp.hdf5"),
             ]
         )
 
@@ -877,6 +881,8 @@ def test_main(mock_webapi, monkeypatch, mock_job_status, tmp_path):
                 "--folder_name",
                 PROJECT_NAME,
                 "--inspect_sim",
+                "-o",
+                str(tmp_path / "tmp.hdf5"),
             ]
         )
 


### PR DESCRIPTION
<h2>Greptile Overview</h2>

### Greptile Summary

This PR successfully eliminates HDF5 file leakage in tests by systematically updating all test functions to use pytest's `tmp_path` fixture for temporary file operations.

**Major changes:**
- Added `tmp_path` parameter to test functions that previously wrote HDF5 files to the working directory
- Updated `msweb.run()` and `msweb.run_batch()` calls to use `results_file` parameter with temporary paths
- Modified `web.run()`, `Job.run()`, and `load_simulation_if_cached()` calls to use `path` parameter with temporary locations
- Added `-o` flag to `main()` CLI calls in tests to direct output to temporary files

The changes follow consistent patterns across all three files and properly utilize pytest's standard fixture for temporary file handling.

### Confidence Score: 5/5

- This PR is safe to merge with no issues found
- All changes are test-only modifications that properly utilize pytest's tmp_path fixture to prevent HDF5 file leakage. The implementation is consistent, follows best practices, and doesn't affect production code.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tests/test_plugins/test_mode_solver.py | 5/5 | Updated mode solver tests to use tmp_path fixture for all HDF5 file operations, preventing file leakage |
| tests/test_web/test_local_cache.py | 5/5 | Refactored caching tests to properly use tmp_path for all file I/O operations |
| tests/test_web/test_webapi.py | 5/5 | Added -o flag with tmp_path to main() calls to direct output to temporary locations |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Test Function
    participant Pytest as Pytest Framework
    participant TmpPath as tmp_path Fixture
    participant WebAPI as Web API (msweb/web)
    participant FileSystem as File System

    Note over Test,FileSystem: Before: Tests wrote HDF5 files to working directory
    
    Test->>Pytest: Request tmp_path fixture
    Pytest->>TmpPath: Create temporary directory
    TmpPath-->>Test: Return temp path
    
    alt Mode Solver Tests (test_mode_solver.py)
        Test->>Test: Create tmp file path (tmp_path / "tmp.hdf5")
        Test->>WebAPI: msweb.run(ms, results_file=tmp_path / "tmp.hdf5")
        WebAPI->>FileSystem: Write to temporary location
        FileSystem-->>WebAPI: File saved
        WebAPI-->>Test: Return ModeSolverData
    end
    
    alt Cache Tests (test_local_cache.py)
        Test->>Test: Create tmp file path
        Test->>WebAPI: web.run(sim, path=tmp_file)
        WebAPI->>FileSystem: Write to temporary location
        FileSystem-->>WebAPI: File saved
        Test->>WebAPI: load_simulation_if_cached(sim, path=tmp_file)
        WebAPI->>FileSystem: Read from temporary location
        FileSystem-->>WebAPI: File data
    end
    
    alt CLI Tests (test_webapi.py)
        Test->>Test: Build main() args with -o flag
        Test->>WebAPI: main([..., "-o", str(tmp_path / "tmp.hdf5")])
        WebAPI->>FileSystem: Write to temporary location
        FileSystem-->>WebAPI: File saved
    end
    
    Note over Pytest,FileSystem: After test: Pytest cleans up tmp_path automatically
    Pytest->>FileSystem: Remove temporary directory
    FileSystem-->>Pytest: Cleanup complete
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures all test-generated HDF5 artifacts are written to pytest-managed temp locations to prevent leakage and interference between runs.
> 
> - Added `tmp_path` to relevant tests and routed outputs via `results_file` in `msweb.run(...)`/`run_batch(...)`
> - Updated web API tests to pass `path` to `web.run(...)`, `Job.run(...)`, `load_simulation_if_cached(...)`, and batch `path_dir`
> - CLI tests now pass `-o` with a temp file to `main(...)`
> - Minor refactors in mode solver tests to persist remote results to `tmp_path` and verify batch outputs
> 
> All changes are test-only; no production code modified.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16e434e201eb36ddcca0b89aa6445b6e0ec3beba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->