### PR TITLE
fix(tidy3d): FXC-4878-fix-gradient-for-custom-pole-residue-eps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Fixed interpolation handling for permittivity and conductivity gradients in `CustomPoleResidue`.
 
 ## [2.10.1] - 2026-01-14
 

--- a/tests/test_components/autograd/numerical/test_autograd_custom_pole_residue_numerical.py
+++ b/tests/test_components/autograd/numerical/test_autograd_custom_pole_residue_numerical.py
@@ -1,0 +1,208 @@
+"""Numerical test for CustomPoleResidue adjoint gradients."""
+
+from __future__ import annotations
+
+import sys
+
+import autograd.numpy as anp
+import numpy as np
+import pytest
+from autograd import value_and_grad
+
+import tidy3d as td
+import tidy3d.web as web
+from tidy3d.components.autograd import get_static
+
+td.config.local_cache.enabled = True
+
+SIM_SIZE_SCALE = (4, 3, 4)
+BOX_SIZE_SCALE = (1, 1, 1)
+GRID_STEPS_PER_WVL = 30
+RUN_TIME = 2e-12
+ANGLE_TOL = 10.0
+FD_STEP = 5e-2
+
+DENSITY_SHAPE = (2, 2, 2)
+EPS_BACKGROUND = 1.0
+EPS_INF_BASE = 2.8
+A_BASE = -1.5e15
+C_BASE = 0.8e15
+
+POLE_RESIDUE_CASE = {
+    "name": "custom_pole_residue",
+    "wavelength": 1.3,
+    "objective_kind": "flux",
+    "monitor_size": (np.inf, np.inf, 0.0),
+    "polarization": 0.0,
+}
+
+
+def _scale_monitor_dim(dim: float, wavelength: float) -> float:
+    if np.isinf(dim):
+        return np.inf
+    return dim * wavelength
+
+
+def _box_geometry(wavelength: float) -> td.Box:
+    size = tuple(scale * wavelength for scale in BOX_SIZE_SCALE)
+    return td.Box(size=size, center=(0.0, 0.0, 0.0))
+
+
+def _build_base_sim(case):
+    wavelength = case["wavelength"]
+    freq0 = td.C_0 / wavelength
+    sim_size = tuple(scale * wavelength for scale in SIM_SIZE_SCALE)
+
+    plane_wave = td.PlaneWave(
+        center=(0.0, 0.0, -0.75 * sim_size[2] / 2),
+        size=(sim_size[0], sim_size[1], 0.0),
+        source_time=td.GaussianPulse(freq0=freq0, fwidth=freq0 / 10.0),
+        direction="+",
+        pol_angle=case.get("polarization", 0.0),
+    )
+
+    monitor_center = (0.0, 0.0, sim_size[2] / 2 * 0.75)
+    monitor_size = tuple(_scale_monitor_dim(dim, wavelength) for dim in case["monitor_size"])
+    monitor_name = f"{case['name']}_monitor"
+    monitor = td.FieldMonitor(
+        center=monitor_center,
+        size=monitor_size,
+        freqs=[freq0],
+        name=monitor_name,
+        colocate=False,
+    )
+
+    sim = td.Simulation(
+        size=sim_size,
+        center=(0.0, 0.0, 0.0),
+        grid_spec=td.GridSpec.auto(min_steps_per_wvl=GRID_STEPS_PER_WVL, wavelength=wavelength),
+        boundary_spec=td.BoundarySpec.pml(x=True, y=True, z=True),
+        sources=[plane_wave],
+        monitors=[monitor],
+        structures=[],
+        run_time=RUN_TIME,
+    )
+    return sim, monitor_name, freq0
+
+
+def _density_coords(box_geom: td.Box) -> dict[str, np.ndarray]:
+    return {
+        "x": np.linspace(-box_geom.size[0] / 2, box_geom.size[0] / 2, DENSITY_SHAPE[0]),
+        "y": np.linspace(-box_geom.size[1] / 2, box_geom.size[1] / 2, DENSITY_SHAPE[1]),
+        "z": np.linspace(-box_geom.size[2] / 2, box_geom.size[2] / 2, DENSITY_SHAPE[2]),
+    }
+
+
+def _custom_pole_residue_from_density(density, coords):
+    eps_inf = EPS_BACKGROUND + density * (EPS_INF_BASE - EPS_BACKGROUND)
+    eps_inf_da = td.SpatialDataArray(eps_inf, coords=coords)
+
+    a_vals = A_BASE * anp.ones_like(density)
+    c_vals = C_BASE * density
+    a_da = td.SpatialDataArray(a_vals, coords=coords)
+    c_da = td.SpatialDataArray(c_vals, coords=coords)
+
+    return td.CustomPoleResidue(eps_inf=eps_inf_da, poles=((a_da, c_da),), interp_method="linear")
+
+
+def _add_custom_pole_residue(base_sim: td.Simulation, box_geom: td.Box, params) -> td.Simulation:
+    density = anp.reshape(params, DENSITY_SHAPE)
+    coords = _density_coords(box_geom)
+    medium = _custom_pole_residue_from_density(density, coords)
+    structure = td.Structure(geometry=box_geom, medium=medium)
+    return base_sim.updated_copy(structures=[structure])
+
+
+def _metric_value(case, dataset, freq0):
+    if case["objective_kind"] == "flux":
+        return dataset.flux.values.item()
+    ex_vals = dataset.Ex.values
+    ey_vals = dataset.Ey.values
+    ez_vals = dataset.Ez.values
+    intensity = np.abs(ex_vals) ** 2 + np.abs(ey_vals) ** 2 + np.abs(ez_vals) ** 2
+    return anp.real(anp.mean(intensity))
+
+
+def _angle_deg(vec_a: np.ndarray, vec_b: np.ndarray) -> float:
+    norm_a = np.linalg.norm(vec_a)
+    norm_b = np.linalg.norm(vec_b)
+    if norm_a == 0 or norm_b == 0:
+        return np.nan
+    cos_theta = np.clip(np.dot(vec_a, vec_b) / (norm_a * norm_b), -1.0, 1.0)
+    return float(np.degrees(np.arccos(cos_theta)))
+
+
+def _run_simulation(
+    case, base_sim, box_geom, params, label, tmp_path, monitor_name, freq0, local_gradient
+):
+    sim = _add_custom_pole_residue(base_sim, box_geom, params)
+    sim_data = web.run(
+        sim,
+        task_name=f"custom_pole_residue_grad_{case['name']}_{label}",
+        local_gradient=local_gradient,
+        verbose=False,
+        path=str(tmp_path / f"{case['name']}_{label}.hdf5"),
+    )
+    return _metric_value(case, sim_data[monitor_name], freq0)
+
+
+@pytest.mark.numerical
+def test_custom_pole_residue_grads_match_fd(numerical_case_dir, tmp_path):
+    case = POLE_RESIDUE_CASE
+    base_sim, monitor_name, freq0 = _build_base_sim(case)
+    box_geom = _box_geometry(case["wavelength"])
+    params0 = anp.linspace(0.2, 0.8, num=int(np.prod(DENSITY_SHAPE)))
+
+    def objective(params):
+        return _run_simulation(
+            case,
+            base_sim,
+            box_geom,
+            params,
+            label="adjoint",
+            tmp_path=tmp_path,
+            monitor_name=monitor_name,
+            freq0=freq0,
+            local_gradient=True,
+        )
+
+    _, grad_adj = value_and_grad(objective)(params0)
+    grad_adj = get_static(grad_adj).reshape(-1)
+
+    fd_sims = {}
+    base_params = get_static(params0)
+    for idx in range(base_params.size):
+        delta = np.zeros_like(base_params)
+        delta[idx] = FD_STEP
+        fd_sims[f"fd_plus_{idx}"] = _add_custom_pole_residue(
+            base_sim, box_geom, base_params + delta
+        )
+        fd_sims[f"fd_minus_{idx}"] = _add_custom_pole_residue(
+            base_sim, box_geom, base_params - delta
+        )
+
+    fd_results = web.run_async(
+        fd_sims,
+        path_dir=str(numerical_case_dir / f"fd_batch_{case['name']}"),
+        local_gradient=False,
+        verbose=False,
+    )
+
+    grad_fd = np.zeros_like(grad_adj)
+    for idx in range(base_params.size):
+        plus = _metric_value(case, fd_results[f"fd_plus_{idx}"][monitor_name], freq0)
+        minus = _metric_value(case, fd_results[f"fd_minus_{idx}"][monitor_name], freq0)
+        grad_fd[idx] = (plus - minus) / (2.0 * FD_STEP)
+
+    angle_deg = _angle_deg(grad_adj, grad_fd)
+
+    print(
+        f"[custom-pole-residue-grad-test:{case['name']}] adjoint={grad_adj}, "
+        f"finite-difference={grad_fd}, angle_deg={angle_deg:.3f}",
+        file=sys.stderr,
+    )
+
+    assert angle_deg <= ANGLE_TOL or np.isnan(angle_deg), (
+        f"Gradient angle deviation {angle_deg:.3f} deg exceeds tolerance ({ANGLE_TOL}). "
+        f"adj={grad_adj}, fd={grad_fd}"
+    )

