### PR TITLE
Remove support for inconsistent interp_spec in EME (FXC-4152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed docstrings with missing Notes sections causing spurious parameters in Sphinx documentation.
 - Fixed coordinate snapping in shape gradient computation to handle 0 normal and grid spacing components.
 - Fixed duplicate printing of cost estimation of `Job`.
+- Fixed EME with inconsistent `interp_spec`.
 
 ## [2.10.1] - 2026-01-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed docstrings with missing Notes sections causing spurious parameters in Sphinx documentation.
 - Fixed coordinate snapping in shape gradient computation to handle 0 normal and grid spacing components.
 - Fixed duplicate printing of cost estimation of `Job`.
-- Fixed EME with inconsistent `interp_spec`.
+- Fixed `outer_dot` with EME port modes `interpolated_copy`.
+
+### Removed
+- Removed support for inconsistent `interp_specs` in the EME grid.
 
 ## [2.10.1] - 2026-01-14
 

--- a/tests/test_components/test_eme.py
+++ b/tests/test_components/test_eme.py
@@ -1334,6 +1334,33 @@ def test_eme_sim_data():
             eme_cell_index=0,
         )
 
+    # test _validate_interp_specs warning for inconsistent interp_specs
+    mode_spec1 = td.EMEModeSpec(num_modes=10, interp_spec=td.ModeInterpSpec.cheb(num_points=3))
+    mode_spec2 = td.EMEModeSpec(num_modes=10, interp_spec=td.ModeInterpSpec.cheb(num_points=5))
+    eme_grid_spec_inconsistent = td.EMECompositeGrid(
+        subgrids=[
+            td.EMEUniformGrid(num_cells=2, mode_spec=mode_spec1),
+            td.EMEUniformGrid(num_cells=2, mode_spec=mode_spec2),
+        ],
+        subgrid_boundaries=[0],
+    )
+    with AssertLogLevel("WARNING", contains_str="interp_spec"):
+        sim_interp_test = sim.updated_copy(eme_grid_spec=eme_grid_spec_inconsistent)
+
+    # test _validate_interp_specs no warning for consistent interp_specs
+    mode_spec_consistent = td.EMEModeSpec(
+        num_modes=10, interp_spec=td.ModeInterpSpec.cheb(num_points=4)
+    )
+    eme_grid_spec_consistent = td.EMECompositeGrid(
+        subgrids=[
+            td.EMEUniformGrid(num_cells=2, mode_spec=mode_spec_consistent),
+            td.EMEUniformGrid(num_cells=2, mode_spec=mode_spec_consistent),
+        ],
+        subgrid_boundaries=[0],
+    )
+    with AssertLogLevel(None):
+        sim_interp_test = sim.updated_copy(eme_grid_spec=eme_grid_spec_consistent)
+
     # test freq sweep smatrix_in_basis
     sim = sim.updated_copy(sweep_spec=td.EMEFreqSweep(freq_scale_factors=np.linspace(1, 2, 10)))
     port_modes = _get_eme_port_modes(num_sweep=10)

--- a/tests/test_components/test_eme.py
+++ b/tests/test_components/test_eme.py
@@ -1334,7 +1334,7 @@ def test_eme_sim_data():
             eme_cell_index=0,
         )
 
-    # test _validate_interp_specs warning for inconsistent interp_specs
+    # test _validate_interp_specs error for inconsistent interp_specs
     mode_spec1 = td.EMEModeSpec(num_modes=10, interp_spec=td.ModeInterpSpec.cheb(num_points=3))
     mode_spec2 = td.EMEModeSpec(num_modes=10, interp_spec=td.ModeInterpSpec.cheb(num_points=5))
     eme_grid_spec_inconsistent = td.EMECompositeGrid(
@@ -1344,10 +1344,10 @@ def test_eme_sim_data():
         ],
         subgrid_boundaries=[0],
     )
