### PR TITLE
fix(tidy3d): FXC-5313 improve broadband frequency range warning message

### DIFF
--- a/tests/test_components/test_source.py
+++ b/tests/test_components/test_source.py
@@ -133,7 +133,7 @@ def test_gaussian_from_frequency_range():
     g2 = td.GaussianPulse.from_frequency_range(fmin=fmin, fmax=fmax)
     assert g2.remove_dc_component
 
-    with AssertLogLevel("WARNING", contains_str="not sufficiently large"):
+    with AssertLogLevel("WARNING", contains_str="broadband"):
         g_small = td.GaussianPulse.from_frequency_range(
             fmin=fmin, fmax=60e9, remove_dc_component=True
         )

--- a/tidy3d/components/source/time.py
+++ b/tidy3d/components/source/time.py
@@ -389,8 +389,8 @@ class GaussianPulse(Pulse):
         pulse = cls(freq0=freq0, fwidth=fwidth, **kwargs)
         if np.abs(pulse._rel_amp_freq(fmin)) < WARN_SOURCE_AMPLITUDE:
             log.warning(
-                "Source amplitude is not sufficiently large throughout the specified frequency range, "
-                "which can result in inaccurate simulation results. Please decrease the frequency range.",
+                "Default source time profile is less accurate for the specified broadband frequency range. "
+                "For more accurate results, consider reducing the frequency range or using a 'BroadbandSource'.",
             )
         return pulse
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only updates a warning string and adjusts the corresponding test expectation; no behavioral or numerical logic changes.
> 
> **Overview**
> Improves the warning emitted by `GaussianPulse.from_frequency_range` when the default (DC-removed) Gaussian pulse is likely inaccurate for *broadband* frequency ranges, explicitly suggesting reducing the range or using `BroadbandSource`.
> 
> Updates the unit test to assert against the new warning text by matching on "broadband" instead of the previous "not sufficiently large" phrasing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17c949bb121b4201d71f5790f1f5c6ee99ad1e2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->