### PR TITLE
feat(tidy3d): FXC-5311-enable-cached-loading-from-batch-data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added deprecation warning for ``TemperatureMonitor`` and ``SteadyPotentialMonitor`` when ``unstructured`` parameter is not explicitly set. The default value of ``unstructured`` will change from ``False`` to ``True`` after the 2.11 release.
 - Added flag `remove_fragments` to the base `UnstructuredGrid` to remove fragments in unstructured grids. This can ease meshing by eliminating internal boundaries in overlapping structures.
 - Added deprecation warning for `conformal` in TCAD heat/charge monitors when explicitly set; this option is ignored (treated as `False`) when meshing with `remove_fragments=True`.
+- Added in-memory caching for downloaded batch results, configurable via ``config.batch_data_cache``.
 
 ### Breaking Changes
 - Added optional automatic extrusion of structures at the simulation boundaries into/through PML/Absorber layers via `extrude_structures` field in class `AbsorberSpec`.

--- a/docs/configuration/reference.rst
+++ b/docs/configuration/reference.rst
@@ -245,6 +245,29 @@ Controls the optional on-disk cache for simulation artifacts.
      - Maximum number of cached simulations retained. ``0`` means no limit and eviction falls back to size constraints.
 
 
+Batch Data Cache (``config.batch_data_cache``)
+----------------------------------------------
+
+Controls the in-memory cache used when accessing entries in ``BatchData``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 18 10 48
+
+   * - Option
+     - Default
+     - Persisted
+     - Description
+   * - ``enabled``
+     - ``True``
+     - No
+     - Cache batch results in memory when all task data files are below the size threshold.
+   * - ``max_total_size_gb``
+     - ``1.0``
+     - No
+     - Cache batch task data only when the combined size of all task data files is at or below this threshold. ``0`` disables caching.
+
+
 Plugins (``config.plugins``)
 ----------------------------
 

