### PR TITLE
FXC-1530: add total current normalization to UniformCurrentSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added deprecation warning for `conformal` in TCAD heat/charge monitors when explicitly set; this option is ignored (treated as `False`) when meshing with `remove_fragments=True`.
 - Added in-memory caching for downloaded batch results, configurable via ``config.batch_data_cache``.
 - Added `DesignSpace` support for sweeping `WorkflowType` objects, including mode/EME simulations and component modelers.
+- Added `current_amplitude_definition` parameter to `UniformCurrentSource` for size-independent total current injection. Set to `"total"` to interpret the source amplitude as total current rather than current density.
 
 ### Breaking Changes
 - Added optional automatic extrusion of structures at the simulation boundaries into/through PML/Absorber layers via `extrude_structures` field in class `AbsorberSpec`.

--- a/schemas/Simulation.json
+++ b/schemas/Simulation.json
@@ -15233,6 +15233,14 @@
           "default": false,
           "type": "boolean"
         },
+        "current_amplitude_definition": {
+          "default": "density",
+          "enum": [
+            "density",
+            "total"
+          ],
+          "type": "string"
+        },
         "interpolate": {
           "default": true,
           "type": "boolean"

--- a/schemas/TerminalComponentModeler.json
+++ b/schemas/TerminalComponentModeler.json
@@ -16017,6 +16017,14 @@
           "default": false,
           "type": "boolean"
         },
+        "current_amplitude_definition": {
+          "default": "density",
+          "enum": [
+            "density",
+            "total"
+          ],
+          "type": "string"
+        },
         "interpolate": {
           "default": true,
           "type": "boolean"

--- a/tests/test_components/autograd/test_autograd.py
+++ b/tests/test_components/autograd/test_autograd.py
@@ -2147,6 +2147,7 @@ def test_autograd_multi_source_normalize_index(use_emulated_run):
         center=(0.0, -0.2, 0.0),
         polarization="Hx",
         source_time=source_time,
+        current_amplitude_definition="total",
     )
     source1 = source0.updated_copy(center=(0.0, 0.2, 0.0))
 

--- a/tests/test_components/test_grid_spec.py
+++ b/tests/test_components/test_grid_spec.py
@@ -208,6 +208,7 @@ def test_autogrid_2dmaterials():
         source_time=td.GaussianPulse(freq0=1.5e14, fwidth=0.5e14),
         size=(0, 0, 0),
         polarization="Ex",
+        current_amplitude_definition="total",
     )
     sim = td.Simulation(
         size=(10, 10, 10),

--- a/tests/test_components/test_meshgenerate.py
+++ b/tests/test_components/test_meshgenerate.py
@@ -663,6 +663,7 @@ def test_small_structure_size():
         source_time=td.GaussianPulse(freq0=2e14, fwidth=1e13),
         size=(0, 0, 0),
         polarization="Ex",
+        current_amplitude_definition="total",
     )
 
     # Warning raised as structure is too thin

--- a/tests/test_components/test_simulation.py
+++ b/tests/test_components/test_simulation.py
@@ -65,6 +65,7 @@ def test_sim_init():
                     fwidth=1e12,
                 ),
                 name="my_dipole",
+                current_amplitude_definition="total",
             ),
             td.PointDipole(
                 center=(0, 0, 0),
@@ -171,6 +172,7 @@ def test_monitors_data_size():
                     fwidth=1e12,
                 ),
                 name="my_dipole",
+                current_amplitude_definition="total",
             ),
             td.PointDipole(
                 center=(0, 0, 0),
@@ -326,6 +328,7 @@ def test_monitor_medium_frequency_range(freq, log_level):
         source_time=td.GaussianPulse(freq0=2.5e12, fwidth=0.5e12),
         size=(0, 0, 0),
         polarization="Ex",
+        current_amplitude_definition="total",
     )
     with AssertLogLevel(log_level):
         _ = td.Simulation(
@@ -348,6 +351,7 @@ def test_monitor_simulation_frequency_range(monitor_freq, log_level):
         source_time=td.GaussianPulse(freq0=2.0e12, fwidth=0.1e12),
         size=(0, 0, 0),
         polarization="Ex",
+        current_amplitude_definition="total",
     )
     mnt = td.FieldMonitor(size=(0, 0, 0), name="freq", freqs=[monitor_freq])
 
@@ -368,6 +372,7 @@ def test_validate_monitor_simulation_frequency_range():
         source_time=td.GaussianPulse(freq0=2.0e12, fwidth=0.1e12),
         size=(0, 0, 0),
         polarization="Ex",
