### PR TITLE
handle 0 local grid or normal component in shape gradient coordinate snapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed interpolation handling for permittivity and conductivity gradients in `CustomPoleResidue`.
 - Fixed docstrings with missing Notes sections causing spurious parameters in Sphinx documentation.
+- Fixed coordinate snapping in shape gradient computation to handle 0 normal and grid spacing components.
 
 ## [2.10.1] - 2026-01-14
 

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -568,11 +568,27 @@ class DerivativeInfo:
                 grid_centers_select[nearest_grid] - grid_centers_select[nearest_grid - 1]
             )
 
-        # assuming we move in the normal direction, finds which dimension we need to move the least
+        #
+        # Assuming we move in the normal direction, finds which dimension we need to move the least
         # in order to ensure we snap to a point outside the boundary in the worst case (i.e. - the
         # nearest point is just inside the surface)
+        #
+        # Cover for 2D cases using filter below:
+        # 2D case 1:
+        #    - in plane gradients where normal: [a, b, 0] and grid: [dx, dy, 0]
+        #    - want to rely on in plane normals for boundary snapping (filter on normal component = 0)
+        # 2D case 2:
+        #    - out of plane gradietns where normal: [0, 0, 1] and grid: [dx, dy, 0]
+        #    - want to rely on out of plane normal (so do not want to filter on grid component = 0)
+        #    - data may not be captured out of plane, so no snapping will occur even with coords_dn = 0
+        #
+        small_number = np.finfo(normals.dtype).eps
         coords_dn = np.min(
-            np.abs(grid_ddim) / (np.abs(normals) + np.finfo(normals.dtype).eps),
+            np.where(
+                (np.abs(normals) > small_number),
+                np.abs(grid_ddim) / (np.abs(normals) + small_number),
+                np.inf,
+            ),
             axis=1,
             keepdims=True,
         )


### PR DESCRIPTION
Bugfix from shape gradient overhaul PR that I caught when updating RF optimization notebook for the patch antenna. 

When normal components or the local grid from the data array coordinates are 0 it can lead to the coordinate snapping not working properly. This is a case I would have expected to come up in the numerical tests I ran, but I didn't come cross it until running the RF autograd notebook. 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses a bug in shape-gradient boundary snapping that failed when a normal or local grid spacing component was zero.
> 
> - Updates `_snap_spatial_coords_boundary` in `derivative_utils.py` to use an epsilon-guarded `np.where(...)` and `np.inf` masking, preventing division by zero and correctly handling 2D normals/components
> - Keeps snapping direction logic intact; only the `coords_dn` computation is made robust
> - Adds a corresponding "Fixed" entry to `CHANGELOG.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 951cc32f8df802c8bd461850e89eac7c730a3b73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed a bug in shape gradient coordinate snapping that occurred when normal components or local grid spacing were 0, which prevented proper coordinate adjustment.

- Replaced direct division with conditional `np.where()` logic that returns `np.inf` when either normal component or grid spacing is effectively 0 (below machine epsilon)
- This prevents division by zero and ensures coordinates are properly snapped to grid centers outside/inside boundaries
- Bug was discovered during RF optimization notebook testing with patch antenna

**Issue found:**
- Duplicate line at line 585 should be removed (same assignment repeated at line 589)

<h3>Confidence Score: 3/5</h3>


- Safe to merge after removing the duplicate line on line 585
- The core bug fix is correct and addresses a real issue with division by zero when normal components or grid spacing are 0. However, there's a duplicate line that should be removed before merging
- tidy3d/components/autograd/derivative_utils.py - remove duplicate line 585

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Added appropriate bug fix entry under Fixed section |
| tidy3d/components/autograd/derivative_utils.py | Fixed 0-component handling in coordinate snapping, but contains duplicate line |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as Shape Gradient Computation
    participant SGF as snap_coordinates_to_grid()
    participant NumPy as NumPy Operations
    
    Caller->>SGF: spatial_coords, normals, is_outside, data_array
    Note over SGF: Extract grid centers from data_array.coords
    
    loop For each dimension (x, y, z)
        SGF->>NumPy: Find nearest grid center
        SGF->>NumPy: Compute local grid spacing (grid_ddim)
    end
    
    Note over SGF: Calculate small_number = eps
    
    SGF->>NumPy: np.where() to filter valid components
    Note over NumPy: If |normal| > eps AND |grid_ddim| > eps:<br/>compute grid_ddim / |normal|<br/>else: return inf
    
    SGF->>NumPy: np.min() to find minimum movement needed
    Note over SGF: coords_dn = minimum distance to move
    
    Note over SGF: Determine normal_direction (+1 or -1)
    
    SGF->>NumPy: Adjust coordinates along normal
    Note over NumPy: adjusted = coords + direction * normals * fraction * coords_dn
    
    SGF-->>Caller: Return adjusted spatial coordinates
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->