### PR TITLE
fix(tidy3d): FXC-5094-fix-deprecation-warnings-in-tests

### DIFF
--- a/tests/config/test_legacy.py
+++ b/tests/config/test_legacy.py
@@ -9,7 +9,11 @@ from tidy3d.config.__init__ import get_manager, reload_config
 
 def test_legacy_logging_level(config_manager):
     cfg = reload_config(profile=config_manager.profile)
-    cfg.logging_level = "DEBUG"
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"config\.logging_level.*deprecated",
+    ):
+        cfg.logging_level = "DEBUG"
     manager = get_manager()
     assert manager.get_section("logging").level == "DEBUG"
 

--- a/tests/config/test_legacy_env.py
+++ b/tests/config/test_legacy_env.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
+import importlib
 import os
 import ssl
 import warnings
 
+import pytest
+
 from tidy3d.config import Env, get_manager, reload_config
 from tidy3d.config import config as config_wrapper
+
+
+@pytest.fixture
+def suppress_legacy_env_deprecated_warning(monkeypatch):
+    """Patch Env deprecation helper to a no-op for tests that don't want the warning."""
+    legacy_module = importlib.import_module("tidy3d.config.legacy")
+    monkeypatch.setattr(legacy_module, "_warn_env_deprecated", lambda: None)
 
 
 def test_env_tracks_profile_switch(config_manager):
@@ -21,7 +31,11 @@ def test_env_tracks_profile_switch(config_manager):
         reload_config(profile="default")
 
 
-def test_env_pending_overrides_apply_on_activation(mock_config_dir, config_manager):
+def test_env_pending_overrides_apply_on_activation(
+    mock_config_dir,
+    config_manager,
+    suppress_legacy_env_deprecated_warning,
+):
     """Queued overrides should land once the corresponding profile is activated."""
 
     del mock_config_dir
@@ -50,7 +64,12 @@ def test_env_pending_overrides_apply_on_activation(mock_config_dir, config_manag
         reload_config(profile="default")
 
 
-def test_env_vars_follow_profile_switch(mock_config_dir, monkeypatch, config_manager):
+def test_env_vars_follow_profile_switch(
+    mock_config_dir,
+    monkeypatch,
+    config_manager,
+    suppress_legacy_env_deprecated_warning,
+):
     """Environment variables applied via Env should restore previous values on switch."""
 
     del mock_config_dir

--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -2163,7 +2163,7 @@ def test_custom_sellmeier(monkeypatch):
     def eps_from(B, C):
         return 1.0 + B * lam2 / (lam2 - C)
 
-    eps_arr = eps_from(B1.values, C1.values) + eps_from(B2.values, C2.values)
+    eps_arr = eps_from(B1.values, C1.values) + eps_from(B2.values, C2.values) + 0j
     dJ = np.conj(ag.holomorphic_grad(lambda e: anp.sum(anp.abs(e)))(eps_arr))
 
     _patch_cmp_to_const(monkeypatch, td.CustomSellmeier, dJ)

--- a/tests/test_components/autograd/test_autograd_custom_dispersive_vjps.py
+++ b/tests/test_components/autograd/test_autograd_custom_dispersive_vjps.py
@@ -75,7 +75,9 @@ def test_custom_sellmeier_vjp():
 
     freq = 2.5e14
     lam2 = (C_0 / freq) ** 2
-    eps_arr = 1.0 + B1.values * lam2 / (lam2 - C1.values) + B2.values * lam2 / (lam2 - C2.values)
+    eps_arr = (
+        1.0 + B1.values * lam2 / (lam2 - C1.values) + B2.values * lam2 / (lam2 - C2.values) + 0j
+    )
     dJ = np.conj(ag.holomorphic_grad(_J)(eps_arr))
 
     # Monkeypatch derivative provider
@@ -126,7 +128,7 @@ def test_custom_lorentz_vjp():
         eps_inf.values
         + (de1.values * (f01.values**2)) / den1
         + (de2.values * (f02.values**2)) / den2
-    )
+    ) + 0j
     dJ = np.conj(ag.holomorphic_grad(_J)(eps_arr))
 
     from tidy3d.components import medium as medium_mod
@@ -183,7 +185,7 @@ def test_custom_drude_vjp():
 
     den1 = Drude._den(freq, dl1.values)
     den2 = Drude._den(freq, dl2.values)
-    eps_arr = eps_inf.values - (fp1.values**2) / den1 - (fp2.values**2) / den2
+    eps_arr = eps_inf.values - (fp1.values**2) / den1 - (fp2.values**2) / den2 + 0j
     dJ = np.conj(ag.holomorphic_grad(_J)(eps_arr))
 
     from tidy3d.components import medium as medium_mod
@@ -232,7 +234,7 @@ def test_custom_debye_vjp():
 
     den1 = Debye._den(freq, tau1.values)
     den2 = Debye._den(freq, tau2.values)
-    eps_arr = eps_inf.values + de1.values / den1 + de2.values / den2
+    eps_arr = eps_inf.values + de1.values / den1 + de2.values / den2 + 0j
     dJ = np.conj(ag.holomorphic_grad(_J)(eps_arr))
 
     from tidy3d.components import medium as medium_mod

--- a/tests/test_components/autograd/test_autograd_rf_box.py
+++ b/tests/test_components/autograd/test_autograd_rf_box.py
@@ -11,7 +11,7 @@ import pytest
 import tidy3d as td
 import tidy3d.web as web
 
-td.config.logging_level = "ERROR"
+td.config.logging.level = "ERROR"
 
 PLOT_FD_ADJ_COMPARISON = False
 NUM_BOXES_PER_FD_TESTS = 1

--- a/tests/test_components/autograd/test_autograd_rf_polyslab.py
+++ b/tests/test_components/autograd/test_autograd_rf_polyslab.py
@@ -11,7 +11,7 @@ import pytest
 import tidy3d as td
 import tidy3d.web as web
 
-td.config.logging_level = "ERROR"
+td.config.logging.level = "ERROR"
 
 PLOT_FD_ADJ_COMPARISON = False
 NUM_VERTICES_PER_FD_TESTS = 10

--- a/tests/test_components/test_heat_charge.py
+++ b/tests/test_components/test_heat_charge.py
@@ -2459,7 +2459,7 @@ def test_heat_conduction_simulations():
     # test error if structures aren't conducting
     with pytest.raises(ValidationError):
         struct_error = struct1.updated_copy(
-            medium=struct1.medium.updated_copy(charge=td.ChargeInsulatorMedium)
+            medium=struct1.medium.updated_copy(charge=td.ChargeInsulatorMedium())
         )
         _ = sim.updated_copy(structures=[struct_error])
 

--- a/tests/test_components/test_microwave.py
+++ b/tests/test_components/test_microwave.py
@@ -564,13 +564,15 @@ def test_composite_current_integral_validation():
 
     current_spec = td.AxisAlignedCurrentIntegralSpec(center=(1, 2, 3), size=(0, 1, 1), sign="-")
     voltage_spec = td.AxisAlignedVoltageIntegralSpec(center=(1, 2, 3), size=(0, 0, 1), sign="-")
-    path_spec = td.CompositeCurrentIntegralSpec(path_specs=[current_spec], sum_spec="sum")
-
+    path_spec = td.CompositeCurrentIntegralSpec(path_specs=(current_spec,), sum_spec="sum")
     with pytest.raises(pd.ValidationError):
         path_spec.updated_copy(path_specs=[])
-
-    with pytest.raises(pd.ValidationError):
-        path_spec.updated_copy(path_specs=[voltage_spec])
+    with pytest.warns(
+        UserWarning,
+        match=r"(?s)Pydantic serializer warnings:.*path_specs.*",
+    ):
+        with pytest.raises(pd.ValidationError):
+            path_spec.updated_copy(path_specs=[voltage_spec])
 
 
 def test_composite_current_integral_bounds():

--- a/tests/test_components/test_mode_interp.py
+++ b/tests/test_components/test_mode_interp.py
@@ -967,11 +967,11 @@ def test_mode_solver_data_stored_freqs(num_freqs, num_points, reduce_data, expec
     )
 
     if rf:
-        mode_spec = td.MicrowaveModeSpec(**mode_spec.dict(exclude={"type"}))
+        mode_spec = td.MicrowaveModeSpec(**mode_spec.model_dump(exclude={"type"}))
         monitor = td.MicrowaveModeSolverMonitor(
-            **monitor.dict(exclude={"type", "mode_spec"}), mode_spec=mode_spec
+            **monitor.model_dump(exclude={"type", "mode_spec"}), mode_spec=mode_spec
         )
-        data = td.ModeSolverData(**data.dict(exclude={"type", "monitor"}), monitor=monitor)
+        data = td.ModeSolverData(**data.model_dump(exclude={"type", "monitor"}), monitor=monitor)
 
     # Check _stored_freqs length
     assert len(data.monitor._stored_freqs) == expected_stored_len, (

--- a/tests/test_components/test_scene.py
+++ b/tests/test_components/test_scene.py
@@ -146,7 +146,7 @@ def test_get_structure_plot_params():
     pp = SCENE_FULL._get_structure_eps_plot_params(
         medium=SCENE_FULL.medium, freq=1, eps_min=1, eps_max=2
     )
-    expected_color = mpl.cm.get_cmap(STRUCTURE_EPS_CMAP)(0.0)
+    expected_color = plt.get_cmap(STRUCTURE_EPS_CMAP)(0.0)
     assert np.allclose(pp.facecolor, expected_color)
     pp = SCENE_FULL._get_structure_eps_plot_params(medium=td.PEC, freq=1, eps_min=1, eps_max=2)
     assert pp.facecolor == "gold"
@@ -165,7 +165,7 @@ def test_structure_eps_color_mapping():
         norm=norm,
         reverse=False,
     )
-    expected_min = mpl.cm.get_cmap(STRUCTURE_EPS_CMAP)(norm(1.0))
+    expected_min = plt.get_cmap(STRUCTURE_EPS_CMAP)(norm(1.0))
     assert np.allclose(pp_min.facecolor, expected_min)
 
     pp_max = SCENE_FULL._get_structure_eps_plot_params(
@@ -176,7 +176,7 @@ def test_structure_eps_color_mapping():
         norm=norm,
         reverse=False,
     )
-    expected_max = mpl.cm.get_cmap(STRUCTURE_EPS_CMAP)(norm(5.0))
+    expected_max = plt.get_cmap(STRUCTURE_EPS_CMAP)(norm(5.0))
     assert np.allclose(pp_max.facecolor, expected_max)
 
     pp_min_reverse = SCENE_FULL._get_structure_eps_plot_params(
@@ -187,7 +187,7 @@ def test_structure_eps_color_mapping():
         norm=norm,
         reverse=True,
     )
-    expected_min_reverse = mpl.cm.get_cmap(STRUCTURE_EPS_CMAP_R)(norm(1.0))
+    expected_min_reverse = plt.get_cmap(STRUCTURE_EPS_CMAP_R)(norm(1.0))
     assert np.allclose(pp_min_reverse.facecolor, expected_min_reverse)
 
     pp_max_reverse = SCENE_FULL._get_structure_eps_plot_params(
@@ -198,7 +198,7 @@ def test_structure_eps_color_mapping():
         norm=norm,
         reverse=True,
     )
-    expected_max_reverse = mpl.cm.get_cmap(STRUCTURE_EPS_CMAP_R)(norm(5.0))
+    expected_max_reverse = plt.get_cmap(STRUCTURE_EPS_CMAP_R)(norm(5.0))
     assert np.allclose(pp_max_reverse.facecolor, expected_max_reverse)
 
 

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -453,13 +453,17 @@ def test_validate_normalize_index():
     )
 
     # normalize by zero-amplitude source
-    with pytest.raises(ValidationError):
-        td.Simulation(
-            size=(1, 1, 1),
-            run_time=1e-12,
-            grid_spec=td.GridSpec.uniform(dl=0.1),
-            sources=(src0,),
-        )
+    with pytest.warns(
+        RuntimeWarning,
+        match=r"invalid value encountered in scalar divide",
+    ):
+        with pytest.raises(ValidationError):
+            td.Simulation(
+                size=(1, 1, 1),
+                run_time=1e-12,
+                grid_spec=td.GridSpec.uniform(dl=0.1),
+                sources=(src0,),
+            )
 
 
 def test_validate_plane_wave_boundaries():

--- a/tests/test_components/test_types.py
+++ b/tests/test_components/test_types.py
@@ -18,7 +18,7 @@ def test_schemas():
         c: Complex
 
     _ = S(f=[13], c=1 + 1j, ca=[1 + 1j])
-    S.schema()
+    S.model_json_schema()
 
 
 def test_array_like():

--- a/tests/test_package/test_config.py
+++ b/tests/test_package/test_config.py
@@ -17,13 +17,13 @@ def test_logging_level():
 
     # check setting all levels
     for key, val in _level_value.items():
-        td.config.logging_level = key
+        td.config.logging.level = key
         assert td.log.handlers["console"].level == val
 
 
 def test_log_level_not_found():
     with pytest.raises(ValidationError):
-        td.config.logging_level = "NOT_A_LEVEL"
+        td.config.logging.level = "NOT_A_LEVEL"
 
 
 def _test_frozen():

--- a/tests/test_package/test_log.py
+++ b/tests/test_package/test_log.py
@@ -25,7 +25,7 @@ def test_log():
 
 
 def test_log_config(tmp_path):
-    td.config.logging_level = "DEBUG"
+    td.config.logging.level = "DEBUG"
     td.set_logging_file(str(tmp_path / "test.log"))
     assert len(td.log.handlers) == 2
     assert td.log.handlers["console"].level == _get_level_int("DEBUG")
@@ -51,15 +51,15 @@ def test_exception_message():
 
 def test_logging_upper():
     """Make sure we get an error if lowercase."""
-    td.config.logging_level = "WARNING"
+    td.config.logging.level = "WARNING"
     with pytest.raises(ValidationError):
-        td.config.logging_level = "warning"
+        td.config.logging.level = "warning"
 
 
 def test_logging_unrecognized():
     """If unrecognized option, raise validation error."""
     with pytest.raises(ValidationError):
-        td.config.logging_level = "blah"
+        td.config.logging.level = "blah"
 
 
 def test_logging_warning_capture():
@@ -291,14 +291,14 @@ def test_log_suppression():
             suppressed_log.warning("Warning message")
         assert td.log._counts[30] == 3
 
-    td.config.log_suppression = False
+    td.config.logging.suppression = False
     with td.log as suppressed_log:
         assert td.log._counts is None
         for _ in range(4):
             suppressed_log.warning("Warning message")
         assert td.log._counts is None
 
-    td.config.log_suppression = True
+    td.config.logging.suppression = True
 
 
 def test_warn_once():

--- a/tests/test_plugins/autograd/test_functions.py
+++ b/tests/test_plugins/autograd/test_functions.py
@@ -720,5 +720,7 @@ class TestLeastSquares:
         initial_guess = (1.0, 0.0)
 
         check_grads(
-            lambda params: least_squares(linear_model, x, y, params), modes=["fwd", "rev"], order=2
+            lambda params: least_squares(linear_model, x, y, params, max_iterations=1),
+            modes=["fwd", "rev"],
+            order=2,
         )(initial_guess)

--- a/tests/test_plugins/expressions/test_dispatch.py
+++ b/tests/test_plugins/expressions/test_dispatch.py
@@ -8,7 +8,7 @@ from tidy3d.plugins.expressions.variables import Constant
 
 def test_expression_parse_obj_round_trip():
     expr = Constant(3.14)
-    parsed = Expression.model_validate(expr.dict())
+    parsed = Expression.model_validate(expr.model_dump())
     assert isinstance(parsed, Constant)
     assert parsed.value == pytest.approx(3.14)
 

