### PR TITLE
fix(docs): point canonical to latest [FXC-5290]

### DIFF
--- a/docs/_ext/custom-robots.py
+++ b/docs/_ext/custom-robots.py
@@ -27,7 +27,8 @@ def process_robots_txt(app, exception):
     lines = [
         line
         for line in contents.splitlines()
-        if not line.startswith("Sitemap:") and line.strip() != "Disallow: /projects/tidy3d/en/v*/"
+        if not line.startswith("Sitemap:")
+        and line.strip().lower() != "disallow: /projects/tidy3d/en/v*/"
     ]
     inserted = False
     for index, line in enumerate(lines):

--- a/docs/_ext/custom-robots.py
+++ b/docs/_ext/custom-robots.py
@@ -11,12 +11,12 @@ def process_robots_txt(app, exception):
 
     expected_baseurl = "https://docs.flexcompute.com/projects/tidy3d/en/latest/"
     html_baseurl = f"{app.config['html_baseurl'].rstrip('/')}/"
-    if html_baseurl != expected_baseurl:
+    if app.config.get("version") == "latest" and html_baseurl != expected_baseurl:
         raise ValueError(
             "html_baseurl must be the latest docs URL for robots.txt generation. "
             f"Expected {expected_baseurl!r}, got {html_baseurl!r}."
         )
