### PR TITLE
fix(tidy3d): FXC-4911-multi-frequency-adjoint-gradients-incorrect-for-custom-dispersive-media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed intermittent "API key not found" errors in parallel job launches by making configuration directory detection race-safe.
+- Fixed frequency accumulation of gradients for custom dispersive media.
 
 ## [2.10.2] - 2026-01-21
 

--- a/tests/test_components/autograd/numerical/test_autograd_custom_dispersive_numerical.py
+++ b/tests/test_components/autograd/numerical/test_autograd_custom_dispersive_numerical.py
@@ -1,0 +1,369 @@
+"""Numerical validation for multi-frequency custom dispersive medium gradients."""
+
+from __future__ import annotations
+
+import sys
+
+import autograd.numpy as anp
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from autograd import value_and_grad
+
+import tidy3d as td
+import tidy3d.web as web
+from tidy3d.components.autograd import get_static
+
+
+@pytest.fixture(autouse=True)
+def _enable_local_cache(monkeypatch):
+    monkeypatch.setattr(td.config.local_cache, "enabled", True)
+
+
+SIM_SIZE_SCALE = (3.0, 2.5, 3.0)
+BOX_SIZE_SCALE = (0.8, 0.8, 0.8)
+GRID_STEPS_PER_WVL = 40
+RUN_TIME = 2e-13
+FD_STEP = 5e-3
+ANGLE_TOL = 5.0
+
+FREQS = np.array([1.7e14, 2.4e14])
+FREQ_WEIGHTS = np.array([1.0, 0.6])
+
+PARAM_SHAPE_2D = (2, 2)
+PARAM_SHAPE = (2, 2, 2)
+FD_SWEEP_STEPS = np.logspace(-3, -1, num=7)
+
+SELLMEIER_C_VAL = 0.6 * (td.C_0 / np.max(FREQS)) ** 2
+
+TEST_CASES = [
+    {
+        "name": "lo1",  # keep names short, filenames get too long otherwise
+        "kind": "lorentz",
+        "eps_inf": 1.6,
+        "param0": 0.5,
+        "f0": 2.6e14,
+        "delta": 0.2e14,
+    },
+    {
+        "name": "lo2",
+        "kind": "lorentz",
+        "eps_inf": 2.3,
+        "param0": 0.7,
+        "f0": 2.3e14,
+        "delta": 0.2e14,
+    },
+    {
+        "name": "lo3",
+        "kind": "lorentz",
+        "eps_inf": 1.9,
+        "param0": 0.35,
+        "f0": 3.0e14,
+        "delta": 0.2e14,
+    },
+    {
+        "name": "sl",
+        "kind": "sellmeier",
+        "param0": 0.6,
+        "c_val": SELLMEIER_C_VAL,
+    },
+    {
+        "name": "dd",
+        "kind": "drude",
+        "eps_inf": 1.6,
+        "param0": 0.5,
+        "param_scale": 2.0e14,
+        "delta": 0.3e14,
+    },
+    {
+        "name": "db",
+        "kind": "debye",
+        "eps_inf": 2.5,
+        "param0": 0.5,
+        "tau": 0.4e-14,
+    },
+    {
+        "name": "pr",
+        "kind": "pole_residue",
+        "eps_inf": 1.6,
+        "param0": 0.5,
+        "param_scale": 1.0e14,
+        "a_val": -1.2e14,
+    },
+]
+
+
+def _build_base_sim(freqs: np.ndarray) -> tuple[td.Simulation, str, float]:
+    wavelength_min = td.C_0 / np.max(freqs)
+    sim_size = tuple(scale * wavelength_min for scale in SIM_SIZE_SCALE)
+
+    freq0 = float(np.mean(freqs))
+    fwidth = float(max(freqs.max() - freqs.min(), 0.4 * freq0))
+
+    src = td.PlaneWave(
+        center=(0.0, 0.0, -0.75 * sim_size[2] / 2),
+        size=(sim_size[0], sim_size[1], 0.0),
+        source_time=td.GaussianPulse(freq0=freq0, fwidth=fwidth),
+        direction="+",
+        pol_angle=0.0,
+    )
+
+    monitor_name = "field_monitor"
+    monitor = td.FieldMonitor(
+        center=(0.0, 0.0, sim_size[2] / 2 * 0.6),
+        size=(sim_size[0], sim_size[1], 0.0),
+        freqs=list(freqs),
+        name=monitor_name,
+        colocate=False,
+    )
+
+    sim = td.Simulation(
+        size=sim_size,
+        center=(0.0, 0.0, 0.0),
+        grid_spec=td.GridSpec.auto(
+            min_steps_per_wvl=GRID_STEPS_PER_WVL,
+            wavelength=wavelength_min,
+        ),
+        boundary_spec=td.BoundarySpec.pml(x=True, y=True, z=True),
+        sources=[src],
+        monitors=[monitor],
+        structures=[],
+        run_time=RUN_TIME,
+    )
+    return sim, monitor_name, wavelength_min
+
+
+def _box_geometry(wavelength_min: float) -> td.Box:
+    size = tuple(scale * wavelength_min for scale in BOX_SIZE_SCALE)
+    return td.Box(size=size, center=(0.0, 0.0, 0.0))
+
+
+def _coords_for_bounds(bounds, shape):
+    return {
+        "x": np.linspace(bounds[0][0], bounds[1][0], shape[0]),
+        "y": np.linspace(bounds[0][1], bounds[1][1], shape[1]),
+        "z": np.linspace(bounds[0][2], bounds[1][2], shape[2]),
+    }
+
+
+def _custom_medium(case, param_vals: anp.ndarray, box_geom: td.Box):
+    bounds = box_geom.bounds
+    coords = _coords_for_bounds(bounds, param_vals.shape)
+    kind = case["kind"]
+    param_scale = case.get("param_scale", 1.0)
+    scaled = param_scale * param_vals
+
+    if kind == "lorentz":
+        eps_inf = td.SpatialDataArray(np.full(param_vals.shape, case["eps_inf"]), coords=coords)
+        de = td.SpatialDataArray(scaled, coords=coords)
+        f0 = td.SpatialDataArray(np.full(param_vals.shape, case["f0"]), coords=coords)
+        delta = td.SpatialDataArray(np.full(param_vals.shape, case["delta"]), coords=coords)
+        return td.CustomLorentz(eps_inf=eps_inf, coeffs=[(de, f0, delta)])
+    if kind == "sellmeier":
+        b = td.SpatialDataArray(scaled, coords=coords)
+        c = td.SpatialDataArray(np.full(param_vals.shape, case["c_val"]), coords=coords)
+        return td.CustomSellmeier(coeffs=[(b, c)])
+    if kind == "drude":
+        eps_inf = td.SpatialDataArray(np.full(param_vals.shape, case["eps_inf"]), coords=coords)
+        fp = td.SpatialDataArray(scaled, coords=coords)
+        delta = td.SpatialDataArray(np.full(param_vals.shape, case["delta"]), coords=coords)
+        return td.CustomDrude(eps_inf=eps_inf, coeffs=[(fp, delta)])
+    if kind == "debye":
+        eps_inf = td.SpatialDataArray(np.full(param_vals.shape, case["eps_inf"]), coords=coords)
+        de = td.SpatialDataArray(scaled, coords=coords)
+        tau = td.SpatialDataArray(np.full(param_vals.shape, case["tau"]), coords=coords)
+        return td.CustomDebye(eps_inf=eps_inf, coeffs=[(de, tau)])
+    if kind == "pole_residue":
+        eps_inf = td.SpatialDataArray(np.full(param_vals.shape, case["eps_inf"]), coords=coords)
+        a_val = td.SpatialDataArray(np.full(param_vals.shape, case["a_val"]), coords=coords)
+        c_val = td.SpatialDataArray(scaled, coords=coords)
+        return td.CustomPoleResidue(eps_inf=eps_inf, poles=[(a_val, c_val)])
+    raise ValueError(f"Unsupported medium kind: {kind}")
+
+
+def _add_medium(
+    sim: td.Simulation, box_geom: td.Box, case, param_vals: anp.ndarray
+) -> td.Simulation:
+    medium = _custom_medium(case, param_vals, box_geom)
+    structure = td.Structure(geometry=box_geom, medium=medium)
+    return sim.updated_copy(structures=[structure])
+
+
+def _metric_value(dataset) -> float:
+    ex_vals = dataset.Ex.values
+    ey_vals = dataset.Ey.values
+    ez_vals = dataset.Ez.values
+    intensity = anp.abs(ex_vals) ** 2 + anp.abs(ey_vals) ** 2 + anp.abs(ez_vals) ** 2
+    weighted = intensity * anp.asarray(FREQ_WEIGHTS)
+    return anp.real(anp.mean(weighted))
+
+
+def _angle_deg(vec_a: np.ndarray, vec_b: np.ndarray) -> float:
+    norm_a = np.linalg.norm(vec_a)
+    norm_b = np.linalg.norm(vec_b)
+    if norm_a == 0 or norm_b == 0:
+        return np.nan
+    cos_theta = np.clip(np.dot(vec_a, vec_b) / (norm_a * norm_b), -1.0, 1.0)
+    return float(np.degrees(np.arccos(cos_theta)))
+
+
+def _expand_params(params: anp.ndarray) -> anp.ndarray:
+    vals_2d = anp.reshape(params, PARAM_SHAPE_2D)
+    return anp.repeat(vals_2d[..., None], PARAM_SHAPE[2], axis=2)
+
+
+def _run_simulation(
+    sim: td.Simulation,
+    monitor_name: str,
+    tmp_path,
+    label: str,
+    local_gradient: bool,
+) -> float:
+    sim_data = web.run(
+        sim,
+        task_name=f"custom_disp_{label}",
+        local_gradient=local_gradient,
+        verbose=False,
+        path=str(tmp_path / f"custom_disp_{label}.hdf5"),
+    )
+    return _metric_value(sim_data[monitor_name])
+
+
+@pytest.mark.numerical
+@pytest.mark.parametrize("case", TEST_CASES, ids=lambda c: c["name"])
+def test_custom_dispersive_multifreq_grad_matches_fd(
+    case, numerical_case_dir, tmp_path, _enable_local_cache
+):
+    base_sim, monitor_name, wavelength_min = _build_base_sim(FREQS)
+    box_geom = _box_geometry(wavelength_min)
+
+    params0 = anp.full(PARAM_SHAPE_2D, case["param0"]).reshape(-1)
+
+    def objective(param_vec):
+        param_vals = _expand_params(param_vec)
+        sim = _add_medium(base_sim, box_geom, case, param_vals)
+        return _run_simulation(
+            sim=sim,
+            monitor_name=monitor_name,
+            tmp_path=tmp_path,
+            label="adjoint",
+            local_gradient=True,
+        )
+
+    _, grad_adj = value_and_grad(objective)(params0)
+    grad_adj = np.asarray(get_static(grad_adj), dtype=float).reshape(-1)
+
+    fd_sims: dict[str, td.Simulation] = {}
+    for idx in range(params0.size):
+        delta = np.zeros_like(params0)
+        delta[idx] = FD_STEP
+        plus_vals = _expand_params(params0 + delta)
+        minus_vals = _expand_params(params0 - delta)
+        fd_sims[f"plus_{idx}"] = _add_medium(base_sim, box_geom, case, plus_vals)
+        fd_sims[f"minus_{idx}"] = _add_medium(base_sim, box_geom, case, minus_vals)
+
+    fd_results = web.run_async(
+        fd_sims,
+        path_dir=str(numerical_case_dir / f"{case['name']}"),
+        local_gradient=False,
+        verbose=False,
+    )
+
+    grad_fd = np.zeros_like(grad_adj)
+    for idx in range(params0.size):
+        val_plus = _metric_value(fd_results[f"plus_{idx}"][monitor_name])
+        val_minus = _metric_value(fd_results[f"minus_{idx}"][monitor_name])
+        grad_fd[idx] = (val_plus - val_minus) / (2.0 * FD_STEP)
+
+    angle_deg = _angle_deg(grad_adj, grad_fd)
+    print(
+        (
+            f"[custom-dispersive-multifreq:{case['name']}] adjoint={grad_adj}, "
+            f"finite-difference={grad_fd}, angle_deg={angle_deg:.3f}"
+        ),
+        file=sys.stderr,
+    )
+
+    assert angle_deg <= ANGLE_TOL or np.isnan(angle_deg), (
+        f"Multi-frequency CustomDispersive gradient mismatch for {case['name']}. "
+        f"angle_deg={angle_deg:.3f}, adj={grad_adj}, fd={grad_fd}"
+    )
+
+
+@pytest.mark.numerical
+def test_custom_lorentz_fd_step_sweep(numerical_case_dir, tmp_path, _enable_local_cache):
+    base_sim, monitor_name, wavelength_min = _build_base_sim(FREQS)
+    box_geom = _box_geometry(wavelength_min)
+
+    case = TEST_CASES[0]
+    params0 = anp.full(PARAM_SHAPE_2D, case["param0"]).reshape(-1)
+
+    def objective(de_params):
+        de_vals = _expand_params(de_params)
+        sim = _add_medium(base_sim, box_geom, case, de_vals)
+        return _run_simulation(
+            sim=sim,
+            monitor_name=monitor_name,
+            tmp_path=tmp_path,
+            label="adjoint_sweep",
+            local_gradient=True,
+        )
+
+    _, grad_adj = value_and_grad(objective)(params0)
+    grad_adj = np.asarray(get_static(grad_adj), dtype=float).reshape(-1)
+
+    sweep_runs: dict[str, td.Simulation] = {}
+    step_labels = [f"{step:.3e}" for step in FD_SWEEP_STEPS]
+    for step_label, step in zip(step_labels, FD_SWEEP_STEPS):
+        plus_vals = _expand_params(params0 + step)
+        minus_vals = _expand_params(params0 - step)
+        sweep_runs[f"step_{step_label}_plus"] = _add_medium(base_sim, box_geom, case, plus_vals)
+        sweep_runs[f"step_{step_label}_minus"] = _add_medium(base_sim, box_geom, case, minus_vals)
+
+    sweep_results = web.run_async(
+        sweep_runs,
+        path_dir=str(numerical_case_dir / f"fd_sweep_{case['name']}"),
+        local_gradient=False,
+        verbose=False,
+    )
+
+    fd_sweep = []
+    for step_label, step in zip(step_labels, FD_SWEEP_STEPS):
+        plus_key = f"step_{step_label}_plus"
+        minus_key = f"step_{step_label}_minus"
+        plus_val = _metric_value(sweep_results[plus_key][monitor_name])
+        minus_val = _metric_value(sweep_results[minus_key][monitor_name])
+        fd_sweep.append((plus_val - minus_val) / (2.0 * step))
+
+    fd_sweep = np.array(fd_sweep, dtype=float)
+    fd_min = float(np.min(fd_sweep))
+    fd_max = float(np.max(fd_sweep))
+
+    fig, ax = plt.subplots(figsize=(6, 4))
+    ax.plot(FD_SWEEP_STEPS, fd_sweep, marker="o", label="FD")
+    ax.axhline(
+        np.mean(grad_adj),
+        color=ax.get_lines()[-1].get_color(),
+        linestyle="--",
+        alpha=0.7,
+        label="Adjoint (mean)",
+    )
+    ax.set_xscale("log")
+    ax.set_xlabel("Finite difference step")
+    ax.set_ylabel("Gradient value")
+    ax.set_title("CustomLorentz FD sweep")
+    ax.grid(True, which="both", ls=":")
+    ax.legend()
+
+    fig_path = numerical_case_dir / "custom_lorentz_fd_step_sweep.png"
+    fig.savefig(fig_path, dpi=200)
+    plt.close(fig)
+
+    print(
+        (
+            "[custom-dispersive-fd-sweep] "
+            f"grad_adj={grad_adj} "
+            f"fd_grad[min,max]=({fd_min:.6e},{fd_max:.6e})"
+        ),
+        file=sys.stderr,
+    )

