### PR TITLE
reduce computation time for adaptive_vjp_spacing via caching for GeometryGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added deprecation warning for ``TemperatureMonitor`` and ``SteadyPotentialMonitor`` when ``unstructured`` parameter is not explicitly set. The default value of ``unstructured`` will change from ``False`` to ``True`` after the 2.11 release.
 - Added validation to `GaussianDoping` to ensure `ref_con < concentration`, validate `source` face identifier, and warn the user when the box size is not sufficient for the specified transition width.
 - Local caching is now enabled by default (set `td.config.local_cache.enabled=False` to opt out).
+- Reduced computation time of `adaptive_vjp_spacing` for `GeometryGroup` by allowing permittivity based spacing value to be cached.
 
 ### Fixed
 - Fixed intermittent "API key not found" errors in parallel job launches by making configuration directory detection race-safe.

--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -5,6 +5,7 @@ import copy
 import cProfile
 import typing
 import warnings
+from contextlib import nullcontext
 from dataclasses import dataclass
 from importlib import reload
 from os.path import join
@@ -1967,6 +1968,96 @@ def test_adaptive_spacing(eps_real):
         assert np.isclose(expected_vjp_spacing, vjp_spacing), "Unexpected adaptive vjp spacing!"
 
 
+def test_adaptive_spacing_cache(rng, redirect_stdout_to_stderr, monkeypatch):
+    """Ensure the cache is not affecting `GeometryGroup` results or persisting after derivative computation."""
+    x_geom = [-0.5, 0.5]
+    y_geom = [-0.5, 0.5]
+
+    radius = 0.3
+
+    geometries = []
+    for x_center in x_geom:
+        for y_center in y_geom:
+            geometries.append(
+                td.Cylinder(center=(x_center, y_center, 0.0), length=0.5, radius=radius)
+            )
+
+    field_paths = []
+    for idx in range(len(geometries)):
+        field_paths.append(("geometries", idx, "radius"))
+
+    geometry = td.GeometryGroup(geometries=geometries)
+
+    eps_keys = ["eps_xx", "eps_yy", "eps_zz"]
+
+    N = 20
+    xcoord = np.linspace(-1, 1, N)
+    ycoord = np.linspace(-1, 1, N)
+    zcoord = np.linspace(-1, 1, N)
+
+    eps_out_data = rng.uniform(1, 2, (N, N, N, 1))
+    eps_in_data = rng.uniform(1, 2, (N, N, N, 1))
+
+    freq = 1.94e14
+
+    def random_scalar_data_array():
+        return td.ScalarFieldDataArray(
+            rng.uniform(1, 2, (N, N, N, 1)),
+            coords={"x": xcoord, "y": ycoord, "z": zcoord, "f": [freq]},
+        )
+
+    E_fwd = {key: random_scalar_data_array() for key in ["Ex", "Ey", "Ez"]}
+    E_adj = {key: random_scalar_data_array() for key in ["Ex", "Ey", "Ez"]}
+    D_fwd = {key: random_scalar_data_array() for key in ["Ex", "Ey", "Ez"]}
+    D_adj = {key: random_scalar_data_array() for key in ["Ex", "Ey", "Ez"]}
+    E_der_map = {key: random_scalar_data_array() for key in ["Ex", "Ey", "Ez"]}
+    D_der_map = {key: random_scalar_data_array() for key in ["Ex", "Ey", "Ez"]}
+
+    derivative_info = DerivativeInfo(
+        paths=tuple(field_paths),
+        E_der_map=E_der_map,
+        D_der_map=D_der_map,
+        E_fwd=E_fwd,
+        D_fwd=D_fwd,
+        E_adj=E_adj,
+        D_adj=D_adj,
+        eps_data={
+            key: td.ScalarFieldDataArray(
+                rng.uniform(1, 2, (N, N, N, 1)),
+                coords={"x": xcoord, "y": ycoord, "z": zcoord, "f": [freq]},
+            )
+            for key in eps_keys
+        },
+        frequencies=[freq],
+        bounds=((-1, -1, -1), (1, 1, 1)),
+        eps_out=td.ScalarFieldDataArray(
+            eps_out_data, coords={"x": xcoord, "y": ycoord, "z": zcoord, "f": [freq]}
+        ),
+        eps_in=td.ScalarFieldDataArray(
+            eps_in_data, coords={"x": xcoord, "y": ycoord, "z": zcoord, "f": [freq]}
+        ),
+        bounds_intersect=((-1, -1, -1), (1, 1, 1)),
+        simulation_bounds=((-2, -2, -2), (2, 2, 2)),
+    )
+
+    vjp_with_cache = geometry._compute_derivatives(derivative_info)
+
+    assert derivative_info.cached_min_spacing_from_permittivity is None, (
+        "Unexpected cached variable persistence."
+    )
+
+    monkeypatch.setattr(
+        derivative_info, "cache_min_spacing_from_permittivity", lambda: nullcontext()
+    )
+
+    vjp_without_cache = geometry._compute_derivatives(derivative_info)
+
+    for k, v in vjp_with_cache.items():
+        assert v == vjp_without_cache[k], (
+            "Geometry group computation changed when running with cache."
+        )
+
+
 @pytest.mark.parametrize("eps_real", [1e6, -1e8])
 def test_cylinder_discretization(eps_real):
     freq = 5e9
