### PR TITLE
FXC-4927 enable source differentiation

### DIFF
--- a/changelog.d/3197.added.md
+++ b/changelog.d/3197.added.md
@@ -1,0 +1,1 @@
+Added autograd support for custom source gradients with respect to `field_dataset` and `current_dataset`.

--- a/tests/test_components/autograd/numerical/test_autograd_source_numerical.py
+++ b/tests/test_components/autograd/numerical/test_autograd_source_numerical.py
@@ -1,0 +1,502 @@
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, replace
+from typing import Callable
+
+import autograd as ag
+import numpy as np
+import pytest
+
+import tidy3d as td
+import tidy3d.web as web
+
+
+@pytest.fixture(autouse=True)
+def _enable_local_cache(monkeypatch):
+    monkeypatch.setattr(td.config.local_cache, "enabled", True)
+
+
+ANGLE_LIMIT_DEG = 5.0
+NORM_RTOL = 0.1
+NORM_ATOL = 1e-6
+
+BASE_WVL0 = 2.0
+BASE_MIN_STEPS_PER_WVL = 40
+BASE_DATASET_SPACING = 0.125
+BASE_SOURCE_SIZE = (1.0, 1.0, 0.0)
+BASE_SOURCE_CENTER = (0.1, 0.4, -0.2)
+BASE_PARAM_AMPLITUDES = (1.0, -0.5, 0.25)
+
+SIM_RUN_TIME = 1e-12
+MONITOR_CENTER = (-0.3, 0.1, 0.2)
+MONITOR_SIZE = (0.5, 0.5, 0.0)
+FLUX_MONITOR_NAME = "flux_monitor"
+
+DATASET_SPACING_VALUES = (0.25, 0.125, 0.0625)
+MIN_STEPS_PER_WVL_VALUES = (40, 60, 80)
+WVL0_VALUES = (0.5, 1.0, 2.0)
+SOURCE_SIZE_XY_VALUES = (0.5, 1.0, 2.0)
+AMPLITUDE_SCALE_VALUES = (0.25, 0.5, 1.0)
+# Tuple format is (background_permittivity, source_structure_permittivity).
+# ``None`` means "no enclosing structure around the source", so this sweep varies
+# only the simulation background medium.
+PERMITTIVITY_VALUES = (
+    (1.0, None),
+    (2.0, None),
+    (4.0, None),
+)
+
+
+def _axis_coords(size: float, spacing: float) -> np.ndarray:
+    if size <= 0:
+        return np.array([0.0], dtype=float)
+    n = max(2, int(np.round(size / spacing)))
+    return np.linspace(-size / 2, size / 2, n)
+
+
+def _make_coords(
+    source_size: tuple[float, float, float], dataset_spacing: float, freq0: float
+) -> dict[str, object]:
+    return {
+        "x": _axis_coords(source_size[0], dataset_spacing),
+        "y": _axis_coords(source_size[1], dataset_spacing),
+        "z": _axis_coords(source_size[2], dataset_spacing),
+        "f": [freq0],
+    }
+
+
+def _make_field_dataset(
+    field_prefix: str,
+    amplitudes: tuple[float, float, float],
+    coords: dict[str, object],
+) -> td.FieldDataset:
+    shape = (
+        len(np.asarray(coords["x"])),
+        len(np.asarray(coords["y"])),
+        len(np.asarray(coords["z"])),
+        1,
+    )
+    components = {}
+    for amp, axis in zip(amplitudes, "xyz"):
+        data = amp * np.ones(shape, dtype=float)
+        components[f"{field_prefix}{axis}"] = td.ScalarFieldDataArray(data, coords=coords)
+    return td.FieldDataset(**components)
+
+
+def _scaled_amplitudes(scale: float) -> tuple[float, float, float]:
+    return tuple(scale * value for value in BASE_PARAM_AMPLITUDES)
+
+
+def angled_overlap_deg(v1: np.ndarray, v2: np.ndarray) -> float:
+    norm_v1 = np.linalg.norm(v1)
+    norm_v2 = np.linalg.norm(v2)
+    if np.isclose(norm_v1, 0.0) or np.isclose(norm_v2, 0.0):
+        if not (np.isclose(norm_v1, 0.0) and np.isclose(norm_v2, 0.0)):
+            return np.inf
+        return 0.0
+    dot = np.sum((v1 / norm_v1) * (v2 / norm_v2))
+    dot = np.clip(dot, -1.0, 1.0)
+    return float(np.arccos(dot) * 180.0 / np.pi)
+
+
+@dataclass(frozen=True)
+class SweepConfig:
+    dataset_spacing: float = BASE_DATASET_SPACING
+    min_steps_per_wvl: int = BASE_MIN_STEPS_PER_WVL
+    wvl0: float = BASE_WVL0
+    source_size: tuple[float, float, float] = BASE_SOURCE_SIZE
+    amplitude_scale: float = 1.0
+    background_permittivity: float = 1.0
+    source_structure_permittivity: float | None = None
+    source_structure_custom_medium: bool = False
+
+
+@dataclass(frozen=True)
+class SourceCase:
+    name: str
+    monitor_components: tuple[str, str, str]
+    source_kind: str
+    field_prefix: str
+    delta: float = 1e-4
+
+
+@dataclass(frozen=True)
+class GradientMetrics:
+    grad_adjoint: np.ndarray
+    grad_fd: np.ndarray
+    angle_deg: float
+    adjoint_norm: float
+    fd_norm: float
+
+
+SOURCE_CASES = (
+    SourceCase(
+        name="custom_field_vec_e",
+        monitor_components=("Ex", "Ey", "Ez"),
+        source_kind="field",
+        field_prefix="E",
+    ),
+    SourceCase(
+        name="custom_field_vec_h",
+        monitor_components=("Hx", "Hy", "Hz"),
+        source_kind="field",
+        field_prefix="H",
+    ),
+    SourceCase(
+        name="custom_current_vec_e",
+        monitor_components=("Ex", "Ey", "Ez"),
+        source_kind="current",
+        field_prefix="E",
+    ),
+    SourceCase(
+        name="custom_current_vec_h",
+        monitor_components=("Hx", "Hy", "Hz"),
+        source_kind="current",
+        field_prefix="H",
+    ),
+)
+
+
+def _make_source(
+    case: SourceCase,
+    amplitudes: tuple[float, float, float],
+    config: SweepConfig,
+    freq0: float,
+    pulse: td.GaussianPulse,
+) -> td.Source:
+    if case.source_kind == "field":
+        source_size = (config.source_size[0], config.source_size[1], 0.0)
+        coords = _make_coords(source_size, config.dataset_spacing, freq0)
+        field_dataset = _make_field_dataset(case.field_prefix, amplitudes, coords)
+        return td.CustomFieldSource(
+            center=BASE_SOURCE_CENTER,
+            size=source_size,
+            source_time=pulse,
+            field_dataset=field_dataset,
+        )
+
+    if case.source_kind == "current":
+        coords = _make_coords(config.source_size, config.dataset_spacing, freq0)
+        current_dataset = _make_field_dataset(case.field_prefix, amplitudes, coords)
+        return td.CustomCurrentSource(
+            center=BASE_SOURCE_CENTER,
+            size=config.source_size,
+            source_time=pulse,
+            current_dataset=current_dataset,
+        )
+
+    raise ValueError(f"Unsupported source_kind: {case.source_kind}")
+
+
+def _source_host_structure(
+    source: td.Source,
+    source_structure_permittivity: float,
+) -> td.Structure:
+    """Create the enclosing structure ("host") that contains the source."""
+    source_size = tuple(float(value) for value in source.size)
+    host_size = (
+        source_size[0] + 0.2,
+        source_size[1] + 0.2,
+        max(source_size[2] + 0.2, 0.3),
+    )
+    return td.Structure(
+        geometry=td.Box(center=source.center, size=host_size),
+        medium=td.Medium(permittivity=source_structure_permittivity),
+    )
+
+
+def _source_host_custom_medium(source: td.Source) -> td.Structure:
+    """Create a nonuniform custom-medium host structure that encloses the source."""
+    source_size = tuple(float(value) for value in source.size)
+    host_size = (
+        source_size[0] + 0.2,
+        source_size[1] + 0.2,
+        max(source_size[2] + 0.2, 0.3),
+    )
+    host_center = tuple(float(value) for value in source.center)
+    host_bounds_min = [c - 0.5 * s for c, s in zip(host_center, host_size)]
+    host_bounds_max = [c + 0.5 * s for c, s in zip(host_center, host_size)]
+
+    x = np.linspace(host_bounds_min[0], host_bounds_max[0], 9)
+    y = np.linspace(host_bounds_min[1], host_bounds_max[1], 9)
+    z = np.linspace(host_bounds_min[2], host_bounds_max[2], 5)
+    X, Y, Z = np.meshgrid(x, y, z, indexing="ij")
+    eps = 2.5 + 0.2 * (X - host_center[0]) + 0.15 * (Y - host_center[1]) ** 2
+    eps += 0.05 * (Z - host_center[2])
+
+    return td.Structure(
+        geometry=td.Box(center=source.center, size=host_size),
+        medium=td.CustomMedium(
+            permittivity=td.SpatialDataArray(
+                eps,
+                coords={"x": x, "y": y, "z": z},
+            )
+        ),
+    )
+
+
+def _make_sim(
+    source: td.Source,
+    config: SweepConfig,
+) -> td.Simulation:
+    freq0 = td.C_0 / config.wvl0
+    monitor = td.FieldMonitor(
+        name=FLUX_MONITOR_NAME,
+        center=MONITOR_CENTER,
+        size=MONITOR_SIZE,
+        freqs=[freq0],
+    )
+    structures = []
+    if config.source_structure_permittivity is not None and config.source_structure_custom_medium:
+        raise ValueError(
+            "Only one source host type is allowed: set either "
+            "'source_structure_permittivity' or 'source_structure_custom_medium'."
+        )
+
+    if config.source_structure_permittivity is not None:
+        structures.append(_source_host_structure(source, config.source_structure_permittivity))
+    if config.source_structure_custom_medium:
+        structures.append(_source_host_custom_medium(source))
+
+    sim_size = (3 * config.wvl0, 3 * config.wvl0, 3 * config.wvl0)
+    return td.Simulation(
+        size=sim_size,
+        run_time=SIM_RUN_TIME,
+        grid_spec=td.GridSpec.auto(
+            min_steps_per_wvl=config.min_steps_per_wvl,
+            wavelength=config.wvl0,
+        ),
+        medium=td.Medium(permittivity=config.background_permittivity),
+        structures=structures,
+        sources=[source],
+        monitors=[monitor],
+        boundary_spec=td.BoundarySpec.all_sides(boundary=td.PML()),
+    )
+
+
+def _eval_objective_flux(sim_data: td.SimulationData) -> float:
+    field_data = sim_data.load_field_monitor(FLUX_MONITOR_NAME)
+    return field_data.flux.values
+
+
+def _run_gradient_case(
+    tmp_path,
+    case: SourceCase,
+    config: SweepConfig,
+    *,
+    label: str,
+) -> GradientMetrics:
+    freq0 = td.C_0 / config.wvl0
+    pulse = td.GaussianPulse(freq0=freq0, fwidth=freq0 / 10)
+    params = _scaled_amplitudes(config.amplitude_scale)
+
+    def make_source(amps: tuple[float, float, float]) -> td.Source:
+        return _make_source(case, amps, config, freq0, pulse)
+
+    def objective_adj(ax: float, ay: float, az: float) -> float:
+        sim = _make_sim(make_source((ax, ay, az)), config)
+        sim_data = web.run(
+            sim,
+            task_name=f"{label}_adj",
+            path=tmp_path / f"{label}_adj.hdf5",
+            local_gradient=True,
+            verbose=False,
+        )
+        return _eval_objective_flux(sim_data)
+
+    grad_adjoint = np.array(
+        [
+            ag.grad(objective_adj, 0)(*params),
+            ag.grad(objective_adj, 1)(*params),
+            ag.grad(objective_adj, 2)(*params),
+        ],
+        dtype=float,
+    )
+
+    sims = {}
+    for idx, axis in enumerate("xyz"):
+        params_plus = list(params)
+        params_plus[idx] += case.delta
+        params_minus = list(params)
+        params_minus[idx] -= case.delta
+        sims[f"{label}_fd_{axis}_plus"] = _make_sim(make_source(tuple(params_plus)), config)
+        sims[f"{label}_fd_{axis}_minus"] = _make_sim(make_source(tuple(params_minus)), config)
+
+    sim_data_map = web.run_async(
+        sims,
+        path_dir=tmp_path,
+        local_gradient=False,
+        verbose=False,
+    )
+
+    grad_fd = np.zeros(3, dtype=float)
+    for idx, axis in enumerate("xyz"):
+        obj_plus = float(
+            np.asarray(_eval_objective_flux(sim_data_map[f"{label}_fd_{axis}_plus"])).squeeze()
+        )
+        obj_minus = float(
+            np.asarray(_eval_objective_flux(sim_data_map[f"{label}_fd_{axis}_minus"])).squeeze()
+        )
+        grad_fd[idx] = (obj_plus - obj_minus) / (2 * case.delta)
+
+    angle_deg = angled_overlap_deg(grad_adjoint, grad_fd)
+    adjoint_norm = float(np.linalg.norm(grad_adjoint))
+    fd_norm = float(np.linalg.norm(grad_fd))
+
+    print(f"[{label}] grad_adjoint = {grad_adjoint}", file=sys.stderr)
+    print(f"[{label}] grad_fd      = {grad_fd}", file=sys.stderr)
+    print(f"[{label}] angle_deg    = {angle_deg}", file=sys.stderr)
+    print(f"[{label}] adjoint_norm = {adjoint_norm}", file=sys.stderr)
+    print(f"[{label}] fd_norm      = {fd_norm}", file=sys.stderr)
+
+    return GradientMetrics(
+        grad_adjoint=grad_adjoint,
+        grad_fd=grad_fd,
+        angle_deg=angle_deg,
+        adjoint_norm=adjoint_norm,
+        fd_norm=fd_norm,
+    )
+
+
+def _assert_fd_agreement(metrics: GradientMetrics, *, label: str) -> None:
+    assert metrics.angle_deg < ANGLE_LIMIT_DEG, label
+    assert np.isfinite(metrics.adjoint_norm), label
+    assert np.isfinite(metrics.fd_norm), label
+    np.testing.assert_allclose(
+        metrics.adjoint_norm,
+        metrics.fd_norm,
+        rtol=NORM_RTOL,
+        atol=NORM_ATOL,
+        err_msg=label,
+    )
+
+
+def _run_variation_sweep(
+    tmp_path,
+    case: SourceCase,
+    variation_name: str,
+    values: tuple,
+    update_config: Callable[[SweepConfig, object], SweepConfig],
+) -> None:
+    base_config = SweepConfig()
+    for value in values:
+        config = update_config(base_config, value)
+        label = f"{case.name}_{variation_name}_{value}"
+        metrics = _run_gradient_case(tmp_path, case, config, label=label)
+        _assert_fd_agreement(metrics, label=label)
+
+
+@pytest.mark.numerical
+@pytest.mark.parametrize("case", SOURCE_CASES, ids=lambda case: case.name)
+def test_custom_source_gradient_vs_dataset_spacing(_enable_local_cache, tmp_path, case):
+    _run_variation_sweep(
+        tmp_path,
+        case,
+        "dataset_spacing",
+        DATASET_SPACING_VALUES,
+        lambda base, value: replace(base, dataset_spacing=value),
+    )
+
+
+@pytest.mark.numerical
+@pytest.mark.parametrize("case", SOURCE_CASES, ids=lambda case: case.name)
+def test_custom_source_gradient_vs_grid_resolution(_enable_local_cache, tmp_path, case):
+    _run_variation_sweep(
+        tmp_path,
+        case,
+        "min_steps_per_wvl",
+        MIN_STEPS_PER_WVL_VALUES,
+        lambda base, value: replace(base, min_steps_per_wvl=value),
+    )
+
+
+@pytest.mark.numerical
+@pytest.mark.parametrize("case", SOURCE_CASES, ids=lambda case: case.name)
+def test_custom_source_gradient_vs_source_size(_enable_local_cache, tmp_path, case):
+    _run_variation_sweep(
+        tmp_path,
+        case,
+        "source_size_xy",
+        SOURCE_SIZE_XY_VALUES,
+        lambda base, value: replace(base, source_size=(value, value, 0.0)),
+    )
+
+
+@pytest.mark.numerical
+@pytest.mark.parametrize("case", SOURCE_CASES, ids=lambda case: case.name)
+def test_custom_source_gradient_vs_amplitude(_enable_local_cache, tmp_path, case):
+    _run_variation_sweep(
+        tmp_path,
+        case,
+        "amplitude_scale",
+        AMPLITUDE_SCALE_VALUES,
+        lambda base, value: replace(base, amplitude_scale=value),
+    )
+
+
+@pytest.mark.numerical
+@pytest.mark.parametrize("case", SOURCE_CASES, ids=lambda case: case.name)
+def test_custom_source_gradient_vs_permittivity(_enable_local_cache, tmp_path, case):
+    _run_variation_sweep(
+        tmp_path,
+        case,
+        "permittivity",
+        PERMITTIVITY_VALUES,
+        lambda base, value: replace(
+            base,
+            background_permittivity=value[0],
+            source_structure_permittivity=value[1],
+        ),
+    )
+
+
+@pytest.mark.numerical
+@pytest.mark.parametrize("case", SOURCE_CASES, ids=lambda case: case.name)
+def test_custom_source_gradient_vs_wavelength(_enable_local_cache, tmp_path, case):
+    _run_variation_sweep(
+        tmp_path,
+        case,
+        "wvl0",
+        WVL0_VALUES,
+        lambda base, value: replace(base, wvl0=value),
+    )
+
+
+@pytest.mark.numerical
+@pytest.mark.parametrize("case", SOURCE_CASES, ids=lambda case: case.name)
+def test_custom_source_gradient_inside_structure(_enable_local_cache, tmp_path, case):
+    structure_config = replace(SweepConfig(), source_structure_permittivity=4.0)
+    structure_metrics = _run_gradient_case(
+        tmp_path,
+        case,
+        structure_config,
+        label=f"{case.name}_source_in_structure_eps_4",
+    )
+    _assert_fd_agreement(structure_metrics, label=f"{case.name}_source_in_structure_eps_4")
+
+
+@pytest.mark.numerical
+def test_custom_current_source_gradient_cube_size(_enable_local_cache, tmp_path):
+    current_case = next(case for case in SOURCE_CASES if case.name == "custom_current_vec_e")
+    cube_config = replace(SweepConfig(), source_size=(0.5, 0.5, 0.5))
+    cube_metrics = _run_gradient_case(
+        tmp_path,
+        current_case,
+        cube_config,
+        label=f"{current_case.name}_source_size_xyz_0.5",
+    )
+    _assert_fd_agreement(cube_metrics, label=f"{current_case.name}_source_size_xyz_0.5")
+
+
+@pytest.mark.numerical
+@pytest.mark.parametrize("case", SOURCE_CASES, ids=lambda case: case.name)
+def test_custom_source_gradient_in_nonuniform_custom_medium(_enable_local_cache, tmp_path, case):
+    custom_medium_config = replace(SweepConfig(), source_structure_custom_medium=True)
+    custom_medium_metrics = _run_gradient_case(
+        tmp_path,
+        case,
+        custom_medium_config,
+        label=f"{case.name}_source_in_custom_medium",
+    )
+    _assert_fd_agreement(custom_medium_metrics, label=f"{case.name}_source_in_custom_medium")

--- a/tests/test_components/autograd/numerical/test_autograd_source_numerical.py
+++ b/tests/test_components/autograd/numerical/test_autograd_source_numerical.py
@@ -53,6 +53,7 @@ SIM_DIMS_VALUES = (3, 2)
 OBJECTIVE_3D_MODE = (
     "flux"  # or "intensity" # flux turned out to be more stable in finite difference gradient
 )
+OFF_CENTER_MONITOR_FREQ_SCALE = 0.95
 
 
 def _axis_coords(size: float, spacing: float) -> np.ndarray:
@@ -115,6 +116,7 @@ class SweepConfig:
     source_size: tuple[float, float, float] = BASE_SOURCE_SIZE
     sim_dims: int = 3
     objective_3d: str = OBJECTIVE_3D_MODE
+    monitor_freq_scale: float = 1.0
     amplitude_scale: float = 1.0
     background_permittivity: float = 1.0
     source_structure_permittivity: float | None = None
@@ -326,13 +328,14 @@ def _make_sim(
     config: SweepConfig,
 ) -> td.Simulation:
     freq0 = td.C_0 / config.wvl0
+    monitor_freq = config.monitor_freq_scale * freq0
     monitor_center = _collapse_y_center(MONITOR_CENTER, config.sim_dims)
     monitor_size = _collapse_y_size(MONITOR_SIZE, config.sim_dims)
     monitor = td.FieldMonitor(
         name=FLUX_MONITOR_NAME,
         center=monitor_center,
         size=monitor_size,
-        freqs=[freq0],
+        freqs=[monitor_freq],
     )
     structures = []
     if config.source_structure_permittivity is not None and config.source_structure_custom_medium:
@@ -592,6 +595,27 @@ def test_custom_source_gradient_vs_wavelength(_enable_local_cache, tmp_path, cas
         WVL0_VALUES,
         lambda base, value: replace(base, wvl0=value),
     )
+
+
+@pytest.mark.numerical
+@pytest.mark.parametrize("case_name", ("custom_field_vec_e", "custom_current_vec_e"))
+def test_custom_source_gradient_off_center_monitor_frequency(
+    _enable_local_cache, tmp_path, case_name
+):
+    """Check source gradients when objective frequency is offset from source center frequency."""
+    case = next(candidate for candidate in SOURCE_CASES if candidate.name == case_name)
+    config = replace(
+        SweepConfig(sim_dims=3),
+        monitor_freq_scale=OFF_CENTER_MONITOR_FREQ_SCALE,
+    )
+    label = f"{case.name}_monitor_freq_scale_{OFF_CENTER_MONITOR_FREQ_SCALE}_3d"
+    metrics = _run_gradient_case(
+        tmp_path,
+        case,
+        config,
+        label=label,
+    )
+    _assert_fd_agreement(metrics, label=label)
 
 
 @pytest.mark.numerical

--- a/tests/test_components/autograd/numerical/test_autograd_source_numerical.py
+++ b/tests/test_components/autograd/numerical/test_autograd_source_numerical.py
@@ -32,6 +32,9 @@ SIM_RUN_TIME = 1e-12
 MONITOR_CENTER = (-0.3, 0.1, 0.2)
 MONITOR_SIZE = (0.5, 0.5, 0.0)
 FLUX_MONITOR_NAME = "flux_monitor"
+FAR_CORNER_BLOCK_SIZE = (0.1, 0.1, 0.1)
+FAR_CORNER_BLOCK_PERMITTIVITY = 100.0
+FAR_CORNER_BLOCK_OFFSET_FACTOR = 1.35
 
 DATASET_SPACING_VALUES = (0.25, 0.125, 0.0625)
 MIN_STEPS_PER_WVL_VALUES = (40, 60, 80)
@@ -110,6 +113,7 @@ class SweepConfig:
     background_permittivity: float = 1.0
     source_structure_permittivity: float | None = None
     source_structure_custom_medium: bool = False
+    add_far_corner_structure: bool = False
 
 
 @dataclass(frozen=True)
@@ -236,6 +240,18 @@ def _source_host_custom_medium(source: td.Source) -> td.Structure:
     )
 
 
