### PR TITLE
FXC-5153: making trimesh and matplotlib lazy

### DIFF
--- a/tests/test_package/test_lazy_imports.py
+++ b/tests/test_package/test_lazy_imports.py
@@ -1,0 +1,158 @@
+"""Tests that heavy optional packages are not imported at top-level tidy3d import.
+
+These tests ensure that packages like matplotlib, scipy, trimesh, and vtk
+are only imported when actually needed (lazy imports), not at module load time.
+This keeps the initial import time low for users who don't need these features.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def subprocess_env() -> dict[str, str]:
+    """Return a clean environment for subprocess calls.
+
+    Removes coverage-related variables that could cause additional imports
+    in the subprocess and interfere with lazy import tests.
+    """
+    env = dict(os.environ)
+    # Remove coverage-related variables that might cause extra imports
+    for key in list(env.keys()):
+        if "COV" in key.upper() or "COVERAGE" in key.upper():
+            del env[key]
+    return env
+
+
+# List of packages that should NOT be imported on top-level tidy3d import
+# Note: scipy is excluded because xarray (a core dependency) imports its
+# scipy backend automatically via entrypoints
+LAZY_PACKAGES = [
+    "matplotlib",
+    "trimesh",
+    "vtk",
+    "networkx",  # transitive dependency of trimesh
+]
+
+
+@pytest.mark.parametrize("package", LAZY_PACKAGES)
+def test_package_not_imported_on_tidy3d_import(package: str) -> None:
+    """Test that a package is not imported when importing tidy3d.
+
+    We run this in a subprocess to ensure a clean Python environment
+    without any prior imports that might pollute sys.modules.
+    """
+    # Create a script that imports tidy3d and checks if the package is in sys.modules
+    script = f"""
+import sys
+import tidy3d
+if "{package}" in sys.modules:
+    print(f"FAIL: {package} was imported")
+    sys.exit(1)
+else:
+    print(f"OK: {package} was not imported")
+    sys.exit(0)
+"""
+    # Use -E to ignore PYTHON* env vars and -s to disable site customization
+    # that might be installed by coverage tools
+    result = subprocess.run(
+        [sys.executable, "-E", "-s", "-c", script],
+        capture_output=True,
+        text=True,
+        env=subprocess_env(),
+    )
+
+    # Print output for debugging
+    if result.stdout:
+        print(result.stdout)
+    if result.stderr:
+        print(result.stderr, file=sys.stderr)
+
+    assert result.returncode == 0, (
+        f"Package '{package}' was imported on top-level tidy3d import. "
+        f"This increases import time. Consider making the import lazy."
+    )
+
+
+def test_all_lazy_packages_not_imported() -> None:
+    """Test that none of the lazy packages are imported when importing tidy3d.
+
+    This is a combined test that checks all packages at once, which is faster
+    than running separate subprocesses for each package.
+    """
+    packages_str = ", ".join(f'"{p}"' for p in LAZY_PACKAGES)
+    script = f"""
+import sys
+# Import tidy3d
+import tidy3d
+# Check which packages were imported
+lazy_packages = [{packages_str}]
+imported = [p for p in lazy_packages if p in sys.modules]
+if imported:
+    print(f"FAIL: These packages were imported: {{imported}}")
+    sys.exit(1)
+else:
+    print(f"OK: None of the lazy packages were imported")
+    sys.exit(0)
+"""
+    # Use -E to ignore PYTHON* env vars and -s to disable site customization
+    result = subprocess.run(
+        [sys.executable, "-E", "-s", "-c", script],
+        capture_output=True,
+        text=True,
+        env=subprocess_env(),
+    )
+
+    # Print output for debugging
+    if result.stdout:
+        print(result.stdout)
+    if result.stderr:
+        print(result.stderr, file=sys.stderr)
+
+    assert result.returncode == 0, (
+        f"Some lazy packages were imported on top-level tidy3d import: {result.stdout}"
+    )
+
+
+def test_matplotlib_imported_on_plot() -> None:
+    """Test that matplotlib IS imported when a plot function is called."""
+    script = """
+import sys
+import tidy3d as td
+
+# matplotlib should not be imported yet
+assert "matplotlib" not in sys.modules, "matplotlib imported too early"
+
+# Create a simple simulation and try to plot it
+sim = td.Simulation(
+    size=(1, 1, 1),
+    grid_spec=td.GridSpec.auto(wavelength=1.0),
+    run_time=1e-12,
+)
+
+# This should trigger matplotlib import (backend set via MPLBACKEND env var)
+ax = sim.plot(z=0)
+
+# Now matplotlib should be imported
+assert "matplotlib" in sys.modules, "matplotlib should be imported after plotting"
+print("OK: matplotlib imported only when needed")
+"""
+    # Use -E to ignore PYTHON* env vars and -s to disable site customization
+    result = subprocess.run(
+        [sys.executable, "-E", "-s", "-c", script],
+        capture_output=True,
+        text=True,
+        env={**subprocess_env(), "MPLBACKEND": "Agg"},  # Use non-interactive backend
+    )
+
+    # Print output for debugging
+    if result.stdout:
+        print(result.stdout)
+    if result.stderr:
+        print(result.stderr, file=sys.stderr)
+
+    assert result.returncode == 0, f"Test failed: {result.stderr}"

--- a/tidy3d/components/data/unstructured/triangular.py
+++ b/tidy3d/components/data/unstructured/triangular.py
@@ -8,11 +8,8 @@ import numpy as np
 from pydantic import Field
 from xarray import DataArray as XrDataArray
 
-try:
-    from matplotlib import pyplot as plt
+if TYPE_CHECKING:
     from matplotlib.tri import Triangulation
-except ImportError:
-    pass
 
 from tidy3d.components.base import cached_property
 from tidy3d.components.data.data_array import (
@@ -583,6 +580,8 @@ class TriangularGridDataset(UnstructuredGridDataset):
     @property
     def _triangulation_obj(self) -> Triangulation:
         """Matplotlib triangular representation of the grid to use in plotting."""
+        from matplotlib.tri import Triangulation
+
         return Triangulation(self.points[:, 0], self.points[:, 1], self.cells)
 
     @equal_aspect
@@ -659,6 +658,8 @@ class TriangularGridDataset(UnstructuredGridDataset):
             )
 
             if cbar:
+                from matplotlib import pyplot as plt
+
                 label_kwargs = {}
                 if "label" not in cbar_kwargs:
                     label_kwargs["label"] = self.values.name

--- a/tidy3d/components/eme/simulation.py
+++ b/tidy3d/components/eme/simulation.py
@@ -51,11 +51,6 @@ if TYPE_CHECKING:
 
     from .grid import EMEGrid, EMEGridSpec
 
-try:
-    import matplotlib as mpl
-except ImportError:
-    pass
-
 # maximum numbers of simulation parameters
 WARN_MONITOR_DATA_SIZE_GB = 10
 MAX_MONITOR_INTERNAL_DATA_SIZE_GB = 50
@@ -340,6 +335,8 @@ class EMESimulation(AbstractYeeGridSimulation):
         **kwargs: Any,
     ) -> Ax:
         """Plot the EME ports."""
+        import matplotlib as mpl
+
         kwargs.setdefault("linewidth", 0.4)
         kwargs.setdefault("colors", "black")
         rmin = self.geometry.bounds[0][self.axis]
@@ -387,6 +384,8 @@ class EMESimulation(AbstractYeeGridSimulation):
         Does nothing if ``eme_grid_spec`` is not :class:`.EMECompositeGrid`.
         Operates recursively on subgrids.
         """