@@ -3284,6 +3375,18 @@ def test_geometry_group_passes_intersected_bounds_to_children():
         bounds_intersect: tuple
         simulation_bounds: tuple
         interpolators: dict | None = None
+        cached_min_spacing_from_permittivity: float | None = None
+        eps_data = {
+            key: td.ScalarFieldDataArray(
+                [[[[2.0]]]], coords={"x": [0], "y": [0], "z": [0], "f": [200e12]}
+            )
+            for key in ["eps_xx", "eps_yy", "eps_zz"]
+        }
+        frequencies = [200e12]
+
+        cache_min_spacing_from_permittivity = DerivativeInfo.cache_min_spacing_from_permittivity
+        min_spacing_from_permittivity = DerivativeInfo.min_spacing_from_permittivity
+        wavelength_min = property(lambda self: DerivativeInfo.wavelength_min.fget(self))
 
         def create_interpolators(self, dtype: float = float):
             return self.interpolators or {}
@@ -3295,6 +3398,7 @@ def test_geometry_group_passes_intersected_bounds_to_children():
                 "bounds_intersect": self.bounds_intersect,
                 "simulation_bounds": self.simulation_bounds,
                 "interpolators": self.interpolators,
+                "cached_min_spacing_from_permittivity": self.cached_min_spacing_from_permittivity,
             }
             data.update({k: v for k, v in kwargs.items() if k in data})
             return SimpleDerivativeInfo(**data)

--- a/tests/test_components/autograd/test_autograd_polyslab.py
+++ b/tests/test_components/autograd/test_autograd_polyslab.py
@@ -132,6 +132,9 @@ class DummyDI:
             else ((-2e3, -2e3, -2e3), (2e3, 2e3, 2e3))
         )
 
+        self.cached_min_spacing_from_permittivity = None
+
+    min_spacing_from_permittivity = DerivativeInfo.min_spacing_from_permittivity
     adaptive_vjp_spacing = DerivativeInfo.adaptive_vjp_spacing
     wavelength_min = property(lambda self: DerivativeInfo.wavelength_min.fget(self))
     wavelength_max = property(lambda self: DerivativeInfo.wavelength_max.fget(self))

--- a/tidy3d/components/autograd/derivative_utils.py
+++ b/tidy3d/components/autograd/derivative_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from functools import reduce
 from typing import TYPE_CHECKING, Any, Optional
@@ -20,6 +21,7 @@ from .types import PathType
 from .utils import get_static
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from typing import Callable, Union
 
     import xarray as xr
