### PR TITLE
fix(adjoint): fixes for CustomMedium and FieldMonitor gradients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed frequency accumulation of gradients for custom dispersive media.
 - Fixed `snap_box_to_grid` producing zero-size boxes when using `Expand` behavior with very small intervals centered on a grid point.
 - Fixed sliver polygon artifacts in 2D material subdivision by filtering polygons based on grid cell size, preventing numerical issues with large-coordinate geometries.
+- Fixed `CustomMedium` gradient calculation when field coordinates exactly align with boundaries.
+- Fixed adjoint simulation `grid_spec` to align exactly with forward simulation for correct `FieldData` adjoint source power.
 
 ## [2.10.2] - 2026-01-21
 

--- a/tests/test_components/autograd/numerical/test_autograd_numerical.py
+++ b/tests/test_components/autograd/numerical/test_autograd_numerical.py
@@ -117,7 +117,21 @@ def make_base_sim(
     return sim_base
 
 
-def create_objective_function(geometry, create_sim_base, eval_fn, sim_path_dir):
+def create_objective_function(
+    geometry, create_sim_base, eval_fn, sim_path_dir, perm_init, cm_interp_method
+):
+    block_structure = td.Structure.from_permittivity_array(
+        eps_data=perm_init,
+        geometry=geometry,
+    )
+
+    sim_base = create_sim_base()
+
+    sim_with_block = sim_base.updated_copy(structures=(*sim_base.structures, block_structure))
+
+    # use a fixed grid for all forward and finite difference simulations
+    grid_fixed = sim_with_block.grid
+
     def objective(perm_arrays):
         sim_base = create_sim_base()
 
@@ -128,8 +142,13 @@ def create_objective_function(geometry, create_sim_base, eval_fn, sim_path_dir):
                 geometry=geometry,
             )
 
+            block_structure = block_structure.updated_copy(
+                medium=block_structure.medium.updated_copy(interp_method=cm_interp_method)
+            )
+
             sim_with_block = sim_base.updated_copy(
-                structures=(*sim_base.structures, block_structure)
+                structures=(*sim_base.structures, block_structure),
+                grid_spec=td.GridSpec.from_grid(grid_fixed),
             )
 
             simulation_dict[f"numerical_field_testing_{idx}"] = sim_with_block.copy()
@@ -184,6 +203,7 @@ background_indices = [1.0, 1.5]
 mesh_wvls_um = [1.55, 1.55, 10 * 1.55, 10 * 1.55]
 adj_wvls_um = [1.55, 2.2, 10 * 1.55, 10 * 2.2]
 monitor_sizes_3d_wvl = [(0.5, 0.5, 0), (0.5, 0.5, 0.5), (0.5, 0, 0), (0, 0.5, 0), (0, 0, 0)]
+cm_interp_methods = ["nearest", "linear"]
 
 field_data_test_parameters = []
 
@@ -197,19 +217,21 @@ for idx in range(len(mesh_wvls_um)):
 
         for monitor_bg_index in background_indices:
             for eval_fn_idx, eval_fn in enumerate(eval_fns):
-                field_data_test_parameters.append(
-                    {
-                        "mesh_wvl_um": mesh_wvl_um,
-                        "adj_wvl_um": adj_wvl_um,
-                        "monitor_size_wvl": monitor_size_wvl,
-                        "monitor_bg_index": monitor_bg_index,
-                        "eval_fn": eval_fn,
-                        "eval_fn_name": eval_fn_names[eval_fn_idx],
-                        "test_number": test_number,
-                    }
-                )
+                for cm_interp_method in cm_interp_methods:
+                    field_data_test_parameters.append(
+                        {
+                            "mesh_wvl_um": mesh_wvl_um,
+                            "adj_wvl_um": adj_wvl_um,
+                            "monitor_size_wvl": monitor_size_wvl,
+                            "monitor_bg_index": monitor_bg_index,
+                            "eval_fn": eval_fn,
+                            "eval_fn_name": eval_fn_names[eval_fn_idx],
+                            "cm_interp_method": cm_interp_method,
+                            "test_number": test_number,
+                        }
+                    )
 
-                test_number += 1
+                    test_number += 1
 
 
 @pytest.mark.numerical
