### PR TITLE
feat: warning about excessive refinement from gap meshing (FXC-3919)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added validation to `GaussianDoping` to ensure `ref_con < concentration`, validate `source` face identifier, and warn the user when the box size is not sufficient for the specified transition width.
 - Local caching is now enabled by default (set `td.config.local_cache.enabled=False` to opt out).
 - Reduced computation time of `adaptive_vjp_spacing` for `GeometryGroup` by allowing permittivity based spacing value to be cached.
+- Added warning in `LayerRefinementSpec` when `dl_min_from_gaps` (derived from automatic gap refinement) is very small relative to the lateral grid size for identifying cases where excessive grid refinement may occur due to very small detected gaps.
 
 ### Fixed
 - Fixed intermittent "API key not found" errors in parallel job launches by making configuration directory detection race-safe.

--- a/tests/test_components/test_layerrefinement.py
+++ b/tests/test_components/test_layerrefinement.py
@@ -1002,3 +1002,91 @@ def test_gap_meshing_tiny_nearly_parallel():
     # sim.plot_grid(y=0, ax=ax)
     # plt.show()
     assert sim.grid_info["min_grid_size"] > 0.05
+
+
+def test_gap_meshing_dl_min_warning():
+    """Test that warning is displayed when dl_min_from_gaps is very small relative to lateral grid size."""
+    from ..utils import AssertLogStr
+
+    wavelength = 1.0
+    # Create a very small gap that will trigger the warning
+    # For a grid with min_steps_per_wvl=10 and wavelength=1, the grid size will be around 0.1
+    # We need gap_width such that DL_MIN_FROM_GAPS_FRACTION * gap_width < GAP_REFINEMENT_WARNING_THRESH * min_lateral_grid_size
+    # gap_width < (0.1 * 0.1) / 0.45 ≈ 0.022
+    small_gap_width = 0.01  # Very small gap that will trigger warning
+
+    # Create two parallel PEC strips with a small gap between them
+    # Make structures smaller to avoid edge warnings (size 0.3 instead of 0.5 in y-direction)
+    strip1 = td.Structure(
+        geometry=td.Box(center=(-small_gap_width / 2 - 0.05, 0, 0), size=(0.1, 0.3, 0.2)),
+        medium=td.PECMedium(),
+    )
+
+    strip2 = td.Structure(
+        geometry=td.Box(center=(small_gap_width / 2 + 0.05, 0, 0), size=(0.1, 0.3, 0.2)),
+        medium=td.PECMedium(),
+    )
+
+    # Create layer refinement spec with gap meshing enabled
+    layer_spec = td.LayerRefinementSpec(
+        axis=2,  # z-axis
+        size=(td.inf, td.inf, 0.2),
+        center=(0, 0, 0),
+        gap_meshing_iters=1,
+        dl_min_from_gap_width=True,
+        corner_snapping=False,
+        corner_refinement=None,
+    )
+
+    grid_spec = td.GridSpec.auto(
+        wavelength=wavelength,
+        min_steps_per_wvl=10,  # This will create grid cells of ~0.1 size
+        layer_refinement_specs=[layer_spec],
+    )
+
+    # Test that warning IS displayed for very small gap
+    # Use AssertLogStr to filter out edge warnings and only check for our specific warning
+    with AssertLogStr("WARNING", contains_str="detected a very small gap width"):
+        sim = td.Simulation(
+            size=(1, 1, 0.2),
+            structures=[strip1, strip2],
+            grid_spec=grid_spec,
+            run_time=1e-15,
+        )
+
+    # Now test with a larger gap that should NOT trigger warning
+    # gap_width should be large enough: gap_width > (GAP_REFINEMENT_WARNING_THRESH * min_lateral_grid_size) / DL_MIN_FROM_GAPS_FRACTION
+    # For min_lateral_grid_size ~ 0.1: gap_width > (0.1 * 0.1) / 0.45 ≈ 0.022
+    large_gap_width = 0.05  # Large enough to not trigger warning
+
+    strip1_large = td.Structure(
+        geometry=td.Box(center=(-large_gap_width / 2 - 0.05, 0, 0), size=(0.1, 0.3, 0.2)),
+        medium=td.PECMedium(),
+    )
+
+    strip2_large = td.Structure(
+        geometry=td.Box(center=(large_gap_width / 2 + 0.05, 0, 0), size=(0.1, 0.3, 0.2)),
+        medium=td.PECMedium(),
+    )
+
+    # Test that warning is NOT displayed for larger gap
+    # Use AssertLogStr to exclude edge warnings and check that our specific warning is not present
+    with AssertLogStr("WARNING", excludes_str="detected a very small gap width"):
+        sim_large = td.Simulation(
+            size=(1, 1, 0.2),
+            structures=[strip1_large, strip2_large],
+            grid_spec=grid_spec,
+            run_time=1e-15,
+        )
+
+    # Test with dl_min_from_gap_width=False - should not warn even with small gap
+    layer_spec_no_gap = layer_spec.updated_copy(dl_min_from_gap_width=False)
+    grid_spec_no_gap = grid_spec.updated_copy(layer_refinement_specs=[layer_spec_no_gap])
+
+    with AssertLogStr("WARNING", excludes_str="detected a very small gap width"):
+        sim_no_gap = td.Simulation(
+            size=(1, 1, 0.2),
+            structures=[strip1, strip2],
+            grid_spec=grid_spec_no_gap,
+            run_time=1e-15,
+        )

