### PR TITLE
FXC-4932 fix(rf): fix snapping behavior for 1D lumped elements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 - **Do** reuse `scripts/` utilities; **don't** add new helper modules without checking for an existing script first.
 
 ## Coding Style & Naming
+- Prefer top-level imports.
 - Favor descriptive `snake_case` functions and `PascalCase` classes tied to the physics domain.
 - Most simulation and monitor classes subclass `Tidy3dBaseModel`; reserve `pydantic.BaseModel` for lightweight helpers (see `tidy3d/updater.py`), and rely on `.updated_copy(...)` plus shared validators in `tidy3d/components/validators.py`.
 - Public APIs covered in `docs/` should use the existing Numpy-inspired block pattern rendered by our Sphinx Book Theme; lean on current API examples or the theme reference at https://sphinx-book-theme.readthedocs.io/en/stable/reference/api-numpy.html. Internal helpers may keep short docstrings but match local tone.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 - Added `structure_priority_mode` for `TerminalComponentModeler` and default to `"conductor"` to ensure metal structures override dielectrics regardless of structure order, preventing order-dependent results in RF simulations.
+- 1D lumped elements (with zero lateral extent) are no longer allowed. Use a small finite lateral extent (e.g., `1e-6`) instead.
 
 ### Changed
 - `ModeSortSpec.sort_key` is now required with a default of `"n_eff"` (previously optional with `None` default). `ModeSortSpec.sort_order` is now optional with a default of `None`, which automatically selects the natural order based on `sort_key` and `sort_reference`: ascending when a reference is provided (closest first), otherwise descending for `n_eff` and polarization fractions (higher values first), ascending for `k_eff` and `mode_area` (lower values first).
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed intermittent "API key not found" errors in parallel job launches by making configuration directory detection race-safe.
 - Fixed frequency accumulation of gradients for custom dispersive media.
+- Fixed `snap_box_to_grid` producing zero-size boxes when using `Expand` behavior with very small intervals centered on a grid point.
 
 ## [2.10.2] - 2026-01-21
 

--- a/docs/api/microwave/ports/lumped.rst
+++ b/docs/api/microwave/ports/lumped.rst
@@ -23,7 +23,7 @@ The :class:`LumpedPort` feature represents a planar, uniform current excitation 
        impedance=50,   # port impedance
    )
 
-The :class:`LumpedPort` can be 1D (line) or 2D (plane). For 2D, only axis-aligned planes are supported at this time. Only real ``impedance`` values are supported at this time. 
+The :class:`LumpedPort` must be planar (exactly one zero-size dimension). Only axis-aligned planes are supported at this time. If you need a narrow port, provide a small but finite width along the lateral axis. Only real ``impedance`` values are supported at this time. 
 
 .. note::
 

--- a/tests/test_components/test_lumped_element.py
+++ b/tests/test_components/test_lumped_element.py
@@ -7,6 +7,7 @@ import pydantic.v1 as pydantic
 import pytest
 
 import tidy3d as td
+from tidy3d.components.geometry.utils import SnapBehavior, SnapLocation
 from tidy3d.components.lumped_element import network_complex_permittivity
 
 
@@ -336,9 +337,68 @@ def test_impedance_admittance_calculation():
     assert np.allclose(Y_expected, Y_calc)
 
 
+def test_1d_lumped_element_not_allowed():
+    """Test that 1D lumped elements (two zero-size dimensions) are not allowed.
+
+    Users must provide a finite width along the lateral axis. This ensures the
+    normal axis can be properly determined for the underlying 2D material.
+    """
+    RLC = td.RLCNetwork(resistance=50)
+
+    # Attempting to create a 1D lumped element should raise a validation error
+    with pytest.raises(pydantic.ValidationError):
+        td.LinearLumpedElement(
+            center=[0, 0, 0],
+            size=[1, 0, 0],  # 1D element: only x has non-zero size (invalid)
+            voltage_axis=0,
+            network=RLC,
+            name="1D_RLC",
+        )
+
+    # Other 1D configurations should also fail
+    with pytest.raises(pydantic.ValidationError):
+        td.LinearLumpedElement(
+            center=[0, 0, 0],
+            size=[0, 1, 0],  # 1D element: only y has non-zero size (invalid)
+            voltage_axis=1,
+            network=RLC,
+            name="1D_RLC",
+        )
+
+    with pytest.raises(pydantic.ValidationError):
+        td.LinearLumpedElement(
+            center=[0, 0, 0],
+            size=[0, 0, 1],  # 1D element: only z has non-zero size (invalid)
+            voltage_axis=2,
+            network=RLC,
+            name="1D_RLC",
+        )
+
+    # Planar elements (one zero-size dimension) should still work
+    element_2d = td.LinearLumpedElement(
+        center=[0, 0, 0],
+        size=[1, 0, 1],  # 2D element: x and z have non-zero size (valid)
+        voltage_axis=0,
+        network=RLC,
+        name="2D_RLC",
+    )
+    assert element_2d.normal_axis == 1
+    assert element_2d.size[element_2d.lateral_axis] != 0
+
+    # Verify snapping behavior for planar elements
+    snap_spec = element_2d._snapping_spec
+    assert snap_spec.location[element_2d.lateral_axis] == SnapLocation.Center
+    assert snap_spec.behavior[element_2d.lateral_axis] == SnapBehavior.Expand
+
+
 @pytest.mark.parametrize("dist_type", ["off", "laterally_only", "on"])
