### PR TITLE
fix: http_interceptor crash on non-dict JSON responses (FXC-4642)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `Batch.download()` silently succeeding when background downloads fail (e.g., gzip extraction errors).
 - Handling of zero values when using `sim_data.plot_field` with `scale=dB`.
 - Fixed `intersections_plane` method in `PolySlab`, which sometimes missed vertices for planes coincident with `PolySlab` side faces.
+- Fixed `http_interceptor` crash on non-dict JSON responses
 
 ## [2.10.0] - 2025-12-18
 

--- a/tidy3d/web/core/http_util.py
+++ b/tidy3d/web/core/http_util.py
@@ -195,7 +195,10 @@ def http_interceptor(func: Callable[..., Any]) -> Callable[..., JSONType]:
                 log = get_logger()
                 log.warning(warning)
 
-        return result.get("data") if "data" in result else result
+            if "data" in result:
+                return result["data"]
+
+        return result
 
     return wrapper
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Fix**
> 
> - Updates `http_interceptor` to unwrap `result["data"]` and log `warning` only when `resp.json()` returns a `dict`; otherwise returns the JSON (list/string/int) directly, avoiding `AttributeError`.
> - Adds CHANGELOG entry documenting the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 400fd1b1cf5951b7193c2bde0c21054db2d61798. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR fixes a crash in the `http_interceptor` decorator that occurred when the Tidy3D API returned non-dictionary JSON responses (such as lists, strings, or integers).

## The Bug
The original code attempted to call `.get("data")` on the result object regardless of its type:
```python
return result.get("data") if "data" in result else result
```

This would crash with an `AttributeError` when the API returned a list, string, or integer, since these types don't have a `.get()` method.

## The Fix
The fix moves the data extraction logic inside the `isinstance(result, dict)` check:
```python
if isinstance(result, dict):
    # ... warning handling ...
    if "data" in result:
        return result["data"]
return result
```

This ensures that:
1. Dict responses with a "data" key are unwrapped correctly
2. Dict responses without a "data" key are returned as-is
3. Non-dict responses (lists, strings, integers) are returned directly without crashing

## Impact
This fix prevents crashes when calling API endpoints that return list responses (like `Folder.list()` or `MaterialLibray.list()`) or other non-dict JSON types. The change maintains backward compatibility with existing dict-based responses while properly handling edge cases that were previously causing runtime errors.

### Confidence Score: 4/5

- This PR is safe to merge with minimal risk - it fixes a clear bug without introducing new issues
- The fix correctly addresses the crash on non-dict JSON responses with a simple, focused change. The logic is sound and handles all edge cases (dict with/without 'data' key, lists, strings, integers). Score is 4 (not 5) because the PR lacks test coverage for the fixed behavior, which means there's a small risk of regression in the future. Adding tests would bring this to a 5.
- No files require special attention - the changes are straightforward and correct

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/web/core/http_util.py | 4/5 | Fixed crash when API returns non-dict JSON (list, string, int). Logic is correct but lacks test coverage for the fix. |
| CHANGELOG.md | 5/5 | Changelog entry added correctly under Fixed section, describes the bug fix appropriately. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as API Client
    participant Decorator as http_interceptor
    participant HTTP as HTTP Method
    participant API as Tidy3D API

    Client->>HTTP: http.get/post/put/delete(path, params)
    HTTP->>Decorator: @http_interceptor wrapper
    Decorator->>API: Execute HTTP request
    API-->>Decorator: Response (status code, body)
    
    alt Response not 200 OK
        alt 404 and suppress_404=True
            Decorator-->>Client: return None
        else
            Decorator->>Decorator: Build error message from JSON
            Decorator-->>Client: raise WebError
        end
    else Response 200 OK
        alt Empty response body
            Decorator-->>Client: return None
        else Has response body
            Decorator->>Decorator: Parse resp.json()
            alt result is dict
                Decorator->>Decorator: Check for warnings, log if present
                alt "data" key exists
                    Decorator-->>Client: return result["data"]
                else No "data" key
                    Decorator-->>Client: return result (full dict)
                end
            else result is list/string/int
                Note over Decorator: FIX: Previously crashed here<br/>with result.get("data")
                Decorator-->>Client: return result (as-is)
            end
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->