+        current_amplitude_definition="total",
     )
 
     mnt = td.FieldMonitor(size=(0, 0, 0), name="freq", freqs=[2e12])
@@ -423,7 +428,9 @@ def test_validate_normalize_index():
         source_time=td.GaussianPulse(freq0=2.0e12, fwidth=1.0e12),
         size=(0, 0, 0),
         polarization="Ex",
+        current_amplitude_definition="total",
     )
+
     # negative normalize index
     with pytest.raises(ValidationError):
         td.Simulation(
@@ -841,6 +848,7 @@ class TestAnisotropicPlotting:
                 freq0=td.C_0,
                 fwidth=10e14,
             ),
+            current_amplitude_definition="total",
         )
         structures = (td.Structure(geometry=td.Sphere(center=(0, 0, 0), radius=1), medium=medium),)
 
@@ -1197,6 +1205,7 @@ def test_sim_structure_gap(box_size, log_level):
         source_time=td.GaussianPulse(freq0=3e14, fwidth=1e13),
         size=(0, 0, 0),
         polarization="Ex",
+        current_amplitude_definition="total",
     )
 
     with AssertLogLevel(log_level):
@@ -1611,6 +1620,7 @@ def test_sim_structure_extent(box_size, log_level):
         source_time=td.GaussianPulse(freq0=3e14, fwidth=1e13),
         size=(0, 0, 0),
         polarization="Ex",
+        current_amplitude_definition="total",
     )
     box = td.Structure(geometry=td.Box(size=box_size), medium=td.Medium(permittivity=2))
 
@@ -1633,6 +1643,7 @@ def test_warn_lumped_elements_outside_sim_bounds():
         source_time=td.GaussianPulse(freq0=10e9, fwidth=8e9),
         size=(0, 0, 0),
         polarization="Ex",
+        current_amplitude_definition="total",
     )
 
     # Lumped element fully contained - should work
@@ -1718,6 +1729,7 @@ def test_sim_validate_structure_bounds_pml(box_length, absorb_type, log_level):
         source_time=td.GaussianPulse(freq0=3e14, fwidth=1e13),
         size=(0, 0, 0),
         polarization="Ex",
+        current_amplitude_definition="total",
     )
     box = td.Structure(
         geometry=td.Box(size=(box_length, 0.5, 0.5), center=(0, 0, 0)),
@@ -1831,18 +1843,21 @@ def _test_names_default():
                 center=(0, -0.5, 0),
                 polarization="Hx",
                 source_time=td.GaussianPulse(freq0=1e14, fwidth=1e12),
+                current_amplitude_definition="total",
             ),
             td.UniformCurrentSource(
                 size=(0, 0, 0),
                 center=(0, -0.5, 0),
                 polarization="Ex",
                 source_time=td.GaussianPulse(freq0=1e14, fwidth=1e12),
+                current_amplitude_definition="total",
             ),
             td.UniformCurrentSource(
                 size=(0, 0, 0),
                 center=(0, -0.5, 0),
                 polarization="Ey",
                 source_time=td.GaussianPulse(freq0=1e14, fwidth=1e12),
+                current_amplitude_definition="total",
             ),
         ),
         monitors=(
@@ -1891,6 +1906,7 @@ def test_names_unique():
                     polarization="Hx",
                     source_time=td.GaussianPulse(freq0=1e14, fwidth=1e12),
                     name="source1",
+                    current_amplitude_definition="total",
                 ),
                 td.UniformCurrentSource(
                     size=(0, 0, 0),
@@ -1898,6 +1914,7 @@ def test_names_unique():
                     polarization="Ex",
                     source_time=td.GaussianPulse(freq0=1e14, fwidth=1e12),
                     name="source1",
+                    current_amplitude_definition="total",
                 ),
             ),
             boundary_spec=td.BoundarySpec.all_sides(boundary=td.Periodic()),
@@ -2499,6 +2516,7 @@ def test_sim_volumetric_structures(tmp_path):
         source_time=td.GaussianPulse(freq0=1.5e14, fwidth=0.5e14),
         size=(0, 0, 0),
         polarization="Ex",