--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -34,7 +34,7 @@ from tidy3d.plugins.polyslab import ComplexPolySlab
 from tidy3d.web import run, run_async
 from tidy3d.web.api.autograd import autograd as autograd_module
 
-from ...utils import SIM_FULL, AssertLogLevel, run_emulated, tracer_arr
+from ...utils import SIM_FULL, AssertLogLevel, custom_poleresidue_u, run_emulated, tracer_arr
 
 """ Test configuration """
 
@@ -1998,8 +1998,15 @@ def test_custom_pole_residue(monkeypatch):
 
     monkeypatch.setattr(
         td.CustomPoleResidue,
-        "_derivative_field_cmp",
-        lambda self, E_der_map, spatial_data, dim, freqs, component="real": dJ_deps / 3.0,
+        "_derivative_field_cmp_custom",
+        lambda self,
+        E_der_map,
+        spatial_data,
+        dim,
+        freqs,
+        bounds=None,
+        component="real",
+        interp_method=None: dJ_deps / 3.0,
     )
 
     import importlib
@@ -2058,6 +2065,38 @@ def test_custom_pole_residue(monkeypatch):
         for j in range(2):
             field_path = ("poles", i, j)
             assert np.allclose(grads_computed[field_path], np.conj(grad_poles[i][j]))
