### PR TITLE
chore(tidy3d): FXC-5132-ignore-jira-branch-lint-for-dependabot

### DIFF
--- a/.github/workflows/tidy3d-python-client-tests.yml
+++ b/.github/workflows/tidy3d-python-client-tests.yml
@@ -328,6 +328,7 @@ jobs:
 
       - name: enforce-jira-key
         id: enforce-jira-key
+        if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
         env:
           STEPS_EXTRACT_BRANCH_NAME_OUTPUTS_BRANCH_NAME: ${{ steps.extract-branch-name.outputs.branch_name }}
         run: |


### PR DESCRIPTION
PRs from dependabot are currently rejected due to branch name linting. Think we might just disable it?
https://github.com/flexcompute/tidy3d/actions/runs/21400098223/job/61608502300

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exempts Dependabot PRs from branch name Jira key checks to prevent CI failures on automated dependency updates.
> 
> - Adds condition to `enforce-jira-key` step in `tidy3d-python-client-tests.yml` to run only for PRs not opened by `dependabot[bot]`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ed594a9efd735cda1d0bac92d4b3d987c43a498. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added conditional logic to skip Jira key enforcement for Dependabot PRs. The change adds `if: github.actor != 'dependabot[bot]'` to the `enforce-jira-key` step in the branch name linting job, preventing automated dependency update PRs from failing due to missing Jira keys in their branch names.

- Resolves CI failures for Dependabot PRs that cannot include Jira keys in their automated branch names
- Aligns with existing exemption pattern (chore, hotfix, daily-chore prefixes already exempt)
- Follows custom rule 42c6ce6c-d2b4-4972-b7ef-11f53cd63cc3 which recommends exemptions for automated processes like dependabot

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a single-line conditional addition that precisely addresses the stated problem of Dependabot PRs failing branch name validation. The implementation follows GitHub Actions best practices, correctly uses the `github.actor` context variable, and aligns with the repository's custom rule for exempting automated processes. No logic errors, security concerns, or unintended side effects are present.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/tidy3d-python-client-tests.yml | Added conditional to skip Jira key enforcement for `dependabot[bot]` PRs, resolving CI failures for automated dependency updates |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dependabot
    participant GitHub
    participant Workflow as CI Workflow
    participant JiraCheck as Jira Key Check
    
    Dependabot->>GitHub: Create PR (dependency update)
    GitHub->>Workflow: Trigger tidy3d-python-client-tests
    Workflow->>Workflow: determine-test-scope
    Workflow->>Workflow: lint-branch-name job
    Workflow->>Workflow: extract-branch-name
    Workflow->>JiraCheck: enforce-jira-key step
    
    alt github.actor != 'dependabot[bot]'
        JiraCheck->>JiraCheck: Check branch name for Jira key
        JiraCheck->>JiraCheck: Check PR title for Jira key
        JiraCheck-->>Workflow: Pass/Fail based on Jira key presence
    else github.actor == 'dependabot[bot]'
        Note over JiraCheck: Step skipped (if: condition false)
        JiraCheck-->>Workflow: Step skipped - Pass
    end
    
    Workflow->>GitHub: Report workflow status
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - When implementing branch name validation rules, ensure exemptions are added for automated processes ... ([source](https://app.greptile.com/review/custom-context?memory=42c6ce6c-d2b4-4972-b7ef-11f53cd63cc3))

<!-- /greptile_comment -->