+        current_amplitude_definition="total",
     )
     for struct in [box, cyl, pslab]:
         sim = td.Simulation(
@@ -3669,6 +3687,7 @@ def test_sim_volumetric_structures_with_lumped_elements(tmp_path):
         source_time=td.GaussianPulse(freq0=1.5e14, fwidth=0.5e14),
         size=(0, 0, 0),
         polarization="Ex",
+        current_amplitude_definition="total",
     )
     substrate = td.Structure(
         geometry=td.Box(size=(4, td.inf, td.inf)), medium=td.Medium(permittivity=3.5)
@@ -3785,6 +3804,7 @@ def test_messages_contain_object_names():
         size=(1, 0, 0.5),
         polarization="Ex",
         source_time=td.GaussianPulse(freq0=100e14, fwidth=10e14),
+        current_amplitude_definition="total",
     )
     with pytest.raises(ValidationError, match=name) as e:
         _ = sim.updated_copy(sources=[source])

--- a/tests/test_components/test_source.py
+++ b/tests/test_components/test_source.py
@@ -70,8 +70,47 @@ def test_UniformCurrentSource():
     g = td.GaussianPulse(freq0=1e12, fwidth=0.1e12)
 
     # test we can make generic UniformCurrentSource
-    _ = td.UniformCurrentSource(size=(1, 1, 1), source_time=g, polarization="Ez", interpolate=False)
-    _ = td.UniformCurrentSource(size=(1, 1, 1), source_time=g, polarization="Ez", interpolate=True)
+    _ = td.UniformCurrentSource(
+        size=(1, 1, 1),
+        source_time=g,
+        polarization="Ez",
+        interpolate=False,
+        current_amplitude_definition="total",
+    )
+    _ = td.UniformCurrentSource(
+        size=(1, 1, 1),
+        source_time=g,
+        polarization="Ez",
+        interpolate=True,
+        current_amplitude_definition="total",
+    )
+
+
+def test_UniformCurrentSource_amplitude_definition_warning():
+    """Test deprecation warning when current_amplitude_definition is not explicitly set."""
+    g = td.GaussianPulse(freq0=1e12, fwidth=0.1e12)
+
+    # Not set: should warn
+    with AssertLogLevel("WARNING", contains_str="current_amplitude_definition"):
+        _ = td.UniformCurrentSource(size=(1, 1, 1), source_time=g, polarization="Ez")
+
+    # Explicitly "density": no warning
+    with AssertLogLevel(None):
+        _ = td.UniformCurrentSource(
+            size=(1, 1, 1),
+            source_time=g,
+            polarization="Ez",
+            current_amplitude_definition="density",
+        )
+
+    # Explicitly "total": no warning
+    with AssertLogLevel(None):
+        _ = td.UniformCurrentSource(
+            size=(1, 1, 1),
+            source_time=g,
+            polarization="Ez",
+            current_amplitude_definition="total",
+        )
 
 
 def test_source_times():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -699,6 +699,7 @@ SIM_FULL = td.Simulation(
                 freq0=2e14,
                 fwidth=4e13,
             ),
+            current_amplitude_definition="total",
         ),
         td.PointDipole(
             center=(0, 0.5, 0),
@@ -805,6 +806,7 @@ SIM_FULL = td.Simulation(
             source_time=td.CustomSourceTime.from_values(
                 freq0=2e14, fwidth=4e13, values=np.linspace(0, 10, 1000), dt=1e-12 / 100
             ),
+            current_amplitude_definition="total",
         ),
     ),
     monitors=(

--- a/tidy3d/components/data/index.py
+++ b/tidy3d/components/data/index.py
@@ -68,6 +68,7 @@ class SimulationDataMap(ValueMap, Mapping[str, SimulationDataType]):
     ...             center=(0, 0.5, 0),
     ...             polarization="Hx",
     ...             source_time=GaussianPulse(freq0=2e14, fwidth=4e13),
+    ...             current_amplitude_definition="total",
     ...         )
     ...     ],
     ...     monitors=[

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -919,6 +919,7 @@ class SimulationData(AbstractYeeGridSimulationData):
     ...                 freq0=2e14,
     ...                 fwidth=4e13,
     ...             ),
+    ...             current_amplitude_definition="total",
     ...         )
     ...     ],
     ... )

--- a/tidy3d/components/index.py
+++ b/tidy3d/components/index.py
@@ -173,6 +173,7 @@ class SimulationMap(ValueMap, Mapping[str, SimulationType]):
     ...             center=(0, 0.5, 0),
     ...             polarization="Hx",
     ...             source_time=GaussianPulse(freq0=2e14, fwidth=4e13),