+        import matplotlib as mpl
+
         if not isinstance(eme_grid_spec, EMECompositeGrid):
             return ax
         kwargs.setdefault("linewidth", 0.4)
@@ -436,6 +435,8 @@ class EMESimulation(AbstractYeeGridSimulation):
         **kwargs: Any,
     ) -> Ax:
         """Plot the EME grid."""
+        import matplotlib as mpl
+
         kwargs.setdefault("linewidth", 0.2)
         kwargs.setdefault("colors", "black")
         cell_boundaries = self.eme_grid.boundaries

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -29,7 +29,6 @@ from tidy3d.components.viz import (
     ARROW_LENGTH,
     PLOT_BUFFER,
     add_ax_if_none,
-    arrow_style,
     equal_aspect,
     plot_params_geometry,
     polygon_patch,
@@ -72,11 +71,6 @@ if TYPE_CHECKING:
         Size,
     )
     from tidy3d.components.viz import PlotParams, VisualizationSpec
-
-try:
-    from matplotlib import patches
-except ImportError:
-    pass
 
 POLY_GRID_SIZE = 1e-12
 POLY_TOLERANCE_RATIO = 1e-12
@@ -2512,6 +2506,9 @@ class Box(SimplePlaneIntersection, Centered):
         matplotlib.axes._subplots.Axes
             The matplotlib axes with the arrow added.
         """
+        from matplotlib import patches
+
+        from tidy3d.components.viz.styles import arrow_style
 
         plot_axis, _ = self.parse_xyz_kwargs(x=x, y=y, z=z)
         _, (dx, dy) = self.pop_axis(direction, axis=plot_axis)
@@ -2546,7 +2543,7 @@ class Box(SimplePlaneIntersection, Centered):
                 arrow = patches.FancyArrowPatch(
                     (x0, y0),
                     (x0 + v_x, y0 + v_y),
-                    arrowstyle=arrow_style,
+                    arrowstyle=arrow_style(),
                     color=color,
                     alpha=alpha,
                     zorder=np.inf,
@@ -2574,6 +2571,8 @@ class Box(SimplePlaneIntersection, Centered):
         sign: float,
         bend_radius: float | None,
     ) -> Callable[[Event], None]:
+        from matplotlib import patches
+
         def _cb(event: Event) -> None:
             # We only want to set the shape once, so we disconnect ourselves
             event.canvas.mpl_disconnect(arrow.set_shape_cb[0])

--- a/tidy3d/components/scene.py
+++ b/tidy3d/components/scene.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Optional
 
 import autograd.numpy as np
+from pydantic import Field, field_validator
 
 if TYPE_CHECKING:
     from typing import Literal, Union
@@ -27,14 +28,6 @@ if TYPE_CHECKING:
         Size,
     )
     from .viz import PlotParams
-
-try:
-    import matplotlib as mpl
-    import matplotlib.pylab as plt
-    from mpl_toolkits.axes_grid1 import make_axes_locatable
-except ImportError:
-    mpl = None
-from pydantic import Field, field_validator
 
 from tidy3d.components.material.tcad.charge import (
     ChargeConductorMedium,
@@ -87,12 +80,14 @@ from .viz import (
     polygon_path,
 )
 
-try:
-    import matplotlib as mpl
-    import matplotlib.pylab as plt
-    from mpl_toolkits.axes_grid1 import make_axes_locatable
-except ImportError:
-    pass
+# Sentinel to indicate matplotlib hasn't been loaded yet
+_MPL_NOT_LOADED = object()
+
+# Module-level mpl reference for lazy loading and test mocking
+# - _MPL_NOT_LOADED: not yet imported (will import on first use)
+# - None: explicitly unavailable (for testing fallback behavior)
+# - module: matplotlib module when successfully imported
+mpl: Any = _MPL_NOT_LOADED
 
 # maximum number of mediums supported
 MAX_NUM_MEDIUMS = 65530
@@ -664,9 +659,13 @@ class Scene(Tidy3dBaseModel):
         label: str,
         cmap: str,
         ax: Ax = None,
-        norm: mpl.colors.Normalize = None,
+        norm: mpl.colors.Normalize | None = None,
     ) -> None:
         """Add a colorbar to plot."""
+        import matplotlib as mpl
+        import matplotlib.pylab as plt
+        from mpl_toolkits.axes_grid1 import make_axes_locatable
+
         divider = make_axes_locatable(ax)
         cax = divider.append_axes("right", size="5%", pad=0.15)
         if norm is None:
@@ -1039,6 +1038,7 @@ class Scene(Tidy3dBaseModel):
         matplotlib.axes._subplots.Axes
             The supplied or created matplotlib axes.
         """
