### PR TITLE
 fix: missing discreitization 'index' on /api/index.rst (FXC-4917)

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -12,7 +12,7 @@ API |:computer:|
     mediums
     material_library
     boundary_conditions
-    discretization
+    discretization/index
     sources
     monitors
     output_data


### PR DESCRIPTION
Fixed missing discretization index

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes a broken Sphinx toctree entry in `docs/api/index.rst`.
> 
> - Updates `discretization` to `discretization/index` so the API docs correctly link to the discretization section index
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8289bfff301a69be2a4547c8029ef04a7e810e10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR corrects a documentation reference in the API index table of contents. The change updates `discretization` to `discretization/index` in the toctree directive, which aligns with the established pattern used by other multi-file API sections (mesh, heat, charge, eme, mode, microwave, plugins). This ensures the Sphinx documentation builder correctly references the discretization module's index file.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risks - it's a straightforward documentation path correction
- This is a minimal documentation-only change that corrects a single toctree reference. The change is verified to follow the established pattern used by all other multi-file API sections in the documentation. The referenced file (`docs/api/discretization/index.rst`) exists and contains proper content. No code logic, dependencies, or runtime behavior is affected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/api/index.rst | Fixed toctree reference to use `discretization/index` instead of `discretization` to correctly point to the index.rst file in the discretization subdirectory. This change aligns with the established pattern used by other multi-file API sections (mesh, heat, charge, eme, mode, microwave, plugins) that all reference their subdirectories with `/index`. |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->