+
+
+def test_custom_pole_residue_unstructured_derivatives():
+    """Ensure unstructured pole residue adjoints are explicitly unsupported."""
+    pr = custom_poleresidue_u
+    field_paths = [("eps_inf",), ("poles", 0, 0), ("poles", 0, 1)]
+
+    info = DerivativeInfo(
+        paths=field_paths,
+        E_der_map={},
+        D_der_map={},
+        E_fwd={},
+        D_fwd={},
+        E_adj={},
+        D_adj={},
+        eps_data={},
+        eps_in=2.0,
+        eps_out=1.0,
+        frequencies=[3e8],
+        bounds=((-1, -1, -1), (1, 1, 1)),
+        eps_no_structure=td.ScalarFieldDataArray(
+            [[[[1.0]]]], coords={"x": [0], "y": [0], "z": [0], "f": [1.94e14]}
+        ),
+        eps_inf_structure=td.ScalarFieldDataArray(
+            [[[[2.0]]]], coords={"x": [0], "y": [0], "z": [0], "f": [1.94e14]}
+        ),
+        bounds_intersect=((-1, -1, -1), (1, 1, 1)),
+        simulation_bounds=((-2, -2, -2), (2, 2, 2)),
+    )
+
+    with pytest.raises(NotImplementedError, match="unstructured"):
+        pr._compute_derivatives(derivative_info=info)
 
 
 def test_custom_sellmeier(monkeypatch):

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -1107,6 +1107,10 @@ class AbstractCustomMedium(AbstractMedium, ABC):
         spatial_data: PermittivityDataset,
         dim: str,
     ) -> np.ndarray:
+        if isinstance(spatial_data, UnstructuredGridDataset):
+            raise NotImplementedError(
+                "Adjoint derivatives for unstructured custom media are not supported."
+            )
         coords_interp = {key: val for key, val in spatial_data.coords.items() if len(val) > 1}
         dims_sum = {dim for dim in spatial_data.coords.keys() if dim not in coords_interp}
 
@@ -1160,6 +1164,203 @@ class AbstractCustomMedium(AbstractMedium, ABC):
                 "message and some information about your simulation setup and we will investigate. "
             )
         return vjp_array