--- a/tests/test_plugins/smatrix/test_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_component_modeler.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings
+
 import gdstk
 import matplotlib.pyplot as plt
 import numpy as np
@@ -316,9 +318,15 @@ def test_component_modeler_run_only(monkeypatch):
     assert np.all(s_matrix.values == 0.0)
 
     # make sure lists are correctly converted into tuples
-    run_only = [list(ONLY_SOURCE)]
-    modeler = modeler.updated_copy(run_only=run_only)
-    assert ONLY_SOURCE in modeler.matrix_indices_run_sim
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"(?s)Pydantic serializer warnings:.*field_name='run_only'.*",
+            category=UserWarning,
+        )
+        run_only = [list(ONLY_SOURCE)]
+        modeler = modeler.updated_copy(run_only=run_only)
+        assert ONLY_SOURCE in modeler.matrix_indices_run_sim
 
 
 def _test_mappings(element_mappings, s_matrix):

--- a/tests/test_plugins/smatrix/test_component_modeler_autograd.py
+++ b/tests/test_plugins/smatrix/test_component_modeler_autograd.py
@@ -28,7 +28,7 @@ def _run_emulated_minimal(simulation: td.Simulation, path=None, **kwargs) -> td.
 
     def _coords_for_monitor(sim: td.Simulation, mnt: td.Monitor):
         grid = sim.discretize_monitor(mnt)
-        bounds = grid.boundaries.dict()
+        bounds = grid.boundaries.model_dump()
 
         def centers(arr):
             arr = np.asarray(arr)
@@ -215,8 +215,8 @@ def build_terminal_modeler(scale: float) -> TerminalComponentModeler:
 
 
 def test_component_modeler_autograd_tracing(patch_web_autograd_emulator, tmp_path):
-    td.config.logging_level = "ERROR"
-    td.config.log_suppression = True
+    td.config.logging.level = "ERROR"
+    td.config.logging.suppression = True
 
     def objective(scale: float) -> float:
         modeler = build_modal_modeler(scale)
@@ -240,8 +240,8 @@ def test_component_modeler_autograd_error_with_element_mappings(
     patch_web_autograd_emulator, tmp_path
 ):
     """Verify that we get the expected error when running a component modeler with `element_mappings` in autograd."""
-    td.config.logging_level = "ERROR"
-    td.config.log_suppression = True
+    td.config.logging.level = "ERROR"
+    td.config.logging.suppression = True
 
     def objective(scale: float) -> float:
         modeler = build_modal_modeler(scale)
