### PR TITLE
fix: consistency between mode source and mode frame (FXC-4332)

### DIFF
--- a/tests/test_components/test_grid.py
+++ b/tests/test_components/test_grid.py
@@ -402,3 +402,37 @@ def test_get_geo_inds_with_span():
 
     inds = g._get_geo_inds(geo_full, span_inds=span_inds)
     assert np.array_equal(inds, expected)
+
+
+def test_discretize_inds_relax_precision():
+    """Test that relax_precision handles floating-point precision issues at cell boundaries."""
+    g = make_grid()
+
+    # Create a box where boundaries are exactly on cell boundaries
+    box_exact = td.Box(center=(0, 0, 0), size=(2, 2, 2))
+    inds_exact = g.discretize_inds(box=box_exact, extend=False, relax_precision=False)
+
+    # Create a box where min boundary is slightly below the cell boundary (precision issue)
+    # The grid has boundaries at x = -1, 0, 1; y = -2, -1, 0, 1, 2; z = -3, -2, -1, 0, 1, 2, 3
+    # A box from -1 to 1 should span indices [0, 2] in x
+    eps = 1e-14  # Small epsilon to simulate floating-point precision issues
+    box_min_below = td.Box(center=(0, 0, 0), size=(2 + eps, 2 + eps, 2 + eps))
+
+    # Without relax_precision, the slightly larger box may include extra cells
+    inds_no_relax = g.discretize_inds(box=box_min_below, extend=False, relax_precision=False)
+
+    # With relax_precision, the indices should match the exact case since boundaries are "close enough"
+    inds_with_relax = g.discretize_inds(box=box_min_below, extend=False, relax_precision=True)
+
+    # The relaxed precision should produce the same result as the exact box
+    assert inds_exact == inds_with_relax
+    assert inds_no_relax != inds_with_relax
+
+    # Test case where box max is slightly below a cell boundary
+    box_max_below = td.Box(center=(0, 0, 0), size=(2 - eps, 2 - eps, 2 - eps))
+    inds_max_no_relax = g.discretize_inds(box=box_max_below, extend=False, relax_precision=False)
+    inds_max_with_relax = g.discretize_inds(box=box_max_below, extend=False, relax_precision=True)
+
+    # With relaxed precision, the boundaries close to cell boundaries should be treated as equal
+    assert inds_exact == inds_max_with_relax
+    assert inds_max_no_relax != inds_max_with_relax

--- a/tidy3d/components/grid/grid.py
+++ b/tidy3d/components/grid/grid.py
@@ -605,7 +605,9 @@ class Grid(Tidy3dBaseModel):
 
         return Coords(**yee_coords)
 
-    def discretize_inds(self, box: Box, extend: bool = False) -> list[tuple[int, int]]:
+    def discretize_inds(
+        self, box: Box, extend: bool = False, relax_precision: bool = False
+    ) -> list[tuple[int, int]]:
         """Start and stopping indexes for the cells that intersect with a :class:`Box`.
 
         Parameters
@@ -616,6 +618,9 @@ class Grid(Tidy3dBaseModel):
             If ``True``, ensure that the returned indexes extend sufficiently in every direction to
             be able to interpolate any field component at any point within the ``box``, for field
             components sampled on the Yee grid.
+        relax_precision : bool = False
+            If ``True``, relax the precision of the discretization to allow for small numerical
+            differences between the box boundaries and the cell boundaries.
 
         Returns
         -------
@@ -646,7 +651,7 @@ class Grid(Tidy3dBaseModel):
             # handle extensions
             if ind_max > ind_min and extend:
                 # Left side
-                if box.bounds[0][axis] < self.centers.to_list[axis][ind_min]:
+                if pts_min[axis] < self.centers.to_list[axis][ind_min]:
                     # Box bounds on the left side are to the left of the closest grid center
                     ind_min -= 1
 
@@ -654,9 +659,28 @@ class Grid(Tidy3dBaseModel):
                 ind_max += 1
 
             # store indexes
-            inds_list.append((ind_min, ind_max))
+            inds_list.append([ind_min, ind_max])
 
-        return inds_list
+        if relax_precision:
+            for dim in range(3):
+                # Fix some corner cases when the box boundary is very close to
+                # cell boundaries but due to finite precision is slightly smaller or larger
+                cell_bounds = np.array(boundaries.to_list[dim])
+                num_cells = len(cell_bounds) - 1
+                min_ind = inds_list[dim][0]
+                max_ind = inds_list[dim][1]
+                box_min = pts_min[dim]
+                box_max = pts_max[dim]
+                # Check if the cell boundary after current min is close to the box min,
+                # if it is close enough then choose that to be the new minimum cell index
+                if min_ind + 1 < num_cells and np.isclose(box_min, cell_bounds[min_ind + 1]):
+                    inds_list[dim][0] += 1
+                # Same but for the max cell boundary. If the current cell boundary is close to the box bounds,
+                # then it is considered equal and the stop index should be incremented
+                if max_ind < num_cells and np.isclose(box_max, cell_bounds[max_ind]):
+                    inds_list[dim][1] += 1
+
+        return [(ind_min, ind_max) for ind_min, ind_max in inds_list]
 
     def extended_subspace(
         self,

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -2212,7 +2212,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
     ) -> tuple[Box, int, str]:
         """Return pec bounding box, frame axis and object's direction"""
 
