### PR TITLE
Fix: pydantic model_fields warning

### DIFF
--- a/tidy3d/config/sections.py
+++ b/tidy3d/config/sections.py
@@ -266,7 +266,7 @@ def apply_adjoint(config: AdjointConfig) -> None:
     defaults = AdjointConfig()
     overridden = [
         name
-        for name in config.model_fields
+        for name in type(config).model_fields
         if name != "local_gradient" and getattr(config, name) != getattr(defaults, name)
     ]
     if not overridden:


### PR DESCRIPTION
I got this when running some tests:

```
16:33:53 CET ERROR: Failed to apply configuration handler for 'adjoint':        
             Accessing the 'model_fields' attribute on the instance is          
             deprecated. Instead, you should access this attribute from the     
             model class. Deprecated in Pydantic V2.11 to be removed in V3.0. 
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses a Pydantic v2.11 deprecation warning in autograd config handling.
> 
> - In `tidy3d/config/sections.py`, `apply_adjoint` now accesses `model_fields` via the class (`type(config).model_fields`) instead of the instance to avoid the warning
> - No behavioral changes; only eliminates deprecation noise during config handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 586217e8f770380e6ff015eae212b48ff13f81a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed Pydantic V2.11 deprecation warning by accessing `model_fields` from the model class instead of the instance in the `apply_adjoint()` configuration handler.

- Changed `config.model_fields` to `type(config).model_fields` on line 269
- This aligns with Pydantic V2.11+ requirements where instance access to `model_fields` is deprecated and will be removed in V3.0
- No functional changes to the code behavior, only addresses the deprecation warning

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a straightforward fix for a Pydantic deprecation warning with no behavioral changes. The fix correctly changes instance attribute access to class attribute access, which is the proper way to access `model_fields` in Pydantic V2.11+. All other uses of `model_fields` in the codebase already access it from the class correctly.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/config/sections.py | Fixed Pydantic V2.11 deprecation warning by accessing `model_fields` from the class instead of instance |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ConfigManager
    participant apply_adjoint
    participant AdjointConfig

    User->>ConfigManager: Load/apply configuration
    ConfigManager->>apply_adjoint: apply_adjoint(config)
    Note over apply_adjoint: config is AdjointConfig instance
    apply_adjoint->>AdjointConfig: type(config).model_fields
    Note over AdjointConfig: Access from class (not instance)
    AdjointConfig-->>apply_adjoint: Returns field definitions
    apply_adjoint->>apply_adjoint: Check for overridden fields
    alt Has overridden fields & local_gradient=False
        apply_adjoint->>User: Log warning about ignored overrides
    end
    apply_adjoint-->>ConfigManager: Configuration applied
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->