@@ -250,7 +250,7 @@ def test_component_modeler_autograd_error_with_element_mappings(
         right = ("p2", 0)
 
         element_mappings = [
-            ((left, right), (right, left), 1.0),
+            ((left, right), (right, left), 1.0 + 0j),
         ]
 
         modeler_with_mappings = modeler.updated_copy(element_mappings=element_mappings)
@@ -266,8 +266,8 @@ def test_component_modeler_autograd_error_with_element_mappings(
 
 
 def test_component_modeler_autograd_tracing_modeler_run(patch_web_autograd_emulator, tmp_path):
-    td.config.logging_level = "ERROR"
-    td.config.log_suppression = True
+    td.config.logging.level = "ERROR"
+    td.config.logging.suppression = True
 
     def objective(scale: float) -> float:
         modeler = build_modal_modeler(scale)
@@ -295,8 +295,8 @@ def test_terminal_component_modeler_autograd_tracing_stubbed(
     a stub to keep the test fast and robust.
     """
 
-    td.config.logging_level = "ERROR"
-    td.config.log_suppression = True
+    td.config.logging.level = "ERROR"
+    td.config.logging.suppression = True
 
     # Minimal stub: reduce first available FieldData per port over space (keep f), place on diagonal
     def _fake_terminal_construct_smatrix(
@@ -359,8 +359,8 @@ def test_terminal_component_modeler_autograd_tracing_modeler_run_stubbed(
 ):
     """Same as terminal autograd test, but running via modeler.run()."""
 
-    td.config.logging_level = "ERROR"
-    td.config.log_suppression = True
+    td.config.logging.level = "ERROR"
+    td.config.logging.suppression = True
 
     def _fake_terminal_construct_smatrix(
         modeler_data, assume_ideal_excitation=False, s_param_def="pseudo"

--- a/tests/test_plugins/smatrix/test_terminal_component_modeler.py
+++ b/tests/test_plugins/smatrix/test_terminal_component_modeler.py
@@ -1397,12 +1397,12 @@ def test_run_only_and_element_mappings(monkeypatch, tmp_path):
     S21 = (port1_idx, port0_idx)
     S12 = (port0_idx, port1_idx)
     S22 = (port1_idx, port1_idx)
-    element_mappings = ((S11, S22, 1),)
+    element_mappings = ((S11, S22, 1 + 0j),)
     modeler_with_mappings = modeler.updated_copy(element_mappings=element_mappings)
     assert len(modeler_with_mappings.sim_dict) == 2
 
     # Column 1 is mapped to column 2, resulting in one simulation
-    element_mappings = ((S11, S22, 1), (S21, S12, 1))
+    element_mappings = ((S11, S22, 1 + 0j), (S21, S12, 1 + 0j))
     modeler_with_mappings = modeler.updated_copy(element_mappings=element_mappings)
     tcm_data = run_component_modeler(monkeypatch, modeler_with_mappings)
     s_matrix = tcm_data.smatrix().data
@@ -1411,7 +1411,7 @@ def test_run_only_and_element_mappings(monkeypatch, tmp_path):
     assert len(modeler_with_mappings.sim_dict) == 1
 
     # Mapping is incomplete, so two simulations are run
-    element_mappings = ((S11, S22, 1), (S12, S21, 1))
+    element_mappings = ((S11, S22, 1 + 0j), (S12, S21, 1 + 0j))
     modeler_with_mappings = modeler.updated_copy(element_mappings=element_mappings)
     assert len(modeler_with_mappings.sim_dict) == 2
 

--- a/tests/test_plugins/test_invdes.py
+++ b/tests/test_plugins/test_invdes.py
@@ -333,9 +333,9 @@ def test_warn_zero_grad(use_emulated_run):  # noqa: F811
     design_region = optimizer.design.design_region.updated_copy(penalties=())
     design = optimizer.design.updated_copy(design_region=design_region)
     optimizer = optimizer.updated_copy(design=design)
-
-    with pytest.raises(SetupError, match="All elements of the gradient are exactly zero"):
-        optimizer.run(post_process_fn=post_process_fn_untraced)
+    with pytest.warns(UserWarning, match=r"Output seems independent of input"):
+        with pytest.raises(SetupError, match=r"All elements of the gradient are exactly zero"):
+            optimizer.run(post_process_fn=post_process_fn_untraced)
 
 
 def test_scaled_objective_grad_not_filtered(use_emulated_run):  # noqa: F811

--- a/tests/test_web/test_local_cache.py
+++ b/tests/test_web/test_local_cache.py
@@ -85,7 +85,7 @@ def basic_simulation():
         size=(1, 1, 1),
         grid_spec=td.GridSpec.auto(wavelength=1.0),
         run_time=1e-12,
-        sources=[pt_dipole],
+        sources=(pt_dipole,),
     )
 
 

--- a/tests/test_web/test_material_fitter.py
+++ b/tests/test_web/test_material_fitter.py
@@ -4,11 +4,12 @@ import pytest
 import responses
 
 import tidy3d as td
+from tidy3d import config
 from tidy3d.plugins.dispersion import DispersionFitter
 from tidy3d.web.api.material_fitter import FitterOptions, MaterialFitterTask
 from tidy3d.web.core.environment import Env
 
-Env.dev.active()
+config.switch_profile("dev")
 
 
 @pytest.fixture

--- a/tests/test_web/test_tidy3d_folder.py
+++ b/tests/test_web/test_tidy3d_folder.py
@@ -5,10 +5,11 @@ import responses
 from responses import matchers
 
 import tidy3d as td
+from tidy3d import config
 from tidy3d.web.core.environment import Env
 from tidy3d.web.core.task_core import Folder
 
-Env.dev.active()
+config.switch_profile("dev")
 
 
 @pytest.fixture

--- a/tests/test_web/test_tidy3d_material_library.py
+++ b/tests/test_web/test_tidy3d_material_library.py
@@ -4,10 +4,11 @@ import pytest
 import responses
 
 import tidy3d as td
+from tidy3d import config
 from tidy3d.web.api.material_library import MaterialLibrary
 from tidy3d.web.core.environment import Env
 
-Env.dev.active()
+config.switch_profile("dev")
 
 
 @pytest.fixture

--- a/tests/test_web/test_tidy3d_stub.py
+++ b/tests/test_web/test_tidy3d_stub.py
@@ -9,6 +9,7 @@ import responses
 
 import tidy3d as td
 from tests.utils import AssertLogLevel
+from tidy3d import config
 from tidy3d.components.data.data_array import ScalarFieldDataArray
 from tidy3d.components.data.monitor_data import FieldData
 from tidy3d.components.data.sim_data import SimulationData
@@ -17,17 +18,9 @@ from tidy3d.components.monitor import FieldMonitor
 from tidy3d.components.source.current import PointDipole
 from tidy3d.components.source.time import GaussianPulse
 from tidy3d.web.api.tidy3d_stub import Tidy3dStub, Tidy3dStubData
-from tidy3d.web.core.environment import Env, EnvironmentConfig
 from tidy3d.web.core.types import TaskType
 
-test_env = EnvironmentConfig(
-    name="test",
-    s3_region="test",
-    web_api_endpoint="https://test",
-    website_endpoint="https://test",
-)
-
-Env.set_current(test_env)
+config.switch_profile("test")
 
 
 def make_sim():

--- a/tests/test_web/test_tidy3d_task.py
+++ b/tests/test_web/test_tidy3d_task.py
@@ -7,19 +7,13 @@ import responses
 from responses import matchers
 
 import tidy3d as td
+from tidy3d import config
 from tidy3d.web.core import http_util
-from tidy3d.web.core.environment import Env, EnvironmentConfig
+from tidy3d.web.core.environment import Env
 from tidy3d.web.core.task_core import Folder, SimulationTask
 from tidy3d.web.core.types import PayType, TaskType
 
-test_env = EnvironmentConfig(
-    name="test",
-    s3_region="test",
-    web_api_endpoint="https://test",
-    website_endpoint="https://test",
-)
-
-Env.set_current(test_env)
+config.switch_profile("test")
 
 
 def make_sim():

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -16,7 +16,7 @@ from responses import matchers
 
 import tidy3d as td
 from tests.test_web.test_tidy3d_stub import is_lazy_object
-from tidy3d import Simulation
+from tidy3d import Simulation, config
 from tidy3d.__main__ import main
 from tidy3d.components.data.data_array import ScalarFieldDataArray
 from tidy3d.components.data.monitor_data import FieldData
@@ -67,7 +67,7 @@ INVALID_TASK_ID = "INVALID_TASK_ID"
 task_core_path = "tidy3d.web.core.task_core"
 api_path = "tidy3d.web.api.webapi"
 
-Env.dev.active()
+config.switch_profile("dev")
 
 
 class FakeJob:

--- a/tests/test_web/test_webapi_account.py
+++ b/tests/test_web/test_webapi_account.py
@@ -5,6 +5,7 @@ import pytest
 import responses
 
 import tidy3d as td
+from tidy3d import config
 from tidy3d.web.api.webapi import (
     account,
 )
@@ -13,7 +14,7 @@ from tidy3d.web.core.environment import Env
 task_core_path = "tidy3d.web.core.task_core"
 api_path = "tidy3d.web.api.webapi"
 
-Env.dev.active()
+config.switch_profile("dev")
 
 
 @pytest.fixture

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -618,13 +618,13 @@ SIM_FULL = td.Simulation(
             medium=td.Medium(
                 nonlinear_spec=td.NonlinearSpec(
                     num_iters=10,
-                    models=[
+                    models=(
                         td.NonlinearSusceptibility(chi3=0.1),
                         td.TwoPhotonAbsorption(
                             beta=1, sigma=1, tau=1, e_e=1, e_h=0.8, c_e=1, c_h=1
                         ),
                         td.KerrNonlinearity(n2=1),
-                    ],
+                    ),
                 )
             ),
         ),
@@ -1304,7 +1304,7 @@ def run_emulated(simulation: td.Simulation, path=None, **kwargs) -> td.Simulatio
 
     def make_medium_data(monitor: td.MediumMonitor) -> td.MediumData:
         """make a random PermittivityData from a PermittivityMonitor."""
-        field_mnt = td.FieldMonitor(**monitor.dict(exclude={"type", "fields"}))
+        field_mnt = td.FieldMonitor(**monitor.model_dump(exclude={"type", "fields"}))
         field_data = make_field_data(monitor=field_mnt)
         return td.MediumData(
             monitor=monitor,

--- a/tidy3d/components/apodization.py
+++ b/tidy3d/components/apodization.py
@@ -37,21 +37,21 @@ class ApodizationSpec(Tidy3dBaseModel):
         None,
         title="Start Interval",
         description="Defines the time at which the start apodization ends.",
-        units=SECOND,
+        json_schema_extra={"units": SECOND},
     )
 
     end: Optional[NonNegativeFloat] = Field(
         None,
         title="End Interval",
         description="Defines the time at which the end apodization begins.",
-        units=SECOND,
+        json_schema_extra={"units": SECOND},
     )
 
     width: Optional[PositiveFloat] = Field(
         None,
         title="Apodization Width",
         description="Characteristic decay length of the apodization function, i.e., the width of the ramping up of the scaling function from 0 to 1.",
-        units=SECOND,
+        json_schema_extra={"units": SECOND},
     )
 
     @model_validator(mode="after")

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -975,7 +975,7 @@ class DerivativeInfo:
             if min_allowed_spacing_fraction is None:
                 min_allowed_spacing_fraction = config.adjoint.minimum_spacing_fraction
 
-        def spacing_by_permittivity(eps_array: ScalarFieldDataArray) -> np.ndarray:
+        def spacing_by_permittivity(eps_array: ScalarFieldDataArray) -> float:
             eps_real = np.asarray(eps_array.values, dtype=np.complex128).real
 
             dx_candidates = []

--- a/tidy3d/components/base_sim/data/sim_data.py
+++ b/tidy3d/components/base_sim/data/sim_data.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import pathlib
 from abc import ABC
-from os import PathLike
-from typing import Optional, TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import numpy as np
 from pydantic import Field, field_validator, model_validator

--- a/tidy3d/components/beam.py
+++ b/tidy3d/components/beam.py
@@ -38,13 +38,13 @@ class BeamProfile(Box):
         title="Sampling resolution",
         description="Sampling resolution in the tangential directions of the beam (defines a "
         "number of equally spaced points).",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     freqs: FreqArray = Field(
         title="Frequencies",
         description="List of frequencies at which the beam is sampled.",
-        units=HERTZ,
+        json_schema_extra={"units": HERTZ},
     )
 
     background_medium: MediumType = Field(
@@ -57,7 +57,7 @@ class BeamProfile(Box):
         0.0,
         title="Polar Angle",
         description="Polar angle of the propagation axis from the normal axis.",
-        units=RADIAN,
+        json_schema_extra={"units": RADIAN},
     )
 
     angle_phi: float = Field(
@@ -65,7 +65,7 @@ class BeamProfile(Box):
         title="Azimuth Angle",
         description="Azimuth angle of the propagation axis in the plane orthogonal to the "
         "normal axis.",
-        units=RADIAN,
+        json_schema_extra={"units": RADIAN},
     )
 
     pol_angle: float = Field(
@@ -79,7 +79,7 @@ class BeamProfile(Box):
         "- ``Ey`` polarization for propagation along ``x``."
         "- ``Ex`` polarization for propagation along ``y``."
         "- ``Ex`` polarization for propagation along ``z``.",
-        units=RADIAN,
+        json_schema_extra={"units": RADIAN},
     )
 
     direction: Direction = Field(
@@ -370,7 +370,7 @@ class GaussianBeamProfile(BeamProfile):
         1.0,
         title="Waist Radius",
         description="Radius of the beam at the waist.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     waist_distance: float = Field(
@@ -382,7 +382,7 @@ class GaussianBeamProfile(BeamProfile):
         "means the beam waist is positioned in the ``-`` direction (behind the beam). "
         "A negative value means the beam waist is in the ``+`` direction (in front of the beam). "
         "For an angled beam, the distance is defined along the rotated propagation direction.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
     _backward_waist_warning = warn_backward_waist_distance("waist_distance")
 
@@ -439,7 +439,7 @@ class AstigmaticGaussianBeamProfile(BeamProfile):
         (1.0, 1.0),
         title="Waist sizes",
         description="Size of the beam at the waist in the local x and y directions.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     waist_distances: tuple[float, float] = Field(
@@ -451,7 +451,7 @@ class AstigmaticGaussianBeamProfile(BeamProfile):
         "is on the ``-`` side (behind) the beam plane. When ``direction`` is ``+`` and "
         "``waist_distances`` are negative, the waist is on the ``+`` side (in front) of "
         "the beam plane.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
     _backward_waist_warning = warn_backward_waist_distance("waist_distances")
 

--- a/tidy3d/components/boundary.py
+++ b/tidy3d/components/boundary.py
@@ -135,7 +135,7 @@ class ABCBoundary(AbstractABCBoundary):
         description="Effective conductivity for determining propagation constant. "
         "If ``None``, this value will be automatically inferred from the medium at "
         "the domain boundary and the central frequency of the source.",
-        units=CONDUCTIVITY,
+        json_schema_extra={"units": CONDUCTIVITY},
     )
 
     @model_validator(mode="after")
@@ -199,7 +199,7 @@ class BroadbandModeABCSpec(Tidy3dBaseModel):
     frequency_range: FreqBound = Field(
         title="Frequency Range",
         description="Frequency range for the broadband mode absorption boundary conditions.",
-        units=(HERTZ, HERTZ),
+        json_schema_extra={"units": (HERTZ, HERTZ)},
     )
 
     fit_param: BroadbandModeABCFitterParam = Field(
@@ -605,14 +605,14 @@ class AbsorberParams(Tidy3dBaseModel):
         0.0,
         title="Sigma Minimum",
         description="Minimum value of the absorber conductivity.",
-        units=PML_SIGMA,
+        json_schema_extra={"units": PML_SIGMA},
     )
 
     sigma_max: NonNegativeFloat = Field(
         1.5,
         title="Sigma Maximum",
         description="Maximum value of the absorber conductivity.",
-        units=PML_SIGMA,
+        json_schema_extra={"units": PML_SIGMA},
     )
 
 
@@ -643,11 +643,17 @@ class PMLParams(AbsorberParams):
     )
 
     alpha_min: NonNegativeFloat = Field(
-        0.0, title="Alpha Minimum", description="Minimum value of the PML alpha.", units=PML_SIGMA
+        0.0,
+        title="Alpha Minimum",
+        description="Minimum value of the PML alpha.",
+        json_schema_extra={"units": PML_SIGMA},
     )
 
     alpha_max: NonNegativeFloat = Field(
-        1.5, title="Alpha Maximum", description="Maximum value of the PML alpha.", units=PML_SIGMA
+        1.5,
+        title="Alpha Maximum",
+        description="Maximum value of the PML alpha.",
+        json_schema_extra={"units": PML_SIGMA},
     )
 
 

--- a/tidy3d/components/data/data_array.py
+++ b/tidy3d/components/data/data_array.py
@@ -727,12 +727,12 @@ class AbstractSpatialDataArray(DataArray, ABC):
                     if smin < coord[0]:
                         ind_min = 0
                     else:
-                        ind_min = max(0, (coord >= smin).argmax().data - 1)
+                        ind_min = max(0, (coord >= smin).data.argmax() - 1)
 
                     if smax > coord[-1]:
                         ind_max = length - 1
                     else:
-                        ind_max = (coord >= smax).argmax().data
+                        ind_max = (coord >= smax).data.argmax()
 
                     comp_inds = np.arange(ind_min, ind_max + 1)
 

--- a/tidy3d/components/data/dataset.py
+++ b/tidy3d/components/data/dataset.py
@@ -710,7 +710,7 @@ class ModeSolverDataset(ElectromagneticFieldDataset, ModeFreqDataset):
         None,
         title="Dispersion",
         description="Dispersion parameter for the mode.",
-        units=PICOSECOND_PER_NANOMETER_PER_KILOMETER,
+        json_schema_extra={"units": PICOSECOND_PER_NANOMETER_PER_KILOMETER},
     )
 
     @property

--- a/tidy3d/components/data/monitor_data.py
+++ b/tidy3d/components/data/monitor_data.py
@@ -3355,7 +3355,9 @@ class FieldProjectionAngleData(AbstractFieldProjectionData):
         slice_opposite_phi = slice_opposite_phi.assign_coords(
             theta=(2 * np.pi - slice_opposite_phi.theta)
         )
-        data_array = xr.concat((slice_phi, slice_opposite_phi), dim="theta").sortby("theta")
+        data_array = xr.concat(
+            (slice_phi, slice_opposite_phi), dim="theta", coords="minimal", compat="override"
+        ).sortby("theta")
         return FieldProjectionAngleDataArray(data_array)
 
 
@@ -3694,7 +3696,7 @@ class DiffractionData(AbstractFieldProjectionData):
     sim_size: tuple[float, float] = Field(
         title="Domain size",
         description="Size of the near field in the local x and y directions.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     bloch_vecs: Union[tuple[float, float], tuple[ArrayFloat1D, ArrayFloat1D]] = Field(

--- a/tidy3d/components/eme/grid.py
+++ b/tidy3d/components/eme/grid.py
@@ -48,7 +48,7 @@ class EMEModeSpec(ModeSpec):
         description="Polar angle of the propagation axis from the injection axis. Not currently "
         "supported in EME cells. Use an additional 'ModeSolverMonitor' and "
         "'sim_data.smatrix_in_basis' to achieve off-normal injection in EME.",
-        units=RADIAN,
+        json_schema_extra={"units": RADIAN},
     )
 
     angle_phi: Literal[0.0] = Field(
@@ -58,7 +58,7 @@ class EMEModeSpec(ModeSpec):
         "injection axis. Not currently supported in EME cells. Use an additional "
         "'ModeSolverMonitor' and 'sim_data.smatrix_in_basis' to achieve off-normal "
         "injection in EME.",
-        units=RADIAN,
+        json_schema_extra={"units": RADIAN},
     )
 
     precision: Literal["auto", "single", "double"] = Field(

--- a/tidy3d/components/field_projection.py
+++ b/tidy3d/components/field_projection.py
@@ -223,7 +223,7 @@ class FieldProjector(Tidy3dBaseModel):
         title="Local origin",
         description="Local origin used for defining observation points. If ``None``, uses the "
         "average of the centers of all surface monitors.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     @model_validator(mode="after")

--- a/tidy3d/components/frequencies.py
+++ b/tidy3d/components/frequencies.py
@@ -279,14 +279,14 @@ class FreqRange(Tidy3dBaseModel):
         ...,
         title="Central frequency",
         description="Real-valued positive central frequency.",
-        units="Hz",
+        json_schema_extra={"units": "Hz"},
     )
 
     fwidth: PositiveFloat = Field(
         ...,
         title="Frequency bandwidth",
         description="Real-valued positive width of the frequency range (bandwidth).",
-        units="Hz",
+        json_schema_extra={"units": "Hz"},
     )
 
     @model_validator(mode="after")

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -1567,7 +1567,7 @@ class Centered(Geometry, ABC):
         None,
         title="Center",
         description="Center of object in x, y, and z.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     @field_validator("center", mode="before")
@@ -1692,7 +1692,7 @@ class Planar(SimplePlaneIntersection, Geometry, ABC):
         "along the ``axis`` direction; "
         "and ``-np.pi/2<sidewall_angle<0`` specifies an expanding cross section "
         "along the ``axis`` direction.",
-        units=RADIAN,
+        json_schema_extra={"units": RADIAN},
     )
 
     reference_plane: PlanePosition = Field(
@@ -1884,7 +1884,7 @@ class Circular(Geometry):
     radius: NonNegativeFloat = Field(
         title="Radius",
         description="Radius of geometry.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     @field_validator("radius")
@@ -1931,7 +1931,7 @@ class Box(SimplePlaneIntersection, Centered):
     size: TracedSize = Field(
         title="Size",
         description="Size in x, y, and z directions.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     @classmethod

--- a/tidy3d/components/geometry/polyslab.py
+++ b/tidy3d/components/geometry/polyslab.py
@@ -84,7 +84,7 @@ class PolySlab(base.Planar):
     slab_bounds: tuple[TracedFloat, TracedFloat] = Field(
         title="Slab Bounds",
         description="Minimum and maximum positions of the slab along axis dimension.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     dilation: float = Field(
@@ -92,7 +92,7 @@ class PolySlab(base.Planar):
         title="Dilation",
         description="Dilation of the supplied polygon by shifting each edge along its "
         "normal outwards direction by a distance; a negative value corresponds to erosion.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     vertices: TracedArrayFloat2D = Field(
@@ -101,7 +101,7 @@ class PolySlab(base.Planar):
         "face vertices at the ``reference_plane``. "
         "The index of dimension should be in the ascending order: e.g. if "
         "the slab normal axis is ``axis=y``, the coordinate of the vertices will be in (x, z)",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     @staticmethod

--- a/tidy3d/components/geometry/primitives.py
+++ b/tidy3d/components/geometry/primitives.py
@@ -379,13 +379,13 @@ class Cylinder(base.Centered, base.Circular, base.Planar):
     radius: TracedSize1D = Field(
         title="Radius",
         description="Radius of geometry at the ``reference_plane``.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     length: TracedSize1D = Field(
         title="Length",
         description="Defines thickness of cylinder along axis dimension.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     @model_validator(mode="after")

--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -300,7 +300,7 @@ class UniformGrid(GridSpec1d):
     dl: PositiveFloat = Field(
         title="Grid Size",
         description="Grid size for uniform grid generation.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     @field_validator("dl")
@@ -385,7 +385,7 @@ class CustomGridBoundaries(GridSpec1d):
     coords: Coords1D = Field(
         title="Grid Boundary Coordinates",
         description="An array of grid boundary coordinates.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     def _make_coords_initial(
@@ -472,7 +472,7 @@ class CustomGrid(GridSpec1d):
         "``(center - sum(dl)/2, center + sum(dl)/2)``, unless a ``custom_offset`` is given. "
         "Note: if supplied sizes do not cover the simulation size, the first and last sizes "
         "are repeated to cover the simulation domain.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     custom_offset: Optional[float] = Field(
@@ -481,7 +481,7 @@ class CustomGrid(GridSpec1d):
         description="The starting coordinate of the grid which defines the simulation center. "
         "If ``None``, the simulation center is set such that it spans the region "
         "``(center - sum(dl)/2, center + sum(dl)/2)``.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     def _make_coords_initial(
@@ -572,7 +572,7 @@ class AbstractAutoGrid(GridSpec1d):
         "with ``enforced=True``. It is a soft bound, meaning that the actual minimal "
         "grid size might be slightly smaller. If ``None`` or 0, a heuristic lower bound "
         "value will be applied.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     @abstractmethod
@@ -823,7 +823,7 @@ class QuasiUniformGrid(AbstractAutoGrid):
         title="Grid Size",
         description="Grid size for quasi-uniform grid generation. Grid size at some locations can be "
         "slightly smaller.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     def _preprocessed_structures(self, structures: list[StructureType]) -> list[StructureType]:
@@ -1012,7 +1012,7 @@ class GridRefinement(Tidy3dBaseModel):
         None,
         title="Grid Size",
         description="Grid step size in the refined region.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     num_cells: PositiveInt = Field(
@@ -2469,7 +2469,7 @@ class GridSpec(Tidy3dBaseModel):
         "the source central frequency. "
         "Note: it only takes effect when at least one of the three dimensions "
         "uses :class:`.AutoGrid`.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     override_structures: tuple[discriminated_union(StructureType), ...] = Field(

--- a/tidy3d/components/lumped_element.py
+++ b/tidy3d/components/lumped_element.py
@@ -298,7 +298,7 @@ class LumpedResistor(RectangularLumpedElement):
     resistance: PositiveFloat = Field(
         title="Resistance",
         description="Resistance value in ohms.",
-        unit=OHM,
+        json_schema_extra={"units": OHM},
     )
 
     def _sheet_conductance(self, box: Optional[Box] = None) -> float:
@@ -333,26 +333,26 @@ class CoaxialLumpedResistor(LumpedElement):
     resistance: PositiveFloat = Field(
         title="Resistance",
         description="Resistance value in ohms.",
-        unit=OHM,
+        json_schema_extra={"units": OHM},
     )
 
     center: Coordinate = Field(
         (0.0, 0.0, 0.0),
         title="Center",
         description="Center of object in x, y, and z.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     outer_diameter: PositiveFloat = Field(
         title="Outer Diameter",
         description="Diameter of the outer concentric circle.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     inner_diameter: PositiveFloat = Field(
         title="Inner Diameter",
         description="Diameter of the inner concentric circle.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     normal_axis: Axis = Field(
@@ -577,21 +577,21 @@ class RLCNetwork(MicrowaveBaseModel):
         None,
         title="Resistance",
         description="Resistance value in ohms.",
-        unit=OHM,
+        json_schema_extra={"units": OHM},
     )
 
     capacitance: Optional[PositiveFloat] = Field(
         None,
         title="Capacitance",
         description="Capacitance value in farads.",
-        unit=FARAD,
+        json_schema_extra={"units": FARAD},
     )
 
     inductance: Optional[PositiveFloat] = Field(
         None,
         title="Inductance",
         description="Inductance value in henrys.",
-        unit=HENRY,
+        json_schema_extra={"units": HENRY},
     )
 
     network_topology: Literal["series", "parallel"] = Field(

--- a/tidy3d/components/material/tcad/charge.py
+++ b/tidy3d/components/material/tcad/charge.py
@@ -34,7 +34,7 @@ class AbstractChargeMedium(AbstractMedium):
         ge=1.0,
         title="Permittivity",
         description="Relative permittivity.",
-        units=PERMITTIVITY,
+        json_schema_extra={"units": PERMITTIVITY},
     )
 
     @property
@@ -85,7 +85,7 @@ class ChargeConductorMedium(AbstractChargeMedium):
     conductivity: PositiveFloat = Field(
         title="Electric conductivity",
         description="Electric conductivity of material.",
-        units=CONDUCTIVITY,
+        json_schema_extra={"units": CONDUCTIVITY},
     )
 
 
@@ -265,19 +265,19 @@ class SemiconductorMedium(AbstractChargeMedium):
     N_c: Union[EffectiveDOSModelType, PositiveFloat] = Field(
         title="Effective density of electron states",
         description=":math:`N_c` Effective density of states in the conduction band.",
-        units=PERCMCUBE,
+        json_schema_extra={"units": PERCMCUBE},
     )
 
     N_v: Union[EffectiveDOSModelType, PositiveFloat] = Field(
         title="Effective density of hole states",
         description=":math:`N_v` Effective density of states in the valence band.",
-        units=PERCMCUBE,
+        json_schema_extra={"units": PERCMCUBE},
     )
 
     E_g: Union[EnergyBandGapModelType, PositiveFloat] = Field(
         title="Band-gap energy",
         description=":math:`E_g` Band-gap energy",
-        units=ELECTRON_VOLT,
+        json_schema_extra={"units": ELECTRON_VOLT},
     )
 
     mobility_n: MobilityModelType = Field(
@@ -300,7 +300,7 @@ class SemiconductorMedium(AbstractChargeMedium):
         None,
         title="Bandgap narrowing model.",
         description=":math:`\\Delta E_g` Bandgap narrowing model.",
-        units=ELECTRON_VOLT,
+        json_schema_extra={"units": ELECTRON_VOLT},
     )
 
     N_a: Union[
@@ -314,7 +314,7 @@ class SemiconductorMedium(AbstractChargeMedium):
         description="Concentration of acceptor impurities, which create mobile holes, resulting in p-type material. "
         "Can be specified as a single float for uniform doping, a :class:`SpatialDataArray` for a custom profile, "
         "or a tuple/list of geometric shapes to define specific doped regions.",
-        units=PERCMCUBE,
+        json_schema_extra={"units": PERCMCUBE},
     )
 
     N_d: Union[
@@ -328,7 +328,7 @@ class SemiconductorMedium(AbstractChargeMedium):
         description="Concentration of donor impurities, which create mobile electrons, resulting in n-type material. "
         "Can be specified as a single float for uniform doping, a :class:`SpatialDataArray` for a custom profile, "
         "or a tuple/list of geometric shapes to define specific doped regions.",
-        units=PERCMCUBE,
+        json_schema_extra={"units": PERCMCUBE},
     )
 
     # DEPRECATION VALIDATORS

--- a/tidy3d/components/material/tcad/heat.py
+++ b/tidy3d/components/material/tcad/heat.py
@@ -93,31 +93,31 @@ class FluidMedium(AbstractHeatMedium):
         default=None,
         title="Fluid Thermal Conductivity",
         description="Thermal conductivity (k) of the fluid.",
-        units=THERMAL_CONDUCTIVITY,
+        json_schema_extra={"units": THERMAL_CONDUCTIVITY},
     )
     viscosity: Optional[NonNegativeFloat] = Field(
         default=None,
         title="Fluid Dynamic Viscosity",
         description="Dynamic viscosity (μ) of the fluid.",
-        units=DYNAMIC_VISCOSITY,
+        json_schema_extra={"units": DYNAMIC_VISCOSITY},
     )
     specific_heat: Optional[NonNegativeFloat] = Field(
         default=None,
         title="Fluid Specific Heat",
         description="Specific heat of the fluid at constant pressure.",
-        units=SPECIFIC_HEAT,
+        json_schema_extra={"units": SPECIFIC_HEAT},
     )
     density: Optional[NonNegativeFloat] = Field(
         default=None,
         title="Fluid Density",
         description="Density (ρ) of the fluid.",
-        units=DENSITY,
+        json_schema_extra={"units": DENSITY},
     )
     expansivity: Optional[NonNegativeFloat] = Field(
         default=None,
         title="Fluid Thermal Expansivity",
         description="Thermal expansion coefficient (β) of the fluid.",
-        units=THERMAL_EXPANSIVITY,
+        json_schema_extra={"units": THERMAL_EXPANSIVITY},
     )
 
     @classmethod
@@ -163,20 +163,20 @@ class SolidMedium(AbstractHeatMedium):
         None,
         title="Heat capacity",
         description=f"Specific heat capacity in unit of {SPECIFIC_HEAT_CAPACITY}.",
-        units=SPECIFIC_HEAT_CAPACITY,
+        json_schema_extra={"units": SPECIFIC_HEAT_CAPACITY},
     )
 
     conductivity: PositiveFloat = Field(
         title="Thermal conductivity",
         description=f"Thermal conductivity of material in units of {THERMAL_CONDUCTIVITY}.",
-        units=THERMAL_CONDUCTIVITY,
+        json_schema_extra={"units": THERMAL_CONDUCTIVITY},
     )
 
     density: Optional[PositiveFloat] = Field(
         None,
         title="Density",
         description=f"Mass density of material in units of {DENSITY}.",
-        units=DENSITY,
+        json_schema_extra={"units": DENSITY},
     )
 
     @classmethod

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -188,7 +188,7 @@ class AbstractMedium(ABC, Tidy3dBaseModel):
         None,
         title="Frequency Range",
         description="Optional range of validity for the medium.",
-        units=(HERTZ, HERTZ),
+        json_schema_extra={"units": (HERTZ, HERTZ)},
     )
 
     allow_gain: bool = Field(
@@ -1523,7 +1523,11 @@ class Medium(AbstractMedium):
     """
 
     permittivity: TracedFloat = Field(
-        1.0, ge=1.0, title="Permittivity", description="Relative permittivity.", units=PERMITTIVITY
+        1.0,
+        ge=1.0,
+        title="Permittivity",
+        description="Relative permittivity.",
+        json_schema_extra={"units": PERMITTIVITY},
     )
 
     conductivity: TracedFloat = Field(
@@ -1531,7 +1535,7 @@ class Medium(AbstractMedium):
         title="Conductivity",
         description="Electric conductivity. Defined such that the imaginary part of the complex "
         "permittivity at angular frequency omega is given by conductivity/omega.",
-        units=CONDUCTIVITY,
+        json_schema_extra={"units": CONDUCTIVITY},
     )
 
     @model_validator(mode="after")
@@ -1712,7 +1716,7 @@ class CustomIsotropicMedium(AbstractCustomMedium, Medium):
     permittivity: CustomSpatialDataTypeAnnotated = Field(
         title="Permittivity",
         description="Relative permittivity.",
-        units=PERMITTIVITY,
+        json_schema_extra={"units": PERMITTIVITY},
     )
 
     conductivity: Optional[CustomSpatialDataTypeAnnotated] = Field(
@@ -1720,7 +1724,7 @@ class CustomIsotropicMedium(AbstractCustomMedium, Medium):
         title="Conductivity",
         description="Electric conductivity. Defined such that the imaginary part of the complex "
         "permittivity at angular frequency omega is given by conductivity/omega.",
-        units=CONDUCTIVITY,
+        json_schema_extra={"units": CONDUCTIVITY},
     )
 
     _no_nans = validate_no_nans("permittivity", "conductivity")
@@ -1894,7 +1898,7 @@ class CustomMedium(AbstractCustomMedium):
         None,
         title="Permittivity",
         description="Spatial profile of relative permittivity.",
-        units=PERMITTIVITY,
+        json_schema_extra={"units": PERMITTIVITY},
     )
 
     conductivity: Optional[CustomSpatialDataTypeAnnotated] = Field(
@@ -1903,7 +1907,7 @@ class CustomMedium(AbstractCustomMedium):
         description="Spatial profile Electric conductivity. Defined such "
         "that the imaginary part of the complex permittivity at angular "
         "frequency omega is given by conductivity/omega.",
-        units=CONDUCTIVITY,
+        json_schema_extra={"units": CONDUCTIVITY},
     )
 
     _no_nans = validate_no_nans("eps_dataset", "permittivity", "conductivity")
@@ -2962,14 +2966,14 @@ class PoleResidue(DispersiveMedium):
         1.0,
         title="Epsilon at Infinity",
         description="Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).",
-        units=PERMITTIVITY,
+        json_schema_extra={"units": PERMITTIVITY},
     )
 
     poles: TracedPolesAndResidues = Field(
         (),
         title="Poles",
         description="Tuple of complex-valued (:math:`a_i, c_i`) poles for the model.",
-        units=(RADPERSEC, RADPERSEC),
+        json_schema_extra={"units": (RADPERSEC, RADPERSEC)},
     )
 
     @field_validator("poles")
@@ -3550,7 +3554,7 @@ class CustomPoleResidue(CustomDispersiveMedium, PoleResidue):
     eps_inf: CustomSpatialDataTypeAnnotated = Field(
         title="Epsilon at Infinity",
         description="Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).",
-        units=PERMITTIVITY,
+        json_schema_extra={"units": PERMITTIVITY},
     )
 
     poles: tuple[tuple[CustomSpatialDataTypeAnnotated, CustomSpatialDataTypeAnnotated], ...] = (
@@ -3558,7 +3562,7 @@ class CustomPoleResidue(CustomDispersiveMedium, PoleResidue):
             (),
             title="Poles",
             description="Tuple of complex-valued (:math:`a_i, c_i`) poles for the model.",
-            units=(RADPERSEC, RADPERSEC),
+            json_schema_extra={"units": (RADPERSEC, RADPERSEC)},
         )
     )
 
