### PR TITLE
fix: taking BatchDetail taskType from statistics api

### DIFF
--- a/tidy3d/web/core/task_core.py
+++ b/tidy3d/web/core/task_core.py
@@ -830,6 +830,10 @@ class SimulationTask(WebTask):
 class BatchTask(WebTask):
     """Interface for managing a batch task on the server."""
 
+    task_type: Optional[str] = Field(
+        None, title="task_type", description="The type of task.", alias="taskType"
+    )
+
     @classmethod
     def get(cls, task_id: str, verbose: bool = True) -> BatchTask:
         """Get batch task by id.
@@ -851,8 +855,11 @@ class BatchTask(WebTask):
         except WebNotFoundError as e:
             td.log.error(f"The requested batch ID '{task_id}' does not exist.")
             raise e
-        # We only need to validate existence; store id on the instance.
-        return BatchTask(taskId=task_id) if resp else None
+        # Extract taskType from response if available
+        if resp:
+            task_type = resp.get("taskType") if isinstance(resp, dict) else None
+            return BatchTask(taskId=task_id, taskType=task_type)
+        return None
 
     def detail(self) -> BatchDetail:
         """Fetches the detailed information and status of the batch.

--- a/tidy3d/web/core/task_info.py
+++ b/tidy3d/web/core/task_info.py
@@ -259,7 +259,7 @@ class BatchDetail(TaskBase):
     message: str = None
     tasks: list[BatchMember] = []
     validateErrors: dict = None
-    taskType: str = "RF"
+    taskType: str = None
     version: str = None
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Aligns batch task typing with server-provided data.
> 
> - Add `task_type` to `BatchTask` and populate it in `BatchTask.get` from `rf/task/{id}/statistics`
> - Set `BatchDetail.taskType` default to `None` (was `"RF"`) so the type reflects backend data
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24c4f52922b7c8b864f26eca5297772bd0ee2a18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes how `BatchDetail` gets its `taskType` by sourcing it from the statistics API response instead of using a hardcoded `"RF"` default. The `BatchTask` class now includes a `task_type` field and extracts it from the API response when calling `BatchTask.get()`.

Key changes:
- Added `task_type` field to `BatchTask` class with alias `"taskType"`
- Modified `BatchTask.get()` to extract and pass `taskType` from the statistics API response
- Changed `BatchDetail.taskType` default from `"RF"` to `None` to rely on API data

The change assumes the statistics API (`rf/task/{task_id}/statistics`) consistently returns the `taskType` field. This is important because downstream code at `tidy3d/web/api/webapi.py:1455` uses this value to determine the check task type.

<h3>Confidence Score: 4/5</h3>


- Safe to merge with minimal risk, assuming the statistics API consistently returns taskType
- The change improves code by sourcing taskType from the API instead of hardcoding a default value. The implementation is defensive with isinstance checks. Main risk is if the statistics API doesn't consistently return taskType, which could result in None values.
- Pay attention to `tidy3d/web/core/task_info.py` to ensure the API returns taskType

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/web/core/task_core.py | Adds `task_type` field to `BatchTask` and extracts it from statistics API response in the `get()` method |
| tidy3d/web/core/task_info.py | Changes `BatchDetail.taskType` default from hardcoded `"RF"` to `None` to receive actual value from API |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant BatchTask
    participant HTTP
    participant API as Statistics API
    participant BatchDetail

    Note over Client,BatchDetail: BatchTask.get() flow
    Client->>BatchTask: get(task_id)
    BatchTask->>HTTP: get("rf/task/{task_id}/statistics")
    HTTP->>API: GET request
    API-->>HTTP: response with taskType
    HTTP-->>BatchTask: resp dict
    BatchTask->>BatchTask: Extract taskType from response
    BatchTask->>Client: return BatchTask(taskId, taskType)

    Note over Client,BatchDetail: BatchTask.detail() flow
    Client->>BatchTask: detail()
    BatchTask->>HTTP: get("rf/task/{task_id}/statistics")
    HTTP->>API: GET request
    API-->>HTTP: response with taskType and other fields
    HTTP-->>BatchTask: resp dict
    BatchTask->>BatchDetail: BatchDetail(**resp)
    BatchDetail-->>BatchTask: BatchDetail instance (taskType from API)
    BatchTask-->>Client: return BatchDetail
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->