### PR TITLE
FXC-4775: Surface batch download failures when gzip extraction fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restored original batch-load logging by suppressing per-task “Loading simulation…” messages. 
 - Fixed output range of `tidy3d.plugins.invdes.FilterAndProject` to be between 0 and 1.
 - Cropped adjoint monitor sizes in 2D simulations to planar geometry intersection.
+- Fixed `Batch.download()` silently succeeding when background downloads fail (e.g., gzip extraction errors).
 
 ## [2.10.0] - 2025-12-18
 

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -816,6 +816,23 @@ def test_batch_monitor_skips_existing_download(monkeypatch, tmp_path):
     assert downloads == [("task_b_id", "download", os.path.join(str(tmp_path), "task_b_id.hdf5"))]
 
 
+def test_batch_download_surfaces_download_errors(monkeypatch, tmp_path):
+    monkeypatch.setattr("tidy3d.web.api.container.Job.status", property(lambda self: "success"))
+    monkeypatch.setattr("tidy3d.web.api.container.Job.load_if_cached", property(lambda self: False))
+    monkeypatch.setattr("tidy3d.web.api.container.Job.task_id", property(lambda self: "task_a_id"))
+
+    def _raise_download(self, path):
+        raise RuntimeError("gzip extraction failed")
+
+    monkeypatch.setattr("tidy3d.web.api.container.Job.download", _raise_download)
+
+    sims = {"task_a": make_sim()}
+    batch = Batch(simulations=sims, folder_name=PROJECT_NAME, verbose=False)
+
+    with pytest.raises(RuntimeError, match="gzip extraction failed"):
+        batch.download(path_dir=str(tmp_path))
+
+
 """ Async """
 
 

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -1290,13 +1290,14 @@ class Batch(WebContainer):
                     pbar_message = f"Downloading data for {len(fns)} tasks"
                     pbar = progress.add_task(pbar_message, total=len(fns))
                     completed = 0
-                    for _ in concurrent.futures.as_completed(futures):
+                    for fut in concurrent.futures.as_completed(futures):
+                        fut.result()
                         completed += 1
                         progress.update(pbar, completed=completed)
             else:
                 # Still ensure completion if verbose is off
