### PR TITLE
feat(FXC-5402): Option to remove fragments before meshing in unstructured grids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `GaussianPort` and `AstigmaticGaussianPort` for S-matrix calculations using Gaussian beam sources and overlap monitors.
 - Added `symmetric_pseudo` option for `s_param_def` in `TerminalComponentModeler` which applies a scaling factor that ensures the S-matrix is symmetric in reciprocal systems.
 - Added deprecation warning for ``TemperatureMonitor`` and ``SteadyPotentialMonitor`` when ``unstructured`` parameter is not explicitly set. The default value of ``unstructured`` will change from ``False`` to ``True`` after the 2.11 release.
+- Added flag `remove_fragments` to the base `UnstructuredGrid` to remove fragments in unstructured grids. This can ease meshing by eliminating internal boundaries in overlapping structures.
+- Added deprecation warning for `conformal` in TCAD heat/charge monitors when explicitly set; this option is ignored (treated as `False`) when meshing with `remove_fragments=True`.
 
 ### Breaking Changes
 - Added optional automatic extrusion of structures at the simulation boundaries into/through PML/Absorber layers via `extrude_structures` field in class `AbsorberSpec`.

--- a/schemas/HeatChargeSimulation.json
+++ b/schemas/HeatChargeSimulation.json
@@ -3322,6 +3322,10 @@
           "minimum": 0,
           "type": "number"
         },
+        "remove_fragments": {
+          "default": false,
+          "type": "boolean"
+        },
         "sampling": {
           "default": 100,
           "exclusiveMinimum": 0,
@@ -9515,6 +9519,10 @@
           "default": 0.001,
           "minimum": 0,
           "type": "number"
+        },
+        "remove_fragments": {
+          "default": false,
+          "type": "boolean"
         },
         "type": {
           "default": "UniformUnstructuredGrid",

--- a/schemas/HeatSimulation.json
+++ b/schemas/HeatSimulation.json
@@ -3322,6 +3322,10 @@
           "minimum": 0,
           "type": "number"
         },
+        "remove_fragments": {
+          "default": false,
+          "type": "boolean"
+        },
         "sampling": {
           "default": 100,
           "exclusiveMinimum": 0,
@@ -9515,6 +9519,10 @@
           "default": 0.001,
           "minimum": 0,
           "type": "number"
+        },
+        "remove_fragments": {
+          "default": false,
+          "type": "boolean"
         },
         "type": {
           "default": "UniformUnstructuredGrid",

--- a/tidy3d/components/tcad/grid.py
+++ b/tidy3d/components/tcad/grid.py
@@ -25,6 +25,12 @@ class UnstructuredGrid(Tidy3dBaseModel, ABC):
         "Use ``relative_min_dl=0`` to remove this constraint.",
     )
 
+    remove_fragments: bool = pd.Field(
+        False,
+        title="Remove Fragments",
+        description="Whether to remove fragments before meshing. This is useful when overlapping structures generate internal boundaries that can lead to very small cell volumes.",
+    )
+
 
 class UniformUnstructuredGrid(UnstructuredGrid):
     """Uniform grid.

--- a/tidy3d/components/tcad/monitors/abstract.py
+++ b/tidy3d/components/tcad/monitors/abstract.py
@@ -8,6 +8,7 @@ import pydantic.v1 as pd
 
 from tidy3d.components.base_sim.monitor import AbstractMonitor
 from tidy3d.components.types import ArrayFloat1D
+from tidy3d.log import log
 
 BYTES_REAL = 4
 
@@ -29,8 +30,21 @@ class HeatChargeMonitor(AbstractMonitor, ABC):
         "significance for the latter ones. Effectively, setting ``conformal = True`` for "
         "unstructured monitors (``unstructured = True``) ensures that returned values "
         "will not be obtained by interpolation during postprocessing but rather directly "
-        "transferred from the computational grid.",
+        "transferred from the computational grid. Note: if the simulation mesh uses "
+        "``remove_fragments=True``, this option is ignored (treated as ``False``). "
+        "Deprecated: this field will be removed in version 2.12.",
     )
+
+    @pd.root_validator(pre=True)
+    def _warn_conformal_deprecated(cls, values):
+        """Warn if deprecated ``conformal`` field is provided."""
+        # Note:  Only warn when the deprecated flag is actually enabled.
+        if isinstance(values, dict) and values.get("conformal"):
+            log.warning(
+                "The `conformal` flag is deprecated and will be removed in version 2.12. "
+                "It has no effect when the simulation mesh is created with `remove_fragments=True`.",
+            )
+        return values
 
     def storage_size(self, num_cells: int, tmesh: ArrayFloat1D) -> int:
         """Size of monitor storage given the number of points after discretization."""


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new meshing control flag and changes validation/warning behavior for monitors, which could alter meshing results and user expectations even though defaults remain unchanged.
> 
> **Overview**
> Adds a new `remove_fragments` boolean option to TCAD `UnstructuredGrid` (and schema exports for Heat/HeatCharge simulations) to allow fragment removal prior to unstructured meshing, aimed at reducing tiny cells from overlapping/internal boundaries.
> 
> Marks TCAD heat/charge monitor `conformal` meshing as *deprecated* and now warns when it is explicitly enabled; documentation clarifies it is ignored when `remove_fragments=True`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea585fe061e3226c84dc65e49074cdc6d249df05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->