### PR TITLE
Fix flaky model hashing TypeError under log capture

### DIFF
--- a/tests/test_web/test_tidy3d_stub.py
+++ b/tests/test_web/test_tidy3d_stub.py
@@ -118,20 +118,22 @@ def test_stub_data_to_file(tmp_path):
 def test_stub_data_postprocess_logs(tmp_path):
     """Tests the postprocess method of Tidy3dStubData when simulation diverged."""
     td.log.set_capture(True)
+    try:
+        # test diverged
+        sim_data = make_sim_data()
+        sim_data = sim_data.updated_copy(diverged=True, log="The simulation has diverged!")
+        file_path = os.path.join(tmp_path, "test_diverged.hdf5")
+        sim_data.to_file(file_path)
+        Tidy3dStubData.postprocess(file_path)
 
-    # test diverged
-    sim_data = make_sim_data()
-    sim_data = sim_data.updated_copy(diverged=True, log="The simulation has diverged!")
-    file_path = os.path.join(tmp_path, "test_diverged.hdf5")
-    sim_data.to_file(file_path)
-    Tidy3dStubData.postprocess(file_path)
-
-    # test warnings
-    sim_data = make_sim_data()
-    sim_data = sim_data.updated_copy(log="WARNING: messages were found in the solver log.")
-    file_path = os.path.join(tmp_path, "test_warnings.hdf5")
-    sim_data.to_file(file_path)
-    Tidy3dStubData.postprocess(file_path)
+        # test warnings
+        sim_data = make_sim_data()
+        sim_data = sim_data.updated_copy(log="WARNING: messages were found in the solver log.")
+        file_path = os.path.join(tmp_path, "test_warnings.hdf5")
+        sim_data.to_file(file_path)
+        Tidy3dStubData.postprocess(file_path)
+    finally:
+        td.log.set_capture(False)
 
 
 @responses.activate
@@ -139,32 +141,34 @@ def test_stub_data_lazy_loading(tmp_path):
     """Tests the postprocess method with lazy loading of Tidy3dStubData when simulation diverged."""
     td.log.set_capture(True)
     sim_diverged_log = "The simulation has diverged!"
+    try:
+        # make sim data where test diverged
+        sim_data = make_sim_data()
+        sim_data = sim_data.updated_copy(diverged=True, log=sim_diverged_log)
+        file_path = os.path.join(tmp_path, "test_diverged.hdf5")
+        sim_data.to_file(file_path)
 
-    # make sim data where test diverged
-    sim_data = make_sim_data()
-    sim_data = sim_data.updated_copy(diverged=True, log=sim_diverged_log)
-    file_path = os.path.join(tmp_path, "test_diverged.hdf5")
-    sim_data.to_file(file_path)
+        # default case with lazy=False should output a warning
+        with AssertLogLevel("WARNING", contains_str=sim_diverged_log):
+            Tidy3dStubData.postprocess(file_path, lazy=False)
 
-    # default case with lazy=False should output a warning
-    with AssertLogLevel("WARNING", contains_str=sim_diverged_log):
-        Tidy3dStubData.postprocess(file_path, lazy=False)
+        # we expect no warning in lazy mode as object should not be loaded
+        with AssertLogLevel(None):
+            sim_data = Tidy3dStubData.postprocess(file_path, lazy=True)
 
-    # we expect no warning in lazy mode as object should not be loaded
-    with AssertLogLevel(None):
-        sim_data = Tidy3dStubData.postprocess(file_path, lazy=True)
+        sim_data_copy = sim_data.copy()
 
-    sim_data_copy = sim_data.copy()
+        # variable dict should only contain metadata to load the data, not the data itself
+        assert is_lazy_object(sim_data)
 
-    # variable dict should only contain metadata to load the data, not the data itself
-    assert is_lazy_object(sim_data)
+        # the type should be still SimulationData despite being lazy
+        assert isinstance(sim_data, SimulationData)
 