--- a/tests/test_web/test_batch_data_cache.py
+++ b/tests/test_web/test_batch_data_cache.py
@@ -1,0 +1,95 @@
+"""Tests for BatchData in-memory caching."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import tidy3d as td
+from tidy3d.web.api import container as web_container
+
+
+def _write_bytes(path: Path, size: int) -> None:
+    path.write_bytes(b"0" * size)
+
+
+def test_batch_data_caches_small_files(monkeypatch, tmp_path):
+    task_paths = {
+        "task1": str(tmp_path / "task1.hdf5"),
+        "task2": str(tmp_path / "task2.hdf5"),
+    }
+    task_ids = {"task1": "task-1", "task2": "task-2"}
+    _write_bytes(Path(task_paths["task1"]), 1)
+    _write_bytes(Path(task_paths["task2"]), 2)
+
+    monkeypatch.setattr(td.config.batch_data_cache, "enabled", True)
+    monkeypatch.setattr(td.config.batch_data_cache, "max_total_size_gb", 1.0)
+
+    calls = {"load": 0, "info": 0}
+    sentinels = [object(), object()]
+
+    def fake_load(*args, **kwargs):
+        result = sentinels[calls["load"]]
+        calls["load"] += 1
+        return result
+
+    def fake_get_info(*args, **kwargs):
+        calls["info"] += 1
+        return None
+
+    monkeypatch.setattr(web_container.web, "load", fake_load)
+    monkeypatch.setattr(web_container.web, "get_info", fake_get_info)
+
+    batch_data = td.web.BatchData(
+        task_paths=task_paths,
+        task_ids=task_ids,
+        is_downloaded=True,
+    )
+
+    first = batch_data["task1"]
+    second = batch_data["task1"]
+
+    assert first is second
+    assert calls["load"] == 1
+    assert calls["info"] == 1
+
+
+def test_batch_data_skips_cache_when_any_file_is_large(monkeypatch, tmp_path):
+    task_paths = {
+        "task1": str(tmp_path / "task1.hdf5"),
+        "task2": str(tmp_path / "task2.hdf5"),
+    }
+    task_ids = {"task1": "task-1", "task2": "task-2"}
+    _write_bytes(Path(task_paths["task1"]), 1)
+    _write_bytes(Path(task_paths["task2"]), 2)
+
+    threshold_gb = 2 / (1024**3)
+    monkeypatch.setattr(td.config.batch_data_cache, "enabled", True)
+    monkeypatch.setattr(td.config.batch_data_cache, "max_total_size_gb", threshold_gb)
+
+    calls = {"load": 0, "info": 0}
+    sentinels = [object(), object()]
+
+    def fake_load(*args, **kwargs):
+        result = sentinels[calls["load"]]
+        calls["load"] += 1
+        return result
+
+    def fake_get_info(*args, **kwargs):
+        calls["info"] += 1
+        return None
+
+    monkeypatch.setattr(web_container.web, "load", fake_load)
+    monkeypatch.setattr(web_container.web, "get_info", fake_get_info)
+
+    batch_data = td.web.BatchData(
+        task_paths=task_paths,
+        task_ids=task_ids,
+        is_downloaded=True,
+    )
+
+    first = batch_data["task1"]
+    second = batch_data["task1"]
+
+    assert first is not second
+    assert calls["load"] == 2
+    assert calls["info"] == 2

--- a/tidy3d/config/README.md
+++ b/tidy3d/config/README.md
@@ -50,7 +50,7 @@ flowchart LR
 
 ## Module Reference
 
-- `sections.py` - Pydantic models for built-in sections (logging, simulation, microwave, adjoint, web, local cache, plugin container) registered via `register_section`. The bundled models inherit from the internal `ConfigSection` helper, but external code can use plain `BaseModel` subclasses. Optional handlers perform side effects. Fields mark persistence with `json_schema_extra={"persist": True}`.
+- `sections.py` - Pydantic models for built-in sections (logging, simulation, microwave, adjoint, web, local cache, in-memory batch data cache, plugin container) registered via `register_section`. The bundled models inherit from the internal `ConfigSection` helper, but external code can use plain `BaseModel` subclasses. Optional handlers perform side effects. Fields mark persistence with `json_schema_extra={"persist": True}`.
 - `registry.py` - Stores section and handler registries and notifies the attached manager so new entries appear immediately.
 - `manager.py` - `ConfigManager` caches validated models, tracks runtime overrides per profile, filters persisted fields, exposes helpers such as `plugins`, `profiles`, and `format`. `SectionAccessor` routes attribute access to `update_section`.
 - `loader.py` - Resolves the config directory, loads `config.toml` and `profiles/<name>.toml`, parses environment overrides, and writes atomically through `serializer.build_document`.

--- a/tidy3d/config/sections.py
+++ b/tidy3d/config/sections.py
@@ -517,6 +517,25 @@ class LocalCacheConfig(ConfigSection):
         return str(value)
 
 
+class BatchDataCacheConfig(ConfigSection):
+    """Settings controlling in-memory caching for batch data."""
+
+    enabled: bool = Field(
+        True,
+        title="Enable batch data cache",
+        description="Cache batch results in memory when files are below the size threshold.",
+    )
+
+    max_total_size_gb: NonNegativeFloat = Field(
+        1.0,
+        title="Maximum total batch data size (GB)",
+        description=(
+            "Cache batch task data only when the combined size of all task data files is at or "
+            "below this threshold. Set to 0 to disable."
+        ),
+    )
+
+
 @register_section("plugins")
 class PluginsContainer(ConfigSection):
     """Container that holds plugin-specific configuration sections."""
@@ -530,10 +549,12 @@ if not WASM_BUILD:
     register_section("web")(WebConfig)
     register_handler("web")(apply_web)
     register_section("local_cache")(LocalCacheConfig)
+    register_section("batch_data_cache")(BatchDataCacheConfig)
 
 
 __all__ = [
     "AdjointConfig",
+    "BatchDataCacheConfig",
     "LocalCacheConfig",
     "LoggingConfig",
     "MicrowaveConfig",

--- a/tidy3d/web/api/container.py
+++ b/tidy3d/web/api/container.py
@@ -18,10 +18,12 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 from pydantic import Field, PositiveInt, PrivateAttr, model_validator
 from rich.progress import BarColumn, Progress, TaskProgressColumn, TextColumn, TimeElapsedColumn
 
+from tidy3d._runtime import WASM_BUILD
 from tidy3d.components.base import Tidy3dBaseModel, cached_property
 from tidy3d.components.mode.mode_solver import ModeSolver
 from tidy3d.components.types.base import discriminated_union
 from tidy3d.components.types.workflow import WorkflowType
+from tidy3d.config import config
 from tidy3d.exceptions import DataError
 from tidy3d.log import get_logging_console, log
 from tidy3d.web.api import webapi as web
@@ -629,15 +631,61 @@ class BatchData(Tidy3dBaseModel, Mapping):
         description="Whether the simulation data was downloaded before.",
     )
 
+    _data_cache: dict[TaskName, WorkflowDataType] = PrivateAttr(default_factory=dict)
+    _cache_enabled: Optional[bool] = PrivateAttr(default=None)
+
+    def _should_cache_data(self) -> bool:
+        """Return True when in-memory caching should be enabled for batch data."""
+        if self._cache_enabled is not None:
+            return self._cache_enabled
+
+        self._cache_enabled = False
+        if WASM_BUILD:
+            return False
+
+        try:
+            cache_config = config.batch_data_cache
+        except AttributeError:
+            return False
+        if not cache_config.enabled:
+            return False
+
+        max_bytes = int(cache_config.max_total_size_gb * (1024**3))
+        if max_bytes <= 0:
+            return False
+
+        total_size = 0
+        for task_path in self.task_paths.values():
+            try:
+                file_size = Path(task_path).stat().st_size
+            except FileNotFoundError:  # not downloaded yet
+                self._cache_enabled = None
+                return False
+            total_size += file_size
+            if total_size > max_bytes:
+                return False
+
+        self._cache_enabled = True
+        return True
+
     def load_sim_data(self, task_name: str) -> WorkflowDataType:
-        """Load a simulation data object from file by task name."""
+        """Load a simulation data object from file by task name.
+
+        When ``config.batch_data_cache.enabled`` is ``True`` and the total size of all task
+        files stays under the configured threshold, the loaded object is cached in
+        memory for subsequent accesses.
+        """
+        cache_enabled = self._should_cache_data()
+        if cache_enabled and task_name in self._data_cache:
+            return self._data_cache[task_name]
+
         task_data_path = Path(self.task_paths[task_name])
         task_id = self.task_ids[task_name]
         from_cache = self.cached_tasks[task_name] if self.cached_tasks else False
         if not from_cache:
             web.get_info(task_id)
 
-        return web.load(
+        data = web.load(
             task_id=None if from_cache else task_id,
             path=task_data_path,
             verbose=False,
@@ -645,8 +693,18 @@ class BatchData(Tidy3dBaseModel, Mapping):
             lazy=self.lazy,
         )
 
+        if not cache_enabled and self._cache_enabled is None:
+            cache_enabled = self._should_cache_data()
+        if cache_enabled:
+            self._data_cache[task_name] = data
+        return data
+
     def __getitem__(self, task_name: TaskName) -> WorkflowDataType:
-        """Get the simulation data object for a given ``task_name``."""
+        """Get the simulation data object for a given ``task_name``.
+
+        When ``config.batch_data_cache.enabled`` is `True` and the batch data size is within
+        the configured threshold, the result is cached in memory.
+        """
         return self.load_sim_data(task_name)
 
     def __iter__(self) -> Iterator[TaskName]:
@@ -825,9 +883,11 @@ class Batch(WebContainer):
         >>> for task_name, sim_data in batch_data.items(): # doctest: +SKIP
         ...     # do something with data. # doctest: +SKIP
 
-        ``batch_data`` does not store all of the data objects in memory,
-        rather it iterates over the task names and loads the corresponding
-        data from file one by one. If no file exists for that task, it downloads it.
+        ``batch_data`` iterates over task names and loads the corresponding data
+        from file one by one. If no file exists for that task, it downloads it.
+        When ``config.batch_data_cache.enabled`` is ``True`` and the
+        total size of all task files is below `config.batch_data_cache.max_total_size_gb`,
+        accessed results are cached in memory to avoid repeated loads.
         """
         loaded = [job.load_if_cached for job in self.jobs.values()]
         self._check_path_dir(path_dir)


