### PR TITLE
FXC-4931: Add log_once to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `warn_once` option to logging configuration (`td.config.logging.warn_once`) that causes each unique warning message to be shown only once per process, reducing noise from repeated validation warnings.
 
 ### Changed
 

--- a/tests/test_package/test_log.py
+++ b/tests/test_package/test_log.py
@@ -275,6 +275,59 @@ def test_log_suppression():
     td.config.log_suppression = True
 
 
+def test_warn_once():
+    """Test that warn_once setting causes each unique warning to only be shown once."""
+
+    # Clear the static cache to ensure clean test state
+    td.log._static_cache.clear()
+
+    # By default, warn_once should be False
+    assert td.log.warn_once is False
+    assert td.config.logging.warn_once is False
+
+    # Enable warn_once via config
+    td.config.logging.warn_once = True
+    assert td.log.warn_once is True
+
+    # First warning should go through
+    initial_cache_size = len(td.log._static_cache)
+    td.log.warning("unique_test_warning_message_1234")
+    assert len(td.log._static_cache) == initial_cache_size + 1
+    assert "unique_test_warning_message_1234" in td.log._static_cache
+
+    # Same warning should be skipped (cache doesn't grow)
+    td.log.warning("unique_test_warning_message_1234")
+    assert len(td.log._static_cache) == initial_cache_size + 1
+
+    # Different warning should go through
+    td.log.warning("different_warning_message_5678")
+    assert len(td.log._static_cache) == initial_cache_size + 2
+    assert "different_warning_message_5678" in td.log._static_cache
+
+    # Info messages should NOT be affected by warn_once
+    td.log.info("info_message_should_not_cache")
+    td.log.info("info_message_should_not_cache")
+    # Info messages don't use the cache when warn_once is enabled (only warnings do)
+    assert "info_message_should_not_cache" not in td.log._static_cache
+
+    # Error messages should NOT be affected by warn_once
+    td.log.error("error_message_should_not_cache")
+    td.log.error("error_message_should_not_cache")
+    assert "error_message_should_not_cache" not in td.log._static_cache
+
+    # Critical messages should NOT be affected by warn_once
+    td.log.critical("critical_message_should_not_cache")
+    td.log.critical("critical_message_should_not_cache")
+    assert "critical_message_should_not_cache" not in td.log._static_cache
+
+    # Disable warn_once
+    td.config.logging.warn_once = False
+    assert td.log.warn_once is False
+
+    # Clear cache for cleanup
+    td.log._static_cache.clear()
+
+
 def test_assert_log_level():
     """Test features of the assert_log_level"""
 

--- a/tidy3d/config/sections.py
+++ b/tidy3d/config/sections.py
@@ -23,7 +23,14 @@ from pydantic import (
 )
 
 from tidy3d._runtime import WASM_BUILD
-from tidy3d.log import DEFAULT_LEVEL, LogLevel, log, set_log_suppression, set_logging_level
+from tidy3d.log import (
+    DEFAULT_LEVEL,
+    LogLevel,
+    log,
+    set_log_suppression,
+    set_logging_level,
+    set_warn_once,
+)
 
 from .registry import get_manager as _get_attached_manager
 from .registry import register_handler, register_section
@@ -69,6 +76,12 @@ class LoggingConfig(ConfigSection):
         description="Suppress repeated log messages when True.",
     )
 
+    warn_once: bool = Field(
+        False,
+        title="Warn once",
+        description="When True, each unique warning message is only shown once per process.",
+    )
+
 
 @register_handler("logging")
 def apply_logging(config: LoggingConfig) -> None:
@@ -76,6 +89,7 @@ def apply_logging(config: LoggingConfig) -> None:
 
     set_logging_level(config.level)
     set_log_suppression(config.suppression)
+    set_warn_once(config.warn_once)
 
 
 @register_section("simulation")

--- a/tidy3d/log.py
+++ b/tidy3d/log.py
@@ -123,6 +123,7 @@ class Logger:
     def __init__(self) -> None:
         self.handlers = {}
         self.suppression = True
+        self.warn_once = False
         self._counts = None
         self._stack = None
         self._capture = False
@@ -251,8 +252,10 @@ class Logger:
     ) -> None:
         """Distribute log messages to all handlers"""
 
-        # Check global cache if requested (before composing/capturing to avoid duplicates)
-        if log_once:
+        # Check global cache if requested or if warn_once is enabled for warnings
+        # (before composing/capturing to avoid duplicates)
+        should_check_cache = log_once or (self.warn_once and level_name == "WARNING")
+        if should_check_cache:
             # Use the message body before composition as key
             if message in self._static_cache:
                 return
