### PR TITLE
bug: hacky `verbose_estimate_cost` in `web.upload`

### DIFF
--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -360,14 +360,14 @@ class Job(WebContainer):
         if self.task_id_cached:
             return self.task_id_cached
         self._check_folder(self.folder_name)
-        return self._upload(verbose=False)
+        return self._upload(verbose_estimate_cost=False)
 
-    def _upload(self, verbose: Optional[bool] = None) -> TaskId:
+    def _upload(self, verbose_estimate_cost: Optional[bool] = None) -> TaskId:
         """Upload this job and return the task ID for handling."""
         # upload kwargs with all fields except task_id
         upload_kwargs = {key: getattr(self, key) for key in self._upload_fields}
-        if verbose is not None:
-            upload_kwargs["verbose"] = verbose
+        if verbose_estimate_cost is not None:
+            upload_kwargs["verbose_estimate_cost"] = verbose_estimate_cost
         task_id = web.upload(**upload_kwargs)
         return task_id
 

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -458,6 +458,7 @@ def upload(
     source_required: bool = True,
     solver_version: Optional[str] = None,
     reduce_simulation: Literal["auto", True, False] = "auto",
+    verbose_estimate_cost: bool = True,
 ) -> TaskId:
     """
     Upload simulation to server, but do not start running :class:`.Simulation`.
@@ -487,6 +488,8 @@ def upload(
         target solver version.
     reduce_simulation: Literal["auto", True, False] = "auto"
         Whether to reduce structures in the simulation to the simulation domain only. Note: currently only implemented for the mode solver.
+    verbose_estimate_cost : bool = True
+        If ``True``, will print cost estimation output.
 
     Returns
     -------
@@ -561,7 +564,7 @@ def upload(
         remote_sim_file=remote_sim_file,
     )
 
-    estimate_cost(task_id=resource_id, solver_version=solver_version, verbose=verbose)
+    estimate_cost(task_id=resource_id, solver_version=solver_version, verbose=verbose_estimate_cost)
 
     task.validate_post_upload(parent_tasks=parent_tasks)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a dedicated `verbose_estimate_cost` flag to control cost estimation output independently of general verbosity and avoids duplicate cost prints.
> 
> - Adds `verbose_estimate_cost` (default `True`) to `web.upload()` and wires it to `estimate_cost(..., verbose=verbose_estimate_cost)`
> - Updates `Job._upload()` to accept/pass `verbose_estimate_cost`; `Job.task_id` now calls `_upload(verbose_estimate_cost=False)` to suppress printing during property access
> - Updates `web.upload()` docstring to document the new parameter
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62c2549119075780e8d41f07027d38b72be34a6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR refines the fix for duplicate cost estimation output (FXC-5005) by introducing a dedicated `verbose_estimate_cost` parameter to `web.upload()`. The previous fix attempted to suppress duplicate output by passing `verbose=False` to internal upload calls, but this was not sufficient. The new approach separates control of cost estimation output from general verbose logging, allowing the `Job.task_id` property to suppress cost printing while `Job.upload()` can still display it when appropriate.

**Changes made:**
- Removed the `estimate_cost()` call from `Job.upload()` method that was added in the base commit
- Renamed the `verbose` parameter to `verbose_estimate_cost` in `Job._upload()` for clarity
- Added `verbose_estimate_cost` parameter to `web.upload()` function to explicitly control cost estimation output
- The parameter defaults to `True` to maintain backward compatibility

**Issue found:**
- Missing docstring documentation for the new `verbose_estimate_cost` parameter in `web.upload()` function

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge once the missing parameter documentation is added
- The refactoring correctly addresses the duplicate output issue by introducing a dedicated parameter. The logic is sound and the change is localized. However, the missing docstring for the new public API parameter needs to be addressed before merge, as it violates documentation standards.
- Pay attention to `tidy3d/web/api/webapi.py` - the new parameter needs docstring documentation

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/web/api/container.py | Removed duplicate `estimate_cost` call from `Job.upload()` and renamed parameter from `verbose` to `verbose_estimate_cost` in `_upload()` method to fix duplicate cost printing |
| tidy3d/web/api/webapi.py | Added `verbose_estimate_cost` parameter to `upload()` function but missing docstring documentation for the new parameter |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Job
    participant Job._upload
    participant web.upload
    participant estimate_cost

    Note over User,estimate_cost: Before PR: Duplicate cost estimation

    User->>Job: access task_id property
    Job->>Job._upload: _upload(verbose=False)
    Job._upload->>web.upload: upload(..., verbose=False)
    web.upload->>estimate_cost: estimate_cost(verbose=False)
    Note over estimate_cost: No output (suppressed)
    
    User->>Job: upload()
    Job->>Job: estimate_cost(verbose=True)
    Note over estimate_cost: Prints cost output
    Job->>Job: access task_id property (cached)
    
    Note over User,estimate_cost: After PR: Single cost estimation

    User->>Job: access task_id property
    Job->>Job._upload: _upload(verbose_estimate_cost=False)
    Job._upload->>web.upload: upload(..., verbose_estimate_cost=False)
    web.upload->>estimate_cost: estimate_cost(verbose=False)
    Note over estimate_cost: No output (suppressed)
    
    User->>Job: upload()
    Job->>Job: access task_id property (cached)
    Note over Job: No duplicate estimate_cost call
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Ensure all parameters in a function's signature are documented in its docstring. ([source](https://app.greptile.com/review/custom-context?memory=e4b0671a-18ac-4d59-b20d-69e8122c11f1))

<!-- /greptile_comment -->