### PR DESCRIPTION
**What changed**

- Added in-memory caching for `BatchData` access when results are already downloaded and the total size of all batch data files stays under a configurable threshold.
- Introduced `config.batch_data_cache.max_total_size_gb` (with enabled) to control this behavior.
- Updated docs and changelog to document the new configuration.
- Added tests for cache-hit and cache-miss behavior based on total batch size.

**Why**

- Avoids repeated `web.load` calls when users iterate or index batch results multiple times, while preventing large batches from staying in memory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes data-loading behavior in `BatchData` and adds stateful caching, which could impact memory usage and freshness if edge cases aren’t covered; guarded by a size threshold and explicit config flags.
> 
> **Overview**
> Speeds up repeated access to `td.web.BatchData` results by **optionally caching loaded task data objects in memory** when the batch’s local result files are already present and their combined size is below a configurable threshold.
> 
> Introduces a new config section `config.batch_data_cache` (with `enabled` and `max_total_size_gb`) and wires `BatchData.load_sim_data()` / `__getitem__` to reuse cached objects when eligible, while explicitly disabling the behavior for WASM builds and for large/non-downloaded batches. Documentation, changelog, and new unit tests cover cache-hit vs cache-miss behavior based on total file size.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ad9e26c45fcc135df270b66cd5fa9edc660d69d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->