### PR TITLE
chore: add GaussianDoping frontend validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `symmetric_pseudo` option for `s_param_def` in `TerminalComponentModeler` which applies a scaling factor that ensures the S-matrix is symmetric in reciprocal systems.
 - Added deprecation warning for `TemperatureMonitor` and `SteadyPotentialMonitor` when `unstructured` parameter is not explicitly set. The default value of `unstructured` will change from `False` to `True` in the next release.
 - Added deprecation warning for ``TemperatureMonitor`` and ``SteadyPotentialMonitor`` when ``unstructured`` parameter is not explicitly set. The default value of ``unstructured`` will change from ``False`` to ``True`` after the 2.11 release.
+- Added validation to `GaussianDoping` to ensure `ref_con < concentration`, validate `source` face identifier, and warn the user when the box size is not sufficient for the specified transition width.
 
 ### Fixed
 - Fixed intermittent "API key not found" errors in parallel job launches by making configuration directory detection race-safe.

--- a/schemas/EMESimulation.json
+++ b/schemas/EMESimulation.json
@@ -5936,6 +5936,14 @@
         },
         "source": {
           "default": "xmin",
+          "enum": [
+            "xmax",
+            "xmin",
+            "ymax",
+            "ymin",
+            "zmax",
+            "zmin"
+          ],
           "type": "string"
         },
         "type": {

--- a/schemas/HeatChargeSimulation.json
+++ b/schemas/HeatChargeSimulation.json
@@ -3894,6 +3894,14 @@
         },
         "source": {
           "default": "xmin",
+          "enum": [
+            "xmax",
+            "xmin",
+            "ymax",
+            "ymin",
+            "zmax",
+            "zmin"
+          ],
           "type": "string"
         },
         "type": {

--- a/schemas/HeatSimulation.json
+++ b/schemas/HeatSimulation.json
@@ -3894,6 +3894,14 @@
         },
         "source": {
           "default": "xmin",
+          "enum": [
+            "xmax",
+            "xmin",
+            "ymax",
+            "ymin",
+            "zmax",
+            "zmin"
+          ],
           "type": "string"
         },
         "type": {

--- a/schemas/ModeSimulation.json
+++ b/schemas/ModeSimulation.json
@@ -5116,6 +5116,14 @@
         },
         "source": {
           "default": "xmin",
+          "enum": [
+            "xmax",
+            "xmin",
+            "ymax",
+            "ymin",
+            "zmax",
+            "zmin"
+          ],
           "type": "string"
         },
         "type": {

--- a/schemas/Simulation.json
+++ b/schemas/Simulation.json
@@ -8715,6 +8715,14 @@
         },
         "source": {
           "default": "xmin",
+          "enum": [
+            "xmax",
+            "xmin",
+            "ymax",
+            "ymin",
+            "zmax",
+            "zmin"
+          ],
           "type": "string"
         },
         "type": {

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -8882,6 +8882,14 @@
         },
         "source": {
           "default": "xmin",
+          "enum": [
+            "xmax",
+            "xmin",
+            "ymax",
+            "ymin",
+            "zmax",
+            "zmin"
+          ],
           "type": "string"
         },
         "type": {

--- a/tests/test_components/test_heat_charge.py
+++ b/tests/test_components/test_heat_charge.py
@@ -1920,12 +1920,17 @@ def test_gaussian_doping_initialization():
 
 
 def test_gaussian_doping_sigma_calculation():
-    """Test sigma calculation in GaussianDoping."""
+    """Test sigma calculation in GaussianDoping and ref_con validator."""
     box = td.GaussianDoping(
         size=(1, 1, 1), ref_con=1e15, concentration=1e18, width=0.1, source="xmin"
     )
     expected_sigma = np.sqrt(-(0.1**2) / (2 * np.log(1e15 / 1e18)))
     assert np.isclose(box.sigma, expected_sigma), "Sigma calculation is incorrect."
+
+    with pytest.raises(pd.ValidationError, match="must be less than.*concentration"):
+        _ = td.GaussianDoping(
+            size=(1, 1, 1), ref_con=1e19, concentration=1e18, width=0.1, source="xmin"
+        )
 
 
 def test_gaussian_doping_get_contrib():
@@ -1973,6 +1978,44 @@ def test_gaussian_doping_bounds_behavior():
         source="xmin",
     )
     assert box.bounds == box_coords, "Bounds should match provided box_coords."
+
+
+def test_gaussian_doping_validator_source():
+    """Test validator for source face."""
+    valid_sources = ["xmin", "xmax", "ymin", "ymax", "zmin", "zmax"]
+    for source in valid_sources:
+        _ = td.GaussianDoping(
+            size=(1, 1, 1), ref_con=1e15, concentration=1e18, width=0.1, source=source
+        )
+
+    with pytest.raises(pd.ValidationError):
+        _ = td.GaussianDoping(
+            size=(1, 1, 1), ref_con=1e15, concentration=1e18, width=0.1, source="invalid"
+        )
+
+
+def test_gaussian_doping_validator_width():
+    """Test validator for width vs size."""
+    width = 0.1
+    _ = td.GaussianDoping(
+        size=(0.2, 0.2, 0.2), ref_con=1e15, concentration=1e18, width=width, source="xmin"
+    )
+    _ = td.GaussianDoping(
+        size=(np.inf, 1, 1), ref_con=1e15, concentration=1e18, width=width, source="xmin"
+    )
+
+    with AssertLogLevel("WARNING", contains_str="'x' direction"):
+        _ = td.GaussianDoping(
+            size=(0.15, 1, 1), ref_con=1e15, concentration=1e18, width=width, source="xmin"
+        )
+    with AssertLogLevel("WARNING", contains_str="'y' direction"):
+        _ = td.GaussianDoping(
+            size=(1, 0.15, 1), ref_con=1e15, concentration=1e18, width=width, source="xmin"
+        )
+    with AssertLogLevel("WARNING", contains_str="'z' direction"):
+        _ = td.GaussianDoping(
+            size=(1, 1, 0.15), ref_con=1e15, concentration=1e18, width=width, source="xmin"
+        )
 
 
 def test_2D_doping_box():