-    site_map = f"{html_baseurl.rstrip('/')}/sitemap.xml"
+    site_map = f"{expected_baseurl.rstrip('/')}/sitemap.xml"
 
     lines = [
         line

--- a/docs/_ext/custom-robots.py
+++ b/docs/_ext/custom-robots.py
@@ -9,10 +9,9 @@ def process_robots_txt(app, exception):
     with open(robots_file) as f:
         contents = f.read()
 
-    site_map = "/".join(
-        [app.config["html_baseurl"], app.config["language"], app.config["version"], "sitemap.xml"]
-    ).replace("//", "/")
-    contents += f"\nSitemap: {site_map}"
+    site_map = f"{app.config['html_baseurl'].rstrip('/')}/en/latest/sitemap.xml"
+    contents += f"\nSitemap: {site_map}\n"
+    contents += "Disallow: /projects/tidy3d/en/v*/\n"
 
     # Update the robots.txt file with the modified contents
     with open(robots_file, "w") as f:

--- a/docs/_ext/custom-robots.py
+++ b/docs/_ext/custom-robots.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from urllib.parse import urlsplit, urlunsplit
 
 
 def process_robots_txt(app, exception):
@@ -9,9 +10,38 @@ def process_robots_txt(app, exception):
     with open(robots_file) as f:
         contents = f.read()
 
-    site_map = f"{app.config['html_baseurl'].rstrip('/')}/en/latest/sitemap.xml"
-    contents += f"\nSitemap: {site_map}\n"
-    contents += "Disallow: /projects/tidy3d/en/v*/\n"
+    html_baseurl = app.config["html_baseurl"].rstrip("/")
+    parts = urlsplit(html_baseurl)
+    path = parts.path.rstrip("/")
+    segments = [segment for segment in path.split("/") if segment]
+    if (
+        len(segments) >= 2
+        and segments[-2] == "en"
+        and (segments[-1] == "latest" or segments[-1].startswith("v"))
+    ):
+        segments = segments[:-2]
+    base_path = f"/{'/'.join(segments)}" if segments else ""
+    base_url = urlunsplit((parts.scheme, parts.netloc, base_path, "", ""))
+    site_map = f"{base_url}/en/latest/sitemap.xml"
+
+    lines = [
+        line
+        for line in contents.splitlines()
+        if not line.startswith("Sitemap:") and line.strip() != "Disallow: /projects/tidy3d/en/v*/"
+    ]
+    inserted = False
+    for index, line in enumerate(lines):
+        if line.lower().startswith("user-agent:"):
+            lines.insert(index + 1, "Disallow: /projects/tidy3d/en/v*/")
+            inserted = True
+            break
+    if not inserted:
+        lines.append("User-agent: *")
+        lines.append("Disallow: /projects/tidy3d/en/v*/")
+    if lines and lines[-1].strip():
+        lines.append("")
+    lines.append(f"Sitemap: {site_map}")
+    contents = "\n".join(lines) + "\n"
 
     # Update the robots.txt file with the modified contents
     with open(robots_file, "w") as f:

--- a/docs/_ext/custom-robots.py
+++ b/docs/_ext/custom-robots.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-from urllib.parse import urlsplit, urlunsplit
 
 
 def process_robots_txt(app, exception):
@@ -10,19 +9,14 @@ def process_robots_txt(app, exception):
     with open(robots_file) as f:
         contents = f.read()
 
-    html_baseurl = app.config["html_baseurl"].rstrip("/")
-    parts = urlsplit(html_baseurl)
-    path = parts.path.rstrip("/")
-    segments = [segment for segment in path.split("/") if segment]
-    if (
-        len(segments) >= 2
-        and segments[-2] == "en"
-        and (segments[-1] == "latest" or segments[-1].startswith("v"))
-    ):
-        segments = segments[:-2]
-    base_path = f"/{'/'.join(segments)}" if segments else ""
-    base_url = urlunsplit((parts.scheme, parts.netloc, base_path, "", ""))
-    site_map = f"{base_url}/en/latest/sitemap.xml"
+    expected_baseurl = "https://docs.flexcompute.com/projects/tidy3d/en/latest/"
+    html_baseurl = f"{app.config['html_baseurl'].rstrip('/')}/"
+    if html_baseurl != expected_baseurl:
+        raise ValueError(
+            "html_baseurl must be the latest docs URL for robots.txt generation. "
+            f"Expected {expected_baseurl!r}, got {html_baseurl!r}."
+        )
+    site_map = f"{html_baseurl.rstrip('/')}/sitemap.xml"
 
     lines = [
         line

--- a/docs/_ext/custom-robots.py
+++ b/docs/_ext/custom-robots.py
@@ -11,7 +11,8 @@ def process_robots_txt(app, exception):
 
     expected_baseurl = "https://docs.flexcompute.com/projects/tidy3d/en/latest/"
     html_baseurl = f"{app.config['html_baseurl'].rstrip('/')}/"
-    if app.config.get("version") == "latest" and html_baseurl != expected_baseurl:
+    rtd_version = os.environ.get("READTHEDOCS_VERSION")
+    if rtd_version == "latest" and html_baseurl != expected_baseurl:
         raise ValueError(
             "html_baseurl must be the latest docs URL for robots.txt generation. "
             f"Expected {expected_baseurl!r}, got {html_baseurl!r}."

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -132,7 +132,10 @@ language = "en"
 latex_documents = [
     (master_doc, "main.tex", "tidy3d Documentation", "Flexcompute", "manual"),
 ]
-html_baseurl = "https://docs.flexcompute.com/projects/tidy3d/"  # for sphinx-sitemap
+html_baseurl = os.environ.get(
+    "READTHEDOCS_CANONICAL_URL",
+    "https://docs.flexcompute.com/projects/tidy3d/en/latest/",
+)  # for sphinx-sitemap
 html_css_files = [
     "css/custom.css",
 ]


### PR DESCRIPTION
## Summary
- use READTHEDOCS_CANONICAL_URL with /en/latest fallback for canonical links
- assert html_baseurl only on RTD latest builds (READTHEDOCS_VERSION == latest)
- ensure Disallow for versioned docs is inside a User-agent block

## Testing
- ~/.local/bin/poetry run pre-commit run --all-files
- ~/.local/bin/poetry run pytest
- ~/.local/bin/poetry run sphinx-build -b html docs docs/_build/html (warnings: 4506)

## Notes
- robots.txt generation enforces the canonical base URL only for RTD latest builds; branch/PR builds are allowed to use their versioned base URL.
- robots.txt Disallow directives must live under a User-agent block; we insert Disallow: /projects/tidy3d/en/v*/ immediately after the first User-agent entry.

## Supporting Docs
```
https://docs.readthedocs.com/platform/stable/canonical-urls.html
https://docs.readthedocs.com/platform/stable/reference/robots.html
https://www.sitemaps.org/protocol.html
```

## Manual Follow-ups
- Fix 3 (RTD Admin): Versions → mark old versions (v2.4.3, v2.5.1, etc.) as Hidden to add noindex.
- Fix 4 (Post-deploy): Submit updated sitemap in Google Search Console and request indexing for key pages.

## Verification Checklist
- [ ] docs/conf.py uses READTHEDOCS_CANONICAL_URL env var
- [ ] docs/_ext/custom-robots.py points sitemap to /en/latest/
- [ ] robots.txt will include Disallow: /projects/tidy3d/en/v*/

Resolves FXC-5290.