@@ -3865,7 +3869,7 @@ class Sellmeier(DispersiveMedium):
     coeffs: tuple[tuple[float, PositiveFloat], ...] = Field(
         title="Coefficients",
         description="List of Sellmeier (:math:`B_i, C_i`) coefficients.",
-        units=(None, MICROMETER + "^2"),
+        json_schema_extra={"units": (None, MICROMETER + "^2")},
     )
 
     @model_validator(mode="after")
@@ -4079,7 +4083,7 @@ class CustomSellmeier(CustomDispersiveMedium, Sellmeier):
         Field(
             title="Coefficients",
             description="List of Sellmeier (:math:`B_i, C_i`) coefficients.",
-            units=(None, MICROMETER + "^2"),
+            json_schema_extra={"units": (None, MICROMETER + "^2")},
         )
     )
 
@@ -4355,13 +4359,13 @@ class Lorentz(DispersiveMedium):
         1.0,
         title="Epsilon at Infinity",
         description="Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).",
-        units=PERMITTIVITY,
+        json_schema_extra={"units": PERMITTIVITY},
     )
 
     coeffs: tuple[tuple[float, float, NonNegativeFloat], ...] = Field(
         title="Coefficients",
         description="List of (:math:`\\Delta\\epsilon_i, f_i, \\delta_i`) values for model.",
-        units=(PERMITTIVITY, HERTZ, HERTZ),
+        json_schema_extra={"units": (PERMITTIVITY, HERTZ, HERTZ)},
     )
 
     @field_validator("coeffs")
@@ -4611,7 +4615,7 @@ class CustomLorentz(CustomDispersiveMedium, Lorentz):
     eps_inf: CustomSpatialDataTypeAnnotated = Field(
         title="Epsilon at Infinity",
         description="Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).",
-        units=PERMITTIVITY,
+        json_schema_extra={"units": PERMITTIVITY},
     )
 
     coeffs: tuple[
@@ -4624,7 +4628,7 @@ class CustomLorentz(CustomDispersiveMedium, Lorentz):
     ] = Field(
         title="Coefficients",
         description="List of (:math:`\\Delta\\epsilon_i, f_i, \\delta_i`) values for model.",
-        units=(PERMITTIVITY, HERTZ, HERTZ),
+        json_schema_extra={"units": (PERMITTIVITY, HERTZ, HERTZ)},
     )
 
     _no_nans = validate_no_nans("eps_inf", "coeffs")
@@ -4882,13 +4886,13 @@ class Drude(DispersiveMedium):
         1.0,
         title="Epsilon at Infinity",
         description="Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).",
-        units=PERMITTIVITY,
+        json_schema_extra={"units": PERMITTIVITY},
     )
 
     coeffs: tuple[tuple[float, PositiveFloat], ...] = Field(
         title="Coefficients",
         description="List of (:math:`f_i, \\delta_i`) values for model.",
-        units=(HERTZ, HERTZ),
+        json_schema_extra={"units": (HERTZ, HERTZ)},
     )
 
     _validate_permittivity_modulation = DispersiveMedium._permittivity_modulation_validation()
@@ -5031,14 +5035,14 @@ class CustomDrude(CustomDispersiveMedium, Drude):
     eps_inf: CustomSpatialDataTypeAnnotated = Field(
         title="Epsilon at Infinity",
         description="Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).",
-        units=PERMITTIVITY,
+        json_schema_extra={"units": PERMITTIVITY},
     )
 
     coeffs: tuple[tuple[CustomSpatialDataTypeAnnotated, CustomSpatialDataTypeAnnotated], ...] = (
         Field(
             title="Coefficients",
             description="List of (:math:`f_i, \\delta_i`) values for model.",
-            units=(HERTZ, HERTZ),
+            json_schema_extra={"units": (HERTZ, HERTZ)},
         )
     )
 
@@ -5229,13 +5233,13 @@ class Debye(DispersiveMedium):
         1.0,
         title="Epsilon at Infinity",
         description="Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).",
-        units=PERMITTIVITY,
+        json_schema_extra={"units": PERMITTIVITY},
     )
 
     coeffs: tuple[tuple[float, PositiveFloat], ...] = Field(
         title="Coefficients",
         description="List of (:math:`\\Delta\\epsilon_i, \\tau_i`) values for model.",
-        units=(PERMITTIVITY, SECOND),
+        json_schema_extra={"units": (PERMITTIVITY, SECOND)},
     )
 
     @model_validator(mode="after")
@@ -5391,14 +5395,14 @@ class CustomDebye(CustomDispersiveMedium, Debye):
     eps_inf: CustomSpatialDataTypeAnnotated = Field(
         title="Epsilon at Infinity",
         description="Relative permittivity at infinite frequency (:math:`\\epsilon_\\infty`).",
-        units=PERMITTIVITY,
+        json_schema_extra={"units": PERMITTIVITY},
     )
 
     coeffs: tuple[tuple[CustomSpatialDataTypeAnnotated, CustomSpatialDataTypeAnnotated], ...] = (
         Field(
             title="Coefficients",
             description="List of (:math:`\\Delta\\epsilon_i, \\tau_i`) values for model.",
-            units=(PERMITTIVITY, SECOND),
+            json_schema_extra={"units": (PERMITTIVITY, SECOND)},
         )
     )
 
@@ -5673,7 +5677,7 @@ class HammerstadSurfaceRoughness(AbstractSurfaceRoughness):
     rq: PositiveFloat = Field(
         title="RMS Peak-to-Valley Height",
         description="RMS peak-to-valley height (Rq) of the surface roughness.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     roughness_factor: float = Field(
@@ -5750,7 +5754,7 @@ class HuraySurfaceRoughness(AbstractSurfaceRoughness):
         description="List of (:math:`f_i, r_i`) values for model, where :math:`f_i` is "
         "the ratio of total sphere surface area to the flat surface area, and :math:`r_i` "
         "the radius of the sphere.",
-        units=(None, MICROMETER),
+        json_schema_extra={"units": (None, MICROMETER)},
     )
 
     @classmethod
