### PR TITLE
feat: Unify handling of EME coefficients (FXC-4311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `warn_once` option to logging configuration (`td.config.logging.warn_once`) that causes each unique warning message to be shown only once per process, reducing noise from repeated validation warnings.
+- `EMECoefficientMonitor` now supports all of the same fields as `EMESimulationData.coeffs`, with the benefit of downsampling. The fields can be selected via the `EMECoefficientMonitor.fields` property.
 
 ### Changed
 - Unified inside/outside permittivity handling for all geometries when computing shape gradients.

--- a/schemas/EMESimulation.json
+++ b/schemas/EMESimulation.json
@@ -4666,6 +4666,24 @@
           "exclusiveMinimum": 0,
           "type": "integer"
         },
+        "fields": {
+          "default": [
+            "A",
+            "B"
+          ],
+          "items": {
+            "enum": [
+              "A",
+              "B",
+              "flux",
+              "interface_smatrices",
+              "n_complex",
+              "overlaps"
+            ],
+            "type": "string"
+          },
+          "type": "array"
+        },
         "freqs": {
           "anyOf": [
             {

--- a/tests/test_components/test_eme.py
+++ b/tests/test_components/test_eme.py
@@ -278,9 +278,531 @@ def test_eme_monitor():
         colocate=False,
         name="eme_field",
     )
-    _ = td.EMECoefficientMonitor(
+    # test default fields
+    monitor_default = td.EMECoefficientMonitor(
         center=(1, 2, 3), size=(2, 2, 2), freqs=[300e12], num_modes=2, name="eme_coeffs"
     )
+    assert monitor_default.fields == (
+        "A",
+        "B",
+    )
+
+    # test custom fields subset
+    monitor_subset = td.EMECoefficientMonitor(
+        center=(1, 2, 3),
+        size=(2, 2, 2),
+        freqs=[300e12],
+        num_modes=2,
+        fields=["A", "B", "overlaps"],
+        name="eme_coeffs_subset",
+    )
+    assert monitor_subset.fields == ("A", "B", "overlaps")
+
+    # test storage_size varies with fields
+    num_cells, num_transverse, num_eme_cells, num_virtual_eme_cells = 100, 50, 5, 5
+    num_freqs, num_modes = 2, 3
+    size_default = monitor_default.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=None,
+    )
+    size_subset = monitor_subset.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=None,
+    )
+    assert size_subset > size_default
+    assert size_subset > 0
+
+    # test empty fields gives zero storage
+    monitor_empty = td.EMECoefficientMonitor(
+        center=(1, 2, 3),
+        size=(2, 2, 2),
+        freqs=[300e12],
+        num_modes=2,
+        fields=[],
+        name="eme_coeffs_empty",
+    )
+    size_empty = monitor_empty.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=None,
+    )
+    assert size_empty == 0
+
+
+def test_eme_monitor_storage_size_with_sweep_spec():
+    """Test that storage_size correctly handles different sweep_spec types."""
+    import numpy as np
+
+    num_cells, num_transverse, num_eme_cells, num_virtual_eme_cells = 100, 50, 5, 5
+    num_freqs, num_modes = 2, 3
+    num_sweep = 10
+
+    # Create sweep specs
+    length_sweep = td.EMELengthSweep(scale_factors=np.linspace(0.5, 1.5, num_sweep))
+    mode_sweep = td.EMEModeSweep(num_modes=np.arange(1, num_sweep + 1))
+    freq_sweep = td.EMEFreqSweep(freq_scale_factors=np.linspace(0.9, 1.1, num_sweep))
+
+    # Verify sweep_spec properties
+    assert length_sweep.sweep_modes is False
+    assert length_sweep.sweep_interfaces is False
+    assert length_sweep.sweep_cells is True
+
+    assert mode_sweep.sweep_modes is False
+    assert mode_sweep.sweep_interfaces is True
+    assert mode_sweep.sweep_cells is True
+
+    assert freq_sweep.sweep_modes is True
+    assert freq_sweep.sweep_interfaces is True
+    assert freq_sweep.sweep_cells is True
+
+    # Monitor with only A and B fields (uses full sweep)
+    monitor_ab = td.EMECoefficientMonitor(
+        center=(1, 2, 3),
+        size=(2, 2, 2),
+        freqs=[300e12],
+        num_modes=2,
+        num_sweep=None,
+        fields=["A", "B"],
+        name="eme_coeffs_ab",
+    )
+
+    # Monitor with only n_complex and flux (uses sweep_modes)
+    monitor_nf = td.EMECoefficientMonitor(
+        center=(1, 2, 3),
+        size=(2, 2, 2),
+        freqs=[300e12],
+        num_modes=2,
+        num_sweep=None,
+        fields=["n_complex", "flux"],
+        name="eme_coeffs_nf",
+    )
+
+    # Monitor with only interface_smatrices (uses sweep_interfaces)
+    monitor_is = td.EMECoefficientMonitor(
+        center=(1, 2, 3),
+        size=(2, 2, 2),
+        freqs=[300e12],
+        num_modes=2,
+        num_sweep=None,
+        fields=["interface_smatrices"],
+        name="eme_coeffs_is",
+    )
+
+    # Monitor with overlaps (uses sweep_modes)
+    monitor_ov = td.EMECoefficientMonitor(
+        center=(1, 2, 3),
+        size=(2, 2, 2),
+        freqs=[300e12],
+        num_modes=2,
+        num_sweep=None,
+        fields=["overlaps"],
+        name="eme_coeffs_ov",
+    )
+    monitor_ab_limited = td.EMECoefficientMonitor(
+        center=(1, 2, 3),
+        size=(2, 2, 2),
+        freqs=[300e12],
+        num_modes=2,
+        num_sweep=3,
+        fields=["A", "B"],
+        name="eme_coeffs_ab_limited",
+    )
+
+    # Get storage sizes with no sweep (baseline)
+    size_ab_none = monitor_ab.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=None,
+    )
+    size_nf_none = monitor_nf.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=None,
+    )
+    size_is_none = monitor_is.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=None,
+    )
+    size_ov_none = monitor_ov.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=None,
+    )
+
+    # Test EMELengthSweep: only A, B should scale with sweep
+    size_ab_length = monitor_ab.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=length_sweep,
+    )
+    size_nf_length = monitor_nf.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=length_sweep,
+    )
+    size_is_length = monitor_is.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=length_sweep,
+    )
+    size_ov_length = monitor_ov.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=length_sweep,
+    )
+
+    # A, B should scale by num_sweep
+    assert size_ab_length == size_ab_none * num_sweep
+    # n_complex, flux should NOT scale (sweep_modes=False)
+    assert size_nf_length == size_nf_none
+    # interface_smatrices should NOT scale (sweep_interfaces=False)
+    assert size_is_length == size_is_none
+    # overlaps should NOT scale (sweep_modes=False)
+    assert size_ov_length == size_ov_none
+
+    # Test EMEModeSweep: A, B, interface_smatrices should scale
+    size_ab_mode = monitor_ab.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=mode_sweep,
+    )
+    size_nf_mode = monitor_nf.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=mode_sweep,
+    )
+    size_is_mode = monitor_is.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=mode_sweep,
+    )
+    size_ov_mode = monitor_ov.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=mode_sweep,
+    )
+
+    # A, B should scale by num_sweep
+    assert size_ab_mode == size_ab_none * num_sweep
+    # n_complex, flux should NOT scale (sweep_modes=False)
+    assert size_nf_mode == size_nf_none
+    # interface_smatrices SHOULD scale (sweep_interfaces=True)
+    assert size_is_mode == size_is_none * num_sweep
+    # overlaps should NOT scale (sweep_modes=False)
+    assert size_ov_mode == size_ov_none
+    # monitor.num_sweep limits scaling
+    size_ab_mode_limited = monitor_ab_limited.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=mode_sweep,
+    )
+    assert size_ab_mode_limited == size_ab_none * 3
+
+    # Test EMEFreqSweep: everything should scale
+    size_ab_freq = monitor_ab.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=freq_sweep,
+    )
+    size_nf_freq = monitor_nf.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=freq_sweep,
+    )
+    size_is_freq = monitor_is.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=freq_sweep,
+    )
+    size_ov_freq = monitor_ov.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=freq_sweep,
+    )
+
+    # All fields should scale by num_sweep
+    assert size_ab_freq == size_ab_none * num_sweep
+    assert size_nf_freq == size_nf_none * num_sweep
+    assert size_is_freq == size_is_none * num_sweep
+    assert size_ov_freq == size_ov_none * num_sweep
+
+    # Test EMEModeSolverMonitor with sweep_spec
+    mode_solver_monitor = td.EMEModeSolverMonitor(
+        center=(1, 2, 3),
+        size=(2, 2, 2),
+        freqs=[300e12],
+        num_modes=2,
+        num_sweep=None,
+        name="eme_mode_solver",
+    )
+    mode_solver_monitor_limited = td.EMEModeSolverMonitor(
+        center=(1, 2, 3),
+        size=(2, 2, 2),
+        freqs=[300e12],
+        num_modes=2,
+        num_sweep=4,
+        name="eme_mode_solver_limited",
+    )
+
+    size_ms_none = mode_solver_monitor.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=None,
+    )
+    size_ms_length = mode_solver_monitor.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=length_sweep,
+    )
+    size_ms_mode = mode_solver_monitor.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=mode_sweep,
+    )
+    size_ms_freq = mode_solver_monitor.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=freq_sweep,
+    )
+
+    # EMEModeSolverMonitor only scales with sweep_modes (EMEFreqSweep)
+    assert size_ms_length == size_ms_none
+    assert size_ms_mode == size_ms_none
+    assert size_ms_freq == size_ms_none * num_sweep
+    size_ms_freq_limited = mode_solver_monitor_limited.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=freq_sweep,
+    )
+    assert size_ms_freq_limited == size_ms_none * 4
+
+    # Test EMEFieldMonitor with sweep_spec (uses full sweep)
+    field_monitor = td.EMEFieldMonitor(
+        center=(1, 2, 3),
+        size=(2, 2, 0),
+        freqs=[300e12],
+        num_modes=2,
+        num_sweep=None,
+        name="eme_field",
+    )
+    field_monitor_limited = td.EMEFieldMonitor(
+        center=(1, 2, 3),
+        size=(2, 2, 0),
+        freqs=[300e12],
+        num_modes=2,
+        num_sweep=2,
+        name="eme_field_limited",
+    )
+
+    size_fm_none = field_monitor.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=None,
+    )
+    size_fm_length = field_monitor.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=length_sweep,
+    )
+    size_fm_mode = field_monitor.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=mode_sweep,
+    )
+    size_fm_freq = field_monitor.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=freq_sweep,
+    )
+
+    # EMEFieldMonitor uses full sweep for all sweep types
+    assert size_fm_length == size_fm_none * num_sweep
+    assert size_fm_mode == size_fm_none * num_sweep
+    assert size_fm_freq == size_fm_none * num_sweep
+    size_fm_freq_limited = field_monitor_limited.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=freq_sweep,
+    )
+    assert size_fm_freq_limited == size_fm_none * 2
+
+    # Test EMEPeriodicitySweep: all sweep properties are False, so only A, B scale
+    periodicity_sweep = td.EMEPeriodicitySweep(
+        num_reps=[{"unit_cell": i} for i in range(1, num_sweep + 1)]
+    )
+
+    assert periodicity_sweep.sweep_modes is False
+    assert periodicity_sweep.sweep_interfaces is False
+    assert periodicity_sweep.sweep_cells is False
+
+    size_ab_period = monitor_ab.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=periodicity_sweep,
+    )
+    size_nf_period = monitor_nf.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=periodicity_sweep,
+    )
+    size_is_period = monitor_is.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=periodicity_sweep,
+    )
+    size_ov_period = monitor_ov.storage_size(
+        num_cells,
+        num_transverse,
+        num_eme_cells,
+        num_virtual_eme_cells,
+        num_freqs,
+        num_modes,
+        sweep_spec=periodicity_sweep,
+    )
+
+    # A, B should scale by num_sweep (full sweep)
+    assert size_ab_period == size_ab_none * num_sweep
+    # n_complex, flux should NOT scale
+    assert size_nf_period == size_nf_none
+    # interface_smatrices should NOT scale
+    assert size_is_period == size_is_none
+    # overlaps should NOT scale
+    assert size_ov_period == size_ov_none
 
 
 def test_eme_simulation():