+
+    def _derivative_field_cmp_custom(
+        self,
+        E_der_map: ElectromagneticFieldDataset,
+        spatial_data: SpatialDataArray,
+        dim: str,
+        freqs: NDArray,
+        bounds: Optional[Bound] = None,
+        component: str = "real",
+        interp_method: Optional[InterpMethod] = None,
+    ) -> NDArray:
+        """Compute the derivative with respect to a material property component."""
+        param_coords = {axis: np.asarray(spatial_data.coords[axis]) for axis in "xyz"}
+        eps_shape = [len(param_coords[axis]) for axis in "xyz"]
+        dtype_out = complex if component == "complex" else float
+
+        E_der_dim = E_der_map.get(f"E{dim}")
+        if E_der_dim is None or np.all(E_der_dim.values == 0):
+            return np.zeros(eps_shape, dtype=dtype_out)
+
+        field_coords = {axis: np.asarray(E_der_dim.coords[axis]) for axis in "xyz"}
+        values = E_der_dim.values
+
+        def _bounds_slice(axis: NDArray, vmin: float, vmax: float, *, name: str) -> slice:
+            n = axis.size
+            i0 = int(np.searchsorted(axis, vmin, side="left"))
+            i1 = int(np.searchsorted(axis, vmax, side="right"))
+            if i1 <= i0 and n:
+                old = (i0, i1)
+                if i1 < n:
+                    i1 = i0 + 1  # expand right
+                elif i0 > 0:
+                    i0 = i1 - 1  # expand left
+                log.warning(
+                    f"Empty bounds crop on '{name}' while computing CustomMedium parameter gradients "
+                    f"(adjoint field grid -> medium grid): bounds=[{vmin!r}, {vmax!r}], "
+                    f"grid=[{axis[0]!r}, {axis[-1]!r}] -> indices {old}; using ({i0}, {i1}).",
+                    log_once=True,
+                )
+            return slice(i0, i1)
+
+        # usage
+        if bounds is not None:
+            (xmin, ymin, zmin), (xmax, ymax, zmax) = bounds
+
+            sx = _bounds_slice(field_coords["x"], xmin, xmax, name="x")
+            sy = _bounds_slice(field_coords["y"], ymin, ymax, name="y")
+            sz = _bounds_slice(field_coords["z"], zmin, zmax, name="z")
+
+            field_coords = {k: field_coords[k][s] for k, s in (("x", sx), ("y", sy), ("z", sz))}
+            values = values[sx, sy, sz, :]
+
+        def _axis_sizes(coords: NDArray) -> NDArray:
+            if coords.size <= 1:
+                return np.array([1.0])
+            mid_points = (coords[1:] + coords[:-1]) / 2.0
+            dists = np.diff(mid_points)
+            sizes = np.zeros(coords.size)
+            sizes[1:-1] = dists
+            sizes[0] = 2 * abs(mid_points[0] - coords[0])
+            sizes[-1] = 2 * abs(coords[-1] - mid_points[-1])
+            return sizes
+
+        size_x = _axis_sizes(field_coords["x"])
+        size_y = _axis_sizes(field_coords["y"])
+        size_z = _axis_sizes(field_coords["z"])
+        scale = (
+            size_x[:, None, None, None] * size_y[None, :, None, None] * size_z[None, None, :, None]
+        )
+        np.multiply(values, scale, out=values)
+
+        method = interp_method if interp_method is not None else self.interp_method
+
+        def _transpose_interp_axis(
+            field_values: NDArray, field_coords_1d: NDArray, param_coords_1d: NDArray
+        ) -> NDArray:
+            """
+            Transpose (adjoint) of 1D interpolation along one axis.
+
+            Parameters
+            ----------
+            field_values : np.ndarray
+                Array of values sampled on the field grid along this axis.
+                Shape: (n_field, ...rest...).
+                Notes:
+                  - The first axis corresponds to `field_coords_1d`.
+                  - The remaining axes (...rest...) are treated as batch dimensions and are
+                    carried through unchanged.
+
+            field_coords_1d : np.ndarray
+                1D coordinates of the field grid along this axis.
+                Shape: (n_field,).
+
+            param_coords_1d : np.ndarray
+                1D coordinates of the parameter grid along this axis.
+                Shape: (n_param,). Must be sorted ascending for the searchsorted-based logic.
+
+            Returns
+            -------
+            param_values : np.ndarray
+                Field contributions accumulated onto the parameter grid along this axis.
+                Shape: (n_param, ...rest...).
+
+            Implementation note
+            -------------------
+            For efficient accumulation, we flatten the trailing dimensions (...rest...) into a single
+            dimension so we can run a vectorized `np.add.at` on a 2D buffer of shape (n_param, n_rest),
+            then reshape back to (n_param, ...rest...).
+            """
+            # Single-point parameter grid: every field sample maps to the only parameter entry,
+            if param_coords_1d.size == 1:
+                return field_values.sum(axis=0, keepdims=True)
+
+            # Ensure parameter coordinates are sorted for searchsorted-based binning.
+            if np.any(param_coords_1d[1:] < param_coords_1d[:-1]):
+                raise ValueError("Spatial coordinates must be sorted before computing derivatives.")
+            param_coords_sorted = param_coords_1d
+
+            n_param = param_coords_sorted.size
+            if method not in ALLOWED_INTERP_METHODS:
+                raise ValueError(
+                    f"Unsupported interpolation method: {method!r}. "
+                    f"Choose one of: {', '.join(ALLOWED_INTERP_METHODS)}."
+                )
+
+            # Flatten trailing dimensions into a single "rest" dimension for vectorized accumulation.
+            n_field = field_values.shape[0]
+            field_values_2d = field_values.reshape(n_field, -1)
+
+            if method == "nearest":
+                # Midpoints define bin edges between adjacent parameter coordinates.
+                param_midpoints = (param_coords_sorted[1:] + param_coords_sorted[:-1]) / 2.0
+                # Map each field coordinate to a nearest parameter-bin index.
+                param_index_nearest = np.searchsorted(param_midpoints, field_coords_1d)
+
+                # Accumulate all field samples into their assigned parameter bins.
+                param_values_2d = npo.zeros(
+                    (n_param, field_values_2d.shape[1]), dtype=field_values.dtype
+                )
+                npo.add.at(param_values_2d, param_index_nearest, field_values_2d)
+
+                param_values = param_values_2d.reshape((n_param,) + field_values.shape[1:])
+                return param_values
+
+            # linear
+            # Find bracketing parameter indices for each field coordinate.
+            param_index_upper = np.searchsorted(param_coords_sorted, field_coords_1d, side="right")
+            param_index_upper = np.clip(param_index_upper, 1, n_param - 1)
+            param_index_lower = param_index_upper - 1
+
+            # Compute interpolation fraction within the bracketing segment.
+            segment_width = (
+                param_coords_sorted[param_index_upper] - param_coords_sorted[param_index_lower]
+            )
+            segment_width = np.where(segment_width == 0, 1.0, segment_width)
+            frac_upper = (field_coords_1d - param_coords_sorted[param_index_lower]) / segment_width
+            frac_upper = np.clip(frac_upper, 0.0, 1.0)
+
+            # Weights per field sample (broadcast across the flattened trailing dimensions).
+            w_lower = (1.0 - frac_upper)[:, None]
+            w_upper = frac_upper[:, None]
+
+            # Accumulate contributions into both bracketing parameter indices.
+            param_values_2d = npo.zeros(
+                (n_param, field_values_2d.shape[1]), dtype=field_values.dtype
+            )
+            npo.add.at(param_values_2d, param_index_lower, field_values_2d * w_lower)
+            npo.add.at(param_values_2d, param_index_upper, field_values_2d * w_upper)
+
+            param_values = param_values_2d.reshape((n_param,) + field_values.shape[1:])
+            return param_values
+
+        def _interp_axis(
+            arr: NDArray, axis: int, field_axis: NDArray, param_axis: NDArray
+        ) -> NDArray:
+            """Accumulate values from the field grid onto the parameter grid along one axis.
+
+            Moves ``axis`` to the front, applies ``_transpose_interp_axis`` (adjoint of 1D interpolation)
+            to map from ``field_axis`` (n_field) to ``param_axis`` (n_param), then moves the axis back.
+            """
+            moved = np.moveaxis(arr, axis, 0)
+            moved = _transpose_interp_axis(moved, field_axis, param_axis)
+            return np.moveaxis(moved, 0, axis)
+
+        values = _interp_axis(values, 0, field_coords["x"], param_coords["x"])
+        values = _interp_axis(values, 1, field_coords["y"], param_coords["y"])
+        values = _interp_axis(values, 2, field_coords["z"], param_coords["z"])
+
+        freqs_da = np.asarray(E_der_dim.coords["f"])
+        if component == "sigma":
+            values = values.imag * (-1.0 / (2.0 * np.pi * freqs_da * EPSILON_0))
+        elif component == "imag":
+            values = values.imag
+        elif component == "real":
+            values = values.real
+
+        return values.sum(axis=-1).reshape(eps_shape)
 
 
 """ Dispersionless Medium """
