### PR TITLE
fix(tidy3d): FXC-5400-misleading-re-run-warning-for-batch-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed sliver polygon artifacts in 2D material subdivision by filtering polygons based on grid cell size, preventing numerical issues with large-coordinate geometries.
 - Fixed `CustomMedium` gradient calculation when field coordinates exactly align with boundaries.
 - Fixed adjoint simulation `grid_spec` to align exactly with forward simulation for correct `FieldData` adjoint source power.
+- Fixed redundant logging when `Batch.download()` skips existing files, and added `replace_existing` to `Batch.run()` so overwrite behavior can be controlled directly.
 
 ## [2.10.2] - 2026-01-21
 

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -799,6 +799,7 @@ class Batch(WebContainer):
         self,
         path_dir: PathLike = DEFAULT_DATA_DIR,
         priority: Optional[int] = None,
+        replace_existing: bool = False,
     ) -> BatchData:
         """Upload and run each simulation in :class:`Batch`.
 
@@ -809,6 +810,9 @@ class Batch(WebContainer):
         priority: int = None
             Priority of the simulation in the Virtual GPU (vGPU) queue (1 = lowest, 10 = highest).
             It affects only simulations from vGPU licenses and does not impact simulations using FlexCredits.
+        replace_existing : bool = False
+            Downloads the data even if path exists (overwriting the existing). Applies when
+            downloading cached results or when `download_on_success=True`.
         Returns
         ------
         :class:`BatchData`
@@ -838,12 +842,16 @@ class Batch(WebContainer):
                 self.start()
             else:
                 self.start(priority=priority)
-            self.monitor(path_dir=path_dir, download_on_success=True)
+            self.monitor(
+                path_dir=path_dir,
+                download_on_success=True,
+                replace_existing=replace_existing,
+            )
         else:
             if self.verbose:
                 console = get_logging_console()
                 console.log("Found all simulations in cache.")
-            self.download(path_dir=path_dir)  # moves cache files
+            self.download(path_dir=path_dir, replace_existing=replace_existing)  # moves cache files
         return self.load(path_dir=path_dir, skip_download=True)
 
     @cached_property
@@ -1258,10 +1266,10 @@ class Batch(WebContainer):
             )
             if num_existing > 0:
                 files_plural = "files have" if num_existing > 1 else "file has"
-                log.warning(
-                    f"{num_existing} {files_plural} already been downloaded "
-                    f"and will be skipped. To forcibly overwrite existing files, invoke "
-                    "the load or download function with `replace_existing=True`.",
+                log.info(
+                    f"{num_existing} {files_plural} already been downloaded and will be skipped. "
+                    "To forcibly overwrite existing files, invoke the run, load, or download "
+                    "function with `replace_existing=True`.",
                     log_once=True,
                 )
 
@@ -1276,9 +1284,9 @@ class Batch(WebContainer):
 
             if job_path.exists():
                 if replace_existing:
-                    log.info(f"File '{job_path}' already exists. Overwriting.")
+                    log.debug(f"File '{job_path}' already exists. Overwriting.")
                 else:
-                    log.info(f"File '{job_path}' already exists. Skipping.")
+                    log.debug(f"File '{job_path}' already exists. Skipping.")
                     continue
 
             if job.load_if_cached:


### PR DESCRIPTION
- Added `replace_existing` to `Batch.run()` and threaded it through cached-download and `download_on_success` paths so overwrite behavior is controllable from the top-level API.
- Reduced redundant batch download logs:
  - A single warning now reports existing files.
  - Per-file skips are downgraded to debug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to batch file download/overwrite control and logging levels; minimal impact beyond download semantics when users opt into overwriting.
> 
> **Overview**
> Makes `Batch.run()` expose a `replace_existing` flag and threads it through both the cached-results path and the `download_on_success` monitoring path, so callers can control overwrite behavior from the top-level run API.
> 
> Reduces download log noise by emitting a single *info* message when existing batch result files will be skipped (instead of warning-level/duplicated output) and downgrading per-file “skipping/overwriting” messages to debug. Updates the changelog entry accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 753839d59075741694aebf84e752c5ef67996ff0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->