@@ -474,6 +996,17 @@ def test_eme_simulation():
     )
     with AssertLogLevel("WARNING", contains_str="store_coeffs"):
         sim_bad.updated_copy(store_coeffs=True).validate_pre_upload()
+    # port_modes warning
+    sim_bad = sim.updated_copy(
+        size=(10, 10, 10),
+        monitors=[],
+        store_coeffs=False,
+        freqs=list(1e14 * np.linspace(1, 2, 100)),
+        eme_grid_spec=td.EMEUniformGrid(mode_spec=td.EMEModeSpec(num_modes=100), num_cells=100),
+        grid_spec=sim.grid_spec.updated_copy(wavelength=1),
+    )
+    with AssertLogLevel("WARNING", contains_str="store_port_modes"):
+        sim_bad.updated_copy(store_port_modes=True).validate_pre_upload()
     sim_bad = sim.updated_copy(
         size=(10, 10, 10),
         monitors=[large_monitor],
@@ -591,6 +1124,17 @@ def test_eme_simulation():
         sim_bad.validate_pre_upload()
 
     _ = sim.port_modes_monitor
+
+    # test coeffs_full_monitor
+    coeffs_monitor = sim.coeffs_full_monitor
+    assert isinstance(coeffs_monitor, td.EMECoefficientMonitor)
+    assert coeffs_monitor.name == "_eme_coeffs_full_monitor"
+    # coeffs monitor is included in _monitors_full when store_coeffs=True
+    sim_with_coeffs = sim.updated_copy(store_coeffs=True, monitors=[])
+    assert any(m.name == "_eme_coeffs_full_monitor" for m in sim_with_coeffs._monitors_full)
+    # coeffs monitor is not included when store_coeffs=False
+    sim_no_coeffs = sim.updated_copy(store_coeffs=False, monitors=[])
+    assert not any(m.name == "_eme_coeffs_full_monitor" for m in sim_no_coeffs._monitors_full)
 
     # test freq sweep
     sim = sim.updated_copy(sweep_spec=None)

--- a/tidy3d/components/eme/data/sim_data.py
+++ b/tidy3d/components/eme/data/sim_data.py
@@ -18,7 +18,7 @@ from tidy3d.exceptions import SetupError
 from tidy3d.log import log
 
 from .dataset import EMECoefficientDataset, EMESMatrixDataset
-from .monitor_data import EMEFieldData, EMEModeSolverData, EMEMonitorDataType
+from .monitor_data import EMECoefficientData, EMEFieldData, EMEModeSolverData, EMEMonitorDataType
 
 
 class EMESimulationData(AbstractYeeGridSimulationData):
@@ -39,7 +39,7 @@ class EMESimulationData(AbstractYeeGridSimulationData):
         None, title="S Matrix", description="Scattering matrix of the EME simulation."
     )
 