+    ...             current_amplitude_definition="total",
     ...         )
     ...     ],
     ...     monitors=[

--- a/tidy3d/components/simulation.py
+++ b/tidy3d/components/simulation.py
@@ -2456,6 +2456,7 @@ class Simulation(AbstractYeeGridSimulation):
     ...             size=(0, 0, 0),
     ...             center=(0, 0.5, 0),
     ...             polarization="Hx",
+    ...             current_amplitude_definition='total',
     ...             source_time=GaussianPulse(
     ...                 freq0=2e14,
     ...                 fwidth=4e13,

--- a/tidy3d/components/source/current.py
+++ b/tidy3d/components/source/current.py
@@ -6,7 +6,7 @@ from abc import ABC
 from math import cos, isclose, sin
 from typing import TYPE_CHECKING, Any, Literal, Optional
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from tidy3d.components.base import cached_property
 from tidy3d.components.data.dataset import FieldDataset
@@ -14,11 +14,13 @@ from tidy3d.components.data.validators import validate_can_interpolate, validate
 from tidy3d.components.types import Polarization
 from tidy3d.components.validators import assert_single_freq_in_range, warn_if_dataset_none
 from tidy3d.constants import MICROMETER
+from tidy3d.log import log
 
 from .base import Source
 
 if TYPE_CHECKING:
-    from .time import SourceTimeType
+    from tidy3d.compat import Self
+    from tidy3d.components.source import SourceTimeType
 
 
 class CurrentSource(Source, ABC):
@@ -73,8 +75,36 @@ class UniformCurrentSource(CurrentSource, ReverseInterpolatedSource):
     -------
     >>> from tidy3d import GaussianPulse
     >>> pulse = GaussianPulse(freq0=200e12, fwidth=20e12)
-    >>> pt_source = UniformCurrentSource(size=(0,0,0), source_time=pulse, polarization='Ex')
+    >>> pt_source = UniformCurrentSource(
+    ...     size=(0,0,0), source_time=pulse, polarization='Ex', current_amplitude_definition='total',
+    ... )
     """
+
+    current_amplitude_definition: Literal["density", "total"] = Field(
+        "density",
+        title="Current Amplitude Definition",
+        description="Defines how the ``source_time`` amplitude is interpreted. "
+        "If ``'total'``, the ``source_time`` parameter is interpreted as the total "
+        "current in Amperes (A) / Volts (V) when an electric / magnetic current polarization "
+        "is chosen. The solver automatically scales the current density by the source "
+        "cross-sectional area to ensure the integrated current equals the specified amplitude, "
+        "regardless of mesh resolution. If ``'density'`` (default), ``source_time`` represents "
+        "the current density (e.g., A/m²), meaning the total injected current will scale with "
+        "the source geometry size.",
+    )
+
+    @model_validator(mode="after")
+    def _warn_current_amplitude_definition_default_change(self) -> Self:
+        """Warn that the default of 'current_amplitude_definition' will change from 'density' to 'total'."""
+        if "current_amplitude_definition" not in self.model_fields_set:
+            log.warning(
+                "The default value of 'current_amplitude_definition' for 'UniformCurrentSource' "
+                "will change from 'density' to 'total' in a future release. To avoid this warning "
+                "and ensure consistent behavior, please explicitly set "
+                "current_amplitude_definition='density' or current_amplitude_definition='total' "
+                "when creating the source."
+            )
+        return self
 
 
 class PointDipole(CurrentSource, ReverseInterpolatedSource):

--- a/tidy3d/plugins/smatrix/ports/rectangular_lumped.py
+++ b/tidy3d/plugins/smatrix/ports/rectangular_lumped.py
@@ -141,6 +141,7 @@ class LumpedPort(AbstractLumpedPort, Box):
             name=self.name,
             interpolate=True,
             confine_to_bounds=True,
+            current_amplitude_definition="total",
         )
 
     def to_load(self, snap_center: Optional[float] = None) -> LumpedResistor:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily additive and schema/test/documentation updates; runtime behavior is unchanged unless users opt into `current_amplitude_definition="total"`, with the main impact being new warnings when the field is omitted.
> 
> **Overview**
> Adds `current_amplitude_definition` to `UniformCurrentSource` (and schemas) to let users choose whether `source_time` amplitude is interpreted as a *current density* (`"density"`, default) or as *total injected current* (`"total"`) for size/mesh-independent normalization.
> 
> Introduces a validation warning when the field is not explicitly set (announcing a future default change), updates smatrix lumped-rectangular port source generation to use `"total"`, and refreshes docs/examples plus widespread tests to set the new field explicitly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0946e677a78b108ca40ee935714d9b838a477ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->