### PR TITLE
fix corrupted data in vtk-based arrays

### DIFF
--- a/tidy3d/components/data/unstructured/base.py
+++ b/tidy3d/components/data/unstructured/base.py
@@ -729,7 +729,7 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
                     f" of grid points ({num_points})."
                 )
 
-            values_numpy = vtk["vtk_to_numpy"](array_vtk)
+            values_numpy = np.array(vtk["vtk_to_numpy"](array_vtk), copy=True)
             values_name = array_vtk.GetName()
 
             # vtk doesn't support complex numbers
@@ -1260,12 +1260,17 @@ class UnstructuredGridDataset(Dataset, np.lib.mixins.NDArrayOperatorsMixin, ABC)
         array_id = 0 if self.values.name is None else self.values.name
 
         # TODO: generalize this
-        values_numpy = vtk["vtk_to_numpy"](interpolated.GetPointData().GetAbstractArray(array_id))
+        values_numpy = np.array(
+            vtk["vtk_to_numpy"](interpolated.GetPointData().GetAbstractArray(array_id)), copy=True
+        )
 
         # fill points without interpolated values
         if fill_value != 0:
-            mask = vtk["vtk_to_numpy"](
-                interpolated.GetPointData().GetAbstractArray("vtkValidPointMask")
+            mask = np.array(
+                vtk["vtk_to_numpy"](
+                    interpolated.GetPointData().GetAbstractArray("vtkValidPointMask")
+                ),
+                copy=True,
             )
             values_numpy[mask != 1] = fill_value
 

--- a/tidy3d/components/data/unstructured/tetrahedral.py
+++ b/tidy3d/components/data/unstructured/tetrahedral.py
@@ -105,18 +105,24 @@ class TetrahedralGridDataset(UnstructuredGridDataset):
         """Initialize from a vtkUnstructuredGrid instance."""
 
         # read point, cells, and values info from a vtk instance
-        cells_numpy = vtk["vtk_to_numpy"](vtk_obj.GetCells().GetConnectivityArray())
-        points_numpy = vtk["vtk_to_numpy"](vtk_obj.GetPoints().GetData())
+        cells_numpy = np.array(
+            vtk["vtk_to_numpy"](vtk_obj.GetCells().GetConnectivityArray()),
+            copy=True,
+        )
+        points_numpy = np.array(vtk["vtk_to_numpy"](vtk_obj.GetPoints().GetData()), copy=True)
         values = cls._get_values_from_vtk(
             vtk_obj, len(points_numpy), field, values_type, expect_complex
         )
 
         # verify cell_types
-        cells_types = vtk["vtk_to_numpy"](vtk_obj.GetCellTypesArray())
+        cells_types = np.array(vtk["vtk_to_numpy"](vtk_obj.GetCellTypesArray()), copy=True)
         invalid_cells = cells_types != cls._vtk_cell_type()
         if any(invalid_cells):
             if ignore_invalid_cells:
-                cell_offsets = vtk["vtk_to_numpy"](vtk_obj.GetCells().GetOffsetsArray())
+                cell_offsets = np.array(
+                    vtk["vtk_to_numpy"](vtk_obj.GetCells().GetOffsetsArray()),
+                    copy=True,
+                )
                 valid_cell_offsets = cell_offsets[:-1][invalid_cells == 0]
                 cells_numpy = cells_numpy[
                     np.ravel(

--- a/tidy3d/components/data/unstructured/triangular.py
+++ b/tidy3d/components/data/unstructured/triangular.py
@@ -149,10 +149,13 @@ class TriangularGridDataset(UnstructuredGridDataset):
         elif isinstance(vtk_obj, vtk["mod"].vtkUnstructuredGrid):
             cells_vtk = vtk_obj.GetCells()
 
-        cells_numpy = vtk["vtk_to_numpy"](cells_vtk.GetConnectivityArray())
+        cells_numpy = np.array(
+            vtk["vtk_to_numpy"](cells_vtk.GetConnectivityArray()),
+            copy=True,
+        )
 
         # verify cell_types
-        cell_offsets = vtk["vtk_to_numpy"](cells_vtk.GetOffsetsArray())
+        cell_offsets = np.array(vtk["vtk_to_numpy"](cells_vtk.GetOffsetsArray()), copy=True)
         invalid_cells = np.diff(cell_offsets) != cls._cell_num_vertices()
         if np.any(invalid_cells):
             if ignore_invalid_cells:
@@ -166,7 +169,7 @@ class TriangularGridDataset(UnstructuredGridDataset):
                     "'TriangularGridDataset'."
                 )
 
-        points_numpy = vtk["vtk_to_numpy"](vtk_obj.GetPoints().GetData())
+        points_numpy = np.array(vtk["vtk_to_numpy"](vtk_obj.GetPoints().GetData()), copy=True)
 
         # data values are read directly into Tidy3D array
         values = cls._get_values_from_vtk(
@@ -250,7 +253,7 @@ class TriangularGridDataset(UnstructuredGridDataset):
 
         # perform slicing in vtk and get unprocessed points and values
         slice_vtk = self._plane_slice_raw(axis=axis, pos=pos)
-        points_numpy = vtk["vtk_to_numpy"](slice_vtk.GetPoints().GetData())
+        points_numpy = np.array(vtk["vtk_to_numpy"](slice_vtk.GetPoints().GetData()), copy=True)
         values = self._get_values_from_vtk(
             slice_vtk,
             len(points_numpy),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures NumPy arrays derived from VTK no longer share memory with VTK buffers, preventing data corruption during parallel operations.
> 
> - In `base.py`, copies arrays in `_get_values_from_vtk()` and `_interp_vtk()` (interpolated values and `vtkValidPointMask`), preserving complex handling and result reshaping
> - In `tetrahedral.py`, copies cell connectivity, point coordinates, cell types, and cell offsets in `_from_vtk_obj()`; downstream packing/cleaning unchanged
> - In `triangular.py`, copies cell connectivity, offsets, points in `_from_vtk_obj()` and points in `plane_slice()`; value extraction pipelines retained
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1af8f86ed32eddbfb102c0ac428b09b5bed611f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

## What Changed

This PR fixes shared-memory corruption when reading VTK data in parallel tests by wrapping `vtk_to_numpy()` calls with `np.array(..., copy=True)`.

**Problem**: The VTK library's `vtk_to_numpy()` function returns NumPy arrays that share memory with the underlying VTK data structures. When multiple parallel tests read VTK files simultaneously, they can corrupt each other's data by modifying shared memory.

**Solution**: Wrap all `vtk_to_numpy()` calls with `np.array(..., copy=True)` to create independent copies of the data. The PR applies this fix to:
- Point data arrays in `_get_values_from_vtk()` (base.py, line 732)
- Cell connectivity, point coordinates, cell types, and offset arrays in `_from_vtk_obj()` methods (tetrahedral.py and triangular.py)

**Test Aid**: Added `debug_tests.sh` script to repeatedly run parallel tests until failure, making it easier to reproduce and debug race conditions.

## Architecture

The fix follows the existing pattern where complex number handling was already done correctly: first copy the data with `np.array(..., copy=True)`, then create views as needed (e.g., `.view("complex")`). This ensures views don't share memory with the original VTK data.

### Confidence Score: 3/5

- This PR addresses a critical race condition but has incomplete coverage of vtk_to_numpy calls
- Score of 3 reflects that while the PR correctly identifies and fixes the core issue, there are 3 additional locations where vtk_to_numpy is called without copy=True. These missed locations (lines 1263 and 1267 in base.py, line 256 in triangular.py) could still cause shared memory corruption in specific scenarios. The fix applied is correct where implemented, but incomplete coverage prevents a higher confidence score.
- Pay close attention to 'tidy3d/components/data/unstructured/base.py' lines 1263-1270 where vtk_to_numpy is used in _interp_vtk method with subsequent modification of the array

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| debug_tests.sh | 5/5 | Adds bash script for debugging flaky parallel tests by running pytest repeatedly until failure with timestamped logs |
| tidy3d/components/data/unstructured/base.py | 4/5 | Adds copy=True to vtk_to_numpy in _get_values_from_vtk method (line 732) to prevent shared memory corruption, but _interp_vtk method still missing the fix |
| tidy3d/components/data/unstructured/tetrahedral.py | 5/5 | Adds copy=True to all vtk_to_numpy calls for cells, points, cell types, and offsets arrays to prevent shared memory corruption |
| tidy3d/components/data/unstructured/triangular.py | 4/5 | Adds copy=True to vtk_to_numpy calls for cells, cell_offsets, and points arrays, but plane_slice method still missing the fix |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Dataset as UnstructuredGridDataset
    participant VTK as VTK Library
    participant NumPy as NumPy Array
    
    User->>Dataset: from_vtu() / from_vtk()
    Dataset->>VTK: Read VTK file
    VTK-->>Dataset: vtkUnstructuredGrid object
    
    Dataset->>VTK: GetCells().GetConnectivityArray()
    VTK-->>Dataset: VTK array (shared memory)
    
    Dataset->>NumPy: vtk_to_numpy()
    Note over Dataset,NumPy: ⚠️ Returns view with shared memory
    NumPy-->>Dataset: NumPy array (view)
    
    Dataset->>NumPy: np.array(..., copy=True)
    Note over Dataset,NumPy: ✅ Creates independent copy
    NumPy-->>Dataset: NumPy array (copy)
    
    Dataset->>VTK: GetPoints().GetData()
    VTK-->>Dataset: VTK array (shared memory)
    
    Dataset->>NumPy: vtk_to_numpy()
    NumPy-->>Dataset: NumPy array (view)
    
    Dataset->>NumPy: np.array(..., copy=True)
    NumPy-->>Dataset: NumPy array (copy)
    
    Dataset->>Dataset: Store in PointDataArray/CellDataArray
    Dataset-->>User: UnstructuredGridDataset
    
    Note over User,Dataset: Without copy=True, parallel tests<br/>can corrupt shared VTK memory
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->