-    coeffs: Optional[EMECoefficientDataset] = pd.Field(
+    coeffs: Optional[Union[EMECoefficientData, EMECoefficientDataset]] = pd.Field(
         None,
         title="Coefficients",
         description="Coefficients from the EME simulation. Useful for debugging and optimization.",

--- a/tidy3d/components/eme/monitor.py
+++ b/tidy3d/components/eme/monitor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Literal, Optional, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
 import pydantic.v1 as pd
 
@@ -15,6 +15,9 @@ from tidy3d.components.monitor import (
     PermittivityMonitor,
 )
 from tidy3d.components.types import FreqArray
+
+if TYPE_CHECKING:
+    from .sweep import EMESweepSpecType
 
 BYTES_COMPLEX = 8
 
@@ -79,9 +82,10 @@ class EMEMonitor(AbstractMonitor, ABC):
         num_cells: int,
         num_transverse_cells: int,
         num_eme_cells: int,
+        num_virtual_eme_cells: int,
         num_freqs: int,
         num_modes: int,
-        num_sweep: int,
+        sweep_spec: Optional[EMESweepSpecType],
     ) -> int:
         """Size of monitor storage given the number of points after discretization.
 
@@ -94,16 +98,26 @@ class EMEMonitor(AbstractMonitor, ABC):
             after discretization by a :class:`.Simulation`.
         num_eme_cells: int
             Number of EME cells intersecting the monitor.
+        num_virtual_eme_cells: int
+            Number of virtual EME cells intersecting the monitor (includes repetitions).
         num_freqs: int
             Number of frequencies in the monitor.
         num_modes: int
             Number of modes in the monitor.
+        sweep_spec: Optional[EMESweepSpecType]
+            The sweep specification used in the simulation.
 
         Returns
         -------
         int
             Number of bytes to be stored in monitor.
         """
+
+    def _effective_num_sweep(self, num_sweep: int) -> int:
+        """Apply monitor sweep limiting if specified."""
+        if self.num_sweep is None:
+            return num_sweep
+        return min(num_sweep, self.num_sweep)
 
 
 class EMEModeSolverMonitor(EMEMonitor):
@@ -172,11 +186,15 @@ class EMEModeSolverMonitor(EMEMonitor):
         num_cells: int,
         num_transverse_cells: int,
         num_eme_cells: int,
+        num_virtual_eme_cells: int,
         num_freqs: int,
         num_modes: int,
-        num_sweep: int,
+        sweep_spec: Optional[EMESweepSpecType],
     ) -> int:
         """Size of monitor storage given the number of points after discretization."""