@@ -2398,203 +2599,6 @@ class CustomMedium(AbstractCustomMedium):
 
         return vjps
 
-    def _derivative_field_cmp_custom(
-        self,
-        E_der_map: ElectromagneticFieldDataset,
-        spatial_data: SpatialDataArray,
-        dim: str,
-        freqs: NDArray,
-        bounds: Optional[Bound] = None,
-        component: str = "real",
-        interp_method: Optional[InterpMethod] = None,
-    ) -> NDArray:
-        """Compute the derivative with respect to a material property component."""
-        param_coords = {axis: np.asarray(spatial_data.coords[axis]) for axis in "xyz"}
-        eps_shape = [len(param_coords[axis]) for axis in "xyz"]
-        dtype_out = complex if component == "complex" else float
-
-        E_der_dim = E_der_map.get(f"E{dim}")
-        if E_der_dim is None or np.all(E_der_dim.values == 0):
-            return np.zeros(eps_shape, dtype=dtype_out)
-
-        field_coords = {axis: np.asarray(E_der_dim.coords[axis]) for axis in "xyz"}
-        values = E_der_dim.values
-
-        def _bounds_slice(axis: NDArray, vmin: float, vmax: float, *, name: str) -> slice:
-            n = axis.size
-            i0 = int(np.searchsorted(axis, vmin, side="left"))
-            i1 = int(np.searchsorted(axis, vmax, side="right"))
-            if i1 <= i0 and n:
-                old = (i0, i1)
-                if i1 < n:
-                    i1 = i0 + 1  # expand right
-                elif i0 > 0:
-                    i0 = i1 - 1  # expand left
-                log.warning(
-                    f"Empty bounds crop on '{name}' while computing CustomMedium parameter gradients "
-                    f"(adjoint field grid -> medium grid): bounds=[{vmin!r}, {vmax!r}], "
-                    f"grid=[{axis[0]!r}, {axis[-1]!r}] -> indices {old}; using ({i0}, {i1}).",
-                    log_once=True,
-                )
-            return slice(i0, i1)
-
-        # usage
-        if bounds is not None:
-            (xmin, ymin, zmin), (xmax, ymax, zmax) = bounds
-
-            sx = _bounds_slice(field_coords["x"], xmin, xmax, name="x")
-            sy = _bounds_slice(field_coords["y"], ymin, ymax, name="y")
-            sz = _bounds_slice(field_coords["z"], zmin, zmax, name="z")
-
-            field_coords = {k: field_coords[k][s] for k, s in (("x", sx), ("y", sy), ("z", sz))}
-            values = values[sx, sy, sz, :]
-
-        def _axis_sizes(coords: NDArray) -> NDArray:
-            if coords.size <= 1:
-                return np.array([1.0])
-            mid_points = (coords[1:] + coords[:-1]) / 2.0
-            dists = np.diff(mid_points)
-            sizes = np.zeros(coords.size)
-            sizes[1:-1] = dists
-            sizes[0] = 2 * abs(mid_points[0] - coords[0])
-            sizes[-1] = 2 * abs(coords[-1] - mid_points[-1])
-            return sizes
-
-        size_x = _axis_sizes(field_coords["x"])
-        size_y = _axis_sizes(field_coords["y"])
-        size_z = _axis_sizes(field_coords["z"])
-        scale = (
-            size_x[:, None, None, None] * size_y[None, :, None, None] * size_z[None, None, :, None]
-        )
-        np.multiply(values, scale, out=values)
-
-        method = interp_method if interp_method is not None else self.interp_method
-
-        def _transpose_interp_axis(
-            field_values: NDArray, field_coords_1d: NDArray, param_coords_1d: NDArray
-        ) -> NDArray:
-            """
-            Transpose (adjoint) of 1D interpolation along one axis.
-
-            Parameters
-            ----------
-            field_values : np.ndarray
-                Array of values sampled on the field grid along this axis.
-                Shape: (n_field, ...rest...).
-                Notes:
-                  - The first axis corresponds to `field_coords_1d`.
-                  - The remaining axes (...rest...) are treated as batch dimensions and are
-                    carried through unchanged.
-
-            field_coords_1d : np.ndarray
-                1D coordinates of the field grid along this axis.
-                Shape: (n_field,).
-
-            param_coords_1d : np.ndarray
-                1D coordinates of the parameter grid along this axis.
-                Shape: (n_param,). Must be sorted ascending for the searchsorted-based logic.
-
-            Returns
-            -------
-            param_values : np.ndarray
-                Field contributions accumulated onto the parameter grid along this axis.
-                Shape: (n_param, ...rest...).
-
-            Implementation note
-            -------------------
-            For efficient accumulation, we flatten the trailing dimensions (...rest...) into a single
-            dimension so we can run a vectorized `np.add.at` on a 2D buffer of shape (n_param, n_rest),
-            then reshape back to (n_param, ...rest...).
-            """
-            # Single-point parameter grid: every field sample maps to the only parameter entry,
-            if param_coords_1d.size == 1:
-                return field_values.sum(axis=0, keepdims=True)
-
-            # Ensure parameter coordinates are sorted for searchsorted-based binning.
-            if np.any(param_coords_1d[1:] < param_coords_1d[:-1]):
-                raise ValueError("Spatial coordinates must be sorted before computing derivatives.")
-            param_coords_sorted = param_coords_1d
-
-            n_param = param_coords_sorted.size
-            if method not in ALLOWED_INTERP_METHODS:
-                raise ValueError(
-                    f"Unsupported interpolation method: {method!r}. "
-                    f"Choose one of: {', '.join(ALLOWED_INTERP_METHODS)}."
-                )
-
-            # Flatten trailing dimensions into a single "rest" dimension for vectorized accumulation.
-            n_field = field_values.shape[0]
-            field_values_2d = field_values.reshape(n_field, -1)
-
-            if method == "nearest":
-                # Midpoints define bin edges between adjacent parameter coordinates.
-                param_midpoints = (param_coords_sorted[1:] + param_coords_sorted[:-1]) / 2.0
-                # Map each field coordinate to a nearest parameter-bin index.
-                param_index_nearest = np.searchsorted(param_midpoints, field_coords_1d)
-
-                # Accumulate all field samples into their assigned parameter bins.
-                param_values_2d = npo.zeros(
-                    (n_param, field_values_2d.shape[1]), dtype=field_values.dtype
-                )
-                npo.add.at(param_values_2d, param_index_nearest, field_values_2d)
-
-                param_values = param_values_2d.reshape((n_param,) + field_values.shape[1:])
-                return param_values
-
-            # linear
-            # Find bracketing parameter indices for each field coordinate.
-            param_index_upper = np.searchsorted(param_coords_sorted, field_coords_1d, side="right")
-            param_index_upper = np.clip(param_index_upper, 1, n_param - 1)
-            param_index_lower = param_index_upper - 1
-
-            # Compute interpolation fraction within the bracketing segment.
-            segment_width = (
-                param_coords_sorted[param_index_upper] - param_coords_sorted[param_index_lower]
-            )
-            segment_width = np.where(segment_width == 0, 1.0, segment_width)
-            frac_upper = (field_coords_1d - param_coords_sorted[param_index_lower]) / segment_width
-            frac_upper = np.clip(frac_upper, 0.0, 1.0)
-
-            # Weights per field sample (broadcast across the flattened trailing dimensions).
-            w_lower = (1.0 - frac_upper)[:, None]
-            w_upper = frac_upper[:, None]
-
-            # Accumulate contributions into both bracketing parameter indices.
-            param_values_2d = npo.zeros(
-                (n_param, field_values_2d.shape[1]), dtype=field_values.dtype
-            )
-            npo.add.at(param_values_2d, param_index_lower, field_values_2d * w_lower)
-            npo.add.at(param_values_2d, param_index_upper, field_values_2d * w_upper)
-
-            param_values = param_values_2d.reshape((n_param,) + field_values.shape[1:])
-            return param_values
-
-        def _interp_axis(
-            arr: NDArray, axis: int, field_axis: NDArray, param_axis: NDArray
-        ) -> NDArray:
-            """Accumulate values from the field grid onto the parameter grid along one axis.
-
-            Moves ``axis`` to the front, applies ``_transpose_interp_axis`` (adjoint of 1D interpolation)
-            to map from ``field_axis`` (n_field) to ``param_axis`` (n_param), then moves the axis back.
-            """
-            moved = np.moveaxis(arr, axis, 0)
-            moved = _transpose_interp_axis(moved, field_axis, param_axis)
-            return np.moveaxis(moved, 0, axis)
-
-        values = _interp_axis(values, 0, field_coords["x"], param_coords["x"])
-        values = _interp_axis(values, 1, field_coords["y"], param_coords["y"])
-        values = _interp_axis(values, 2, field_coords["z"], param_coords["z"])
-
-        freqs_da = np.asarray(E_der_dim.coords["f"])
-        if component == "sigma":
-            values = values.imag * (-1.0 / (2.0 * np.pi * freqs_da * EPSILON_0))
-        elif component == "imag":
-            values = values.imag
-        elif component == "real":
-            values = values.real
-
-        return values.sum(axis=-1).reshape(eps_shape)
-
 
 """ Dispersive Media """
 