--- a/tidy3d/components/grid/grid_spec.py
+++ b/tidy3d/components/grid/grid_spec.py
@@ -54,6 +54,12 @@ GAP_MESHING_TOL = 1e-3
 
 CornersAndConvexity = tuple[list[ArrayFloat2D], list[ArrayFloat1D]]
 
+# Fraction of detected gap width used to set dl_min_from_gaps
+DL_MIN_FROM_GAPS_FRACTION = 0.45
+
+# Threshold for warning when dl_min_from_gaps is very small relative to lateral grid size
+GAP_REFINEMENT_WARNING_THRESH = 0.1
+
 
 class GridSpec1d(Tidy3dBaseModel, ABC):
     """Abstract base class, defines 1D grid generation specifications."""
@@ -3129,6 +3135,44 @@ class GridSpec(Tidy3dBaseModel):
                         if layer_spec.dl_min_from_gap_width:
                             min_gap_width = min(min_gap_width, gap_width)
 
+                            # Warn if dl_min_from_gaps would be very small relative to lateral grid size
+                            if gap_width < inf:
+                                # Get lateral dimensions (perpendicular to layer axis)
+                                _, tan_dims = Box.pop_axis([0, 1, 2], layer_spec.axis)
+                                dim_names = ["x", "y", "z"]
+
+                                # Get grid sizes along lateral dimensions
+                                grid_sizes = old_grid.sizes.to_dict
+                                lateral_grid_sizes = [
+                                    grid_sizes[dim_names[tan_dims[0]]],
+                                    grid_sizes[dim_names[tan_dims[1]]],
+                                ]
+
+                                # Find minimum grid size along lateral dimensions
+                                min_lateral_grid_size = min(
+                                    min(sizes) if len(sizes) > 0 else inf
+                                    for sizes in lateral_grid_sizes
+                                )
+
+                                # Calculate dl_min_from_gaps for this layer spec
+                                dl_min_from_gaps = DL_MIN_FROM_GAPS_FRACTION * gap_width
+
+                                # Warn if dl_min_from_gaps is too small relative to lateral grid size
+                                if (
+                                    min_lateral_grid_size < inf
+                                    and dl_min_from_gaps
+                                    < GAP_REFINEMENT_WARNING_THRESH * min_lateral_grid_size
+                                ):
+                                    log.warning(
+                                        f"'LayerRefinementSpec' (axis={layer_spec.axis}) detected a very small gap width "
+                                        f"({gap_width:.2e}), resulting in 'dl_min_from_gaps'={dl_min_from_gaps:.2e}. "
+                                        f"This is less than {GAP_REFINEMENT_WARNING_THRESH * 100:.0f}% of the smallest "
+                                        f"lateral grid size ({min_lateral_grid_size:.2e}). This may lead to "
+                                        "excessive grid refinement. Consider adjusting the geometry or grid "
+                                        "specification.",
+                                        log_once=True,
+                                    )
+
                 if len(new_snapping_lines) == 0:
                     log.info(
                         "Grid is no longer changing. "
@@ -3147,7 +3191,7 @@ class GridSpec(Tidy3dBaseModel):
                     lumped_elements=lumped_elements,
                     internal_override_structures=internal_override_structures,
                     internal_snapping_points=snapping_lines + internal_snapping_points,
-                    dl_min_from_gaps=0.45 * min_gap_width,
+                    dl_min_from_gaps=DL_MIN_FROM_GAPS_FRACTION * min_gap_width,
                     structure_priority_mode=structure_priority_mode,
                     boundary_types=boundary_types,
                     parse_structures_interval_coords=parse_structures_interval_coords,


### PR DESCRIPTION
Warn if automatically calculated dl from gap meshing is less than 0.1 x (current min mesh size). Threshold (0.1) is somewhat random, we could adjust if needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds logging and constants around existing gap-meshing behavior; functional impact is limited to emitting a warning and is covered by targeted tests.
> 
> **Overview**
> Adds a new `LayerRefinementSpec` warning during automatic gap meshing when the derived `dl_min_from_gaps` (based on detected gap width) would be *very small* relative to the current lateral grid cell size, helping users catch cases that could trigger excessive mesh refinement.
> 
> Replaces the hardcoded `0.45` scaling with a named constant (`DL_MIN_FROM_GAPS_FRACTION`) and introduces a configurable warning threshold (`GAP_REFINEMENT_WARNING_THRESH`), updates the changelog, and adds a regression test covering warning/non-warning scenarios and the opt-out path (`dl_min_from_gap_width=False`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4a624b4fef2b19124bc522cc0fa6a91a32eaafd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a warning to alert users when gap meshing creates excessively fine mesh refinement. It introduces two new constants (`DL_MIN_FROM_GAPS_FRACTION` and `GAP_REFINEMENT_WARNING_THRESH`) and refactors existing code to use the named constant instead of a magic number.

**Key changes:**
- Extracts hardcoded value `0.45` into `DL_MIN_FROM_GAPS_FRACTION` constant
- Adds warning logic that triggers when calculated `dl_min_from_gaps` is less than 10% of the smallest lateral grid size
- Includes comprehensive test coverage with three scenarios: small gap (warning triggered), large gap (no warning), and disabled feature (no warning)

**Minor issue:**
- Missing CHANGELOG.md entry (required by custom instruction a109c62a-aa8c-4cc4-b515-0ad947c47929)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor style improvements recommended
- The implementation adds a helpful warning for users and includes thorough test coverage. The logic is sound and uses appropriate threshold values. The only issues are a missing CHANGELOG entry and a minor formatting inconsistency in the warning message (backticks vs single quotes). No functional bugs or security issues were detected.
- No files require special attention - the changes are straightforward and well-tested

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/components/grid/grid_spec.py | Added warning logic for excessive gap refinement with new constants; replaced magic number with named constant |
| tests/test_components/test_layerrefinement.py | Added comprehensive test for gap meshing warning with three test cases (small gap, large gap, disabled feature) |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant GridSpec
    participant LayerRefinementSpec
    participant Logger

    User->>GridSpec: Create simulation with gap meshing enabled
    GridSpec->>GridSpec: _make_grid_multiple_iterations()
    
    loop For each gap meshing iteration
        GridSpec->>LayerRefinementSpec: _resolve_gaps(old_grid, merged_geos)
        LayerRefinementSpec-->>GridSpec: (snapping_lines, gap_width)
        
        alt dl_min_from_gap_width enabled
            GridSpec->>GridSpec: Update min_gap_width
            
            alt gap_width < inf
                GridSpec->>GridSpec: Calculate lateral_grid_sizes
                GridSpec->>GridSpec: Find min_lateral_grid_size
                GridSpec->>GridSpec: Calculate dl_min_from_gaps = 0.45 * gap_width
                
                alt dl_min_from_gaps < 0.1 * min_lateral_grid_size
                    GridSpec->>Logger: log.warning("detected a very small gap width...")
                    Logger-->>User: Display warning about excessive refinement
                end
            end
        end
        
        GridSpec->>GridSpec: _make_grid_one_iteration() with dl_min_from_gaps
    end
    
    GridSpec-->>User: Return final grid with refined gaps
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Update the CHANGELOG.md file when making changes that affect user-facing functionality or fix bugs. ([source](https://app.greptile.com/review/custom-context?memory=a109c62a-aa8c-4cc4-b515-0ad947c47929))

<!-- /greptile_comment -->