### PR TITLE
chore: ubuntu-latest runners rather than slurm (FXC-4769)

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -575,8 +575,9 @@ jobs:
     # Run on open PRs OR when manually triggered with local_tests=true
     needs: determine-test-scope
     if: needs.determine-test-scope.outputs.local_tests == 'true'
-    name: python-${{ matrix.python-version }}-self-hosted-runner 
-    runs-on: [ slurm-runner, 4xcpu, container=ghcr.io/astral-sh/uv:debian ]
+    name: python-${{ matrix.python-version }}-ubuntu-latest
+    runs-on: ubuntu-latest
+    container: ghcr.io/astral-sh/uv:debian
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.event_name }}-${{ matrix.python-version }}-local
       cancel-in-progress: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves local unit test execution to GitHub-hosted infrastructure.
> 
> - `local-tests` job now runs on `ubuntu-latest` with `container: ghcr.io/astral-sh/uv:debian` and updated job name; replaces the previous self-hosted `slurm-runner` configuration
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb47fcf550b4d61b54a0ad1104d116bcd10b62a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR migrates the `local-tests` job from self-hosted Slurm runners to GitHub-hosted `ubuntu-latest` runners, while maintaining the same container image (`ghcr.io/astral-sh/uv:debian`).

## Key Changes

The workflow configuration for the `local-tests` job has been updated:
- **Before**: `runs-on: [ slurm-runner, 4xcpu, container=ghcr.io/astral-sh/uv:debian ]`
- **After**: `runs-on: ubuntu-latest` with `container: ghcr.io/astral-sh/uv:debian`
- Job name updated from `python-${{ matrix.python-version }}-self-hosted-runner` to `python-${{ matrix.python-version }}-ubuntu-latest`

## Infrastructure Impact

This change moves test execution from self-hosted infrastructure to GitHub-managed runners, which should:
- Reduce operational overhead for maintaining self-hosted runners
- Provide consistent, ephemeral test environments
- Use the same container image, maintaining environment consistency

## Documentation Gap

The PR updates the workflow but does not update supporting documentation that references the old self-hosted runner configuration:
1. `.github/workflows/README.md` line 83 still mentions "Self-hosted Slurm runners"
2. `docs/development/release/version.rst` line 52 still mentions "self-hosted runners"

## Test Behavior Changes

The change may affect test parallelization behavior in `tests/conftest.py`. The `pytest_xdist_auto_num_workers` function checks for `RUNNER_ENVIRONMENT == "self-hosted"` to cap at 8 cores. With GitHub-hosted runners, this cap won't apply, and the function will use all available cores (limited by memory at 1.2GB per core). This should be acceptable as GitHub-hosted ubuntu-latest runners have predictable resources.

### Confidence Score: 4/5

- This PR is safe to merge with minor documentation updates needed
- The workflow change is straightforward and well-contained, moving from self-hosted to GitHub-hosted runners while maintaining the same container environment. The main issue is outdated documentation that needs updating. No logic errors or security issues were found. The change should improve maintainability by using managed infrastructure.
- Documentation files (.github/workflows/README.md and docs/development/release/version.rst) need updates to reflect the new runner configuration

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/tidy3d-python-client-tests.yml | 4/5 | Changed local-tests job from self-hosted slurm-runner to ubuntu-latest with container; requires documentation updates |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Event
    participant Scope as determine-test-scope
    participant Local as local-tests (ubuntu-latest)
    participant Container as ghcr.io/astral-sh/uv:debian
    participant Tests as pytest
    participant Coverage as diff-cover

    GH->>Scope: PR Event / workflow_dispatch / merge_group
    Scope->>Scope: Evaluate event type & inputs
    Scope-->>Local: local_tests=true
    
    alt local_tests enabled
        Local->>Container: Initialize container on ubuntu-latest
        Container->>Container: Setup Python 3.10 or 3.13
        Container->>Container: Install dependencies with uv
        Container->>Tests: Run pytest with coverage
        Tests-->>Container: Test results
        Container->>Coverage: Generate diff-coverage (Python 3.13 only)
        Coverage-->>GH: Post PR comment
        Local-->>GH: Test results & coverage
    end
    
    Note over Local,Container: Changed from: slurm-runner, 4xcpu<br/>Changed to: ubuntu-latest + container
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->