+def _far_corner_structure(wvl0: float) -> td.Structure:
+    """Create a tiny high-index block near a far corner of the simulation domain."""
+    center_val = FAR_CORNER_BLOCK_OFFSET_FACTOR * wvl0
+    return td.Structure(
+        geometry=td.Box(
+            center=(center_val, center_val, center_val),
+            size=FAR_CORNER_BLOCK_SIZE,
+        ),
+        medium=td.Medium(permittivity=FAR_CORNER_BLOCK_PERMITTIVITY),
+    )
+
+
 def _make_sim(
     source: td.Source,
     config: SweepConfig,
@@ -258,6 +274,8 @@ def _make_sim(
         structures.append(_source_host_structure(source, config.source_structure_permittivity))
     if config.source_structure_custom_medium:
         structures.append(_source_host_custom_medium(source))
+    if config.add_far_corner_structure:
+        structures.append(_far_corner_structure(config.wvl0))
 
     sim_size = (3 * config.wvl0, 3 * config.wvl0, 3 * config.wvl0)
     return td.Simulation(
@@ -500,3 +518,40 @@ def test_custom_source_gradient_in_nonuniform_custom_medium(_enable_local_cache,
         label=f"{case.name}_source_in_custom_medium",
     )
     _assert_fd_agreement(custom_medium_metrics, label=f"{case.name}_source_in_custom_medium")
+
+
+@pytest.mark.numerical
+def test_custom_source_gradient_stable_with_remote_dt_constraint(_enable_local_cache, tmp_path):
+    """Source gradients should stay stable when unrelated remote cells constrain global dt."""
+    case = next(candidate for candidate in SOURCE_CASES if candidate.name == "custom_current_vec_h")
+    base_config = replace(SweepConfig(), source_structure_permittivity=4.0)
+    constrained_config = replace(base_config, add_far_corner_structure=True)
+
+    base_metrics = _run_gradient_case(
+        tmp_path,
+        case,
+        base_config,
+        label=f"{case.name}_inside_structure_base",
+    )
+    constrained_metrics = _run_gradient_case(
+        tmp_path,
+        case,
+        constrained_config,
+        label=f"{case.name}_inside_structure_remote_dt",
+    )
+
+    _assert_fd_agreement(base_metrics, label=f"{case.name}_inside_structure_base")
+    _assert_fd_agreement(constrained_metrics, label=f"{case.name}_inside_structure_remote_dt")
+
+    np.testing.assert_allclose(
+        constrained_metrics.fd_norm,
+        base_metrics.fd_norm,
+        rtol=0.1,
+        atol=NORM_ATOL,
+    )
+    np.testing.assert_allclose(
+        constrained_metrics.adjoint_norm,
+        base_metrics.adjoint_norm,
+        rtol=0.1,
+        atol=NORM_ATOL,
+    )

--- a/tests/test_components/autograd/numerical/test_autograd_source_numerical.py
+++ b/tests/test_components/autograd/numerical/test_autograd_source_numerical.py
@@ -49,6 +49,7 @@ PERMITTIVITY_VALUES = (
     (2.0, None),
     (4.0, None),
 )
+SIM_DIMS_VALUES = (3, 2)
 
 
 def _axis_coords(size: float, spacing: float) -> np.ndarray:
@@ -109,6 +110,7 @@ class SweepConfig:
     min_steps_per_wvl: int = BASE_MIN_STEPS_PER_WVL
     wvl0: float = BASE_WVL0
     source_size: tuple[float, float, float] = BASE_SOURCE_SIZE
+    sim_dims: int = 3
     amplitude_scale: float = 1.0
     background_permittivity: float = 1.0
     source_structure_permittivity: float | None = None
@@ -122,6 +124,7 @@ class SourceCase:
     monitor_components: tuple[str, str, str]
     source_kind: str
     field_prefix: str
+    source_size_mask: tuple[bool, bool, bool]
     delta: float = 1e-4
 
 
@@ -140,26 +143,73 @@ SOURCE_CASES = (
         monitor_components=("Ex", "Ey", "Ez"),
         source_kind="field",
         field_prefix="E",
+        source_size_mask=(True, True, False),
     ),
     SourceCase(
         name="custom_field_vec_h",
         monitor_components=("Hx", "Hy", "Hz"),
         source_kind="field",
         field_prefix="H",
+        source_size_mask=(True, True, False),
     ),
     SourceCase(
         name="custom_current_vec_e",
         monitor_components=("Ex", "Ey", "Ez"),
         source_kind="current",
         field_prefix="E",
+        source_size_mask=(True, True, True),
     ),
     SourceCase(
         name="custom_current_vec_h",
         monitor_components=("Hx", "Hy", "Hz"),
         source_kind="current",
         field_prefix="H",
+        source_size_mask=(True, True, True),
+    ),
+    SourceCase(
+        name="custom_current_vec_e_1d",
+        monitor_components=("Ex", "Ey", "Ez"),
+        source_kind="current",
+        field_prefix="E",
+        source_size_mask=(True, False, False),
+    ),
+    SourceCase(
+        name="custom_current_vec_e_0d",
+        monitor_components=("Ex", "Ey", "Ez"),
+        source_kind="current",
+        field_prefix="E",
+        source_size_mask=(False, False, False),
     ),
 )
+
+
+def _source_size_for_case(
+    case: SourceCase, source_size: tuple[float, float, float], sim_dims: int
+) -> tuple[float, float, float]:
+    masked_size = tuple(
+        source_size[axis] if case.source_size_mask[axis] else 0.0 for axis in range(3)
+    )
+    if sim_dims == 2:
+        if case.source_kind == "field":
+            # Keep CustomFieldSource planar in 2D: collapse y and use the second
+            # in-plane extent on z.
+            return (masked_size[0], 0.0, masked_size[1])
+        return (masked_size[0], 0.0, masked_size[2])
+    return masked_size
+
+
+def _collapse_y_size(size: tuple[float, float, float], sim_dims: int) -> tuple[float, float, float]:
+    if sim_dims == 2:
+        return (size[0], 0.0, size[2])
+    return size
+
+
+def _collapse_y_center(
+    center: tuple[float, float, float], sim_dims: int
+) -> tuple[float, float, float]:
+    if sim_dims == 2:
+        return (center[0], 0.0, center[2])
+    return center
 
 
 def _make_source(
@@ -169,23 +219,25 @@ def _make_source(
     freq0: float,
     pulse: td.GaussianPulse,
 ) -> td.Source:
+    source_size = _source_size_for_case(case, config.source_size, config.sim_dims)
+    source_center = _collapse_y_center(BASE_SOURCE_CENTER, config.sim_dims)
+
     if case.source_kind == "field":
-        source_size = (config.source_size[0], config.source_size[1], 0.0)
         coords = _make_coords(source_size, config.dataset_spacing, freq0)
         field_dataset = _make_field_dataset(case.field_prefix, amplitudes, coords)
         return td.CustomFieldSource(
-            center=BASE_SOURCE_CENTER,
+            center=source_center,
             size=source_size,
             source_time=pulse,
             field_dataset=field_dataset,
         )
 
     if case.source_kind == "current":
-        coords = _make_coords(config.source_size, config.dataset_spacing, freq0)
+        coords = _make_coords(source_size, config.dataset_spacing, freq0)
         current_dataset = _make_field_dataset(case.field_prefix, amplitudes, coords)
         return td.CustomCurrentSource(
-            center=BASE_SOURCE_CENTER,
-            size=config.source_size,
+            center=source_center,
+            size=source_size,
             source_time=pulse,
             current_dataset=current_dataset,
         )
@@ -196,34 +248,45 @@ def _make_source(
 def _source_host_structure(
     source: td.Source,
     source_structure_permittivity: float,
+    sim_dims: int,
 ) -> td.Structure:
     """Create the enclosing structure ("host") that contains the source."""
     source_size = tuple(float(value) for value in source.size)
-    host_size = (
-        source_size[0] + 0.2,
-        source_size[1] + 0.2,
-        max(source_size[2] + 0.2, 0.3),
+    host_size = _collapse_y_size(
+        (
+            source_size[0] + 0.2,
+            source_size[1] + 0.2,
+            max(source_size[2] + 0.2, 0.3),
+        ),
+        sim_dims,
     )
+    host_center = _collapse_y_center(tuple(float(value) for value in source.center), sim_dims)
     return td.Structure(
-        geometry=td.Box(center=source.center, size=host_size),
+        geometry=td.Box(center=host_center, size=host_size),
         medium=td.Medium(permittivity=source_structure_permittivity),
     )
 
 
-def _source_host_custom_medium(source: td.Source) -> td.Structure:
+def _source_host_custom_medium(source: td.Source, sim_dims: int) -> td.Structure:
     """Create a nonuniform custom-medium host structure that encloses the source."""
     source_size = tuple(float(value) for value in source.size)
-    host_size = (
-        source_size[0] + 0.2,
-        source_size[1] + 0.2,
-        max(source_size[2] + 0.2, 0.3),
+    host_size = _collapse_y_size(
+        (
+            source_size[0] + 0.2,
+            source_size[1] + 0.2,
+            max(source_size[2] + 0.2, 0.3),
+        ),
+        sim_dims,
     )
-    host_center = tuple(float(value) for value in source.center)
+    host_center = _collapse_y_center(tuple(float(value) for value in source.center), sim_dims)
     host_bounds_min = [c - 0.5 * s for c, s in zip(host_center, host_size)]
     host_bounds_max = [c + 0.5 * s for c, s in zip(host_center, host_size)]
 
     x = np.linspace(host_bounds_min[0], host_bounds_max[0], 9)
-    y = np.linspace(host_bounds_min[1], host_bounds_max[1], 9)
+    if sim_dims == 2:
+        y = np.array([host_center[1]], dtype=float)
+    else:
+        y = np.linspace(host_bounds_min[1], host_bounds_max[1], 9)
     z = np.linspace(host_bounds_min[2], host_bounds_max[2], 5)
     X, Y, Z = np.meshgrid(x, y, z, indexing="ij")
     eps = 2.5 + 0.2 * (X - host_center[0]) + 0.15 * (Y - host_center[1]) ** 2
@@ -240,13 +303,15 @@ def _source_host_custom_medium(source: td.Source) -> td.Structure:
     )
 
 
-def _far_corner_structure(wvl0: float) -> td.Structure:
+def _far_corner_structure(wvl0: float, sim_dims: int) -> td.Structure:
     """Create a tiny high-index block near a far corner of the simulation domain."""
     center_val = FAR_CORNER_BLOCK_OFFSET_FACTOR * wvl0
+    center = _collapse_y_center((center_val, center_val, center_val), sim_dims)
+    size = _collapse_y_size(FAR_CORNER_BLOCK_SIZE, sim_dims)
     return td.Structure(
         geometry=td.Box(
-            center=(center_val, center_val, center_val),
-            size=FAR_CORNER_BLOCK_SIZE,
+            center=center,
+            size=size,
         ),
         medium=td.Medium(permittivity=FAR_CORNER_BLOCK_PERMITTIVITY),
     )
@@ -257,10 +322,12 @@ def _make_sim(
     config: SweepConfig,
 ) -> td.Simulation:
     freq0 = td.C_0 / config.wvl0
+    monitor_center = _collapse_y_center(MONITOR_CENTER, config.sim_dims)
+    monitor_size = _collapse_y_size(MONITOR_SIZE, config.sim_dims)
     monitor = td.FieldMonitor(
         name=FLUX_MONITOR_NAME,
-        center=MONITOR_CENTER,
-        size=MONITOR_SIZE,
+        center=monitor_center,
+        size=monitor_size,
         freqs=[freq0],
     )
     structures = []
@@ -271,13 +338,17 @@ def _make_sim(
         )
 
     if config.source_structure_permittivity is not None:
-        structures.append(_source_host_structure(source, config.source_structure_permittivity))
+        structures.append(
+            _source_host_structure(source, config.source_structure_permittivity, config.sim_dims)
+        )
     if config.source_structure_custom_medium:
-        structures.append(_source_host_custom_medium(source))
+        structures.append(_source_host_custom_medium(source, config.sim_dims))
     if config.add_far_corner_structure:
-        structures.append(_far_corner_structure(config.wvl0))
+        structures.append(_far_corner_structure(config.wvl0, config.sim_dims))
 
-    sim_size = (3 * config.wvl0, 3 * config.wvl0, 3 * config.wvl0)
+    sim_size = _collapse_y_size(
+        (3 * config.wvl0, 3 * config.wvl0, 3 * config.wvl0), config.sim_dims
+    )
     return td.Simulation(
         size=sim_size,
         run_time=SIM_RUN_TIME,
@@ -293,8 +364,10 @@ def _make_sim(
     )
 
 
-def _eval_objective_flux(sim_data: td.SimulationData) -> float:
+def _eval_objective(sim_data: td.SimulationData, sim_dims: int) -> float:
     field_data = sim_data.load_field_monitor(FLUX_MONITOR_NAME)
+    if sim_dims == 2:
+        return np.sum(field_data.intensity.values)
     return field_data.flux.values
 
 
@@ -321,7 +394,7 @@ def _run_gradient_case(
             local_gradient=True,
             verbose=False,
         )
-        return _eval_objective_flux(sim_data)
+        return _eval_objective(sim_data, config.sim_dims)
 
     grad_adjoint = np.array(
         [
@@ -351,10 +424,14 @@ def _run_gradient_case(
     grad_fd = np.zeros(3, dtype=float)
     for idx, axis in enumerate("xyz"):
         obj_plus = float(
-            np.asarray(_eval_objective_flux(sim_data_map[f"{label}_fd_{axis}_plus"])).squeeze()
+            np.asarray(
+                _eval_objective(sim_data_map[f"{label}_fd_{axis}_plus"], config.sim_dims)
+            ).squeeze()
         )
         obj_minus = float(
-            np.asarray(_eval_objective_flux(sim_data_map[f"{label}_fd_{axis}_minus"])).squeeze()
+            np.asarray(
+                _eval_objective(sim_data_map[f"{label}_fd_{axis}_minus"], config.sim_dims)
+            ).squeeze()
         )
         grad_fd[idx] = (obj_plus - obj_minus) / (2 * case.delta)
 
@@ -393,24 +470,33 @@ def _assert_fd_agreement(metrics: GradientMetrics, *, label: str) -> None:
 def _run_variation_sweep(
     tmp_path,
     case: SourceCase,
+    sim_dims: int,
     variation_name: str,
     values: tuple,
     update_config: Callable[[SweepConfig, object], SweepConfig],
 ) -> None:
-    base_config = SweepConfig()
+    base_config = replace(SweepConfig(), sim_dims=sim_dims)
     for value in values:
         config = update_config(base_config, value)
-        label = f"{case.name}_{variation_name}_{value}"
+        label = f"{case.name}_{variation_name}_{value}_{sim_dims}d"
         metrics = _run_gradient_case(tmp_path, case, config, label=label)
         _assert_fd_agreement(metrics, label=label)
 
 
+def _skip_2d_field_cases(sim_dims: int, case: SourceCase) -> None:
+    if sim_dims == 2 and case.source_kind == "field":
+        pytest.skip("2D variation sweeps are only run for CustomCurrentSource cases.")
+
+
 @pytest.mark.numerical
+@pytest.mark.parametrize("sim_dims", SIM_DIMS_VALUES, ids=lambda dims: f"{dims}d")
 @pytest.mark.parametrize("case", SOURCE_CASES, ids=lambda case: case.name)
-def test_custom_source_gradient_vs_dataset_spacing(_enable_local_cache, tmp_path, case):
+def test_custom_source_gradient_vs_dataset_spacing(_enable_local_cache, tmp_path, case, sim_dims):
+    _skip_2d_field_cases(sim_dims, case)
     _run_variation_sweep(
         tmp_path,
         case,
+        sim_dims,
         "dataset_spacing",
         DATASET_SPACING_VALUES,
         lambda base, value: replace(base, dataset_spacing=value),
@@ -418,11 +504,14 @@ def test_custom_source_gradient_vs_dataset_spacing(_enable_local_cache, tmp_path
 
 
 @pytest.mark.numerical
+@pytest.mark.parametrize("sim_dims", SIM_DIMS_VALUES, ids=lambda dims: f"{dims}d")
 @pytest.mark.parametrize("case", SOURCE_CASES, ids=lambda case: case.name)
-def test_custom_source_gradient_vs_grid_resolution(_enable_local_cache, tmp_path, case):
+def test_custom_source_gradient_vs_grid_resolution(_enable_local_cache, tmp_path, case, sim_dims):
+    _skip_2d_field_cases(sim_dims, case)
     _run_variation_sweep(
         tmp_path,
         case,
+        sim_dims,
         "min_steps_per_wvl",
         MIN_STEPS_PER_WVL_VALUES,
         lambda base, value: replace(base, min_steps_per_wvl=value),
@@ -430,11 +519,14 @@ def test_custom_source_gradient_vs_grid_resolution(_enable_local_cache, tmp_path
 
 
 @pytest.mark.numerical
+@pytest.mark.parametrize("sim_dims", SIM_DIMS_VALUES, ids=lambda dims: f"{dims}d")
 @pytest.mark.parametrize("case", SOURCE_CASES, ids=lambda case: case.name)
-def test_custom_source_gradient_vs_source_size(_enable_local_cache, tmp_path, case):
+def test_custom_source_gradient_vs_source_size(_enable_local_cache, tmp_path, case, sim_dims):
+    _skip_2d_field_cases(sim_dims, case)
     _run_variation_sweep(
         tmp_path,
         case,
+        sim_dims,
         "source_size_xy",
         SOURCE_SIZE_XY_VALUES,
         lambda base, value: replace(base, source_size=(value, value, 0.0)),
@@ -442,11 +534,14 @@ def test_custom_source_gradient_vs_source_size(_enable_local_cache, tmp_path, ca
 
 
 @pytest.mark.numerical
+@pytest.mark.parametrize("sim_dims", SIM_DIMS_VALUES, ids=lambda dims: f"{dims}d")
 @pytest.mark.parametrize("case", SOURCE_CASES, ids=lambda case: case.name)
-def test_custom_source_gradient_vs_amplitude(_enable_local_cache, tmp_path, case):
+def test_custom_source_gradient_vs_amplitude(_enable_local_cache, tmp_path, case, sim_dims):
+    _skip_2d_field_cases(sim_dims, case)
     _run_variation_sweep(
         tmp_path,
         case,
+        sim_dims,
         "amplitude_scale",
         AMPLITUDE_SCALE_VALUES,
         lambda base, value: replace(base, amplitude_scale=value),
@@ -454,11 +549,14 @@ def test_custom_source_gradient_vs_amplitude(_enable_local_cache, tmp_path, case
 
 
 @pytest.mark.numerical
+@pytest.mark.parametrize("sim_dims", SIM_DIMS_VALUES, ids=lambda dims: f"{dims}d")
 @pytest.mark.parametrize("case", SOURCE_CASES, ids=lambda case: case.name)
-def test_custom_source_gradient_vs_permittivity(_enable_local_cache, tmp_path, case):
+def test_custom_source_gradient_vs_permittivity(_enable_local_cache, tmp_path, case, sim_dims):
+    _skip_2d_field_cases(sim_dims, case)
     _run_variation_sweep(
         tmp_path,
         case,
+        sim_dims,
         "permittivity",
         PERMITTIVITY_VALUES,
         lambda base, value: replace(
@@ -470,11 +568,14 @@ def test_custom_source_gradient_vs_permittivity(_enable_local_cache, tmp_path, c
 
 
 @pytest.mark.numerical
+@pytest.mark.parametrize("sim_dims", SIM_DIMS_VALUES, ids=lambda dims: f"{dims}d")
 @pytest.mark.parametrize("case", SOURCE_CASES, ids=lambda case: case.name)
-def test_custom_source_gradient_vs_wavelength(_enable_local_cache, tmp_path, case):
+def test_custom_source_gradient_vs_wavelength(_enable_local_cache, tmp_path, case, sim_dims):
+    _skip_2d_field_cases(sim_dims, case)
     _run_variation_sweep(
         tmp_path,
         case,
+        sim_dims,
         "wvl0",
         WVL0_VALUES,
         lambda base, value: replace(base, wvl0=value),

--- a/tests/test_components/autograd/numerical/test_autograd_source_numerical.py
+++ b/tests/test_components/autograd/numerical/test_autograd_source_numerical.py
@@ -18,7 +18,7 @@ def _enable_local_cache(monkeypatch):
 
 
 ANGLE_LIMIT_DEG = 5.0
-NORM_RTOL = 0.1
+NORM_RTOL = 0.12
 NORM_ATOL = 1e-6
 
 BASE_WVL0 = 2.0
@@ -50,6 +50,9 @@ PERMITTIVITY_VALUES = (
     (4.0, None),
 )
 SIM_DIMS_VALUES = (3, 2)
+OBJECTIVE_3D_MODE = (
+    "flux"  # or "intensity" # flux turned out to be more stable in finite difference gradient
+)
 
 
 def _axis_coords(size: float, spacing: float) -> np.ndarray:
@@ -111,6 +114,7 @@ class SweepConfig:
     wvl0: float = BASE_WVL0
     source_size: tuple[float, float, float] = BASE_SOURCE_SIZE
     sim_dims: int = 3
+    objective_3d: str = OBJECTIVE_3D_MODE
     amplitude_scale: float = 1.0
     background_permittivity: float = 1.0
     source_structure_permittivity: float | None = None
@@ -364,11 +368,15 @@ def _make_sim(
     )
 
 
-def _eval_objective(sim_data: td.SimulationData, sim_dims: int) -> float:
+def _eval_objective(sim_data: td.SimulationData, sim_dims: int, objective_3d: str) -> float:
     field_data = sim_data.load_field_monitor(FLUX_MONITOR_NAME)
     if sim_dims == 2:
         return np.sum(field_data.intensity.values)
-    return field_data.flux.values
+    if objective_3d == "flux":
+        return field_data.flux.values
+    if objective_3d == "intensity":
+        return np.sum(field_data.intensity.values)
+    raise ValueError(f"Unsupported 3D objective mode: {objective_3d!r}")
 
 
 def _run_gradient_case(
@@ -394,7 +402,7 @@ def _run_gradient_case(
             local_gradient=True,
             verbose=False,
         )
-        return _eval_objective(sim_data, config.sim_dims)
+        return _eval_objective(sim_data, config.sim_dims, config.objective_3d)
 
     grad_adjoint = np.array(
         [
@@ -425,12 +433,16 @@ def _run_gradient_case(
     for idx, axis in enumerate("xyz"):
         obj_plus = float(
             np.asarray(
-                _eval_objective(sim_data_map[f"{label}_fd_{axis}_plus"], config.sim_dims)
+                _eval_objective(
+                    sim_data_map[f"{label}_fd_{axis}_plus"], config.sim_dims, config.objective_3d
+                )
             ).squeeze()
         )
         obj_minus = float(
             np.asarray(
-                _eval_objective(sim_data_map[f"{label}_fd_{axis}_minus"], config.sim_dims)
+                _eval_objective(
+                    sim_data_map[f"{label}_fd_{axis}_minus"], config.sim_dims, config.objective_3d
+                )
             ).squeeze()
         )
         grad_fd[idx] = (obj_plus - obj_minus) / (2 * case.delta)
@@ -647,12 +659,12 @@ def test_custom_source_gradient_stable_with_remote_dt_constraint(_enable_local_c
     np.testing.assert_allclose(
         constrained_metrics.fd_norm,
         base_metrics.fd_norm,
-        rtol=0.1,
+        rtol=NORM_RTOL,
         atol=NORM_ATOL,
     )
     np.testing.assert_allclose(
         constrained_metrics.adjoint_norm,
         base_metrics.adjoint_norm,
-        rtol=0.1,
+        rtol=NORM_RTOL,
         atol=NORM_ATOL,
     )

--- a/tests/test_components/autograd/test_adjoint_monitors.py
+++ b/tests/test_components/autograd/test_adjoint_monitors.py
@@ -7,7 +7,7 @@ import pytest
 
 import tidy3d as td
 
-SIM_FIELDS_KEYS = [("dummy", 0, "geometry")]
+SIM_FIELDS_KEYS = [("structures", 0, "geometry")]
 
 POLY_VERTS_2D: np.ndarray = np.array(
     [

--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -38,7 +38,7 @@ from tidy3d.plugins.smatrix import ComponentModeler, Port
 from tidy3d.plugins.smatrix.run import _run_local
 from tidy3d.web import run, run_async
 from tidy3d.web.api.autograd import autograd as autograd_module
-from tidy3d.web.api.autograd.autograd import run_async_custom, run_custom
+from tidy3d.web.api.autograd.autograd import run_async_custom, run_custom, verify_custom_vjp
 from tidy3d.web.api.autograd.types import CustomVJPConfig
 
 from ...utils import SIM_FULL, AssertLogLevel, custom_poleresidue_u, run_emulated, tracer_arr
@@ -1315,6 +1315,28 @@ def test_autograd_cm_custom_vjp(
         assert np.isclose(
             np.sum(np.abs(grad * (custom_vjp_val_scale / custom_vjp_val) - grad_scale)), 0.0
         ), "Gradients were not set by the user vjp"
+
+
+def test_verify_custom_vjp_ignores_source_traces():
+    """Custom VJP validation must only consider traced structures, not traced sources."""
+
+    def _dummy_vjp(_field, derivative_info):
+        return dict.fromkeys(derivative_info.paths, 0.0)
+
+    traced_fields = {("sources", 0, "current_dataset", "Ex"): np.array([1.0])}
+    custom_vjp = (
+        CustomVJPConfig(
+            structure=0,
+            compute_derivatives=_dummy_vjp,
+            path_key=("geometry", "vertices"),
+        ),
+    )
+
+    with pytest.raises(
+        AdjointError,
+        match="CustomVJPConfig structure index 0 not in traced structure indices.",
+    ):
+        verify_custom_vjp(custom_vjp, traced_fields)
 
 
 @pytest.mark.skipif(not RUN_NUMERICAL, reason="Numerical gradient tests runs through web API.")

--- a/tests/test_components/autograd/test_autograd_sources.py
+++ b/tests/test_components/autograd/test_autograd_sources.py
@@ -15,6 +15,7 @@ Test coverage:
 from __future__ import annotations
 
 import sys
+from types import SimpleNamespace
 
 import autograd as ag
 import autograd.numpy as anp
@@ -213,6 +214,39 @@ class TestSpatialWeights:
         )
         npt.assert_allclose(result.values, 1.0)
 
+    def test_transpose_interp_single_target_frequency_accumulates_all_inputs(self):
+        """Single-frequency source datasets must accumulate all adjoint-frequency contributions."""
+        from tidy3d.components.autograd.derivative_utils import transpose_interp_field_to_dataset
+
+        adjoint_coords = {
+            "x": np.array([0.0]),
+            "y": np.array([0.0]),
+            "z": np.array([0.0]),
+            "f": np.array([2.0e14, 3.0e14, 4.0e14]),
+        }
+        adjoint_field = td.ScalarFieldDataArray(
+            np.array([[[[1.0, 2.0, 3.0]]]]),
+            coords=adjoint_coords,
+            dims=("x", "y", "z", "f"),
+        )
+
+        dataset_coords = {
+            "x": np.array([0.0]),
+            "y": np.array([0.0]),
+            "z": np.array([0.0]),
+            "f": np.array([2.5e14]),
+        }
+        dataset_field = td.ScalarFieldDataArray(
+            np.array([[[[1.0]]]]),
+            coords=dataset_coords,
+            dims=("x", "y", "z", "f"),
+        )
+
+        result = transpose_interp_field_to_dataset(
+            adjoint_field, dataset_field, center=(0.0, 0.0, 0.0)
+        )
+        npt.assert_allclose(result.values, np.array([[[[6.0]]]]), rtol=1e-12, atol=1e-12)
+
 
 def analytical_uniform_source_gradient(
     source_bounds: tuple[tuple[float, float, float], tuple[float, float, float]],
@@ -296,9 +330,8 @@ class TestCustomCurrentSourceUniform:
     def test_uniform_adjoint_field(self, source, source_bounds):
         """Test with uniform adjoint field."""
         # Create uniform adjoint field
-        adjoint_field_value = -1j * 2.0
-        source_scale = 2.0
-        E_adj = {"Ex": source_scale * create_adjoint_field_dataarray(adjoint_field_value)}
+        adjoint_field_value = 2.0
+        E_adj = {"Ex": create_adjoint_field_dataarray(adjoint_field_value)}
 
         di = DummySourceDI(
             paths=[("current_dataset", "Ex")],
@@ -310,16 +343,64 @@ class TestCustomCurrentSourceUniform:
         results = source._compute_derivatives(di)
 
         field_data = source.current_dataset.Ex
-        from tidy3d.components.autograd.derivative_utils import transpose_interp_field_to_dataset
+        from tidy3d.components.autograd.derivative_utils import (
+            source_scale_factor,
+            transpose_interp_field_to_dataset,
+        )
 
         adjoint_on_dataset = transpose_interp_field_to_dataset(
             E_adj["Ex"], field_data, center=source.center
         )
-        expected_gradient = 0.5 * np.sum(np.real(adjoint_on_dataset).values)
+        source_scale = source_scale_factor(E_adj["Ex"], field_data)
+        expected_gradient = np.sum(np.real(source_scale * adjoint_on_dataset).values)
 
         grad = results[("current_dataset", "Ex")]
         assert grad.shape == source.current_dataset.Ex.shape
+        assert not np.isclose(expected_gradient, 0.0)
+        assert not np.isclose(np.sum(grad), 0.0)
         npt.assert_allclose(np.sum(grad), expected_gradient, rtol=1e-2)
+
+    def test_multi_frequency_adjoint_accumulates_for_single_frequency_dataset(self):
+        """Current-source VJP must sum contributions from all adjoint frequencies."""
+        coords = {
+            "x": np.array([0.0]),
+            "y": np.array([0.0]),
+            "z": np.array([0.0]),
+            "f": np.array([2.5e14]),
+        }
+        source = td.CustomCurrentSource(
+            center=(0.0, 0.0, 0.0),
+            size=(0.0, 0.0, 0.0),
+            source_time=td.GaussianPulse(freq0=3.0e14, fwidth=1.0e14),
+            current_dataset=td.FieldDataset(
+                Ex=td.ScalarFieldDataArray(
+                    np.array([[[[1.0]]]]), coords=coords, dims=("x", "y", "z", "f")
+                )
+            ),
+        )
+
+        adjoint_coords = {
+            "x": np.array([0.0]),
+            "y": np.array([0.0]),
+            "z": np.array([0.0]),
+            "f": np.array([2.0e14, 3.0e14, 4.0e14]),
+        }
+        E_adj = {
+            "Ex": td.ScalarFieldDataArray(
+                np.array([[[[1.0, 2.0, 3.0]]]]),
+                coords=adjoint_coords,
+                dims=("x", "y", "z", "f"),
+            )
+        }
+        di = DummySourceDI(
+            paths=[("current_dataset", "Ex")],
+            E_adj=E_adj,
+            frequencies=adjoint_coords["f"],
+            bounds=source.geometry.bounds,
+        )
+
+        grad = source._compute_derivatives(di)[("current_dataset", "Ex")]
+        npt.assert_allclose(grad, np.array([[[[12.0 * np.pi]]]]), rtol=1e-12, atol=1e-12)
 
     def test_uniform_adjoint_field_with_permittivity_scaling(self, source, source_bounds):
         """Current-source gradients are invariant to supplied epsilon data."""
@@ -417,7 +498,7 @@ class TestCustomCurrentSourceUniform:
 
     def test_multiple_field_components(self, source, source_bounds):
         """Test with multiple field components."""
-        adjoint_field_value = -1j * 1.5
+        adjoint_field_value = 1.5
         E_adj = {
             "Ex": create_adjoint_field_dataarray(adjoint_field_value),
             "Ey": create_adjoint_field_dataarray(0.5 * adjoint_field_value),
@@ -434,7 +515,10 @@ class TestCustomCurrentSourceUniform:
 
         # Check each component
         field_data = source.current_dataset.Ex
-        from tidy3d.components.autograd.derivative_utils import transpose_interp_field_to_dataset
+        from tidy3d.components.autograd.derivative_utils import (
+            source_scale_factor,
+            transpose_interp_field_to_dataset,
+        )
 
         adjoint_on_dataset_ex = transpose_interp_field_to_dataset(
             E_adj["Ex"], field_data, center=source.center
@@ -443,10 +527,14 @@ class TestCustomCurrentSourceUniform:
             E_adj["Ey"], field_data, center=source.center
         )
 
-        expected_ex = 0.5 * np.sum(np.real(adjoint_on_dataset_ex).values)
-        expected_ey = 0.5 * np.sum(np.real(adjoint_on_dataset_ey).values)
+        source_scale_ex = source_scale_factor(E_adj["Ex"], field_data)
+        source_scale_ey = source_scale_factor(E_adj["Ey"], field_data)
+        expected_ex = np.sum(np.real(source_scale_ex * adjoint_on_dataset_ex).values)
+        expected_ey = np.sum(np.real(source_scale_ey * adjoint_on_dataset_ey).values)
         expected_ez = 0.0
 
+        assert not np.isclose(expected_ex, 0.0)
+        assert not np.isclose(expected_ey, 0.0)
         npt.assert_allclose(np.sum(results[("current_dataset", "Ex")]), expected_ex, rtol=1e-2)
         npt.assert_allclose(np.sum(results[("current_dataset", "Ey")]), expected_ey, rtol=1e-2)
         npt.assert_allclose(np.sum(results[("current_dataset", "Ez")]), expected_ez, rtol=1e-10)
@@ -477,7 +565,7 @@ class TestCustomFieldSourceUniform:
     def test_uniform_adjoint_field(self, source, source_bounds):
         """Test with uniform adjoint field."""
         # Create uniform adjoint field
-        adjoint_field_value = 1j * 2.0
+        adjoint_field_value = 2.0
         E_adj = {}
         H_adj = {"Hy": create_adjoint_field_dataarray(adjoint_field_value)}
 
@@ -492,16 +580,20 @@ class TestCustomFieldSourceUniform:
         results = source._compute_derivatives(di)
 
         # Analytical solution
-        from tidy3d.components.autograd.derivative_utils import transpose_interp_field_to_dataset
-        from tidy3d.constants import EPSILON_0
+        from tidy3d.components.autograd.derivative_utils import (
+            source_scale_factor,
+            transpose_interp_field_to_dataset,
+        )
 
-        omega = 2 * np.pi * 2e14
         field_data = source.field_dataset.Ex
         adjoint_on_dataset = transpose_interp_field_to_dataset(
             H_adj["Hy"], field_data, center=source.center
         )
-        expected_gradient = 0.5 * np.sum(np.real(omega * EPSILON_0 * adjoint_on_dataset).values)
+        source_scale = source_scale_factor(H_adj["Hy"], field_data)
+        expected_gradient = np.sum(np.real(source_scale * adjoint_on_dataset).values)
 
+        assert not np.isclose(expected_gradient, 0.0)
+        assert not np.isclose(np.sum(results[("field_dataset", "Ex")]), 0.0)
         npt.assert_allclose(np.sum(results[("field_dataset", "Ex")]), expected_gradient, rtol=1e-2)
 
     def test_uniform_adjoint_field_invariant_to_dataset_spacing(self, source_bounds):
@@ -701,7 +793,7 @@ class TestCustomCurrentSourceGaussian:
     def test_gaussian_adjoint_field(self, source, source_bounds):
         """Test with Gaussian adjoint field."""
         # Create Gaussian adjoint field
-        adjoint_amplitude = -1j * 1.0
+        adjoint_amplitude = 1.0
         sigma = 0.1
         x = np.linspace(-0.25, 0.25, 10)
         y = np.linspace(-0.25, 0.25, 10)
@@ -729,15 +821,21 @@ class TestCustomCurrentSourceGaussian:
 
         results = source._compute_derivatives(di)
 
-        from tidy3d.components.autograd.derivative_utils import transpose_interp_field_to_dataset
+        from tidy3d.components.autograd.derivative_utils import (
+            source_scale_factor,
+            transpose_interp_field_to_dataset,
+        )
 
         adjoint_on_dataset = transpose_interp_field_to_dataset(
             adjoint_field,
             source.current_dataset.Ex,
             center=source.center,
         )
-        expected_gradient = 0.5 * np.sum(np.real(adjoint_on_dataset).values)
+        source_scale = source_scale_factor(adjoint_field, source.current_dataset.Ex)
+        expected_gradient = np.sum(np.real(source_scale * adjoint_on_dataset).values)
 
+        assert not np.isclose(expected_gradient, 0.0)
+        assert not np.isclose(np.sum(results[("current_dataset", "Ex")]), 0.0)
         npt.assert_allclose(
             np.sum(results[("current_dataset", "Ex")]), expected_gradient, rtol=5e-1
         )
@@ -1035,6 +1133,37 @@ def test_mixed_structure_source_adjoint_monitors():
                 break
 
     assert source_monitor_found, "No source monitor found in adjoint monitors"
+
+
+def test_split_adjoint_data_logs_mixed_source_structure_counts(monkeypatch):
+    """Adjoint split log should report field/eps counts without assuming 1:1 pairing."""
+    from tidy3d.components.data import sim_data as sim_data_module
+
+    monitors = [
+        td.FieldMonitor(center=(0, 0, 0), size=(0, 0, 0), freqs=[2e14], name="orig"),
+        td.FieldMonitor(center=(0, 0, 0), size=(0, 0, 0), freqs=[2e14], name="adjoint_fld_0"),
+        td.FieldMonitor(center=(0, 0, 0), size=(0, 0, 0), freqs=[2e14], name="source_adjoint_0"),
+        td.PermittivityMonitor(
+            center=(0, 0, 0), size=(0, 0, 0), freqs=[2e14], name="adjoint_eps_0"
+        ),
+    ]
+    dummy_sim_data = SimpleNamespace(
+        data=["orig_data", "adj_fld_data", "source_adj_data", "adj_eps_data"],
+        simulation=SimpleNamespace(monitors=monitors),
+    )
+
+    messages = []
+    monkeypatch.setattr(sim_data_module.log, "info", lambda msg: messages.append(msg))
+
+    data_original, data_adjoint = sim_data_module.SimulationData._split_adjoint_data(
+        dummy_sim_data, num_mnts_original=1
+    )
+
+    assert data_original == ["orig_data"]
+    assert data_adjoint == ["adj_fld_data", "source_adj_data", "adj_eps_data"]
+    assert any(
+        "1 monitors, 2 adjoint field monitors, 1 adjoint eps monitors." in msg for msg in messages
+    )
 
 
 def _make_uniform_field_dataset(val, data_shape=(10, 10, 1, 1), freq=2e14):

--- a/tests/test_components/autograd/test_autograd_sources.py
+++ b/tests/test_components/autograd/test_autograd_sources.py
@@ -247,62 +247,20 @@ class TestSpatialWeights:
         )
         npt.assert_allclose(result.values, np.array([[[[6.0]]]]), rtol=1e-12, atol=1e-12)
 
+    def test_transpose_interp_axis_requires_sorted_coordinates(self):
+        """Axis-level transpose interpolation should enforce sorted source coordinates."""
+        from tidy3d.components.autograd.derivative_utils import transpose_interp_axis
 
-def analytical_uniform_source_gradient(
-    source_bounds: tuple[tuple[float, float, float], tuple[float, float, float]],
-    adjoint_field_value: complex,
-    source_scale: complex,
-    field_component: str = "Ex",
-) -> float:
-    """
-    Analytical gradient for uniform source with uniform adjoint field.
+        field_values = np.ones((3, 1), dtype=float)
+        field_coords = np.array([0.0, 0.5, 1.0])
+        unsorted_param_coords = np.array([0.0, -0.5, 0.5])
 
-    The gradient is the volume integral of the scaled adjoint field.
-    """
-    (x_min, y_min, z_min), (x_max, y_max, z_max) = source_bounds
-    volume = (x_max - x_min) * (y_max - y_min) * (z_max - z_min)
-    return np.real(1j * source_scale * adjoint_field_value) * volume
-
-
-def analytical_gaussian_source_gradient(
-    source_bounds: tuple[tuple[float, float, float], tuple[float, float, float]],
-    adjoint_amplitude: complex,
-    source_scale: complex,
-    sigma: float = 0.1,
-    field_component: str = "Ex",
-) -> float:
-    """
-    Analytical gradient for uniform source with Gaussian adjoint field.
-
-    The gradient is the volume integral of the Gaussian adjoint field.
-    For a Gaussian centered at the source center, we compute the actual
-    integral over the source bounds.
-    """
-    (x_min, y_min, z_min), (x_max, y_max, z_max) = source_bounds
-
-    # For a Gaussian field exp(-(x^2 + y^2 + z^2)/(2*sigma^2)), the integral
-    # over a rectangular domain can be approximated by the sum of field values
-    # times the volume element, which is what the numerical integration does.
-
-    # Since the test uses a 10x10x1 grid over the bounds, we can compute
-    # the expected value by sampling the Gaussian at those points
-    x = np.linspace(x_min, x_max, 10)
-    y = np.linspace(y_min, y_max, 10)
-    z = np.array([0.0])  # Single z point as in the test
-
-    X, Y, Z = np.meshgrid(x, y, z, indexing="ij")
-    r_sq = (X**2 + Y**2 + Z**2) / (2 * sigma**2)
-    field_data = adjoint_amplitude * np.exp(-r_sq)
-
-    # Compute the volume element
-    dx = x[1] - x[0]
-    dy = y[1] - y[0]
-
-    # The integral is the sum of field values times the area element (2D integral)
-    # since z has only one point, integrate_within_bounds only integrates over x and y
-    integral = np.sum(np.real(1j * source_scale * field_data)) * dx * dy
-
-    return integral
+        with pytest.raises(ValueError, match="must be sorted"):
+            transpose_interp_axis(
+                field_values=field_values,
+                field_coords_1d=field_coords,
+                param_coords_1d=unsorted_param_coords,
+            )
 
 
 class TestCustomCurrentSourceUniform:
@@ -402,8 +360,210 @@ class TestCustomCurrentSourceUniform:
         grad = source._compute_derivatives(di)[("current_dataset", "Ex")]
         npt.assert_allclose(grad, np.array([[[[12.0 * np.pi]]]]), rtol=1e-12, atol=1e-12)
 
-    def test_uniform_adjoint_field_with_permittivity_scaling(self, source, source_bounds):
-        """Current-source gradients are invariant to supplied epsilon data."""
+    def test_interpolate_flag_changes_vjp_projection_on_zero_size_axis(self):
+        """Current-source VJP should switch to nearest only along zero-size source axes."""
+        coords = {
+            "x": np.array([-0.4, -0.1, 0.2, 0.5]),
+            "y": np.array([0.0]),
+            "z": np.array([0.0]),
+            "f": np.array([2e14]),
+        }
+        dataset = td.FieldDataset(
+            Ex=td.ScalarFieldDataArray(
+                np.ones((4, 1, 1, 1)),
+                coords=coords,
+                dims=("x", "y", "z", "f"),
+            )
+        )
+        source_linear = td.CustomCurrentSource(
+            center=(0.0, 0.0, 0.0),
+            size=(0.0, 0.5, 0.0),
+            source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
+            current_dataset=dataset,
+            interpolate=True,
+        )
+        source_nearest = source_linear.updated_copy(interpolate=False)
+
+        adjoint_coords = {
+            "x": np.array([-0.5, 0.0, 0.5]),
+            "y": np.array([0.0]),
+            "z": np.array([0.0]),
+            "f": np.array([2e14]),
+        }
+        E_adj = {
+            "Ex": td.ScalarFieldDataArray(
+                np.array([[[[1.0]]], [[[2.0]]], [[[3.0]]]]),
+                coords=adjoint_coords,
+                dims=("x", "y", "z", "f"),
+            )
+        }
+        di = DummySourceDI(
+            paths=[("current_dataset", "Ex")],
+            E_adj=E_adj,
+            frequencies=adjoint_coords["f"],
+            bounds=source_linear.geometry.bounds,
+        )
+
+        grad_linear = source_linear._compute_derivatives(di)[("current_dataset", "Ex")]
+        grad_nearest = source_nearest._compute_derivatives(di)[("current_dataset", "Ex")]
+        assert not np.allclose(grad_linear, grad_nearest)
+
+    def test_interpolate_flag_keeps_linear_projection_on_nonzero_axis(self):
+        """Current-source VJP should stay linear on nonzero-size source axes."""
+        coords = {
+            "x": np.array([-0.4, -0.1, 0.2, 0.5]),
+            "y": np.array([0.0]),
+            "z": np.array([0.0]),
+            "f": np.array([2e14]),
+        }
+        dataset = td.FieldDataset(
+            Ex=td.ScalarFieldDataArray(
+                np.ones((4, 1, 1, 1)),
+                coords=coords,
+                dims=("x", "y", "z", "f"),
+            )
+        )
+        source_linear = td.CustomCurrentSource(
+            center=(0.0, 0.0, 0.0),
+            size=(0.5, 0.0, 0.0),
+            source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
+            current_dataset=dataset,
+            interpolate=True,
+        )
+        source_nearest = source_linear.updated_copy(interpolate=False)
+
+        adjoint_coords = {
+            "x": np.array([-0.5, 0.0, 0.5]),
+            "y": np.array([0.0]),
+            "z": np.array([0.0]),
+            "f": np.array([2e14]),
+        }
+        E_adj = {
+            "Ex": td.ScalarFieldDataArray(
+                np.array([[[[1.0]]], [[[2.0]]], [[[3.0]]]]),
+                coords=adjoint_coords,
+                dims=("x", "y", "z", "f"),
+            )
+        }
+        di = DummySourceDI(
+            paths=[("current_dataset", "Ex")],
+            E_adj=E_adj,
+            frequencies=adjoint_coords["f"],
+            bounds=source_linear.geometry.bounds,
+        )
+
+        grad_linear = source_linear._compute_derivatives(di)[("current_dataset", "Ex")]
+        grad_nearest = source_nearest._compute_derivatives(di)[("current_dataset", "Ex")]
+        npt.assert_allclose(grad_nearest, grad_linear, rtol=1e-12, atol=1e-12)
+
+    def test_confine_to_bounds_masks_out_of_bounds_dataset_points(self):
+        """VJP should be zeroed at out-of-bounds dataset points when ``confine_to_bounds=True``."""
+        coords = {
+            "x": np.array([-1.0, 0.0, 1.0]),
+            "y": np.array([0.0]),
+            "z": np.array([0.0]),
+            "f": np.array([2e14]),
+        }
+        dataset = td.FieldDataset(
+            Ex=td.ScalarFieldDataArray(
+                np.ones((3, 1, 1, 1)),
+                coords=coords,
+                dims=("x", "y", "z", "f"),
+            )
+        )
+        source = td.CustomCurrentSource(
+            center=(0.0, 0.0, 0.0),
+            size=(1.0, 1.0, 0.0),
+            source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
+            current_dataset=dataset,
+            confine_to_bounds=False,
+        )
+        source_confined = source.updated_copy(confine_to_bounds=True)
+
+        adjoint_coords = {
+            "x": np.linspace(-1.0, 1.0, 9),
+            "y": np.array([0.0]),
+            "z": np.array([0.0]),
+            "f": np.array([2e14]),
+        }
+        E_adj = {
+            "Ex": td.ScalarFieldDataArray(
+                np.ones((9, 1, 1, 1)),
+                coords=adjoint_coords,
+                dims=("x", "y", "z", "f"),
+            )
+        }
+        di = DummySourceDI(
+            paths=[("current_dataset", "Ex")],
+            E_adj=E_adj,
+            frequencies=adjoint_coords["f"],
+            bounds=source.geometry.bounds,
+        )
+
+        grad_full = source._compute_derivatives(di)[("current_dataset", "Ex")]
+        grad_confined = source_confined._compute_derivatives(di)[("current_dataset", "Ex")]
+
+        assert not np.isclose(grad_full[0, 0, 0, 0], 0.0)
+        assert not np.isclose(grad_full[2, 0, 0, 0], 0.0)
+        npt.assert_allclose(grad_confined[0, 0, 0, 0], 0.0, atol=1e-12)
+        npt.assert_allclose(grad_confined[2, 0, 0, 0], 0.0, atol=1e-12)
+        assert np.isclose(grad_confined[1, 0, 0, 0], grad_full[1, 0, 0, 0])
+
+    def test_unsorted_dataset_coords_supported(self):
+        """Current-source VJP should support unsorted dataset coordinates by sorting internally."""
+        coords = {
+            "x": np.array([0.5, 0.0, -0.5]),
+            "y": np.array([0.0]),
+            "z": np.array([0.0]),
+            "f": np.array([2e14]),
+        }
+        source = td.CustomCurrentSource(
+            center=(0.0, 0.0, 0.0),
+            size=(1.0, 0.0, 0.0),
+            source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
+            current_dataset=td.FieldDataset(
+                Ex=td.ScalarFieldDataArray(
+                    np.ones((3, 1, 1, 1)),
+                    coords=coords,
+                    dims=("x", "y", "z", "f"),
+                )
+            ),
+        )
+        adjoint_coords = {
+            "x": np.array([-0.5, 0.0, 0.5]),
+            "y": np.array([0.0]),
+            "z": np.array([0.0]),
+            "f": np.array([2e14]),
+        }
+        E_adj = {
+            "Ex": td.ScalarFieldDataArray(
+                np.ones((3, 1, 1, 1)),
+                coords=adjoint_coords,
+                dims=("x", "y", "z", "f"),
+            )
+        }
+        di = DummySourceDI(
+            paths=[("current_dataset", "Ex")],
+            E_adj=E_adj,
+            frequencies=adjoint_coords["f"],
+            bounds=source.geometry.bounds,
+        )
+
+        grad = source._compute_derivatives(di)[("current_dataset", "Ex")]
+        assert grad.shape == (3, 1, 1, 1)
+        assert np.all(np.isfinite(grad))
+
+    @pytest.mark.parametrize(
+        ("shift_coords", "label"),
+        (
+            (False, "current_permittivity_scaling"),
+            (True, "current_permittivity_shifted_coords"),
+        ),
+    )
+    def test_uniform_adjoint_field_permittivity_invariance(
+        self, source, source_bounds, shift_coords, label
+    ):
+        """Current-source gradients are invariant to supplied epsilon data and coordinate shifts."""
         adjoint_field_value = 2.0
         E_adj = {"Ex": create_adjoint_field_dataarray(adjoint_field_value)}
         field_data = source.current_dataset.Ex
@@ -416,11 +576,14 @@ class TestCustomCurrentSourceUniform:
         )
 
         eps_rel = 2.25
+        coord_offset = 8e-3 if shift_coords else 0.0
+        z_offset = -8e-3 if shift_coords else 0.0
+        freq_scale = 1 + 1e-9 if shift_coords else 1.0
         eps_coords = {
-            "x": np.asarray(field_data.coords["x"].data) + source.center[0],
-            "y": np.asarray(field_data.coords["y"].data) + source.center[1],
-            "z": np.asarray(field_data.coords["z"].data) + source.center[2],
-            "f": np.asarray(field_data.coords["f"].data),
+            "x": np.asarray(field_data.coords["x"].data) + source.center[0] + coord_offset,
+            "y": np.asarray(field_data.coords["y"].data) + source.center[1] + coord_offset,
+            "z": np.asarray(field_data.coords["z"].data) + source.center[2] + z_offset,
+            "f": np.asarray(field_data.coords["f"].data) * freq_scale,
         }
         eps_values = eps_rel * np.ones(field_data.shape)
         eps_data = td.ScalarFieldDataArray(eps_values, coords=eps_coords, dims=field_data.dims)
@@ -438,46 +601,7 @@ class TestCustomCurrentSourceUniform:
 
         assert not np.isclose(grad_air, 0.0)
         assert not np.isclose(grad_eps, 0.0)
-        print(f"[current_permittivity_scaling] ratio = {ratio}", file=sys.stderr)
-        npt.assert_allclose(ratio, 1.0, rtol=1e-3)
-
-    def test_uniform_adjoint_field_with_shifted_eps_coords(self, source, source_bounds):
-        """Shifted epsilon coordinates should not change current-source gradients."""
-        adjoint_field_value = 2.0
-        E_adj = {"Ex": create_adjoint_field_dataarray(adjoint_field_value)}
-        field_data = source.current_dataset.Ex
-
-        di_air = DummySourceDI(
-            paths=[("current_dataset", "Ex")],
-            E_adj=E_adj,
-            frequencies=np.array([2e14]),
-            bounds=source_bounds,
-        )
-
-        eps_rel = 2.25
-        eps_coords = {
-            "x": np.asarray(field_data.coords["x"].data) + source.center[0] + 8e-3,
-            "y": np.asarray(field_data.coords["y"].data) + source.center[1] + 8e-3,
-            "z": np.asarray(field_data.coords["z"].data) + source.center[2] - 8e-3,
-            "f": np.asarray(field_data.coords["f"].data) * (1 + 1e-9),
-        }
-        eps_values = eps_rel * np.ones(field_data.shape)
-        eps_data = td.ScalarFieldDataArray(eps_values, coords=eps_coords, dims=field_data.dims)
-        di_eps = DummySourceDI(
-            paths=[("current_dataset", "Ex")],
-            E_adj=E_adj,
-            frequencies=np.array([2e14]),
-            bounds=source_bounds,
-            eps_data={"eps": eps_data},
-        )
-
-        grad_air = np.sum(source._compute_derivatives(di_air)[("current_dataset", "Ex")])
-        grad_eps = np.sum(source._compute_derivatives(di_eps)[("current_dataset", "Ex")])
-        ratio = grad_air / grad_eps
-
-        assert not np.isclose(grad_air, 0.0)
-        assert not np.isclose(grad_eps, 0.0)
-        print(f"[current_permittivity_shifted_coords] ratio = {ratio}", file=sys.stderr)
+        print(f"[{label}] ratio = {ratio}", file=sys.stderr)
         npt.assert_allclose(ratio, 1.0, rtol=1e-3)
 
     def test_zero_adjoint_field(self, source, source_bounds):
@@ -632,8 +756,17 @@ class TestCustomFieldSourceUniform:
         print(f"[field_spacing_invariance] ratio = {spacing_ratio}", file=sys.stderr)
         npt.assert_allclose(spacing_ratio, 1.0, rtol=2e-2)
 
-    def test_uniform_adjoint_field_with_permittivity_scaling(self, source, source_bounds):
-        """Field-source gradients are invariant to supplied epsilon data."""
+    @pytest.mark.parametrize(
+        ("shift_coords", "label"),
+        (
+            (False, "field_permittivity_scaling"),
+            (True, "field_permittivity_shifted_coords"),
+        ),
+    )
+    def test_uniform_adjoint_field_permittivity_invariance(
+        self, source, source_bounds, shift_coords, label
+    ):
+        """Field-source gradients are invariant to supplied epsilon data and coordinate shifts."""
         adjoint_field_value = 2.0
         H_adj = {"Hy": create_adjoint_field_dataarray(adjoint_field_value)}
         field_data = source.field_dataset.Ex
@@ -647,11 +780,14 @@ class TestCustomFieldSourceUniform:
         )
 
         eps_rel = 2.25
+        coord_offset = 8e-3 if shift_coords else 0.0
+        z_offset = -8e-3 if shift_coords else 0.0
+        freq_scale = 1 + 1e-9 if shift_coords else 1.0
         eps_coords = {
-            "x": np.asarray(field_data.coords["x"].data) + source.center[0],
-            "y": np.asarray(field_data.coords["y"].data) + source.center[1],
-            "z": np.asarray(field_data.coords["z"].data) + source.center[2],
-            "f": np.asarray(field_data.coords["f"].data),
+            "x": np.asarray(field_data.coords["x"].data) + source.center[0] + coord_offset,
+            "y": np.asarray(field_data.coords["y"].data) + source.center[1] + coord_offset,
+            "z": np.asarray(field_data.coords["z"].data) + source.center[2] + z_offset,
+            "f": np.asarray(field_data.coords["f"].data) * freq_scale,
         }
         eps_values = eps_rel * np.ones(field_data.shape)
         eps_data = td.ScalarFieldDataArray(eps_values, coords=eps_coords, dims=field_data.dims)
@@ -670,49 +806,53 @@ class TestCustomFieldSourceUniform:
 
         assert not np.isclose(grad_air, 0.0)
         assert not np.isclose(grad_eps, 0.0)
-        print(f"[field_permittivity_scaling] ratio = {ratio}", file=sys.stderr)
+        print(f"[{label}] ratio = {ratio}", file=sys.stderr)
         npt.assert_allclose(ratio, 1.0, rtol=1e-3)
 
-    def test_uniform_adjoint_field_with_shifted_eps_coords(self, source, source_bounds):
-        """Shifted epsilon coordinates should not change field-source gradients."""
-        adjoint_field_value = 2.0
-        H_adj = {"Hy": create_adjoint_field_dataarray(adjoint_field_value)}
-        field_data = source.field_dataset.Ex
-
-        di_air = DummySourceDI(
-            paths=[("field_dataset", "Ex")],
-            E_adj={},
-            H_adj=H_adj,
-            frequencies=np.array([2e14]),
-            bounds=source_bounds,
-        )
-
-        eps_rel = 2.25
-        eps_coords = {
-            "x": np.asarray(field_data.coords["x"].data) + source.center[0] + 8e-3,
-            "y": np.asarray(field_data.coords["y"].data) + source.center[1] + 8e-3,
-            "z": np.asarray(field_data.coords["z"].data) + source.center[2] - 8e-3,
-            "f": np.asarray(field_data.coords["f"].data) * (1 + 1e-9),
+    def test_unsorted_dataset_coords_supported(self):
+        """Field-source VJP should support unsorted dataset coordinates by sorting internally."""
+        coords = {
+            "x": np.array([0.5, 0.0, -0.5]),
+            "y": np.array([-0.5, 0.0, 0.5]),
+            "z": np.array([0.0]),
+            "f": np.array([2e14]),
         }
-        eps_values = eps_rel * np.ones(field_data.shape)
-        eps_data = td.ScalarFieldDataArray(eps_values, coords=eps_coords, dims=field_data.dims)
-        di_eps = DummySourceDI(
+        source = td.CustomFieldSource(
+            center=(0.0, 0.0, 0.0),
+            size=(1.0, 1.0, 0.0),
+            source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
+            field_dataset=td.FieldDataset(
+                Ex=td.ScalarFieldDataArray(
+                    np.ones((3, 3, 1, 1)),
+                    coords=coords,
+                    dims=("x", "y", "z", "f"),
+                )
+            ),
+        )
+        adjoint_coords = {
+            "x": np.array([-0.5, 0.0, 0.5]),
+            "y": np.array([-0.5, 0.0, 0.5]),
+            "z": np.array([0.0]),
+            "f": np.array([2e14]),
+        }
+        H_adj = {
+            "Hy": td.ScalarFieldDataArray(
+                np.ones((3, 3, 1, 1)),
+                coords=adjoint_coords,
+                dims=("x", "y", "z", "f"),
+            )
+        }
+        di = DummySourceDI(
             paths=[("field_dataset", "Ex")],
             E_adj={},
             H_adj=H_adj,
-            frequencies=np.array([2e14]),
-            bounds=source_bounds,
-            eps_data={"eps": eps_data},
+            frequencies=adjoint_coords["f"],
+            bounds=source.geometry.bounds,
         )
 
-        grad_air = np.sum(source._compute_derivatives(di_air)[("field_dataset", "Ex")])
-        grad_eps = np.sum(source._compute_derivatives(di_eps)[("field_dataset", "Ex")])
-        ratio = grad_air / grad_eps
-
-        assert not np.isclose(grad_air, 0.0)
-        assert not np.isclose(grad_eps, 0.0)
-        print(f"[field_permittivity_shifted_coords] ratio = {ratio}", file=sys.stderr)
-        npt.assert_allclose(ratio, 1.0, rtol=1e-3)
+        grad = source._compute_derivatives(di)[("field_dataset", "Ex")]
+        assert grad.shape == (3, 3, 1, 1)
+        assert np.all(np.isfinite(grad))
 
 
 @pytest.mark.parametrize(
@@ -839,148 +979,6 @@ class TestCustomCurrentSourceGaussian:
         npt.assert_allclose(
             np.sum(results[("current_dataset", "Ex")]), expected_gradient, rtol=5e-1
         )
-
-
-def test_source_autograd(use_emulated_run):  # noqa: F811
-    """Test autograd differentiation with respect to CustomCurrentSource parameters."""
-
-    def make_sim_with_traced_source(val):
-        """Create a simulation with a traced CustomCurrentSource."""
-
-        # Create a simple simulation
-        sim = td.Simulation(
-            size=(2.0, 2.0, 2.0),
-            run_time=1e-12,
-            grid_spec=td.GridSpec.uniform(dl=0.1),
-            sources=[],
-            monitors=[
-                td.FieldMonitor(
-                    size=(1.0, 1.0, 0.0), center=(0, 0, 0), freqs=[2e14], name="field_monitor"
-                )
-            ],
-        )
-
-        data_shape = (10, 10, 1, 1)
-
-        # Create a traced CustomCurrentSource
-        x = np.linspace(-0.5, 0.5, data_shape[0])
-        y = np.linspace(-0.5, 0.5, data_shape[1])
-        z = np.array([0])
-        f = [2e14]
-        coords = {"x": x, "y": y, "z": z, "f": f}
-
-        # Create traced field data
-        field_data = val * np.ones(data_shape)
-        scalar_field = td.ScalarFieldDataArray(field_data, coords=coords)
-
-        # Create field dataset with traced data
-        field_dataset = td.FieldDataset(Ex=scalar_field)
-
-        # Create CustomCurrentSource with traced dataset
-        custom_source = td.CustomCurrentSource(
-            center=(0, 0, 0),
-            size=(1.0, 1.0, 0.0),
-            source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
-            current_dataset=field_dataset,
-        )
-
-        # Add source to simulation
-        sim = sim.updated_copy(sources=[custom_source])
-
-        return sim
-
-    def objective(val):
-        """Objective function that depends on source parameters."""
-
-        sim = make_sim_with_traced_source(val)
-
-        # Run simulation
-        sim_data = run(sim, task_name="test_source_autograd")
-
-        # Extract field data from monitor
-        field_data = sim_data.load_field_monitor("field_monitor")
-        Ex_field = field_data.Ex
-
-        # Compute objective (e.g., field intensity at a point)
-        objective_value = anp.abs(Ex_field.isel(x=5, y=5, z=0, f=0).values) ** 2
-
-        return objective_value
-
-    # Compute gradient
-    grad = ag.grad(objective)(1.0)
-
-    assert anp.all(grad != 0.0), "some gradients are 0"
-
-
-def test_field_source_autograd(use_emulated_run):  # noqa: F811
-    """Test autograd differentiation with respect to CustomFieldSource parameters."""
-
-    def make_sim_with_traced_field_source(val):
-        """Create a simulation with a traced CustomFieldSource."""
-
-        # Create a simple simulation
-        sim = td.Simulation(
-            size=(2.0, 2.0, 2.0),
-            run_time=1e-12,
-            grid_spec=td.GridSpec.uniform(dl=0.1),
-            sources=[],
-            monitors=[
-                td.FieldMonitor(
-                    size=(1.0, 1.0, 0.0), center=(0, 0, 0), freqs=[2e14], name="field_monitor"
-                )
-            ],
-        )
-
-        data_shape = (10, 10, 1, 1)
-
-        # Create a traced CustomFieldSource
-        x = np.linspace(-0.5, 0.5, data_shape[0])
-        y = np.linspace(-0.5, 0.5, data_shape[1])
-        z = np.array([0])
-        f = [2e14]
-        coords = {"x": x, "y": y, "z": z, "f": f}
-
-        # Create traced field data
-        field_data = val * np.ones(data_shape)
-        scalar_field = td.ScalarFieldDataArray(field_data, coords=coords)
-
-        # Create field dataset with traced data
-        field_dataset = td.FieldDataset(Ex=scalar_field)
-
-        # Create CustomFieldSource with traced dataset
-        custom_source = td.CustomFieldSource(
-            center=(0, 0, 0),
-            size=(1.0, 1.0, 0.0),
-            source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
-            field_dataset=field_dataset,
-        )
-
-        # Add source to simulation
-        sim = sim.updated_copy(sources=[custom_source])
-
-        return sim
-
-    def objective(val):
-        """Objective function that depends on source parameters."""
-
-        sim = make_sim_with_traced_field_source(val)
-
-        # Run simulation
-        sim_data = run(sim, task_name="test_field_source_autograd")
-
-        # Extract field data from monitor
-        field_data = sim_data.load_field_monitor("field_monitor")
-        Ex_field = field_data.Ex
-
-        # Compute objective (e.g., field intensity at a point)
-        objective_value = anp.abs(Ex_field.isel(x=5, y=5, z=0, f=0).values) ** 2
-
-        return objective_value
-
-    # Compute gradient
-    grad = ag.grad(objective)(1.0)
-
-    assert anp.all(grad != 0.0), "some gradients are 0"
 
 
 @pytest.mark.parametrize(
@@ -1236,3 +1234,4 @@ def test_traced_source_derivative_computation(use_emulated_run, kind, make_sourc
 
     assert grad is not None
     assert isinstance(grad, (float, np.ndarray))
+    assert np.all(np.asarray(grad) != 0.0), "some gradients are 0"

--- a/tests/test_components/autograd/test_autograd_sources.py
+++ b/tests/test_components/autograd/test_autograd_sources.py
@@ -24,6 +24,11 @@ import numpy.testing as npt
 import pytest
 
 import tidy3d as td
+from tidy3d.components.autograd.derivative_utils import (
+    compute_spatial_weights,
+    transpose_interp_axis,
+    transpose_interp_field_to_dataset,
+)
 from tidy3d.web import run
 
 from .test_autograd import use_emulated_run  # noqa: F401
@@ -148,8 +153,6 @@ class TestSpatialWeights:
 
     def test_compute_spatial_weights_cell_sizes(self):
         """Cell-size weights should match averaged coordinate spacing."""
-        from tidy3d.components.autograd.derivative_utils import compute_spatial_weights
-
         coords = {"x": np.array([0.0, 1.0, 2.0]), "y": np.array([0.0, 2.0]), "z": np.array([0.0])}
         values = np.zeros((3, 2, 1))
         arr = td.ScalarFieldDataArray(values, coords=coords, dims=("x", "y", "z"))
@@ -161,11 +164,6 @@ class TestSpatialWeights:
 
     def test_transpose_interp_identity(self):
         """Adjoint interpolation should preserve weighted values on identical grids."""
-        from tidy3d.components.autograd.derivative_utils import (
-            compute_spatial_weights,
-            transpose_interp_field_to_dataset,
-        )
-
         coords = {
             "x": np.array([0.0, 1.0]),
             "y": np.array([0.0, 2.0]),
@@ -186,8 +184,6 @@ class TestSpatialWeights:
 
     def test_transpose_interp_collapsed_axis(self):
         """Collapsed dataset axis should respect source-bounds cropping."""
-        from tidy3d.components.autograd.derivative_utils import transpose_interp_field_to_dataset
-
         adjoint_coords = {
             "x": np.array([0.0, 1.0]),
             "y": np.array([0.0]),
@@ -216,8 +212,6 @@ class TestSpatialWeights:
 
     def test_transpose_interp_single_target_frequency_accumulates_all_inputs(self):
         """Single-frequency source datasets must accumulate all adjoint-frequency contributions."""
-        from tidy3d.components.autograd.derivative_utils import transpose_interp_field_to_dataset
-
         adjoint_coords = {
             "x": np.array([0.0]),
             "y": np.array([0.0]),
@@ -249,8 +243,6 @@ class TestSpatialWeights:
 
     def test_transpose_interp_axis_requires_sorted_coordinates(self):
         """Axis-level transpose interpolation should enforce sorted source coordinates."""
-        from tidy3d.components.autograd.derivative_utils import transpose_interp_axis
-
         field_values = np.ones((3, 1), dtype=float)
         field_coords = np.array([0.0, 0.5, 1.0])
         unsorted_param_coords = np.array([0.0, -0.5, 0.5])
@@ -301,16 +293,11 @@ class TestCustomCurrentSourceUniform:
         results = source._compute_derivatives(di)
 
         field_data = source.current_dataset.Ex
-        from tidy3d.components.autograd.derivative_utils import (
-            source_scale_factor,
-            transpose_interp_field_to_dataset,
-        )
 
         adjoint_on_dataset = transpose_interp_field_to_dataset(
             E_adj["Ex"], field_data, center=source.center
         )
-        source_scale = source_scale_factor(E_adj["Ex"], field_data)
-        expected_gradient = np.sum(np.real(source_scale * adjoint_on_dataset).values)
+        expected_gradient = np.sum(np.real(adjoint_on_dataset).values)
 
         grad = results[("current_dataset", "Ex")]
         assert grad.shape == source.current_dataset.Ex.shape
@@ -358,7 +345,9 @@ class TestCustomCurrentSourceUniform:
         )
 
         grad = source._compute_derivatives(di)[("current_dataset", "Ex")]
-        npt.assert_allclose(grad, np.array([[[[12.0 * np.pi]]]]), rtol=1e-12, atol=1e-12)
+        # Source-wide constant scaling is applied upstream in backward.py.
+        # Here we only verify accumulation over adjoint frequencies.
+        npt.assert_allclose(grad, np.array([[[[6.0]]]]), rtol=1e-12, atol=1e-12)
 
     def test_interpolate_flag_changes_vjp_projection_on_zero_size_axis(self):
         """Current-source VJP should switch to nearest only along zero-size source axes."""
@@ -639,10 +628,6 @@ class TestCustomCurrentSourceUniform:
 
         # Check each component
         field_data = source.current_dataset.Ex
-        from tidy3d.components.autograd.derivative_utils import (
-            source_scale_factor,
-            transpose_interp_field_to_dataset,
-        )
 
         adjoint_on_dataset_ex = transpose_interp_field_to_dataset(
             E_adj["Ex"], field_data, center=source.center
@@ -651,10 +636,8 @@ class TestCustomCurrentSourceUniform:
             E_adj["Ey"], field_data, center=source.center
         )
 
-        source_scale_ex = source_scale_factor(E_adj["Ex"], field_data)
-        source_scale_ey = source_scale_factor(E_adj["Ey"], field_data)
-        expected_ex = np.sum(np.real(source_scale_ex * adjoint_on_dataset_ex).values)
-        expected_ey = np.sum(np.real(source_scale_ey * adjoint_on_dataset_ey).values)
+        expected_ex = np.sum(np.real(adjoint_on_dataset_ex).values)
+        expected_ey = np.sum(np.real(adjoint_on_dataset_ey).values)
         expected_ez = 0.0
 
         assert not np.isclose(expected_ex, 0.0)
@@ -662,6 +645,46 @@ class TestCustomCurrentSourceUniform:
         npt.assert_allclose(np.sum(results[("current_dataset", "Ex")]), expected_ex, rtol=1e-2)
         npt.assert_allclose(np.sum(results[("current_dataset", "Ey")]), expected_ey, rtol=1e-2)
         npt.assert_allclose(np.sum(results[("current_dataset", "Ez")]), expected_ez, rtol=1e-10)
+
+    def test_uniform_adjoint_field_resolution_scaling_matches_formula(self, source, source_bounds):
+        """Current-source VJP across adjoint grids should match the explicit formula."""
+        grad_sums = {}
+        expected_sums = {}
+
+        field_data = source.current_dataset.Ex
+        for nx in (10, 20):
+            ny = nx
+            coords = {
+                "x": np.linspace(-0.5, 0.5, nx),
+                "y": np.linspace(-0.5, 0.5, ny),
+                "z": np.array([0.0]),
+                "f": [2e14],
+            }
+            E_adj = {
+                "Ex": td.ScalarFieldDataArray(
+                    2.0 * np.ones((nx, ny, 1, 1)),
+                    coords=coords,
+                    dims=("x", "y", "z", "f"),
+                )
+            }
+            di = DummySourceDI(
+                paths=[("current_dataset", "Ex")],
+                E_adj=E_adj,
+                frequencies=np.array([2e14]),
+                bounds=source_bounds,
+            )
+            grad_sums[nx] = np.sum(source._compute_derivatives(di)[("current_dataset", "Ex")])
+            adjoint_on_dataset = transpose_interp_field_to_dataset(
+                E_adj["Ex"], field_data, center=source.center
+            )
+            expected_sums[nx] = np.sum(np.real(adjoint_on_dataset).values)
+            npt.assert_allclose(grad_sums[nx], expected_sums[nx], rtol=1e-2)
+
+        assert not np.isclose(grad_sums[10], 0.0)
+        resolution_ratio = grad_sums[20] / grad_sums[10]
+        print(f"[current_adjoint_grid_invariance] ratio = {resolution_ratio}", file=sys.stderr)
+        expected_ratio = expected_sums[20] / expected_sums[10]
+        npt.assert_allclose(resolution_ratio, expected_ratio, rtol=1e-2)
 
 
 class TestCustomFieldSourceUniform:
@@ -704,17 +727,11 @@ class TestCustomFieldSourceUniform:
         results = source._compute_derivatives(di)
 
         # Analytical solution
-        from tidy3d.components.autograd.derivative_utils import (
-            source_scale_factor,
-            transpose_interp_field_to_dataset,
-        )
-
         field_data = source.field_dataset.Ex
         adjoint_on_dataset = transpose_interp_field_to_dataset(
             H_adj["Hy"], field_data, center=source.center
         )
-        source_scale = source_scale_factor(H_adj["Hy"], field_data)
-        expected_gradient = np.sum(np.real(source_scale * adjoint_on_dataset).values)
+        expected_gradient = np.sum(np.real(adjoint_on_dataset).values)
 
         assert not np.isclose(expected_gradient, 0.0)
         assert not np.isclose(np.sum(results[("field_dataset", "Ex")]), 0.0)
@@ -755,6 +772,47 @@ class TestCustomFieldSourceUniform:
         spacing_ratio = grad_sums[20] / grad_sums[10]
         print(f"[field_spacing_invariance] ratio = {spacing_ratio}", file=sys.stderr)
         npt.assert_allclose(spacing_ratio, 1.0, rtol=2e-2)
+
+    def test_uniform_adjoint_field_resolution_scaling_matches_formula(self, source, source_bounds):
+        """Field-source VJP across adjoint grids should match the explicit formula."""
+        grad_sums = {}
+        expected_sums = {}
+
+        field_data = source.field_dataset.Ex
+        for nx in (10, 20):
+            ny = nx
+            coords = {
+                "x": np.linspace(-0.5, 0.5, nx),
+                "y": np.linspace(-0.5, 0.5, ny),
+                "z": np.array([0.0]),
+                "f": [2e14],
+            }
+            H_adj = {
+                "Hy": td.ScalarFieldDataArray(
+                    2.0 * np.ones((nx, ny, 1, 1)),
+                    coords=coords,
+                    dims=("x", "y", "z", "f"),
+                )
+            }
+            di = DummySourceDI(
+                paths=[("field_dataset", "Ex")],
+                E_adj={},
+                H_adj=H_adj,
+                frequencies=np.array([2e14]),
+                bounds=source_bounds,
+            )
+            grad_sums[nx] = np.sum(source._compute_derivatives(di)[("field_dataset", "Ex")])
+            adjoint_on_dataset = transpose_interp_field_to_dataset(
+                H_adj["Hy"], field_data, center=source.center
+            )
+            expected_sums[nx] = np.sum(np.real(adjoint_on_dataset).values)
+            npt.assert_allclose(grad_sums[nx], expected_sums[nx], rtol=1e-2)
+
+        assert not np.isclose(grad_sums[10], 0.0)
+        resolution_ratio = grad_sums[20] / grad_sums[10]
+        print(f"[field_adjoint_grid_invariance] ratio = {resolution_ratio}", file=sys.stderr)
+        expected_ratio = expected_sums[20] / expected_sums[10]
+        npt.assert_allclose(resolution_ratio, expected_ratio, rtol=1e-2)
 
     @pytest.mark.parametrize(
         ("shift_coords", "label"),
@@ -961,18 +1019,12 @@ class TestCustomCurrentSourceGaussian:
 
         results = source._compute_derivatives(di)
 
-        from tidy3d.components.autograd.derivative_utils import (
-            source_scale_factor,
-            transpose_interp_field_to_dataset,
-        )
-
         adjoint_on_dataset = transpose_interp_field_to_dataset(
             adjoint_field,
             source.current_dataset.Ex,
             center=source.center,
         )
-        source_scale = source_scale_factor(adjoint_field, source.current_dataset.Ex)
-        expected_gradient = np.sum(np.real(source_scale * adjoint_on_dataset).values)
+        expected_gradient = np.sum(np.real(adjoint_on_dataset).values)
 
         assert not np.isclose(expected_gradient, 0.0)
         assert not np.isclose(np.sum(results[("current_dataset", "Ex")]), 0.0)

--- a/tests/test_components/autograd/test_autograd_sources.py
+++ b/tests/test_components/autograd/test_autograd_sources.py
@@ -1,0 +1,1109 @@
+"""
+Analytical tests for source VJP computation.
+
+Tests for ``td.CustomCurrentSource._compute_derivatives`` and
+``td.CustomFieldSource._compute_derivatives`` using analytical solutions
+for simple geometries and field distributions.
+
+Test coverage:
+ - Rectangular sources with uniform field distributions
+ - Gaussian field distributions
+ - Different source orientations and sizes
+ - Edge cases with zero fields and boundary conditions
+"""
+
+from __future__ import annotations
+
+import sys
+
+import autograd as ag
+import autograd.numpy as anp
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+import tidy3d as td
+from tidy3d.web import run
+
+from .test_autograd import use_emulated_run  # noqa: F401
+
+
+class DummySourceDI:
+    """Stand-in for DerivativeInfo for source testing."""
+
+    def __init__(
+        self,
+        *,
+        paths,
+        E_adj: dict,
+        H_adj: dict | None = None,
+        frequencies: np.ndarray,
+        bounds: tuple[tuple[float, float, float], tuple[float, float, float]],
+        background_medium: td.Medium | None = None,
+        eps_data: dict | None = None,
+    ) -> None:
+        self.paths = paths
+        self.E_adj = E_adj
+        self.H_adj = H_adj or {}
+        self.frequencies = frequencies
+        self.bounds = bounds
+        self.E_fwd = {}  # Not used for sources
+        self.D_adj = {}
+        self.D_fwd = {}
+        self.eps_data = eps_data
+        self.eps_in = None
+        self.eps_out = None
+        self.eps_background = None
+        self.eps_no_structure = None
+        self.eps_inf_structure = None
+        self.bounds_intersect = bounds
+        self.background_medium = background_medium
+
+
+def create_uniform_field_data(
+    center: tuple[float, float, float],
+    size: tuple[float, float, float],
+    field_value: float = 1.0,
+    num_points: int = 10,
+) -> td.FieldDataset:
+    """Create uniform field data for testing."""
+
+    # Create grid coordinates
+    x_min, x_max = center[0] - size[0] / 2, center[0] + size[0] / 2
+    y_min, y_max = center[1] - size[1] / 2, center[1] + size[1] / 2
+    z_min, z_max = center[2] - size[2] / 2, center[2] + size[2] / 2
+
+    x = np.linspace(x_min, x_max, num_points)
+    y = np.linspace(y_min, y_max, num_points)
+    z = np.linspace(z_min, z_max, max(1, num_points // 10))  # Fewer z points for 2D sources
+    f = [2e14]  # Single frequency
+
+    coords = {"x": x, "y": y, "z": z, "f": f}
+
+    # Create uniform field data
+    data_shape = (len(x), len(y), len(z), len(f))
+    field_data = field_value * np.ones(data_shape)
+
+    scalar_field = td.ScalarFieldDataArray(field_data, coords=coords)
+    return td.FieldDataset(Ex=scalar_field, Ey=scalar_field, Ez=scalar_field)
+
+
+def create_adjoint_field_dataarray(
+    field_value: float,
+    shape: tuple[int, int, int, int] = (10, 10, 5, 1),
+) -> td.ScalarFieldDataArray:
+    """Create adjoint field DataArray for testing."""
+
+    # Create grid coordinates
+    x = np.linspace(-0.5, 0.5, shape[0])
+    y = np.linspace(-0.5, 0.5, shape[1])
+    z = np.linspace(-0.05, 0.05, shape[2])
+    f = [2e14]
+
+    coords = {"x": x, "y": y, "z": z, "f": f}
+
+    # Create uniform field data
+    field_data = field_value * np.ones(shape)
+
+    return td.ScalarFieldDataArray(field_data, coords=coords)
+
+
+def create_gaussian_field_data(
+    center: tuple[float, float, float],
+    size: tuple[float, float, float],
+    amplitude: float = 1.0,
+    sigma: float = 0.1,
+    num_points: int = 20,
+) -> td.FieldDataset:
+    """Create Gaussian field data for testing."""
+
+    # Create grid coordinates
+    x_min, x_max = center[0] - size[0] / 2, center[0] + size[0] / 2
+    y_min, y_max = center[1] - size[1] / 2, center[1] + size[1] / 2
+    z_min, z_max = center[2] - size[2] / 2, center[2] + size[2] / 2
+
+    x = np.linspace(x_min, x_max, num_points)
+    y = np.linspace(y_min, y_max, num_points)
+    z = np.linspace(z_min, z_max, max(1, num_points // 10))
+    f = [2e14]
+
+    # Create Gaussian field data
+    X, Y, Z = np.meshgrid(x, y, z, indexing="ij")
+
+    # Gaussian centered at source center
+    r_sq = ((X - center[0]) ** 2 + (Y - center[1]) ** 2 + (Z - center[2]) ** 2) / (2 * sigma**2)
+    field_data = amplitude * np.exp(-r_sq)
+
+    # Add frequency dimension to match coordinates
+    field_data = field_data[..., np.newaxis]
+
+    coords = {"x": x, "y": y, "z": z, "f": f}
+    scalar_field = td.ScalarFieldDataArray(field_data, coords=coords, dims=("x", "y", "z", "f"))
+    return td.FieldDataset(Ex=scalar_field)
+
+
+class TestSpatialWeights:
+    """Unit tests for spatial weight helpers."""
+
+    def test_compute_spatial_weights_cell_sizes(self):
+        """Cell-size weights should match averaged coordinate spacing."""
+        from tidy3d.components.autograd.derivative_utils import compute_spatial_weights
+
+        coords = {"x": np.array([0.0, 1.0, 2.0]), "y": np.array([0.0, 2.0]), "z": np.array([0.0])}
+        values = np.zeros((3, 2, 1))
+        arr = td.ScalarFieldDataArray(values, coords=coords, dims=("x", "y", "z"))
+
+        weights = compute_spatial_weights(arr, dims=("x", "y", "z"))
+
+        expected = np.array([[2.0, 2.0], [2.0, 2.0], [2.0, 2.0]])
+        npt.assert_allclose(weights.values, expected)
+
+    def test_transpose_interp_identity(self):
+        """Adjoint interpolation should preserve weighted values on identical grids."""
+        from tidy3d.components.autograd.derivative_utils import (
+            compute_spatial_weights,
+            transpose_interp_field_to_dataset,
+        )
+
+        coords = {
+            "x": np.array([0.0, 1.0]),
+            "y": np.array([0.0, 2.0]),
+            "z": np.array([0.0]),
+            "f": np.array([2e14]),
+        }
+        values = np.ones((2, 2, 1, 1), dtype=complex)
+        adjoint_field = td.ScalarFieldDataArray(values, coords=coords, dims=("x", "y", "z", "f"))
+        dataset_field = td.ScalarFieldDataArray(values, coords=coords, dims=("x", "y", "z", "f"))
+
+        result = transpose_interp_field_to_dataset(
+            adjoint_field, dataset_field, center=(0.0, 0.0, 0.0)
+        )
+        weights = compute_spatial_weights(adjoint_field, dims=("x", "y", "z"))
+        expected = (adjoint_field * weights).transpose(*dataset_field.dims)
+
+        npt.assert_allclose(result.values, expected.values)
+
+    def test_transpose_interp_collapsed_axis(self):
+        """Collapsed dataset axis should respect source-bounds cropping."""
+        from tidy3d.components.autograd.derivative_utils import transpose_interp_field_to_dataset
+
+        adjoint_coords = {
+            "x": np.array([0.0, 1.0]),
+            "y": np.array([0.0]),
+            "z": np.array([0.0]),
+            "f": np.array([2e14]),
+        }
+        adjoint_values = np.ones((2, 1, 1, 1), dtype=complex)
+        adjoint_field = td.ScalarFieldDataArray(
+            adjoint_values, coords=adjoint_coords, dims=("x", "y", "z", "f")
+        )
+
+        dataset_coords = {
+            "x": np.array([0.0]),
+            "y": np.array([0.0]),
+            "z": np.array([0.0]),
+            "f": np.array([2e14]),
+        }
+        dataset_field = td.ScalarFieldDataArray(
+            np.ones((1, 1, 1, 1)), coords=dataset_coords, dims=("x", "y", "z", "f")
+        )
+
+        result = transpose_interp_field_to_dataset(
+            adjoint_field, dataset_field, center=(0.0, 0.0, 0.0)
+        )
+        npt.assert_allclose(result.values, 1.0)
+
+
+def analytical_uniform_source_gradient(
+    source_bounds: tuple[tuple[float, float, float], tuple[float, float, float]],
+    adjoint_field_value: complex,
+    source_scale: complex,
+    field_component: str = "Ex",
+) -> float:
+    """
+    Analytical gradient for uniform source with uniform adjoint field.
+
+    The gradient is the volume integral of the scaled adjoint field.
+    """
+    (x_min, y_min, z_min), (x_max, y_max, z_max) = source_bounds
+    volume = (x_max - x_min) * (y_max - y_min) * (z_max - z_min)
+    return np.real(1j * source_scale * adjoint_field_value) * volume
+
+
+def analytical_gaussian_source_gradient(
+    source_bounds: tuple[tuple[float, float, float], tuple[float, float, float]],
+    adjoint_amplitude: complex,
+    source_scale: complex,
+    sigma: float = 0.1,
+    field_component: str = "Ex",
+) -> float:
+    """
+    Analytical gradient for uniform source with Gaussian adjoint field.
+
+    The gradient is the volume integral of the Gaussian adjoint field.
+    For a Gaussian centered at the source center, we compute the actual
+    integral over the source bounds.
+    """
+    (x_min, y_min, z_min), (x_max, y_max, z_max) = source_bounds
+
+    # For a Gaussian field exp(-(x^2 + y^2 + z^2)/(2*sigma^2)), the integral
+    # over a rectangular domain can be approximated by the sum of field values
+    # times the volume element, which is what the numerical integration does.
+
+    # Since the test uses a 10x10x1 grid over the bounds, we can compute
+    # the expected value by sampling the Gaussian at those points
+    x = np.linspace(x_min, x_max, 10)
+    y = np.linspace(y_min, y_max, 10)
+    z = np.array([0.0])  # Single z point as in the test
+
+    X, Y, Z = np.meshgrid(x, y, z, indexing="ij")
+    r_sq = (X**2 + Y**2 + Z**2) / (2 * sigma**2)
+    field_data = adjoint_amplitude * np.exp(-r_sq)
+
+    # Compute the volume element
+    dx = x[1] - x[0]
+    dy = y[1] - y[0]
+
+    # The integral is the sum of field values times the area element (2D integral)
+    # since z has only one point, integrate_within_bounds only integrates over x and y
+    integral = np.sum(np.real(1j * source_scale * field_data)) * dx * dy
+
+    return integral
+
+
+class TestCustomCurrentSourceUniform:
+    """Test CustomCurrentSource with uniform field distributions."""
+
+    @pytest.fixture
+    def source(self):
+        """Create a CustomCurrentSource with uniform field data."""
+        center = (0.0, 0.0, 0.0)
+        size = (1.0, 1.0, 0.1)  # 2D source
+        field_dataset = create_uniform_field_data(center, size, field_value=1.0)
+
+        return td.CustomCurrentSource(
+            center=center,
+            size=size,
+            source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
+            current_dataset=field_dataset,
+        )
+
+    @pytest.fixture
+    def source_bounds(self, source):
+        """Get the source bounds."""
+        return source.geometry.bounds
+
+    def test_uniform_adjoint_field(self, source, source_bounds):
+        """Test with uniform adjoint field."""
+        # Create uniform adjoint field
+        adjoint_field_value = -1j * 2.0
+        source_scale = 2.0
+        E_adj = {"Ex": source_scale * create_adjoint_field_dataarray(adjoint_field_value)}
+
+        di = DummySourceDI(
+            paths=[("current_dataset", "Ex")],
+            E_adj=E_adj,
+            frequencies=np.array([2e14]),
+            bounds=source_bounds,
+        )
+
+        results = source._compute_derivatives(di)
+
+        field_data = source.current_dataset.Ex
+        from tidy3d.components.autograd.derivative_utils import transpose_interp_field_to_dataset
+
+        adjoint_on_dataset = transpose_interp_field_to_dataset(
+            E_adj["Ex"], field_data, center=source.center
+        )
+        expected_gradient = 0.5 * np.sum(np.real(adjoint_on_dataset).values)
+
+        grad = results[("current_dataset", "Ex")]
+        assert grad.shape == source.current_dataset.Ex.shape
+        npt.assert_allclose(np.sum(grad), expected_gradient, rtol=1e-2)
+
+    def test_uniform_adjoint_field_with_permittivity_scaling(self, source, source_bounds):
+        """Current-source gradients are invariant to supplied epsilon data."""
+        adjoint_field_value = 2.0
+        E_adj = {"Ex": create_adjoint_field_dataarray(adjoint_field_value)}
+        field_data = source.current_dataset.Ex
+
+        di_air = DummySourceDI(
+            paths=[("current_dataset", "Ex")],
+            E_adj=E_adj,
+            frequencies=np.array([2e14]),
+            bounds=source_bounds,
+        )
+
+        eps_rel = 2.25
+        eps_coords = {
+            "x": np.asarray(field_data.coords["x"].data) + source.center[0],
+            "y": np.asarray(field_data.coords["y"].data) + source.center[1],
+            "z": np.asarray(field_data.coords["z"].data) + source.center[2],
+            "f": np.asarray(field_data.coords["f"].data),
+        }
+        eps_values = eps_rel * np.ones(field_data.shape)
+        eps_data = td.ScalarFieldDataArray(eps_values, coords=eps_coords, dims=field_data.dims)
+        di_eps = DummySourceDI(
+            paths=[("current_dataset", "Ex")],
+            E_adj=E_adj,
+            frequencies=np.array([2e14]),
+            bounds=source_bounds,
+            eps_data={"eps": eps_data},
+        )
+
+        grad_air = np.sum(source._compute_derivatives(di_air)[("current_dataset", "Ex")])
+        grad_eps = np.sum(source._compute_derivatives(di_eps)[("current_dataset", "Ex")])
+        ratio = grad_air / grad_eps
+
+        assert not np.isclose(grad_air, 0.0)
+        assert not np.isclose(grad_eps, 0.0)
+        print(f"[current_permittivity_scaling] ratio = {ratio}", file=sys.stderr)
+        npt.assert_allclose(ratio, 1.0, rtol=1e-3)
+
+    def test_uniform_adjoint_field_with_shifted_eps_coords(self, source, source_bounds):
+        """Shifted epsilon coordinates should not change current-source gradients."""
+        adjoint_field_value = 2.0
+        E_adj = {"Ex": create_adjoint_field_dataarray(adjoint_field_value)}
+        field_data = source.current_dataset.Ex
+
+        di_air = DummySourceDI(
+            paths=[("current_dataset", "Ex")],
+            E_adj=E_adj,
+            frequencies=np.array([2e14]),
+            bounds=source_bounds,
+        )
+
+        eps_rel = 2.25
+        eps_coords = {
+            "x": np.asarray(field_data.coords["x"].data) + source.center[0] + 8e-3,
+            "y": np.asarray(field_data.coords["y"].data) + source.center[1] + 8e-3,
+            "z": np.asarray(field_data.coords["z"].data) + source.center[2] - 8e-3,
+            "f": np.asarray(field_data.coords["f"].data) * (1 + 1e-9),
+        }
+        eps_values = eps_rel * np.ones(field_data.shape)
+        eps_data = td.ScalarFieldDataArray(eps_values, coords=eps_coords, dims=field_data.dims)
+        di_eps = DummySourceDI(
+            paths=[("current_dataset", "Ex")],
+            E_adj=E_adj,
+            frequencies=np.array([2e14]),
+            bounds=source_bounds,
+            eps_data={"eps": eps_data},
+        )
+
+        grad_air = np.sum(source._compute_derivatives(di_air)[("current_dataset", "Ex")])
+        grad_eps = np.sum(source._compute_derivatives(di_eps)[("current_dataset", "Ex")])
+        ratio = grad_air / grad_eps
+
+        assert not np.isclose(grad_air, 0.0)
+        assert not np.isclose(grad_eps, 0.0)
+        print(f"[current_permittivity_shifted_coords] ratio = {ratio}", file=sys.stderr)
+        npt.assert_allclose(ratio, 1.0, rtol=1e-3)
+
+    def test_zero_adjoint_field(self, source, source_bounds):
+        """Test with zero adjoint field."""
+        E_adj = {"Ex": create_adjoint_field_dataarray(0.0)}
+
+        di = DummySourceDI(
+            paths=[("current_dataset", "Ex")],
+            E_adj=E_adj,
+            frequencies=np.array([2e14]),
+            bounds=source_bounds,
+        )
+
+        results = source._compute_derivatives(di)
+
+        # Should be zero
+        npt.assert_allclose(results[("current_dataset", "Ex")], 0.0, rtol=1e-10)
+
+    def test_multiple_field_components(self, source, source_bounds):
+        """Test with multiple field components."""
+        adjoint_field_value = -1j * 1.5
+        E_adj = {
+            "Ex": create_adjoint_field_dataarray(adjoint_field_value),
+            "Ey": create_adjoint_field_dataarray(0.5 * adjoint_field_value),
+            "Ez": create_adjoint_field_dataarray(0.0),
+        }
+        di = DummySourceDI(
+            paths=[("current_dataset", "Ex"), ("current_dataset", "Ey"), ("current_dataset", "Ez")],
+            E_adj=E_adj,
+            frequencies=np.array([2e14]),
+            bounds=source_bounds,
+        )
+
+        results = source._compute_derivatives(di)
+
+        # Check each component
+        field_data = source.current_dataset.Ex
+        from tidy3d.components.autograd.derivative_utils import transpose_interp_field_to_dataset
+
+        adjoint_on_dataset_ex = transpose_interp_field_to_dataset(
+            E_adj["Ex"], field_data, center=source.center
+        )
+        adjoint_on_dataset_ey = transpose_interp_field_to_dataset(
+            E_adj["Ey"], field_data, center=source.center
+        )
+
+        expected_ex = 0.5 * np.sum(np.real(adjoint_on_dataset_ex).values)
+        expected_ey = 0.5 * np.sum(np.real(adjoint_on_dataset_ey).values)
+        expected_ez = 0.0
+
+        npt.assert_allclose(np.sum(results[("current_dataset", "Ex")]), expected_ex, rtol=1e-2)
+        npt.assert_allclose(np.sum(results[("current_dataset", "Ey")]), expected_ey, rtol=1e-2)
+        npt.assert_allclose(np.sum(results[("current_dataset", "Ez")]), expected_ez, rtol=1e-10)
+
+
+class TestCustomFieldSourceUniform:
+    """Test CustomFieldSource with uniform field distributions."""
+
+    @pytest.fixture
+    def source(self):
+        """Create a CustomFieldSource with uniform field data."""
+        center = (0.0, 0.0, 0.0)
+        size = (1.0, 1.0, 0.0)  # Planar source (z=0)
+        field_dataset = create_uniform_field_data(center, size, field_value=1.0)
+
+        return td.CustomFieldSource(
+            center=center,
+            size=size,
+            source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
+            field_dataset=field_dataset,
+        )
+
+    @pytest.fixture
+    def source_bounds(self, source):
+        """Get the source bounds."""
+        return source.geometry.bounds
+
+    def test_uniform_adjoint_field(self, source, source_bounds):
+        """Test with uniform adjoint field."""
+        # Create uniform adjoint field
+        adjoint_field_value = 1j * 2.0
+        E_adj = {}
+        H_adj = {"Hy": create_adjoint_field_dataarray(adjoint_field_value)}
+
+        di = DummySourceDI(
+            paths=[("field_dataset", "Ex")],
+            E_adj=E_adj,
+            H_adj=H_adj,
+            frequencies=np.array([2e14]),
+            bounds=source_bounds,
+        )
+
+        results = source._compute_derivatives(di)
+
+        # Analytical solution
+        from tidy3d.components.autograd.derivative_utils import transpose_interp_field_to_dataset
+        from tidy3d.constants import EPSILON_0
+
+        omega = 2 * np.pi * 2e14
+        field_data = source.field_dataset.Ex
+        adjoint_on_dataset = transpose_interp_field_to_dataset(
+            H_adj["Hy"], field_data, center=source.center
+        )
+        expected_gradient = 0.5 * np.sum(np.real(omega * EPSILON_0 * adjoint_on_dataset).values)
+
+        npt.assert_allclose(np.sum(results[("field_dataset", "Ex")]), expected_gradient, rtol=1e-2)
+
+    def test_uniform_adjoint_field_invariant_to_dataset_spacing(self, source_bounds):
+        """Summed field-source VJP should be resolution-invariant for same physical profile."""
+        center = (0.0, 0.0, 0.0)
+        size = (1.0, 1.0, 0.0)
+        H_adj = {"Hy": create_adjoint_field_dataarray(2.0)}
+        grad_sums = {}
+
+        for num_points in (10, 20):
+            x = np.linspace(-0.5, 0.5, num_points)
+            y = np.linspace(-0.5, 0.5, num_points)
+            z = np.array([0.0])
+            f = [2e14]
+            coords = {"x": x, "y": y, "z": z, "f": f}
+            field_data = td.ScalarFieldDataArray(
+                np.ones((num_points, num_points, 1, 1)), coords=coords
+            )
+            source = td.CustomFieldSource(
+                center=center,
+                size=size,
+                source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
+                field_dataset=td.FieldDataset(Ex=field_data),
+            )
+            di = DummySourceDI(
+                paths=[("field_dataset", "Ex")],
+                E_adj={},
+                H_adj=H_adj,
+                frequencies=np.array([2e14]),
+                bounds=source.geometry.bounds,
+            )
+            grad_sums[num_points] = np.sum(source._compute_derivatives(di)[("field_dataset", "Ex")])
+
+        assert not np.isclose(grad_sums[10], 0.0)
+        spacing_ratio = grad_sums[20] / grad_sums[10]
+        print(f"[field_spacing_invariance] ratio = {spacing_ratio}", file=sys.stderr)
+        npt.assert_allclose(spacing_ratio, 1.0, rtol=2e-2)
+
+    def test_uniform_adjoint_field_with_permittivity_scaling(self, source, source_bounds):
+        """Field-source gradients are invariant to supplied epsilon data."""
+        adjoint_field_value = 2.0
+        H_adj = {"Hy": create_adjoint_field_dataarray(adjoint_field_value)}
+        field_data = source.field_dataset.Ex
+
+        di_air = DummySourceDI(
+            paths=[("field_dataset", "Ex")],
+            E_adj={},
+            H_adj=H_adj,
+            frequencies=np.array([2e14]),
+            bounds=source_bounds,
+        )
+
+        eps_rel = 2.25
+        eps_coords = {
+            "x": np.asarray(field_data.coords["x"].data) + source.center[0],
+            "y": np.asarray(field_data.coords["y"].data) + source.center[1],
+            "z": np.asarray(field_data.coords["z"].data) + source.center[2],
+            "f": np.asarray(field_data.coords["f"].data),
+        }
+        eps_values = eps_rel * np.ones(field_data.shape)
+        eps_data = td.ScalarFieldDataArray(eps_values, coords=eps_coords, dims=field_data.dims)
+        di_eps = DummySourceDI(
+            paths=[("field_dataset", "Ex")],
+            E_adj={},
+            H_adj=H_adj,
+            frequencies=np.array([2e14]),
+            bounds=source_bounds,
+            eps_data={"eps": eps_data},
+        )
+
+        grad_air = np.sum(source._compute_derivatives(di_air)[("field_dataset", "Ex")])
+        grad_eps = np.sum(source._compute_derivatives(di_eps)[("field_dataset", "Ex")])
+        ratio = grad_air / grad_eps
+
+        assert not np.isclose(grad_air, 0.0)
+        assert not np.isclose(grad_eps, 0.0)
+        print(f"[field_permittivity_scaling] ratio = {ratio}", file=sys.stderr)
+        npt.assert_allclose(ratio, 1.0, rtol=1e-3)
+
+    def test_uniform_adjoint_field_with_shifted_eps_coords(self, source, source_bounds):
+        """Shifted epsilon coordinates should not change field-source gradients."""
+        adjoint_field_value = 2.0
+        H_adj = {"Hy": create_adjoint_field_dataarray(adjoint_field_value)}
+        field_data = source.field_dataset.Ex
+
+        di_air = DummySourceDI(
+            paths=[("field_dataset", "Ex")],
+            E_adj={},
+            H_adj=H_adj,
+            frequencies=np.array([2e14]),
+            bounds=source_bounds,
+        )
+
+        eps_rel = 2.25
+        eps_coords = {
+            "x": np.asarray(field_data.coords["x"].data) + source.center[0] + 8e-3,
+            "y": np.asarray(field_data.coords["y"].data) + source.center[1] + 8e-3,
+            "z": np.asarray(field_data.coords["z"].data) + source.center[2] - 8e-3,
+            "f": np.asarray(field_data.coords["f"].data) * (1 + 1e-9),
+        }
+        eps_values = eps_rel * np.ones(field_data.shape)
+        eps_data = td.ScalarFieldDataArray(eps_values, coords=eps_coords, dims=field_data.dims)
+        di_eps = DummySourceDI(
+            paths=[("field_dataset", "Ex")],
+            E_adj={},
+            H_adj=H_adj,
+            frequencies=np.array([2e14]),
+            bounds=source_bounds,
+            eps_data={"eps": eps_data},
+        )
+
+        grad_air = np.sum(source._compute_derivatives(di_air)[("field_dataset", "Ex")])
+        grad_eps = np.sum(source._compute_derivatives(di_eps)[("field_dataset", "Ex")])
+        ratio = grad_air / grad_eps
+
+        assert not np.isclose(grad_air, 0.0)
+        assert not np.isclose(grad_eps, 0.0)
+        print(f"[field_permittivity_shifted_coords] ratio = {ratio}", file=sys.stderr)
+        npt.assert_allclose(ratio, 1.0, rtol=1e-3)
+
+
+@pytest.mark.parametrize(
+    (
+        "source_ctor",
+        "dataset_key",
+        "source_size",
+        "unsupported_path",
+        "adjoint_component",
+        "adjoint_value",
+    ),
+    (
+        (td.CustomCurrentSource, "current_dataset", (1.0, 1.0, 0.1), ("center", 0), "Ex", -1j),
+        (td.CustomFieldSource, "field_dataset", (1.0, 1.0, 0.0), ("size", 0), "Hy", 1j),
+    ),
+)
+def test_unsupported_traced_paths_raise_error(
+    source_ctor,
+    dataset_key,
+    source_size,
+    unsupported_path,
+    adjoint_component,
+    adjoint_value,
+):
+    """Unsupported traced source parameters should raise an explicit error."""
+
+    center = (0.0, 0.0, 0.0)
+    field_dataset = create_uniform_field_data(center, source_size, field_value=1.0)
+
+    source = source_ctor(
+        center=center,
+        size=source_size,
+        source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
+        **{dataset_key: field_dataset},
+    )
+
+    E_adj = {}
+    H_adj = {}
+    if adjoint_component.startswith("E"):
+        E_adj[adjoint_component] = create_adjoint_field_dataarray(adjoint_value)
+    else:
+        H_adj[adjoint_component] = create_adjoint_field_dataarray(adjoint_value)
+
+    di = DummySourceDI(
+        paths=[(dataset_key, "Ex"), unsupported_path, ("source_time", "freq0")],
+        E_adj=E_adj,
+        H_adj=H_adj,
+        frequencies=np.array([2e14]),
+        bounds=source.geometry.bounds,
+    )
+
+    with pytest.raises(ValueError, match="not supported"):
+        source._compute_derivatives(di)
+
+
+class TestCustomCurrentSourceGaussian:
+    """Test CustomCurrentSource with Gaussian field distributions."""
+
+    @pytest.fixture
+    def source(self):
+        """Create a CustomCurrentSource with Gaussian field data."""
+        center = (0.0, 0.0, 0.0)
+        size = (0.5, 0.5, 0.1)  # Smaller source for Gaussian test
+        field_dataset = create_gaussian_field_data(center, size, amplitude=1.0, sigma=0.1)
+
+        return td.CustomCurrentSource(
+            center=center,
+            size=size,
+            source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
+            current_dataset=field_dataset,
+        )
+
+    @pytest.fixture
+    def source_bounds(self, source):
+        """Get the source bounds."""
+        return source.geometry.bounds
+
+    def test_gaussian_adjoint_field(self, source, source_bounds):
+        """Test with Gaussian adjoint field."""
+        # Create Gaussian adjoint field
+        adjoint_amplitude = -1j * 1.0
+        sigma = 0.1
+        x = np.linspace(-0.25, 0.25, 10)
+        y = np.linspace(-0.25, 0.25, 10)
+        z = np.array([0.0])
+        f = [2e14]
+
+        X, Y, Z = np.meshgrid(x, y, z, indexing="ij")
+        r_sq = (X**2 + Y**2 + Z**2) / (2 * sigma**2)
+        adjoint_field_data = adjoint_amplitude * np.exp(-r_sq)
+
+        # Add frequency dimension to match coordinates
+        adjoint_field_data = adjoint_field_data[..., np.newaxis]
+        coords = {"x": x, "y": y, "z": z, "f": f}
+        adjoint_field = td.ScalarFieldDataArray(
+            adjoint_field_data, coords=coords, dims=("x", "y", "z", "f")
+        )
+
+        E_adj = {"Ex": adjoint_field}
+        di = DummySourceDI(
+            paths=[("current_dataset", "Ex")],
+            E_adj=E_adj,
+            frequencies=np.array([2e14]),
+            bounds=source_bounds,
+        )
+
+        results = source._compute_derivatives(di)
+
+        from tidy3d.components.autograd.derivative_utils import transpose_interp_field_to_dataset
+
+        adjoint_on_dataset = transpose_interp_field_to_dataset(
+            adjoint_field,
+            source.current_dataset.Ex,
+            center=source.center,
+        )
+        expected_gradient = 0.5 * np.sum(np.real(adjoint_on_dataset).values)
+
+        npt.assert_allclose(
+            np.sum(results[("current_dataset", "Ex")]), expected_gradient, rtol=5e-1
+        )
+
+
+def test_source_autograd(use_emulated_run):  # noqa: F811
+    """Test autograd differentiation with respect to CustomCurrentSource parameters."""
+
+    def make_sim_with_traced_source(val):
+        """Create a simulation with a traced CustomCurrentSource."""
+
+        # Create a simple simulation
+        sim = td.Simulation(
+            size=(2.0, 2.0, 2.0),
+            run_time=1e-12,
+            grid_spec=td.GridSpec.uniform(dl=0.1),
+            sources=[],
+            monitors=[
+                td.FieldMonitor(
+                    size=(1.0, 1.0, 0.0), center=(0, 0, 0), freqs=[2e14], name="field_monitor"
+                )
+            ],
+        )
+
+        data_shape = (10, 10, 1, 1)
+
+        # Create a traced CustomCurrentSource
+        x = np.linspace(-0.5, 0.5, data_shape[0])
+        y = np.linspace(-0.5, 0.5, data_shape[1])
+        z = np.array([0])
+        f = [2e14]
+        coords = {"x": x, "y": y, "z": z, "f": f}
+
+        # Create traced field data
+        field_data = val * np.ones(data_shape)
+        scalar_field = td.ScalarFieldDataArray(field_data, coords=coords)
+
+        # Create field dataset with traced data
+        field_dataset = td.FieldDataset(Ex=scalar_field)
+
+        # Create CustomCurrentSource with traced dataset
+        custom_source = td.CustomCurrentSource(
+            center=(0, 0, 0),
+            size=(1.0, 1.0, 0.0),
+            source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
+            current_dataset=field_dataset,
+        )
+
+        # Add source to simulation
+        sim = sim.updated_copy(sources=[custom_source])
+
+        return sim
+
+    def objective(val):
+        """Objective function that depends on source parameters."""
+
+        sim = make_sim_with_traced_source(val)
+
+        # Run simulation
+        sim_data = run(sim, task_name="test_source_autograd")
+
+        # Extract field data from monitor
+        field_data = sim_data.load_field_monitor("field_monitor")
+        Ex_field = field_data.Ex
+
+        # Compute objective (e.g., field intensity at a point)
+        objective_value = anp.abs(Ex_field.isel(x=5, y=5, z=0, f=0).values) ** 2
+
+        return objective_value
+
+    # Compute gradient
+    grad = ag.grad(objective)(1.0)
+
+    assert anp.all(grad != 0.0), "some gradients are 0"
+
+
+def test_field_source_autograd(use_emulated_run):  # noqa: F811
+    """Test autograd differentiation with respect to CustomFieldSource parameters."""
+
+    def make_sim_with_traced_field_source(val):
+        """Create a simulation with a traced CustomFieldSource."""
+
+        # Create a simple simulation
+        sim = td.Simulation(
+            size=(2.0, 2.0, 2.0),
+            run_time=1e-12,
+            grid_spec=td.GridSpec.uniform(dl=0.1),
+            sources=[],
+            monitors=[
+                td.FieldMonitor(
+                    size=(1.0, 1.0, 0.0), center=(0, 0, 0), freqs=[2e14], name="field_monitor"
+                )
+            ],
+        )
+
+        data_shape = (10, 10, 1, 1)
+
+        # Create a traced CustomFieldSource
+        x = np.linspace(-0.5, 0.5, data_shape[0])
+        y = np.linspace(-0.5, 0.5, data_shape[1])
+        z = np.array([0])
+        f = [2e14]
+        coords = {"x": x, "y": y, "z": z, "f": f}
+
+        # Create traced field data
+        field_data = val * np.ones(data_shape)
+        scalar_field = td.ScalarFieldDataArray(field_data, coords=coords)
+
+        # Create field dataset with traced data
+        field_dataset = td.FieldDataset(Ex=scalar_field)
+
+        # Create CustomFieldSource with traced dataset
+        custom_source = td.CustomFieldSource(
+            center=(0, 0, 0),
+            size=(1.0, 1.0, 0.0),
+            source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
+            field_dataset=field_dataset,
+        )
+
+        # Add source to simulation
+        sim = sim.updated_copy(sources=[custom_source])
+
+        return sim
+
+    def objective(val):
+        """Objective function that depends on source parameters."""
+
+        sim = make_sim_with_traced_field_source(val)
+
+        # Run simulation
+        sim_data = run(sim, task_name="test_field_source_autograd")
+
+        # Extract field data from monitor
+        field_data = sim_data.load_field_monitor("field_monitor")
+        Ex_field = field_data.Ex
+
+        # Compute objective (e.g., field intensity at a point)
+        objective_value = anp.abs(Ex_field.isel(x=5, y=5, z=0, f=0).values) ** 2
+
+        return objective_value
+
+    # Compute gradient
+    grad = ag.grad(objective)(1.0)
+
+    assert anp.all(grad != 0.0), "some gradients are 0"
+
+
+@pytest.mark.parametrize(
+    ("source_ctor", "dataset_key"),
+    (
+        (td.CustomCurrentSource, "current_dataset"),
+        (td.CustomFieldSource, "field_dataset"),
+    ),
+)
+def test_source_adjoint_monitors(source_ctor, dataset_key):
+    """Test that adjoint monitors are properly created for traced source datasets."""
+
+    sim = td.Simulation(
+        size=(2.0, 2.0, 2.0),
+        run_time=1e-12,
+        grid_spec=td.GridSpec.uniform(dl=0.1),
+        sources=[],
+        monitors=[
+            td.FieldMonitor(
+                size=(1.0, 1.0, 0.0), center=(0, 0, 0), freqs=[2e14], name="field_monitor"
+            )
+        ],
+    )
+
+    # Create traced field data
+    data_shape = (10, 10, 1, 1)
+    x = np.linspace(-0.5, 0.5, data_shape[0])
+    y = np.linspace(-0.5, 0.5, data_shape[1])
+    z = np.array([0])
+    f = [2e14]
+    coords = {"x": x, "y": y, "z": z, "f": f}
+
+    field_data = 1.0 * np.ones(data_shape)
+    scalar_field = td.ScalarFieldDataArray(field_data, coords=coords)
+    field_dataset = td.FieldDataset(Ex=scalar_field)
+
+    custom_source = source_ctor(
+        center=(0, 0, 0),
+        size=(1.0, 1.0, 0.0),
+        source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
+        **{dataset_key: field_dataset},
+    )
+    sim = sim.updated_copy(sources=[custom_source])
+    sim_fields_keys = [("sources", 0, dataset_key, "Ex")]
+
+    # Test that adjoint monitors are created
+    adjoint_monitors_fld, adjoint_monitors_eps = sim._make_adjoint_monitors(sim_fields_keys)
+
+    # Check that field monitors were created for sources, but no for eps
+    assert len(adjoint_monitors_fld) == 1
+    assert len(adjoint_monitors_eps) == 0
+
+    # Check that the field monitor covers the source region
+    field_monitor = adjoint_monitors_fld[0]
+    assert isinstance(field_monitor, td.FieldMonitor)
+    assert field_monitor.center == custom_source.center
+    assert field_monitor.size == custom_source.size
+    assert len(field_monitor.freqs) == len(sim._freqs_adjoint)
+    assert len(field_monitor.freqs) > 0
+
+
+def test_mixed_structure_source_adjoint_monitors():
+    """Test that adjoint monitors work correctly when both structures and sources are traced."""
+
+    # Create a simulation with both structures and sources
+    sim = td.Simulation(
+        size=(2.0, 2.0, 2.0),
+        run_time=1e-12,
+        grid_spec=td.GridSpec.uniform(dl=0.1),
+        sources=[],
+        structures=[
+            td.Structure(
+                geometry=td.Box(center=(0.5, 0, 0), size=(0.5, 0.5, 0.5)),
+                medium=td.Medium(permittivity=2.0),
+            )
+        ],
+        monitors=[
+            td.FieldMonitor(
+                size=(1.0, 1.0, 0.0), center=(0, 0, 0), freqs=[2e14], name="field_monitor"
+            )
+        ],
+    )
+
+    # Create traced field data for source
+    data_shape = (10, 10, 1, 1)
+    x = np.linspace(-0.5, 0.5, data_shape[0])
+    y = np.linspace(-0.5, 0.5, data_shape[1])
+    z = np.array([0])
+    f = [2e14]
+    coords = {"x": x, "y": y, "z": z, "f": f}
+
+    field_data = 1.0 * np.ones(data_shape)
+    scalar_field = td.ScalarFieldDataArray(field_data, coords=coords)
+    field_dataset = td.FieldDataset(Ex=scalar_field)
+
+    # Create CustomCurrentSource with traced dataset
+    custom_source = td.CustomCurrentSource(
+        center=(-0.5, 0, 0),
+        size=(0.5, 0.5, 0.0),
+        source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
+        current_dataset=field_dataset,
+    )
+
+    # Add source to simulation
+    sim = sim.updated_copy(sources=[custom_source])
+
+    # Create sim_fields_keys for both structure and source
+    sim_fields_keys = [
+        ("structures", 0, "medium", "permittivity"),
+        ("sources", 0, "current_dataset", "Ex"),
+    ]
+
+    # Test that adjoint monitors are created for both
+    adjoint_monitors_fld, adjoint_monitors_eps = sim._make_adjoint_monitors(sim_fields_keys)
+
+    # Should have monitors for both structure and source
+    # Note: The structure might not create monitors if it doesn't have the right field keys
+    # Let's be more flexible about the expected number
+    assert len(adjoint_monitors_fld) == 2  # two field monitors (one for structure, one for source)
+    assert len(adjoint_monitors_eps) == 1  # only one eps monitor for structure
+
+    # Check that we have at least one source monitor
+    source_monitor_found = False
+    for _i, field_monitor_item in enumerate(adjoint_monitors_fld):
+        # Handle both direct FieldMonitor and list of FieldMonitor
+        if isinstance(field_monitor_item, td.FieldMonitor):
+            # Direct FieldMonitor (could be structure or source)
+            field_monitor = field_monitor_item
+            # Check if this is our source monitor
+            if (
+                field_monitor.center == custom_source.center
+                and field_monitor.size == custom_source.size
+            ):
+                assert len(field_monitor.freqs) > 0
+                source_monitor_found = True
+                break
+        elif isinstance(field_monitor_item, list):
+            # List of FieldMonitor (source monitors are wrapped in lists)
+            for field_monitor in field_monitor_item:
+                if isinstance(field_monitor, td.FieldMonitor):
+                    # Check if this is our source monitor
+                    if (
+                        field_monitor.center == custom_source.center
+                        and field_monitor.size == custom_source.size
+                    ):
+                        assert len(field_monitor.freqs) > 0
+                        source_monitor_found = True
+                        break
+            if source_monitor_found:
+                break
+
+    assert source_monitor_found, "No source monitor found in adjoint monitors"
+
+
+def _make_uniform_field_dataset(val, data_shape=(10, 10, 1, 1), freq=2e14):
+    x = np.linspace(-0.5, 0.5, data_shape[0])
+    y = np.linspace(-0.5, 0.5, data_shape[1])
+    z = np.array([0])
+    f = [freq]
+    coords = {"x": x, "y": y, "z": z, "f": f}
+
+    field_data = val * np.ones(data_shape)
+    scalar_field = td.ScalarFieldDataArray(field_data, coords=coords)
+    return td.FieldDataset(Ex=scalar_field)
+
+
+SOURCE_CASES = [
+    pytest.param(
+        "custom_current_source",
+        lambda val, freq: td.CustomCurrentSource(
+            center=(0, 0, 0),
+            size=(1.0, 1.0, 0.0),
+            source_time=td.GaussianPulse(freq0=freq, fwidth=1e13),
+            current_dataset=_make_uniform_field_dataset(val, freq=freq),
+        ),
+        id="CustomCurrentSource",
+    ),
+    pytest.param(
+        "custom_field_source",
+        lambda val, freq: td.CustomFieldSource(
+            center=(0, 0, 0),
+            size=(1.0, 1.0, 0.0),
+            source_time=td.GaussianPulse(freq0=freq, fwidth=1e13),
+            field_dataset=_make_uniform_field_dataset(val, freq=freq),
+        ),
+        id="CustomFieldSource",
+    ),
+]
+
+
+@pytest.mark.parametrize("kind, make_source", SOURCE_CASES)
+def test_traced_source_derivative_computation(use_emulated_run, kind, make_source):  # noqa: F811
+    """Test that traced source derivative computation works for different source types."""
+    freq = 2e14
+
+    def make_sim(val):
+        sim = td.Simulation(
+            size=(2.0, 2.0, 2.0),
+            run_time=1e-12,
+            grid_spec=td.GridSpec.uniform(dl=0.1),
+            sources=[],
+            monitors=[
+                td.FieldMonitor(
+                    size=(1.0, 1.0, 0.0),
+                    center=(0, 0, 0),
+                    freqs=[freq],
+                    name="field_monitor",
+                )
+            ],
+        )
+        src = make_source(val, freq)
+        return sim.updated_copy(sources=[src])
+
+    def objective(val):
+        sim = make_sim(val)
+        sim_data = run(sim, task_name=f"test_derivative_{kind}")
+        field_data = sim_data.load_field_monitor("field_monitor")
+        Ex_field = field_data.Ex
+        return anp.abs(Ex_field.isel(x=5, y=5, z=0, f=0).values) ** 2
+
+    grad = ag.grad(objective)(1.0)
+
+    assert grad is not None
+    assert isinstance(grad, (float, np.ndarray))

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -10,8 +10,9 @@ from typing import TYPE_CHECKING, Any, Optional
 import numpy as np
 from numpy.typing import NDArray
 
-from tidy3d.components.data.data_array import ScalarFieldDataArray
+from tidy3d.components.data.data_array import ScalarFieldDataArray, SpatialDataArray
 from tidy3d.components.data.utils import _zeros_like
+from tidy3d.components.grid.grid import _compute_1d_cell_sizes
 from tidy3d.components.types import ArrayLike, Bound
 from tidy3d.config import config
 from tidy3d.constants import C_0, EPSILON_0, LARGE_NUMBER, MU_0
@@ -34,6 +35,7 @@ PermittivityData = dict[str, ScalarFieldDataArray]
 EpsType = ScalarFieldDataArray
 ArrayFloat = NDArray[np.floating]
 ArrayComplex = NDArray[np.complexfloating]
+TRANSPOSE_INTERP_COORDINATE_TOLERANCE = 1e-12
 
 
 class LazyInterpolator:
@@ -101,19 +103,6 @@ class DerivativeInfo:
     Dataset of relative permittivity values along all three dimensions.
     Used for automatically computing permittivity inside or outside of a simple geometry."""
 
-    eps_in: EpsType | None
-    """Permittivity inside the Structure.
-    Computed only when structure.medium.is_custom is False. Contains the simulation
-    permittivity inside the structure when the simulation background medium is set to
-    the structure medium and all structures after the current structure are kept. Should
-    be used as the inside permittivity for shape derivative computations."""
-
-    eps_out: EpsType
-    """Permittivity outside the Structure.
-    Contains the simulation permittivity outside the structure when the current structure
-    is removed from the structure list. Should be used as the outside permittivity for
-    shape derivative computations."""
-
     bounds: Bound
     """Geometry bounds.
     Bounds corresponding to the structure, used in Medium calculations."""
@@ -136,6 +125,19 @@ class DerivativeInfo:
     """Function to return the permittivity upon geometry replacement in the simulation."""
 
     # Optional fields with defaults
+
+    eps_in: Optional[EpsType] = None
+    """Permittivity inside the Structure.
+    Computed only when structure.medium.is_custom is False. Contains the simulation
+    permittivity inside the structure when the simulation background medium is set to
+    the structure medium and all structures after the current structure are kept. Should
+    be used as the inside permittivity for shape derivative computations."""
+
+    eps_out: Optional[EpsType] = None
+    """Permittivity outside the Structure.
+    Contains the simulation permittivity outside the structure when the current structure
+    is removed from the structure list. Should be used as the outside permittivity for
+    shape derivative computations."""
 
     H_der_map: Optional[FieldDataDict] = None
     """Magnetic field gradient map.
@@ -383,6 +385,14 @@ class DerivativeInfo:
                 "Please create interpolators using 'create_interpolators()' first."
             )
 
+        if self.eps_in is None or self.eps_out is None:
+            raise ValueError(
+                "Missing permittivity data for geometry gradients: both "
+                "'eps_in' and 'eps_out' must be provided."
+            )
+        eps_in = self.eps_in
+        eps_out = self.eps_out
+
         # In all paths below, we need to have computed the gradient integration for a
         # dielectric-dielectric interface.
         vjps_dielectric = self._evaluate_dielectric_gradient_at_points(
@@ -391,8 +401,8 @@ class DerivativeInfo:
             perps1,
             perps2,
             interpolators,
-            self.eps_in,
-            self.eps_out,
+            eps_in,
+            eps_out,
         )
 
         if self.is_medium_pec:
@@ -405,7 +415,7 @@ class DerivativeInfo:
             mask_pec = self._detect_pec_gradient_points(
                 spatial_coords,
                 normals,
-                self.eps_in,
+                eps_in,
                 interpolators["eps_data"],
                 is_outside=False,
             )
@@ -417,7 +427,7 @@ class DerivativeInfo:
                 perps1,
                 perps2,
                 interpolators,
-                ("eps_out", self.eps_out),
+                ("eps_out", eps_out),
                 is_outside=True,
             )
 
@@ -432,7 +442,7 @@ class DerivativeInfo:
             mask_pec = self._detect_pec_gradient_points(
                 spatial_coords,
                 normals,
-                self.eps_out,
+                eps_out,
                 interpolators["eps_data"],
                 is_outside=True,
             )
@@ -445,7 +455,7 @@ class DerivativeInfo:
                 perps1,
                 perps2,
                 interpolators,
-                ("eps_in", self.eps_in),
+                ("eps_in", eps_in),
                 is_outside=False,
             )
 
@@ -1075,7 +1085,280 @@ def integrate_within_bounds(arr: xr.DataArray, dims: list[str], bounds: Bound) -
     return _arr.integrate(coord=dims_integrate)
 
 
+def compute_spatial_weights(
+    arr: SpatialDataArray, dims: tuple[str, ...] = ("x", "y", "z")
+) -> SpatialDataArray:
+    """Compute cell-size weights for spatial coordinates.
+
+    Parameters
+    ----------
+    arr : SpatialDataArray
+        Data array providing spatial coordinates.
+    dims : tuple[str, ...]
+        Spatial dimension names to include in the weights.
+
+    Returns
+    -------
+    SpatialDataArray
+        DataArray of weights broadcastable to ``arr``.
+    """
+
+    weight_dims = []
+    weight_arrays = []
+    for dim in dims:
+        if dim not in arr.coords:
+            continue
+        coord = np.asarray(arr.coords[dim].data)
+        if coord.size <= 1:
+            continue
+        weight_dims.append(dim)
+        weight_arrays.append(_compute_1d_cell_sizes(coord))
+
+    if not weight_dims:
+        return SpatialDataArray(1.0)
+
+    weights = np.ix_(*weight_arrays)
+    weights_data = weights[0]
+    for weight_array in weights[1:]:
+        weights_data = weights_data * weight_array
+
+    coords = {dim: np.asarray(arr.coords[dim].data) for dim in weight_dims}
+    return SpatialDataArray(weights_data, coords=coords, dims=tuple(weight_dims))
+
+
+def source_grid_step(
+    adjoint_field: SpatialDataArray,
+    field_data: SpatialDataArray,
+) -> float:
+    """Compute a source-adjoint grid step used in source VJP normalization.
+
+    Uses the minimum positive spacing found on the adjoint field grid across spatial
+    coordinates, and falls back to the source dataset grid when the adjoint grid is
+    degenerate.
+    """
+
+    steps: list[float] = []
+
+    for dim in "xyz":
+        if dim not in adjoint_field.coords:
+            continue
+        coord = np.asarray(adjoint_field.coords[dim].data, dtype=float)
+        if coord.size <= 1:
+            continue
+        diffs = np.abs(np.diff(coord))
+        diffs = diffs[np.isfinite(diffs) & (diffs > 0.0)]
+        if diffs.size:
+            steps.append(float(np.min(diffs)))
+
+    if not steps:
+        for dim in "xyz":
+            if dim not in field_data.coords:
+                continue
+            coord = np.asarray(field_data.coords[dim].data, dtype=float)
+            if coord.size <= 1:
+                continue
+            diffs = np.abs(np.diff(coord))
+            diffs = diffs[np.isfinite(diffs) & (diffs > 0.0)]
+            if diffs.size:
+                steps.append(float(np.min(diffs)))
+
+    return float(min(steps)) if steps else 1.0
+
+
+def source_scale_factor(
+    adjoint_field: SpatialDataArray,
+    field_data: ScalarFieldDataArray,
+    component_axis: int,
+    eps_data: Optional[PermittivityData] = None,
+    center: Optional[tuple[float, float, float]] = None,
+) -> float:
+    """Compute the multiplicative source VJP scale factor."""
+    # Keep optional permittivity inputs in signature for forward compatibility and to
+    # preserve the calling contract from source derivative paths.
+    _ = (component_axis, eps_data, center)
+
+    grid_step = source_grid_step(adjoint_field, field_data)
+    return 2.0 * np.pi * grid_step
+
+
+def transpose_interp_axis(
+    field_values: np.ndarray,
+    field_coords_1d: np.ndarray,
+    param_coords_1d: np.ndarray,
+    *,
+    method: str = "linear",
+    coordinate_tolerance: float = TRANSPOSE_INTERP_COORDINATE_TOLERANCE,
+) -> np.ndarray:
+    """Transpose (adjoint) of 1D interpolation along one axis."""
+    if param_coords_1d.size == 1:
+        return field_values.sum(axis=0, keepdims=True)
+    if np.any(param_coords_1d[1:] < param_coords_1d[:-1]):
+        raise ValueError("Spatial coordinates must be sorted before computing derivatives.")
+    if method not in ("linear", "nearest"):
+        raise ValueError(f"Unsupported interpolation method: {method!r}.")
+
+    n_param = param_coords_1d.size
+    n_field = field_values.shape[0]
+    field_values_2d = field_values.reshape(n_field, -1)
+
+    field_coords = np.asarray(field_coords_1d, dtype=float)
+    if coordinate_tolerance > 0.0:
+        field_coords = np.clip(
+            field_coords,
+            param_coords_1d[0] - coordinate_tolerance,
+            param_coords_1d[-1] + coordinate_tolerance,
+        )
+
+    if method == "nearest":
+        param_midpoints = (param_coords_1d[1:] + param_coords_1d[:-1]) / 2.0
+        param_index_nearest = np.searchsorted(param_midpoints, field_coords)
+        param_values_2d = np.zeros((n_param, field_values_2d.shape[1]), dtype=field_values.dtype)
+        np.add.at(param_values_2d, param_index_nearest, field_values_2d)
+        return param_values_2d.reshape((n_param,) + field_values.shape[1:])
+
+    param_index_upper = np.searchsorted(param_coords_1d, field_coords, side="right")
+    param_index_upper = np.clip(param_index_upper, 1, n_param - 1)
+    param_index_lower = param_index_upper - 1
+
+    segment_width = param_coords_1d[param_index_upper] - param_coords_1d[param_index_lower]
+    segment_width = np.where(segment_width == 0, 1.0, segment_width)
+    frac_upper = (field_coords - param_coords_1d[param_index_lower]) / segment_width
+    frac_upper = np.clip(frac_upper, 0.0, 1.0)
+
+    w_lower = (1.0 - frac_upper)[:, None]
+    w_upper = frac_upper[:, None]
+
+    param_values_2d = np.zeros((n_param, field_values_2d.shape[1]), dtype=field_values.dtype)
+    np.add.at(param_values_2d, param_index_lower, field_values_2d * w_lower)
+    np.add.at(param_values_2d, param_index_upper, field_values_2d * w_upper)
+
+    return param_values_2d.reshape((n_param,) + field_values.shape[1:])
+
+
+def bounds_slice(
+    axis: NDArray,
+    vmin: float,
+    vmax: float,
+    *,
+    name: str,
+    warning_context: str,
+) -> slice:
+    """Compute a robust crop slice on a 1D axis."""
+    axis = np.asarray(axis, dtype=float)
+    n = axis.size
+
+    vmin_tol = vmin - TRANSPOSE_INTERP_COORDINATE_TOLERANCE
+    vmax_tol = vmax + TRANSPOSE_INTERP_COORDINATE_TOLERANCE
+
+    i0 = int(np.searchsorted(axis, vmin_tol, side="left"))
+    i1 = int(np.searchsorted(axis, vmax_tol, side="right"))
+    if i1 <= i0 and n:
+        old = (i0, i1)
+        if i1 < n:
+            i1 = i0 + 1
+        elif i0 > 0:
+            i0 = i1 - 1
+        log.warning(
+            f"Empty bounds crop on '{name}' while computing {warning_context}: "
+            f"bounds=[{vmin_tol!r}, {vmax_tol!r}], "
+            f"grid=[{axis[0]!r}, {axis[-1]!r}] -> indices {old}; using ({i0}, {i1}).",
+            log_once=True,
+        )
+    return slice(i0, i1)
+
+
+def transpose_interp_field_to_dataset(
+    adjoint_field: SpatialDataArray,
+    dataset_field: SpatialDataArray,
+    *,
+    center: tuple[float, float, float],
+) -> SpatialDataArray:
+    """Accumulate adjoint fields onto dataset coordinates using adjoint interpolation."""
+
+    def _align_freq(field: SpatialDataArray, target: SpatialDataArray) -> SpatialDataArray:
+        target_freqs = np.asarray(target.coords["f"].data)
+        source_freqs = np.asarray(field.coords["f"].data)
+        if target_freqs.size == source_freqs.size and np.allclose(
+            target_freqs, source_freqs, rtol=1e-12, atol=0.0
+        ):
+            return field
+        method = "nearest" if target_freqs.size <= 1 or source_freqs.size <= 1 else "linear"
+        return field.interp(
+            {"f": target_freqs},
+            method=method,
+            kwargs={"bounds_error": False, "fill_value": 0.0},
+        ).fillna(0.0)
+
+    def _interp_axis(
+        arr: np.ndarray, axis: int, field_axis: np.ndarray, param_axis: np.ndarray
+    ) -> np.ndarray:
+        moved = np.moveaxis(arr, axis, 0)
+        moved = transpose_interp_axis(
+            moved,
+            field_axis,
+            param_axis,
+            method="linear",
+        )
+        return np.moveaxis(moved, 0, axis)
+
+    center = tuple(get_static(val) for val in center)
+    aligned = _align_freq(adjoint_field, dataset_field)
+    weights = compute_spatial_weights(aligned, dims=tuple("xyz"))
+    if weights.size > 1:
+        weights = weights.transpose(*weights.dims)
+    weighted = aligned * weights
+
+    field_coords = {
+        dim: np.asarray(weighted.coords[dim].data) for dim in weighted.dims if dim in "xyz"
+    }
+    param_coords = {}
+    for axis, dim in enumerate("xyz"):
+        if dim in dataset_field.coords:
+            param_coords[dim] = np.asarray(dataset_field.coords[dim].data) + center[axis]
+
+    crop_slices = {}
+    for dim in "xyz":
+        if dim not in field_coords or dim not in param_coords:
+            continue
+        param_axis = param_coords[dim]
+        vmin = float(np.min(param_axis))
+        vmax = float(np.max(param_axis))
+        crop_slices[dim] = bounds_slice(
+            field_coords[dim],
+            vmin,
+            vmax,
+            name=dim,
+            warning_context="source gradients (adjoint field grid -> source dataset)",
+        )
+
+    if crop_slices:
+        weighted = weighted.isel(**crop_slices)
+        field_coords = {
+            dim: np.asarray(weighted.coords[dim].data) for dim in weighted.dims if dim in "xyz"
+        }
+
+    values = np.asarray(weighted.data)
+    dims = list(weighted.dims)
+    for dim in "xyz":
+        if dim not in field_coords or dim not in param_coords:
+            continue
+        axis_index = dims.index(dim)
+        values = _interp_axis(values, axis_index, field_coords[dim], param_coords[dim])
+
+    out_coords = {dim: np.asarray(dataset_field.coords[dim].data) for dim in dataset_field.dims}
+    result = SpatialDataArray(values, coords=out_coords, dims=tuple(dims))
+    if tuple(dims) != tuple(dataset_field.dims):
+        result = result.transpose(*dataset_field.dims)
+    return result
+
+
 __all__ = [
     "DerivativeInfo",
+    "bounds_slice",
+    "compute_spatial_weights",
     "integrate_within_bounds",
+    "source_grid_step",
+    "source_scale_factor",
+    "transpose_interp_axis",
+    "transpose_interp_field_to_dataset",
 ]

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -1168,15 +1168,8 @@ def source_grid_step(
 def source_scale_factor(
     adjoint_field: SpatialDataArray,
     field_data: ScalarFieldDataArray,
-    component_axis: int,
-    eps_data: Optional[PermittivityData] = None,
-    center: Optional[tuple[float, float, float]] = None,
 ) -> float:
     """Compute the multiplicative source VJP scale factor."""
-    # Keep optional permittivity inputs in signature for forward compatibility and to
-    # preserve the calling contract from source derivative paths.
-    _ = (component_axis, eps_data, center)
-
     grid_step = source_grid_step(adjoint_field, field_data)
     return 2.0 * np.pi * grid_step
 

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -1190,6 +1190,7 @@ def transpose_interp_axis(
     if method not in ("linear", "nearest"):
         raise ValueError(f"Unsupported interpolation method: {method!r}.")
 
+    param_coords_1d = np.asarray(param_coords_1d, dtype=float)
     n_param = param_coords_1d.size
     n_field = field_values.shape[0]
     field_values_2d = field_values.reshape(n_field, -1)
@@ -1265,8 +1266,28 @@ def transpose_interp_field_to_dataset(
     dataset_field: SpatialDataArray,
     *,
     center: tuple[float, float, float],
+    method: str | dict[str, str] = "linear",
 ) -> SpatialDataArray:
     """Accumulate adjoint fields onto dataset coordinates using adjoint interpolation."""
+
+    allowed_methods = ("linear", "nearest")
+    if isinstance(method, str):
+        method_by_dim = dict.fromkeys("xyz", method)
+    elif isinstance(method, dict):
+        invalid_dims = set(method) - set("xyz")
+        if invalid_dims:
+            raise ValueError(
+                f"Unsupported interpolation axis keys: {sorted(invalid_dims)!r}. "
+                "Expected subset of ('x', 'y', 'z')."
+            )
+        method_by_dim = {dim: method.get(dim, "linear") for dim in "xyz"}
+    else:
+        raise TypeError("Interpolation method must be a string or a dict keyed by 'x', 'y', 'z'.")
+    for dim, interp_method in method_by_dim.items():
+        if interp_method not in allowed_methods:
+            raise ValueError(
+                f"Unsupported interpolation method {interp_method!r} for axis '{dim}'."
+            )
 
     def _align_freq(field: SpatialDataArray, target: SpatialDataArray) -> SpatialDataArray:
         target_freqs = np.asarray(target.coords["f"].data)
@@ -1290,19 +1311,24 @@ def transpose_interp_field_to_dataset(
         ).fillna(0.0)
 
     def _interp_axis(
-        arr: np.ndarray, axis: int, field_axis: np.ndarray, param_axis: np.ndarray
+        arr: np.ndarray,
+        axis: int,
+        field_axis: np.ndarray,
+        param_axis: np.ndarray,
+        interp_method: str,
     ) -> np.ndarray:
         moved = np.moveaxis(arr, axis, 0)
         moved = transpose_interp_axis(
             moved,
             field_axis,
             param_axis,
-            method="linear",
+            method=interp_method,
         )
         return np.moveaxis(moved, 0, axis)
 
+    dataset_field_sorted = dataset_field._spatially_sorted
     center = tuple(get_static(val) for val in center)
-    aligned = _align_freq(adjoint_field, dataset_field)
+    aligned = _align_freq(adjoint_field, dataset_field_sorted)
     weights = compute_spatial_weights(aligned, dims=tuple("xyz"))
     if weights.size > 1:
         weights = weights.transpose(*weights.dims)
@@ -1313,8 +1339,8 @@ def transpose_interp_field_to_dataset(
     }
     param_coords = {}
     for axis, dim in enumerate("xyz"):
-        if dim in dataset_field.coords:
-            param_coords[dim] = np.asarray(dataset_field.coords[dim].data) + center[axis]
+        if dim in dataset_field_sorted.coords:
+            param_coords[dim] = np.asarray(dataset_field_sorted.coords[dim].data) + center[axis]
 
     crop_slices = {}
     for dim in "xyz":
@@ -1343,11 +1369,38 @@ def transpose_interp_field_to_dataset(
         if dim not in field_coords or dim not in param_coords:
             continue
         axis_index = dims.index(dim)
-        values = _interp_axis(values, axis_index, field_coords[dim], param_coords[dim])
+        values = _interp_axis(
+            values,
+            axis_index,
+            field_coords[dim],
+            param_coords[dim],
+            method_by_dim[dim],
+        )
 
-    out_coords = {dim: np.asarray(dataset_field.coords[dim].data) for dim in dataset_field.dims}
+    out_coords = {
+        dim: np.asarray(dataset_field_sorted.coords[dim].data) for dim in dataset_field_sorted.dims
+    }
     result = SpatialDataArray(values, coords=out_coords, dims=tuple(dims))
-    if tuple(dims) != tuple(dataset_field.dims):
+    if tuple(dims) != tuple(dataset_field_sorted.dims):
+        result = result.transpose(*dataset_field_sorted.dims)
+
+    needs_restore_order = any(
+        dim in dataset_field.coords
+        and not np.array_equal(
+            np.asarray(dataset_field.coords[dim].data),
+            np.asarray(dataset_field_sorted.coords[dim].data),
+        )
+        for dim in "xyz"
+    )
+    if needs_restore_order:
+        selection = {}
+        for dim in "xyz":
+            if dim in dataset_field.coords:
+                selection[dim] = np.asarray(dataset_field.coords[dim].data)
+        if selection:
+            result = result.sel(selection)
+
+    if tuple(result.dims) != tuple(dataset_field.dims):
         result = result.transpose(*dataset_field.dims)
     return result
 

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -1275,6 +1275,13 @@ def transpose_interp_field_to_dataset(
             target_freqs, source_freqs, rtol=1e-12, atol=0.0
         ):
             return field
+        if target_freqs.size == 1 and source_freqs.size > 1:
+            # Source datasets are single-frequency by construction. When adjoint
+            # fields carry multiple frequencies, gradients must accumulate all
+            # frequency contributions onto that single source-frequency slot.
+            summed = field.sum(dim="f")
+            summed = summed.expand_dims({"f": target_freqs}, axis=-1)
+            return summed.transpose(*field.dims)
         method = "nearest" if target_freqs.size <= 1 or source_freqs.size <= 1 else "linear"
         return field.interp(
             {"f": target_freqs},

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -1126,54 +1126,6 @@ def compute_spatial_weights(
     return SpatialDataArray(weights_data, coords=coords, dims=tuple(weight_dims))
 
 
-def source_grid_step(
-    adjoint_field: SpatialDataArray,
-    field_data: SpatialDataArray,
-) -> float:
-    """Compute a source-adjoint grid step used in source VJP normalization.
-
-    Uses the minimum positive spacing found on the adjoint field grid across spatial
-    coordinates, and falls back to the source dataset grid when the adjoint grid is
-    degenerate.
-    """
-
-    steps: list[float] = []
-
-    for dim in "xyz":
-        if dim not in adjoint_field.coords:
-            continue
-        coord = np.asarray(adjoint_field.coords[dim].data, dtype=float)
-        if coord.size <= 1:
-            continue
-        diffs = np.abs(np.diff(coord))
-        diffs = diffs[np.isfinite(diffs) & (diffs > 0.0)]
-        if diffs.size:
-            steps.append(float(np.min(diffs)))
-
-    if not steps:
-        for dim in "xyz":
-            if dim not in field_data.coords:
-                continue
-            coord = np.asarray(field_data.coords[dim].data, dtype=float)
-            if coord.size <= 1:
-                continue
-            diffs = np.abs(np.diff(coord))
-            diffs = diffs[np.isfinite(diffs) & (diffs > 0.0)]
-            if diffs.size:
-                steps.append(float(np.min(diffs)))
-
-    return float(min(steps)) if steps else 1.0
-
-
-def source_scale_factor(
-    adjoint_field: SpatialDataArray,
-    field_data: ScalarFieldDataArray,
-) -> float:
-    """Compute the multiplicative source VJP scale factor."""
-    grid_step = source_grid_step(adjoint_field, field_data)
-    return 2.0 * np.pi * grid_step
-
-
 def transpose_interp_axis(
     field_values: np.ndarray,
     field_coords_1d: np.ndarray,
@@ -1300,6 +1252,8 @@ def transpose_interp_field_to_dataset(
             # Source datasets are single-frequency by construction. When adjoint
             # fields carry multiple frequencies, gradients must accumulate all
             # frequency contributions onto that single source-frequency slot.
+            # Any source-spectrum weighting has already been applied upstream
+            # to the adjoint fields in ``_process_source_gradients``.
             summed = field.sum(dim="f")
             summed = summed.expand_dims({"f": target_freqs}, axis=-1)
             return summed.transpose(*field.dims)
@@ -1410,8 +1364,6 @@ __all__ = [
     "bounds_slice",
     "compute_spatial_weights",
     "integrate_within_bounds",
-    "source_grid_step",
-    "source_scale_factor",
     "transpose_interp_axis",
     "transpose_interp_field_to_dataset",
 ]

--- a/tidy3d/components/base.py
+++ b/tidy3d/components/base.py
@@ -1532,14 +1532,17 @@ class Tidy3dBaseModel(BaseModel):
         return self.model_dump_json(indent=INDENT, exclude_unset=False)
 
     def _strip_traced_fields(
-        self, starting_path: tuple[str, ...] = (), include_untraced_data_arrays: bool = False
+        self,
+        starting_paths: tuple[tuple[str, ...], ...] = (),
+        include_untraced_data_arrays: bool = False,
     ) -> AutogradFieldMap:
         """Extract a dictionary mapping paths in the model to the data traced by ``autograd``.
 
         Parameters
         ----------
-        starting_path : tuple[str, ...] = ()
-            If provided, starts recursing in self.model_dump() from this path of field names
+        starting_paths : tuple[tuple[str, ...], ...] = ()
+            If provided, starts recursing in self.model_dump() from these paths of field names.
+            Can be a single path tuple or multiple path tuples.
         include_untraced_data_arrays : bool = False
             Whether to include ``DataArray`` objects without tracers.
             We need to include these when returning data, but are unnecessary for structures.
@@ -1551,7 +1554,7 @@ class Tidy3dBaseModel(BaseModel):
 
         """
 
-        path = tuple(starting_path)
+        paths = tuple(starting_paths)
         if self._has_tracers is False and not include_untraced_data_arrays:
             return TracedDict()
 
@@ -1585,19 +1588,31 @@ class Tidy3dBaseModel(BaseModel):
         # recursively parse the dictionary of this object
         self_dict = self.model_dump(round_trip=True)
 
-        # if an include_only string was provided, only look at that subset of the dict
-        if path:
-            for key in path:
-                self_dict = self_dict[key]
+        # Handle multiple starting paths
+        if paths:
+            # If paths is a single tuple, convert to tuple of tuples
+            if isinstance(paths[0], str):
+                paths = (paths,)
 
-        handle_value(self_dict, path=path)
+            # Process each starting path
+            for starting_path in paths:
+                # Navigate to the starting path in the dictionary
+                current_dict = self_dict
+                for key in starting_path:
+                    current_dict = current_dict[key]
+
+                # Handle the subtree starting from this path
+                handle_value(current_dict, path=starting_path)
+        else:
+            # No starting paths specified, process entire dictionary
+            handle_value(self_dict, path=())
 
         if field_mapping:
             if not include_untraced_data_arrays:
                 self._has_tracers = True
             return TracedDict(field_mapping)
 
-        if not include_untraced_data_arrays and not path:
+        if not include_untraced_data_arrays and not paths:
             self._has_tracers = False
         return TracedDict()
 

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -1048,10 +1048,15 @@ class SimulationData(AbstractYeeGridSimulationData):
         """Split data list into original, adjoint field, and adjoint permittivity."""
 
         data_all = list(self.data)
-        num_mnts_adjoint = (len(data_all) - num_mnts_original) // 2
+        adjoint_monitors = list(self.simulation.monitors[num_mnts_original:])
+        num_mnts_adjoint = len(adjoint_monitors)
+        num_mnts_eps = sum(
+            getattr(monitor, "name", "").startswith("adjoint_eps_") for monitor in adjoint_monitors
+        )
+        num_mnts_fld = num_mnts_adjoint - num_mnts_eps
 
         log.info(
-            f" -> {num_mnts_original} monitors, {num_mnts_adjoint} adjoint field monitors, {num_mnts_adjoint} adjoint eps monitors."
+            f" -> {num_mnts_original} monitors, {num_mnts_fld} adjoint field monitors, {num_mnts_eps} adjoint eps monitors."
         )
 
         data_original, data_adjoint = split_list(data_all, index=num_mnts_original)

--- a/tidy3d/components/grid/grid.py
+++ b/tidy3d/components/grid/grid.py
@@ -33,6 +33,18 @@ MIN_CELL_SIZE_TOLERANCE = 0.05  # 5%
 MAX_MIN_SIZE_LOCATIONS = 10
 
 
+def _compute_1d_cell_sizes(coord: np.ndarray) -> np.ndarray:
+    """Compute 1D cell sizes from coordinate centers."""
+    if coord.size <= 1:
+        return np.array([1.0], dtype=float)
+
+    diff = coord[1:] - coord[:-1]
+    diff_left = np.pad(diff, ((1, 0)), mode="edge")
+    diff_right = np.pad(diff, ((0, 1)), mode="edge")
+
+    return 0.5 * (diff_left + diff_right)
+
+
 class Coords(Tidy3dBaseModel):
     """Holds data about a set of x,y,z positions on a grid.
 
@@ -76,16 +88,10 @@ class Coords(Tidy3dBaseModel):
 
         coord_dict = self.to_dict
         for dim in "xyz":
-            if len(coord_dict[dim]) > 1:
-                diff = coord_dict[dim][1:] - coord_dict[dim][0:-1]
-
-                diff_left = np.pad(diff, ((1, 0)), mode="edge")
-                diff_right = np.pad(diff, ((0, 1)), mode="edge")
-
-                diff_avg = 0.5 * (diff_left + diff_right)
-                cell_sizes[dim] = diff_avg
-            else:
+            if len(coord_dict[dim]) <= 1:
                 cell_sizes[dim] = 1
+            else:
+                cell_sizes[dim] = _compute_1d_cell_sizes(np.asarray(coord_dict[dim]))
 
         return cell_sizes
 

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -41,7 +41,12 @@ from tidy3d.constants import (
 from tidy3d.exceptions import SetupError, ValidationError
 from tidy3d.log import log
 
-from .autograd.derivative_utils import integrate_within_bounds
+from .autograd.derivative_utils import (
+    bounds_slice,
+    compute_spatial_weights,
+    integrate_within_bounds,
+    transpose_interp_axis,
+)
 from .autograd.types import TracedFloat, TracedPolesAndResidues, TracedPositiveFloat
 from .base import Tidy3dBaseModel, cached_property
 from .data.data_array import DATA_ARRAY_MAP, ScalarFieldDataArray, SpatialDataArray
@@ -127,8 +132,6 @@ LOSSY_METAL_DEFAULT_MAX_POLES = 5
 LOSSY_METAL_DEFAULT_TOLERANCE_RMS = 1e-3
 
 ALLOWED_INTERP_METHODS = get_args(InterpMethod)
-
-CUSTOM_MEDIUM_BOUNDARY_COORDINATE_TOLERANCE = 1e-12
 
 
 def ensure_freq_in_range(
@@ -1154,163 +1157,47 @@ class AbstractCustomMedium(AbstractMedium, ABC):
         if E_der_dim is None or np.all(E_der_dim.values == 0):
             return np.zeros(eps_shape, dtype=dtype_out)
 
-        field_coords = {axis: np.asarray(E_der_dim.coords[axis]) for axis in "xyz"}
-        # copy here to avoid modifying the derivative_info object data in E_der_map
-        values = E_der_dim.values.copy()
-
-        def _bounds_slice(axis: NDArray, vmin: float, vmax: float, *, name: str) -> slice:
-            n = axis.size
-
-            # protect against field value coordinates right at the structure boundary being
-            # exluded due to numerical precision
-            vmin -= CUSTOM_MEDIUM_BOUNDARY_COORDINATE_TOLERANCE
-            vmax += CUSTOM_MEDIUM_BOUNDARY_COORDINATE_TOLERANCE
-
-            i0 = int(np.searchsorted(axis, vmin, side="left"))
-            i1 = int(np.searchsorted(axis, vmax, side="right"))
-            if i1 <= i0 and n:
-                old = (i0, i1)
-                if i1 < n:
-                    i1 = i0 + 1  # expand right
-                elif i0 > 0:
-                    i0 = i1 - 1  # expand left
-                log.warning(
-                    f"Empty bounds crop on '{name}' while computing CustomMedium parameter gradients "
-                    f"(adjoint field grid -> medium grid): bounds=[{vmin!r}, {vmax!r}], "
-                    f"grid=[{axis[0]!r}, {axis[-1]!r}] -> indices {old}; using ({i0}, {i1}).",
-                    log_once=True,
-                )
-            return slice(i0, i1)
+        field_values_da = E_der_dim
 
         if bounds is not None:
             (xmin, ymin, zmin), (xmax, ymax, zmax) = bounds
+            warning_context = "CustomMedium parameter gradients (adjoint field grid -> medium grid)"
+            sx = bounds_slice(
+                np.asarray(field_values_da.coords["x"]),
+                xmin,
+                xmax,
+                name="x",
+                warning_context=warning_context,
+            )
+            sy = bounds_slice(
+                np.asarray(field_values_da.coords["y"]),
+                ymin,
+                ymax,
+                name="y",
+                warning_context=warning_context,
+            )
+            sz = bounds_slice(
+                np.asarray(field_values_da.coords["z"]),
+                zmin,
+                zmax,
+                name="z",
+                warning_context=warning_context,
+            )
+            field_values_da = field_values_da.isel(x=sx, y=sy, z=sz)
 
-            sx = _bounds_slice(field_coords["x"], xmin, xmax, name="x")
-            sy = _bounds_slice(field_coords["y"], ymin, ymax, name="y")
-            sz = _bounds_slice(field_coords["z"], zmin, zmax, name="z")
-
-            field_coords = {k: field_coords[k][s] for k, s in (("x", sx), ("y", sy), ("z", sz))}
-            values = values[sx, sy, sz, :]
-
-        def _axis_sizes(coords: NDArray) -> NDArray:
-            if coords.size <= 1:
-                return np.array([1.0])
-            mid_points = (coords[1:] + coords[:-1]) / 2.0
-            dists = np.diff(mid_points)
-            sizes = np.zeros(coords.size)
-            sizes[1:-1] = dists
-            sizes[0] = 2 * abs(mid_points[0] - coords[0])
-            sizes[-1] = 2 * abs(coords[-1] - mid_points[-1])
-            return sizes
-
-        size_x = _axis_sizes(field_coords["x"])
-        size_y = _axis_sizes(field_coords["y"])
-        size_z = _axis_sizes(field_coords["z"])
-        scale = (
-            size_x[:, None, None, None] * size_y[None, :, None, None] * size_z[None, None, :, None]
-        )
-        np.multiply(values, scale, out=values)
+        field_coords = {axis: np.asarray(field_values_da.coords[axis]) for axis in "xyz"}
+        weights = compute_spatial_weights(field_values_da, dims=("x", "y", "z"))
+        weighted_values_da = field_values_da * weights
+        # Copy to avoid modifying underlying data through in-place operations below.
+        values = weighted_values_da.values.copy()
 
         method = interp_method if interp_method is not None else self.interp_method
 
-        def _transpose_interp_axis(
-            field_values: NDArray, field_coords_1d: NDArray, param_coords_1d: NDArray
-        ) -> NDArray:
-            """
-            Transpose (adjoint) of 1D interpolation along one axis.
-
-            Parameters
-            ----------
-            field_values : np.ndarray
-                Array of values sampled on the field grid along this axis.
-                Shape: (n_field, ...rest...).
-                Notes:
-                  - The first axis corresponds to `field_coords_1d`.
-                  - The remaining axes (...rest...) are treated as batch dimensions and are
-                    carried through unchanged.
-
-            field_coords_1d : np.ndarray
-                1D coordinates of the field grid along this axis.
-                Shape: (n_field,).
-
-            param_coords_1d : np.ndarray
-                1D coordinates of the parameter grid along this axis.
-                Shape: (n_param,). Must be sorted ascending for the searchsorted-based logic.
-
-            Returns
-            -------
-            param_values : np.ndarray
-                Field contributions accumulated onto the parameter grid along this axis.
-                Shape: (n_param, ...rest...).
-
-            Implementation note
-            -------------------
-            For efficient accumulation, we flatten the trailing dimensions (...rest...) into a single
-            dimension so we can run a vectorized `np.add.at` on a 2D buffer of shape (n_param, n_rest),
-            then reshape back to (n_param, ...rest...).
-            """
-            # Single-point parameter grid: every field sample maps to the only parameter entry,
-            if param_coords_1d.size == 1:
-                return field_values.sum(axis=0, keepdims=True)
-
-            # Ensure parameter coordinates are sorted for searchsorted-based binning.
-            if np.any(param_coords_1d[1:] < param_coords_1d[:-1]):
-                raise ValueError("Spatial coordinates must be sorted before computing derivatives.")
-            param_coords_sorted = param_coords_1d
-
-            n_param = param_coords_sorted.size
-            if method not in ALLOWED_INTERP_METHODS:
-                raise ValueError(
-                    f"Unsupported interpolation method: {method!r}. "
-                    f"Choose one of: {', '.join(ALLOWED_INTERP_METHODS)}."
-                )
-
-            # Flatten trailing dimensions into a single "rest" dimension for vectorized accumulation.
-            n_field = field_values.shape[0]
-            field_values_2d = field_values.reshape(n_field, -1)
-
-            if method == "nearest":
-                # Midpoints define bin edges between adjacent parameter coordinates.
-                param_midpoints = (param_coords_sorted[1:] + param_coords_sorted[:-1]) / 2.0
-                # Map each field coordinate to a nearest parameter-bin index.
-                param_index_nearest = np.searchsorted(param_midpoints, field_coords_1d)
-
-                # Accumulate all field samples into their assigned parameter bins.
-                param_values_2d = npo.zeros(
-                    (n_param, field_values_2d.shape[1]), dtype=field_values.dtype
-                )
-                npo.add.at(param_values_2d, param_index_nearest, field_values_2d)
-
-                param_values = param_values_2d.reshape((n_param,) + field_values.shape[1:])
-                return param_values
-
-            # linear
-            # Find bracketing parameter indices for each field coordinate.
-            param_index_upper = np.searchsorted(param_coords_sorted, field_coords_1d, side="right")
-            param_index_upper = np.clip(param_index_upper, 1, n_param - 1)
-            param_index_lower = param_index_upper - 1
-
-            # Compute interpolation fraction within the bracketing segment.
-            segment_width = (
-                param_coords_sorted[param_index_upper] - param_coords_sorted[param_index_lower]
+        if method not in ALLOWED_INTERP_METHODS:
+            raise ValueError(
+                f"Unsupported interpolation method: {method!r}. "
+                f"Choose one of: {', '.join(ALLOWED_INTERP_METHODS)}."
             )
-            segment_width = np.where(segment_width == 0, 1.0, segment_width)
-            frac_upper = (field_coords_1d - param_coords_sorted[param_index_lower]) / segment_width
-            frac_upper = np.clip(frac_upper, 0.0, 1.0)
-
-            # Weights per field sample (broadcast across the flattened trailing dimensions).
-            w_lower = (1.0 - frac_upper)[:, None]
-            w_upper = frac_upper[:, None]
-
-            # Accumulate contributions into both bracketing parameter indices.
-            param_values_2d = npo.zeros(
-                (n_param, field_values_2d.shape[1]), dtype=field_values.dtype
-            )
-            npo.add.at(param_values_2d, param_index_lower, field_values_2d * w_lower)
-            npo.add.at(param_values_2d, param_index_upper, field_values_2d * w_upper)
-
-            param_values = param_values_2d.reshape((n_param,) + field_values.shape[1:])
-            return param_values
 
         def _interp_axis(
             arr: NDArray, axis: int, field_axis: NDArray, param_axis: NDArray
@@ -1321,14 +1208,19 @@ class AbstractCustomMedium(AbstractMedium, ABC):
             to map from ``field_axis`` (n_field) to ``param_axis`` (n_param), then moves the axis back.
             """
             moved = np.moveaxis(arr, axis, 0)
-            moved = _transpose_interp_axis(moved, field_axis, param_axis)
+            moved = transpose_interp_axis(
+                moved,
+                field_axis,
+                param_axis,
+                method=method,
+            )
             return np.moveaxis(moved, 0, axis)
 
         values = _interp_axis(values, 0, field_coords["x"], param_coords["x"])
         values = _interp_axis(values, 1, field_coords["y"], param_coords["y"])
         values = _interp_axis(values, 2, field_coords["z"], param_coords["z"])
 
-        freqs_da = np.asarray(E_der_dim.coords["f"])
+        freqs_da = np.asarray(field_values_da.coords["f"])
         if component == "sigma":
             values = values.imag * (-1.0 / (2.0 * np.pi * freqs_da * EPSILON_0))
         elif component == "imag":

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -5047,10 +5047,21 @@ class Simulation(AbstractYeeGridSimulation):
     def _make_adjoint_monitors(self, sim_fields_keys: list) -> tuple[list, list]:
         """Get lists of field and permittivity monitors for this simulation."""
 
-        index_to_keys = defaultdict(list)
+        # Separate structures and sources into different dictionaries
+        structure_index_to_keys = defaultdict(list)
+        source_index_to_keys = defaultdict(list)
 
-        for _, index, *fields in sim_fields_keys:
-            index_to_keys[index].append(fields)
+        for component_type, index, *fields in sim_fields_keys:
+            if component_type == "structures":
+                structure_index_to_keys[index].append(fields)
+            elif component_type == "sources":
+                source_index_to_keys[index].append(fields)
+            else:
+                raise ValueError(
+                    f"Unknown component type '{component_type}' encountered while "
+                    "constructing adjoint monitors. "
+                    "Expected one of: 'structures', 'sources'."
+                )
 
         freqs = self._freqs_adjoint
         sim_plane = self if self.size.count(0.0) == 1 else None
@@ -5058,24 +5069,43 @@ class Simulation(AbstractYeeGridSimulation):
         adjoint_monitors_fld = []
         adjoint_monitors_eps = []
 
-        # make a field and permittivity monitor for every structure needing one
-        for i, field_keys in index_to_keys.items():
+        # Handle structures first
+        for i, field_keys in structure_index_to_keys.items():
             structure = self.structures[i]
-
             mnt_fld, mnt_eps = structure._make_adjoint_monitors(
                 freqs=freqs, index=i, field_keys=field_keys, plane=sim_plane
             )
-
             adjoint_monitors_fld.append(mnt_fld)
             adjoint_monitors_eps.append(mnt_eps)
+
+        # Handle sources
+        for i, _field_keys in source_index_to_keys.items():
+            source = self.sources[i]
+
+            # For sources, we only need field monitors (no permittivity monitors)
+            # Create a field monitor that covers the source region
+            source_center = source.center
+            source_size = source.size
+
+            # Create field monitor for the source
+            field_monitor = FieldMonitor(
+                center=source_center,
+                size=source_size,
+                freqs=freqs,
+                name=f"source_adjoint_{i}",
+            )
+
+            # For sources, we only return field monitors (no permittivity monitors)
+            adjoint_monitors_fld.append(field_monitor)
 
         return adjoint_monitors_fld, adjoint_monitors_eps
 
     def _check_custom_medium_geometry_overlap(self, sim_fields_keys: AutogradFieldMap) -> None:
         index_to_keys = defaultdict(list)
 
-        for _, index, *fields in sim_fields_keys:
-            index_to_keys[index].append(fields)
+        for path_type, index, *fields in sim_fields_keys:
+            if path_type == "structures":
+                index_to_keys[index].append(fields)
 
         for structure_index, gradient_paths in index_to_keys.items():
             if self.structures[structure_index].medium.is_custom:

--- a/tidy3d/components/source/base.py
+++ b/tidy3d/components/source/base.py
@@ -12,7 +12,7 @@ from tidy3d.components.base_sim.source import AbstractSource
 from tidy3d.components.geometry.base import Box
 from tidy3d.components.types import TYPE_TAG_STR
 from tidy3d.components.types.time import SourceTimeType
-from tidy3d.components.validators import _assert_min_freq, _warn_unsupported_traced_argument
+from tidy3d.components.validators import _assert_min_freq
 from tidy3d.components.viz import (
     ARROW_ALPHA,
     ARROW_COLOR_POLARIZATION,
@@ -23,6 +23,8 @@ from tidy3d.components.viz import (
 if TYPE_CHECKING:
     from typing import Optional
 
+    from tidy3d.components.autograd import AutogradFieldMap
+    from tidy3d.components.autograd.derivative_utils import DerivativeInfo
     from tidy3d.components.types import Ax
     from tidy3d.components.viz import PlotParams
 
@@ -62,8 +64,30 @@ class Source(Box, AbstractSource, ABC):
         """Returns a vector indicating the source polarization for arrow plotting, if not None."""
         return None
 
-    _warn_traced_center = _warn_unsupported_traced_argument("center")
-    _warn_traced_size = _warn_unsupported_traced_argument("size")
+    _unsupported_traced_source_fields = ("center", "size", "source_time")
+
+    def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
+        """Compute adjoint derivatives for source parameters."""
+        raise NotImplementedError(f"Can't compute derivative for 'Source': '{type(self)}'.")
+
+    def _validate_traced_source_path(self, field_path: tuple[Any, ...], dataset_key: str) -> None:
+        """Validate traced source path, raising when unsupported source fields are traced."""
+        if not field_path:
+            raise ValueError(f"Empty traced source path encountered in '{type(self).__name__}'.")
+
+        field_root = field_path[0]
+        if field_root in self._unsupported_traced_source_fields:
+            raise ValueError(
+                f"Automatic differentiation with respect to source field '{field_root}' is not "
+                f"supported for '{type(self).__name__}'. Only '{dataset_key}' field components "
+                "are differentiable."
+            )
+
+        if field_root != dataset_key:
+            raise ValueError(
+                f"Unsupported traced source path '{field_path}' for '{type(self).__name__}'. "
+                f"Only '{dataset_key}' field components are differentiable."
+            )
 
     @field_validator("source_time")
     @classmethod

--- a/tidy3d/components/source/current.py
+++ b/tidy3d/components/source/current.py
@@ -282,13 +282,7 @@ class CustomCurrentSource(ReverseInterpolatedSource):
 
     def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
         """Compute derivatives with respect to CustomCurrentSource parameters."""
-        from tidy3d.components.autograd.derivative_utils import (
-            source_scale_factor,
-            transpose_interp_field_to_dataset,
-        )
-
-        if self.current_dataset is None:
-            return {tuple(path): 0.0 for path in derivative_info.paths}
+        from tidy3d.components.autograd.derivative_utils import transpose_interp_field_to_dataset
 
         derivative_map = {}
         center = tuple(self.center)
@@ -336,12 +330,8 @@ class CustomCurrentSource(ReverseInterpolatedSource):
             if self.confine_to_bounds:
                 adjoint_on_dataset = adjoint_on_dataset * self._confine_mask(field_data)
 
-            source_scale = source_scale_factor(
-                adjoint_field=adjoint_field,
-                field_data=field_data,
-            )
             # Keep source gradients stable against simulation grid-refinement changes.
-            vjp_field = np.real(component_sign * source_scale * adjoint_on_dataset)
+            vjp_field = np.real(component_sign * adjoint_on_dataset)
 
             derivative_map[field_path] = vjp_field.transpose(*field_data.dims).values
 

--- a/tidy3d/components/source/current.py
+++ b/tidy3d/components/source/current.py
@@ -266,7 +266,6 @@ class CustomCurrentSource(ReverseInterpolatedSource):
         center = tuple(self.center)
         h_adj = derivative_info.H_adj or {}
         e_adj = derivative_info.E_adj or {}
-        eps_data = derivative_info.eps_data or {}
 
         for field_path in derivative_info.paths:
             field_path = tuple(field_path)
@@ -302,13 +301,9 @@ class CustomCurrentSource(ReverseInterpolatedSource):
             adjoint_on_dataset = transpose_interp_field_to_dataset(
                 adjoint_field, field_data, center=center
             )
-            component_axis = "xyz".index(field_name[1])
             source_scale = source_scale_factor(
                 adjoint_field=adjoint_field,
                 field_data=field_data,
-                component_axis=component_axis,
-                eps_data=eps_data,
-                center=center,
             )
             # Keep source gradients stable against simulation grid-refinement changes.
             vjp_field = np.real(component_sign * source_scale * adjoint_on_dataset)

--- a/tidy3d/components/source/current.py
+++ b/tidy3d/components/source/current.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from tidy3d.compat import Self
     from tidy3d.components.autograd import AutogradFieldMap
     from tidy3d.components.autograd.derivative_utils import DerivativeInfo
+    from tidy3d.components.data.data_array import ScalarFieldDataArray
     from tidy3d.components.types.time import SourceTimeType
 
 
@@ -252,6 +253,33 @@ class CustomCurrentSource(ReverseInterpolatedSource):
     _current_dataset_single_freq = assert_single_freq_in_range("current_dataset")
     _can_interpolate = validate_can_interpolate("current_dataset")
 
+    def _confine_mask(self, field_data: ScalarFieldDataArray) -> np.ndarray:
+        """Mask selecting dataset points inside source bounds on nonzero-size axes."""
+        mask = np.ones(field_data.shape, dtype=float)
+        for dim in "xyz":
+            if dim not in field_data.coords:
+                continue
+            axis = "xyz".index(dim)
+            half_size = 0.5 * float(self.size[axis])
+            if half_size <= 0.0:
+                continue
+            coords = np.asarray(field_data.coords[dim].data, dtype=float)
+            inside = np.abs(coords) <= (half_size + 1e-12)
+            reshape = [1] * mask.ndim
+            reshape[field_data.dims.index(dim)] = coords.size
+            mask *= inside.reshape(reshape)
+        return mask
+
+    def _adjoint_interp_methods(self) -> dict[str, str]:
+        """Interpolation mode per axis for source VJP projection."""
+        if self.interpolate:
+            return dict.fromkeys("xyz", "linear")
+
+        axis_methods = {}
+        for axis, dim in enumerate("xyz"):
+            axis_methods[dim] = "nearest" if np.isclose(self.size[axis], 0.0) else "linear"
+        return axis_methods
+
     def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
         """Compute derivatives with respect to CustomCurrentSource parameters."""
         from tidy3d.components.autograd.derivative_utils import (
@@ -264,6 +292,7 @@ class CustomCurrentSource(ReverseInterpolatedSource):
 
         derivative_map = {}
         center = tuple(self.center)
+        interp_methods = self._adjoint_interp_methods()
         h_adj = derivative_info.H_adj or {}
         e_adj = derivative_info.E_adj or {}
 
@@ -299,8 +328,14 @@ class CustomCurrentSource(ReverseInterpolatedSource):
                 component_sign = 1.0
 
             adjoint_on_dataset = transpose_interp_field_to_dataset(
-                adjoint_field, field_data, center=center
+                adjoint_field,
+                field_data,
+                center=center,
+                method=interp_methods,
             )
+            if self.confine_to_bounds:
+                adjoint_on_dataset = adjoint_on_dataset * self._confine_mask(field_data)
+
             source_scale = source_scale_factor(
                 adjoint_field=adjoint_field,
                 field_data=field_data,

--- a/tidy3d/components/source/current.py
+++ b/tidy3d/components/source/current.py
@@ -6,6 +6,7 @@ from abc import ABC
 from math import cos, isclose, sin
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
+import numpy as np
 from pydantic import Field, model_validator
 
 from tidy3d.components.base import cached_property
@@ -20,6 +21,8 @@ from .base import Source
 
 if TYPE_CHECKING:
     from tidy3d.compat import Self
+    from tidy3d.components.autograd import AutogradFieldMap
+    from tidy3d.components.autograd.derivative_utils import DerivativeInfo
     from tidy3d.components.types.time import SourceTimeType
 
 
@@ -248,3 +251,68 @@ class CustomCurrentSource(ReverseInterpolatedSource):
     _current_dataset_none_warning = warn_if_dataset_none("current_dataset")
     _current_dataset_single_freq = assert_single_freq_in_range("current_dataset")
     _can_interpolate = validate_can_interpolate("current_dataset")
+
+    def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
+        """Compute derivatives with respect to CustomCurrentSource parameters."""
+        from tidy3d.components.autograd.derivative_utils import (
+            source_scale_factor,
+            transpose_interp_field_to_dataset,
+        )
+
+        if self.current_dataset is None:
+            return {tuple(path): 0.0 for path in derivative_info.paths}
+
+        derivative_map = {}
+        center = tuple(self.center)
+        h_adj = derivative_info.H_adj or {}
+        e_adj = derivative_info.E_adj or {}
+        eps_data = derivative_info.eps_data or {}
+
+        for field_path in derivative_info.paths:
+            field_path = tuple(field_path)
+            self._validate_traced_source_path(field_path, dataset_key="current_dataset")
+            if len(field_path) < 2:
+                raise ValueError(
+                    "Current source derivative paths must include dataset component names, "
+                    f"got '{field_path}'."
+                )
+
+            field_name = field_path[1]
+            if (
+                len(field_name) != 2
+                or field_name[0] not in ("E", "H")
+                or field_name[1] not in ("x", "y", "z")
+            ):
+                raise ValueError(
+                    f"Unsupported field component '{field_name}' in CustomCurrentSource. "
+                    "Expected one of Ex, Ey, Ez, Hx, Hy, Hz."
+                )
+
+            field_data = getattr(self.current_dataset, field_name, None)
+            if field_data is None:
+                raise ValueError(f"Cannot find field '{field_name}' in current dataset.")
+
+            if field_name.startswith("H"):
+                adjoint_field = h_adj[field_name]
+                component_sign = -1.0
+            else:  # "E" case
+                adjoint_field = e_adj[field_name]
+                component_sign = 1.0
+
+            adjoint_on_dataset = transpose_interp_field_to_dataset(
+                adjoint_field, field_data, center=center
+            )
+            component_axis = "xyz".index(field_name[1])
+            source_scale = source_scale_factor(
+                adjoint_field=adjoint_field,
+                field_data=field_data,
+                component_axis=component_axis,
+                eps_data=eps_data,
+                center=center,
+            )
+            # Keep source gradients stable against simulation grid-refinement changes.
+            vjp_field = np.real(component_sign * source_scale * adjoint_on_dataset)
+
+            derivative_map[field_path] = vjp_field.transpose(*field_data.dims).values
+
+        return derivative_map

--- a/tidy3d/components/source/field.py
+++ b/tidy3d/components/source/field.py
@@ -274,34 +274,16 @@ class CustomFieldSource(FieldSource, PlanarSource):
 
         if field_name.startswith("E"):
             target_component = f"H{'xyz'[target_axis]}"
-            try:
-                adjoint_field = h_adj[target_component]
-            except KeyError as exc:
-                raise ValueError(
-                    "Missing adjoint field component "
-                    f"'{target_component}' required by CustomFieldSource derivative."
-                ) from exc
+            adjoint_field = h_adj[target_component]
         else:
             target_component = f"E{'xyz'[target_axis]}"
-            try:
-                adjoint_field = e_adj[target_component]
-            except KeyError as exc:
-                raise ValueError(
-                    "Missing adjoint field component "
-                    f"'{target_component}' required by CustomFieldSource derivative."
-                ) from exc
+            adjoint_field = e_adj[target_component]
 
         return adjoint_field, component_sign
 
     def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
         """Compute derivatives with respect to CustomFieldSource parameters."""
-        from tidy3d.components.autograd.derivative_utils import (
-            source_scale_factor,
-            transpose_interp_field_to_dataset,
-        )
-
-        if self.field_dataset is None:
-            return {tuple(path): 0.0 for path in derivative_info.paths}
+        from tidy3d.components.autograd.derivative_utils import transpose_interp_field_to_dataset
 
         derivative_map = {}
         center = tuple(self.center)
@@ -355,13 +337,9 @@ class CustomFieldSource(FieldSource, PlanarSource):
             adjoint_on_dataset = transpose_interp_field_to_dataset(
                 adjoint_field, field_data, center=center
             )
-            source_scale = source_scale_factor(
-                adjoint_field=adjoint_field,
-                field_data=field_data,
-            )
 
             # Keep source gradients stable against simulation grid-refinement changes.
-            vjp_field = np.real(component_sign * source_scale * adjoint_on_dataset)
+            vjp_field = np.real(component_sign * adjoint_on_dataset)
             derivative_map[field_path] = vjp_field.transpose(*field_data.dims).values
 
         return derivative_map

--- a/tidy3d/components/source/field.py
+++ b/tidy3d/components/source/field.py
@@ -32,6 +32,9 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
     from tidy3d.compat import Self
+    from tidy3d.components.autograd import AutogradFieldMap
+    from tidy3d.components.autograd.derivative_utils import DerivativeInfo
+    from tidy3d.components.data.data_array import ScalarFieldDataArray
     from tidy3d.components.types import Ax, Coordinate
 
 # width of Chebyshev grid used for broadband sources (in units of pulse width)
@@ -247,6 +250,123 @@ class CustomFieldSource(FieldSource, PlanarSource):
                 if tangential_field in val.field_components:
                     return self
         raise SetupError("No tangential field found in the suppled 'field_dataset'.")
+
+    def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
+        """Compute derivatives with respect to CustomFieldSource parameters."""
+        from tidy3d.components.autograd.derivative_utils import (
+            source_scale_factor,
+            transpose_interp_field_to_dataset,
+        )
+
+        if self.field_dataset is None:
+            return {tuple(path): 0.0 for path in derivative_info.paths}
+
+        derivative_map = {}
+        center = tuple(self.center)
+        e_adj = derivative_info.E_adj or {}
+        h_adj = derivative_info.H_adj or {}
+        eps_data = derivative_info.eps_data or {}
+        if self.injection_axis is None:
+            return {tuple(path): 0.0 for path in derivative_info.paths}
+
+        for field_path in derivative_info.paths:
+            field_path = tuple(field_path)
+            self._validate_traced_source_path(field_path, dataset_key="field_dataset")
+            if len(field_path) < 2:
+                raise ValueError(
+                    "Field source derivative paths must include dataset component names, "
+                    f"got '{field_path}'."
+                )
+
+            field_name = field_path[1]
+            field_data = getattr(self.field_dataset, field_name, None)
+            if field_data is None:
+                raise ValueError(f"Cannot find field '{field_name}' in field dataset.")
+
+            if (
+                len(field_name) != 2
+                or field_name[0] not in ("E", "H")
+                or field_name[1] not in ("x", "y", "z")
+            ):
+                raise ValueError(
+                    f"Unsupported field component '{field_name}' in CustomFieldSource. "
+                    "Expected one of Ex, Ey, Ez, Hx, Hy, Hz."
+                )
+
+            component_axis = "xyz".index(field_name[1])
+            if component_axis == self.injection_axis:
+                derivative_map[field_path] = np.zeros_like(field_data.data)
+                continue
+
+            def _get_adjoint_and_sign(
+                *,
+                field_name: str,
+                injection_axis: int,
+                component_axis: int,
+                e_adj: dict[str, ScalarFieldDataArray],
+                h_adj: dict[str, ScalarFieldDataArray],
+            ) -> tuple[Optional[ScalarFieldDataArray], float]:
+                # n x e determines which orthogonal component couples (and its sign)
+                n_vec = np.eye(3)[injection_axis]
+                e_vec = np.eye(3)[component_axis]
+                cross = np.cross(n_vec, e_vec)
+
+                if not np.any(cross):
+                    return None, 0.0  # indicates "no gradient"
+
+                target_axis = int(np.flatnonzero(cross)[0])
+                component_sign = float(cross[target_axis])
+
+                if field_name.startswith("E"):
+                    target_component = f"H{'xyz'[target_axis]}"
+                    try:
+                        adjoint_field = h_adj[target_component]
+                    except KeyError as exc:
+                        raise ValueError(
+                            "Missing adjoint field component "
+                            f"'{target_component}' required by CustomFieldSource derivative."
+                        ) from exc
+                else:
+                    target_component = f"E{'xyz'[target_axis]}"
+                    try:
+                        adjoint_field = e_adj[target_component]
+                    except KeyError as exc:
+                        raise ValueError(
+                            "Missing adjoint field component "
+                            f"'{target_component}' required by CustomFieldSource derivative."
+                        ) from exc
+
+                return adjoint_field, component_sign
+
+            adjoint_field, component_sign = _get_adjoint_and_sign(
+                field_name=field_name,
+                injection_axis=self.injection_axis,
+                component_axis=component_axis,
+                e_adj=e_adj,
+                h_adj=h_adj,
+            )
+
+            if component_sign == 0.0:
+                # no gradient for injection_axis == component_axis
+                derivative_map[field_path] = np.zeros_like(field_data.data)
+                continue
+
+            adjoint_on_dataset = transpose_interp_field_to_dataset(
+                adjoint_field, field_data, center=center
+            )
+            source_scale = source_scale_factor(
+                adjoint_field=adjoint_field,
+                field_data=field_data,
+                component_axis=component_axis,
+                eps_data=eps_data,
+                center=center,
+            )
+
+            # Keep source gradients stable against simulation grid-refinement changes.
+            vjp_field = np.real(component_sign * source_scale * adjoint_on_dataset)
+            derivative_map[field_path] = vjp_field.transpose(*field_data.dims).values
+
+        return derivative_map
 
 
 """ Source current profiles defined by (1) angle or (2) desired mode. Sets theta and phi angles."""

--- a/tidy3d/components/source/field.py
+++ b/tidy3d/components/source/field.py
@@ -307,7 +307,6 @@ class CustomFieldSource(FieldSource, PlanarSource):
         center = tuple(self.center)
         e_adj = derivative_info.E_adj or {}
         h_adj = derivative_info.H_adj or {}
-        eps_data = derivative_info.eps_data or {}
         if self.injection_axis is None:
             return {tuple(path): 0.0 for path in derivative_info.paths}
 
@@ -359,9 +358,6 @@ class CustomFieldSource(FieldSource, PlanarSource):
             source_scale = source_scale_factor(
                 adjoint_field=adjoint_field,
                 field_data=field_data,
-                component_axis=component_axis,
-                eps_data=eps_data,
-                center=center,
             )
 
             # Keep source gradients stable against simulation grid-refinement changes.

--- a/tidy3d/components/source/field.py
+++ b/tidy3d/components/source/field.py
@@ -251,6 +251,48 @@ class CustomFieldSource(FieldSource, PlanarSource):
                     return self
         raise SetupError("No tangential field found in the suppled 'field_dataset'.")
 
+    @staticmethod
+    def _get_adjoint_and_sign(
+        *,
+        field_name: str,
+        injection_axis: int,
+        component_axis: int,
+        e_adj: dict[str, ScalarFieldDataArray],
+        h_adj: dict[str, ScalarFieldDataArray],
+    ) -> tuple[Optional[ScalarFieldDataArray], float]:
+        """Return coupled adjoint field and orientation sign for a source component."""
+        # n x e determines which orthogonal component couples (and its sign)
+        n_vec = np.eye(3)[injection_axis]
+        e_vec = np.eye(3)[component_axis]
+        cross = np.cross(n_vec, e_vec)
+
+        if not np.any(cross):
+            return None, 0.0  # indicates "no gradient"
+
+        target_axis = int(np.flatnonzero(cross)[0])
+        component_sign = float(cross[target_axis])
+
+        if field_name.startswith("E"):
+            target_component = f"H{'xyz'[target_axis]}"
+            try:
+                adjoint_field = h_adj[target_component]
+            except KeyError as exc:
+                raise ValueError(
+                    "Missing adjoint field component "
+                    f"'{target_component}' required by CustomFieldSource derivative."
+                ) from exc
+        else:
+            target_component = f"E{'xyz'[target_axis]}"
+            try:
+                adjoint_field = e_adj[target_component]
+            except KeyError as exc:
+                raise ValueError(
+                    "Missing adjoint field component "
+                    f"'{target_component}' required by CustomFieldSource derivative."
+                ) from exc
+
+        return adjoint_field, component_sign
+
     def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
         """Compute derivatives with respect to CustomFieldSource parameters."""
         from tidy3d.components.autograd.derivative_utils import (
@@ -298,47 +340,7 @@ class CustomFieldSource(FieldSource, PlanarSource):
                 derivative_map[field_path] = np.zeros_like(field_data.data)
                 continue
 
-            def _get_adjoint_and_sign(
-                *,
-                field_name: str,
-                injection_axis: int,
-                component_axis: int,
-                e_adj: dict[str, ScalarFieldDataArray],
-                h_adj: dict[str, ScalarFieldDataArray],
-            ) -> tuple[Optional[ScalarFieldDataArray], float]:
-                # n x e determines which orthogonal component couples (and its sign)
-                n_vec = np.eye(3)[injection_axis]
-                e_vec = np.eye(3)[component_axis]
-                cross = np.cross(n_vec, e_vec)
-
-                if not np.any(cross):
-                    return None, 0.0  # indicates "no gradient"
-
-                target_axis = int(np.flatnonzero(cross)[0])
-                component_sign = float(cross[target_axis])
-
-                if field_name.startswith("E"):
-                    target_component = f"H{'xyz'[target_axis]}"
-                    try:
-                        adjoint_field = h_adj[target_component]
-                    except KeyError as exc:
-                        raise ValueError(
-                            "Missing adjoint field component "
-                            f"'{target_component}' required by CustomFieldSource derivative."
-                        ) from exc
-                else:
-                    target_component = f"E{'xyz'[target_axis]}"
-                    try:
-                        adjoint_field = e_adj[target_component]
-                    except KeyError as exc:
-                        raise ValueError(
-                            "Missing adjoint field component "
-                            f"'{target_component}' required by CustomFieldSource derivative."
-                        ) from exc
-
-                return adjoint_field, component_sign
-
-            adjoint_field, component_sign = _get_adjoint_and_sign(
+            adjoint_field, component_sign = self._get_adjoint_and_sign(
                 field_name=field_name,
                 injection_axis=self.injection_axis,
                 component_axis=component_axis,

--- a/tidy3d/plugins/autograd/README.md
+++ b/tidy3d/plugins/autograd/README.md
@@ -190,6 +190,7 @@ The following components are traceable as inputs to the `td.Simulation`
 | dispersive materials                                              | `PoleResidue.eps_inf`, `PoleResidue.poles`              |
 | spatially dependent dispersive materials                          | `CustomPoleResidue.eps_inf`, `CustomPoleResidue.poles`  |
 | cylinders                                                         | `Cylinder.radius`, `Cylinder.center`                    |
+| sources                                                           | `CustomCurrentSource.current_dataset`, `CustomFieldSource.field_dataset`|
 
 The following components are traceable as outputs of the `td.SimulationData`
 
@@ -223,12 +224,6 @@ We currently have the following restrictions:
   This can cause unnecessary data usage during the forward pass, especially if the monitors contain many frequencies that are not relevant for the objective function (i.e., they are not being differentiated w.r.t.).
   To avoid this, restrict the frequencies in the monitors only to the ones that are relevant for differentiation during optimization.
 
-### To be supported soon
-
-Next on our roadmap (targeting 2.8 and 2.9, 2025) is to support:
-
-- `TriangleMesh`.
-- `GUI` integration of invdes plugin.
 
 ### Finally
 

--- a/tidy3d/web/api/autograd/autograd.py
+++ b/tidy3d/web/api/autograd/autograd.py
@@ -76,7 +76,7 @@ def is_valid_for_autograd(simulation: td.Simulation) -> bool:
 
     # if no tracers just use regular web.run()
     traced_fields = simulation._strip_traced_fields(
-        include_untraced_data_arrays=False, starting_path=("structures",)
+        include_untraced_data_arrays=False, starting_paths=(("structures",), ("sources",))
     )
     if not traced_fields:
         return False
@@ -178,8 +178,11 @@ def verify_custom_vjp(
     argument is named derivative_info.
     """
 
-    custom_vjp_index_options = [full_path[1] for full_path in traced_fields]
-    custom_vjp_path_options = [full_path[2:4] for full_path in traced_fields]
+    traced_structure_fields = [
+        full_path for full_path in traced_fields if full_path and full_path[0] == "structures"
+    ]
+    custom_vjp_index_options = [full_path[1] for full_path in traced_structure_fields]
+    custom_vjp_path_options = [full_path[2:4] for full_path in traced_structure_fields]
 
     for vjp_config in custom_vjp:
         sig = inspect.signature(vjp_config.compute_derivatives)
@@ -841,7 +844,7 @@ def setup_run(simulation: td.Simulation) -> SetupRunResult:
 
     # get a mapping of all the traced fields in the provided simulation
     sim_fields_map = simulation._strip_traced_fields(
-        include_untraced_data_arrays=False, starting_path=("structures",)
+        include_untraced_data_arrays=False, starting_paths=(("structures",), ("sources",))
     )
 
     return SetupRunResult(
@@ -925,7 +928,7 @@ def _run_primitive(
         aux_data[AUX_KEY_FWD_TASK_ID] = task_id_fwd
         aux_data[AUX_KEY_SIM_DATA_ORIGINAL] = sim_data_orig
         field_map = sim_data_orig._strip_traced_fields(
-            include_untraced_data_arrays=True, starting_path=("data",)
+            include_untraced_data_arrays=True, starting_paths=(("data",),)
         )
 
     return field_map
@@ -990,7 +993,7 @@ def _run_async_primitive(
             aux_data_dict[task_name][AUX_KEY_FWD_TASK_ID] = task_id_fwd
             aux_data_dict[task_name][AUX_KEY_SIM_DATA_ORIGINAL] = sim_data_orig
             field_map = sim_data_orig._strip_traced_fields(
-                include_untraced_data_arrays=True, starting_path=("data",)
+                include_untraced_data_arrays=True, starting_paths=(("data",),)
             )
             field_map_fwd_dict[task_name] = field_map
 

--- a/tidy3d/web/api/autograd/backward.py
+++ b/tidy3d/web/api/autograd/backward.py
@@ -10,17 +10,18 @@ import xarray as xr
 import tidy3d as td
 from tidy3d.components.autograd import get_static
 from tidy3d.components.autograd.derivative_utils import DerivativeInfo
+from tidy3d.components.data.data_array import FreqDataArray
 from tidy3d.config import config
 from tidy3d.exceptions import AdjointError
 from tidy3d.packaging import disable_local_subpixel
 
-from .utils import E_to_D, get_derivative_maps
+from .utils import E_to_D, get_derivative_maps, scale_field_data
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Optional, Union
 
     from tidy3d.components.autograd import AutogradFieldMap
-    from tidy3d.components.data.data_array import FreqDataArray, ScalarFieldDataArray
+    from tidy3d.components.data.data_array import ScalarFieldDataArray
     from tidy3d.components.geometry.base import Box
     from tidy3d.components.geometry.utils import GeometryType
 
@@ -61,7 +62,7 @@ def setup_adj(
     # start with the full simulation data structure and either zero out the fields
     # that have no tracer data for them or insert the tracer data
     full_sim_data_dict = sim_data_orig._strip_traced_fields(
-        include_untraced_data_arrays=True, starting_path=("data",)
+        include_untraced_data_arrays=True, starting_paths=(("data",),)
     )
     for path in full_sim_data_dict.keys():
         if path in data_fields_vjp:
@@ -124,6 +125,44 @@ def _slice_field_data(
     return sliced_data
 
 
+def _get_freq_coords(field_data: td.FieldData) -> np.ndarray:
+    """Extract frequency coordinates from a field dataset."""
+    first_field_component = next(iter(field_data.field_components.values()))
+    return np.array(first_field_component.coords["f"].values)
+
+
+def _validate_adjoint_frequencies(
+    *,
+    adjoint_frequencies: np.ndarray,
+    monitor_freqs: np.ndarray,
+    component_type: str,
+    component_index: int,
+) -> None:
+    """Validate that field-data frequencies match monitor frequencies."""
+    if len(adjoint_frequencies) != len(monitor_freqs) or not np.allclose(
+        np.sort(adjoint_frequencies), np.sort(monitor_freqs), rtol=1e-10, atol=0
+    ):
+        raise ValueError(
+            f"Frequency mismatch in adjoint postprocessing for {component_type} "
+            f"{component_index}. Expected frequencies from monitor: {monitor_freqs}, "
+            f"but derivative map has: {adjoint_frequencies}. "
+        )
+
+
+def _to_sim_fields_vjp(
+    *,
+    component_type: str,
+    component_index: int,
+    component_vjp: AutogradFieldMap,
+) -> AutogradFieldMap:
+    """Map component-local derivative paths to simulation-level paths."""
+    sim_fields_vjp = {}
+    for component_path, vjp_value in component_vjp.items():
+        sim_path = (component_type, component_index, *list(component_path))
+        sim_fields_vjp[sim_path] = vjp_value
+    return sim_fields_vjp
+
+
 @disable_local_subpixel
 def postprocess_adj(
     sim_data_adj: td.SimulationData,
@@ -134,17 +173,18 @@ def postprocess_adj(
 ) -> AutogradFieldMap:
     """Postprocess some data from the adjoint simulation into the VJP for the original sim flds."""
 
-    def get_all_paths(match_structure_index: int) -> tuple[tuple[str, str, int]]:
-        """Get all the paths that may appear in autograd for this structure index. This allows a
-        custom_vjp to be called for all autograd paths for the structure.
-        """
-        all_paths = tuple(
-            tuple(structure_path)
-            for namespace, structure_index_, *structure_path in sim_fields_keys
-            if structure_index_ == match_structure_index
-        )
+    def get_all_paths(match_structure_index: int) -> tuple[tuple[Any, ...], ...]:
+        """Get traced autograd paths for one structure index.
 
-        return all_paths
+        ``sim_fields_keys`` can contain entries for both ``"structures"`` and ``"sources"``.
+        Restricting to ``"structures"`` here avoids mixing source paths into
+        structure-level ``custom_vjp`` expansion when indices overlap.
+        """
+        return tuple(
+            tuple(component_path)
+            for component_type, component_index, *component_path in sim_fields_keys
+            if component_type == "structures" and component_index == match_structure_index
+        )
 
     custom_vjp_lookup: dict[int, dict[tuple[str, str], Callable[..., Any]]] = {}
     if custom_vjp:
@@ -159,321 +199,441 @@ def postprocess_adj(
             else:
                 custom_vjp_lookup.setdefault(structure_index, {})[path] = vjp_fn
 
-    # map of index into 'structures' to the paths we need VJPs for
-    sim_vjp_map: defaultdict[int, list[tuple[Any, ...]]] = defaultdict(list)
-    for namespace, structure_index, *structure_path in sim_fields_keys:
-        structure_path = tuple(structure_path)
-        if namespace == "structures":
-            sim_vjp_map[structure_index].append(structure_path)
+    # group the paths by component type and index
+    sim_vjp_map = defaultdict(list)
+    for component_type, component_index, *component_path in sim_fields_keys:
+        sim_vjp_map[(component_type, component_index)].append(tuple(component_path))
 
-    # store the derivative values given the forward and adjoint data
+    # compute the VJP for each component
     sim_fields_vjp = {}
-    all_structure_indices = sorted(set(sim_vjp_map.keys()))
-
-    for structure_index in all_structure_indices:
-        structure_paths = tuple(sim_vjp_map.get(structure_index, ()))
-
-        # grab the forward and adjoint data
-        fld_fwd = sim_data_fwd._get_adjoint_data(structure_index, data_type="fld")
-        eps_fwd = sim_data_fwd._get_adjoint_data(structure_index, data_type="eps")
-        fld_adj = sim_data_adj._get_adjoint_data(structure_index, data_type="fld")
-        eps_adj = sim_data_adj._get_adjoint_data(structure_index, data_type="eps")
-
-        def sort_by_freq_ascending(
-            dataset: Union[td.PermittivityData, td.FieldData],
-        ) -> Union[td.PermittivityData, td.FieldData]:
-            dataset_sort = {}
-            for key, val in dataset.field_components.items():
-                dataset_sort[key] = val.sortby("f", ascending=True)
-
-            return dataset.updated_copy(**dataset_sort)
-
-        # sort data by ascending frequency value to ensure data ordering is consistent
-        fld_fwd = sort_by_freq_ascending(fld_fwd)
-        eps_fwd = sort_by_freq_ascending(eps_fwd)
-        fld_adj = sort_by_freq_ascending(fld_adj)
-        eps_adj = sort_by_freq_ascending(eps_adj)
-
-        freqs_adj = np.array(fld_adj.monitor.freqs)
-
-        # post normalize the adjoint fields if a single, broadband source
-        fwd_flds_adj_normed = {}
-        for key, val in fld_adj.field_components.items():
-            fwd_flds_adj_normed[key] = val * sim_data_adj.simulation.post_norm
-
-        fld_adj = fld_adj.updated_copy(**fwd_flds_adj_normed)
-
-        # maps of the E_fwd * E_adj and D_fwd * D_adj, each as as td.FieldData & 'Ex', 'Ey', 'Ez'
-        der_maps = get_derivative_maps(
-            fld_fwd=fld_fwd,
-            eps_fwd=eps_fwd,
-            fld_adj=fld_adj,
-            eps_adj=eps_adj,
-        )
-        E_der_map = der_maps["E"]
-        D_der_map = der_maps["D"]
-        H_der_map = der_maps["H"]
-
-        H_info_exists = H_der_map is not None
-
-        def filter_adj_freq(
-            dataset: Union[td.PermittivityData, td.FieldData], filter_freqs: np.ndarray
-        ) -> Union[td.PermittivityData, td.FieldData]:
-            dataset_filter_freq = {}
-            for key, val in dataset.field_components.items():
-                dataset_filter_freq[key] = val.sel(f=filter_freqs)
-
-            return dataset.updated_copy(**dataset_filter_freq)
-
-        fld_fwd = filter_adj_freq(fld_fwd, freqs_adj)
-        eps_fwd = filter_adj_freq(eps_fwd, freqs_adj)
-
-        D_fwd = E_to_D(fld_fwd, eps_fwd)
-        D_adj = E_to_D(fld_adj, eps_fwd)
-
-        structure = sim_data_fwd.simulation.structures[structure_index]
-
-        # compute epsilon arrays for all frequencies
-        # use frequencies from the actual computed derivative map to ensure they exist
-        # in both forward and adjoint data (E_der_map = fld_fwd * fld_adj)
-        first_field_component = next(iter(E_der_map.field_components.values()))
-        adjoint_frequencies = np.array(first_field_component.coords["f"].values)
-
-        monitor_freqs = np.array(fld_adj.monitor.freqs)
-        if len(adjoint_frequencies) != len(monitor_freqs) or not np.allclose(
-            np.sort(adjoint_frequencies), np.sort(monitor_freqs), rtol=1e-10, atol=0
-        ):
+    for (component_type, component_index), component_paths in sim_vjp_map.items():
+        if component_type == "structures":
+            sim_fields_vjp.update(
+                _process_structure_gradients(
+                    sim_data_adj,
+                    sim_data_orig,
+                    sim_data_fwd,
+                    component_index,
+                    component_paths,
+                    custom_vjp=custom_vjp_lookup.get(component_index),
+                )
+            )
+        elif component_type == "sources":
+            sim_fields_vjp.update(
+                _process_source_gradients(
+                    sim_data_adj, sim_data_orig, sim_data_fwd, component_index, component_paths
+                )
+            )
+        else:
             raise ValueError(
-                f"Frequency mismatch in adjoint postprocessing for structure {structure_index}. "
-                f"Expected frequencies from monitor: {monitor_freqs}, "
-                f"but derivative map has: {adjoint_frequencies}. "
+                f"Unexpected component_type='{component_type}' for component_index={component_index}. "
+                "Expected 'structures' or 'sources'."
             )
 
-        # auto permittivity detection
-        sim_orig = sim_data_orig.simulation
-        plane_eps = eps_fwd.monitor.geometry
-        sim_orig_grid_spec = td.components.grid.grid_spec.GridSpec.from_grid(sim_orig.grid)
+    return sim_fields_vjp
 
-        # permittivity without this structure
-        structs_no_struct = list(sim_orig.structures)
-        structs_no_struct.pop(structure_index)
-        sim_no_structure = sim_orig.updated_copy(
-            structures=structs_no_struct, monitors=[], sources=[], grid_spec=sim_orig_grid_spec
+
+def _compute_source_time_scaling(
+    source: td.Source,
+    simulation: td.Simulation,
+    frequencies: np.ndarray,
+) -> FreqDataArray:
+    """Compute frequency-dependent source-time scale for source VJP processing."""
+    spectrum = source.source_time.spectrum(
+        simulation.tmesh,
+        frequencies,
+        simulation.dt,
+    )
+    spectrum = np.asarray(spectrum)
+    scale = (4.0 * np.sqrt(np.pi) * spectrum) / simulation.dt
+    return FreqDataArray(scale, coords={"f": frequencies})
+
+
+def _compute_source_eps_data(
+    simulation: td.Simulation,
+    source: td.Source,
+    frequencies: np.ndarray,
+) -> ScalarFieldDataArray:
+    """Compute spatially resolved relative permittivity at source locations."""
+    eps_source_by_f = [
+        simulation.epsilon(box=source.geometry, coord_key="centers", freq=f) for f in frequencies
+    ]
+    eps_source = xr.concat(eps_source_by_f, dim="f").assign_coords(f=frequencies)
+    if not {"x", "y", "z", "f"}.issubset(eps_source.dims):
+        raise ValueError(
+            "Source permittivity data must include dimensions ('x', 'y', 'z', 'f'), "
+            f"got {eps_source.dims}."
+        )
+    eps_source = eps_source.transpose("x", "y", "z", "f")
+    coords = {dim: np.asarray(eps_source.coords[dim].data) for dim in ("x", "y", "z", "f")}
+    return td.ScalarFieldDataArray(np.asarray(eps_source.data), coords=coords)
+
+
+def _process_source_gradients(
+    sim_data_adj: td.SimulationData,
+    sim_data_orig: td.SimulationData,
+    sim_data_fwd: td.SimulationData,
+    source_index: int,
+    source_paths: list[tuple],
+) -> AutogradFieldMap:
+    """Process gradients for a specific source."""
+
+    source = sim_data_fwd.simulation.sources[source_index]
+    monitor_name = f"source_adjoint_{source_index}"
+
+    fld_adj = sim_data_adj[monitor_name]
+    fld_adj = fld_adj.grid_corrected_copy
+
+    adjoint_frequencies = _get_freq_coords(fld_adj)
+    monitor_freqs = np.array(fld_adj.monitor.freqs)
+    _validate_adjoint_frequencies(
+        adjoint_frequencies=adjoint_frequencies,
+        monitor_freqs=monitor_freqs,
+        component_type="source",
+        component_index=source_index,
+    )
+
+    source_time_scaling = _compute_source_time_scaling(
+        source=source,
+        simulation=sim_data_orig.simulation,
+        frequencies=adjoint_frequencies,
+    )
+
+    # Apply both adjoint post-normalization and source-time scaling in one pass.
+    combined_scale = sim_data_adj.simulation.post_norm * source_time_scaling
+    fld_adj = scale_field_data(fld_adj, combined_scale)
+
+    e_adj = {k: v for k, v in fld_adj.field_components.items() if k.startswith("E")}
+    h_adj = {k: v for k, v in fld_adj.field_components.items() if k.startswith("H")}
+
+    # Spatially resolved relative permittivity at source locations, inferred from the
+    # simulation object (no extra monitor required).
+    eps_source = _compute_source_eps_data(
+        simulation=sim_data_orig.simulation,
+        source=source,
+        frequencies=adjoint_frequencies,
+    )
+
+    bounds = source.geometry.bounds
+    # Source VJP uses spatially resolved `eps_data`.
+    derivative_info = DerivativeInfo(
+        paths=source_paths,
+        E_der_map={},
+        D_der_map={},
+        E_fwd={},
+        E_adj=e_adj,
+        D_fwd={},
+        D_adj={},
+        H_fwd={},
+        H_adj=h_adj,
+        eps_data={"eps": eps_source},
+        frequencies=adjoint_frequencies,
+        bounds=bounds,
+        bounds_intersect=bounds,
+        simulation_bounds=sim_data_orig.simulation.bounds,
+        updated_epsilon=lambda _replacement_geometry: None,
+    )
+
+    source_vjp = source._compute_derivatives(derivative_info)
+
+    return _to_sim_fields_vjp(
+        component_type="sources",
+        component_index=source_index,
+        component_vjp=source_vjp,
+    )
+
+
+def _process_structure_gradients(
+    sim_data_adj: td.SimulationData,
+    sim_data_orig: td.SimulationData,
+    sim_data_fwd: td.SimulationData,
+    structure_index: int,
+    structure_paths: list[tuple],
+    custom_vjp: Optional[dict[tuple[str, str], Callable[..., Any]]] = None,
+) -> AutogradFieldMap:
+    """Process gradients for a specific structure."""
+
+    # grab the forward and adjoint data
+    fld_fwd = sim_data_fwd._get_adjoint_data(structure_index, data_type="fld")
+    eps_fwd = sim_data_fwd._get_adjoint_data(structure_index, data_type="eps")
+    fld_adj = sim_data_adj._get_adjoint_data(structure_index, data_type="fld")
+    eps_adj = sim_data_adj._get_adjoint_data(structure_index, data_type="eps")
+
+    def sort_by_freq_ascending(
+        dataset: Union[td.PermittivityData, td.FieldData],
+    ) -> Union[td.PermittivityData, td.FieldData]:
+        dataset_sort = {}
+        for key, val in dataset.field_components.items():
+            dataset_sort[key] = val.sortby("f", ascending=True)
+
+        return dataset.updated_copy(**dataset_sort)
+
+    # sort data by ascending frequency value to ensure data ordering is consistent
+    fld_fwd = sort_by_freq_ascending(fld_fwd)
+    eps_fwd = sort_by_freq_ascending(eps_fwd)
+    fld_adj = sort_by_freq_ascending(fld_adj)
+    eps_adj = sort_by_freq_ascending(eps_adj)
+
+    freqs_adj = np.array(fld_adj.monitor.freqs)
+
+    # post normalize the adjoint fields if a single, broadband source
+    fld_adj = scale_field_data(fld_adj, sim_data_adj.simulation.post_norm)
+
+    # maps of the E_fwd * E_adj and D_fwd * D_adj, each as as td.FieldData & 'Ex', 'Ey', 'Ez'
+    der_maps = get_derivative_maps(
+        fld_fwd=fld_fwd,
+        eps_fwd=eps_fwd,
+        fld_adj=fld_adj,
+        eps_adj=eps_adj,
+    )
+    E_der_map = der_maps["E"]
+    D_der_map = der_maps["D"]
+    H_der_map = der_maps["H"]
+
+    H_info_exists = H_der_map is not None
+
+    def filter_adj_freq(
+        dataset: Union[td.PermittivityData, td.FieldData], filter_freqs: np.ndarray
+    ) -> Union[td.PermittivityData, td.FieldData]:
+        dataset_filter_freq = {}
+        for key, val in dataset.field_components.items():
+            dataset_filter_freq[key] = val.sel(f=filter_freqs)
+
+        return dataset.updated_copy(**dataset_filter_freq)
+
+    fld_fwd = filter_adj_freq(fld_fwd, freqs_adj)
+    eps_fwd = filter_adj_freq(eps_fwd, freqs_adj)
+
+    D_fwd = E_to_D(fld_fwd, eps_fwd)
+    D_adj = E_to_D(fld_adj, eps_fwd)
+
+    structure = sim_data_fwd.simulation.structures[structure_index]
+
+    # compute epsilon arrays for all frequencies
+    # use frequencies from the actual computed derivative map to ensure they exist
+    # in both forward and adjoint data (E_der_map = fld_fwd * fld_adj)
+    adjoint_frequencies = _get_freq_coords(E_der_map)
+    monitor_freqs = np.array(fld_adj.monitor.freqs)
+    _validate_adjoint_frequencies(
+        adjoint_frequencies=adjoint_frequencies,
+        monitor_freqs=monitor_freqs,
+        component_type="structure",
+        component_index=structure_index,
+    )
+
+    # auto permittivity detection
+    sim_orig = sim_data_orig.simulation
+    plane_eps = eps_fwd.monitor.geometry
+    sim_orig_grid_spec = td.components.grid.grid_spec.GridSpec.from_grid(sim_orig.grid)
+
+    # permittivity without this structure
+    structs_no_struct = list(sim_orig.structures)
+    structs_no_struct.pop(structure_index)
+    sim_no_structure = sim_orig.updated_copy(
+        structures=structs_no_struct, monitors=[], sources=[], grid_spec=sim_orig_grid_spec
+    )
+
+    # for the outside permittivity of the structure, resize the bounds of the permittivity region
+    # to make sure we capture data outside the structure bounds
+    low_coords = [center - 0.5 * size for center, size in zip(plane_eps.center, plane_eps.size)]
+    high_coords = [center + 0.5 * size for center, size in zip(plane_eps.center, plane_eps.size)]
+
+    low_bounds = sim_orig.grid.boundaries.get_bounding_values(low_coords, "left", buffer=1)
+    high_bounds = sim_orig.grid.boundaries.get_bounding_values(high_coords, "right", buffer=1)
+
+    resized_center = [0.5 * (low + high) for low, high in zip(low_bounds, high_bounds)]
+    resized_size = [(high - low) for low, high in zip(low_bounds, high_bounds)]
+
+    resize_plane_eps = plane_eps.updated_copy(center=resized_center, size=resized_size)
+
+    eps_no_structure_data = [
+        sim_no_structure.epsilon(box=resize_plane_eps, coord_key="centers", freq=f)
+        for f in adjoint_frequencies
+    ]
+
+    eps_no_structure = xr.concat(eps_no_structure_data, dim="f").assign_coords(
+        f=adjoint_frequencies
+    )
+
+    if structure.medium.is_custom:
+        # we can't make an infinite structure from a custom medium permittivity
+        eps_inf_structure = None
+    else:
+        geometry_box = structure.geometry.bounding_box
+        background_structures_2d = []
+        sim_inf_background_medium = sim_orig.medium
+        if np.any(np.array(geometry_box.size) == 0.0):
+            zero_coordinate = tuple(geometry_box.size).index(0.0)
+            new_size = [td.inf, td.inf, td.inf]
+            new_size[zero_coordinate] = 0.0
+
+            background_structures_2d = [
+                structure.updated_copy(geometry=geometry_box.updated_copy(size=new_size))
+            ]
+        else:
+            sim_inf_background_medium = structure.medium
+
+        # permittivity with infinite structure
+        structs_inf_struct = list(sim_orig.structures)[structure_index + 1 :]
+        sim_inf_structure = sim_orig.updated_copy(
+            structures=background_structures_2d + structs_inf_struct,
+            medium=sim_inf_background_medium,
+            monitors=[],
+            sources=[],
+            grid_spec=sim_orig_grid_spec,
         )
 
-        # for the outside permittivity of the structure, resize the bounds of the permittivity region
-        # to make sure we capture data outside the structure bounds
-        low_coords = [center - 0.5 * size for center, size in zip(plane_eps.center, plane_eps.size)]
-        high_coords = [
-            center + 0.5 * size for center, size in zip(plane_eps.center, plane_eps.size)
-        ]
-
-        low_bounds = sim_orig.grid.boundaries.get_bounding_values(low_coords, "left", buffer=1)
-        high_bounds = sim_orig.grid.boundaries.get_bounding_values(high_coords, "right", buffer=1)
-
-        resized_center = [0.5 * (low + high) for low, high in zip(low_bounds, high_bounds)]
-        resized_size = [(high - low) for low, high in zip(low_bounds, high_bounds)]
-
-        resize_plane_eps = plane_eps.updated_copy(center=resized_center, size=resized_size)
-
-        eps_no_structure_data = [
-            sim_no_structure.epsilon(box=resize_plane_eps, coord_key="centers", freq=f)
+        eps_inf_structure_data = [
+            sim_inf_structure.epsilon(box=plane_eps, coord_key="centers", freq=f)
             for f in adjoint_frequencies
         ]
 
-        eps_no_structure = xr.concat(eps_no_structure_data, dim="f").assign_coords(
+        eps_inf_structure = xr.concat(eps_inf_structure_data, dim="f").assign_coords(
             f=adjoint_frequencies
         )
 
-        if structure.medium.is_custom:
-            # we can't make an infinite structure from a custom medium permittivity
-            eps_inf_structure = None
-        else:
-            geometry_box = structure.geometry.bounding_box
-            background_structures_2d = []
-            sim_inf_background_medium = sim_orig.medium
-            if np.any(np.array(geometry_box.size) == 0.0):
-                zero_coordinate = tuple(geometry_box.size).index(0.0)
-                new_size = [td.inf, td.inf, td.inf]
-                new_size[zero_coordinate] = 0.0
+    # compute bounds intersection
+    struct_bounds = rmin_struct, rmax_struct = structure.geometry.bounds
+    rmin_sim, rmax_sim = sim_orig.bounds
+    rmin_intersect = tuple([max(a, b) for a, b in zip(rmin_sim, rmin_struct)])
+    rmax_intersect = tuple([min(a, b) for a, b in zip(rmax_sim, rmax_struct)])
+    bounds_intersect = (rmin_intersect, rmax_intersect)
 
-                background_structures_2d = [
-                    structure.updated_copy(geometry=geometry_box.updated_copy(size=new_size))
-                ]
-            else:
-                sim_inf_background_medium = structure.medium
+    def updated_epsilon_full_impl(
+        replacement_geometry: GeometryType,
+        adjoint_frequencies: Optional[FreqDataArray],
+        structure_index: Optional[int],
+        eps_box: Optional[Box],
+        sim_orig: td.Simulation,
+    ) -> ScalarFieldDataArray:
+        """Permittivity in ``eps_box`` after replacing this structure geometry."""
+        updated_sim = sim_orig.updated_copy(
+            structures=[
+                sim_orig.structures[idx].updated_copy(geometry=replacement_geometry)
+                if idx == structure_index
+                else sim_orig.structures[idx]
+                for idx in range(len(sim_orig.structures))
+            ],
+            grid_spec=td.components.grid.grid_spec.GridSpec.from_grid(sim_orig.grid),
+        )
+        eps_by_f = [
+            updated_sim.epsilon(box=eps_box, coord_key="centers", freq=f)
+            for f in adjoint_frequencies
+        ]
+        return xr.concat(eps_by_f, dim="f").assign_coords(f=adjoint_frequencies)
 
-            # permittivity with infinite structure
-            structs_inf_struct = list(sim_orig.structures)[structure_index + 1 :]
-            sim_inf_structure = sim_orig.updated_copy(
-                structures=background_structures_2d + structs_inf_struct,
-                medium=sim_inf_background_medium,
-                monitors=[],
-                sources=[],
-                grid_spec=sim_orig_grid_spec,
+    updated_epsilon_full = functools.partial(
+        updated_epsilon_full_impl,
+        adjoint_frequencies=adjoint_frequencies,
+        structure_index=structure_index,
+        eps_box=resize_plane_eps,
+        sim_orig=sim_orig,
+    )
+
+    # get chunk size - if None, process all frequencies as one chunk
+    freq_chunk_size = config.adjoint.solver_freq_chunk_size
+    n_freqs = len(adjoint_frequencies)
+    if not freq_chunk_size or freq_chunk_size <= 0:
+        freq_chunk_size = n_freqs
+    else:
+        freq_chunk_size = min(freq_chunk_size, n_freqs)
+
+    # process in chunks
+    vjp_value_map = {}
+
+    for chunk_start in range(0, n_freqs, freq_chunk_size):
+        chunk_end = min(chunk_start + freq_chunk_size, n_freqs)
+        freq_slice = slice(chunk_start, chunk_end)
+
+        select_adjoint_freqs = adjoint_frequencies[freq_slice]
+
+        # slice field data for current chunk
+        E_der_map_chunk = _slice_field_data(E_der_map.field_components, freq_slice)
+        D_der_map_chunk = _slice_field_data(D_der_map.field_components, freq_slice)
+        E_fwd_chunk = _slice_field_data(
+            fld_fwd.field_components, freq_slice, component_indicator="E"
+        )
+        E_adj_chunk = _slice_field_data(
+            fld_adj.field_components, freq_slice, component_indicator="E"
+        )
+        D_fwd_chunk = _slice_field_data(D_fwd.field_components, freq_slice)
+        D_adj_chunk = _slice_field_data(D_adj.field_components, freq_slice)
+        eps_data_chunk = _slice_field_data(eps_fwd.field_components, freq_slice)
+
+        H_der_map_chunk = None
+        H_fwd_chunk = None
+        H_adj_chunk = None
+
+        if H_info_exists:
+            H_der_map_chunk = _slice_field_data(H_der_map.field_components, freq_slice)
+            H_fwd_chunk = _slice_field_data(
+                fld_fwd.field_components, freq_slice, component_indicator="H"
+            )
+            H_adj_chunk = _slice_field_data(
+                fld_adj.field_components, freq_slice, component_indicator="H"
             )
 
-            eps_inf_structure_data = [
-                sim_inf_structure.epsilon(box=plane_eps, coord_key="centers", freq=f)
-                for f in adjoint_frequencies
-            ]
-
-            eps_inf_structure = xr.concat(eps_inf_structure_data, dim="f").assign_coords(
-                f=adjoint_frequencies
-            )
-
-        # compute bounds intersection
-        struct_bounds = rmin_struct, rmax_struct = structure.geometry.bounds
-        rmin_sim, rmax_sim = sim_orig.bounds
-        rmin_intersect = tuple([max(a, b) for a, b in zip(rmin_sim, rmin_struct)])
-        rmax_intersect = tuple([min(a, b) for a, b in zip(rmax_sim, rmax_struct)])
-        bounds_intersect = (rmin_intersect, rmax_intersect)
-
-        def updated_epsilon_full_impl(
-            replacement_geometry: GeometryType,
-            adjoint_frequencies: Optional[FreqDataArray],
-            structure_index: Optional[int],
-            eps_box: Optional[Box],
-            sim_orig: td.Simulation,
-        ) -> ScalarFieldDataArray:
-            """Return the simulation permittivity for eps_box after replacing the geometry
-            for this structure with a new geometry. This is helpful for carrying out finite
-            difference permittivity computations.
-            """
-            update_sim = sim_orig.updated_copy(
-                structures=[
-                    sim_orig.structures[idx].updated_copy(geometry=replacement_geometry)
-                    if idx == structure_index
-                    else sim_orig.structures[idx]
-                    for idx in range(len(sim_orig.structures))
-                ],
-                grid_spec=td.components.grid.grid_spec.GridSpec.from_grid(sim_orig.grid),
-            )
-
-            eps_by_f = [
-                update_sim.epsilon(box=eps_box, coord_key="centers", freq=f)
-                for f in adjoint_frequencies
-            ]
-
-            return xr.concat(eps_by_f, dim="f").assign_coords(f=adjoint_frequencies)
-
-        updated_epsilon_full = functools.partial(
-            updated_epsilon_full_impl,
-            adjoint_frequencies=adjoint_frequencies,
-            structure_index=structure_index,
-            eps_box=resize_plane_eps,
-            sim_orig=sim_orig,
+        # slice epsilon arrays
+        eps_no_structure_chunk = (
+            eps_no_structure.isel(f=freq_slice) if eps_no_structure is not None else None
+        )
+        eps_inf_structure_chunk = (
+            eps_inf_structure.isel(f=freq_slice) if eps_inf_structure is not None else None
         )
 
-        # get chunk size - if None, process all frequencies as one chunk
-        freq_chunk_size = config.adjoint.solver_freq_chunk_size
-        n_freqs = len(adjoint_frequencies)
-        if not freq_chunk_size or freq_chunk_size <= 0:
-            freq_chunk_size = n_freqs
-        else:
-            freq_chunk_size = min(freq_chunk_size, n_freqs)
+        def updated_epsilon_wrapper(
+            replacement_geometry: GeometryType,
+            select_adjoint_freqs: Optional[FreqDataArray],
+            updated_epsilon_full: Optional[Callable],
+        ) -> ScalarFieldDataArray:
+            return updated_epsilon_full(replacement_geometry).sel(f=select_adjoint_freqs)
 
-        # process in chunks
-        vjp_value_map = {}
+        updated_epsilon = functools.partial(
+            updated_epsilon_wrapper,
+            select_adjoint_freqs=select_adjoint_freqs,
+            updated_epsilon_full=updated_epsilon_full,
+        )
 
-        for chunk_start in range(0, n_freqs, freq_chunk_size):
-            chunk_end = min(chunk_start + freq_chunk_size, n_freqs)
-            freq_slice = slice(chunk_start, chunk_end)
+        # create derivative info with sliced data
+        derivative_info = DerivativeInfo(
+            paths=structure_paths,
+            E_der_map=E_der_map_chunk,
+            D_der_map=D_der_map_chunk,
+            H_der_map=H_der_map_chunk,
+            E_fwd=E_fwd_chunk,
+            E_adj=E_adj_chunk,
+            D_fwd=D_fwd_chunk,
+            D_adj=D_adj_chunk,
+            H_fwd=H_fwd_chunk,
+            H_adj=H_adj_chunk,
+            eps_data=eps_data_chunk,
+            eps_in=eps_inf_structure_chunk,
+            eps_out=eps_no_structure_chunk,
+            frequencies=select_adjoint_freqs,  # only chunk frequencies
+            updated_epsilon=updated_epsilon,
+            bounds=struct_bounds,
+            bounds_intersect=bounds_intersect,
+            simulation_bounds=sim_data_orig.simulation.bounds,
+            is_medium_pec=structure.medium.is_pec,
+            background_medium_is_pec=structure.background_medium
+            and structure.background_medium.is_pec,
+        )
 
-            select_adjoint_freqs = adjoint_frequencies[freq_slice]
+        # compute derivatives for chunk
+        vjp_chunk = structure._compute_derivatives(derivative_info, vjp_fns=custom_vjp)
 
-            # slice field data for current chunk
-            E_der_map_chunk = _slice_field_data(E_der_map.field_components, freq_slice)
-            D_der_map_chunk = _slice_field_data(D_der_map.field_components, freq_slice)
-            E_fwd_chunk = _slice_field_data(
-                fld_fwd.field_components, freq_slice, component_indicator="E"
-            )
-            E_adj_chunk = _slice_field_data(
-                fld_adj.field_components, freq_slice, component_indicator="E"
-            )
-            D_fwd_chunk = _slice_field_data(D_fwd.field_components, freq_slice)
-            D_adj_chunk = _slice_field_data(D_adj.field_components, freq_slice)
-            eps_data_chunk = _slice_field_data(eps_fwd.field_components, freq_slice)
-
-            H_der_map_chunk = None
-            H_fwd_chunk = None
-            H_adj_chunk = None
-
-            if H_info_exists:
-                H_der_map_chunk = _slice_field_data(H_der_map.field_components, freq_slice)
-                H_fwd_chunk = _slice_field_data(
-                    fld_fwd.field_components, freq_slice, component_indicator="H"
-                )
-                H_adj_chunk = _slice_field_data(
-                    fld_adj.field_components, freq_slice, component_indicator="H"
-                )
-
-            # slice epsilon arrays
-            eps_no_structure_chunk = (
-                eps_no_structure.isel(f=freq_slice) if eps_no_structure is not None else None
-            )
-            eps_inf_structure_chunk = (
-                eps_inf_structure.isel(f=freq_slice) if eps_inf_structure is not None else None
-            )
-
-            def updated_epsilon_wrapper(
-                replacement_geometry: GeometryType,
-                select_adjoint_freqs: Optional[FreqDataArray],
-                updated_epsilon_full: Optional[Callable],
-            ) -> ScalarFieldDataArray:
-                # Get permittivity function for a subset of frequencies
-                return updated_epsilon_full(replacement_geometry).sel(f=select_adjoint_freqs)
-
-            updated_epsilon = functools.partial(
-                updated_epsilon_wrapper,
-                select_adjoint_freqs=select_adjoint_freqs,
-                updated_epsilon_full=updated_epsilon_full,
-            )
-
-            if structure_paths:
-                # create derivative info with sliced data
-                derivative_info_struct = DerivativeInfo(
-                    paths=structure_paths,
-                    E_der_map=E_der_map_chunk,
-                    D_der_map=D_der_map_chunk,
-                    H_der_map=H_der_map_chunk,
-                    E_fwd=E_fwd_chunk,
-                    E_adj=E_adj_chunk,
-                    D_fwd=D_fwd_chunk,
-                    D_adj=D_adj_chunk,
-                    H_fwd=H_fwd_chunk,
-                    H_adj=H_adj_chunk,
-                    eps_data=eps_data_chunk,
-                    eps_in=eps_inf_structure_chunk,
-                    eps_out=eps_no_structure_chunk,
-                    updated_epsilon=updated_epsilon,
-                    frequencies=select_adjoint_freqs,  # only chunk frequencies
-                    bounds=struct_bounds,
-                    bounds_intersect=bounds_intersect,
-                    simulation_bounds=sim_data_orig.simulation.bounds,
-                    is_medium_pec=structure.medium.is_pec,
-                    background_medium_is_pec=structure.background_medium
-                    and structure.background_medium.is_pec,
-                )
-
-                vjp_fns = custom_vjp_lookup.get(structure_index)
-                vjp_chunk = structure._compute_derivatives(derivative_info_struct, vjp_fns=vjp_fns)
-
-                for path, value in vjp_chunk.items():
-                    if path in vjp_value_map:
-                        existing = vjp_value_map[path]
-                        if isinstance(existing, (list, tuple)) and isinstance(value, (list, tuple)):
-                            vjp_value_map[path] = type(existing)(
-                                x + y for x, y in zip(existing, value)
-                            )
-                        else:
-                            vjp_value_map[path] = existing + value
-                    else:
-                        vjp_value_map[path] = value
-
-        # store vjps in output map
-        for structure_path, vjp_value in vjp_value_map.items():
-            sim_path = ("structures", structure_index, *list(structure_path))
-            sim_fields_vjp[sim_path] = vjp_value
-
-    return sim_fields_vjp
+        # accumulate results
+        for path, value in vjp_chunk.items():
+            if path in vjp_value_map:
+                val = vjp_value_map[path]
+                if isinstance(val, (list, tuple)) and isinstance(value, (list, tuple)):
+                    vjp_value_map[path] = type(val)(x + y for x, y in zip(val, value))
+                else:
+                    vjp_value_map[path] += value
+            else:
+                vjp_value_map[path] = value
+    return _to_sim_fields_vjp(
+        component_type="structures",
+        component_index=structure_index,
+        component_vjp=vjp_value_map,
+    )

--- a/tidy3d/web/api/autograd/backward.py
+++ b/tidy3d/web/api/autograd/backward.py
@@ -248,16 +248,50 @@ def _compute_source_time_scaling(
     source: td.Source,
     simulation: td.Simulation,
     frequencies: np.ndarray,
+    source_dataset_freq: float,
 ) -> FreqDataArray:
     """Compute frequency-dependent source-time scale for source VJP processing."""
+
+    freqs = np.asarray(frequencies, dtype=float)
+    spectrum_freqs = np.full_like(freqs, source_dataset_freq)
     spectrum = source.source_time.spectrum(
         simulation.tmesh,
-        frequencies,
+        spectrum_freqs,
         simulation.dt,
     )
-    spectrum = np.asarray(spectrum)
-    scale = 2.0 * (2.0 * np.pi) ** 2 * td.C_0 * spectrum
-    return FreqDataArray(scale, coords={"f": frequencies})
+    spectrum = np.asarray(spectrum, dtype=complex)
+
+    # - 2.0: real-objective / one-sided-frequency adjoint convention.
+    # - 2*pi (f -> omega): convert Hz-based quantities to angular-frequency form.
+    # - 2*pi (domega = 2*pi*df): Fourier measure conversion for the current convention.
+    # - c0: wavelength/frequency conversion (omega * lambda = 2*pi*c0).
+    real_objective_factor = 2.0
+    hz_to_omega_factor = 2.0 * np.pi
+    fourier_measure_factor = 2.0 * np.pi
+    wavelength_frequency_factor = td.C_0
+    scale_prefactor = (
+        real_objective_factor
+        * hz_to_omega_factor
+        * fourier_measure_factor
+        * wavelength_frequency_factor
+    )
+    scale = scale_prefactor * spectrum * (source_dataset_freq / freqs)
+    return FreqDataArray(scale, coords={"f": freqs})
+
+
+def _get_source_dataset_frequency(source: td.Source) -> float:
+    """Get source-dataset frequency for custom sources."""
+    if isinstance(source, td.CustomFieldSource):
+        dataset = source.field_dataset
+    elif isinstance(source, td.CustomCurrentSource):
+        dataset = source.current_dataset
+    else:
+        raise TypeError(
+            f"Source dataset frequency is only defined for custom sources, got '{source.type}'."
+        )
+    component = next(iter(dataset.field_components.values()))
+    freqs = np.asarray(component.coords["f"].data, dtype=float).reshape(-1)
+    return float(freqs[0])
 
 
 def _process_source_gradients(
@@ -285,10 +319,12 @@ def _process_source_gradients(
         component_index=source_index,
     )
 
+    source_dataset_freq = _get_source_dataset_frequency(source)
     source_time_scaling = _compute_source_time_scaling(
         source=source,
         simulation=sim_data_orig.simulation,
         frequencies=adjoint_frequencies,
+        source_dataset_freq=source_dataset_freq,
     )
 
     # Apply both adjoint post-normalization and source-time scaling in one pass.

--- a/tidy3d/web/api/autograd/backward.py
+++ b/tidy3d/web/api/autograd/backward.py
@@ -249,26 +249,6 @@ def _compute_source_time_scaling(
     return FreqDataArray(scale, coords={"f": frequencies})
 
 
-def _compute_source_eps_data(
-    simulation: td.Simulation,
-    source: td.Source,
-    frequencies: np.ndarray,
-) -> ScalarFieldDataArray:
-    """Compute spatially resolved relative permittivity at source locations."""
-    eps_source_by_f = [
-        simulation.epsilon(box=source.geometry, coord_key="centers", freq=f) for f in frequencies
-    ]
-    eps_source = xr.concat(eps_source_by_f, dim="f").assign_coords(f=frequencies)
-    if not {"x", "y", "z", "f"}.issubset(eps_source.dims):
-        raise ValueError(
-            "Source permittivity data must include dimensions ('x', 'y', 'z', 'f'), "
-            f"got {eps_source.dims}."
-        )
-    eps_source = eps_source.transpose("x", "y", "z", "f")
-    coords = {dim: np.asarray(eps_source.coords[dim].data) for dim in ("x", "y", "z", "f")}
-    return td.ScalarFieldDataArray(np.asarray(eps_source.data), coords=coords)
-
-
 def _process_source_gradients(
     sim_data_adj: td.SimulationData,
     sim_data_orig: td.SimulationData,
@@ -306,16 +286,8 @@ def _process_source_gradients(
     e_adj = {k: v for k, v in fld_adj.field_components.items() if k.startswith("E")}
     h_adj = {k: v for k, v in fld_adj.field_components.items() if k.startswith("H")}
 
-    # Spatially resolved relative permittivity at source locations, inferred from the
-    # simulation object (no extra monitor required).
-    eps_source = _compute_source_eps_data(
-        simulation=sim_data_orig.simulation,
-        source=source,
-        frequencies=adjoint_frequencies,
-    )
-
     bounds = source.geometry.bounds
-    # Source VJP uses spatially resolved `eps_data`.
+    # Source VJP currently does not use permittivity data.
     derivative_info = DerivativeInfo(
         paths=source_paths,
         E_der_map={},
@@ -326,7 +298,7 @@ def _process_source_gradients(
         D_adj={},
         H_fwd={},
         H_adj=h_adj,
-        eps_data={"eps": eps_source},
+        eps_data={},
         frequencies=adjoint_frequencies,
         bounds=bounds,
         bounds_intersect=bounds,

--- a/tidy3d/web/api/autograd/backward.py
+++ b/tidy3d/web/api/autograd/backward.py
@@ -256,7 +256,7 @@ def _compute_source_time_scaling(
         simulation.dt,
     )
     spectrum = np.asarray(spectrum)
-    scale = 2.0 * np.pi * 4.0 * np.sqrt(np.pi) * td.C_0 * np.sqrt(3.0) * spectrum
+    scale = 2.0 * (2.0 * np.pi) ** 2 * td.C_0 * spectrum
     return FreqDataArray(scale, coords={"f": frequencies})
 
 

--- a/tidy3d/web/api/autograd/backward.py
+++ b/tidy3d/web/api/autograd/backward.py
@@ -256,7 +256,7 @@ def _compute_source_time_scaling(
         simulation.dt,
     )
     spectrum = np.asarray(spectrum)
-    scale = (4.0 * np.sqrt(np.pi) * spectrum) / simulation.dt
+    scale = 2.0 * np.pi * 4.0 * np.sqrt(np.pi) * td.C_0 * np.sqrt(3.0) * spectrum
     return FreqDataArray(scale, coords={"f": frequencies})
 
 

--- a/tidy3d/web/api/autograd/backward.py
+++ b/tidy3d/web/api/autograd/backward.py
@@ -131,6 +131,17 @@ def _get_freq_coords(field_data: td.FieldData) -> np.ndarray:
     return np.array(first_field_component.coords["f"].values)
 
 
+def _sort_by_freq_ascending(
+    dataset: Union[td.PermittivityData, td.FieldData],
+) -> Union[td.PermittivityData, td.FieldData]:
+    """Sort all field components by ascending frequency coordinates."""
+    dataset_sorted = {}
+    for key, val in dataset.field_components.items():
+        dataset_sorted[key] = val.sortby("f", ascending=True)
+
+    return dataset.updated_copy(**dataset_sorted)
+
+
 def _validate_adjoint_frequencies(
     *,
     adjoint_frequencies: np.ndarray,
@@ -263,6 +274,7 @@ def _process_source_gradients(
 
     fld_adj = sim_data_adj[monitor_name]
     fld_adj = fld_adj.grid_corrected_copy
+    fld_adj = _sort_by_freq_ascending(fld_adj)
 
     adjoint_frequencies = _get_freq_coords(fld_adj)
     monitor_freqs = np.array(fld_adj.monitor.freqs)
@@ -331,20 +343,11 @@ def _process_structure_gradients(
     fld_adj = sim_data_adj._get_adjoint_data(structure_index, data_type="fld")
     eps_adj = sim_data_adj._get_adjoint_data(structure_index, data_type="eps")
 
-    def sort_by_freq_ascending(
-        dataset: Union[td.PermittivityData, td.FieldData],
-    ) -> Union[td.PermittivityData, td.FieldData]:
-        dataset_sort = {}
-        for key, val in dataset.field_components.items():
-            dataset_sort[key] = val.sortby("f", ascending=True)
-
-        return dataset.updated_copy(**dataset_sort)
-
     # sort data by ascending frequency value to ensure data ordering is consistent
-    fld_fwd = sort_by_freq_ascending(fld_fwd)
-    eps_fwd = sort_by_freq_ascending(eps_fwd)
-    fld_adj = sort_by_freq_ascending(fld_adj)
-    eps_adj = sort_by_freq_ascending(eps_adj)
+    fld_fwd = _sort_by_freq_ascending(fld_fwd)
+    eps_fwd = _sort_by_freq_ascending(eps_fwd)
+    fld_adj = _sort_by_freq_ascending(fld_adj)
+    eps_adj = _sort_by_freq_ascending(eps_adj)
 
     freqs_adj = np.array(fld_adj.monitor.freqs)
 

--- a/tidy3d/web/api/autograd/forward.py
+++ b/tidy3d/web/api/autograd/forward.py
@@ -40,7 +40,7 @@ def postprocess_fwd(
 
     # strip out the tracer AutogradFieldMap for the .data from the original sim
     data_traced = sim_data_original._strip_traced_fields(
-        include_untraced_data_arrays=True, starting_path=("data",)
+        include_untraced_data_arrays=True, starting_paths=(("data",),)
     )
 
     # return the AutogradFieldMap that autograd registers as the "output" of the primitive

--- a/tidy3d/web/api/autograd/utils.py
+++ b/tidy3d/web/api/autograd/utils.py
@@ -10,7 +10,21 @@ import tidy3d as td
 if TYPE_CHECKING:
     from typing import Optional, Union
 
+    from tidy3d.components.data.data_array import DataArray
+
 """ E and D field gradient map calculation helpers. """
+
+
+def scale_field_data(
+    fld_data: td.FieldData,
+    scale: Union[float, complex, DataArray],
+) -> td.FieldData:
+    """Scale all field components in a ``FieldData`` object."""
+
+    field_components = {
+        name: component * scale for name, component in fld_data.field_components.items()
+    }
+    return fld_data.updated_copy(**field_components)
 
 
 def get_derivative_maps(


### PR DESCRIPTION
Implemented adjoint gradients for `CustomCurrentSource.current_dataset` and `CustomFieldSource.field_dataset`.

here some raw results from the numerical tests
```

[custom_field_vec_e_noise_(1.0, -0.5, 0.25)] grad_adjoint = [ 0.17309422 -0.08330589  0.        ]
[custom_field_vec_e_noise_(1.0, -0.5, 0.25)] grad_fd      = [ 0.15962869 -0.07763505  0.        ]
[custom_field_vec_e_noise_(1.0, -0.5, 0.25)] angle_deg    = 0.23552397635418437

[custom_field_vec_e_noise_(0.2, 0.7, -0.9)] grad_adjoint = [0.04982851 0.13126495 0.        ]
[custom_field_vec_e_noise_(0.2, 0.7, -0.9)] grad_fd      = [0.04645437 0.12250617 0.        ]
[custom_field_vec_e_noise_(0.2, 0.7, -0.9)] angle_deg    = 0.02015207770121852

[custom_field_vec_h_noise_(1.0, -0.5, 0.25)] grad_adjoint = [ 0.17501316 -0.08719919  0.        ]
[custom_field_vec_h_noise_(1.0, -0.5, 0.25)] grad_fd      = [ 0.16290694 -0.07942319  0.        ]
[custom_field_vec_h_noise_(1.0, -0.5, 0.25)] angle_deg    = 0.49353584832671316

[custom_current_vec_e_clean_(0.2, 0.7, -0.9)] grad_adjoint = [ 99.45885067 263.29361833 -67.95866614]
[custom_current_vec_e_clean_(0.2, 0.7, -0.9)] grad_fd      = [ 89.9887085  250.85449219 -50.69732666]
[custom_current_vec_e_clean_(0.2, 0.7, -0.9)] angle_deg    = 2.9567202337319016

[custom_current_vec_h_clean_(1.0, -0.5, 0.25)] grad_adjoint = [ 2.31835088e-08 -3.51533076e-09  3.38876971e-09]
[custom_current_vec_h_clean_(1.0, -0.5, 0.25)] grad_fd      = [ 2.15072404e-08 -3.56603636e-09  3.82804899e-09]
[custom_current_vec_h_clean_(1.0, -0.5, 0.25)] angle_deg    = 1.9038311935062815

[custom_current_vec_h_noise_(0.2, 0.7, -0.9)] grad_adjoint = [ 6.10464396e-09  1.36642137e-08 -4.35298592e-09]
[custom_current_vec_h_noise_(0.2, 0.7, -0.9)] grad_fd      = [ 6.24833518e-09  1.31894495e-08 -3.64153152e-09]
[custom_current_vec_h_noise_(0.2, 0.7, -0.9)] angle_deg    = 2.5278326000493307

[custom_field_vec_h_clean_(1.0, -0.5, 0.25)] grad_adjoint = [ 0.20265503 -0.057224    0.        ]
[custom_field_vec_h_clean_(1.0, -0.5, 0.25)] grad_fd      = [ 0.18961728 -0.05118549  0.        ]
[custom_field_vec_h_clean_(1.0, -0.5, 0.25)] angle_deg    = 0.6617374116909891

[custom_field_vec_h_noise_(0.2, 0.7, -0.9)] grad_adjoint = [0.0495895  0.12431687 0.        ]
[custom_field_vec_h_noise_(0.2, 0.7, -0.9)] grad_fd      = [0.04731119 0.11537224 0.        ]
[custom_field_vec_h_noise_(0.2, 0.7, -0.9)] angle_deg    = 0.5504151622847467

[custom_current_vec_h_clean_(0.2, 0.7, -0.9)] grad_adjoint = [ 5.26759494e-09  1.29291713e-08 -3.78763451e-09]
[custom_current_vec_h_clean_(0.2, 0.7, -0.9)] grad_fd      = [ 5.35793632e-09  1.24344979e-08 -3.17523785e-09]
[custom_current_vec_h_clean_(0.2, 0.7, -0.9)] angle_deg    = 2.2701833801929077

[custom_field_vec_h_clean_(0.2, 0.7, -0.9)] grad_adjoint = [0.07723136 0.15429205 0.        ]
[custom_field_vec_h_clean_(0.2, 0.7, -0.9)] grad_fd      = [0.07404014 0.14368445 0.        ]
[custom_field_vec_h_clean_(0.2, 0.7, -0.9)] angle_deg    = 0.6715144060362552

[custom_current_vec_e_clean_(1.0, -0.5, 0.25)] grad_adjoint = [474.49067083 -74.59588806  76.7800313 ]
[custom_current_vec_e_clean_(1.0, -0.5, 0.25)] grad_fd      = [444.25964355 -76.37023926  91.62902832]
[custom_current_vec_e_clean_(1.0, -0.5, 0.25)] angle_deg    = 2.539341918234507

[custom_current_vec_e_noise_(1.0, -0.5, 0.25)] grad_adjoint = [477.40864118 -40.94562373  65.26307893]
[custom_current_vec_e_noise_(1.0, -0.5, 0.25)] grad_fd      = [447.15881348 -44.02160645  84.38110352]
[custom_current_vec_e_noise_(1.0, -0.5, 0.25)] angle_deg    = 2.9664772611479786

[custom_field_vec_e_clean_(1.0, -0.5, 0.25)] grad_adjoint = [ 0.20166847 -0.05835947  0.        ]
[custom_field_vec_e_clean_(1.0, -0.5, 0.25)] grad_fd      = [ 0.18898398 -0.05148351  0.        ]
[custom_field_vec_e_clean_(1.0, -0.5, 0.25)] angle_deg    = 0.900684114155899

[custom_current_vec_h_noise_(1.0, -0.5, 0.25)] grad_adjoint = [ 2.40205526e-08 -2.78028553e-09  2.82341683e-09]
[custom_current_vec_h_noise_(1.0, -0.5, 0.25)] grad_fd      = [ 2.24620322e-08 -2.76223489e-09  3.33510997e-09]
[custom_current_vec_h_noise_(1.0, -0.5, 0.25)] angle_deg    = 1.7702686329253479

[custom_current_vec_e_noise_(0.2, 0.7, -0.9)] grad_adjoint = [102.37676179 296.94389099 -79.4756258 ]
[custom_current_vec_e_noise_(0.2, 0.7, -0.9)] grad_fd      = [ 93.15490723 283.50830078 -59.66186523]
[custom_current_vec_e_noise_(0.2, 0.7, -0.9)] angle_deg    = 3.0055478992711557

[custom_field_vec_e_clean_(0.2, 0.7, -0.9)] grad_adjoint = [0.07840275 0.15621138 0.        ]
[custom_field_vec_e_clean_(0.2, 0.7, -0.9)] grad_fd      = [0.07607043 0.14856458 0.        ]
[custom_field_vec_e_clean_(0.2, 0.7, -0.9)] angle_deg    = 0.46193485235168164

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends the core autograd/adjoint pipeline (monitor generation, traced-field extraction, and backward postprocessing) to include sources, so regressions could affect gradient correctness/performance for existing autograd workflows.
> 
> **Overview**
> Enables autograd differentiation w.r.t. `CustomCurrentSource.current_dataset` and `CustomFieldSource.field_dataset` by adding source-side `_compute_derivatives()` implementations and wiring source paths into the adjoint pipeline.
> 
> `Simulation._make_adjoint_monitors()` now creates dedicated `source_adjoint_*` field monitors for traced sources (no eps monitors), and `backward.postprocess_adj()` is refactored to process VJPs for **structures and sources** separately, including frequency validation, ordering, and source-time scaling.
> 
> Adds reusable adjoint-projection utilities in `derivative_utils` (cell-size weighting + transpose interpolation with robust bounds cropping) and reuses them for `CustomMedium` gradients; updates `_strip_traced_fields()` to accept multiple `starting_paths`, adjusts adjoint-data split logging, and adds extensive analytical + numerical test coverage plus README/changelog updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da9aaeacf68e9616e46eb9405e7d81896caf9e25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR implements adjoint gradient computation for `CustomCurrentSource.current_dataset` and `CustomFieldSource.field_dataset`, enabling automatic differentiation with respect to source field data. The implementation extends the existing autograd infrastructure to support sources in addition to structures.

**Key Changes:**

- Added `_compute_derivatives()` methods to `CustomCurrentSource` and `CustomFieldSource` that compute vector-Jacobian products (VJPs) by interpolating adjoint fields onto source datasets
- Extended `_make_adjoint_monitors()` in `Simulation` to create field monitors for sources alongside existing structure monitors
- Refactored `postprocess_adj()` in backward.py to handle both structures and sources through separate processing functions
- Added utility functions `transpose_interp_field_to_dataset()`, `compute_source_weights()`, and `get_frequency_omega()` for source gradient computations
- Modified `_strip_traced_fields()` in base.py to support multiple starting paths instead of a single path
- Included comprehensive analytical and numerical tests validating the gradient implementation

**Implementation Details:**

For `CustomCurrentSource`, the gradient is computed as `0.5 * Re(source_time_scaling * adjoint_field * sign)` where the sign depends on whether the component is E (+1) or H (-1).

For `CustomFieldSource`, the implementation uses the equivalence principle with cross products to determine the relationship between field components and injected currents, scaled by `omega * epsilon_0 / cell_size`.

The numerical test results in the PR description show angle differences between adjoint and finite-difference gradients ranging from 0.02° to 3.0°, indicating good agreement.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge with minor style improvements recommended
- The implementation is well-structured with comprehensive test coverage (analytical and numerical tests). The gradient computation follows established patterns from structure gradients. Two minor style issues with error message formatting were identified. The numerical results show good agreement between adjoint and finite-difference methods (angles < 3°). The refactoring properly separates concerns between structures and sources.
- Pay attention to error message formatting in `tidy3d/components/source/current.py` and `tidy3d/web/api/autograd/backward.py` to align with coding standards

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/components/source/current.py | Added `_compute_derivatives` method to `CustomCurrentSource` for adjoint gradient computation with proper field interpolation and scaling |
| tidy3d/components/source/field.py | Added `_compute_derivatives` method to `CustomFieldSource` for adjoint gradient computation with cross-product based current scaling |
| tidy3d/web/api/autograd/backward.py | Refactored adjoint processing to support both structures and sources, added `_process_source_gradients` function with source time scaling |
| tidy3d/components/simulation.py | Extended `_make_adjoint_monitors` to create field monitors for sources in addition to structures |
| tidy3d/components/base.py | Changed `_strip_traced_fields` to support multiple starting paths instead of single path |
| tidy3d/components/autograd/derivative_utils.py | Added helper functions `compute_source_weights`, `transpose_interp_field_to_dataset`, and `get_frequency_omega` for source gradient computation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant AutogradAPI as Autograd API
    participant Simulation
    participant Source as CustomSource
    participant BackwardPass as Backward Pass
    participant DerivativeInfo
    
    User->>AutogradAPI: run with traced source parameters
    AutogradAPI->>Simulation: execute forward simulation
    Simulation->>Simulation: _make_adjoint_monitors()
    Simulation->>Simulation: create source field monitors
    
    Note over Simulation: Forward simulation runs
    
    User->>AutogradAPI: compute gradients (backward pass)
    AutogradAPI->>BackwardPass: setup_adj(data_fields_vjp)
    BackwardPass->>BackwardPass: filter traced fields
    BackwardPass->>Simulation: _make_adjoint_sims()
    
    Note over Simulation: Adjoint simulation runs
    
    BackwardPass->>BackwardPass: postprocess_adj()
    BackwardPass->>BackwardPass: _process_source_gradients()
    BackwardPass->>DerivativeInfo: create DerivativeInfo with E_adj, H_adj
    BackwardPass->>Source: _compute_derivatives(derivative_info)
    
    alt CustomCurrentSource
        Source->>Source: transpose_interp_field_to_dataset()
        Source->>Source: compute VJP with source_time_scaling
        Source-->>BackwardPass: derivative_map
    else CustomFieldSource
        Source->>Source: compute cross products (n x E, n x H)
        Source->>Source: transpose_interp_field_to_dataset()
        Source->>Source: apply current_scale (omega * epsilon_0)
        Source-->>BackwardPass: derivative_map
    end
    
    BackwardPass-->>AutogradAPI: sim_fields_vjp
    AutogradAPI-->>User: gradients w.r.t. source parameters
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->