--- a/tests/test_components/autograd/numerical/test_autograd_custom_pole_residue_numerical.py
+++ b/tests/test_components/autograd/numerical/test_autograd_custom_pole_residue_numerical.py
@@ -13,7 +13,11 @@ import tidy3d as td
 import tidy3d.web as web
 from tidy3d.components.autograd import get_static
 
-td.config.local_cache.enabled = True
+
+@pytest.fixture(autouse=True)
+def _enable_local_cache(monkeypatch):
+    monkeypatch.setattr(td.config.local_cache, "enabled", True)
+
 
 SIM_SIZE_SCALE = (4, 3, 4)
 BOX_SIZE_SCALE = (1, 1, 1)
@@ -147,7 +151,7 @@ def _run_simulation(
 
 
 @pytest.mark.numerical
-def test_custom_pole_residue_grads_match_fd(numerical_case_dir, tmp_path):
+def test_custom_pole_residue_grads_match_fd(numerical_case_dir, tmp_path, _enable_local_cache):
     case = POLE_RESIDUE_CASE
     base_sim, monitor_name, freq0 = _build_base_sim(case)
     box_geom = _box_geometry(case["wavelength"])

--- a/tests/test_components/autograd/numerical/test_autograd_medium_numerical.py
+++ b/tests/test_components/autograd/numerical/test_autograd_medium_numerical.py
@@ -12,7 +12,11 @@ import tidy3d as td
 import tidy3d.web as web
 from tidy3d.components.autograd import get_static
 
-td.config.local_cache.enabled = True
+
+@pytest.fixture(autouse=True)
+def _enable_local_cache(monkeypatch):
+    monkeypatch.setattr(td.config.local_cache, "enabled", True)
+
 
 SIM_SIZE_SCALE = (4, 3, 4)
 BOX_SIZE_SCALE = (1, 1, 1)
@@ -250,7 +254,7 @@ def _run_simulation(
 
 @pytest.mark.numerical
 @pytest.mark.parametrize("case", TEST_CASES, ids=lambda c: c["name"])
-def test_medium_grads_match_fd(case, numerical_case_dir, tmp_path):
+def test_medium_grads_match_fd(case, numerical_case_dir, tmp_path, _enable_local_cache):
     base_sim, monitor_name, freq0 = _build_base_sim(case)
     box_geom = _box_geometry(case)
     params0 = anp.array(case["permittivities"])
@@ -309,7 +313,7 @@ def test_medium_grads_match_fd(case, numerical_case_dir, tmp_path):
 
 @pytest.mark.skip
 @pytest.mark.parametrize("case", TEST_CASES, ids=lambda c: c["name"])
-def test_medium_fd_step_sweep(case, numerical_case_dir, tmp_path):
+def test_medium_fd_step_sweep(case, numerical_case_dir, tmp_path, _enable_local_cache):
     base_sim, monitor_name, freq0 = _build_base_sim(case)
     box_geom = _box_geometry(case)
     params0 = anp.array(case["permittivities"])

--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -72,13 +72,18 @@ CALL_OBJECTIVE = False
 
 
 # --- helpers for custom dispersive tests ---
-def _patch_cmp_to_const(monkeypatch, cls, dJ_const):
-    """Monkeypatch `_derivative_field_cmp` to return a constant split across xyz."""
-    monkeypatch.setattr(
-        cls,
-        "_derivative_field_cmp",
-        lambda self, E_der_map, spatial_data, dim: dJ_const / 3.0,
-    )
+def _patch_cmp_custom_to_const(monkeypatch, cls, dJ_const):
+    """Monkeypatch `_derivative_field_cmp_custom` to return a constant split across xyz."""
+
+    def _fake(self, E_der_map, spatial_data, dim, sum_over_freqs=True, **kwargs):
+        if sum_over_freqs:
+            if dJ_const.ndim > 3:
+                return dJ_const.sum(axis=-1) / 3.0
+            return dJ_const / 3.0
+        dJ_with_freq = dJ_const[..., None]
+        return dJ_with_freq / 3.0
+
+    monkeypatch.setattr(cls, "_derivative_field_cmp_custom", _fake)
 
 
 def _make_di(paths, freq):
@@ -2025,22 +2030,11 @@ def test_custom_pole_residue(monkeypatch):
 
     dJ_deps = np.conj(ag.holomorphic_grad(J)(eps0))
 
-    monkeypatch.setattr(
-        td.CustomPoleResidue,
-        "_derivative_field_cmp_custom",
-        lambda self,
-        E_der_map,
-        spatial_data,
-        dim,
-        freqs,
-        bounds=None,
-        component="real",
-        interp_method=None: dJ_deps / 3.0,
-    )
-
     import importlib
 
     importlib.reload(td)
+
+    _patch_cmp_custom_to_const(monkeypatch, td.CustomPoleResidue, dJ_deps)
 
     pr = td.CustomPoleResidue(eps_inf=eps_inf, poles=poles)
     field_paths = [("eps_inf",)]
@@ -2166,7 +2160,7 @@ def test_custom_sellmeier(monkeypatch):
     eps_arr = eps_from(B1.values, C1.values) + eps_from(B2.values, C2.values)
     dJ = np.conj(ag.holomorphic_grad(lambda e: anp.sum(anp.abs(e)))(eps_arr))
 
-    _patch_cmp_to_const(monkeypatch, td.CustomSellmeier, dJ)
+    _patch_cmp_custom_to_const(monkeypatch, td.CustomSellmeier, dJ)
 
     di = _make_di(
         paths=[("coeffs", 0, 0), ("coeffs", 0, 1), ("coeffs", 1, 0), ("coeffs", 1, 1)],
@@ -2220,7 +2214,7 @@ def test_custom_lorentz(monkeypatch):
     )
     dJ = np.conj(ag.holomorphic_grad(lambda e: anp.sum(anp.abs(e)))(eps_arr))
 
-    _patch_cmp_to_const(monkeypatch, td.CustomLorentz, dJ)
+    _patch_cmp_custom_to_const(monkeypatch, td.CustomLorentz, dJ)
 
     di = _make_di(
         paths=[
@@ -2300,7 +2294,7 @@ def test_custom_drude(monkeypatch):
     eps_arr = eps_inf.values + term(fp1.values, dl1.values) + term(fp2.values, dl2.values)
     dJ = np.conj(ag.holomorphic_grad(lambda e: anp.sum(anp.abs(e)))(eps_arr))
 
-    _patch_cmp_to_const(monkeypatch, td.CustomDrude, dJ)
+    _patch_cmp_custom_to_const(monkeypatch, td.CustomDrude, dJ)
 
     di = _make_di(
         paths=[
@@ -2368,7 +2362,7 @@ def test_custom_debye(monkeypatch):
     eps_arr = eps_inf.values + term(de1.values, tau1.values) + term(de2.values, tau2.values)
     dJ = np.conj(ag.holomorphic_grad(lambda e: anp.sum(anp.abs(e)))(eps_arr))
 
-    _patch_cmp_to_const(monkeypatch, td.CustomDebye, dJ)
+    _patch_cmp_custom_to_const(monkeypatch, td.CustomDebye, dJ)
 
     di = _make_di(
         paths=[

--- a/tests/test_components/autograd/test_autograd_custom_dispersive_vjps.py
+++ b/tests/test_components/autograd/test_autograd_custom_dispersive_vjps.py
@@ -49,10 +49,15 @@ def _deriv_info(freq):
     }
 
 
-def _patch_derivative_field_cmp(cls, dJ):
+def _patch_derivative_field_cmp_custom(cls, dJ):
     # Return dJ/3 for each of x,y,z so their sum equals dJ
-    def _fake(self, E_der_map, spatial_data, dim):
-        return dJ / 3.0
+    def _fake(self, E_der_map, spatial_data, dim, sum_over_freqs=True, **kwargs):
+        if sum_over_freqs:
+            if dJ.ndim > 3:
+                return dJ.sum(axis=-1) / 3.0
+            return dJ / 3.0
+        dJ_with_freq = dJ[..., None] if dJ.ndim == 3 else dJ
+        return dJ_with_freq / 3.0
 
     return _fake
 
@@ -81,10 +86,10 @@ def test_custom_sellmeier_vjp():
     # Monkeypatch derivative provider
     from tidy3d.components import medium as medium_mod
 
-    _orig = CustomSellmeier._derivative_field_cmp
+    _orig = CustomSellmeier._derivative_field_cmp_custom
     try:
-        medium_mod.CustomSellmeier._derivative_field_cmp = _patch_derivative_field_cmp(
-            CustomSellmeier, dJ
+        medium_mod.CustomSellmeier._derivative_field_cmp_custom = (
+            _patch_derivative_field_cmp_custom(CustomSellmeier, dJ)
         )
 
         paths = [("coeffs", 0, 0), ("coeffs", 0, 1), ("coeffs", 1, 0), ("coeffs", 1, 1)]
@@ -102,7 +107,7 @@ def test_custom_sellmeier_vjp():
         np.testing.assert_allclose(grads[("coeffs", 1, 0)], gB2, rtol=5e-6, atol=5e-7)
         np.testing.assert_allclose(grads[("coeffs", 1, 1)], gC2, rtol=5e-6, atol=5e-7)
     finally:
-        medium_mod.CustomSellmeier._derivative_field_cmp = _orig
+        medium_mod.CustomSellmeier._derivative_field_cmp_custom = _orig
 
 
 def test_custom_lorentz_vjp():
@@ -131,9 +136,9 @@ def test_custom_lorentz_vjp():
 
     from tidy3d.components import medium as medium_mod
 
-    _orig = CustomLorentz._derivative_field_cmp
+    _orig = CustomLorentz._derivative_field_cmp_custom
     try:
-        medium_mod.CustomLorentz._derivative_field_cmp = _patch_derivative_field_cmp(
+        medium_mod.CustomLorentz._derivative_field_cmp_custom = _patch_derivative_field_cmp_custom(
             CustomLorentz, dJ
         )
 
@@ -165,7 +170,7 @@ def test_custom_lorentz_vjp():
         np.testing.assert_allclose(grads[("coeffs", 1, 1)], g_f02, rtol=5e-6, atol=5e-7)
         np.testing.assert_allclose(grads[("coeffs", 1, 2)], g_dl2, rtol=5e-6, atol=5e-7)
     finally:
-        medium_mod.CustomLorentz._derivative_field_cmp = _orig
+        medium_mod.CustomLorentz._derivative_field_cmp_custom = _orig
 
 
 def test_custom_drude_vjp():
@@ -188,9 +193,11 @@ def test_custom_drude_vjp():
 
     from tidy3d.components import medium as medium_mod
 
-    _orig = CustomDrude._derivative_field_cmp
+    _orig = CustomDrude._derivative_field_cmp_custom
     try:
-        medium_mod.CustomDrude._derivative_field_cmp = _patch_derivative_field_cmp(CustomDrude, dJ)
+        medium_mod.CustomDrude._derivative_field_cmp_custom = _patch_derivative_field_cmp_custom(
+            CustomDrude, dJ
+        )
 
         paths = [
             ("eps_inf",),
@@ -214,7 +221,7 @@ def test_custom_drude_vjp():
         np.testing.assert_allclose(grads[("coeffs", 1, 0)], g_fp2, rtol=5e-6, atol=5e-7)
         np.testing.assert_allclose(grads[("coeffs", 1, 1)], g_dl2, rtol=5e-6, atol=5e-7)
     finally:
-        medium_mod.CustomDrude._derivative_field_cmp = _orig
+        medium_mod.CustomDrude._derivative_field_cmp_custom = _orig
 
 
 def test_custom_debye_vjp():
@@ -237,9 +244,11 @@ def test_custom_debye_vjp():
 
     from tidy3d.components import medium as medium_mod
 
-    _orig = CustomDebye._derivative_field_cmp
+    _orig = CustomDebye._derivative_field_cmp_custom
     try:
-        medium_mod.CustomDebye._derivative_field_cmp = _patch_derivative_field_cmp(CustomDebye, dJ)
+        medium_mod.CustomDebye._derivative_field_cmp_custom = _patch_derivative_field_cmp_custom(
+            CustomDebye, dJ
+        )
 
         paths = [
             ("eps_inf",),
@@ -263,4 +272,4 @@ def test_custom_debye_vjp():
         np.testing.assert_allclose(grads[("coeffs", 1, 0)], g_de2, rtol=5e-6, atol=5e-7)
         np.testing.assert_allclose(grads[("coeffs", 1, 1)], g_tau2, rtol=5e-6, atol=5e-7)
     finally:
-        medium_mod.CustomDebye._derivative_field_cmp = _orig
+        medium_mod.CustomDebye._derivative_field_cmp_custom = _orig

--- a/tests/test_components/autograd/test_custom_dispersive_multifreq.py
+++ b/tests/test_components/autograd/test_custom_dispersive_multifreq.py
@@ -1,0 +1,99 @@
+"""Multi-frequency adjoint gradient checks for custom dispersive media."""
+
+from __future__ import annotations
+
+import numpy as np
+
+import tidy3d as td
+from tidy3d.components.autograd.derivative_utils import DerivativeInfo
+
+
+def _make_derivative_info(freqs, paths):
+    freqs = np.asarray(freqs, float)
+    return DerivativeInfo(
+        paths=paths,
+        E_der_map={},
+        D_der_map={},
+        E_fwd={},
+        D_fwd={},
+        E_adj={},
+        D_adj={},
+        eps_data={},
+        eps_in=2.0,
+        eps_out=1.0,
+        frequencies=list(freqs),
+        bounds=((-1, -1, -1), (1, 1, 1)),
+        bounds_intersect=((-1, -1, -1), (1, 1, 1)),
+        simulation_bounds=((-2, -2, -2), (2, 2, 2)),
+    )
+
+
+def _patch_derivative_field_cmp_custom(dJ):
+    def _fake(self, E_der_map, spatial_data, dim, sum_over_freqs=True, **kwargs):
+        if sum_over_freqs:
+            return dJ.sum(axis=-1) / 3.0
+        return dJ / 3.0
+
+    return _fake
+
+
+def test_custom_sellmeier_multifrequency_weights(monkeypatch):
+    freqs = np.array([1.5e14, 2.1e14])
+    coords = {"x": [0.0], "y": [0.0], "z": [0.0]}
+
+    B = td.SpatialDataArray(np.array([[[0.2]]]), coords=coords)
+    C = td.SpatialDataArray(np.array([[[0.3]]]), coords=coords)
+    med = td.CustomSellmeier(coeffs=[(B, C)])
+
+    dJ = np.array([[[[1.1 + 0.4j, -0.6 + 0.2j]]]])
+    monkeypatch.setattr(
+        td.CustomSellmeier, "_derivative_field_cmp_custom", _patch_derivative_field_cmp_custom(dJ)
+    )
+
+    paths = [("coeffs", 0, 0), ("coeffs", 0, 1)]
+    grads = med._compute_derivatives(_make_derivative_info(freqs, paths))
+
+    expected_gB = 0.0
+    expected_gC = 0.0
+    for idx, f in enumerate(freqs):
+        dJ_f = dJ[..., idx]
+        expected_gB += np.real(dJ_f * np.conj(td.Sellmeier._w_B(f, C.values)))
+        expected_gC += np.real(dJ_f * np.conj(td.Sellmeier._w_C(f, B.values, C.values)))
+
+    np.testing.assert_allclose(grads[("coeffs", 0, 0)], expected_gB)
+    np.testing.assert_allclose(grads[("coeffs", 0, 1)], expected_gC)
+
+
+def test_custom_pole_residue_multifrequency_weights(monkeypatch):
+    freqs = np.array([1.2e14, 1.8e14])
+    coords = {"x": [0.0], "y": [0.0], "z": [0.0]}
+
+    eps_inf = td.SpatialDataArray(np.array([[[2.0]]]), coords=coords)
+    a1 = td.SpatialDataArray(np.array([[[-1.0 + 0.1j]]]), coords=coords)
+    c1 = td.SpatialDataArray(np.array([[[0.5 + 0.2j]]]), coords=coords)
+    med = td.CustomPoleResidue(eps_inf=eps_inf, poles=[(a1, c1)])
+
+    dJ = np.array([[[[0.4 + 0.2j, -0.1 + 0.3j]]]])
+    monkeypatch.setattr(
+        td.CustomPoleResidue, "_derivative_field_cmp_custom", _patch_derivative_field_cmp_custom(dJ)
+    )
+
+    paths = [("eps_inf",), ("poles", 0, 0), ("poles", 0, 1)]
+    grads = med._compute_derivatives(_make_derivative_info(freqs, paths))
+
+    poles_vals = [(np.array(a1.values, dtype=complex), np.array(c1.values, dtype=complex))]
+    expected = {}
+    for idx, f in enumerate(freqs):
+        dJ_f = dJ[..., idx]
+        vjps_f = td.PoleResidue._get_vjps_from_params(
+            dJ_deps_complex=dJ_f,
+            poles_vals=poles_vals,
+            omega=2 * np.pi * f,
+            requested_paths=paths,
+            project_real=False,
+        )
+        for path, vjp in vjps_f.items():
+            expected[path] = expected.get(path, 0.0) + vjp
+
+    for path in paths:
+        np.testing.assert_allclose(grads[path], expected[path])

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -19,7 +19,7 @@ from tidy3d.log import log
 from .types import PathType
 from .utils import get_static
 
-FieldData = dict[str, ScalarFieldDataArray]
+FieldDataDict = dict[str, ScalarFieldDataArray]
 PermittivityData = dict[str, ScalarFieldDataArray]
 EpsType = FreqDataArray
 
@@ -51,35 +51,35 @@ class DerivativeInfo:
     paths: list[PathType]
     """List of paths to the traced fields that need derivatives calculated."""
 
-    E_der_map: FieldData
+    E_der_map: FieldDataDict
     """Electric field gradient map.
     Dataset where the field components ("Ex", "Ey", "Ez") store the multiplication
     of the forward and adjoint electric fields. The tangential components of this
     dataset are used when computing adjoint gradients for shifting boundaries.
     All components are used when computing volume-based gradients."""
 
-    D_der_map: FieldData
+    D_der_map: FieldDataDict
     """Displacement field gradient map.
     Dataset where the field components ("Ex", "Ey", "Ez") store the multiplication
     of the forward and adjoint displacement fields. The normal component of this
     dataset is used when computing adjoint gradients for shifting boundaries."""
 
-    E_fwd: FieldData
+    E_fwd: FieldDataDict
     """Forward electric fields.
     Dataset where the field components ("Ex", "Ey", "Ez") represent the forward
     electric fields used for computing gradients for a given structure."""
 
-    E_adj: FieldData
+    E_adj: FieldDataDict
     """Adjoint electric fields.
     Dataset where the field components ("Ex", "Ey", "Ez") represent the adjoint
     electric fields used for computing gradients for a given structure."""
 
-    D_fwd: FieldData
+    D_fwd: FieldDataDict
     """Forward displacement fields.
     Dataset where the field components ("Ex", "Ey", "Ez") represent the forward
     displacement fields used for computing gradients for a given structure."""
 
-    D_adj: FieldData
+    D_adj: FieldDataDict
     """Adjoint displacement fields.
     Dataset where the field components ("Ex", "Ey", "Ez") represent the adjoint
     displacement fields used for computing gradients for a given structure."""
@@ -119,19 +119,19 @@ class DerivativeInfo:
 
     # Optional fields with defaults
 
-    H_der_map: Optional[FieldData] = None
+    H_der_map: Optional[FieldDataDict] = None
     """Magnetic field gradient map.
     Dataset where the field components ("Hx", "Hy", "Hz") store the multiplication
     of the forward and adjoint magnetic fields. The tangential component of this
     dataset is used when computing adjoint gradients for shifting boundaries of
     structures composed of PEC mediums."""
 
-    H_fwd: Optional[FieldData] = None
+    H_fwd: Optional[FieldDataDict] = None
     """Forward magnetic fields.
     Dataset where the field components ("Hx", "Hy", "Hz") represent the forward
     magnetic fields used for computing gradients for a given structure."""
 
-    H_adj: Optional[FieldData] = None
+    H_adj: Optional[FieldDataDict] = None
     """Adjoint magnetic fields.
     Dataset where the field components ("Hx", "Hy", "Hz") represent the adjoint
     magnetic fields used for computing gradients for a given structure."""
@@ -688,7 +688,7 @@ class DerivativeInfo:
     ) -> np.ndarray:
         eps_dielectric_key, eps_dielectric_data = eps_dielectric
 
-        def _snap_coordinate_outside(field_components: FieldData):
+        def _snap_coordinate_outside(field_components: FieldDataDict):
             """Helper function to perform coordinate adjustment and compute edge distance for each
             component in `field_components`.
 

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -49,6 +49,7 @@ from .data.unstructured.base import UnstructuredGridDataset
 from .data.utils import (
     CustomSpatialDataType,
     CustomSpatialDataTypeAnnotated,
+    UnstructuredGridDatasetType,
     _check_same_coordinates,
     _get_numpy_array,
     _ones_like,
@@ -1101,79 +1102,15 @@ class AbstractCustomMedium(AbstractMedium, ABC):
         if isinstance(field, UnstructuredGridDataset):
             return any(len(subfield) == 0 for subfield in [field.points, field.cells, field.values])
 
-    def _derivative_field_cmp(
-        self,
-        E_der_map: ElectromagneticFieldDataset,
-        spatial_data: PermittivityDataset,
-        dim: str,
-    ) -> np.ndarray:
-        if isinstance(spatial_data, UnstructuredGridDataset):
-            raise NotImplementedError(
-                "Adjoint derivatives for unstructured custom media are not supported."
-            )
-        coords_interp = {key: val for key, val in spatial_data.coords.items() if len(val) > 1}
-        dims_sum = {dim for dim in spatial_data.coords.keys() if dim not in coords_interp}
-
-        eps_coordinate_shape = [
-            len(spatial_data.coords[dim]) for dim in spatial_data.dims if dim in "xyz"
-        ]
-
-        # compute sizes along each of the interpolation dimensions
-        sizes_list = []
-        for _, coords in coords_interp.items():
-            num_coords = len(coords)
-            coords = np.array(coords)
-
-            # compute distances between midpoints for all internal coords
-            mid_points = (coords[1:] + coords[:-1]) / 2.0
-            dists = np.diff(mid_points)
-            sizes = np.zeros(num_coords)
-            sizes[1:-1] = dists
-
-            # estimate the sizes on the edges using 2 x the midpoint distance
-            sizes[0] = 2 * abs(mid_points[0] - coords[0])
-            sizes[-1] = 2 * abs(coords[-1] - mid_points[-1])
-
-            sizes_list.append(sizes)
-
-        # turn this into a volume element, should be re-sizeable to the gradient shape
-        if sizes_list:
-            d_vol = functools.reduce(np.outer, sizes_list)
-        else:
-            # if sizes_list is empty, then reduce() fails
-            d_vol = np.array(1.0)
-
-        # TODO: probably this could be more robust. eg if the DataArray has weird edge cases
-        E_der_dim = E_der_map[f"E{dim}"]
-        E_der_dim_interp = (
-            E_der_dim.interp(**coords_interp, assume_sorted=True).fillna(0.0).sum(dims_sum).sum("f")
-        )
-        vjp_array = np.array(E_der_dim_interp.values).astype(complex)
-        vjp_array = vjp_array.reshape(eps_coordinate_shape)
-
-        # multiply by volume elements (if possible, being defensive here..)
-        try:
-            vjp_array *= d_vol.reshape(vjp_array.shape)
-        except ValueError:
-            log.warning(
-                "Skipping volume element normalization of 'CustomMedium' gradients. "
-                f"Could not reshape the volume elements of shape {d_vol.shape} "
-                f"to the shape of the gradient {vjp_array.shape}. "
-                "If you encounter this warning, gradient direction will be accurate but the norm "
-                "will be inaccurate. Please raise an issue on the tidy3d front end with this "
-                "message and some information about your simulation setup and we will investigate. "
-            )
-        return vjp_array
-
     def _derivative_field_cmp_custom(
         self,
-        E_der_map: ElectromagneticFieldDataset,
+        E_der_map: dict[str, ScalarFieldDataArray],
         spatial_data: SpatialDataArray,
         dim: str,
-        freqs: NDArray,
         bounds: Optional[Bound] = None,
         component: str = "real",
         interp_method: Optional[InterpMethod] = None,
+        sum_over_freqs: bool = True,
     ) -> NDArray:
         """Compute the derivative with respect to a material property component."""
         param_coords = {axis: np.asarray(spatial_data.coords[axis]) for axis in "xyz"}
@@ -1205,7 +1142,6 @@ class AbstractCustomMedium(AbstractMedium, ABC):
                 )
             return slice(i0, i1)
 
-        # usage
         if bounds is not None:
             (xmin, ymin, zmin), (xmax, ymax, zmax) = bounds
 
@@ -1360,7 +1296,9 @@ class AbstractCustomMedium(AbstractMedium, ABC):
         elif component == "real":
             values = values.real
 
-        return values.sum(axis=-1).reshape(eps_shape)
+        if sum_over_freqs:
+            return values.sum(axis=-1).reshape(eps_shape)
+        return values.reshape([*eps_shape, values.shape[-1]])
 
 
 """ Dispersionless Medium """
@@ -2556,7 +2494,6 @@ class CustomMedium(AbstractCustomMedium):
                         E_der_map=derivative_info.E_der_map,
                         spatial_data=spatial_data,
                         dim=dim,
-                        freqs=derivative_info.frequencies,
                         bounds=derivative_info.bounds_intersect,
                         component="real",
                     )
@@ -2572,7 +2509,6 @@ class CustomMedium(AbstractCustomMedium):
                         E_der_map=derivative_info.E_der_map,
                         spatial_data=spatial_data,
                         dim=dim,
-                        freqs=derivative_info.frequencies,
                         bounds=derivative_info.bounds_intersect,
                         component="sigma",
                     )
@@ -2588,7 +2524,6 @@ class CustomMedium(AbstractCustomMedium):
                     E_der_map=derivative_info.E_der_map,
                     spatial_data=spatial_data,
                     dim=dim,
-                    freqs=derivative_info.frequencies,
                     bounds=derivative_info.bounds_intersect,
                     component="complex",
                 )
@@ -2839,14 +2774,15 @@ class CustomDispersiveMedium(AbstractCustomMedium, DispersiveMedium, ABC):
         Returns
         -------
         np.ndarray
-            Complex-valued aggregated dJ array with the same spatial shape as ``spatial_ref``.
+            Complex-valued aggregated dJ array with frequency as the last axis.
         """
         dJ = 0.0 + 0.0j
         for dim in "xyz":
-            dJ += self._derivative_field_cmp(
+            dJ += self._derivative_field_cmp_custom(
                 E_der_map=derivative_info.E_der_map,
                 spatial_data=spatial_ref,
                 dim=dim,
+                sum_over_freqs=False,
             )
         return dJ
 
@@ -2855,8 +2791,24 @@ class CustomDispersiveMedium(AbstractCustomMedium, DispersiveMedium, ABC):
         """Compute Re(dJ * conj(weight)) with proper broadcasting."""
         return np.real(dJ * np.conj(weight))
 
+    def _sum_real_over_freqs(self, dJ: np.ndarray, freqs: list[float] | np.ndarray) -> np.ndarray:
+        """Sum real parts over the frequency axis using the shared accumulator."""
+        freqs = np.asarray(freqs, float)
+        if freqs.size == 0:
+            raise ValueError("freqs must not be empty")
+        if np.ndim(dJ) == 0 or np.shape(dJ)[-1] != freqs.size:
+            raise ValueError(
+                f"Expected frequency axis on dJ with size {freqs.size}, got shape {np.shape(dJ)}."
+            )
+
+        ones = np.ones_like(dJ[..., 0], dtype=float)
+        return self._sum_over_freqs(freqs=freqs, dJ=dJ, weight_fn=lambda _f, ones=ones: ones)
+
     def _sum_over_freqs(
-        self, freqs: list[float] | np.ndarray, dJ: np.ndarray, weight_fn
+        self,
+        freqs: list[float] | np.ndarray,
+        dJ: np.ndarray,
+        weight_fn: Callable[[float], np.ndarray],
     ) -> np.ndarray:
         """Accumulate gradient contributions over frequencies using provided weight function.
 
@@ -2874,8 +2826,19 @@ class CustomDispersiveMedium(AbstractCustomMedium, DispersiveMedium, ABC):
         np.ndarray
             Real-valued gradient array matching dJ's broadcasted shape.
         """
-        g = 0.0
-        for f in freqs:
+        freqs = np.asarray(freqs, float)
+        if freqs.size == 0:
+            raise ValueError("freqs must not be empty")
+
+        weight0 = weight_fn(freqs[0])
+        if dJ.ndim == np.ndim(weight0) + 1 and dJ.shape[-1] == freqs.size:
+            g = self._accum_real_inner(dJ[..., 0], weight0)
+            for idx, f in enumerate(freqs[1:], start=1):
+                g = g + self._accum_real_inner(dJ[..., idx], weight_fn(f))
+            return g
+
+        g = self._accum_real_inner(dJ, weight0)
+        for f in freqs[1:]:
             g = g + self._accum_real_inner(dJ, weight_fn(f))
         return g
 
@@ -3707,61 +3670,38 @@ class CustomPoleResidue(CustomDispersiveMedium, PoleResidue):
 
         return self.updated_copy(eps_inf=eps_inf_reduced, poles=poles_reduced)
 
-    def _derivative_field_cmp(
-        self,
-        E_der_map: ElectromagneticFieldDataset,
-        spatial_data: CustomSpatialDataTypeAnnotated,
-        dim: str,
-        freqs=None,
-        component: str = "complex",
-    ) -> np.ndarray:
-        """Compatibility wrapper for derivative computation.
-
-        Accepts the extended signature used by other custom media (
-        e.g., `CustomMedium._derivative_field_cmp`) while delegating the actual
-        computation to the base implementation that only depends on
-        `E_der_map`, `spatial_data`, and `dim`.
-
-        Parameters `freqs` and `component` are ignored for this model since the
-        derivative is taken with respect to the complex permittivity directly.
-        """
-        return super()._derivative_field_cmp(
-            E_der_map=E_der_map, spatial_data=spatial_data, dim=dim
-        )
-
     def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
         """Compute adjoint derivatives by preparing array data and calling the static helper."""
 
         eps_inf_sorted = self._eps_inf_sorted
-        use_custom_derivative = isinstance(eps_inf_sorted, SpatialDataArray)
+        is_unstructured = isinstance(eps_inf_sorted, UnstructuredGridDatasetType)
+        if is_unstructured:
+            raise NotImplementedError(
+                "Adjoint derivatives for unstructured custom media are not supported."
+            )
 
         dJ_deps_complex = 0.0 + 0.0j
         for dim in "xyz":
-            if use_custom_derivative:
-                dJ_deps_complex += self._derivative_field_cmp_custom(
-                    E_der_map=derivative_info.E_der_map,
-                    spatial_data=eps_inf_sorted,
-                    dim=dim,
-                    freqs=derivative_info.frequencies,
-                    bounds=derivative_info.bounds_intersect,
-                    component="complex",
-                )
-            else:
-                dJ_deps_complex += self._derivative_field_cmp(
-                    E_der_map=derivative_info.E_der_map,
-                    spatial_data=eps_inf_sorted,
-                    dim=dim,
-                )
+            dJ_deps_complex += self._derivative_field_cmp_custom(
+                E_der_map=derivative_info.E_der_map,
+                spatial_data=eps_inf_sorted,
+                dim=dim,
+                bounds=derivative_info.bounds_intersect,
+                component="complex",
+                sum_over_freqs=False,
+            )
 
         poles_vals = [
             (np.array(a_sorted.values, dtype=complex), np.array(c_sorted.values, dtype=complex))
             for a_sorted, c_sorted in self._poles_sorted
         ]
 
+        freqs = np.asarray(derivative_info.frequencies, float)
         vjps_total = {}
-        for freq in derivative_info.frequencies:
+        for idx, freq in enumerate(freqs):
+            dJ_deps_complex_f = dJ_deps_complex[..., idx]
             vjps_f = PoleResidue._get_vjps_from_params(
-                dJ_deps_complex=dJ_deps_complex,
+                dJ_deps_complex=dJ_deps_complex_f,
                 poles_vals=poles_vals,
                 omega=2 * np.pi * freq,
                 requested_paths=derivative_info.paths,
@@ -4702,7 +4642,7 @@ class CustomLorentz(CustomDispersiveMedium, Lorentz):
 
         # eps_inf path
         if ("eps_inf",) in derivative_info.paths:
-            grads[("eps_inf",)] = np.real(dJ)
+            grads[("eps_inf",)] = self._sum_real_over_freqs(dJ, derivative_info.frequencies)
 
         # per-coefficient contributions
         for i, (de_da, f0_da, dl_da) in enumerate(self.coeffs):
@@ -5059,7 +4999,7 @@ class CustomDrude(CustomDispersiveMedium, Drude):
 
         grads: AutogradFieldMap = {}
         if ("eps_inf",) in derivative_info.paths:
-            grads[("eps_inf",)] = np.real(dJ)
+            grads[("eps_inf",)] = self._sum_real_over_freqs(dJ, derivative_info.frequencies)
 
         for i, (fp_da, dl_da) in enumerate(self.coeffs):
             need_fp = ("coeffs", i, 0) in derivative_info.paths
@@ -5338,7 +5278,7 @@ class CustomDebye(CustomDispersiveMedium, Debye):
 
         grads: AutogradFieldMap = {}
         if ("eps_inf",) in derivative_info.paths:
-            grads[("eps_inf",)] = np.real(dJ)
+            grads[("eps_inf",)] = self._sum_real_over_freqs(dJ, derivative_info.frequencies)
 
         for i, (de_da, tau_da) in enumerate(self.coeffs):
             need_de = ("coeffs", i, 0) in derivative_info.paths


### PR DESCRIPTION
This PR fixes an issue in the adjoint gradient computation for custom dispersive media when multiple adjoint frequencies are used.

Previously, adjoint sensitivities were summed over frequency before applying frequency-dependent material weights. For custom dispersive models (`CustomPoleResidue`, `CustomSellmeier`, `CustomLorentz`, `CustomDrude`, `CustomDebye`), this led to incorrect gradients whenever more than one adjoint frequency was present. Single-frequency adjoints were not affected.

The fix keeps sensitivities frequency-resolved until after frequency-dependent weighting is applied, and only then performs the summation. This restores correct gradients for multi-frequency adjoint simulations while preserving existing single-frequency behavior.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes incorrect multi-frequency adjoint gradients by preserving the frequency axis through sensitivity computation and applying frequency-dependent weights before summation.
> 
> - Refactors `_derivative_field_cmp_custom` to return per-frequency sensitivity (new `sum_over_freqs` arg); introduces `_sum_over_freqs` and `_sum_real_over_freqs` helpers and uses them across `CustomSellmeier`, `CustomLorentz`, `CustomDrude`, `CustomDebye`, and `CustomPoleResidue`
> - Updates `PoleResidue` derivatives to iterate per-frequency; blocks unstructured datasets for custom dispersive adjoint derivatives
> - Type hygiene: `FieldData` → `FieldDataDict`; minor internal API/param changes to derivative utils
> - Adds targeted unit tests for multi-frequency weighting and extensive numerical FD vs adjoint validations; standardizes local cache via pytest fixture
> - Updates CHANGELOG
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9058eb666adebc85a0215999ffba2e0b8f0f4566. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes a critical bug in adjoint gradient computation for custom dispersive media (`CustomPoleResidue`, `CustomSellmeier`, `CustomLorentz`, `CustomDrude`, `CustomDebye`) when using multiple adjoint frequencies.

**The Problem:**
Previously, field sensitivities were summed over all frequencies before applying frequency-dependent material weights. This caused incorrect gradients whenever more than one adjoint frequency was used, because different frequencies require different material weights based on the dispersion model.

**The Solution:**
- Modified `_derivative_field_cmp` and `_derivative_field_cmp_custom` to preserve the frequency axis (new `sum_over_freqs=False` parameter)
- Field sensitivities now remain frequency-resolved through the computation pipeline
- Added `_sum_over_freqs` helper that applies frequency-dependent weights to each frequency's sensitivity before summing
- Added `_sum_real_over_freqs` for simpler cases where only real part summation is needed
- Updated all custom dispersive media classes to use the new pattern

**Testing:**
- Comprehensive new unit tests validate the correct frequency-weighting behavior
- New numerical validation tests compare adjoint gradients to finite differences for all 7 dispersive model types
- Existing single-frequency behavior is preserved (backward compatible)

The fix is mathematically sound and well-tested. Type hints were improved for clarity (`FieldData` → `FieldDataDict`).

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it fixes a critical bug with comprehensive testing and maintains backward compatibility
- The fix addresses a well-defined bug with a clear root cause and solution. The implementation is mathematically correct, preserving frequency information through the gradient computation pipeline. Comprehensive test coverage includes both unit tests and numerical validation against finite differences. The changes are localized to gradient computation logic and maintain backward compatibility for single-frequency cases. Code quality is high with proper error handling and clear documentation.
- No files require special attention - all changes follow established patterns and are well-tested

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/components/medium.py | Core fix for multi-frequency adjoint gradients - modified _derivative_field_cmp and _derivative_field_cmp_custom to preserve frequency axis, added _sum_over_freqs and _sum_real_over_freqs helpers, updated all custom dispersive media gradient computations |
| tests/test_components/autograd/test_custom_dispersive_multifreq.py | New unit tests validating multi-frequency gradient computation for CustomSellmeier and CustomPoleResidue |
| tests/test_components/autograd/numerical/test_autograd_custom_dispersive_numerical.py | New comprehensive numerical validation tests comparing adjoint gradients to finite differences for all custom dispersive media types with multi-frequency adjoints |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as Adjoint Simulation
    participant CustomMed as CustomDispersiveMedium
    participant Compute as _compute_derivatives
    participant FieldCmp as _derivative_field_cmp_custom
    participant SumFreq as _sum_over_freqs
    participant Weight as weight_fn(freq)
    
    User->>CustomMed: Multi-frequency adjoint run
    CustomMed->>Compute: _compute_derivatives(derivative_info)
    Compute->>FieldCmp: _derivative_field_cmp_custom(sum_over_freqs=False)
    Note over FieldCmp: Preserves frequency axis<br/>Returns shape [..., n_freqs]
    FieldCmp-->>Compute: dJ with freq dimension
    
    loop For each parameter
        Compute->>SumFreq: _sum_over_freqs(freqs, dJ, weight_fn)
        Note over SumFreq: Check if dJ has freq axis
        alt dJ has frequency axis
            loop For each frequency
                SumFreq->>Weight: weight_fn(freq[i])
                Weight-->>SumFreq: weight at freq[i]
                Note over SumFreq: gradient += Re(dJ[..., i] * conj(weight))
            end
        else Single frequency (backward compat)
            loop For each frequency
                SumFreq->>Weight: weight_fn(freq)
                Weight-->>SumFreq: weight at freq
                Note over SumFreq: gradient += Re(dJ * conj(weight))
            end
        end
        SumFreq-->>Compute: Real-valued gradient
    end
    
    Compute-->>CustomMed: AutogradFieldMap
    CustomMed-->>User: Correct gradients
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->