-        span_inds = np.array(self.grid.discretize_inds(obj))
+        span_inds = np.array(self.grid.discretize_inds(obj, relax_precision=True))
         coords = self.grid.boundaries.to_list
         direction = obj.direction
         if isinstance(obj, ModeSource):


### PR DESCRIPTION
There was slight discrepancy between mode source discretization and size of mode frames. This PR makes everything more consistent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves consistency between mode source discretization and mode frame sizing by handling floating-point boundary edge cases.
> 
> - Adds `relax_precision` option to `Grid.discretize_inds` to snap box boundaries to nearby cell boundaries using `np.isclose`
> - Updates `Simulation._pec_frame_box` to call `discretize_inds(..., relax_precision=True)` for mode sources
> - Introduces `test_discretize_inds_relax_precision` to validate behavior at cell boundaries
> - Minor internal adjustments in `discretize_inds` (index handling and extend check)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84db0006ecd79dae90150378f4ff13be752d8626. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR improves consistency between mode source discretization and mode frame calculations by introducing a `relax_precision` parameter to the `Grid.discretize_inds` method. The new parameter uses tolerance-based comparison (`np.isclose`) to "snap" box boundaries to cell boundaries when they differ only due to floating-point precision errors, preventing discrepancies of 1 cell in the discretization.

**Key Changes:**
- Added `relax_precision` parameter (default `False`) to `Grid.discretize_inds` method in `grid.py`
- Updated `_pec_frame_box` in `simulation.py` to use `relax_precision=True` when discretizing mode sources
- Added comprehensive test coverage for the new precision-relaxing behavior

**Issues Found:**
- **Critical logic errors** in boundary condition checks (lines 637 and 641 in `grid.py`) that prevent the relax_precision logic from working correctly when box boundaries are close to the last cell boundary
- Missing CHANGELOG.md entry for this user-facing bug fix

The boundary condition bugs would cause the test assertions on lines 428-429 and 437-438 to potentially fail, as the relaxed precision might not correctly snap boundaries in edge cases involving the last cells of the grid.

<h3>Confidence Score: 2/5</h3>


- This PR contains critical logic errors in boundary condition checks that will cause incorrect behavior in edge cases
- The PR addresses a real consistency issue between mode source discretization and frame calculations, and includes good test coverage. However, the implementation has two critical boundary condition bugs (lines 637 and 641) that use `num_cells` instead of `len(cell_bounds)` in the comparison, preventing the relax_precision logic from working correctly when box boundaries are near the last cell boundary. These bugs would likely cause test failures and incorrect discretization in production for certain grid configurations.
- Pay close attention to `tidy3d/components/grid/grid.py` - the boundary condition checks on lines 637 and 641 need to be fixed before merging

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/components/grid/grid.py | Added `relax_precision` parameter to `discretize_inds` method to handle floating-point precision issues. Contains logic errors in boundary condition checks that prevent snapping to the last cell boundary. |
| tidy3d/components/simulation.py | Updated `_pec_frame_box` to use `relax_precision=True` when discretizing mode source boundaries for consistency with frame calculation. |
| tests/test_components/test_grid.py | Added comprehensive test `test_discretize_inds_relax_precision` to verify floating-point precision handling in grid discretization. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Sim as Simulation._pec_frame_box
    participant Grid as Grid.discretize_inds
    participant Relax as relax_precision logic
    
    Note over Sim: Mode source or absorber<br/>needs frame box calculation
    
    Sim->>Grid: discretize_inds(obj, relax_precision=True)
    
    Note over Grid: Calculate base indices<br/>from box boundaries
    
    Grid->>Grid: Find ind_min (largest boundary ≤ box_min)
    Grid->>Grid: Find ind_max (smallest boundary > box_max)
    
    alt extend=True
        Grid->>Grid: Adjust indices for field interpolation
    end
    
    alt relax_precision=True
        Grid->>Relax: Check each dimension
        
        loop for each dimension
            Relax->>Relax: Check if box_min ≈ cell_bounds[min_ind+1]
            alt boundaries are close (np.isclose)
                Relax->>Relax: Snap: increment min_ind
            end
            
            Relax->>Relax: Check if box_max ≈ cell_bounds[max_ind]
            alt boundaries are close (np.isclose)
                Relax->>Relax: Snap: increment max_ind
            end
        end
    end
    
    Grid-->>Sim: Return [(ind_min, ind_max), ...]
    
    Note over Sim: Use indices to construct<br/>PEC frame boundaries
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Use a tolerance-based comparison (e.g., np.isclose) for floating-point numbers instead of direct equ... ([source](https://app.greptile.com/review/custom-context?memory=4a0cb6d3-6973-448b-b5dd-168bc7b26dc3))
- Rule from `dashboard` - Update the CHANGELOG.md file when making changes that affect user-facing functionality or fix bugs. ([source](https://app.greptile.com/review/custom-context?memory=a109c62a-aa8c-4cc4-b515-0ad947c47929))

<!-- /greptile_comment -->