@@ -354,6 +357,17 @@ def set_logging_level(level: LogValue = DEFAULT_LEVEL) -> None:
 def set_log_suppression(value: bool) -> None:
     """Control log suppression for repeated messages."""
     log.suppression = value
+
+
+def set_warn_once(value: bool) -> None:
+    """Control whether warnings are only shown once per unique message.
+
+    Parameters
+    ----------
+    value : bool
+        When True, each unique warning message is only shown once per process.
+    """
+    log.warn_once = value
 
 
 def get_aware_datetime() -> datetime:


### PR DESCRIPTION
This adds a global logging config option to log messages only once (within the current process).

This keeps things nice and clean. We have many places in the notebooks where we set the logging level to "ERROR" because there are too many (usually identical) warnings. Switching to this usage would be much better as it shows the messages, but just once.

I think we should even switch this on in the solvers, so the solver log is kept clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces optional per-process suppression of duplicate warnings to reduce log noise.
> 
> - **Add** `td.config.logging.warn_once` in `LoggingConfig`; applied via `apply_logging()` calling `set_warn_once()`
> - **Implement** `Logger.warn_once` and cache check in `Logger._log()` so `WARNING` messages are shown once when enabled; reuse `_static_cache`
> - **Expose** `set_warn_once(value)` in `tidy3d/log.py`
> - **Tests**: `test_warn_once` verifies config toggle and cache behavior for warning/info/error/critical
> - **Docs**: CHANGELOG entry describing new option
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d0c1252c7f2485a8d52be133f9487f78a1a81ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds a global `warn_once` configuration option that suppresses repeated warning messages within the same process, keeping logs clean while still showing important warnings once.

- Added `warn_once` boolean field to `LoggingConfig` (defaults to `False`)
- Modified `Logger._log()` to check `_static_cache` for warnings when `warn_once` is enabled
- Added `set_warn_once()` function to control the setting programmatically
- Added comprehensive test coverage for the new functionality
- The implementation reuses the existing `_static_cache` and `log_once` parameter infrastructure

The change is backward-compatible and non-breaking. However, a CHANGELOG entry should be added to document this new user-facing feature.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor documentation improvements needed
- The implementation is clean, well-tested, and follows existing patterns in the codebase. It reuses the existing `_static_cache` infrastructure and integrates seamlessly with the config system. The only issue is the missing CHANGELOG entry, which is required for user-facing features per the project's custom rules.
- No files require special attention - the implementation is straightforward and properly tested

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/log.py | Added `warn_once` attribute and `set_warn_once` function; modified `_log` to check cache for warnings when enabled |
| tidy3d/config/sections.py | Added `warn_once` field to `LoggingConfig` and applied it in `apply_logging` handler; missing CHANGELOG entry |
| tests/test_package/test_log.py | Added comprehensive test `test_warn_once` covering config toggling, cache behavior, and different log levels |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Config as td.config.logging
    participant Logger as td.log
    participant Cache as _static_cache
    participant Handler as LogHandler
    
    User->>Config: Set warn_once = True
    Config->>Logger: set_warn_once(True)
    Logger->>Logger: self.warn_once = True
    
    User->>Logger: log.warning("message1")
    Logger->>Logger: Check if warn_once enabled
    alt warn_once is True
        Logger->>Cache: Check if "message1" in cache
        Cache-->>Logger: Not found
        Logger->>Cache: Add "message1" to cache
        Logger->>Handler: Forward warning to handlers
        Handler-->>User: Display warning
    end
    
    User->>Logger: log.warning("message1")
    Logger->>Logger: Check if warn_once enabled
    alt warn_once is True
        Logger->>Cache: Check if "message1" in cache
        Cache-->>Logger: Found in cache
        Logger-->>User: (No output - suppressed)
    end
    
    User->>Logger: log.info("message2")
    Logger->>Logger: Check if warn_once enabled
    Note over Logger,Cache: Info messages bypass cache check
    Logger->>Handler: Forward info to handlers
    Handler-->>User: Display info
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Update the CHANGELOG.md file when making changes that affect user-facing functionality or fix bugs. ([source](https://app.greptile.com/review/custom-context?memory=a109c62a-aa8c-4cc4-b515-0ad947c47929))

<!-- /greptile_comment -->