### PR TITLE
feat(tidy3d): FXC-5198-design-plugin-using-any-simulation-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added flag `remove_fragments` to the base `UnstructuredGrid` to remove fragments in unstructured grids. This can ease meshing by eliminating internal boundaries in overlapping structures.
 - Added deprecation warning for `conformal` in TCAD heat/charge monitors when explicitly set; this option is ignored (treated as `False`) when meshing with `remove_fragments=True`.
 - Added in-memory caching for downloaded batch results, configurable via ``config.batch_data_cache``.
+- Added `DesignSpace` support for sweeping `WorkflowType` objects, including mode/EME simulations and component modelers.
 
 ### Breaking Changes
 - Added optional automatic extrusion of structures at the simulation boundaries into/through PML/Absorber layers via `extrude_structures` field in class `AbsorberSpec`.

--- a/tests/test_plugins/test_design.py
+++ b/tests/test_plugins/test_design.py
@@ -40,8 +40,69 @@ expected_task_names = {
 }
 
 
+def make_mode_solver_data(freqs, num_modes=1):
+    mode_spec = td.ModeSpec(num_modes=num_modes)
+    monitor = td.ModeSolverMonitor(
+        size=(1.0, 0.0, 1.0),
+        center=(0.0, 0.0, 0.0),
+        freqs=freqs,
+        mode_spec=mode_spec,
+        name="modes",
+    )
+    coords = {
+        "x": np.array([0.0]),
+        "y": np.array([0.0]),
+        "z": np.array([0.0]),
+        "f": np.array(freqs),
+        "mode_index": np.arange(num_modes),
+    }
+    field_values = (1 + 1j) * np.ones((1, 1, 1, len(coords["f"]), num_modes))
+    field = td.ScalarModeFieldDataArray(field_values, coords=coords)
+    n_complex = td.ModeIndexDataArray(
+        (1 + 1j) * np.ones((len(coords["f"]), num_modes)),
+        coords={"f": coords["f"], "mode_index": coords["mode_index"]},
+    )
+    grid = td.Grid(
+        boundaries=td.Coords(
+            x=np.array([-0.5, 0.5]),
+            y=np.array([-0.5, 0.5]),
+            z=np.array([-0.5, 0.5]),
+        )
+    )
+    return td.ModeSolverData(
+        monitor=monitor,
+        symmetry=(0, 0, 0),
+        symmetry_center=(0.0, 0.0, 0.0),
+        grid_expanded=grid,
+        n_complex=n_complex,
+        Ex=field,
+        Ey=field,
+        Ez=field,
+        Hx=field,
+        Hy=field,
+        Hz=field,
+    )
+
+
+def run_emulated_workflow(simulation, path=None, **kwargs):
+    if isinstance(simulation, td.Simulation):
+        return run_emulated(simulation, path=path, **kwargs)
+    if isinstance(simulation, td.ModeSimulation):
+        mode_data = make_mode_solver_data(
+            freqs=simulation.freqs, num_modes=simulation.mode_spec.num_modes
+        )
+        return td.ModeSimulationData(simulation=simulation, modes_raw=mode_data)
+    if isinstance(simulation, td.ModeSolver):
+        return make_mode_solver_data(
+            freqs=simulation.freqs, num_modes=simulation.mode_spec.num_modes
+        )
+    raise TypeError(f"Unsupported workflow type for emulation: {type(simulation).__name__}")
+
+
 def emulated_batch_run(simulations, path_dir: Optional[str] = None, **kwargs):
-    data_dict = {task_name: run_emulated(sim) for task_name, sim in simulations.simulations.items()}
+    data_dict = {
+        task_name: run_emulated_workflow(sim) for task_name, sim in simulations.simulations.items()
+    }
     task_ids = dict(zip(simulations.simulations.keys(), data_dict.keys()))
     task_paths = {key: f"/path/to/{key}" for key in simulations.simulations.keys()}
 
@@ -319,6 +380,26 @@ def scs_post_aux(sim_data):
     )
 
 