-    with AssertLogLevel("WARNING", contains_str="interp_spec"):
+    with pytest.raises(SetupError):
         sim_interp_test = sim.updated_copy(eme_grid_spec=eme_grid_spec_inconsistent)
 
-    # test _validate_interp_specs no warning for consistent interp_specs
+    # test _validate_interp_specs no error for consistent interp_specs
     mode_spec_consistent = td.EMEModeSpec(
         num_modes=10, interp_spec=td.ModeInterpSpec.cheb(num_points=4)
     )

--- a/tidy3d/components/eme/data/sim_data.py
+++ b/tidy3d/components/eme/data/sim_data.py
@@ -20,11 +20,6 @@ from tidy3d.log import log
 from .dataset import EMECoefficientDataset, EMESMatrixDataset
 from .monitor_data import EMEFieldData, EMEModeSolverData, EMEMonitorDataType
 
-# Tolerance for frequency matching when filtering mode data to monitor-sampled frequencies.
-# Set to 1e-5 to provide sufficient margin for floating-point precision while ensuring
-# correct frequency alignment in broadband simulations with interpolation.
-MODE_FREQ_TOL = 1e-5
-
 
 class EMESimulationData(AbstractYeeGridSimulationData):
     """Data associated with an EME simulation."""
@@ -122,16 +117,6 @@ class EMESimulationData(AbstractYeeGridSimulationData):
                 "certain derived quantities, like the flux."
             )
         grid_expanded = self.simulation.discretize_monitor(monitor=monitor)
-
-        # filter only the relevant frequencies
-        monitor_freqs = np.asarray(
-            monitor.mode_spec._sampling_freqs_mode_solver_data(freqs=self.simulation.freqs),
-            dtype=float,
-        )
-        update_dict = {
-            key: field.sel(f=monitor_freqs, method="nearest", tolerance=MODE_FREQ_TOL)
-            for key, field in update_dict.items()
-        }
 
         return ModeSolverData(
             **update_dict,
@@ -242,25 +227,6 @@ class EMESimulationData(AbstractYeeGridSimulationData):
         interp_spec1 = mode_spec1.interp_spec if mode_spec1 is not None else None
         interp_spec2 = mode_spec2.interp_spec if mode_spec2 is not None else None
 
-        modes1, port_modes1 = modes1._interpolated_copies_if_needed(other=port_modes1)
-        modes2, port_modes2 = modes2._interpolated_copies_if_needed(other=port_modes2)
-
-        # Normalize modes if simulation.normalize is True
-        def normalize_modes_for_basis_conversion(modes):
-            """Normalize modes by flux magnitude if simulation.normalize is True."""
-            if not self.simulation.normalize:
-                return modes
-
-            scaling = np.sqrt(np.abs(modes.flux))
-            scaling = scaling.where(scaling != 0, 1)
-            normalized_fields = {
-                name: field / scaling for name, field in modes.field_components.items()
-            }
-            return modes.updated_copy(**normalized_fields)
-
-        modes1 = normalize_modes_for_basis_conversion(modes1)
-        modes2 = normalize_modes_for_basis_conversion(modes2)
-
         modes_in_1 = "mode_index" in list(modes1.field_components.values())[0].coords
         modes_in_2 = "mode_index" in list(modes2.field_components.values())[0].coords
 
@@ -313,6 +279,10 @@ class EMESimulationData(AbstractYeeGridSimulationData):
 
             if self.simulation._sweep_modes:
                 port_modes1, port_modes2 = self.port_modes_list_sweep[sweep_index]
+                if not modes1_provided:
+                    modes1 = port_modes1
+                if not modes2_provided:
+                    modes2 = port_modes2
 
             if modes1_provided:
                 overlaps1 = modes1.outer_dot(port_modes1, conjugate=False)

--- a/tidy3d/components/eme/data/sim_data.py
+++ b/tidy3d/components/eme/data/sim_data.py
@@ -20,6 +20,11 @@ from tidy3d.log import log
 from .dataset import EMECoefficientDataset, EMESMatrixDataset
 from .monitor_data import EMEFieldData, EMEModeSolverData, EMEMonitorDataType
 
+# Tolerance for frequency matching when filtering mode data to monitor-sampled frequencies.
+# Set to 1e-5 to provide sufficient margin for floating-point precision while ensuring
+# correct frequency alignment in broadband simulations with interpolation.
+MODE_FREQ_TOL = 1e-5
+
 
 class EMESimulationData(AbstractYeeGridSimulationData):
     """Data associated with an EME simulation."""
@@ -89,6 +94,18 @@ class EMESimulationData(AbstractYeeGridSimulationData):
                 key: field.squeeze(dim="sweep_index") for key, field in update_dict.items()
             }
 
