### PR TITLE
fix(smatrix): reorder WavePort validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed `AutoImpedanceSpec` validation to check path intersections against all conductors, not just filtered ones, as well as the mode plane bounds.
+- Fixed `WavePort` validation so invalid `mode_spec` errors are no longer masked by a `KeyError`.
 - Fixed adjoint gradients being treated as zero due to scale-dependent `np.allclose(..., atol=1e-8)` checks, which could skip adjoint simulations and return zero gradients.
 - Fixed interpolation handling for permittivity and conductivity gradients in CustomMedium.
 - Restored original batch-load logging by suppressing per-task “Loading simulation…” messages. 

--- a/tidy3d/plugins/smatrix/ports/wave.py
+++ b/tidy3d/plugins/smatrix/ports/wave.py
@@ -295,8 +295,8 @@ class WavePort(AbstractTerminalPort, Box):
             ) from e
         return val
 
-    @skip_if_fields_missing(["mode_spec"])
     @pd.validator("mode_selection", always=True)
+    @skip_if_fields_missing(["mode_spec"])
     def _validate_mode_selection(cls, val, values):
         """Validate that mode_selection contains valid, unique indices within range."""
         if val is None:
@@ -352,8 +352,8 @@ class WavePort(AbstractTerminalPort, Box):
             )
         return val
 
-    @skip_if_fields_missing(["mode_spec"])
     @pd.validator("mode_index", always=True)
+    @skip_if_fields_missing(["mode_spec"])
     def _validate_mode_index(cls, val, values):
         """Validate that mode_selection contains valid, unique indices within range."""
         if val is None:


### PR DESCRIPTION
Fixes #3141

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 352db7875c648630fbbe8a3473cd6a7e744588db. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

This PR fixes a decorator ordering issue in the `WavePort` class validators that was causing `KeyError` exceptions to mask the real validation errors from `mode_spec`.

## The Problem

When `mode_spec` validation failed, subsequent validators (`_validate_mode_selection` and `_validate_mode_index`) would attempt to access `values["mode_spec"]`, which would raise a `KeyError` since the field was not added to the values dict after a validation failure. This `KeyError` would mask the actual `mode_spec` validation error, making debugging difficult.

## The Solution

The fix reorders the decorators on two validators:
- `_validate_mode_selection` (lines 298-331)
- `_validate_mode_index` (lines 355-367)

**Before:** `@skip_if_fields_missing` was placed above `@pd.validator`
**After:** `@skip_if_fields_missing` is placed below `@pd.validator`

Since decorators are applied bottom-to-top in Python, this ensures that `skip_if_fields_missing` wraps the validator function. When executed, it checks whether `mode_spec` exists in the `values` dict before running the validator logic. If `mode_spec` is missing (because its validation failed), the validator is skipped entirely, allowing the original `mode_spec` error to be shown to the user.

## Verification

The fix is consistent with other validators in the codebase that follow the same pattern (e.g., in `components/medium.py`, `plugins/smatrix/component_modelers/base.py`). Existing tests in `test_terminal_component_modeler.py` validate the mode_index and mode_selection behavior.

### Confidence Score: 5/5

- This PR is safe to merge with no risk. It's a simple, well-understood fix to decorator ordering.
- The fix is minimal, correct, and follows established patterns in the codebase. The decorator reordering is the proper solution to prevent KeyError from masking validation errors. No new functionality is added, only the order of existing decorators is changed. The change is covered by existing tests and the CHANGELOG is appropriately updated.
- No files require special attention. The changes are straightforward and correct.

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/smatrix/ports/wave.py | 5/5 | Reordered decorators on `_validate_mode_selection` and `_validate_mode_index` to fix KeyError masking issue. The fix correctly places `@skip_if_fields_missing` after `@pd.validator` so the field existence check happens before accessing `values['mode_spec']`. |
| CHANGELOG.md | 5/5 | Added changelog entry under 'Fixed' section describing the bug fix for WavePort validation. Entry is clear and follows project conventions. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Pydantic
    participant WavePort
    participant SkipDecorator as @skip_if_fields_missing
    participant Validator as _validate_mode_selection

    User->>Pydantic: Create WavePort(mode_spec=invalid, mode_selection=[0,1])
    Pydantic->>WavePort: Validate 'mode_spec' field
    WavePort->>WavePort: _validate_path_integrals_within_port()
    Note over WavePort: mode_spec validation FAILS
    WavePort-->>Pydantic: ValidationError raised
    Note over Pydantic: 'mode_spec' not added to values dict
    
    Pydantic->>WavePort: Validate 'mode_selection' field
    WavePort->>SkipDecorator: @pd.validator decorator applied first
    Note over SkipDecorator: Then @skip_if_fields_missing applied
    SkipDecorator->>SkipDecorator: Check if 'mode_spec' in values
    Note over SkipDecorator: 'mode_spec' missing (failed validation)
    SkipDecorator-->>Pydantic: Skip validator, return original value
    Note over Pydantic: mode_spec validation error shown<br/>NOT masked by KeyError!
    
    Pydantic-->>User: ValidationError: mode_spec issue
```

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/plugins/smatrix/ports/wave.py | 5/5 | Reordered decorators on `_validate_mode_selection` and `_validate_mode_index` to fix KeyError masking issue. The fix correctly places `@skip_if_fields_missing` after `@pd.validator` so the field existence check happens before accessing `values['mode_spec']`. |
| CHANGELOG.md | 5/5 | Added changelog entry under 'Fixed' section describing the bug fix for WavePort validation. Entry is clear and follows project conventions. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Pydantic
    participant WavePort
    participant SkipDecorator as @skip_if_fields_missing
    participant Validator as _validate_mode_selection

    User->>Pydantic: Create WavePort(mode_spec=invalid, mode_selection=[0,1])
    Pydantic->>WavePort: Validate 'mode_spec' field
    WavePort->>WavePort: _validate_path_integrals_within_port()
    Note over WavePort: mode_spec validation FAILS
    WavePort-->>Pydantic: ValidationError raised
    Note over Pydantic: 'mode_spec' not added to values dict
    
    Pydantic->>WavePort: Validate 'mode_selection' field
    WavePort->>SkipDecorator: @pd.validator decorator applied first
    Note over SkipDecorator: Then @skip_if_fields_missing applied
    SkipDecorator->>SkipDecorator: Check if 'mode_spec' in values
    Note over SkipDecorator: 'mode_spec' missing (failed validation)
    SkipDecorator-->>Pydantic: Skip validator, return original value
    Note over Pydantic: mode_spec validation error shown<br/>NOT masked by KeyError!
    
    Pydantic-->>User: ValidationError: mode_spec issue
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->