### PR TITLE
fix(config): make config directory detection race-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fixed intermittent "API key not found" errors in parallel job launches by making configuration directory detection race-safe.
+
 ## [2.10.2] - 2026-01-21
 
 ### Added

--- a/tests/config/test_loader.py
+++ b/tests/config/test_loader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pathlib
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -198,3 +199,49 @@ def test_migrate_legacy_config_promotes_structured_config(tmp_path, monkeypatch)
     assert extra_file.exists()
     assert extra_file.read_text(encoding="utf-8") == "keep"
     assert legacy_dir.exists()
+
+
+def test_is_writable_ignores_file_not_found_cleanup(tmp_path, monkeypatch):
+    original_unlink = pathlib.Path.unlink
+
+    def flaky_unlink(self, *args, **kwargs):
+        if self.name.startswith(".tidy3d_write_test_"):
+            raise FileNotFoundError
+        return original_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "unlink", flaky_unlink)
+    assert config_loader._is_writable(tmp_path)
+
+
+def test_resolve_config_directory_prefers_existing_canonical_dir(tmp_path, monkeypatch):
+    canonical_dir = tmp_path / "xdg" / "tidy3d"
+    canonical_dir.mkdir(parents=True)
+    legacy_dir = tmp_path / "legacy"
+    legacy_dir.mkdir()
+
+    monkeypatch.setattr(config_loader, "canonical_config_directory", lambda: canonical_dir)
+    monkeypatch.setattr(config_loader, "legacy_config_directory", lambda: legacy_dir)
+
+    def _boom(_):
+        raise AssertionError(
+            "_is_writable should not be called when canonical config directory exists"
+        )
+
+    monkeypatch.setattr(config_loader, "_is_writable", _boom)
+
+    assert config_loader.resolve_config_directory() == canonical_dir
+
+
+def test_resolve_config_directory_prefers_existing_base_dir(tmp_path, monkeypatch):
+    base_dir = tmp_path / "base"
+    config_dir = base_dir / "config"
+    config_dir.mkdir(parents=True)
+
+    monkeypatch.setenv("TIDY3D_BASE_DIR", str(base_dir))
+
+    def _boom(_):
+        raise AssertionError("_is_writable should not be called when base config directory exists")
+
+    monkeypatch.setattr(config_loader, "_is_writable", _boom)
+
+    assert config_loader.resolve_config_directory() == config_dir

--- a/tidy3d/config/loader.py
+++ b/tidy3d/config/loader.py
@@ -322,6 +322,16 @@ def canonical_config_directory() -> Path:
     return _xdg_config_home() / "tidy3d"
 
 
+def _warn_legacy_dir_ignored(*, canonical_dir: Path, legacy_dir: Path) -> None:
+    if legacy_dir.exists():
+        log.warning(
+            f"Using canonical configuration directory at '{canonical_dir}'. "
+            "Found legacy directory at '~/.tidy3d', which will be ignored. "
+            "Remove it manually or run 'tidy3d config migrate --delete-legacy' to clean up.",
+            log_once=True,
+        )
+
+
 def resolve_config_directory() -> Path:
     """Determine the directory used to store tidy3d configuration files."""
 
@@ -329,6 +339,8 @@ def resolve_config_directory() -> Path:
     if base_override:
         base_path = Path(base_override).expanduser().resolve()
         path = base_path / "config"