-    # the type should be still SimulationData despite being lazy
-    assert isinstance(sim_data, SimulationData)
-
-    # we expect a warning from the lazy object if some field is accessed
-    with AssertLogLevel("WARNING", contains_str=sim_diverged_log):
-        _ = sim_data_copy.monitor_data
+        # we expect a warning from the lazy object if some field is accessed
+        with AssertLogLevel("WARNING", contains_str=sim_diverged_log):
+            _ = sim_data_copy.monitor_data
+    finally:
+        td.log.set_capture(False)
 
 
 @pytest.mark.parametrize(

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -26,7 +26,6 @@ import yaml
 from autograd.numpy.numpy_boxes import ArrayBox
 from autograd.tracer import isbox
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_validator
-from pydantic.functional_validators import ModelWrapValidatorHandler
 
 from tidy3d.exceptions import FileError
 from tidy3d.log import log
@@ -42,6 +41,7 @@ if TYPE_CHECKING:
     from typing import Callable
 
     from pydantic.fields import FieldInfo
+    from pydantic.functional_validators import ModelWrapValidatorHandler
 
     from tidy3d.compat import Self
 
@@ -306,11 +306,16 @@ class Tidy3dBaseModel(BaseModel):
         if isinstance(value, Tidy3dBaseModel):
             # This function needs to take special care because of mutable attributes inside of frozen pydantic models
             to_hash_list = []
-            for k, v in dict(value).items():
+            for k in type(value).model_fields:
                 if k == "attrs":
                     continue
-                v_hash = Tidy3dBaseModel._recursive_hash(v)
+                v_hash = Tidy3dBaseModel._recursive_hash(getattr(value, k))
                 to_hash_list.append((k, v_hash))
+            extra = getattr(value, "__pydantic_extra__", None)
+            if extra:
+                for k, v in extra.items():
+                    v_hash = Tidy3dBaseModel._recursive_hash(v)
+                    to_hash_list.append((k, v_hash))
             # attrs is mutable, use serialized output as safe hashing option
             if value.attrs:
                 attrs_str = value._attrs_digest()


### PR DESCRIPTION
## Summary
- avoid dict(value) in hashing when models define a keys attribute
- reset log capture in stub tests to prevent cross-test leakage

## Testing
- pre-commit hooks (via git commit)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 13a46370fdd0910054afc7958e40b3a721df4d70. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR fixes a flaky TypeError that occurred during model hashing when models define a `keys` attribute or property. The issue manifested when `dict(value)` was called on Pydantic models that implement a `keys` property (like `Result` in `invdes` and `AbstractComponentModelerData` in `smatrix`), causing Python's dict constructor to attempt using the dict protocol, which failed.

## Changes Made

**Core Fix (tidy3d/components/base.py):**
- Replaced `dict(value).items()` iteration with direct iteration over `type(value).model_fields`
- Uses `getattr(value, k)` to access field values instead of relying on dict conversion
- Added explicit handling of `__pydantic_extra__` for models with `extra="allow"`
- Moved `ModelWrapValidatorHandler` import to `TYPE_CHECKING` block (runtime optimization)

**Test Improvements (tests/test_web/test_tidy3d_stub.py):**
- Wrapped log capture tests in try/finally blocks to ensure `log.set_capture(False)` is called
- Prevents log capture state from leaking between tests, which could cause cross-test contamination

## Implementation Quality

The hashing fix is well-designed and maintains backward compatibility. The new approach:
- Produces identical hashes for models without `keys` attributes
- Correctly handles all Pydantic v2 field types including extra fields
- Is more robust and doesn't rely on the dict protocol
- Maintains field iteration order (important for hash consistency)

### Confidence Score: 5/5

- This PR is safe to merge with no identified risks
- The changes are focused, well-tested, and solve a specific bug without introducing new issues. The hashing logic refactor is sound and maintains backward compatibility while fixing the TypeError. The test cleanup prevents flaky test behavior.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| tidy3d/components/base.py | 5/5 | Fixed hashing TypeError by avoiding dict() call on models with 'keys' attribute; moved import to TYPE_CHECKING |
| tests/test_web/test_tidy3d_stub.py | 5/5 | Added try/finally blocks to ensure log.set_capture(False) is called, preventing test cross-contamination |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Test Function
    participant Log as td.log
    participant Model as Tidy3dBaseModel
    participant Hash as _recursive_hash
    
    Note over Test,Log: Test Setup
    Test->>Log: set_capture(True)
    Log-->>Test: Log capture enabled
    
    Note over Test,Model: Model Operations (may fail)
    Test->>Model: Create/Hash model instances
    Model->>Hash: __hash__() called
    
    alt Model has 'keys' attribute (OLD)
        Hash->>Model: dict(value)
        Model-->>Hash: TypeError! (keys() incompatible)
    else Model has 'keys' attribute (NEW)
        Hash->>Model: type(value).model_fields
        Hash->>Model: getattr(value, field)
        Model-->>Hash: Success!
    end
    
    Note over Test,Log: Test Cleanup (try/finally)
    Test->>Log: set_capture(False)
    Log-->>Test: Log capture disabled
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->