### PR TITLE
fix: clean up changelog, log waist_distance warning once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Grid.fine_mesh_info` property to identify and report locations where grid cell sizes are fine for understanding meshing hotspots.
 - Added visualization of finest grid regions in `Simulation.plot_grid()` with shaded regions highlighting areas of fine meshing.
 - Added autograd support for `Sphere`.
+- Added `GaussianOverlapMonitor` and `AstigmaticGaussianOverlapMonitor` for decomposing electromagnetic fields onto Gaussian beam profiles.
+- Added `GaussianPort` and `AstigmaticGaussianPort` for S-matrix calculations using Gaussian beam sources and overlap monitors.
+- Added `symmetric_pseudo` option for `s_param_def` in `TerminalComponentModeler` which applies a scaling factor that ensures the S-matrix is symmetric in reciprocal systems.
+- Added deprecation warning for ``TemperatureMonitor`` and ``SteadyPotentialMonitor`` when ``unstructured`` parameter is not explicitly set. The default value of ``unstructured`` will change from ``False`` to ``True`` after the 2.11 release.
 
 ### Breaking Changes
 - Added `structure_priority_mode` for `TerminalComponentModeler` and default to `"conductor"` to ensure metal structures override dielectrics regardless of structure order, preventing order-dependent results in RF simulations.
 - 1D lumped elements (with zero lateral extent) are no longer allowed. Use a small finite lateral extent (e.g., `1e-6`) instead.
-- Added `GaussianOverlapMonitor` and `AstigmaticGaussianOverlapMonitor` for decomposing electromagnetic fields onto Gaussian beam profiles.
-- Added `GaussianPort` and `AstigmaticGaussianPort` for S-matrix calculations using Gaussian beam sources and overlap monitors.
+- `ModeSortSpec.sort_key` is now required with a default of `"n_eff"` (previously optional with `None` default). `ModeSortSpec.sort_order` is now optional with a default of `None`, which automatically selects the natural order based on `sort_key` and `sort_reference`: ascending when a reference is provided (closest first), otherwise descending for `n_eff` and polarization fractions (higher values first), ascending for `k_eff` and `mode_area` (lower values first).
+- Changed the interpretation of `waist_distance` and `waist_distances` for backward-propagating Gaussian beams (`GaussianBeam`, `AstigmaticGaussianBeam`, `GaussianBeamProfile`, `AstigmaticGaussianBeamProfile`). Previously, the waist position was interpreted relative to the directed propagation axis, meaning switching `direction` from `+` to `-` would also flip the waist position in the global reference frame. Now, the waist position is defined consistently for both directions: a positive `waist_distance` always places the beam waist behind the source/monitor plane (toward the negative normal axis), regardless of propagation direction. This ensures reciprocity between Gaussian sources and overlap monitors used in port-based S-matrix calculations. Users with existing simulations using backward-propagating Gaussian beams with non-zero waist distances may need to adjust their values.
 
 ### Changed
 - `ModeSortSpec.sort_key` is now required with a default of `"n_eff"` (previously optional with `None` default). `ModeSortSpec.sort_order` is now optional with a default of `None`, which automatically selects the natural order based on `sort_key` and `sort_reference`: ascending when a reference is provided (closest first), otherwise descending for `n_eff` and polarization fractions (higher values first), ascending for `k_eff` and `mode_area` (lower values first).
@@ -65,7 +69,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added validation to `DCVoltageSource` that warns when duplicate voltage values are detected in the `voltage` array, including treating `0` and `-0` as the same value.
 
 ### Changed
-- **Breaking**: Changed the interpretation of `waist_distance` and `waist_distances` for backward-propagating Gaussian beams (`GaussianBeam`, `AstigmaticGaussianBeam`, `GaussianBeamProfile`, `AstigmaticGaussianBeamProfile`). Previously, the waist position was interpreted relative to the directed propagation axis, meaning switching `direction` from `+` to `-` would also flip the waist position in the global reference frame. Now, the waist position is defined consistently for both directions: a positive `waist_distance` always places the beam waist behind the source/monitor plane (toward the negative normal axis), regardless of propagation direction. This ensures reciprocity between Gaussian sources and overlap monitors used in port-based S-matrix calculations. Users with existing simulations using backward-propagating Gaussian beams with non-zero waist distances may need to adjust their values.
 - For `HeatChargeSimulation` objects, the `plot` function now adds the simulation boundary conditions.
 - Improved memory performance in `postprocess_adj` by using `isel` instead of `sel` for xarray slicing.
 

--- a/tidy3d/components/validators.py
+++ b/tidy3d/components/validators.py
@@ -327,6 +327,7 @@ def warn_backward_waist_distance(field_name: str):
                 "sources and overlap monitors used for port-based S-matrix calculations. "
                 "If your simulation relied on the previous behavior (where the waist position "
                 "flipped with direction), you may need to adjust your waist distance values.",
+                log_once=True,
             )
         return values
 


### PR DESCRIPTION
The changelog has gotten a bit messed up with the recent 2.11 merging spree.

I'm also adding a `log_once` for the `waist_distance` warning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only affects changelog text and warning emission frequency; no functional simulation behavior is changed.
> 
> **Overview**
> **Documentation cleanup:** Reorganizes the `[Unreleased]` section in `CHANGELOG.md` after recent merges, fixing duplicated/misplaced entries (notably around Gaussian beam ports/monitors and deprecation notes).
> 
> **Less noisy validation logging:** Updates `warn_backward_waist_distance` in `tidy3d/components/validators.py` to pass `log_once=True` so the backward-propagating Gaussian beam `waist_distance` behavior-change warning isn’t repeated on every validation call.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db5090c702b428e141e57faf8ce95c75ac935918. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR cleans up the `CHANGELOG.md` by removing duplicate entries and reorganizing items between sections. The changelog had become disorganized during the recent 2.11 merging process, with duplicated deprecation warnings and misplaced entries.

Additionally, the PR adds `log_once=True` to the backward-propagating Gaussian beam `waist_distance` warning in `tidy3d/components/validators.py:330`, ensuring the migration warning is only shown once per process instead of repeatedly during validation.

**Key changes:**
- Removed duplicate deprecation warning for `TemperatureMonitor` and `SteadyPotentialMonitor`
- Reorganized Gaussian monitor/port entries from "Breaking Changes" to "Changed" section
- Added `log_once=True` parameter to reduce warning noise

**Minor issue:**
- The new monitor/port entries (`GaussianOverlapMonitor`, `AstigmaticGaussianOverlapMonitor`, `GaussianPort`, `AstigmaticGaussianPort`) on lines 24-25 use "Added" language but are placed in the "Changed" section. These should ideally be in the "Added" section per changelog conventions.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it only touches documentation and logging behavior
- The changes are low-risk: changelog cleanup doesn't affect functionality, and adding log_once=True is a straightforward improvement that reduces warning noise without changing validation logic. Only minor style issue with changelog categorization.
- No files require special attention - both changes are straightforward

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Reorganized changelog entries by removing duplicates and moving items between sections; new monitor/port additions should be under "Added" section |
| tidy3d/components/validators.py | Added log_once=True to waist_distance warning to reduce noise; change is correct and minimal |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Validator as warn_backward_waist_distance
    participant Logger as log.warning
    
    User->>Validator: Create Gaussian beam with direction='-' and waist_distance != 0
    Validator->>Validator: Check if waist_array is non-zero
    alt waist_distance is non-zero
        Validator->>Logger: log.warning(..., log_once=True)
        Note over Logger: Warning shown only once per process
        Logger-->>User: Display migration warning
    end
    Validator-->>User: Return validated values
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - Use changelog categories correctly: "Fixed" for bug fixes, "Changed" for modifications to existing f... ([source](https://app.greptile.com/review/custom-context?memory=17997812-233f-4a81-bee2-4d7666605061))
- Rule from `dashboard` - In changelogs, enclose code identifiers (class, function names) in backticks and use specific names ... ([source](https://app.greptile.com/review/custom-context?memory=0af1d6df-6cf7-4988-b3fc-f5f8ec5cae30))

<!-- /greptile_comment -->