+        if path.is_dir():
+            return path
         if _is_writable(path.parent):
             return path
         log.warning(
@@ -337,18 +349,14 @@ def resolve_config_directory() -> Path:
         return _temporary_config_dir()
 
     canonical_dir = canonical_config_directory()
+    legacy_dir = legacy_config_directory()
+    if canonical_dir.is_dir():
+        _warn_legacy_dir_ignored(canonical_dir=canonical_dir, legacy_dir=legacy_dir)
+        return canonical_dir
     if _is_writable(canonical_dir.parent):
-        legacy_dir = legacy_config_directory()
-        if legacy_dir.exists():
-            log.warning(
-                f"Using canonical configuration directory at '{canonical_dir}'. "
-                "Found legacy directory at '~/.tidy3d', which will be ignored. "
-                "Remove it manually or run 'tidy3d config migrate --delete-legacy' to clean up.",
-                log_once=True,
-            )
+        _warn_legacy_dir_ignored(canonical_dir=canonical_dir, legacy_dir=legacy_dir)
         return canonical_dir
 
-    legacy_dir = legacy_config_directory()
     if legacy_dir.exists():
         log.warning(
             "Configuration found in legacy location '~/.tidy3d'. Consider running 'tidy3d config migrate'.",
@@ -376,10 +384,12 @@ def _temporary_config_dir() -> Path:
 def _is_writable(path: Path) -> bool:
     try:
         path.mkdir(parents=True, exist_ok=True)
-        test_file = path / ".tidy3d_write_test"
-        with open(test_file, "w", encoding="utf-8"):
+        fd, test_path = tempfile.mkstemp(dir=path, prefix=".tidy3d_write_test_")
+        os.close(fd)
+        try:
+            Path(test_path).unlink()
+        except FileNotFoundError:
             pass
-        test_file.unlink()
         return True
     except Exception:
         return False


### PR DESCRIPTION
Fixes intermittent 'API key not found' in parallel launches by using per-call temp files for writability checks and preferring existing config dirs.

Adds regression tests and changelog entry (FXC-5090).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves robustness of config directory resolution to avoid races in parallel launches.
> 
> - Update `resolve_config_directory()` to prefer existing canonical/base `config` dirs and factor out `_warn_legacy_dir_ignored()`
> - Make `_is_writable()` race-safe via `tempfile.mkstemp()` and tolerate `FileNotFoundError` during cleanup
> - Add regression tests covering flaky cleanup and directory preference logic
> - Update `CHANGELOG.md` with the fix
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2aa0e2c8613e06f4f18c63375f1cd5d1520c8da8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a race condition in parallel job launches where multiple processes could interfere with each other when checking if the config directory is writable, causing intermittent "API key not found" errors.

**Key changes:**
- Modified `_is_writable()` to use `tempfile.mkstemp()` instead of a fixed filename, ensuring each process uses a unique temp file
- Added `FileNotFoundError` handling in cleanup to gracefully handle edge cases where the temp file is deleted by another process
- Updated `resolve_config_directory()` to prefer existing directories and skip writability checks when the canonical or base config directory already exists
- Added comprehensive regression tests to verify the fix works correctly in race conditions

The fix is well-designed and follows best practices for concurrent filesystem operations. The tests provide good coverage of the edge cases.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-tested with comprehensive regression tests, use standard library functions correctly, and follow best practices for concurrent filesystem operations. The only minor concern is ensuring the `tempfile` and `os` imports are used correctly, but they are already present in the file.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/config/loader.py | Fixed race condition in config directory detection by using mkstemp and preferring existing directories |
| tests/config/test_loader.py | Added comprehensive regression tests for race-safe directory detection |
| CHANGELOG.md | Added clear changelog entry describing the fix for parallel launch issue |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant P1 as Parallel Process 1
    participant P2 as Parallel Process 2
    participant FS as File System
    participant CD as Config Directory

    Note over P1,P2: Before Fix: Race Condition

    P1->>CD: resolve_config_directory()
    P2->>CD: resolve_config_directory()
    P1->>CD: Check if canonical_dir writable
    P2->>CD: Check if canonical_dir writable
    P1->>FS: Create .tidy3d_write_test
    P2->>FS: Create .tidy3d_write_test (overwrites P1's file)
    P1->>FS: Delete .tidy3d_write_test (may fail)
    P2->>FS: Delete .tidy3d_write_test
    Note over P1,P2: Race: Both processes interfere

    Note over P1,P2: After Fix: Race-Safe

    P1->>CD: resolve_config_directory()
    P2->>CD: resolve_config_directory()
    
    alt canonical_dir.is_dir()
        P1->>CD: Return existing canonical_dir
        P2->>CD: Return existing canonical_dir
        Note over P1,P2: Skip writability check entirely
    else canonical_dir doesn't exist
        P1->>CD: _is_writable(canonical_dir.parent)
        P2->>CD: _is_writable(canonical_dir.parent)
        P1->>FS: mkstemp(prefix=".tidy3d_write_test_")
        P2->>FS: mkstemp(prefix=".tidy3d_write_test_")
        Note over P1,P2: Unique temp files per process
        P1->>FS: unlink temp file (with FileNotFoundError handling)
        P2->>FS: unlink temp file (with FileNotFoundError handling)
        Note over P1,P2: No race: Each process uses unique file
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->