+        # Re-introduce the normal coordinate with the correct value from eme_grid.centers
+        axis = self.simulation.axis
+        # convert propagation axis index to coordinate name
+        axis_name = "xyz"[axis]
+        center_value = self.simulation.eme_grid.centers[eme_cell_index]
+        update_dict = {
+            key: field.assign_coords({axis_name: [center_value]})
+            if axis_name in field.dims
+            else field
+            for key, field in update_dict.items()
+        }
+
         monitor = self.simulation.mode_solver_monitors[eme_cell_index]
         monitor = monitor.updated_copy(colocate=data.monitor.colocate)
         box = Box.from_bounds(
@@ -105,6 +122,17 @@ class EMESimulationData(AbstractYeeGridSimulationData):
                 "certain derived quantities, like the flux."
             )
         grid_expanded = self.simulation.discretize_monitor(monitor=monitor)
+
+        # filter only the relevant frequencies
+        monitor_freqs = np.asarray(
+            monitor.mode_spec._sampling_freqs_mode_solver_data(freqs=self.simulation.freqs),
+            dtype=float,
+        )
+        update_dict = {
+            key: field.sel(f=monitor_freqs, method="nearest", tolerance=MODE_FREQ_TOL)
+            for key, field in update_dict.items()
+        }
+
         return ModeSolverData(
             **update_dict,
             monitor=monitor,
@@ -214,7 +242,24 @@ class EMESimulationData(AbstractYeeGridSimulationData):
         interp_spec1 = mode_spec1.interp_spec if mode_spec1 is not None else None
         interp_spec2 = mode_spec2.interp_spec if mode_spec2 is not None else None
 
-        modes1, modes2 = modes1._interpolated_copies_if_needed(other=modes2)
+        modes1, port_modes1 = modes1._interpolated_copies_if_needed(other=port_modes1)
+        modes2, port_modes2 = modes2._interpolated_copies_if_needed(other=port_modes2)
+
+        # Normalize modes if simulation.normalize is True
+        def normalize_modes_for_basis_conversion(modes):
+            """Normalize modes by flux magnitude if simulation.normalize is True."""
+            if not self.simulation.normalize:
+                return modes
+
+            scaling = np.sqrt(np.abs(modes.flux))
+            scaling = scaling.where(scaling != 0, 1)
+            normalized_fields = {
+                name: field / scaling for name, field in modes.field_components.items()
+            }
+            return modes.updated_copy(**normalized_fields)
+
+        modes1 = normalize_modes_for_basis_conversion(modes1)
+        modes2 = normalize_modes_for_basis_conversion(modes2)
 
         modes_in_1 = "mode_index" in list(modes1.field_components.values())[0].coords
         modes_in_2 = "mode_index" in list(modes2.field_components.values())[0].coords

--- a/tidy3d/components/eme/simulation.py
+++ b/tidy3d/components/eme/simulation.py
@@ -830,10 +830,9 @@ class EMESimulation(AbstractYeeGridSimulation):
         for mode_spec in self.eme_grid.mode_specs:
             interp_specs.append(mode_spec.interp_spec)
         if len(set(interp_specs)) > 1:
-            log.warning(
-                "The EME grid does not have identical 'interp_spec' in each "
-                "cell. This can decrease performance as the modes must be "
-                "interpolated before overlaps are computed."
+            raise SetupError(
+                "All of the 'mode_spec.interp_spec' in the EME grid must be identical. "
+                f"Currently, they are {set(interp_specs)}."
             )
 
     def _validate_size(self) -> None:

--- a/tidy3d/components/eme/simulation.py
+++ b/tidy3d/components/eme/simulation.py
@@ -600,6 +600,7 @@ class EMESimulation(AbstractYeeGridSimulation):
         self._validate_sweep_spec()
         self._validate_symmetry()
         self._validate_monitor_setup()
+        self._validate_interp_specs()
 
     def validate_pre_upload(self) -> None:
         """Validate the fully initialized EME simulation is ok for upload to our servers."""
@@ -822,6 +823,18 @@ class EMESimulation(AbstractYeeGridSimulation):
                         "which is not compatible with periodic repetition "
                         "('num_reps != 1' in any 'EMEGridSpec'.)"
                     )
+
+    def _validate_interp_specs(self) -> None:
+        """Require that the interp_specs are identical."""
+        interp_specs = []
+        for mode_spec in self.eme_grid.mode_specs:
+            interp_specs.append(mode_spec.interp_spec)
+        if len(set(interp_specs)) > 1:
+            log.warning(
+                "The EME grid does not have identical 'interp_spec' in each "
+                "cell. This can decrease performance as the modes must be "
+                "interpolated before overlaps are computed."
+            )
 
     def _validate_size(self) -> None:
         """Ensures the simulation is within size limits before simulation is uploaded."""
@@ -1112,7 +1125,7 @@ class EMESimulation(AbstractYeeGridSimulation):
                 freqs |= set(self.freqs)
             else:
                 freqs |= set(interp_spec.sampling_points(self.freqs))
-        return list(freqs)
+        return sorted(freqs)
 
     def _monitor_num_freqs(self, monitor: Monitor) -> int:
         """Total number of freqs included in monitor."""


### PR DESCRIPTION
Support for inconsistent interp_spec had bugs due to added complexity and intrinsic performance issues, so it's best to get rid of it.

Also reintroduces the normal component in `port_modes_tuple` and similar, which fixes `outer_dot` support.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Scope**
> - Enforces consistent mode interpolation in EME and fixes port mode coordinate handling used in overlaps.
> 
> **Key changes**
> - Added `EMESimulation._validate_interp_specs()` and invoked it in post-init to require identical `mode_spec.interp_spec` across all EME cells (raises `SetupError` on mismatch).
> - Reintroduced the normal-axis coordinate in `_extract_mode_solver_data()` using `eme_grid.centers[eme_cell_index]`, fixing `outer_dot` with port modes `interpolated_copy`.
> - Removed implicit `modes._interpolated_copies_if_needed(...)` in `EMESimulationData.smatrix_in_basis()` and aligned sweep behavior to use port modes when user modes are not provided.
> - `_monitor_mode_freqs()` now returns `sorted(...)` for deterministic frequency ordering.
> - Tests added to cover both inconsistent and consistent `interp_spec` cases; CHANGELOG updated under Fixed/Removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60331802f89e054b33df799046734d47b7e376a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR removes support for inconsistent `interp_spec` values across EME grid subgrids, addressing performance issues and implementation complexity. The changes enforce consistency through validation while fixing the reintroduction of normal-axis coordinates in mode solver data extraction.

**Key Changes:**
- Adds `_validate_interp_specs()` method to enforce identical `interp_spec` values across all EME cells, raising `SetupError` if inconsistent
- Reintroduces the normal-axis coordinate in `_extract_mode_solver_data()` using `eme_grid.centers[eme_cell_index]`, fixing `outer_dot` support
- Returns sorted frequency lists from `_monitor_mode_freqs()` for deterministic behavior
- Removes implicit mode interpolation from `smatrix_in_basis()` (line 230 removal) since consistent specs are now guaranteed
- Extends test coverage with assertions for both error and success cases

**Issues Found:**
- CHANGELOG.md entry is incorrectly categorized under "Removed" instead of "Fixed" section, and lacks specificity about user impact

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor documentation correction needed; core implementation correctly enforces consistency and fixes spatial coordinate handling.
- Score reflects solid implementation of the core feature (validation and coordinate fix) with comprehensive test coverage. One point deducted for the CHANGELOG.md categorization issue which violates established conventions and reduces clarity of the change's user impact. The removal of implicit interpolation is well-justified by the now-enforced consistency guarantee, and the normal coordinate reintroduction is properly implemented with correct axis mapping. All three modified source files have correct logic with no runtime issues identified.
- CHANGELOG.md - requires recategorization from 'Removed' to 'Fixed' section and improved user-facing description

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/components/eme/simulation.py | Added `_validate_interp_specs()` validation method (lines 827-836) that ensures all EME grid subgrids use identical `interp_spec` values, raising a `SetupError` if they differ. Method is invoked in `_post_init_validators()` (line 603). Also modified `_monitor_mode_freqs()` (line 1127) to return `sorted(freqs)` instead of `list(freqs)` for deterministic frequency ordering. Changes are correct and address the core issue of preventing inconsistent interpolation specs. |
| tidy3d/components/eme/data/sim_data.py | Reintroduced the normal-axis coordinate in `_extract_mode_solver_data()` (lines 92-102) using `eme_grid.centers[eme_cell_index]` to set the correct position along the propagation axis. This fixes `outer_dot` support by ensuring the extracted `ModeSolverData` has the proper spatial coordinate. Also removed implicit mode interpolation at line 230 (`modes1, modes2 = modes1._interpolated_copies_if_needed(other=modes2)`) from `smatrix_in_basis()`. With consistent `interp_spec` now enforced, this implicit interpolation is no longer needed. |
| tests/test_components/test_eme.py | Extended test coverage for `_validate_interp_specs()` with two new test cases (lines 1337-1362): one that expects a `SetupError` when subgrids have different `interp_spec` values, and another that verifies no error is raised when `interp_spec` values are consistent across all subgrids. Test structure is correct and properly exercises the new validation. |
| CHANGELOG.md | Entry placed under "Removed" section (line 23) instead of "Fixed" section. According to PR description and custom rules (ba940925-eeaf-4e60-b3a8-b33d7af52cd1), this is a bug fix that removes problematic functionality due to complexity and performance issues. Should be under "Fixed" section with backticks around `interp_spec`. Entry lacks specificity about user impact. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as Developer
    participant EMESim as EMESimulation
    participant Validator as _validate_interp_specs()
    participant Grid as eme_grid

    User->>EMESim: Create/update EMESimulation
    EMESim->>EMESim: _post_init_validators()
    EMESim->>Validator: Call _validate_interp_specs()
    Validator->>Grid: Get mode_specs
    Grid-->>Validator: Return mode_specs
    Validator->>Validator: Collect all interp_spec values
    alt Inconsistent interp_specs detected
        Validator->>EMESim: Raise SetupError
        EMESim-->>User: Reject with error message
    else Consistent interp_specs
        Validator-->>EMESim: Validation passes
        EMESim-->>User: Simulation created successfully
    end
    
    Note over EMESim: Later: smatrix_in_basis() call
    User->>EMESim: Call smatrix_in_basis()
    EMESim->>EMESim: No implicit interpolation needed<br/>(specs are guaranteed consistent)
    EMESim-->>User: Return transformed smatrix
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Bug fixes should be categorized under 'Fixed' section in CHANGELOG.md, not under 'Changed' section. ([source](https://app.greptile.com/review/custom-context?memory=ba940925-eeaf-4e60-b3a8-b33d7af52cd1))

<!-- /greptile_comment -->