### PR TITLE
feat(FXC-5154) Warn gmsh min cylinder radii

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Grid.fine_mesh_info` property to identify and report locations where grid cell sizes are fine for understanding meshing hotspots.
 - Added visualization of finest grid regions in `Simulation.plot_grid()` with shaded regions highlighting areas of fine meshing.
 - Added autograd support for `Sphere`.
+- Added validation warning in `HeatChargeSimulation` for very small `Cylinder` radii to help users avoid meshing and numerical issues.
 - Added `GaussianOverlapMonitor` and `AstigmaticGaussianOverlapMonitor` for decomposing electromagnetic fields onto Gaussian beam profiles.
 - Added `GaussianPort` and `AstigmaticGaussianPort` for S-matrix calculations using Gaussian beam sources and overlap monitors.
 - Added `symmetric_pseudo` option for `s_param_def` in `TerminalComponentModeler` which applies a scaling factor that ensures the S-matrix is symmetric in reciprocal systems.

--- a/tests/test_components/test_heat_charge.py
+++ b/tests/test_components/test_heat_charge.py
@@ -2830,3 +2830,72 @@ def test_heat_charge_simulation_plot():
         "for CHARGE simulations, resulting in at least 2 more visual elements "
         "than charge_sim.scene.plot()"
     )
+
+
+def test_cylinder_small_radius_warning():
+    """Test that warning is issued for very small cylinder radii in HeatChargeSimulation."""
+    solid = td.MultiPhysicsMedium(
+        heat=td.SolidSpec(conductivity=1, capacity=1),
+        name="solid",
+    )
+    background = td.MultiPhysicsMedium(
+        heat=td.FluidSpec(),
+        name="background",
+    )
+
+    # Test non-tapered cylinder with tiny radius
+    tiny_cylinder = td.Structure(
+        geometry=td.Cylinder(center=(0, 0, 0), radius=1e-8, length=1, axis=2),
+        medium=solid,
+        name="tiny",
+    )
+    with AssertLogLevel("WARNING", contains_str="radius"):
+        _ = td.HeatChargeSimulation(
+            center=(0, 0, 0),
+            size=(2, 2, 2),
+            medium=background,
+            structures=[tiny_cylinder],
+            grid_spec=td.UniformUnstructuredGrid(dl=0.1),
+            monitors=[td.TemperatureMonitor(size=(1, 1, 1), name="tmp")],
+        )
+
+    # Test transformed (translated) cylinder with tiny radius
+    tiny_cylinder_transformed = td.Structure(
+        geometry=td.Cylinder(center=(0, 0, 0), radius=1e-8, length=1, axis=2).translated(
+            x=0.1, y=0.0, z=0.0
+        ),
+        medium=solid,
+        name="tiny_transformed",
+    )
+    with AssertLogLevel("WARNING", contains_str="radius"):
+        _ = td.HeatChargeSimulation(
+            center=(0, 0, 0),
+            size=(2, 2, 2),
+            medium=background,
+            structures=[tiny_cylinder_transformed],
+            grid_spec=td.UniformUnstructuredGrid(dl=0.1),
+            monitors=[td.TemperatureMonitor(size=(1, 1, 1), name="tmp")],
+        )
+
+    # Test tapered cylinder with steep sidewall causing negative radius_top
+    tapered_cylinder = td.Structure(
+        geometry=td.Cylinder(
+            center=(0, 0, 0),
+            radius=0.1,
+            length=1,
+            axis=2,
+            sidewall_angle=np.pi / 3,  # 60 degrees - causes negative radius_top
+            reference_plane="bottom",
+        ),
+        medium=solid,
+        name="tapered",
+    )
+    with AssertLogLevel("WARNING", contains_str="radius_top"):
+        _ = td.HeatChargeSimulation(
+            center=(0, 0, 0),
+            size=(2, 2, 2),
+            medium=background,
+            structures=[tapered_cylinder],
+            grid_spec=td.UniformUnstructuredGrid(dl=0.1),
+            monitors=[td.TemperatureMonitor(size=(1, 1, 1), name="tmp")],
+        )

--- a/tidy3d/components/tcad/simulation/heat_charge.py
+++ b/tidy3d/components/tcad/simulation/heat_charge.py
@@ -16,7 +16,9 @@ from tidy3d.components.bc_placement import (
     StructureSimulationBoundary,
     StructureStructureInterface,
 )
-from tidy3d.components.geometry.base import Box
+from tidy3d.components.geometry.base import Box, Transformed
+from tidy3d.components.geometry.primitives import Cylinder
+from tidy3d.components.geometry.utils import flatten_groups
 from tidy3d.components.material.tcad.charge import (
     ChargeConductorMedium,
     SemiconductorMedium,
@@ -122,6 +124,11 @@ AnalysisSpecType = Union[ElectricalAnalysisType, UnsteadyHeatAnalysis]
 
 # define some limits for transient heat simulations
 TRANSIENT_HEAT_MAX_STEPS = 1000
+
+# OpenCASCADE minimum tolerance for cylinder radii
+OPENCASCADE_CYLINDER_RADIUS_TOL = 1e-6
+# Minimum radius as fraction of the larger radius (for tapered cylinders)
+MIN_CYLINDER_RADIUS_FRACTION = 0.01
 
 
 class TCADAnalysisTypes(str, Enum):
@@ -352,6 +359,50 @@ class HeatChargeSimulation(AbstractSimulation):
                 raise SetupError(
                     f"'HeatSimulation' does not currently support structures with dimensions of zero size ('structures[{ind}]')."
                 )
+        return val
+
+    @field_validator("structures")
+    @classmethod
+    def _warn_small_cylinder_radius(cls, val: tuple[Structure, ...]) -> tuple[Structure, ...]:
+        """Warn if any Cylinder geometry has radius too small for meshing."""
+        for structure in val:
+            for geometry in flatten_groups(
+                structure.geometry, flatten_nonunion_type=True, flatten_transformed=True
+            ):
+                # Unwrap Transformed to get the base geometry
+                base_geometry = geometry.geometry if isinstance(geometry, Transformed) else geometry
+                if isinstance(base_geometry, Cylinder):
+                    r_bottom = base_geometry.radius_bottom
+                    r_top = base_geometry.radius_top
+                    is_tapered = not np.isclose(r_bottom, r_top)
+
+                    # Compute minimum allowed radius (matches backend heat_mesh.py logic)
+                    min_radius = max(
+                        OPENCASCADE_CYLINDER_RADIUS_TOL,
+                        MIN_CYLINDER_RADIUS_FRACTION * max(abs(r_bottom), abs(r_top)),
+                    )
+
+                    # Warn if radii are below minimum
+                    if is_tapered:
+                        if r_bottom < min_radius:
+                            log.warning(
+                                f"Cylinder 'radius_bottom' ({r_bottom:.3e}) is below the minimum "
+                                f"radius for meshing ({min_radius:.3e}). The sidewall angle may be "
+                                f"too steep. Will be clamped to minimum radius or mesh size, whichever is larger."
+                            )
+                        if r_top < min_radius:
+                            log.warning(
+                                f"Cylinder 'radius_top' ({r_top:.3e}) is below the minimum "
+                                f"radius for meshing ({min_radius:.3e}). The sidewall angle may be "
+                                f"too steep. Will be clamped to minimum radius or mesh size, whichever is larger."
+                            )
+                    else:
+                        if r_bottom < min_radius:
+                            log.warning(
+                                f"Cylinder 'radius' ({r_bottom:.3e}) is below the minimum "
+                                f"radius for meshing ({min_radius:.3e}). "
+                                f"Will be clamped to minimum radius or mesh size, whichever is larger."
+                            )
         return val
 
     def _check_cross_solids(self, objs: tuple[Box, ...]) -> tuple[int, ...]:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Warning-only validation change plus tests and changelog update; no solver behavior changes beyond emitting log warnings.
> 
> **Overview**
> Adds validation-time warnings in `HeatChargeSimulation` when any `Cylinder` (including inside `GeometryGroup` and `Transformed` geometries) has a radius below the minimum tolerated by the gmsh/OpenCASCADE meshing path, with special handling for tapered cylinders (`radius_bottom`/`radius_top`).
> 
> Adds regression tests asserting warnings for tiny-radius cylinders (including translated cylinders) and for steeply tapered cylinders that would produce an invalid/small `radius_top`, and documents the new user-facing warning in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea7795b02e04a9e29be369cdd996ae69fb89a8a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds validation-time warnings for `HeatChargeSimulation` when `Cylinder` geometries have radii below the minimum threshold required for gmsh/OpenCASCADE meshing. The implementation correctly traverses nested geometries and checks both tapered and non-tapered cylinders.

**Key Changes:**
- Added `MIN_GMSH_RADIUS` constant (1e-6) to define OpenCASCADE tolerance
- Implemented `_warn_small_cylinder_radius` validator that checks `radius_bottom` and `radius_top` against computed minimum
- Added comprehensive test coverage for both tiny-radius and steeply-tapered cylinder cases

**Issues Found:**
- Line 379 uses direct float equality (`!=`) which can be unreliable; should use tolerance-based comparison with `np.isclose`
- Missing CHANGELOG.md entry (required per custom rules for user-facing changes)

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the floating-point comparison issue and adding CHANGELOG entry
- The feature is well-tested and adds useful warnings without changing behavior. The main concern is the floating-point comparison bug on line 379 which could cause incorrect `is_tapered` detection in edge cases. Missing CHANGELOG is a process violation but doesn't affect code quality.
- Pay attention to `tidy3d/components/tcad/simulation/heat_charge.py` line 379 for the float comparison fix

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tidy3d/components/tcad/simulation/heat_charge.py | Adds validator to warn about small cylinder radii; has floating-point comparison issue on line 379 that needs fixing |
| tests/test_components/test_heat_charge.py | Adds test coverage for small cylinder radius warnings; covers both tiny radius and tapered cylinder cases |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant HeatChargeSimulation
    participant Validator as _warn_small_cylinder_radius
    participant GeomUtils as traverse_geometries
    participant Cylinder
    participant Logger as log.warning

    User->>HeatChargeSimulation: Create simulation with structures
    HeatChargeSimulation->>Validator: Validate structures field
    
    loop For each structure
        Validator->>GeomUtils: traverse_geometries(structure.geometry)
        GeomUtils-->>Validator: Yields nested geometries
        
        loop For each geometry
            alt geometry is Cylinder
                Validator->>Cylinder: Get radius_bottom
                Cylinder-->>Validator: r_bottom
                Validator->>Cylinder: Get radius_top
                Cylinder-->>Validator: r_top
                
                Validator->>Validator: Check if tapered (r_bottom != r_top)
                Validator->>Validator: Compute min_radius = max(MIN_GMSH_RADIUS, 0.01*max(abs(r_bottom), abs(r_top)))
                
                alt is_tapered
                    alt r_bottom < min_radius
                        Validator->>Logger: Warn about radius_bottom
                    end
                    alt r_top < min_radius
                        Validator->>Logger: Warn about radius_top
                    end
                else not tapered
                    alt r_bottom < min_radius
                        Validator->>Logger: Warn about radius
                    end
                end
            end
        end
    end
    
    Validator-->>HeatChargeSimulation: Return validated structures
    HeatChargeSimulation-->>User: Simulation created (with warnings)
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Use a tolerance-based comparison (e.g., np.isclose) for floating-point numbers instead of direct equ... ([source](https://app.greptile.com/review/custom-context?memory=4a0cb6d3-6973-448b-b5dd-168bc7b26dc3))
- Rule from `dashboard` - Update the CHANGELOG.md file when making changes that affect user-facing functionality or fix bugs. ([source](https://app.greptile.com/review/custom-context?memory=a109c62a-aa8c-4cc4-b515-0ad947c47929))

<!-- /greptile_comment -->