@@ -3552,6 +3556,27 @@ class CustomPoleResidue(CustomDispersiveMedium, PoleResidue):
                     return False
         return True
 
+    @staticmethod
+    def _sorted_spatial_data(data: CustomSpatialDataTypeAnnotated):
+        """Return spatial data sorted along its coordinates if applicable."""
+        if isinstance(data, SpatialDataArray):
+            return data._spatially_sorted
+        return data
+
+    @cached_property
+    def _eps_inf_sorted(self) -> CustomSpatialDataTypeAnnotated:
+        """Cached sorted copy of eps_inf when structured data is provided."""
+        return self._sorted_spatial_data(self.eps_inf)
+
+    @cached_property
+    def _poles_sorted(
+        self,
+    ) -> tuple[tuple[CustomSpatialDataTypeAnnotated, CustomSpatialDataTypeAnnotated], ...]:
+        """Cached sorted copies of pole coefficients when structured data is provided."""
+        return tuple(
+            (self._sorted_spatial_data(a), self._sorted_spatial_data(c)) for a, c in self.poles
+        )
+
     def eps_dataarray_freq(
         self, frequency: float
     ) -> tuple[CustomSpatialDataType, CustomSpatialDataType, CustomSpatialDataType]:
@@ -3707,20 +3732,30 @@ class CustomPoleResidue(CustomDispersiveMedium, PoleResidue):
     def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
         """Compute adjoint derivatives by preparing array data and calling the static helper."""
 
