### PR TITLE
feat(geometry): add GeometryArray for efficient repeated geometries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `GeometryArray` class for efficiently representing multiple copies of a base geometry at specified offsets with transformation matrices. Includes a convenience method `geometry.array(offsets=..., transforms=...)` on all geometry objects.
 - Added `ModeSortSpec.keep_modes` which can be set to `"all"` to keep all modes in the mode solver (the default), `"filtered"` to keep only modes passing the filter defined by the `ModeSortSpec`, or an integer `N` to keep only the top `N` modes after filtering and sorting.
 - Added `fill_fraction_box` as a new filtering and sorting key which computes the field-energy fill fraction within a specified bounding box (`ModeSortSpec.bounding_box`).
 - Added `Grid.fine_mesh_info` property to identify and report locations where grid cell sizes are fine for understanding meshing hotspots.

--- a/docs/api/geometry.rst
+++ b/docs/api/geometry.rst
@@ -244,6 +244,43 @@ When working with a large number of geometry objects belonging to the same ``tid
 
 ~~~~
 
+Geometry Arrays
+---------------
+
+.. autosummary::
+   :toctree: _autosummary/
+   :template: module.rst
+
+   tidy3d.GeometryArray
+   tidy3d.Geometry.array
+
+``GeometryArray`` provides a memory-efficient way to represent arrays of repeated geometries
+by storing a single base geometry along with per-instance transformations. Each instance can
+be positioned using ``offsets`` (translations) and/or ``transforms`` (linear transformations
+such as rotation, reflection, or scale). When both are provided, the transform is
+applied first, then the translation.
+
+**Notes:** The base geometry must have finite bounds. Transforms must be linear-only with no
+translation component—use ``offsets`` for translations.
+
+.. code-block:: python
+
+   # create a grid of boxes using GeometryArray
+   offsets = [[2*i, 2*j, 0] for i in range(5) for j in range(5)]
+   my_geom_array = GeometryArray(geometry=Box(size=(1,1,1)), offsets=offsets)
+   my_structure = Structure(geometry=my_geom_array, medium=my_medium)
+
+   # alternatively, use the convenience method on any geometry
+   my_box = Box(size=(1,1,1))
+   my_geom_array = my_box.array(offsets=offsets)
+
+   # optionally apply per-instance transforms before translation
+   transforms = [Transformed.rotation(i * np.pi/12, axis=2) for i in range(25)]
+   my_geom_array = my_box.array(offsets=offsets, transforms=transforms)
+
+
+~~~~
+
 Working with GDS
 -------------------
 

--- a/schemas/EMESimulation.json
+++ b/schemas/EMESimulation.json
@@ -1553,6 +1553,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -1573,6 +1574,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -1598,6 +1602,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -1618,6 +1623,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -5841,6 +5849,123 @@
       ],
       "type": "object"
     },