@@ -5839,14 +5843,17 @@ class LossyMetalMedium(Medium):
     )
 
     permittivity: Literal[1.0] = Field(
-        1.0, title="Permittivity", description="Relative permittivity.", units=PERMITTIVITY
+        1.0,
+        title="Permittivity",
+        description="Relative permittivity.",
+        json_schema_extra={"units": PERMITTIVITY},
     )
 
     conductivity: PositiveFloat = Field(
         title="Conductivity",
         description="Electric conductivity. Defined such that the imaginary part of the complex "
         "permittivity at angular frequency omega is given by conductivity/omega.",
-        units=CONDUCTIVITY,
+        json_schema_extra={"units": CONDUCTIVITY},
     )
 
     roughness: Optional[SurfaceRoughnessType] = Field(
@@ -5862,13 +5869,13 @@ class LossyMetalMedium(Medium):
         title="Conductor Thickness",
         description="When the thickness of the conductor is not much greater than skin depth, "
         "1D transmission line model is applied to compute the surface impedance of the thin conductor.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     frequency_range: FreqBound = Field(
         title="Frequency Range",
         description="Frequency range of validity for the medium.",
-        units=(HERTZ, HERTZ),
+        json_schema_extra={"units": (HERTZ, HERTZ)},
     )
 
     fit_param: SurfaceImpedanceFitterParam = Field(
@@ -6358,7 +6365,7 @@ class FullyAnisotropicMedium(AbstractMedium):
         [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
         title="Permittivity",
         description="Relative permittivity tensor.",
-        units=PERMITTIVITY,
+        json_schema_extra={"units": PERMITTIVITY},
     )
 
     conductivity: TensorReal = Field(
@@ -6366,7 +6373,7 @@ class FullyAnisotropicMedium(AbstractMedium):
         title="Conductivity",
         description="Electric conductivity tensor. Defined such that the imaginary part "
         "of the complex permittivity at angular frequency omega is given by conductivity/omega.",
-        units=CONDUCTIVITY,
+        json_schema_extra={"units": CONDUCTIVITY},
     )
 
     @field_validator("modulation_spec")
@@ -6979,14 +6986,14 @@ class PerturbationMedium(Medium, AbstractPerturbationMedium):
         None,
         title="Permittivity Perturbation",
         description="List of heat and/or charge perturbations to permittivity.",
-        units=PERMITTIVITY,
+        json_schema_extra={"units": PERMITTIVITY},
     )
 
     conductivity_perturbation: Optional[ParameterPerturbation] = Field(
         None,
         title="Permittivity Perturbation",
         description="List of heat and/or charge perturbations to permittivity.",
-        units=CONDUCTIVITY,
+        json_schema_extra={"units": CONDUCTIVITY},
     )
 
     _permittivity_perturbation_validator = validate_parameter_perturbation(
@@ -7155,7 +7162,7 @@ class PerturbationPoleResidue(PoleResidue, AbstractPerturbationMedium):
         title="Perturbation of Epsilon at Infinity",
         description="Perturbations to relative permittivity at infinite frequency "
         "(:math:`\\epsilon_\\infty`).",
-        units=PERMITTIVITY,
+        json_schema_extra={"units": PERMITTIVITY},
     )
 
     poles_perturbation: Optional[
@@ -7164,7 +7171,7 @@ class PerturbationPoleResidue(PoleResidue, AbstractPerturbationMedium):
         None,
         title="Perturbations of Poles",
         description="Perturbations to poles of the model.",
-        units=(RADPERSEC, RADPERSEC),
+        json_schema_extra={"units": (RADPERSEC, RADPERSEC)},
     )
 
     _eps_inf_perturbation_validator = validate_parameter_perturbation(

--- a/tidy3d/components/microwave/data/monitor_data.py
+++ b/tidy3d/components/microwave/data/monitor_data.py
@@ -397,7 +397,7 @@ class MicrowaveModeDataBase(MicrowaveBaseModel):
     def _classify_mode(self, mode_index: int) -> ModeClassification:
         """Classify mode as TEM, quasi-TEM, TE, TM, or Hybrid based on TE/TM fractions."""
         # Make quasi-TEM classification choice based on lowest frequency available
-        min_f_idx = self.wg_TE_fraction.f.argmin()
+        min_f_idx = self.wg_TE_fraction.f.data.argmin()
         low_f_TE_frac = self.wg_TE_fraction.sel(mode_index=mode_index).isel(f=min_f_idx).values
         low_f_TM_frac = self.wg_TM_fraction.sel(mode_index=mode_index).isel(f=min_f_idx).values
         # Otherwise we use the average value of the fraction across frequencies

--- a/tidy3d/components/microwave/path_integrals/specs/base.py
+++ b/tidy3d/components/microwave/path_integrals/specs/base.py
@@ -152,7 +152,7 @@ class Custom2DPathIntegralSpec(AbstractAxesRH):
         "if the axis corresponds with ``y``, the coordinates of the vertices should be (x, z). "
         "If you wish to indicate a closed contour, the final vertex should be made "
         "equal to the first vertex, i.e., ``vertices[-1] == vertices[0]``",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     @staticmethod

--- a/tidy3d/components/mode_spec.py
+++ b/tidy3d/components/mode_spec.py
@@ -493,7 +493,7 @@ class AbstractModeSpec(Tidy3dBaseModel, ABC):
         0.0,
         title="Polar Angle",
         description="Polar angle of the propagation axis from the injection axis.",
-        units=RADIAN,
+        json_schema_extra={"units": RADIAN},
     )
 
     angle_phi: float = Field(
@@ -501,7 +501,7 @@ class AbstractModeSpec(Tidy3dBaseModel, ABC):
         title="Azimuth Angle",
         description="Azimuth angle of the propagation axis in the plane orthogonal to the "
         "injection axis.",
-        units=RADIAN,
+        json_schema_extra={"units": RADIAN},
     )
 
     precision: Literal["auto", "single", "double"] = Field(
@@ -519,7 +519,7 @@ class AbstractModeSpec(Tidy3dBaseModel, ABC):
         description="A curvature radius for simulation of waveguide bends. Can be negative, in "
         "which case the mode plane center has a smaller value than the curvature center along the "
         "tangential axis perpendicular to the bend axis.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     bend_axis: Optional[Axis2D] = Field(

--- a/tidy3d/components/monitor.py
+++ b/tidy3d/components/monitor.py
@@ -95,7 +95,7 @@ class FreqMonitor(Monitor, ABC):
     freqs: FreqArray = Field(
         title="Frequencies",
         description="Array or list of frequencies stored by the field monitor.",
-        units=HERTZ,
+        json_schema_extra={"units": HERTZ},
     )
 
     apodization: ApodizationSpec = Field(
@@ -146,7 +146,7 @@ class TimeMonitor(Monitor, ABC):
         0.0,
         title="Start Time",
         description="Time at which to start monitor recording.",
-        units=SECOND,
+        json_schema_extra={"units": SECOND},
     )
 
     stop: Optional[NonNegativeFloat] = Field(
@@ -154,7 +154,7 @@ class TimeMonitor(Monitor, ABC):
         title="Stop Time",
         description="Time at which to stop monitor recording.  "
         "If not specified, record until end of simulation.",
-        units=SECOND,
+        json_schema_extra={"units": SECOND},
     )
 
     interval: Optional[PositiveInt] = Field(
@@ -947,7 +947,7 @@ class AbstractFieldProjectionMonitor(SurfaceIntegrationMonitor, FreqMonitor):
         title="Local Origin",
         description="Local origin used for defining observation points. If ``None``, uses the "
         "monitor's center.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     far_field_approx: bool = Field(
@@ -1221,21 +1221,21 @@ class FieldProjectionAngleMonitor(AbstractFieldProjectionMonitor):
         1e6,
         title="Projection Distance",
         description="Radial distance of the projection points from ``local_origin``.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     theta: ObsGridArray = Field(
         title="Polar Angles",
         description="Polar angles with respect to the global z axis, relative to the location of "
         "``local_origin``, at which to project fields.",
-        units=RADIAN,
+        json_schema_extra={"units": RADIAN},
     )
 
     phi: ObsGridArray = Field(
         title="Azimuth Angles",
         description="Azimuth angles with respect to the global z axis, relative to the location of "
         "``local_origin``, at which to project fields.",
-        units=RADIAN,
+        json_schema_extra={"units": RADIAN},
     )
 
     def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
@@ -1408,7 +1408,7 @@ class FieldProjectionCartesianMonitor(AbstractFieldProjectionMonitor):
         title="Projection Distance",
         description="Signed distance of the projection plane along ``proj_axis``. "
         "from the plane containing ``local_origin``.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     x: ObsGridArray = Field(
@@ -1417,7 +1417,7 @@ class FieldProjectionCartesianMonitor(AbstractFieldProjectionMonitor):
         "When ``proj_axis`` is 0, this corresponds to the global y axis. "
         "When ``proj_axis`` is 1, this corresponds to the global x axis. "
         "When ``proj_axis`` is 2, this corresponds to the global x axis. ",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     y: ObsGridArray = Field(
@@ -1426,7 +1426,7 @@ class FieldProjectionCartesianMonitor(AbstractFieldProjectionMonitor):
         "When ``proj_axis`` is 0, this corresponds to the global z axis. "
         "When ``proj_axis`` is 1, this corresponds to the global z axis. "
         "When ``proj_axis`` is 2, this corresponds to the global y axis. ",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
@@ -1513,7 +1513,7 @@ class FieldProjectionKSpaceMonitor(AbstractFieldProjectionMonitor):
         1e6,
         title="Projection Distance",
         description="Radial distance of the projection points from ``local_origin``.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     ux: ObsGridArray = Field(

--- a/tidy3d/components/nonlinear.py
+++ b/tidy3d/components/nonlinear.py
@@ -107,7 +107,7 @@ class NonlinearSusceptibility(NonlinearModel):
         0,
         title="Chi3",
         description=":math:`\\chi_3` nonlinear susceptibility.",
-        units=f"{MICROMETER}^2 / {VOLT}^2",
+        json_schema_extra={"units": f"{MICROMETER}^2 / {VOLT}^2"},
     )
 
     numiters: Optional[PositiveInt] = Field(
@@ -188,14 +188,14 @@ class TwoPhotonAbsorption(NonlinearModel):
         0,
         title="TPA coefficient",
         description="Coefficient for two-photon absorption (TPA).",
-        units=f"{MICROMETER} / {WATT}",
+        json_schema_extra={"units": f"{MICROMETER} / {WATT}"},
     )
 
     tau: NonNegativeFloat = Field(
         0,
         title="Carrier lifetime",
         description="Lifetime for the free carriers created by two-photon absorption (TPA).",
-        units=f"{SECOND}",
+        json_schema_extra={"units": f"{SECOND}"},
     )
 
     sigma: NonNegativeFloat = Field(
@@ -203,7 +203,7 @@ class TwoPhotonAbsorption(NonlinearModel):
         title="FCA cross section",
         description="Total cross section for free-carrier absorption (FCA). "
         "Contains contributions from electrons and from holes.",
-        units=f"{MICROMETER}^2",
+        json_schema_extra={"units": f"{MICROMETER}^2"},
     )
     e_e: NonNegativeFloat = Field(
         1,
@@ -219,13 +219,13 @@ class TwoPhotonAbsorption(NonlinearModel):
         0,
         title="Electron coefficient",
         description="Coefficient for the free electron refractive index shift in the free-carrier plasma dispersion (FCPD).",
-        units=f"{MICROMETER}^(3 e_e)",
+        json_schema_extra={"units": f"{MICROMETER}^(3 e_e)"},
     )
     c_h: float = Field(
         0,
         title="Hole coefficient",
         description="Coefficient for the free hole refractive index shift in the free-carrier plasma dispersion (FCPD).",
-        units=f"{MICROMETER}^(3 e_h)",
+        json_schema_extra={"units": f"{MICROMETER}^(3 e_h)"},
     )
 
     n0: Optional[float] = Field(
@@ -316,7 +316,7 @@ class KerrNonlinearity(NonlinearModel):
         0,
         title="Nonlinear refractive index",
         description="Nonlinear refractive index in the Kerr nonlinearity.",
-        units=f"{MICROMETER}^2 / {WATT}",
+        json_schema_extra={"units": f"{MICROMETER}^2 / {WATT}"},
     )
 
     n0: Optional[float] = Field(

--- a/tidy3d/components/parameter_perturbation.py
+++ b/tidy3d/components/parameter_perturbation.py
@@ -136,7 +136,7 @@ class HeatPerturbation(AbstractPerturbation):
         (0, inf),
         title="Temperature range",
         description="Temperature range in which perturbation model is valid.",
-        units=KELVIN,
+        json_schema_extra={"units": KELVIN},
     )
 
     @abstractmethod
@@ -238,13 +238,13 @@ class LinearHeatPerturbation(HeatPerturbation):
     temperature_ref: NonNegativeFloat = Field(
         title="Reference temperature",
         description="Temperature at which perturbation is zero.",
-        units=KELVIN,
+        json_schema_extra={"units": KELVIN},
     )
 
     coeff: Union[float, Complex] = Field(
         title="Thermo-optic Coefficient",
         description="Sensitivity (derivative) of perturbation with respect to temperature.",
-        units=f"1/{KELVIN}",
+        json_schema_extra={"units": f"1/{KELVIN}"},
     )
 
     @cached_property
@@ -332,7 +332,7 @@ class CustomHeatPerturbation(HeatPerturbation):
         description="Temperature range in which perturbation model is valid. For "
         ":class:`.CustomHeatPerturbation` this field is computed automatically based on "
         "temperature sample points provided in ``perturbation_values``.",
-        units=KELVIN,
+        json_schema_extra={"units": KELVIN},
     )
 
     interp_method: InterpMethod = Field(
@@ -642,25 +642,25 @@ class LinearChargePerturbation(ChargePerturbation):
         title="Reference Electron Density",
         description="Electron density value at which there is no perturbation due to electrons's "
         "presence.",
-        units=PERCMCUBE,
+        json_schema_extra={"units": PERCMCUBE},
     )
 
     hole_ref: NonNegativeFloat = Field(
         title="Reference Hole Density",
         description="Hole density value at which there is no perturbation due to holes' presence.",
-        units=PERCMCUBE,
+        json_schema_extra={"units": PERCMCUBE},
     )
 
     electron_coeff: float = Field(
         title="Sensitivity to Electron Density",
         description="Sensitivity (derivative) of perturbation with respect to electron density.",
-        units=CMCUBE,
+        json_schema_extra={"units": CMCUBE},
     )
 
     hole_coeff: float = Field(
         title="Sensitivity to Hole Density",
         description="Sensitivity (derivative) of perturbation with respect to hole density.",
-        units=CMCUBE,
+        json_schema_extra={"units": CMCUBE},
     )
 
     @cached_property