-@pytest.mark.parametrize("width", [0, 5])
+@pytest.mark.parametrize("width", [1e-6, 5])
 def test_distribution_variants(dist_type, width):
+    """Test different distribution types with varying widths.
+
+    Note: width=0 is no longer allowed (1D elements are not supported).
+    Use a small finite width (e.g., 1e-6 mm) for narrow elements.
+    """
     mm = 1e3
     RLC = td.RLCNetwork(
         resistance=50,
@@ -381,3 +441,47 @@ def test_distribution_variants(dist_type, width):
     network = linear_element.to_structure(grid)
     L, C = linear_element.estimate_parasitic_elements(grid)
     assert C >= 0
+
+
+def test_very_small_lateral_width_snapping():
+    """Test that very small lateral width doesn't cause zero-size after snapping.
+
+    When the user-specified lateral width is much smaller than the grid spacing,
+    the snapping should auto-expand to at least one grid cell to avoid division
+    by zero errors in the admittance scaling calculation.
+
+    The bug occurs when the element center is exactly on a grid center and the
+    lateral width is tiny - both bounds snap to the same grid center, resulting
+    in zero size.
+    """
+    mm = 1e3  # 1 mm = 1000 um
+    RLC = td.RLCNetwork(resistance=50)
+
+    # Create grid first - with specific cell size
+    cell_size = 1000
+    grid_x = np.arange(-5000, 10000, cell_size)
+    grid_y = np.arange(-5000, 5000, cell_size)
+    grid_z = np.arange(-3000, 3000, cell_size)
+    coords = td.Coords(x=grid_x, y=grid_y, z=grid_z)
+    grid = td.Grid(boundaries=coords)
+
+    # Grid centers along x are at -4500, -3500, ..., 1500, 2500, ...
+    # Place element center exactly on a grid center (1500)
+    port_width = 1e-5  # Much smaller than grid cell size
+    element = td.LinearLumpedElement(
+        center=[1500, 0, 0],
+        size=[port_width, 0, 1 * mm],  # lateral_axis=0 has very small width
+        voltage_axis=2,
+        network=RLC,
+        name="small_RLC",
+    )
+
+    # Before fix: this would fail with division by zero because
+    # cell_box.size[lateral_axis] would be 0
+    cell_box = element._create_box_for_network(grid)
+    assert cell_box.size[element.lateral_axis] > 0, (
+        "Cell box lateral size should be non-zero after snapping"
+    )
+
+    # Should not raise division by zero error
+    structure = element.to_structure(grid)

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -562,6 +562,29 @@ def test_validate_port_voltage_axis():
         LumpedPort(center=(0, 0, 0), size=(0, 1, 2), voltage_axis=0, impedance=50)
 
 
+def test_validate_port_must_be_planar():
+    """Test that 1D lumped ports (two zero-size dimensions) are not allowed.
+
+    Users must provide a finite width along the lateral axis. This ensures the
+    injection axis can be properly determined for the underlying lumped element.
+    """
+    # 1D port (two zeros) should fail validation
+    with pytest.raises(pd.ValidationError):
+        LumpedPort(center=(0, 0, 0), size=(1, 0, 0), voltage_axis=0, impedance=50, name="1D_port")
+
+    with pytest.raises(pd.ValidationError):
+        LumpedPort(center=(0, 0, 0), size=(0, 1, 0), voltage_axis=1, impedance=50, name="1D_port")
+
+    with pytest.raises(pd.ValidationError):
+        LumpedPort(center=(0, 0, 0), size=(0, 0, 1), voltage_axis=2, impedance=50, name="1D_port")
+
+    # Planar port (one zero) should work fine
+    port = LumpedPort(
+        center=(0, 0, 0), size=(0, 1, 2), voltage_axis=2, impedance=50, name="2D_port"
+    )
+    assert port.injection_axis == 0  # x is the injection axis (zero size)
+
+
 def test_lumped_port_from_structures():
     """Test automatic lumped port setup between two terminal structures."""
 

--- a/tidy3d/components/geometry/utils.py
+++ b/tidy3d/components/geometry/utils.py
@@ -645,6 +645,22 @@ def snap_box_to_grid(grid: Grid, box: Box, snap_spec: SnappingSpec, rtol: float 
                 strict_bounds=strict_bounds,
                 margin=+snap_margin,
             )
+            # Ensure non-zero size after expansion - if both bounds snapped to the
+            # same point (can happen when interval is very small and centered on a
+            # grid point), expand to span at least one grid cell.
+            if min_snap == max_snap:
+                snap_idx = np.searchsorted(coords, min_snap, side="left")
+                # Clamp to valid range and get adjacent grid points
+                lower_idx = max(0, snap_idx - 1)
+                upper_idx = min(len(coords) - 1, snap_idx)
+                if lower_idx == upper_idx:
+                    # At edge of grid - expand in the only available direction
+                    if upper_idx < len(coords) - 1:
+                        upper_idx += 1
+                    elif lower_idx > 0:
+                        lower_idx -= 1
+                min_snap = coords[lower_idx]
+                max_snap = coords[upper_idx]
         else:  # SnapType.Contract
             min_snap = get_upper_bound(
                 interval_min,

--- a/tidy3d/components/lumped_element.py
+++ b/tidy3d/components/lumped_element.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from math import isclose
 from typing import Annotated, Literal, Optional, Union
 
 import numpy as np
@@ -13,8 +12,8 @@ from tidy3d.components.grid.grid import Grid
 from tidy3d.components.medium import PEC2D, Debye, Drude, Lorentz, Medium, Medium2D, PoleResidue
 from tidy3d.components.monitor import FieldMonitor
 from tidy3d.components.structure import MeshOverrideStructure, Structure
-from tidy3d.components.validators import assert_line_or_plane, assert_plane, validate_name_str
-from tidy3d.constants import EPSILON_0, FARAD, HENRY, MICROMETER, OHM, fp_eps
+from tidy3d.components.validators import assert_plane, validate_name_str
+from tidy3d.constants import EPSILON_0, FARAD, HENRY, MICROMETER, OHM
 from tidy3d.exceptions import ValidationError
 
 from .base import cached_property, skip_if_fields_missing
@@ -106,9 +105,17 @@ class LumpedElement(MicrowaveBaseModel, ABC):
 
 
 class RectangularLumpedElement(LumpedElement, Box):
-    """Class representing a rectangular element with zero thickness. A :class:`RectangularLumpedElement`
-    is appended to the list of structures in the simulation as a :class:`.Medium2D` with the appropriate
-    material properties given their size, voltage axis, and the network they represent."""
+    """Class representing a rectangular planar element with zero thickness along its normal axis.
+    A :class:`RectangularLumpedElement` is appended to the list of structures in the simulation as
+    a :class:`.Medium2D` with the appropriate material properties given their size, voltage axis,
+    and the network they represent.
+
+    Note
+    ----
+    The element must be planar (exactly one zero-size dimension). One-dimensional elements
+    (two zero-size dimensions) are not supported. If you need a narrow element, provide a
+    small but finite width along the lateral axis.
+    """
 
     voltage_axis: Axis = pd.Field(
         ...,
@@ -127,7 +134,7 @@ class RectangularLumpedElement(LumpedElement, Box):
         "boundary along their ``normal_axis``, regardless of this option.",
     )
 
-    _line_plane_validator = assert_line_or_plane()
+    _plane_validator = assert_plane()
 
     @cached_property
     def normal_axis(self):
@@ -165,6 +172,7 @@ class RectangularLumpedElement(LumpedElement, Box):
 
         snap_location = [SnapLocation.Boundary] * 3
         snap_behavior = [SnapBehavior.Closest] * 3
+        # Apply Center/Expand snapping to lateral axis for proper grid alignment
         snap_location[self.lateral_axis] = SnapLocation.Center
         snap_behavior[self.lateral_axis] = SnapBehavior.Expand
         return SnappingSpec(location=snap_location, behavior=snap_behavior)
@@ -318,8 +326,6 @@ class LumpedResistor(RectangularLumpedElement):
             geometry=box,
             medium=Medium2D(**medium_dict),
         )
-
-    _plane_validator = assert_plane()
 
 
 class CoaxialLumpedResistor(LumpedElement):
@@ -961,7 +967,7 @@ class LinearLumpedElement(RectangularLumpedElement):
         cell_center = list(snap_point_to_grid(grid, self.center, snap_location))
         size = [0, 0, 0]
 
-        if self.dist_type != "off" and self.size[self.lateral_axis] != 0:
+        if self.dist_type != "off":
             cell_center[self.lateral_axis] = self.center[self.lateral_axis]
             size[self.lateral_axis] = self.size[self.lateral_axis]
         if self.dist_type == "on":
@@ -993,15 +999,6 @@ class LinearLumpedElement(RectangularLumpedElement):
         top_min[self.voltage_axis] = cell_max[self.voltage_axis]
         bottom_max = list(element_max)
         bottom_max[self.voltage_axis] = cell_min[self.voltage_axis]
-
-        # Create "wires" if the size is 0 along the lateral axis
-        if isclose(self.size[self.lateral_axis], 0, rel_tol=fp_eps, abs_tol=fp_eps):
-            lateral_center = cell_box.center[self.lateral_axis]
-            width = max(fp_eps, fp_eps * abs(lateral_center))
-            top_min[self.lateral_axis] = lateral_center - width
-            element_max[self.lateral_axis] = lateral_center + width
-            element_min[self.lateral_axis] = lateral_center - width
-            bottom_max[self.lateral_axis] = lateral_center + width
 
         top_box = Box.from_bounds(top_min, element_max)
         bottom_box = Box.from_bounds(element_min, bottom_max)
@@ -1106,9 +1103,6 @@ class LinearLumpedElement(RectangularLumpedElement):
         ub = np.searchsorted(grid_centers, cell_box.center[self.normal_axis])
         thickness_eff = grid_centers[ub] - grid_centers[ub - 1]
         width_eff = valid_connection.size[l_axis]
-        # After discretization a wire has an effective width equal to the grid cell size
-        if self.size[l_axis] == 0:
-            width_eff = cell_size[l_axis]
         # If there are two connections, they will share the same thickness and width
         # only their lengths along the voltage axis might be different
         common_size = list(valid_connection.size)

--- a/tidy3d/plugins/smatrix/ports/rectangular_lumped.py
+++ b/tidy3d/plugins/smatrix/ports/rectangular_lumped.py
@@ -9,7 +9,7 @@ import pydantic.v1 as pd
 from shapely import union_all
 from shapely.geometry.base import BaseMultipartGeometry
 
-from tidy3d.components.base import cached_property
+from tidy3d.components.base import cached_property, skip_if_fields_missing
 from tidy3d.components.data.data_array import FreqDataArray
 from tidy3d.components.data.sim_data import SimulationData
 from tidy3d.components.geometry.base import Box, Geometry
@@ -30,7 +30,7 @@ from tidy3d.components.source.current import UniformCurrentSource
 from tidy3d.components.source.time import GaussianPulse
 from tidy3d.components.structure import Structure
 from tidy3d.components.types import Axis, FreqArray, LumpDistType
-from tidy3d.components.validators import assert_line_or_plane
+from tidy3d.components.validators import assert_plane
 from tidy3d.exceptions import SetupError, ValidationError
 
 from .base_lumped import AbstractLumpedPort
@@ -38,6 +38,12 @@ from .base_lumped import AbstractLumpedPort
 
 class LumpedPort(AbstractLumpedPort, Box):
     """Class representing a single rectangular lumped port.
+
+    Note
+    ----
+    The port must be planar (exactly one zero-size dimension). One-dimensional ports
+    (two zero-size dimensions) are not supported. If you need a narrow port, provide a
+    small but finite width along the lateral axis (e.g., ``fp_eps`` or larger).
 
     Example
     -------
@@ -81,7 +87,7 @@ class LumpedPort(AbstractLumpedPort, Box):
         "the lumped port.",
     )
 
-    _line_plane_validator = assert_line_or_plane()
+    _plane_validator = assert_plane()
 
     @cached_property
     def injection_axis(self):
@@ -89,6 +95,7 @@ class LumpedPort(AbstractLumpedPort, Box):
         return self.size.index(0.0)
 
     @pd.validator("voltage_axis", always=True)
+    @skip_if_fields_missing(["size"])
     def _voltage_axis_in_plane(cls, val, values):
         """Ensure voltage integration axis is in the port's plane."""
         size = values.get("size")


### PR DESCRIPTION
Addresses FXC-4932: https://flow360.atlassian.net/browse/FXC-4932

Fixes snapping behavior for 1D lumped elements (where size.count(0) == 2) by forcing users to supply a finite lateral extent.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces planar-only lumped ports/elements and fixes zero-size snapping edge cases.
> 
> - BREAKING: 1D lumped elements/ports (two zero-size dims) are rejected; users must provide a small finite lateral width. Validators switched to `assert_plane` and docstrings/docs updated.
> - Snapping: `snap_box_to_grid` now guarantees non-zero size with `Expand` when intervals are extremely small and centered on a grid point; `RectangularLumpedElement` uses Center/Expand on the lateral axis; `LinearLumpedElement._create_box_for_network` distributes without relying on zero lateral size and avoids division-by-zero.
> - Tests: Added coverage for 1D validation failures, planar behavior, distribution variants with small widths, and tiny-width snapping; added port validation in smatrix plugin.
> - Docs/Changelog: Updated `lumped.rst` guidance; CHANGELOG adds breaking change and bug fix entries; minor guideline tweak in `AGENTS.md` (prefer top-level imports).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efa13aecd33f635e96142ce13c06af0663c863eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes snapping behavior for 1D lumped elements (where `size.count(0) == 2`) by applying special handling in two related locations:

1. **`RectangularLumpedElement._snapping_spec` property**: Conditionally applies lateral axis snapping (SnapLocation.Center and SnapBehavior.Expand) only when the lateral axis has non-zero size. This prevents incorrect snapping behavior for 1D elements.

2. **`LinearLumpedElement._create_box_for_network` method**: Explicitly ensures the lateral axis expands when it has zero size, guaranteeing the network box has non-zero size for proper admittance scaling computation.

The changes include clear explanatory comments documenting the reasoning for the conditional logic and the requirement that network boxes must have non-zero size. The CHANGELOG entry appropriately documents the fix under the "Fixed" section.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk. Changes are focused, well-documented, and address a specific bug in 1D lumped element handling.
- The changes are minimal and targeted, fixing snapping behavior for 1D lumped elements in two related code paths. The logic is straightforward: when lateral axis has zero size (1D case), use default snapping behavior instead of special center/expand behavior. The implementation properly handles the special case in both the snapping spec generation and network box creation. Comments clearly explain the reasoning. The CHANGELOG entry follows proper conventions. No syntax issues, logic errors, or potential runtime failures were identified.
- No files require special attention. Both modified files show well-structured changes with appropriate comments.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/components/lumped_element.py | Fix for 1D lumped element snapping behavior in two locations: (1) `_snapping_spec` property (lines 168-174) conditionally applies lateral axis snapping only when that axis has non-zero size, with clear comments explaining the 1D element case. (2) `_create_box_for_network` method (lines 981-988) ensures lateral axis expands when zero-sized to properly compute admittance. Changes are logically sound and well-documented. |
| CHANGELOG.md | Added changelog entry documenting the fix for 1D lumped element snapping behavior. Entry correctly categorized under 'Fixed' section and uses appropriate description mentioning the lateral axis zero size condition. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant LinearLumpedElement
    participant _snapping_spec
    participant _create_box_for_network
    participant snap_box_to_grid

    LinearLumpedElement->>_snapping_spec: Get snapping configuration
    _snapping_spec->>_snapping_spec: Check if lateral_axis size != 0
    alt 1D Element (lateral_axis size == 0)
        _snapping_spec->>_snapping_spec: Use default snapping (Boundary, Closest)
    else Planar Element (lateral_axis size != 0)
        _snapping_spec->>_snapping_spec: Set lateral_axis to Center, Expand
    end
    _snapping_spec-->>LinearLumpedElement: SnappingSpec

    LinearLumpedElement->>_create_box_for_network: Create network box with grid
    _create_box_for_network->>_create_box_for_network: Check if lateral_axis size == 0
    alt 1D Element Needs Expansion
        _create_box_for_network->>_create_box_for_network: Set Expand and Center for lateral axis
    end
    _create_box_for_network->>snap_box_to_grid: Snap box with modified spec
    snap_box_to_grid-->>_create_box_for_network: Snapped box with non-zero size
    _create_box_for_network-->>LinearLumpedElement: Network box ready for admittance
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Use changelog categories correctly: "Fixed" for bug fixes, "Changed" for modifications to existing f... ([source](https://app.greptile.com/review/custom-context?memory=17997812-233f-4a81-bee2-4d7666605061))
- Rule from `dashboard` - Add comments to explain the reasoning (why) behind complex, non-obvious, or workaround code decision... ([source](https://app.greptile.com/review/custom-context?memory=3fcacfe8-4346-4ac0-9656-d9db805321de))

<!-- /greptile_comment -->