-        # accumulate complex-valued derivatives across xyz; start as complex to avoid casting issues
+        eps_inf_sorted = self._eps_inf_sorted
+        use_custom_derivative = isinstance(eps_inf_sorted, SpatialDataArray)
+
         dJ_deps_complex = 0.0 + 0.0j
         for dim in "xyz":
-            dJ_deps_complex += self._derivative_field_cmp(
-                E_der_map=derivative_info.E_der_map,
-                spatial_data=self.eps_inf,
-                dim=dim,
-                freqs=derivative_info.frequencies,
-                component="complex",
-            )
+            if use_custom_derivative:
+                dJ_deps_complex += self._derivative_field_cmp_custom(
+                    E_der_map=derivative_info.E_der_map,
+                    spatial_data=eps_inf_sorted,
+                    dim=dim,
+                    freqs=derivative_info.frequencies,
+                    bounds=derivative_info.bounds_intersect,
+                    component="complex",
+                )
+            else:
+                dJ_deps_complex += self._derivative_field_cmp(
+                    E_der_map=derivative_info.E_der_map,
+                    spatial_data=eps_inf_sorted,
+                    dim=dim,
+                )
 
         poles_vals = [
-            (np.array(a.values, dtype=complex), np.array(c.values, dtype=complex))
-            for a, c in self.poles
+            (np.array(a_sorted.values, dtype=complex), np.array(c_sorted.values, dtype=complex))
+            for a_sorted, c_sorted in self._poles_sorted
         ]
 
         vjps_total = {}


### PR DESCRIPTION
we missed to handle CustomPoleResidue when fixing this bug on custom medium gradients (correct backward interpolation) https://github.com/flexcompute/tidy3d/pull/3113




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes gradient backpropagation for `CustomPoleResidue` by applying the transpose-based spatial interpolation used for custom media, and adds targeted tests.
> 
> - Implements `_derivative_field_cmp_custom` once (moved to shared logic) and uses it in `CustomPoleResidue._compute_derivatives` when structured `SpatialDataArray` is provided; caches sorted coord data via `_eps_inf_sorted`/`_poles_sorted`
> - Guards `_derivative_field_cmp` against unstructured datasets and raises `NotImplementedError` for unstructured `CustomPoleResidue` adjoints
> - Adds numerical test `test_autograd_custom_pole_residue_numerical.py` validating adjoint vs finite-difference gradients; updates existing autograd test hooks
> - Updates `CHANGELOG.md` entry for the fix
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8a7caa25a4da8edb92bf8c0b01c6d4a41d86b03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR extends the gradient computation fix from PR #3113 to handle `CustomPoleResidue` medium by applying the same custom transpose-based interpolation approach used for `CustomMedium`.

