### PR TITLE
FXC-4774: Soft-fail commitlint on PRs

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -370,6 +370,8 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.determine-test-scope.outputs.code_quality_tests == 'true'
     name: lint-commit-messages
+    # Soft-fail on PRs (early feedback), hard-fail in merge queue (enforced)
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Check out source code
         uses: actions/checkout@v4
@@ -391,7 +393,18 @@ jobs:
           node --version
           npm --version
           npx commitlint --version
-        
+
+      - name: Check commit messages (pull_request)
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          npx commitlint --from $BASE_SHA --to $HEAD_SHA --verbose || {
+            echo "::warning::Commit messages don't follow conventional commits format. Fix before merge queue."
+            exit 1
+          }
+
       - name: Check commit messages (merge_group)
         if: github.event_name == 'merge_group'
         env:


### PR DESCRIPTION
Summary:
- Make commit message linting non-blocking on pull_request runs (continue-on-error), while keeping merge queue enforcement.

Checks:
- poetry run pre-commit run --files .github/workflows/tidy3d-python-client-tests.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Commit message linting behavior updated**
> 
> - Add `continue-on-error` to `lint-commit-messages` for `pull_request` events (soft-fail for early feedback)
> - New PR-specific step runs `commitlint` between PR base/head SHAs and emits a `::warning::` on failure
> - Retain strict `merge_group` step that fails the job on lint errors using base/head SHAs
> - Changes limited to `.github/workflows/tidy3d-python-client-tests.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e1d3a5e2c2d297aecc24dc5a5f92a5fd1b134c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

This PR modifies the GitHub Actions workflow to make commit message linting non-blocking on pull requests while maintaining strict enforcement in the merge queue. 

## Changes Made

1. **Added `continue-on-error` flag** to the `lint-commit-messages` job that evaluates to `true` only for pull_request events
2. **Created a new step** "Check commit messages (pull_request)" that specifically handles PR commit linting with a warning annotation
3. **Split the linting logic** into two separate steps: one for pull_request events and one for merge_group events

## How It Works

**On Pull Requests:**
- The job runs with `continue-on-error: true`
- If commits fail linting, a GitHub warning annotation is displayed: `::warning::Commit messages don't follow conventional commits format. Fix before merge queue.`
- The step exits with code 1, but the job result is converted to "success" due to `continue-on-error`
- The `workflow-validation` job sees the "success" result and doesn't block the PR
- Developers receive early feedback without being blocked

**On Merge Queue:**
- The job runs with `continue-on-error: false` (default)
- If commits fail linting, the job fails with exit code 1
- The `workflow-validation` job detects the failure and blocks the merge
- Ensures clean commit history in main branches

This approach provides a better developer experience by giving early feedback on PRs without blocking progress, while still enforcing standards at the merge gate.

### Confidence Score: 5/5

- This PR is safe to merge with minimal risk
- The changes are well-designed and correctly implement the soft-fail behavior for commit linting on PRs. The logic properly uses GitHub Actions' continue-on-error mechanism to convert step failures into job success on pull_request events while maintaining strict enforcement on merge_group events. The implementation includes appropriate warning annotations for developer feedback. The changes are isolated to CI/CD configuration with no code changes, and the YAML structure is valid with proper conditionals.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/tidy3d-python-client-tests.yml | 5/5 | Added continue-on-error flag to make commit linting non-blocking on PRs while keeping merge queue enforcement strict. Added new pull_request-specific commit checking step with warning annotations. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PR as Pull Request Event
    participant MQ as Merge Queue Event
    participant Job as lint-commit-messages Job
    participant Step as Check Commit Step
    participant Validation as workflow-validation Job
    
    Note over PR,Validation: Pull Request Flow (Soft-fail)
    PR->>Job: Trigger with continue-on-error=true
    Job->>Step: Run commitlint (pull_request step)
    alt Commits pass linting
        Step-->>Job: Exit 0 (success)
        Job-->>Validation: Job result: success
        Validation-->>PR: PR not blocked ✓
    else Commits fail linting
        Step->>Step: Print ::warning:: annotation
        Step-->>Job: Exit 1 (step fails)
        Note over Job: continue-on-error converts to success
        Job-->>Validation: Job result: success
        Validation-->>PR: PR not blocked (warning shown) ✓
    end
    
    Note over MQ,Validation: Merge Queue Flow (Hard-fail)
    MQ->>Job: Trigger with continue-on-error=false
    Job->>Step: Run commitlint (merge_group step)
    alt Commits pass linting
        Step-->>Job: Exit 0 (success)
        Job-->>Validation: Job result: success
        Validation-->>MQ: Merge allowed ✓
    else Commits fail linting
        Step-->>Job: Exit 1 (step fails)
        Job-->>Validation: Job result: failure
        Validation->>Validation: Check fails (result != success)
        Validation-->>MQ: Merge blocked ✗
    end
```

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/tidy3d-python-client-tests.yml | 5/5 | Added continue-on-error flag to make commit linting non-blocking on PRs while keeping merge queue enforcement strict. Added new pull_request-specific commit checking step with warning annotations. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PR as Pull Request Event
    participant MQ as Merge Queue Event
    participant Job as lint-commit-messages Job
    participant Step as Check Commit Step
    participant Validation as workflow-validation Job
    
    Note over PR,Validation: Pull Request Flow (Soft-fail)
    PR->>Job: Trigger with continue-on-error=true
    Job->>Step: Run commitlint (pull_request step)
    alt Commits pass linting
        Step-->>Job: Exit 0 (success)
        Job-->>Validation: Job result: success
        Validation-->>PR: PR not blocked ✓
    else Commits fail linting
        Step->>Step: Print ::warning:: annotation
        Step-->>Job: Exit 1 (step fails)
        Note over Job: continue-on-error converts to success
        Job-->>Validation: Job result: success
        Validation-->>PR: PR not blocked (warning shown) ✓
    end
    
    Note over MQ,Validation: Merge Queue Flow (Hard-fail)
    MQ->>Job: Trigger with continue-on-error=false
    Job->>Step: Run commitlint (merge_group step)
    alt Commits pass linting
        Step-->>Job: Exit 0 (success)
        Job-->>Validation: Job result: success
        Validation-->>MQ: Merge allowed ✓
    else Commits fail linting
        Step-->>Job: Exit 1 (step fails)
        Job-->>Validation: Job result: failure
        Validation->>Validation: Check fails (result != success)
        Validation-->>MQ: Merge blocked ✗
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->