@@ -161,6 +163,10 @@ class DerivativeInfo:
     When provided, avoids redundant interpolator creation for multiple geometries
     sharing the same field data. This significantly improves performance for
     GeometryGroup processing."""
+
+    cached_min_spacing_from_permittivity: Optional[float] = None
+    """Cached `min_spacing_from_permittivity` to be used for objects like GeometryGroup
+    to avoid recomputing this value multiple times in `adaptive_vjp_spacing`."""
 
     # private cache for interpolators
     _interpolators_cache: dict = field(default_factory=dict, init=False, repr=False)
@@ -942,6 +948,54 @@ class DerivativeInfo:
                 projected[key] = field_map[key]
         return projected
 
+    @property
+    def min_spacing_from_permittivity(self) -> float:
+        if self.cached_min_spacing_from_permittivity is not None:
+            return self.cached_min_spacing_from_permittivity
+
+        def spacing_by_permittivity(eps_array: ScalarFieldDataArray) -> float:
+            eps_real = np.asarray(eps_array.values, dtype=np.complex128).real
+
+            dx_candidates = []
+            max_frequency = np.max(self.frequencies)
+
+            # wavelength-based sampling for dielectrics
+            if np.any(eps_real > 0):
+                eps_max = eps_real[eps_real > 0].max()
+                lambda_min = self.wavelength_min / np.sqrt(eps_max)
+                dx_candidates.append(lambda_min)
+
+            # skin depth sampling for metals
+            if np.any(eps_real <= 0):
+                omega = 2 * np.pi * max_frequency
+                eps_neg = eps_real[eps_real <= 0]
+                delta_min = C_0 / (omega * np.sqrt(np.abs(eps_neg).max()))
+                dx_candidates.append(delta_min)
+
+            computed_spacing = min(dx_candidates)
+
+            return computed_spacing
+
+        eps_spacings = [
+            spacing_by_permittivity(eps_array) for _, eps_array in self.eps_data.items()
+        ]
+        min_spacing = np.min(eps_spacings)
+
+        return min_spacing
+
+    @contextmanager
+    def cache_min_spacing_from_permittivity(self) -> Iterator[None]:
+        """
+        Cache min_spacing_from_permittivity for the duration of the block. Cache
+        is always cleared on exit.
+        """
+
+        self.cached_min_spacing_from_permittivity = self.min_spacing_from_permittivity
+        try:
+            yield
+        finally:
+            self.cached_min_spacing_from_permittivity = None
+
     def adaptive_vjp_spacing(
         self,
         wl_fraction: Optional[float] = None,
@@ -975,33 +1029,7 @@ class DerivativeInfo:
             if min_allowed_spacing_fraction is None:
                 min_allowed_spacing_fraction = config.adjoint.minimum_spacing_fraction
 
-        def spacing_by_permittivity(eps_array: ScalarFieldDataArray) -> float:
-            eps_real = np.asarray(eps_array.values, dtype=np.complex128).real
-
-            dx_candidates = []
-            max_frequency = np.max(self.frequencies)
-
-            # wavelength-based sampling for dielectrics
-            if np.any(eps_real > 0):
-                eps_max = eps_real[eps_real > 0].max()
-                lambda_min = self.wavelength_min / np.sqrt(eps_max)
-                dx_candidates.append(wl_fraction * lambda_min)
-
-            # skin depth sampling for metals
-            if np.any(eps_real <= 0):
-                omega = 2 * np.pi * max_frequency
-                eps_neg = eps_real[eps_real <= 0]
-                delta_min = C_0 / (omega * np.sqrt(np.abs(eps_neg).max()))
-                dx_candidates.append(wl_fraction * delta_min)
-
-            computed_spacing = min(dx_candidates)
-
-            return computed_spacing
-
-        eps_spacings = [
-            spacing_by_permittivity(eps_array) for _, eps_array in self.eps_data.items()
-        ]
-        computed_spacing = np.min(eps_spacings)
+        computed_spacing = wl_fraction * self.min_spacing_from_permittivity
 
         min_allowed_spacing = self.wavelength_min * min_allowed_spacing_fraction
 

--- a/tidy3d/components/geometry/base.py
+++ b/tidy3d/components/geometry/base.py
@@ -3593,26 +3593,28 @@ class GeometryGroup(Geometry):
         # create interpolators once for all geometries to avoid redundant field data conversions
         interpolators = derivative_info.interpolators or derivative_info.create_interpolators()
 
-        for field_path in derivative_info.paths:
-            _, index, *geo_path = field_path
-            geo = self.geometries[index]
-            # pass pre-computed interpolators if available
-            geo_info = derivative_info.updated_copy(
-                paths=[tuple(geo_path)],
-                bounds=geo.bounds,
-                bounds_intersect=self.bounds_intersection(
-                    geo.bounds, derivative_info.simulation_bounds
-                ),
-                deep=False,
-                interpolators=interpolators,
-            )
+        with derivative_info.cache_min_spacing_from_permittivity():
+            for field_path in derivative_info.paths:
+                _, index, *geo_path = field_path
 
-            vjp_dict_geo = geo._compute_derivatives(geo_info)
+                geo = self.geometries[index]
+                # pass pre-computed interpolators if available
+                geo_info = derivative_info.updated_copy(
+                    paths=[tuple(geo_path)],
+                    bounds=geo.bounds,
+                    bounds_intersect=self.bounds_intersection(
+                        geo.bounds, derivative_info.simulation_bounds
+                    ),
+                    deep=False,
+                    interpolators=interpolators,
+                )
 
-            if len(vjp_dict_geo) != 1:
-                raise AssertionError("Got multiple gradients for single geometry field.")
+                vjp_dict_geo = geo._compute_derivatives(geo_info)
 
-            grad_vjps[field_path] = vjp_dict_geo.popitem()[1]
+                if len(vjp_dict_geo) != 1:
+                    raise AssertionError("Got multiple gradients for single geometry field.")
+
+                grad_vjps[field_path] = vjp_dict_geo.popitem()[1]
 
         return grad_vjps
 


### PR DESCRIPTION
`adapative_vjp_spacing` takes longer to run now that we use the full `eps_data` inside of `DerivativeInfo`. For geometry groups this was running for every geometry and adding a significant overhead. Just caching the property didn't work because the `derivative_info` variable is copied and updated with new derivative paths in `GeometryGroup`. Instead, we allow the variable to be cached inside of `DerivativeInfo`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance optimization: changes are localized to spacing computation/caching and are covered by new tests asserting unchanged derivative outputs and cache cleanup.
> 
> **Overview**
> Reduces autograd shape-derivative overhead for `GeometryGroup` by caching the permittivity-derived minimum spacing used by `DerivativeInfo.adaptive_vjp_spacing`, so it’s computed once per group instead of once per child geometry.
> 
> This refactors the permittivity spacing calculation into a reusable `DerivativeInfo.min_spacing_from_permittivity` property, adds a `cache_min_spacing_from_permittivity()` context manager to control cache lifetime, and wraps `GeometryGroup._compute_derivatives()` in that cache scope; tests were updated to assert identical VJP results with/without caching and that the cache is cleared after derivative computation. The changelog notes the performance improvement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4b2f2fb7b937b1ce35480643c38d6bdcf133bd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR optimizes the performance of `adaptive_vjp_spacing` for `GeometryGroup` by implementing a caching mechanism for the permittivity-based spacing calculation.

**Key Changes:**
- Extracted the core permittivity-based spacing computation into a new `@cached_property` method `min_spacing_from_permittivity` in `DerivativeInfo`
- Added a `cached_min_spacing_from_permittivity` field to enable explicit caching that survives `dataclasses.replace()` operations
- Added helper methods `cache_min_spacing_from_permittivity()` and `uncache_min_spacing_from_permittivity()` to control cache lifecycle
- Modified `GeometryGroup._compute_derivatives()` to cache the value once before the loop and uncache after, so all child geometries share the same cached value

**Implementation Details:**
The caching approach cleverly handles the fact that `GeometryGroup` creates copies of `DerivativeInfo` for each child geometry using `updated_copy()` (which uses `dataclasses.replace()`). Since `@cached_property` stores its cache in the instance's `__dict__`, it doesn't survive across `replace()` operations. The solution is to store the computed value in an explicit field (`cached_min_spacing_from_permittivity`) which DOES get copied during `replace()`. The `@cached_property` decorator checks this field first, so copied instances use the pre-computed value without recalculation.

**Performance Impact:**
Previously, `adaptive_vjp_spacing` would compute the permittivity-based spacing for every geometry in a `GeometryGroup`, even though all geometries share the same `eps_data`. With this change, it's computed once and reused across all geometries in the group.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk - it's a performance optimization with a well-thought-out caching mechanism
- The implementation is sound and the caching logic correctly handles the interaction between `@cached_property` and `dataclasses.replace()`. The confidence is 4 (not 5) because this is a subtle performance optimization involving cached properties and dataclass copies, which could benefit from additional testing to verify the performance improvement and ensure no edge cases were missed.
- No files require special attention - all changes are straightforward

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Added performance improvement entry for `adaptive_vjp_spacing` caching in `GeometryGroup` |
| tidy3d/components/autograd/derivative_utils.py | Refactored `adaptive_vjp_spacing` to cache permittivity-based spacing via new `cached_min_spacing_from_permittivity` field and `@cached_property` decorator |
| tidy3d/components/geometry/base.py | Added caching calls around geometry loop in `GeometryGroup._compute_derivatives` to enable cache sharing across geometries |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GG as GeometryGroup
    participant DI as DerivativeInfo (original)
    participant DI_copy as DerivativeInfo (copy)
    participant G1 as Geometry 1
    participant G2 as Geometry 2
    
    Note over GG: _compute_derivatives called
    GG->>DI: cache_min_spacing_from_permittivity()
    activate DI
    DI->>DI: Access min_spacing_from_permittivity (@cached_property)
    DI->>DI: Compute spacing from eps_data
    DI->>DI: Store in cached_min_spacing_from_permittivity field
    deactivate DI
    
    loop For each geometry in GeometryGroup
        GG->>DI: updated_copy(paths, bounds, ...)
        DI-->>DI_copy: Create shallow copy via dataclasses.replace()
        Note over DI_copy: cached_min_spacing_from_permittivity<br/>is copied to new instance
        
        GG->>G1: _compute_derivatives(DI_copy)
        activate G1
        G1->>DI_copy: adaptive_vjp_spacing()
        DI_copy->>DI_copy: Access min_spacing_from_permittivity
        Note over DI_copy: Check cached_min_spacing_from_permittivity<br/>Return cached value immediately
        DI_copy-->>G1: Return cached spacing
        G1-->>GG: Return gradient
        deactivate G1
    end
    
    GG->>DI: uncache_min_spacing_from_permittivity()
    Note over DI: Set cached_min_spacing_from_permittivity = None
    
    Note over GG: All geometries used cached value,<br/>avoiding redundant computation
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->