### PR TITLE
fix: _finalized_volumetric_structures should respect structure_priority_mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed coordinate snapping in shape gradient computation to handle 0 normal and grid spacing components.
 - Fixed duplicate printing of cost estimation of `Job`.
 - Fixed `outer_dot` with EME port modes `interpolated_copy`.
+- Fixed `_finalized_volumetric_structures` not respecting `structure_priority_mode` when no 2D materials or lumped elements are present.
 
 ### Removed
 - Removed support for inconsistent `interp_specs` in the EME grid.

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -3905,3 +3905,51 @@ def test_uniformly_padded_copy():
 
     with pytest.raises(ValueError):
         padded_sim = sim.uniformly_padded_copy(padding=-1)
+
+
+@pytest.mark.parametrize("structure_priority_mode", ["equal", "conductor"])
+def test_finalized_volumetric_structures_respects_priority_mode(structure_priority_mode):
+    """Test that _finalized_volumetric_structures respects structure_priority_mode."""
+    # Create structures with different media types
+    dielectric = td.Structure(
+        geometry=td.Box(size=(1, 1, 1), center=(0, 0, 0)),
+        medium=td.Medium(permittivity=2.0),
+    )
+    pec_struct = td.Structure(
+        geometry=td.Box(size=(0.5, 0.5, 0.5), center=(0, 0, 0)),
+        medium=td.PEC,
+    )
+    lossy_metal = td.Structure(
+        geometry=td.Box(size=(0.8, 0.8, 0.8), center=(0, 0, 0)),
+        medium=td.LossyMetalMedium(conductivity=1e7, frequency_range=(1e14, 2e14)),
+    )
+
+    structures = [pec_struct, lossy_metal, dielectric]
+
+    sim = td.Simulation(
+        size=(2, 2, 2),
+        structures=structures,
+        structure_priority_mode=structure_priority_mode,
+        run_time=1e-12,
+        grid_spec=td.GridSpec.uniform(dl=0.1),
+    )
+
+    # No 2D materials or lumped elements, so _finalized_volumetric_structures
+    # should use scene.sorted_structures
+    finalized_structures = sim._finalized_volumetric_structures
+    sorted_structures = sim.scene.sorted_structures
+
+    # Should match sorted_structures (modal_frames are empty in this case)
+    assert len(finalized_structures) == len(sorted_structures)
+    for fin, sorted_s in zip(finalized_structures, sorted_structures):
+        assert fin.medium == sorted_s.medium
+
+    if structure_priority_mode == "conductor":
+        # In conductor mode: PEC should be last, lossy metal second to last
+        assert finalized_structures[-1].medium == td.PEC
+        assert isinstance(finalized_structures[-2].medium, td.LossyMetalMedium)
+    else:
+        # In equal mode: original order preserved
+        assert finalized_structures[-1].medium == dielectric.medium
+        assert isinstance(finalized_structures[1].medium, td.LossyMetalMedium)
+        assert finalized_structures[0].medium == td.PEC

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -2277,7 +2277,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         """Volumetric structures in the simulation, including automatic frames around mode sources and internal absorbers, and 2d strutures converted into volumetric analogues."""
         modal_frames = self._modal_plane_frames
         if not self._contains_converted_volumetric_structures:
-            return list(self.structures) + modal_frames
+            return list(self.static_structures) + modal_frames
         return list(self.volumetric_structures) + modal_frames
 
     @cached_property


### PR DESCRIPTION
A bug discovered by Claude when testing other notebooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix: priority mode honored in finalized structures**
> 
> - `_finalized_volumetric_structures` now returns `list(self.static_structures) + modal_frames` (instead of `self.structures`) when no 2D/lumped conversions are present, ensuring `structure_priority_mode` ordering is respected.
> - Adds parametric test validating ordering for `structure_priority_mode` = `"equal"` and `"conductor"`.
> - Updates `CHANGELOG.md` to note the bug fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0f385cde38d0360e914e90fd4e27796a71031b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed `_finalized_volumetric_structures` to respect `structure_priority_mode` by using `static_structures` instead of `structures` when no 2D materials or lumped elements are present.

- **Bug**: `_finalized_volumetric_structures` returned `list(self.structures)` which doesn't respect priority ordering set by `structure_priority_mode`
- **Fix**: Changed to use `list(self.static_structures)` which calls `scene.sorted_structures` and applies the correct priority-based sorting
- **Impact**: In 'conductor' mode, PEC and lossy metal structures now correctly have higher priority; in 'equal' mode, original order is preserved
- **Test**: Added parametric test validating correct ordering for both 'equal' and 'conductor' priority modes

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is a simple one-line change that correctly addresses the bug by using the already-sorted structures. The change is well-tested with a parametric test covering both priority modes, and the logic is straightforward with no edge cases or potential side effects.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/components/simulation.py | Changed `_finalized_volumetric_structures` to use `self.static_structures` instead of `self.structures` to respect `structure_priority_mode` ordering |
| tests/test_components/test_simulation.py | Added parametric test validating that `_finalized_volumetric_structures` respects `structure_priority_mode` for both 'equal' and 'conductor' modes |
| CHANGELOG.md | Added entry documenting the bug fix under the 'Fixed' section |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Simulation
    participant Scene
    participant Structure
    
    User->>Simulation: Create with structure_priority_mode
    User->>Simulation: Access _finalized_volumetric_structures
    
    Simulation->>Simulation: Check _contains_converted_volumetric_structures
    
    alt No 2D materials or lumped elements
        Simulation->>Simulation: Call static_structures property
        Simulation->>Scene: Call scene.sorted_structures
        Scene->>Structure: Call _sort_structures(structures, priority_mode)
        Structure->>Structure: Sort by _priority() values
        Structure-->>Scene: Return sorted structures
        Scene-->>Simulation: Return sorted structures
        Simulation->>Simulation: Convert to static (remove tracers)
        Simulation->>Simulation: Add modal_frames
        Simulation-->>User: Return sorted structures
    else Has 2D materials or lumped elements
        Simulation->>Simulation: Use volumetric_structures
        Simulation->>Simulation: Add modal_frames
        Simulation-->>User: Return volumetric structures
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->