### PR TITLE
fix(tidy3d): FXC-5311-minimize-http-calls-for-web-load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `CustomMedium` gradient calculation when field coordinates exactly align with boundaries.
 - Fixed adjoint simulation `grid_spec` to align exactly with forward simulation for correct `FieldData` adjoint source power.
 - Fixed redundant logging when `Batch.download()` skips existing files, and added `replace_existing` to `Batch.run()` so overwrite behavior can be controlled directly.
+- Fixed redundant server lookups when loading simulation results.
 
 ## [2.10.2] - 2026-01-21
 

--- a/tests/test_web/test_batch_data_cache.py
+++ b/tests/test_web/test_batch_data_cache.py
@@ -24,7 +24,7 @@ def test_batch_data_caches_small_files(monkeypatch, tmp_path):
     monkeypatch.setattr(td.config.batch_data_cache, "enabled", True)
     monkeypatch.setattr(td.config.batch_data_cache, "max_total_size_gb", 1.0)
 
-    calls = {"load": 0, "info": 0}
+    calls = {"load": 0}
     sentinels = [object(), object()]
 
     def fake_load(*args, **kwargs):
@@ -32,12 +32,7 @@ def test_batch_data_caches_small_files(monkeypatch, tmp_path):
         calls["load"] += 1
         return result
 
-    def fake_get_info(*args, **kwargs):
-        calls["info"] += 1
-        return None
-
     monkeypatch.setattr(web_container.web, "load", fake_load)