-                for _ in concurrent.futures.as_completed(futures):
-                    pass
+                for fut in concurrent.futures.as_completed(futures):
+                    fut.result()
 
     def load(
         self,

--- a/tidy3d/web/core/s3utils.py
+++ b/tidy3d/web/core/s3utils.py
@@ -447,10 +447,22 @@ def download_gz_file(
             verbose=verbose,
             progress_callback=progress_callback,
         )
-        if os.path.exists(tmp_file_path_str):
-            extract_gzip_file(Path(tmp_file_path_str), to_path)
-        else:
+        if not Path(tmp_file_path_str).exists():
             raise WebError(f"Failed to download and extract '{remote_filename}'.")
+
+        tmp_out_fd, tmp_out_path_str = tempfile.mkstemp(
+            suffix=IN_TRANSIT_SUFFIX, dir=to_path.parent
+        )
+        os.close(tmp_out_fd)
+        tmp_out_path = Path(tmp_out_path_str)
+        try:
+            extract_gzip_file(Path(tmp_file_path_str), tmp_out_path)
+            tmp_out_path.replace(to_path)
+        except Exception as e:
+            tmp_out_path.unlink(missing_ok=True)
+            raise WebError(
+                f"Failed to extract '{remote_filename}' from '{tmp_file_path_str}' to '{to_path}'."
+            ) from e
     finally:
-        os.unlink(tmp_file_path_str)
+        Path(tmp_file_path_str).unlink(missing_ok=True)
     return to_path


### PR DESCRIPTION
## Summary
- Fix `Batch.download()` to raise when any background download fails.
- Make gzip extraction atomic and report clearer errors.
- Add regression test.

## Testing
- `poetry run pytest -q tests/test_web/test_webapi.py -k "batch_download_surfaces_download_errors"`
- `poetry run pytest -q tests/test_web/test_s3utils.py`
- `poetry run pre-commit run --all-files`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 830223666d3447bc30e17f84781f6286a3c0183a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

This PR fixes a critical bug where `Batch.download()` would silently succeed even when background downloads failed due to gzip extraction errors.

## Key Changes

**container.py**: Modified the batch download mechanism to call `fut.result()` on each completed future. This ensures exceptions from background worker threads are propagated to the main thread rather than being silently swallowed.

**s3utils.py**: Made gzip extraction atomic by:
- Creating a temporary output file in the target directory using `tempfile.mkstemp()`
- Extracting the gzip to the temp file
- Using atomic `replace()` to move it to the final destination
- Properly cleaning up temp files on error
- Providing clearer error messages when extraction fails

**test_webapi.py**: Added regression test `test_batch_download_surfaces_download_errors` that verifies exceptions from background downloads are properly surfaced to the caller.

**CHANGELOG.md**: Added user-facing entry describing the bug fix.

## Impact

This fix ensures that users are immediately notified when batch downloads fail, preventing silent data corruption or missing files that could lead to confusing downstream errors. The atomic extraction also prevents partially-written files from appearing as successful downloads.

### Confidence Score: 4/5

- This PR is safe to merge with minor style improvements recommended
- The core logic correctly fixes the critical bug by propagating exceptions from background downloads. The atomic extraction pattern is sound and follows established best practices. Two style-level suggestions were provided: (1) improving the error message clarity when replace() fails, and (2) handling an extremely unlikely edge case with temp file cleanup. These are non-critical improvements that don't affect the correctness of the fix.
- tidy3d/web/core/s3utils.py - review error message wording and temp file cleanup edge case

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/web/core/s3utils.py | 4/5 | Makes gzip extraction atomic using temp files and improves error messages; minor edge case with cleanup order |
| tidy3d/web/api/container.py | 5/5 | Correctly calls fut.result() to propagate exceptions from background downloads |
| tests/test_web/test_webapi.py | 5/5 | Adds regression test for batch download error propagation |
| CHANGELOG.md | 5/5 | Clear and accurate changelog entry following project guidelines |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Batch
    participant ThreadPool
    participant Job
    participant download_gz_file
    participant extract_gzip
    participant FileSystem

    User->>Batch: download(path_dir)
    Batch->>Batch: Create download tasks for each job
    Batch->>ThreadPool: Submit futures for parallel downloads
    
    loop For each completed future
        ThreadPool-->>Batch: future completes
        Batch->>Batch: fut.result() [NEW: propagates exceptions]
        
        alt Download succeeds
            Batch->>Batch: Update progress
        else Download fails (e.g., gzip error)
            Job->>download_gz_file: download and extract
            download_gz_file->>FileSystem: Download .gz to temp file
            download_gz_file->>FileSystem: Create temp output file [NEW: atomic]
            download_gz_file->>extract_gzip: Extract to temp output
            
            alt Extraction fails
                extract_gzip-->>download_gz_file: Exception
                download_gz_file->>FileSystem: Clean up temp output [NEW]
                download_gz_file-->>Job: Raise WebError [NEW]
                Job-->>Batch: RuntimeError
                Batch-->>User: Exception raised [FIXED]
            end
        end
    end
    
    Batch-->>User: Download complete or error raised
```

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/web/core/s3utils.py | 4/5 | Makes gzip extraction atomic using temp files and improves error messages; minor edge case with cleanup order |
| tidy3d/web/api/container.py | 5/5 | Correctly calls fut.result() to propagate exceptions from background downloads |
| tests/test_web/test_webapi.py | 5/5 | Adds regression test for batch download error propagation |
| CHANGELOG.md | 5/5 | Clear and accurate changelog entry following project guidelines |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Batch
    participant ThreadPool
    participant Job
    participant download_gz_file
    participant extract_gzip
    participant FileSystem

    User->>Batch: download(path_dir)
    Batch->>Batch: Create download tasks for each job
    Batch->>ThreadPool: Submit futures for parallel downloads
    
    loop For each completed future
        ThreadPool-->>Batch: future completes
        Batch->>Batch: fut.result() [NEW: propagates exceptions]
        
        alt Download succeeds
            Batch->>Batch: Update progress
        else Download fails (e.g., gzip error)
            Job->>download_gz_file: download and extract
            download_gz_file->>FileSystem: Download .gz to temp file
            download_gz_file->>FileSystem: Create temp output file [NEW: atomic]
            download_gz_file->>extract_gzip: Extract to temp output
            
            alt Extraction fails
                extract_gzip-->>download_gz_file: Exception
                download_gz_file->>FileSystem: Clean up temp output [NEW]
                download_gz_file-->>Job: Raise WebError [NEW]
                Job-->>Batch: RuntimeError
                Batch-->>User: Exception raised [FIXED]
            end
        end
    end
    
    Batch-->>User: Download complete or error raised
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->