+    "GeometryArray": {
+      "additionalProperties": false,
+      "properties": {
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "geometry": {
+          "discriminator": {
+            "mapping": {
+              "Box": "#/$defs/Box",
+              "ClipOperation": "#/$defs/ClipOperation",
+              "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
+              "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
+              "GeometryGroup": "#/$defs/GeometryGroup",
+              "PolySlab": "#/$defs/PolySlab",
+              "Sphere": "#/$defs/Sphere",
+              "Transformed": "#/$defs/Transformed",
+              "TriangleMesh": "#/$defs/TriangleMesh"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/Box"
+            },
+            {
+              "$ref": "#/$defs/ClipOperation"
+            },
+            {
+              "$ref": "#/$defs/ComplexPolySlabBase"
+            },
+            {
+              "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
+            },
+            {
+              "$ref": "#/$defs/GeometryGroup"
+            },
+            {
+              "$ref": "#/$defs/PolySlab"
+            },
+            {
+              "$ref": "#/$defs/Sphere"
+            },
+            {
+              "$ref": "#/$defs/Transformed"
+            },
+            {
+              "$ref": "#/$defs/TriangleMesh"
+            }
+          ]
+        },
+        "offsets": {
+          "anyOf": [
+            {
+              "items": {
+                "maxItems": 3,
+                "minItems": 3,
+                "prefixItems": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "transforms": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "ArrayLike",
+                "x-array-dtype": "<f8",
+                "x-array-forbid_nan": true,
+                "x-array-ndim": 2,
+                "x-array-scalar_to_1d": false,
+                "x-array-shape": [
+                  4,
+                  4
+                ],
+                "x-array-strict": false
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "type": {
+          "const": "GeometryArray",
+          "default": "GeometryArray",
+          "type": "string"
+        }
+      },
+      "required": [
+        "geometry"
+      ],
+      "type": "object"
+    },
     "GeometryGroup": {
       "additionalProperties": false,
       "properties": {
@@ -5856,6 +5981,7 @@
                 "ClipOperation": "#/$defs/ClipOperation",
                 "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
                 "Cylinder": "#/$defs/Cylinder",
+                "GeometryArray": "#/$defs/GeometryArray",
                 "GeometryGroup": "#/$defs/GeometryGroup",
                 "PolySlab": "#/$defs/PolySlab",
                 "Sphere": "#/$defs/Sphere",
@@ -5876,6 +6002,9 @@
               },
               {
                 "$ref": "#/$defs/Cylinder"
+              },
+              {
+                "$ref": "#/$defs/GeometryArray"
               },
               {
                 "$ref": "#/$defs/GeometryGroup"
@@ -7726,6 +7855,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -7746,6 +7876,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -11282,6 +11415,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -11302,6 +11436,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -11713,6 +11850,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -11733,6 +11871,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"

--- a/schemas/HeatChargeSimulation.json
+++ b/schemas/HeatChargeSimulation.json
@@ -966,6 +966,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -986,6 +987,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -1011,6 +1015,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -1031,6 +1036,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -4184,6 +4192,123 @@
       ],
       "type": "object"
     },
+    "GeometryArray": {
+      "additionalProperties": false,
+      "properties": {
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "geometry": {
+          "discriminator": {
+            "mapping": {
+              "Box": "#/$defs/Box",
+              "ClipOperation": "#/$defs/ClipOperation",
+              "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
+              "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
+              "GeometryGroup": "#/$defs/GeometryGroup",
+              "PolySlab": "#/$defs/PolySlab",
+              "Sphere": "#/$defs/Sphere",
+              "Transformed": "#/$defs/Transformed",
+              "TriangleMesh": "#/$defs/TriangleMesh"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/Box"
+            },
+            {
+              "$ref": "#/$defs/ClipOperation"
+            },
+            {
+              "$ref": "#/$defs/ComplexPolySlabBase"
+            },
+            {
+              "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
+            },
+            {
+              "$ref": "#/$defs/GeometryGroup"
+            },
+            {
+              "$ref": "#/$defs/PolySlab"
+            },
+            {
+              "$ref": "#/$defs/Sphere"
+            },
+            {
+              "$ref": "#/$defs/Transformed"
+            },
+            {
+              "$ref": "#/$defs/TriangleMesh"
+            }
+          ]
+        },
+        "offsets": {
+          "anyOf": [
+            {
+              "items": {
+                "maxItems": 3,
+                "minItems": 3,
+                "prefixItems": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "transforms": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "ArrayLike",
+                "x-array-dtype": "<f8",
+                "x-array-forbid_nan": true,
+                "x-array-ndim": 2,
+                "x-array-scalar_to_1d": false,
+                "x-array-shape": [
+                  4,
+                  4
+                ],
+                "x-array-strict": false
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "type": {
+          "const": "GeometryArray",
+          "default": "GeometryArray",
+          "type": "string"
+        }
+      },
+      "required": [
+        "geometry"
+      ],
+      "type": "object"
+    },
     "GeometryGroup": {
       "additionalProperties": false,
       "properties": {
@@ -4199,6 +4324,7 @@
                 "ClipOperation": "#/$defs/ClipOperation",
                 "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
                 "Cylinder": "#/$defs/Cylinder",
+                "GeometryArray": "#/$defs/GeometryArray",
                 "GeometryGroup": "#/$defs/GeometryGroup",
                 "PolySlab": "#/$defs/PolySlab",
                 "Sphere": "#/$defs/Sphere",
@@ -4219,6 +4345,9 @@
               },
               {
                 "$ref": "#/$defs/Cylinder"
+              },
+              {
+                "$ref": "#/$defs/GeometryArray"
               },
               {
                 "$ref": "#/$defs/GeometryGroup"
@@ -8489,6 +8618,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -8509,6 +8639,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -8964,6 +9097,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -8984,6 +9118,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"

--- a/schemas/HeatSimulation.json
+++ b/schemas/HeatSimulation.json
@@ -966,6 +966,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -986,6 +987,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -1011,6 +1015,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -1031,6 +1036,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -4184,6 +4192,123 @@
       ],
       "type": "object"
     },
+    "GeometryArray": {
+      "additionalProperties": false,
+      "properties": {
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "geometry": {
+          "discriminator": {
+            "mapping": {
+              "Box": "#/$defs/Box",
+              "ClipOperation": "#/$defs/ClipOperation",
+              "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
+              "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
+              "GeometryGroup": "#/$defs/GeometryGroup",
+              "PolySlab": "#/$defs/PolySlab",
+              "Sphere": "#/$defs/Sphere",
+              "Transformed": "#/$defs/Transformed",
+              "TriangleMesh": "#/$defs/TriangleMesh"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/Box"
+            },
+            {
+              "$ref": "#/$defs/ClipOperation"
+            },
+            {
+              "$ref": "#/$defs/ComplexPolySlabBase"
+            },
+            {
+              "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
+            },
+            {
+              "$ref": "#/$defs/GeometryGroup"
+            },
+            {
+              "$ref": "#/$defs/PolySlab"
+            },
+            {
+              "$ref": "#/$defs/Sphere"
+            },
+            {
+              "$ref": "#/$defs/Transformed"
+            },
+            {
+              "$ref": "#/$defs/TriangleMesh"
+            }
+          ]
+        },
+        "offsets": {
+          "anyOf": [
+            {
+              "items": {
+                "maxItems": 3,
+                "minItems": 3,
+                "prefixItems": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "transforms": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "ArrayLike",
+                "x-array-dtype": "<f8",
+                "x-array-forbid_nan": true,
+                "x-array-ndim": 2,
+                "x-array-scalar_to_1d": false,
+                "x-array-shape": [
+                  4,
+                  4
+                ],
+                "x-array-strict": false
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "type": {
+          "const": "GeometryArray",
+          "default": "GeometryArray",
+          "type": "string"
+        }
+      },
+      "required": [
+        "geometry"
+      ],
+      "type": "object"
+    },
     "GeometryGroup": {
       "additionalProperties": false,
       "properties": {
@@ -4199,6 +4324,7 @@
                 "ClipOperation": "#/$defs/ClipOperation",
                 "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
                 "Cylinder": "#/$defs/Cylinder",
+                "GeometryArray": "#/$defs/GeometryArray",
                 "GeometryGroup": "#/$defs/GeometryGroup",
                 "PolySlab": "#/$defs/PolySlab",
                 "Sphere": "#/$defs/Sphere",
@@ -4219,6 +4345,9 @@
               },
               {
                 "$ref": "#/$defs/Cylinder"
+              },
+              {
+                "$ref": "#/$defs/GeometryArray"
               },
               {
                 "$ref": "#/$defs/GeometryGroup"
@@ -8489,6 +8618,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -8509,6 +8639,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -8964,6 +9097,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -8984,6 +9118,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"

--- a/schemas/ModeSimulation.json
+++ b/schemas/ModeSimulation.json
@@ -1603,6 +1603,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -1623,6 +1624,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -1648,6 +1652,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -1668,6 +1673,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -5176,6 +5184,123 @@
       ],
       "type": "object"
     },
+    "GeometryArray": {
+      "additionalProperties": false,
+      "properties": {
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "geometry": {
+          "discriminator": {
+            "mapping": {
+              "Box": "#/$defs/Box",
+              "ClipOperation": "#/$defs/ClipOperation",
+              "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
+              "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
+              "GeometryGroup": "#/$defs/GeometryGroup",
+              "PolySlab": "#/$defs/PolySlab",
+              "Sphere": "#/$defs/Sphere",
+              "Transformed": "#/$defs/Transformed",
+              "TriangleMesh": "#/$defs/TriangleMesh"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/Box"
+            },
+            {
+              "$ref": "#/$defs/ClipOperation"
+            },
+            {
+              "$ref": "#/$defs/ComplexPolySlabBase"
+            },
+            {
+              "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
+            },
+            {
+              "$ref": "#/$defs/GeometryGroup"
+            },
+            {
+              "$ref": "#/$defs/PolySlab"
+            },
+            {
+              "$ref": "#/$defs/Sphere"
+            },
+            {
+              "$ref": "#/$defs/Transformed"
+            },
+            {
+              "$ref": "#/$defs/TriangleMesh"
+            }
+          ]
+        },
+        "offsets": {
+          "anyOf": [
+            {
+              "items": {
+                "maxItems": 3,
+                "minItems": 3,
+                "prefixItems": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "transforms": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "ArrayLike",
+                "x-array-dtype": "<f8",
+                "x-array-forbid_nan": true,
+                "x-array-ndim": 2,
+                "x-array-scalar_to_1d": false,
+                "x-array-shape": [
+                  4,
+                  4
+                ],
+                "x-array-strict": false
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "type": {
+          "const": "GeometryArray",
+          "default": "GeometryArray",
+          "type": "string"
+        }
+      },
+      "required": [
+        "geometry"
+      ],
+      "type": "object"
+    },
     "GeometryGroup": {
       "additionalProperties": false,
       "properties": {
@@ -5191,6 +5316,7 @@
                 "ClipOperation": "#/$defs/ClipOperation",
                 "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
                 "Cylinder": "#/$defs/Cylinder",
+                "GeometryArray": "#/$defs/GeometryArray",
                 "GeometryGroup": "#/$defs/GeometryGroup",
                 "PolySlab": "#/$defs/PolySlab",
                 "Sphere": "#/$defs/Sphere",
@@ -5211,6 +5337,9 @@
               },
               {
                 "$ref": "#/$defs/Cylinder"
+              },
+              {
+                "$ref": "#/$defs/GeometryArray"
               },
               {
                 "$ref": "#/$defs/GeometryGroup"
@@ -7061,6 +7190,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -7081,6 +7211,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -10881,6 +11014,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -10901,6 +11035,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -11333,6 +11470,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -11353,6 +11491,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"

--- a/schemas/Simulation.json
+++ b/schemas/Simulation.json
@@ -2027,6 +2027,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -2047,6 +2048,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -2072,6 +2076,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -2092,6 +2097,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -7897,6 +7905,123 @@
       ],
       "type": "object"
     },
+    "GeometryArray": {
+      "additionalProperties": false,
+      "properties": {
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "geometry": {
+          "discriminator": {
+            "mapping": {
+              "Box": "#/$defs/Box",
+              "ClipOperation": "#/$defs/ClipOperation",
+              "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
+              "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
+              "GeometryGroup": "#/$defs/GeometryGroup",
+              "PolySlab": "#/$defs/PolySlab",
+              "Sphere": "#/$defs/Sphere",
+              "Transformed": "#/$defs/Transformed",
+              "TriangleMesh": "#/$defs/TriangleMesh"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/Box"
+            },
+            {
+              "$ref": "#/$defs/ClipOperation"
+            },
+            {
+              "$ref": "#/$defs/ComplexPolySlabBase"
+            },
+            {
+              "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
+            },
+            {
+              "$ref": "#/$defs/GeometryGroup"
+            },
+            {
+              "$ref": "#/$defs/PolySlab"
+            },
+            {
+              "$ref": "#/$defs/Sphere"
+            },
+            {
+              "$ref": "#/$defs/Transformed"
+            },
+            {
+              "$ref": "#/$defs/TriangleMesh"
+            }
+          ]
+        },
+        "offsets": {
+          "anyOf": [
+            {
+              "items": {
+                "maxItems": 3,
+                "minItems": 3,
+                "prefixItems": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "transforms": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "ArrayLike",
+                "x-array-dtype": "<f8",
+                "x-array-forbid_nan": true,
+                "x-array-ndim": 2,
+                "x-array-scalar_to_1d": false,
+                "x-array-shape": [
+                  4,
+                  4
+                ],
+                "x-array-strict": false
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "type": {
+          "const": "GeometryArray",
+          "default": "GeometryArray",
+          "type": "string"
+        }
+      },
+      "required": [
+        "geometry"
+      ],
+      "type": "object"
+    },
     "GeometryGroup": {
       "additionalProperties": false,
       "properties": {
@@ -7912,6 +8037,7 @@
                 "ClipOperation": "#/$defs/ClipOperation",
                 "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
                 "Cylinder": "#/$defs/Cylinder",
+                "GeometryArray": "#/$defs/GeometryArray",
                 "GeometryGroup": "#/$defs/GeometryGroup",
                 "PolySlab": "#/$defs/PolySlab",
                 "Sphere": "#/$defs/Sphere",
@@ -7932,6 +8058,9 @@
               },
               {
                 "$ref": "#/$defs/Cylinder"
+              },
+              {
+                "$ref": "#/$defs/GeometryArray"
               },
               {
                 "$ref": "#/$defs/GeometryGroup"
@@ -9910,6 +10039,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -9930,6 +10060,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -14257,6 +14390,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -14277,6 +14411,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -14827,6 +14964,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -14847,6 +14985,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -2027,6 +2027,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -2047,6 +2048,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -2072,6 +2076,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -2092,6 +2097,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -8071,6 +8079,123 @@
       ],
       "type": "object"
     },
+    "GeometryArray": {
+      "additionalProperties": false,
+      "properties": {
+        "attrs": {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        "geometry": {
+          "discriminator": {
+            "mapping": {
+              "Box": "#/$defs/Box",
+              "ClipOperation": "#/$defs/ClipOperation",
+              "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
+              "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
+              "GeometryGroup": "#/$defs/GeometryGroup",
+              "PolySlab": "#/$defs/PolySlab",
+              "Sphere": "#/$defs/Sphere",
+              "Transformed": "#/$defs/Transformed",
+              "TriangleMesh": "#/$defs/TriangleMesh"
+            },
+            "propertyName": "type"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/Box"
+            },
+            {
+              "$ref": "#/$defs/ClipOperation"
+            },
+            {
+              "$ref": "#/$defs/ComplexPolySlabBase"
+            },
+            {
+              "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
+            },
+            {
+              "$ref": "#/$defs/GeometryGroup"
+            },
+            {
+              "$ref": "#/$defs/PolySlab"
+            },
+            {
+              "$ref": "#/$defs/Sphere"
+            },
+            {
+              "$ref": "#/$defs/Transformed"
+            },
+            {
+              "$ref": "#/$defs/TriangleMesh"
+            }
+          ]
+        },
+        "offsets": {
+          "anyOf": [
+            {
+              "items": {
+                "maxItems": 3,
+                "minItems": 3,
+                "prefixItems": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ],
+                "type": "array"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "transforms": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "ArrayLike",
+                "x-array-dtype": "<f8",
+                "x-array-forbid_nan": true,
+                "x-array-ndim": 2,
+                "x-array-scalar_to_1d": false,
+                "x-array-shape": [
+                  4,
+                  4
+                ],
+                "x-array-strict": false
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "type": {
+          "const": "GeometryArray",
+          "default": "GeometryArray",
+          "type": "string"
+        }
+      },
+      "required": [
+        "geometry"
+      ],
+      "type": "object"
+    },
     "GeometryGroup": {
       "additionalProperties": false,
       "properties": {
@@ -8086,6 +8211,7 @@
                 "ClipOperation": "#/$defs/ClipOperation",
                 "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
                 "Cylinder": "#/$defs/Cylinder",
+                "GeometryArray": "#/$defs/GeometryArray",
                 "GeometryGroup": "#/$defs/GeometryGroup",
                 "PolySlab": "#/$defs/PolySlab",
                 "Sphere": "#/$defs/Sphere",
@@ -8106,6 +8232,9 @@
               },
               {
                 "$ref": "#/$defs/Cylinder"
+              },
+              {
+                "$ref": "#/$defs/GeometryArray"
               },
               {
                 "$ref": "#/$defs/GeometryGroup"
@@ -10177,6 +10306,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -10197,6 +10327,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -15041,6 +15174,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -15061,6 +15195,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"
@@ -15611,6 +15748,7 @@
               "ClipOperation": "#/$defs/ClipOperation",
               "ComplexPolySlabBase": "#/$defs/ComplexPolySlabBase",
               "Cylinder": "#/$defs/Cylinder",
+              "GeometryArray": "#/$defs/GeometryArray",
               "GeometryGroup": "#/$defs/GeometryGroup",
               "PolySlab": "#/$defs/PolySlab",
               "Sphere": "#/$defs/Sphere",
@@ -15631,6 +15769,9 @@
             },
             {
               "$ref": "#/$defs/Cylinder"
+            },
+            {
+              "$ref": "#/$defs/GeometryArray"
             },
             {
               "$ref": "#/$defs/GeometryGroup"

--- a/tests/test_components/test_geometry.py
+++ b/tests/test_components/test_geometry.py
@@ -80,6 +80,11 @@ TRANSFORMED = td.Transformed(
     transform=td.Transformed.rotation(np.pi / 6, 0),
 )
 
+GEOMETRY_ARRAY = td.GeometryArray(
+    geometry=BOX,
+    offsets=[[0, 0, 0], [2, 0, 0], [0, 2, 0]],
+)
+
 
 GEO_TYPES = [
     BOX,
@@ -92,6 +97,7 @@ GEO_TYPES = [
     SYM_DIFFERENCE,
     GROUP,
     TRANSFORMED,
+    GEOMETRY_ARRAY,
 ]
 
 _, AX = plt.subplots()
@@ -1791,3 +1797,225 @@ def test_flatten_shapely_geometries():
     # Test 13: Edge case - single empty geometry
     result = flatten_shapely_geometries(empty_polygon)
     assert len(result) == 0
+
+
+# ======================= GeometryArray Tests =======================
+
+
+def test_geometry_array_basic():
+    """Test GeometryArray creation, bounds, and inside methods."""
+    box = td.Box(size=(1, 1, 1))
+    offsets = [[0, 0, 0], [3, 0, 0]]
+    array = td.GeometryArray(geometry=box, offsets=offsets)
+
+    # Creation
+    assert array.num_geometries == 2
+    assert array.geometry == box
+
+    # Bounds: boxes at (0,0,0) and (3,0,0)
+    np.testing.assert_allclose(array.bounds[0], (-0.5, -0.5, -0.5))
+    np.testing.assert_allclose(array.bounds[1], (3.5, 0.5, 0.5))
+
+    # Inside with scalars
+    assert array.inside(0, 0, 0)
+    assert array.inside(3, 0, 0)
+    assert not array.inside(1.5, 0, 0)
+
+    # Inside with arrays
+    result = array.inside(np.array([0, 1.5, 3]), np.zeros(3), np.zeros(3))
+    np.testing.assert_array_equal(result, [True, False, True])
+
+    # Convenience method
+    array2 = box.array(offsets=offsets)
+    assert isinstance(array2, td.GeometryArray)
+    assert array2.num_geometries == 2
+
+
+def test_geometry_array_with_transforms():
+    """Test GeometryArray with transforms (with and without offsets)."""
+    box = td.Box(size=(2, 1, 1))
+    rotation = td.Transformed.rotation(np.pi / 2, 2)
+
+    # Transforms only (no offsets)
+    array = td.GeometryArray(geometry=box, transforms=[np.eye(4), rotation])
+    assert array.num_geometries == 2
+    assert array.offsets is None
+    assert array.inside(0.5, 0, 0)  # First instance along x
+    assert array.inside(0, 0.8, 0)  # Second instance rotated, long axis now along y
+
+    # Transforms with offsets
+    array = td.GeometryArray(
+        geometry=box, offsets=[[0, 0, 0], [4, 0, 0]], transforms=[np.eye(4), rotation]
+    )
+    assert array.inside(0.5, 0, 0)  # First instance
+    assert array.inside(4, 0.5, 0)  # Second instance rotated and translated
+
+
+def test_geometry_array_both_none():
+    """Test GeometryArray with both offsets and transforms as None."""
+    box = td.Box(size=(1, 1, 1))
+    array = td.GeometryArray(geometry=box)
+
+    assert array.num_geometries == 1
+    assert array.inside(0, 0, 0)
+    assert not array.inside(1, 0, 0)
+    np.testing.assert_allclose(array.bounds[0], (-0.5, -0.5, -0.5))
+
+
+def _transform_with_translation():
+    """Helper to create a transform matrix with translation (invalid for GeometryArray)."""
+    t = np.eye(4)
+    t[:3, 3] = [1, 2, 3]  # Add translation - not allowed in GeometryArray
+    return t
+
+
+def _transform_with_bad_bottom_row():
+    """Helper to create a transform matrix with invalid bottom row."""
+    t = np.eye(4)
+    t[3, :] = [1, 0, 0, 1]  # Invalid bottom row
+    return t
+
+
+@pytest.mark.parametrize(
+    "kwargs,error_match",
+    [
+        ({"offsets": []}, "at least one offset"),
+        ({"transforms": []}, "at least one transform"),
+        ({"offsets": [[0, 0], [2, 0]]}, None),  # Wrong shape
+        ({"offsets": [0, 0, 0]}, None),  # 1D instead of 2D
+        ({"offsets": [[0, 0, 0], [2, 0, 0]], "transforms": [np.eye(4)]}, "must match"),
+        ({"offsets": [[0, 0, 0]], "transforms": [np.zeros((4, 4))]}, "singular"),
+        # Linear-only transform validation
+        ({"transforms": [_transform_with_translation()]}, "contains translation"),
+        ({"transforms": [_transform_with_bad_bottom_row()]}, "invalid homogeneous form"),
+    ],
+)
+def test_geometry_array_validation(kwargs, error_match):
+    """Test GeometryArray validation errors."""
+    box = td.Box(size=(1, 1, 1))
+    with pytest.raises(pd.ValidationError):
+        td.GeometryArray(geometry=box, **kwargs)
+
+
+def test_geometry_array_validation_infinite_geometry():
+    """Test validation rejects infinite geometry."""
+    with pytest.raises(pd.ValidationError):
+        td.GeometryArray(geometry=td.Box(size=(1, 1, td.inf)), offsets=[[0, 0, 0]])
+
+
+def test_geometry_array_geometry_operations():
+    """Test plot, intersections, volume, and surface_area."""
+    box = td.Box(size=(1, 1, 1))
+    offsets = [[0, 0, 0], [3, 0, 0]]
+    array = td.GeometryArray(geometry=box, offsets=offsets)
+
+    # Plot
+    fig, ax = plt.subplots()
+    array.plot(z=0, ax=ax)
+    plt.close(fig)
+
+    # Intersections
+    assert len(array.intersections_plane(z=0)) == 2
+    assert len(array.intersections_plane(z=10)) == 0
+
+    # Volume and surface area
+    assert np.isclose(array.volume(), 2.0)
+    assert np.isclose(array.surface_area(), 12.0)
+
+
+def test_geometry_array_equivalence_with_geometry_group():
+    """Test that GeometryArray matches equivalent GeometryGroup."""
+    box = td.Box(size=(1, 1, 1))
+    offsets = [[0, 0, 0], [2, 0, 0], [0, 2, 0]]
+
+    array = td.GeometryArray(geometry=box, offsets=offsets)
+    group = td.GeometryGroup(
+        geometries=[box.translated(0, 0, 0), box.translated(2, 0, 0), box.translated(0, 2, 0)]
+    )
+
+    # Bounds match
+    np.testing.assert_allclose(array.bounds[0], group.bounds[0], atol=1e-10)
+    np.testing.assert_allclose(array.bounds[1], group.bounds[1], atol=1e-10)
+
+    # Inside matches
+    for point in [(0, 0, 0), (2, 0, 0), (0, 2, 0), (1, 1, 0), (10, 10, 10)]:
+        assert array.inside(*point) == group.inside(*point)
+
+
+def test_geometry_array_with_different_geometries():
+    """Test GeometryArray with Sphere, Cylinder, and PolySlab."""
+    offsets = [[0, 0, 0], [2, 0, 0]]
+
+    for geom in [
+        td.Sphere(radius=0.5),
+        td.Cylinder(radius=0.5, length=1, axis=2),
+    ]:
+        array = td.GeometryArray(geometry=geom, offsets=offsets)
+        assert array.inside(0, 0, 0)
+        assert array.inside(2, 0, 0)
+        assert not array.inside(1, 0, 0)
+
+    # PolySlab
+    polyslab = td.PolySlab(vertices=((0, 0), (1, 0), (1, 1), (0, 1)), slab_bounds=(-0.5, 0.5))
+    array = td.GeometryArray(geometry=polyslab, offsets=offsets)
+    assert array.inside(0.5, 0.5, 0)
+    assert array.inside(2.5, 0.5, 0)
+
+
+def test_geometry_array_adjoint_not_supported():
+    """Test that GeometryArray raises NotImplementedError for adjoint/autodiff."""
+    box = td.Box(size=(1, 1, 1))
+    array = td.GeometryArray(geometry=box, offsets=[[0, 0, 0], [2, 0, 0]])
+
+    with pytest.raises(NotImplementedError):
+        array._compute_derivatives(derivative_info=None)
+
+
+def test_geometry_array_normal_2dmaterial():
+    """Test _normal_2dmaterial for GeometryArray with 2D geometries."""
+    # Zero-thickness box normal to z
+    box_2d = td.Box(center=(0, 0, 0), size=(1, 1, 0))
+    offsets = np.array([[0, 0, 0], [2, 0, 0], [4, 0, 0]])
+    array = td.GeometryArray(geometry=box_2d, offsets=offsets)
+    assert array._normal_2dmaterial == 2
+
+    # Zero-thickness box normal to y
+    box_2d_y = td.Box(center=(0, 0, 0), size=(1, 0, 1))
+    array_y = td.GeometryArray(geometry=box_2d_y, offsets=offsets)
+    assert array_y._normal_2dmaterial == 1
+
+    # 3D geometry should raise
+    box_3d = td.Box(size=(1, 1, 1))
+    array_3d = td.GeometryArray(geometry=box_3d, offsets=offsets)
+    with pytest.raises(ValidationError):
+        _ = array_3d._normal_2dmaterial
+
+
+def test_geometry_array_update_from_bounds():
+    """Test _update_from_bounds for GeometryArray with 2D geometries."""
+    box_2d = td.Box(center=(0, 0, 0), size=(1, 1, 0))
+    offsets = np.array([[0, 0, 0], [2, 0, 0]])
+    array = td.GeometryArray(geometry=box_2d, offsets=offsets)
+
+    new_bounds = (3.2, 6.4)
+    axis = 2
+    updated = array._update_from_bounds(bounds=new_bounds, axis=axis)
+
+    # Result should be a GeometryGroup
+    assert isinstance(updated, td.GeometryGroup)
+
+    # All sub-geometries should have the new bounds along the axis
+    for geom in updated.geometries:
+        geom_bounds = (geom.bounds[0][axis], geom.bounds[1][axis])
+        assert np.isclose(geom_bounds, new_bounds).all()
+
+
+def test_geometry_array_medium2d_structure():
+    """Test that GeometryArray works with Medium2D in a Structure."""
+    box_2d = td.Box(center=(0, 0, 0.5), size=(1, 1, 0))
+    offsets = np.array([[0, 0, 0], [2, 0, 0]])
+    array = td.GeometryArray(geometry=box_2d, offsets=offsets)
+
+    med2d = td.Medium2D(ss=td.Medium(), tt=td.Medium())
+    struct = td.Structure(geometry=array, medium=med2d)
+    assert struct is not None

--- a/tidy3d/__init__.py
+++ b/tidy3d/__init__.py
@@ -278,7 +278,14 @@ from .components.field_projection import FieldProjector
 from .components.frequencies import FreqRange, FrequencyUtils, frequencies, wavelengths
 
 # geometry
-from .components.geometry.base import Box, ClipOperation, Geometry, GeometryGroup, Transformed
+from .components.geometry.base import (
+    Box,
+    ClipOperation,
+    Geometry,
+    GeometryArray,
+    GeometryGroup,
+    Transformed,
+)
 from .components.geometry.mesh import TriangleMesh
 from .components.geometry.polyslab import PolySlab
 from .components.geometry.primitives import Cylinder, Sphere
@@ -490,6 +497,7 @@ log.info(f"Using client version: {__version__}")
 Transformed.model_rebuild()
 ClipOperation.model_rebuild()
 GeometryGroup.model_rebuild()
+GeometryArray.model_rebuild()
 
 # Backwards compatibility: Remove 2.11 renamed integral classes
 VoltageIntegralAxisAligned = AxisAlignedVoltageIntegral
@@ -675,6 +683,7 @@ __all__ = [
     "GaussianOverlapMonitor",
     "GaussianPulse",
     "Geometry",
+    "GeometryArray",
     "GeometryGroup",
     "Graphene",
     "Grid",

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -17,7 +17,13 @@ from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.geometry.bound_ops import bounds_intersection, bounds_union
 from tidy3d.components.geometry.float_utils import increment_float
 from tidy3d.components.transformation import ReflectionFromPlane, RotationAroundAxis
-from tidy3d.components.types import Axis, ClipOperationType, MatrixReal4x4, PlanePosition
+from tidy3d.components.types import (
+    Axis,
+    ClipOperationType,
+    Coordinate,
+    MatrixReal4x4,
+    PlanePosition,
+)
 from tidy3d.components.types.base import discriminated_union
 from tidy3d.components.viz import (
     ARROW_LENGTH,
@@ -60,7 +66,6 @@ if TYPE_CHECKING:
         ArrayFloat3D,
         Ax,
         Bound,
-        Coordinate,
         Coordinate2D,
         LengthUnit,
         Shapely,
@@ -76,6 +81,8 @@ except ImportError:
 POLY_GRID_SIZE = 1e-12
 POLY_TOLERANCE_RATIO = 1e-12
 POLY_DISTANCE_TOLERANCE = 8e-12
+# Tolerance for validating linear-only transforms (no translation)
+LINEAR_TRANSFORM_TOL = 1e-12
 
 
 _shapely_operations = {
@@ -91,6 +98,47 @@ _bit_operations = {
     "difference": lambda a, b: a & ~b,
     "symmetric_difference": lambda a, b: a != b,
 }
+
+
+# Validators for geometry classes (defined here instead of validators.py to avoid circular imports)
+def assert_geometry_finite(field_name: str = "geometry") -> Callable[[type, Geometry], Geometry]:
+    """Validator that ensures a geometry field has finite bounds."""
+
+    @field_validator(field_name)
+    @classmethod
+    def geometry_has_finite_bounds(cls: type, val: Geometry) -> Geometry:
+        """Raise validation error if geometry has non-finite bounds."""
+        if not np.isfinite(val.bounds).all():
+            raise ValidationError(
+                f"'{cls.__name__}' requires a geometry with finite dimensions. "
+                "Try using a large value instead of 'inf' when creating geometries."
+            )
+        return val
+
+    return geometry_has_finite_bounds
+
+
+def check_transform_invertible(transform: MatrixReal4x4, index: Optional[int] = None) -> None:
+    """Check if a transform matrix is invertible.
+
+    Parameters
+    ----------
+    transform : MatrixReal4x4
+        The 4x4 transformation matrix to check.
+    index : Optional[int]
+        If provided, includes the index in the error message (for array of transforms).
+
+    Raises
+    ------
+    ValidationError
+        If the transform matrix is not invertible.
+    """
+    try:
+        _ = np.linalg.inv(transform)
+    except np.linalg.LinAlgError as err:
+        if index is not None:
+            raise ValidationError(f"Transform at index {index} is not invertible.") from err
+        raise ValidationError("Transform matrix is not invertible.") from err
 
 
 class Geometry(Tidy3dBaseModel, ABC):
@@ -1024,6 +1072,62 @@ class Geometry(Tidy3dBaseModel, ABC):
             Reflected copy of this geometry.
         """
         return Transformed(geometry=self, transform=Transformed.reflection(normal))
+
+    def array(
+        self,
+        offsets: Optional[ArrayLike] = None,
+        transforms: Optional[ArrayLike] = None,
+    ) -> GeometryArray:
+        """Return an array of copies of this geometry with optional offsets and/or linear transforms.
+
+        This method creates a :class:`GeometryArray` containing multiple copies of this
+        geometry. When both ``offsets`` and ``transforms`` are provided, transforms are
+        applied to each copy before the translation given by offsets is applied.
+
+        Parameters
+        ----------
+        offsets : Optional[ArrayLike] = None
+            Optional array of offset vectors with shape (N, 3) where N is the number of
+            geometries. Each row specifies the (x, y, z) translation for one geometry
+            (after any transform is applied). If not provided, no additional translation
+            is applied beyond any transforms.
+        transforms : Optional[ArrayLike] = None
+            Optional array of 4x4 linear-only transform matrices with shape (N, 4, 4).
+            Each transform must be a valid homogeneous linear transform
+            (rotation/reflection/scale/shear) with no translation component.
+            Typical transforms can be created using ``Transformed.rotation``,
+            ``Transformed.reflection``, or ``Transformed.scaling``.
+
+        Returns
+        -------
+        :class:`GeometryArray`
+            Array containing N copies of this geometry.
+
+        Notes
+        -----
+        - ``offsets`` represent all per-instance translation.
+        - ``transforms`` represent linear transforms only and must not contain translation.
+        - If both ``offsets`` and ``transforms`` are ``None``, the array contains a single
+          instance of the base geometry.
+        - If both are provided, they must have the same length and transforms are applied
+          before the translation given by offsets.
+        - Adjoint/autodiff is not currently supported for ``GeometryArray``.
+
+        Example
+        -------
+        >>> import tidy3d as td
+        >>> import numpy as np
+        >>> box = td.Box(size=(1, 1, 1))
+        >>> # Create a 2x2 grid of boxes using offsets
+        >>> offsets = [[0, 0, 0], [2, 0, 0], [0, 2, 0], [2, 2, 0]]
+        >>> array = box.array(offsets=offsets)
+        >>> # Create array using linear transforms only (rotation around z-axis)
+        >>> transforms = [np.eye(4), td.Transformed.rotation(np.pi/4, 2)]
+        >>> array = box.array(transforms=transforms)
+        >>> # Both None gives single instance of base geometry
+        >>> array = box.array()
+        """
+        return GeometryArray(geometry=self, offsets=offsets, transforms=transforms)
 
     """ Field and coordinate transformations """
 
@@ -2782,22 +2886,13 @@ class Transformed(Geometry):
         description="Transform matrix applied to the base geometry.",
     )
 
+    _geometry_is_finite = assert_geometry_finite("geometry")
+
     @field_validator("transform")
     @classmethod
     def _transform_is_invertible(cls, val: MatrixReal4x4) -> MatrixReal4x4:
-        # If the transform is not invertible, this will raise an error
-        _ = np.linalg.inv(val)
-        return val
-
-    @field_validator("geometry")
-    @classmethod
-    def _geometry_is_finite(cls, val: GeometryType) -> GeometryType:
-        if not np.isfinite(val.bounds).all():
-            raise ValidationError(
-                "Transformations are only supported on geometries with finite dimensions. "
-                "Try using a large value instead of 'inf' when creating geometries that undergo "
-                "transformations."
-            )
+        """Raise validation error if transform is not invertible."""
+        check_transform_invertible(val)
         return val
 
     @model_validator(mode="after")
@@ -2931,6 +3026,17 @@ class Transformed(Geometry):
         """Returns object's surface area within given bounds."""
         log.warning("Surface area of transformed elements cannot be calculated.")
         return None
+
+    @staticmethod
+    def identity() -> MatrixReal4x4:
+        """Return an identity matrix where no transform is applied.
+
+        Returns
+        -------
+        numpy.ndarray
+            Identity transform matrix with shape (4, 4).
+        """
+        return np.eye(4)
 
     @staticmethod
     def translation(x: float, y: float, z: float) -> MatrixReal4x4:
@@ -3617,6 +3723,368 @@ class GeometryGroup(Geometry):
                 grad_vjps[field_path] = vjp_dict_geo.popitem()[1]
 
         return grad_vjps
+
+
+class GeometryArray(Geometry):
+    """A geometry representing an array of copies of a base geometry, with optional offsets
+    and/or linear transformations applied to each copy.
+
+    This class provides an efficient way to represent arrays of repeated geometries,
+    avoiding the need to create many individual geometry objects.
+
+    The instance pose for each copy is defined as: ``T(offsets[i]) @ L(transforms[i])``,
+    where ``T`` is a translation matrix and ``L`` is the linear transform. In other words,
+    the transform is applied first, then the translation.
+
+    Notes
+    -----
+    - ``offsets`` represent all per-instance translation.
+    - ``transforms`` represent linear transforms only (rotation/reflection/scale/shear)
+      and must not contain translation. Use ``offsets`` for translations.
+    - If both ``offsets`` and ``transforms`` are ``None``, the array contains a single
+      instance of the base geometry at the origin.
+    - If both are provided, they must have the same length.
+    - Adjoint/autodiff is not currently supported for ``GeometryArray``.
+
+    Parameters
+    ----------
+    geometry : GeometryType
+        Base geometry to be repeated in the array. Must have finite bounds.
+    offsets : Optional[tuple[Coordinate, ...]]
+        Optional tuple of 3D coordinate offsets. Each offset translates the base geometry
+        (after any transform is applied) to create a copy. If not provided, no additional
+        translation is applied beyond any transforms.
+    transforms : Optional[tuple[MatrixReal4x4, ...]]
+        Optional tuple of 4x4 linear-only transformation matrices. Each transform must be
+        a valid homogeneous linear transform (rotation/reflection/scale/shear) with no
+        translation component (i.e., ``transform[:3, 3] == 0`` and
+        ``transform[3, :] == [0, 0, 0, 1]``). Typical transforms can be created using
+        ``Transformed.rotation``, ``Transformed.reflection``, or ``Transformed.scaling``.
+
+    Example
+    -------
+    >>> import tidy3d as td
+    >>> import numpy as np
+    >>> box = td.Box(size=(1, 1, 1))
+    >>> # Using offsets only:
+    >>> offsets = [[0, 0, 0], [2, 0, 0], [0, 2, 0], [2, 2, 0]]
+    >>> array = td.GeometryArray(geometry=box, offsets=offsets)
+    >>> # Or use the convenience method:
+    >>> array = box.array(offsets=offsets)
+    >>> # Using linear transforms only (rotation around z-axis):
+    >>> rot_0 = td.Transformed.rotation(0, 2)  # no rotation
+    >>> rot_90 = td.Transformed.rotation(np.pi/2, 2)  # 90 degree rotation
+    >>> array = td.GeometryArray(geometry=box, transforms=[rot_0, rot_90])
+    >>> # Both None gives single instance of base geometry:
+    >>> array = td.GeometryArray(geometry=box)
+    """
+
+    geometry: discriminated_union(GeometryType) = Field(
+        ...,
+        title="Geometry",
+        description="Base geometry to be repeated in the array.",
+    )
+
+    offsets: Optional[tuple[Coordinate, ...]] = Field(
+        None,
+        title="Offsets",
+        description="A tuple of 3D coordinate offsets. Each offset translates the base "
+        "geometry (after any transform is applied) to create a copy. If not provided, no "
+        "additional translation is applied beyond any transforms.",
+    )
+
+    transforms: Optional[tuple[MatrixReal4x4, ...]] = Field(
+        None,
+        title="Transforms",
+        description="A tuple of 4x4 linear-only transformation matrices "
+        "(rotation/reflection/scale/shear, no translation). Typical transforms can be "
+        "created using ``Transformed.rotation``, ``Transformed.reflection``, or ``Transformed.scaling``. "
+        "Each transform is applied to the base geometry before the corresponding offset translation. "
+        "If not provided, only translations from offsets are applied.",
+    )
+
+    _geometry_is_finite = assert_geometry_finite("geometry")
+
+    @field_validator("transforms")
+    @classmethod
+    def _validate_transforms(
+        cls, val: Optional[tuple[MatrixReal4x4, ...]]
+    ) -> Optional[tuple[MatrixReal4x4, ...]]:
+        """Validate that transforms are invertible, linear-only, and non-empty if provided."""
+        if val is None:
+            return val
+
+        # Must not be empty if provided
+        if len(val) < 1:
+            raise ValidationError("'transforms' must have at least one transform when provided.")
+
+        # Check each transform
+        for i, transform in enumerate(val):
+            # Check invertibility
+            check_transform_invertible(transform, index=i)
+
+            # Check linear-only (no translation)
+            transform_array = np.asarray(transform)
+
+            # Check translation column: transform[:3, 3] should be zero
+            translation = transform_array[:3, 3]
+            if not np.allclose(translation, 0, atol=LINEAR_TRANSFORM_TOL):
+                idx_msg = f"at index {i}"
+                raise ValidationError(
+                    f"Transform {idx_msg} contains translation in [:3, 3] = {translation.tolist()}. "
+                    "GeometryArray transforms must be linear-only (rotation/reflection/scale/shear). "
+                    "Use the 'offsets' parameter for translations."
+                )
+
+            # Check bottom row: transform[3, :] should be [0, 0, 0, 1]
+            bottom_row = transform_array[3, :]
+            expected_bottom = np.array([0, 0, 0, 1])
+            if not np.allclose(bottom_row, expected_bottom, atol=LINEAR_TRANSFORM_TOL):
+                idx_msg = f"at index {i}"
+                raise ValidationError(
+                    f"Transform {idx_msg} has invalid homogeneous form: [3, :] = {bottom_row.tolist()}. "
+                    "Expected [0, 0, 0, 1]."
+                )
+
+        return val
+
+    @model_validator(mode="after")
+    def _validate_offsets_and_transforms(self) -> Self:
+        """Validate offsets and transforms are consistent."""
+        offsets = self.offsets
+        transforms = self.transforms
+
+        # If offsets provided, must not be empty
+        if offsets is not None and len(offsets) < 1:
+            raise ValidationError("'offsets' must have at least one offset when provided.")
+
+        # If both provided, lengths must match
+        if offsets is not None and transforms is not None:
+            if len(offsets) != len(transforms):
+                raise ValidationError(
+                    f"Number of transforms ({len(transforms)}) must match "
+                    f"number of offsets ({len(offsets)}) when both are provided."
+                )
+
+        return self
+
+    @cached_property
+    def num_geometries(self) -> int:
+        """Number of geometries in the array."""
+        if self.offsets is not None:
+            return len(self.offsets)
+        if self.transforms is not None:
+            return len(self.transforms)
+        # Both None means single geometry (base geometry at origin)
+        return 1
+
+    @cached_property
+    def _all_transforms(self) -> np.ndarray:
+        """Compute all 4x4 transforms for all geometries in a vectorized way.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of shape (num_geometries, 4, 4) containing the full transform
+            (rotation/scale + translation) for each geometry in the array.
+        """
+        n = self.num_geometries
+        shape = (n, 4, 4)
+
+        # Get all transforms, defaulting to identity if not provided
+        if self.transforms is not None:
+            transforms = np.array(self.transforms)
+        else:
+            transforms = np.broadcast_to(Transformed.identity(), shape)
+
+        # Build translation matrices for all offsets
+        # translation matrix: [[1,0,0,x], [0,1,0,y], [0,0,1,z], [0,0,0,1]]
+        translations = np.broadcast_to(Transformed.identity(), shape).copy()
+        if self.offsets is not None:
+            translations[:, :3, 3] = self.offsets
+
+        # Apply transform, then translation: result = translation @ transform
+        return np.matmul(translations, transforms)
+
+    def _get_full_transform(self, index: int) -> MatrixReal4x4:
+        """Get the full 4x4 transform for a geometry at given index (transform + translation)."""
+        return self._all_transforms[index]
+
+    @cached_property
+    def _transformed_geometries(self) -> list[Transformed]:
+        """List of transformed geometries in the array."""
+        return [
+            Transformed(geometry=self.geometry, transform=transform)
+            for transform in self._all_transforms
+        ]
+
+    @cached_property
+    def _geometry_group(self) -> GeometryGroup:
+        """Return a GeometryGroup containing all transformed geometries in the array."""
+        return GeometryGroup(geometries=tuple(self._transformed_geometries))
+
+    @cached_property
+    def bounds(self) -> Bound:
+        """Returns bounding box min and max coordinates.
+
+        Returns
+        -------
+        Tuple[float, float, float], Tuple[float, float, float]
+            Min and max bounds packaged as ``(minx, miny, minz), (maxx, maxy, maxz)``.
+        """
+        return self._geometry_group.bounds
+
+    def intersections_tilted_plane(
+        self,
+        normal: Coordinate,
+        origin: Coordinate,
+        to_2D: MatrixReal4x4,
+        cleanup: bool = True,
+        quad_segs: Optional[int] = None,
+    ) -> list[Shapely]:
+        """Return a list of shapely geometries at the plane specified by normal and origin.
+
+        Parameters
+        ----------
+        normal : Coordinate
+            Vector defining the normal direction to the plane.
+        origin : Coordinate
+            Vector defining the plane origin.
+        to_2D : MatrixReal4x4
+            Transformation matrix to apply to resulting shapes.
+        cleanup : bool = True
+            If True, removes extremely small features from each polygon's boundary.
+        quad_segs : Optional[int] = None
+            Number of segments used to discretize circular shapes. If ``None``, uses
+            high-quality visualization settings.
+
+        Returns
+        -------
+        List[shapely.geometry.base.BaseGeometry]
+            List of 2D shapes that intersect plane.
+            For more details refer to
+            `Shapely's Documentation <https://shapely.readthedocs.io/en/stable/project.html>`_.
+        """
+        return self._geometry_group.intersections_tilted_plane(
+            normal, origin, to_2D, cleanup=cleanup, quad_segs=quad_segs
+        )
+
+    def intersections_plane(
+        self,
+        x: Optional[float] = None,
+        y: Optional[float] = None,
+        z: Optional[float] = None,
+        cleanup: bool = True,
+        quad_segs: Optional[int] = None,
+    ) -> list[Shapely]:
+        """Returns list of shapely geometries at plane specified by one non-None value of x,y,z.
+
+        Parameters
+        ----------
+        x : float = None
+            Position of plane in x direction, only one of x,y,z can be specified to define plane.
+        y : float = None
+            Position of plane in y direction, only one of x,y,z can be specified to define plane.
+        z : float = None
+            Position of plane in z direction, only one of x,y,z can be specified to define plane.
+        cleanup : bool = True
+            If True, removes extremely small features from each polygon's boundary.
+        quad_segs : Optional[int] = None
+            Number of segments used to discretize circular shapes. If ``None``, uses
+            high-quality visualization settings.
+
+        Returns
+        -------
+        List[shapely.geometry.base.BaseGeometry]
+            List of 2D shapes that intersect plane.
+            For more details refer to
+            `Shapely's Documentation <https://shapely.readthedocs.io/en/stable/project.html>`_.
+        """
+        return self._geometry_group.intersections_plane(
+            x=x, y=y, z=z, cleanup=cleanup, quad_segs=quad_segs
+        )
+
+    def intersects_axis_position(self, axis: int, position: float) -> bool:
+        """Whether self intersects plane specified by a given position along a normal axis.
+
+        Parameters
+        ----------
+        axis : int = None
+            Axis normal to the plane.
+        position : float = None
+            Position of plane along the normal axis.
+
+        Returns
+        -------
+        bool
+            Whether this geometry intersects the plane.
+        """
+        return self._geometry_group.intersects_axis_position(axis, position)
+
+    def inside(self, x: NDArray[float], y: NDArray[float], z: NDArray[float]) -> NDArray[bool]:
+        """For input arrays ``x``, ``y``, ``z`` of arbitrary but identical shape, return an array
+        with the same shape which is ``True`` for every point in zip(x, y, z) that is inside the
+        volume of the :class:`Geometry`, and ``False`` otherwise.
+
+        Parameters
+        ----------
+        x : np.ndarray[float]
+            Array of point positions in x direction.
+        y : np.ndarray[float]
+            Array of point positions in y direction.
+        z : np.ndarray[float]
+            Array of point positions in z direction.
+
+        Returns
+        -------
+        np.ndarray[bool]
+            ``True`` for every point that is inside the geometry.
+        """
+        return self._geometry_group.inside(x, y, z)
+
+    def _volume(self, bounds: Bound) -> float:
+        """Returns object's volume within given bounds."""
+        return self._geometry_group._volume(bounds)
+
+    def _surface_area(self, bounds: Bound) -> float:
+        """Returns object's surface area within given bounds."""
+        # Surface area cannot be reliably computed when non-trivial transforms are present
+        if self.transforms is not None:
+            log.warning("Surface area of transformed elements cannot be calculated.")
+            return None
+        # For pure translations, sum surface areas using local bounds for base geometry
+        total_area = 0.0
+        for geom in self._transformed_geometries:
+            # Transform bounds to local coordinate system
+            vertices = np.dot(geom.inverse, Transformed._vertices_from_bounds(bounds))[:3]
+            local_bounds = (tuple(vertices.min(axis=1)), tuple(vertices.max(axis=1)))
+            instance_area = self.geometry.surface_area(local_bounds)
+            if instance_area is None:
+                return None
+            total_area += instance_area
+        return total_area
+
+    @cached_property
+    def _normal_2dmaterial(self) -> Axis:
+        """Get the normal to the given geometry, checking that it is a 2D geometry."""
+        return self._geometry_group._normal_2dmaterial
+
+    def _update_from_bounds(self, bounds: tuple[float, float], axis: Axis) -> GeometryGroup:
+        """Returns an updated geometry which has been transformed to fit within ``bounds``
+        along the ``axis`` direction."""
+        return self._geometry_group._update_from_bounds(bounds=bounds, axis=axis)
+
+    def _compute_derivatives(self, derivative_info: DerivativeInfo) -> AutogradFieldMap:
+        """Compute the adjoint derivatives for this object.
+
+        Raises
+        ------
+        NotImplementedError
+            Adjoint/autodiff is not currently supported for GeometryArray.
+        """
+        raise NotImplementedError(
+            "Adjoint is not currently supported for 'GeometryArray'.",
+        )
 
 
 def cleanup_shapely_object(obj: Shapely, tolerance_ratio: float = POLY_TOLERANCE_RATIO) -> Shapely:

--- a/tidy3d/components/geometry/utils.py
+++ b/tidy3d/components/geometry/utils.py
@@ -47,6 +47,7 @@ GeometryType = Union[
     base.Transformed,
     base.ClipOperation,
     base.GeometryGroup,
+    base.GeometryArray,
     primitives.Sphere,
     primitives.Cylinder,
     polyslab.PolySlab,
@@ -196,6 +197,7 @@ def flatten_groups(
     *geometries: GeometryType,
     flatten_nonunion_type: bool = False,
     flatten_transformed: bool = False,
+    flatten_array: bool = False,
     transform: Optional[MatrixReal4x4] = None,
 ) -> GeometryType:
     """Iterates over all geometries, flattening groups and unions.
@@ -209,6 +211,8 @@ def flatten_groups(
         all clip operations.
     flatten_transformed : bool = False
         If ``True``, ``Transformed`` groups are flattened into individual transformed geometries.
+    flatten_array : bool = False
+        If ``True``, ``GeometryArray`` is flattened into its individual transformed geometries.
     transform : Optional[MatrixReal4x4]
         Accumulated transform from parents. Only used when ``flatten_transformed`` is ``True``.
 
@@ -223,6 +227,7 @@ def flatten_groups(
                 *geometry.geometries,
                 flatten_nonunion_type=flatten_nonunion_type,
                 flatten_transformed=flatten_transformed,
+                flatten_array=flatten_array,
                 transform=transform,
             )
         elif isinstance(geometry, base.ClipOperation) and (
@@ -233,6 +238,7 @@ def flatten_groups(
                 geometry.geometry_b,
                 flatten_nonunion_type=flatten_nonunion_type,
                 flatten_transformed=flatten_transformed,
+                flatten_array=flatten_array,
                 transform=transform,
             )
         elif flatten_transformed and isinstance(geometry, base.Transformed):
@@ -243,7 +249,16 @@ def flatten_groups(
                 geometry.geometry,
                 flatten_nonunion_type=flatten_nonunion_type,
                 flatten_transformed=flatten_transformed,
+                flatten_array=flatten_array,
                 transform=new_transform,
+            )
+        elif flatten_array and isinstance(geometry, base.GeometryArray):
+            yield from flatten_groups(
+                *geometry._transformed_geometries,
+                flatten_nonunion_type=flatten_nonunion_type,
+                flatten_transformed=flatten_transformed,
+                flatten_array=flatten_array,
+                transform=transform,
             )
         elif flatten_transformed and transform is not None:
             yield base.Transformed(geometry=geometry, transform=transform)
@@ -272,6 +287,8 @@ def traverse_geometries(geometry: GeometryType) -> GeometryType:
     elif isinstance(geometry, base.ClipOperation):
         yield from traverse_geometries(geometry.geometry_a)
         yield from traverse_geometries(geometry.geometry_b)
+    elif isinstance(geometry, base.GeometryArray):
+        yield from traverse_geometries(geometry.geometry)
     yield geometry
 
 
@@ -402,6 +419,11 @@ def validate_no_transformed_polyslabs(
     elif isinstance(geometry, base.ClipOperation):
         validate_no_transformed_polyslabs(geometry.geometry_a, transform)
         validate_no_transformed_polyslabs(geometry.geometry_b, transform)
+    elif isinstance(geometry, base.GeometryArray):
+        # For GeometryArray, check each instance's transform combined with the base geometry
+        for i in range(geometry.num_geometries):
+            instance_transform = np.dot(transform, geometry._get_full_transform(i))
+            validate_no_transformed_polyslabs(geometry.geometry, instance_transform)
 
 
 class SnapLocation(Enum):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core geometry modeling and schema/serialization surfaces, so regressions could affect simulation setup and geometry traversal/flattening. Test coverage is strong, but new transform/validation paths and geometry delegation warrant careful review.
> 
> **Overview**
> Introduces **`GeometryArray`** to represent many repeated copies of a base geometry using per-instance `offsets` and optional *linear-only* 4x4 `transforms` (transform then translate), plus a convenience `Geometry.array(offsets=..., transforms=...)` constructor.
> 
> Integrates the new geometry type across the library: exports it in `tidy3d.__init__`, extends geometry utilities (`flatten_groups`, `traverse_geometries`, `validate_no_transformed_polyslabs`) to understand arrays, and updates JSON schemas so simulations/components can accept `GeometryArray` anywhere a geometry union is allowed.
> 
> Adds extensive unit tests for creation/validation, bounds/inside behavior, operations (plot, intersections, volume/surface area), and equivalence vs `GeometryGroup`, and documents the new API in `docs/api/geometry.rst` and the changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit faac2eb2a5d7831e0b7998948de529f37daadcd6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces `GeometryArray`, a new class for efficiently representing repeated geometry instances with optional transformations and translations. The implementation includes a convenience method `geometry.array()` available on all geometry objects.

## Key Changes

- **New `GeometryArray` class**: Stores a single base geometry with arrays of offsets and/or transformation matrices, creating transformed instances on-demand via cached properties
- **Helper validators**: Extracted `assert_geometry_finite()` and `check_transform_invertible()` validators to avoid code duplication between `Transformed` and `GeometryArray`
- **Utility function updates**: Added `GeometryArray` support in `flatten_groups()`, `traverse_geometries()`, and `validate_no_transformed_polyslabs()`
- **Comprehensive testing**: Added 20+ test cases covering creation, validation, bounds, inside checks, transforms, plotting, and equivalence with `GeometryGroup`
- **Documentation**: Added dedicated section in API docs with usage examples

## Implementation Details

The class efficiently handles three modes:
1. **Offsets only**: Pure translations of the base geometry
2. **Transforms only**: Rotations/reflections at the origin
3. **Both**: Transforms applied before translation offsets

The implementation internally creates `Transformed` geometries (cached) and delegates most operations to them, ensuring consistency with existing geometry behavior.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor docstring formatting fixes
- High-quality implementation with excellent test coverage and documentation. Two minor syntax issues found with docstring formatting (backticks should be doubled for RST). Core logic is sound with proper validation, caching, and integration with existing utilities.
- Pay attention to `tidy3d/components/geometry/base.py` for the docstring syntax corrections

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tests/test_components/test_geometry.py | Added comprehensive test coverage for GeometryArray with 20+ test cases |
| tidy3d/components/geometry/base.py | Implemented GeometryArray class with helper validators and Geometry.array() method; minor issue with validation message formatting |
| tidy3d/components/geometry/utils.py | Added GeometryArray support in utility functions (flatten_groups, traverse_geometries, validate_no_transformed_polyslabs) |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Geometry
    participant GeometryArray
    participant Transformed
    participant Structure

    User->>Geometry: Create base geometry (e.g., Box)
    User->>Geometry: Call geometry.array(offsets, transforms)
    Geometry->>GeometryArray: Create GeometryArray instance
    GeometryArray->>GeometryArray: Validate offsets and transforms
    GeometryArray->>GeometryArray: Check transforms are invertible
    GeometryArray->>GeometryArray: Validate geometry has finite bounds
    GeometryArray-->>User: Return GeometryArray instance
    
    User->>Structure: Create Structure with GeometryArray
    Structure->>GeometryArray: Query bounds
    GeometryArray->>GeometryArray: Compute _get_full_transform() for each instance
    GeometryArray->>Transformed: Create Transformed geometries (cached)
    Transformed-->>GeometryArray: Return transformed instances
    GeometryArray->>GeometryArray: Compute combined bounds
    GeometryArray-->>Structure: Return bounds
    
    User->>GeometryArray: Call inside(x, y, z)
    GeometryArray->>Transformed: Check inside() for each instance
    Transformed-->>GeometryArray: Return boolean arrays
    GeometryArray->>GeometryArray: OR results together
    GeometryArray-->>User: Return combined result
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->