-    monkeypatch.setattr(web_container.web, "get_info", fake_get_info)
 
     batch_data = td.web.BatchData(
         task_paths=task_paths,
@@ -50,7 +45,6 @@ def test_batch_data_caches_small_files(monkeypatch, tmp_path):
 
     assert first is second
     assert calls["load"] == 1
-    assert calls["info"] == 1
 
 
 def test_batch_data_skips_cache_when_any_file_is_large(monkeypatch, tmp_path):
@@ -66,7 +60,7 @@ def test_batch_data_skips_cache_when_any_file_is_large(monkeypatch, tmp_path):
     monkeypatch.setattr(td.config.batch_data_cache, "enabled", True)
     monkeypatch.setattr(td.config.batch_data_cache, "max_total_size_gb", threshold_gb)
 
-    calls = {"load": 0, "info": 0}
+    calls = {"load": 0}
     sentinels = [object(), object()]
 
     def fake_load(*args, **kwargs):
@@ -74,12 +68,7 @@ def test_batch_data_skips_cache_when_any_file_is_large(monkeypatch, tmp_path):
         calls["load"] += 1
         return result
 
-    def fake_get_info(*args, **kwargs):
-        calls["info"] += 1
-        return None
-
     monkeypatch.setattr(web_container.web, "load", fake_load)
-    monkeypatch.setattr(web_container.web, "get_info", fake_get_info)
 
     batch_data = td.web.BatchData(
         task_paths=task_paths,
@@ -92,4 +81,3 @@ def test_batch_data_skips_cache_when_any_file_is_large(monkeypatch, tmp_path):
 
     assert first is not second
     assert calls["load"] == 2
-    assert calls["info"] == 2

--- a/tests/test_web/test_webapi.py
+++ b/tests/test_web/test_webapi.py
@@ -28,7 +28,7 @@ from tidy3d.components.source.time import GaussianPulse
 from tidy3d.exceptions import SetupError
 from tidy3d.web import common
 from tidy3d.web.api.asynchronous import run_async
-from tidy3d.web.api.container import Batch, Job, WebContainer
+from tidy3d.web.api.container import Batch, BatchData, Job, WebContainer
 from tidy3d.web.api.run import _collect_by_hash, run
 from tidy3d.web.api.tidy3d_stub import Tidy3dStubData, task_type_name_of
 from tidy3d.web.api.webapi import (
@@ -433,6 +433,30 @@ def _test_load(mock_load, mock_get_info, tmp_path):
 
     monkeypatch.setattr(f"{task_core_path}.download_file", mock_download)
     load(TASK_ID, str(tmp_path / "monitor_data.hdf5"))
+
+
+def test_batch_load_sim_data_skips_task_lookup(monkeypatch, tmp_path):
+    data_path = tmp_path / "batch_results.hdf5"
+    data_path.write_text("stub")
+    batch_data = BatchData(
+        task_paths={"task_1": str(data_path)},
+        task_ids={"task_1": TASK_ID},
+        cached_tasks={"task_1": False},
+        is_downloaded=True,
+    )
+
+    def _raise(*args, **kwargs):
+        raise AssertionError("Unexpected web lookup during batch load.")
+
+    monkeypatch.setattr(f"{api_path}.get_info", _raise)
+    monkeypatch.setattr(f"{task_core_path}.TaskFactory.get", _raise)
+    monkeypatch.setattr(f"{task_core_path}.TaskFactory.get_kind", _raise)
+    monkeypatch.setattr(f"{api_path}.resolve_local_cache", lambda: None)
+    monkeypatch.setattr(
+        f"{api_path}.Tidy3dStubData.postprocess", lambda *args, **kwargs: "stub_data"
+    )
+
+    assert batch_data.load_sim_data("task_1") == "stub_data"
 
 
 @responses.activate

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -682,8 +682,6 @@ class BatchData(Tidy3dBaseModel, Mapping):
         task_data_path = Path(self.task_paths[task_name])
         task_id = self.task_ids[task_name]
         from_cache = self.cached_tasks[task_name] if self.cached_tasks else False
-        if not from_cache:
-            web.get_info(task_id)
 
         data = web.load(
             task_id=None if from_cache else task_id,

--- a/tidy3d/web/api/webapi.py
+++ b/tidy3d/web/api/webapi.py
@@ -790,8 +790,8 @@ def monitor(task_id: TaskId, verbose: bool = True, worker_group: Optional[str] =
     """
 
     # Batch/modeler monitoring path
-    task = TaskFactory.get(task_id)
-    if isinstance(task, BatchTask):
+    task_kind = TaskFactory.get_kind(task_id)
+    if task_kind is BatchTask:
         return _monitor_modeler_batch(task_id, verbose=verbose)
 
     console = get_logging_console() if verbose else None
@@ -1147,32 +1147,26 @@ def load(
         Object containing simulation data.
     """
     path = Path(path)
-    task = TaskFactory.get(task_id) if task_id else None
+    from_cache = task_id is None  # for readability
     # For component modeler batches, default to a clearer filename if the default was used.
-    if (
-        task_id
-        and isinstance(task, BatchTask)
-        and path.name in {"simulation_data.hdf5", "simulation_data.hdf5.gz"}
-    ):
-        path = path.with_name(path.name.replace("simulation", "cm"))
+    if not from_cache and path.name in {"simulation_data.hdf5", "simulation_data.hdf5.gz"}:
+        if TaskFactory.get_kind(task_id) is BatchTask:
+            path = path.with_name(path.name.replace("simulation", "cm"))
 
-    if task_id is None:
+    if from_cache:
         if not path.exists():
             raise FileNotFoundError("Cached file not found.")
     elif not path.exists() or replace_existing:
         download(task_id=task_id, path=path, verbose=verbose, progress_callback=progress_callback)
 
-    if verbose and task_id is not None:
+    if verbose and not from_cache:
         console = get_logging_console()
-        if isinstance(task, BatchTask):
-            console.log(f"Loading component modeler data from {path}")
-        else:
-            console.log(f"Loading simulation from {path}")
+        console.log(f"Loading results from {path}")
 
     stub_data = Tidy3dStubData.postprocess(path, lazy=lazy)
 
     simulation_cache = resolve_local_cache()
-    if simulation_cache is not None and task_id is not None:
+    if simulation_cache is not None and not from_cache:
         info = get_info(task_id, verbose=False)
         workflow_type = getattr(info, "taskType", None)
         if (

--- a/tidy3d/web/core/task_core.py
+++ b/tidy3d/web/core/task_core.py
@@ -963,7 +963,7 @@ class BatchTask(WebTask):
 class TaskFactory:
     """Factory for obtaining the correct task subclass."""
 
-    _REGISTRY: dict[str, str] = {}
+    _REGISTRY: dict[str, type[WebTask]] = {}
 
     @classmethod
     def reset(cls) -> None:
@@ -971,21 +971,35 @@ class TaskFactory:
         cls._REGISTRY.clear()
 
     @classmethod
-    def register(cls, task_id: str, kind: str) -> None:
+    def register(cls, task_id: str, kind: type[WebTask]) -> None:
         cls._REGISTRY[task_id] = kind
+
+    @classmethod
+    def get_kind(cls, task_id: str, verbose: bool = True) -> type[WebTask]:
+        """Return cached task class, fetching and caching if needed."""
+        kind = cls._REGISTRY.get(task_id)
+        if kind:
+            return kind
+        if WebTask.is_batch(task_id):
+            cls.register(task_id, BatchTask)
+            return BatchTask
+        task = SimulationTask.get(task_id, verbose=verbose)
+        if task:
+            cls.register(task_id, SimulationTask)
+        return SimulationTask
 
     @classmethod
     def get(cls, task_id: str, verbose: bool = True) -> WebTask:
         kind = cls._REGISTRY.get(task_id)
-        if kind == "batch":
+        if kind is BatchTask:
             return BatchTask.get(task_id, verbose=verbose)
-        if kind == "simulation":
+        if kind is SimulationTask:
             task = SimulationTask.get(task_id, verbose=verbose)
             return task
         if WebTask.is_batch(task_id):
-            cls.register(task_id, "batch")
+            cls.register(task_id, BatchTask)
             return BatchTask.get(task_id, verbose=verbose)
         task = SimulationTask.get(task_id, verbose=verbose)
         if task:
-            cls.register(task_id, "simulation")
+            cls.register(task_id, SimulationTask)
         return task


### PR DESCRIPTION
- Reduced redundant server lookups when loading batch and task results.
- Cached task kind as class in TaskFactory and used it to avoid unnecessary fetches.
- Simplified load logging message.
- Added regression test to ensure batch item loads skip task lookups when filename isn’t default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core web loading/monitoring paths and task-kind detection; risk is mainly incorrect task classification or missed lookups leading to wrong filenames or load behavior, but changes are small and covered by regression tests.
> 
> **Overview**
> Reduces redundant web API calls during result loading by caching task “kind” in `TaskFactory` (as the task class) and using `get_kind()` in `monitor()`/`load()` to decide batch vs simulation behavior without fetching full task objects.
> 
> `BatchData.load_sim_data()` no longer performs an eager `web.get_info()` lookup before calling `web.load()`, and `web.load()` simplifies its verbose output while still handling component-modeler batch default filenames based on task kind. Tests were updated/added to assert batch loads don’t trigger web lookups, and the changelog notes the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e939322376fe4656bb3900ec867222c3802b5188. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->