### PR TITLE
fix: regenerate lockfile by default on extras-integration (FXC-4769)

### DIFF
--- a/.github/workflows/tidy3d-extras-python-client-tests-integration.yml
+++ b/.github/workflows/tidy3d-extras-python-client-tests-integration.yml
@@ -123,6 +123,13 @@ jobs:
         poetry config http-basic.codeartifact aws $CODEARTIFACT_AUTH_TOKEN
         echo "✅ CodeArtifact authentication configured"
 
+    - name: regenerate-lockfile
+      run: |
+        set -e
+        echo "Regenerating poetry.lock..."
+        poetry update --lock
+        echo "✅ Lockfile regenerated"
+
     - name: install-project
       shell: bash
       run: |
@@ -259,6 +266,13 @@ jobs:
         echo "Configuring Poetry with CodeArtifact credentials..."
         poetry config http-basic.codeartifact aws $CODEARTIFACT_AUTH_TOKEN
         echo "✅ CodeArtifact authentication configured"
+
+    - name: regenerate-lockfile
+      run: |
+        set -e
+        echo "Regenerating poetry.lock..."
+        poetry update --lock
+        echo "✅ Lockfile regenerated"
 
     - name: install-project
       shell: bash


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures dependencies are freshly resolved during CI for extras integration tests.
> 
> - Adds `regenerate-lockfile` step (`poetry update --lock`) after CodeArtifact auth and before project install in both `integration-tests-basic` and `integration-tests-full` jobs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc3236069b74752860352ba649b2be1bd79204f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds `poetry update --lock` step to both `integration-tests-basic` and `integration-tests-full` jobs to regenerate the lockfile before installing dependencies, ensuring tests run against freshly resolved dependencies from CodeArtifact.

**Key concerns:**
- Running `poetry update --lock` on every CI run means tests execute against different dependency versions than the committed `poetry.lock`, which defeats the purpose of lockfiles and can mask version-specific issues
- The regenerated lockfile is never committed, creating a mismatch between CI and local/production environments
- Adds dependency resolution overhead to every test run (typically 30-60+ seconds)
- The PR description mentions "freshly resolved dependencies" as the goal, but this approach trades reproducibility for freshness

**Alternative approaches to consider:**
- Use `poetry lock --check` to validate the existing lockfile is up-to-date
- Only regenerate when the lockfile is missing or explicitly requested via workflow input
- Run this workflow separately as a scheduled dependency update check rather than on every integration test

<h3>Confidence Score: 2/5</h3>

- This PR introduces a significant change to CI behavior that undermines lockfile reproducibility
- While the change is syntactically correct and won't cause immediate failures, it fundamentally changes how dependencies are tested in CI by regenerating the lockfile on every run. This means CI tests run against different versions than what's committed in the repository, defeating the purpose of having a lockfile. The approach trades reproducibility for freshness, which could mask dependency-related bugs that would appear in production. A score of 2 reflects that this needs reconsideration of the approach.
- Pay close attention to `.github/workflows/tidy3d-extras-python-client-tests-integration.yml` - the lockfile regeneration strategy should be reconsidered

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/tidy3d-extras-python-client-tests-integration.yml | Added `regenerate-lockfile` step using `poetry update --lock` to both integration test jobs; this regenerates dependencies on every CI run which may mask dependency issues and increase build times |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant AWS as AWS CodeArtifact
    participant Poetry as Poetry
    participant Tests as Integration Tests

    GHA->>GHA: Checkout code
    GHA->>GHA: Setup Python & Poetry
    GHA->>AWS: Configure AWS credentials
    GHA->>AWS: Get CodeArtifact auth token
    AWS-->>GHA: Return auth token
    GHA->>Poetry: Configure CodeArtifact credentials
    Note over Poetry: NEW STEP
    GHA->>Poetry: poetry update --lock
    Poetry->>AWS: Fetch latest dependency versions
    AWS-->>Poetry: Return dependency metadata
    Poetry->>Poetry: Regenerate poetry.lock
    Note over Poetry: Lock file now has fresh versions
    GHA->>Poetry: poetry install -E extras -E dev
    Poetry->>AWS: Download dependencies
    AWS-->>Poetry: Return packages
    Poetry->>GHA: Installation complete
    GHA->>Tests: Run integration tests
    Tests-->>GHA: Test results
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->