@@ -236,6 +258,7 @@ def test_finite_difference_field_data(
         monitor_bg_index,
         eval_fn,
         eval_fn_name,
+        cm_interp_method,
         test_number,
     ) = operator.itemgetter(
         "mesh_wvl_um",
@@ -244,10 +267,10 @@ def test_finite_difference_field_data(
         "monitor_bg_index",
         "eval_fn",
         "eval_fn_name",
+        "cm_interp_method",
         "test_number",
     )(field_data_test_parameters)
 
-    dim_um = mesh_wvl_um
     dim_um = mesh_wvl_um
     thickness_um = 0.5 * mesh_wvl_um
     block = td.Box(center=(0, 0, 0), size=(dim_um, dim_um, thickness_um))
@@ -266,6 +289,8 @@ def test_finite_difference_field_data(
     sim_path_dir = numerical_case_dir / "simulations" / f"test{test_number}"
     sim_path_dir.mkdir(parents=True, exist_ok=True)
 
+    perm_init = FINITE_DIFF_PERM_SEED * np.ones((dim, dim, Nz))
+
     objective = create_objective_function(
         block,
         lambda mesh_wvl_um=mesh_wvl_um,
@@ -281,11 +306,11 @@ def test_finite_difference_field_data(
         ),
         eval_fn,
         sim_path_dir=str(sim_path_dir),
+        perm_init=perm_init,
+        cm_interp_method=cm_interp_method,
     )
 
     obj_val_and_grad = ag.value_and_grad(objective)
-
-    perm_init = FINITE_DIFF_PERM_SEED * np.ones((dim, dim, Nz))
 
     obj, adj_grad = obj_val_and_grad([perm_init])
 
@@ -332,11 +357,21 @@ def test_finite_difference_field_data(
     print(f"Monitor size: {monitor_size_wvl}")
     print(f"Background index for monitor: {monitor_bg_index}")
     print(f"Eval function: {eval_fn_name}")
+    print(f"Custom medium interpolation method: {cm_interp_method}")
     print(f"RMS Error: {rms_error}")
     print(f"FD, Adj magnitudes: {fd_mag}, {adj_mag}")
     print(f"Percentage Error: {percentage_error}")
     print("-" * 20)
     print("\n" * 3)
+
+    if PLOT_FD_ADJ_COMPARISON:
+        plt.plot(pattern_dot_adj_gradient, color="g", linewidth=2.0, label="Adjoint")
+        plt.plot(fd_grad, color="b", linewidth=1.5, linestyle="--", label="Finite difference")
+        plt.title(f"Gradient for objective: {eval_fn_name}")
+        plt.xlabel("Sample number")
+        plt.ylabel("Gradient value")
+        plt.legend()
+        plt.show()
 
     test_results[SAVE_FD_LOC, :] = fd_grad
     test_results[SAVE_ADJ_LOC, :] = pattern_dot_adj_gradient
@@ -355,13 +390,3 @@ def test_finite_difference_field_data(
             np.save(save_path, test_results)
 
     test_number += 1
-
-    if PLOT_FD_ADJ_COMPARISON:
-        plt.plot(pattern_dot_adj_gradient, color="g", linewidth=2.0)
-        plt.plot(fd_grad, color="b", linewidth=1.5, linestyle="--")
-        plt.title(f"Gradient for objective: {eval_fn_name}")
-        plt.legend(["Finite difference", "Adjoint"])
-        plt.xlabel("Sample number")
-        plt.ylabel("Gradient value")
-        plt.legend()
-        plt.show()

--- a/tidy3d/components/data/sim_data.py
+++ b/tidy3d/components/data/sim_data.py
@@ -17,6 +17,7 @@ from pydantic import Field
 from tidy3d.components.autograd.utils import split_list
 from tidy3d.components.base import JSON_TAG, Tidy3dBaseModel, cached_property
 from tidy3d.components.base_sim.data.sim_data import AbstractSimulationData
+from tidy3d.components.grid.grid_spec import GridSpec
 from tidy3d.components.simulation import Simulation
 from tidy3d.components.source.current import CustomCurrentSource
 from tidy3d.components.source.time import GaussianPulse
@@ -1112,11 +1113,8 @@ class SimulationData(AbstractYeeGridSimulationData):
         # grab boundary conditions with flipped Bloch vectors (for adjoint)
         bc_adj = sim_original.boundary_spec.flipped_bloch_vecs
 
-        # set the ADJ grid spec wavelength to the original wavelength (for same meshing)
-        grid_spec_original = sim_original.grid_spec
-        if sim_original.sources and grid_spec_original.wavelength is None:
-            wavelength_original = grid_spec_original.wavelength_from_sources(sim_original.sources)
-            grid_spec_adj = grid_spec_original.updated_copy(wavelength=wavelength_original)
+        # set the ADJ grid spec to use the same grid as sim_original for consistent meshing
+        grid_spec_adj = GridSpec.from_grid(sim_original.grid)
 
         adj_sims = []
         for adjoint_source_info in adjoint_source_infos:
@@ -1131,6 +1129,7 @@ class SimulationData(AbstractYeeGridSimulationData):
                 "boundary_spec": bc_adj,
                 "monitors": monitors,
                 "post_norm": adjoint_source_info.post_norm,
+                "grid_spec": grid_spec_adj,
             }
 
             if adjoint_source_info.normalize_sim:
@@ -1139,9 +1138,6 @@ class SimulationData(AbstractYeeGridSimulationData):
                 normalize_index_adj = None
 
             sim_adj_update_dict["normalize_index"] = normalize_index_adj
-
-            if sim_original.sources and grid_spec_original.wavelength is None:
-                sim_adj_update_dict["grid_spec"] = grid_spec_adj
 
             adj_sims.append(sim_original.updated_copy(**sim_adj_update_dict))
 

--- a/tidy3d/components/medium.py
+++ b/tidy3d/components/medium.py
@@ -128,6 +128,8 @@ LOSSY_METAL_DEFAULT_TOLERANCE_RMS = 1e-3
 
 ALLOWED_INTERP_METHODS = get_args(InterpMethod)
 
+CUSTOM_MEDIUM_BOUNDARY_COORDINATE_TOLERANCE = 1e-12
+
 
 def ensure_freq_in_range(
     eps_model: Callable[[AbstractMedium, float], complex],
@@ -1140,10 +1142,17 @@ class AbstractCustomMedium(AbstractMedium, ABC):
             return np.zeros(eps_shape, dtype=dtype_out)
 
         field_coords = {axis: np.asarray(E_der_dim.coords[axis]) for axis in "xyz"}
-        values = E_der_dim.values
+        # copy here to avoid modifying the derivative_info object data in E_der_map
+        values = E_der_dim.values.copy()
 
         def _bounds_slice(axis: NDArray, vmin: float, vmax: float, *, name: str) -> slice:
             n = axis.size
+
+            # protect against field value coordinates right at the structure boundary being
+            # exluded due to numerical precision
+            vmin -= CUSTOM_MEDIUM_BOUNDARY_COORDINATE_TOLERANCE
+            vmax += CUSTOM_MEDIUM_BOUNDARY_COORDINATE_TOLERANCE
+
             i0 = int(np.searchsorted(axis, vmin, side="left"))
             i1 = int(np.searchsorted(axis, vmax, side="right"))
             if i1 <= i0 and n:


### PR DESCRIPTION
- handle numerical precision errors at CustomMedium boundaries
- correct adjoint grid_spec to fully align grid between forward and adjoint simulations


Here are the fixes to get the custom medium numerical test working again. I'm running the full test for it right now including both interpolation types in the custom medium.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches adjoint simulation construction and `CustomMedium` gradient cropping, which can change gradient values and convergence behavior; test coverage is expanded to reduce regression risk but downstream optimization workflows may be sensitive to these numerical changes.
> 
> **Overview**
> Fixes autograd gradient regressions for `CustomMedium`/`FieldData` by **forcing adjoint simulations to reuse the exact forward simulation grid** (`GridSpec.from_grid(sim_original.grid)`) rather than relying on wavelength-based remeshing.
> 
> Hardens `CustomMedium` parameter-gradient computation against numerical precision at geometry boundaries by adding a small coordinate tolerance when cropping field data, and avoids mutating cached derivative arrays by copying values before slicing.
> 
> Updates the numerical autograd regression test to hold the grid fixed across forward and finite-difference runs and to run coverage for both `CustomMedium` interpolation modes (`nearest`/`linear`), with optional improved plotting output. Changelog entries are added for both fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9f967836c73f83572197b6eda06f00d9e364e9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->