+        # EMEModeSolverMonitor only varies with sweep for EMEFreqSweep (sweep_modes)
+        num_sweep = sweep_spec.num_sweep if sweep_spec and sweep_spec.sweep_modes else 1
+        num_sweep = self._effective_num_sweep(num_sweep)
         bytes_single = (
             6
             * BYTES_COMPLEX
@@ -242,11 +260,15 @@ class EMEFieldMonitor(EMEMonitor, AbstractFieldMonitor):
         num_cells: int,
         num_transverse_cells: int,
         num_eme_cells: int,
+        num_virtual_eme_cells: int,
         num_freqs: int,
         num_modes: int,
-        num_sweep: int,
+        sweep_spec: Optional[EMESweepSpecType],
     ) -> int:
         """Size of monitor storage given the number of points after discretization."""
+        # EMEFieldMonitor uses full sweep count
+        num_sweep = sweep_spec.num_sweep if sweep_spec else 1
+        num_sweep = self._effective_num_sweep(num_sweep)
         bytes_single = 6 * BYTES_COMPLEX * num_cells * num_freqs * num_modes * 2 * num_sweep
         return bytes_single
 
@@ -263,9 +285,22 @@ class EMECoefficientMonitor(EMEMonitor):
     ...     size=(2,2,2),
     ...     freqs=[300e12],
     ...     num_modes=2,