@@ -1516,7 +1516,7 @@ class NedeljkovicSorefMashanovich(AbstractDeltaModel):
     ref_freq: NonNegativeFloat = Field(
         title="Reference Frequency",
         description="Reference frequency to evaluate perturbation at (Hz).",
-        units=HERTZ,
+        json_schema_extra={"units": HERTZ},
     )
 
     electrons_grid: ArrayFloat = Field(
@@ -1669,7 +1669,7 @@ class IndexPerturbation(Tidy3dBaseModel):
     freq: NonNegativeFloat = Field(
         title="Frequency",
         description="Frequency to evaluate permittivity at (Hz).",
-        units=HERTZ,
+        json_schema_extra={"units": HERTZ},
     )
 
     @model_validator(mode="after")

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -1480,7 +1480,7 @@ class Scene(Tidy3dBaseModel):
             color_value = min(1.0, max(0.0, color_value))
             if mpl is not None:
                 cmap_name = _get_colormap(reverse=reverse)
-                cmap = mpl.cm.get_cmap(cmap_name)
+                cmap = plt.get_cmap(cmap_name)
                 rgba = tuple(float(component) for component in cmap(color_value))
             else:
                 gray_value = color_value if reverse else 1.0 - color_value

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -33,7 +33,6 @@ from tidy3d.log import log
 from tidy3d.packaging import disable_local_subpixel, supports_local_subpixel, tidy3d_extras
 from tidy3d.updater import Updater
 
-from .autograd.types import AutogradFieldMap
 from .base import cached_property
 from .base_sim.simulation import AbstractSimulation
 from .boundary import (
@@ -142,6 +141,7 @@ if TYPE_CHECKING:
 
     from tidy3d.compat import Self
 
+    from .autograd.types import AutogradFieldMap
     from .boundary import BoundaryEdgeType
     from .data.dataset import Dataset
     from .data.utils import CustomSpatialDataType
@@ -2975,7 +2975,7 @@ class Simulation(AbstractYeeGridSimulation):
         "Alternatively, user may supply a :class:`RunTimeSpec` to this field, which will auto-"
         "compute the ``run_time`` based on the contents of the spec. If this option is used, "
         "the evaluated ``run_time`` value is available in the ``Simulation._run_time`` property.",
-        units=SECOND,
+        json_schema_extra={"units": SECOND},
     )
     """
     Total electromagnetic evolution time in seconds. If simulation 'shutoff' is specified, simulation will

--- a/tidy3d/components/source/current.py
+++ b/tidy3d/components/source/current.py
@@ -106,7 +106,7 @@ class PointDipole(CurrentSource, ReverseInterpolatedSource):
         (0, 0, 0),
         title="Size",
         description="Size in x, y, and z directions, constrained to ``(0, 0, 0)``.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     @classmethod

--- a/tidy3d/components/source/field.py
+++ b/tidy3d/components/source/field.py
@@ -270,7 +270,7 @@ class AngledFieldSource(DirectionalSource, ABC):
         0.0,
         title="Polar Angle",
         description="Polar angle of the propagation axis from the injection axis.",
-        units=RADIAN,
+        json_schema_extra={"units": RADIAN},
     )
 
     angle_phi: float = Field(
@@ -278,7 +278,7 @@ class AngledFieldSource(DirectionalSource, ABC):
         title="Azimuth Angle",
         description="Azimuth angle of the propagation axis in the plane orthogonal to the "
         "injection axis.",
-        units=RADIAN,
+        json_schema_extra={"units": RADIAN},
     )
 
     pol_angle: float = Field(
@@ -292,7 +292,7 @@ class AngledFieldSource(DirectionalSource, ABC):
         "- ``Ey`` polarization for propagation along ``x``."
         "- ``Ex`` polarization for propagation along ``y``."
         "- ``Ex`` polarization for propagation along ``z``.",
-        units=RADIAN,
+        json_schema_extra={"units": RADIAN},
     )
 
     @field_validator("angle_theta")
@@ -584,7 +584,7 @@ class GaussianBeam(AngledFieldSource, PlanarSource, BroadbandSource):
         1.0,
         title="Waist Radius",
         description="Radius of the beam at the waist.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     waist_distance: float = Field(
@@ -596,7 +596,7 @@ class GaussianBeam(AngledFieldSource, PlanarSource, BroadbandSource):
         "means the beam waist is positioned in the ``-`` direction (behind the source). "
         "A negative value means the beam waist is in the ``+`` direction (in front of the source). "
         "For an angled source, the distance is defined along the rotated propagation direction.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     num_freqs: int = Field(
@@ -645,7 +645,7 @@ class AstigmaticGaussianBeam(AngledFieldSource, PlanarSource, BroadbandSource):
         (1.0, 1.0),
         title="Waist sizes",
         description="Size of the beam at the waist in the local x and y directions.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     waist_distances: tuple[float, float] = Field(
@@ -657,7 +657,7 @@ class AstigmaticGaussianBeam(AngledFieldSource, PlanarSource, BroadbandSource):
         "is on the ``-`` side (behind) the source plane. When ``direction`` is ``+`` and "
         "``waist_distances`` are negative, the waist is on the ``+`` side (in front) of "
         "the source plane.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     num_freqs: int = Field(

--- a/tidy3d/components/source/freq_range.py
+++ b/tidy3d/components/source/freq_range.py
@@ -42,13 +42,13 @@ class FreqRange(Tidy3dBaseModel):
     freq0: PositiveFloat = Field(
         title="Central frequency",
         description="Real-valued positive central frequency.",
-        units="Hz",
+        json_schema_extra={"units": "Hz"},
     )
 
     fwidth: PositiveFloat = Field(
         title="Frequency bandwidth",
         description="Real-valued positive width of the frequency range (bandwidth).",
-        units="Hz",
+        json_schema_extra={"units": "Hz"},
     )
 
     @property

--- a/tidy3d/components/source/time.py
+++ b/tidy3d/components/source/time.py
@@ -110,12 +110,12 @@ class Pulse(SourceTime, ABC):
     freq0: PositiveFloat = Field(
         title="Central Frequency",
         description="Central frequency of the pulse.",
-        units=HERTZ,
+        json_schema_extra={"units": HERTZ},
     )
     fwidth: PositiveFloat = Field(
         title="",
         description="Standard deviation of the frequency content of the pulse.",
-        units=HERTZ,
+        json_schema_extra={"units": HERTZ},
     )
 
     offset: float = Field(
@@ -617,7 +617,7 @@ class BroadbandPulse(SourceTime):
     freq_range: FreqBound = Field(
         title="Frequency Range",
         description="Frequency range where the pulse should have significant energy.",
-        units=HERTZ,
+        json_schema_extra={"units": HERTZ},
     )
     minimum_amplitude: float = Field(
         0.3,

--- a/tidy3d/components/spice/analysis/ac.py
+++ b/tidy3d/components/spice/analysis/ac.py
@@ -39,7 +39,7 @@ class AbstractSSACAnalysis(Tidy3dBaseModel, ABC):
         title="Small Signal AC Frequencies",
         description="List of frequencies for small signal AC analysis. "
         "At least one :class:`.SSACVoltageSource` must be present in the boundary conditions.",
-        units=HERTZ,
+        json_schema_extra={"units": HERTZ},
     )
 
     @field_validator("freqs")

--- a/tidy3d/components/spice/analysis/dc.py
+++ b/tidy3d/components/spice/analysis/dc.py
@@ -89,5 +89,5 @@ class IsothermalSteadyChargeDCAnalysis(SteadyChargeDCAnalysis):
         title="Temperature",
         description="Lattice temperature. Assumed constant throughout the device. "
         "Carriers are assumed to be at thermodynamic equilibrium with the lattice.",
-        units=KELVIN,
+        json_schema_extra={"units": KELVIN},
     )

--- a/tidy3d/components/spice/sources/ac.py
+++ b/tidy3d/components/spice/sources/ac.py
@@ -43,14 +43,14 @@ class SSACVoltageSource(Tidy3dBaseModel):
     voltage: ArrayFloat1D = Field(
         title="DC Bias Voltages",
         description="List of DC operating point voltages (above ground) used with :class:`VoltageBC`.",
-        units=VOLT,
+        json_schema_extra={"units": VOLT},
     )
 
     amplitude: FiniteFloat = Field(
         default=1.0,
         title="Small Signal Amplitude",
         description="Amplitude of the small-signal perturbation for SSAC analysis.",
-        units=VOLT,
+        json_schema_extra={"units": VOLT},
     )
 
     @field_validator("voltage")

--- a/tidy3d/components/spice/sources/dc.py
+++ b/tidy3d/components/spice/sources/dc.py
@@ -62,7 +62,7 @@ class DCVoltageSource(Tidy3dBaseModel):
     voltage: ArrayFloat1D = Field(
         title="Voltage",
         description="DC voltage usually used as source in :class:`VoltageBC` boundary conditions.",
-        units=VOLT,
+        json_schema_extra={"units": VOLT},
     )
 
     # TODO: This should have always been in the field above but was introduced wrongly as a
@@ -158,7 +158,7 @@ class DCCurrentSource(Tidy3dBaseModel):
     current: FiniteFloat = Field(
         title="Current",
         description="DC current usually used as source in :class:`CurrentBC` boundary conditions.",
-        units=AMP,
+        json_schema_extra={"units": AMP},
     )
 
     # TODO: This should have always been in the field above but was introduced wrongly as a

--- a/tidy3d/components/structure.py
+++ b/tidy3d/components/structure.py
@@ -786,7 +786,7 @@ class MeshOverrideStructure(AbstractStructure):
     ] = Field(
         title="Grid Size",
         description="Grid size along x, y, z directions.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     priority: int = Field(

--- a/tidy3d/components/tcad/analysis/heat_simulation_type.py
+++ b/tidy3d/components/tcad/analysis/heat_simulation_type.py
@@ -24,7 +24,7 @@ class UnsteadySpec(Tidy3dBaseModel):
         ...,
         title="Time-step",
         description="Time step taken for each iteration of the time integration loop.",
-        units=SECOND,
+        json_schema_extra={"units": SECOND},
     )
 
     total_time_steps: PositiveInt = Field(
@@ -54,7 +54,7 @@ class UnsteadyHeatAnalysis(Tidy3dBaseModel):
         ...,
         title="Initial temperature.",
         description="Initial value for the temperature field.",
-        units=KELVIN,
+        json_schema_extra={"units": KELVIN},
     )
 
     unsteady_spec: UnsteadySpec = Field(

--- a/tidy3d/components/tcad/bandgap.py
+++ b/tidy3d/components/tcad/bandgap.py
@@ -40,13 +40,13 @@ class SlotboomBandGapNarrowing(Tidy3dBaseModel):
     v1: PositiveFloat = Field(
         title=":math:`V_{1,bgn}` parameter",
         description=":math:`V_{1,bgn}` parameter",
-        units=VOLT,
+        json_schema_extra={"units": VOLT},
     )
 
     n2: PositiveFloat = Field(
         title=":math:`N_{2,bgn}` parameter",
         description=":math:`N_{2,bgn}` parameter",
-        units=PERCMCUBE,
+        json_schema_extra={"units": PERCMCUBE},
     )
 
     c2: float = Field(
@@ -58,5 +58,5 @@ class SlotboomBandGapNarrowing(Tidy3dBaseModel):
         title="Minimum total doping",
         description="Bandgap narrowing is applied at location where total doping "
         "is higher than ``min_N``.",
-        units=PERCMCUBE,
+        json_schema_extra={"units": PERCMCUBE},
     )

--- a/tidy3d/components/tcad/bandgap_energy.py
+++ b/tidy3d/components/tcad/bandgap_energy.py
@@ -12,7 +12,7 @@ class ConstantEnergyBandGap(Tidy3dBaseModel):
     eg: PositiveFloat = Field(
         title="Band Gap",
         description="Energy band gap",
-        units=ELECTRON_VOLT,
+        json_schema_extra={"units": ELECTRON_VOLT},
     )
 
 
@@ -48,17 +48,17 @@ class VarshniEnergyBandGap(Tidy3dBaseModel):
     eg_0: PositiveFloat = Field(
         title="Band Gap at 0 K",
         description="Energy band gap at absolute zero (0 Kelvin).",
-        units=ELECTRON_VOLT,
+        json_schema_extra={"units": ELECTRON_VOLT},
     )
 
     alpha: PositiveFloat = Field(
         title="Varshni Alpha Coefficient",
         description="Empirical Varshni coefficient (α).",
-        units="eV/K",
+        json_schema_extra={"units": "eV/K"},
     )
 
     beta: PositiveFloat = Field(
         title="Varshni Beta Coefficient",
         description="Empirical Varshni coefficient (β), related to the Debye temperature.",
-        units="K",
+        json_schema_extra={"units": "K"},
     )

--- a/tidy3d/components/tcad/boundary/charge.py
+++ b/tidy3d/components/tcad/boundary/charge.py
@@ -31,7 +31,7 @@ class VoltageBC(HeatChargeBC):
     source: VoltageSourceType = Field(
         title="Voltage",
         description="Electric potential to be applied at the specified boundary.",
-        units=VOLT,
+        json_schema_extra={"units": VOLT},
     )
 
 
@@ -49,7 +49,7 @@ class CurrentBC(HeatChargeBC):
     source: CurrentSourceType = Field(
         title="Current Source",
         description="A current source",
-        units=CURRENT_DENSITY,
+        json_schema_extra={"units": CURRENT_DENSITY},
     )
     # TODO translation between currentsource amps and currentdensity, why not amps here?
 

--- a/tidy3d/components/tcad/boundary/heat.py
+++ b/tidy3d/components/tcad/boundary/heat.py
@@ -34,7 +34,7 @@ class TemperatureBC(HeatChargeBC):
     temperature: PositiveFloat = Field(
         title="Temperature",
         description="Temperature value.",
-        units=KELVIN,
+        json_schema_extra={"units": KELVIN},
     )
 
 
@@ -50,7 +50,7 @@ class HeatFluxBC(HeatChargeBC):
     flux: float = Field(
         title="Heat Flux",
         description="Heat flux value.",
-        units=HEAT_FLUX,
+        json_schema_extra={"units": HEAT_FLUX},
     )
 
 
@@ -84,14 +84,14 @@ class VerticalNaturalConvectionCoeffModel(Tidy3dBaseModel):
     plate_length: NonNegativeFloat = Field(
         title="Plate Characteristic Length",
         description="Characteristic length (L), defined as the height of the vertical plate.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     gravity: NonNegativeFloat = Field(
         default=GRAV_ACC,
         title="Gravitational Acceleration",
         description="Gravitational acceleration (g).",
-        units=ACCELERATION,
+        json_schema_extra={"units": ACCELERATION},
     )
 
     @classmethod
@@ -164,11 +164,11 @@ class ConvectionBC(HeatChargeBC):
     ambient_temperature: PositiveFloat = Field(
         title="Ambient Temperature",
         description="Ambient temperature.",
-        units=KELVIN,
+        json_schema_extra={"units": KELVIN},
     )
 
     transfer_coeff: Union[NonNegativeFloat, VerticalNaturalConvectionCoeffModel] = Field(
         title="Heat Transfer Coefficient",
         description="Heat transfer coefficient value.",
-        units=HEAT_TRANSFER_COEFF,
+        json_schema_extra={"units": HEAT_TRANSFER_COEFF},
     )

--- a/tidy3d/components/tcad/data/monitor_data/abstract.py
+++ b/tidy3d/components/tcad/data/monitor_data/abstract.py
@@ -42,7 +42,7 @@ class HeatChargeMonitorData(AbstractMonitorData, ABC):
         (0, 0, 0),
         title="Symmetry Center",
         description="Symmetry center of the original simulation in x, y, and z.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     @abstractmethod

--- a/tidy3d/components/tcad/data/monitor_data/charge.py
+++ b/tidy3d/components/tcad/data/monitor_data/charge.py
@@ -369,7 +369,7 @@ class SteadyElectricFieldData(HeatChargeMonitorData):
         None,
         title="Electric field",
         description="Contains the computed electric field.",
-        units=":math:`V/\\mu m`",
+        json_schema_extra={"units": ":math:`V/\\mu m`"},
     )
 
     @property
@@ -407,7 +407,7 @@ class SteadyCurrentDensityData(HeatChargeMonitorData):
         title="Current density",
         description="Contains the computed current density.",
         discriminator=TYPE_TAG_STR,
-        units=":math:`A/\\mu m^2`",
+        json_schema_extra={"units": ":math:`A/\\mu m^2`"},
     )
 
     @property

--- a/tidy3d/components/tcad/data/monitor_data/heat.py
+++ b/tidy3d/components/tcad/data/monitor_data/heat.py
@@ -51,7 +51,7 @@ class TemperatureData(HeatChargeMonitorData):
         None,
         title="Temperature",
         description="Spatial temperature field.",
-        units=KELVIN,
+        json_schema_extra={"units": KELVIN},
     )
 
     @property

--- a/tidy3d/components/tcad/doping.py
+++ b/tidy3d/components/tcad/doping.py
@@ -29,7 +29,7 @@ class AbstractDopingBox(Box):
         (inf, inf, inf),
         title="Size",
         description="Size in x, y, and z directions.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     def _get_indices_in_box(
@@ -96,7 +96,7 @@ class ConstantDoping(AbstractDopingBox):
         default=0,
         title="Doping concentration density.",
         description="Doping concentration density.",
-        units=PERCMCUBE,
+        json_schema_extra={"units": PERCMCUBE},
     )
 
     def _get_contrib(self, coords: dict, meshgrid: bool = True) -> NDArray:
@@ -163,13 +163,13 @@ class GaussianDoping(AbstractDopingBox):
         title="Reference concentration.",
         description="Reference concentration. This is the minimum concentration in the box "
         "and it is attained at the edges/faces of the box.",
-        units=PERCMCUBE,
+        json_schema_extra={"units": PERCMCUBE},
     )
 
     concentration: PositiveFloat = Field(
         title="Concentration",
         description="The concentration at the center of the box.",
-        units=PERCMCUBE,
+        json_schema_extra={"units": PERCMCUBE},
     )
 
     width: PositiveFloat = Field(
@@ -177,7 +177,7 @@ class GaussianDoping(AbstractDopingBox):
         description="Width of the gaussian. The concentration will transition from "
         "``concentration`` at the center of the box to ``ref_con`` at the edge/face "
         "of the box in a distance equal to ``width``. ",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     source: str = Field(
@@ -316,7 +316,7 @@ class CustomDoping(AbstractDopingBox):
     concentration: SpatialDataArray = Field(
         title="Doping concentration data array.",
         description="Doping concentration data array.",
-        units=PERCMCUBE,
+        json_schema_extra={"units": PERCMCUBE},
     )
 
     def _get_contrib(self, coords: dict, meshgrid: bool = True) -> NDArray:

--- a/tidy3d/components/tcad/effective_DOS.py
+++ b/tidy3d/components/tcad/effective_DOS.py
@@ -33,7 +33,9 @@ class ConstantEffectiveDOS(EffectiveDOS):
     """Constant effective density of states model."""
 
     N: PositiveFloat = Field(
-        title="Effective DOS", description="Effective density of states", units=PERCMCUBE
+        title="Effective DOS",
+        description="Effective density of states",
+        json_schema_extra={"units": PERCMCUBE},
     )
 
     def calc_eff_dos(self, T: float) -> float:

--- a/tidy3d/components/tcad/generation_recombination.py
+++ b/tidy3d/components/tcad/generation_recombination.py
@@ -49,7 +49,7 @@ class FossumCarrierLifetime(Tidy3dBaseModel):
     tau_300: PositiveFloat = Field(
         title="Tau at 300K",
         description="Carrier lifetime at 300K",
-        units=SECOND,
+        json_schema_extra={"units": SECOND},
     )
 
     alpha_T: float = Field(
@@ -60,7 +60,7 @@ class FossumCarrierLifetime(Tidy3dBaseModel):
     N0: PositiveFloat = Field(
         title="Reference concentration",
         description="Reference concentration",
-        units=PERCMCUBE,
+        json_schema_extra={"units": PERCMCUBE},
     )
 
     A: float = Field(
@@ -113,13 +113,13 @@ class AugerRecombination(Tidy3dBaseModel):
     c_n: PositiveFloat = Field(
         title="Constant for electrons",
         description="Constant for electrons.",
-        units="cm^6/s",
+        json_schema_extra={"units": "cm^6/s"},
     )
 
     c_p: PositiveFloat = Field(
         title="Constant for holes",
         description="Constant for holes.",
-        units="cm^6/s",
+        json_schema_extra={"units": "cm^6/s"},
     )
 
 
@@ -147,7 +147,7 @@ class RadiativeRecombination(Tidy3dBaseModel):
     r_const: float = Field(
         title="Radiation constant",
         description="Radiation constant of the radiative recombination model.",
-        units="cm^3/s",
+        json_schema_extra={"units": "cm^3/s"},
     )
 
 
@@ -188,13 +188,13 @@ class ShockleyReedHallRecombination(Tidy3dBaseModel):
     tau_n: Union[PositiveFloat, CarrierLifetimeType] = Field(
         title="Electron lifetime",
         description="Electron lifetime",
-        units=SECOND,
+        json_schema_extra={"units": SECOND},
     )
 
     tau_p: Union[PositiveFloat, CarrierLifetimeType] = Field(
         title="Hole lifetime",
         description="Hole lifetime",
-        units=SECOND,
+        json_schema_extra={"units": SECOND},
     )
 
 
@@ -221,7 +221,7 @@ class DistributedGeneration(Tidy3dBaseModel):
     rate: SpatialDataArray = Field(
         title="Generation rate",
         description="Spatially varying generation rate.",
-        units="1/(cm^3 s^1)",
+        json_schema_extra={"units": "1/(cm^3 s^1)"},
     )
 
     @classmethod
@@ -283,19 +283,19 @@ class HurkxDirectBandToBandTunneling(Tidy3dBaseModel):
         4e14,
         title="Parameter :math:`A`",
         description="Parameter :math:`A` in the direct BTBT Hurkx model.",
-        units="1/(cm^3 s)",
+        json_schema_extra={"units": "1/(cm^3 s)"},
     )
     B: float = Field(
         1.9e6,
         title="Parameter :math:`B`",
         description="Parameter :math:`B` in the direct BTBT Hurkx model.",
-        units="V/cm",
+        json_schema_extra={"units": "V/cm"},
     )
     E_0: PositiveFloat = Field(
         1,
         title="Reference electric field :math:`E_0`",
         description="Reference electric field :math:`E_0` in the direct BTBT Hurkx model.",
-        units="V/cm",
+        json_schema_extra={"units": "V/cm"},
     )
     sigma: float = Field(
         2.5,
@@ -344,23 +344,23 @@ class SelberherrImpactIonization(Tidy3dBaseModel):
     alpha_n_inf: PositiveFloat = Field(
         title="Electron ionization coefficient at infinite field",
         description="Electron ionization coefficient at infinite field.",
-        units="1/cm",
+        json_schema_extra={"units": "1/cm"},
     )
     alpha_p_inf: PositiveFloat = Field(
         title="Hole ionization coefficient at infinite field",
         description="Hole ionization coefficient at infinite field.",
-        units="1/cm",
+        json_schema_extra={"units": "1/cm"},
     )
     E_n_crit: PositiveFloat = Field(
         title="Critical electric field for electrons",
         description="Critical electric field for electrons.",
-        units="V/cm",
+        json_schema_extra={"units": "V/cm"},
     )
     E_p_crit: PositiveFloat = Field(
         ...,
         title="Critical electric field for holes",
         description="Critical electric field for holes.",
-        units="V/cm",
+        json_schema_extra={"units": "V/cm"},
     )
     beta_n: PositiveFloat = Field(
         title="Exponent for electrons",

--- a/tidy3d/components/tcad/grid.py
+++ b/tidy3d/components/tcad/grid.py
@@ -41,7 +41,7 @@ class UniformUnstructuredGrid(UnstructuredGrid):
     dl: PositiveFloat = Field(
         title="Grid Size",
         description="Grid size for uniform grid generation.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     min_edges_per_circumference: PositiveFloat = Field(
@@ -73,14 +73,14 @@ class GridRefinementRegion(Box):
     dl_internal: PositiveFloat = Field(
         title="Internal mesh cell size",
         description="Mesh cell size inside the refinement region",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     transition_thickness: NonNegativeFloat = Field(
         title="Interface Distance",
         description="Thickness of a transition layer outside the box where the mesh cell size changes from the"
         "internal size to the external one.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
 
@@ -90,13 +90,13 @@ class GridRefinementLine(Tidy3dBaseModel, ABC):
     r1: Coordinate = Field(
         title="Start point of the line",
         description="Start point of the line in x, y, and z.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     r2: Coordinate = Field(
         title="End point of the line",
         description="End point of the line in x, y, and z.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     @field_validator("r1", "r2")
@@ -110,14 +110,14 @@ class GridRefinementLine(Tidy3dBaseModel, ABC):
     dl_near: PositiveFloat = Field(
         title="Mesh cell size near the line",
         description="Mesh cell size near the line",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     distance_near: NonNegativeFloat = Field(
         title="Near distance",
         description="Distance from the line within which ``dl_near`` is enforced."
         "Typically the same as ``dl_near`` or its multiple.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     distance_bulk: NonNegativeFloat = Field(
@@ -125,7 +125,7 @@ class GridRefinementLine(Tidy3dBaseModel, ABC):
         description="Distance from the line outside of which ``dl_bulk`` is enforced."
         "Typically twice of ``dl_bulk`` or its multiple. Use larger values for a smoother "
         "transition from ``dl_near`` to ``dl_bulk``.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     @model_validator(mode="after")
@@ -154,20 +154,20 @@ class DistanceUnstructuredGrid(UnstructuredGrid):
     dl_interface: PositiveFloat = Field(
         title="Interface Grid Size",
         description="Grid size near material interfaces.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     dl_bulk: PositiveFloat = Field(
         title="Bulk Grid Size",
         description="Grid size away from material interfaces.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     distance_interface: NonNegativeFloat = Field(
         title="Interface Distance",
         description="Distance from interface within which ``dl_interface`` is enforced."
         "Typically the same as ``dl_interface`` or its multiple.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     distance_bulk: NonNegativeFloat = Field(
@@ -175,7 +175,7 @@ class DistanceUnstructuredGrid(UnstructuredGrid):
         description="Distance from interface outside of which ``dl_bulk`` is enforced."
         "Typically twice of ``dl_bulk`` or its multiple. Use larger values for a smoother "
         "transition from ``dl_interface`` to ``dl_bulk``.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     sampling: PositiveFloat = Field(

--- a/tidy3d/components/tcad/mobility.py
+++ b/tidy3d/components/tcad/mobility.py
@@ -18,7 +18,7 @@ class ConstantMobilityModel(Tidy3dBaseModel):
     mu: NonNegativeFloat = Field(
         title="Mobility",
         description="Mobility",
-        units="cm²/V-s",
+        json_schema_extra={"units": "cm²/V-s"},
     )
 
 
@@ -120,13 +120,13 @@ class CaugheyThomasMobility(Tidy3dBaseModel):
     mu_min: PositiveFloat = Field(
         title="Minimum electron mobility",
         description="Minimum electron mobility  :math:`\\mu_{\\text{min}}`  at reference temperature (300K).",
-        units="cm^2/V-s",
+        json_schema_extra={"units": "cm^2/V-s"},
     )
 
     mu: PositiveFloat = Field(
         title="Reference mobility",
         description="Reference mobility at reference temperature (300K).",
-        units="cm^2/V-s",
+        json_schema_extra={"units": "cm^2/V-s"},
     )
 
     # thermal exponent for reference mobility
@@ -144,7 +144,7 @@ class CaugheyThomasMobility(Tidy3dBaseModel):
     ref_N: PositiveFloat = Field(
         title="Reference doping",
         description="Reference doping at reference temperature (300K).",
-        units=PERCMCUBE,
+        json_schema_extra={"units": PERCMCUBE},
     )
 
     # temperature exponent

--- a/tidy3d/components/tcad/source/heat.py
+++ b/tidy3d/components/tcad/source/heat.py
@@ -24,7 +24,7 @@ class HeatSource(StructureBasedHeatChargeSource):
     rate: Union[float, SpatialDataArray] = Field(
         title="Volumetric Heat Rate",
         description="Volumetric rate of heating or cooling (if negative).",
-        units=VOLUMETRIC_HEAT_RATE,
+        json_schema_extra={"units": VOLUMETRIC_HEAT_RATE},
     )
 
 

--- a/tidy3d/components/time.py
+++ b/tidy3d/components/time.py
@@ -29,7 +29,10 @@ class AbstractTimeDependence(ABC, Tidy3dBaseModel):
     )
 
     phase: float = Field(
-        0.0, title="Phase", description="Phase shift of the time dependence.", units=RADIAN
+        0.0,
+        title="Phase",
+        description="Phase shift of the time dependence.",
+        json_schema_extra={"units": RADIAN},
     )
 
     @abstractmethod

--- a/tidy3d/components/time_modulation.py
+++ b/tidy3d/components/time_modulation.py
@@ -71,7 +71,9 @@ class ContinuousWaveTimeModulation(AbstractTimeDependence):
     """
 
     freq0: PositiveFloat = Field(
-        title="Modulation Frequency", description="Modulation frequency.", units=HERTZ
+        title="Modulation Frequency",
+        description="Modulation frequency.",
+        json_schema_extra={"units": HERTZ},
     )
 
     def amp_time(self, time: float) -> complex:
@@ -146,7 +148,7 @@ class SpaceModulation(AbstractSpaceModulation):
         0,
         title="Phase of modulation in space",
         description="Phase of modulation that can vary spatially.",
-        units=RADIAN,
+        json_schema_extra={"units": RADIAN},
     )
 
     interp_method: InterpMethod = Field(

--- a/tidy3d/components/transformation.py
+++ b/tidy3d/components/transformation.py
@@ -88,7 +88,7 @@ class RotationAroundAxis(AbstractRotation):
         0.0,
         title="Angle of Rotation",
         description="Angle of rotation in radians.",
-        units=RADIAN,
+        json_schema_extra={"units": RADIAN},
     )
 
     @field_validator("axis")

