### PR TITLE
FXC-4875: fix docstrings with missing Notes sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed interpolation handling for permittivity and conductivity gradients in `CustomPoleResidue`.
+- Fixed docstrings with missing Notes sections causing spurious parameters in Sphinx documentation.
 
 ## [2.10.1] - 2026-01-14
 

--- a/tidy3d/components/beam.py
+++ b/tidy3d/components/beam.py
@@ -260,7 +260,9 @@ class PlaneWaveBeamProfile(BeamProfile):
     """Component for constructing plane wave beam data. The normal direction is implicitly
     defined by the ``size`` parameter.
 
-    See also :class:`.PlaneWave`.
+    See Also
+    --------
+    :class:`.PlaneWave`
     """
 
     angular_spec: Union[FixedInPlaneKSpec, FixedAngleSpec] = pd.Field(
@@ -353,7 +355,9 @@ class GaussianBeamProfile(BeamProfile):
     """Component for constructing Gaussian beam data. The normal direction is implicitly
     defined by the ``size`` parameter.
 
-    See also :class:`.GaussianBeam`.
+    See Also
+    --------
+    :class:`.GaussianBeam`
     """
 
     waist_radius: pd.PositiveFloat = pd.Field(
@@ -420,7 +424,9 @@ class AstigmaticGaussianBeamProfile(BeamProfile):
     """Component for constructing astigmatic Gaussian beam data. The normal direction is implicitly
     defined by the ``size`` parameter.
 
-    See also :class:`.AstigmaticGaussianBeam`.
+    See Also
+    --------
+    :class:`.AstigmaticGaussianBeam`
     """
 
     waist_sizes: tuple[pd.PositiveFloat, pd.PositiveFloat] = pd.Field(

--- a/tidy3d/components/data/index.py
+++ b/tidy3d/components/data/index.py
@@ -16,12 +16,14 @@ from tidy3d.components.types.simulation import SimulationDataType
 class SimulationDataMap(ValueMap, Mapping[str, SimulationDataType]):
     """An immutable dictionary-like container for simulation data.
 
-    It provides standard dictionary
-    behaviors like item access (`data["key"]`), iteration (`for key in data`), and
-    length checking (`len(data)`).
+    Notes
+    -----
+        It provides standard dictionary
+        behaviors like item access (`data["key"]`), iteration (`for key in data`), and
+        length checking (`len(data)`).
 
-    It automatically validates that the `keys` and `values`
-    tuples have matching lengths upon instantiation.
+        It automatically validates that the `keys` and `values`
+        tuples have matching lengths upon instantiation.
 
     Attributes
     ----------

--- a/tidy3d/components/eme/data/dataset.py
+++ b/tidy3d/components/eme/data/dataset.py
@@ -74,11 +74,13 @@ class EMEInterfaceSMatrixDataset(Dataset):
 class EMEOverlapDataset(Dataset):
     """Dataset storing overlaps between EME modes.
 
-    ``Oij`` is the unconjugated overlap computed using the E field of cell ``i``
-    and the H field of cell ``j``.
+    Notes
+    -----
+        ``Oij`` is the unconjugated overlap computed using the E field of cell ``i``
+        and the H field of cell ``j``.
 
-    For consistency with ``Sij``, ``mode_index_out`` refers to the mode index
-    in cell ``i``, and ``mode_index_in`` refers to the mode index in cell ``j``.
+        For consistency with ``Sij``, ``mode_index_out`` refers to the mode index
+        in cell ``i``, and ``mode_index_in`` refers to the mode index in cell ``j``.
     """
 
     O11: EMEInterfaceSMatrixDataArray = pd.Field(
@@ -100,17 +102,20 @@ class EMEOverlapDataset(Dataset):
 
 class EMECoefficientDataset(Dataset):
     """Dataset storing various coefficients related to the EME simulation.
-    These coefficients can be used for debugging or optimization.
 
-    The ``A`` and ``B`` fields store the expansion coefficients for the modes in a cell.
-    These are defined at the cell centers.
+    Notes
+    -----
+        These coefficients can be used for debugging or optimization.
 
-    The ``n_complex`` and ``flux`` fields respectively store the complex-valued effective
-    propagation index and the power flux associated with the modes used in the
-    EME calculation.
+        The ``A`` and ``B`` fields store the expansion coefficients for the modes in a cell.
+        These are defined at the cell centers.
 
-    The ``interface_Sij`` fields store the S matrices associated with the interfaces
-    between EME cells.
+        The ``n_complex`` and ``flux`` fields respectively store the complex-valued effective
+        propagation index and the power flux associated with the modes used in the
+        EME calculation.
+
+        The ``interface_Sij`` fields store the S matrices associated with the interfaces
+        between EME cells.
     """
 
     A: Optional[EMECoefficientDataArray] = pd.Field(

--- a/tidy3d/components/eme/sweep.py
+++ b/tidy3d/components/eme/sweep.py
@@ -86,13 +86,16 @@ class EMEFreqSweep(EMESweepSpec):
 
 class EMEPeriodicitySweep(EMESweepSpec):
     """Spec for sweeping number of repetitions of EME subgrids.
-    Useful for simulating long periodic structures like Bragg gratings,
-    as it allows the EME solver to reuse the modes and cell interface
-    scattering matrices.
 
-    Compared to setting ``num_reps`` directly in the ``eme_grid_spec``,
-    this sweep spec allows varying the number of repetitions,
-    effectively simulating multiple structures in a single EME simulation.
+    Notes
+    -----
+        Useful for simulating long periodic structures like Bragg gratings,
+        as it allows the EME solver to reuse the modes and cell interface
+        scattering matrices.
+
+        Compared to setting ``num_reps`` directly in the ``eme_grid_spec``,
+        this sweep spec allows varying the number of repetitions,
+        effectively simulating multiple structures in a single EME simulation.
 
     Example
     -------

--- a/tidy3d/components/field_projection.py
+++ b/tidy3d/components/field_projection.py
@@ -178,17 +178,17 @@ def _far_field_integral(
 
 
 class FieldProjector(Tidy3dBaseModel):
-    """
-    Projection of near fields to points on a given observation grid.
+    """Projection of near fields to points on a given observation grid.
 
+    Notes
+    -----
     .. TODO make images to illustrate this
 
     See Also
     --------
-
-    :class:`FieldProjectionAngleMonitor
+    :class:`FieldProjectionAngleMonitor`
         :class:`Monitor` that samples electromagnetic near fields in the frequency domain
-        and projects them at given observation angles.`
+        and projects them at given observation angles.
 
     **Notebooks**:
         * `Performing near field to far field projections <../../notebooks/FieldProjections.html>`_

--- a/tidy3d/components/index.py
+++ b/tidy3d/components/index.py
@@ -17,13 +17,15 @@ from tidy3d.components.types.simulation import SimulationType
 class ValueMap(Tidy3dBaseModel, Mapping[str, Any]):
     """An immutable dictionary-like container for objects.
 
-    This class maps unique string keys to corresponding value objects.
-    By inheriting from `collections.abc.Mapping`, it provides standard dictionary
-    behaviors like item access (`my_dict["my_key"]`), iteration (`for name in my_dict`), and
-    length checking (`len(my_dict)`).
+    Notes
+    -----
+        This class maps unique string keys to corresponding value objects.
+        By inheriting from `collections.abc.Mapping`, it provides standard dictionary
+        behaviors like item access (`my_dict["my_key"]`), iteration (`for name in my_dict`), and
+        length checking (`len(my_dict)`).
 
-    It automatically validates that the `keys` and `values`
-    tuples have matching lengths upon instantiation.
+        It automatically validates that the `keys` and `values`
+        tuples have matching lengths upon instantiation.
 
     Attributes
     ----------
@@ -121,13 +123,15 @@ class ValueMap(Tidy3dBaseModel, Mapping[str, Any]):
 class SimulationMap(ValueMap, Mapping[str, SimulationType]):
     """An immutable dictionary-like container for simulations.
 
-    This class maps unique string keys to corresponding `Simulation` objects.
-    By inheriting from `collections.abc.Mapping`, it provides standard dictionary
-    behaviors like item access (`sims["sim_A"]`), iteration (`for name in sims`), and
-    length checking (`len(sims)`).
+    Notes
+    -----
+        This class maps unique string keys to corresponding `Simulation` objects.
+        By inheriting from `collections.abc.Mapping`, it provides standard dictionary
+        behaviors like item access (`sims["sim_A"]`), iteration (`for name in sims`), and
+        length checking (`len(sims)`).
 
-    It automatically validates that the `keys` and `values`
-    tuples have matching lengths upon instantiation.
+        It automatically validates that the `keys` and `values`
+        tuples have matching lengths upon instantiation.
 
     Attributes
     ----------

--- a/tidy3d/components/microwave/data/data_array.py
+++ b/tidy3d/components/microwave/data/data_array.py
@@ -7,8 +7,10 @@ from tidy3d.constants import NEPERPERMETER, PERMETER, RADPERMETER, VELOCITY_SI
 class PropagationConstantArray(FreqModeDataArray):
     """Data array for the complex propagation constant :math:`\\gamma = -\\alpha + j\\beta` with units of 1/m.
 
-    In the physics convention where time-harmonic fields evolve with :math:`e^{-j\\omega t}`, a wave
-    propagating in the +z direction varies as :math:`E(z) = E_0 e^{\\gamma z} = E_0 e^{-\\alpha z} e^{j\\beta z}`.
+    Notes
+    -----
+        In the physics convention where time-harmonic fields evolve with :math:`e^{-j\\omega t}`, a wave
+        propagating in the +z direction varies as :math:`E(z) = E_0 e^{\\gamma z} = E_0 e^{-\\alpha z} e^{j\\beta z}`.
     """
 
     __slots__ = ()

--- a/tidy3d/components/microwave/mode_spec.py
+++ b/tidy3d/components/microwave/mode_spec.py
@@ -25,10 +25,13 @@ QTEM_POLARIZATION_THRESHOLD = 0.95
 
 
 class MicrowaveModeSpec(AbstractModeSpec, MicrowaveBaseModel):
-    """
-    The :class:`.MicrowaveModeSpec` class specifies how quantities related to transmission line
-    modes and microwave waveguides are computed. For example, it defines the paths for line integrals, which are used to
-    compute voltage, current, and characteristic impedance of the transmission line.
+    """Specification for transmission line modes and microwave waveguides.
+
+    Notes
+    -----
+        The :class:`.MicrowaveModeSpec` class specifies how quantities related to transmission line
+        modes and microwave waveguides are computed. For example, it defines the paths for line integrals, which are used to
+        compute voltage, current, and characteristic impedance of the transmission line.
 
     Example
     -------

--- a/tidy3d/components/microwave/path_integrals/mode_plane_analyzer.py
+++ b/tidy3d/components/microwave/path_integrals/mode_plane_analyzer.py
@@ -30,7 +30,9 @@ from tidy3d.exceptions import SetupError
 class ModePlaneAnalyzer(Box):
     """Analyzes conductor geometry intersecting a mode plane.
 
-    This class analyzes the geometry of conductors in a simulation cross-section and is for internal use.
+    Notes
+    -----
+        This class analyzes the geometry of conductors in a simulation cross-section and is for internal use.
     """
 
     _plane_validator = assert_plane()

--- a/tidy3d/components/microwave/path_integrals/specs/current.py
+++ b/tidy3d/components/microwave/path_integrals/specs/current.py
@@ -294,8 +294,10 @@ class Custom2DCurrentIntegralSpec(Custom2DPathIntegralSpec):
 class CompositeCurrentIntegralSpec(MicrowaveBaseModel):
     """Specification for a composite current integral.
 
-    This class is used to set up a ``CompositeCurrentIntegral``, which combines
-    multiple current integrals. It does not perform any integration itself.
+    Notes
+    -----
+        This class is used to set up a ``CompositeCurrentIntegral``, which combines
+        multiple current integrals. It does not perform any integration itself.
 
     Example
     -------

--- a/tidy3d/components/microwave/path_integrals/specs/impedance.py
+++ b/tidy3d/components/microwave/path_integrals/specs/impedance.py
@@ -18,21 +18,25 @@ from tidy3d.exceptions import SetupError
 class AutoImpedanceSpec(MicrowaveBaseModel):
     """Specification for fully automatic transmission line impedance computation.
 
-    This specification automatically calculates impedance by current
-    paths based on the simulation geometry and conductors that intersect the mode plane.
-    No user-defined path specifications are required.
+    Notes
+    -----
+        Automatically calculates impedance using paths based on simulation geometry
+        and conductors that intersect the mode plane. No user-defined path
+        specifications are required.
     """
 
 
 class CustomImpedanceSpec(MicrowaveBaseModel):
     """Specification for custom transmission line voltages and currents in mode solvers.
 
-    The :class:`.CustomImpedanceSpec` class specifies how quantities related to transmission line
-    modes are computed. It defines the paths for line integrals, which are used to
-    compute voltage, current, and characteristic impedance of the transmission line.
+    Notes
+    -----
+        The :class:`.CustomImpedanceSpec` class specifies how quantities related to transmission line
+        modes are computed. It defines the paths for line integrals, which are used to
+        compute voltage, current, and characteristic impedance of the transmission line.
 
-    Users must supply at least one of voltage or current path specifications to control where these integrals
-    are evaluated. Both voltage_spec and current_spec cannot be ``None`` simultaneously.
+        Users must supply at least one of voltage or current path specifications to control where these integrals
+        are evaluated. Both voltage_spec and current_spec cannot be ``None`` simultaneously.
 
     Example
     -------

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -281,9 +281,12 @@ class AbstractFieldMonitor(Monitor, ABC):
 class AbstractAuxFieldMonitor(Monitor, ABC):
     """:class:`.Monitor` that records auxiliary fields as a function of x,y,z.
 
-    Auxiliary fields are used in certain nonlinear material models.
-    :class:`.TwoPhotonAbsorption` uses `Nfx`, `Nfy`, and `Nfz` for the
-    free-carrier density."""
+    Notes
+    -----
+        Auxiliary fields are used in certain nonlinear material models.
+        :class:`.TwoPhotonAbsorption` uses `Nfx`, `Nfy`, and `Nfz` for the
+        free-carrier density.
+    """
 
     fields: tuple[AuxField, ...] = pydantic.Field(
         (),
@@ -531,9 +534,11 @@ class FieldTimeMonitor(AbstractFieldMonitor, TimeMonitor):
 class AuxFieldTimeMonitor(AbstractAuxFieldMonitor, TimeMonitor):
     """:class:`.Monitor` that records auxiliary fields in the time domain.
 
-    Auxiliary fields are used in certain nonlinear material models.
-    :class:`.TwoPhotonAbsorption` uses `Nfx`, `Nfy`, and `Nfz` for the
-    free-carrier density.
+    Notes
+    -----
+        Auxiliary fields are used in certain nonlinear material models.
+        :class:`.TwoPhotonAbsorption` uses `Nfx`, `Nfy`, and `Nfz` for the
+        free-carrier density.
 
     Example
     -------
@@ -895,15 +900,14 @@ class ModeSolverMonitor(AbstractModeMonitor):
 
 
 class FieldProjectionSurface(Tidy3dBaseModel):
-    """
-    Data structure to store surface monitors where near fields are recorded for
-    field projections.
+    """Data structure to store surface monitors where near fields are recorded for field projections.
 
+    Notes
+    -----
     .. TODO add example and derivation, and more relevant links.
 
     See Also
     --------
-
     **Notebooks**:
         * `Performing near field to far field projections <../../notebooks/FieldProjections.html>`_
     """

--- a/tidy3d/components/parameter_perturbation.py
+++ b/tidy3d/components/parameter_perturbation.py
@@ -1251,12 +1251,12 @@ class NedeljkovicSorefMashanovich(AbstractDeltaModel):
     """Nedeljkovic-Soref-Mashanovich model for the perturbation of the refractive index and
     extinction coefficient due to free carriers.
 
-    M. Nedeljkovic, R. Soref and G. Z. Mashanovich, "Free-Carrier Electrorefraction and Electroabsorption
-    Modulation Predictions for Silicon Over the 1–14- μm Infrared Wavelength Range," in IEEE Photonics
-    Journal, vol. 3, no. 6, pp. 1171-1180, Dec. 2011, doi: 10.1109/JPHOT.2011.2171930
+    References
+    ----------
+    .. [1] M. Nedeljkovic, R. Soref and G. Z. Mashanovich, "Free-Carrier Electrorefraction and Electroabsorption
+        Modulation Predictions for Silicon Over the 1–14- μm Infrared Wavelength Range," in IEEE Photonics
+        Journal, vol. 3, no. 6, pp. 1171-1180, Dec. 2011, doi: 10.1109/JPHOT.2011.2171930
 
-    Example
-    -------
     """
 
     perturb_coeffs: PerturbationCoefficientDataArray = pd.Field(

--- a/tidy3d/log.py
+++ b/tidy3d/log.py
@@ -106,16 +106,18 @@ class LogHandler:
 
 
 class Logger:
-    """Custom logger to avoid the complexities of the logging module
+    """Custom logger to avoid the complexities of the logging module.
 
-    The logger can be used in a context manager to avoid the emission of multiple messages. In this
-    case, the first message in the context is emitted normally, but any others are discarded. When
-    the context is exited, the number of discarded messages of each level is displayed with the
-    highest level of the captures messages.
+    Notes
+    -----
+        The logger can be used in a context manager to avoid the emission of multiple messages. In this
+        case, the first message in the context is emitted normally, but any others are discarded. When
+        the context is exited, the number of discarded messages of each level is displayed with the
+        highest level of the captures messages.
 
-    Messages can also be captured for post-processing. That can be enabled through 'set_capture' to
-    record all warnings emitted during model validation. A structured copy of all validation
-    messages can then be recovered through 'captured_warnings'.
+        Messages can also be captured for post-processing. That can be enabled through 'set_capture' to
+        record all warnings emitted during model validation. A structured copy of all validation
+        messages can then be recovered through 'captured_warnings'.
     """
 
     _static_cache = set()

--- a/tidy3d/plugins/expressions/base.py
+++ b/tidy3d/plugins/expressions/base.py
@@ -24,11 +24,12 @@ if TYPE_CHECKING:
 
 
 class Expression(Tidy3dBaseModel, ABC):
-    """
-    Base class for all expressions in the metrics module.
+    """Base class for all expressions in the metrics module.
 
-    This class serves as the foundation for all other components in the metrics module.
-    It provides common functionality and operator overloading for derived classes.
+    Notes
+    -----
+        This class serves as the foundation for all other components in the metrics module.
+        It provides common functionality and operator overloading for derived classes.
     """
 
     class Config:

--- a/tidy3d/plugins/expressions/metrics.py
+++ b/tidy3d/plugins/expressions/metrics.py
@@ -34,11 +34,12 @@ def generate_validation_data(expr: Expression) -> dict[str, xr.Dataset]:
 
 
 class Metric(Variable, ABC):
-    """
-    Base class for all metrics.
+    """Base class for all metrics.
 
-    To subclass Metric, you must implement an evaluate() method that takes a SimulationData
-    object and returns a scalar value.
+    Notes
+    -----
+        To subclass Metric, you must implement an evaluate() method that takes a SimulationData
+        object and returns a scalar value.
     """
 
     @property

--- a/tidy3d/plugins/expressions/operators.py
+++ b/tidy3d/plugins/expressions/operators.py
@@ -9,11 +9,12 @@ from .types import NumberOrExpression, NumberType
 
 
 class UnaryOperator(Expression):
-    """
-    Base class for unary operators in the metrics module.
+    """Base class for unary operators in the metrics module.
 
-    This class represents an operation with a single operand.
-    Subclasses should implement the evaluate method to define the specific operation.
+    Notes
+    -----
+        This class represents an operation with a single operand.
+        Subclasses should implement the evaluate method to define the specific operation.
     """
 
     operand: NumberOrExpression = pd.Field(
@@ -34,11 +35,12 @@ class UnaryOperator(Expression):
 
 
 class BinaryOperator(Expression):
-    """
-    Base class for binary operators in the metrics module.
+    """Base class for binary operators in the metrics module.
 
-    This class represents an operation with two operands.
-    Subclasses should implement the evaluate method to define the specific operation.
+    Notes
+    -----
+        This class represents an operation with two operands.
+        Subclasses should implement the evaluate method to define the specific operation.
     """
 
     left: NumberOrExpression = pd.Field(

--- a/tidy3d/plugins/invdes/initialization.py
+++ b/tidy3d/plugins/invdes/initialization.py
@@ -26,7 +26,9 @@ class AbstractInitializationSpec(Tidy3dBaseModel, ABC):
 class RandomInitializationSpec(AbstractInitializationSpec):
     """Specification for random initial parameters.
 
-    When a seed is provided, a call to `create_parameters` will always return the same array.
+    Notes
+    -----
+        When a seed is provided, a call to `create_parameters` will always return the same array.
     """
 
     min_value: float = pd.Field(

--- a/tidy3d/plugins/smatrix/component_modelers/modal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/modal.py
@@ -24,9 +24,11 @@ from .base import FWIDTH_FRAC, AbstractComponentModeler
 class ModalComponentModeler(AbstractComponentModeler):
     """A tool for modeling devices and computing scattering matrix elements.
 
-    This class orchestrates the process of running multiple simulations to
-    derive the scattering matrix (S-matrix) of a component. It uses modal
-    sources and monitors defined by a set of ports.
+    Notes
+    -----
+        This class orchestrates the process of running multiple simulations to
+        derive the scattering matrix (S-matrix) of a component. It uses modal
+        sources and monitors defined by a set of ports.
 
     See Also
     --------

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -48,18 +48,17 @@ AUTO_RADIATION_MONITOR_NUM_POINTS_PHI = 200
 
 
 class DirectivityMonitorSpec(MicrowaveBaseModel):
-    """
-    Specification for automatically generating a :class:`.DirectivityMonitor`.
+    """Specification for automatically generating a :class:`.DirectivityMonitor`.
 
-    When included in the :attr:`.TerminalComponentModeler.radiation_monitors` tuple,
-    a :class:`.DirectivityMonitor` will be automatically generated with the specified
-    parameters. This allows users to mix manual :class:`.DirectivityMonitor` objects
-    with automatically generated ones, each with customizable parameters.
+    Notes
+    -----
+        When included in the :attr:`.TerminalComponentModeler.radiation_monitors` tuple,
+        a :class:`.DirectivityMonitor` will be automatically generated with the specified
+        parameters. This allows users to mix manual :class:`.DirectivityMonitor` objects
+        with automatically generated ones, each with customizable parameters.
 
-    Note
-    ----
-    The default origin (`custom_origin`) for defining observation points in the automatically
-    generated monitor is set to (0, 0, 0) in the global coordinate system.
+        The default origin (`custom_origin`) for defining observation points in the automatically
+        generated monitor is set to (0, 0, 0) in the global coordinate system.
 
     Example
     -------

--- a/tidy3d/plugins/smatrix/data/base.py
+++ b/tidy3d/plugins/smatrix/data/base.py
@@ -15,9 +15,11 @@ from tidy3d.plugins.smatrix.component_modelers.base import AbstractComponentMode
 class AbstractComponentModelerData(ABC, Tidy3dBaseModel):
     """A data container for the results of a :class:`.AbstractComponentModeler` run.
 
-    This class stores the original modeler and the simulation data obtained
-    from running the simulations it defines. It also provides a method to
-    compute the S-matrix from the simulation data.
+    Notes
+    -----
+        This class stores the original modeler and the simulation data obtained
+        from running the simulations it defines. It also provides a method to
+        compute the S-matrix from the simulation data.
     """
 
     modeler: AbstractComponentModeler = pd.Field(

--- a/tidy3d/plugins/smatrix/data/modal.py
+++ b/tidy3d/plugins/smatrix/data/modal.py
@@ -12,9 +12,11 @@ from tidy3d.plugins.smatrix.data.data_array import ModalPortDataArray
 class ModalComponentModelerData(AbstractComponentModelerData):
     """A data container for the results of a :class:`.ModalComponentModeler` run.
 
-    This class stores the original modeler and the simulation data obtained
-    from running the simulations it defines. It also provides a method to
-    compute the S-matrix from the simulation data.
+    Notes
+    -----
+        This class stores the original modeler and the simulation data obtained
+        from running the simulations it defines. It also provides a method to
+        compute the S-matrix from the simulation data.
     """
 
     modeler: ModalComponentModeler = pd.Field(

--- a/tidy3d/plugins/smatrix/ports/modal.py
+++ b/tidy3d/plugins/smatrix/ports/modal.py
@@ -40,8 +40,10 @@ class ModalPortDataArray(DataArray):
 class Port(AbstractBasePort, Box):
     """Specifies a port for S-matrix calculation.
 
-    A port defines a location and a set of modes for which the S-matrix
-    is calculated.
+    Notes
+    -----
+        A port defines a location and a set of modes for which the S-matrix
+        is calculated.
     """
 
     direction: Direction = pd.Field(

--- a/tidy3d/plugins/waveguide/rectangular_dielectric.py
+++ b/tidy3d/plugins/waveguide/rectangular_dielectric.py
@@ -37,14 +37,17 @@ EVANESCENT_TAIL = 1.5
 
 
 class RectangularDielectric(Tidy3dBaseModel):
-    """General rectangular dielectric waveguide
+    """General rectangular dielectric waveguide.
 
-    Supports:
-    - Strip and rib geometries
-    - Angled sidewalls
-    - Modes in waveguide bends
-    - Surface and sidewall loss models
-    - Coupled waveguides
+    Notes
+    -----
+        Supports:
+
+        - Strip and rib geometries
+        - Angled sidewalls
+        - Modes in waveguide bends
+        - Surface and sidewall loss models
+        - Coupled waveguides
     """
 
     wavelength: Union[float, ArrayFloat1D] = pydantic.Field(

--- a/tidy3d/web/core/task_info.py
+++ b/tidy3d/web/core/task_info.py
@@ -33,8 +33,10 @@ class ChargeType(str, Enum):
 class TaskBlockInfo(TaskBase):
     """Information about the task's block status.
 
-    This includes details about how the task can be blocked by various features
-    such as user limits and insufficient balance.
+    Notes
+    -----
+        This includes details about how the task can be blocked by various features
+        such as user limits and insufficient balance.
     """
 
     chargeType: ChargeType = None
@@ -213,31 +215,51 @@ class BatchMember(TaskBase):
 
 
 class BatchDetail(TaskBase):
-    """
-    Provides a detailed, top-level view of a batch of tasks.
+    """Provides a detailed, top-level view of a batch of tasks.
 
-    This model serves as the main payload for retrieving comprehensive
-    information about a batch operation.
+    Notes
+    -----
+        This model serves as the main payload for retrieving comprehensive
+        information about a batch operation.
 
-    Attributes:
-        refId: A reference identifier for the entire batch.
-        optimizationId: Identifier for the optimization process, if any.
-        groupId: Identifier for the group the batch belongs to.
-        name: The user-defined name of the batch.
-        status: The current status of the batch.
-        totalTask: The total number of tasks in the batch.
-        preprocessSuccess: The count of tasks that completed preprocessing.
-        postprocessStatus: The status of the batch's postprocessing stage.
-        validateSuccess: The count of tasks that passed validation.
-        runSuccess: The count of tasks that ran successfully.
-        postprocessSuccess: The count of tasks that completed postprocessing.
-        taskBlockInfo: Information on what might be blocking the batch.
-        estFlexUnit: The estimated total flexible compute units for the batch.
-        totalSeconds: The total time in seconds the batch has taken.
-        totalCheckMillis: Total time in milliseconds spent on checks.
-        message: A general message providing information about the batch status.
-        tasks: A list of `BatchMember` objects, one for each task in the batch.
-        taskType: The type of tasks contained in the batch.
+    Attributes
+    ----------
+    refId
+        A reference identifier for the entire batch.
+    optimizationId
+        Identifier for the optimization process, if any.
+    groupId
+        Identifier for the group the batch belongs to.
+    name
+        The user-defined name of the batch.
+    status
+        The current status of the batch.
+    totalTask
+        The total number of tasks in the batch.
+    preprocessSuccess
+        The count of tasks that completed preprocessing.
+    postprocessStatus
+        The status of the batch's postprocessing stage.
+    validateSuccess
+        The count of tasks that passed validation.
+    runSuccess
+        The count of tasks that ran successfully.
+    postprocessSuccess
+        The count of tasks that completed postprocessing.
+    taskBlockInfo
+        Information on what might be blocking the batch.
+    estFlexUnit
+        The estimated total flexible compute units for the batch.
+    totalSeconds
+        The total time in seconds the batch has taken.
+    totalCheckMillis
+        Total time in milliseconds spent on checks.
+    message
+        A general message providing information about the batch status.
+    tasks
+        A list of `BatchMember` objects, one for each task in the batch.
+    taskType
+        The type of tasks contained in the batch.
     """
 
     refId: str = None
@@ -264,25 +286,36 @@ class BatchDetail(TaskBase):
 
 
 class AsyncJobDetail(TaskBase):
-    """
-    Provides a detailed view of an asynchronous job and its sub-tasks.
+    """Provides a detailed view of an asynchronous job and its sub-tasks.
 
-    This model represents a long-running operation. The 'result' attribute holds
-    the output of a completed job, which for orchestration jobs, is often a
-    JSON string mapping sub-task names to their unique IDs.
+    Notes
+    -----
+        This model represents a long-running operation. The 'result' attribute holds
+        the output of a completed job, which for orchestration jobs, is often a
+        JSON string mapping sub-task names to their unique IDs.
 
-    Attributes:
-        asyncId: The unique identifier for the asynchronous job.
-        status: The current overall status of the job (e.g., 'RUNNING', 'COMPLETED').
-        progress: The completion percentage of the job (from 0.0 to 100.0).
-        createdAt: The timestamp when the job was created.
-        completedAt: The timestamp when the job finished (successfully or not).
-        tasks: A dictionary mapping logical task keys to their unique task IDs.
-               This is often populated by parsing the 'result' of an orchestration task.
-        result: The raw string output of the completed job. If the job spawns other
-                tasks, this is expected to be a JSON string detailing those tasks.
-        taskBlockInfo: Information on any dependencies blocking the job from running.
-        message: A human-readable message about the job's status.
+    Attributes
+    ----------
+    asyncId
+        The unique identifier for the asynchronous job.
+    status
+        The current overall status of the job (e.g., 'RUNNING', 'COMPLETED').
+    progress
+        The completion percentage of the job (from 0.0 to 100.0).
+    createdAt
+        The timestamp when the job was created.
+    completedAt
+        The timestamp when the job finished (successfully or not).
+    tasks
+        A dictionary mapping logical task keys to their unique task IDs.
+        This is often populated by parsing the 'result' of an orchestration task.
+    result
+        The raw string output of the completed job. If the job spawns other
+        tasks, this is expected to be a JSON string detailing those tasks.
+    taskBlockInfo
+        Information on any dependencies blocking the job from running.
+    message
+        A human-readable message about the job's status.
     """
 
     asyncId: str


### PR DESCRIPTION
## Summary
- Fixed docstrings across the codebase where paragraphs followed blank lines without proper section headers (Notes, Attributes, See Also), which caused Sphinx/Napoleon to misinterpret them as spurious parameters


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes and normalizes documentation strings to follow NumPy/Sphinx conventions, eliminating spurious parameters in generated docs.
> 
> - Wraps free-form paragraphs into `Notes` sections and converts informal "See also" to `See Also` across many classes (e.g., beams, microwave specs, monitors, plugins, web models)
> - Cleans up `Attributes` blocks with proper section formatting and indentation for Sphinx/Napoleon
> - Minor docstring touch-ups (opening summary lines, punctuation) without functional changes
> - Updates `CHANGELOG.md` to record the documentation fix
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1284e0fa2c54598fa20cce43b031140555c52565. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed docstring formatting issues across 26 files where paragraphs following blank lines lacked proper section headers, causing Sphinx/Napoleon to misinterpret them as spurious parameters.

Key changes:
- Wrapped descriptive paragraphs in proper `Notes` sections with RST formatting (`-----`)
- Converted informal "See also" text to proper `See Also` sections
- Standardized `Attributes:` format to proper `Attributes` section with correct RST syntax
- Fixed indentation to ensure proper Sphinx parsing
- Removed extraneous blank lines in section headers

The changes follow NumPy/Sphinx docstring conventions and ensure documentation builds cleanly without warnings.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Score reflects systematic documentation formatting fixes with no functional code changes. All changes follow established RST/Sphinx conventions, are consistent across files, and address a specific documentation build issue. Only minor style issue found in CHANGELOG.md (missing backticks).
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Added changelog entry for docstring fix; minor style issue with missing backticks |
| tidy3d/components/monitor.py | Added `Notes` section to wrap descriptive paragraphs, removed extra blank line in `FieldProjectionSurface` |
| tidy3d/log.py | Wrapped multi-paragraph description in `Notes` section for proper Sphinx parsing |
| tidy3d/web/core/task_info.py | Converted `Attributes:` style to proper `Attributes` section with RST format, wrapped descriptions in `Notes` section |
| tidy3d/components/index.py | Added `Notes` section to wrap multi-paragraph descriptions in `ValueMap` and `SimulationMap` classes |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Sphinx as Sphinx/Napoleon Parser
    participant Docs as Generated Documentation
    
    Note over Dev,Docs: Before Fix
    Dev->>Sphinx: Docstring with paragraph after blank line
    Note right of Sphinx: No proper section header<br/>(Notes, See Also, etc.)
    Sphinx->>Sphinx: Misinterprets as spurious parameter
    Sphinx->>Docs: Generates documentation with errors
    
    Note over Dev,Docs: After Fix
    Dev->>Sphinx: Docstring with proper Notes section
    Note right of Sphinx: "Notes" section header present<br/>with proper RST formatting
    Sphinx->>Sphinx: Correctly parses as Notes section
    Sphinx->>Docs: Generates clean documentation
    
    Note over Dev: Also fixed:<br/>- "Attributes:" → "Attributes"<br/>- "See also" → "See Also"<br/>- Proper RST formatting (-------)
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Adhere to the established docstring format and use correct syntax (e.g., double backticks for code) ... ([source](https://app.greptile.com/review/custom-context?memory=2f1f3aa0-b672-45d8-9bd5-136bcc28ce16))
- Rule from `dashboard` - Keep docstrings and comments synchronized with code changes to ensure they are always accurate and n... ([source](https://app.greptile.com/review/custom-context?memory=8947a127-e303-4dbf-b326-493579e5f047))

<!-- /greptile_comment -->