--- a/tidy3d/components/tcad/doping.py
+++ b/tidy3d/components/tcad/doping.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Union
+from typing import Literal, Union
 
 import numpy as np
 import pydantic.v1 as pd
@@ -14,6 +14,7 @@ from tidy3d.components.data.data_array import SpatialDataArray
 from tidy3d.components.geometry.base import Box
 from tidy3d.constants import MICROMETER, PERCMCUBE, inf
 from tidy3d.exceptions import SetupError
+from tidy3d.log import log
 
 
 class AbstractDopingBox(Box):
@@ -171,7 +172,7 @@ class GaussianDoping(AbstractDopingBox):
         units=MICROMETER,
     )
 
-    source: str = pd.Field(
+    source: Literal["xmin", "xmax", "ymin", "ymax", "zmin", "zmax"] = pd.Field(
         "xmin",
         title="Source face",
         description="Specifies the side of the box acting as the source, i.e., "
@@ -179,6 +180,33 @@ class GaussianDoping(AbstractDopingBox):
         "the concentration is constant from this face. Accepted values for ``source`` "
         "are [``xmin``, ``xmax``, ``ymin``, ``ymax``, ``zmin``, ``zmax``]",
     )
+
+    @pd.validator("concentration")
+    def _validate_ref_con_less_than_concentration(cls, val, values):
+        """Ensure ref_con < concentration to avoid negative sqrt in sigma calculation."""
+        if "ref_con" in values:
+            if values["ref_con"] >= val:
+                raise ValueError(
+                    f"'ref_con' ({values['ref_con']}) must be less than 'concentration' ({val}) "
+                    "for GaussianDoping. The reference concentration at the edges must be lower "
+                    "than the peak concentration at the center."
+                )
+        return val
+
+    @pd.validator("width")
+    def _validate_width_vs_size(cls, val, values):
+        """Warn if box size may be too small for the specified transition width."""
+        if "size" in values:
+            size = values["size"]
+            for i, s in enumerate(size):
+                if not np.isinf(s) and s < 2 * val:
+                    dim_name = ["x", "y", "z"][i]
+                    log.warning(
+                        f"Box size in '{dim_name}' direction ({s} μm) is less than "
+                        f"'2*width' ({2 * val} μm) for 'GaussianDoping'. "
+                        "This may result in unexpected behavior in the transition region."
+                    )
+        return val
 
     @cached_property
     def sigma(self):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily adds parameter validation and warnings with targeted schema/test updates; low risk aside from potential new validation failures for previously-accepted invalid inputs.
> 
> **Overview**
> Strengthens `GaussianDoping` validation by restricting `source` to valid box faces, enforcing `ref_con < concentration` to prevent invalid sigma computation, and warning when finite box dimensions are smaller than `2*width`.
> 
> Updates generated JSON schemas to enumerate allowed `source` values, expands unit tests to cover the new validation/error/warning behavior, and documents the change in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ac1e9a8ea06245f94434963c1d6b7a76dc418ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR strengthens input validation for `GaussianDoping` by adding three frontend validators. The changes enforce that `ref_con < concentration` (preventing mathematical errors in sigma calculation), restrict `source` to valid face identifiers via `Literal` type, and warn users when any finite box dimension is smaller than `2*width` (indicating potential issues in the transition region). The implementation follows established patterns using pydantic validators and the logging system. Test coverage is comprehensive, validating all three scenarios including edge cases like `np.inf` dimensions and all coordinate directions.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor style improvements needed
- The validators implement correct mathematical constraints and the test coverage is comprehensive. Previous review comments have identified style guide violations (single quotes in messages, changelog categorization) that should be addressed but don't affect functionality
- Pay attention to `tidy3d/components/tcad/doping.py` for style guide compliance with single quotes in error/warning messages

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/components/tcad/doping.py | Added validators for ref_con < concentration check, source face validation via Literal type, and width-vs-size warnings; addresses reported issues with single quotes, np.inf handling |
| tests/test_components/test_heat_charge.py | Added comprehensive tests for ref_con validation, source validator, and width-vs-size warnings; includes all three dimensions (x, y, z) and np.inf handling |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant GaussianDoping
    participant Validator
    participant Logger

    User->>GaussianDoping: Create with params (ref_con, concentration, width, size, source)
    
    GaussianDoping->>Validator: Validate source field
    Note over Validator: Type checking via Literal["xmin", "xmax", "ymin", "ymax", "zmin", "zmax"]
    Validator-->>GaussianDoping: Valid source or ValidationError
    
    GaussianDoping->>Validator: _validate_ref_con_less_than_concentration(concentration)
    Validator->>Validator: Check ref_con < concentration
    alt ref_con >= concentration
        Validator-->>GaussianDoping: Raise ValueError
    else ref_con < concentration
        Validator-->>GaussianDoping: Return valid concentration
    end
    
    GaussianDoping->>Validator: _validate_width_vs_size(width)
    Validator->>Validator: Loop over size dimensions (x, y, z)
    loop For each dimension
        alt not np.isinf(size[i]) and size[i] < 2*width
            Validator->>Logger: log.warning about insufficient size
        end
    end
    Validator-->>GaussianDoping: Return valid width
    
    GaussianDoping-->>User: Instance created or ValidationError raised
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->