--- a/tidy3d/config/profiles.py
+++ b/tidy3d/config/profiles.py
@@ -52,6 +52,13 @@ BUILTIN_PROFILES: dict[str, dict[str, Any]] = {
             },
         }
     },
+    "test": {
+        "web": {
+            "s3_region": "test",
+            "api_endpoint": "https://test",
+            "website_endpoint": "https://test",
+        }
+    },
 }
 
 __all__ = ["BUILTIN_PROFILES"]

--- a/tidy3d/material_library/parametric_materials.py
+++ b/tidy3d/material_library/parametric_materials.py
@@ -73,16 +73,19 @@ class Graphene(ParametricVariantItem2D):
         GRAPHENE_DEF_MU_C,
         title="Chemical potential in eV",
         description="Chemical potential in eV.",
-        units=ELECTRON_VOLT,
+        json_schema_extra={"units": ELECTRON_VOLT},
     )
     temp: float = Field(
-        GRAPHENE_DEF_TEMP, title="Temperature in K", description="Temperature in K.", units=KELVIN
+        GRAPHENE_DEF_TEMP,
+        title="Temperature in K",
+        description="Temperature in K.",
+        json_schema_extra={"units": KELVIN},
     )
     gamma: float = Field(
         GRAPHENE_DEF_GAMMA,
         title="Scattering rate in eV",
         description="Scattering rate in eV. Must be small compared to the optical frequency.",
-        units=ELECTRON_VOLT,
+        json_schema_extra={"units": ELECTRON_VOLT},
     )
     scaling: float = Field(
         1,

--- a/tidy3d/plugins/autograd/invdes/parametrizations.py
+++ b/tidy3d/plugins/autograd/invdes/parametrizations.py
@@ -9,6 +9,7 @@ from pydantic import Field, NonNegativeFloat
 from scipy.optimize import minimize
 
 import tidy3d as td
+from tidy3d import log
 from tidy3d.components.autograd.functions import _straight_through_clip
 from tidy3d.components.base import Tidy3dBaseModel
 from tidy3d.components.grid.grid import Coords
@@ -313,6 +314,8 @@ def initialize_params_from_simulation(
 
     bounds_list = [bounds] * params0.size
     try:
+        if verbose:
+            log.warning("SciPy's L-BFGS-B optimizer no longer supports verbose output. ")
         res = minimize(
             fun=val_and_grad,
             x0=params0.ravel(),
@@ -320,7 +323,7 @@ def initialize_params_from_simulation(
             jac=True,
             bounds=bounds_list,
             callback=callback,
-            options={"maxiter": maxiter, "disp": verbose},
+            options={"maxiter": maxiter},
         )
         x_final = res.x
     except StopIteration:

--- a/tidy3d/plugins/dispersion/fit.py
+++ b/tidy3d/plugins/dispersion/fit.py
@@ -38,7 +38,7 @@ class DispersionFitter(Tidy3dBaseModel):
     wvl_um: ArrayFloat1D = Field(
         title="Wavelength data",
         description="Wavelength data in micrometers.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     n_data: ArrayFloat1D = Field(
@@ -57,7 +57,7 @@ class DispersionFitter(Tidy3dBaseModel):
         title="Wavelength range [wvl_min,wvl_max] for fitting",
         description="Truncate the wavelength, n and k data to the wavelength range '[wvl_min, "
         "wvl_max]' for fitting.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     @field_validator("wvl_um")

--- a/tidy3d/plugins/dispersion/web.py
+++ b/tidy3d/plugins/dispersion/web.py
@@ -48,7 +48,7 @@ class AdvancedFitterParam(Tidy3dBaseModel):
         description="Upper bound of real and imagniary part of oscillator "
         "strength ``c`` in the model :class:`.PoleResidue` (The default 'None' will trigger "
         "automatic setup based on the frequency range of interest).",
-        units=HERTZ,
+        json_schema_extra={"units": HERTZ},
     )
     bound_f: Optional[NonNegativeFloat] = Field(
         None,
@@ -56,14 +56,14 @@ class AdvancedFitterParam(Tidy3dBaseModel):
         description="Upper bound of real and imaginary part of ``a`` that corresponds to pole "
         "damping rate and frequency in the model :class:`.PoleResidue` (The default 'None' "
         "will trigger automatic setup based on the frequency range of interest).",
-        units=HERTZ,
+        json_schema_extra={"units": HERTZ},
     )
     bound_f_lower: NonNegativeFloat = Field(
         0.0,
         title="Lower bound of pole frequency",
         description="Lower bound of imaginary part of ``a`` that corresponds to pole "
         "frequency in the model :class:`.PoleResidue`.",
-        units=HERTZ,
+        json_schema_extra={"units": HERTZ},
     )
     bound_eps_inf: float = Field(
         10.0,
@@ -114,7 +114,7 @@ class FitterData(AdvancedFitterParam):
     wvl_um: tuple[float, ...] = Field(
         title="Wavelengths",
         description="A set of wavelengths for dispersion data.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
     n_data: tuple[float, ...] = Field(
         title="Index of refraction",
@@ -144,13 +144,13 @@ class FitterData(AdvancedFitterParam):
         100.0,
         title="Upper bound of oscillator strength",
         description="Upper bound of oscillator strength in the model.",
-        units="eV",
+        json_schema_extra={"units": "eV"},
     )
     bound_f: PositiveFloat = Field(
         100.0,
         title="Upper bound of pole frequency",
         description="Upper bound of pole frequency in the model.",
-        units="eV",
+        json_schema_extra={"units": "eV"},
     )
 
     @staticmethod

--- a/tidy3d/plugins/invdes/penalty.py
+++ b/tidy3d/plugins/invdes/penalty.py
@@ -57,7 +57,7 @@ class ErosionDilationPenalty(AbstractPenalty):
         "Corresponds to ``radius`` in the :class:`ConicFilter` used for filtering. "
         "The parameter array is dilated and eroded by half of this value with each operation. "
         "Roughly corresponds to the desired minimum feature size and radius of curvature.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     beta: float = Field(

--- a/tidy3d/plugins/invdes/region.py
+++ b/tidy3d/plugins/invdes/region.py
@@ -33,13 +33,13 @@ class DesignRegion(InvdesBaseModel, abc.ABC):
     size: Size = Field(
         title="Size",
         description="Size in x, y, and z directions.",
-        units=td.constants.MICROMETER,
+        json_schema_extra={"units": td.constants.MICROMETER},
     )
 
     center: Coordinate = Field(
         title="Center",
         description="Center of object in x, y, and z.",
-        units=td.constants.MICROMETER,
+        json_schema_extra={"units": td.constants.MICROMETER},
     )
 
     eps_bounds: tuple[float, float] = Field(

--- a/tidy3d/plugins/invdes/transformation.py
+++ b/tidy3d/plugins/invdes/transformation.py
@@ -47,7 +47,7 @@ class FilterProject(InvdesBaseModel):
         "It is useful to apply a ``FilterProject`` transformation to 'encourage' larger "
         "feature sizes, but we ultimately recommend creating a ``ErosionDilationPenalty`` to the "
         "``DesignRegion.penalties`` if you have strict fabrication constraints.",
-        units=td.constants.MICROMETER,
+        json_schema_extra={"units": td.constants.MICROMETER},
     )
 
     beta: float = Field(

--- a/tidy3d/plugins/klayout/drc/results.py
+++ b/tidy3d/plugins/klayout/drc/results.py
@@ -380,7 +380,7 @@ class DRCResults(Tidy3dBaseModel):
             resultsfile=resultsfile,
             max_results=max_results,
         )
-        return cls.construct(violations_by_category=violations)
+        return cls.model_construct(violations_by_category=violations)
 
 
 def violations_from_file(

--- a/tidy3d/plugins/microwave/array_factor.py
+++ b/tidy3d/plugins/microwave/array_factor.py
@@ -1033,7 +1033,7 @@ class ChebWindow(AbstractWindow):
         default=30,
         title="Attenuation",
         description="Desired attenuation level of sidelobes.",
-        units="dB",
+        json_schema_extra={"units": "dB"},
     )
 
     def _get_weights_discrete(self, N: int) -> ArrayLike:
@@ -1086,7 +1086,7 @@ class TaylorWindow(AbstractWindow):
         default=30,
         title="Sidelobe Suppression Level",
         description="Desired suppression of sidelobe level relative to the DC gain.",
-        units="dB",
+        json_schema_extra={"units": "dB"},
     )
 
     nbar: conint(gt=0, le=10) = Field(

--- a/tidy3d/plugins/resonance/resonance.py
+++ b/tidy3d/plugins/resonance/resonance.py
@@ -90,7 +90,7 @@ class ResonanceFinder(Tidy3dBaseModel):
         "frequencies. Note that frequencies outside this window may be returned. "
         "A narrow frequency window that only contains a few resonances may give enhanced "
         "accuracy compared to a broad frequency window with many resonances.",
-        units=HERTZ,
+        json_schema_extra={"units": HERTZ},
     )
 
     init_num_freqs: PositiveInt = Field(

--- a/tidy3d/plugins/smatrix/component_modelers/base.py
+++ b/tidy3d/plugins/smatrix/component_modelers/base.py
@@ -67,7 +67,7 @@ class AbstractComponentModeler(ABC, Tidy3dBaseModel):
     freqs: FreqArray = Field(
         title="Frequencies",
         description="Array or list of frequencies at which to compute port parameters.",
-        units=HERTZ,
+        json_schema_extra={"units": HERTZ},
     )
 
     remove_dc_component: bool = Field(

--- a/tidy3d/plugins/smatrix/component_modelers/terminal.py
+++ b/tidy3d/plugins/smatrix/component_modelers/terminal.py
@@ -114,7 +114,7 @@ class DirectivityMonitorSpec(MicrowaveBaseModel):
         title="Local Origin",
         description="Local origin used for defining observation points. If ``None``, uses the "
         "monitor's center.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
 

--- a/tidy3d/plugins/smatrix/ports/base_lumped.py
+++ b/tidy3d/plugins/smatrix/ports/base_lumped.py
@@ -31,7 +31,7 @@ class AbstractLumpedPort(AbstractTerminalPort):
         DEFAULT_REFERENCE_IMPEDANCE,
         title="Reference impedance",
         description="Reference port impedance for scattering parameter computation.",
-        units=OHM,
+        json_schema_extra={"units": OHM},
     )
 
     num_grid_cells: Optional[PositiveInt] = Field(

--- a/tidy3d/plugins/smatrix/ports/coaxial_lumped.py
+++ b/tidy3d/plugins/smatrix/ports/coaxial_lumped.py
@@ -58,19 +58,19 @@ class CoaxialLumpedPort(AbstractLumpedPort, AbstractAxesRH):
         (0.0, 0.0, 0.0),
         title="Center",
         description="Center of object in x, y, and z.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     outer_diameter: PositiveFloat = Field(
         title="Outer Diameter",
         description="Diameter of the outer coaxial circle.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     inner_diameter: PositiveFloat = Field(
         title="Inner Diameter",
         description="Diameter of the inner coaxial circle.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     normal_axis: Axis = Field(

--- a/tidy3d/plugins/waveguide/rectangular_dielectric.py
+++ b/tidy3d/plugins/waveguide/rectangular_dielectric.py
@@ -59,20 +59,20 @@ class RectangularDielectric(Tidy3dBaseModel):
     wavelength: Union[float, ArrayFloat1D] = Field(
         title="Wavelength",
         description="Wavelength(s) at which to calculate modes (in μm).",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     core_width: Union[Size1D, ArrayFloat1D] = Field(
         title="Core width",
         description="Core width at the top of the waveguide. If set to an array, defines "
         "the widths of adjacent waveguides.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     core_thickness: Size1D = Field(
         title="Core Thickness",
         description="Thickness of the core layer.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     core_medium: MediumType = Field(
@@ -98,7 +98,7 @@ class RectangularDielectric(Tidy3dBaseModel):
         0.0,
         title="Slab Thickness",
         description="Thickness of the slab for rib geometry.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     clad_thickness: Optional[Union[Size1D, ArrayFloat1D]] = Field(
@@ -106,7 +106,7 @@ class RectangularDielectric(Tidy3dBaseModel):
         title="Clad Thickness",
         description="Domain size above the core layer. An array can be used to define a layered "
         "clad. The last layer is extended into the PML as an infinitely thick layer.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     box_thickness: Optional[Union[Size1D, ArrayFloat1D]] = Field(
@@ -114,14 +114,14 @@ class RectangularDielectric(Tidy3dBaseModel):
         title="Box Thickness",
         description="Domain size below the core layer. An array can be used to define a layered "
         "substrate. The last layer is extended into the PML as an infinitely thick layer.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     side_margin: Optional[Size1D] = Field(
         None,
         title="Side Margin",
         description="Domain size to the sides of the waveguide core.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     sidewall_angle: float = Field(
@@ -130,7 +130,7 @@ class RectangularDielectric(Tidy3dBaseModel):
         description="Angle of the core sidewalls measured from the vertical direction (in "
         "radians).  Positive (negative) values create waveguides with bases wider (narrower) "
         "than their tops.",
-        units=RADIAN,
+        json_schema_extra={"units": RADIAN},
     )
 
     gap: Union[float, ArrayFloat1D] = Field(
@@ -138,14 +138,14 @@ class RectangularDielectric(Tidy3dBaseModel):
         title="Gap",
         description="Distance between adjacent waveguides, measured at the top core edges.  "
         "An array can be used to define one gap per pair of adjacent waveguides.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     sidewall_thickness: Size1D = Field(
         0.0,
         title="Sidewall Thickness",
         description="Sidewall layer thickness (within core).",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     sidewall_medium: Optional[MediumType] = Field(
@@ -160,7 +160,7 @@ class RectangularDielectric(Tidy3dBaseModel):
         title="Surface Thickness",
         description="Thickness of the surface layers defined on the top of the waveguide and  "
         "slab regions (if any).",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     surface_medium: Optional[MediumType] = Field(
@@ -176,14 +176,14 @@ class RectangularDielectric(Tidy3dBaseModel):
         description="Center of the waveguide geometry.  This coordinate represents the base "
         "of the waveguides (substrate surface) in the normal axis, and center of the geometry "
         "in the remaining axes.",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     length: Size1D = Field(
         1e30,
         title="Length",
         description="Length of the waveguides in the propagation direction",
-        units=MICROMETER,
+        json_schema_extra={"units": MICROMETER},
     )
 
     propagation_axis: Axis = Field(


### PR DESCRIPTION
Fixed all DeprecationWarnings from tests.
This includes:
- v1-style: `model.dict()` and `model.schema()` in tests
- `dataarray.argmin()` -> `dataarray.data.argmin()`
- `DeprecationWarning` of our own config (like `config.logging_level` or `config.log_suppression` in some tests)
- `mpl.cm.get_cmap` -> `plt.get_cmap`
- `Field(..., units=...) `-> `Field(..., json_schema_extra={"units":...})`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Systematically removes deprecation warnings and aligns code/tests with newer dependencies.
> 
> - Migrate `Field(..., units=...)` to `json_schema_extra={"units": ...}` across components; no runtime logic changes
> - Update tests and utilities to Pydantic v2 (`model_dump`, `model_json_schema`), xarray (`.data.argmax/argmin`), and matplotlib (`plt.get_cmap`)
> - Switch deprecated config access to `config.logging.level`/`config.logging.suppression`; add built-in `test` profile and use `config.switch_profile("test"/"dev")`
> - Tests: add/adjust expected warnings, convert lists→tuples where required, ensure complex arrays (`+0j`) in autograd cases, and small API-safe tweaks (e.g., `xr.concat` params)
> 
> - Minor cleanups: type hints/imports, tuple normalization in specs, and helper return type clarifications
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b4af3174886c26521e8481306bcf4ded47f218a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR systematically fixes deprecation warnings in preparation for Pydantic v2 migration. The changes include:

- **Pydantic v2 migration**: Updated `Field(..., units=...)` to `Field(..., json_schema_extra={"units":...})` across 60+ component files
- **Config API updates**: Migrated from deprecated `config.logging_level` to `config.logging.level` and `config.log_suppression` to `config.logging.suppression`
- **Matplotlib updates**: Replaced deprecated `mpl.cm.get_cmap()` with `plt.get_cmap()`
- **XArray updates**: Migrated from `dataarray.argmax()` to `dataarray.data.argmax()` to avoid xarray deprecation warnings
- **Test environment simplification**: Added `test` profile to config and replaced manual `EnvironmentConfig` setup with `config.switch_profile("test")`
- **Pydantic model methods**: Updated `.dict()` to `.model_dump()` in test utilities

The changes are mechanical and follow consistent patterns throughout. One minor style inconsistency was found in the `argmax` migration (`np.argmax(arr.data)` vs `arr.data.argmax()`), but both approaches are functionally correct.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The PR addresses deprecation warnings through mechanical, well-established migration patterns (Pydantic v2, xarray, matplotlib). All changes are backwards-compatible API updates that maintain the same functionality. The only issue found is a minor style inconsistency in `argmax` usage that doesn't affect correctness. The changes are focused, well-tested, and follow standard migration practices.
- No files require special attention - all changes follow standard deprecation fix patterns

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/components/data/data_array.py | Migrated `.argmax()` calls from xarray to numpy, but inconsistent style between `np.argmax(arr.data)` and `arr.data.argmax()` |
| tidy3d/components/medium.py | Migrated `units=` parameter to `json_schema_extra={"units":...}` for Pydantic v2 compatibility |
| tests/test_package/test_config.py | Updated config API from `config.logging_level` to `config.logging.level` |
| tidy3d/config/profiles.py | Added 'test' profile to builtin profiles for test environment configuration |
| tests/test_web/test_tidy3d_stub.py | Simplified test setup by using `config.switch_profile("test")` instead of manual environment configuration |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Tests as Test Suite
    participant Pydantic as Pydantic v2
    participant Config as Config System
    participant XArray as XArray
    participant MPL as Matplotlib

    Note over Dev,MPL: Deprecation Warning Fixes

    Dev->>Tests: Run test suite
    Tests->>Pydantic: Call Field(units=...)
    Pydantic-->>Tests: DeprecationWarning
    Dev->>Pydantic: Update to Field(json_schema_extra={"units":...})
    
    Tests->>Config: Access config.logging_level
    Config-->>Tests: DeprecationWarning
    Dev->>Config: Update to config.logging.level
    
    Tests->>XArray: Call dataarray.argmax()
    XArray-->>Tests: DeprecationWarning
    Dev->>XArray: Update to dataarray.data.argmax()
    
    Tests->>MPL: Call mpl.cm.get_cmap()
    MPL-->>Tests: DeprecationWarning
    Dev->>MPL: Update to plt.get_cmap()
    
    Dev->>Config: Add "test" profile to BUILTIN_PROFILES
    Tests->>Config: Use config.switch_profile("test")
    Config-->>Tests: Environment configured
    
    Dev->>Tests: Run test suite again
    Tests-->>Dev: All deprecation warnings resolved
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->