+        import matplotlib as mpl
 
         structures = self.sorted_structures
 
@@ -1218,7 +1218,7 @@ class Scene(Tidy3dBaseModel):
         eps_max: float,
         ax: Ax = None,
         reverse: bool = False,
-        norm: Optional[mpl.colors.Normalize] = None,
+        norm: mpl.colors.Normalize | None = None,
     ) -> None:
         """Add a permittivity colorbar to plot."""
         Scene._add_cbar(
@@ -1289,7 +1289,7 @@ class Scene(Tidy3dBaseModel):
         ax: Ax,
         grid: Grid,
         eps_component: Optional[PermittivityComponent] = None,
-        norm: mpl.colors.Normalize = None,
+        norm: mpl.colors.Normalize | None = None,
     ) -> None:
         """
         Plot shape made of custom medium with ``pcolormesh``.
@@ -1441,9 +1441,17 @@ class Scene(Tidy3dBaseModel):
         reverse: bool = False,
         alpha: Optional[float] = None,
         eps_component: Optional[PermittivityComponent] = None,
-        norm: Optional[mpl.colors.Normalize] = None,
+        norm: mpl.colors.Normalize | None = None,
     ) -> PlotParams:
         """Constructs the plot parameters for a given medium in scene.plot_eps()."""
+        global mpl
+        if mpl is _MPL_NOT_LOADED:
+            try:
+                import matplotlib as _mpl
+
+                mpl = _mpl
+            except ImportError:
+                mpl = None  # Triggers grayscale fallback
 
         plot_params = plot_params_structure.copy(update={"linewidth": 0})
         if isinstance(medium, AbstractMedium):
@@ -1469,22 +1477,24 @@ class Scene(Tidy3dBaseModel):
             eps_medium = medium._eps_plot(frequency=freq, eps_component=eps_component)
             if norm is not None:
                 color_value = float(norm(eps_medium))
-            elif mpl is not None:
-                active_norm = mpl.colors.Normalize(vmin=eps_min, vmax=eps_max)
-                color_value = float(active_norm(eps_medium))
+            elif eps_min == eps_max:
+                # Avoid division by zero; use midpoint
+                color_value = 0.5
             else:
-                if eps_max == eps_min:
-                    color_value = 0.5
-                else:
-                    color_value = (eps_medium - eps_min) / (eps_max - eps_min)
+                color_value = (eps_medium - eps_min) / (eps_max - eps_min)
             color_value = min(1.0, max(0.0, color_value))
+
+            # Use matplotlib colormap if available, otherwise fallback to grayscale
             if mpl is not None:
                 cmap_name = _get_colormap(reverse=reverse)
-                cmap = plt.get_cmap(cmap_name)
+                cmap = mpl.colormaps[cmap_name]
                 rgba = tuple(float(component) for component in cmap(color_value))
             else:
-                gray_value = color_value if reverse else 1.0 - color_value
-                rgba = (gray_value, gray_value, gray_value, 1.0)
+                # Grayscale fallback when matplotlib is unavailable
+                # Forward (Greys): 0 -> white, 1 -> black
+                # Reverse (Greys_r): 0 -> black, 1 -> white
+                grayscale = color_value if reverse else (1.0 - color_value)
+                rgba = (grayscale, grayscale, grayscale, 1.0)
             plot_params = plot_params.copy(update={"facecolor": rgba})
 
         return plot_params
@@ -1500,7 +1510,7 @@ class Scene(Tidy3dBaseModel):
         reverse: bool = False,
         alpha: Optional[float] = None,
         eps_component: Optional[PermittivityComponent] = None,
-        norm: Optional[mpl.colors.Normalize] = None,
+        norm: mpl.colors.Normalize | None = None,
     ) -> Ax:
         """Plot a structure's cross section shape for a given medium, grayscale for permittivity."""
         plot_params = self._get_structure_eps_plot_params(

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -162,11 +162,6 @@ if TYPE_CHECKING:
     )
 
 try:
-    import matplotlib as mpl
-except ImportError:
-    pass
-
-try:
     gdstk_available = True
     import gdstk
 except ImportError:
@@ -1177,6 +1172,8 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         matplotlib.axes._subplots.Axes
             The supplied or created matplotlib axes.
         """
+        import matplotlib as mpl
+
         kwargs.setdefault("linewidth", 0.2)
         kwargs.setdefault("colors", "black")
         kwargs.setdefault("colors_internal", "darkmagenta")
@@ -1348,6 +1345,7 @@ class AbstractYeeGridSimulation(AbstractSimulation, ABC):
         matplotlib.axes._subplots.Axes
             The supplied or created matplotlib axes.
         """
+        import matplotlib as mpl
 
         def set_plot_params(
             boundary_edge: Union[ABCBoundary, ModeABCBoundary, BoundaryEdgeType],

--- a/tidy3d/components/tcad/simulation/heat_charge.py
+++ b/tidy3d/components/tcad/simulation/heat_charge.py
@@ -96,11 +96,6 @@ if TYPE_CHECKING:
     from tidy3d.components.types.base import ArrayFloat1D
     from tidy3d.components.viz import PlotParams
 
-try:
-    from matplotlib import colormaps
-except ImportError:
-    pass
-
 HEAT_CHARGE_BACK_STRUCTURE_STR = "<<<HEAT_CHARGE_BACKGROUND_STRUCTURE>>>"
 
 HeatBCTypes = (TemperatureBC, HeatFluxBC, ConvectionBC)
@@ -1960,6 +1955,8 @@ class HeatChargeSimulation(AbstractSimulation):
         if isinstance(source, HeatSource):
             rate = np.mean(source.rate)
             if rate is not None:
+                from matplotlib import colormaps
+
                 delta_rate = rate - source_min
                 delta_rate_max = source_max - source_min + 1e-5
                 rate_fraction = delta_rate / delta_rate_max

--- a/tidy3d/components/types/__init__.py
+++ b/tidy3d/components/types/__init__.py
@@ -63,7 +63,6 @@ from tidy3d.components.types.base import (
     UnitsZBF,
     xyz,
 )
-from tidy3d.components.types.third_party import TrimeshType
 from tidy3d.components.types.utils import _add_schema
 
 __all__ = [
@@ -123,7 +122,6 @@ __all__ = [
     "Symmetry",
     "TensorReal",
     "TrackFreq",
-    "TrimeshType",
     "Undefined",
     "UnitsZBF",
     "_add_schema",

--- a/tidy3d/components/types/base.py
+++ b/tidy3d/components/types/base.py
@@ -21,9 +21,10 @@ from pydantic.json_schema import WithJsonSchema
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-try:
+if TYPE_CHECKING:
     from matplotlib.axes import Axes
-except ImportError:
+else:
+    # At runtime, Axes is just Any to avoid importing matplotlib
     Axes = None
 
 from shapely.geometry.base import BaseGeometry

--- a/tidy3d/components/types/third_party.py
+++ b/tidy3d/components/types/third_party.py
@@ -7,8 +7,12 @@ from tidy3d.packaging import check_import
 # TODO Complicated as trimesh should be a core package unless decoupled implementation types in functional location.
 #  We need to restructure.
 if check_import("trimesh"):
-    import trimesh  # Won't add much overhead if already imported
+    try:
+        import trimesh
 
-    TrimeshType = trimesh.Trimesh
+        TrimeshType = trimesh.Trimesh
+    except ImportError:
+        # Package is installed but broken (e.g., missing dependencies)
+        TrimeshType = Any
 else:
     TrimeshType = Any

--- a/tidy3d/components/viz/__init__.py
+++ b/tidy3d/components/viz/__init__.py
@@ -38,11 +38,21 @@ from .styles import (
     STRUCTURE_EPS_CMAP,
     STRUCTURE_EPS_CMAP_R,
     STRUCTURE_HEAT_COND_CMAP,
-    arrow_style,
 )
 from .visualization_spec import MATPLOTLIB_IMPORTED, VisualizationSpec
 
-apply_tidy3d_params()
+# Note: apply_tidy3d_params() is no longer called at import time to reduce import overhead.
+# It will be called automatically when matplotlib is first used for plotting.
+_tidy3d_style_applied = False
+
+
+def _ensure_tidy3d_style() -> None:
+    """Apply tidy3d matplotlib style if not already applied."""
+    global _tidy3d_style_applied
+    if not _tidy3d_style_applied:
+        apply_tidy3d_params()
+        _tidy3d_style_applied = True
+
 
 __all__ = [
     "ARROW_ALPHA",
@@ -64,7 +74,6 @@ __all__ = [
     "Polygon",
     "VisualizationSpec",
     "add_ax_if_none",
-    "arrow_style",
     "equal_aspect",
     "make_ax",
     "plot_params_abc",

--- a/tidy3d/components/viz/axes_utils.py
+++ b/tidy3d/components/viz/axes_utils.py
@@ -111,6 +111,10 @@ def _create_unit_aware_locator() -> ticker.Locator:
 
 def make_ax() -> Ax:
     """makes an empty ``ax``."""
+    from tidy3d.components.viz import _ensure_tidy3d_style
+
+    _ensure_tidy3d_style()
+
     import matplotlib.pyplot as plt
 
     _, ax = plt.subplots(1, 1, tight_layout=True)
@@ -120,11 +124,16 @@ def make_ax() -> Ax:
 def add_ax_if_none(plot: T) -> T:
     """Decorates ``plot(*args, **kwargs, ax=None)`` function.
     if ax=None in the function call, creates an ax and feeds it to rest of function.
+    Also ensures tidy3d matplotlib style is applied.
     """
 
     @wraps(plot)
     def _plot(*args: P.args, **kwargs: P.kwargs) -> Axes:
         """New plot function using a generated ax if None."""
+        from tidy3d.components.viz import _ensure_tidy3d_style
+
+        _ensure_tidy3d_style()
+
         if kwargs.get("ax") is None:
             ax = make_ax()
             kwargs["ax"] = ax

--- a/tidy3d/components/viz/descartes.py
+++ b/tidy3d/components/viz/descartes.py
@@ -18,14 +18,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from matplotlib.patches import PathPatch
+    from matplotlib.path import Path
     from numpy.typing import NDArray
     from shapely.geometry.base import BaseGeometry
 
-try:
-    from matplotlib.patches import PathPatch
-    from matplotlib.path import Path
-except ImportError:
-    pass
 from numpy import array, concatenate, ones
 
 
@@ -58,6 +55,7 @@ class Polygon:
 def polygon_path(polygon: BaseGeometry) -> Path:
     """Constructs a compound matplotlib path from a Shapely or GeoJSON-like
     geometric object"""
+    from matplotlib.path import Path
 
     def coding(obj: Any) -> NDArray:
         # The codes will be all "LINETO" commands, except for "MOVETO"s at the
@@ -106,6 +104,8 @@ def polygon_patch(polygon: BaseGeometry, **kwargs: Any) -> PathPatch:
     >>> axis.add_patch(patch) # doctest: +SKIP
 
     """
+    from matplotlib.patches import PathPatch
+
     return PathPatch(polygon_path(polygon), **kwargs)
 
 

--- a/tidy3d/components/viz/styles.py
+++ b/tidy3d/components/viz/styles.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
-try:
-    from matplotlib.patches import ArrowStyle
+from typing import Any
 
-    arrow_style = ArrowStyle.Simple(head_length=11, head_width=9, tail_width=4)
-except ImportError:
-    arrow_style = None
+_arrow_style = None
+
+
+def arrow_style() -> Any:
+    """Lazily create arrow style to avoid importing matplotlib at module load."""
+    global _arrow_style
+    if _arrow_style is None:
+        from matplotlib.patches import ArrowStyle
+
+        _arrow_style = ArrowStyle.Simple(head_length=11, head_width=9, tail_width=4)
+    return _arrow_style
+
 
 FLEXCOMPUTE_COLORS = {
     "brand_green": "#00643C",

--- a/tidy3d/components/viz/visualization_spec.py
+++ b/tidy3d/components/viz/visualization_spec.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from importlib.util import find_spec
 from typing import TYPE_CHECKING
 
 from pydantic import Field, field_validator
@@ -10,23 +11,40 @@ from tidy3d.log import log
 if TYPE_CHECKING:
     from pydantic import ValidationInfo
 
-MATPLOTLIB_IMPORTED = True
-try:
-    from matplotlib.colors import is_color_like
-except ImportError:
-    is_color_like = None
-    MATPLOTLIB_IMPORTED = False
+# Cached reference to is_color_like, set on first use
+_is_color_like = None
+
+# Check if matplotlib is available without importing it
+MATPLOTLIB_IMPORTED = find_spec("matplotlib") is not None
 
 
 def is_valid_color(value: str) -> str:
+    global _is_color_like
+    # Check MATPLOTLIB_IMPORTED first to allow test mocking
     if not MATPLOTLIB_IMPORTED:
         log.warning(
             "matplotlib was not successfully imported, but is required "
             "to validate colors in the VisualizationSpec. The specified colors "
             "have not been validated."
         )
+        return value
+
+    if _is_color_like is None:
+        try:
+            from matplotlib.colors import is_color_like
+
+            _is_color_like = is_color_like
+        except ImportError:
+            _is_color_like = False  # Sentinel to indicate import failed
+
+    if _is_color_like is False:
+        log.warning(
+            "matplotlib was not successfully imported, but is required "
+            "to validate colors in the VisualizationSpec. The specified colors "
+            "have not been validated."
+        )
     else:
-        if is_color_like is not None and not is_color_like(value):
+        if not _is_color_like(value):
             raise ValueError(f"{value} is not a valid plotting color")
 
     return value

--- a/tidy3d/packaging.py
+++ b/tidy3d/packaging.py
@@ -7,7 +7,6 @@ This section should only depend on the standard core installation in the pyproje
 from __future__ import annotations
 
 import functools
-from importlib import import_module
 from importlib.util import find_spec
 from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
@@ -36,23 +35,23 @@ tidy3d_extras = {"mod": None, "use_local_subpixel": None}
 
 def check_import(module_name: str) -> bool:
     """
-    Check if a module or submodule section has been imported. This is a functional way of loading packages that will still load the corresponding module into the total space.
+    Check if a module or submodule is available for import without actually importing it.
+
+    This uses `importlib.util.find_spec` to check availability without importing,
+    which keeps the module out of `sys.modules` until it's actually needed.
 
     Parameters
     ----------
-    module_name
+    module_name : str
+        The name of the module to check.
 
     Returns
     -------
     bool
-        True if the module has been imported, False otherwise.
+        True if the module is available for import, False otherwise.
 
     """
-    try:
-        import_module(module_name)
-        return True
-    except ImportError:
-        return False
+    return find_spec(module_name) is not None
 
 
 def verify_packages_import(


### PR DESCRIPTION
`trimesh` was not being lazy because of TrimeshType. That was an easy fix.

The bulk of the changes were needed to make matplotlib lazy. This doesn't look too bad, what do you think @yaugenst ?

On my PC import time dropped from 1.9s to 1.2s.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR implements lazy imports for `trimesh` and `matplotlib` to reduce initial import overhead for the tidy3d package.

**Key Changes:**
- Fixed `trimesh` lazy loading by moving `TrimeshType` import check from module-level to usage-time
- Implemented comprehensive lazy loading for `matplotlib` across visualization components
- Changed `arrow_style` from module-level constant to lazy-loading function
- Added `_ensure_tidy3d_style()` mechanism to defer matplotlib style configuration until first plot
- Moved all matplotlib imports to either `TYPE_CHECKING` blocks (for type hints) or function-level imports
- Added comprehensive test suite using subprocess isolation to verify lazy import behavior

**Impact:**
The changes successfully defer heavy optional dependencies until they're actually needed, improving import performance for users who don't require visualization features.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor style improvement suggested
- The implementation is well-structured and comprehensive, with proper TYPE_CHECKING usage and function-level imports. Tests validate the behavior. Minor inefficiency in `is_valid_color` that could be optimized but doesn't affect correctness.
- Check `tidy3d/components/viz/visualization_spec.py` for the redundant import optimization

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tests/test_package/test_lazy_imports.py | New comprehensive test suite for lazy imports using subprocess isolation |
| tidy3d/components/types/base.py | Changed matplotlib Axes import to TYPE_CHECKING pattern for lazy loading |
| tidy3d/components/viz/__init__.py | Added lazy style application mechanism to defer matplotlib initialization |
| tidy3d/components/viz/styles.py | Converted arrow_style from module-level constant to lazy-loading function |
| tidy3d/components/viz/visualization_spec.py | Made is_color_like import lazy but imports it twice per validation call |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Tidy3d
    participant VizModule as viz/__init__.py
    participant MakeAx as make_ax()
    participant EnsureStyle as _ensure_tidy3d_style()
    participant Matplotlib

    User->>Tidy3d: import tidy3d
    Note over Tidy3d,VizModule: No matplotlib import at this stage
    Tidy3d-->>User: Module loaded (fast)
    
    User->>Tidy3d: sim.plot(z=0)
    Tidy3d->>MakeAx: ax is None, create one
    MakeAx->>EnsureStyle: Check if style applied
    
    alt First plot call
        EnsureStyle->>Matplotlib: import matplotlib
        EnsureStyle->>Matplotlib: apply_tidy3d_params()
        Note over EnsureStyle: Set _tidy3d_style_applied = True
    else Subsequent calls
        Note over EnsureStyle: Style already applied, skip
    end
    
    MakeAx->>Matplotlib: plt.subplots()
    Matplotlib-->>MakeAx: ax created
    MakeAx-->>Tidy3d: Return ax
    Tidy3d->>Matplotlib: Render plot
    Matplotlib-->>User: Display plot
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes import-time behavior and plotting paths across multiple modules; failures would surface as runtime ImportErrors or subtle plotting/style differences rather than at import time.
> 
> **Overview**
> **Makes optional heavy deps truly lazy.** Removes/avoids module-level `matplotlib` imports across plotting-related code and defers style initialization by introducing `_ensure_tidy3d_style()` (no longer calling `apply_tidy3d_params()` at `tidy3d.components.viz` import).
> 
> Moves `matplotlib` imports into plot-time code paths (e.g., `Simulation`/EME plotting, triangular dataset plotting, geometry arrow rendering, colorbar helpers) and updates arrow styling to a lazy `arrow_style()` factory. Also adjusts `VisualizationSpec` color validation to check availability via `find_spec` and lazily import `is_color_like`, and updates `check_import()` to use `find_spec` to avoid importing modules just to check presence.
> 
> Fixes `TrimeshType` so `trimesh` isn’t imported during `tidy3d` import (including handling “installed but broken” cases), and adds subprocess-based tests ensuring `matplotlib`/`trimesh`/`vtk` (and `networkx`) are not imported on `import tidy3d` while `matplotlib` *is* imported when calling `plot()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdd9e22783c006d78430c088d24751d801c48e42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->