**Key changes:**
- Moved `_derivative_field_cmp_custom` method from `CustomMedium` to `AbstractCustomMedium` class to enable code reuse across both `CustomMedium` and `CustomPoleResidue`
- Added cached properties (`_eps_inf_sorted`, `_poles_sorted`) to `CustomPoleResidue` that ensure spatial coordinates are sorted before gradient computation, preventing errors during interpolation
- Updated `CustomPoleResidue._compute_derivatives` to use the custom derivative method when `eps_inf` is a `SpatialDataArray`, falling back to the scalar method otherwise
- Added comprehensive numerical test file validating adjoint gradients against finite-difference gradients for `CustomPoleResidue` with pole-residue dispersion model

**Technical improvements:**
- The custom implementation correctly handles the transpose (adjoint) operation needed for gradient backpropagation by accumulating field values onto parameter grid points using weighted contributions
- Proper boundary handling via `searchsorted` clips field data to intersection bounds before processing
- Volume elements computed from field coordinates and applied before interpolation fix normalization issues from the previous xarray-based approach

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor suggestions for improvement
- The implementation is mathematically sound and includes comprehensive numerical validation tests. The refactor addresses real bugs in gradient computation by extending the fix from PR #3113 to CustomPoleResidue. Score reduced from 5 to 4 due to one style suggestion regarding floating-point comparison (using == instead of np.isclose for norm checks) that could improve robustness, though this is a minor issue in the test code rather than production logic.
- No files require special attention - the implementation is solid with good test coverage

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tests/test_components/autograd/numerical/test_autograd_custom_pole_residue_numerical.py | New comprehensive numerical test validating CustomPoleResidue adjoint gradients against finite differences; well-structured with good parametrization |
| tidy3d/components/medium.py | Moved _derivative_field_cmp_custom to AbstractCustomMedium for code reuse; added cached sorted properties and updated CustomPoleResidue gradient computation to use custom derivative method |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Autograd System
    participant CPR as CustomPoleResidue
    participant ACM as AbstractCustomMedium
    participant CDC as _compute_derivatives
    participant DFCC as _derivative_field_cmp_custom
    participant TIA as _transpose_interp_axis
    
    Client->>CPR: Request gradients for eps_inf/poles
    CPR->>CPR: Access cached _eps_inf_sorted, _poles_sorted
    CPR->>CDC: _compute_derivatives(derivative_info)
    
    Note over CDC: Check if eps_inf is SpatialDataArray
    
    alt eps_inf is SpatialDataArray
        loop For each dimension (x, y, z)
            CDC->>DFCC: _derivative_field_cmp_custom(E_der_map, eps_inf_sorted, dim, freqs, bounds, "complex")
            DFCC->>ACM: Extract field coordinates and values
            DFCC->>ACM: Apply bounds filtering (searchsorted)
            DFCC->>ACM: Compute volume element scaling (_axis_sizes)
            DFCC->>ACM: Multiply values by scale
            
            loop For each axis (x, y, z)
                DFCC->>TIA: _transpose_interp_axis(arr, field_axis, param_axis)
                
                alt method == "nearest"
                    TIA->>TIA: Compute midpoints between param coords
                    TIA->>TIA: Use searchsorted to find indices
                    TIA->>TIA: Accumulate using npo.add.at
                else method == "linear"
                    TIA->>TIA: Find upper/lower indices via searchsorted
                    TIA->>TIA: Compute interpolation weights
                    TIA->>TIA: Check segment_width == 0, use 1.0 if zero
                    TIA->>TIA: Accumulate weighted contributions using npo.add.at
                end
                
                TIA-->>DFCC: Return interpolated array
            end
            
            DFCC->>DFCC: Extract complex component
            DFCC->>DFCC: Sum over frequencies
            DFCC-->>CDC: Return gradient array
        end
        CDC->>CDC: Sum dJ_deps_complex from all dimensions
    else eps_inf is scalar
        loop For each dimension (x, y, z)
            CDC->>ACM: _derivative_field_cmp(E_der_map, eps_inf_sorted, dim)
            ACM-->>CDC: Return scalar gradient
        end
    end
    
    CDC->>CDC: Extract sorted pole values from _poles_sorted
    
    loop For each frequency
        CDC->>CDC: _get_vjps_from_params(dJ_deps_complex, poles_vals, omega, paths)
        Note over CDC: Compute VJPs for eps_inf and pole coefficients (a, c)
        CDC->>CDC: Accumulate vjps_total
    end
    
    CDC-->>Client: Return vjps (gradient dictionary)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->