+    ...     fields=['A', 'B'],
     ...     name="eme_coeffs"
     ... )
     """
+
+    fields: tuple[
+        Literal["A", "B", "n_complex", "flux", "interface_smatrices", "overlaps"], ...
+    ] = pd.Field(
+        ("A", "B"),
+        title="Coefficient Fields",
+        description="Collection of coefficient fields to store in the monitor. "
+        "Available fields: 'A' (forward mode coefficients), 'B' (backward mode coefficients), "
+        "'n_complex' (propagation indices), 'flux' (power flux), "
+        "'interface_smatrices' (S matrices at cell interfaces), "
+        "'overlaps' (mode overlaps).",
+    )
 
     interval_space: tuple[Literal[1], Literal[1], Literal[1]] = pd.Field(
         (1, 1, 1),
@@ -291,15 +326,85 @@ class EMECoefficientMonitor(EMEMonitor):
         num_cells: int,
         num_transverse_cells: int,
         num_eme_cells: int,
+        num_virtual_eme_cells: int,
         num_freqs: int,
         num_modes: int,
-        num_sweep: int,
+        sweep_spec: Optional[EMESweepSpecType],
     ) -> int:
         """Size of monitor storage given the number of points after discretization."""
-        bytes_single = (
-            4 * BYTES_COMPLEX * num_freqs * num_modes * num_modes * num_eme_cells * num_sweep
+        bytes_total = 0
+        num_interfaces = num_eme_cells - 1
+
+        # Compute per-field sweep counts based on sweep_spec properties
+        # A and B: use full sweep count
+        num_sweep_full = sweep_spec.num_sweep if sweep_spec else 1
+        num_sweep_full = self._effective_num_sweep(num_sweep_full)
+        # n_complex, flux, overlaps: only vary with EMEFreqSweep (sweep_modes)
+        num_sweep_modes = sweep_spec.num_sweep if sweep_spec and sweep_spec.sweep_modes else 1
+        num_sweep_modes = self._effective_num_sweep(num_sweep_modes)
+        # interface_smatrices: only vary with EMEFreqSweep or EMEModeSweep (sweep_interfaces)
+        num_sweep_interfaces = (
+            sweep_spec.num_sweep if sweep_spec and sweep_spec.sweep_interfaces else 1
         )
-        return bytes_single
+        num_sweep_interfaces = self._effective_num_sweep(num_sweep_interfaces)
+
+        # A and B: each is (f, sweep, 2 ports, virtual_cells, modes_out, modes_in)
+        # Each field has 2 ports, so: 2 ports * virtual_cells * modes * modes
+        if "A" in self.fields:
+            bytes_total += (
+                2
+                * BYTES_COMPLEX
+                * num_freqs
+                * num_sweep_full
+                * num_virtual_eme_cells
+                * num_modes
+                * num_modes
+            )
+        if "B" in self.fields:
+            bytes_total += (
+                2
+                * BYTES_COMPLEX
+                * num_freqs
+                * num_sweep_full
+                * num_virtual_eme_cells
+                * num_modes
+                * num_modes
+            )
+
+        # n_complex and flux: (f, sweep, cells, modes)
+        if "n_complex" in self.fields:
+            bytes_total += BYTES_COMPLEX * num_freqs * num_sweep_modes * num_eme_cells * num_modes
+        if "flux" in self.fields:
+            bytes_total += BYTES_COMPLEX * num_freqs * num_sweep_modes * num_eme_cells * num_modes
+
+        # interface_smatrices: 4 S matrices (S11, S12, S21, S22), each (f, sweep, cells-1, modes, modes)
+        if "interface_smatrices" in self.fields:
+            bytes_total += (
+                4
+                * BYTES_COMPLEX
+                * num_freqs
+                * num_sweep_interfaces
+                * num_interfaces
+                * num_modes
+                * num_modes
+            )
+
+        # overlaps: O11 (f, sweep, cells, modes, modes) + O12, O21 (f, sweep, cells-1, modes, modes)
+        if "overlaps" in self.fields:
+            bytes_total += (
+                BYTES_COMPLEX * num_freqs * num_sweep_modes * num_eme_cells * num_modes * num_modes
+            )  # O11
+            bytes_total += (
+                2
+                * BYTES_COMPLEX
+                * num_freqs
+                * num_sweep_modes
+                * num_interfaces
+                * num_modes
+                * num_modes
+            )  # O12, O21
+
+        return bytes_total
 
 
 EMEMonitorType = Union[

--- a/tidy3d/components/eme/simulation.py
+++ b/tidy3d/components/eme/simulation.py
@@ -49,6 +49,7 @@ MAX_SIMULATION_DATA_SIZE_GB = 50
 WARN_MODE_NUM_CELLS = 1e5
 MAX_MODE_NUM_CELLS = 5e6
 WARN_COEFF_DATA_SIZE_GB = 0.5
+WARN_PORT_MODES_DATA_SIZE_GB = 0.5
 
 
 # eme specific simulation parameters
@@ -589,6 +590,18 @@ class EMESimulation(AbstractYeeGridSimulation):
             normalize=self.normalize,
         )
 
+    @property
+    def coeffs_full_monitor(self) -> EMECoefficientMonitor:
+        """EME coefficient monitor for storing all coefficients without downsampling."""
+        size = [inf, inf, inf]
+        return EMECoefficientMonitor(
+            center=self.center,
+            size=size,
+            name="_eme_coeffs_full_monitor",
+            num_sweep=None,
+            fields=("A", "B", "n_complex", "flux", "interface_smatrices", "overlaps"),
+        )
+
     def _post_init_validators(self) -> None:
         """Call validators taking `self` that get run after init."""
         self._validate_port_offsets()
@@ -856,6 +869,33 @@ class EMESimulation(AbstractYeeGridSimulation):
             datas = self.monitors_data_size
             for monitor_ind, (monitor_name, monitor_size) in enumerate(datas.items()):
                 monitor_size_gb = monitor_size / 1e9
+
+                # specific warning for store_coeffs
+                if monitor_name == self.coeffs_full_monitor.name:
+                    if monitor_size_gb > WARN_COEFF_DATA_SIZE_GB:
+                        consolidated_logger.warning(
+                            f"Simulation 'coeffs' have estimated storage size "
+                            f"{monitor_size_gb:1.2f}GB. "
+                            "Consider setting 'store_coeffs=False' "
+                            "or reducing the number of frequencies, modes, "
+                            "EME cells, or sweep indices.",
+                        )
+                    total_size_gb += monitor_size_gb
+                    continue
+
+                # specific warning for store_port_modes
+                if monitor_name == self.port_modes_monitor.name:
+                    if monitor_size_gb > WARN_PORT_MODES_DATA_SIZE_GB:
+                        consolidated_logger.warning(
+                            f"Simulation 'port_modes' have estimated storage size "
+                            f"{monitor_size_gb:1.2f}GB. "
+                            "Consider setting 'store_port_modes=False' "
+                            "or reducing the number of frequencies, modes, or sweep indices.",
+                        )
+                    total_size_gb += monitor_size_gb
+                    continue
+
+                # general warning for user monitors
                 if monitor_size_gb > WARN_MONITOR_DATA_SIZE_GB:
                     consolidated_logger.warning(
                         f"Monitor '{monitor_name}' estimated storage is {monitor_size_gb:1.2f}GB. "
@@ -865,64 +905,6 @@ class EMESimulation(AbstractYeeGridSimulation):
                     )
 
                 total_size_gb += monitor_size_gb
-
-        # coefficients
-        if self.store_coeffs:
-            coeffs_size_b = 0
-            bytes_complex = 8
-            num_freqs = len(self.freqs)
-            num_modes = self.max_num_modes
-            num_eme_cells = self.eme_grid.num_cells
-            num_sweep = self._num_sweep
-            # A and B coefficients
-            coeffs_size_b += (
-                4 * bytes_complex * num_freqs * num_modes * num_modes * num_eme_cells * num_sweep
-            )
-            # interface smatrices
-            coeffs_size_b += (
-                4
-                * bytes_complex
-                * num_freqs
-                * num_modes
-                * num_modes
-                * (num_eme_cells - 1)
-                * self._num_sweep_interfaces
-            )
-            # n_complex and flux
-            coeffs_size_b += (
-                2 * bytes_complex * num_freqs * num_modes * num_eme_cells * self._num_sweep_modes
-            )
-            # overlaps
-            coeffs_size_b += (
-                2
-                * bytes_complex
-                * num_freqs
-                * num_modes
-                * num_modes
-                * (num_eme_cells - 1)
-                * self._num_sweep_modes
-            )
-            # self-overlaps
-            coeffs_size_b += (
-                bytes_complex
-                * num_freqs
-                * num_modes
-                * num_modes
-                * num_eme_cells
-                * self._num_sweep_modes
-            )
-
-            coeffs_size_gb = coeffs_size_b / 1e9
-            if coeffs_size_gb > WARN_COEFF_DATA_SIZE_GB:
-                log.warning(
-                    "Simulation 'coeffs' have estimated storage size "
-                    f"{coeffs_size_gb:1.2f}GB. "
-                    "Consider setting 'store_coeffs=False' "
-                    "or reducing the number of frequencies, modes, "
-                    "EME cells, or sweep indices."
-                )
-
-            total_size_gb += coeffs_size_gb
 
         if total_size_gb > MAX_SIMULATION_DATA_SIZE_GB:
             raise SetupError(
@@ -980,9 +962,12 @@ class EMESimulation(AbstractYeeGridSimulation):
     @property
     def _monitors_full(self) -> tuple[EMEMonitorType, ...]:
         """All monitors, including port modes monitor."""
+        monitors = list(self.monitors)
+        if self.store_coeffs:
+            monitors.append(self.coeffs_full_monitor)
         if self.store_port_modes:
-            return [*list(self.monitors), self.port_modes_monitor]
-        return list(self.monitors)
+            monitors.append(self.port_modes_monitor)
+        return monitors
 
     @cached_property
     def monitors_data_size(self) -> dict[str, float]:
@@ -993,17 +978,18 @@ class EMESimulation(AbstractYeeGridSimulation):
             if isinstance(monitor, EMEMonitor):
                 num_transverse_cells = self._monitor_num_transverse_cells(monitor)
                 num_eme_cells = self._monitor_num_eme_cells(monitor)
+                num_virtual_eme_cells = self._monitor_num_virtual_eme_cells(monitor)
                 num_freqs = self._monitor_num_freqs(monitor)
                 num_modes = self._monitor_num_modes(monitor)
-                num_sweep = self._monitor_num_sweep(monitor)
                 storage_size = float(
                     monitor.storage_size(
                         num_cells=num_cells,
                         num_transverse_cells=num_transverse_cells,
                         num_eme_cells=num_eme_cells,
+                        num_virtual_eme_cells=num_virtual_eme_cells,
                         num_freqs=num_freqs,
                         num_modes=num_modes,
-                        num_sweep=num_sweep,
+                        sweep_spec=self.sweep_spec,
                     )
                 )
             else:
@@ -1033,7 +1019,7 @@ class EMESimulation(AbstractYeeGridSimulation):
     @property
     def _sweep_modes(self) -> bool:
         """Whether the sweep changes the modes."""
-        return self.sweep_spec is not None and isinstance(self.sweep_spec, EMEFreqSweep)
+        return self.sweep_spec is not None and self.sweep_spec.sweep_modes
 
     @property
     def _num_sweep_modes(self) -> pd.PositiveInt:
@@ -1045,9 +1031,7 @@ class EMESimulation(AbstractYeeGridSimulation):
     @property
     def _sweep_interfaces(self) -> bool:
         """Whether the sweep changes the cell interface scattering matrices."""
-        return self.sweep_spec is not None and isinstance(
-            self.sweep_spec, (EMEFreqSweep, EMEModeSweep)
-        )
+        return self.sweep_spec is not None and self.sweep_spec.sweep_interfaces
 
     @property
     def _num_sweep_interfaces(self) -> pd.PositiveInt:
@@ -1059,9 +1043,7 @@ class EMESimulation(AbstractYeeGridSimulation):
     @property
     def _sweep_cells(self) -> bool:
         """Whether the sweep changes the propagation within a cell."""
-        return self.sweep_spec is not None and isinstance(
-            self.sweep_spec, (EMELengthSweep, EMEFreqSweep, EMEModeSweep)
-        )
+        return self.sweep_spec is not None and self.sweep_spec.sweep_cells
 
     @property
     def _num_sweep_cells(self) -> pd.PositiveInt:
@@ -1095,6 +1077,21 @@ class EMESimulation(AbstractYeeGridSimulation):
     def _monitor_num_eme_cells(self, monitor: EMEMonitor) -> int:
         """Total number of EME cells included in monitor based on simulation grid."""
         return len(self._monitor_eme_cell_indices(monitor=monitor))
+
+    def _monitor_virtual_cell_indices(self, monitor: EMEMonitor) -> list[pd.NonNegativeInt]:
+        """Virtual EME cell indices inside monitor.
+        Returns the indices into the virtual_cell_indices list where the
+        physical cell index is in the monitor's eme_cell_indices.
+        """
+        physical_cell_indices = set(self._monitor_eme_cell_indices(monitor=monitor))
+        all_virtual_indices = self.eme_grid_spec.virtual_cell_indices
+        return [
+            i for i, phys_idx in enumerate(all_virtual_indices) if phys_idx in physical_cell_indices
+        ]
+
+    def _monitor_num_virtual_eme_cells(self, monitor: EMEMonitor) -> int:
+        """Number of virtual EME cells inside monitor."""
+        return len(self._monitor_virtual_cell_indices(monitor=monitor))
 
     def _monitor_freqs(self, monitor: Monitor) -> list[pd.NonNegativeFloat]:
         """Monitor frequencies."""

--- a/tidy3d/components/eme/sweep.py
+++ b/tidy3d/components/eme/sweep.py
@@ -22,6 +22,21 @@ class EMESweepSpec(Tidy3dBaseModel, ABC):
     def num_sweep(self) -> pd.PositiveInt:
         """Number of sweep indices."""
 
+    @property
+    def sweep_modes(self) -> bool:
+        """Whether the sweep changes the modes."""
+        return False
+
+    @property
+    def sweep_interfaces(self) -> bool:
+        """Whether the sweep changes the cell interface scattering matrices."""
+        return False
+
+    @property
+    def sweep_cells(self) -> bool:
+        """Whether the sweep changes the propagation within a cell."""
+        return False
+
 
 class EMELengthSweep(EMESweepSpec):
     """Spec for sweeping EME cell lengths."""
@@ -40,6 +55,11 @@ class EMELengthSweep(EMESweepSpec):
     def num_sweep(self) -> pd.PositiveInt:
         """Number of sweep indices."""
         return len(self.scale_factors)
+
+    @property
+    def sweep_cells(self) -> bool:
+        """Whether the sweep changes the propagation within a cell."""
+        return True
 
 
 class EMEModeSweep(EMESweepSpec):
@@ -60,6 +80,16 @@ class EMEModeSweep(EMESweepSpec):
     def num_sweep(self) -> pd.PositiveInt:
         """Number of sweep indices."""
         return len(self.num_modes)
+
+    @property
+    def sweep_interfaces(self) -> bool:
+        """Whether the sweep changes the cell interface scattering matrices."""
+        return True
+
+    @property
+    def sweep_cells(self) -> bool:
+        """Whether the sweep changes the propagation within a cell."""
+        return True
 
 
 class EMEFreqSweep(EMESweepSpec):
@@ -82,6 +112,21 @@ class EMEFreqSweep(EMESweepSpec):
     def num_sweep(self) -> pd.PositiveInt:
         """Number of sweep indices."""
         return len(self.freq_scale_factors)
+
+    @property
+    def sweep_modes(self) -> bool:
+        """Whether the sweep changes the modes."""
+        return True
+
+    @property
+    def sweep_interfaces(self) -> bool:
+        """Whether the sweep changes the cell interface scattering matrices."""
+        return True
+
+    @property
+    def sweep_cells(self) -> bool:
+        """Whether the sweep changes the propagation within a cell."""
+        return True
 
 
 class EMEPeriodicitySweep(EMESweepSpec):


### PR DESCRIPTION
This PR:

- Adds `EMECoefficientMonitor.fields` which can be a list of some of "A", "B", "overlaps", "interface_smatrices", "n_complex", and "flux"
- By default this is just ("A", "B") so the default behavior is unchanged. But now the other fields are also supported
- This unifies the behavior with `EMESimulationData.coeffs` which is like the full monitor but with no downsampling. `EMECoefficientMonitor` supports downsampling via `eme_cell_interval_space`, `num_sweep`, and `num_modes`.
- The memory computation and validation has also been unified and the warnings have been clarified for this and for the port modes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies EME coefficient handling and storage estimation while enabling selective coefficient capture.
> 
> - **`EMECoefficientMonitor`**: adds `fields` ("A", "B", "n_complex", "flux", "interface_smatrices", "overlaps"); `storage_size()` rewritten to be field- and sweep-aware and to use virtual EME cells
> - **Sweeps**: introduces `sweep_modes/interfaces/cells` flags on sweep specs; all EME monitor `storage_size()` methods now accept `sweep_spec` and respect per-monitor `num_sweep` limits
> - **Simulation integration**: adds `coeffs_full_monitor` and includes it in `_monitors_full` when `store_coeffs=True`; removes manual coeff size math in favor of monitor-based sizing
> - **Data model**: `EMESimulationData.coeffs` accepts `EMECoefficientData | EMECoefficientDataset`
> - **Validation & warnings**: per-monitor size map updated; specific warnings for large coeffs and port modes; schema updated to expose `fields`
> - **Tests**: cover default/custom `fields`, zero-storage edge case, sweep-specific scaling, per-monitor limits, and inclusion logic
> - **Docs/Changelog**: CHANGELOG entry for new monitor fields
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0975a4d8a38fafb4121f0f8a08faf496d757bc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR unifies the handling of EME coefficients by adding a configurable `fields` property to `EMECoefficientMonitor` that supports the same fields as `EMESimulationData.coeffs` ("A", "B", "n_complex", "flux", "interface_smatrices", "overlaps"). The default behavior remains unchanged with `fields=("A", "B")`, but users can now select additional fields with the benefit of downsampling via `eme_cell_interval_space`, `num_sweep`, and `num_modes`.

Key changes:
- Added `EMECoefficientMonitor.fields` property with comprehensive field selection options
- Refactored storage size calculation to be field-aware and accurate for each coefficient type
- Unified memory validation logic by moving coefficient storage from manual calculation to the monitor-based system
- Improved warning messages to distinguish between `store_coeffs` and `store_port_modes` warnings
- Changed `EMESimulationData.coeffs` type from `EMECoefficientDataset` to `EMECoefficientData` for consistency with monitor data architecture
- Added comprehensive tests covering field selection, storage calculation, and monitor inclusion logic

The implementation correctly calculates storage sizes for each field type based on their respective dimensionalities (cells, modes, interfaces, sweeps).

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with one minor docstring correction needed
- The implementation is solid with comprehensive tests and proper refactoring. The storage calculation logic is mathematically correct for each field type. Only one syntax issue was found: an incorrect docstring on `coeffs_full_monitor` that states it returns a mode solver monitor when it actually returns a coefficient monitor. This is a documentation issue that doesn't affect functionality but should be fixed for clarity.
- tidy3d/components/eme/simulation.py needs a docstring correction on line 594-595

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/components/eme/monitor.py | Added `fields` property to `EMECoefficientMonitor` with correct storage size calculation logic |
| tidy3d/components/eme/simulation.py | Unified coefficient monitoring logic with improved validation and clearer warnings, but has incorrect docstring |
| tests/test_components/test_eme.py | Added comprehensive tests for new fields functionality, storage calculation, and monitor inclusion logic |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant EMESimulation
    participant EMECoefficientMonitor
    participant storage_size
    participant validate_pre_upload
    
    User->>EMESimulation: Create simulation with store_coeffs=True
    EMESimulation->>EMECoefficientMonitor: Create coeffs_full_monitor
    Note over EMECoefficientMonitor: fields=("A", "B") by default<br/>num_sweep=None (all sweeps)
    
    User->>EMECoefficientMonitor: Optionally set custom fields
    Note over EMECoefficientMonitor: fields can include:<br/>"A", "B", "n_complex",<br/>"flux", "interface_smatrices",<br/>"overlaps"
    
    User->>EMESimulation: Call validate_pre_upload()
    EMESimulation->>EMESimulation: Build _monitors_full
    Note over EMESimulation: Includes coeffs_full_monitor<br/>if store_coeffs=True
    
    EMESimulation->>storage_size: Calculate storage for each monitor
    storage_size->>EMECoefficientMonitor: Calculate bytes based on fields
    Note over EMECoefficientMonitor: Adds bytes for each field:<br/>- A/B: 2*cells*modes²<br/>- n_complex/flux: cells*modes<br/>- interface_smatrices: 4*(cells-1)*modes²<br/>- overlaps: cells*modes² + 2*(cells-1)*modes²
    
    EMECoefficientMonitor-->>storage_size: Return total bytes
    storage_size-->>validate_pre_upload: Return size
    
    validate_pre_upload->>validate_pre_upload: Check if size > WARN_COEFF_DATA_SIZE_GB
    alt Size exceeds warning threshold
        validate_pre_upload->>User: Warn: coeffs storage too large
    end
    
    validate_pre_upload-->>User: Validation complete
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->