+def mode_sim_pre(width: float) -> td.ModeSimulation:
+    mode_spec = td.ModeSpec(num_modes=1)
+    return td.ModeSimulation(
+        size=(width, width, 0.0),
+        freqs=[td.C_0 / 1.55],
+        mode_spec=mode_spec,
+        grid_spec=td.GridSpec(wavelength=1.55),
+    )
+
+
+def mode_sim_post(sim_data: td.ModeSimulationData) -> float:
+    return float(np.real(sim_data.modes_raw.n_complex.values).sum())
+
+
+def mode_sim_combined(width: float) -> float:
+    sim = mode_sim_pre(width=width)
+    sim_data = web.run(sim, task_name="mode_design")
+    return mode_sim_post(sim_data)
+
+
 def init_design_space(sweep_method):
     radius_variable = tdd.ParameterFloat(
         name="radius",
@@ -343,6 +424,21 @@ def init_design_space(sweep_method):
     return design_space
 
 
+def init_mode_design_space():
+    width_variable = tdd.ParameterFloat(
+        name="width",
+        span=(0.5, 1.0),
+        num_points=2,
+    )
+    design_space = tdd.DesignSpace(
+        parameters=[width_variable],
+        method=tdd.MethodGrid(),
+        name="mode sweep",
+        task_name="ModeGrid",
+    )
+    return design_space
+
+
 @pytest.mark.parametrize("sweep_method", SWEEP_METHODS.values())
 @pytest.mark.slow
 def test_sweep(sweep_method, monkeypatch):
@@ -351,7 +447,7 @@ def test_sweep(sweep_method, monkeypatch):
     #   use defines `scs` function to set up and run simulation as function of inputs.
     #   then postprocesses the data to give the SCS.
 
-    monkeypatch.setattr(web, "run", run_emulated)
+    monkeypatch.setattr(web, "run", run_emulated_workflow)
 
     monkeypatch.setattr(web.Batch, "run", emulated_batch_run)
 
@@ -480,6 +576,19 @@ def test_priority_forwarded_to_batch(monkeypatch):
     assert captured_priority["value"] == 7
 
 
+def test_mode_simulation_sweep(monkeypatch):
+    monkeypatch.setattr(web, "run", run_emulated_workflow)
+    monkeypatch.setattr(web.Batch, "run", emulated_batch_run)
+
+    design_space = init_mode_design_space()
+
+    pre_post = design_space.run(mode_sim_pre, mode_sim_post, verbose=False)
+    combined = design_space.run(mode_sim_combined, verbose=False)
+
+    assert np.allclose(pre_post.values, combined.values)
+    assert all("ModeGrid" in name for name in pre_post.task_names)
+
+
 def emulated_estimate_cost_return(self, verbose=True):
     return 0.5
 
@@ -499,7 +608,7 @@ def test_estimate_cost(est_cost_func, sweep_method, monkeypatch):
         pass
 
     # Still need to emulate the run as tests may call tidy3d
-    monkeypatch.setattr(web, "run", run_emulated)
+    monkeypatch.setattr(web, "run", run_emulated_workflow)
 
     monkeypatch.setattr(web.Batch, "run", emulated_batch_run)
 
@@ -545,7 +654,7 @@ def test_estimate_cost(est_cost_func, sweep_method, monkeypatch):
 def test_sample_specific(sweep_method, monkeypatch):
     """Run tests that are only relevant to MethodSample"""
 
-    monkeypatch.setattr(web, "run", run_emulated)
+    monkeypatch.setattr(web, "run", run_emulated_workflow)
 
     monkeypatch.setattr(web.Batch, "run", emulated_batch_run)
 
@@ -579,7 +688,7 @@ method_module_convert = {
 def test_optimize_specific(sweep_method, monkeypatch):
     """Run tests that are only relevant to MethodOptimize"""
 
-    monkeypatch.setattr(web, "run", run_emulated)
+    monkeypatch.setattr(web, "run", run_emulated_workflow)
 
     monkeypatch.setattr(web.Batch, "run", emulated_batch_run)
 

--- a/tidy3d/plugins/design/README.md
+++ b/tidy3d/plugins/design/README.md
@@ -50,6 +50,8 @@ def transmission_split(n: int, r: float) -> float:
 
 Putting it in this form is useful as it allows the `Design` plugin to automate parallelization through `Batch` objects, although it is not necessary.
 
+`DesignSpace.run` supports any runnable workflow, including `Simulation`, `HeatSimulation`, `EMESimulation`, `ModeSimulation`, `ModeSolver`, `VolumeMesher`, and component modelers (modal or terminal). These can be returned directly, or wrapped in lists or dicts, and the plugin will batch and run them for you.
+
 ##  Parameters
 
 Now, we could query our transmission function directly to construct a parameter scan, but it would be more convenient to simply **define** our parameter scan as a specification and have the `Tidy3D` wrapper do the accounting for us.

--- a/tidy3d/plugins/design/design.py
+++ b/tidy3d/plugins/design/design.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import inspect
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, get_args
 
 from pydantic import Field
 
 from tidy3d.components.base import Tidy3dBaseModel, cached_property
-from tidy3d.components.data.sim_data import SimulationData
-from tidy3d.components.simulation import Simulation
 from tidy3d.components.types import TYPE_TAG_STR
+from tidy3d.components.types.workflow import WorkflowDataType, WorkflowType
 from tidy3d.log import get_logging_console, log
 from tidy3d.web.api.container import Batch, BatchData, Job
 
@@ -28,6 +27,9 @@ if TYPE_CHECKING:
     from typing import Callable, Union
 
     from tidy3d.log import Console
+
+WORKFLOW_TYPES = get_args(WorkflowType)
+WORKFLOW_DATA_TYPES = get_args(WorkflowDataType)
 
 
 class DesignSpace(Tidy3dBaseModel):
@@ -87,7 +89,7 @@ class DesignSpace(Tidy3dBaseModel):
         "",
         title="Task Name",
         description="Task name assigned to tasks along with a simulation counter in the form of {task_name}_{sim_index}_{counter} where ``sim_index`` is "
-        "the index of the ``Simulation`` from the pre function output. "
+        "the index of the workflow/simulation object from the pre function output. "
         "If the pre function outputs a dictionary the key will be included in the task name as {task_name}_{dict_key}_{counter}. "
         "Only used when pre-post functions are supplied.",
     )
@@ -171,9 +173,9 @@ class DesignSpace(Tidy3dBaseModel):
         The ``fn`` function must take a dictionary input - this can be stored a dictionary ``def example_fn(**params)``
         or left as keyword arguments ``def example_fn(arg1, arg2)`` where the keywords correspond to the ``name`` of the parameters in the design space.
 
-        If used as a pre function, the output of ``fn`` must be a float, ``Simulation``, ``Batch``, list, or dict. Supplied ``Batch`` objects are
-        run without modification and are run in series. A list or dict of ``Simulation`` objects is flattened into a single ``Batch`` to enable
-        parallel computation on the cloud. The original structure is then restored for output; all ``Simulation`` objects are replaced by ``SimulationData`` objects.
+        If used as a pre function, the output of ``fn`` must be a float, a ``WorkflowType`` (for example ``Simulation``, ``ModeSimulation``, ``EMESimulation``),
+        a ``Batch``, list, or dict. Supplied ``Batch`` objects are run without modification and are run in series. A list or dict of workflow objects is flattened
+        into a single ``Batch`` to enable parallel computation on the cloud. The original structure is then restored for output; all workflow objects are replaced by their corresponding data objects.
         Example pre return formats and associated post inputs can be seen in the table below.
 
         .. list-table:: Pre return formats and post input formats
@@ -337,7 +339,7 @@ class DesignSpace(Tidy3dBaseModel):
                 sim_dict = {str(idx): fn_pre(**arg_list) for idx, arg_list in enumerate(args_list)}
 
                 if not all(
-                    isinstance(val, (int, float, Simulation, Batch, list, dict))
+                    isinstance(val, (int, float, *WORKFLOW_TYPES, Batch, list, dict))
                     for val in sim_dict.values()
                 ):
                     raise ValueError(
@@ -416,7 +418,7 @@ class DesignSpace(Tidy3dBaseModel):
         batches = {}
         naming_keys = {}
 
-        _find_and_map(pre_out, Simulation, simulations, naming_keys)
+        _find_and_map(pre_out, WORKFLOW_TYPES, simulations, naming_keys)
         _find_and_map(pre_out, Batch, batches, naming_keys)
 
         # Exit fn_mid here if no td computation is required
@@ -490,7 +492,7 @@ class DesignSpace(Tidy3dBaseModel):
                     new_dict[key] = new_sub_dict
 
                 else:
-                    if isinstance(value, SimulationData):
+                    if isinstance(value, WORKFLOW_DATA_TYPES):
                         new_dict[key] = value.attrs[attr_name]
 
                     elif isinstance(value, BatchData):
@@ -519,9 +521,9 @@ class DesignSpace(Tidy3dBaseModel):
 
     def run_batch(
         self,
-        fn_pre: Callable[Any, Union[Simulation, list[Simulation], dict[str, Simulation]]],
+        fn_pre: Callable[Any, Union[WorkflowType, list[WorkflowType], dict[str, WorkflowType]]],
         fn_post: Callable[
-            Union[SimulationData, list[SimulationData], dict[str, SimulationData]], Any
+            Union[WorkflowDataType, list[WorkflowDataType], dict[str, WorkflowDataType]], Any
         ],
         path_dir: str = ".",
         priority: Optional[int] = None,
@@ -549,7 +551,7 @@ class DesignSpace(Tidy3dBaseModel):
     def estimate_cost(self, fn_pre: Callable) -> float:
         """Compute the maximum FlexCredit charge for the ``DesignSpace.run`` computation.
 
-        Require a pre function that should return a ``Simulation`` object, a ``Batch`` object, or collection of either.
+        Require a pre function that should return a ``WorkflowType`` object, a ``Batch`` object, or collection of either.
         The pre function is called to estimate the cost - complicated pre functions may cause long runtimes. The cost per
         iteration is multiplied by the theoretical maximum number of iterations to give the maximum cost.
 
@@ -557,7 +559,7 @@ class DesignSpace(Tidy3dBaseModel):
         ----------
         fn_pre : Callable
             Function accepting arguments that correspond to the ``name`` fields
-            of the ``DesignSpace.parameters``. Should return a ``Simulation`` or ``Batch`` object, or a
+            of the ``DesignSpace.parameters``. Should return a ``WorkflowType`` or ``Batch`` object, or a
             ``list`` / ``dict`` of these objects.
 
         Returns
@@ -574,15 +576,15 @@ class DesignSpace(Tidy3dBaseModel):
         # Compute fn_pre
         pre_out = fn_pre(**arg_dict)
 
-        def _estimate_sim_cost(sim: Simulation) -> float:
-            job = Job(simulation=sim, task_name="estimate_cost")
+        def _estimate_sim_cost(workflow: WorkflowType) -> float:
+            job = Job(simulation=workflow, task_name="estimate_cost")
 
             estimate = job.estimate_cost()
             job.delete()  # Deleted as only a test with initial parameters
 
             return estimate
 
-        if isinstance(pre_out, Simulation):
+        if isinstance(pre_out, WORKFLOW_TYPES):
             per_run_estimate = _estimate_sim_cost(pre_out)
 
         elif isinstance(pre_out, Batch):
@@ -599,7 +601,7 @@ class DesignSpace(Tidy3dBaseModel):
             sims = []
             batches = []
             for value in pre_out:
-                if isinstance(value, Simulation):
+                if isinstance(value, WORKFLOW_TYPES):
                     sims.append(value)
                 elif isinstance(value, Batch):
                     batches.append(value)


### PR DESCRIPTION
Since we have the generic web.run() now , this PR refactors the design plugin to simplify the running and allow it to generalize to things like Mode and EME.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Design plugin’s core batching/extraction and cost-estimation paths; regressions could affect existing sweeps and task/result mapping across different return shapes.
> 
> **Overview**
> `DesignSpace` now treats the pre-function output as a generic `WorkflowType` (and corresponding `WorkflowDataType`) instead of only `Simulation`/`SimulationData`, so sweeps can batch and run additional runnable workflows via the unified `web.run()` API.
> 
> Updates extraction/type-checking, task naming, and cost estimation to work across workflow objects, and extends tests plus plugin docs to cover mode workflows (including a new `ModeSimulation` sweep test and emulated mode data helpers).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7753c8b807ebf820e229ca978a3087863f392ac1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->