### PR TITLE
feat(smatrix): change default structure_priority_mode to conductor for TerminalComponentModeler 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ModeSortSpec.keep_modes` which can be set to `"all"` to keep all modes in the mode solver (the default), `"filtered"` to keep only modes passing the filter defined by the `ModeSortSpec`, or an integer `N` to keep only the top `N` modes after filtering and sorting.
 - Added `fill_fraction_box` as a new filtering and sorting key which computes the field-energy fill fraction within a specified bounding box (`ModeSortSpec.bounding_box`).
 
+### Breaking Changes
+- Added `structure_priority_mode` for `TerminalComponentModeler` and default to `"conductor"` to ensure metal structures override dielectrics regardless of structure order, preventing order-dependent results in RF simulations.
+
 ### Changed
 
 ### Fixed

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -18356,6 +18356,14 @@
         }
       ]
     },
+    "structure_priority_mode": {
+      "default": "conductor",
+      "enum": [
+        "conductor",
+        "equal"
+      ],
+      "type": "string"
+    },
     "type": {
       "default": "TerminalComponentModeler",
       "enum": [

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -2333,3 +2333,26 @@ def test_validate_port_refinement_with_uniform_grid():
         make_coaxial_component_modeler(
             port_types=(CoaxialLumpedPort, WavePort), grid_spec=uniform_grid
         )
+
+
+def test_structure_priority_mode_default():
+    """Test that TerminalComponentModeler defaults to conductor priority mode."""
+    modeler = make_component_modeler(planar_pec=True)
+
+    # Check that the modeler defaults to "conductor" mode
+    assert modeler.structure_priority_mode == "conductor"
+
+    # Check that base_sim uses this priority mode
+    assert modeler.base_sim.structure_priority_mode == "conductor"
+
+
+def test_structure_priority_mode_override():
+    """Test that structure_priority_mode can be overridden."""
+    # Create modeler with "equal" mode
+    modeler = make_component_modeler(planar_pec=True, structure_priority_mode="equal")
+
+    # Check that the override is applied
+    assert modeler.structure_priority_mode == "equal"
+
+    # Check that base_sim uses the overridden priority mode
+    assert modeler.base_sim.structure_priority_mode == "equal"

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -24,7 +24,7 @@ from tidy3d.components.monitor import DirectivityMonitor, ModeMonitor
 from tidy3d.components.simulation import Simulation
 from tidy3d.components.source.time import GaussianPulse
 from tidy3d.components.types import Ax, Complex, Coordinate
-from tidy3d.components.types.base import annotate_type
+from tidy3d.components.types.base import PriorityMode, annotate_type
 from tidy3d.components.viz import add_ax_if_none, equal_aspect
 from tidy3d.constants import C_0, MICROMETER, OHM, fp_eps, inf
 from tidy3d.exceptions import SetupError, Tidy3dKeyError, ValidationError
@@ -209,6 +209,16 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
         description="The low frequency smoothing parameters for the terminal component simulation.",
     )
 
+    structure_priority_mode: Optional[PriorityMode] = pd.Field(
+        "conductor",
+        title="Structure Priority Setting",
+        description="If not `None`, override the structure priority mode in the simulation. "
+        "This field only affects structures of `priority=None`. "
+        "If `equal`, the priority of those structures is set to 0; if `conductor`, "
+        "the priority of structures made of :class:`LossyMetalMedium` is set to 90, "
+        ":class:`PECMedium` to 100, and others to 0.",
+    )
+
     @property
     def _sim_with_sources(self) -> Simulation:
         """Instance of :class:`.Simulation` with all sources and absorbers added for each port, for plotting."""
@@ -387,7 +397,8 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
 
     @cached_property
     def _base_sim_no_radiation_monitors(self) -> Simulation:
-        """The intermediate base simulation with all grid refinement options, port loads (if present), and monitors added,
+        """The intermediate base simulation with all grid refinement options, structure priority mode,
+        port loads (if present), and monitors added,
         which is only missing the source excitations and radiation monitors.
         """
         # internal mesh override and snapping points are automatically generated from lumped elements.
@@ -400,11 +411,15 @@ class TerminalComponentModeler(AbstractComponentModeler, MicrowaveBaseModel):
                 "wavelength": C_0 / np.max(self.freqs),
             }
         )
-
+        update_dict = {
+            "grid_spec": grid_spec,
+            "lumped_elements": lumped_resistors,
+        }
+        if self.structure_priority_mode is not None:
+            update_dict["structure_priority_mode"] = self.structure_priority_mode
         # Make an initial simulation with new grid_spec to determine where LumpedPorts are snapped
         sim_wo_source = self.simulation.updated_copy(
-            grid_spec=grid_spec,
-            lumped_elements=lumped_resistors,
+            **update_dict,
             validate=False,
             deep=False,
         )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces explicit structure priority control in `TerminalComponentModeler`, defaulting to conductor-first behavior to avoid order-dependent RF results.
> 
> - Added `structure_priority_mode: Optional[PriorityMode]` (default: `"conductor"`) to `TerminalComponentModeler` and imported `PriorityMode`
> - Propagates `structure_priority_mode` to the underlying `Simulation` in `_base_sim_no_radiation_monitors`
> - Updated JSON schema for `TerminalComponentModeler` with `structure_priority_mode`
> - Added tests verifying default and override behavior; updated `CHANGELOG.md` under **Breaking Changes**
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 405c2055820ce36fbbb0780034a5b6aa6459e81e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `structure_priority_mode` field to `TerminalComponentModeler` with a default value of `"conductor"`, changing the default behavior to ensure metal structures (PEC and lossy metals) take priority over dielectrics regardless of structure ordering in RF simulations.

**Key Changes:**
- Added `structure_priority_mode: Optional[PriorityMode]` field to `TerminalComponentModeler` with default `"conductor"` (breaking change from implicit `"equal"` behavior)
- Propagated the priority mode setting to the underlying `Simulation` in `_base_sim_no_radiation_monitors` when the field is not `None`
- Imported `PriorityMode` type from `tidy3d.components.types.base`
- Added CHANGELOG entry under "Breaking Changes" section documenting the new default behavior
- Added comprehensive tests verifying both default and override behavior

**Minor Issue:**
- Docstring uses single backticks for class names (`LossyMetalMedium`, `PECMedium`) instead of the RST `:class:` syntax used in the base `Simulation` class

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk once the minor docstring formatting is addressed
- The implementation is well-structured with proper field addition, correct propagation through the simulation building process, and comprehensive tests. The breaking change is appropriately documented in CHANGELOG.md. Score is 4/5 due to a minor style issue with RST syntax in docstrings that should be fixed for consistency with the codebase standards.
- The docstring formatting in `tidy3d/plugins/smatrix/component_modelers/terminal.py` should use `:class:` RST syntax for class references to match the pattern in `Simulation` class and ensure proper documentation rendering

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Added breaking change entry for new structure_priority_mode field with clear user impact description |
| tidy3d/plugins/smatrix/component_modelers/terminal.py | Added structure_priority_mode field (default: "conductor") and propagated to base_sim; minor docstring formatting inconsistency with RST syntax |
| tests/test_plugins/smatrix/test_terminal_component_modeler.py | Added tests verifying default "conductor" mode and override to "equal" mode, checking both field and propagation to base_sim |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant TCM as TerminalComponentModeler
    participant Sim as Simulation
    
    User->>TCM: Create with structure_priority_mode="conductor" (default)
    TCM->>TCM: Store structure_priority_mode field
    
    User->>TCM: Access base_sim property
    TCM->>TCM: Call _base_sim_no_radiation_monitors
    TCM->>TCM: Build update_dict with grid_spec and lumped_elements
    
    alt structure_priority_mode is not None
        TCM->>TCM: Add structure_priority_mode to update_dict
    end
    
    TCM->>Sim: Call simulation.updated_copy(**update_dict)
    Sim->>Sim: Apply structure_priority_mode to structures
    Sim-->>TCM: Return updated simulation
    
    TCM->>TCM: Add radiation monitors
    TCM-->>User: Return base_sim with conductor priority mode applied
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->